### PR TITLE
feat(api)!: default estimation method to FOCEI instead of FOCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Set via `method` in `[fit_options]`:
 
 | Method | Description |
 |--------|-------------|
-| `foce` | First-Order Conditional Estimation (default) |
-| `focei` | FOCE with Interaction |
+| `foce` | First-Order Conditional Estimation |
+| `focei` | FOCE with Interaction (default) |
 | `gn` | Gauss-Newton (BHHH) with Levenberg-Marquardt damping |
 | `gn_hybrid` | Gauss-Newton followed by FOCEI polish |
 | `saem` | Stochastic Approximation EM |

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -113,7 +113,7 @@ pub struct FitOptions {
 }
 ```
 
-Use `FitOptions::default()` for standard FOCE settings.
+Use `FitOptions::default()` for standard FOCEI settings.
 
 ## FitResult
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -17,7 +17,7 @@ ferx <model.ferx> --simulate
 ferx model.ferx --data data.csv
 ```
 
-Parses the model file, reads the data, and runs the estimation method specified in `[fit_options]` (defaults to FOCE).
+Parses the model file, reads the data, and runs the estimation method specified in `[fit_options]` (defaults to FOCEI).
 
 ### Simulate and Fit
 

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -13,7 +13,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
-| `method` | `foce`, `focei`, `saem` | `foce` | Estimation method |
+| `method` | `foce`, `focei`, `saem` | `focei` | Estimation method |
 | `maxiter` | integer | `500` | Maximum outer loop iterations |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
 | `optimizer` | `slsqp`, `lbfgs`, `nlopt_lbfgs`, `mma`, `bfgs`, `bobyqa`, `trust_region` | `slsqp` | Optimization algorithm |
@@ -29,17 +29,17 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 ## Estimation Methods
 
-### FOCE (default)
-```
-method = foce
-```
-First-Order Conditional Estimation. Linearizes the model around the empirical Bayes estimates. Fast and reliable for most models.
-
-### FOCEI
+### FOCEI (default)
 ```
 method = focei
 ```
 FOCE with Interaction. Includes the dependence of the residual error on random effects. More accurate than FOCE when the error model depends on individual predictions, but slightly slower.
+
+### FOCE
+```
+method = foce
+```
+First-Order Conditional Estimation. Linearizes the model around the empirical Bayes estimates. Fast and reliable for most models.
 
 ### SAEM
 ```
@@ -119,10 +119,10 @@ The number of global evaluations is auto-scaled based on the number of parameter
 
 ## Examples
 
-Standard FOCE with defaults:
+Standard FOCEI with defaults:
 ```
 [fit_options]
-  method     = foce
+  method     = focei
   maxiter    = 300
   covariance = true
 ```

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3116,7 +3116,7 @@ mod tests {
     #[test]
     fn test_method_chain_helper_default() {
         let opts = FitOptions::default();
-        assert_eq!(opts.method_chain(), vec![EstimationMethod::Foce]);
+        assert_eq!(opts.method_chain(), vec![EstimationMethod::FoceI]);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -881,7 +881,7 @@ pub struct FitOptions {
 impl Default for FitOptions {
     fn default() -> Self {
         Self {
-            method: EstimationMethod::Foce,
+            method: EstimationMethod::FoceI,
             methods: Vec::new(),
             outer_maxiter: 500,
             outer_gtol: 1e-6,
@@ -897,7 +897,7 @@ impl Default for FitOptions {
             // tighter EBEs (e.g. very-small-data simulation work).
             inner_tol: 1e-4,
             run_covariance_step: true,
-            interaction: false,
+            interaction: true,
             verbose: true,
             optimizer: Optimizer::Bobyqa,
             lbfgs_memory: 5,


### PR DESCRIPTION
## Why
FOCE is currently the default in `FitOptions::default()`, but FOCEI is the safer default for typical PK models with proportional or combined error: it accounts for the dependence of the residual variance on η, which FOCE ignores. The cost is a modest per-iteration slowdown but more accurate parameter estimates and OFV in the typical case.

## What changed
- `src/types.rs`: `FitOptions::default()` now sets `method: EstimationMethod::FoceI` and `interaction: true`.
- Docs updated to reflect the new default: `README.md`, `docs/src/cli.md`, `docs/src/api/types.md`, `docs/src/model-file/fit-options.md` (default column, "(default)" heading swap, "Standard FOCE/FOCEI" example block).

Code paths that run a fit go through `apply_method_overrides`, which already sets the per-stage `interaction` flag from the chosen method — this PR only affects callers that read `FitOptions::default()` directly without going through that path.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | [FeRx-NLME/ferx-r#9](https://github.com/FeRx-NLME/ferx-r/pull/9) | open | together |

The companion ferx-r PR flips the R-side `method = "foce"` default to `"focei"`. They are independent edits that both implement the same user-facing change — neither blocks the other technically, but they should land together to keep the defaults consistent across language bindings.

## Breaking changes
- [x] Public Rust API (`api.rs` / `types.rs`) — behavior of `FitOptions::default()` changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] None

<details>
<summary>Migration notes</summary>

Callers that relied on `FitOptions::default()` giving them FOCE must now set `method: EstimationMethod::Foce` and `interaction: false` explicitly. Most callers either set `method` explicitly or run via the parser (which honors the `[fit_options] method = ...` block), so they are unaffected.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit
- [x] Not applicable — change is to the default selector, not to either estimator's numerics. Tests that build off `FitOptions::default()` (e.g. `tests/new_optimizers.rs`, `tests/map_estimates_outputs.rs`) now run FOCEI under the hood; their assertions look method-agnostic (`is_finite`, etc.) but should be confirmed with `cargo test` before merge.

## Performance
- [x] No significant impact expected — same engine, slightly more work per iteration (interaction term).

## Tests
- [ ] Unit test(s) added in the same module
- [ ] Regression test added that fails without this fix
- [x] No new tests needed — existing FOCE / FOCEI tests both still set `method` explicitly, so they exercise both methods regardless of the default.

## Example (user-facing features only)
- [ ] Example added to `examples/`
- [x] Not applicable — internal default change.

## Docs
- [x] `docs/src/` updated for user-visible changes (cli, api/types, model-file/fit-options)
- [ ] `mdbook build` run and `docs/book/` committed — please regenerate before merge
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [ ] `cargo check --features autodiff` still compiles
- [ ] `Cargo.toml` version bumped if breaking — recommend a minor bump since `FitOptions::default()` semantics change

## Reviewer hints
The hot path is `src/types.rs:884` and `src/types.rs:900`. The doc edits are straightforward swaps of "(default)" markers. The `interaction: true` change keeps the default struct internally consistent with the new method, even though the per-stage override in `api.rs:407` would correct it for any real fit.

## Open questions
None — this is a one-line semantic change with doc cleanup. The main thing to confirm is whether any test fixture pinned an OFV produced by FOCE-via-default (I didn't find one).