### PR TITLE
chore: fix two pre-existing compiler warnings

### DIFF
--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1379,7 +1379,6 @@ fn parse_csv_row(line: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::*;
     use nalgebra::{DMatrix, DVector};
 
     fn dummy_subject(id: &str, n_eta: usize, n_obs: usize) -> SubjectResult {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -640,7 +640,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // theta_names is extended below after diffusion thetas are appended
     let mut theta_names: Vec<String> = thetas.iter().map(|t| t.name.clone()).collect();
     let sigma_names: Vec<String> = sigmas.iter().map(|s| s.name.clone()).collect();
-    let mut n_theta = theta_names.len(); // updated below after diffusion thetas
+    let n_theta;
     let n_eta = eta_names_bsv.len(); // BSV-only count
     let n_kappa = kappa_info.names_ordered.len();
     let n_epsilon = sigma_names.len();
@@ -784,7 +784,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         theta_upper.push(f64::INFINITY);
         theta_fixed.push(is_fixed);
     }
-    n_theta = theta_names.len();
+    n_theta = theta_names.len(); // set here after diffusion thetas are appended above
     // BSV omega is built from the BSV-only eta names (no kappas)
     let omega = build_omega_matrix(&omegas, &block_omegas, &eta_names_bsv)?;
     let omega_fixed = build_omega_fixed(&omegas, &block_omegas, &eta_names_bsv)?;


### PR DESCRIPTION
## Why

Two pre-existing warnings in the CI build (`--no-default-features --features ci`):

1. `fitrx.rs:1382` — `use crate::types::*` inside the test module was redundant; `use super::*` already imports everything needed.
2. `model_parser.rs:643` — `n_theta` was assigned `theta_names.len()` at declaration, then unconditionally overwritten at line 787 (after diffusion thetas are appended) before ever being read. The first assignment was dead.

## What changed

- Remove the redundant import in `fitrx.rs`.
- Replace `let mut n_theta = theta_names.len()` with `let n_theta;` and keep the single real assignment at line 787 as the sole initialisation.

## Alternatives considered

The `inner_optimizer.rs` warnings (`AdSingleSnapshot`, `AdEventDriven`, `record_ad`, `record_jac_ad` unused without `autodiff`) are intentional — those code paths are gated by `#[cfg(feature = "autodiff")]` and the warning is an honest signal. No change made there.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (no logic changes)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (warning-only fixes)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean
- [x] No example execution step needed

## Docs & examples
- [x] No example execution step needed (internal / no user-visible change)