### PR TITLE
test(api): mark slow fit() tests as #[ignore], add weekly CI job [closes #32]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,29 @@ jobs:
       - name: cargo fmt
         run: cargo fmt -- --check
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Generate coverage report
+        run: cargo llvm-cov --lib --no-default-features --features ci --include-ignored --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   slow-tests:
     name: Slow tests (ignored)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'  # weekly on Monday at 03:00 UTC
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -57,3 +60,16 @@ jobs:
 
       - name: cargo fmt
         run: cargo fmt -- --check
+
+  slow-tests:
+    name: Slow tests (ignored)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test (including ignored)
+        run: cargo test --lib --no-default-features --features ci -- --include-ignored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,16 @@ Inline `#[cfg(test)] mod tests` blocks at the bottom of each module (e.g. `src/p
 
 Prefer unit tests of the smallest helper that isolates the new behaviour (e.g. test `detect_mu_refs` directly, not just through a full `fit()` call) — end-to-end fits are too slow and flaky for the default test suite.
 
+**Any test that calls `fit()` and runs to convergence must be marked `#[ignore]`** to keep `cargo test --lib` fast. Add the attribute immediately after `#[test]`:
+
+```rust
+#[test]
+#[ignore = "slow: runs a full optimisation to convergence"]
+fn test_my_new_estimator() { ... }
+```
+
+Ignored tests still run in CI on a weekly schedule and can be triggered manually via `workflow_dispatch`. Fast-failing tests (those that call `fit()` but expect an immediate `Err` without running the optimiser) do not need `#[ignore]`.
+
 ## Documentation
 
 Docs live in `docs/` as an [mdBook](https://rust-lang.github.io/mdBook/):

--- a/src/api.rs
+++ b/src/api.rs
@@ -1764,6 +1764,7 @@ mod iov_integration {
     // ── Tests: FOCE + all outer optimizers ───────────────────────────────────
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_bobyqa() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1773,6 +1774,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_slsqp() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1782,6 +1784,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_lbfgs() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1791,6 +1794,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_nlopt_lbfgs() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1800,6 +1804,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_mma() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1809,6 +1814,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_bfgs() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1820,6 +1826,7 @@ mod iov_integration {
     // ── Tests: FOCEI ─────────────────────────────────────────────────────────
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_focei_bobyqa() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1831,6 +1838,7 @@ mod iov_integration {
     // ── Tests: mu-referencing ─────────────────────────────────────────────────
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_foce_mu_referencing_on() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1841,6 +1849,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_focei_mu_referencing_on() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1853,6 +1862,7 @@ mod iov_integration {
     // ── Tests: GN and GN_Hybrid ───────────────────────────────────────────────
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_gn() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -1863,6 +1873,7 @@ mod iov_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_iov_gn_hybrid() {
         let model = make_iov_model();
         let pop = make_iov_population();
@@ -2709,6 +2720,7 @@ mod sde_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_sde_fit_uses_sde_flag() {
         let parsed = parse_full_model(SDE_MODEL_SRC).expect("SDE model should parse");
         let pop = make_sde_population();
@@ -2719,6 +2731,7 @@ mod sde_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_sde_fit_diff_central_positive() {
         let parsed = parse_full_model(SDE_MODEL_SRC).expect("SDE model should parse");
         let pop = make_sde_population();
@@ -2738,6 +2751,7 @@ mod sde_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_sde_fit_ofv_finite() {
         let parsed = parse_full_model(SDE_MODEL_SRC).expect("SDE model should parse");
         let pop = make_sde_population();
@@ -2752,6 +2766,7 @@ mod sde_integration {
     }
 
     #[test]
+    #[ignore = "slow: runs a full optimisation to convergence"]
     fn test_sde_ofv_le_base_ofv() {
         let pop = make_sde_population();
         let opts = fast_foce_opts();


### PR DESCRIPTION
## Why

The test suite was taking >20 minutes on every PR (issue #32). 15 tests in `src/api.rs` call `fit()` and run full FOCE/FOCEI/GN optimisations to convergence — these are integration-style tests masquerading as unit tests. They were also blocking the new `Coverage` job added in PR #25.

## What changed

- Added `#[ignore = "slow: runs a full optimisation to convergence"]` to 15 tests:
  - 11 IOV optimizer tests (`test_iov_foce_*`, `test_iov_focei_*`, `test_iov_gn*`, mu-referencing variants)
  - 4 SDE end-to-end tests (`test_sde_fit_*`, `test_sde_ofv_le_base_ofv`)
- Fast-failing tests (SAEM/trust-region error guards, `sde_gn_returns_error`) are left as-is — they return `Err` immediately without running the optimiser.
- Added a `slow-tests` CI job to `.github/workflows/ci.yml` that runs `-- --include-ignored` on a weekly schedule (Monday 03:00 UTC) and on manual `workflow_dispatch`. This job does **not** run on push/PR so it never blocks merges.

## Alternatives considered

Moving slow tests to `tests/` (integration test dir) — same effect, more file churn. `#[ignore]` is the idiomatic Rust approach and keeps the tests co-located with the helpers they use.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] Faster — `cargo test --lib` goes from >20 min to ~seconds; slow tests still run weekly

## Tests
- [x] No new tests needed — this PR only changes test scheduling, not behaviour

## Example (user-facing features only)
- [x] Not applicable

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

The 15 ignored tests are still fully intact and correct — they just won't run on every PR. Run them locally with:
```
cargo test --lib --no-default-features --features ci -- --include-ignored
```
or trigger the `slow-tests` workflow manually from the Actions tab.

## Open questions

Weekly cadence for the slow job felt right — open to changing to nightly if preferred.