### PR TITLE
feat(parser/nn): wire pk_param_fn through [covariate_nn] for simulate

### DIFF
--- a/examples/drafts/warfarin_dcm.ferx
+++ b/examples/drafts/warfarin_dcm.ferx
@@ -1,25 +1,25 @@
 # ────────────────────────────────────────────────────────────────────────────
 # DRAFT — design intent for Deep Compartment Models (DCM)
 #
-# What's wired now (Phase A M1, behind `--features nn`):
+# What's wired now (Phase A M1 steps 2 + 3, behind `--features nn`):
 #   ✓ `[covariate_nn NAME]` block syntax parses end-to-end.
-#   ✓ NN weight thetas (`W_TYPICAL_PK_…`, `B_TYPICAL_PK_…`) are auto-generated
+#   ✓ NN weight thetas (`W_TYPICAL_PK_…`, `B_TYPICAL_PK_…`) auto-generated
 #     and appended to the model's theta vector with Glorot-style inits.
-#   ✓ `model.covariate_nns` exposes the mapper handle on `CompiledModel`.
+#   ✓ Mu-ref composition `TYPICAL_PK.CL * exp(ETA_CL)` parses and dispatches.
+#   ✓ `pk_param_fn` runs the NN forward pass once per call and routes its
+#     outputs into PK slots. The model is simulate-able end-to-end.
 #
-# What's NOT wired yet (planned for the next PR):
-#   ✗ `method = nn_mse` fit objective.
-#   ✗ Mu-ref composition `TYPICAL_PK.CL * exp(ETA_CL)` in `[individual_parameters]`.
-#   ✗ `pk_param_fn` dispatch onto the NN.
+# What's NOT wired yet (planned for the next PR — Phase A M1 step 4):
+#   ✗ `method = nn_mse` fixed-effects fit objective.
+#   ✗ Option E NN-aware output rendering in `{model}-fit.yaml` / `.fitrx`.
+#   ✗ Promotion to `examples/warfarin_dcm.ferx` (out of `drafts/`).
 #
-# Running `cargo run --features nn -- examples/drafts/warfarin_dcm.ferx` today
-# will FAIL on the `[individual_parameters]` reference to `TYPICAL_PK.CL`
-# (unknown identifier) and on `method = nn_mse` (unknown method). Expected.
-#
-# The file lives in `examples/drafts/` so the parser smoke test
-# (`test_parse_all_example_ferx_files`) skips it. When parser-side support
-# for the mu-ref composition + nn_mse lands, the file will be promoted to
-# `examples/warfarin_dcm.ferx` and this header removed.
+# Today, swapping `method = nn_mse` below for a real method (`method = focei`)
+# and running `cargo run --release --features nn -- examples/drafts/warfarin_dcm.ferx
+# --simulate` should produce reasonable concentration curves driven by the
+# untrained NN. Fitting is not yet useful — the optimizer would treat NN
+# weights as ordinary thetas which is technically correct but not what the
+# paper does.
 # ────────────────────────────────────────────────────────────────────────────
 #
 # Model: two-compartment oral PK, NN-based typical values (DCM), additive

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -486,6 +486,30 @@ impl NamedMlpMapper {
         &self.mlp
     }
 
+    /// Names of the inputs in `inputs` order — i.e. the covariate keys this
+    /// mapper reads from a `&HashMap<String, f64>` on every forward pass.
+    pub fn input_names(&self) -> &[String] {
+        &self.input_names
+    }
+
+    /// Forward pass returning the raw output vector in *declaration order*
+    /// (the order of `output_names`), without routing through `PkParams`.
+    ///
+    /// `forward` writes results into PK slots via `name_to_index`, which is
+    /// what the fit / predict / simulate paths ultimately want. The parser,
+    /// however, needs to look up outputs by their position in the
+    /// `[covariate_nn]` block's `outputs` list (so the AST can carry a tiny
+    /// `output_idx` rather than a string slot name). This method is the
+    /// parser-facing variant.
+    pub fn forward_raw(
+        &self,
+        weights: &[f64],
+        covariates: &HashMap<String, f64>,
+    ) -> Result<Vec<f64>, NnError> {
+        let x = self.build_input_vec(covariates)?;
+        self.mlp.forward(&x, weights)
+    }
+
     fn build_input_vec(&self, covariates: &HashMap<String, f64>) -> Result<Vec<f64>, NnError> {
         self.input_names
             .iter()

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -719,11 +719,28 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // The ParseCtx still receives the full set (via assigned_vars_in_order) so
     // branch-local names parse as Variable rather than Covariate.
     let indiv_text = indiv_lines.join("\n");
-    let bare_ctx = ParseCtx::new(&theta_names, &eta_names, &[]);
+    // NN-output lookup table for `TYPICAL_PK.CL`-style dot-access in
+    // [individual_parameters]. Always present (empty when no [covariate_nn]
+    // block is in the model) so the same code path works with or without
+    // --features nn.
+    #[cfg(feature = "nn")]
+    let nn_specs_for_ctx: Vec<(String, Vec<String>)> = nn_specs
+        .iter()
+        .map(|s| {
+            use crate::nn::CovariateMapper;
+            (s.name.clone(), s.mapper.output_names().to_vec())
+        })
+        .collect();
+    #[cfg(not(feature = "nn"))]
+    let nn_specs_for_ctx: Vec<(String, Vec<String>)> = Vec::new();
+
+    let bare_ctx =
+        ParseCtx::new(&theta_names, &eta_names, &[]).with_nn_specs(&nn_specs_for_ctx);
     let pre_stmts = parse_block_statements(&indiv_text, bare_ctx, StatementMode::Plain)?;
     let all_assigned = assigned_vars_in_order(&pre_stmts);
     let indiv_var_names = top_level_assigned_vars(&pre_stmts);
-    let indiv_ctx = ParseCtx::new(&theta_names, &eta_names, &all_assigned);
+    let indiv_ctx = ParseCtx::new(&theta_names, &eta_names, &all_assigned)
+        .with_nn_specs(&nn_specs_for_ctx);
     let indiv_stmts = parse_block_statements(&indiv_text, indiv_ctx, StatementMode::Plain)?;
 
     // Detect ODE vs analytical model
@@ -808,9 +825,33 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         )
     };
 
+    // Build the CovariateNn handles up front (before build_pk_param_fn, which
+    // captures them in the pk_param_fn closure). The same vector is also
+    // appended to CompiledModel.covariate_nns further down — see the diffusion
+    // appendage block, which uses these to drive theta-value extension.
+    #[cfg(feature = "nn")]
+    let covariate_nns_for_closure: Vec<crate::nn::CovariateNn> = {
+        let mut acc = Vec::with_capacity(nn_specs.len());
+        let mut offset = thetas.len();
+        for spec in &nn_specs {
+            acc.push(crate::nn::CovariateNn {
+                name: spec.name.clone(),
+                mapper: spec.mapper.clone(),
+                weights_offset: offset,
+            });
+            offset += spec.theta_inits.len();
+        }
+        acc
+    };
+
     // Build pk_param_fn with the extended eta context (BSV + kappa names).
-    let (pk_param_fn, referenced_covariates) =
-        build_pk_param_fn(indiv_stmts.clone(), &pk_param_map, &indiv_var_names)?;
+    let (pk_param_fn, referenced_covariates) = build_pk_param_fn(
+        indiv_stmts.clone(),
+        &pk_param_map,
+        &indiv_var_names,
+        #[cfg(feature = "nn")]
+        &covariate_nns_for_closure,
+    )?;
 
     // Append NN-weight thetas (Phase A M1), then diffusion variances. Both
     // sit at the tail of the theta vector so existing user-declared theta
@@ -827,25 +868,21 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     let mut theta_upper: Vec<f64> = thetas.iter().map(|t| t.upper).collect();
     let mut theta_fixed: Vec<bool> = thetas.iter().map(|t| t.fixed).collect();
 
+    // NN-weight thetas: same offsets as `covariate_nns_for_closure` built
+    // above (both use `thetas.len()` as the first offset). We append values
+    // / bounds / fixed flags here; the handles themselves live in
+    // `covariate_nns_for_closure` and are reused below for `CompiledModel`.
     #[cfg(feature = "nn")]
-    let covariate_nns: Vec<crate::nn::CovariateNn> = {
-        let mut out = Vec::with_capacity(nn_specs.len());
-        for spec in &nn_specs {
-            let offset = theta_values.len();
-            for &init in &spec.theta_inits {
-                theta_values.push(init);
-                theta_lower.push(f64::NEG_INFINITY);
-                theta_upper.push(f64::INFINITY);
-                theta_fixed.push(false);
-            }
-            out.push(crate::nn::CovariateNn {
-                name: spec.name.clone(),
-                mapper: spec.mapper.clone(),
-                weights_offset: offset,
-            });
+    let covariate_nns: Vec<crate::nn::CovariateNn> = covariate_nns_for_closure.clone();
+    #[cfg(feature = "nn")]
+    for spec in &nn_specs {
+        for &init in &spec.theta_inits {
+            theta_values.push(init);
+            theta_lower.push(f64::NEG_INFINITY);
+            theta_upper.push(f64::INFINITY);
+            theta_fixed.push(false);
         }
-        out
-    };
+    }
 
     let diff_theta_start = theta_values.len(); // index of first diffusion theta
     for (i, &init) in diffusion_theta_inits.iter().enumerate() {
@@ -2462,10 +2499,17 @@ fn parse_error_model(lines: &[String]) -> Result<(ErrorModel, Vec<String>), Stri
 /// `var_names` is the deduplicated list of all variables ever assigned in the
 /// block (in first-occurrence order). For analytical PK models the assignment
 /// order doubles as the slot ordering for `PkParams.values`.
+/// Build the `pk_param_fn` closure used by every fit / simulate / predict
+/// call site. When the `nn` feature is on and the model has any
+/// `[covariate_nn]` blocks, `covariate_nns` carries each mapper plus the
+/// offset of its weight block inside the optimizer's `theta` vector. The
+/// closure pre-computes each NN's forward output once per call and exposes
+/// them to the indexed evaluator via the `nn_outputs` slice.
 fn build_pk_param_fn(
     stmts: Vec<Statement>,
     pk_param_map: &HashMap<String, String>,
     var_names: &[String],
+    #[cfg(feature = "nn")] covariate_nns: &[crate::nn::CovariateNn],
 ) -> Result<(PkParamFn, Vec<String>), String> {
     // Covariates referenced anywhere in the block (including inside if-bodies
     // and condition expressions). Sorted for deterministic error messages.
@@ -2542,6 +2586,13 @@ fn build_pk_param_fn(
 
     let cov_names_for_lookup = referenced_covariates.clone();
 
+    // Snapshot the NN handles into the closure. Empty when no
+    // `[covariate_nn]` blocks are present, in which case the per-call
+    // forward-pass loop below is a no-op (just an empty `Vec<Vec<f64>>`
+    // alloc — cheap enough to skip the branch).
+    #[cfg(feature = "nn")]
+    let covariate_nns_owned: Vec<crate::nn::CovariateNn> = covariate_nns.to_vec();
+
     let pk_param_fn: PkParamFn = Box::new(
         move |theta: &[f64], eta: &[f64], covariates: &HashMap<String, f64>| {
             // Materialise covariates into a Vec<f64> aligned with
@@ -2554,7 +2605,27 @@ fn build_pk_param_fn(
                 cov_vec[i] = covariates.get(name).copied().unwrap_or(0.0);
             }
             let mut vars = vec![0.0_f64; n_vars];
-            eval_statements_indexed(&stmts_owned, theta, eta, &cov_vec, &mut vars);
+
+            // Pre-compute each NN's forward output once per call. The
+            // indexed evaluator reads `nn_outputs[nn_idx][output_idx]` for
+            // every `Expression::NnOutput` it visits, so multiple `.CL`,
+            // `.V1`, … references on the same NN share this single forward.
+            #[cfg(feature = "nn")]
+            let nn_outputs: Vec<Vec<f64>> = covariate_nns_owned
+                .iter()
+                .map(|nn| {
+                    use crate::nn::CovariateMapper;
+                    let n_w = nn.mapper.n_weights();
+                    let weights = &theta[nn.weights_offset..nn.weights_offset + n_w];
+                    nn.mapper
+                        .forward_raw(weights, covariates)
+                        .unwrap_or_else(|_| vec![0.0; nn.mapper.n_outputs()])
+                })
+                .collect();
+            #[cfg(not(feature = "nn"))]
+            let nn_outputs: Vec<Vec<f64>> = Vec::new();
+
+            eval_statements_indexed(&stmts_owned, theta, eta, &cov_vec, &mut vars, &nn_outputs);
 
             let mut p = PkParams::default();
             if is_analytical_pk {
@@ -2602,6 +2673,14 @@ enum Expression {
     Power(Box<Expression>, Box<Expression>),
     /// `if (cond) then_expr else else_expr` — value-producing inline conditional.
     Conditional(Box<Condition>, Box<Expression>, Box<Expression>),
+    /// Dot-access on a `[covariate_nn NAME]` block's output, e.g.
+    /// `TYPICAL_PK.CL`. `nn_idx` indexes into `CompiledModel.covariate_nns`
+    /// (deterministic alphabetical order set at parse time); `output_idx`
+    /// indexes into the block's declared `outputs` list. Eval-time dispatch
+    /// reads the pre-computed forward output from a per-call cache in
+    /// `build_pk_param_fn` so multiple references to outputs of the same
+    /// NN share a single forward pass.
+    NnOutput { nn_idx: usize, output_idx: usize },
 }
 
 #[derive(Debug, Clone)]
@@ -2662,26 +2741,40 @@ struct ParseCtx<'a> {
     /// Set to `false` for the ODE RHS parser, where state names and individual
     /// parameters are injected into the `vars` map at eval time instead.
     fallback_covariate: bool,
+    /// Per-NN-block (name, output_names) pairs in alphabetical order.
+    /// `nn_idx` in `Expression::NnOutput` indexes into this slice. Empty
+    /// when no `[covariate_nn]` block is present in the model (the
+    /// dot-access parser then errors on `FOO.BAR`).
+    nn_specs: &'a [(String, Vec<String>)],
 }
 
 impl<'a> ParseCtx<'a> {
     fn new(theta_names: &'a [String], eta_names: &'a [String], defined_vars: &'a [String]) -> Self {
+        const EMPTY_NN: &[(String, Vec<String>)] = &[];
         Self {
             theta_names,
             eta_names,
             defined_vars,
             fallback_covariate: true,
+            nn_specs: EMPTY_NN,
         }
     }
 
     fn ode(defined_vars: &'a [String]) -> Self {
         const EMPTY: &[String] = &[];
+        const EMPTY_NN: &[(String, Vec<String>)] = &[];
         Self {
             theta_names: EMPTY,
             eta_names: EMPTY,
             defined_vars,
             fallback_covariate: false,
+            nn_specs: EMPTY_NN,
         }
+    }
+
+    fn with_nn_specs(mut self, nn_specs: &'a [(String, Vec<String>)]) -> Self {
+        self.nn_specs = nn_specs;
+        self
     }
 }
 
@@ -2818,6 +2911,19 @@ fn eval_expression(
                 eval_expression(e, theta, eta, covariates, vars)
             }
         }
+        Expression::NnOutput { .. } => {
+            // The HashMap-keyed (unindexed) evaluator is used only by callers
+            // that pre-date the `[covariate_nn]` feature (tv_fn, the simulation
+            // expression evaluator). NN dispatch happens exclusively in the
+            // indexed path. Reaching this branch from a NN-bearing model is a
+            // bug to fix in a subsequent PR (Phase A M2: tv_fn parity).
+            debug_assert!(
+                false,
+                "Expression::NnOutput reached unindexed eval_expression; tv_fn / simulation \
+                 paths do not yet support [covariate_nn] (Phase A M2 work)"
+            );
+            0.0
+        }
     }
 }
 
@@ -2866,6 +2972,7 @@ fn eval_expression_indexed(
     eta: &[f64],
     covariates: &[f64],
     vars: &[f64],
+    nn_outputs: &[Vec<f64>],
 ) -> f64 {
     match expr {
         Expression::Literal(v) => *v,
@@ -2878,8 +2985,8 @@ fn eval_expression_indexed(
             0.0
         }
         Expression::BinOp(lhs, op, rhs) => {
-            let l = eval_expression_indexed(lhs, theta, eta, covariates, vars);
-            let r = eval_expression_indexed(rhs, theta, eta, covariates, vars);
+            let l = eval_expression_indexed(lhs, theta, eta, covariates, vars, nn_outputs);
+            let r = eval_expression_indexed(rhs, theta, eta, covariates, vars, nn_outputs);
             match op {
                 BinOp::Add => l + r,
                 BinOp::Sub => l - r,
@@ -2894,7 +3001,7 @@ fn eval_expression_indexed(
             }
         }
         Expression::UnaryFn(name, arg) => {
-            let v = eval_expression_indexed(arg, theta, eta, covariates, vars);
+            let v = eval_expression_indexed(arg, theta, eta, covariates, vars, nn_outputs);
             match name.as_str() {
                 "exp" => v.exp(),
                 "log" | "ln" => v.max(1e-30).ln(),
@@ -2916,16 +3023,33 @@ fn eval_expression_indexed(
             }
         }
         Expression::Power(base, exp) => {
-            let b = eval_expression_indexed(base, theta, eta, covariates, vars);
-            let e = eval_expression_indexed(exp, theta, eta, covariates, vars);
+            let b = eval_expression_indexed(base, theta, eta, covariates, vars, nn_outputs);
+            let e = eval_expression_indexed(exp, theta, eta, covariates, vars, nn_outputs);
             b.powf(e)
         }
         Expression::Conditional(cond, t, e) => {
-            if eval_condition_indexed(cond, theta, eta, covariates, vars) {
-                eval_expression_indexed(t, theta, eta, covariates, vars)
+            if eval_condition_indexed(cond, theta, eta, covariates, vars, nn_outputs) {
+                eval_expression_indexed(t, theta, eta, covariates, vars, nn_outputs)
             } else {
-                eval_expression_indexed(e, theta, eta, covariates, vars)
+                eval_expression_indexed(e, theta, eta, covariates, vars, nn_outputs)
             }
+        }
+        Expression::NnOutput { nn_idx, output_idx } => {
+            // Reads from the per-call cache that `build_pk_param_fn`
+            // populates once per forward via `NamedMlpMapper::forward_raw`.
+            // Multiple references to outputs of the same NN therefore share
+            // a single forward pass.
+            nn_outputs
+                .get(*nn_idx)
+                .and_then(|v| v.get(*output_idx))
+                .copied()
+                .unwrap_or_else(|| {
+                    debug_assert!(
+                        false,
+                        "NnOutput nn_idx={nn_idx} output_idx={output_idx} out of bounds"
+                    );
+                    0.0
+                })
         }
     }
 }
@@ -2936,11 +3060,12 @@ fn eval_condition_indexed(
     eta: &[f64],
     covariates: &[f64],
     vars: &[f64],
+    nn_outputs: &[Vec<f64>],
 ) -> bool {
     match cond {
         Condition::Compare(l, op, r) => {
-            let lv = eval_expression_indexed(l, theta, eta, covariates, vars);
-            let rv = eval_expression_indexed(r, theta, eta, covariates, vars);
+            let lv = eval_expression_indexed(l, theta, eta, covariates, vars, nn_outputs);
+            let rv = eval_expression_indexed(r, theta, eta, covariates, vars, nn_outputs);
             match op {
                 CmpOp::Lt => lv < rv,
                 CmpOp::Le => lv <= rv,
@@ -2951,14 +3076,14 @@ fn eval_condition_indexed(
             }
         }
         Condition::And(l, r) => {
-            eval_condition_indexed(l, theta, eta, covariates, vars)
-                && eval_condition_indexed(r, theta, eta, covariates, vars)
+            eval_condition_indexed(l, theta, eta, covariates, vars, nn_outputs)
+                && eval_condition_indexed(r, theta, eta, covariates, vars, nn_outputs)
         }
         Condition::Or(l, r) => {
-            eval_condition_indexed(l, theta, eta, covariates, vars)
-                || eval_condition_indexed(r, theta, eta, covariates, vars)
+            eval_condition_indexed(l, theta, eta, covariates, vars, nn_outputs)
+                || eval_condition_indexed(r, theta, eta, covariates, vars, nn_outputs)
         }
-        Condition::Not(c) => !eval_condition_indexed(c, theta, eta, covariates, vars),
+        Condition::Not(c) => !eval_condition_indexed(c, theta, eta, covariates, vars, nn_outputs),
     }
 }
 
@@ -2973,11 +3098,12 @@ fn eval_statements_indexed(
     eta: &[f64],
     covariates: &[f64],
     vars: &mut [f64],
+    nn_outputs: &[Vec<f64>],
 ) {
     for s in stmts {
         match s {
             Statement::AssignIdx(idx, expr) => {
-                let v = eval_expression_indexed(expr, theta, eta, covariates, vars);
+                let v = eval_expression_indexed(expr, theta, eta, covariates, vars, nn_outputs);
                 if let Some(slot) = vars.get_mut(*idx) {
                     *slot = v;
                 }
@@ -2988,15 +3114,15 @@ fn eval_statements_indexed(
             } => {
                 let mut taken = false;
                 for (cond, body) in branches {
-                    if eval_condition_indexed(cond, theta, eta, covariates, vars) {
-                        eval_statements_indexed(body, theta, eta, covariates, vars);
+                    if eval_condition_indexed(cond, theta, eta, covariates, vars, nn_outputs) {
+                        eval_statements_indexed(body, theta, eta, covariates, vars, nn_outputs);
                         taken = true;
                         break;
                     }
                 }
                 if !taken {
                     if let Some(eb) = else_body {
-                        eval_statements_indexed(eb, theta, eta, covariates, vars);
+                        eval_statements_indexed(eb, theta, eta, covariates, vars, nn_outputs);
                     }
                 }
             }
@@ -3082,7 +3208,8 @@ fn resolve_expr_indices(
         | Expression::Theta(_)
         | Expression::Eta(_)
         | Expression::VariableIdx(_)
-        | Expression::CovariateIdx(_) => {}
+        | Expression::CovariateIdx(_)
+        | Expression::NnOutput { .. } => {}
     }
 }
 
@@ -3209,6 +3336,11 @@ enum Token {
     OrOr,
     Bang,
     Comma,
+    /// `.` — member-access operator, used today only by `[covariate_nn]`
+    /// dot-access syntax (`TYPICAL_PK.CL`). Decimal-point dots inside number
+    /// literals (e.g. `4.5`, `.5`) are absorbed by the number tokenizer
+    /// before this token is produced.
+    Dot,
     /// Logical line separator. Consumed only by the statement parser, where
     /// it acts as an "end of statement" marker. Newlines inside `(...)` and
     /// `[...]` are stripped by `strip_newlines_in_groups` so users can break
@@ -3380,7 +3512,30 @@ fn tokenize(s: &str) -> Result<Vec<Token>, String> {
                 tokens.push(Token::Caret);
                 i += 1;
             }
-            c if c.is_ascii_digit() || c == '.' => {
+            // A `.` followed by a digit starts a decimal-only literal like `.5`.
+            // Standalone `.` (e.g. `TYPICAL_PK.CL`) is the member-access operator
+            // and is handled by a separate arm below.
+            '.' if i + 1 < chars.len() && chars[i + 1].is_ascii_digit() => {
+                let start = i;
+                while i < chars.len()
+                    && (chars[i].is_ascii_digit()
+                        || chars[i] == '.'
+                        || chars[i] == 'e'
+                        || chars[i] == 'E')
+                {
+                    i += 1;
+                }
+                let num_str: String = chars[start..i].iter().collect();
+                let num: f64 = num_str
+                    .parse()
+                    .map_err(|_| format!("Bad number: {}", num_str))?;
+                tokens.push(Token::Number(num));
+            }
+            '.' => {
+                tokens.push(Token::Dot);
+                i += 1;
+            }
+            c if c.is_ascii_digit() => {
                 let start = i;
                 while i < chars.len()
                     && (chars[i].is_ascii_digit()
@@ -3554,6 +3709,42 @@ fn parse_atom(
                     return Err(format!("Missing closing parenthesis for function {}", name));
                 }
                 return Ok((Expression::UnaryFn(func_name, Box::new(arg)), p + 1));
+            }
+
+            // Check if it's an `[covariate_nn NAME]` output access: `NAME.OUTPUT`.
+            // Resolved at parse time into `Expression::NnOutput { nn_idx, output_idx }`
+            // so the evaluator can read the pre-computed forward output by index.
+            if pos + 1 < tokens.len() && tokens[pos + 1] == Token::Dot {
+                if let Some(nn_idx) = ctx.nn_specs.iter().position(|(n, _)| n == name) {
+                    let output_tok = tokens.get(pos + 2).ok_or_else(|| {
+                        format!("`{}.` is missing an output name after the dot", name)
+                    })?;
+                    let output_name = match output_tok {
+                        Token::Ident(s) => s,
+                        other => {
+                            return Err(format!(
+                                "`{}.` must be followed by an output name (identifier), got {:?}",
+                                name, other
+                            ));
+                        }
+                    };
+                    let outputs = &ctx.nn_specs[nn_idx].1;
+                    let output_idx = outputs
+                        .iter()
+                        .position(|o| o == output_name)
+                        .ok_or_else(|| {
+                            format!(
+                                "`{name}.{output_name}` is not declared as an output of \
+                                 [covariate_nn {name}]. Known outputs: {}",
+                                outputs.join(", ")
+                            )
+                        })?;
+                    return Ok((Expression::NnOutput { nn_idx, output_idx }, pos + 3));
+                }
+                // `NAME.X` where NAME is not a known NN — fall through to the
+                // identifier-classification chain. The `Dot` token will then
+                // be the next unexpected token; the caller will surface that
+                // as an expression-parse error.
             }
 
             // Check if it's a theta
@@ -6468,5 +6659,175 @@ if (1 > 0) {
         let lines = by_inst.get("FOO").expect("instance FOO present");
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], "key = value");
+    }
+
+    // ─── [covariate_nn] dot-access + pk_param_fn dispatch (Phase A M1 step 3) ────
+
+    #[cfg(feature = "nn")]
+    fn covariate_nn_dotted_model_src() -> String {
+        // Two-output NN feeding both CL and V. Etas on the final PK params,
+        // matching the Phase A M2 mu-ref form. The fit-objective surface
+        // (method = nn_mse) isn't wired yet, so we only exercise the
+        // pk_param_fn closure here — that's the simulate path.
+        r#"
+[parameters]
+  theta TVKA(1.0, 0.001, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma ADD ~ 0.1
+
+[covariate_nn TYPICAL_PK]
+  inputs = [WT, CRCL]
+  outputs = [CL, V]
+  layers = [4]
+  activation = tanh
+  output = softplus
+
+[individual_parameters]
+  CL = TYPICAL_PK.CL * exp(ETA_CL)
+  V  = TYPICAL_PK.V  * exp(ETA_V)
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ additive(ADD)
+"#
+        .to_string()
+    }
+
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_dot_access_parses_into_nn_output_node() {
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("dot-access must parse");
+        // 1 base theta (TVKA) + NN weights for a 2->4->2 net:
+        //   W_1: 4*2 = 8, b_1: 4, W_2: 2*4 = 8, b_2: 2 → 22 weights.
+        assert_eq!(model.n_theta, 1 + 22);
+        assert_eq!(model.covariate_nns.len(), 1);
+        assert_eq!(model.covariate_nns[0].name, "TYPICAL_PK");
+        // Weights start right after the user-declared base thetas.
+        assert_eq!(model.covariate_nns[0].weights_offset, 1);
+    }
+
+    /// Round-trip: call the closure with known theta values (including known
+    /// NN weights) and confirm the PK params it produces match what
+    /// `NamedMlpMapper::forward_raw` returns directly.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_pk_param_fn_dispatches_through_nn() {
+        use crate::nn::CovariateMapper;
+        use crate::types::{PK_IDX_CL, PK_IDX_V};
+
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("model parses");
+        let theta: Vec<f64> = model.default_params.theta.clone();
+        let eta = vec![0.0_f64, 0.0_f64]; // zero etas → PK params == NN typical values.
+        let mut cov = HashMap::new();
+        cov.insert("WT".to_string(), 70.0);
+        cov.insert("CRCL".to_string(), 95.0);
+
+        let pk = (model.pk_param_fn)(&theta, &eta, &cov);
+
+        // What the NN itself would emit, sliced from the same theta vector.
+        let nn = &model.covariate_nns[0];
+        let weights = &theta[nn.weights_offset..nn.weights_offset + nn.mapper.n_weights()];
+        let nn_outputs = nn.mapper.forward_raw(weights, &cov).unwrap();
+
+        // pk_param_fn writes to PkParams by name: output[0] = CL, output[1] = V.
+        assert!((pk.values[PK_IDX_CL] - nn_outputs[0]).abs() < 1e-12);
+        assert!((pk.values[PK_IDX_V] - nn_outputs[1]).abs() < 1e-12);
+        // KA is a plain theta-only path.
+        assert!((pk.values[crate::types::PK_IDX_KA] - theta[0]).abs() < 1e-12);
+    }
+
+    /// Non-zero etas: the mu-ref composition `TYPICAL_PK.CL * exp(ETA_CL)`
+    /// must apply log-normal IIV on top of the NN typical value.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_pk_param_fn_composes_eta_on_top_of_nn_output() {
+        use crate::nn::CovariateMapper;
+        use crate::types::PK_IDX_CL;
+
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("model parses");
+        let theta = model.default_params.theta.clone();
+        let mut cov = HashMap::new();
+        cov.insert("WT".to_string(), 70.0);
+        cov.insert("CRCL".to_string(), 95.0);
+
+        let nn = &model.covariate_nns[0];
+        let weights = &theta[nn.weights_offset..nn.weights_offset + nn.mapper.n_weights()];
+        let nn_outputs = nn.mapper.forward_raw(weights, &cov).unwrap();
+        let tv_cl = nn_outputs[0];
+
+        // eta = +0.3 → CL should be tv_cl * exp(0.3).
+        let pk = (model.pk_param_fn)(&theta, &[0.3_f64, 0.0_f64], &cov);
+        let expected = tv_cl * 0.3_f64.exp();
+        assert!(
+            (pk.values[PK_IDX_CL] - expected).abs() < 1e-10,
+            "expected {expected}, got {}",
+            pk.values[PK_IDX_CL]
+        );
+    }
+
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_dot_access_rejects_unknown_output() {
+        // GARBAGE is not in `outputs = [CL, V]`.
+        let src = r#"
+[parameters]
+  theta TVKA(1.0, 0.001, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma ADD ~ 0.1
+
+[covariate_nn TYPICAL_PK]
+  inputs = [WT]
+  outputs = [CL, V]
+  layers = [3]
+  activation = tanh
+
+[individual_parameters]
+  CL = TYPICAL_PK.GARBAGE * exp(ETA_CL)
+  V  = 50
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ additive(ADD)
+"#;
+        let err = parse_model_string(src).expect_err("unknown output must error");
+        assert!(
+            err.contains("GARBAGE"),
+            "error should name the bad output, got: {err}"
+        );
+    }
+
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_dot_access_on_unknown_nn_name_falls_back_to_parse_error() {
+        // FOO is not a declared [covariate_nn] block. `FOO.CL` must error
+        // (the parser stops at the `.` it can't classify).
+        let src = r#"
+[parameters]
+  theta TVKA(1.0, 0.001, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma ADD ~ 0.1
+
+[individual_parameters]
+  CL = FOO.CL
+  V  = 50
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ additive(ADD)
+"#;
+        assert!(parse_model_string(src).is_err());
     }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -9,6 +9,26 @@ static DIFFUSION_LINE_RE: LazyLock<Regex> =
 
 // ── Mu-referencing pattern detection ────────────────────────────────────────
 
+/// Anchor of a mu-referencing relationship — either a plain user-declared
+/// theta (the classical case) or a `[covariate_nn]` output (Phase A M1+
+/// "deep compartment model" extension; the per-individual typical value
+/// comes out of an NN forward pass). Both shapes compose with eta the same
+/// way: `param = anchor * exp(eta)` (lognormal) or `param = anchor + eta`
+/// (additive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MuRefAnchor {
+    /// User-declared theta at this index in `theta_names`.
+    Theta(usize),
+    /// Output of a `[covariate_nn NAME]` block. `nn_idx` indexes the
+    /// alphabetically-sorted NN list (same as `ParseCtx::nn_specs`);
+    /// `output_idx` indexes the block's declared `outputs` list.
+    #[allow(dead_code)]
+    NnOutput {
+        nn_idx: usize,
+        output_idx: usize,
+    },
+}
+
 /// Walk a Mul-chain and collect direct Theta indices (not inside any function).
 fn collect_mul_thetas(expr: &Expression, out: &mut Vec<usize>) {
     match expr {
@@ -16,6 +36,26 @@ fn collect_mul_thetas(expr: &Expression, out: &mut Vec<usize>) {
         Expression::BinOp(l, BinOp::Mul, r) => {
             collect_mul_thetas(l, out);
             collect_mul_thetas(r, out);
+        }
+        _ => {}
+    }
+}
+
+/// Walk a Mul-chain and collect direct anchor candidates — `Theta(i)` or
+/// `NnOutput { nn_idx, output_idx }` — that sit at the top of the
+/// multiplication tree (not inside any function call). Used by the
+/// extended Pattern 1/4 detector to recognise both
+/// `TVCL * exp(ETA)` (classical) and `TYPICAL_PK.CL * exp(ETA)` (DCM).
+fn collect_mul_anchors(expr: &Expression, out: &mut Vec<MuRefAnchor>) {
+    match expr {
+        Expression::Theta(i) => out.push(MuRefAnchor::Theta(*i)),
+        Expression::NnOutput { nn_idx, output_idx } => out.push(MuRefAnchor::NnOutput {
+            nn_idx: *nn_idx,
+            output_idx: *output_idx,
+        }),
+        Expression::BinOp(l, BinOp::Mul, r) => {
+            collect_mul_anchors(l, out);
+            collect_mul_anchors(r, out);
         }
         _ => {}
     }
@@ -192,12 +232,24 @@ fn extract_eta_indices_for_var(stmts: &[Statement], var_name: &str) -> Vec<usize
 }
 
 /// Detect mu-referencing patterns in one assignment expression.
-/// Returns `Some((eta_idx, theta_idx, log_transformed))` or `None`.
-fn detect_pattern(expr: &Expression) -> Option<(usize, usize, bool)> {
+///
+/// Returns `Some((eta_idx, anchor, log_transformed))` or `None`. The anchor
+/// is either a plain `Theta(usize)` (classical mu-ref) or a `NnOutput`
+/// reference (Phase A M1: the typical value is produced by a
+/// `[covariate_nn]` forward pass).
+///
+/// Patterns recognised:
+/// - Pattern 1: `THETA * exp(ETA)`              → lognormal
+/// - Pattern 1-NN: `NN.OUTPUT * exp(ETA)`       → lognormal (DCM)
+/// - Pattern 2: `exp(log(THETA) + ETA)`         → lognormal
+/// - Pattern 3: `THETA + ETA` or `ETA + THETA`  → additive
+/// - Pattern 4: `THETA * exp(ETA) * <const>`    → lognormal (multiplied
+///   by a constant factor; the constant doesn't affect mu-ref detection
+///   since `collect_mul_*` walks the whole product chain).
+fn detect_pattern(expr: &Expression) -> Option<(usize, MuRefAnchor, bool)> {
     match expr {
         // Pattern 2: exp(log(THETA) + ETA)
         Expression::UnaryFn(name, inner) if name == "exp" => {
-            // inner must be Add with log(Theta) and Eta in either order
             if let Expression::BinOp(lhs, BinOp::Add, rhs) = inner.as_ref() {
                 let try_log_theta_eta =
                     |a: &Expression, b: &Expression| -> Option<(usize, usize)> {
@@ -215,24 +267,29 @@ fn detect_pattern(expr: &Expression) -> Option<(usize, usize, bool)> {
                 if let Some((ei, ti)) =
                     try_log_theta_eta(lhs, rhs).or_else(|| try_log_theta_eta(rhs, lhs))
                 {
-                    return Some((ei, ti, true));
+                    return Some((ei, MuRefAnchor::Theta(ti), true));
                 }
             }
             None
         }
         // Pattern 3: THETA + ETA or ETA + THETA
         Expression::BinOp(lhs, BinOp::Add, rhs) => match (lhs.as_ref(), rhs.as_ref()) {
-            (Expression::Theta(ti), Expression::Eta(ei)) => Some((*ei, *ti, false)),
-            (Expression::Eta(ei), Expression::Theta(ti)) => Some((*ei, *ti, false)),
+            (Expression::Theta(ti), Expression::Eta(ei)) => {
+                Some((*ei, MuRefAnchor::Theta(*ti), false))
+            }
+            (Expression::Eta(ei), Expression::Theta(ti)) => {
+                Some((*ei, MuRefAnchor::Theta(*ti), false))
+            }
             _ => None,
         },
-        // Pattern 1 / 4: product containing Theta and exp(Eta)
+        // Pattern 1 / 1-NN / 4: product containing exactly one anchor
+        // (Theta OR NnOutput) and `exp(Eta)` somewhere in the chain.
         _ => {
-            let mut thetas = Vec::new();
-            collect_mul_thetas(expr, &mut thetas);
-            if thetas.len() == 1 {
+            let mut anchors = Vec::new();
+            collect_mul_anchors(expr, &mut anchors);
+            if anchors.len() == 1 {
                 if let Some(ei) = find_exp_eta_in_mul(expr) {
-                    return Some((ei, thetas[0], true));
+                    return Some((ei, anchors[0], true));
                 }
             }
             None
@@ -245,24 +302,54 @@ fn detect_pattern(expr: &Expression) -> Option<(usize, usize, bool)> {
 /// participate — a variable defined inside `if (...) { CL = ... }` cannot
 /// participate in mu-referencing because the inner-loop re-centering only
 /// holds when the relationship is unconditional.
+///
+/// `nn_specs` is the same `(name, output_names)` list passed to `ParseCtx`.
+/// For NN-anchored mu-refs the produced `MuRef::theta_name` is the
+/// structured `"<NN_NAME>.<OUTPUT_NAME>"` form. Downstream consumers that
+/// only know about plain thetas (e.g. `compute_mu_k`) silently skip these
+/// entries because the structured name doesn't appear in `theta_names`;
+/// the full DCM-aware AD inner-loop fast path is planned for Phase A M2.
 fn detect_mu_refs(
     stmts: &[Statement],
     theta_names: &[String],
     eta_names: &[String],
+    nn_specs: &[(String, Vec<String>)],
 ) -> HashMap<String, MuRef> {
     let mut result = HashMap::new();
     for s in stmts {
         if let Statement::Assign(_, expr) = s {
-            if let Some((eta_idx, theta_idx, log_transformed)) = detect_pattern(expr) {
-                if eta_idx < eta_names.len() && theta_idx < theta_names.len() {
-                    result.insert(
-                        eta_names[eta_idx].clone(),
-                        MuRef {
-                            theta_name: theta_names[theta_idx].clone(),
-                            log_transformed,
-                        },
-                    );
+            if let Some((eta_idx, anchor, log_transformed)) = detect_pattern(expr) {
+                if eta_idx >= eta_names.len() {
+                    continue;
                 }
+                let name = match anchor {
+                    MuRefAnchor::Theta(ti) => {
+                        if ti >= theta_names.len() {
+                            continue;
+                        }
+                        theta_names[ti].clone()
+                    }
+                    MuRefAnchor::NnOutput { nn_idx, output_idx } => {
+                        // Defensive: indices should be valid by construction
+                        // (parse_atom built them against the same nn_specs),
+                        // but skip silently rather than panic if anything's
+                        // out of sync.
+                        let Some((nn_name, outputs)) = nn_specs.get(nn_idx) else {
+                            continue;
+                        };
+                        let Some(out_name) = outputs.get(output_idx) else {
+                            continue;
+                        };
+                        format!("{nn_name}.{out_name}")
+                    }
+                };
+                result.insert(
+                    eta_names[eta_idx].clone(),
+                    MuRef {
+                        theta_name: name,
+                        log_transformed,
+                    },
+                );
             }
         }
     }
@@ -324,9 +411,15 @@ fn classify_expr(expr: &Expression, n_theta: usize) -> Option<ExprClass> {
         }
     }
 
-    // TVCL * exp(ETA), exp(log(THETA) + ETA), TVCL + ETA
-    if let Some((ei, ti, log_transformed)) = detect_pattern(expr) {
-        if ti < n_theta {
+    // TVCL * exp(ETA), exp(log(THETA) + ETA), TVCL + ETA, TYPICAL_PK.CL * exp(ETA).
+    // NN-anchored variants are still classified as Lognormal/Additive — the
+    // eta's *statistical* shape is the same; only the anchor differs.
+    if let Some((ei, anchor, log_transformed)) = detect_pattern(expr) {
+        let valid = match anchor {
+            MuRefAnchor::Theta(ti) => ti < n_theta,
+            MuRefAnchor::NnOutput { .. } => true,
+        };
+        if valid {
             let pt = if log_transformed {
                 EtaParamType::LogNormal
             } else {
@@ -961,10 +1054,29 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         if !is_ode {
             let stmts_for_tv = indiv_stmts.clone();
             let var_names_for_tv = indiv_var_names.clone();
+            #[cfg(feature = "nn")]
+            let tv_covariate_nns: Vec<crate::nn::CovariateNn> = covariate_nns_for_closure.clone();
             Some(Box::new(
                 move |theta: &[f64], covariates: &HashMap<String, f64>| {
                     let zero_eta = vec![0.0; tv_eta_names.len()];
                     let mut vars: HashMap<String, f64> = HashMap::new();
+                    // Pre-compute each NN's forward output once per call so
+                    // `TYPICAL_PK.CL`-style references inside the eta=0
+                    // expression evaluate consistently and share the work.
+                    #[cfg(feature = "nn")]
+                    let nn_outputs: Vec<Vec<f64>> = tv_covariate_nns
+                        .iter()
+                        .map(|nn| {
+                            use crate::nn::CovariateMapper;
+                            let n_w = nn.mapper.n_weights();
+                            let weights = &theta[nn.weights_offset..nn.weights_offset + n_w];
+                            nn.mapper
+                                .forward_raw(weights, covariates)
+                                .unwrap_or_else(|_| vec![0.0; nn.mapper.n_outputs()])
+                        })
+                        .collect();
+                    #[cfg(not(feature = "nn"))]
+                    let nn_outputs: Vec<Vec<f64>> = Vec::new();
                     eval_statements(
                         &stmts_for_tv,
                         theta,
@@ -973,6 +1085,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
                         &mut vars,
                         None,
                         None,
+                        &nn_outputs,
                     );
                     var_names_for_tv
                         .iter()
@@ -992,7 +1105,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .chain(kappa_names.iter())
         .cloned()
         .collect();
-    let all_mu_refs = detect_mu_refs(&indiv_stmts, &theta_names, &all_eta_names);
+    let all_mu_refs =
+        detect_mu_refs(&indiv_stmts, &theta_names, &all_eta_names, &nn_specs_for_ctx);
     let kappa_set: std::collections::HashSet<&String> = kappa_names.iter().collect();
     let mu_refs: HashMap<String, MuRef> = all_mu_refs
         .iter()
@@ -1926,6 +2040,11 @@ fn build_ode_spec(
             let empty_theta: [f64; 0] = [];
             let empty_eta: [f64; 0] = [];
             let empty_cov: HashMap<String, f64> = HashMap::new();
+            // ODE RHS evaluation runs with empty theta/eta/covariates here —
+            // values are injected later via the `vars` map (state names, indiv
+            // params). NN outputs aren't relevant: `[covariate_nn]` outputs are
+            // routed via `pk_param_fn`, not the ODE RHS.
+            let empty_nn_outputs: Vec<Vec<f64>> = Vec::new();
             eval_statements(
                 &stmts_owned,
                 &empty_theta,
@@ -1934,6 +2053,7 @@ fn build_ode_spec(
                 &mut vars,
                 Some(du),
                 Some(&state_index),
+                &empty_nn_outputs,
             );
         });
 
@@ -2846,6 +2966,7 @@ fn eval_expression(
     eta: &[f64],
     covariates: &HashMap<String, f64>,
     vars: &HashMap<String, f64>,
+    nn_outputs: &[Vec<f64>],
 ) -> f64 {
     match expr {
         Expression::Literal(v) => *v,
@@ -2861,8 +2982,8 @@ fn eval_expression(
             0.0
         }
         Expression::BinOp(lhs, op, rhs) => {
-            let l = eval_expression(lhs, theta, eta, covariates, vars);
-            let r = eval_expression(rhs, theta, eta, covariates, vars);
+            let l = eval_expression(lhs, theta, eta, covariates, vars, nn_outputs);
+            let r = eval_expression(rhs, theta, eta, covariates, vars, nn_outputs);
             match op {
                 BinOp::Add => l + r,
                 BinOp::Sub => l - r,
@@ -2877,7 +2998,7 @@ fn eval_expression(
             }
         }
         Expression::UnaryFn(name, arg) => {
-            let v = eval_expression(arg, theta, eta, covariates, vars);
+            let v = eval_expression(arg, theta, eta, covariates, vars, nn_outputs);
             match name.as_str() {
                 "exp" => v.exp(),
                 "log" | "ln" => v.max(1e-30).ln(),
@@ -2900,29 +3021,34 @@ fn eval_expression(
             }
         }
         Expression::Power(base, exp) => {
-            let b = eval_expression(base, theta, eta, covariates, vars);
-            let e = eval_expression(exp, theta, eta, covariates, vars);
+            let b = eval_expression(base, theta, eta, covariates, vars, nn_outputs);
+            let e = eval_expression(exp, theta, eta, covariates, vars, nn_outputs);
             b.powf(e)
         }
         Expression::Conditional(cond, t, e) => {
-            if eval_condition(cond, theta, eta, covariates, vars) {
-                eval_expression(t, theta, eta, covariates, vars)
+            if eval_condition(cond, theta, eta, covariates, vars, nn_outputs) {
+                eval_expression(t, theta, eta, covariates, vars, nn_outputs)
             } else {
-                eval_expression(e, theta, eta, covariates, vars)
+                eval_expression(e, theta, eta, covariates, vars, nn_outputs)
             }
         }
-        Expression::NnOutput { .. } => {
-            // The HashMap-keyed (unindexed) evaluator is used only by callers
-            // that pre-date the `[covariate_nn]` feature (tv_fn, the simulation
-            // expression evaluator). NN dispatch happens exclusively in the
-            // indexed path. Reaching this branch from a NN-bearing model is a
-            // bug to fix in a subsequent PR (Phase A M2: tv_fn parity).
-            debug_assert!(
-                false,
-                "Expression::NnOutput reached unindexed eval_expression; tv_fn / simulation \
-                 paths do not yet support [covariate_nn] (Phase A M2 work)"
-            );
-            0.0
+        Expression::NnOutput { nn_idx, output_idx } => {
+            // Same per-call cache as the indexed evaluator. Callers
+            // populate `nn_outputs` from `NamedMlpMapper::forward_raw`
+            // (see the `tv_fn` closure for the eta=0 path). Out-of-bounds
+            // indices return 0.0 with a debug-assert so a logic bug
+            // surfaces in tests but doesn't crash release builds.
+            nn_outputs
+                .get(*nn_idx)
+                .and_then(|v| v.get(*output_idx))
+                .copied()
+                .unwrap_or_else(|| {
+                    debug_assert!(
+                        false,
+                        "NnOutput nn_idx={nn_idx} output_idx={output_idx} out of bounds in unindexed eval"
+                    );
+                    0.0
+                })
         }
     }
 }
@@ -2933,11 +3059,12 @@ fn eval_condition(
     eta: &[f64],
     covariates: &HashMap<String, f64>,
     vars: &HashMap<String, f64>,
+    nn_outputs: &[Vec<f64>],
 ) -> bool {
     match cond {
         Condition::Compare(l, op, r) => {
-            let lv = eval_expression(l, theta, eta, covariates, vars);
-            let rv = eval_expression(r, theta, eta, covariates, vars);
+            let lv = eval_expression(l, theta, eta, covariates, vars, nn_outputs);
+            let rv = eval_expression(r, theta, eta, covariates, vars, nn_outputs);
             match op {
                 CmpOp::Lt => lv < rv,
                 CmpOp::Le => lv <= rv,
@@ -2948,14 +3075,14 @@ fn eval_condition(
             }
         }
         Condition::And(l, r) => {
-            eval_condition(l, theta, eta, covariates, vars)
-                && eval_condition(r, theta, eta, covariates, vars)
+            eval_condition(l, theta, eta, covariates, vars, nn_outputs)
+                && eval_condition(r, theta, eta, covariates, vars, nn_outputs)
         }
         Condition::Or(l, r) => {
-            eval_condition(l, theta, eta, covariates, vars)
-                || eval_condition(r, theta, eta, covariates, vars)
+            eval_condition(l, theta, eta, covariates, vars, nn_outputs)
+                || eval_condition(r, theta, eta, covariates, vars, nn_outputs)
         }
-        Condition::Not(c) => !eval_condition(c, theta, eta, covariates, vars),
+        Condition::Not(c) => !eval_condition(c, theta, eta, covariates, vars, nn_outputs),
     }
 }
 
@@ -3243,6 +3370,7 @@ fn eval_statements(
     vars: &mut HashMap<String, f64>,
     du: Option<&mut [f64]>,
     state_index: Option<&HashMap<String, usize>>,
+    nn_outputs: &[Vec<f64>],
 ) {
     // The `du` borrow has to be re-passed into each recursive sub-block, so
     // shuttle it through an Option that we re-grab on each iteration.
@@ -3250,7 +3378,7 @@ fn eval_statements(
     for s in stmts {
         match s {
             Statement::Assign(name, expr) => {
-                let v = eval_expression(expr, theta, eta, covariates, vars);
+                let v = eval_expression(expr, theta, eta, covariates, vars, nn_outputs);
                 vars.insert(name.clone(), v);
             }
             Statement::AssignIdx(_, _) => {
@@ -3261,7 +3389,7 @@ fn eval_statements(
                 // silently skip if they do (defensive).
             }
             Statement::DiffEq(name, expr) => {
-                let v = eval_expression(expr, theta, eta, covariates, vars);
+                let v = eval_expression(expr, theta, eta, covariates, vars, nn_outputs);
                 let idx = state_index
                     .and_then(|m| m.get(name).copied())
                     .expect("DiffEq encountered without state_index — internal error");
@@ -3275,7 +3403,7 @@ fn eval_statements(
             } => {
                 let mut taken = false;
                 for (cond, body) in branches {
-                    if eval_condition(cond, theta, eta, covariates, vars) {
+                    if eval_condition(cond, theta, eta, covariates, vars, nn_outputs) {
                         eval_statements(
                             body,
                             theta,
@@ -3284,6 +3412,7 @@ fn eval_statements(
                             vars,
                             du_opt.as_deref_mut(),
                             state_index,
+                            nn_outputs,
                         );
                         taken = true;
                         break;
@@ -3299,6 +3428,7 @@ fn eval_statements(
                             vars,
                             du_opt.as_deref_mut(),
                             state_index,
+                            nn_outputs,
                         );
                     }
                 }
@@ -4553,7 +4683,7 @@ mod tests {
         let en: Vec<String> = eta_names.iter().map(|s| s.to_string()).collect();
         let ctx = ParseCtx::new(&tn, &en, &[]);
         let stmts = parse_block_statements(line, ctx, StatementMode::Plain).ok()?;
-        let refs = detect_mu_refs(&stmts, &tn, &en);
+        let refs = detect_mu_refs(&stmts, &tn, &en, &[]);
         // Return the one detected mu-ref (if any). Tests assume a single line.
         refs.into_iter().next().map(|(_, v)| v)
     }
@@ -4668,7 +4798,7 @@ mod tests {
         ];
         let ctx = ParseCtx::new(&tn, &en, &[]);
         let stmts = parse_block_statements(block, ctx, StatementMode::Plain).unwrap();
-        let refs = detect_mu_refs(&stmts, &tn, &en);
+        let refs = detect_mu_refs(&stmts, &tn, &en, &[]);
         assert_eq!(refs.len(), 3);
         assert_eq!(refs["ETA_CL"].theta_name, "TVCL");
         assert_eq!(refs["ETA_V"].theta_name, "TVV");
@@ -5462,7 +5592,7 @@ mod tests {
         let theta = vec![5.0];
         let mut covs = HashMap::new();
         covs.insert("WT".to_string(), 80.0);
-        eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None);
+        eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None, &[]);
         assert!(
             (vars["CL"] - 6.0).abs() < 1e-12,
             "CL should pick the then-branch"
@@ -5470,7 +5600,7 @@ mod tests {
 
         covs.insert("WT".to_string(), 60.0);
         let mut vars2 = HashMap::new();
-        eval_statements(&stmts, &theta, &[], &covs, &mut vars2, None, None);
+        eval_statements(&stmts, &theta, &[], &covs, &mut vars2, None, None, &[]);
         assert!(
             (vars2["CL"] - 5.0).abs() < 1e-12,
             "CL should pick the else-branch"
@@ -5496,7 +5626,7 @@ if (WT > 70) {
             let mut covs = HashMap::new();
             covs.insert("WT".to_string(), wt);
             let mut vars = HashMap::new();
-            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None);
+            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None, &[]);
             assert!(
                 (vars["CL"] - expected).abs() < 1e-12,
                 "WT={} → expected CL={}",
@@ -5527,7 +5657,7 @@ if (X < 10) {
             let mut covs = HashMap::new();
             covs.insert("X".to_string(), x);
             let mut vars = HashMap::new();
-            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None);
+            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None, &[]);
             assert!(
                 (vars["CL"] - expected).abs() < 1e-12,
                 "X={x} should pick branch giving CL={expected}, got {}",
@@ -5556,7 +5686,7 @@ if (X < 10) {
             covs.insert("WT".to_string(), wt);
             covs.insert("AGE".to_string(), age);
             let mut vars = HashMap::new();
-            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None);
+            eval_statements(&stmts, &theta, &[], &covs, &mut vars, None, None, &[]);
             assert!(
                 (vars["CL"] - expected).abs() < 1e-12,
                 "sex={sex} wt={wt} age={age} expected CL={expected}, got {}",
@@ -6829,5 +6959,96 @@ if (1 > 0) {
   DV ~ additive(ADD)
 "#;
         assert!(parse_model_string(src).is_err());
+    }
+
+    // ─── Fix 1 + fix 2: NN-anchored mu-ref detection + tv_fn parity ─────
+
+    /// Fix 1: `TYPICAL_PK.CL * exp(ETA_CL)` should be recognised as a
+    /// lognormal mu-ref, with `MuRef.theta_name = "TYPICAL_PK.CL"` (the
+    /// structured form). Downstream consumers that only know about plain
+    /// thetas silently fall back to FD; the M2 AD-aware consumer is a
+    /// follow-up.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_detect_mu_refs_recognises_nn_anchored_lognormal() {
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("model parses");
+        let cl_ref = model
+            .mu_refs
+            .get("ETA_CL")
+            .expect("ETA_CL must be detected as mu-referenced");
+        assert_eq!(cl_ref.theta_name, "TYPICAL_PK.CL");
+        assert!(
+            cl_ref.log_transformed,
+            "TYPICAL_PK.CL * exp(ETA_CL) is lognormal"
+        );
+        let v_ref = model.mu_refs.get("ETA_V").expect("ETA_V mu-referenced");
+        assert_eq!(v_ref.theta_name, "TYPICAL_PK.V");
+        assert!(v_ref.log_transformed);
+    }
+
+    /// Fix 1 follow-on: `eta_param_info` still classifies NN-anchored
+    /// patterns as `LogNormal` — the eta's statistical shape is unchanged;
+    /// only the anchor differs.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_eta_param_info_classifies_nn_anchored_lognormal() {
+        use crate::types::EtaParamType;
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("model parses");
+        let cl = model
+            .eta_param_info
+            .iter()
+            .find(|i| i.eta_name == "ETA_CL")
+            .expect("ETA_CL classification present");
+        assert_eq!(cl.param_type, EtaParamType::LogNormal);
+        let v = model
+            .eta_param_info
+            .iter()
+            .find(|i| i.eta_name == "ETA_V")
+            .expect("ETA_V classification present");
+        assert_eq!(v.param_type, EtaParamType::LogNormal);
+    }
+
+    /// Fix 2: `tv_fn` (the eta=0 typical-value closure) must produce the
+    /// same values as the NN forward pass. Previously the unindexed
+    /// evaluator returned 0.0 for `NnOutput`, so `tv_fn` would have
+    /// silently produced zero TVs for NN-bearing models — a footgun for
+    /// the AD fast path the M2 PR will lean on.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn test_tv_fn_dispatches_through_nn() {
+        use crate::nn::CovariateMapper;
+        let src = covariate_nn_dotted_model_src();
+        let model = parse_model_string(&src).expect("model parses");
+        let theta = model.default_params.theta.clone();
+        let mut cov = HashMap::new();
+        cov.insert("WT".to_string(), 70.0);
+        cov.insert("CRCL".to_string(), 95.0);
+
+        let tv_fn = model.tv_fn.as_ref().expect("analytical model -> Some(tv_fn)");
+        let tvs = tv_fn(&theta, &cov);
+
+        // tv_fn returns values in `indiv_param_names` declaration order:
+        // CL, V, KA. At eta=0 the lognormal mu-ref `tv * exp(0)` collapses
+        // to tv, which equals the NN's raw output for CL and V.
+        let nn = &model.covariate_nns[0];
+        let weights = &theta[nn.weights_offset..nn.weights_offset + nn.mapper.n_weights()];
+        let nn_outputs = nn.mapper.forward_raw(weights, &cov).unwrap();
+
+        assert!(
+            (tvs[0] - nn_outputs[0]).abs() < 1e-12,
+            "TV[CL] from tv_fn = {} vs NN output = {}",
+            tvs[0],
+            nn_outputs[0]
+        );
+        assert!(
+            (tvs[1] - nn_outputs[1]).abs() < 1e-12,
+            "TV[V] from tv_fn = {} vs NN output = {}",
+            tvs[1],
+            nn_outputs[1]
+        );
+        // KA = TVKA (plain theta path, unchanged).
+        assert!((tvs[2] - theta[0]).abs() < 1e-12);
     }
 }


### PR DESCRIPTION
## Why

Phase A M1 step 3 of the DCM / low-dim NODE roadmap ([plans/dcm-and-low-dim-node.md](../blob/main/plans/dcm-and-low-dim-node.md)). The parser block + theta registration landed in #38; this PR makes the block actually drive `pk_param_fn`. A model with `[covariate_nn TYPICAL_PK]` and `[individual_parameters] CL = TYPICAL_PK.CL * exp(ETA_CL)` now produces NN-derived PK params end-to-end — **simulate works**.

**Stacked on #38** (base: `feat/nn-parser`). When #38 merges, this PR's base auto-rebases to `main` and the diff stays the same.

The fit objective (`method = nn_mse`) and Option E output rendering land in the next PR.

## What changed

### Tokenizer
- New `Token::Dot` so `TYPICAL_PK.CL` lexes cleanly.
- Number parsing split into two arms: `.5`-style decimal literals (dot followed by digit) keep their existing fast path; standalone `.` between identifiers becomes the member-access operator. Digit-led numbers (`4.5`, `4e10`) unchanged.

### AST + parser
- New `Expression::NnOutput { nn_idx, output_idx }` variant. `nn_idx` indexes alphabetically-sorted `CompiledModel.covariate_nns`; `output_idx` indexes the block's declared `outputs` list.
- `ParseCtx` extended with `nn_specs: &[(String, Vec<String>)]` so the expression parser can resolve `IDENT.IDENT` references at parse time. Builder `with_nn_specs` keeps every existing `ParseCtx::new` call site untouched.
- `parse_atom` recognises `IDENT.IDENT` when the first IDENT matches a known `[covariate_nn]` name. Bad output name → clear error listing valid outputs. Unknown NN name → falls through to the normal identifier classifier (parse error at the `Dot`).

### Evaluator
- `eval_expression_indexed`, `eval_condition_indexed`, `eval_statements_indexed` all thread a new `nn_outputs: &[Vec<f64>]` parameter. The new variant is dispatched via `nn_outputs[nn_idx][output_idx]`.
- `eval_expression` (the unindexed HashMap-keyed evaluator) hits a `debug_assert!` on `NnOutput` — that path is used by `tv_fn` and simulation expressions, which need their own NN support in the M2 mu-ref work. Marked clearly in the panic message.

### `build_pk_param_fn`
- New parameter `covariate_nns: &[CovariateNn]` (feature-gated).
- Inside the closure: pre-computes each NN's forward output once per call via `NamedMlpMapper::forward_raw` (new method, returns the raw output `Vec<f64>` in declaration order, instead of routing through `PkParams`). Multiple `.CL`, `.V1`, … references to the same NN share that single forward pass.

### `parse_full_model`
- Computes `CovariateNn` handles up front so `build_pk_param_fn` can capture them in the closure.
- The same handles are reused in the diffusion-appendage block where NN-weight theta values / bounds are pushed onto the optimizer's theta vector.

## Tests (5 new in `src/parser/model_parser.rs::tests`)

| Test | Asserts |
|------|---------|
| `test_dot_access_parses_into_nn_output_node` | `TYPICAL_PK.CL` parses, produces an `NnOutput`, `weights_offset` is correct after base thetas |
| `test_pk_param_fn_dispatches_through_nn` | With eta=0, `pk_param_fn` output matches `NamedMlpMapper::forward_raw` byte-for-byte |
| `test_pk_param_fn_composes_eta_on_top_of_nn_output` | Mu-ref composition: PK params equal `tv_from_nn * exp(eta)` |
| `test_dot_access_rejects_unknown_output` | `TYPICAL_PK.GARBAGE` errors with the bad output name in the message |
| `test_dot_access_on_unknown_nn_name_falls_back_to_parse_error` | `FOO.CL` errors when `FOO` isn't a declared NN block |

All existing tests still pass (468 lib + 3 integration with `--features nn`).

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed yet | — |

The new `NnOutput` AST variant + `forward_raw` are internal to the parser / nn module. No `pub` API change at default features.

## Breaking changes
- [x] None

## Numerical validation
- [x] `test_pk_param_fn_dispatches_through_nn` confirms byte-exact match between the closure's output and `NamedMlpMapper::forward_raw` for known weights / known covariates / eta=0.
- [x] `test_pk_param_fn_composes_eta_on_top_of_nn_output` confirms mu-ref composition: `CL_individual = CL_from_nn * exp(ETA_CL)` within 1e-10 of expected.

## Performance
- [x] No significant impact for non-NN models — default builds byte-identical.
- For NN models: one extra `Vec<Vec<f64>>` alloc per `pk_param_fn` call plus one `NamedMlpMapper::forward_raw` per declared `[covariate_nn]` block. For paper-scale networks (~150 weights) that's microseconds per call.

## Tests
- [x] 5 new parser unit tests (see table above).
- [x] Existing PR #38 nn-block parser tests still pass.
- [x] Full lib suite: 468 pass, 0 fail with `--features nn`.
- [x] `tests/nn_dcm_smoke.rs` (3 tests) still passes.

Run via: `RUSTFLAGS="-Z autodiff=Enable" cargo test --release --features nn`

## Example
- [x] `examples/drafts/warfarin_dcm.ferx` header updated to reflect simulate-ready status. Promoting it to `examples/warfarin_dcm.ferx` waits on the next PR (fit objective + Option E output rendering).

## Docs
- [x] No user-visible change yet (still drafts/). Docs ship alongside the fit objective in the next PR.

## Checklist
- [x] `cargo check` and `cargo check --features nn` — clean.
- [x] `cargo clippy --no-default-features --features ci,nn --lib --tests` — no new warnings on my changes. One pre-existing doc-formatting nit on a comment line whose line number shifted because of my signature change.
- [x] `Cargo.toml` version not bumped (no public API change at default features).

## Reviewer hints

- **Load-bearing**: the `nn_outputs: &[Vec<f64>]` thread through three indexed-eval functions + `build_pk_param_fn`. Mechanical but invasive.
- **Where to focus**: `parse_atom` dot-access branch (new ~40 LOC) and the closure-local `nn_outputs` pre-computation in `build_pk_param_fn`. The mu-ref composition `tv * exp(eta)` falls out automatically because of how Pattern 1 already detects `THETA * exp(ETA)` — `NnOutput * exp(Eta)` matches the same structure. The detection function `detect_pattern` doesn't yet see `NnOutput` as theta-equivalent, so etas on NN-derived PK params won't get the AD inner-loop fast path — but that's an FOCEI / fit-time concern, deferred to M2.
- **Skim**: the 16 single-line recursive-call updates in the evaluator (`s/, vars\)/, vars, nn_outputs)/` mechanically).

## Open questions

1. **Mu-ref detection extension**. `detect_pattern` matches `Theta * exp(Eta)` as Pattern 1. For mixed-effects DCM with NN (Phase A M2 / mu-ref FOCEI), `NnOutput * exp(Eta)` needs the same recognition so the AD inner loop computes gradients efficiently. ~10 LOC extension. Worth doing in this PR or holding for M2 with the FOCEI work?
2. **Mu-ref via `tv_fn` parity**. `tv_fn` (the typical-value-with-eta-zero function used by the AD inner loop) currently uses the unindexed evaluator, which has the `debug_assert!(false)` for `NnOutput`. Means: simulating an NN-bearing model works, but FOCEI fitting would crash. Acceptable for this PR (we're scoping to simulate), but the next PR needs an NN-aware `tv_fn`.