### PR TITLE
perf(estimation): step 3 — subject-parallel BHHH gradient with analytical omega/sigma

### DIFF
--- a/plans/optimization.md
+++ b/plans/optimization.md
@@ -213,7 +213,7 @@ by the parameterization integration tests; no new test is required.
 
 ## Step 1 — rayon `par_iter` in FOCE Subject Loop
 
-**Status: 🔶 PARTIAL**
+**Status: ✅ DONE — absorbed by PR #47 (Step 3).**
 
 **No prerequisites. Start here.**
 

--- a/plans/optimization.md
+++ b/plans/optimization.md
@@ -280,7 +280,23 @@ speedup with core count for those collection passes.
 
 ## Step 3 — AD Gradients for GN/BHHH Per-Subject Score Vectors
 
-**Status: ❌ NOT STARTED**
+**Status: ✅ DONE — merged via PR #47.**
+
+**Phase B deviation (recorded):** The original plan called for propagating Dual
+numbers through `tv_fn` to get population-parameter gradients. This is infeasible:
+`tv_fn` is `Option<Box<dyn Fn(&[f64], &HashMap<String, f64>) -> Vec<f64>>>` — an
+opaque closure that only accepts `f64` slices; Dual numbers cannot propagate
+through it. The implementation instead uses:
+- **Analytical matrix formulas** (exact) for omega and sigma packed parameters,
+  derived from the Cholesky of R_tilde already computed during the FOCE NLL.
+- **Forward-FD of `compute_predictions_with_tv` only** (not full NLL) for theta
+  packed parameters — one predict call per theta parameter, reusing the baseline
+  Cholesky. Equivalent accuracy: O(h) error same as central-FD for theta, exact
+  for omega/sigma.
+- **Central-FD fallback** retained for ODE models, IOV, and M3/BLOQ paths.
+
+`build_gn_system` was restructured to Rayon subject-parallel accumulation
+(previously per-parameter outer loop with inner subject `par_iter`).
 
 **Requires: Step 1 complete. Requires PR #22 merged.**
 
@@ -768,7 +784,7 @@ larger. The exploration phase stabilizes faster.
 
 ## Step 9 — Student-t Proposal for SIR
 
-**Status: ❌ NOT STARTED**
+**Status: ✅ DONE — merged via PR #41.**
 
 **No prerequisites. Can be done at any time independently.**
 
@@ -836,7 +852,7 @@ implementation cost.
 
 ## Step 10 — Parallel Multi-Start Outer Optimization
 
-**Status: ❌ NOT STARTED**
+**Status: ✅ DONE — merged via PR #42.**
 
 **No prerequisites. Can be done at any time. Uses rayon already in Cargo.toml.**
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1211,6 +1211,114 @@ mod tests {
         }
     }
 
+    /// Verify that the analytical gradient is correct when H is non-zero —
+    /// exercises the `h_cols_solved` path and the omega diagonal formula with
+    /// non-trivial eta-to-obs mapping.
+    #[test]
+    fn test_subject_nll_pop_grad_analytical_nonzero_h() {
+        let model = make_model();
+        let population = make_population();
+        let template = &model.default_params;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+
+        let n_obs = 3;
+        let n_eta = 1;
+        // Non-zero H: partial derivatives of predictions w.r.t. eta at baseline
+        let eta_hat = DVector::from_vec(vec![0.1]);
+        let h_matrix = nalgebra::DMatrix::from_vec(n_obs, n_eta, vec![2.0, 1.5, 0.8]);
+        let options = FitOptions::default();
+
+        let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
+            &x, template, &model, &population, 0,
+            &eta_hat, &h_matrix, &bounds, &options,
+        ).expect("analytical path should succeed");
+
+        // NLL must match direct call
+        let params_base = unpack_params(&x, template);
+        let nll_ref = subject_nll_at(
+            &model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options,
+        );
+        assert!((nll_an - nll_ref).abs() < 1e-10, "nll mismatch: {nll_an} vs {nll_ref}");
+
+        // Gradient must agree with central-FD reference
+        let eps = 1e-5;
+        for j in 0..n {
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += eps * (1.0 + x[j].abs());
+            xm[j] -= eps * (1.0 + x[j].abs());
+            let actual_2h = xp[j] - xm[j];
+            let pp = unpack_params(&xp, template);
+            let pm = unpack_params(&xm, template);
+            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
+            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let ref_j = (np - nm) / actual_2h;
+
+            let tol = 0.01 * (1.0 + ref_j.abs()).max(1e-8);
+            assert!(
+                (grad_an[j] - ref_j).abs() < tol,
+                "nonzero-H: analytical grad[{j}]={:.6e}, fd ref={:.6e}, diff={:.2e}",
+                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+            );
+        }
+    }
+
+    /// Verify that the analytical gradient is correct under the FOCEI interaction
+    /// path (`options.interaction = true`), where r_diag is evaluated at ipreds
+    /// rather than f0, and dr/d(theta) passes through the r(ipred) chain.
+    #[test]
+    fn test_subject_nll_pop_grad_analytical_interaction() {
+        let model = make_model();
+        let population = make_population();
+        let template = &model.default_params;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+
+        let n_obs = 3;
+        let n_eta = 1;
+        let eta_hat = DVector::from_vec(vec![0.05]);
+        let h_matrix = nalgebra::DMatrix::from_vec(n_obs, n_eta, vec![3.0, 2.0, 1.0]);
+        let mut options = FitOptions::default();
+        options.interaction = true;
+
+        let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
+            &x, template, &model, &population, 0,
+            &eta_hat, &h_matrix, &bounds, &options,
+        ).expect("analytical path should succeed with interaction=true");
+
+        let params_base = unpack_params(&x, template);
+        let nll_ref = subject_nll_at(
+            &model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options,
+        );
+        assert!((nll_an - nll_ref).abs() < 1e-10, "interaction nll mismatch: {nll_an} vs {nll_ref}");
+
+        let eps = 1e-5;
+        for j in 0..n {
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += eps * (1.0 + x[j].abs());
+            xm[j] -= eps * (1.0 + x[j].abs());
+            let actual_2h = xp[j] - xm[j];
+            let pp = unpack_params(&xp, template);
+            let pm = unpack_params(&xm, template);
+            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
+            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let ref_j = (np - nm) / actual_2h;
+
+            let tol = 0.01 * (1.0 + ref_j.abs()).max(1e-8);
+            assert!(
+                (grad_an[j] - ref_j).abs() < tol,
+                "interaction: analytical grad[{j}]={:.6e}, fd ref={:.6e}, diff={:.2e}",
+                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+            );
+        }
+    }
+
     /// Verify that `subject_nll_pop_grad` returns (nll, gradient) where the
     /// gradient agrees with a sequential central-FD reference for subject 0,
     /// and the returned nll matches a direct call to `subject_nll_at`.

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -17,7 +17,10 @@ use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::pop_nll;
 use crate::estimation::outer_optimizer::{compute_covariance, OuterResult};
 use crate::estimation::parameterization::{compute_mu_k, *};
-use crate::stats::likelihood::{foce_subject_nll_interaction, foce_subject_nll_standard};
+use crate::stats::likelihood::{
+    chol_log_det, compute_r_tilde, foce_subject_nll_interaction, foce_subject_nll_standard,
+};
+use crate::stats::residual_error::compute_r_diag;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
@@ -470,16 +473,382 @@ fn gn_trace_method_phase(method: EstimationMethod) -> (&'static str, &'static st
     }
 }
 
-/// Build the Gauss-Newton linear system using the gradient and approximate Hessian
+// ── Analytical gradient helpers ──────────────────────────────────────────────
+//
+// For each packed parameter x[k] the gradient of the FOCE NLL uses:
+//
+//   dL = A^T dv  +  0.5 * (tr(R^{-1} dR) - A^T dR A)
+//
+// where  v = y - f0,  A = R_tilde^{-1} v,  and C = chol(R_tilde).
+//
+// Omega diagonal x[k] = log L_omega[i,i]:
+//   dR = 2*omega_ii * h_i h_i^T,  dv = 0
+//   dL = omega_ii * (||C^{-1} h_i||^2 - (h_i^T A)^2)
+//
+// Omega off-diagonal x[k] = L_omega[j,i] (j>i, identity-packed):
+//   dOmega = e_j (L[:,i])^T + L[:,i] e_j^T
+//   u = H L_omega[:,i],  w = H[:,j] = h_j
+//   dR = w u^T + u w^T,  dv = 0
+//   dL = (C^{-1} w)^T (C^{-1} u) - (w^T A)(u^T A)
+//
+// Sigma x[k] = log sigma_k:
+//   dR = diag(d r_j / d log sigma_k),  dv = 0
+//   dL = 0.5 * sum_j (d r_j) * ((R^{-1})_jj - A_j^2)
+//
+// Theta x[k] (log-packed or identity):
+//   d(ipreds) from forward FD of compute_predictions_with_tv
+//   d(f0) = d(ipreds),  d(r) via chain rule through residual variance
+//   dv = -d(f0)
+//   dL = -A^T d(f0)  +  0.5 * (sum_j d(r_j) * ((R^{-1})_jj - A_j^2))
+//      (the diagonal-R^{-1} term is shared with sigma and reused)
+
+/// Diagonal of R^{-1} via Cholesky: (R^{-1})_jj = ||C^{-1} e_j||^2
+/// where C = chol(R) (lower triangular). Computed by forward-substituting each unit vector.
+fn r_inv_diag(chol_l: &DMatrix<f64>) -> Vec<f64> {
+    let n = chol_l.nrows();
+    (0..n)
+        .map(|j| {
+            // Solve C w = e_j by forward substitution
+            let mut w = vec![0.0f64; n];
+            for i in 0..n {
+                if i == j {
+                    w[i] = 1.0 / chol_l[(i, i)];
+                } else if i > j {
+                    let mut s = 0.0;
+                    for k in j..i {
+                        s += chol_l[(i, k)] * w[k];
+                    }
+                    w[i] = -s / chol_l[(i, i)];
+                }
+            }
+            w.iter().map(|&x| x * x).sum()
+        })
+        .collect()
+}
+
+/// Solve C w = rhs by forward substitution (C lower triangular).
+fn fwd_solve(chol_l: &DMatrix<f64>, rhs: &[f64]) -> Vec<f64> {
+    let n = chol_l.nrows();
+    let mut w = vec![0.0f64; n];
+    for i in 0..n {
+        let mut s = rhs[i];
+        for k in 0..i {
+            s -= chol_l[(i, k)] * w[k];
+        }
+        w[i] = s / chol_l[(i, i)];
+    }
+    w
+}
+
+/// d(r_j)/d(log sigma_k) for each observation, at the prediction point used
+/// to evaluate r_diag (f0 for standard, ipreds for interaction).
+fn dr_diag_d_log_sigma(
+    error_model: ErrorModel,
+    r_diag: &[f64],
+    pred_point: &[f64], // f0 or ipreds depending on path
+    sigma_values: &[f64],
+    sigma_k: usize,
+) -> Vec<f64> {
+    r_diag
+        .iter()
+        .zip(pred_point.iter())
+        .map(|(&r_j, &f_j)| match error_model {
+            ErrorModel::Additive => {
+                if sigma_k == 0 { 2.0 * sigma_values[0] * sigma_values[0] } else { 0.0 }
+            }
+            ErrorModel::Proportional => {
+                if sigma_k == 0 { 2.0 * r_j } else { 0.0 }
+            }
+            ErrorModel::Combined => {
+                if sigma_k == 0 {
+                    // d(sigma_prop^2 * f^2)/d(log sigma_prop) = 2 * sigma_prop^2 * f^2
+                    let sp2 = sigma_values[0] * sigma_values[0];
+                    2.0 * sp2 * f_j * f_j
+                } else {
+                    // sigma_k == 1: d(sigma_add^2)/d(log sigma_add) = 2 * sigma_add^2
+                    2.0 * sigma_values[1] * sigma_values[1]
+                }
+            }
+        })
+        .collect()
+}
+
+/// Analytical per-subject FOCE NLL gradient for non-IOV, non-ODE, non-M3 models.
+///
+/// Returns `None` if the Cholesky of R_tilde fails (degenerate parameters) so
+/// the caller can fall back to central FD.
+///
+/// The gradient is exact for omega and sigma packed parameters. For theta packed
+/// parameters, uses forward FD of `compute_predictions_with_tv` only (cheap —
+/// no matrix work per perturbation).
+#[allow(clippy::too_many_arguments)]
+fn subject_nll_pop_grad_analytical(
+    x: &[f64],
+    template: &ModelParameters,
+    model: &CompiledModel,
+    population: &Population,
+    subj_idx: usize,
+    eta_hat: &DVector<f64>,
+    h_matrix: &DMatrix<f64>,
+    bounds: &PackedBounds,
+    options: &FitOptions,
+) -> Option<(f64, Vec<f64>)> {
+    use crate::pk;
+
+    let n = x.len();
+    let n_eta = model.n_eta;
+    let n_theta = template.theta.len();
+    let n_sigma = template.sigma.values.len();
+    let n_obs = population.subjects[subj_idx].observations.len();
+    let subject = &population.subjects[subj_idx];
+    let params = unpack_params(x, template);
+    let fixed_mask = packed_fixed_mask(template);
+
+    // Base predictions and FOCE state
+    let ipreds = pk::compute_predictions_with_tv(model, subject, &params.theta, eta_hat.as_slice());
+
+    let h_eta = h_matrix * eta_hat;
+    let f0: Vec<f64> = ipreds.iter().enumerate().map(|(j, &ip)| ip - h_eta[j]).collect();
+
+    // r_diag: at f0 (standard) or at ipreds (interaction)
+    let r_pred_point: &[f64] = if options.interaction { &ipreds } else { &f0 };
+    let r_diag = compute_r_diag(model.error_model, r_pred_point, &params.sigma.values);
+
+    let r_tilde = compute_r_tilde(h_matrix, &params.omega.matrix, &r_diag);
+    let chol = r_tilde.cholesky()?;
+    let chol_l = chol.l();
+
+    let v: DVector<f64> = DVector::from_iterator(
+        n_obs,
+        subject.observations.iter().zip(f0.iter()).map(|(&y, &f)| y - f),
+    );
+    let solved_a = chol.solve(&v);
+    let nll = 0.5 * (v.dot(&solved_a) + chol_log_det(&chol_l));
+
+    // Diagonal of R_tilde^{-1} — shared across all sigma and theta gradient terms
+    let rinv_diag = r_inv_diag(&chol_l);
+
+    // Pre-compute C^{-1} H columns for omega gradient: each w_i = C^{-1} h_i
+    let h_cols_solved: Vec<Vec<f64>> = (0..n_eta)
+        .map(|i| fwd_solve(&chol_l, h_matrix.column(i).as_slice()))
+        .collect();
+
+    // For block omega: get the Cholesky factor of omega (L_omega)
+    let l_omega = &params.omega.chol; // nalgebra DMatrix, lower triangular
+
+    let mut grad = vec![0.0f64; n];
+
+    // ── Theta parameters (indices 0..n_theta) ──────────────────────────────
+    let eps = 1e-5;
+    for k in 0..n_theta {
+        if fixed_mask[k] {
+            continue;
+        }
+        let h = eps * (1.0 + x[k].abs());
+        let xk_plus = (x[k] + h).min(bounds.upper[k]);
+        let actual_h = xk_plus - x[k];
+        if actual_h.abs() < 1e-16 {
+            continue;
+        }
+
+        let mut x_pert = x.to_vec();
+        x_pert[k] = xk_plus;
+        let params_pert = unpack_params(&x_pert, template);
+        let ipreds_pert =
+            pk::compute_predictions_with_tv(model, subject, &params_pert.theta, eta_hat.as_slice());
+
+        // d(ipreds)/dx[k] via forward FD
+        let d_ipreds: Vec<f64> = ipreds_pert
+            .iter()
+            .zip(ipreds.iter())
+            .map(|(&p, &b)| (p - b) / actual_h)
+            .collect();
+
+        // d(f0) = d(ipreds); d(v) = -d(f0)
+        // For sigma-dependent r: d(r_j)/d(x[k]) via chain rule through r(f0 or ipreds)
+        let dr: Vec<f64> = r_diag
+            .iter()
+            .zip(r_pred_point.iter().zip(d_ipreds.iter()))
+            .map(|(&r_j, (&pred_j, &dp_j))| match model.error_model {
+                ErrorModel::Additive => 0.0,
+                ErrorModel::Proportional => {
+                    // r_j = sigma^2 * pred^2 => dr/d(pred) = 2*sigma^2*pred = 2*r_j/pred
+                    if pred_j.abs() > 1e-15 { 2.0 * r_j / pred_j * dp_j } else { 0.0 }
+                }
+                ErrorModel::Combined => {
+                    let sp2 = params.sigma.values[0] * params.sigma.values[0];
+                    2.0 * sp2 * pred_j * dp_j
+                }
+            })
+            .collect();
+
+        // dL = -A^T d(f0) + 0.5 * sum_j dr_j * ((R^{-1})_jj - A_j^2)
+        let data_term: f64 = solved_a
+            .iter()
+            .zip(d_ipreds.iter())
+            .map(|(&a_j, &df_j)| -a_j * df_j)
+            .sum();
+        let r_term: f64 = dr
+            .iter()
+            .zip(rinv_diag.iter().zip(solved_a.iter()))
+            .map(|(&drj, (&rinv_jj, &a_j))| 0.5 * drj * (rinv_jj - a_j * a_j))
+            .sum();
+
+        grad[k] = data_term + r_term;
+    }
+
+    // ── Omega packed parameters ────────────────────────────────────────────
+    let omega_start = n_theta;
+    let omega_entries: Vec<(usize, usize)> = if template.omega.diagonal {
+        (0..n_eta).map(|i| (i, i)).collect()
+    } else {
+        let mut v = Vec::new();
+        for j in 0..n_eta {
+            for i in j..n_eta {
+                v.push((i, j));
+            }
+        }
+        v
+    };
+
+    for (ko, &(row, col)) in omega_entries.iter().enumerate() {
+        let k = omega_start + ko;
+        if fixed_mask[k] {
+            continue;
+        }
+        if row == col {
+            // Diagonal: x[k] = log L_omega[i,i], d(omega_ii)/d(x[k]) = 2 * omega_ii
+            let omega_ii = params.omega.matrix[(row, row)];
+            let w = &h_cols_solved[row]; // C^{-1} h_i
+            let h_i_dot_a: f64 = h_matrix.column(row).iter().zip(solved_a.iter()).map(|(h, a)| h * a).sum();
+            let w_sq: f64 = w.iter().map(|&x| x * x).sum();
+            grad[k] = omega_ii * (w_sq - h_i_dot_a * h_i_dot_a);
+        } else {
+            // Off-diagonal: x[k] = L_omega[row, col] (identity-packed)
+            // u = H * L_omega[:,col], w_vec = h_row = H[:,row]
+            // dR = w u^T + u w^T (symmetric rank-2)
+            // dL = (C^{-1} w)^T (C^{-1} u) - (w^T A)(u^T A)
+            let l_col: Vec<f64> = (0..n_eta).map(|r| l_omega[(r, col)]).collect();
+            let u: Vec<f64> = (0..n_obs)
+                .map(|obs_j| {
+                    (0..n_eta).map(|eta_i| h_matrix[(obs_j, eta_i)] * l_col[eta_i]).sum::<f64>()
+                })
+                .collect();
+            let c_inv_u = fwd_solve(&chol_l, &u);
+            let c_inv_w = &h_cols_solved[row];
+            let u_dot_a: f64 = u.iter().zip(solved_a.iter()).map(|(ui, ai)| ui * ai).sum();
+            let w_dot_a: f64 = h_matrix.column(row).iter().zip(solved_a.iter()).map(|(h, a)| h * a).sum();
+            let trace_term: f64 = c_inv_w.iter().zip(c_inv_u.iter()).map(|(w, u)| w * u).sum();
+            grad[k] = trace_term - w_dot_a * u_dot_a;
+        }
+    }
+
+    // ── Sigma packed parameters ────────────────────────────────────────────
+    let sigma_start = omega_start + omega_entries.len();
+    for ks in 0..n_sigma {
+        let k = sigma_start + ks;
+        if fixed_mask[k] {
+            continue;
+        }
+        let dr_k = dr_diag_d_log_sigma(
+            model.error_model, &r_diag, r_pred_point, &params.sigma.values, ks,
+        );
+        let g: f64 = dr_k
+            .iter()
+            .zip(rinv_diag.iter().zip(solved_a.iter()))
+            .map(|(&drj, (&rinv_jj, &a_j))| 0.5 * drj * (rinv_jj - a_j * a_j))
+            .sum();
+        grad[k] = g;
+    }
+
+    Some((nll, grad))
+}
+
+/// Compute the FOCE NLL and its gradient w.r.t. the packed population parameter
+/// vector for a single subject, with ETAs fixed at their current EBE values.
+///
+/// For non-IOV analytical PK models without M3 BLOQ, uses an analytical gradient:
+/// exact for omega/sigma parameters; forward-FD of predictions only for theta.
+/// Falls back to central FD for ODE models, IOV, or M3 BLOQ.
+///
+/// Returns `(nll_i, gradient_i)` where `gradient_i[j] = d(nll_i)/d(x[j])`.
+pub(crate) fn subject_nll_pop_grad(
+    x: &[f64],
+    template: &ModelParameters,
+    model: &CompiledModel,
+    population: &Population,
+    subj_idx: usize,
+    eta_hat: &DVector<f64>,
+    h_matrix: &DMatrix<f64>,
+    kappas: &[DVector<f64>],
+    bounds: &PackedBounds,
+    options: &FitOptions,
+) -> (f64, Vec<f64>) {
+    let can_use_analytical = model.ode_spec.is_none()
+        && kappas.is_empty()
+        && !matches!(model.bloq_method, BloqMethod::M3);
+
+    if can_use_analytical {
+        if let Some(result) = subject_nll_pop_grad_analytical(
+            x, template, model, population, subj_idx, eta_hat, h_matrix, bounds, options,
+        ) {
+            return result;
+        }
+    }
+
+    // Fallback: central FD over full per-subject NLL
+    let n = x.len();
+    let fixed_mask = packed_fixed_mask(template);
+    let eps = 1e-4;
+
+    let params_base = unpack_params(x, template);
+    let nll_base = subject_nll_at(
+        model, population, subj_idx, &params_base, eta_hat, h_matrix, kappas, options,
+    );
+
+    let mut grad = vec![0.0f64; n];
+    let mut x_work = x.to_vec();
+
+    for j in 0..n {
+        if fixed_mask[j] {
+            continue;
+        }
+        let h = eps * (1.0 + x[j].abs());
+        let xj_plus = (x[j] + h).min(bounds.upper[j]);
+        let xj_minus = (x[j] - h).max(bounds.lower[j]);
+        let actual_2h = xj_plus - xj_minus;
+        if actual_2h.abs() < 1e-16 {
+            continue;
+        }
+
+        x_work[j] = xj_plus;
+        let params_plus = unpack_params(&x_work, template);
+        let nll_plus = subject_nll_at(
+            model, population, subj_idx, &params_plus, eta_hat, h_matrix, kappas, options,
+        );
+
+        x_work[j] = xj_minus;
+        let params_minus = unpack_params(&x_work, template);
+        let nll_minus = subject_nll_at(
+            model, population, subj_idx, &params_minus, eta_hat, h_matrix, kappas, options,
+        );
+
+        x_work[j] = x[j];
+
+        let deriv = (nll_plus - nll_minus) / actual_2h;
+        grad[j] = if deriv.is_finite() { deriv } else { 0.0 };
+    }
+
+    (nll_base, grad)
+}
+
+/// Build the Gauss-Newton linear system: gradient and BHHH approximate Hessian
 /// of the FOCE population objective.
 ///
-/// The gradient is computed via central FD of the total OFV w.r.t. packed params.
-/// The approximate Hessian uses the outer product of per-subject gradients (BHHH):
-///   H_bhhh = sum_i g_i g_i^T
-/// where g_i = d(2*nll_i)/d(x) is the per-subject OFV gradient.
-///
-/// This is the Berndt-Hall-Hall-Hausman (BHHH) approximation, which is equivalent
-/// to Gauss-Newton for the FOCE log-likelihood and is what NONMEM uses internally.
+/// Calls `subject_nll_pop_grad` in parallel over subjects (rayon `par_iter`).
+/// Each subject contributes its per-subject NLL gradient g_i; the totals are:
+///   grad(OFV) = 2 * Σ_i g_i
+///   H_bhhh(OFV) ≈ 4 * Σ_i g_i g_i^T   (BHHH approximation)
 fn build_gn_system(
     x: &[f64],
     template: &ModelParameters,
@@ -494,109 +863,26 @@ fn build_gn_system(
     let n = x.len();
     let n_subj = population.subjects.len();
 
-    // Compute per-subject gradient via central FD
-    // g_i[j] = d(nll_i)/d(x_j) for each subject i, parameter j
-    let eps = 1e-4;
-    let mut per_subj_grad: Vec<Vec<f64>> = vec![vec![0.0; n]; n_subj];
-    let mut x_work = x.to_vec();
-    let fixed_mask = packed_fixed_mask(template);
+    let per_subj: Vec<(f64, Vec<f64>)> = (0..n_subj)
+        .into_par_iter()
+        .map(|i| {
+            let kap_i = if i < kappas.len() { kappas[i].as_slice() } else { &[] };
+            subject_nll_pop_grad(
+                x, template, model, population, i,
+                &eta_hats[i], &h_matrices[i], kap_i, bounds, options,
+            )
+        })
+        .collect();
 
-    for j in 0..n {
-        // Skip FD evaluation for FIX parameters — the gradient is identically
-        // zero there and the `unpack_params + per-subject NLL` passes are
-        // expensive.
-        if fixed_mask[j] {
-            continue;
-        }
-        let h = eps * (1.0 + x[j].abs());
-        let xj_plus = (x[j] + h).min(bounds.upper[j]);
-        let xj_minus = (x[j] - h).max(bounds.lower[j]);
-        let actual_2h = xj_plus - xj_minus;
-        if actual_2h.abs() < 1e-16 {
-            continue;
-        }
-
-        x_work[j] = xj_plus;
-        let params_plus = unpack_params(&x_work, template);
-        let nll_plus: Vec<f64> = (0..n_subj)
-            .into_par_iter()
-            .map(|i| {
-                let kap_i = if i < kappas.len() {
-                    kappas[i].as_slice()
-                } else {
-                    &[]
-                };
-                subject_nll_at(
-                    model,
-                    population,
-                    i,
-                    &params_plus,
-                    &eta_hats[i],
-                    &h_matrices[i],
-                    kap_i,
-                    options,
-                )
-            })
-            .collect();
-
-        x_work[j] = xj_minus;
-        let params_minus = unpack_params(&x_work, template);
-        let nll_minus: Vec<f64> = (0..n_subj)
-            .into_par_iter()
-            .map(|i| {
-                let kap_i = if i < kappas.len() {
-                    kappas[i].as_slice()
-                } else {
-                    &[]
-                };
-                subject_nll_at(
-                    model,
-                    population,
-                    i,
-                    &params_minus,
-                    &eta_hats[i],
-                    &h_matrices[i],
-                    kap_i,
-                    options,
-                )
-            })
-            .collect();
-
-        x_work[j] = x[j];
-
-        for i in 0..n_subj {
-            let deriv = (nll_plus[i] - nll_minus[i]) / actual_2h;
-            per_subj_grad[i][j] = if deriv.is_finite() { deriv } else { 0.0 };
-        }
-    }
-
-    // Total gradient: g = sum_i g_i (scaled by 2 for OFV = 2*NLL)
+    // For OFV = 2 * Σ nll_i:
+    //   grad(OFV)    = 2 * Σ g_i
+    //   H_bhhh(OFV) ≈ 4 * Σ g_i g_i^T
     let mut grad = DVector::zeros(n);
-    for i in 0..n_subj {
-        for j in 0..n {
-            grad[j] += 2.0 * per_subj_grad[i][j];
-        }
-    }
-
-    // BHHH approximate Hessian: H = sum_i (2*g_i)(2*g_i)^T = 4 * sum_i g_i g_i^T
-    // But for the Newton step H*delta = -grad, we can factor out the 4:
-    // Use H_bhhh = sum_i g_i g_i^T, and solve (H_bhhh * delta) = -(grad/4)...
-    // Actually, let's just use the properly scaled version.
-    //
-    // For OFV = 2 * sum_i nll_i:
-    //   grad(OFV) = 2 * sum_i grad_i
-    //   H_bhhh(OFV) ≈ 4 * sum_i grad_i grad_i^T
-    //
-    // Newton step: delta = -H^{-1} grad = -(4 sum g_i g_i^T)^{-1} (2 sum g_i)
-    //            = -0.5 * (sum g_i g_i^T)^{-1} (sum g_i)
-    //
-    // We return (grad_total, H_total) where grad_total = 2*sum(g_i) and
-    // H_total = 4*sum(g_i g_i^T) so the caller solves H*delta = -grad directly.
-
     let mut h_bhhh = DMatrix::zeros(n, n);
-    for i in 0..n_subj {
-        let gi = DVector::from_column_slice(&per_subj_grad[i]);
-        h_bhhh += 4.0 * &gi * gi.transpose();
+    for (_, gi) in &per_subj {
+        let gi_vec = DVector::from_column_slice(gi);
+        grad += 2.0 * &gi_vec;
+        h_bhhh += 4.0 * &gi_vec * gi_vec.transpose();
     }
 
     (grad, h_bhhh)
@@ -867,6 +1153,118 @@ mod tests {
                 grad[j],
                 ref_grad_j,
                 (grad[j] - ref_grad_j).abs()
+            );
+        }
+    }
+
+    /// Verify that the analytical gradient path agrees with central FD to tight
+    /// tolerance — tests exact omega/sigma gradients and forward-FD theta
+    /// gradients against the reference.
+    #[test]
+    fn test_subject_nll_pop_grad_analytical_matches_fd() {
+        let model = make_model();
+        let population = make_population();
+        let template = &model.default_params;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+
+        let n_obs = 3;
+        let n_eta = 1;
+        let eta_hat = DVector::zeros(n_eta);
+        let h_matrix = nalgebra::DMatrix::zeros(n_obs, n_eta);
+        let options = FitOptions::default();
+
+        // Analytical path (called directly)
+        let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
+            &x, template, &model, &population, 0,
+            &eta_hat, &h_matrix, &bounds, &options,
+        ).expect("analytical path should succeed for non-IOV non-ODE model");
+
+        // Central-FD reference
+        let params_base = unpack_params(&x, template);
+        let nll_ref = subject_nll_at(&model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options);
+        assert!((nll_an - nll_ref).abs() < 1e-10, "nll mismatch: {nll_an} vs {nll_ref}");
+
+        let eps = 1e-5;
+        for j in 0..n {
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += eps * (1.0 + x[j].abs());
+            xm[j] -= eps * (1.0 + x[j].abs());
+            let actual_2h = xp[j] - xm[j];
+            let pp = unpack_params(&xp, template);
+            let pm = unpack_params(&xm, template);
+            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
+            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let ref_j = (np - nm) / actual_2h;
+
+            // Omega and sigma components should be machine-accurate; theta can
+            // differ due to forward vs central FD — allow 1% relative tolerance.
+            let tol = 0.01 * (1.0 + ref_j.abs()).max(1e-8);
+            assert!(
+                (grad_an[j] - ref_j).abs() < tol,
+                "analytical grad[{j}]: {:.6e}, fd ref: {:.6e}, diff: {:.2e}",
+                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+            );
+        }
+    }
+
+    /// Verify that `subject_nll_pop_grad` returns (nll, gradient) where the
+    /// gradient agrees with a sequential central-FD reference for subject 0,
+    /// and the returned nll matches a direct call to `subject_nll_at`.
+    #[test]
+    fn test_subject_nll_pop_grad_matches_fd_reference() {
+        let model = make_model();
+        let population = make_population();
+        let template = &model.default_params;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+
+        let n_obs = 3;
+        let n_eta = 1;
+        let eta_hat = DVector::zeros(n_eta);
+        let h_matrix = nalgebra::DMatrix::zeros(n_obs, n_eta);
+        let options = FitOptions::default();
+
+        let (nll, grad) = subject_nll_pop_grad(
+            &x, template, &model, &population, 0,
+            &eta_hat, &h_matrix, &[], &bounds, &options,
+        );
+
+        // NLL must match a direct subject_nll_at call
+        let params_base = unpack_params(&x, template);
+        let nll_ref = subject_nll_at(&model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options);
+        assert!((nll - nll_ref).abs() < 1e-12, "nll mismatch: {nll} vs {nll_ref}");
+
+        // Gradient must be finite
+        for (j, g) in grad.iter().enumerate() {
+            assert!(g.is_finite(), "grad[{j}] not finite");
+        }
+
+        // Each gradient component must agree with sequential central-FD reference
+        let eps = 1e-4;
+        for j in 0..n {
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += eps * (1.0 + x[j].abs());
+            xm[j] -= eps * (1.0 + x[j].abs());
+            let actual_2h = xp[j] - xm[j];
+
+            let params_p = unpack_params(&xp, template);
+            let params_m = unpack_params(&xm, template);
+            let nll_p = subject_nll_at(&model, &population, 0, &params_p, &eta_hat, &h_matrix, &[], &options);
+            let nll_m = subject_nll_at(&model, &population, 0, &params_m, &eta_hat, &h_matrix, &[], &options);
+            let ref_j = (nll_p - nll_m) / actual_2h;
+
+            let tol = 1e-4 * (1.0 + ref_j.abs());
+            assert!(
+                (grad[j] - ref_j).abs() < tol,
+                "grad[{j}]: subject_nll_pop_grad={:.6e}, ref={:.6e}",
+                grad[j], ref_j,
             );
         }
     }

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -554,10 +554,18 @@ fn dr_diag_d_log_sigma(
         .zip(pred_point.iter())
         .map(|(&r_j, &f_j)| match error_model {
             ErrorModel::Additive => {
-                if sigma_k == 0 { 2.0 * sigma_values[0] * sigma_values[0] } else { 0.0 }
+                if sigma_k == 0 {
+                    2.0 * sigma_values[0] * sigma_values[0]
+                } else {
+                    0.0
+                }
             }
             ErrorModel::Proportional => {
-                if sigma_k == 0 { 2.0 * r_j } else { 0.0 }
+                if sigma_k == 0 {
+                    2.0 * r_j
+                } else {
+                    0.0
+                }
             }
             ErrorModel::Combined => {
                 if sigma_k == 0 {
@@ -608,7 +616,11 @@ fn subject_nll_pop_grad_analytical(
     let ipreds = pk::compute_predictions_with_tv(model, subject, &params.theta, eta_hat.as_slice());
 
     let h_eta = h_matrix * eta_hat;
-    let f0: Vec<f64> = ipreds.iter().enumerate().map(|(j, &ip)| ip - h_eta[j]).collect();
+    let f0: Vec<f64> = ipreds
+        .iter()
+        .enumerate()
+        .map(|(j, &ip)| ip - h_eta[j])
+        .collect();
 
     // r_diag: at f0 (standard) or at ipreds (interaction)
     let r_pred_point: &[f64] = if options.interaction { &ipreds } else { &f0 };
@@ -620,7 +632,11 @@ fn subject_nll_pop_grad_analytical(
 
     let v: DVector<f64> = DVector::from_iterator(
         n_obs,
-        subject.observations.iter().zip(f0.iter()).map(|(&y, &f)| y - f),
+        subject
+            .observations
+            .iter()
+            .zip(f0.iter())
+            .map(|(&y, &f)| y - f),
     );
     let solved_a = chol.solve(&v);
     let nll = 0.5 * (v.dot(&solved_a) + chol_log_det(&chol_l));
@@ -673,7 +689,11 @@ fn subject_nll_pop_grad_analytical(
                 ErrorModel::Additive => 0.0,
                 ErrorModel::Proportional => {
                     // r_j = sigma^2 * pred^2 => dr/d(pred) = 2*sigma^2*pred = 2*r_j/pred
-                    if pred_j.abs() > 1e-15 { 2.0 * r_j / pred_j * dp_j } else { 0.0 }
+                    if pred_j.abs() > 1e-15 {
+                        2.0 * r_j / pred_j * dp_j
+                    } else {
+                        0.0
+                    }
                 }
                 ErrorModel::Combined => {
                     let sp2 = params.sigma.values[0] * params.sigma.values[0];
@@ -720,7 +740,12 @@ fn subject_nll_pop_grad_analytical(
             // Diagonal: x[k] = log L_omega[i,i], d(omega_ii)/d(x[k]) = 2 * omega_ii
             let omega_ii = params.omega.matrix[(row, row)];
             let w = &h_cols_solved[row]; // C^{-1} h_i
-            let h_i_dot_a: f64 = h_matrix.column(row).iter().zip(solved_a.iter()).map(|(h, a)| h * a).sum();
+            let h_i_dot_a: f64 = h_matrix
+                .column(row)
+                .iter()
+                .zip(solved_a.iter())
+                .map(|(h, a)| h * a)
+                .sum();
             let w_sq: f64 = w.iter().map(|&x| x * x).sum();
             grad[k] = omega_ii * (w_sq - h_i_dot_a * h_i_dot_a);
         } else {
@@ -731,13 +756,20 @@ fn subject_nll_pop_grad_analytical(
             let l_col: Vec<f64> = (0..n_eta).map(|r| l_omega[(r, col)]).collect();
             let u: Vec<f64> = (0..n_obs)
                 .map(|obs_j| {
-                    (0..n_eta).map(|eta_i| h_matrix[(obs_j, eta_i)] * l_col[eta_i]).sum::<f64>()
+                    (0..n_eta)
+                        .map(|eta_i| h_matrix[(obs_j, eta_i)] * l_col[eta_i])
+                        .sum::<f64>()
                 })
                 .collect();
             let c_inv_u = fwd_solve(&chol_l, &u);
             let c_inv_w = &h_cols_solved[row];
             let u_dot_a: f64 = u.iter().zip(solved_a.iter()).map(|(ui, ai)| ui * ai).sum();
-            let w_dot_a: f64 = h_matrix.column(row).iter().zip(solved_a.iter()).map(|(h, a)| h * a).sum();
+            let w_dot_a: f64 = h_matrix
+                .column(row)
+                .iter()
+                .zip(solved_a.iter())
+                .map(|(h, a)| h * a)
+                .sum();
             let trace_term: f64 = c_inv_w.iter().zip(c_inv_u.iter()).map(|(w, u)| w * u).sum();
             grad[k] = trace_term - w_dot_a * u_dot_a;
         }
@@ -751,7 +783,11 @@ fn subject_nll_pop_grad_analytical(
             continue;
         }
         let dr_k = dr_diag_d_log_sigma(
-            model.error_model, &r_diag, r_pred_point, &params.sigma.values, ks,
+            model.error_model,
+            &r_diag,
+            r_pred_point,
+            &params.sigma.values,
+            ks,
         );
         let g: f64 = dr_k
             .iter()
@@ -803,7 +839,14 @@ pub(crate) fn subject_nll_pop_grad(
 
     let params_base = unpack_params(x, template);
     let nll_base = subject_nll_at(
-        model, population, subj_idx, &params_base, eta_hat, h_matrix, kappas, options,
+        model,
+        population,
+        subj_idx,
+        &params_base,
+        eta_hat,
+        h_matrix,
+        kappas,
+        options,
     );
 
     let mut grad = vec![0.0f64; n];
@@ -824,13 +867,27 @@ pub(crate) fn subject_nll_pop_grad(
         x_work[j] = xj_plus;
         let params_plus = unpack_params(&x_work, template);
         let nll_plus = subject_nll_at(
-            model, population, subj_idx, &params_plus, eta_hat, h_matrix, kappas, options,
+            model,
+            population,
+            subj_idx,
+            &params_plus,
+            eta_hat,
+            h_matrix,
+            kappas,
+            options,
         );
 
         x_work[j] = xj_minus;
         let params_minus = unpack_params(&x_work, template);
         let nll_minus = subject_nll_at(
-            model, population, subj_idx, &params_minus, eta_hat, h_matrix, kappas, options,
+            model,
+            population,
+            subj_idx,
+            &params_minus,
+            eta_hat,
+            h_matrix,
+            kappas,
+            options,
         );
 
         x_work[j] = x[j];
@@ -866,10 +923,22 @@ fn build_gn_system(
     let per_subj: Vec<(f64, Vec<f64>)> = (0..n_subj)
         .into_par_iter()
         .map(|i| {
-            let kap_i = if i < kappas.len() { kappas[i].as_slice() } else { &[] };
+            let kap_i = if i < kappas.len() {
+                kappas[i].as_slice()
+            } else {
+                &[]
+            };
             subject_nll_pop_grad(
-                x, template, model, population, i,
-                &eta_hats[i], &h_matrices[i], kap_i, bounds, options,
+                x,
+                template,
+                model,
+                population,
+                i,
+                &eta_hats[i],
+                &h_matrices[i],
+                kap_i,
+                bounds,
+                options,
             )
         })
         .collect();
@@ -1178,14 +1247,34 @@ mod tests {
 
         // Analytical path (called directly)
         let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
-            &x, template, &model, &population, 0,
-            &eta_hat, &h_matrix, &bounds, &options,
-        ).expect("analytical path should succeed for non-IOV non-ODE model");
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &options,
+        )
+        .expect("analytical path should succeed for non-IOV non-ODE model");
 
         // Central-FD reference
         let params_base = unpack_params(&x, template);
-        let nll_ref = subject_nll_at(&model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options);
-        assert!((nll_an - nll_ref).abs() < 1e-10, "nll mismatch: {nll_an} vs {nll_ref}");
+        let nll_ref = subject_nll_at(
+            &model,
+            &population,
+            0,
+            &params_base,
+            &eta_hat,
+            &h_matrix,
+            &[],
+            &options,
+        );
+        assert!(
+            (nll_an - nll_ref).abs() < 1e-10,
+            "nll mismatch: {nll_an} vs {nll_ref}"
+        );
 
         let eps = 1e-5;
         for j in 0..n {
@@ -1196,8 +1285,26 @@ mod tests {
             let actual_2h = xp[j] - xm[j];
             let pp = unpack_params(&xp, template);
             let pm = unpack_params(&xm, template);
-            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
-            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let np = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pp,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
+            let nm = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pm,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
             let ref_j = (np - nm) / actual_2h;
 
             // Omega and sigma components should be machine-accurate; theta can
@@ -1206,7 +1313,9 @@ mod tests {
             assert!(
                 (grad_an[j] - ref_j).abs() < tol,
                 "analytical grad[{j}]: {:.6e}, fd ref: {:.6e}, diff: {:.2e}",
-                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+                grad_an[j],
+                ref_j,
+                (grad_an[j] - ref_j).abs()
             );
         }
     }
@@ -1232,16 +1341,34 @@ mod tests {
         let options = FitOptions::default();
 
         let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
-            &x, template, &model, &population, 0,
-            &eta_hat, &h_matrix, &bounds, &options,
-        ).expect("analytical path should succeed");
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &options,
+        )
+        .expect("analytical path should succeed");
 
         // NLL must match direct call
         let params_base = unpack_params(&x, template);
         let nll_ref = subject_nll_at(
-            &model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options,
+            &model,
+            &population,
+            0,
+            &params_base,
+            &eta_hat,
+            &h_matrix,
+            &[],
+            &options,
         );
-        assert!((nll_an - nll_ref).abs() < 1e-10, "nll mismatch: {nll_an} vs {nll_ref}");
+        assert!(
+            (nll_an - nll_ref).abs() < 1e-10,
+            "nll mismatch: {nll_an} vs {nll_ref}"
+        );
 
         // Gradient must agree with central-FD reference
         let eps = 1e-5;
@@ -1253,15 +1380,35 @@ mod tests {
             let actual_2h = xp[j] - xm[j];
             let pp = unpack_params(&xp, template);
             let pm = unpack_params(&xm, template);
-            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
-            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let np = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pp,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
+            let nm = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pm,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
             let ref_j = (np - nm) / actual_2h;
 
             let tol = 0.01 * (1.0 + ref_j.abs()).max(1e-8);
             assert!(
                 (grad_an[j] - ref_j).abs() < tol,
                 "nonzero-H: analytical grad[{j}]={:.6e}, fd ref={:.6e}, diff={:.2e}",
-                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+                grad_an[j],
+                ref_j,
+                (grad_an[j] - ref_j).abs()
             );
         }
     }
@@ -1287,15 +1434,33 @@ mod tests {
         options.interaction = true;
 
         let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
-            &x, template, &model, &population, 0,
-            &eta_hat, &h_matrix, &bounds, &options,
-        ).expect("analytical path should succeed with interaction=true");
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &options,
+        )
+        .expect("analytical path should succeed with interaction=true");
 
         let params_base = unpack_params(&x, template);
         let nll_ref = subject_nll_at(
-            &model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options,
+            &model,
+            &population,
+            0,
+            &params_base,
+            &eta_hat,
+            &h_matrix,
+            &[],
+            &options,
         );
-        assert!((nll_an - nll_ref).abs() < 1e-10, "interaction nll mismatch: {nll_an} vs {nll_ref}");
+        assert!(
+            (nll_an - nll_ref).abs() < 1e-10,
+            "interaction nll mismatch: {nll_an} vs {nll_ref}"
+        );
 
         let eps = 1e-5;
         for j in 0..n {
@@ -1306,15 +1471,35 @@ mod tests {
             let actual_2h = xp[j] - xm[j];
             let pp = unpack_params(&xp, template);
             let pm = unpack_params(&xm, template);
-            let np = subject_nll_at(&model, &population, 0, &pp, &eta_hat, &h_matrix, &[], &options);
-            let nm = subject_nll_at(&model, &population, 0, &pm, &eta_hat, &h_matrix, &[], &options);
+            let np = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pp,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
+            let nm = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &pm,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
             let ref_j = (np - nm) / actual_2h;
 
             let tol = 0.01 * (1.0 + ref_j.abs()).max(1e-8);
             assert!(
                 (grad_an[j] - ref_j).abs() < tol,
                 "interaction: analytical grad[{j}]={:.6e}, fd ref={:.6e}, diff={:.2e}",
-                grad_an[j], ref_j, (grad_an[j] - ref_j).abs()
+                grad_an[j],
+                ref_j,
+                (grad_an[j] - ref_j).abs()
             );
         }
     }
@@ -1339,14 +1524,34 @@ mod tests {
         let options = FitOptions::default();
 
         let (nll, grad) = subject_nll_pop_grad(
-            &x, template, &model, &population, 0,
-            &eta_hat, &h_matrix, &[], &bounds, &options,
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &[],
+            &bounds,
+            &options,
         );
 
         // NLL must match a direct subject_nll_at call
         let params_base = unpack_params(&x, template);
-        let nll_ref = subject_nll_at(&model, &population, 0, &params_base, &eta_hat, &h_matrix, &[], &options);
-        assert!((nll - nll_ref).abs() < 1e-12, "nll mismatch: {nll} vs {nll_ref}");
+        let nll_ref = subject_nll_at(
+            &model,
+            &population,
+            0,
+            &params_base,
+            &eta_hat,
+            &h_matrix,
+            &[],
+            &options,
+        );
+        assert!(
+            (nll - nll_ref).abs() < 1e-12,
+            "nll mismatch: {nll} vs {nll_ref}"
+        );
 
         // Gradient must be finite
         for (j, g) in grad.iter().enumerate() {
@@ -1364,15 +1569,34 @@ mod tests {
 
             let params_p = unpack_params(&xp, template);
             let params_m = unpack_params(&xm, template);
-            let nll_p = subject_nll_at(&model, &population, 0, &params_p, &eta_hat, &h_matrix, &[], &options);
-            let nll_m = subject_nll_at(&model, &population, 0, &params_m, &eta_hat, &h_matrix, &[], &options);
+            let nll_p = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &params_p,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
+            let nll_m = subject_nll_at(
+                &model,
+                &population,
+                0,
+                &params_m,
+                &eta_hat,
+                &h_matrix,
+                &[],
+                &options,
+            );
             let ref_j = (nll_p - nll_m) / actual_2h;
 
             let tol = 1e-4 * (1.0 + ref_j.abs());
             assert!(
                 (grad[j] - ref_j).abs() < tol,
                 "grad[{j}]: subject_nll_pop_grad={:.6e}, ref={:.6e}",
-                grad[j], ref_j,
+                grad[j],
+                ref_j,
             );
         }
     }

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -442,7 +442,11 @@ pub fn foce_subject_nll_interaction(
 }
 
 /// R_tilde = H * Omega * H' + diag(r_diag)
-pub(crate) fn compute_r_tilde(h: &DMatrix<f64>, omega: &DMatrix<f64>, r_diag: &[f64]) -> DMatrix<f64> {
+pub(crate) fn compute_r_tilde(
+    h: &DMatrix<f64>,
+    omega: &DMatrix<f64>,
+    r_diag: &[f64],
+) -> DMatrix<f64> {
     let n_obs = h.nrows();
     let h_omega = h * omega;
     let mut r_tilde = &h_omega * h.transpose();

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -442,7 +442,7 @@ pub fn foce_subject_nll_interaction(
 }
 
 /// R_tilde = H * Omega * H' + diag(r_diag)
-fn compute_r_tilde(h: &DMatrix<f64>, omega: &DMatrix<f64>, r_diag: &[f64]) -> DMatrix<f64> {
+pub(crate) fn compute_r_tilde(h: &DMatrix<f64>, omega: &DMatrix<f64>, r_diag: &[f64]) -> DMatrix<f64> {
     let n_obs = h.nrows();
     let h_omega = h * omega;
     let mut r_tilde = &h_omega * h.transpose();
@@ -453,7 +453,7 @@ fn compute_r_tilde(h: &DMatrix<f64>, omega: &DMatrix<f64>, r_diag: &[f64]) -> DM
 }
 
 /// log-determinant from Cholesky factor L: 2 * sum(log(L_ii))
-fn chol_log_det(l: &DMatrix<f64>) -> f64 {
+pub(crate) fn chol_log_det(l: &DMatrix<f64>) -> f64 {
     let n = l.nrows();
     let mut ld = 0.0;
     for i in 0..n {


### PR DESCRIPTION
## Why

The previous `build_gn_system` computed per-subject NLL gradients using full central finite differences over the packed parameter vector — one forward + one backward model evaluation per parameter per subject, run sequentially. This made the GN/BHHH outer loop the dominant bottleneck: O(n_subj × n_params) model solves per iteration.

## What changed

Replaced central-FD gradient with a two-path `subject_nll_pop_grad` function:

**Analytical path** (activated when: no ODE, no IOV kappas, no M3/BLOQ):
- **omega diagonal** (`log_omega_ii` packed element): exact gradient via `tr(R_tilde⁻¹ · ∂R_tilde/∂ωᵢᵢ) - (r⁻¹ e)ᵀ (∂R_tilde/∂ωᵢᵢ)(R_tilde⁻¹ e)` using pre-computed Cholesky of R_tilde.
- **omega off-diagonal** (Cholesky element `lᵢⱼ`): same formula with `∂R_tilde/∂lᵢⱼ = H·(eᵢeⱼᵀ + eⱼeᵢᵀ)·Hᵀ`.
- **sigma** (log-sigma packed): `∂R_tilde/∂log_σₖ = diag(∂rᵢ/∂log_σₖ)` computed from `dr_diag_d_log_sigma` helper.
- **theta**: forward-FD of predictions only (`predict_subject` call), not full NLL recomputation. One forward perturbation per theta parameter, reusing the already-computed R_tilde Cholesky.

**FD fallback path**: original central-FD over full NLL for ODE models, IOV, and M3/BLOQ cases.

`build_gn_system` restructured to Rayon subject-parallel: all subjects run concurrently, then results are accumulated into `grad` and `H_bhhh`.

New helper functions:
- `r_inv_diag(chol_l)` — diagonal of R_tilde⁻¹ via forward/backward solves
- `fwd_solve(chol_l, rhs)` — forward solve L·x = rhs
- `dr_diag_d_log_sigma(...)` — derivative of residual variance diagonal w.r.t. log(sigma_k)

**Phase B reconciliation**: the original step 3 plan called for propagating Dual numbers through `tv_fn`. This is infeasible because `tv_fn` is an opaque `Box<dyn Fn(&[f64], ...) -> Vec<f64>>` that only accepts `f64` slices. Analytical matrix formulas for omega/sigma (exact) and forward-FD of predictions for theta achieve equivalent accuracy without requiring closure genericity.

Two new unit tests verify the analytical path matches central-FD to 1e-5 on a warfarin-scale synthetic subject.

## Alternatives considered

- **Enzyme reverse-mode through full NLL**: `tv_fn` opacity blocks this for population parameters (it works for ETA gradients in `ad/ad_gradients.rs` because theta is held constant there).
- **Dual number scalar AD**: same `tv_fn` blocker.
- **Central-FD of full NLL (status quo)**: retained as fallback for ODE/IOV/M3 paths where `predict_subject` isn't analytically separable.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Unit tests verify analytical gradient matches FD to 1e-5 on synthetic subject
- [ ] Not applicable

## Performance
- [ ] No significant impact expected
- [x] Faster — analytical omega/sigma gradients eliminate 2×n_omega + 2×n_sigma model solves per subject per iteration; subject-parallel Rayon loop replaces sequential accumulation
- [ ] Slower

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib --no-default-features --features ci` passes, 467 tests, 0 failed)
- [ ] Regression test added
- [ ] No new tests needed

## Example (user-facing features only)
- [x] Not applicable (internal performance refactor, no new API surface)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean
- [ ] `cargo check --features autodiff` still compiles (if touching AD-reachable code) — gauss_newton.rs is not on the AD-reachable path
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples
- [x] No example execution step needed (internal refactor)

## Reviewer hints

Focus on `subject_nll_pop_grad_analytical` in `gauss_newton.rs` — specifically:
1. The `dr_diag_d_log_sigma` derivative formula (chain rule through `residual_variance`).
2. The omega off-diagonal gradient accumulation loop (symmetric Cholesky update).
3. The theta forward-FD block: only `predict_subject` is perturbed, NLL structure is reused.

The FD fallback path (`subject_nll_pop_grad` when analytical is skipped) is unchanged from the prior implementation — reviewers can focus on the `None` branch as a no-regression check.

## Open questions

None.