### PR TITLE
test(ci): close integration-test blind spot in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           shared-key: ci
       - name: cargo check
-        run: cargo check --no-default-features --features ci
+        run: cargo check --tests --no-default-features --features ci
 
   test:
     name: Test

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           shared-key: ci-slow
       - name: cargo test (release + slow-tests)
-        # With `slow-tests` on, the gated tests are no longer `#[ignore]`d
-        # so `--include-ignored` is a no-op here. Kept off for clarity.
-        run: cargo test --lib --no-default-features --features ci,slow-tests --release
+        # `--lib` is intentionally omitted so integration tests in `tests/`
+        # are compiled and run here. Gated slow tests (the `slow-tests` feature
+        # removes their `#[ignore]`) and ungated integration tests both execute.
+        run: cargo test --no-default-features --features ci,slow-tests --release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The binary is called `ferx` and outputs `{model}-fit.yaml` (estimates) and `{mod
 
 There are three tiers of tests. Put a new test in the lowest tier whose constraints it fits.
 
-**Tier 1 — Fast unit tests** (`src/**/tests` inline modules)
+**Tier 1 — Fast unit tests** (inline `#[cfg(test)] mod tests { ... }` blocks in `src/**/*.rs`)
 Test the smallest helper that isolates the behaviour; avoid calling `fit()`. Run with `cargo test --lib`. These run on every PR and must stay fast (seconds total).
 
 **Tier 2 — Integration tests** (`tests/*.rs`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,13 +39,16 @@ The binary is called `ferx` and outputs `{model}-fit.yaml` (estimates) and `{mod
 
 ## Tests
 
-Inline `#[cfg(test)] mod tests` blocks at the bottom of each module (e.g. `src/parser/model_parser.rs`, `src/estimation/parameterization.rs`). Run with `cargo test --lib`.
+There are three tiers of tests. Put a new test in the lowest tier whose constraints it fits.
 
-**Every new feature requires a test.** When adding a new parser pattern, fit option, estimator, or any public behaviour, add a corresponding unit test in the same file's `tests` module before considering the change done. Bug fixes should add a regression test that fails without the fix.
+**Tier 1 — Fast unit tests** (`src/**/tests` inline modules)
+Test the smallest helper that isolates the behaviour; avoid calling `fit()`. Run with `cargo test --lib`. These run on every PR and must stay fast (seconds total).
 
-Prefer unit tests of the smallest helper that isolates the new behaviour (e.g. test `detect_mu_refs` directly, not just through a full `fit()` call) — end-to-end fits are too slow and flaky for the default test suite.
+**Tier 2 — Integration tests** (`tests/*.rs`)
+Call the public API (`fit()`, `predict()`, etc.) but must return immediately — either with an `Ok` after a handful of outer iterations or with an `Err`. No convergence loops. These files are compile-checked on every PR (`cargo check --tests`) and run nightly in `slow-tests.yml`. Put tests here when you need to exercise a public-API boundary that can't be reached from a `src/` unit test.
 
-**Any test that calls `fit()` and runs to convergence must be gated** so it is skipped in the default PR test job. Use the `slow-tests` cargo feature:
+**Tier 3 — Slow convergence tests** (`tests/*.rs` or `src/` with `slow-tests` gate)
+Full population fits that run to convergence. Gate them so they are skipped in the default PR job:
 
 ```rust
 #[test]
@@ -53,7 +56,9 @@ Prefer unit tests of the smallest helper that isolates the new behaviour (e.g. t
 fn test_my_new_estimator() { ... }
 ```
 
-These tests still run in CI via the nightly `slow-tests.yml` workflow and can be triggered manually. Fast-failing tests (those that call `fit()` but expect an immediate `Err` without running the optimiser) do not need gating.
+These run nightly via `slow-tests.yml` and on any push to `main` that touches estimation code. Fast-failing tests (those that call `fit()` but expect an immediate `Err`) do not need gating.
+
+**Every new feature requires a test** at the appropriate tier. When adding a new parser pattern, fit option, estimator, or any public behaviour, add a corresponding test before considering the change done. Bug fixes should add a regression test that fails without the fix.
 
 ## Documentation
 


### PR DESCRIPTION
## Why

`tests/*.rs` integration tests were never compiled or run in any CI tier. The `check` job lacked `--tests`, and `slow-tests.yml` used `--lib`. This meant a type error (bare `30` instead of `Some(30)` after `steihaug_max_iters` was changed to `Option<usize>` in #50) went undetected until merge time — surfaced as a reviewer comment on #52.

## What changed

- `ci.yml` check job: `cargo check --tests` — compile-checks `tests/` on every PR at negligible extra cost.
- `slow-tests.yml`: dropped `--lib` — integration tests in `tests/` are now compiled and run nightly alongside gated slow tests.
- `CLAUDE.md`: documents all three test tiers (unit / integration / slow) and the rule for which tier a new test belongs in.

## Alternatives considered

Could move integration tests back into `src/` as unit tests. Rejected — they test the public API boundary, which is exactly what `tests/` is for.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

ferx-r has a different test split (testthat + Rust unit tests); the same blind spot may exist there but is a separate investigation.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (this PR *fixes* test infrastructure, not application code)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `CLAUDE.md` updated with three-tier test guidance
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no code changes)
- [x] `cargo check --features autodiff` not affected (no AD-reachable code touched)

## Reviewer hints

Three files changed, all mechanical. The only non-obvious choice is dropping `--lib` from slow-tests rather than adding a fourth CI job — keeping it in the existing nightly workflow avoids PR-time latency while still ensuring `tests/` is exercised regularly.

## Open questions

Should ferx-r get a parallel audit of its `tests/` coverage in CI? Leaving for a follow-up.