### PR TITLE
fix(ad): apply F1 bioavailability in event-driven AD paths [closes #16]

### DIFF
--- a/src/ad/event_driven_ad.rs
+++ b/src/ad/event_driven_ad.rs
@@ -274,6 +274,12 @@ pub fn individual_nll_event_driven_ad(
         let mut ev_ka = 0.0_f64;
         let mut ev_q3 = 0.0_f64;
         let mut ev_v3 = 0.0_f64;
+        // F (bioavailability) defaults to 1.0 — matches PkParams::default()
+        // and the analytical event-driven path. If the model doesn't
+        // declare F as an individual parameter, the loop below never
+        // overwrites this and the bolus / infusion scaling reduces to a
+        // no-op multiplication by 1.
+        let mut ev_f = 1.0_f64;
         let row_off = ev_idx * n_tv;
         for i in 0..n_tv {
             let mut eta_contrib = 0.0;
@@ -293,6 +299,8 @@ pub fn individual_nll_event_driven_ad(
                 ev_v2 = val;
             } else if idx == PK_IDX_KA {
                 ev_ka = val;
+            } else if idx == PK_IDX_F {
+                ev_f = val;
             } else if idx == PK_IDX_Q3 {
                 ev_q3 = val;
             } else if idx == PK_IDX_V3 {
@@ -320,6 +328,7 @@ pub fn individual_nll_event_driven_ad(
             ev_ka,
             ev_q3,
             ev_v3,
+            ev_f,
             dose_times,
             dose_rates,
             dose_durations,
@@ -343,14 +352,18 @@ pub fn individual_nll_event_driven_ad(
 
         // ── Dose branch. is_dose=0 for obs and pk-only events, so
         // their state0 is unchanged regardless of dose_amts/dose_rates
-        // values. Const inputs throughout.
+        // values. Const inputs throughout. `ev_f` applies bioavailability
+        // F1 at bolus injection — mirrors the analytical event-driven
+        // path (`pk::event_driven`) and the single-snapshot AD path
+        // (`ad::ad_gradients`). Without it, oral / extravascular subjects
+        // with F ≠ 1 silently got wrong AD gradients on TV-covariate fits.
         let is_dose = if kind < 0.5 { 1.0 } else { 0.0 };
         let is_bolus = if dose_rates[dose_idx] == 0.0 {
             1.0
         } else {
             0.0
         };
-        state0 += is_dose * is_bolus * dose_amts[dose_idx];
+        state0 += is_dose * is_bolus * dose_amts[dose_idx] * ev_f;
 
         // ── Observation branch. is_obs=0 for dose and pk-only events.
         let is_obs = if kind > 0.5 && kind < 1.5 { 1.0 } else { 0.0 };
@@ -436,6 +449,7 @@ fn propagate_state_ad(
     ka: f64,
     q3: f64,
     v3: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -443,7 +457,11 @@ fn propagate_state_ad(
     n_doses: usize,
 ) -> (f64, f64, f64, f64) {
     // Const-only branch on pk_model_id — constant-folds under LLVM. Only
-    // the relevant arm contains real adjoint flow per build.
+    // the relevant arm contains real adjoint flow per build. `f_bio`
+    // scales every active infusion's rate inside the IV propagators
+    // (mirrors `pk::event_driven::propagate_with_bounds`). Oral
+    // propagators take no doses internally — bolus into depot is
+    // handled in the main event loop with `f_bio` applied there.
     if pk_model_id == 0 || pk_model_id == 2 {
         // 1-cpt IV bolus / infusion: state = [central].
         let s0 = propagate_one_cpt_ad(
@@ -452,6 +470,7 @@ fn propagate_state_ad(
             t_to,
             cl,
             v,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -473,6 +492,7 @@ fn propagate_state_ad(
             v,
             q,
             v2,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -499,6 +519,7 @@ fn propagate_state_ad(
             v2,
             q3,
             v3,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -529,6 +550,7 @@ fn propagate_one_cpt_ad(
     t_to: f64,
     cl: f64,
     v: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -552,7 +574,8 @@ fn propagate_one_cpt_ad(
         let tau_total_raw = t_to - p_start;
         let diff = tau_total_raw - tau_to;
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
-        let contribution = (dose_rates[d] / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
+        let r = f_bio * dose_rates[d];
+        let contribution = (r / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
         s0 += contribution;
     }
     s0
@@ -573,6 +596,7 @@ fn propagate_two_cpt_ad(
     v1: f64,
     q: f64,
     v2: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -620,9 +644,11 @@ fn propagate_two_cpt_ad(
         let diff = tau_total_raw - tau_to;
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
 
-        // Per-channel A_ss.
+        // Per-channel A_ss. `f_bio` scales the active infusion rate so a
+        // dur→0 infusion limits to a bolus of amount F·AMT — same
+        // convention as the bolus injection step in the event loop.
         let cmt = dose_cmts_f64[d] as i32;
-        let r = dose_rates[d];
+        let r = f_bio * dose_rates[d];
         let (a_ss_1, a_ss_2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -875,6 +901,7 @@ fn propagate_three_cpt_ad(
     v2: f64,
     q3: f64,
     v3: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -918,9 +945,10 @@ fn propagate_three_cpt_ad(
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
 
         // Per-channel A_ss. Const-branch on dose_cmts_f64 selects which
-        // channel formula applies.
+        // channel formula applies. `f_bio` scales the active infusion
+        // rate so dur→0 limits to a bolus of amount F·AMT.
         let cmt = dose_cmts_f64[d] as i32;
-        let r = dose_rates[d];
+        let r = f_bio * dose_rates[d];
         let (a_ss_c, a_ss_p1, a_ss_p2) = if cmt == 2 {
             // Channel 2 (periph1).
             (

--- a/src/ad/event_driven_ad_jac.rs
+++ b/src/ad/event_driven_ad_jac.rs
@@ -82,6 +82,8 @@ pub fn predict_all_event_driven_ad(
         let mut ev_ka = 0.0_f64;
         let mut ev_q3 = 0.0_f64;
         let mut ev_v3 = 0.0_f64;
+        // F defaults to 1.0 — see sibling `event_driven_ad.rs`.
+        let mut ev_f = 1.0_f64;
         let row_off = ev_idx * n_tv;
         for i in 0..n_tv {
             let mut eta_contrib = 0.0;
@@ -100,6 +102,8 @@ pub fn predict_all_event_driven_ad(
                 ev_v2 = val;
             } else if idx == PK_IDX_KA {
                 ev_ka = val;
+            } else if idx == PK_IDX_F {
+                ev_f = val;
             } else if idx == PK_IDX_Q3 {
                 ev_q3 = val;
             } else if idx == PK_IDX_V3 {
@@ -122,6 +126,7 @@ pub fn predict_all_event_driven_ad(
             ev_ka,
             ev_q3,
             ev_v3,
+            ev_f,
             dose_times,
             dose_rates,
             dose_durations,
@@ -138,14 +143,15 @@ pub fn predict_all_event_driven_ad(
         let dose_idx = if kind < 0.5 { orig } else { 0 };
 
         // is_dose=0 for obs (kind=1) and pk-only (kind=2), so their
-        // state0 is unchanged regardless of dose_*[dose_idx].
+        // state0 is unchanged regardless of dose_*[dose_idx]. `ev_f`
+        // applies F1 at bolus injection — see sibling `event_driven_ad.rs`.
         let is_dose = if kind < 0.5 { 1.0 } else { 0.0 };
         let is_bolus = if dose_rates[dose_idx] == 0.0 {
             1.0
         } else {
             0.0
         };
-        state0 += is_dose * is_bolus * dose_amts[dose_idx];
+        state0 += is_dose * is_bolus * dose_amts[dose_idx] * ev_f;
 
         let central_amt = if pk_model_id == 1 || pk_model_id == 4 || pk_model_id == 7 {
             state1
@@ -191,6 +197,7 @@ fn propagate_state_jac(
     ka: f64,
     q3: f64,
     v3: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -204,6 +211,7 @@ fn propagate_state_jac(
             t_to,
             cl,
             v,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -223,6 +231,7 @@ fn propagate_state_jac(
             v,
             q,
             v2,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -247,6 +256,7 @@ fn propagate_state_jac(
             v2,
             q3,
             v3,
+            f_bio,
             dose_times,
             dose_rates,
             dose_durations,
@@ -270,6 +280,7 @@ fn propagate_one_cpt_jac(
     t_to: f64,
     cl: f64,
     v: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -293,7 +304,8 @@ fn propagate_one_cpt_jac(
         let tau_total_raw = t_to - p_start;
         let diff = tau_total_raw - tau_to;
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
-        let contribution = (dose_rates[d] / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
+        let r = f_bio * dose_rates[d];
+        let contribution = (r / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
         s0 += contribution;
     }
     s0
@@ -309,6 +321,7 @@ fn propagate_two_cpt_jac(
     v1: f64,
     q: f64,
     v2: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -354,7 +367,7 @@ fn propagate_two_cpt_jac(
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
 
         let cmt = dose_cmts_f64[d] as i32;
-        let r = dose_rates[d];
+        let r = f_bio * dose_rates[d];
         let (a_ss_1, a_ss_2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -570,6 +583,7 @@ fn propagate_three_cpt_jac(
     v2: f64,
     q3: f64,
     v3: f64,
+    f_bio: f64,
     dose_times: &[f64],
     dose_rates: &[f64],
     dose_durations: &[f64],
@@ -608,7 +622,7 @@ fn propagate_three_cpt_jac(
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
 
         let cmt = dose_cmts_f64[d] as i32;
-        let r = dose_rates[d];
+        let r = f_bio * dose_rates[d];
         let (a_ss_c, a_ss_p1, a_ss_p2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -795,4 +809,166 @@ pub fn compute_jacobian_event_driven_ad(
     }
 
     jac
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ad::ad_gradients::pk_model_to_id;
+    use approx::assert_relative_eq;
+
+    // Helper: build the minimum tv_per_event row layout the kernel needs.
+    // `pk_idx_f64` declares which PK indices the row covers (and in what
+    // order); each row carries one value per declared index.
+    fn build_tv_constant(pk_idx: &[usize], values: &[f64], n_events: usize) -> Vec<f64> {
+        assert_eq!(pk_idx.len(), values.len());
+        let mut out = Vec::with_capacity(n_events * pk_idx.len());
+        for _ in 0..n_events {
+            out.extend_from_slice(values);
+        }
+        out
+    }
+
+    /// F scales bolus and infusion dose amounts linearly in the event-
+    /// driven AD path. Regression for issue #16: the AD path was
+    /// silently dropping `f_bio` at the dose-injection step (bolus) and
+    /// in the propagator infusion contributions, so subjects with
+    /// TV-covariates + F ≠ 1 got wrong AD gradients / predictions.
+    /// We assert the linear-scaling invariant
+    /// `pred(F=F0) == F0 * pred(F=1)` separately for an oral bolus and
+    /// an IV infusion, since that catches both fix sites without
+    /// requiring a hand-computed reference.
+    #[test]
+    fn ad_event_driven_applies_f_bio_to_oral_bolus() {
+        // 1-cpt oral, single bolus at t=0, observations spread over the
+        // absorption + elimination phase.
+        let pk_model_id = pk_model_to_id(PkModel::OneCptOral) as f64;
+        let event_times = vec![0.0_f64, 0.5, 1.0, 2.0, 4.0, 8.0];
+        let event_kinds = vec![0.0_f64, 1.0, 1.0, 1.0, 1.0, 1.0]; // dose then 5 obs
+        let event_orig = vec![0.0_f64, 0.0, 1.0, 2.0, 3.0, 4.0];
+        let dose_times = vec![0.0_f64];
+        let dose_amts = vec![1000.0_f64];
+        let dose_rates = vec![0.0_f64]; // bolus
+        let dose_durations = vec![0.0_f64];
+        let dose_cmts = vec![1.0_f64];
+
+        // No eta — single fake row to satisfy n_eta >= 1.
+        let eta = vec![0.0_f64];
+        // Include F in pk_idx so the per-event row carries it.
+        let pk_idx = vec![PK_IDX_CL, PK_IDX_V, PK_IDX_KA, PK_IDX_F];
+        let pk_idx_f64: Vec<f64> = pk_idx.iter().map(|&i| i as f64).collect();
+        let n_tv = pk_idx.len();
+        let n_eta = eta.len();
+        let sel_flat = vec![0.0_f64; n_tv * n_eta]; // all-zero: no eta on any tv
+
+        let cl = 5.0;
+        let v = 50.0;
+        let ka = 1.2;
+
+        let run = |f: f64| -> Vec<f64> {
+            let tv = build_tv_constant(&pk_idx, &[cl, v, ka, f], event_times.len());
+            let mut out = vec![0.0_f64; event_times.len()];
+            predict_all_event_driven_ad(
+                &eta,
+                &tv,
+                &event_times,
+                &event_kinds,
+                &event_orig,
+                &dose_times,
+                &dose_amts,
+                &dose_rates,
+                &dose_durations,
+                &dose_cmts,
+                &pk_idx_f64,
+                &sel_flat,
+                pk_model_id,
+                &mut out,
+            );
+            // Drop the dose slot (kind=0) — only obs slots carry preds.
+            event_kinds
+                .iter()
+                .zip(out.iter())
+                .filter(|(k, _)| **k > 0.5)
+                .map(|(_, p)| *p)
+                .collect()
+        };
+
+        let preds_unit = run(1.0);
+        let preds_half = run(0.5);
+        let preds_tall = run(2.5);
+
+        // Sanity: at F=1 some obs has non-trivial concentration.
+        assert!(preds_unit.iter().any(|p| *p > 1e-3));
+        for (a, b) in preds_unit.iter().zip(preds_half.iter()) {
+            assert_relative_eq!(*b, 0.5 * *a, epsilon = 1e-12, max_relative = 1e-12);
+        }
+        for (a, b) in preds_unit.iter().zip(preds_tall.iter()) {
+            assert_relative_eq!(*b, 2.5 * *a, epsilon = 1e-12, max_relative = 1e-12);
+        }
+    }
+
+    #[test]
+    fn ad_event_driven_applies_f_bio_to_iv_infusion() {
+        // 1-cpt IV infusion: dose split across a finite duration so the
+        // propagator's per-dose `f_bio * dose_rates[d]` path runs (not the
+        // main loop's bolus step).
+        let pk_model_id = pk_model_to_id(PkModel::OneCptInfusion) as f64;
+        let event_times = vec![0.0_f64, 0.5, 1.0, 2.0, 4.0, 8.0];
+        let event_kinds = vec![0.0_f64, 1.0, 1.0, 1.0, 1.0, 1.0];
+        let event_orig = vec![0.0_f64, 0.0, 1.0, 2.0, 3.0, 4.0];
+        let dose_times = vec![0.0_f64];
+        let dose_amts = vec![1000.0_f64];
+        let dose_rates = vec![500.0_f64]; // 2-hour infusion
+        let dose_durations = vec![2.0_f64];
+        let dose_cmts = vec![1.0_f64];
+
+        let eta = vec![0.0_f64];
+        let pk_idx = vec![PK_IDX_CL, PK_IDX_V, PK_IDX_F];
+        let pk_idx_f64: Vec<f64> = pk_idx.iter().map(|&i| i as f64).collect();
+        let n_tv = pk_idx.len();
+        let n_eta = eta.len();
+        let sel_flat = vec![0.0_f64; n_tv * n_eta];
+
+        let cl = 10.0;
+        let v = 100.0;
+
+        let run = |f: f64| -> Vec<f64> {
+            let tv = build_tv_constant(&pk_idx, &[cl, v, f], event_times.len());
+            let mut out = vec![0.0_f64; event_times.len()];
+            predict_all_event_driven_ad(
+                &eta,
+                &tv,
+                &event_times,
+                &event_kinds,
+                &event_orig,
+                &dose_times,
+                &dose_amts,
+                &dose_rates,
+                &dose_durations,
+                &dose_cmts,
+                &pk_idx_f64,
+                &sel_flat,
+                pk_model_id,
+                &mut out,
+            );
+            event_kinds
+                .iter()
+                .zip(out.iter())
+                .filter(|(k, _)| **k > 0.5)
+                .map(|(_, p)| *p)
+                .collect()
+        };
+
+        let preds_unit = run(1.0);
+        let preds_half = run(0.5);
+        let preds_tall = run(2.5);
+
+        assert!(preds_unit.iter().any(|p| *p > 1e-3));
+        for (a, b) in preds_unit.iter().zip(preds_half.iter()) {
+            assert_relative_eq!(*b, 0.5 * *a, epsilon = 1e-12, max_relative = 1e-12);
+        }
+        for (a, b) in preds_unit.iter().zip(preds_tall.iter()) {
+            assert_relative_eq!(*b, 2.5 * *a, epsilon = 1e-12, max_relative = 1e-12);
+        }
+    }
 }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2241,8 +2241,8 @@ mod tests {
         };
         let model_path = "examples/two_cpt_oral_cov.ferx";
         let data_path = "data/two_cpt_oral_cov.csv";
-        let result = fit_from_files(model_path, data_path, None, Some(opts))
-            .expect("fit should succeed");
+        let result =
+            fit_from_files(model_path, data_path, None, Some(opts)).expect("fit should succeed");
 
         // Initial theta from the .ferx file: [4.0, 40.0, 8.0, 80.0, 1.0, 0.6, 0.3].
         let init = [4.0, 40.0, 8.0, 80.0, 1.0, 0.6, 0.3];

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1345,7 +1345,15 @@ fn wire_to_fit_result(
                     .transpose()?,
             )
         }
-        None => (None, Vec::new(), Vec::new(), Vec::new(), None, Vec::new(), None),
+        None => (
+            None,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            None,
+            Vec::new(),
+            None,
+        ),
     };
 
     let (sir_ci_theta, sir_ci_omega, sir_ci_sigma, sir_ess, sir_resamples_packed) = match w.sir {

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -589,22 +589,13 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                 .map_err(|e| e.to_string())?;
             writeln!(f, "    output_activation: {}", nn.output_activation)
                 .map_err(|e| e.to_string())?;
-            writeln!(
-                f,
-                "    inputs: [{}]",
-                nn.input_names.join(", ")
-            )
-            .map_err(|e| e.to_string())?;
-            writeln!(
-                f,
-                "    outputs: [{}]",
-                nn.output_names.join(", ")
-            )
-            .map_err(|e| e.to_string())?;
+            writeln!(f, "    inputs: [{}]", nn.input_names.join(", "))
+                .map_err(|e| e.to_string())?;
+            writeln!(f, "    outputs: [{}]", nn.output_names.join(", "))
+                .map_err(|e| e.to_string())?;
             writeln!(f, "    n_weights: {}", nn.n_weights).map_err(|e| e.to_string())?;
             // Summary statistics over the trained weight values.
-            let w_slice =
-                &result.theta[nn.weights_offset..nn.weights_offset + nn.n_weights];
+            let w_slice = &result.theta[nn.weights_offset..nn.weights_offset + nn.n_weights];
             let (mn, mx, mean, sd) = weight_summary(w_slice);
             writeln!(f, "    weights_summary:").map_err(|e| e.to_string())?;
             writeln!(f, "      min:  {:.6}", mn).map_err(|e| e.to_string())?;
@@ -1039,7 +1030,10 @@ mod tests {
         let yaml = std::fs::read_to_string(&path).expect("yaml read");
 
         // The user-declared theta (TVKA) is still in the per-theta listing.
-        assert!(yaml.contains("  TVKA:"), "TVKA must appear in theta section:\n{yaml}");
+        assert!(
+            yaml.contains("  TVKA:"),
+            "TVKA must appear in theta section:\n{yaml}"
+        );
 
         // None of the 17 NN-weight thetas appear in the per-theta listing.
         for layer in 1..3 {
@@ -1058,15 +1052,39 @@ mod tests {
         }
 
         // The compact `neural_networks:` section IS present.
-        assert!(yaml.contains("\nneural_networks:"), "neural_networks section missing:\n{yaml}");
-        assert!(yaml.contains("  TYPICAL_PK:"), "NN block name missing:\n{yaml}");
-        assert!(yaml.contains("    shape: [2, 3, 2]"), "shape missing:\n{yaml}");
-        assert!(yaml.contains("hidden_activation: tanh"), "hidden activation missing:\n{yaml}");
-        assert!(yaml.contains("output_activation: softplus"), "output activation missing:\n{yaml}");
-        assert!(yaml.contains("inputs: [WT, CRCL]"), "inputs missing:\n{yaml}");
-        assert!(yaml.contains("outputs: [CL, V]"), "outputs missing:\n{yaml}");
+        assert!(
+            yaml.contains("\nneural_networks:"),
+            "neural_networks section missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("  TYPICAL_PK:"),
+            "NN block name missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("    shape: [2, 3, 2]"),
+            "shape missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("hidden_activation: tanh"),
+            "hidden activation missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("output_activation: softplus"),
+            "output activation missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("inputs: [WT, CRCL]"),
+            "inputs missing:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("outputs: [CL, V]"),
+            "outputs missing:\n{yaml}"
+        );
         assert!(yaml.contains("n_weights: 17"), "n_weights missing:\n{yaml}");
-        assert!(yaml.contains("weights_summary:"), "weights_summary missing:\n{yaml}");
+        assert!(
+            yaml.contains("weights_summary:"),
+            "weights_summary missing:\n{yaml}"
+        );
         assert!(yaml.contains("      min:"), "min stat missing:\n{yaml}");
         assert!(yaml.contains("      max:"), "max stat missing:\n{yaml}");
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -23,10 +23,7 @@ enum MuRefAnchor {
     /// alphabetically-sorted NN list (same as `ParseCtx::nn_specs`);
     /// `output_idx` indexes the block's declared `outputs` list.
     #[allow(dead_code)]
-    NnOutput {
-        nn_idx: usize,
-        output_idx: usize,
-    },
+    NnOutput { nn_idx: usize, output_idx: usize },
 }
 
 /// Walk a Mul-chain and collect direct anchor candidates — `Theta(i)` or
@@ -815,13 +812,12 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     #[cfg(not(feature = "nn"))]
     let nn_specs_for_ctx: Vec<(String, Vec<String>)> = Vec::new();
 
-    let bare_ctx =
-        ParseCtx::new(&theta_names, &eta_names, &[]).with_nn_specs(&nn_specs_for_ctx);
+    let bare_ctx = ParseCtx::new(&theta_names, &eta_names, &[]).with_nn_specs(&nn_specs_for_ctx);
     let pre_stmts = parse_block_statements(&indiv_text, bare_ctx, StatementMode::Plain)?;
     let all_assigned = assigned_vars_in_order(&pre_stmts);
     let indiv_var_names = top_level_assigned_vars(&pre_stmts);
-    let indiv_ctx = ParseCtx::new(&theta_names, &eta_names, &all_assigned)
-        .with_nn_specs(&nn_specs_for_ctx);
+    let indiv_ctx =
+        ParseCtx::new(&theta_names, &eta_names, &all_assigned).with_nn_specs(&nn_specs_for_ctx);
     let indiv_stmts = parse_block_statements(&indiv_text, indiv_ctx, StatementMode::Plain)?;
 
     // Detect ODE vs analytical model
@@ -1127,8 +1123,12 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .chain(kappa_names.iter())
         .cloned()
         .collect();
-    let all_mu_refs =
-        detect_mu_refs(&indiv_stmts, &theta_names, &all_eta_names, &nn_specs_for_ctx);
+    let all_mu_refs = detect_mu_refs(
+        &indiv_stmts,
+        &theta_names,
+        &all_eta_names,
+        &nn_specs_for_ctx,
+    );
     let kappa_set: std::collections::HashSet<&String> = kappa_names.iter().collect();
     let mu_refs: HashMap<String, MuRef> = all_mu_refs
         .iter()
@@ -1778,17 +1778,14 @@ fn parse_covariate_nn_block(name: &str, lines: &[String]) -> Result<CovariateNnS
         let key = key.trim().to_ascii_lowercase();
         let value = value.trim().to_string();
         if fields.insert(key.clone(), value).is_some() {
-            return Err(format!(
-                "[covariate_nn {}] duplicate key `{}`",
-                name, key
-            ));
+            return Err(format!("[covariate_nn {}] duplicate key `{}`", name, key));
         }
     }
 
     let take_list = |field: &str| -> Result<Vec<String>, String> {
-        let raw = fields.get(field).ok_or_else(|| {
-            format!("[covariate_nn {}] missing required `{}`", name, field)
-        })?;
+        let raw = fields
+            .get(field)
+            .ok_or_else(|| format!("[covariate_nn {}] missing required `{}`", name, field))?;
         let inner = raw
             .strip_prefix('[')
             .and_then(|s| s.strip_suffix(']'))
@@ -2939,7 +2936,10 @@ enum Expression {
     /// reads the pre-computed forward output from a per-call cache in
     /// `build_pk_param_fn` so multiple references to outputs of the same
     /// NN share a single forward pass.
-    NnOutput { nn_idx: usize, output_idx: usize },
+    NnOutput {
+        nn_idx: usize,
+        output_idx: usize,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -3998,16 +3998,17 @@ fn parse_atom(
                         }
                     };
                     let outputs = &ctx.nn_specs[nn_idx].1;
-                    let output_idx = outputs
-                        .iter()
-                        .position(|o| o == output_name)
-                        .ok_or_else(|| {
-                            format!(
-                                "`{name}.{output_name}` is not declared as an output of \
+                    let output_idx =
+                        outputs
+                            .iter()
+                            .position(|o| o == output_name)
+                            .ok_or_else(|| {
+                                format!(
+                                    "`{name}.{output_name}` is not declared as an output of \
                                  [covariate_nn {name}]. Known outputs: {}",
-                                outputs.join(", ")
-                            )
-                        })?;
+                                    outputs.join(", ")
+                                )
+                            })?;
                     return Ok((Expression::NnOutput { nn_idx, output_idx }, pos + 3));
                 }
                 // `NAME.X` where NAME is not a known NN — fall through to the
@@ -7106,7 +7107,10 @@ if (1 > 0) {
             "[covariate_nn FOO]\n  inputs = [WT]\n  outputs = [CL]\n  layers = [3]\n  activation = quack\n",
         );
         let err = parse_model_string(&src).expect_err("bad activation must error");
-        assert!(err.contains("quack"), "error should name the bad activation, got: {err}");
+        assert!(
+            err.contains("quack"),
+            "error should name the bad activation, got: {err}"
+        );
     }
 
     #[cfg(feature = "nn")]
@@ -7130,7 +7134,10 @@ if (1 > 0) {
             "[covariate_nn FOO]\n  inputs = [WT]\n  outputs = [CL]\n  activation = relu\n",
         );
         let err = parse_model_string(&src).expect_err("missing layers must error");
-        assert!(err.contains("layers"), "error should mention `layers`, got: {err}");
+        assert!(
+            err.contains("layers"),
+            "error should mention `layers`, got: {err}"
+        );
     }
 
     #[cfg(feature = "nn")]
@@ -7427,7 +7434,10 @@ if (1 > 0) {
         cov.insert("WT".to_string(), 70.0);
         cov.insert("CRCL".to_string(), 95.0);
 
-        let tv_fn = model.tv_fn.as_ref().expect("analytical model -> Some(tv_fn)");
+        let tv_fn = model
+            .tv_fn
+            .as_ref()
+            .expect("analytical model -> Some(tv_fn)");
         let tvs = tv_fn(&theta, &cov);
 
         // tv_fn returns values in `indiv_param_names` declaration order:

--- a/tests/new_optimizers.rs
+++ b/tests/new_optimizers.rs
@@ -217,8 +217,8 @@ fn final_ofv_no_worse_than_best_seen_during_trace() {
     opts.optimizer_trace = true;
     opts.run_covariance_step = false;
 
-    let result = fit(&model, &population, &model.default_params, &opts)
-        .expect("slsqp fit must succeed");
+    let result =
+        fit(&model, &population, &model.default_params, &opts).expect("slsqp fit must succeed");
     assert!(result.ofv.is_finite());
 
     let trace_path = result

--- a/tests/nn_fit_convergence.rs
+++ b/tests/nn_fit_convergence.rs
@@ -69,7 +69,10 @@ const MODEL: &str = r#"
 "#;
 
 #[test]
-#[cfg_attr(not(feature = "slow-tests"), ignore = "slow: opt in with --features slow-tests")]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
 fn focei_makes_substantial_progress_on_nn_model() {
     let parsed = parse_full_model(MODEL).expect("model parses with --features nn");
     let model = parsed.model;
@@ -90,17 +93,16 @@ fn focei_makes_substantial_progress_on_nn_model() {
     // with refactors.
     let mut baseline_opts: FitOptions = options.clone();
     baseline_opts.outer_maxiter = 1;
-    let baseline =
-        fit(&model, &population, &model.default_params, &baseline_opts)
-            .expect("baseline fit (maxiter=1) runs");
+    let baseline = fit(&model, &population, &model.default_params, &baseline_opts)
+        .expect("baseline fit (maxiter=1) runs");
     let baseline_ofv = baseline.ofv;
     assert!(
         baseline_ofv.is_finite(),
         "baseline OFV at Glorot init must be finite (got {baseline_ofv})"
     );
 
-    let result = fit(&model, &population, &model.default_params, &options)
-        .expect("fit runs to completion");
+    let result =
+        fit(&model, &population, &model.default_params, &options).expect("fit runs to completion");
 
     // ── Assertion 1: OFV decreased substantially.
     //
@@ -164,7 +166,9 @@ fn focei_makes_substantial_progress_on_nn_model() {
                 .find(|s| s.id == sr.id)
                 .and_then(|s| s.observations.get(j))
                 .copied();
-            let Some(obs) = obs else { continue; };
+            let Some(obs) = obs else {
+                continue;
+            };
             if obs <= 0.0 {
                 continue;
             }
@@ -192,6 +196,12 @@ fn focei_makes_substantial_progress_on_nn_model() {
     eprintln!(
         "\nNN fit summary: baseline OFV {:.2} -> {:.2} ({:.1}% better) | \
          RMS weight step {:.4} | pred-vs-obs in [0.2x, 5x]: {:.0}% ({}/{})",
-        baseline_ofv, result.ofv, improvement_pct, rms_move, frac * 100.0, n_within, n_total,
+        baseline_ofv,
+        result.ofv,
+        improvement_pct,
+        rms_move,
+        frac * 100.0,
+        n_within,
+        n_total,
     );
 }

--- a/tests/nn_fit_smoke.rs
+++ b/tests/nn_fit_smoke.rs
@@ -66,7 +66,10 @@ const NN_DCM_MODEL: &str = r#"
 "#;
 
 #[test]
-#[cfg_attr(not(feature = "slow-tests"), ignore = "slow: opt in with --features slow-tests")]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
 fn fit_runs_without_panicking_on_nn_bearing_model() {
     let parsed = parse_full_model(NN_DCM_MODEL).expect("model parses with --features nn");
     let model = parsed.model;
@@ -91,13 +94,7 @@ fn fit_runs_without_panicking_on_nn_bearing_model() {
 
     // Run the fit. The point is to verify nothing panics and that fit
     // produces a finite OFV.
-    let result = fit(
-        &model,
-        &population,
-        &model.default_params,
-        &options,
-    )
-    .expect("fit returns Ok");
+    let result = fit(&model, &population, &model.default_params, &options).expect("fit returns Ok");
 
     // OFV must be finite.
     assert!(


### PR DESCRIPTION
## Why

[Issue #16](https://github.com/FeRx-NLME/ferx-core/issues/16) — the event-driven AD path (both reverse-mode NLL in `src/ad/event_driven_ad.rs` and forward-mode Jacobian in `src/ad/event_driven_ad_jac.rs`) was silently dropping `f_bio` at the dose-injection step and inside the IV propagators' infusion-contribution loops.

Impact: any subject with TV covariates + oral/extravascular model + `F != 1` got incorrect AD gradients and predictions during `fit()`. Severity scales with `|F - 1|`. The analytical event-driven path was already fixed in commit `2e36f5d` ("fix(pk): apply F1 bioavailability in event-driven prediction path"); this PR mirrors that fix in the AD modules so the second half of the issue's acceptance criteria is satisfied.

## What changed

**`src/ad/event_driven_ad.rs` (reverse-mode NLL kernel):**
- Extract `ev_f` from `tv_per_event` alongside `ev_cl`, `ev_v`, etc., initialized to 1.0 so models that don't declare F as an individual parameter behave identically to before (matches `PkParams::default()`).
- Apply `ev_f` at the bolus injection step in the main event loop: `state0 += is_dose * is_bolus * dose_amts[dose_idx] * ev_f`.
- Thread `f_bio` through `propagate_state_ad` into the IV propagators (`propagate_one_cpt_ad`, `propagate_two_cpt_ad`, `propagate_three_cpt_ad`), scaling `dose_rates[d]` so a dur→0 infusion limits to a bolus of amount `F * AMT` — same convention as `pk::event_driven::propagate_with_bounds`.

**`src/ad/event_driven_ad_jac.rs` (forward-mode Jacobian kernel):** identical changes. The two modules are intentional copy-paste siblings per the AD-pass isolation note at the top of each file.

The oral propagators are unchanged — they have no infusion handling, so F is applied entirely at the bolus injection step in the main loop.

AD-safety: `ev_f` is derived from `tv_per_event` (Const) and `eta` via the same `tv * exp(sel · eta)` form as the other PK params, with a Const branch on `idx == PK_IDX_F`. The new arithmetic is plain multiplication — no `.max()`/`.min()` introduced (CLAUDE.md AD constraint).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API surface changed; ferx-r consumes `fit()`/`predict()` and the affected behaviour is purely internal to the AD inner loop.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable in the traditional sense (this is a correctness fix for a silent bug; behaviour with `F = 1` is unchanged). Verified via linear-scaling invariants in unit tests — predictions from the event-driven AD path now scale as `pred(F=F0) == F0 * pred(F=1)` for both oral bolus and IV infusion, matching the analytical path's contract.

## Performance
- [x] No significant impact expected. One extra scalar load per event + one extra multiply per dose injection / per active infusion per propagator step. Negligible compared to the exponential evaluations already on the hot path.

## Tests
- [x] Unit tests added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

Two unit tests in `src/ad/event_driven_ad_jac.rs::tests`:
- `ad_event_driven_applies_f_bio_to_oral_bolus` — 1-cpt oral bolus, asserts `pred(F=F0) == F0 * pred(F=1)` at F ∈ {0.5, 2.5}. Exercises the main-loop bolus injection.
- `ad_event_driven_applies_f_bio_to_iv_infusion` — 1-cpt IV infusion (2-hour duration), same invariant. Exercises the propagator's per-dose infusion loop.

Both invariants would fail with the pre-fix code: `pred(F=F0) == pred(F=1)` regardless of F.

Verification commands run locally:
- `cargo test --no-default-features --features ci --release --lib` → 496 passed (pre-existing baseline preserved).
- `RUSTFLAGS="-Z autodiff=Enable" cargo test --features autodiff --release --lib` → 498 passed (+ 2 new tests).

## Docs
- [x] No user-visible change — bug fix in internal AD code path; user-facing behaviour of `fit()` with `F != 1` becomes correct.

## Checklist
- [x] `cargo clippy` clean on touched files
- [x] `cargo check --features autodiff` still compiles

## Reviewer hints

Focus on `src/ad/event_driven_ad.rs` — the `event_driven_ad_jac.rs` diff is a mechanical mirror. Key places:
1. The `let mut ev_f = 1.0_f64;` initialization + `else if idx == PK_IDX_F { ev_f = val; }` Const-branch in the per-event tv-expansion loop.
2. The `* ev_f` factor added to the bolus injection step.
3. The new `f_bio` parameter threaded through `propagate_state_ad` → `propagate_{one,two,three}_cpt_ad`, where `let r = f_bio * dose_rates[d];` scales the active infusion rate.

The oral propagators are intentionally untouched — they have no internal dose handling, so all F application happens at the main-loop bolus step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)