### PR TITLE
fix(estimation): SIR samples on free subspace so FIX-ed parameters don't break SIR

### DIFF
--- a/src/estimation/run_sir.rs
+++ b/src/estimation/run_sir.rs
@@ -522,6 +522,54 @@ mod tests {
     }
 
     #[test]
+    fn run_sir_succeeds_with_fixed_parameters() {
+        // Regression: before run_sir_core was restricted to the free
+        // subspace, every SIR sample for a model with at least one FIX-ed
+        // parameter failed the bounds check. `compute_covariance` zeroes the
+        // rows/cols of FIX-ed indices, the proposal-cov regularisation
+        // (eigenvalue floor of 1e-8) then perturbs them by ~1e-4, and
+        // `compute_bounds` pins them with `lower == upper == x_hat[i]` — so
+        // the strict bounds check rejected every sample and SIR returned
+        // "All SIR samples had invalid weights".
+        //
+        // `examples/warfarin_fix.ferx` exercises FIX on a theta, an omega,
+        // and a sigma in one go.
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model_fix.ferx");
+        let data_path = dir.path().join("data.csv");
+        std::fs::copy("examples/warfarin_fix.ferx", &model_path).unwrap();
+        std::fs::copy(DATA_PATH, &data_path).unwrap();
+
+        let opts = quick_opts();
+        let Some(fit) = fit_with_cov_or_skip(
+            model_path.to_str().unwrap(),
+            data_path.to_str().unwrap(),
+            opts.clone(),
+        ) else {
+            return;
+        };
+
+        // Sanity-check the fit actually carries FIX-ed parameters — without
+        // this the test would silently degenerate into a non-FIX path.
+        assert!(
+            fit.theta_fixed.iter().any(|&b| b)
+                || fit.omega_fixed.iter().any(|&b| b)
+                || fit.sigma_fixed.iter().any(|&b| b),
+            "expected at least one FIX-ed parameter in warfarin_fix.ferx"
+        );
+
+        let out = run_sir(&fit, None, None, &opts)
+            .expect("SIR must succeed on a model with FIX-ed parameters");
+        let ess = out.sir_ess.expect("sir_ess populated");
+        assert!(
+            ess > 0.0 && ess <= opts.sir_samples as f64,
+            "ess = {} out of (0, {}]",
+            ess,
+            opts.sir_samples
+        );
+    }
+
+    #[test]
     fn run_sir_errors_when_no_model_path_recorded_and_no_caller_model() {
         // Cover the "no model path recorded and caller didn't supply one"
         // branch — the in-memory `fit()` path leaves `model_path = None`,

--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -10,7 +10,7 @@
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::pop_nll;
 use crate::estimation::parameterization::{
-    compute_bounds, compute_mu_k, pack_params, unpack_params,
+    compute_bounds, compute_mu_k, pack_params, packed_fixed_mask, unpack_params,
 };
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -79,25 +79,50 @@ pub fn run_sir_core(
         ));
     }
 
-    // Symmetrize and Cholesky-decompose the proposal covariance.
-    // The FD covariance may not be perfectly symmetric or positive definite;
-    // regularize with an eigenvalue floor if needed (same pattern as OmegaMatrix::from_matrix).
-    let sym_cov = (proposal_cov + proposal_cov.transpose()) * 0.5;
-    let proposal_chol = match sym_cov.clone().cholesky() {
+    // Restrict the proposal to the free subspace. `compute_covariance` zeroes
+    // the rows/cols of FIX-ed parameters, and `compute_bounds` pins their
+    // bounds to `lower == upper == x_hat[i]`. Sampling on the full space would
+    // (after regularising the singular covariance) perturb fixed indices by
+    // ~sqrt(reg) ≈ 1e-4, which then fails the strict bounds check on every
+    // sample — yielding "All SIR samples had invalid weights" for any model
+    // with at least one FIX-ed parameter. Sampling on the free block instead
+    // keeps fixed indices exactly at `x_hat`, and uses `d = n_free` as the
+    // Student-t dimensionality so the importance weights are consistent.
+    let fixed_mask = packed_fixed_mask(params);
+    let free_idx: Vec<usize> = (0..n_packed).filter(|&i| !fixed_mask[i]).collect();
+    let n_free = free_idx.len();
+    if n_free == 0 {
+        return Err(
+            "run_sir_core: every packed parameter is FIX — nothing to sample.".to_string(),
+        );
+    }
+
+    // Symmetrize first, then extract the free block (rows/cols of non-FIX
+    // indices) before Cholesky.
+    let sym_cov_full = (proposal_cov + proposal_cov.transpose()) * 0.5;
+    let mut sub_cov = DMatrix::zeros(n_free, n_free);
+    for (a, &i) in free_idx.iter().enumerate() {
+        for (b, &j) in free_idx.iter().enumerate() {
+            sub_cov[(a, b)] = sym_cov_full[(i, j)];
+        }
+    }
+
+    // Cholesky-decompose the free block; regularise with an eigenvalue floor
+    // if the free block is not strictly positive definite.
+    let proposal_chol = match sub_cov.clone().cholesky() {
         Some(c) => c.l(),
         None => {
-            // Regularize: shift eigenvalues to be at least 1e-8
-            let eig = sym_cov.clone().symmetric_eigen();
+            let eig = sub_cov.clone().symmetric_eigen();
             let min_eig = eig.eigenvalues.min();
             let reg = if min_eig < 1e-8 {
                 -min_eig + 1e-8
             } else {
                 1e-8
             };
-            let reg_cov = &sym_cov + DMatrix::identity(n_packed, n_packed) * reg;
+            let reg_cov = &sub_cov + DMatrix::identity(n_free, n_free) * reg;
             if options.verbose {
                 eprintln!(
-                    "  SIR: proposal covariance not PD (min eigenvalue = {:.2e}), regularizing",
+                    "  SIR: free-block proposal covariance not PD (min eigenvalue = {:.2e}), regularizing",
                     min_eig
                 );
             }
@@ -108,9 +133,10 @@ pub fn run_sir_core(
         }
     };
 
-    // Log-determinant of proposal covariance (for density computation)
+    // Log-determinant of the free-block proposal covariance (for density
+    // computation). Uses n_free, matching the dimensionality of the Student-t.
     let log_det_proposal = 2.0
-        * (0..n_packed)
+        * (0..n_free)
             .map(|i| proposal_chol[(i, i)].ln())
             .sum::<f64>();
 
@@ -133,7 +159,7 @@ pub fn run_sir_core(
     let nu = options.sir_df;
     let chi2_dist = ChiSquared::new(nu).map_err(|e| format!("sir_df invalid: {e}"))?;
 
-    let d = n_packed as f64;
+    let d = n_free as f64;
     // Cache lgamma terms that are constant across all samples.
     let log_norm =
         lgamma((nu + d) / 2.0) - lgamma(nu / 2.0) - (d / 2.0) * (nu * std::f64::consts::PI).ln();
@@ -143,15 +169,22 @@ pub fn run_sir_core(
     let mut z_vectors: Vec<Vec<f64>> = Vec::with_capacity(n_samples);
     let mut samples: Vec<Vec<f64>> = Vec::with_capacity(n_samples);
     for _ in 0..n_samples {
-        let z: Vec<f64> = (0..n_packed).map(|_| rng.sample(StandardNormal)).collect();
+        let z_free: Vec<f64> = (0..n_free).map(|_| rng.sample(StandardNormal)).collect();
         let chi2: f64 = chi2_dist.sample(&mut rng);
         let scale = (nu / chi2).sqrt();
-        let z_vec = DVector::from_column_slice(&z);
-        let delta = &proposal_chol * &z_vec * scale;
-        let x_k: Vec<f64> = x_hat.iter().zip(delta.iter()).map(|(a, b)| a + b).collect();
+        let z_vec_free = DVector::from_column_slice(&z_free);
+        let delta_free = &proposal_chol * &z_vec_free * scale;
+        // Build the full packed sample: free indices get x_hat + delta_free,
+        // fixed indices stay pinned at x_hat (so the strict bounds check
+        // `lower == upper == x_hat[i]` passes).
+        let mut x_k = x_hat.clone();
+        for (a, &i) in free_idx.iter().enumerate() {
+            x_k[i] += delta_free[a];
+        }
         samples.push(x_k);
-        // store L⁻¹(x_k − x_hat) = z * scale for the quadratic form in log_q_k
-        z_vectors.push(z.into_iter().map(|zi| zi * scale).collect());
+        // store L_free⁻¹(delta_free) = z_free * scale for the quadratic form
+        // in log_q_k. Length = n_free.
+        z_vectors.push(z_free.into_iter().map(|zi| zi * scale).collect());
     }
 
     // Step 2: Evaluate importance weights in parallel (warm-started inner loop)


### PR DESCRIPTION
## Why

`ferx_sir(fit)` on any model with at least one FIX-ed parameter failed with `"All SIR samples had invalid weights"`. Reported via a Vanco peds model (`run60.ferx` with `theta GAM_MAT(2.4, FIX)` and `theta MAT50(0.6, FIX)`).

Root cause:

1. `compute_covariance` leaves the rows/cols of FIX-ed indices at exactly zero.
2. The proposal-cov regularisation (eigenvalue floor of 1e-8) made the singular cov PD by shifting fixed diagonals to ~1e-8 — so the Cholesky now produced a ~1e-4 perturbation on FIX-ed indices for every draw.
3. `compute_bounds` pins FIX-ed indices with `lower == upper == x_hat[i]`. The strict bounds check (no tolerance) in `run_sir_core` rejected every sample → `log_weight = -inf` for all of them → `max_log_w == -inf` → the "all invalid weights" error.

The asymptotic uncertainty sampler in `uncertainty_samples.rs` already had a `clamp_fixed_indices` fix for the analogous case; SIR never got the equivalent treatment and had no regression test.

## What changed

Restrict the SIR proposal to the free subspace:

- Build a `sub_cov` from the non-FIX rows/cols of the proposal covariance and Cholesky-decompose that (rather than the singular full matrix).
- Sample `z_free` of length `n_free`, lift `delta` into the full packed vector with FIX-ed indices left at `x_hat[i]`.
- Use `d = n_free` as the Student-t dimensionality so the importance-weight quadratic form is consistent with what was actually perturbed.

For models with no FIX-ed parameters, `n_free == n_packed` and the math is identical to before — no regression for the existing happy path.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Fix is purely in `ferx-core`; the R wrapper picks it up via the existing cargo `[patch]` once rebuilt.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (bug fix — the previous behaviour was a hard error, not a numerical result)

For the no-FIX case the algorithm is identical to before (`n_free == n_packed`). The existing `run_sir_happy_path_populates_sir_fields` test still passes unchanged.

## Performance
- [x] No significant impact expected

`n_free <= n_packed`, so the per-sample cost is at most the same and typically smaller (Cholesky and Student-t evaluation now over the free block only).

## Tests
- [x] Regression test added that fails without this fix: `run_sir_succeeds_with_fixed_parameters` in `src/estimation/run_sir.rs`, using `examples/warfarin_fix.ferx` (which has FIX on a theta, an omega, and a sigma).
- [x] All 19 existing SIR tests still pass: `cargo test --lib --no-default-features --features ci sir`.

## Example
- [x] Not applicable (internal fix with no new API surface)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean for the touched files (pre-existing warnings elsewhere are unrelated)
- [x] `cargo check --tests` compiles
- [x] `Cargo.toml` version bumped if breaking — not breaking

## Docs & examples
### Example execution
- [x] No example execution step needed (internal fix / no user-visible change)

## Reviewer hints

- The key insight: the importance-weight formula has `log_norm` and `log_det_proposal` cancelling between `log_q_hat` and `log_q_k`, but `((nu + d) / 2.0) * log(1 + quad_form / nu)` does **not** cancel — so `d` matters. Using `d = n_free` (matching the dimensionality actually sampled) is the correct choice.
- The bounds check at sir.rs:204 still uses the full `bounds` (n_packed-length). That's fine: for FIX-ed indices, `x_k[i] == x_hat[i] == lower[i] == upper[i]`, and the strict comparison `x < lo || x > hi` is false on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)