### PR TITLE
fix(api): drop inline fit summary from library; CLI keeps it [closes #60]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,6 @@ use crate::estimation::outer_optimizer::optimize_population;
 use crate::estimation::parameterization::theta_packs_log;
 use crate::estimation::saem;
 use crate::io::datareader::read_nonmem_csv;
-use crate::io::output;
 use crate::pk;
 use crate::stats::likelihood::{
     compute_cwres, foce_subject_nll, foce_subject_nll_iov, split_obs_by_occasion,
@@ -1046,10 +1045,6 @@ fn fit_inner(
         #[cfg(feature = "nn")]
         neural_networks: build_neural_network_infos(model),
     };
-
-    if options.verbose {
-        output::print_results(&fit_result);
-    }
 
     if time_gradients {
         let (ad_c, ad_n, fd_c, fd_n, jac_ad_c, jac_ad_n, jac_fd_c, jac_fd_n) =

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -64,6 +64,11 @@ fn main() {
 
     match result {
         Ok((fit_result, population)) => {
+            // CLI prints the human-readable summary. The library `fit()` no longer
+            // prints it — language bindings (e.g. ferx-r's print.ferx_fit) are the
+            // single source of truth for formatted summaries (see issue #60).
+            ferx_core::io::output::print_results(&fit_result);
+
             // Derive model name from model file path
             let model_name = std::path::Path::new(model_path)
                 .file_stem()


### PR DESCRIPTION
## Why

When `ferx_fit()` runs from R, two separate summaries get printed: the inline summary from ferx-core (compact, older format), and the R wrapper's `print.ferx_fit` output (full format). They've drifted apart — the inline one is missing `[log-normal]` / `[additive]` / `[logit]` tags on OMEGA lines, the `[initial specified as SD]` annotation, the `[proportional]` / `[additive]` tag on SIGMA lines, and the `var =` display. See issue #60 for the example output.

Per the resolution in #60, the fix is structural: the Rust library — when called as a library, like from R — should not print final results. Bindings (R now, Python later) become the single source of truth for formatted summaries, eliminating the format-drift problem for good.

## What changed

- Removed the `output::print_results(&fit_result)` call from `fit()` in `src/api.rs` (and its now-unused `use crate::io::output;`).
- Added the same call to the `ferx` CLI binary in `src/bin/run_model.rs`, right at the start of the `Ok` branch, so terminal users still get the summary in the same position it appeared before.
- The `verbose` flag continues to gate the convergence trace (`Eval N: OFV=…`), stage banners, and the SIR notice — only the final summary block moves.

## Alternatives considered

Updating the inline ferx-core printer to match the R-side format was the other option mentioned in the issue. Rejected because it just postpones the problem — every new field added on either side risks drifting again. Removing one of the two outputs is the only durable fix.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r already has `print.ferx_fit`; nothing on the R side needs to change. If anything, ferx-r could drop any logic that was working around the duplicated output, but that's a follow-up, not a blocker.

## Breaking changes
- [x] None

The removed call only affected stderr output. `fit()` still returns the same `FitResult`. No public types or fields changed.

## Numerical validation
- [x] Not applicable (no estimation / numerical change — only removes a stderr side effect)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (the change is removing a stderr side effect; there were no existing tests asserting on the inline summary, and asserting on stderr from `fit()` would be brittle. CLI behaviour is unchanged — same `print_results` runs, just from `run_model.rs` instead of inside `fit()`.)

## Example (user-facing features only)
- [x] Not applicable (no new API surface — this removes duplicated output)

## Docs
- [x] No user-visible change (R users will simply stop seeing the duplicate compact summary; the R-side `print.ferx_fit` output is unchanged)

## Checklist
- [x] `cargo clippy` clean (verified `cargo check` and `cargo check --tests`)
- [x] `cargo check --features autodiff` still compiles (no AD-reachable code touched)
- [x] `Cargo.toml` version bumped if breaking (n/a — not breaking)

## Docs & examples

### ferx-site
- [x] No new DSL syntax / fit option / example / data file

### ferx-book
- [x] No estimator / DSL feature / fit option changes

### Example execution
- [x] No example execution step needed (internal change / no user-visible behavior for fit results)

## Reviewer hints

The whole diff is 10 lines across two files. The thing to confirm is that there's no other caller of `ferx_core::fit` in this repo that was relying on the auto-printed summary — I checked `ferx-r/src/rust/src/lib.rs` (calls `ferx_core::fit` directly and has its own print path) and the CLI binary (now calls `print_results` explicitly). No other callers found.

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)