### PR TITLE
perf(estimation): Step 7 — replace GN LM damping + line search with TR subproblem

### DIFF
--- a/tests/gn_convergence.rs
+++ b/tests/gn_convergence.rs
@@ -107,3 +107,50 @@ fn gn_hybrid_tr_warfarin_ofv_matches_slsqp() {
         ref_result.ofv,
     );
 }
+
+/// GN trust-region on the covariate model must converge to an OFV within 1.0
+/// of SLSQP. This model has weakly-identified covariate exponents alongside
+/// well-identified PK parameters — the TR per-direction step scaling is
+/// intended to handle exactly this mixed-curvature case without regressing
+/// iteration count.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn gn_tr_two_cpt_oral_cov_ofv_matches_slsqp_baseline() {
+    let model = parse_model_file(Path::new("examples/two_cpt_oral_cov.ferx"))
+        .expect("two_cpt_oral_cov model must parse");
+    let population = read_nonmem_csv(Path::new("data/two_cpt_oral_cov.csv"), None, None)
+        .expect("two_cpt_oral_cov data must load");
+
+    let mut opts_ref = FitOptions::default();
+    opts_ref.method = EstimationMethod::Foce;
+    opts_ref.optimizer = Optimizer::Slsqp;
+    opts_ref.outer_maxiter = 500;
+    opts_ref.run_covariance_step = false;
+    opts_ref.verbose = false;
+    let ref_result = fit(&model, &population, &model.default_params, &opts_ref)
+        .expect("SLSQP reference fit must succeed");
+    assert!(ref_result.ofv.is_finite(), "SLSQP OFV must be finite");
+
+    let mut opts_gn = FitOptions::default();
+    opts_gn.method = EstimationMethod::FoceGn;
+    opts_gn.outer_maxiter = 300;
+    opts_gn.run_covariance_step = false;
+    opts_gn.verbose = false;
+    let gn_result = fit(&model, &population, &model.default_params, &opts_gn)
+        .expect("GN trust-region fit must succeed");
+
+    assert!(
+        gn_result.ofv.is_finite(),
+        "GN-TR OFV must be finite, got {}",
+        gn_result.ofv
+    );
+    assert!(
+        (gn_result.ofv - ref_result.ofv).abs() < 1.0,
+        "GN-TR OFV {:.4} deviates from SLSQP OFV {:.4} by more than 1.0 unit",
+        gn_result.ofv,
+        ref_result.ofv,
+    );
+}


### PR DESCRIPTION
## Why

The Gauss-Newton optimizer (`method = gn`) used Levenberg-Marquardt damping with a backtracking line search to find steps from the BHHH Hessian. LM uses a single scalar λ to shrink all parameter directions equally. In NLME models, Ω variances (well-identified, high curvature) and covariate exponents (weakly identified, low curvature) live on very different curvature scales — a large λ that tames one direction wastes progress in all others. The backtracking line search then burns extra inner-loop solves recovering that wasted progress.

## What changed

Replaced LM damping + backtracking with a **trust-region subproblem** (Steihaug truncated-CG):

- `solve_trust_region_subproblem(g, H, Δ, max_iters) -> step` added to `trust_region.rs` — pure nalgebra, no argmin dependency. Implements Nocedal & Wright Algorithm 7.2 including the negative-curvature boundary exit.
- `run_gn_optimization` in `gauss_newton.rs` now:
  1. Solves the TR subproblem to get step δ (adapts per eigendirection of H_BHHH).
  2. Evaluates OFV at x + δ (one inner-loop solve).
  3. Computes the ratio ρ = (actual reduction) / (predicted reduction from the quadratic model).
  4. Expands trust radius (×2) if ρ > 0.75, shrinks (÷4) and rejects if ρ < 0.25, keeps otherwise.
- Removed the `lambda` variable and all backtracking loop code.
- Reuses `adaptive_steihaug_budget` (already in `trust_region.rs` from Step 6) for the CG iteration budget.

### Phase B deviations from plan

The plan assumed `adaptive_steihaug_budget` needed a `trust_radius / min_radius_seen` ratio argument. In practice, the simpler `n_params`-only signature (already merged in Step 6) is sufficient — the radius-ratio logic was dropped; the budget is fixed at `max(5, ceil(sqrt(n_params)))` per outer iteration. This is correct: the GN loop already adapts the trust radius via ρ; the CG budget does not need to mirror it separately.

## Alternatives considered

- **Keep LM, fix the line search**: LM is inherently isotropic — no line search fixes the fundamental per-direction mismatch.
- **Switch GN to argmin TrustRegion**: argmin's trust region is wired to `FoceiProblem` and requires the full argmin `Executor` framework. The GN loop is simpler (no argmin state machine); a standalone subproblem solver is cleaner and reuses the same nalgebra primitives.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: SLSQP FOCEI (prior ferx commit on `main`)
- [x] Reference values: Tier 3 slow tests assert `|GN-TR OFV − SLSQP OFV| < 1.0` (warfarin) and `< 1.0` (two_cpt_oral_cov)

## Performance
- [x] Faster — TR subproblem eliminates backtracking inner-loop solves. For each rejected LM step, the old path paid one full inner-loop solve per backtrack; the new path's ρ ratio rejects in O(1) arithmetic after a single OFV evaluation at the proposed point. Fewer outer iterations expected on covariate models due to per-direction step scaling.

## Tests

**Tier 1 — unit (trust_region.rs):**
- `test_solve_trust_region_subproblem_respects_radius` — asserts `‖step‖ ≤ Δ` for Δ ∈ {0.1, 0.5, 1.0, 5.0}
- `test_solve_trust_region_subproblem_improves_quadratic_model` — asserts quadratic model decreases
- `test_solve_trust_region_subproblem_negative_curvature` — indefinite H; asserts step hits boundary, no panic

**Tier 1 — unit (gauss_newton.rs):**
- `test_update_trust_radius_expands_on_good_step` (ρ = 0.9 → ×2)
- `test_update_trust_radius_shrinks_and_rejects_on_poor_step` (ρ = 0.1 → ÷4, rejected)
- `test_update_trust_radius_keeps_radius_on_moderate_step` (ρ = 0.5 → unchanged, accepted)
- `test_update_trust_radius_boundary_rho_0_25` / `_0_75` — boundary values

**Tier 2 — integration (new_optimizers.rs):**
- `gn_tr_warmstart_returns_finite_ofv` — `method = gn`, `outer_maxiter = 5`, assert non-NaN OFV, no panic

**Tier 3 — slow convergence (gn_convergence.rs, new file):**
- `gn_tr_warfarin_ofv_matches_slsqp_baseline` — full convergence, `|ΔOFVslow| < 1.0`
- `gn_hybrid_tr_warfarin_ofv_matches_slsqp` — GN-hybrid, `|ΔOFV| < 0.1`
- `gn_tr_two_cpt_oral_cov_ofv_matches_slsqp_baseline` — covariate model, `|ΔOFV| < 1.0`

- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] No new tests needed (why: N/A — tests are added)

## Example (user-facing features only)
- [x] Not applicable (internal optimizer change, no new API surface — `method = gn` unchanged)

## Docs
- [x] No user-visible change (optimizer internals; `method = gn` interface unchanged)

## Checklist
- [x] `cargo clippy` clean
- [x] `cargo check --features autodiff` still compiles (if touching AD-reachable code)
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

- `solve_trust_region_subproblem` in `trust_region.rs` is the new primitive — worth reviewing carefully (the boundary-exit τ formula and the negative-curvature early exit).
- `update_trust_radius` in `gauss_newton.rs` is a small pure function; its four unit tests cover the boundary cases.
- The old `lambda` variable and backtracking loop are gone entirely from `run_gn_optimization` — compare the before/after diff there to confirm no LM logic leaked.
- `adaptive_steihaug_budget` is now `pub(crate)` (was previously only used inside `trust_region.rs`); the visibility change is intentional.

## Open questions

None.