### PR TITLE
ci: notify on coverage job failure by opening an issue [closes #34]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,31 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      # The coverage job runs unattended (scheduled / manual dispatch) so a
+      # failure otherwise goes unnoticed until someone checks the Actions tab.
+      # Opening an issue triggers GitHub's built-in email notifications to
+      # watchers and the assignee without requiring SMTP secrets. See #34.
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Coverage job failed (${context.eventName}, run ${context.runId})`,
+              body: [
+                `The weekly \`Coverage\` job failed.`,
+                ``,
+                `- Workflow: \`${context.workflow}\``,
+                `- Event: \`${context.eventName}\``,
+                `- Commit: \`${context.sha}\``,
+                `- Run: ${runUrl}`,
+                ``,
+                `Opened automatically by \`.github/workflows/ci.yml\`.`,
+              ].join('\n'),
+              labels: ['ci-failure'],
+              assignees: ['TeunP'],
+            });


### PR DESCRIPTION
## Why
Issue #34: the weekly `Coverage` job in `.github/workflows/ci.yml` runs unattended. The companion `slow-tests` workflow surfaces failures on every main push, but the coverage job has no alerting — if it fails on its weekly run someone has to check the Actions tab manually.

## What changed
Added an `if: failure()` step at the end of the `coverage` job that uses `actions/github-script@v7` to open a labeled (`ci-failure`) GitHub issue assigned to `TeunP`, with the failing run's URL, commit SHA, and triggering event in the body. GitHub's built-in notification system emails the assignee (and any watchers), so no SMTP secrets are required.

## Alternatives considered
- **SMTP email via `dawidd6/action-send-mail`** — would deliver a "real" email but requires provisioning `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_SERVER` secrets in the repo. Higher setup cost for no observable benefit over GitHub-issue-driven email.
- **Slack webhook** — same shape, requires a `SLACK_WEBHOOK_URL` secret and assumes the team monitors a specific channel.
- **Doing nothing / relying on per-user GitHub notification settings** — was the status quo; #34 was filed precisely because that wasn't sufficient.

The issue-opening approach is one of the options listed in #34, requires no new secrets, and leaves a persistent failure record that can be triaged and closed.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (CI workflow change; the new step only runs `on: failure()` and is exercised the first time the coverage job fails. A synthetic test would require deliberately failing the job, which isn't worth wiring up.)

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no Rust code touched)
- [x] `cargo check --features autodiff` still compiles (no Rust code touched)
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site
- [x] No DSL / fit-option / example / data change

### ferx-book
- [x] No estimator / DSL / fit-option change

### Example execution
- [x] No example execution step needed (CI-only change)

## Reviewer hints
The script body is inline JS in YAML, which is awkward to review — focus on (a) the `if: failure()` gating, (b) the `assignees` value (currently `['TeunP']` — happy to change), and (c) whether `ci-failure` is the right label (the repo doesn't seem to have it yet; GitHub will create it on first issue).

## Open questions
- **Missing `schedule:` trigger.** The `coverage` job is gated on `github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`, but `ci.yml`'s `on:` block has no `schedule:` entry — so today the job only runs via manual dispatch, not the "weekly, Monday 03:00 UTC" cadence #34 describes. Worth a follow-up issue/PR; intentionally out of scope here so this change stays focused on the notification mechanism.
- **Issue assignee.** Defaulted to `TeunP` (the assignee on #34). If a different owner / team would be more appropriate, easy to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)