### PR TITLE
feat(pk): SS for 2-cpt and 3-cpt analytical PK [#74]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -652,36 +652,27 @@ fn fit_inner(
     accumulated_warnings.extend(nlopt_missing.iter().cloned());
 
     // Steady-state (SS=1) coverage warning. SS is supported via closed-form
-    // for 1-cpt analytical models without time-varying covariates; other
-    // paths (2-/3-cpt analytical, ODE-based, and any subject with TV
-    // covariates routed through the event-driven path) silently treat SS
-    // doses as single doses. Warn so users know predictions are biased on
-    // those paths.
+    // for 1-cpt, 2-cpt, and 3-cpt analytical models without time-varying
+    // covariates. ODE-based models and any subject with TV covariates
+    // (routed through the event-driven path) silently treat SS doses as
+    // single doses. Warn so users know predictions are biased on those
+    // paths.
     let n_ss_subjects = population
         .subjects
         .iter()
         .filter(|s| s.has_ss_doses())
         .count();
     if n_ss_subjects > 0 {
-        let one_cpt_analytical = !model.is_ode_based()
-            && matches!(
-                model.pk_model,
-                crate::types::PkModel::OneCptIvBolus
-                    | crate::types::PkModel::OneCptOral
-                    | crate::types::PkModel::OneCptInfusion
-            );
         let n_ss_with_tv = population
             .subjects
             .iter()
             .filter(|s| s.has_ss_doses() && s.has_tv_covariates())
             .count();
-        if !one_cpt_analytical {
+        if model.is_ode_based() {
             accumulated_warnings.push(format!(
-                "{} subject(s) have steady-state (SS=1) doses but the model uses \
-                 a path that does not yet implement SS (2-/3-cpt analytical, \
-                 ODE, or event-driven). SS doses are treated as single doses on \
-                 these paths — predictions for these subjects are biased. \
-                 Tracked in issue #74.",
+                "{} subject(s) have steady-state (SS=1) doses but the model is \
+                 ODE-based. The ODE prediction path does not yet implement SS — \
+                 predictions for these subjects are biased. Tracked in issue #74.",
                 n_ss_subjects
             ));
         } else if n_ss_with_tv > 0 {

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -144,10 +144,12 @@ pub fn predict_concentration(
 
 /// Concentration contribution from a single dose at elapsed time tau.
 ///
-/// When `dose.ss` is true and a steady-state closed form is available
-/// (currently 1-cpt only), the SS variant is used. For models without an
-/// SS closed form, SS doses fall back to the single-dose response — see
-/// the warning emitted from `api.rs` when this happens.
+/// When `dose.ss` is true and `dose.ii > 0`, the SS closed-form variant
+/// is dispatched for every analytical PK model (1-/2-/3-cpt IV bolus,
+/// oral, and infusion). The malformed SS configurations that the
+/// closed forms don't handle — `ii <= 0` and `T_inf > ii` for infusion —
+/// fall through to the single-dose formula and are flagged by the
+/// data-validation warning in `api.rs`.
 fn single_dose_concentration(pk_model: PkModel, dose: &DoseEvent, tau: f64, p: &PkParams) -> f64 {
     let cl = p.cl();
     let v = p.v();

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -157,9 +157,35 @@ fn single_dose_concentration(pk_model: PkModel, dose: &DoseEvent, tau: f64, p: &
             PkModel::OneCptIvBolus => return one_cpt_iv_bolus_ss(dose, tau, cl, v),
             PkModel::OneCptInfusion => return one_cpt_infusion_ss(dose, tau, cl, v),
             PkModel::OneCptOral => return one_cpt_oral_f_ss(dose, tau, cl, v, p.ka(), p.f_bio()),
-            // 2-cpt / 3-cpt SS not yet implemented — fall through to the
-            // single-dose formula. `api.rs` emits a warning for these.
-            _ => {}
+            PkModel::TwoCptIvBolus => {
+                return two_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2());
+            }
+            PkModel::TwoCptInfusion => {
+                return two_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2());
+            }
+            PkModel::TwoCptOral => {
+                return two_cpt_oral_f_ss(dose, tau, cl, v, p.q(), p.v2(), p.ka(), p.f_bio());
+            }
+            PkModel::ThreeCptIvBolus => {
+                return three_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3());
+            }
+            PkModel::ThreeCptInfusion => {
+                return three_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3());
+            }
+            PkModel::ThreeCptOral => {
+                return three_cpt_oral_f_ss(
+                    dose,
+                    tau,
+                    cl,
+                    v,
+                    p.q(),
+                    p.v2(),
+                    p.q3(),
+                    p.v3(),
+                    p.ka(),
+                    p.f_bio(),
+                );
+            }
         }
     }
 

--- a/src/pk/three_compartment.rs
+++ b/src/pk/three_compartment.rs
@@ -727,6 +727,45 @@ mod tests {
     }
 
     #[test]
+    fn test_ss_oral_lhopital_ka_near_beta_matches_numerical_sum() {
+        // The L'Hopital branch in `bateman_ss` activates per-eigenvalue —
+        // verify the β branch independently of α (Copilot review on #77).
+        let (_, beta, _, _, _) = macro_rates_three_cpt(CL, V1, Q2, V2, Q3, V3);
+        let ka = beta;
+        let ii: f64 = 24.0;
+        let dose = ss_bolus_dose(100.0, ii);
+        let single = bolus_dose(100.0);
+        for &t in &[0.5, 2.0, 12.0, 23.0] {
+            let cf = three_cpt_oral_ss(&dose, t, CL, V1, Q2, V2, Q3, V3, ka);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_oral(&single, tt, CL, V1, Q2, V2, Q3, V3, ka)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-5, max_relative = 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_lhopital_ka_near_gamma_matches_numerical_sum() {
+        // γ-branch coverage (Copilot review on #77). γ is the slowest
+        // disposition rate; with ka = γ the SS series tail is widest, so
+        // the numerical-sum oracle uses more terms via the default N=400.
+        let (_, _, gamma, _, _) = macro_rates_three_cpt(CL, V1, Q2, V2, Q3, V3);
+        let ka = gamma;
+        let ii: f64 = 24.0;
+        let dose = ss_bolus_dose(100.0, ii);
+        let single = bolus_dose(100.0);
+        for &t in &[0.5, 2.0, 12.0, 23.0] {
+            let cf = three_cpt_oral_ss(&dose, t, CL, V1, Q2, V2, Q3, V3, ka);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_oral(&single, tt, CL, V1, Q2, V2, Q3, V3, ka)
+            });
+            // γ-branch: looser tolerance because the slow-tail truncation
+            // in the 400-term numerical sum is the dominant residual.
+            assert_relative_eq!(cf, num, epsilon = 1e-4, max_relative = 1e-4);
+        }
+    }
+
+    #[test]
     fn test_ss_infusion_during_matches_numerical_sum() {
         let ii: f64 = 24.0;
         let rate = 50.0; // amt=100, duration=2

--- a/src/pk/three_compartment.rs
+++ b/src/pk/three_compartment.rs
@@ -207,6 +207,217 @@ pub fn three_cpt_oral(
     three_cpt_oral_f(dose, t, cl, v1, q2, v2, q3, v3, ka, 1.0)
 }
 
+// --- Steady-state (SS=1) variants ---
+//
+// Same geometric-series pattern as 1-/2-cpt: each exponential A·exp(-λ·t) gets
+// scaled by 1/(1 - exp(-λ·II)). For oral, the per-eigenvalue Bateman function
+// is summed in closed form, including a L'Hopital limit when ka ≈ λ.
+
+#[inline]
+fn ss_coeff_3(lambda: f64, ii: f64) -> f64 {
+    let denom = 1.0 - (-lambda * ii).exp();
+    if denom > 0.0 {
+        1.0 / denom
+    } else {
+        0.0
+    }
+}
+
+/// Three-compartment IV bolus at steady state.
+pub fn three_cpt_iv_bolus_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q2: f64,
+    v2: f64,
+    q3: f64,
+    v3: f64,
+) -> f64 {
+    if t < 0.0
+        || v1 <= 0.0
+        || v2 <= 0.0
+        || v3 <= 0.0
+        || cl <= 0.0
+        || q2 < 0.0
+        || q3 < 0.0
+        || dose.ii <= 0.0
+    {
+        return 0.0;
+    }
+    let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt(cl, v1, q2, v2, q3, v3);
+    let ab = alpha - beta;
+    let ag = alpha - gamma;
+    let bg = beta - gamma;
+    if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let d = dose.amt / v1;
+    let a = d * (alpha - k21) * (alpha - k31) / (ab * ag);
+    let b = d * (beta - k21) * (beta - k31) / (-ab * bg);
+    let g = d * (gamma - k21) * (gamma - k31) / (ag * bg);
+    a * (-alpha * t).exp() * ss_coeff_3(alpha, ii)
+        + b * (-beta * t).exp() * ss_coeff_3(beta, ii)
+        + g * (-gamma * t).exp() * ss_coeff_3(gamma, ii)
+}
+
+/// Three-compartment infusion at steady state.
+///
+/// Closed form requires `T_inf ≤ II` (non-overlapping infusions); returns 0.0
+/// otherwise (api.rs warns).
+pub fn three_cpt_infusion_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q2: f64,
+    v2: f64,
+    q3: f64,
+    v3: f64,
+) -> f64 {
+    if t < 0.0
+        || v1 <= 0.0
+        || v2 <= 0.0
+        || v3 <= 0.0
+        || cl <= 0.0
+        || q2 < 0.0
+        || q3 < 0.0
+        || dose.ii <= 0.0
+    {
+        return 0.0;
+    }
+    let dur = dose.duration;
+    if dur <= 0.0 {
+        return three_cpt_iv_bolus_ss(dose, t, cl, v1, q2, v2, q3, v3);
+    }
+    if dur > dose.ii {
+        return 0.0;
+    }
+    let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt(cl, v1, q2, v2, q3, v3);
+    let ab = alpha - beta;
+    let ag = alpha - gamma;
+    let bg = beta - gamma;
+    if ab.abs() < 1e-12
+        || ag.abs() < 1e-12
+        || bg.abs() < 1e-12
+        || alpha.abs() < 1e-12
+        || beta.abs() < 1e-12
+        || gamma.abs() < 1e-12
+    {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let rate = dose.rate;
+    let rv = rate / v1;
+    let a_coeff = rv * (alpha - k21) * (alpha - k31) / (ab * ag * alpha);
+    let b_coeff = rv * (beta - k21) * (beta - k31) / (-ab * bg * beta);
+    let g_coeff = rv * (gamma - k21) * (gamma - k31) / (ag * bg * gamma);
+
+    // Helper: contribution from past pulses (n ≥ 1) for one eigenvalue —
+    // always "after-infusion" because τ + n·II ≥ II ≥ T_inf.
+    let past = |coeff: f64, lambda: f64| -> f64 {
+        coeff
+            * (1.0 - (-lambda * dur).exp())
+            * (-lambda * (t - dur)).exp()
+            * (-lambda * ii).exp()
+            * ss_coeff_3(lambda, ii)
+    };
+
+    if t <= dur {
+        // n=0 is during the current infusion.
+        a_coeff * (1.0 - (-alpha * t).exp())
+            + b_coeff * (1.0 - (-beta * t).exp())
+            + g_coeff * (1.0 - (-gamma * t).exp())
+            + past(a_coeff, alpha)
+            + past(b_coeff, beta)
+            + past(g_coeff, gamma)
+    } else {
+        // All pulses are "after-infusion" — fold n=0 in by replacing the
+        // tail's (n ≥ 1) sum with (n ≥ 0).
+        let dt = t - dur;
+        a_coeff * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp() * ss_coeff_3(alpha, ii)
+            + b_coeff * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp() * ss_coeff_3(beta, ii)
+            + g_coeff * (1.0 - (-gamma * dur).exp()) * (-gamma * dt).exp() * ss_coeff_3(gamma, ii)
+    }
+}
+
+/// Three-compartment oral absorption at steady state (with bioavailability).
+pub fn three_cpt_oral_f_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q2: f64,
+    v2: f64,
+    q3: f64,
+    v3: f64,
+    ka: f64,
+    f_bio: f64,
+) -> f64 {
+    if t < 0.0
+        || v1 <= 0.0
+        || v2 <= 0.0
+        || v3 <= 0.0
+        || cl <= 0.0
+        || q2 < 0.0
+        || q3 < 0.0
+        || ka <= 0.0
+        || dose.ii <= 0.0
+    {
+        return 0.0;
+    }
+    let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt(cl, v1, q2, v2, q3, v3);
+    let ab = alpha - beta;
+    let ag = alpha - gamma;
+    let bg = beta - gamma;
+    if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let coeff = f_bio * dose.amt * ka / v1;
+    let a = (alpha - k21) * (alpha - k31) / (ab * ag);
+    let b = (beta - k21) * (beta - k31) / (-ab * bg);
+    let c = (gamma - k21) * (gamma - k31) / (ag * bg);
+
+    // SS bateman per eigenvalue λ:
+    //   Σ_n [exp(-λ·(τ + n·II)) - exp(-ka·(τ + n·II))] / (ka - λ)
+    //     = [exp(-λ·τ)/(1-exp(-λ·II)) - exp(-ka·τ)/(1-exp(-ka·II))] / (ka - λ)
+    // L'Hopital limit when ka ≈ λ:
+    //   Σ_n (τ + n·II) · exp(-λ·(τ + n·II))
+    //     = exp(-λ·τ) · [τ/(1-x) + II·x/(1-x)²]  with x = exp(-λ·ii).
+    let bateman_ss = |lambda: f64| -> f64 {
+        if (ka - lambda).abs() < 1e-6 {
+            let x = (-lambda * ii).exp();
+            let one_minus_x = 1.0 - x;
+            if one_minus_x <= 0.0 {
+                return 0.0;
+            }
+            (-lambda * t).exp() * (t / one_minus_x + ii * x / (one_minus_x * one_minus_x))
+        } else {
+            ((-lambda * t).exp() * ss_coeff_3(lambda, ii) - (-ka * t).exp() * ss_coeff_3(ka, ii))
+                / (ka - lambda)
+        }
+    };
+
+    coeff * (a * bateman_ss(alpha) + b * bateman_ss(beta) + c * bateman_ss(gamma))
+}
+
+/// Three-compartment oral absorption at steady state (F = 1).
+pub fn three_cpt_oral_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q2: f64,
+    v2: f64,
+    q3: f64,
+    v3: f64,
+    ka: f64,
+) -> f64 {
+    three_cpt_oral_f_ss(dose, t, cl, v1, q2, v2, q3, v3, ka, 1.0)
+}
+
 /// Predict concentration from a single dose at elapsed time t using 3-cmt model.
 pub fn three_cpt_predict(
     dose: &DoseEvent,
@@ -450,5 +661,124 @@ mod tests {
         let direct = three_cpt_infusion(&dose, 2.0, CL, V1, Q2, V2, Q3, V3);
         let via_predict = three_cpt_predict(&dose, 2.0, CL, V1, Q2, V2, Q3, V3, None, None);
         assert_relative_eq!(direct, via_predict, epsilon = 1e-12);
+    }
+
+    // --- Steady-state variants ---
+    //
+    // 3-cpt SS adds a third eigenvalue γ. The slowest tail (γ ≈ 0.035 for the
+    // default test PK params) takes the most numerical-sum terms to converge,
+    // so N=400 keeps the truncation tail below the test tolerances.
+
+    fn ss_bolus_dose(amt: f64, ii: f64) -> DoseEvent {
+        DoseEvent::new(0.0, amt, 1, 0.0, true, ii)
+    }
+
+    fn ss_infusion_dose(amt: f64, rate: f64, ii: f64) -> DoseEvent {
+        DoseEvent::new(0.0, amt, 1, rate, true, ii)
+    }
+
+    fn ss_numerical_sum<F: Fn(f64) -> f64>(t: f64, ii: f64, c_single: F) -> f64 {
+        const N: usize = 400;
+        (0..N).map(|n| c_single(t + (n as f64) * ii)).sum()
+    }
+
+    #[test]
+    fn test_ss_iv_bolus_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let dose = ss_bolus_dose(100.0, ii);
+        let single = bolus_dose(100.0);
+        for &t in &[0.0, 0.5, 3.0, 10.0, 23.9, 24.0, 48.0] {
+            let cf = three_cpt_iv_bolus_ss(&dose, t, CL, V1, Q2, V2, Q3, V3);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_iv_bolus(&single, tt, CL, V1, Q2, V2, Q3, V3)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-7, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let dose = ss_bolus_dose(100.0, ii);
+        let single = bolus_dose(100.0);
+        for &t in &[0.0, 0.5, 2.0, 5.0, 12.0, 23.0, 48.0] {
+            let cf = three_cpt_oral_ss(&dose, t, CL, V1, Q2, V2, Q3, V3, KA);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_oral(&single, tt, CL, V1, Q2, V2, Q3, V3, KA)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-6, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_lhopital_ka_near_alpha_matches_numerical_sum() {
+        let (alpha, _, _, _, _) = macro_rates_three_cpt(CL, V1, Q2, V2, Q3, V3);
+        let ka = alpha;
+        let ii: f64 = 24.0;
+        let dose = ss_bolus_dose(100.0, ii);
+        let single = bolus_dose(100.0);
+        for &t in &[0.5, 2.0, 5.0, 12.0, 23.0] {
+            let cf = three_cpt_oral_ss(&dose, t, CL, V1, Q2, V2, Q3, V3, ka);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_oral(&single, tt, CL, V1, Q2, V2, Q3, V3, ka)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-5, max_relative = 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_during_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let rate = 50.0; // amt=100, duration=2
+        let dose = ss_infusion_dose(100.0, rate, ii);
+        let single = infusion_dose(100.0, rate);
+        for &t in &[0.0, 0.5, 1.0, 1.9, 2.0] {
+            let cf = three_cpt_infusion_ss(&dose, t, CL, V1, Q2, V2, Q3, V3);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_infusion(&single, tt, CL, V1, Q2, V2, Q3, V3)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-6, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_after_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let rate = 50.0; // dur=2
+        let dose = ss_infusion_dose(100.0, rate, ii);
+        let single = infusion_dose(100.0, rate);
+        for &t in &[2.001, 5.0, 12.0, 23.5, 48.0] {
+            let cf = three_cpt_infusion_ss(&dose, t, CL, V1, Q2, V2, Q3, V3);
+            let num = ss_numerical_sum(t, ii, |tt| {
+                three_cpt_infusion(&single, tt, CL, V1, Q2, V2, Q3, V3)
+            });
+            assert_relative_eq!(cf, num, epsilon = 1e-6, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_continuity_at_end_of_infusion() {
+        let dose = ss_infusion_dose(100.0, 50.0, 24.0); // dur=2
+        let c_at = three_cpt_infusion_ss(&dose, 2.0, CL, V1, Q2, V2, Q3, V3);
+        let c_after = three_cpt_infusion_ss(&dose, 2.0 + 1e-10, CL, V1, Q2, V2, Q3, V3);
+        assert_relative_eq!(c_at, c_after, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn test_ss_infusion_with_t_inf_gt_ii_returns_zero() {
+        // amt=100, rate=200 → duration=0.5; ii=0.25 → t_inf > ii.
+        let dose = DoseEvent::new(0.0, 100.0, 1, 200.0, true, 0.25);
+        assert_eq!(
+            three_cpt_infusion_ss(&dose, 0.1, CL, V1, Q2, V2, Q3, V3),
+            0.0
+        );
+    }
+
+    #[test]
+    fn test_ss_oral_with_bioavailability_scales() {
+        let dose = ss_bolus_dose(100.0, 24.0);
+        let c_full = three_cpt_oral_f_ss(&dose, 4.0, CL, V1, Q2, V2, Q3, V3, KA, 1.0);
+        let c_half = three_cpt_oral_f_ss(&dose, 4.0, CL, V1, Q2, V2, Q3, V3, KA, 0.5);
+        assert_relative_eq!(c_half / c_full, 0.5, epsilon = 1e-10);
     }
 }

--- a/src/pk/two_compartment.rs
+++ b/src/pk/two_compartment.rs
@@ -167,7 +167,7 @@ fn ss_coeff(lambda: f64, ii: f64) -> f64 {
 
 /// Two-compartment IV bolus at steady state.
 pub fn two_cpt_iv_bolus_ss(dose: &DoseEvent, t: f64, cl: f64, v1: f64, q: f64, v2: f64) -> f64 {
-    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || dose.ii <= 0.0 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || v2 <= 0.0 || q < 0.0 || dose.ii <= 0.0 {
         return 0.0;
     }
     let (alpha, beta, k21) = macro_rates(cl, v1, q, v2);
@@ -186,7 +186,7 @@ pub fn two_cpt_iv_bolus_ss(dose: &DoseEvent, t: f64, cl: f64, v1: f64, q: f64, v
 /// Closed form requires `T_inf ≤ II` (non-overlapping infusions); returns 0.0
 /// otherwise. The `api.rs` warning catches this case for users.
 pub fn two_cpt_infusion_ss(dose: &DoseEvent, t: f64, cl: f64, v1: f64, q: f64, v2: f64) -> f64 {
-    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || dose.ii <= 0.0 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || v2 <= 0.0 || q < 0.0 || dose.ii <= 0.0 {
         return 0.0;
     }
     let dur = dose.duration;
@@ -242,7 +242,7 @@ pub fn two_cpt_oral_f_ss(
     ka: f64,
     f_bio: f64,
 ) -> f64 {
-    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || ka <= 0.0 || dose.ii <= 0.0 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || ka <= 0.0 || v2 <= 0.0 || q < 0.0 || dose.ii <= 0.0 {
         return 0.0;
     }
     let (alpha, beta, k21) = macro_rates(cl, v1, q, v2);

--- a/src/pk/two_compartment.rs
+++ b/src/pk/two_compartment.rs
@@ -145,6 +145,160 @@ pub fn two_cpt_predict(
     }
 }
 
+// --- Steady-state (SS=1) variants ---
+//
+// For every exponential A·exp(-λ·t) in the single-dose response, the
+// geometric-series sum Σ_{n=0}^∞ A·exp(-λ·(τ + n·II)) closed form is
+// A·exp(-λ·τ) / (1 - exp(-λ·II)). The 2-cpt formulas just apply this
+// substitution per eigenvalue (α, β, and ka for oral).
+
+/// Helper: SS coefficient `1 / (1 - exp(-λ·ii))`. Returns 0 when the
+/// denominator collapses (λ·ii ≤ 0 — should already be guarded out by
+/// callers' `ii > 0` and `λ > 0` checks).
+#[inline]
+fn ss_coeff(lambda: f64, ii: f64) -> f64 {
+    let denom = 1.0 - (-lambda * ii).exp();
+    if denom > 0.0 {
+        1.0 / denom
+    } else {
+        0.0
+    }
+}
+
+/// Two-compartment IV bolus at steady state.
+pub fn two_cpt_iv_bolus_ss(dose: &DoseEvent, t: f64, cl: f64, v1: f64, q: f64, v2: f64) -> f64 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || dose.ii <= 0.0 {
+        return 0.0;
+    }
+    let (alpha, beta, k21) = macro_rates(cl, v1, q, v2);
+    let diff = alpha - beta;
+    if diff.abs() < 1e-12 {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let a = (dose.amt / v1) * (alpha - k21) / diff;
+    let b = (dose.amt / v1) * (k21 - beta) / diff;
+    a * (-alpha * t).exp() * ss_coeff(alpha, ii) + b * (-beta * t).exp() * ss_coeff(beta, ii)
+}
+
+/// Two-compartment infusion at steady state.
+///
+/// Closed form requires `T_inf ≤ II` (non-overlapping infusions); returns 0.0
+/// otherwise. The `api.rs` warning catches this case for users.
+pub fn two_cpt_infusion_ss(dose: &DoseEvent, t: f64, cl: f64, v1: f64, q: f64, v2: f64) -> f64 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || dose.ii <= 0.0 {
+        return 0.0;
+    }
+    let dur = dose.duration;
+    if dur <= 0.0 {
+        return two_cpt_iv_bolus_ss(dose, t, cl, v1, q, v2);
+    }
+    if dur > dose.ii {
+        return 0.0;
+    }
+    let (alpha, beta, k21) = macro_rates(cl, v1, q, v2);
+    let diff = alpha - beta;
+    if diff.abs() < 1e-12 || alpha.abs() < 1e-12 || beta.abs() < 1e-12 {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let rate = dose.rate;
+    let a_coeff = (rate / v1) * (alpha - k21) / (diff * alpha);
+    let b_coeff = (rate / v1) * (k21 - beta) / (diff * beta);
+
+    // Past-pulses contribution (n ≥ 1): always "after-infusion".
+    let exp_neg_a_ii = (-alpha * ii).exp();
+    let exp_neg_b_ii = (-beta * ii).exp();
+    let past_a = a_coeff
+        * (1.0 - (-alpha * dur).exp())
+        * (-alpha * (t - dur)).exp()
+        * exp_neg_a_ii
+        * ss_coeff(alpha, ii);
+    let past_b = b_coeff
+        * (1.0 - (-beta * dur).exp())
+        * (-beta * (t - dur)).exp()
+        * exp_neg_b_ii
+        * ss_coeff(beta, ii);
+    if t <= dur {
+        // Current pulse is during infusion.
+        a_coeff * (1.0 - (-alpha * t).exp()) + b_coeff * (1.0 - (-beta * t).exp()) + past_a + past_b
+    } else {
+        // Current pulse is after — all pulses are "after"; combine with the
+        // past-pulses tail by replacing the (n ≥ 1) sum with (n ≥ 0).
+        let dt = t - dur;
+        a_coeff * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp() * ss_coeff(alpha, ii)
+            + b_coeff * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp() * ss_coeff(beta, ii)
+    }
+}
+
+/// Two-compartment oral absorption at steady state (with bioavailability).
+pub fn two_cpt_oral_f_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q: f64,
+    v2: f64,
+    ka: f64,
+    f_bio: f64,
+) -> f64 {
+    if t < 0.0 || v1 <= 0.0 || cl <= 0.0 || ka <= 0.0 || dose.ii <= 0.0 {
+        return 0.0;
+    }
+    let (alpha, beta, k21) = macro_rates(cl, v1, q, v2);
+    let diff = alpha - beta;
+    if diff.abs() < 1e-12 {
+        return 0.0;
+    }
+    let ii = dose.ii;
+    let d = f_bio * dose.amt * ka / v1;
+
+    // Standard 2-cpt oral with per-eigenvalue SS geometric-series factor.
+    // L'Hopital limits apply when ka ≈ α or ka ≈ β; the SS sum of
+    // (τ + n·II)·exp(-λ·(τ + n·II)) closed form is
+    //   exp(-λ·τ) · [τ/(1-x) + II·x/(1-x)²]  with x = exp(-λ·ii).
+    fn lhopital_ss_sum(tau: f64, lambda: f64, ii: f64) -> f64 {
+        let x = (-lambda * ii).exp();
+        let one_minus_x = 1.0 - x;
+        if one_minus_x <= 0.0 {
+            return 0.0;
+        }
+        (-lambda * tau).exp() * (tau / one_minus_x + ii * x / (one_minus_x * one_minus_x))
+    }
+
+    let p = if (ka - alpha).abs() < 1e-6 {
+        d * (alpha - k21) / diff * lhopital_ss_sum(t, alpha, ii)
+    } else {
+        d * (k21 - alpha) / ((ka - alpha) * (beta - alpha))
+            * (-alpha * t).exp()
+            * ss_coeff(alpha, ii)
+    };
+    let q_val = if (ka - beta).abs() < 1e-6 {
+        d * (k21 - beta) / diff * lhopital_ss_sum(t, beta, ii)
+    } else {
+        d * (k21 - beta) / ((ka - beta) * (alpha - beta)) * (-beta * t).exp() * ss_coeff(beta, ii)
+    };
+    let r = if (ka - alpha).abs() < 1e-6 || (ka - beta).abs() < 1e-6 {
+        0.0
+    } else {
+        d * (k21 - ka) / ((alpha - ka) * (beta - ka)) * (-ka * t).exp() * ss_coeff(ka, ii)
+    };
+    p + q_val + r
+}
+
+/// Two-compartment oral absorption at steady state (F = 1).
+pub fn two_cpt_oral_ss(
+    dose: &DoseEvent,
+    t: f64,
+    cl: f64,
+    v1: f64,
+    q: f64,
+    v2: f64,
+    ka: f64,
+) -> f64 {
+    two_cpt_oral_f_ss(dose, t, cl, v1, q, v2, ka, 1.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,5 +452,127 @@ mod tests {
         let direct = two_cpt_infusion(&dose, 2.0, CL, V1, Q, V2);
         let via_predict = two_cpt_predict(&dose, 2.0, CL, V1, Q, V2, None, None);
         assert_relative_eq!(direct, via_predict, epsilon = 1e-12);
+    }
+
+    // --- Steady-state variants ---
+    //
+    // Each 2-cpt SS closed form is verified against a 300-term numerical sum
+    // of the single-dose response shifted by n·II. 300 (vs. 200 used for the
+    // 1-cpt suite) gives margin for the slower β eigenvalue tail.
+
+    fn ss_bolus_dose(amt: f64, ii: f64) -> DoseEvent {
+        DoseEvent::new(0.0, amt, 1, 0.0, true, ii)
+    }
+
+    fn ss_infusion_dose(amt: f64, rate: f64, ii: f64) -> DoseEvent {
+        DoseEvent::new(0.0, amt, 1, rate, true, ii)
+    }
+
+    fn ss_numerical_sum<F: Fn(f64) -> f64>(t: f64, ii: f64, c_single: F) -> f64 {
+        const N: usize = 300;
+        (0..N).map(|n| c_single(t + (n as f64) * ii)).sum()
+    }
+
+    #[test]
+    fn test_ss_iv_bolus_matches_numerical_sum() {
+        let ii: f64 = 12.0;
+        let dose = ss_bolus_dose(1000.0, ii);
+        let single = bolus_dose(1000.0);
+        for &t in &[0.0, 0.5, 3.0, 8.0, 11.9, 12.0, 24.0, 48.0] {
+            let cf = two_cpt_iv_bolus_ss(&dose, t, CL, V1, Q, V2);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_iv_bolus(&single, tt, CL, V1, Q, V2));
+            assert_relative_eq!(cf, num, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let ka = 1.0;
+        let dose = ss_bolus_dose(500.0, ii);
+        let single = bolus_dose(500.0);
+        for &t in &[0.0, 0.5, 2.0, 5.0, 12.0, 23.0, 48.0] {
+            let cf = two_cpt_oral_ss(&dose, t, CL, V1, Q, V2, ka);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_oral(&single, tt, CL, V1, Q, V2, ka));
+            assert_relative_eq!(cf, num, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_lhopital_ka_near_alpha_matches_numerical_sum() {
+        // Pick ka exactly equal to α to trigger the L'Hopital branch.
+        let ii: f64 = 24.0;
+        let (alpha, _, _) = macro_rates(CL, V1, Q, V2);
+        let ka = alpha;
+        let dose = ss_bolus_dose(500.0, ii);
+        let single = bolus_dose(500.0);
+        for &t in &[0.5, 2.0, 5.0, 12.0, 23.0] {
+            let cf = two_cpt_oral_ss(&dose, t, CL, V1, Q, V2, ka);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_oral(&single, tt, CL, V1, Q, V2, ka));
+            assert_relative_eq!(cf, num, epsilon = 1e-6, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_oral_lhopital_ka_near_beta_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let (_, beta, _) = macro_rates(CL, V1, Q, V2);
+        let ka = beta;
+        let dose = ss_bolus_dose(500.0, ii);
+        let single = bolus_dose(500.0);
+        for &t in &[0.5, 2.0, 12.0, 23.0] {
+            let cf = two_cpt_oral_ss(&dose, t, CL, V1, Q, V2, ka);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_oral(&single, tt, CL, V1, Q, V2, ka));
+            assert_relative_eq!(cf, num, epsilon = 1e-6, max_relative = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_during_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let rate = 100.0; // dur=10
+        let dose = ss_infusion_dose(1000.0, rate, ii);
+        let single = infusion_dose(1000.0, rate);
+        for &t in &[0.0, 1.0, 5.0, 9.0, 10.0] {
+            let cf = two_cpt_infusion_ss(&dose, t, CL, V1, Q, V2);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_infusion(&single, tt, CL, V1, Q, V2));
+            assert_relative_eq!(cf, num, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_after_matches_numerical_sum() {
+        let ii: f64 = 24.0;
+        let rate = 100.0; // dur=10
+        let dose = ss_infusion_dose(1000.0, rate, ii);
+        let single = infusion_dose(1000.0, rate);
+        for &t in &[10.001, 15.0, 23.5, 48.0, 72.0] {
+            let cf = two_cpt_infusion_ss(&dose, t, CL, V1, Q, V2);
+            let num = ss_numerical_sum(t, ii, |tt| two_cpt_infusion(&single, tt, CL, V1, Q, V2));
+            assert_relative_eq!(cf, num, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
+
+    #[test]
+    fn test_ss_infusion_continuity_at_end_of_infusion() {
+        let dose = ss_infusion_dose(1000.0, 100.0, 24.0);
+        let c_at = two_cpt_infusion_ss(&dose, 10.0, CL, V1, Q, V2);
+        let c_after = two_cpt_infusion_ss(&dose, 10.0 + 1e-10, CL, V1, Q, V2);
+        assert_relative_eq!(c_at, c_after, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn test_ss_infusion_with_t_inf_gt_ii_returns_zero() {
+        // amt=1000, rate=500 → duration=2; ii=1 → t_inf > ii.
+        let dose = DoseEvent::new(0.0, 1000.0, 1, 500.0, true, 1.0);
+        assert_eq!(two_cpt_infusion_ss(&dose, 0.5, CL, V1, Q, V2), 0.0);
+    }
+
+    #[test]
+    fn test_ss_oral_with_bioavailability_scales() {
+        let dose = ss_bolus_dose(500.0, 24.0);
+        let c_full = two_cpt_oral_f_ss(&dose, 4.0, CL, V1, Q, V2, 1.0, 1.0);
+        let c_half = two_cpt_oral_f_ss(&dose, 4.0, CL, V1, Q, V2, 1.0, 0.5);
+        assert_relative_eq!(c_half / c_full, 0.5, epsilon = 1e-10);
     }
 }


### PR DESCRIPTION
**Stacked on #75** — merge that one first, then this one's base auto-updates to `main`.

## Why

PR #75 implemented SS for 1-cpt analytical to validate the geometric-series closed forms. This PR extends the same pattern to 2-cpt and 3-cpt analytical (the remaining acceptance bullet of #74 for the analytical paths). 2-cpt models are very common in real-world PK (e.g. most monoclonals); 3-cpt less so but the implementation cost is small once the per-eigenvalue pattern is in place.

## What changed

- **`src/pk/two_compartment.rs`** — `two_cpt_iv_bolus_ss`, `two_cpt_infusion_ss`, `two_cpt_oral_f_ss` / `two_cpt_oral_ss`. Helper `ss_coeff(λ, ii) = 1/(1-exp(-λ·ii))` factors out the per-eigenvalue geometric-series factor.
- **`src/pk/three_compartment.rs`** — same shape with one more eigenvalue (γ). The oral SS Bateman closure captures `ka` and `ii` and is dispatched per eigenvalue.
- **`src/pk/mod.rs`** — `single_dose_concentration` now dispatches all 9 PK model variants when `dose.ss && dose.ii > 0`. The match becomes exhaustive (no more `_ => {}` fall-through).
- **`src/api.rs`** — warning narrows further: only fires when (a) the model is ODE-based with SS doses, or (b) any SS subject has TV covariates (event-driven path, still unimplemented).

## Numerical validation

- All 552 lib tests pass.
- 17 new SS tests added (9 for 2-cpt, 8 for 3-cpt). Closed forms verified against numerical pulse sums (300 terms for 2-cpt, 400 for 3-cpt to cover the slower γ tail) at tolerances 1e-5 to 1e-7.
- L'Hopital cases for `ka ≈ α` and `ka ≈ β` (2-cpt + 3-cpt) explicitly tested; agreement with numerical sum to 1e-5.
- Continuity at the infusion endpoint (`t = T_inf`) tested.
- Bioavailability scaling property (F=0.5 → C/2) tested.

## Breaking changes
- [x] None

## Performance
- [x] No significant impact expected — same dispatch overhead as PR #75 (one boolean + ii check before each `match`), gated on `dose.ss && dose.ii > 0`. Per-pulse work increases marginally for 2-/3-cpt because each eigenvalue's amplitude now goes through one extra divide. Negligible at fit-loop scale.

## Tests
- [x] Unit tests added in the same modules
- [x] All 552 lib tests pass via `cargo test --lib --no-default-features --features ci`

New tests in `src/pk/two_compartment.rs`:
- `test_ss_iv_bolus_matches_numerical_sum`
- `test_ss_oral_matches_numerical_sum`
- `test_ss_oral_lhopital_ka_near_alpha_matches_numerical_sum`
- `test_ss_oral_lhopital_ka_near_beta_matches_numerical_sum`
- `test_ss_infusion_during_matches_numerical_sum`
- `test_ss_infusion_after_matches_numerical_sum`
- `test_ss_infusion_continuity_at_end_of_infusion`
- `test_ss_infusion_with_t_inf_gt_ii_returns_zero`
- `test_ss_oral_with_bioavailability_scales`

New tests in `src/pk/three_compartment.rs`:
- `test_ss_iv_bolus_matches_numerical_sum`
- `test_ss_oral_matches_numerical_sum`
- `test_ss_oral_lhopital_ka_near_alpha_matches_numerical_sum`
- `test_ss_infusion_during_matches_numerical_sum`
- `test_ss_infusion_after_matches_numerical_sum`
- `test_ss_infusion_continuity_at_end_of_infusion`
- `test_ss_infusion_with_t_inf_gt_ii_returns_zero`
- `test_ss_oral_with_bioavailability_scales`

## Example
- [ ] Deferred — will land with the regression-dataset bullet of #74 once event-driven/ODE/AD paths catch up. A 2-cpt SS example would be misleading until all paths are consistent.

## Docs
- [ ] Same — deferred to the dedicated docs bullet on #74 once the full SS surface (event-driven, ODE) is wrapped up.

## Reviewer hints

Focus on:
1. **The L'Hopital cases in 3-cpt oral SS** (`bateman_ss` closure in `three_cpt_oral_f_ss`). When `ka ≈ λ` for any of α, β, γ, the per-eigenvalue Bateman becomes `t·exp(-λ·t)` and its SS sum is the standard `exp(-λ·τ) · [τ/(1-x) + II·x/(1-x)²]` form. The closure handles each eigenvalue independently — worth confirming the dispatch logic doesn't accidentally drop the singular eigenvalue's contribution.
2. **The exhaustive `match` in `single_dose_concentration`**. With all 9 PkModel variants covered for `dose.ss`, the `_ => {}` arm is gone. If new variants are added later (e.g. a 4-cpt model, or a non-standard absorption like Weibull) they need explicit SS dispatch — the compiler will catch this.
3. **The `ss_coeff_3` helper duplicates `ss_coeff`** in `two_compartment.rs`. I didn't merge them because there's a stylistic preference in this repo for keeping the 1-/2-/3-cpt files mostly self-contained. Open to factoring out into a shared `src/pk/ss_helpers.rs` if reviewers prefer.

Can be skimmed:
- The 17 new test functions are mechanical copies of the 1-cpt SS test pattern (numerical pulse sum as oracle) — same logic, different PK model.

## Open questions

- **Performance**: I haven't benchmarked the SS dispatch overhead on a real fit. For non-SS data the cost is a single boolean check, so I'd expect negligible impact, but worth a sanity check on a 2-cpt benchmark before declaring done.
- **`ss_coeff` consolidation** — see reviewer hint 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)