### PR TITLE
feat(estimation): Step 11 — IOV support for SAEM

### DIFF
--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -1,6 +1,6 @@
 # SAEM
 
-Stochastic Approximation Expectation-Maximization (SAEM) is an alternative estimation method that uses MCMC sampling for random effects instead of MAP optimization. It is more robust to local minima and can handle complex random effect structures.
+Stochastic Approximation Expectation-Maximization (SAEM) is an alternative estimation method that uses MCMC sampling for random effects instead of MAP optimization. It is more robust to local minima and can handle complex random effect structures, including models with **inter-occasion variability (IOV)**.
 
 ## Algorithm Overview
 
@@ -125,6 +125,16 @@ method = [saem, imp]
 ```
 
 See [Importance Sampling (IMP)](importance-sampling.md).
+
+## Inter-Occasion Variability (IOV)
+
+`method = saem` supports models with `kappa` declarations (`n_kappa > 0`). IOV is handled with a per-occasion Gibbs Metropolis-Hastings step interleaved with the standard eta MH:
+
+- **E-step**: After sampling \\( \eta \\), one MH proposal is made for each occasion's \\( \kappa_k \\). Both the eta and kappa samplers target the correct conditional distributions: \\( p(\eta | \kappa, \theta, \text{data}) \\) and \\( p(\kappa_k | \eta, \theta, \text{data}) \\) respectively.
+- **SA update**: \\( S_2^{\text{iov}} \leftarrow (1 - \gamma_k) S_2^{\text{iov}} + \gamma_k \cdot \frac{1}{N_{\text{occ}}} \sum_i \sum_k \kappa_{ik} \kappa_{ik}^T \\)
+- **M-step**: \\( \Omega_{\text{iov}} = S_2^{\text{iov}} \\) (analytic update, same structure as the BSV omega M-step).
+
+No additional configuration is required; `method = saem` works for both BSV-only and IOV models.
 
 ## Configuration
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -583,14 +583,6 @@ fn fit_inner(
         }
     }
 
-    // Guard: SAEM does not support IOV (kappas are not sampled in the SAEM
-    // stochastic approximation loop).  Fail early with a clear message.
-    if model.n_kappa > 0 && chain.iter().any(|&m| m == EstimationMethod::Saem) {
-        return Err("method = saem does not support IOV (n_kappa > 0). \
-             Use method = foce or method = focei for models with kappa declarations."
-            .to_string());
-    }
-
     // Guard: IMP is a likelihood evaluation, not an estimator. It must follow
     // a parameter-estimating stage (it consumes that stage's EBEs + Hessians),
     // may appear at most once, and must be the terminal stage. A non-terminal
@@ -2322,40 +2314,48 @@ mod iov_integration {
         assert_iov_fit_ok(&result);
     }
 
-    // ── Test: SAEM + IOV must return Err ──────────────────────────────────────
+    // ── Test: SAEM + IOV now supported (Step 11) ─────────────────────────────
 
     #[test]
-    fn test_iov_saem_returns_err() {
+    fn test_iov_saem_succeeds() {
         let model = make_iov_model();
         let pop = make_iov_population();
         let opts = fast_opts(EstimationMethod::Saem, Optimizer::Bobyqa, false);
         let result = fit(&model, &pop, &model.default_params, &opts);
-        assert!(result.is_err(), "SAEM with IOV must return an error");
-        let msg = result.unwrap_err();
         assert!(
-            msg.contains("saem") && msg.contains("IOV"),
-            "error message should mention saem and IOV, got: {msg}"
+            result.is_ok(),
+            "SAEM with IOV must succeed, got: {:?}",
+            result.err()
+        );
+        let fr = result.unwrap();
+        assert!(
+            fr.ofv.is_finite(),
+            "SAEM IOV OFV must be finite, got {}",
+            fr.ofv
+        );
+        assert!(
+            fr.omega_iov.is_some(),
+            "omega_iov must be present in result"
         );
     }
 
-    // ── Test: SAEM in a chained methods sequence + IOV must also Err ──────────
-    // The guard checks the full chain, not just `method`; this locks in that
-    // behaviour so a future refactor can't accidentally drop the chain check.
+    // ── Test: SAEM in a chained methods sequence + IOV succeeds ──────────────
     #[test]
-    fn test_iov_saem_in_methods_chain_returns_err() {
+    fn test_iov_saem_in_methods_chain_succeeds() {
         let model = make_iov_model();
         let pop = make_iov_population();
         let mut opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
         opts.methods = vec![EstimationMethod::Saem, EstimationMethod::Foce];
         let result = fit(&model, &pop, &model.default_params, &opts);
         assert!(
-            result.is_err(),
-            "SAEM in methods chain with IOV must return an error"
+            result.is_ok(),
+            "SAEM in methods chain with IOV must succeed, got: {:?}",
+            result.err()
         );
-        let msg = result.unwrap_err();
+        let fr = result.unwrap();
         assert!(
-            msg.contains("saem") && msg.contains("IOV"),
-            "error message should mention saem and IOV, got: {msg}"
+            fr.ofv.is_finite(),
+            "chained SAEM+FOCE IOV OFV must be finite"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -2357,6 +2357,10 @@ mod iov_integration {
             fr.ofv.is_finite(),
             "chained SAEM+FOCE IOV OFV must be finite"
         );
+        assert!(
+            fr.omega_iov.is_some(),
+            "omega_iov must survive the FOCE polishing step in a chained run"
+        );
     }
 
     // ── Test: trust-region optimizer + IOV must return Err ────────────────────

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -10,7 +10,10 @@ use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{compute_covariance, pop_nll, OuterResult};
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::pk::EventPkParams;
-use crate::stats::likelihood::{individual_nll, individual_nll_into, obs_nll_subject_into};
+use crate::stats::likelihood::{
+    individual_nll, individual_nll_into, individual_nll_iov, obs_nll_subject_into,
+    split_obs_by_occasion,
+};
 use crate::stats::residual_error::residual_variance;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -26,22 +29,36 @@ use rand_distr::StandardNormal;
 struct SaemState {
     /// Per-subject current ETAs
     etas: Vec<Vec<f64>>,
-    /// Cached individual NLL at current ETAs
+    /// Per-subject per-occasion kappa samples. `kappas[i][k]` = kappas for
+    /// subject i, occasion k.  Empty outer vecs when `n_kappa == 0`.
+    kappas: Vec<Vec<Vec<f64>>>,
+    /// Cached individual NLL at current ETAs (and kappas for IOV models)
     nll_cache: Vec<f64>,
-    /// Per-subject MH step sizes
+    /// Per-subject MH step sizes (for eta)
     step_scales: Vec<f64>,
+    /// Per-subject kappa MH step sizes.  Empty when `n_kappa == 0`.
+    kappa_step_scales: Vec<f64>,
     /// Per-subject acceptance counts since last adaptation
     accept_counts: Vec<usize>,
     /// Per-subject proposal counts since last adaptation (1 for HMC, n_mh_steps for MH)
     proposal_counts: Vec<usize>,
+    /// Per-subject kappa acceptance counts since last adaptation.
+    kappa_accept_counts: Vec<usize>,
+    /// Per-subject kappa proposal counts since last adaptation.
+    kappa_proposal_counts: Vec<usize>,
     /// Steps since last adaptation
     steps_since_adapt: usize,
     /// SA sufficient statistic for Omega: running average of (1/N) Σ ηᵢηᵢᵀ
     s2: DMatrix<f64>,
+    /// SA sufficient statistic for Omega_iov: running average of (1/N_occ) Σᵢ Σₖ κᵢₖκᵢₖᵀ.
+    /// Zero-sized when `n_kappa == 0`.
+    s2_iov: DMatrix<f64>,
     /// Current theta
     theta: Vec<f64>,
     /// Current omega matrix
     omega_mat: DMatrix<f64>,
+    /// Current Omega_iov matrix (zero-sized when `n_kappa == 0`).
+    omega_iov_mat: DMatrix<f64>,
     /// Current sigma values
     sigma_vals: Vec<f64>,
 }
@@ -121,6 +138,286 @@ fn mh_steps(
 }
 
 // ---------------------------------------------------------------------------
+// Per-occasion kappa MH step for IOV models
+// ---------------------------------------------------------------------------
+
+/// Run one symmetric random-walk MH proposal for each occasion's kappa.
+///
+/// For each occasion k, proposes `κ_k_prop = κ_k + step_scale · L_iov · z` and
+/// accepts/rejects using the full IOV individual NLL (includes both the kappa
+/// prior and the observation likelihood).  The per-occasion Gibbs structure
+/// means proposals are low-dimensional (n_kappa typically 1–3), so the MH
+/// acceptance rate stays high even without HMC.
+///
+/// Returns `(n_accepted, n_proposed, updated_nll)`.
+#[allow(clippy::too_many_arguments)]
+fn mh_kappa_steps(
+    kappas: &mut Vec<Vec<f64>>,
+    nll_current: f64,
+    subject: &Subject,
+    model: &CompiledModel,
+    theta: &[f64],
+    eta: &[f64],
+    omega_bsv: &OmegaMatrix,
+    omega_iov: &OmegaMatrix,
+    sigma_values: &[f64],
+    step_scale: f64,
+    rng: &mut impl Rng,
+) -> (usize, usize, f64) {
+    let n_kappa = omega_iov.matrix.nrows();
+    let l = &omega_iov.chol;
+    let mut nll = nll_current;
+    let mut n_accepted = 0;
+    let n_occ = kappas.len();
+
+    for k in 0..n_occ {
+        let z: Vec<f64> = (0..n_kappa).map(|_| rng.sample(StandardNormal)).collect();
+        let z_vec = DVector::from_column_slice(&z);
+        let perturbation = l * z_vec;
+
+        let kap_prop: Vec<f64> = (0..n_kappa)
+            .map(|j| kappas[k][j] + step_scale * perturbation[j])
+            .collect();
+
+        // Temporarily substitute kappa_k with the proposal.
+        let old_kap = kappas[k].clone();
+        kappas[k] = kap_prop;
+
+        let nll_prop = individual_nll_iov(
+            model,
+            subject,
+            theta,
+            eta,
+            kappas,
+            omega_bsv,
+            Some(omega_iov),
+            sigma_values,
+        );
+
+        let log_u: f64 = rng.gen::<f64>().ln();
+        if log_u < nll - nll_prop {
+            // Accept
+            nll = nll_prop;
+            n_accepted += 1;
+        } else {
+            // Reject — restore old kappa
+            kappas[k] = old_kap;
+        }
+    }
+
+    (n_accepted, n_occ, nll)
+}
+
+// ---------------------------------------------------------------------------
+// IOV-aware observation NLL for M-step (no priors, per-occasion predictions)
+// ---------------------------------------------------------------------------
+
+/// Compute the observation-only NLL for an IOV subject in the SAEM M-step.
+///
+/// ETAs and kappas are held fixed (sampled values from the E-step).  For each
+/// occasion k the combined `[eta, kappa_k]` vector is used to compute predictions;
+/// only the observations belonging to that occasion are scored.  No eta or kappa
+/// prior terms are included — those are handled by the SA sufficient-statistic
+/// update for Ω_bsv and Ω_iov separately.
+fn obs_nll_subject_into_iov(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    sigma_values: &[f64],
+    eta: &[f64],
+    kappas: &[Vec<f64>],
+    pk_scratch: &mut crate::pk::EventPkParams,
+) -> f64 {
+    use crate::stats::special::log_normal_cdf;
+    let m3 = matches!(model.bloq_method, BloqMethod::M3);
+    let occ_groups = split_obs_by_occasion(subject);
+    let mut total_nll = 0.0_f64;
+    for (k, (_, obs_indices)) in occ_groups.iter().enumerate() {
+        let kap: &[f64] = kappas.get(k).map(|v| v.as_slice()).unwrap_or(&[]);
+        let combined: Vec<f64> = eta.iter().chain(kap.iter()).copied().collect();
+        let preds = crate::pk::compute_predictions_with_tv_into(
+            model, subject, theta, &combined, pk_scratch,
+        );
+        for &j in obs_indices {
+            let f = preds[j].max(1e-12);
+            let v =
+                crate::stats::residual_error::residual_variance(model.error_model, f, sigma_values)
+                    .max(1e-12);
+            if m3 && subject.cens.get(j).copied().unwrap_or(0) != 0 {
+                let z = (subject.observations[j] - f) / v.sqrt();
+                total_nll += -log_normal_cdf(z);
+            } else {
+                total_nll += 0.5 * (v.ln() + (subject.observations[j] - f).powi(2) / v);
+            }
+        }
+    }
+    total_nll
+}
+
+/// Gradient of the IOV observation NLL w.r.t. the SAEM packed vector
+/// `[log_theta | log_sigma]` for one subject with ETAs and kappas fixed.
+///
+/// Sigma gradient is analytical (same formula as the non-IOV path but summed
+/// across all occasions' observations).  Theta gradient uses forward-FD of
+/// per-occasion predictions, chain-rule'd through the per-observation obs_nll.
+#[allow(clippy::too_many_arguments)]
+fn obs_nll_subject_grad_iov(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    sigma_values: &[f64],
+    eta: &[f64],
+    kappas: &[Vec<f64>],
+    theta_packs_log_mask: &[bool],
+    lower: &[f64],
+    upper: &[f64],
+    n_theta: usize,
+    n_sigma: usize,
+    pk_scratch: &mut crate::pk::EventPkParams,
+) -> (f64, Vec<f64>) {
+    let n = n_theta + n_sigma;
+    let m3 = matches!(model.bloq_method, BloqMethod::M3);
+
+    if m3 {
+        // M3 path: forward-FD of obs_nll_subject_into_iov.
+        let nll_base =
+            obs_nll_subject_into_iov(model, subject, theta, sigma_values, eta, kappas, pk_scratch);
+        let mut grad = vec![0.0f64; n];
+        let h = 1e-5;
+        for i in 0..n {
+            if lower[i] == upper[i] {
+                continue;
+            }
+            if i < n_theta {
+                let mut theta_p = theta.to_vec();
+                let delta = h * (1.0 + theta[i].abs());
+                theta_p[i] += delta;
+                let nll_p = obs_nll_subject_into_iov(
+                    model,
+                    subject,
+                    &theta_p,
+                    sigma_values,
+                    eta,
+                    kappas,
+                    pk_scratch,
+                );
+                let raw = (nll_p - nll_base) / delta;
+                grad[i] = if theta_packs_log_mask[i] {
+                    theta[i] * raw
+                } else {
+                    raw
+                };
+            } else {
+                let k = i - n_theta;
+                let mut sigma_p = sigma_values.to_vec();
+                let delta = h * (1.0 + sigma_values[k].abs());
+                sigma_p[k] += delta;
+                let nll_p = obs_nll_subject_into_iov(
+                    model, subject, theta, &sigma_p, eta, kappas, pk_scratch,
+                );
+                grad[i] = sigma_values[k] * (nll_p - nll_base) / delta;
+            }
+        }
+        return (nll_base, grad);
+    }
+
+    // Non-M3 path: compute per-occasion base predictions and score.
+    let occ_groups = split_obs_by_occasion(subject);
+    let n_obs = subject.observations.len();
+    let mut nll_base = 0.0_f64;
+    let mut all_preds_base = vec![0.0f64; n_obs];
+    let mut residuals = vec![0.0f64; n_obs];
+    let mut variances = vec![0.0f64; n_obs];
+    let mut d_nll_d_f = vec![0.0f64; n_obs];
+
+    for (k, (_, obs_indices)) in occ_groups.iter().enumerate() {
+        let kap: &[f64] = kappas.get(k).map(|v| v.as_slice()).unwrap_or(&[]);
+        let combined: Vec<f64> = eta.iter().chain(kap.iter()).copied().collect();
+        let preds = crate::pk::compute_predictions_with_tv_into(
+            model, subject, theta, &combined, pk_scratch,
+        );
+        for &j in obs_indices {
+            let f = preds[j].max(1e-12);
+            let v =
+                crate::stats::residual_error::residual_variance(model.error_model, f, sigma_values)
+                    .max(1e-12);
+            let resid = subject.observations[j] - f;
+            nll_base += 0.5 * (v.ln() + resid * resid / v);
+            all_preds_base[j] = f;
+            residuals[j] = resid;
+            variances[j] = v;
+            let dv_df = match model.error_model {
+                ErrorModel::Additive => 0.0,
+                ErrorModel::Proportional | ErrorModel::Combined => {
+                    2.0 * f * sigma_values[0] * sigma_values[0]
+                }
+            };
+            d_nll_d_f[j] = -resid / v + 0.5 * dv_df * (1.0 / v - resid * resid / (v * v));
+        }
+    }
+
+    let mut grad = vec![0.0f64; n];
+
+    // Theta gradient: forward-FD of per-occasion predictions.
+    let h_fd = 1e-5;
+    for i in 0..n_theta {
+        if lower[i] == upper[i] {
+            continue;
+        }
+        let delta = h_fd * (1.0 + theta[i].abs());
+        let mut theta_p = theta.to_vec();
+        theta_p[i] += delta;
+        let mut d_obs_nll = 0.0_f64;
+        for (k, (_, obs_indices)) in occ_groups.iter().enumerate() {
+            let kap: &[f64] = kappas.get(k).map(|v| v.as_slice()).unwrap_or(&[]);
+            let combined: Vec<f64> = eta.iter().chain(kap.iter()).copied().collect();
+            let preds_p = crate::pk::compute_predictions_with_tv_into(
+                model, subject, &theta_p, &combined, pk_scratch,
+            );
+            for &j in obs_indices {
+                d_obs_nll += d_nll_d_f[j] * (preds_p[j] - all_preds_base[j]) / delta;
+            }
+        }
+        grad[i] = if theta_packs_log_mask[i] {
+            theta[i] * d_obs_nll
+        } else {
+            d_obs_nll
+        };
+    }
+
+    // Sigma gradient: analytical — same formula as non-IOV, summed over all obs.
+    for k in 0..n_sigma {
+        let i = n_theta + k;
+        if lower[i] == upper[i] {
+            continue;
+        }
+        let s = sigma_values[k];
+        let g: f64 = (0..n_obs)
+            .map(|j| {
+                let f = all_preds_base[j];
+                let v = variances[j];
+                let resid = residuals[j];
+                let ratio = match model.error_model {
+                    ErrorModel::Additive => 2.0 * s * s,
+                    ErrorModel::Proportional => 2.0 * s * s * f * f,
+                    ErrorModel::Combined => {
+                        if k == 0 {
+                            2.0 * s * s * f * f
+                        } else {
+                            2.0 * s * s
+                        }
+                    }
+                };
+                0.5 * ratio * (1.0 / v - resid * resid / (v * v))
+            })
+            .sum();
+        grad[i] = g;
+    }
+
+    (nll_base, grad)
+}
+
+// ---------------------------------------------------------------------------
 // Gradient of conditional observation NLL w.r.t. log(theta) and log(sigma)
 // ---------------------------------------------------------------------------
 
@@ -136,6 +433,7 @@ fn theta_sigma_mstep_light(
     model: &CompiledModel,
     population: &Population,
     etas: &[Vec<f64>],
+    kappas_opt: Option<&[Vec<Vec<f64>>]>,
     log_theta_init: &[f64],
     log_sigma_init: &[f64],
     log_theta_lower: &[f64],
@@ -198,34 +496,67 @@ fn theta_sigma_mstep_light(
 
         if let Some(g) = grad {
             use rayon::prelude::*;
-            let (val, grad_vec) = population
-                .subjects
-                .par_iter()
-                .zip(etas.par_iter())
-                .map_init(EventPkParams::default, |scratch, (subject, eta)| {
-                    obs_nll_subject_grad(
-                        model,
-                        subject,
-                        &th,
-                        &sg,
-                        eta,
-                        &theta_packs_log_mask,
-                        &lower,
-                        &upper,
-                        n_theta,
-                        n_sigma,
-                        scratch,
+            let (val, grad_vec) = if let Some(kappas) = kappas_opt {
+                population
+                    .subjects
+                    .par_iter()
+                    .zip(etas.par_iter())
+                    .zip(kappas.par_iter())
+                    .map_init(EventPkParams::default, |scratch, ((subject, eta), kaps)| {
+                        obs_nll_subject_grad_iov(
+                            model,
+                            subject,
+                            &th,
+                            &sg,
+                            eta,
+                            kaps,
+                            &theta_packs_log_mask,
+                            &lower,
+                            &upper,
+                            n_theta,
+                            n_sigma,
+                            scratch,
+                        )
+                    })
+                    .reduce(
+                        || (0.0, vec![0.0f64; n]),
+                        |(nll_a, mut ga), (nll_b, gb)| {
+                            for (a, b) in ga.iter_mut().zip(gb.iter()) {
+                                *a += b;
+                            }
+                            (nll_a + nll_b, ga)
+                        },
                     )
-                })
-                .reduce(
-                    || (0.0, vec![0.0f64; n]),
-                    |(nll_a, mut ga), (nll_b, gb)| {
-                        for (a, b) in ga.iter_mut().zip(gb.iter()) {
-                            *a += b;
-                        }
-                        (nll_a + nll_b, ga)
-                    },
-                );
+            } else {
+                population
+                    .subjects
+                    .par_iter()
+                    .zip(etas.par_iter())
+                    .map_init(EventPkParams::default, |scratch, (subject, eta)| {
+                        obs_nll_subject_grad(
+                            model,
+                            subject,
+                            &th,
+                            &sg,
+                            eta,
+                            &theta_packs_log_mask,
+                            &lower,
+                            &upper,
+                            n_theta,
+                            n_sigma,
+                            scratch,
+                        )
+                    })
+                    .reduce(
+                        || (0.0, vec![0.0f64; n]),
+                        |(nll_a, mut ga), (nll_b, gb)| {
+                            for (a, b) in ga.iter_mut().zip(gb.iter()) {
+                                *a += b;
+                            }
+                            (nll_a + nll_b, ga)
+                        },
+                    )
+            };
             for (gi, &gv) in g.iter_mut().zip(grad_vec.iter()) {
                 *gi = if gv.is_finite() { gv } else { 0.0 };
             }
@@ -235,7 +566,11 @@ fn theta_sigma_mstep_light(
                 1e20
             }
         } else {
-            let val = obs_nll_sum(model, population, &th, &sg, etas);
+            let val = if let Some(kappas) = kappas_opt {
+                obs_nll_sum_iov(model, population, &th, &sg, etas, kappas)
+            } else {
+                obs_nll_sum(model, population, &th, &sg, etas)
+            };
             if val.is_finite() {
                 val
             } else {
@@ -485,6 +820,34 @@ fn obs_nll_sum(
         .sum()
 }
 
+/// IOV variant of `obs_nll_sum`: per-occasion predictions using `[eta, kappa_k]`.
+fn obs_nll_sum_iov(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    sigma_values: &[f64],
+    etas: &[Vec<f64>],
+    kappas: &[Vec<Vec<f64>>],
+) -> f64 {
+    use rayon::prelude::*;
+    population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map_init(EventPkParams::default, |scratch, (i, subject)| {
+            obs_nll_subject_into_iov(
+                model,
+                subject,
+                theta,
+                sigma_values,
+                &etas[i],
+                &kappas[i],
+                scratch,
+            )
+        })
+        .sum()
+}
+
 /// Build (theta_idx, eta_idx) pairs for log-transformed mu-references only.
 ///
 /// Only `log_transformed = true` mu-refs (patterns `THETA*exp(ETA)` and
@@ -525,6 +888,7 @@ pub fn run_saem(
 ) -> Result<OuterResult, String> {
     let n_subjects = population.subjects.len();
     let n_eta = model.n_eta;
+    let n_kappa = model.n_kappa;
     let k1 = options.saem_n_exploration;
     let k2 = options.saem_n_convergence;
     let n_iter = k1 + k2;
@@ -575,20 +939,67 @@ pub fn run_saem(
         .collect();
     let step_scales = vec![0.3; n_subjects];
 
-    // Initial NLL cache
+    // Initialize IOV kappa state
+    let (kappas_init, omega_iov_init, s2_iov_init): (
+        Vec<Vec<Vec<f64>>>,
+        DMatrix<f64>,
+        DMatrix<f64>,
+    ) = if n_kappa > 0 {
+        let kaps: Vec<Vec<Vec<f64>>> = population
+            .subjects
+            .iter()
+            .map(|s| {
+                let n_occ = split_obs_by_occasion(s).len();
+                vec![vec![0.0f64; n_kappa]; n_occ]
+            })
+            .collect();
+        let iov_mat = init_params
+            .omega_iov
+            .as_ref()
+            .map(|iov| iov.matrix.clone())
+            .unwrap_or_else(|| DMatrix::identity(n_kappa, n_kappa));
+        (kaps, iov_mat.clone(), iov_mat)
+    } else {
+        (
+            vec![vec![]; n_subjects],
+            DMatrix::zeros(0, 0),
+            DMatrix::zeros(0, 0),
+        )
+    };
+    let kappa_step_scales = vec![0.3; n_subjects];
+
+    // Initial NLL cache — use IOV-aware NLL when kappas are present
+    let omega_iov_init_om = if n_kappa > 0 {
+        init_params.omega_iov.clone()
+    } else {
+        None
+    };
     let nll_cache: Vec<f64> = population
         .subjects
         .iter()
         .enumerate()
         .map(|(i, subject)| {
-            individual_nll(
-                model,
-                subject,
-                &theta_cur,
-                &etas[i],
-                &init_params.omega,
-                &sigma_cur,
-            )
+            if n_kappa > 0 {
+                individual_nll_iov(
+                    model,
+                    subject,
+                    &theta_cur,
+                    &etas[i],
+                    &kappas_init[i],
+                    &init_params.omega,
+                    omega_iov_init_om.as_ref(),
+                    &sigma_cur,
+                )
+            } else {
+                individual_nll(
+                    model,
+                    subject,
+                    &theta_cur,
+                    &etas[i],
+                    &init_params.omega,
+                    &sigma_cur,
+                )
+            }
         })
         .collect();
 
@@ -663,14 +1074,20 @@ pub fn run_saem(
 
     let mut state = SaemState {
         etas,
+        kappas: kappas_init,
         nll_cache,
         step_scales,
+        kappa_step_scales,
         accept_counts: vec![0; n_subjects],
         proposal_counts: vec![0; n_subjects],
+        kappa_accept_counts: vec![0; n_subjects],
+        kappa_proposal_counts: vec![0; n_subjects],
         steps_since_adapt: 0,
         s2,
+        s2_iov: s2_iov_init,
         theta: theta_cur,
         omega_mat: omega_cur,
+        omega_iov_mat: omega_iov_init,
         sigma_vals: sigma_cur,
     };
 
@@ -717,6 +1134,7 @@ pub fn run_saem(
             let sigma_ref = &state.sigma_vals;
             let omega_ref = &omega_k;
 
+            // Returns (eta_new, nll_after_eta, n_acc_eta, n_prop_eta, used_hmc)
             let results: Vec<(Vec<f64>, f64, usize, usize, bool)> = state
                 .etas
                 .par_iter()
@@ -780,6 +1198,47 @@ pub fn run_saem(
                 hmc_subjects[i] |= used_hmc;
             }
         }
+
+        // ---- Step 1b: Per-occasion kappa MH (IOV models only) ----
+        // For each subject, propose one new kappa per occasion and accept/reject
+        // using the full IOV individual NLL (kappa prior + observation likelihood).
+        // This is a sequential per-subject loop (non-parallel) because the kappa
+        // MH is cheap (low-dimensional, analytical PK) and share-free.
+        if n_kappa > 0 {
+            if let Some(omega_iov_ref) = init_params.omega_iov.as_ref() {
+                let omega_iov_cur = OmegaMatrix::from_matrix(
+                    state.omega_iov_mat.clone(),
+                    omega_iov_ref.eta_names.clone(),
+                    omega_iov_ref.diagonal,
+                );
+                for i in 0..n_subjects {
+                    let subject = &population.subjects[i];
+                    let mut rng = StdRng::seed_from_u64(
+                        master_seed
+                            .wrapping_add(k as u64 * 100_000)
+                            .wrapping_add(i as u64)
+                            .wrapping_add(999_999),
+                    );
+                    let (n_acc, n_prop, nll_new) = mh_kappa_steps(
+                        &mut state.kappas[i],
+                        state.nll_cache[i],
+                        subject,
+                        model,
+                        &state.theta,
+                        &state.etas[i],
+                        &omega_k,
+                        &omega_iov_cur,
+                        &state.sigma_vals,
+                        state.kappa_step_scales[i],
+                        &mut rng,
+                    );
+                    state.nll_cache[i] = nll_new;
+                    state.kappa_accept_counts[i] += n_acc;
+                    state.kappa_proposal_counts[i] += n_prop;
+                }
+            }
+        }
+
         state.steps_since_adapt += 1;
 
         // ---- Step 2: SA update of sufficient statistic for Omega ----
@@ -792,7 +1251,25 @@ pub fn run_saem(
 
         state.s2 = (1.0 - gamma) * &state.s2 + gamma * &eta_outer;
 
-        // ---- Step 3: M-step Omega (closed form) ----
+        // ---- Step 2b: SA update for Omega_iov (IOV only) ----
+        // s2_iov = (1 - γ) s2_iov + γ · (1/N_occ) Σᵢ Σₖ κᵢₖ κᵢₖᵀ
+        if n_kappa > 0 {
+            let mut kappa_outer = DMatrix::zeros(n_kappa, n_kappa);
+            let mut n_total_occ = 0_usize;
+            for kappas_i in &state.kappas {
+                for kap in kappas_i {
+                    let kv = DVector::from_column_slice(kap);
+                    kappa_outer += &kv * kv.transpose();
+                    n_total_occ += 1;
+                }
+            }
+            if n_total_occ > 0 {
+                kappa_outer /= n_total_occ as f64;
+            }
+            state.s2_iov = (1.0 - gamma) * &state.s2_iov + gamma * &kappa_outer;
+        }
+
+        // ---- Step 3: M-step Omega_bsv (closed form) ----
         // Restore FIX-ed rows / columns from the template. An eta flagged FIX
         // keeps its initial variance AND its initial off-diagonal couplings
         // (zero for a diagonal declaration, block cov for a FIX-ed block).
@@ -825,9 +1302,47 @@ pub fn run_saem(
             }
         }
 
+        // ---- Step 3b: M-step Omega_iov (analytic, IOV only) ----
+        // Apply the SA sufficient statistic, zeroing structural off-diagonals
+        // and restoring FIX-ed kappa entries, mirroring the BSV omega treatment.
+        if n_kappa > 0 {
+            if let Some(omega_iov_ref) = init_params.omega_iov.as_ref() {
+                state.omega_iov_mat = state.s2_iov.clone();
+                // Zero structurally-absent off-diagonals.
+                for i in 0..n_kappa {
+                    for j in 0..n_kappa {
+                        if !omega_iov_ref.free_mask[(i, j)] {
+                            state.omega_iov_mat[(i, j)] = 0.0;
+                        }
+                    }
+                }
+                // Restore FIX-ed kappa rows/columns from the template.
+                for i in 0..n_kappa {
+                    for j in 0..n_kappa {
+                        let fi = init_params.kappa_fixed.get(i).copied().unwrap_or(false);
+                        let fj = init_params.kappa_fixed.get(j).copied().unwrap_or(false);
+                        if fi || fj {
+                            state.omega_iov_mat[(i, j)] = omega_iov_ref.matrix[(i, j)];
+                        }
+                    }
+                }
+                // Floor diagonal to stay positive-definite.
+                for i in 0..n_kappa {
+                    if state.omega_iov_mat[(i, i)] < 1e-8 {
+                        state.omega_iov_mat[(i, i)] = 1e-8;
+                    }
+                }
+            }
+        }
+
         // ---- Step 4: M-step theta, sigma (lightweight NLopt, warm-started) ----
         // Only run every few iterations during exploration to save time
         let run_mstep = k <= 5 || k % 3 == 0 || k > k1;
+        let kappas_for_mstep = if n_kappa > 0 {
+            Some(state.kappas.as_slice())
+        } else {
+            None
+        };
         if run_mstep {
             let mstep_maxiter = if k <= k1 { 3 } else { 5 }; // more precise in convergence phase
 
@@ -886,6 +1401,7 @@ pub fn run_saem(
                     model,
                     population,
                     &state.etas,
+                    kappas_for_mstep,
                     &log_theta,
                     &log_sigma,
                     &temp_theta_lower,
@@ -906,6 +1422,7 @@ pub fn run_saem(
                     model,
                     population,
                     &state.etas,
+                    kappas_for_mstep,
                     &log_theta,
                     &log_sigma,
                     &log_theta_lower,
@@ -934,7 +1451,31 @@ pub fn run_saem(
             init_params.omega.eta_names.clone(),
             init_params.omega.diagonal,
         );
-        {
+        if n_kappa > 0 {
+            // IOV: rebuild omega_iov_cur and use individual_nll_iov for the cache.
+            let omega_iov_upd = init_params.omega_iov.as_ref().map(|iov_ref| {
+                OmegaMatrix::from_matrix(
+                    state.omega_iov_mat.clone(),
+                    iov_ref.eta_names.clone(),
+                    iov_ref.diagonal,
+                )
+            });
+            let new_nlls: Vec<f64> = (0..n_subjects)
+                .map(|i| {
+                    individual_nll_iov(
+                        model,
+                        &population.subjects[i],
+                        &state.theta,
+                        &state.etas[i],
+                        &state.kappas[i],
+                        &omega_upd,
+                        omega_iov_upd.as_ref(),
+                        &state.sigma_vals,
+                    )
+                })
+                .collect();
+            state.nll_cache = new_nlls;
+        } else {
             use rayon::prelude::*;
             // map_init lets each rayon worker keep one `EventPkParams`
             // scratch alive across every subject it handles, the same
@@ -975,6 +1516,18 @@ pub fn run_saem(
                 }
                 state.accept_counts[i] = 0;
                 state.proposal_counts[i] = 0;
+                // Adapt kappa step sizes (target 40% for MH on kappas).
+                if n_kappa > 0 {
+                    let kappa_total = state.kappa_proposal_counts[i].max(1);
+                    let kappa_rate = state.kappa_accept_counts[i] as f64 / kappa_total as f64;
+                    if kappa_rate > 0.40 {
+                        state.kappa_step_scales[i] = (state.kappa_step_scales[i] * 1.1).min(5.0);
+                    } else {
+                        state.kappa_step_scales[i] = (state.kappa_step_scales[i] * 0.9).max(0.01);
+                    }
+                    state.kappa_accept_counts[i] = 0;
+                    state.kappa_proposal_counts[i] = 0;
+                }
             }
             state.steps_since_adapt = 0;
         }
@@ -1029,7 +1582,17 @@ pub fn run_saem(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
-        omega_iov: init_params.omega_iov.clone(),
+        omega_iov: if n_kappa > 0 {
+            init_params.omega_iov.as_ref().map(|iov_ref| {
+                OmegaMatrix::from_matrix(
+                    state.omega_iov_mat.clone(),
+                    iov_ref.eta_names.clone(),
+                    iov_ref.diagonal,
+                )
+            })
+        } else {
+            init_params.omega_iov.clone()
+        },
         kappa_fixed: init_params.kappa_fixed.clone(),
     };
 
@@ -1559,5 +2122,117 @@ mod tests {
                 rel
             );
         }
+    }
+
+    // ── IOV kappa MH: rejection restores kappa ─────────────────────────────
+
+    /// With `step_scale = 0` the proposal is always identical to the current
+    /// kappa, so ΔH = 0 and every step is accepted.  The kappa values must
+    /// not change (proposal == current).
+    #[test]
+    fn mh_kappa_zero_step_always_accepts_and_preserves_kappa() {
+        use crate::types::test_helpers::analytical_model;
+        use std::collections::HashMap;
+
+        let model = analytical_model(GradientMethod::Auto);
+
+        // One subject with 2 occasions (occasions = [1,1,2,2]).
+        let subject = Subject {
+            id: "S1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 2.0, 3.0, 4.0],
+            observations: vec![50.0, 40.0, 35.0, 28.0],
+            obs_cmts: vec![1; 4],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            cens: vec![0; 4],
+            occasions: vec![1u32, 1, 2, 2],
+            dose_occasions: vec![1u32],
+        };
+
+        let omega_bsv = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
+        let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
+        let theta = vec![5.0, 50.0];
+        let eta = vec![0.0];
+        let sigma = vec![0.1];
+        // Two occasions, each with one kappa.
+        let mut kappas = vec![vec![0.2_f64], vec![-0.1_f64]];
+        let kappas_before = kappas.clone();
+
+        let nll0 = individual_nll_iov(
+            &model,
+            &subject,
+            &theta,
+            &eta,
+            &kappas,
+            &omega_bsv,
+            Some(&omega_iov),
+            &sigma,
+        );
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let (n_acc, n_prop, nll_after) = mh_kappa_steps(
+            &mut kappas,
+            nll0,
+            &subject,
+            &model,
+            &theta,
+            &eta,
+            &omega_bsv,
+            &omega_iov,
+            &sigma,
+            0.0, // step_scale = 0 → proposal == current → always accepted
+            &mut rng,
+        );
+
+        // With step_scale=0 every occasion proposal is accepted (2 occasions).
+        assert_eq!(n_prop, 2, "expected 2 proposals (one per occasion)");
+        assert_eq!(n_acc, 2, "step_scale=0: all proposals must be accepted");
+        // Kappa values must be unchanged (proposal == current point).
+        assert_eq!(
+            kappas, kappas_before,
+            "kappas must not change with step_scale=0"
+        );
+        // NLL must not change either.
+        assert!(
+            (nll_after - nll0).abs() < 1e-10,
+            "NLL must not change with step_scale=0"
+        );
+    }
+
+    // ── IOV omega analytic update formula ──────────────────────────────────
+
+    /// The analytic update `(1/N_occ) Σᵢ Σₖ κᵢₖ κᵢₖᵀ` for a 1-dimensional
+    /// omega_iov with two subjects, two occasions each, and known kappas must
+    /// match the hand-computed value exactly.
+    #[test]
+    fn iov_omega_analytic_update_matches_hand_computation() {
+        // Subject 1: occ1 = [0.2], occ2 = [-0.1]
+        // Subject 2: occ1 = [0.3], occ2 = [-0.2]
+        // Hand sum = 0.2² + 0.1² + 0.3² + 0.2² = 0.04 + 0.01 + 0.09 + 0.04 = 0.18
+        // Divided by 4 occasions → 0.045
+        let kappas: Vec<Vec<Vec<f64>>> =
+            vec![vec![vec![0.2], vec![-0.1]], vec![vec![0.3], vec![-0.2]]];
+        let n_kappa = 1_usize;
+        let mut kappa_outer = DMatrix::zeros(n_kappa, n_kappa);
+        let mut n_total_occ = 0_usize;
+        for kappas_i in &kappas {
+            for kap in kappas_i {
+                let kv = DVector::from_column_slice(kap);
+                kappa_outer += &kv * kv.transpose();
+                n_total_occ += 1;
+            }
+        }
+        kappa_outer /= n_total_occ as f64;
+        let expected = (0.04 + 0.01 + 0.09 + 0.04) / 4.0;
+        assert!(
+            (kappa_outer[(0, 0)] - expected).abs() < 1e-12,
+            "IOV omega analytic update: got {:.6e}, expected {:.6e}",
+            kappa_outer[(0, 0)],
+            expected
+        );
     }
 }

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -971,6 +971,13 @@ pub fn run_saem(
         .collect();
     let step_scales = vec![0.3; n_subjects];
 
+    // Guard: the parser must guarantee omega_iov is present whenever kappas
+    // are declared; if this fires, the caller wired up a broken ModelParameters.
+    debug_assert!(
+        n_kappa == 0 || init_params.omega_iov.is_some(),
+        "n_kappa > 0 but init_params.omega_iov is None — model is misconfigured"
+    );
+
     // Initialize IOV kappa state
     let (kappas_init, omega_iov_init, s2_iov_init): (
         Vec<Vec<Vec<f64>>>,
@@ -1659,11 +1666,17 @@ pub fn run_saem(
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
         omega_iov: if n_kappa > 0 {
+            // Use from_matrix_with_mask so structural free_mask is preserved
+            // when this OuterResult is handed to a chained estimator (e.g.
+            // [saem, foce]); from_matrix would infer the mask from nonzeros
+            // and could mark a legitimately-zero off-diagonal as structurally
+            // fixed, corrupting the next estimator's parameterisation.
             init_params.omega_iov.as_ref().map(|iov_ref| {
-                OmegaMatrix::from_matrix(
+                OmegaMatrix::from_matrix_with_mask(
                     state.omega_iov_mat.clone(),
                     iov_ref.eta_names.clone(),
                     iov_ref.diagonal,
+                    iov_ref.free_mask.clone(),
                 )
             })
         } else {

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -93,6 +93,10 @@ fn mh_steps(
     rng: &mut impl Rng,
     n_steps: usize,
     pk_scratch: &mut EventPkParams,
+    // When Some, eta proposals are evaluated with IOV-aware NLL (kappas held fixed).
+    // This is required for Gibbs correctness in IOV models: the acceptance ratio
+    // must target p(η | κ, θ, data), which includes the per-occasion kappa terms.
+    kappas_opt: Option<(&[Vec<f64>], &OmegaMatrix)>,
 ) -> (usize, f64) {
     let n_eta = eta.len();
     let l = &omega.chol;
@@ -108,20 +112,33 @@ fn mh_steps(
             .map(|j| eta[j] + step_scale * perturbation[j])
             .collect();
 
-        // Reuses `pk_scratch` across all n_steps proposals (and across
-        // outer SAEM iterations when the caller hoists allocation
-        // further). On TV-cov subjects this eliminates the per-call
-        // allocate/discard of three `Vec<PkParams>` per evaluation —
-        // the dominant allocator pressure on the SAEM hot loop.
-        let nll_prop = individual_nll_into(
-            model,
-            subject,
-            theta,
-            &eta_prop,
-            omega,
-            sigma_values,
-            pk_scratch,
-        );
+        // For non-IOV models: reuse pk_scratch to avoid per-call allocation
+        // (dominant allocator pressure on the SAEM hot loop for TV-cov subjects).
+        // For IOV models: individual_nll_iov allocates its own scratch; correctness
+        // of the Gibbs conditional p(η | κ, θ, data) requires the per-occasion
+        // [eta_prop, kappa_k] predictions, which individual_nll_into does not compute.
+        let nll_prop = if let Some((kappas, omega_iov)) = kappas_opt {
+            individual_nll_iov(
+                model,
+                subject,
+                theta,
+                &eta_prop,
+                kappas,
+                omega,
+                Some(omega_iov),
+                sigma_values,
+            )
+        } else {
+            individual_nll_into(
+                model,
+                subject,
+                theta,
+                &eta_prop,
+                omega,
+                sigma_values,
+                pk_scratch,
+            )
+        };
 
         // Symmetric proposal q(η_prop|η) = q(η|η_prop) cancels in the ratio,
         // so the prior+likelihood difference encoded in `individual_nll` is
@@ -152,7 +169,7 @@ fn mh_steps(
 /// Returns `(n_accepted, n_proposed, updated_nll)`.
 #[allow(clippy::too_many_arguments)]
 fn mh_kappa_steps(
-    kappas: &mut Vec<Vec<f64>>,
+    kappas: &mut [Vec<f64>],
     nll_current: f64,
     subject: &Subject,
     model: &CompiledModel,
@@ -239,6 +256,9 @@ fn obs_nll_subject_into_iov(
             model, subject, theta, &combined, pk_scratch,
         );
         for &j in obs_indices {
+            // Floors protect log(0) in the M-step objective.  individual_nll_iov
+            // (the E-step evaluator) does not floor — see obs_nll_subject_grad_iov
+            // for why the asymmetry is intentional.
             let f = preds[j].max(1e-12);
             let v =
                 crate::stats::residual_error::residual_variance(model.error_model, f, sigma_values)
@@ -384,6 +404,18 @@ fn obs_nll_subject_grad_iov(
             d_obs_nll
         };
     }
+
+    // split_obs_by_occasion partitions every index in 0..n_obs (one entry per
+    // observation in subject.occasions).  The sigma gradient below sums over
+    // all_preds_base/residuals/variances which are only populated for indices
+    // that appear in occ_groups.  Assert the partition is complete so an
+    // occasion-code gap would surface as a debug-mode failure rather than a
+    // silent wrong gradient.
+    debug_assert_eq!(
+        occ_groups.iter().map(|(_, v)| v.len()).sum::<usize>(),
+        n_obs,
+        "split_obs_by_occasion must partition every observation index"
+    );
 
     // Sigma gradient: analytical — same formula as non-IOV, summed over all obs.
     for k in 0..n_sigma {
@@ -1124,6 +1156,24 @@ pub fn run_saem(
             init_params.omega.diagonal,
         );
 
+        // Rebuild omega_iov for this iteration.  Using from_matrix_with_mask
+        // (not from_matrix) preserves the structural free_mask so that an
+        // off-diagonal entry that converges to zero is not mistakenly treated
+        // as a structural zero in the Cholesky proposal distribution.
+        // Used in both the eta MH (Bug 2 fix) and the kappa MH (Step 1b).
+        let omega_iov_cur_opt: Option<OmegaMatrix> = if n_kappa > 0 {
+            init_params.omega_iov.as_ref().map(|iov_ref| {
+                OmegaMatrix::from_matrix_with_mask(
+                    state.omega_iov_mat.clone(),
+                    iov_ref.eta_names.clone(),
+                    iov_ref.diagonal,
+                    iov_ref.free_mask.clone(),
+                )
+            })
+        } else {
+            None
+        };
+
         // ---- Step 1: MH simulation (parallelized) ----
         // Symmetric random-walk MH in eta_true space, identical schedule
         // throughout exploration and convergence — the only thing that
@@ -1133,6 +1183,11 @@ pub fn run_saem(
             let theta_ref = &state.theta;
             let sigma_ref = &state.sigma_vals;
             let omega_ref = &omega_k;
+            // For IOV models, eta proposals must target p(η | κ, θ, data):
+            // the per-occasion [eta_prop, kappa_k] predictions determine
+            // which etas are accepted.  Pass omega_iov to mh_steps so it
+            // can call individual_nll_iov with kappas held fixed.
+            let omega_iov_for_eta_mh: Option<&OmegaMatrix> = omega_iov_cur_opt.as_ref();
 
             // Returns (eta_new, nll_after_eta, n_acc_eta, n_prop_eta, used_hmc)
             let results: Vec<(Vec<f64>, f64, usize, usize, bool)> = state
@@ -1140,6 +1195,7 @@ pub fn run_saem(
                 .par_iter()
                 .zip(state.nll_cache.par_iter())
                 .zip(state.step_scales.par_iter())
+                .zip(state.kappas.par_iter())
                 .enumerate()
                 // Per-rayon-worker `EventPkParams` scratch: allocated
                 // once per worker per outer iteration, reused across
@@ -1149,7 +1205,7 @@ pub fn run_saem(
                 // with it, n_workers × N_iter ≈ 10 × N_iter.
                 .map_init(
                     EventPkParams::default,
-                    |pk_scratch, (i, ((eta, &nll), &scale))| {
+                    |pk_scratch, (i, (((eta, &nll), &scale), kappas_i))| {
                         let subject = &population.subjects[i];
                         let mut rng = StdRng::seed_from_u64(
                             master_seed
@@ -1171,6 +1227,8 @@ pub fn run_saem(
                                 return (new_eta, new_nll, accepted as usize, 1_usize, true);
                             }
                         }
+                        let kappas_mh_opt =
+                            omega_iov_for_eta_mh.map(|iov| (kappas_i.as_slice(), iov));
                         let (n_acc, nll_new) = mh_steps(
                             &mut eta_work,
                             nll,
@@ -1183,6 +1241,7 @@ pub fn run_saem(
                             &mut rng,
                             n_mh_steps,
                             pk_scratch,
+                            kappas_mh_opt,
                         );
                         (eta_work, nll_new, n_acc, n_mh_steps, false)
                     },
@@ -1205,12 +1264,7 @@ pub fn run_saem(
         // This is a sequential per-subject loop (non-parallel) because the kappa
         // MH is cheap (low-dimensional, analytical PK) and share-free.
         if n_kappa > 0 {
-            if let Some(omega_iov_ref) = init_params.omega_iov.as_ref() {
-                let omega_iov_cur = OmegaMatrix::from_matrix(
-                    state.omega_iov_mat.clone(),
-                    omega_iov_ref.eta_names.clone(),
-                    omega_iov_ref.diagonal,
-                );
+            if let Some(omega_iov_cur) = omega_iov_cur_opt.as_ref() {
                 for i in 0..n_subjects {
                     let subject = &population.subjects[i];
                     let mut rng = StdRng::seed_from_u64(
@@ -1219,15 +1273,33 @@ pub fn run_saem(
                             .wrapping_add(i as u64)
                             .wrapping_add(999_999),
                     );
+                    // Recompute NLL under the IOV-consistent function before
+                    // proposing kappa.  After the eta MH block, nll_cache[i]
+                    // may have been set by mh_steps via individual_nll_iov
+                    // (with kappas fixed) — but to be safe we always recompute
+                    // with the current kappas so detailed balance is guaranteed:
+                    // both nll_kappa_ref and nll_prop are evaluated by the same
+                    // individual_nll_iov, giving the correct acceptance ratio for
+                    // p(κ | η, θ, data).
+                    let nll_kappa_ref = individual_nll_iov(
+                        model,
+                        subject,
+                        &state.theta,
+                        &state.etas[i],
+                        &state.kappas[i],
+                        &omega_k,
+                        Some(omega_iov_cur),
+                        &state.sigma_vals,
+                    );
                     let (n_acc, n_prop, nll_new) = mh_kappa_steps(
                         &mut state.kappas[i],
-                        state.nll_cache[i],
+                        nll_kappa_ref,
                         subject,
                         model,
                         &state.theta,
                         &state.etas[i],
                         &omega_k,
-                        &omega_iov_cur,
+                        omega_iov_cur,
                         &state.sigma_vals,
                         state.kappa_step_scales[i],
                         &mut rng,
@@ -1452,12 +1524,16 @@ pub fn run_saem(
             init_params.omega.diagonal,
         );
         if n_kappa > 0 {
-            // IOV: rebuild omega_iov_cur and use individual_nll_iov for the cache.
+            // IOV NLL cache refresh — sequential rather than rayon-parallel.
+            // individual_nll_iov is cheap (analytical PK, few occasions) and
+            // the sequential loop avoids a second rayon scatter/gather.
+            // Parallelise here if profiling shows a bottleneck.
             let omega_iov_upd = init_params.omega_iov.as_ref().map(|iov_ref| {
-                OmegaMatrix::from_matrix(
+                OmegaMatrix::from_matrix_with_mask(
                     state.omega_iov_mat.clone(),
                     iov_ref.eta_names.clone(),
                     iov_ref.diagonal,
+                    iov_ref.free_mask.clone(),
                 )
             });
             let new_nlls: Vec<f64> = (0..n_subjects)
@@ -1860,6 +1936,7 @@ mod tests {
             &mut rng,
             100,
             &mut pk_scratch,
+            None,
         );
 
         // Random walk with step=0: every proposal == current eta, accepted as

--- a/tests/iov_convergence.rs
+++ b/tests/iov_convergence.rs
@@ -185,6 +185,7 @@ fn iov_saem_converges_within_tolerance_of_focei() {
         "omega_iov must be present in SAEM IOV result"
     );
     // SAEM and FOCEI are different approximations; allow 2.0 OFV units of slack.
+    // TODO: tighten after nightly baseline is established.
     assert!(
         (saem_result.ofv - focei_result.ofv).abs() < 2.0,
         "SAEM IOV OFV {:.4} differs from FOCEI OFV {:.4} by more than 2.0 units",

--- a/tests/iov_convergence.rs
+++ b/tests/iov_convergence.rs
@@ -101,3 +101,94 @@ fn iov_bfgs_matches_slsqp() {
         ref_result.ofv,
     );
 }
+
+/// SAEM + IOV (Step 11): smoke test — fit() must return Ok with a finite OFV
+/// after a handful of SAEM iterations.  Does NOT assert convergence; just
+/// confirms the SAEM IOV path (kappa MH + omega_iov analytic update) compiles
+/// and runs without panicking.
+///
+/// This is a Tier-2 test: it calls the public API but exits after 5 iterations.
+#[test]
+fn iov_saem_smoke_returns_finite_ofv() {
+    let model = parse_model_file(Path::new("examples/warfarin_iov.ferx"))
+        .expect("warfarin_iov model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, Some("OCC"))
+        .expect("warfarin_iov data must load");
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Saem;
+    opts.outer_maxiter = 5; // just enough to exercise the full E+M loop
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+
+    let result = fit(&model, &population, &model.default_params, &opts)
+        .expect("SAEM IOV smoke must not Err");
+
+    assert!(
+        result.ofv.is_finite(),
+        "SAEM IOV smoke OFV must be finite after 5 iter, got {}",
+        result.ofv
+    );
+    assert!(
+        result.omega_iov.is_some(),
+        "omega_iov must be present in SAEM IOV result"
+    );
+}
+
+/// SAEM + IOV convergence: run to convergence and compare OFV to the SLSQP
+/// FOCEI baseline.  SAEM and FOCE are different approximations so OFVs can
+/// differ; we allow up to 2.0 OFV units of slack.
+///
+/// This is a Tier-3 slow test — gated on the `slow-tests` feature.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn iov_saem_converges_within_tolerance_of_focei() {
+    let model = parse_model_file(Path::new("examples/warfarin_iov.ferx"))
+        .expect("warfarin_iov model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, Some("OCC"))
+        .expect("warfarin_iov data must load");
+
+    // FOCEI reference (SLSQP)
+    let mut opts_ref = FitOptions::default();
+    opts_ref.method = EstimationMethod::FoceI;
+    opts_ref.optimizer = Optimizer::Slsqp;
+    opts_ref.outer_maxiter = 500;
+    opts_ref.run_covariance_step = false;
+    opts_ref.verbose = false;
+    let focei_result = fit(&model, &population, &model.default_params, &opts_ref)
+        .expect("FOCEI IOV reference fit must succeed");
+    assert!(
+        focei_result.ofv.is_finite(),
+        "FOCEI IOV OFV must be finite, got {}",
+        focei_result.ofv
+    );
+
+    // SAEM
+    let mut opts_saem = FitOptions::default();
+    opts_saem.method = EstimationMethod::Saem;
+    opts_saem.outer_maxiter = 800; // saem_n_exploration + saem_n_convergence default
+    opts_saem.run_covariance_step = false;
+    opts_saem.verbose = false;
+    let saem_result = fit(&model, &population, &model.default_params, &opts_saem)
+        .expect("SAEM IOV fit must succeed");
+
+    assert!(
+        saem_result.ofv.is_finite(),
+        "SAEM IOV OFV must be finite, got {}",
+        saem_result.ofv
+    );
+    assert!(
+        saem_result.omega_iov.is_some(),
+        "omega_iov must be present in SAEM IOV result"
+    );
+    // SAEM and FOCEI are different approximations; allow 2.0 OFV units of slack.
+    assert!(
+        (saem_result.ofv - focei_result.ofv).abs() < 2.0,
+        "SAEM IOV OFV {:.4} differs from FOCEI OFV {:.4} by more than 2.0 units",
+        saem_result.ofv,
+        focei_result.ofv
+    );
+}


### PR DESCRIPTION
## Why

SAEM was hard-blocked from running on IOV models (`n_kappa > 0`) with the message _"method = saem does not support IOV"_. This was the last open step in the optimization plan. SAEM+IOV is useful for models with between-occasion variability where FOCE linearisation error accumulates over many occasions; this PR gives users access to the SAEM algorithm for those models.

## What changed

**Phase B deviation from original plan:** The plan proposed extending `run_inner_loop_warm` to return kappa H-matrices and adding a `subject_nll_pop_grad_analytical_iov` function for the M-step gradient. That path was not needed: the SAEM M-step does not use population-level FOCE gradients — it uses observation NLLs with sampled ETAs/kappas fixed. A self-contained IOV-aware obs-NLL path is the correct scope for this step.

### `src/estimation/saem.rs`
- **`SaemState`**: new fields `kappas: Vec<Vec<Vec<f64>>>`, `kappa_step_scales`, `kappa_accept_counts`, `kappa_proposal_counts`, `s2_iov: DMatrix<f64>`, `omega_iov_mat: DMatrix<f64>`
- **`mh_kappa_steps`** (new): per-occasion symmetric-RW MH using `individual_nll_iov` for the acceptance criterion; one proposal per occasion per SAEM iteration
- **`obs_nll_subject_into_iov`** (new): observation-only NLL for IOV subjects — per-occasion predictions with `[eta, κ_k]` combined vector, scored only for observations belonging to that occasion
- **`obs_nll_subject_grad_iov`** (new): gradient of `obs_nll_subject_into_iov` w.r.t. packed `[log_theta | log_sigma]`; sigma analytical, theta forward-FD of per-occasion predictions
- **`obs_nll_sum_iov`** (new): rayon-parallel sum of `obs_nll_subject_into_iov` over subjects
- **`theta_sigma_mstep_light`**: gains `kappas_opt: Option<&[Vec<Vec<f64>>]>` and dispatches to the IOV variants when kappas are present
- **E-step (Step 1b)**: sequential per-occasion kappa MH loop after the parallel eta sampling block; separate acceptance/proposal counters and step-scale adaptation
- **SA update (Step 2b)**: `s2_iov = (1−γ) s2_iov + γ · (1/N_occ) Σᵢ Σₖ κᵢₖκᵢₖᵀ`
- **M-step omega_iov (Step 3b)**: analytic update from `s2_iov`; structural-zero masking via `omega_iov.free_mask`, FIX-entry restoration via `kappa_fixed`, diagonal floor at 1e-8
- **NLL cache refresh**: uses `individual_nll_iov` for IOV models, existing `individual_nll_into` path for non-IOV (unchanged)
- **Final params**: `omega_iov` in `ModelParameters` now set from SAEM-estimated `omega_iov_mat` instead of copying the initial params unchanged

### `src/api.rs`
- Hard guard (lines 588–592) removed entirely
- `test_iov_saem_returns_err` → `test_iov_saem_succeeds`; `test_iov_saem_in_methods_chain_returns_err` → `test_iov_saem_in_methods_chain_succeeds` — both now assert `is_ok()` and finite OFV

### `tests/iov_convergence.rs`
- **Tier 2**: `iov_saem_smoke_returns_finite_ofv` — 5-iteration SAEM run on `warfarin_iov.ferx`; asserts `Ok`, finite OFV, and `omega_iov.is_some()`; always runs (no gate)
- **Tier 3**: `iov_saem_converges_within_tolerance_of_focei` — full SAEM convergence vs SLSQP FOCEI baseline; allows ±2.0 OFV units; gated on `slow-tests`

## Alternatives considered

**Joint HMC for `[eta, κ₁, …, κ_K]`**: Would give better mixing at the cost of a larger leapfrog state and additional AD infrastructure for the kappa gradient. The per-occasion Gibbs MH is correct and sufficient for typical IOV designs (K ≤ 4 occasions); HMC for kappas can be added later as a follow-on.

**NLopt M-step for omega_iov**: The analytic update `(1/N_occ) Σ κκᵀ` is the SAEM-EM equivalent of the BSV omega update — exact, free, and already mirrors the existing pattern. No additional NLopt sub-problem is needed.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

`omega_iov` was already exposed in `FitResult`; no R-side change needed.

## Breaking changes
- [x] None — the SAEM+IOV path previously returned an `Err`; it now returns `Ok`. No existing behaviour changes for non-IOV or non-SAEM fits.

## Numerical validation
- [ ] Warfarin IOV SAEM smoke (5 iter) runs without panic and returns finite OFV ✅ (Tier 2 test)
- [ ] Compared against: FOCE/FOCEI SLSQP baseline (Tier 3 slow test, nightly)
- [ ] Not applicable for non-IOV / non-SAEM paths (unchanged code paths)

## Performance
- [x] No significant impact on non-IOV models (all new code is in `if n_kappa > 0` branches)
- Kappa MH is sequential (non-parallel) per subject; for typical IOV designs (2–4 occasions, 1–2 kappas) the per-iteration cost is small vs the eta sampling and M-step

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes: 606/606)
- [x] Tier 1: `mh_kappa_zero_step_always_accepts_and_preserves_kappa` — zero step size → all proposals accepted, values unchanged
- [x] Tier 1: `iov_omega_analytic_update_matches_hand_computation` — 2 subjects × 2 occasions, hand-verified formula
- [x] Tier 2: `iov_saem_smoke_returns_finite_ofv` (always runs, warfarin_iov, 5 iter)
- [x] Tier 3: `iov_saem_converges_within_tolerance_of_focei` (slow-tests gated)

## Example (user-facing features only)

```toml
[fit_options]
method = saem  # now works with IOV models (n_kappa > 0)
```

## Docs
- [ ] No user-visible `.ferx` DSL change — `method = saem` already existed; the IOV restriction is lifted silently. Will update `docs/src/estimation/saem.md` to note IOV support in a follow-on docs PR alongside the site.

## Checklist
- [x] `cargo clippy` clean
- [x] `cargo check --tests` passes
- [x] `cargo test --lib` — 606 passed, 0 failed

## Reviewer hints

The core logic lives in `run_saem` between the `// ---- Step 1b` and `// ---- Step 3b` comments. The new helper functions (`mh_kappa_steps`, `obs_nll_subject_into_iov`, `obs_nll_subject_grad_iov`, `obs_nll_sum_iov`) are directly above `obs_nll_subject_grad` in the file and follow the same structural pattern.

The kappa MH loop is sequential (not parallel) because kappas are subject-local; no shared state. The IOV NLL cache refresh is also sequential for IOV subjects — this trades a small amount of parallelism for simplicity; can be parallelised later if profiling shows it matters.

## Open questions
- Tier 3 convergence tolerance is ±2.0 OFV units. This is generous — SAEM and FOCE are different approximations and can legitimately differ. Tighten after nightly results are in.