### PR TITLE
feat(ode): initial compartment amounts via init(state) = expr

### DIFF
--- a/docs/src/model-file/ode-models.md
+++ b/docs/src/model-file/ode-models.md
@@ -66,6 +66,17 @@ for an indirect-response / turnover model — declare an initial condition in th
 - Compartments without an `init(...)` line start at zero, as before.
 - This is the analogue of NONMEM's `A_0(n)`.
 
+**Time-varying covariates.** Because the initial condition is a pre-record
+baseline, it is evaluated a single time using the covariate values from the
+subject's **first record**. If a covariate that feeds the `init` expression
+changes later in the record, the initial amount is *not* re-evaluated — the
+later covariate values affect `d/dt(...)` going forward (the system evolves
+from the baseline), but the t=0 starting point is fixed by the first record's
+covariates. For most models this is exactly what you want, since the baseline
+represents the pre-dose steady state. If you need the starting amount to track
+a covariate value observed mid-record, model it as a state driven by `d/dt`
+rather than as an `init`.
+
 A turnover model whose response variable sits at its baseline `KIN/KOUT`
 before any perturbation:
 

--- a/docs/src/model-file/ode-models.md
+++ b/docs/src/model-file/ode-models.md
@@ -91,6 +91,14 @@ expression to initialized compartments (returning them to baseline) and zeros
 all other compartments — so a reset behaves like the start of a fresh episode.
 See [Data Format](../data-format.md) for reset rows.
 
+Note one deliberate asymmetry with the start-of-record seeding described above:
+the re-applied baseline at a reset is evaluated with the covariate values in
+effect **at the reset time**, not the first record's. With time-varying
+covariates this means the post-reset baseline reflects the most recent
+covariate values — appropriate for a "fresh episode" that starts under current
+conditions — whereas the very first baseline uses the first record's
+covariates. For time-constant covariates the two are identical.
+
 ## Example: Michaelis-Menten Elimination
 
 A one-compartment oral model with saturable (Michaelis-Menten) elimination:

--- a/docs/src/model-file/ode-models.md
+++ b/docs/src/model-file/ode-models.md
@@ -45,6 +45,41 @@ Expressions can reference:
   that aren't assigned in the firing branch this step receive a derivative
   of `0`.
 
+## Initial Compartment Amounts
+
+By default every compartment starts at zero, and drug enters only through dose
+records. To start a compartment at a non-zero amount — e.g. a pre-dose baseline
+for an indirect-response / turnover model — declare an initial condition in the
+`[odes]` block:
+
+```
+[odes]
+  init(state_name) = expression
+  d/dt(state_name) = expression
+```
+
+- The right-hand side is evaluated **once per subject** at the start of the
+  record and may reference individual parameters (and therefore folds in
+  `theta`, `eta`, and covariates through the `[individual_parameters]` layer).
+  State names referenced in an `init` expression are treated as `0` (no drug
+  is present yet).
+- Compartments without an `init(...)` line start at zero, as before.
+- This is the analogue of NONMEM's `A_0(n)`.
+
+A turnover model whose response variable sits at its baseline `KIN/KOUT`
+before any perturbation:
+
+```
+[odes]
+  init(response) = KIN / KOUT
+  d/dt(response) = KIN - KOUT * response
+```
+
+**Interaction with system resets (EVID=3/4):** a reset re-applies the `init`
+expression to initialized compartments (returning them to baseline) and zeros
+all other compartments — so a reset behaves like the start of a fresh episode.
+See [Data Format](../data-format.md) for reset rows.
+
 ## Example: Michaelis-Menten Elimination
 
 A one-compartment oral model with saturable (Michaelis-Menten) elimination:

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -562,6 +562,7 @@ fn generate_mm_oral() {
         state_names: vec!["depot".into(), "central".into()],
         readout: ferx_core::ode::OdeReadout::ObsCmt(1),
         diffusion_var: Vec::new(),
+        init_fn: None,
     };
     let model = CompiledModel {
         name: "mm_oral".into(),

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -143,12 +143,14 @@ pub struct EkfObsPoint {
 /// Dose events are handled identically to `ode_predictions`: boluses add to
 /// state; infusions inject a rate term into the wrapped RHS. Covariance is
 /// reset to zero at initial time and propagated forward from there.
+#[allow(clippy::too_many_arguments)]
 pub fn solve_ekf(
     rhs: &(dyn Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync),
     n_states: usize,
     obs_cmt_idx: usize,
     diffusion_var: &[f64],
     pk_params_flat: &[f64],
+    initial_state: &[f64],
     doses: &[DoseEvent],
     obs_times: &[f64],
     r_obs_vec: &[f64],
@@ -159,7 +161,14 @@ pub fn solve_ekf(
     let n_obs = obs_times.len();
     let opts = OdeSolverOptions::default();
 
-    let mut u = vec![0.0f64; n];
+    // Seed the EKF mean from the model's initial compartment amounts
+    // (`init(state) = expr`); zeros for models without an init block. The
+    // covariance still starts at zero — init sets the deterministic mean only.
+    let mut u = if initial_state.len() == n {
+        initial_state.to_vec()
+    } else {
+        vec![0.0f64; n]
+    };
     let mut p_mat = DMatrix::zeros(n, n);
     let mut results = vec![
         EkfObsPoint {
@@ -363,6 +372,7 @@ mod tests {
             0,
             &diffusion_var,
             &pk,
+            &[], // no init block in test: empty seeds zero state
             &doses,
             &obs_times,
             &r_obs_vec,
@@ -390,6 +400,7 @@ mod tests {
             state_names: vec!["central".into()],
             readout: crate::ode::OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
+            init_fn: None,
         };
         let ode_preds = ode_predictions(&ode_spec, &pk, &[], &[], &subj);
 
@@ -430,6 +441,7 @@ mod tests {
             0,
             &[sigma2_w],
             &pk,
+            &[], // no init block in test: empty seeds zero state
             &doses,
             &obs_times,
             &r_obs_vec,
@@ -456,6 +468,7 @@ mod tests {
             0,
             &[0.1],
             &pk,
+            &[], // no init block in test: empty seeds zero state
             &doses,
             &obs_times,
             &r_obs_vec,

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -233,9 +233,33 @@ pub struct OdeSpec {
     /// analogous to sigma/omega notation. Updated each outer iteration as
     /// diffusion thetas are re-estimated.
     pub diffusion_var: Vec<f64>,
+    /// Optional per-subject initial compartment amounts. Declared in the
+    /// `[odes]` block as `init(state) = <expr>`; the expression may reference
+    /// individual parameters (so it folds in theta/eta/covariates via the
+    /// individual-parameter layer, exactly like the RHS). Given the flat
+    /// individual-parameter vector (`PkParams.values`), returns the full
+    /// `n_states`-length initial-amount vector — the init value for declared
+    /// states and `0.0` for the rest. `None` when no `init(...)` is declared,
+    /// in which case every compartment starts at zero (the historical default).
+    /// A system reset (EVID=3/4) re-applies this on the ODE event-driven path.
+    #[allow(clippy::type_complexity)]
+    pub init_fn: Option<Box<dyn Fn(&[f64]) -> Vec<f64> + Send + Sync>>,
 }
 
 impl OdeSpec {
+    /// Initial compartment-amount vector for a subject, given the flat
+    /// individual-parameter vector `params` (`PkParams.values`). Returns the
+    /// `init(...)` expression values where declared and `0.0` elsewhere; when
+    /// no `init(...)` is declared this is all zeros — the historical default.
+    /// Used to seed the integrator at the start of a record and to re-seed it
+    /// after an EVID=3/4 reset.
+    pub fn initial_state(&self, params: &[f64]) -> Vec<f64> {
+        match &self.init_fn {
+            Some(f) => f(params),
+            None => vec![0.0; self.n_states],
+        }
+    }
+
     /// Convenience accessor: returns the canonical `obs_cmt_idx` when the
     /// readout is the default `ObsCmt` variant. Used by EKF (which requires
     /// a single observable compartment) and by callers that need to know
@@ -284,7 +308,8 @@ pub fn ode_predictions(
     let n_obs = subject.obs_times.len();
     let opts = OdeSolverOptions::default();
 
-    let mut u = vec![0.0; n];
+    // Seed compartments from `init(state) = expr` (zeros when none declared).
+    let mut u = ode.initial_state(pk_params_flat);
     let mut predictions = vec![f64::NAN; n_obs];
 
     // Lagtime shifts the effective start (and end) of every dose record.
@@ -478,7 +503,18 @@ pub fn ode_predictions_event_driven(
     let n_obs = subject.obs_times.len();
     let opts = OdeSolverOptions::default();
 
-    let mut u = vec![0.0_f64; n];
+    // Seed compartments from `init(state) = expr` (zeros when none declared).
+    // The init expression folds covariates/eta in via the individual-parameter
+    // layer, so evaluate it with a representative per-event parameter set — the
+    // first event's. For the common no-TV case every event shares one set.
+    let init_pk = pk_at_dose
+        .first()
+        .or_else(|| pk_at_obs.first())
+        .or_else(|| pk_at_pk_only.first());
+    let mut u = match init_pk {
+        Some(p) => ode.initial_state(&p.values),
+        None => vec![0.0_f64; n],
+    };
     let mut predictions = vec![f64::NAN; n_obs];
 
     if n_obs == 0 {
@@ -644,11 +680,16 @@ pub fn ode_predictions_event_driven(
                 // segment's `active_infusions` excludes this infusion.
             }
             Kind::Reset => {
-                // EVID=3 / EVID=4: zero every compartment. For EVID=4 the
-                // dose at this same time follows (Reset sorts before Dose),
-                // so it lands in a freshly emptied system. Record the reset
-                // time so infusions started earlier stop contributing.
-                u.iter_mut().for_each(|x| *x = 0.0);
+                // EVID=3 / EVID=4: reset the system. Compartments with an
+                // `init(state) = expr` return to their initial value; all
+                // others go to zero (a reset starts a fresh episode from
+                // baseline). With no init declared this zeros everything.
+                // Evaluate init with the params in effect at the reset
+                // (`last_pk`). For EVID=4 the dose at this same time follows
+                // (Reset sorts before Dose), so it lands on the re-seeded
+                // state. Record the reset time so infusions started earlier
+                // stop contributing.
+                u = ode.initial_state(&last_pk.values);
                 reset_floor = t_event;
             }
         }
@@ -694,6 +735,7 @@ pub fn ode_predictions_ekf_with_diffusion(
             .expect("EKF requires obs_cmt_idx; SDE + [scaling] y = ... is not supported"),
         diffusion_var,
         pk_params_flat,
+        &ode.initial_state(pk_params_flat),
         &subject.doses,
         &subject.obs_times,
         &r_obs_vec,
@@ -751,6 +793,7 @@ pub fn ode_predictions_ekf(
             .expect("EKF requires obs_cmt_idx; SDE + [scaling] y = ... is not supported"),
         &ode.diffusion_var,
         pk_params_flat,
+        &ode.initial_state(pk_params_flat),
         &subject.doses,
         &subject.obs_times,
         &r_obs_vec,
@@ -780,6 +823,7 @@ mod tests {
             state_names: vec!["central".into()],
             readout: OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
+            init_fn: None,
         }
     }
 
@@ -808,6 +852,67 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
         }
+    }
+
+    /// Turnover model with a baseline initial condition:
+    ///   d/dt(R) = kin - kout*R,  init(R) = kin/kout
+    /// params: kin @ slot 0, kout @ slot 1. Observable reads R (state 0).
+    fn turnover_ode_spec_with_init() -> OdeSpec {
+        OdeSpec {
+            rhs: Box::new(|y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
+                dy[0] = p[0] - p[1] * y[0];
+            }),
+            n_states: 1,
+            state_names: vec!["R".into()],
+            readout: OdeReadout::ObsCmt(0),
+            diffusion_var: Vec::new(),
+            init_fn: Some(Box::new(|p: &[f64]| {
+                let (kin, kout) = (p[0], p[1]);
+                vec![if kout > 0.0 { kin / kout } else { 0.0 }]
+            })),
+        }
+    }
+
+    fn pk_kin_kout(kin: f64, kout: f64) -> PkParams {
+        let mut p = PkParams::default();
+        p.values[0] = kin;
+        p.values[1] = kout;
+        p
+    }
+
+    #[test]
+    fn ode_init_state_seeds_plain_path() {
+        // No doses; the system starts at baseline kin/kout = 5 and stays there
+        // (dR/dt = 0). Without init it would start at 0 and climb.
+        let ode = turnover_ode_spec_with_init();
+        let pk = pk_kin_kout(10.0, 2.0);
+        let subj = make_subject(Vec::new(), vec![0.0, 1.0, 5.0, 20.0]);
+        let preds = ode_predictions(&ode, &pk.values, &[], &[], &subj);
+        for (i, &p) in preds.iter().enumerate() {
+            assert_relative_eq!(p, 5.0, epsilon = 1e-5);
+            let _ = i;
+        }
+    }
+
+    #[test]
+    fn ode_init_state_then_dose_and_reset_reapplies_init() {
+        // Exercises all three: (1) init seeds the start at baseline=5, (2) a
+        // bolus at t=0 lands on top of the seeded state (5 + 20 = 25), and
+        // (3) an EVID=3 reset at t=5 re-applies init (back to 5, NOT zero).
+        let ode = turnover_ode_spec_with_init();
+        let pk = pk_kin_kout(10.0, 2.0); // baseline 5
+        let doses = vec![DoseEvent::new(0.0, 20.0, 1, 0.0, false, 0.0)];
+        let obs_times = vec![0.0, 5.0];
+        let mut subj = make_subject(doses, obs_times.clone());
+        subj.reset_times = vec![5.0];
+        let pk_dose = vec![pk; subj.doses.len()];
+        let pk_obs = vec![pk; obs_times.len()];
+
+        let preds = ode_predictions_event_driven(&ode, &subj, &[], &[], &pk_dose, &pk_obs, &[]);
+        // t=0: init(5) + bolus(20) = 25.
+        assert_relative_eq!(preds[0], 25.0, epsilon = 1e-6);
+        // t=5: reset re-applies init → 5 (a zeroing reset would give 0).
+        assert_relative_eq!(preds[1], 5.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -946,6 +1051,7 @@ mod tests {
             state_names: vec!["depot".into(), "central".into()],
             readout: OdeReadout::ObsCmt(1),
             diffusion_var: Vec::new(),
+            init_fn: None,
         }
     }
 
@@ -1343,6 +1449,7 @@ mod tests {
                 },
             )),
             diffusion_var: Vec::new(),
+            init_fn: None,
         }
     }
 
@@ -1440,6 +1547,7 @@ mod tests {
             state_names: vec!["central".into()],
             readout: OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
+            init_fn: None,
         };
         let pk = pk_one(1.0, 1.0);
         let doses = vec![DoseEvent::new(0.0, 1.0, 1, 0.0, false, 0.0)];

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -505,13 +505,31 @@ pub fn ode_predictions_event_driven(
 
     // Seed compartments from `init(state) = expr` (zeros when none declared).
     // The init expression folds covariates/eta in via the individual-parameter
-    // layer, so evaluate it with a representative per-event parameter set — the
-    // first event's. For the common no-TV case every event shares one set.
-    let init_pk = pk_at_dose
-        .first()
-        .or_else(|| pk_at_obs.first())
-        .or_else(|| pk_at_pk_only.first());
-    let mut u = match init_pk {
+    // layer, so evaluate it with the snapshot from the subject's *first record*
+    // — the smallest record time across dose / obs / pk-only. Selecting by
+    // event kind would wrongly prefer a later dose over an earlier observation
+    // when covariates are time-varying (e.g. a pre-dose baseline obs at t=0).
+    // Raw record times are used (not lagtime-shifted) since `$PK` order follows
+    // the record, not the absorption delay.
+    let init_pk: Option<PkParams> = {
+        let mut best: Option<(f64, PkParams)> = None;
+        let mut consider = |t: f64, p: &PkParams| {
+            if best.map_or(true, |(bt, _)| t < bt) {
+                best = Some((t, *p));
+            }
+        };
+        for (k, d) in subject.doses.iter().enumerate() {
+            consider(d.time, &pk_at_dose[k]);
+        }
+        for (j, &t) in subject.obs_times.iter().enumerate() {
+            consider(t, &pk_at_obs[j]);
+        }
+        for (m, &t) in subject.pk_only_times.iter().enumerate() {
+            consider(t, &pk_at_pk_only[m]);
+        }
+        best.map(|(_, p)| p)
+    };
+    let mut u = match &init_pk {
         Some(p) => ode.initial_state(&p.values),
         None => vec![0.0_f64; n],
     };
@@ -582,7 +600,11 @@ pub fn ode_predictions_event_driven(
     let mut cur_t = timeline[0].0;
     // Most-recent NONMEM record's PK params, used to integrate segments
     // ending at an infusion-end (which is not a record and carries no PK).
-    let mut last_pk: PkParams = PkParams::default();
+    // Seed last_pk with the first record's snapshot (not zeroed defaults) so a
+    // reset that is itself the first event — e.g. an EVID=4 reset+dose at t=0 —
+    // re-applies init from real parameters rather than zeros. Updated as
+    // dose/obs/pk-only records are processed.
+    let mut last_pk: PkParams = init_pk.unwrap_or_default();
     // Most-recent system-reset time (EVID=3/4); `NEG_INFINITY` until the
     // first reset. Infusions started before it are no longer active.
     let mut reset_floor = f64::NEG_INFINITY;
@@ -913,6 +935,46 @@ mod tests {
         assert_relative_eq!(preds[0], 25.0, epsilon = 1e-6);
         // t=5: reset re-applies init → 5 (a zeroing reset would give 0).
         assert_relative_eq!(preds[1], 5.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn ode_init_uses_chronologically_first_record_not_first_dose() {
+        // Regression (Copilot review #1): with time-varying covariates the init
+        // snapshot must come from the earliest record by TIME, not the first
+        // dose. Here a pre-dose observation at t=0 carries KIN=10 (baseline 5)
+        // while a later dose at t=5 carries KIN=100 (baseline 50). Seeding must
+        // use the t=0 obs → prediction at t=0 is 5, not 50.
+        let ode = turnover_ode_spec_with_init();
+        let doses = vec![DoseEvent::new(5.0, 0.0, 1, 0.0, false, 0.0)];
+        let obs_times = vec![0.0];
+        let subj = make_subject(doses, obs_times.clone());
+        let pk_dose = vec![pk_kin_kout(100.0, 2.0)]; // baseline 50 (must NOT be used)
+        let pk_obs = vec![pk_kin_kout(10.0, 2.0)]; // baseline 5 (first record)
+
+        let preds = ode_predictions_event_driven(&ode, &subj, &[], &[], &pk_dose, &pk_obs, &[]);
+        assert_relative_eq!(preds[0], 5.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn ode_init_reapplied_when_reset_is_first_event() {
+        // Regression (Copilot review #2): an EVID=4 reset+dose at t=0 re-applies
+        // init *before* the same-time dose. last_pk must be seeded from the
+        // first record's params (not zeroed defaults), or the re-applied
+        // baseline would evaluate KIN/KOUT with zero params and collapse to 0.
+        // Expected: init(5) re-applied at reset, then bolus 20 → 25.
+        let ode = turnover_ode_spec_with_init();
+        let doses = vec![DoseEvent::new(0.0, 20.0, 1, 0.0, false, 0.0)];
+        let obs_times = vec![0.0];
+        let mut subj = make_subject(doses, obs_times.clone());
+        subj.reset_times = vec![0.0];
+        let pk = pk_kin_kout(10.0, 2.0); // baseline 5
+        let pk_dose = vec![pk];
+        let pk_obs = vec![pk];
+
+        let preds = ode_predictions_event_driven(&ode, &subj, &[], &[], &pk_dose, &pk_obs, &[]);
+        // Re-applied baseline (5) + bolus (20) = 25. A zero-param re-seed would
+        // give 0 + 20 = 20.
+        assert_relative_eq!(preds[0], 25.0, epsilon = 1e-6);
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2469,13 +2469,50 @@ fn build_ode_spec(
         None => NEEDS_FORM_C,
     };
 
+    // Pull `init(state) = <expr>` directives out of the block first. The
+    // statement parser only understands d/dt / assignment / if, so init lines
+    // must be separated before parsing the RHS. Each init expression may
+    // reference individual parameters and (defensively) state names — states
+    // are bound to 0.0 at init time. Build the init_fn closure that seeds the
+    // integrator from these expressions.
+    let init_ctx_defined: Vec<String> = state_names
+        .iter()
+        .cloned()
+        .chain(indiv_param_names.iter().cloned())
+        .collect();
+    let mut init_specs: Vec<(usize, Expression)> = Vec::new();
+    let mut seen_init: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut rhs_lines: Vec<String> = Vec::with_capacity(lines.len());
+    for raw in lines {
+        if let Some((name, expr_str)) = parse_init_line(raw) {
+            let idx = state_names.iter().position(|s| s == &name).ok_or_else(|| {
+                format!(
+                    "[odes]: init({}) references unknown state. Declared states: {:?}",
+                    name, state_names
+                )
+            })?;
+            if !seen_init.insert(name.clone()) {
+                return Err(format!(
+                    "[odes]: duplicate init({}) — initial condition defined more than once",
+                    name
+                ));
+            }
+            let ctx = ParseCtx::ode(&init_ctx_defined);
+            let expr = parse_scalar_expression(&expr_str, ctx)
+                .map_err(|e| format!("[odes] init({}): {}", name, e))?;
+            init_specs.push((idx, expr));
+        } else {
+            rhs_lines.push(raw.clone());
+        }
+    }
+
     // For ODE RHS expressions, states + individual params get injected into the
     // `vars` map at eval time, so every bare identifier should resolve to a
     // Variable (not a Covariate). ParseCtx::ode() flips the fallback accordingly.
     // Local intermediate vars assigned within the [odes] block (e.g. inside an
     // if-body) are also collected from a pre-pass below so they parse as
     // Variable too.
-    let block_text = lines.join("\n");
+    let block_text = rhs_lines.join("\n");
     let pre_defined: Vec<String> = state_names
         .iter()
         .cloned()
@@ -2618,13 +2655,71 @@ fn build_ode_spec(
             );
         });
 
+    // Build the init_fn closure from the extracted `init(state) = expr`
+    // directives. It mirrors the RHS variable binding: individual parameters
+    // by declaration order (PkParams.values slots), plus state names bound to
+    // 0.0 (no drug present at init time). Returns the full n_states vector so
+    // the caller can both seed the integrator and re-seed after a reset.
+    let init_fn: Option<Box<dyn Fn(&[f64]) -> Vec<f64> + Send + Sync>> = if init_specs.is_empty() {
+        None
+    } else {
+        let n = n_states;
+        let indiv = indiv_param_names.to_vec();
+        let states = state_names.to_vec();
+        let specs = init_specs;
+        Some(Box::new(move |params: &[f64]| -> Vec<f64> {
+            let mut vars: HashMap<String, f64> = HashMap::new();
+            for name in &states {
+                vars.insert(name.clone(), 0.0);
+                vars.insert(name.to_lowercase(), 0.0);
+            }
+            for (i, name) in indiv.iter().enumerate() {
+                if i < params.len() {
+                    vars.insert(name.clone(), params[i]);
+                    vars.insert(name.to_uppercase(), params[i]);
+                    vars.insert(name.to_lowercase(), params[i]);
+                }
+            }
+            let empty_theta: [f64; 0] = [];
+            let empty_eta: [f64; 0] = [];
+            let empty_cov: HashMap<String, f64> = HashMap::new();
+            let empty_nn: Vec<Vec<f64>> = Vec::new();
+            let mut u0 = vec![0.0; n];
+            for (idx, expr) in &specs {
+                u0[*idx] =
+                    eval_expression(expr, &empty_theta, &empty_eta, &empty_cov, &vars, &empty_nn);
+            }
+            u0
+        }))
+    };
+
     Ok(crate::ode::OdeSpec {
         rhs,
         n_states,
         state_names: state_names.to_vec(),
         readout: crate::ode::OdeReadout::ObsCmt(obs_cmt_idx),
         diffusion_var: Vec::new(),
+        init_fn,
     })
+}
+
+/// Parse an `init(state) = <expr>` directive line. Returns `(state_name,
+/// expr_str)` when `line` is such a directive, else `None` (so the caller
+/// routes it to the d/dt statement parser). Tolerates whitespace variants
+/// (`init (R)=...`, `init( R ) = ...`).
+fn parse_init_line(line: &str) -> Option<(String, String)> {
+    let rest = line.trim().strip_prefix("init")?.trim_start();
+    let inner = rest.strip_prefix('(')?;
+    let close = inner.find(')')?;
+    let name = inner[..close].trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let expr = inner[close + 1..].trim_start().strip_prefix('=')?.trim();
+    if expr.is_empty() {
+        return None;
+    }
+    Some((name, expr.to_string()))
 }
 
 // ── Helper: parse "[1.0, 2.0, 3.0]" → Vec<f64> ────────────────────────────
@@ -7491,6 +7586,108 @@ if (1 > 0) {
 "#,
             diffusion_lines = diffusion_lines
         )
+    }
+
+    // ── [odes] init(state) = expr ─────────────────────────────────────────
+
+    /// Turnover model `d/dt(response) = KIN - KOUT*response` with a baseline
+    /// initial condition. `init_lines` is spliced into the `[odes]` block.
+    fn turnover_ode_model(init_lines: &str) -> String {
+        format!(
+            r#"
+[parameters]
+  theta TVKIN(10.0, 0.001, 100.0)
+  theta TVKOUT(2.0, 0.001, 100.0)
+  omega ETA_KIN ~ 0.09
+  sigma ADD ~ 0.1
+
+[individual_parameters]
+  KIN  = TVKIN * exp(ETA_KIN)
+  KOUT = TVKOUT
+
+[structural_model]
+  ode(obs_cmt=response, states=[response])
+
+[odes]
+{init_lines}
+  d/dt(response) = KIN - KOUT * response
+
+[error_model]
+  DV ~ additive(ADD)
+
+[fit_options]
+  method = foce
+"#,
+            init_lines = init_lines
+        )
+    }
+
+    #[test]
+    fn test_init_directive_builds_init_fn() {
+        let src = turnover_ode_model("  init(response) = KIN / KOUT");
+        let parsed = parse_full_model(&src).unwrap();
+        let ode = parsed.model.ode_spec.as_ref().expect("ODE spec");
+        assert!(ode.init_fn.is_some(), "init_fn should be populated");
+
+        // Evaluate at typical values (eta = 0): KIN = 10, KOUT = 2 → 5.0.
+        // For an ODE model, individual params occupy PkParams slots in
+        // declaration order: KIN @ 0, KOUT @ 1.
+        let mut params = [0.0; crate::types::MAX_PK_PARAMS];
+        params[0] = 10.0;
+        params[1] = 2.0;
+        let u0 = ode.initial_state(&params);
+        assert_eq!(u0.len(), 1);
+        assert!(
+            (u0[0] - 5.0).abs() < 1e-9,
+            "init(response) = KIN/KOUT = 5, got {}",
+            u0[0]
+        );
+    }
+
+    #[test]
+    fn test_no_init_directive_seeds_zero() {
+        let src = turnover_ode_model("");
+        let parsed = parse_full_model(&src).unwrap();
+        let ode = parsed.model.ode_spec.as_ref().unwrap();
+        assert!(ode.init_fn.is_none());
+        // initial_state falls back to zeros.
+        assert_eq!(ode.initial_state(&[10.0, 2.0]), vec![0.0]);
+    }
+
+    #[test]
+    fn test_init_unknown_state_errors() {
+        let src = turnover_ode_model("  init(nonexistent) = 1.0");
+        let err = match parse_full_model(&src) {
+            Err(e) => e,
+            Ok(_) => panic!("expected unknown-state error"),
+        };
+        assert!(
+            err.contains("init(nonexistent)") && err.contains("unknown state"),
+            "expected unknown-state error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_duplicate_init_errors() {
+        let src = turnover_ode_model("  init(response) = KIN / KOUT\n  init(response) = 0.0");
+        let err = match parse_full_model(&src) {
+            Err(e) => e,
+            Ok(_) => panic!("expected duplicate-init error"),
+        };
+        assert!(
+            err.contains("duplicate init(response)"),
+            "expected duplicate-init error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_init_literal_value() {
+        let src = turnover_ode_model("  init(response) = 7.5");
+        let parsed = parse_full_model(&src).unwrap();
+        let ode = parsed.model.ode_spec.as_ref().unwrap();
+        assert_eq!(ode.initial_state(&[10.0, 2.0]), vec![7.5]);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1883,6 +1883,7 @@ pub(crate) mod test_helpers {
                     state_names: vec!["depot".into(), "central".into()],
                     readout: crate::ode::OdeReadout::ObsCmt(0),
                     diffusion_var: Vec::new(),
+                    init_fn: None,
                 })
             } else {
                 None


### PR DESCRIPTION
## Why
ODE compartments could only start at zero — drug entered solely through dose records. This blocks any model with a non-zero pre-dose baseline (indirect-response / turnover models, biomarker dynamics), where a compartment should start at a parameter-dependent steady state like `KIN/KOUT`. This is NONMEM's `A_0(n)`.

Requested directly: "I'd like to be able to set init states manually per compartment."

## What changed
A new `init(state) = <expr>` directive in the `[odes]` block:

```
[odes]
  init(response) = KIN / KOUT
  d/dt(response) = KIN - KOUT * response
```

- The expression is evaluated **once per subject** at the start of the record and may reference individual parameters — so it folds in `theta`, `eta`, and covariates through the `[individual_parameters]` layer, exactly like the RHS. State names in an init expression bind to `0` (no drug present yet).
- Compartments without `init(...)` start at zero (unchanged default).
- `OdeSpec` gains an optional `init_fn: Box<dyn Fn(&[f64]) -> Vec<f64>>` returning the full `n_states` initial-amount vector. It seeds the integrator on all three ODE paths: plain (`ode_predictions`), event-driven (`ode_predictions_event_driven`), and EKF/SDE (`solve_ekf`, threaded a new `initial_state` arg).
- **Reset interaction (EVID=3/4):** a reset re-applies the init expression to initialized compartments (returning them to baseline) and zeros the rest — a reset starts a fresh episode from baseline.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Depends on the EVID=3/4 reset work (#91), now **merged**. This PR is rebased on `main` and its diff shows only the init changes.

## Breaking changes
- [x] None — `OdeSpec` gains a field, but it's internal; `.ferx` files without `init(...)` behave identically.

## Numerical validation
End-to-end CLI fit, turnover model `d/dt(response) = KIN - KOUT*response` with `init(response) = KIN/KOUT` (KIN=10, KOUT=2 → baseline 5), observations only (no doses):

```
ID  TIME  DV    IPRED
1   0     5.0   4.999897
1   2     5.0   4.999897
1   8     5.0   4.999897
```

IPRED is the baseline (5) at t=0 and holds steady (dR/dt = 0). Without `init` it would start at 0 and climb. A unit test also confirms init + dose + reset compose correctly: init seeds 5, a t=0 bolus of 20 lands on top (25), and an EVID=3 reset re-applies init back to 5 (not 0).

## Tests
- [x] Parser unit tests: `init_fn` built and evaluates correctly; literal init; no-init seeds zero; unknown-state error; duplicate-init error.
- [x] Prediction unit tests: plain-path seeding (turnover stays at baseline); event-driven init + dose + reset-reapply.
- [x] `cargo test --lib` green (630 passed).

## Example
```
[odes]
  init(response) = KIN / KOUT
  d/dt(response) = KIN - KOUT * response
```

## Docs
- [x] `docs/src/model-file/ode-models.md` — new "Initial Compartment Amounts" section (syntax, evaluation semantics, reset interaction).
- [ ] `docs/book/` not regenerated — same mdbook asset-hash version mismatch noted in #91; regenerate with the maintainer's toolchain.

## Checklist
- [x] `cargo clippy` clean (no new warnings in changed files)
- [ ] `cargo check --features autodiff` — not run locally (needs `enzyme` toolchain). ODE models always use FD gradients (`tv_fn = None`), so the AD paths are unaffected by this change.

## Reviewer hints
- `build_ode_spec` in `model_parser.rs`: init lines are extracted before the d/dt statement parser runs (it only understands d/dt/assignment/if); `parse_init_line` handles the directive; the `init_fn` closure mirrors the RHS variable binding (individual params by declaration-order slot, states = 0).
- Seeding/reset re-apply in `ode/predictions.rs`; the EKF gained an `initial_state` parameter.

## Open questions
- Whether a reset should re-apply init (chosen) vs. zero everything — confirmed with the requester: re-apply.
