### PR TITLE
refactor(estimation): address Copilot review on IOV marginal (#103 follow-up)

### DIFF
--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -694,24 +694,18 @@ fn optimize_nlopt(
                 return ofv;
             }
             // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
-            // IOV models need EBE-reconverging FD to move the variance components
-            // (issue #101 rec #2); non-IOV uses the cheap fixed-EBE analytical path.
-            let grad_raw = if model.n_kappa > 0 {
-                reconverged_fd_gradient(&x, init_params, model, population, &ehs, &bounds, options)
-            } else {
-                ad_population_gradient(
-                    &x,
-                    n_subj,
-                    init_params,
-                    model,
-                    population,
-                    &ehs,
-                    &hms,
-                    &kappas,
-                    &bounds,
-                    options,
-                )
-            };
+            let grad_raw = population_gradient(
+                &x,
+                n_subj,
+                init_params,
+                model,
+                population,
+                &ehs,
+                &hms,
+                &kappas,
+                &bounds,
+                options,
+            );
             let mut sq = 0.0_f64;
             for k in 0..g.len() {
                 let gi = if grad_raw[k].is_finite() {
@@ -978,30 +972,18 @@ fn optimize_nlopt(
                     return ofv;
                 }
                 // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
-                let grad_raw = if model.n_kappa > 0 {
-                    reconverged_fd_gradient(
-                        &x,
-                        init_params,
-                        model,
-                        population,
-                        &ehs,
-                        &bounds,
-                        options,
-                    )
-                } else {
-                    ad_population_gradient(
-                        &x,
-                        n_subj,
-                        init_params,
-                        model,
-                        population,
-                        &ehs,
-                        &hms,
-                        &kappas,
-                        &bounds,
-                        options,
-                    )
-                };
+                let grad_raw = population_gradient(
+                    &x,
+                    n_subj,
+                    init_params,
+                    model,
+                    population,
+                    &ehs,
+                    &hms,
+                    &kappas,
+                    &bounds,
+                    options,
+                );
                 let mut sq = 0.0_f64;
                 for k in 0..g.len() {
                     let gi = if grad_raw[k].is_finite() {
@@ -1309,24 +1291,19 @@ fn optimize_bfgs(
             options.min_obs_for_convergence_check as usize,
         );
         let ofv = ofv_at_fixed(x, &ehs, &hms, &kappas);
-        // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x). IOV reconverges EBEs in the FD
-        // stencil so the variance components move (issue #101 rec #2).
-        let g = if model.n_kappa > 0 {
-            reconverged_fd_gradient(x, init_params, model, population, &ehs, &bounds, options)
-        } else {
-            ad_population_gradient(
-                x,
-                n_subj,
-                init_params,
-                model,
-                population,
-                &ehs,
-                &hms,
-                &kappas,
-                &bounds,
-                options,
-            )
-        };
+        // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x).
+        let g = population_gradient(
+            x,
+            n_subj,
+            init_params,
+            model,
+            population,
+            &ehs,
+            &hms,
+            &kappas,
+            &bounds,
+            options,
+        );
         let f = if ofv.is_finite() { ofv } else { 1e20 };
         (f, g, ehs, hms)
     };
@@ -1679,6 +1656,42 @@ fn ad_population_gradient(
     (0..np)
         .map(|k| per_subj.iter().map(|gi| gi[k]).sum::<f64>() * 2.0)
         .collect()
+}
+
+/// Population gradient dispatcher. IOV models (`n_kappa > 0`) use the
+/// EBE-reconverging FD gradient — their weakly-identified variance components
+/// need it (issue #101 rec #2) — and everything else uses the cheap analytical
+/// fixed-EBE gradient. Centralised so the optimizer paths (NLopt objective,
+/// NLopt pre-search, BFGS) can't drift apart in how they pick the gradient.
+#[allow(clippy::too_many_arguments)]
+fn population_gradient(
+    x: &[f64],
+    n_subj: usize,
+    init_params: &ModelParameters,
+    model: &CompiledModel,
+    population: &Population,
+    ehs: &[DVector<f64>],
+    hms: &[DMatrix<f64>],
+    kappas: &[Vec<DVector<f64>>],
+    bounds: &PackedBounds,
+    options: &FitOptions,
+) -> Vec<f64> {
+    if model.n_kappa > 0 {
+        reconverged_fd_gradient(x, init_params, model, population, ehs, bounds, options)
+    } else {
+        ad_population_gradient(
+            x,
+            n_subj,
+            init_params,
+            model,
+            population,
+            ehs,
+            hms,
+            kappas,
+            bounds,
+            options,
+        )
+    }
 }
 
 fn bfgs_update(

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -582,8 +582,15 @@ pub fn foce_subject_nll_iov(
     let n_obs = subject.obs_times.len();
     let n_eta = eta_hat.len();
     let n_iov = omega_iov.matrix.nrows();
-    // One κ block per occasion that actually carries observations.
-    let k_occ = occ_groups.len().min(kappas.len());
+    // Defensive: the EBE pipeline always yields exactly one κ vector per
+    // occasion group, each of width n_iov. A mismatch would silently leave the
+    // unmatched occasions' ipreds (and H columns) at 0.0 and score the
+    // augmented marginal against wrong predictions, so bail with the large
+    // finite sentinel — mirroring the guards in `individual_nll_iov`.
+    if kappas.len() != occ_groups.len() || kappas.iter().any(|k| k.len() != n_iov) {
+        return 1e20;
+    }
+    let k_occ = occ_groups.len();
     let n_b = n_eta + k_occ * n_iov;
 
     // Per-occasion ipreds at the joint EBE, plus the κ sensitivity columns of
@@ -596,11 +603,21 @@ pub fn foce_subject_nll_iov(
             h_full[(j, c)] = h_matrix[(j, c)];
         }
     }
+    // Reused scratch for per-event PK params — avoids a fresh allocation on
+    // every prediction call in this nested (occasion × kappa-dim × ±) loop.
+    let mut pk_scratch = pk::EventPkParams::with_capacity_for(subject);
     const EPS: f64 = 1e-6;
-    for (k, (_occ_id, obs_indices)) in occ_groups.iter().enumerate().take(k_occ) {
+    for (k, (_occ_id, obs_indices)) in occ_groups.iter().enumerate() {
         let kap = kappas[k].as_slice();
         let combined: Vec<f64> = eta_hat.iter().copied().chain(kap.iter().copied()).collect();
-        let all_preds = model_predictions(model, subject, theta, &combined);
+        let all_preds = model_predictions_into_with_schedule(
+            model,
+            subject,
+            theta,
+            &combined,
+            &mut pk_scratch,
+            None,
+        );
         for &j in obs_indices {
             ipreds[j] = all_preds[j];
         }
@@ -612,8 +629,22 @@ pub fn foce_subject_nll_iov(
             let mut combined_minus = combined.clone();
             combined_plus[n_eta + ki] += step;
             combined_minus[n_eta + ki] -= step;
-            let preds_plus = model_predictions(model, subject, theta, &combined_plus);
-            let preds_minus = model_predictions(model, subject, theta, &combined_minus);
+            let preds_plus = model_predictions_into_with_schedule(
+                model,
+                subject,
+                theta,
+                &combined_plus,
+                &mut pk_scratch,
+                None,
+            );
+            let preds_minus = model_predictions_into_with_schedule(
+                model,
+                subject,
+                theta,
+                &combined_minus,
+                &mut pk_scratch,
+                None,
+            );
             let inv_2step = 1.0 / (2.0 * step);
             for &j in obs_indices {
                 h_full[(j, col_base + ki)] = (preds_plus[j] - preds_minus[j]) * inv_2step;
@@ -626,7 +657,7 @@ pub fn foce_subject_nll_iov(
     for i in 0..n_eta {
         b_hat[i] = eta_hat[i];
     }
-    for (k, kap) in kappas.iter().enumerate().take(k_occ) {
+    for (k, kap) in kappas.iter().enumerate() {
         for ki in 0..n_iov {
             b_hat[n_eta + k * n_iov + ki] = kap[ki];
         }


### PR DESCRIPTION
## Why

Copilot left three review comments on #103 (the IOV marginal fix) **after it was merged**. None are correctness bugs in the current pipeline, but all three are valid, low-risk improvements to code that PR introduced. This addresses them.

## What changed

All in code added by #103; **no behavioural change** — `warfarin_iov` still reaches OFV ≈ 266.2 and all IOV tests pass.

1. **Defensive guard** (`foce_subject_nll_iov`, likelihood.rs): the EBE pipeline always produces exactly one κ vector per occasion group (each of width `n_iov`), but the function is `pub` and a mismatch would silently leave unmatched occasions' `ipreds`/H-columns at 0.0 and score the marginal against wrong predictions. Now bails with the `1e20` sentinel on mismatch, matching `individual_nll_iov`'s guard style. (Copilot, likelihood.rs:587)
2. **Scratch reuse** (`foce_subject_nll_iov`): the κ-sensitivity FD loop called `model_predictions` (fresh `EventPkParams` alloc per call) in a nested `occasion × kappa-dim × ±` loop — a FOCE hot path, now hotter since it runs inside the reconverged-EBE outer gradient. Switched to `model_predictions_into_with_schedule` with one reused scratch buffer. (Copilot, likelihood.rs:606)
3. **Gradient-dispatch helper** (`outer_optimizer.rs`): the IOV-vs-non-IOV gradient selection was duplicated across the NLopt objective, NLopt pre-search, and BFGS paths. Extracted `population_gradient` to centralise it so the paths can't drift apart. (Copilot, outer_optimizer.rs:714)

## Alternatives considered

Omitted — these directly implement Copilot's suggestions, which matched the cleanest options.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API signatures changed.

## Breaking changes
- [x] None

## Numerical validation
- [x] Warfarin (IOV) example converges and estimates are within tolerance of the prior run
- [x] Compared against: prior ferx commit (PR #103). OFV ≈ 266.2 unchanged; `tests/iov_convergence.rs` 5/5 pass.
- [x] Behaviour-preserving refactor/guard/perf — no reference values change.

## Performance
- [x] Faster (IOV only) — removes the per-call `EventPkParams` allocation in the κ-sensitivity FD loop; non-IOV unaffected.

## Tests
- [x] No new tests needed (why: behaviour-preserving; existing `test_foce_subject_nll_iov_is_proper_marginal` and the `iov_convergence` suite cover the affected code and still pass)

## Example (user-facing features only)
- [x] Not applicable (internal refactor)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo check --tests` compiles
- [x] No version bump (non-breaking)

## Reviewer hints

- The guard and scratch reuse are localized to `foce_subject_nll_iov`; the helper extraction in `outer_optimizer.rs` is a pure de-duplication of the three identical `if model.n_kappa > 0 { reconverged_fd_gradient } else { ad_population_gradient }` blocks.
