### PR TITLE
fix(ad): update stale predict_all_event_driven_ad test calls

### DIFF
--- a/src/ad/event_driven_ad_jac.rs
+++ b/src/ad/event_driven_ad_jac.rs
@@ -880,6 +880,7 @@ mod tests {
         let run = |f: f64| -> Vec<f64> {
             let tv = build_tv_constant(&pk_idx, &[cl, v, ka, f], event_times.len());
             let mut out = vec![0.0_f64; event_times.len()];
+            let obs_scale = vec![1.0_f64; event_times.len()];
             predict_all_event_driven_ad(
                 &eta,
                 &tv,
@@ -894,7 +895,7 @@ mod tests {
                 &pk_idx_f64,
                 &sel_flat,
                 pk_model_id,
-                1.0,
+                &obs_scale,
                 &mut out,
             );
             // Drop the dose slot (kind=0) — only obs slots carry preds.
@@ -948,6 +949,7 @@ mod tests {
         let run = |f: f64| -> Vec<f64> {
             let tv = build_tv_constant(&pk_idx, &[cl, v, f], event_times.len());
             let mut out = vec![0.0_f64; event_times.len()];
+            let obs_scale = vec![1.0_f64; event_times.len()];
             predict_all_event_driven_ad(
                 &eta,
                 &tv,
@@ -962,7 +964,7 @@ mod tests {
                 &pk_idx_f64,
                 &sel_flat,
                 pk_model_id,
-                1.0,
+                &obs_scale,
                 &mut out,
             );
             event_kinds


### PR DESCRIPTION
## Why
The lib-test target fails to compile under `--features autodiff`: two unit-test
call sites in `src/ad/event_driven_ad_jac.rs` pass a scalar `1.0` where
`predict_all_event_driven_ad` now takes `obs_scale: &[f64]` (the per-event
divisor added with that parameter). The breakage went unnoticed because CI only
builds `--features ci` (no Enzyme), which never compiles the `#[cfg(feature =
"autodiff")]`-gated test code — so this AD-only test rotted silently.

Surfaced while benchmarking AD vs FD gradients across the slow tests: the
`--features autodiff,slow-tests` test build wouldn't compile until this was fixed.

## What changed
Pass a unit `obs_scale` slice (`vec![1.0; event_times.len()]`, 1.0 = no scaling)
at both call sites, matching the current signature.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None (test-only change)

## Numerical validation
- [x] Not applicable (test-only) — the full `--features autodiff,slow-tests`
      suite now compiles and passes (single- and 4-thread), and AD results match
      the FD references within the existing test tolerances.

## Performance
- [x] No significant impact expected

## Tests
- [x] This *is* a test fix — restores the AD Jacobian unit tests that wouldn't compile.

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo +nightly fmt -- --check` clean
- [x] `cargo build --release --features autodiff` compiles (also `cargo test` lib+integration)
- [x] No version bump needed

## Reviewer hints
Trivial signature catch-up. The deeper issue — that `--features autodiff` is
never built in CI, so AD-gated code/tests can rot undetected — is worth a
follow-up (an autodiff smoke-test CI job using a cached from-source toolchain).
