### PR TITLE
feat(estimation): report resolved gradient route (AD/FD) in startup banner

### DIFF
--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -21,7 +21,19 @@ For each subject, the inner loop finds the empirical Bayes estimate (EBE) of the
 
 \\[ -\log p(\eta_i | y_i, \theta, \Omega, \sigma) = \frac{1}{2} \left[ \eta_i^T \Omega^{-1} \eta_i + \log|\Omega| + \sum_j \left( \frac{(y_{ij} - f_{ij})^2}{V_{ij}} + \log V_{ij} \right) \right] \\]
 
-The inner loop uses BFGS with automatic differentiation gradients, falling back to Nelder-Mead simplex if BFGS fails.
+The inner loop uses BFGS, falling back to Nelder-Mead simplex if BFGS fails.
+
+### Gradient route (AD vs FD)
+
+The BFGS gradient is computed by reverse-mode **automatic differentiation (AD)** when available, and by central **finite differences (FD)** otherwise. AD requires the crate built with the `autodiff` feature (the Enzyme toolchain) *and* an analytical PK model; it is resolved **per subject**, so individual subjects fall back to FD for ODE models, steady-state (SS) doses, system resets (EVID 3/4), or time-varying covariates on a model the event-driven AD path doesn't yet support. AD is the default (`gradient_method = auto`) and is typically on par with FD on small models and faster as the parameter count grows.
+
+The startup banner reports the route **actually resolved** across the population — not just the requested setting — so a silent AD→FD fallback is visible:
+
+```
+  gradient: AD (single-snapshot)  [requested: auto]
+```
+
+When the population splits across routes, the banner shows per-route subject counts, e.g. `AD (event-driven) ×118, FD ×3`. A build without the `autodiff` feature always reads `FD  [requested: auto; autodiff not compiled in]`.
 
 If the EBE search wanders into a region where the individual NLL evaluates to a non-finite value (for example, an ODE model whose integration blows up at extreme \\( \eta \\)), that point is treated as the worst possible objective rather than aborting the fit. The subject is reported as non-converged and estimation continues for the remaining subjects.
 

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -35,6 +35,8 @@ The startup banner reports the route **actually resolved** across the population
 
 When the population splits across routes, the banner shows per-route subject counts, e.g. `AD (event-driven) ×118, FD ×3`. A build without the `autodiff` feature always reads `FD  [requested: auto; autodiff not compiled in]`.
 
+This `gradient:` line appears for gradient-driven estimators (FOCE/FOCEI/GN) and for `imp`, which reuses the EBE Hessian built via the same route. SAEM is sampling-based and reports its E-step kernel on a `sampler:` line instead — see [SAEM](saem.md).
+
 If the EBE search wanders into a region where the individual NLL evaluates to a non-finite value (for example, an ODE model whose integration blows up at extreme \\( \eta \\)), that point is treated as the worst possible objective rather than aborting the fit. The subject is reported as non-converged and estimation continues for the remaining subjects.
 
 ## FOCE vs FOCEI

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -67,6 +67,8 @@ In a single run with `n_leapfrog > 0`, different subjects can therefore use diff
 
 The E-step sampling is parallelized across subjects using Rayon.
 
+The startup banner reports the resolved E-step kernel on a `sampler:` line, e.g. `sampler:  Metropolis-Hastings random walk` or `sampler:  HMC (3 leapfrog steps, autodiff gradients)`. If `n_leapfrog > 0` but HMC is unavailable (no `autodiff` build, or an ODE model), the line says so and reflects the MH fallback. Because SAEM is sampling-based rather than gradient-driven, it does not print the `gradient:` line that FOCE/FOCEI use — the `gradient_method` option only governs the inner EBE/Hessian step (used for diagnostics, and consumed by a following `imp` stage), not the SAEM iterations themselves.
+
 ### 2. Stochastic Approximation Update
 
 Update the sufficient statistic for \\( \Omega \\):

--- a/src/api.rs
+++ b/src/api.rs
@@ -926,6 +926,10 @@ fn fit_inner(
             "  {} thetas, {} etas, {} sigmas",
             model.n_theta, model.n_eta, model.n_epsilon
         );
+        eprintln!(
+            "  gradient: {}",
+            crate::estimation::inner_optimizer::gradient_route_summary(model, population)
+        );
     }
 
     // Model / estimation-option compatibility guards: SDE vs SAEM / GN / AD,

--- a/src/api.rs
+++ b/src/api.rs
@@ -943,7 +943,11 @@ fn fit_inner(
         if uses_gradient_route {
             eprintln!(
                 "  gradient: {}",
-                crate::estimation::inner_optimizer::gradient_route_summary(model, population)
+                crate::estimation::inner_optimizer::gradient_route_summary(
+                    model,
+                    population,
+                    options.gradient_method,
+                )
             );
         }
         if chain.iter().any(|m| *m == EstimationMethod::Saem) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -926,10 +926,32 @@ fn fit_inner(
             "  {} thetas, {} etas, {} sigmas",
             model.n_theta, model.n_eta, model.n_epsilon
         );
-        eprintln!(
-            "  gradient: {}",
-            crate::estimation::inner_optimizer::gradient_route_summary(model, population)
-        );
+        // Report the route each method actually uses. Gradient-based estimators
+        // (FOCE/FOCEI/GN) are driven by the inner-loop gradient; IMP consumes
+        // the EBE Hessian built via that same route. SAEM is sampling-based, so
+        // it reports its E-step kernel (MH/HMC) instead of a gradient route.
+        let uses_gradient_route = chain.iter().any(|m| {
+            matches!(
+                m,
+                EstimationMethod::Foce
+                    | EstimationMethod::FoceI
+                    | EstimationMethod::FoceGn
+                    | EstimationMethod::FoceGnHybrid
+                    | EstimationMethod::Imp
+            )
+        });
+        if uses_gradient_route {
+            eprintln!(
+                "  gradient: {}",
+                crate::estimation::inner_optimizer::gradient_route_summary(model, population)
+            );
+        }
+        if chain.iter().any(|m| *m == EstimationMethod::Saem) {
+            eprintln!(
+                "  sampler:  {}",
+                crate::estimation::saem::saem_sampler_summary(model, options)
+            );
+        }
     }
 
     // Model / estimation-option compatibility guards: SDE vs SAEM / GN / AD,

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -172,6 +172,58 @@ fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGra
     }
 }
 
+/// One-line summary of the inner-loop gradient route **actually resolved**
+/// across the population, for the startup banner. Reflects the per-subject
+/// resolution in [`resolve_gradient_method`] — including AD→FD fallbacks for
+/// SS doses, system resets, TV-covariate models the event-driven AD path
+/// doesn't support, ODE/`tv_fn`-less models, or a build without the
+/// `autodiff` feature — rather than the requested [`GradientMethod`]. The
+/// requested setting is appended in brackets so a fallback is visible.
+pub(crate) fn gradient_route_summary(model: &CompiledModel, population: &Population) -> String {
+    let (mut fd, mut ss, mut ed) = (0usize, 0usize, 0usize);
+    for subject in &population.subjects {
+        match resolve_gradient_method(model, subject) {
+            InnerGradientMethod::Fd => fd += 1,
+            InnerGradientMethod::AdSingleSnapshot => ss += 1,
+            InnerGradientMethod::AdEventDriven => ed += 1,
+        }
+    }
+    // Show per-route counts only when the population splits across routes;
+    // a single uniform route reads cleanly as just its label.
+    let mixed = [fd, ss, ed].iter().filter(|&&c| c > 0).count() > 1;
+    let mut parts: Vec<String> = Vec::new();
+    for (count, label) in [
+        (ed, "AD (event-driven)"),
+        (ss, "AD (single-snapshot)"),
+        (fd, "FD"),
+    ] {
+        if count > 0 {
+            parts.push(if mixed {
+                format!("{label} ×{count}")
+            } else {
+                label.to_string()
+            });
+        }
+    }
+    let resolved = if parts.is_empty() {
+        "n/a".to_string()
+    } else {
+        parts.join(", ")
+    };
+
+    let requested = match model.gradient_method {
+        GradientMethod::Auto => "auto",
+        GradientMethod::Ad => "AD",
+        GradientMethod::Fd => "FD",
+    };
+    #[cfg(not(feature = "autodiff"))]
+    let note = "; autodiff not compiled in";
+    #[cfg(feature = "autodiff")]
+    let note = "";
+
+    format!("{resolved}  [requested: {requested}{note}]")
+}
+
 /// Global per-fit timing counters for gradient/Jacobian calls. Printed by
 /// [`fit_inner`] when `FERX_TIME_GRADIENTS=1` in the environment. Atomics so
 /// multiple rayon workers can update concurrently without locking.
@@ -1332,6 +1384,32 @@ mod iov_tests {
         SigmaVector,
     };
     use std::collections::HashMap;
+
+    #[test]
+    fn gradient_route_summary_reports_route_taken_not_requested() {
+        // make_iov_model has `tv_fn: None` and the default `gradient_method:
+        // Auto`. With no `tv_fn`, AD is unavailable, so the route resolves to
+        // FD in every build — even though the *requested* method is `auto`.
+        // The banner must report the route actually taken (FD) and surface the
+        // request, so a silent AD→FD fallback is visible.
+        let model = make_iov_model();
+        let population = Population {
+            subjects: vec![make_iov_subject()],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+        };
+        let summary = gradient_route_summary(&model, &population);
+        assert!(
+            summary.starts_with("FD"),
+            "tv_fn=None must resolve to FD, got: {summary}"
+        );
+        // Matches both "[requested: auto]" (autodiff build) and
+        // "[requested: auto; autodiff not compiled in]" (ci build).
+        assert!(
+            summary.contains("[requested: auto"),
+            "summary must surface the requested method, got: {summary}"
+        );
+    }
 
     fn make_iov_model() -> CompiledModel {
         let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -177,9 +177,19 @@ fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGra
 /// resolution in [`resolve_gradient_method`] — including AD→FD fallbacks for
 /// SS doses, system resets, TV-covariate models the event-driven AD path
 /// doesn't support, ODE/`tv_fn`-less models, or a build without the
-/// `autodiff` feature — rather than the requested [`GradientMethod`]. The
-/// requested setting is appended in brackets so a fallback is visible.
-pub(crate) fn gradient_route_summary(model: &CompiledModel, population: &Population) -> String {
+/// `autodiff` feature.
+///
+/// `requested` is the user's [`FitOptions::gradient_method`], appended in
+/// brackets so a fallback is visible. It is taken as a parameter rather than
+/// read from `model.gradient_method` because the latter is mutated by
+/// compatibility rules (e.g. an SDE model is forced to `Fd` regardless of the
+/// request) — the banner should report what the user asked for, not the
+/// post-compatibility value.
+pub(crate) fn gradient_route_summary(
+    model: &CompiledModel,
+    population: &Population,
+    requested: GradientMethod,
+) -> String {
     let (mut fd, mut ss, mut ed) = (0usize, 0usize, 0usize);
     for subject in &population.subjects {
         match resolve_gradient_method(model, subject) {
@@ -211,7 +221,7 @@ pub(crate) fn gradient_route_summary(model: &CompiledModel, population: &Populat
         parts.join(", ")
     };
 
-    let requested = match model.gradient_method {
+    let requested_label = match requested {
         GradientMethod::Auto => "auto",
         GradientMethod::Ad => "AD",
         GradientMethod::Fd => "FD",
@@ -221,7 +231,7 @@ pub(crate) fn gradient_route_summary(model: &CompiledModel, population: &Populat
     #[cfg(feature = "autodiff")]
     let note = "";
 
-    format!("{resolved}  [requested: {requested}{note}]")
+    format!("{resolved}  [requested: {requested_label}{note}]")
 }
 
 /// Global per-fit timing counters for gradient/Jacobian calls. Printed by
@@ -1398,7 +1408,9 @@ mod iov_tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
         };
-        let summary = gradient_route_summary(&model, &population);
+        // `requested` is the user's FitOptions value, passed independently of
+        // model.gradient_method (which compatibility rules may have mutated).
+        let summary = gradient_route_summary(&model, &population, GradientMethod::Auto);
         assert!(
             summary.starts_with("FD"),
             "tv_fn=None must resolve to FD, got: {summary}"
@@ -1408,6 +1420,13 @@ mod iov_tests {
         assert!(
             summary.contains("[requested: auto"),
             "summary must surface the requested method, got: {summary}"
+        );
+        // The bracket reflects the passed `requested`, not model.gradient_method
+        // — guards against regressing to the SDE-mislabel Copilot flagged on #117.
+        let fd_summary = gradient_route_summary(&model, &population, GradientMethod::Fd);
+        assert!(
+            fd_summary.contains("[requested: FD"),
+            "bracket must echo the requested arg, got: {fd_summary}"
         );
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -860,6 +860,32 @@ fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
     pairs
 }
 
+/// One-line description of the SAEM E-step sampler kernel, for the startup
+/// banner. SAEM's estimation is sampling-based (not gradient-driven), so the
+/// banner reports the kernel here instead of a gradient route. HMC is used
+/// only when `saem_n_leapfrog > 0` *and* the build supports its autodiff
+/// gradients on an analytical PK model — the same gate as [`run_saem`]; this
+/// mirrors that condition so the banner reflects what will actually run.
+pub(crate) fn saem_sampler_summary(model: &CompiledModel, options: &FitOptions) -> String {
+    let n_leapfrog = options.saem_n_leapfrog;
+    #[cfg(feature = "autodiff")]
+    let using_hmc = n_leapfrog > 0 && model.ode_spec.is_none() && model.tv_fn.is_some();
+    #[cfg(not(feature = "autodiff"))]
+    let using_hmc = {
+        let _ = model;
+        false
+    };
+    if using_hmc {
+        format!("HMC ({n_leapfrog} leapfrog steps, autodiff gradients)")
+    } else if n_leapfrog > 0 {
+        "Metropolis-Hastings random walk \
+         (HMC requested but unavailable — needs the autodiff build + an analytical PK model)"
+            .to_string()
+    } else {
+        "Metropolis-Hastings random walk".to_string()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main SAEM loop
 // ---------------------------------------------------------------------------
@@ -1731,6 +1757,32 @@ mod tests {
     use super::*;
     use crate::types::test_helpers::analytical_model;
     use crate::types::{GradientMethod, MuRef};
+
+    #[test]
+    fn saem_sampler_summary_defaults_to_metropolis_hastings() {
+        // Default options (saem_n_leapfrog = 0) → MH random walk in every build.
+        let model = analytical_model(GradientMethod::Auto);
+        let opts = crate::types::FitOptions::default();
+        let s = saem_sampler_summary(&model, &opts);
+        assert!(
+            s.starts_with("Metropolis-Hastings"),
+            "default SAEM kernel should be MH, got: {s}"
+        );
+        // Requesting leapfrog steps without HMC support must say so, not claim HMC.
+        let mut hmc_opts = crate::types::FitOptions::default();
+        hmc_opts.saem_n_leapfrog = 10;
+        let s2 = saem_sampler_summary(&model, &hmc_opts);
+        #[cfg(not(feature = "autodiff"))]
+        assert!(
+            s2.contains("unavailable"),
+            "no-autodiff build can't run HMC, got: {s2}"
+        );
+        #[cfg(feature = "autodiff")]
+        assert!(
+            s2.starts_with("HMC"),
+            "autodiff build with analytical model + leapfrog steps should use HMC, got: {s2}"
+        );
+    }
 
     fn model_with_mu_refs(
         theta_names: &[&str],


### PR DESCRIPTION
## Why
There was no way to tell from a run whether the inner loop actually used
autodiff (AD) or finite-difference (FD) gradients. The choice is resolved
*per subject* and silently falls back to FD in several cases (ODE models,
steady-state doses, system resets, time-varying covariates on an unsupported
model, or a build without the `autodiff` feature), so the requested
`gradient_method` can differ from what's actually run.

## What changed
The verbose startup banner now reports the gradient route **actually
resolved** across the population, with the requested setting in brackets:

```
Starting estimation (chain: FOCE) on 15 threads...
  10 subjects, 110 observations
  3 thetas, 3 etas, 1 sigmas
  gradient: AD (single-snapshot)  [requested: auto]
```

- No-autodiff build: `gradient: FD  [requested: auto; autodiff not compiled in]`
- Mixed populations show per-route counts: `AD (event-driven) ×118, FD ×3`

Implementation: `inner_optimizer::gradient_route_summary` aggregates the
existing per-subject `resolve_gradient_method` over the population; `api.rs`
prints it in the verbose startup block.

## Alternatives considered
Printing only the requested `GradientMethod` — rejected: it hides fallbacks,
which is exactly the information a user needs.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None (additive console output)

## Numerical validation
- [x] Not applicable (reporting only; no change to estimation math). Verified
      the warfarin fit is unchanged and the banner reads `AD (single-snapshot)`
      on the autodiff build and `FD ... autodiff not compiled in` on the ci build.

## Performance
- [x] No significant impact expected (one O(n_subjects) resolution pass at startup)

## Tests
- [x] Unit test added (`gradient_route_summary_reports_route_taken_not_requested`):
      a `tv_fn`-less model resolves to FD even when `auto` is requested — asserts
      the banner shows the route taken, not the argument. Passes under both
      `--features ci` and `--features autodiff`.

## Example (user-facing features only)
- [x] Banner example shown above and in `docs/src/estimation/foce.md`.

## Docs
- [x] `docs/src/estimation/foce.md` updated (new "Gradient route (AD vs FD)" section)
- [x] No `mdbook build` committed (CI builds the book)

## Checklist
- [x] `cargo +nightly fmt -- --check` clean
- [x] `cargo +nightly clippy --no-default-features --features ci` — no new warnings
- [x] `cargo build --release --features autodiff` compiles; banner verified in a live fit
- [x] No version bump needed

## Reviewer hints
`gradient_route_summary` mirrors the branch logic in `resolve_gradient_method`
(same module) by construction — it just counts each subject's resolved route.
If new fallback conditions are added there, they're reflected automatically.
