### PR TITLE
fix(api): error when gradient_method=ad requested without autodiff build

### DIFF
--- a/docs/src/file-formats/check-report.md
+++ b/docs/src/file-formats/check-report.md
@@ -60,6 +60,7 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `E_PER_CMT_ERROR_MODEL` | error | An observed compartment lacks a per-CMT `[error_model]` entry. |
 | `E_DATA` | error | The `--data` file could not be read or parsed. |
 | `E_SDE_INCOMPATIBLE` | error | An SDE (`[diffusion]`) model used with an incompatible method (`saem`, `gn`, `gn_hybrid`) or `gradient_method = ad`. |
+| `E_AD_UNAVAILABLE` | error | `gradient_method = ad` requested, but the binary was built without the `autodiff` feature. Use `auto`/`fd`, or rebuild with the Enzyme toolchain. Only emitted by non-autodiff builds. |
 | `E_IMP_CHAIN` | error | `imp` is mis-placed in a method chain — first stage, repeated, or not the terminal stage. |
 | `E_OPTIMIZER_IOV` | error | `optimizer = trust_region` used with an IOV model (`n_kappa > 0`). |
 | `W_STEADY_STATE_II` | warning | SS=1 doses with missing / non-positive `II` (treated as non-SS). |

--- a/src/api.rs
+++ b/src/api.rs
@@ -367,6 +367,25 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
         }
     }
 
+    // Explicit `gradient_method = ad` on a build compiled WITHOUT the `autodiff`
+    // feature: AD is unavailable, so the inner loop would silently fall back to
+    // FD and run a different method than the user asked for. Reject it instead.
+    // `auto` (defined to fall back) and `fd` are unaffected.
+    #[cfg(not(feature = "autodiff"))]
+    if options.gradient_method == crate::types::GradientMethod::Ad {
+        diags.push(
+            Diagnostic::error(
+                "E_AD_UNAVAILABLE",
+                "gradient_method = ad was requested, but this build was compiled without the \
+                 `autodiff` feature, so automatic differentiation is unavailable — the fit would \
+                 silently use finite differences. Rebuild with the Enzyme toolchain \
+                 (`--features autodiff`), or set gradient_method = auto (falls back to FD \
+                 automatically) or fd.",
+            )
+            .with_block("fit_options"),
+        );
+    }
+
     // IMP is a likelihood evaluation, not an estimator: it must follow a
     // parameter-estimating stage, appear at most once, and be the terminal stage.
     if chain.iter().any(|&m| m == EstimationMethod::Imp) {
@@ -2650,6 +2669,37 @@ mod iov_integration {
         // A compatible optimizer produces no compatibility diagnostics.
         let ok_opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
         assert!(super::check_model_options(&model, &ok_opts).is_empty());
+    }
+
+    // On a build without the `autodiff` feature, explicitly requesting AD must
+    // error rather than silently running FD. `auto`/`fd` must still pass.
+    #[cfg(not(feature = "autodiff"))]
+    #[test]
+    fn ad_requested_without_autodiff_feature_errors() {
+        let model = make_iov_model();
+        let mut opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+
+        opts.gradient_method = crate::types::GradientMethod::Ad;
+        let diags = super::check_model_options(&model, &opts);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.code == "E_AD_UNAVAILABLE" && d.is_error()),
+            "explicit gradient_method=ad on a non-autodiff build must error, got: {diags:?}"
+        );
+
+        for gm in [
+            crate::types::GradientMethod::Auto,
+            crate::types::GradientMethod::Fd,
+        ] {
+            opts.gradient_method = gm;
+            assert!(
+                !super::check_model_options(&model, &opts)
+                    .iter()
+                    .any(|d| d.code == "E_AD_UNAVAILABLE"),
+                "gradient_method={gm:?} must not trigger E_AD_UNAVAILABLE"
+            );
+        }
     }
 }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -27,6 +27,7 @@
 //! | `E_PER_CMT_ERROR_MODEL`   | an observed compartment lacks a per-CMT `[error_model]` entry |
 //! | `E_DATA`                  | the `--data` file could not be read or parsed |
 //! | `E_SDE_INCOMPATIBLE`      | an SDE (`[diffusion]`) model used with SAEM / GN / AD |
+//! | `E_AD_UNAVAILABLE`        | `gradient_method = ad` requested on a build without the `autodiff` feature |
 //! | `E_IMP_CHAIN`             | `imp` mis-placed in a method chain (first / repeated / non-terminal) |
 //! | `E_OPTIMIZER_IOV`         | `optimizer = trust_region` used with an IOV model |
 //! | `W_STEADY_STATE_II`       | SS=1 dose with missing / non-positive II |


### PR DESCRIPTION
## Why
You're right — it was silent. On a build compiled **without** the `autodiff`
feature (the `ci` build, and what CI runs), `resolve_gradient_method`
(`inner_optimizer.rs:118`) returns `Fd` unconditionally, *before* it ever looks
at `model.gradient_method`. So a user who explicitly sets `gradient_method = ad`
gets finite-difference gradients with no warning or error — a different method
than they asked for.

`auto` is supposed to fall back silently (that's its contract), but an explicit
`ad` request should not.

## What changed
Added an `E_AD_UNAVAILABLE` error in `check_model_options` (the validation hook
used by both `fit()` and `ferx check`), gated `#[cfg(not(feature = "autodiff"))]`:

- Explicit `gradient_method = ad` on a non-autodiff build → hard error with a
  clear hint (rebuild with Enzyme, or use `auto`/`fd`).
- `auto` and `fd` are unaffected.
- On autodiff builds the check is compiled out entirely (AD is available there).

Live behaviour on the `ci` binary:
```
Error: gradient_method = ad was requested, but this build was compiled without
the `autodiff` feature, so automatic differentiation is unavailable — the fit
would silently use finite differences. Rebuild with the Enzyme toolchain
(`--features autodiff`), or set gradient_method = auto (falls back to FD
automatically) or fd.
```

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None for valid usage. A non-autodiff build + explicit `ad` previously
  "worked" (silently as FD); it now errors. That's the intended correction —
  the result was misleading, not correct.

## Numerical validation
- [x] Not applicable (validation-only). Verified the `ci` binary errors and the
  autodiff binary still runs `gradient_method = ad` (fits warfarin normally).

## Performance
- [x] No impact (one equality check at startup).

## Tests
- [x] Unit test `ad_requested_without_autodiff_feature_errors` (cfg
  `not(autodiff)`): explicit `ad` errors with `E_AD_UNAVAILABLE`; `auto`/`fd`
  do not. Runs in the default CI (`ci`) job.

## Docs
- [x] `docs/src/file-formats/check-report.md` — documented `E_AD_UNAVAILABLE`.
- [x] No `mdbook build` committed.

## Checklist
- [x] `cargo +nightly fmt -- --check` clean
- [x] `cargo +nightly clippy --no-default-features --features ci` — no new warnings
- [x] Both `ci` and `autodiff` builds compile; behaviour verified live
- [x] No version bump

## Reviewer hints
The guard sits next to the existing `E_SDE_INCOMPATIBLE` `gradient_method = ad`
check and mirrors its `Diagnostic` style. It's the *explicit* `ad` request that
errors; `auto` deliberately still falls back to FD.

## Open questions
Should an explicit `ad` request also error on an *autodiff* build when the
specific model can't use AD (ODE model, SS doses, resets)? Today those fall back
to FD per subject. That's a separate, more debatable case (it'd interact with
mixed populations) — out of scope here; happy to follow up if wanted.
