### PR TITLE
fix(parser): allow block_omega/block_kappa to span multiple lines [closes #121]

### DIFF
--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2996,15 +2996,17 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
 
 // --- Parameter parsing ---
 
-/// Coalesce `[fit_options]`-style bracketed declarations that span several
-/// physical lines back into a single logical line.
+/// Coalesce `block_omega`/`block_kappa` declarations whose lower-triangle list
+/// spans several physical lines back into a single logical line.
 ///
 /// `extract_blocks` hands `parse_parameters` one trimmed string per source
 /// line, so a `block_omega`/`block_kappa` whose lower-triangle list is written
 /// across multiple lines arrives split apart. Here we rejoin any run of lines
 /// from the first unbalanced `[` through the matching `]` into one line (joined
 /// with spaces) so the existing single-line regexes match unchanged. Lines with
-/// no bracket, or with balanced brackets, pass through untouched.
+/// no bracket, or with balanced brackets, pass through untouched. A trailing
+/// bare `FIX` left on its own line after the closing `]` is folded back onto
+/// the block line so the FIX flag isn't silently lost.
 fn join_bracketed_lines(lines: &[String]) -> Vec<String> {
     let mut out = Vec::new();
     let mut buf = String::new();
@@ -3020,7 +3022,19 @@ fn join_bracketed_lines(lines: &[String]) -> Vec<String> {
         depth -= line.matches(']').count() as i32;
         if depth <= 0 {
             depth = 0;
-            out.push(std::mem::take(&mut buf));
+            let logical = std::mem::take(&mut buf);
+            // Fold a bare `FIX` line onto the block declaration just emitted.
+            // Restricted to a previous line containing `]` so we never attach
+            // it to a non-block parameter line.
+            if logical.trim().eq_ignore_ascii_case("FIX")
+                && out.last().is_some_and(|l: &String| l.contains(']'))
+            {
+                let last = out.last_mut().unwrap();
+                last.push(' ');
+                last.push_str(logical.trim());
+            } else {
+                out.push(logical);
+            }
         }
     }
     // An unterminated `[` leaves text in the buffer; emit it so the downstream
@@ -6063,6 +6077,21 @@ mod tests {
         let lines = vec![
             "block_omega (ETA_CL, ETA_V) = [0.09,".to_string(),
             "0.02, 0.04] FIX".to_string(),
+        ];
+        let (_, _, block_omegas, _, _, _) = parse_parameters(&lines).unwrap();
+        assert_eq!(block_omegas.len(), 1);
+        assert!(block_omegas[0].fixed);
+    }
+
+    #[test]
+    fn test_parse_block_omega_multiline_fix_own_line() {
+        // FIX on its own line after the closing bracket must still be honored.
+        let lines = vec![
+            "block_omega (ETA_CL, ETA_V) = [".to_string(),
+            "0.09,".to_string(),
+            "0.02, 0.04".to_string(),
+            "]".to_string(),
+            "FIX".to_string(),
         ];
         let (_, _, block_omegas, _, _, _) = parse_parameters(&lines).unwrap();
         assert_eq!(block_omegas.len(), 1);

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6112,6 +6112,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_block_kappa_multiline_fix_own_line() {
+        // FIX on its own line after the closing bracket must be honored for
+        // IOV blocks too (shared fold logic in join_bracketed_lines).
+        let lines = vec![
+            "block_kappa (KAPPA_CL, KAPPA_V) = [".to_string(),
+            "0.05, 0.01, 0.03".to_string(),
+            "]".to_string(),
+            "FIX".to_string(),
+        ];
+        let (_, _, _, _, _, kappas) = parse_parameters(&lines).unwrap();
+        assert_eq!(kappas.block.len(), 1);
+        assert!(kappas.block[0].fixed);
+    }
+
+    #[test]
     fn test_parse_block_omega_3x3() {
         let lines = vec![
             "block_omega (ETA_CL, ETA_V, ETA_KA) = [0.09, 0.01, 0.04, 0.005, 0.002, 0.16]"

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2996,6 +2996,42 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
 
 // --- Parameter parsing ---
 
+/// Coalesce `[fit_options]`-style bracketed declarations that span several
+/// physical lines back into a single logical line.
+///
+/// `extract_blocks` hands `parse_parameters` one trimmed string per source
+/// line, so a `block_omega`/`block_kappa` whose lower-triangle list is written
+/// across multiple lines arrives split apart. Here we rejoin any run of lines
+/// from the first unbalanced `[` through the matching `]` into one line (joined
+/// with spaces) so the existing single-line regexes match unchanged. Lines with
+/// no bracket, or with balanced brackets, pass through untouched.
+fn join_bracketed_lines(lines: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut buf = String::new();
+    let mut depth: i32 = 0;
+    for line in lines {
+        if depth > 0 {
+            buf.push(' ');
+            buf.push_str(line);
+        } else {
+            buf = line.clone();
+        }
+        depth += line.matches('[').count() as i32;
+        depth -= line.matches(']').count() as i32;
+        if depth <= 0 {
+            depth = 0;
+            out.push(std::mem::take(&mut buf));
+        }
+    }
+    // An unterminated `[` leaves text in the buffer; emit it so the downstream
+    // regex fails to match and the user gets a clear "Bad block_omega" error
+    // rather than the line silently vanishing.
+    if !buf.is_empty() {
+        out.push(buf);
+    }
+    out
+}
+
 fn parse_parameters(
     lines: &[String],
 ) -> Result<
@@ -3073,7 +3109,9 @@ fn parse_parameters(
     let block_kappa_re =
         Regex::new(r"(?i)block_kappa\s*\(([^)]+)\)\s*=\s*\[([^\]]+)\](?:\s+(FIX)\b)?").unwrap();
 
-    for line in lines {
+    // Rejoin multi-line `block_omega`/`block_kappa` declarations before matching.
+    let lines = join_bracketed_lines(lines);
+    for line in &lines {
         if let Some(caps) = theta_re.captures(line) {
             let name = caps[1].to_string();
             let init: f64 = caps[2]
@@ -5998,6 +6036,50 @@ mod tests {
         assert_eq!(block_omegas.len(), 1);
         assert_eq!(block_omegas[0].names, vec!["ETA_CL", "ETA_V"]);
         assert_eq!(block_omegas[0].lower_triangle, vec![0.09, 0.02, 0.04]);
+    }
+
+    #[test]
+    fn test_parse_block_omega_multiline() {
+        // Lower triangle spread across several lines, as extract_blocks would
+        // hand them to parse_parameters (one trimmed string per source line).
+        let lines = vec![
+            "block_omega (ETA_CL, ETA_V) = [".to_string(),
+            "0.09,".to_string(),
+            "0.02, 0.04".to_string(),
+            "]".to_string(),
+        ];
+        let (_, omegas, block_omegas, _, eta_names, _) = parse_parameters(&lines).unwrap();
+        assert_eq!(omegas.len(), 0);
+        assert_eq!(block_omegas.len(), 1);
+        assert_eq!(block_omegas[0].names, vec!["ETA_CL", "ETA_V"]);
+        assert_eq!(block_omegas[0].lower_triangle, vec![0.09, 0.02, 0.04]);
+        assert!(!block_omegas[0].fixed);
+        assert_eq!(eta_names, vec!["ETA_CL", "ETA_V"]);
+    }
+
+    #[test]
+    fn test_parse_block_omega_multiline_fix() {
+        // FIX keyword on the closing-bracket line must still be honored.
+        let lines = vec![
+            "block_omega (ETA_CL, ETA_V) = [0.09,".to_string(),
+            "0.02, 0.04] FIX".to_string(),
+        ];
+        let (_, _, block_omegas, _, _, _) = parse_parameters(&lines).unwrap();
+        assert_eq!(block_omegas.len(), 1);
+        assert!(block_omegas[0].fixed);
+    }
+
+    #[test]
+    fn test_parse_block_kappa_multiline() {
+        let lines = vec![
+            "block_kappa (KAPPA_CL, KAPPA_V) = [".to_string(),
+            "0.05, 0.01, 0.03".to_string(),
+            "]".to_string(),
+        ];
+        let (_, _, _, _, _, kappas) = parse_parameters(&lines).unwrap();
+        assert_eq!(kappas.block.len(), 1);
+        assert_eq!(kappas.block[0].names, vec!["KAPPA_CL", "KAPPA_V"]);
+        assert_eq!(kappas.block[0].lower_triangle, vec![0.05, 0.01, 0.03]);
     }
 
     #[test]


### PR DESCRIPTION
## Why
`block_omega` / `block_kappa` declarations only parsed when written on a single line. A multi-line layout like

```
block_omega (ETA_CL, ETA_V1, ETA_Q, ETA_V2) = [
  0.1,
  0.0, 0.1,
  0.0, 0.0, 0.1,
  0.0, 0.0, 0.0, 0.1
]
```

silently failed to match — even though `docs/src/model-file/parameters.md` already documents this exact example and states "Multi-line and single-line layouts are equivalent — line breaks inside `[ ... ]` are ignored." Fixes #121.

## What changed
`extract_blocks` hands `parse_parameters` one trimmed string per source line, so a bracketed list spread over several lines arrived split apart and the single-line regex never matched. Added `join_bracketed_lines`, which coalesces any run of lines from the first unbalanced `[` through the matching `]` into one logical line (space-joined) before the parameter regexes run. Lines with no bracket, or with balanced brackets, pass through untouched. An unterminated `[` is emitted as-is so the user still gets the existing "Bad block_omega" error rather than a silently vanishing line.

## Alternatives considered
Making each block regex multi-line / `(?s)` would not help, since the lines are already split into separate strings before the regex sees them. Pre-joining at the line level is the minimal change and keeps the regexes untouched.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change; `.ferx` format is a strict superset of what parsed before.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (parser-only change; accepts a layout that previously failed, produces identical specs to the single-line form)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

Added `test_parse_block_omega_multiline`, `test_parse_block_omega_multiline_fix` (FIX on the closing-bracket line), and `test_parse_block_kappa_multiline`. Full lib suite: 692 passed.

## Example (user-facing features only)
- [x] Not applicable — the multi-line example already exists in `docs/src/model-file/parameters.md`; this PR makes the documented behaviour actually work.

## Docs
- [x] No user-visible change to docs needed — the docs already described multi-line as supported; this fix aligns the parser with the docs.

## Checklist
- [x] `cargo clippy` clean (no new warnings from this change)
- [ ] `cargo check --features autodiff` still compiles (if touching AD-reachable code) — N/A, parser not AD-reachable
- [x] `Cargo.toml` version bumped if breaking — N/A, not breaking

## Reviewer hints
The whole change is `join_bracketed_lines` plus one call site in `parse_parameters`. The bracket-depth counter assumes `[`/`]` only appear inside block declarations within `[parameters]`, which holds — no other parameter syntax uses square brackets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
