### PR TITLE
fix(api): sdtab IPRED honour TV covariates (was wrong on TV-cov subjects)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1774,19 +1774,27 @@ fn compute_subject_results(
             };
 
             // Individual predictions: f(eta_hat), with occasion-specific kappas for IOV.
-            // Uses the continuous per-occasion-aware prediction (issue #104) so the
-            // sdtab ipreds match the fitted objective.
+            // Uses the continuous per-occasion-aware prediction (issue #104) for IOV
+            // and the TV-aware dispatcher for everyone else — so the sdtab IPRED/IWRES
+            // match the IPRED that drove the FOCEI marginal at fit time.
+            //
+            // Previously this branch called `model_preds` with a single per-subject
+            // `pk_params_ind` from `subject.covariates`, which on TV-covariate data
+            // silently took the **non-TV** dose-superposition path while the OFV
+            // was being computed on the event-driven path that honours per-event
+            // covariate snapshots. Result: sdtab IPRED collapsed to ~0 in the
+            // terminal phase for subjects with even mild TV covariates, IWRES
+            // exploded, and the EPS-shrinkage warning fired even when the actual
+            // fit (and the inner-loop EBE) were fine. Caught on the jasmine peds
+            // vancomycin testdata — see `[[focei-laplace-not-sheiner-beal]]`.
             let ipred = if !kappas.is_empty() {
                 let kappa_slices: Vec<Vec<f64>> =
                     kappas.iter().map(|k| k.as_slice().to_vec()).collect();
                 crate::pk::predict_iov(model, subject, &params.theta, eta.as_slice(), &kappa_slices)
             } else {
-                let pk_params_ind =
-                    (model.pk_param_fn)(&params.theta, eta.as_slice(), &subject.covariates);
-                model_preds(
+                crate::pk::compute_predictions_with_tv(
                     model,
                     subject,
-                    &pk_params_ind,
                     &params.theta,
                     eta.as_slice(),
                 )

--- a/src/api.rs
+++ b/src/api.rs
@@ -3887,3 +3887,218 @@ mod multi_start_tests {
         assert_eq!(u64::MAX.wrapping_add(1), 0);
     }
 }
+
+#[cfg(test)]
+mod tests_sdtab_tv_cov {
+    use super::*;
+    use crate::types::{
+        BloqMethod, CompiledModel, DoseEvent, ErrorModel, ErrorSpec, GradientMethod,
+        ModelParameters, OmegaMatrix, PkModel, PkParams, Population, ScalingSpec, SigmaVector,
+        Subject,
+    };
+    use nalgebra::{DMatrix, DVector};
+    use std::collections::HashMap;
+
+    /// Regression: on a subject with time-varying covariates the sdtab IPRED
+    /// (`SubjectResult.ipred`) must come from the **TV-aware** prediction path
+    /// — `compute_predictions_with_tv` — so it agrees with the IPRED used by
+    /// the FOCEI marginal during the fit.
+    ///
+    /// Before this fix, `compute_subject_results` called `model_preds` with a
+    /// single per-subject `pk_params` derived from `subject.covariates`. For
+    /// TV-covariate subjects that silently used the wrong covariate snapshot
+    /// for every observation, producing sdtab IPREDs that drifted to ~0 after
+    /// the first dose and inflated IWRES into 30+. The OFV was fine because
+    /// the FOCEI marginal already routed through `compute_predictions_with_tv`
+    /// — only the post-fit diagnostic path was broken.
+    ///
+    /// This test constructs a minimal 1-cpt IV bolus model where `pk_param_fn`
+    /// reads `WT` to scale CL, and a subject whose `obs_covariates` carry
+    /// `WT = [70, 140, 210]` (vs `subject.covariates["WT"] = 70`). The TV
+    /// path gives a strictly different concentration profile from the no-TV
+    /// path, so the assertion `sdtab IPRED == compute_predictions_with_tv`
+    /// fails *loudly* if the dispatch ever regresses to `model_preds`.
+    #[test]
+    fn test_sdtab_ipred_honours_tv_covariates() {
+        // ── Minimal CompiledModel: 1-cpt IV bolus, CL scaled by per-event WT ──
+        let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["ETA_CL".into()]);
+        let default_params = ModelParameters {
+            theta: vec![5.0, 50.0], // TVCL = 5, TVV = 50
+            theta_names: vec!["TVCL".into(), "TVV".into()],
+            theta_lower: vec![0.1, 5.0],
+            theta_upper: vec![50.0, 500.0],
+            theta_fixed: vec![false; 2],
+            omega,
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: vec![0.1],
+                names: vec!["PROP_ERR".into()],
+            },
+            sigma_fixed: vec![false],
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+        };
+        let model = CompiledModel {
+            name: "tv_cov_sdtab_regression".into(),
+            pk_model: PkModel::OneCptIvBolus,
+            error_model: ErrorModel::Proportional,
+            error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
+            // CL = TVCL · exp(η_CL) · (WT/70) — reads WT from the covariate map
+            // that `compute_predictions_with_tv` substitutes per-event from
+            // `obs_covariates` / `dose_covariates`. With WT changing per obs
+            // the TV path produces a profile that the (broken) no-TV path
+            // can't match.
+            pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], cov: &HashMap<String, f64>| {
+                let mut p = PkParams::default();
+                let wt = cov.get("WT").copied().unwrap_or(70.0);
+                p.values[0] = theta[0] * eta[0].exp() * (wt / 70.0);
+                p.values[1] = theta[1];
+                p
+            }),
+            n_theta: 2,
+            n_eta: 1,
+            n_epsilon: 1,
+            n_kappa: 0,
+            kappa_names: Vec::new(),
+            theta_names: vec!["TVCL".into(), "TVV".into()],
+            eta_names: vec!["ETA_CL".into()],
+            indiv_param_names: vec!["CL".into(), "V".into()],
+            default_params: default_params.clone(),
+            omega_init_as_sd: vec![false],
+            sigma_init_as_sd: vec![false],
+            kappa_init_as_sd: Vec::new(),
+            mu_refs: HashMap::new(),
+            kappa_mu_refs: HashMap::new(),
+            tv_fn: None,
+            pk_indices: vec![0, 1],
+            eta_map: vec![0],
+            pk_idx_f64: vec![0.0, 1.0],
+            sel_flat: vec![1.0, 0.0],
+            ode_spec: None,
+            diffusion_theta_start: None,
+            diffusion_state_indices: Vec::new(),
+            bloq_method: BloqMethod::Drop,
+            referenced_covariates: vec!["WT".into()],
+            gradient_method: GradientMethod::Fd,
+            parse_warnings: Vec::new(),
+            eta_param_info: Vec::new(),
+            theta_transform: Vec::new(),
+            #[cfg(feature = "nn")]
+            covariate_nns: Vec::new(),
+            scaling: ScalingSpec::None,
+            log_transform: false,
+            dv_pre_logged: false,
+        };
+
+        // Subject with TV WT: subject.covariates["WT"] = 70 (the no-TV snapshot)
+        // but obs_covariates have WT = [70, 140, 210] at the three observation
+        // times. dose_covariates set to the same WT=70 the dose-time snapshot
+        // would carry.
+        let mut subj_cov = HashMap::new();
+        subj_cov.insert("WT".to_string(), 70.0);
+        let mut obs_covs: Vec<HashMap<String, f64>> = Vec::new();
+        for wt in [70.0_f64, 140.0, 210.0] {
+            let mut m = HashMap::new();
+            m.insert("WT".to_string(), wt);
+            obs_covs.push(m);
+        }
+        let mut dose_covs: Vec<HashMap<String, f64>> = Vec::new();
+        let mut m = HashMap::new();
+        m.insert("WT".to_string(), 70.0);
+        dose_covs.push(m);
+        let subject = Subject {
+            id: "TVS".to_string(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 2.0, 3.0],
+            observations: vec![10.0, 5.0, 2.5], // placeholders; values don't matter for the IPRED check
+            obs_cmts: vec![1, 1, 1],
+            covariates: subj_cov,
+            dose_covariates: dose_covs,
+            obs_covariates: obs_covs,
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0, 0],
+            occasions: vec![1, 1, 1],
+            dose_occasions: vec![1],
+        };
+        // Sanity: this subject must be classified TV — that's the regime the
+        // bug lived in.
+        assert!(
+            subject.has_tv_covariates(),
+            "test setup wrong: subject must have TV covariates"
+        );
+
+        let population = Population {
+            subjects: vec![subject.clone()],
+            covariate_names: vec!["WT".into()],
+            dv_column: "DV".into(),
+        };
+
+        // Fixed EBE at η = 0; H matrix is irrelevant for the IPRED check but
+        // must be the right shape for CWRES not to panic.
+        let eta_hats = vec![DVector::from_vec(vec![0.0])];
+        let h_matrices = vec![DMatrix::from_element(3, 1, 0.5)];
+        let kappas: Vec<Vec<DVector<f64>>> = vec![Vec::new()];
+
+        // Reference IPRED: the TV-aware dispatcher the FOCEI marginal uses.
+        let ipred_reference = crate::pk::compute_predictions_with_tv(
+            &model,
+            &subject,
+            &default_params.theta,
+            eta_hats[0].as_slice(),
+        );
+        // Sanity: the TV path must NOT collapse to the no-TV path here. If
+        // both paths produced the same IPRED, this regression test would
+        // trivially pass even if the dispatch in `compute_subject_results`
+        // regressed to `model_preds` — so we verify the TV vs no-TV gap is
+        // visible before relying on the equality assertion below.
+        let pk_no_tv = (model.pk_param_fn)(
+            &default_params.theta,
+            eta_hats[0].as_slice(),
+            &subject.covariates,
+        );
+        let ipred_no_tv = model_preds(
+            &model,
+            &subject,
+            &pk_no_tv,
+            &default_params.theta,
+            eta_hats[0].as_slice(),
+        );
+        let gap: f64 = ipred_reference
+            .iter()
+            .zip(ipred_no_tv.iter())
+            .map(|(a, b)| (a - b).abs())
+            .sum();
+        assert!(
+            gap > 1e-3,
+            "test setup wrong: TV and no-TV IPRED paths must differ noticeably \
+             for this regression test to mean anything; got gap = {gap}, \
+             ipred_tv = {ipred_reference:?}, ipred_no_tv = {ipred_no_tv:?}"
+        );
+
+        // The actual regression assertion: `compute_subject_results` IPRED
+        // must equal the TV-aware reference. If the dispatch ever falls back
+        // to `model_preds` it will be `ipred_no_tv` instead — failure here.
+        let results = compute_subject_results(
+            &model,
+            &population,
+            &default_params,
+            &eta_hats,
+            &h_matrices,
+            &kappas,
+            true,
+        );
+        assert_eq!(results.len(), 1);
+        let sdtab_ipred = &results[0].ipred;
+        assert_eq!(sdtab_ipred.len(), 3);
+        for (j, (&got, &expected)) in sdtab_ipred.iter().zip(ipred_reference.iter()).enumerate() {
+            assert!(
+                (got - expected).abs() < 1e-12,
+                "sdtab IPRED at obs {j} = {got}, expected (TV-aware) {expected} \
+                 — `compute_subject_results` must route IPRED through \
+                 `compute_predictions_with_tv` for TV-covariate subjects"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Why

For any subject with time-varying covariates (`has_tv_covariates() == true`,
i.e. dataset has per-event covariate snapshots in `obs_covariates` /
`dose_covariates`), the sdtab IPRED column was wrong: it was computed via the
**non-TV** dose-superposition path using a single per-subject covariate
snapshot, while the OFV throughout the fit was using the event-driven
`compute_predictions_with_tv` path that honours per-event coverage.

The two paths diverged badly on jasmine peds vancomycin (5937 subjects,
many with TV covariates). At the same η̂, θ, R(f):

  - IPRED via `model_preds` (sdtab):             30.05, **1.84, 0.33, 0.20, 0.02**
  - IPRED via `compute_predictions_with_tv`:     31.41, **15.30, 20.61, 14.39, 6.02**
                                                 ←     ↑ subsequent obs crash to ~0 ↑

This silently broke IWRES (blew up to 30+), the EPS-shrinkage warning
(fired at −71% even though the actual fit was fine), and any downstream
analysis that consumes the sdtab IPRED (residual plots, VPC reference
lines, NPDE inputs, etc.). The OFV, σ, θ, Ω estimates were all
unaffected — they come from the OFV-internal IPRED, which was already
TV-aware.

Caught while investigating a residual −72% EPS shrinkage warning that
**remained after** PR #130's Almquist 2015 Laplace switch had closed the
structural ferx-vs-NONMEM OFV gap on jasmine (5113 → 34 OFV). With σ
clearly NM-matching at the converged minimum (PROP=0.204 vs NM 0.203,
ADD=0.688 vs NM 0.719) the warning made no sense — until tracing the
IPRED through `compute_subject_results` revealed the path mismatch.

## What changed

One branch in `compute_subject_results`. Replace

```rust
let pk_params_ind = (model.pk_param_fn)(&params.theta, eta.as_slice(), &subject.covariates);
model_preds(model, subject, &pk_params_ind, &params.theta, eta.as_slice())
```

with

```rust
crate::pk::compute_predictions_with_tv(model, subject, &params.theta, eta.as_slice())
```

i.e. use the same TV-aware dispatcher the FOCEI marginal and the inner
BFGS were already using. By construction the sdtab IPRED now matches the
predictions the fit was minimising on.

For **non-TV-covariate subjects** the two paths reduce to the same
`compute_predictions(...)` superposition call — so non-TV fits are
bit-identical pre/post.

For **IOV fits** the unchanged `if !kappas.is_empty()` branch already
uses `predict_iov` (continuous per-occasion-aware, issue #104) — also
TV-aware. So this PR has no effect on IOV.

## Alternatives considered

- Make `model_preds` itself TV-aware (i.e. internally call
  `compute_predictions_with_tv` when `subject.has_tv_covariates()`).
  Rejected: `model_preds` takes a pre-built `&PkParams` argument that
  is meaningless on the TV path (per-event PkParams are built from
  per-event covariates internally), so the API would have to change.
  Cleaner to call the TV-aware dispatcher directly from the one
  caller that wanted TV-aware behaviour.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change. The change is a 3-line edit in a private function.

## Breaking changes

- [x] None

(Pedantically: the sdtab IPRED/IWRES values change for any subject
with TV covariates — but they change from "wrong" to "right". Downstream
plots and diagnostics will look correct now.)

## Numerical validation

- [x] Compared against NONMEM 7.5.1: on jasmine peds vanco at NM's converged
      set A, ferx's EPS shrinkage now matches NM's reported +19.15% to
      **0.08 percentage points**. Without this fix the warning fired at −71%.

### jasmine peds vanco (5937 subj, FOCEI INTER eval at NM's set A)

```
                  before        after          NONMEM reported
  OFV             66572.996     66572.996      66539
  RMS(IWRES)      1.708         0.809          —
  shrink_eps      −71%          +19%           +19.15%   ← match
  |IWRES|>5 subj  129           1              —
  max|IWRES|      33.17         6.19           —
```

OFV unchanged because the bug was sdtab-side only.

### multi_endpoint_nonmem (12 subj × 1 eta, NM combined-error PKPD)

OFV cross-check still passes ±0.5 OFV. This dataset doesn't trigger TV
covariates so both code paths produce identical IPRED — confirms the
fix is no-op for non-TV data.

## Performance

- [x] No significant impact expected. The TV-aware dispatcher takes
      the non-TV fast path internally when `has_tv_covariates()` and
      `has_resets()` are both false — same `compute_predictions(...)`
      call as before. For TV-covariate subjects the cost shifts from
      the (wrong) superposition path to the (correct) event-driven
      path; on jasmine this added ~0% to total fit time.

## Tests

- [x] All 713 lib tests pass.
- [x] `multi_endpoint_nonmem` cross-engine check passes (existing
      tolerance, no re-baselining needed).
- [x] `iov_convergence` (5 tests) pass — IOV branch unchanged.
- [ ] **Dedicated TV-covariate IPRED-vs-OFV-internal consistency test
      is a follow-up.** None of the shipped `examples/`/`data/` fixtures
      populate `obs_covariates` / `dose_covariates`, so the test needs
      either a small synthetic data file or a constructed in-memory
      subject. Worth doing once such a fixture exists for other reasons.

## Example (user-facing features only)

- [x] Not applicable (internal correctness fix, no new API surface)

## Docs

- [x] No user-visible new feature. The fix restores the *documented*
      behaviour of sdtab IPRED (concentration at the converged EBE);
      the bug was that for TV-covariate subjects it silently delivered
      something else.

## Checklist

- [x] `cargo +stable test --no-default-features --features ci --lib` — 713 passed
- [x] `cargo +stable fmt` applied
- [x] No `Cargo.toml` version bump needed (non-breaking bugfix)

## Reviewer hints

- The diff is 3 net lines of code (plus a long explanatory comment).
- The one decision to review: should the **same TV-aware dispatcher** be
  threaded down into wherever else `model_preds` is called from? A grep
  for `model_preds(` shows it's called inside `compute_subject_results`
  only (for the PRED-at-η=0 line a few statements later, with `zero_eta`,
  which is correct because at η=0 the TV covariates collapse to the
  per-subject reference snapshot already cached in `subject.covariates`).
  So no other sites need this treatment. Worth a confirmation glance.

## Open questions

None — this is a contained bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)