### PR TITLE
refactor(estimation): lift ODE + per-CMT gates on analytical Laplace gradient

### DIFF
--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -953,12 +953,12 @@ fn subject_nll_pop_grad_analytical_laplace(
 ) -> Option<(f64, Vec<f64>)> {
     use crate::pk;
 
-    // Same single-error-spec invariant the SB path holds (analytical PK only,
-    // no per-CMT, no M3) — the caller's `can_use_analytical` already ensures it.
-    debug_assert!(
-        matches!(model.error_spec, ErrorSpec::Single(_)),
-        "analytical Laplace GN gradient reached with a non-Single error spec"
-    );
+    // The Almquist Laplace gradient now supports both `ErrorSpec::Single` and
+    // `ErrorSpec::PerCmt`. The per-CMT routing flows through `dvar_df`,
+    // `dvar_dlogsigma`, `d2var_df2`, and `variance_at` — every variance-related
+    // call site already takes `subject.obs_cmts[j]`. The caller still gates on
+    // analytical PK and excludes M3 (`can_use_analytical` in
+    // `subject_nll_pop_grad`).
     // Sibling debug_assert to the SB path: this function computes the Almquist
     // Laplace gradient, which is only consistent with the NLL the outer FOCE
     // loop minimises when `options.interaction == true`. The dispatcher already
@@ -1005,28 +1005,17 @@ fn subject_nll_pop_grad_analytical_laplace(
     let d_vec: Vec<f64> = (0..n_obs)
         .map(|j| error_spec.dvar_df(subject.obs_cmts[j], ipreds[j], sigma_values))
         .collect();
-    // ∂²R/∂f² is constant in f for additive/proportional/combined: it's 0 for
-    // additive and 2·σ_prop² for the other two. We read the inner ErrorModel
-    // off the `Single` ErrorSpec (guaranteed by the debug_assert above) rather
-    // than `model.error_model` so this stays consistent with the `variance_at`
-    // / `dvar_df` / `dvar_dlogsigma` calls below — all of which dispatch on
-    // `error_spec`. (`model.error_model` is the legacy single-error field;
-    // hand-built models can desync the two, and the debug_assert is a no-op
-    // in release.)
-    let inner_em = match error_spec {
-        ErrorSpec::Single(em) => *em,
-        // Guard for release builds where the debug_assert is a no-op; PerCmt
-        // does not have a single representative ∂²R/∂f² so we bail and let
-        // the dispatcher fall back to FD.
-        ErrorSpec::PerCmt(_) => return None,
-    };
-    let d2_scalar = match inner_em {
-        ErrorModel::Additive => 0.0,
-        ErrorModel::Proportional | ErrorModel::Combined => {
-            let sp = sigma_values.first().copied().unwrap_or(0.0);
-            2.0 * sp * sp
-        }
-    };
+    // ∂²R/∂f² per observation. f-independent for additive/proportional/combined
+    // (0 for additive, 2·σ_prop² otherwise), but the *per-CMT* value can differ
+    // across observations: e.g. an Emax PK/PD model with proportional error on
+    // PK (CMT=2) and additive on PD (CMT=3) needs `d2 = 2·σ_prop²` at PK obs
+    // and `d2 = 0` at PD obs. Dispatch through `error_spec.d2var_df2` so the
+    // PerCmt case picks up each endpoint's own contribution; `Single` ignores
+    // the cmt argument and returns the scalar value uniformly. The β_j chain
+    // at line ~1095 then reads `d2_vec[j]` per obs.
+    let d2_vec: Vec<f64> = (0..n_obs)
+        .map(|j| error_spec.d2var_df2(subject.obs_cmts[j], sigma_values))
+        .collect();
 
     // Conditional Hessian H̃ = a'·diag(1/R)·a + ½·c̃'·c̃ + Ω⁻¹.
     // c̃_{j,k} = dⱼ·a_{j,k}/Rⱼ; we only need the symmetric outer products,
@@ -1083,13 +1072,13 @@ fn subject_nll_pop_grad_analytical_laplace(
     //   αⱼ   = −2·errⱼ/Rⱼ + dⱼ·(Rⱼ − errⱼ²)/Rⱼ²
     //   βⱼ   = −dⱼ/Rⱼ² + dⱼ·d2ⱼ/Rⱼ² − dⱼ³/Rⱼ³
     let mut theta_per_j = vec![0.0f64; n_obs];
-    let d2 = d2_scalar; // f-independent for additive/proportional/combined
     for j in 0..n_obs {
         let r = r_diag[j];
         let inv_r = 1.0 / r;
         let inv_r2 = inv_r * inv_r;
         let inv_r3 = inv_r2 * inv_r;
         let d = d_vec[j];
+        let d2 = d2_vec[j]; // per-obs / per-CMT; constant in f for the current error models
         let e = err[j];
         let alpha_j = -2.0 * e * inv_r + d * (r - e * e) * inv_r2;
         let beta_j = -d * inv_r2 + d * d2 * inv_r2 - d * d * d * inv_r3;
@@ -1273,11 +1262,21 @@ pub(crate) fn subject_nll_pop_grad(
     // `subject_nll_at` stays exactly consistent with the objective the outer
     // FOCE loop minimises. (The old analytical κ-prior gradient matched the
     // since-removed MAP-penalty objective and would now disagree.)
-    let can_use_analytical = model.ode_spec.is_none()
-        && !matches!(model.bloq_method, BloqMethod::M3)
-        && kappas.is_empty();
+    // Two analytical paths with different scope:
+    //   - Sheiner–Beal (no INTER): analytical PK only, single error spec — the
+    //     SB chain rule still assumes `ipreds = f₀ + a·η̂` (a linear surface)
+    //     and a single (∂R/∂σ_k, ∂d/∂σ_k) per obs, both untouched here.
+    //   - Almquist Laplace (INTER): every variance call already dispatches
+    //     through `error_spec` (so per-CMT works), and the θ axis is a
+    //     forward-FD on `pk::compute_predictions_with_tv` — which itself
+    //     dispatches to the ODE solver for ODE models. So Laplace can run on
+    //     ODE + PerCmt models too; the only blockers are M3 and IOV.
+    let common_ok = !matches!(model.bloq_method, BloqMethod::M3) && kappas.is_empty();
+    let sb_ok =
+        common_ok && model.ode_spec.is_none() && matches!(model.error_spec, ErrorSpec::Single(_));
+    let laplace_ok = common_ok;
 
-    if can_use_analytical {
+    if (options.interaction && laplace_ok) || (!options.interaction && sb_ok) {
         // Dispatch to the form whose gradient is exactly consistent with the
         // NLL `foce_subject_nll` is computing for this subject:
         //   - `options.interaction == true`  → Almquist 2015 Laplace

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1239,9 +1239,17 @@ fn subject_nll_pop_grad_analytical_laplace(
 /// Compute the FOCE NLL and its gradient w.r.t. the packed population parameter
 /// vector for a single subject, with ETAs fixed at their current EBE values.
 ///
-/// For non-IOV analytical PK models without M3 BLOQ, uses an analytical gradient:
-/// exact for omega/sigma parameters; forward-FD of predictions only for theta.
-/// Falls back to central FD for ODE models, IOV, or M3 BLOQ.
+/// Two analytical paths with different scope (see `sb_ok` / `laplace_ok` below):
+///   - **Almquist Laplace (INTER)**: omega/sigma exact, θ via forward-FD of
+///     predictions. Runs for any model except M3 BLOQ and IOV — ODE models and
+///     per-CMT (`ErrorSpec::PerCmt`) error specs are both supported.
+///   - **Sheiner–Beal (non-INTER)**: same θ axis, but the chain rule still
+///     assumes a single error spec and `ipreds = f₀ + a·η̂`, so this branch
+///     additionally requires analytical PK and `ErrorSpec::Single`.
+///
+/// In all other cases — M3 BLOQ, IOV, or the SB path's extra restrictions —
+/// the dispatcher falls back to central FD over `subject_nll_at`. The Laplace
+/// branch can also bail to FD per call when `H̃` fails Cholesky.
 ///
 /// Returns `(nll_i, gradient_i)` where `gradient_i[j] = d(nll_i)/d(x[j])`.
 pub(crate) fn subject_nll_pop_grad(

--- a/src/types.rs
+++ b/src/types.rs
@@ -669,6 +669,36 @@ impl ErrorSpec {
         }
     }
 
+    /// `d²(residual variance)/d(prediction f)²` for one observation at `cmt`.
+    ///
+    /// Additive endpoints contribute 0 (variance is `σ_add²`, independent of f).
+    /// Proportional and combined endpoints contribute `2·σ_prop²` (variance has
+    /// a `f²·σ_prop²` term, so the second derivative w.r.t. f is constant).
+    /// `Single` ignores `cmt`; `PerCmt` dispatches on the endpoint registered
+    /// for `cmt`. Used by the Almquist Laplace FOCEI gradient's θ-axis β_j
+    /// chain — keeping the per-CMT routing here lets the same closed-form
+    /// gradient handle multi-endpoint models without changing the call site.
+    pub fn d2var_df2(&self, cmt: usize, sigma: &[f64]) -> f64 {
+        let (em, prop_sigma) = match self {
+            ErrorSpec::Single(em) => (*em, sigma.first().copied().unwrap_or(0.0)),
+            ErrorSpec::PerCmt(map) => match map.get(&cmt) {
+                Some(ep) => (
+                    ep.error_model,
+                    ep.sigma_idx
+                        .first()
+                        .and_then(|&i| sigma.get(i))
+                        .copied()
+                        .unwrap_or(0.0),
+                ),
+                None => return 0.0,
+            },
+        };
+        match em {
+            ErrorModel::Additive => 0.0,
+            ErrorModel::Proportional | ErrorModel::Combined => 2.0 * prop_sigma * prop_sigma,
+        }
+    }
+
     /// `d(residual variance)/d(log σ_k)` for one observation at `cmt`, where
     /// `k` indexes the flat global sigma vector. Zero when `σ_k` does not enter
     /// this observation's endpoint, so the SAEM sigma-gradient can sum this over


### PR DESCRIPTION
## Why

Until now `subject_nll_pop_grad` routed any model with `ode_spec.is_some()` or `ErrorSpec::PerCmt(_)` to the central-FD fallback. The gates were holdovers from when the Almquist Laplace closed-form was first added (PR #132); the function header said "analytical PK only, no per-CMT, no M3" but the body already accessed every variance-related quantity through `error_spec.{variance_at,dvar_df,dvar_dlogsigma}` — all of which take `cmt` and dispatch correctly on `PerCmt`. The only blocker was the θ-axis β_j chain, which used a model-wide `d2_scalar = ∂²R/∂f²`.

Discovered while profiling an ODE + per-CMT FOCEI fit (joint PK/PD Emax) for the ferx-experiment benchmark — the FD-fallback path was hot enough that I wanted to lift the analytical gate. Implementing that turned up the comment/code mismatch this PR fixes.

## What changed

* **`ErrorSpec::d2var_df2(cmt, sigma)`** in `src/types.rs`: new per-CMT-aware helper returning `2·σ_prop²` for Proportional/Combined endpoints and `0` for Additive. Same dispatch shape as the existing `dvar_df`.
* **`subject_nll_pop_grad_analytical_laplace`**:
  - Replaces the `d2_scalar` with a per-obs `d2_vec[j]` computed via `error_spec.d2var_df2(subject.obs_cmts[j], …)`.
  - Drops the early `ErrorSpec::PerCmt(_) → return None` bail and the matching `debug_assert!(matches!(model.error_spec, …Single…))`.
* **`subject_nll_pop_grad` dispatcher** splits the analytical gate:
  - `sb_ok` — SB still requires analytical PK + `Single` (its chain rule assumes a single `(∂R/∂σ_k, ∂d/∂σ_k)` per obs and `f₀ + a·η̂`).
  - `laplace_ok` — Almquist Laplace only excludes M3 and IOV; ODE and per-CMT are both fine. `pk::compute_predictions_with_tv` already dispatches to `ode::ode_predictions` for ODE models, so the θ-axis forward-FD-on-predictions reuses the existing ODE solver.

## Alternatives considered

A version that also moved the SB path to support ODE + per-CMT — rejected for scope: the SB chain rule actually does assume single-error-spec semantics in a few more places (`f₀ + a·η̂` linearisation; single `(∂R, ∂d)` per obs) so it'd be a bigger refactor with no immediate user. Left a comment on `sb_ok` documenting why the gate stays.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change.

## Breaking changes
- [x] None

## Numerical validation

- [x] Compared against: prior ferx commit `3ec2847` (main HEAD; result identical at machine precision on the multi_endpoint reference case)
- [x] Reference values:

```
# before / reference (main)
multi_endpoint_nonmem::objective_matches_nonmem_at_reference_params: OFV matches NONMEM
multi_endpoint_nonmem::fit_recovers_theta_and_per_cmt_sigma:         all asserts pass

# after (this PR)
multi_endpoint_nonmem::objective_matches_nonmem_at_reference_params: OFV matches NONMEM
multi_endpoint_nonmem::fit_recovers_theta_and_per_cmt_sigma:         all asserts pass
                                                                     (theta, sigma_prop, sigma_add bit-identical)
```

## Performance

- [x] No significant impact expected (on this model class). On the ferx-experiment Emax PK/PD scenario (100 subjects, 1600 obs, 8 θ, 2 η, 2 σ, `gradient = fd`) wall time is unchanged (~780 s either way). The per-outer-step bottleneck is the inner-loop EBE search (~50 ODE solves per subject) which both paths share. The closed-form Ω/σ gain that gave PR #132 its 15× speedup matters more on models with bigger n_θ / n_η ratios. Filing this as a "lift the gate" refactor so the analytical path's scope matches what the code actually computes; the real perf win for ODE FOCEI needs sensitivity ODEs in the inner loop (follow-up).

Counter instrumentation during a 2-iter smoke fit confirmed 1200 enters / 1200 OK / 0 bails — every subject every outer eval now goes through the analytical path on this model.

## Tests

- [x] No new tests needed — the existing `multi_endpoint_nonmem::*` slow tests (one OFV match against NONMEM, one full ODE + per-CMT fit) already cover the path that's newly reachable. Both passed on main and continue to pass after this PR.
- [x] Full lib suite: 718 / 0; `analytical_laplace_*` direct tests (4): pass; `multi_endpoint_nonmem` slow tests (2): pass.

## Example
- [x] Not applicable (internal refactor; no new API surface, behaviour identical on previously-supported models).

## Docs
- [x] No user-visible change.

## Checklist
- [x] `cargo clippy` — n/a in this env (enzyme toolchain has no clippy)
- [x] `cargo check --features autodiff` — passes (release build under autodiff completes; this code is not on the AD-instrumented path)
- [x] `Cargo.toml` version bumped if breaking — n/a

## Reviewer hints

- The only substantive correctness piece is `ErrorSpec::d2var_df2` and the per-obs `d2_vec[j]` substitution. Everything else in `subject_nll_pop_grad_analytical_laplace` was already CMT-aware; the comments at the top of the function were just lagging.
- `sb_ok` deliberately stays narrow — please push back if you want SB to follow.

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)