### PR TITLE
perf(ode): FSAL stage reuse in DP-RK45 (~11% wall on FOCEI ODE fits)

### DIFF
--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -111,6 +111,27 @@ pub fn solve_ode(
     let mut results: Vec<SolPoint> = Vec::with_capacity(saveat.len());
     let mut save_idx = 0;
 
+    // FSAL (First Same As Last): in DP-RK45, k7 of an accepted step is evaluated
+    // at the same (u, t) the next step's k1 would use. We carry it across via a
+    // k1/k7 swap, eliminating one rhs eval per accepted step (~1 of 7 stages).
+    // After a rejected step (u, t) doesn't move so k1 stays valid too; first
+    // iteration has no prior k1, hence `have_k1`. ≈9% wall reduction on
+    // FOCEI ODE fits with bit-identical outputs (FSAL only reuses a value that
+    // would otherwise be recomputed identically).
+    let mut have_k1 = false;
+
+    // NOTE: a Gustafsson PI step-size controller was tested and rejected here.
+    // While it lowers raw step-rejection rate and integrates faster, the
+    // factor's dependence on err_{n-1} makes accept/reject decisions more
+    // sensitive to small parameter perturbations. That raises the differential
+    // noise floor of the trajectory as a function of θ, which the FOCEI FD
+    // gradient cannot tolerate — BFGS line search stalled at OFV ≈ -1290 on
+    // the dense-Emax PKPD benchmark vs the true -1747 with the I-controller.
+    // The pure I-controller below is memoryless and gives a clean FD signal.
+    // Any future revisit should condition PI on a non-FD gradient route
+    // (analytical / sensitivity / autodiff).
+    const I_EXP: f64 = 1.0 / 5.0; // 0.20 — I-controller exponent for order p=5
+
     for _step in 0..opts.max_steps {
         if t >= tf - 1e-15 {
             break;
@@ -122,8 +143,11 @@ pub fn solve_ode(
             dt_eff = (saveat[save_idx] - t).max(opts.min_dt);
         }
 
-        // RK45 stages
-        rhs(&u, params, t, &mut k1);
+        // RK45 stages — k1 may be carried from previous step via FSAL.
+        if !have_k1 {
+            rhs(&u, params, t, &mut k1);
+            have_k1 = true;
+        }
 
         for i in 0..n {
             u_tmp[i] = u[i] + dt_eff * B21 * k1[i];
@@ -174,6 +198,10 @@ pub fn solve_ode(
             t += dt_eff;
             u.copy_from_slice(&u5);
 
+            // FSAL: k7 at (u_new, t_new) IS the next step's k1 — swap into k1.
+            // Safe because k7 is dead from this point onward in this iteration.
+            std::mem::swap(&mut k1, &mut k7);
+
             // Save at requested times
             while save_idx < saveat.len() && (t - saveat[save_idx]).abs() < 1e-12 {
                 results.push(SolPoint {
@@ -183,11 +211,13 @@ pub fn solve_ode(
                 save_idx += 1;
             }
         }
+        // On reject: (u, t) is unchanged, so the existing k1 is still rhs(u, t)
+        // for the next attempt; nothing to do.
 
-        // Adapt step size (PI controller)
+        // Adapt step size (memoryless I-controller — see note above).
         let safety = 0.9;
         let factor = if err_norm > 1e-15 {
-            safety * err_norm.powf(-0.2)
+            safety * err_norm.powf(-I_EXP)
         } else {
             5.0
         };
@@ -289,5 +319,55 @@ mod tests {
         let opts = OdeSolverOptions::default();
         let result = solve_ode(&rhs, &[1.0], (0.0, 2.0), &[-0.5], &saveat, &opts);
         assert_relative_eq!(result[0].u[0], (-1.0_f64).exp(), epsilon = 1e-4);
+    }
+
+    /// Regression guard for FSAL (First Same As Last) stage reuse.
+    ///
+    /// Without FSAL the solver evaluates `rhs` exactly 7 times per integration
+    /// iteration (k1..k7). With FSAL k1 is recomputed only on the very first
+    /// iteration; every subsequent iteration reuses the prior k7 (or the
+    /// already-valid k1 after a rejection), so total rhs = 6 · N + 1, where N
+    /// is the iteration count. The ratio `(rhs_calls - 1) / 6` therefore
+    /// equals the iteration count exactly when FSAL is active — and the bound
+    /// `rhs_calls ≤ 6·iters + 1` is sharp. We measure both directly by also
+    /// tracking iterations from the saveat side: a known-step diagnostic.
+    ///
+    /// If a future change removes the FSAL swap, `rhs_calls / iters` jumps
+    /// from 6.0+1/N to 7.0 — this test would fail by a comfortable margin.
+    #[test]
+    fn test_fsal_reuses_last_stage() {
+        use std::cell::Cell;
+        let rhs_calls = Cell::new(0_u32);
+        // Smooth exponential decay — adaptive controller rarely rejects, so
+        // the FSAL ratio is clean. Single saveat at the end so no truncation
+        // disturbs free-running step sizes.
+        let rhs = |u: &[f64], _p: &[f64], _t: f64, du: &mut [f64]| {
+            rhs_calls.set(rhs_calls.get() + 1);
+            du[0] = -0.1 * u[0];
+        };
+        let opts = OdeSolverOptions::default();
+        let _ = solve_ode(&rhs, &[1.0], (0.0, 20.0), &[], &[20.0], &opts);
+        let n = rhs_calls.get();
+
+        // Sharp bound: FSAL-active produces exactly 6·iters + 1 rhs evals.
+        // For this ODE/tolerance the solver takes ~25-45 iters (controller-
+        // dependent). We don't know iters from outside, but we know:
+        //   FSAL-on:  n ≡ 1 (mod 6)
+        //   FSAL-off: n ≡ 0 (mod 7)
+        // The structural test is `(n - 1) % 6 == 0` AND `n % 7 != 0` for any
+        // n not in the trivial overlap. (Overlap occurs at n = 1, 43, 85, ...;
+        // the relevant range here is ~150-280, where 169, 211, 253 overlap.)
+        // The simpler robust assertion is the count: with FSAL n < (7/6)·iters
+        // is a 14% gap, easily detectable. Hard-code the upper bound from a
+        // calibration measurement: 25-iter FSAL run = 151, 45-iter = 271; the
+        // matching no-FSAL counts are 175 and 315. Bound at 280 catches the
+        // regression for any reasonable iteration count in this window.
+        assert!(n > 0, "rhs never called — solver early-exited");
+        assert!(
+            (n - 1) % 6 == 0,
+            "rhs calls = {} is not of the form 6·N+1; FSAL appears inactive \
+             (expected: every accepted/rejected iteration reuses prior k1).",
+            n,
+        );
     }
 }

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -323,51 +323,49 @@ mod tests {
 
     /// Regression guard for FSAL (First Same As Last) stage reuse.
     ///
-    /// Without FSAL the solver evaluates `rhs` exactly 7 times per integration
-    /// iteration (k1..k7). With FSAL k1 is recomputed only on the very first
-    /// iteration; every subsequent iteration reuses the prior k7 (or the
-    /// already-valid k1 after a rejection), so total rhs = 6 · N + 1, where N
-    /// is the iteration count. The ratio `(rhs_calls - 1) / 6` therefore
-    /// equals the iteration count exactly when FSAL is active — and the bound
-    /// `rhs_calls ≤ 6·iters + 1` is sharp. We measure both directly by also
-    /// tracking iterations from the saveat side: a known-step diagnostic.
+    /// Structural rather than count-based: with FSAL the k1 of step k+1 is
+    /// reused (swapped in) from the prior step's k7, so the rhs closure is
+    /// **never** invoked twice in a row at the same `(u, t)`. Without FSAL,
+    /// k7 of step k and k1 of step k+1 are two separate rhs calls at
+    /// bit-identical `(u_new, t_new)` — an adjacent duplicate in the call
+    /// sequence. Recording the `(u, t)` of every rhs call and scanning for
+    /// any adjacent duplicate detects FSAL removal regardless of iteration
+    /// count, controller, tolerance, or host platform.
     ///
-    /// If a future change removes the FSAL swap, `rhs_calls / iters` jumps
-    /// from 6.0+1/N to 7.0 — this test would fail by a comfortable margin.
+    /// The earlier modular check `(n - 1) % 6 == 0` was unsharp: FSAL-off
+    /// produces `n = 7N`, which satisfies the check whenever `N ≡ 1 (mod 6)`
+    /// — a 1-in-6 silent-pass rate across the population of iteration counts
+    /// the test might land on.
     #[test]
     fn test_fsal_reuses_last_stage() {
-        use std::cell::Cell;
-        let rhs_calls = Cell::new(0_u32);
-        // Smooth exponential decay — adaptive controller rarely rejects, so
-        // the FSAL ratio is clean. Single saveat at the end so no truncation
-        // disturbs free-running step sizes.
-        let rhs = |u: &[f64], _p: &[f64], _t: f64, du: &mut [f64]| {
-            rhs_calls.set(rhs_calls.get() + 1);
+        use std::cell::RefCell;
+        // Record `(u[0], t)` bit patterns at every rhs invocation. Bit
+        // equality (rather than `==` on f64) sidesteps any ambiguity about
+        // NaN / signed-zero corner cases — though for this smooth ODE there
+        // are none.
+        let calls: RefCell<Vec<(u64, u64)>> = RefCell::new(Vec::new());
+        let rhs = |u: &[f64], _p: &[f64], t: f64, du: &mut [f64]| {
+            calls.borrow_mut().push((u[0].to_bits(), t.to_bits()));
             du[0] = -0.1 * u[0];
         };
         let opts = OdeSolverOptions::default();
         let _ = solve_ode(&rhs, &[1.0], (0.0, 20.0), &[], &[20.0], &opts);
-        let n = rhs_calls.get();
+        let calls = calls.into_inner();
 
-        // Sharp bound: FSAL-active produces exactly 6·iters + 1 rhs evals.
-        // For this ODE/tolerance the solver takes ~25-45 iters (controller-
-        // dependent). We don't know iters from outside, but we know:
-        //   FSAL-on:  n ≡ 1 (mod 6)
-        //   FSAL-off: n ≡ 0 (mod 7)
-        // The structural test is `(n - 1) % 6 == 0` AND `n % 7 != 0` for any
-        // n not in the trivial overlap. (Overlap occurs at n = 1, 43, 85, ...;
-        // the relevant range here is ~150-280, where 169, 211, 253 overlap.)
-        // The simpler robust assertion is the count: with FSAL n < (7/6)·iters
-        // is a 14% gap, easily detectable. Hard-code the upper bound from a
-        // calibration measurement: 25-iter FSAL run = 151, 45-iter = 271; the
-        // matching no-FSAL counts are 175 and 315. Bound at 280 catches the
-        // regression for any reasonable iteration count in this window.
-        assert!(n > 0, "rhs never called — solver early-exited");
         assert!(
-            (n - 1) % 6 == 0,
-            "rhs calls = {} is not of the form 6·N+1; FSAL appears inactive \
-             (expected: every accepted/rejected iteration reuses prior k1).",
-            n,
+            calls.len() > 7,
+            "solver did not perform multiple steps (calls = {})",
+            calls.len(),
+        );
+
+        let dup_at = calls.windows(2).position(|w| w[0] == w[1]);
+        assert!(
+            dup_at.is_none(),
+            "FSAL appears inactive: rhs called twice consecutively at the \
+             same (u, t) at call index {} of {} (k7 of step k and k1 of \
+             step k+1 should reuse a single evaluation).",
+            dup_at.unwrap(),
+            calls.len(),
         );
     }
 }


### PR DESCRIPTION
## Why

Goal: close the wall-time gap with nlmixr2 on pure-ODE NLME fits. Profiling the dense-Emax PKPD benchmark (100 subjects, 1600 obs, FOCEI with FD gradient) showed the solver doing **1.24 billion `rhs` evaluations per fit** — 7 per RK45 step × ~178M total steps × ~2.1M `solve_ode` calls. The DP-RK45 implementation in `src/ode/solver.rs` was recomputing k1 at the start of every step even though k7 of the previous step is, by construction, evaluated at the same `(u, t)` that k1 would land on.

This is the "First Same As Last" (FSAL) property the Dormand-Prince coefficients were designed for — and we were leaving it on the table.

## What changed

Carry `k7` from an accepted step into the next iteration's `k1` via `std::mem::swap`. A `have_k1` flag distinguishes:

- **first iteration** → compute `k1 = rhs(u, t)` normally
- **after accept** → `swap(&mut k1, &mut k7)`; the swapped-in `k1` *is* `rhs(u_new, t_new)`
- **after reject** → `(u, t)` is unchanged, so the existing `k1` is still `rhs(u, t)` — no action needed

The 6 intermediate stages (k2..k7) still run every iteration; only the k1 evaluation is elided. Trajectories are **bit-identical** to the prior code — FSAL only skips a recomputation that would have produced the same `f64` values.

## Alternatives considered

A Gustafsson PI step-size controller was implemented and tested in the same exploration (commented NOTE in `solver.rs` documents why it didn't ship):

| controller | wall | OFV | verdict |
|---|---|---|---|
| baseline (pre-FSAL, I-controller) | 19.1s | –1746.88 | reference (converged) |
| FSAL + I-controller (this PR) | **16.9s** | **–1746.88** | ✅ converged |
| FSAL + PI (β=0.08 standard) | 3.7s | –1379 (early stall) | ❌ non-convergent |
| FSAL + PI (β=0.04 gentle) | 22s | –1289 (early stall) | ❌ non-convergent |

The PI rows are non-convergent runs — wall times are listed only to
show why PI looks attractive on raw step count in isolation, not as a
comparable performance point against the converged baselines.

PI's history dependence makes the binary accept/reject decision more sensitive to small parameter perturbations, which raises the differential noise floor of trajectories as a function of θ. The FD-FOCEI gradient cannot tolerate this — BFGS line search stalls at a non-converged OFV. Documented in source for future revisit; a PI controller is viable but requires a non-FD gradient route (analytical / sensitivity / autodiff).

A separate ODE-solver tolerance loosening experiment confirmed the same fragility (loosening `reltol` 1e-4 → 1e-3 sent the fit to 469s, OFV –1435, no convergence).

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API surface changed; the ferx-r binding sees identical numerical output from `solve_ode`.

## Breaking changes

- [x] None

## Numerical validation

- [x] Compared against: prior ferx commit `912be02` (current `main` HEAD)
- [x] All 38 pre-existing `ode::*` unit tests pass unchanged
- [x] Dense-Emax PKPD FOCEI benchmark, before vs after:

```
# before (main @ 912be02)
OFV  = -1746.8781
TVCL = 4.503560
TVV  = 61.183298
TVKA = 1.026051
TVKE0 = 0.443854
TVE0  = 3.288539
TVEMAX = 45.187791
TVEC50 = 4.954347
TVGAMMA = 1.314655

# after (this PR)
OFV  = -1746.8781       ← byte-identical
TVCL = 4.503560         ← byte-identical
TVV  = 61.183298        ← byte-identical
TVKA = 1.026051         ← byte-identical
TVKE0 = 0.443854        ← byte-identical
TVE0  = 3.288539        ← byte-identical
TVEMAX = 45.187791      ← byte-identical
TVEC50 = 4.954347       ← byte-identical
TVGAMMA = 1.314655      ← byte-identical
```

FSAL elides a recomputation; the value reused is exactly what would have been recomputed. There is no floating-point divergence path.

## Performance

- [x] Faster — benchmark: **19.1s (before) → 16.9s (after, n=3 mean), –11.5%** on dense-Emax PKPD FOCEI fit.

Note: this is one of several levers being explored to close the nlmixr2 gap. A separate cranelift JIT investigation for the bytecode `rhs` interpreter found a realistic 15–35% additional headroom on ODE-bound fits but requires ~7–12 days FTE plus a numerical-equivalence harness prerequisite, given the same FD-FOCEI fragility surfaced by the PI experiment. That work is out of scope here.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 739/739)
- [x] Regression test added — `test_fsal_reuses_last_stage`. **Structural** check: records the `(u, t)` bit pattern of every `rhs` invocation and asserts no two consecutive calls land at the same `(u, t)`. With FSAL the k1 of step k+1 is reused from the prior k7 via swap, so the closure is never invoked twice in a row at the same point. Without FSAL, k7 of step k and k1 of step k+1 are two separate rhs calls at bit-identical `(u_new, t_new)` — an adjacent duplicate the test catches. N-agnostic, controller-agnostic, platform-agnostic.

  An earlier revision of this test used the modular check `(rhs_calls - 1) % 6 == 0`. That check has a 1-in-6 silent-pass rate against FSAL removal: FSAL-off produces `n = 7·iters`, which satisfies the modular check whenever `iters ≡ 1 (mod 6)`. Replaced.

## Example

- [x] Not applicable (internal performance, no user-visible behavior change)

## Docs

- [x] No user-visible change

## Checklist

- [x] `cargo check --features autodiff` still compiles
- [x] `cargo test --release --features autodiff --lib` passes (739/739, 5 ignored = slow-gated)
- [x] No `Cargo.toml` version bump (non-breaking)
- [ ] `cargo clippy` — local enzyme toolchain lacks the clippy component; CI will lint

## Reviewer hints

The whole change is in `src/ode/solver.rs`. Focus areas:

1. **The `have_k1` invariant** (lines ~119–149 + line ~203): is it actually preserved across accept and reject paths? The argument:
   - first iteration: `have_k1=false` → compute → set true
   - accept: `swap(k1, k7)` — k1 now contains the value that *would* be the next `rhs(u_new, t_new)` because k7 was computed exactly there
   - reject: `(u, t)` unchanged → existing k1 is still correct
   - saveat truncation: doesn't move `(u, t)` on rejection or change the FSAL semantics on acceptance (k7 is at the (possibly small) endpoint, which IS the new `(u, t)`)

2. **The PI NOTE** (lines ~123–132): is the reasoning persuasive enough that a future contributor won't re-implement PI without considering the FD-FOCEI side effect?

3. **The regression test's adjacent-duplicate check**: structural, not count-based — see Tests section above. Verified locally that the test passes with FSAL on (this branch) and fails with FSAL off (probe: drop the `if !have_k1` guard) with a clear error message pointing at the first duplicate-call index.

## Open questions

None.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

