### PR TITLE
feat(types): add structured WarningEntry with severity/category to FitResult

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1500,6 +1500,14 @@ fn fit_inner(
         }
     }
 
+    // Build structured warnings from the final accumulated message list.
+    // Classification (severity/category) lives entirely in core so the R
+    // wrapper consumes the structure directly and never re-parses message text.
+    let warnings_structured_entries: Vec<crate::types::WarningEntry> = warnings
+        .iter()
+        .map(|w| crate::types::classify_warning(w))
+        .collect();
+
     let fit_result = FitResult {
         method: final_method,
         method_chain: chain.clone(),
@@ -1530,6 +1538,7 @@ fn fit_inner(
         n_iterations: result.n_iterations,
         interaction: options.interaction,
         warnings,
+        warnings_structured: warnings_structured_entries,
         sir_ci_theta: sir_result.as_ref().map(|s| s.ci_theta.clone()),
         sir_ci_omega: sir_result.as_ref().map(|s| s.ci_omega.clone()),
         sir_ci_sigma: sir_result.as_ref().map(|s| s.ci_sigma.clone()),
@@ -3367,6 +3376,7 @@ mod simulate_with_uncertainty_tests {
             n_iterations: 0,
             interaction: true,
             warnings: vec![],
+            warnings_structured: vec![],
             sir_ci_theta: None,
             sir_ci_omega: None,
             sir_ci_sigma: None,

--- a/src/api.rs
+++ b/src/api.rs
@@ -833,6 +833,7 @@ pub fn fit(
         };
         return res.map(|mut result| {
             result.warnings.splice(0..0, ltbs_warnings);
+            rebuild_warnings_structured(&mut result);
             result
         });
     }
@@ -927,9 +928,22 @@ pub fn fit(
                     result.ofv
                 ));
             }
+            rebuild_warnings_structured(&mut result);
             Ok(result)
         }
     }
+}
+
+/// Rebuild `warnings_structured` from the current `warnings` vec.
+///
+/// Called after all late-injected warnings (LTBS splice, multi-start metadata)
+/// have been appended so the structured field is always in sync with the flat list.
+fn rebuild_warnings_structured(result: &mut FitResult) {
+    result.warnings_structured = result
+        .warnings
+        .iter()
+        .map(|w| crate::types::classify_warning(w))
+        .collect();
 }
 
 /// Probe whether NLopt CRS2-LM (used for global_search) is available.
@@ -1500,14 +1514,6 @@ fn fit_inner(
         }
     }
 
-    // Build structured warnings from the final accumulated message list.
-    // Classification (severity/category) lives entirely in core so the R
-    // wrapper consumes the structure directly and never re-parses message text.
-    let warnings_structured_entries: Vec<crate::types::WarningEntry> = warnings
-        .iter()
-        .map(|w| crate::types::classify_warning(w))
-        .collect();
-
     let fit_result = FitResult {
         method: final_method,
         method_chain: chain.clone(),
@@ -1538,7 +1544,7 @@ fn fit_inner(
         n_iterations: result.n_iterations,
         interaction: options.interaction,
         warnings,
-        warnings_structured: warnings_structured_entries,
+        warnings_structured: vec![],
         sir_ci_theta: sir_result.as_ref().map(|s| s.ci_theta.clone()),
         sir_ci_omega: sir_result.as_ref().map(|s| s.ci_omega.clone()),
         sir_ci_sigma: sir_result.as_ref().map(|s| s.ci_sigma.clone()),

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -357,6 +357,7 @@ mod tests {
             n_iterations: 0,
             interaction: true,
             warnings: vec![],
+            warnings_structured: vec![],
             sir_ci_theta: None,
             sir_ci_omega: None,
             sir_ci_sigma: None,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1588,7 +1588,7 @@ mod tests {
             n_iterations: 10,
             interaction: true,
             warnings: vec!["watch out".into()],
-            warnings_structured: vec![],
+            warnings_structured: vec![crate::types::classify_warning("watch out")],
             sir_ci_theta: None,
             sir_ci_omega: None,
             sir_ci_sigma: None,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1419,6 +1419,11 @@ fn wire_to_fit_result(
         n_parameters: w.n_parameters,
         n_iterations: w.n_iterations,
         interaction: w.interaction,
+        warnings_structured: w
+            .warnings
+            .iter()
+            .map(|s| crate::types::classify_warning(s))
+            .collect(),
         warnings: w.warnings,
         sir_ci_theta,
         sir_ci_omega,
@@ -1583,6 +1588,7 @@ mod tests {
             n_iterations: 10,
             interaction: true,
             warnings: vec!["watch out".into()],
+            warnings_structured: vec![],
             sir_ci_theta: None,
             sir_ci_omega: None,
             sir_ci_sigma: None,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -993,6 +993,7 @@ mod tests {
             n_iterations: 0,
             interaction: false,
             warnings: Vec::new(),
+            warnings_structured: Vec::new(),
             sir_ci_theta: None,
             sir_ci_omega: None,
             sir_ci_sigma: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1525,7 +1525,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Info, "threads")
     } else if lower.contains("n\u{00b2} ofv")
         || lower.contains("n^2 ofv")
-        || lower.contains("parameters") && lower.contains("covariance step:")
+        || (lower.contains("parameters") && lower.contains("covariance step:"))
     {
         (WarningSeverity::Info, "covariance_step")
     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1417,8 +1417,8 @@ pub enum WarningSeverity {
 /// `bloq_method`, `sir`, `importance_sampling`, `data_quality`,
 /// `omega_structure`, `ebe_convergence`, `gradient_fallback`,
 /// `mu_referencing`, `optimizer_config`, `multi_start`, `cancelled`,
-/// `threads`, `condition_number`, `eta_normality`, `general` (fallback for
-/// unrecognised messages).
+/// `threads`, `condition_number`, `eta_normality`, `eps_shrinkage`, `general`
+/// (fallback for unrecognised messages).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WarningEntry {
     pub severity: WarningSeverity,
@@ -1432,26 +1432,6 @@ pub struct WarningEntry {
     pub message: String,
     /// For multi-stage chains, the method that produced this warning.
     pub source_method: Option<String>,
-}
-
-impl WarningEntry {
-    pub fn new(
-        severity: WarningSeverity,
-        category: impl Into<String>,
-        message: impl Into<String>,
-    ) -> Self {
-        Self {
-            severity,
-            category: category.into(),
-            message: message.into(),
-            source_method: None,
-        }
-    }
-
-    pub fn with_source(mut self, method: impl Into<String>) -> Self {
-        self.source_method = Some(method.into());
-        self
-    }
 }
 
 /// Classify a free-text warning message into a structured `WarningEntry`.
@@ -1485,11 +1465,11 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         || lower.contains("no multi-start run converged")
     {
         (WarningSeverity::Critical, "convergence")
-    } else if lower.contains("covariance step failed")
-        || lower.contains("covariance failed")
-        || lower.contains("ses not available")
-        || lower.contains("se not available")
-    {
+    } else if lower.contains("covariance step failed") || lower.contains("covariance failed") {
+        // "ses not available" and "se not available" intentionally omitted:
+        // the only emitter ("Covariance step failed — SEs not available") already
+        // hits "covariance step failed" above, and bare "se not available" is too
+        // broad to safely match future messages.
         (WarningSeverity::Critical, "covariance_step")
     } else if lower.contains("ill-conditioned") || lower.contains("condition number") {
         (WarningSeverity::Critical, "condition_number")
@@ -1505,16 +1485,27 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, "sir")
     } else if lower.contains("ess = 0") || lower.contains("proposal collapse") {
         (WarningSeverity::Warning, "importance_sampling")
-    } else if lower.contains("ltbs") || lower.contains("non-positive dv") {
+    } else if lower.contains("eps shrinkage") {
+        (WarningSeverity::Warning, "eps_shrinkage")
+    } else if lower.contains("ltbs")
+        || lower.contains("non-positive dv")
+        || lower.contains("ss=1 dose")
+        || lower.contains("ss=1 infusion")
+        || lower.contains("evid=3/4")
+        || lower.contains("lagtime evaluates")
+    {
         (WarningSeverity::Warning, "data_quality")
     } else if lower.contains("mixed lognormal") || lower.contains("mixed log-normal") {
         (WarningSeverity::Warning, "omega_structure")
-    } else if lower.contains("ebe") && lower.contains("unconverged") {
-        (WarningSeverity::Warning, "ebe_convergence")
-    } else if lower.contains("hmc is unavailable") || lower.contains("falls back to") {
+    } else if lower.contains("hmc is unavailable") {
+        // "falls back to" intentionally removed: no emitted message uses that exact
+        // phrase. The SAEM HMC message is fully covered by "hmc is unavailable".
         (WarningSeverity::Info, "gradient_fallback")
     } else if lower.contains("mu-ref") || lower.contains("mu-referencing") {
         (WarningSeverity::Info, "mu_referencing")
+    } else if lower.contains("global_search disabled") {
+        // Runtime failure: CRS2-LM init failed — the optimiser ran without global search.
+        (WarningSeverity::Warning, "optimizer_config")
     } else if lower.contains("global_search") {
         (WarningSeverity::Info, "optimizer_config")
     } else if lower.contains("multi-start") {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1417,13 +1417,18 @@ pub enum WarningSeverity {
 /// `bloq_method`, `sir`, `importance_sampling`, `data_quality`,
 /// `omega_structure`, `ebe_convergence`, `gradient_fallback`,
 /// `mu_referencing`, `optimizer_config`, `multi_start`, `cancelled`,
-/// `threads`, `condition_number`, `eta_normality`.
+/// `threads`, `condition_number`, `eta_normality`, `general` (fallback for
+/// unrecognised messages).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WarningEntry {
     pub severity: WarningSeverity,
     /// Fixed lowercase category string (see type-level docs).
     pub category: String,
-    /// Human-readable message (same text as the parallel `warnings` entry).
+    /// Human-readable message. For messages that carry a multi-stage chain
+    /// prefix such as `[FOCEI] ...`, only the body after the prefix is stored
+    /// here; the method tag is moved into `source_method`. For unprefixed
+    /// messages this is identical to the corresponding entry in
+    /// `FitResult.warnings`.
     pub message: String,
     /// For multi-stage chains, the method that produced this warning.
     pub source_method: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1401,6 +1401,140 @@ pub enum CovarianceStatus {
     Failed,
 }
 
+/// Severity level for a structured warning entry.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum WarningSeverity {
+    Critical,
+    Warning,
+    Info,
+}
+
+/// A structured warning with severity, category, and message.
+///
+/// Populated in parallel with `FitResult.warnings` (which remains for
+/// backward compatibility). The `category` is a fixed lowercase vocabulary:
+/// `convergence`, `covariance_step`, `optimizer_health`, `dw_autocorrelation`,
+/// `bloq_method`, `sir`, `importance_sampling`, `data_quality`,
+/// `omega_structure`, `ebe_convergence`, `gradient_fallback`,
+/// `mu_referencing`, `optimizer_config`, `multi_start`, `cancelled`,
+/// `threads`, `condition_number`, `eta_normality`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WarningEntry {
+    pub severity: WarningSeverity,
+    /// Fixed lowercase category string (see type-level docs).
+    pub category: String,
+    /// Human-readable message (same text as the parallel `warnings` entry).
+    pub message: String,
+    /// For multi-stage chains, the method that produced this warning.
+    pub source_method: Option<String>,
+}
+
+impl WarningEntry {
+    pub fn new(
+        severity: WarningSeverity,
+        category: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity,
+            category: category.into(),
+            message: message.into(),
+            source_method: None,
+        }
+    }
+
+    pub fn with_source(mut self, method: impl Into<String>) -> Self {
+        self.source_method = Some(method.into());
+        self
+    }
+}
+
+/// Classify a free-text warning message into a structured `WarningEntry`.
+///
+/// This is the single source of truth for warning severity/category in
+/// ferx-core. The R wrapper consumes the structured output directly and never
+/// re-classifies message text. Multi-stage chain prefixes (`[FOCEI] ...`) are
+/// stripped into `source_method`; the remaining message is matched against the
+/// fixed category vocabulary. Unrecognised messages fall back to
+/// `Warning`/`general`.
+pub fn classify_warning(raw: &str) -> WarningEntry {
+    // Strip a leading "[METHOD] " chain prefix into source_method.
+    let (source_method, msg) = if let Some(rest) = raw.strip_prefix('[') {
+        if let Some(idx) = rest.find(']') {
+            let tag = &rest[..idx];
+            let body = rest[idx + 1..].trim_start();
+            (Some(tag.to_string()), body.to_string())
+        } else {
+            (None, raw.to_string())
+        }
+    } else {
+        (None, raw.to_string())
+    };
+
+    let lower = msg.to_lowercase();
+
+    // (severity, category) keyed off distinctive substrings. Order matters:
+    // more specific patterns first.
+    let (severity, category) = if lower.contains("did not converge")
+        || lower.contains("without convergence")
+        || lower.contains("no multi-start run converged")
+    {
+        (WarningSeverity::Critical, "convergence")
+    } else if lower.contains("covariance step failed")
+        || lower.contains("covariance failed")
+        || lower.contains("ses not available")
+        || lower.contains("se not available")
+    {
+        (WarningSeverity::Critical, "covariance_step")
+    } else if lower.contains("ill-conditioned") || lower.contains("condition number") {
+        (WarningSeverity::Critical, "condition_number")
+    } else if lower.contains("trust radius") || lower.contains("degenerate") {
+        (WarningSeverity::Warning, "optimizer_health")
+    } else if lower.contains("autocorrelation") || lower.contains("durbin") {
+        (WarningSeverity::Warning, "dw_autocorrelation")
+    } else if lower.contains("shapiro") || lower.contains("non-normal") {
+        (WarningSeverity::Warning, "eta_normality")
+    } else if lower.contains("m3 bloq") || lower.contains("bloq handling") {
+        (WarningSeverity::Warning, "bloq_method")
+    } else if lower.contains("sir failed") || lower.contains("sir requested") {
+        (WarningSeverity::Warning, "sir")
+    } else if lower.contains("ess = 0") || lower.contains("proposal collapse") {
+        (WarningSeverity::Warning, "importance_sampling")
+    } else if lower.contains("ltbs") || lower.contains("non-positive dv") {
+        (WarningSeverity::Warning, "data_quality")
+    } else if lower.contains("mixed lognormal") || lower.contains("mixed log-normal") {
+        (WarningSeverity::Warning, "omega_structure")
+    } else if lower.contains("ebe") && lower.contains("unconverged") {
+        (WarningSeverity::Warning, "ebe_convergence")
+    } else if lower.contains("hmc is unavailable") || lower.contains("falls back to") {
+        (WarningSeverity::Info, "gradient_fallback")
+    } else if lower.contains("mu-ref") || lower.contains("mu-referencing") {
+        (WarningSeverity::Info, "mu_referencing")
+    } else if lower.contains("global_search") {
+        (WarningSeverity::Info, "optimizer_config")
+    } else if lower.contains("multi-start") {
+        (WarningSeverity::Info, "multi_start")
+    } else if lower.contains("cancelled by user") {
+        (WarningSeverity::Info, "cancelled")
+    } else if lower.contains("threads configured") || lower.contains("threads than subjects") {
+        (WarningSeverity::Info, "threads")
+    } else if lower.contains("n\u{00b2} ofv")
+        || lower.contains("n^2 ofv")
+        || lower.contains("parameters") && lower.contains("covariance step:")
+    {
+        (WarningSeverity::Info, "covariance_step")
+    } else {
+        (WarningSeverity::Warning, "general")
+    };
+
+    WarningEntry {
+        severity,
+        category: category.to_string(),
+        message: msg,
+        source_method,
+    }
+}
+
 /// Full fit result
 #[derive(Debug, Clone)]
 pub struct FitResult {
@@ -1454,6 +1588,8 @@ pub struct FitResult {
     pub n_iterations: usize,
     pub interaction: bool,
     pub warnings: Vec<String>,
+    /// Structured counterpart to `warnings` — same entries with severity and category metadata.
+    pub warnings_structured: Vec<WarningEntry>,
     // SIR results (optional)
     pub sir_ci_theta: Option<Vec<(f64, f64)>>,
     pub sir_ci_omega: Option<Vec<(f64, f64)>>,
@@ -2245,6 +2381,51 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_warning_convergence_is_critical() {
+        let w = classify_warning("Outer optimization did not converge");
+        assert_eq!(w.severity, WarningSeverity::Critical);
+        assert_eq!(w.category, "convergence");
+        assert!(w.source_method.is_none());
+    }
+
+    #[test]
+    fn classify_warning_covariance_is_critical() {
+        let w = classify_warning("Covariance step failed");
+        assert_eq!(w.severity, WarningSeverity::Critical);
+        assert_eq!(w.category, "covariance_step");
+    }
+
+    #[test]
+    fn classify_warning_dw_is_warning() {
+        let w = classify_warning("Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).");
+        assert_eq!(w.severity, WarningSeverity::Warning);
+        assert_eq!(w.category, "dw_autocorrelation");
+    }
+
+    #[test]
+    fn classify_warning_mu_ref_is_info() {
+        let w = classify_warning("mu-ref: CL, V");
+        assert_eq!(w.severity, WarningSeverity::Info);
+        assert_eq!(w.category, "mu_referencing");
+    }
+
+    #[test]
+    fn classify_warning_strips_chain_prefix() {
+        let w = classify_warning("[FOCEI] Covariance step failed");
+        assert_eq!(w.source_method.as_deref(), Some("FOCEI"));
+        assert_eq!(w.message, "Covariance step failed");
+        assert_eq!(w.severity, WarningSeverity::Critical);
+        assert_eq!(w.category, "covariance_step");
+    }
+
+    #[test]
+    fn classify_warning_unknown_falls_back_to_general() {
+        let w = classify_warning("some entirely novel message");
+        assert_eq!(w.severity, WarningSeverity::Warning);
+        assert_eq!(w.category, "general");
+    }
 
     #[test]
     fn is_ode_based_false_for_analytical() {


### PR DESCRIPTION
## Why

`FitResult.warnings` is a flat `Vec<String>`. The ferx-r print/output layer can't distinguish a critical issue (covariance step failed, didn't converge) from a low-priority info note (mu-referencing detected) without re-parsing the message text in R — which is fragile and duplicates classification logic that already lives in core.

This is the engine half of a planned UX overhaul on the ferx-r side that introduces a new `ferx_warnings(fit)` function with severity-grouped output and per-category guidance. R must consume the classification, not reinvent it.

## What changed

- New `WarningSeverity` enum (`Critical`, `Warning`, `Info`) and `WarningEntry { severity, category, message, source_method }` struct in `src/types.rs`.
- New `classify_warning(&str) -> WarningEntry` function: single source of truth that maps the existing message strings (which already have a stable vocabulary) to severity + category. Strips multi-stage chain prefixes like `[FOCEI] ...` into `source_method`. Unrecognised messages fall back to `Warning` / `general`.
- New `FitResult.warnings_structured: Vec<WarningEntry>` field, populated by `rebuild_warnings_structured()` after all late-injected warnings (LTBS splice, multi-start metadata) have been appended in `fit_with_starts` — not inside `fit_inner` — so the structured field is always derived from the complete flat list.
- `.fitrx` deserialization path rebuilds `warnings_structured` from the persisted message strings via the same classifier — round-trip remains intact.
- 6 unit tests covering each severity level, prefix stripping, and the fallback.

## Classifier coverage (all known emitters mapped)

| Message source | Category | Severity |
|---|---|---|
| "Outer optimization did not converge" | `convergence` | Critical |
| "Gauss-Newton: max iterations reached without convergence" | `convergence` | Critical |
| "Trust-region did not converge" | `convergence` | Critical |
| "No multi-start run converged" | `convergence` | Critical |
| "Covariance step failed" (all sites) | `covariance_step` | Critical |
| "Covariance step failed — SEs not available" (SAEM) | `covariance_step` | Critical |
| "ill-conditioned" / "condition number" | `condition_number` | Critical |
| "trust radius collapsed" / "degenerate BHHH Hessian" | `optimizer_health` | Warning |
| "autocorrelation" / "Durbin-Watson" | `dw_autocorrelation` | Warning |
| "Shapiro" / "non-normal" | `eta_normality` | Warning |
| "M3 BLOQ handling" | `bloq_method` | Warning |
| "SIR failed" / "SIR requested" | `sir` | Warning |
| "ESS = 0" / "proposal collapse" | `importance_sampling` | Warning |
| "EPS shrinkage is notably negative" | `eps_shrinkage` | Warning |
| LTBS floor warning | `data_quality` | Warning |
| SS=1 bad II / SS=1 overlapping infusion | `data_quality` | Warning |
| EVID=3/4 reset rows with SDE model | `data_quality` | Warning |
| Negative lagtime at typical-value point | `data_quality` | Warning |
| Mixed lognormal/additive omega | `omega_structure` | Warning |
| "HMC is unavailable; falling back to MH" (SAEM) | `gradient_fallback` | Info |
| "mu-ref: ..." | `mu_referencing` | Info |
| "global_search disabled: ..." (CRS2 init failed) | `optimizer_config` | **Warning** |
| "global_search = true with n_starts = ..." | `optimizer_config` | Info |
| "Multi-start: best result from start k/n" | `multi_start` | Info |
| "cancelled by user" | `cancelled` | Info |
| Thread count advisory | `threads` | Info |
| Covariance step OFV count advisory | `covariance_step` | Info |
| Anything else | `general` | Warning |

## Alternatives considered

Threading a parallel `Vec<WarningEntry>` through `OuterResult` and every estimation stage was tried first but produced 20+ touchpoints and an error-prone class of "forgot to push to the structured vec" bugs. Centralising classification at final assembly keeps the change small, the vocabulary in one place, and the message-string contract that R already implicitly depends on now explicit and testable.

## Design notes: what warnings_structured is NOT in

**Fit YAML output** — the YAML (`{model}-fit.yaml`) is human-readable console output, not the machine-readable exchange format. R reads the `.fitrx` bundle, not the YAML. Adding `warnings_structured` to the YAML would be noise in a file users read with their eyes; the flat `warnings` strings there are sufficient.

**`FitWire` (`.fitrx` on-disk format)** — `FitWire` intentionally omits `warnings_structured` and re-derives it from the stored strings on every load. This is a feature: if a misclassification in `classify_warning` is fixed in a future release, old `.fitrx` bundles automatically get the corrected severity/category on next load rather than being frozen at stale values. Persisting the structured field would only be needed if callers could set custom severities, which the API does not expose.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | will open as draft after this lands | after |

## Breaking changes
- [ ] `.ferx` model file format
- [x] `FitResult` / sdtab fields changed (ferx-r reads `warnings_structured`)
- [ ] Public Rust API
- [ ] None

Additive only — `FitResult.warnings` is unchanged.

## Numerical validation
- [x] Not applicable (no estimation/numerical change)

## Performance
- [x] No significant impact expected — one extra pass over the warnings vec at final assembly, typically 0–10 entries.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib --features ci --no-default-features classify_warning` — 6/6 pass)
- [x] `cargo test --lib --features ci --no-default-features fitrx` — 13/13 pass (round-trip path)

## Example (user-facing features only)
- [x] Not applicable (no Rust API surface change; R side surfaces this via `ferx_warnings(fit)`)

## Docs
- [x] No user-visible change at the ferx-core level (R-side `ferx_warnings()` PR will carry the user-facing docs)

## Checklist
- [x] `cargo +stable fmt` clean
- [x] `cargo check --no-default-features --features ci` compiles
- [ ] `cargo check --features autodiff` — not run locally (Enzyme codegen bug unrelated to this change blocks the AD build on macOS); CI will exercise it

## Reviewer hints

- `classify_warning` in `src/types.rs` is the contract surface. Any new `warnings.push(...)` site in the engine should produce a message that one of the existing match arms catches; otherwise add a new arm. The fallback (`Warning` / `general`) is deliberately broad so adding new messages won't silently misclassify them as `Critical`.
- The `.fitrx` round-trip rebuilds structured warnings from message strings — this is intentional: the on-disk format stays the same, and the classifier is the single point where severity is decided in either direction.
- The classifier coverage table above lists every known warning emitter and its expected category/severity. Use it when adding new `warnings.push(...)` sites.

## Open questions

None.