### PR TITLE
feat(estimation): switch default outer optimizer from SLSQP to BOBYQA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Any user-visible feature (new fit option, new estimator, new file-format directi
 
 The estimation engine uses a nested optimization structure:
 
-- **Outer loop** (`estimation/outer_optimizer.rs`): Optimizes population parameters (theta, omega, sigma) using NLopt SLSQP (default), L-BFGS, MMA, or built-in BFGS. Parameters are log-transformed for theta/sigma, Cholesky-factored for omega.
+- **Outer loop** (`estimation/outer_optimizer.rs`): Optimizes population parameters (theta, omega, sigma) using NLopt BOBYQA (default), SLSQP, L-BFGS, MMA, or built-in BFGS. Parameters are log-transformed for theta/sigma, Cholesky-factored for omega.
 - **Inner loop** (`estimation/inner_optimizer.rs`): For each subject, finds empirical Bayes estimates (EBEs) of random effects (eta) by minimizing individual negative log-likelihood. Uses BFGS with warm-start from prior iteration; falls back to Nelder-Mead on failure.
 
 ### Gauss-Newton (BHHH) Optimizer

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -100,7 +100,7 @@ pub struct FitOptions {
     pub run_covariance_step: bool,     // Default: true
     pub interaction: bool,             // FOCEI flag
     pub verbose: bool,                 // Default: true
-    pub optimizer: Optimizer,          // Default: Slsqp
+    pub optimizer: Optimizer,          // Default: Bobyqa
     pub lbfgs_memory: usize,           // Default: 5
     pub global_search: bool,           // Default: false
     pub global_maxeval: usize,         // Default: 0 (auto)

--- a/docs/src/estimation/README.md
+++ b/docs/src/estimation/README.md
@@ -20,7 +20,7 @@ These chain after a primary method via `methods = [...]` and refine the result r
 
 ## Outer optimizers
 
-The outer loop optimizer is selected independently of the method. See **[Outer Optimizers](optimizers.md)** for a full comparison of SLSQP, BOBYQA, trust-region, BFGS, and the others. Short version: start with `slsqp` (default), switch to `bobyqa` if it stalls.
+The outer loop optimizer is selected independently of the method. See **[Outer Optimizers](optimizers.md)** for a full comparison of BOBYQA, SLSQP, trust-region, BFGS, and the others. Short version: keep the default (`bobyqa` — derivative-free, robust on ODE/PD models and sparse data); switch to `slsqp` for smooth analytical PK models where the gradient is reliable.
 
 ---
 

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -41,7 +41,7 @@ If the EBE search wanders into a region where the individual NLL evaluates to a 
 
 ### Gradient accuracy vs cost (reconverged EBEs)
 
-By default the population gradient holds each subject's EBEs (\\( \hat\eta \\)) and FOCE Hessian fixed while perturbing the population parameters — the *fixed-EBE* gradient. This is cheap, but it omits the response of the inner solution to \\( \theta \\) and \\( \Omega \\). On well-conditioned problems that omitted term is negligible and a gradient optimizer matches the derivative-free `bobyqa`. On **ill-conditioned** problems it is not: the omitted term is what separates a true descent direction from a flat-looking plateau, and `slsqp` can report `converged` at an OFV far above the `bobyqa` optimum.
+By default the population gradient holds each subject's EBEs (\\( \hat\eta \\)) and FOCE Hessian fixed while perturbing the population parameters — the *fixed-EBE* gradient. This is cheap, but it omits the response of the inner solution to \\( \theta \\) and \\( \Omega \\). On well-conditioned problems that omitted term is negligible and a gradient optimizer matches the derivative-free `bobyqa` (the default; see [Outer Optimizers](optimizers.md)). On **ill-conditioned** problems it is not: the omitted term is what separates a true descent direction from a flat-looking plateau, and `slsqp` can report `converged` at an OFV far above the `bobyqa` optimum — which is exactly why `bobyqa` is the default.
 
 Set `reconverge_gradient_interval = 1` (in `[fit_options]`) to re-solve the inner EBE loop at every finite-difference perturbation, recovering the full surface. This costs roughly **5–6×** per gradient — reserve it for fits whose OFV looks suspiciously high. IOV models (`kappa`/`block_kappa`) always reconverge, so the setting is a no-op there; it only changes non-IOV fits.
 
@@ -51,16 +51,16 @@ To amortize that cost, `reconverge_gradient_interval = N` reconverges only every
 
 | Configuration | OFV | Wall time |
 |---|---:|---:|
-| `slsqp` (default, fixed-EBE gradient) | 68,252 | 390 s |
+| `slsqp` (fixed-EBE gradient) | 68,252 | 390 s |
 | `slsqp` + reconverge every 10 (`interval = 10`) | 66,118 | 633 s |
 | `slsqp` + reconverge every 5 (`interval = 5`) | 66,056 | 1,004 s |
 | `slsqp` + reconverge every eval (`interval = 1`) | **65,485** | 1,871 s |
-| `bobyqa` (derivative-free reference) | 65,598 | 315 s |
+| `bobyqa` (derivative-free, **default**) | 65,598 | 315 s |
 | ferx OFV evaluated at NONMEM's final estimates | 67,514 | — |
 
 The fixed-EBE gradient stalls `slsqp` ~2,650 OFV units above `bobyqa`. Reconverging the EBEs on every gradient evaluation closes the entire gap and reaches an optimum marginally below `bobyqa`'s — and below the point NONMEM converged to (NONMEM's estimates score 67,514 under ferx's likelihood), confirming the stall was a gradient-bias artifact, not a worse model.
 
-A larger `reconverge_gradient_interval` trades that accuracy back for speed: reconverging every 5th or 10th gradient still closes ~80% of the stall, but the OFV degrades monotonically as the interval grows (the cheap fixed-EBE gradients in between bias the direction enough that `slsqp` declares convergence slightly early). On this problem every interval setting is dominated by `bobyqa` on *both* OFV and wall time, so a derivative-free search remains the better choice when it is affordable. The reconverged gradient earns its keep when `bobyqa` is not an option — a gradient optimizer is required, or the parameter count is high enough that derivative-free search scales poorly.
+A larger `reconverge_gradient_interval` trades that accuracy back for speed: reconverging every 5th or 10th gradient still closes ~80% of the stall, but the OFV degrades monotonically as the interval grows (the cheap fixed-EBE gradients in between bias the direction enough that `slsqp` declares convergence slightly early). On this problem every interval setting is dominated by `bobyqa` on *both* OFV and wall time — which is why `bobyqa` is the default. The reconverged-`slsqp` path earns its keep when a gradient optimizer is required (e.g. parameter count high enough that derivative-free search scales poorly, or downstream tooling that consumes the optimizer's gradient).
 
 ## FOCE vs FOCEI
 
@@ -95,7 +95,7 @@ Set via `[fit_options]`:
 ```
 [fit_options]
   method    = focei
-  optimizer = bobyqa   # default: slsqp
+  optimizer = slsqp    # override the default (bobyqa)
 ```
 
 ## Global Search
@@ -139,5 +139,5 @@ The inner loop warm-starts EBE estimation from the previous outer iteration's EB
   method     = focei
   maxiter    = 500
   covariance = true
-  optimizer  = slsqp
+  # optimizer omitted → uses the default (bobyqa); set explicitly to switch
 ```

--- a/docs/src/estimation/gauss-newton.md
+++ b/docs/src/estimation/gauss-newton.md
@@ -59,7 +59,7 @@ The algorithm converges when:
 When `method = gn_hybrid`, the algorithm runs in two phases:
 
 1. **GN phase**: Run Gauss-Newton iterations to quickly find the basin of the minimum
-2. **FOCEI polish**: Run up to 100 iterations of standard FOCEI optimization (via NLopt SLSQP) warm-started from the GN result
+2. **FOCEI polish**: Run up to 100 iterations of standard FOCEI optimization, warm-started from the GN result. The polish stage uses the configured outer optimizer (`optimizer` in `[fit_options]`), which defaults to BOBYQA — see [Outer Optimizers](optimizers.md) for the applicability matrix.
 
 The final result is whichever phase produced the lower OFV. This combines the fast convergence of Gauss-Newton with the refined accuracy of FOCEI.
 

--- a/docs/src/estimation/optimizers.md
+++ b/docs/src/estimation/optimizers.md
@@ -61,7 +61,7 @@ Set via `[fit_options]`:
 
 **`lbfgs` / `nlopt_lbfgs` / `mma`** — rarely needed. Prefer `bobyqa` or `slsqp`.
 
-> **Why is BOBYQA the default?** Until 2026 the default was `slsqp`. The Emax PKPD benchmark in [`saem.md`](saem.md) and the cefepime validation below both showed that the fixed-EBE FD gradient drives `slsqp` to local minima hundreds of OFV units above the true optimum on ODE/PD models and sparse data — exactly the workloads that aren't covered by the analytical-PK comfort zone. `bobyqa` doesn't use the gradient, doesn't see the bias, and reaches the same (or lower) OFV in the same or less wall time. The previous behaviour is one line away: `optimizer = slsqp` in `[fit_options]`.
+> **Why is BOBYQA the default?** Previously the default was `slsqp`. The Emax PKPD benchmark in [`saem.md`](saem.md) and the cefepime validation below both showed that the fixed-EBE FD gradient drives `slsqp` to local minima hundreds of OFV units above the true optimum on ODE/PD models and sparse data — exactly the workloads that aren't covered by the analytical-PK comfort zone. `bobyqa` doesn't use the gradient, doesn't see the bias, and reaches the same (or lower) OFV in the same or less wall time. The previous behaviour is one line away: `optimizer = slsqp` in `[fit_options]`.
 
 ---
 

--- a/docs/src/estimation/optimizers.md
+++ b/docs/src/estimation/optimizers.md
@@ -29,8 +29,8 @@ Set via `[fit_options]`:
 
 | Key | Algorithm | Notes |
 |-----|-----------|-------|
-| `slsqp` | Sequential Least Squares Programming | **Default.** Gradient-based, handles bounds well. Fast on well-conditioned models. |
-| `bobyqa` | Bounded Optimization BY Quadratic Approximation | Derivative-free. Recommended when the fixed-EBE gradient is noisy (ODE models, sparse data). Often reaches a lower OFV than `slsqp` without reconverging. |
+| `bobyqa` | Bounded Optimization BY Quadratic Approximation | **Default.** Derivative-free quadratic trust-region. Avoids the fixed-EBE gradient bias that stalls gradient methods on ill-conditioned fits; consistently reaches a lower OFV on ODE/PD models, sparse data, and Hill-ridge problems without reconverging the inner loop. |
+| `slsqp` | Sequential Least Squares Programming | Gradient-based, handles bounds well. Fast on well-conditioned analytical PK models; can stall above the true minimum on ODE/PD / sparse-data fits unless paired with `reconverge_gradient_interval = 1` (5–6× cost). |
 | `nlopt_lbfgs` | L-BFGS via NLopt | Limited-memory BFGS. Useful for high-parameter-count models. |
 | `mma` | Method of Moving Asymptotes | Alternative constrained gradient optimizer. Rarely needed. |
 
@@ -51,15 +51,17 @@ Set via `[fit_options]`:
 
 ## When to use which
 
-**`slsqp` (default)** — start here. Works well for most 1–2 compartment models with 2–4 random effects.
+**`bobyqa` (default)** — start here. Derivative-free quadratic trust-region; re-evaluates EBEs at every trial point so it avoids the fixed-EBE gradient bias that stalls gradient-based optimizers on ill-conditioned fits. On the cefepime 2-cpt benchmark below it reaches a lower OFV than `slsqp` (even reconverged at full cost) in less wall time. Works equally well on smooth analytical PK models — converges more slowly than gradient methods per iteration but each iteration is cheap (no FD gradient sweep).
 
-**`bobyqa`** — best single alternative. Use when `slsqp` converges to a suspiciously high OFV, or for ODE models and sparse data where the finite-difference gradient is noisy. Derivative-free means it re-evaluates EBEs at every trial point, so it naturally avoids the fixed-EBE gradient bias that can stall `slsqp`.
+**`slsqp`** — switch to this when `bobyqa` is too slow on a smooth, well-conditioned model with many parameters (it can need many quadratic-interpolation samples to triangulate a high-dimensional surface). Gradient-based, handles box constraints cleanly; pair with `reconverge_gradient_interval = 1` if it stalls above an expected OFV.
 
 **`trust_region`** — for models with many parameters (large θ + Ω) or when combined with `inits_from_nca`. The second-order curvature information helps when starting values are already in the basin.
 
-**`gn` / `gn_hybrid`** — these are [Gauss-Newton estimation methods](gauss-newton.md), not outer optimizers in the same sense. They replace the FOCE outer loop entirely rather than selecting an algorithm within it.
+**`gn` / `gn_hybrid`** — these are [Gauss-Newton estimation methods](gauss-newton.md), not outer optimizers in the same sense. They replace the FOCE outer loop entirely rather than selecting an algorithm within it. (`gn_hybrid` polishes via FOCEI and inherits the `optimizer` setting for that stage — so the polish runs with `bobyqa` unless overridden.)
 
-**`lbfgs` / `nlopt_lbfgs` / `mma`** — rarely needed. Prefer `slsqp` or `bobyqa`.
+**`lbfgs` / `nlopt_lbfgs` / `mma`** — rarely needed. Prefer `bobyqa` or `slsqp`.
+
+> **Why is BOBYQA the default?** Until 2026 the default was `slsqp`. The Emax PKPD benchmark in [`saem.md`](saem.md) and the cefepime validation below both showed that the fixed-EBE FD gradient drives `slsqp` to local minima hundreds of OFV units above the true optimum on ODE/PD models and sparse data — exactly the workloads that aren't covered by the analytical-PK comfort zone. `bobyqa` doesn't use the gradient, doesn't see the bias, and reaches the same (or lower) OFV in the same or less wall time. The previous behaviour is one line away: `optimizer = slsqp` in `[fit_options]`.
 
 ---
 
@@ -71,10 +73,10 @@ Set `reconverge_gradient_interval = 1` to re-solve the inner loop at every gradi
 
 | Configuration | OFV | Wall time |
 |---|---:|---:|
-| `slsqp` (fixed-EBE, default) | 68,252 | 390 s |
+| `slsqp` (fixed-EBE) | 68,252 | 390 s |
 | `slsqp` + `interval = 10` | 66,118 | 633 s |
 | `slsqp` + `interval = 1` | **65,485** | 1,871 s |
-| `bobyqa` (derivative-free) | 65,598 | 315 s |
+| `bobyqa` (derivative-free, **default**) | 65,598 | 315 s |
 
 On this cefepime 2-compartment dataset `bobyqa` reaches a near-optimal solution faster than any reconverged `slsqp` setting. The reconverged gradient is most useful when derivative-free search is too slow (high parameter count) or when a gradient optimizer is required for other reasons.
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -112,12 +112,12 @@ prefer a bracketed comparison (`WT >= 70 && WT < 80`) over `WT == 75`.
 
 ## Which outer optimizer should I pick?
 
-`bobyqa` (the default since 2026) is the right choice for most models —
+`bobyqa` (the default) is the right choice for most models —
 derivative-free quadratic trust-region, robust to noisy FD gradients, and
 consistently reaches a lower OFV than `slsqp` on ODE/PD models, sparse data,
-and Hill-ridge identifiability problems. Until the SAEM/FOCEI cleanups for
-ODE models landed the default was `slsqp`; the change is one line away if
-you need the old behaviour (`optimizer = slsqp` in `[fit_options]`).
+and Hill-ridge identifiability problems. Previously the default was `slsqp`;
+the change is one line away if you need the old behaviour
+(`optimizer = slsqp` in `[fit_options]`).
 
 Reach for a different optimizer when the default misbehaves:
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -112,15 +112,19 @@ prefer a bracketed comparison (`WT >= 70 && WT < 80`) over `WT == 75`.
 
 ## Which outer optimizer should I pick?
 
-`slsqp` (the default) is the right choice for most models — it is fast, handles
-box constraints cleanly, and behaves well on the log-transformed parameter
-scale that ferx uses internally.
+`bobyqa` (the default since 2026) is the right choice for most models —
+derivative-free quadratic trust-region, robust to noisy FD gradients, and
+consistently reaches a lower OFV than `slsqp` on ODE/PD models, sparse data,
+and Hill-ridge identifiability problems. Until the SAEM/FOCEI cleanups for
+ODE models landed the default was `slsqp`; the change is one line away if
+you need the old behaviour (`optimizer = slsqp` in `[fit_options]`).
 
-Reach for a different optimizer when SLSQP misbehaves:
+Reach for a different optimizer when the default misbehaves:
 
-- **`bobyqa`** — derivative-free, good when FOCE's FD gradients are noisy and
-  SLSQP stalls or oscillates. Slower per iteration on smooth problems, but
-  often converges when gradient-based methods give up.
+- **`slsqp`** — gradient-based; faster per iteration on smooth, well-conditioned
+  analytical PK models with many parameters. Can stall above the true minimum
+  on ill-conditioned fits unless paired with `reconverge_gradient_interval = 1`
+  (5–6× cost per gradient).
 - **`trust_region`** — second-order Newton trust-region with an AD-based
   gradient and BHHH approximate Hessian. Can be faster near convergence
   because it uses curvature information; the CG budget defaults to
@@ -224,15 +228,15 @@ Both produce IPRED, PRED, IWRES, and CWRES on the log scale (back-transform with
 
 ## Which outer optimizer should I use?
 
-**Default (`slsqp`)** works well for most models. If you're unsure, start here.
+**Default (`bobyqa`)** works well for most models — including ODE/PD models, sparse data, and Hill-ridge problems where gradient-based optimizers stall. If you're unsure, start here.
 
-**`bobyqa`** is the best single alternative: derivative-free quadratic interpolation, robust when the finite-difference gradient is noisy (sparse data, ODE models). Recommended when `slsqp` reports convergence at a suspiciously high OFV.
+**`slsqp`** is the right pick when `bobyqa` is too slow on a smooth, well-conditioned model with many parameters (it can take many quadratic-interpolation samples to triangulate a high-dimensional surface). Pair with `reconverge_gradient_interval = 1` if it stalls above an expected OFV.
 
 **`trust_region`** shines on high-parameter-count models (many thetas/omegas) or when combined with `inits_from_nca` — the second-order curvature helps when starting values are good. Set `steihaug_max_iters` if you want to pin the CG budget.
 
-**`gn` / `gn_hybrid`** for fast iteration during model development: Gauss-Newton converges in 10–30 steps vs 100+ for gradient methods. `gn_hybrid` adds a FOCEI polish pass for robustness.
+**`gn` / `gn_hybrid`** for fast iteration during model development: Gauss-Newton converges in 10–30 steps vs 100+ for gradient methods. `gn_hybrid` adds a FOCEI polish pass for robustness; that polish stage runs with `bobyqa` by default and inherits any `optimizer` override.
 
-**Gradient-based (`lbfgs`, `mma`)** are rarely needed; prefer `slsqp` or `bobyqa`. See [FOCE/FOCEI — Optimizer Options](estimation/foce.md#optimizer-options) for a full comparison.
+**Gradient-based (`lbfgs`, `mma`)** are rarely needed; prefer `bobyqa` or `slsqp`. See [FOCE/FOCEI — Optimizer Options](estimation/foce.md#optimizer-options) for a full comparison.
 
 ## How do I validate a model file without running a full fit?
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -39,7 +39,7 @@ ferx-core is a high-performance Nonlinear Mixed Effects (NLME) modeling engine w
 
 ferx-core uses a two-level optimization structure:
 
-- **Outer loop**: Optimizes population parameters (theta, omega, sigma) using NLopt SLSQP (default), BOBYQA, L-BFGS, MMA, built-in BFGS, Newton trust-region, or Gauss-Newton (BHHH)
+- **Outer loop**: Optimizes population parameters (theta, omega, sigma) using NLopt BOBYQA (default), SLSQP, L-BFGS, MMA, built-in BFGS, Newton trust-region, or Gauss-Newton (BHHH)
 - **Inner loop**: For each subject, finds empirical Bayes estimates (EBEs) of random effects by minimizing individual negative log-likelihood
 
 Parameters are internally transformed for unconstrained optimization: theta and sigma are log-transformed, and omega uses Cholesky factorization to guarantee positive-definiteness.

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -16,7 +16,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 | `method` | `foce`, `focei`, `saem`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). |
 | `maxiter` | integer | `500` | Maximum outer loop iterations |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
-| `optimizer` | `slsqp`, `lbfgs`, `nlopt_lbfgs`, `mma`, `bfgs`, `bobyqa`, `trust_region` | `slsqp` | Outer-loop optimisation algorithm. Applies to `method = foce` / `focei` and to the FOCEI polish phase of `method = gn_hybrid`. Ignored (with a runtime warning) under `method = saem` / `imp` / `gn` — see the [Outer Optimizers](../estimation/optimizers.md) page for the applicability matrix. |
+| `optimizer` | `slsqp`, `lbfgs`, `nlopt_lbfgs`, `mma`, `bfgs`, `bobyqa`, `trust_region` | `bobyqa` | Outer-loop optimisation algorithm. Applies to `method = foce` / `focei` and to the FOCEI polish phase of `method = gn_hybrid`. Ignored (with a runtime warning) under `method = saem` / `imp` / `gn` — see the [Outer Optimizers](../estimation/optimizers.md) page for the applicability matrix and the rationale for the BOBYQA default. |
 | `inner_maxiter` | integer | `200` | Max iterations for the inner (per-subject EBE) optimizer |
 | `inner_tol` | float | `1e-4` | Gradient-norm convergence tolerance for the inner (per-subject EBE) optimizer. The default of `1e-4` matches the precision of typical NLME engines (NONMEM's default inner-loop SIGDIGITS is ~3, equivalent to ~`1e-3`). Tighter values (e.g. `1e-6`, `1e-8`) over-converge the EBE relative to the Sheiner–Beal linearisation error and can slow FOCEI fits by 10–15× without measurable change in the final OFV. Use a tighter value only if you're comparing post-hoc EBE values across runs at high precision. |
 | `steihaug_max_iters` | integer | adaptive | Max CG iterations for the Steihaug subproblem (only used when `optimizer = trust_region`). Default (unset) uses `ceil(sqrt(n_params)).clamp(5, n_params)` — typically 5 for standard NLME models. Set explicitly (e.g. `steihaug_max_iters = 50`) to pin the budget. |
@@ -124,12 +124,12 @@ for the algorithm, IOV caveats, and tuning guidance.
 
 | Optimizer | Description | Recommended For |
 |-----------|-------------|-----------------|
-| `slsqp` | Sequential Least Squares Programming (NLopt) | General use (default) |
+| `bobyqa` | NLopt BOBYQA — derivative-free quadratic interpolation | General use (default); robust on noisy / non-smooth FOCE surfaces (ODE/PD, sparse data, Hill-ridge models) |
+| `slsqp` | Sequential Least Squares Programming (NLopt) | Smooth, well-conditioned analytical PK models where you want gradient-based convergence; pair with `reconverge_gradient_interval` if it stalls |
 | `bfgs` | Built-in BFGS quasi-Newton | When NLopt is unavailable |
 | `lbfgs` | Limited-memory BFGS | Large parameter spaces |
 | `nlopt_lbfgs` | NLopt L-BFGS | Alternative L-BFGS |
 | `mma` | Method of Moving Asymptotes (NLopt) | Constrained problems |
-| `bobyqa` | NLopt BOBYQA — derivative-free quadratic interpolation | Noisy or non-smooth objectives where FD gradients are unreliable |
 | `trust_region` | Newton trust-region with Steihaug CG subproblem (argmin) | Well-conditioned problems where second-order curvature helps convergence |
 
 Notes:

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -8424,11 +8424,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_optimizer_defaults_to_slsqp() {
-        // No [fit_options] block → default optimizer.
+    fn test_parse_optimizer_defaults_to_bobyqa() {
+        // No [fit_options] block → default optimizer is BOBYQA (derivative-free
+        // trust-region). See `FitOptions::default` for the rationale.
         let content = minimal_model_with_fit_options("  maxiter = 100");
         let parsed = parse_full_model(&content).unwrap();
-        assert_eq!(parsed.fit_options.optimizer, Optimizer::Slsqp);
+        assert_eq!(parsed.fit_options.optimizer, Optimizer::Bobyqa);
     }
 
     #[test]
@@ -8459,10 +8460,10 @@ mod tests {
     #[test]
     fn test_fit_options_defaults() {
         // Guard against accidental drift in defaults — documented as:
-        //   optimizer = slsqp, inner_maxiter = 200, inner_tol = 1e-4,
+        //   optimizer = bobyqa, inner_maxiter = 200, inner_tol = 1e-4,
         //   steihaug_max_iters = None (adaptive).
         let opts = FitOptions::default();
-        assert_eq!(opts.optimizer, Optimizer::Slsqp);
+        assert_eq!(opts.optimizer, Optimizer::Bobyqa);
         assert_eq!(opts.inner_maxiter, 200);
         assert!((opts.inner_tol - 1e-4).abs() < 1e-20);
         assert_eq!(opts.steihaug_max_iters, None);

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -8425,8 +8425,9 @@ mod tests {
 
     #[test]
     fn test_parse_optimizer_defaults_to_bobyqa() {
-        // No [fit_options] block → default optimizer is BOBYQA (derivative-free
-        // trust-region). See `FitOptions::default` for the rationale.
+        // `[fit_options]` block present but `optimizer` omitted → default is
+        // BOBYQA (derivative-free trust-region). See `FitOptions::default` for
+        // the rationale.
         let content = minimal_model_with_fit_options("  maxiter = 100");
         let parsed = parse_full_model(&content).unwrap();
         assert_eq!(parsed.fit_options.optimizer, Optimizer::Bobyqa);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1853,7 +1853,16 @@ impl Default for FitOptions {
             run_covariance_step: true,
             interaction: true,
             verbose: true,
-            optimizer: Optimizer::Slsqp,
+            // BOBYQA — derivative-free quadratic trust-region. Chosen as the
+            // default because the fixed-EBE FD gradient that SLSQP/L-BFGS rely
+            // on is biased on ill-conditioned fits (ODE/PD models, sparse data,
+            // Hill-ridge identifiability), and SLSQP can declare convergence
+            // hundreds of OFV units above the true minimum. BOBYQA re-evaluates
+            // EBEs at every trial point and routinely reaches a lower OFV
+            // without the cost of `reconverge_gradient_interval = 1`. See
+            // `docs/src/estimation/optimizers.md` for the cefepime and Emax
+            // PKPD validations and guidance on when to switch back to SLSQP.
+            optimizer: Optimizer::Bobyqa,
             lbfgs_memory: 5,
             global_search: false,
             global_maxeval: 0,


### PR DESCRIPTION
## Why

For both SAEM M-step and FOCE, bobyqa seems more stable / faster choice in most cases. The docs explain when gradient-based optim could have benefit.