### PR TITLE
fix(tests): re-anchor GN-TR baselines to Almquist Laplace minimum [closes #144]

### DIFF
--- a/tests/gn_convergence.rs
+++ b/tests/gn_convergence.rs
@@ -49,9 +49,12 @@ fn warfarin_data_and_model() -> (
 ///
 /// Baseline: best observed OFV from GN-TR under the Almquist Laplace NLL
 /// (-279.1136).  SLSQP reaches -278.7336 on this dataset — GN-TR
-/// consistently finds a marginally better minimum.  Tolerance of 0.5
-/// absorbs minor run-to-run numerical variation; a regression of more
-/// than ~0.5 OFV units indicates a real algorithmic problem.  See the
+/// consistently finds a marginally better minimum (~0.38 OFV).  Tolerance
+/// of 0.25 sits comfortably below that gap, so a regression to SLSQP-level
+/// performance still fails the assert (enforcing the "GN-TR > SLSQP"
+/// invariant), while leaving ~0.24 OFV of headroom for run-to-run
+/// numerical variation (observed variation between GN-TR and GN-hybrid on
+/// this dataset is ~0.01 OFV, so 0.25 is generous).  See the
 /// module-level "Baseline history" comment for why this differs from the
 /// pre-#130 Sheiner-Beal baseline (-285.7163).
 #[test]
@@ -61,7 +64,7 @@ fn warfarin_data_and_model() -> (
 )]
 fn gn_tr_warfarin_ofv_matches_slsqp_baseline() {
     const KNOWN_GOOD_OFV: f64 = -279.1136;
-    const TOLERANCE: f64 = 0.5;
+    const TOLERANCE: f64 = 0.25;
 
     let (model, population) = warfarin_data_and_model();
 
@@ -91,7 +94,10 @@ fn gn_tr_warfarin_ofv_matches_slsqp_baseline() {
 /// must reach the known-good minimum.
 ///
 /// Baseline -279.1243: the FOCEI polish improves on pure GN-TR by ~0.01 OFV.
-/// See the module-level "Baseline history" comment for the Almquist Laplace
+/// SLSQP reaches -278.7336 (gap ~0.39 OFV).  Tolerance of 0.25 keeps the
+/// pass threshold strictly better than SLSQP, so a regression in the
+/// polish stage to SLSQP-level performance fails the assert.  See the
+/// module-level "Baseline history" comment for the Almquist Laplace
 /// shift from the pre-#130 SB baseline.
 #[test]
 #[cfg_attr(
@@ -100,7 +106,7 @@ fn gn_tr_warfarin_ofv_matches_slsqp_baseline() {
 )]
 fn gn_hybrid_tr_warfarin_ofv_matches_slsqp() {
     const KNOWN_GOOD_OFV: f64 = -279.1243;
-    const TOLERANCE: f64 = 0.5;
+    const TOLERANCE: f64 = 0.25;
 
     let (model, population) = warfarin_data_and_model();
 

--- a/tests/gn_convergence.rs
+++ b/tests/gn_convergence.rs
@@ -10,6 +10,25 @@
 //! The assertion is one-sided: finding a *better* (lower) OFV is never a
 //! failure; regressing above `baseline + tolerance` is.  Update the constant
 //! if a deliberate algorithmic improvement raises the bar.
+//!
+//! ## Baseline history
+//!
+//! The original baselines (`-285.7163` warfarin, `-1198.3229` two_cpt_oral_cov)
+//! were captured against the Sheiner–Beal linearised marginal NLL.  PR #130
+//! ([`fix(focei): switch FOCEI INTER marginal to Almquist 2015 Laplace form`])
+//! replaced that NLL with the Almquist Laplace form for `interaction=true`.
+//! These tests run with the `FitOptions::default()` (which sets
+//! `interaction: true`), so the GN optimiser now targets the Laplace NLL —
+//! a different objective whose minimum sits at a different OFV value.  The
+//! baselines below reflect the Almquist Laplace minimum and were re-anchored
+//! at HEAD on the issue #144 fix.  GN-TR still finds a better minimum than
+//! SLSQP on both datasets (the original ordering the tests were written to
+//! enforce):
+//!
+//! | Dataset           | SLSQP    | GN-TR     | GN-hybrid |
+//! |-------------------|----------|-----------|-----------|
+//! | warfarin          | -278.734 | -279.114  | -279.124  |
+//! | two_cpt_oral_cov  |-1144.948 |-1153.071  |   —       |
 
 use ferx_core::parser::model_parser::parse_model_file;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
@@ -28,16 +47,20 @@ fn warfarin_data_and_model() -> (
 
 /// GN trust-region on warfarin must reach the known-good minimum.
 ///
-/// Baseline: best observed OFV from GN-TR (-285.7163).  SLSQP reaches only
-/// -280.1837 on this dataset — GN-TR consistently finds a better minimum.
-/// Tolerance of 0.5 absorbs minor run-to-run numerical variation.
+/// Baseline: best observed OFV from GN-TR under the Almquist Laplace NLL
+/// (-279.1136).  SLSQP reaches -278.7336 on this dataset — GN-TR
+/// consistently finds a marginally better minimum.  Tolerance of 0.5
+/// absorbs minor run-to-run numerical variation; a regression of more
+/// than ~0.5 OFV units indicates a real algorithmic problem.  See the
+/// module-level "Baseline history" comment for why this differs from the
+/// pre-#130 Sheiner-Beal baseline (-285.7163).
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
     ignore = "slow: opt in with --features slow-tests"
 )]
 fn gn_tr_warfarin_ofv_matches_slsqp_baseline() {
-    const KNOWN_GOOD_OFV: f64 = -285.7163;
+    const KNOWN_GOOD_OFV: f64 = -279.1136;
     const TOLERANCE: f64 = 0.5;
 
     let (model, population) = warfarin_data_and_model();
@@ -67,15 +90,16 @@ fn gn_tr_warfarin_ofv_matches_slsqp_baseline() {
 /// GN-hybrid trust-region on warfarin: the GN phase followed by FOCEI polish
 /// must reach the known-good minimum.
 ///
-/// Same baseline as pure GN-TR (-285.7163); the hybrid should be at least as
-/// good since it polishes the GN solution with FOCEI.
+/// Baseline -279.1243: the FOCEI polish improves on pure GN-TR by ~0.01 OFV.
+/// See the module-level "Baseline history" comment for the Almquist Laplace
+/// shift from the pre-#130 SB baseline.
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
     ignore = "slow: opt in with --features slow-tests"
 )]
 fn gn_hybrid_tr_warfarin_ofv_matches_slsqp() {
-    const KNOWN_GOOD_OFV: f64 = -285.7163;
+    const KNOWN_GOOD_OFV: f64 = -279.1243;
     const TOLERANCE: f64 = 0.5;
 
     let (model, population) = warfarin_data_and_model();
@@ -106,18 +130,20 @@ fn gn_hybrid_tr_warfarin_ofv_matches_slsqp() {
 ///
 /// This model has weakly-identified covariate exponents alongside well-identified
 /// PK parameters — the TR per-direction step scaling handles the mixed-curvature
-/// case.  Baseline: best observed OFV from GN-TR (-1198.3229); SLSQP reaches
-/// only -1116.0357, suggesting it gets stuck in a shallow region of the
-/// likelihood surface driven by the flat covariate directions.
-/// Tolerance of 1.0 absorbs minor numerical variation; a jump of more than
-/// ~80 units above the baseline would indicate a real regression.
+/// case.  Baseline: best observed OFV from GN-TR under the Almquist Laplace
+/// NLL (-1153.0708); SLSQP reaches only -1144.9481, so GN-TR still finds a
+/// meaningfully better minimum on the flat covariate directions.  Tolerance
+/// of 1.0 absorbs minor numerical variation; a jump of more than ~8 OFV
+/// units (back toward the SLSQP basin) would indicate a real regression.
+/// See the module-level "Baseline history" comment for the shift from the
+/// pre-#130 SB baseline (-1198.3229).
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
     ignore = "slow: opt in with --features slow-tests"
 )]
 fn gn_tr_two_cpt_oral_cov_ofv_matches_slsqp_baseline() {
-    const KNOWN_GOOD_OFV: f64 = -1198.3229;
+    const KNOWN_GOOD_OFV: f64 = -1153.0708;
     const TOLERANCE: f64 = 1.0;
 
     let model = parse_model_file(Path::new("examples/two_cpt_oral_cov.ferx"))


### PR DESCRIPTION
## Why

`tests/gn_convergence.rs` had three slow tests failing on `main` with
deterministic OFV regressions:

| Test | OFV (got) | OFV (expected) | Tolerance |
|---|---|---|---|
| `gn_tr_warfarin_ofv_matches_slsqp_baseline` | -279.1136 | -285.7163 | 0.5 |
| `gn_hybrid_tr_warfarin_ofv_matches_slsqp` | -279.1243 | -285.7163 | 0.5 |
| `gn_tr_two_cpt_oral_cov_ofv_matches_slsqp_baseline` | -1153.0708 | -1198.3229 | 1.0 |

The baselines were captured against the **Sheiner–Beal** linearised marginal NLL. PR #130 (`fix(focei): switch FOCEI INTER marginal to Almquist 2015 Laplace form`) replaced that NLL with the Almquist Laplace form for `interaction=true`. These tests run with `FitOptions::default()` (which sets `interaction: true`), so they now target the Laplace NLL — a different objective whose minimum sits at a different OFV value. The baselines became stale at the moment #130 merged.

## What changed

Re-anchored the three `KNOWN_GOOD_OFV` constants in `tests/gn_convergence.rs` to the current Almquist Laplace minima, plus added a module-level "Baseline history" comment explaining the shift so the next reader doesn't repeat the bisect:

| Dataset           | SLSQP    | GN-TR     | GN-hybrid |
|-------------------|----------|-----------|-----------|
| warfarin          | -278.734 | -279.114  | -279.124  |
| two_cpt_oral_cov  |-1144.948 |-1153.071  |   —       |

GN-TR still beats SLSQP on both datasets — the *ordering* the tests were written to enforce is preserved; only the absolute OFV shifted because the NLL formula changed.

## Note on issue #144's analysis

The issue author's analysis is incorrect on two points (verified by trace-level reproduction at suspect commits):

1. **Bisect blames PR #98** (`suggest_start`). Re-running the same diagnostic at #98 itself lands cleanly at -285.42 (passes). The actual regression appears at PR #130 — confirmed by testing the commits immediately before #130 (passes -285.42) and at #130 (lands at -279.08, matching the failing baseline).

2. **Proposed mechanism** — `rel_change < 1e-6` OFV-only convergence firing at a non-stationary point — does NOT match the trace. GN-TR exits via the *trust-radius-collapsed* branch with `|g| ≈ 25.7` at iter 39, not via the ftol gate. Adding a `||g|| < gtol` AND-gate to the convergence predicate (the suggested fix) does not fire and does not change the failing OFV.

## Alternatives considered

- **Add a gradient-norm AND-gate to the convergence predicate** (issue's proposed fix). Implemented and verified it does not fire in this scenario — the loop exits earlier via trust-radius collapse, not via OFV ftol. Discarded as ineffective for this issue. (Could be a separate quality improvement, but it tightens convergence and may break unrelated tests that currently converge via ftol-only.)
- **Loosen the test tolerance to 10 OFV units** so the old SB baseline still passes. Discarded — masks the real signal (the NLL form changed). The right thing is to anchor to the new objective.
- **Re-run with `interaction=false`** (SB NLL). Discarded — `interaction=true` is the default and the realistic user path; the test should reflect that.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None

## Numerical validation

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit `e2bdbf4` (pre-#130) and `e5daad4` (#130 merge itself) — values match analysis above
- [x] Reference values:

```
# Before fix (HEAD, fails)
warfarin GN-TR:     OFV=-279.1136  baseline=-285.7163  FAIL
warfarin GN-hybrid: OFV=-279.1243  baseline=-285.7163  FAIL
two_cpt GN-TR:      OFV=-1153.0708 baseline=-1198.3229 FAIL

# After fix (this PR, passes)
warfarin GN-TR:     OFV=-279.1136  baseline=-279.1136  PASS
warfarin GN-hybrid: OFV=-279.1243  baseline=-279.1243  PASS
two_cpt GN-TR:      OFV=-1153.0708 baseline=-1153.0708 PASS
```

## Out-of-scope follow-ups discovered during the investigation

- GN-TR on the Laplace NLL exits with the "trust radius collapsed" warning at a non-stationary point (`|g| ≈ 25.7` on warfarin). Not a regression — OFV is still better than SLSQP — but suggests the BHHH approximation's curvature quality is poorer on the Laplace objective than on SB. Worth a separate investigation if GN-TR is ever asked to deliver a *true* stationary point (covariance step quality, for instance).
- Two other unrelated slow tests are also failing at HEAD and look like test-invariant breakages from earlier improvements (SLSQP got more efficient, SAEM defaults changed): `new_optimizers::stagnation_guard_toggle_runs_to_natural_termination` and `saem_omega_burnin::saem_burnin_recovers_omega_on_sparse_data`. Investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
