### PR TITLE
fix(tests): re-anchor SAEM & stagnation-guard slow tests after recent improvements

### DIFF
--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2234,6 +2234,163 @@ mod tests {
         assert_eq!(r.n_clipped, 0);
     }
 
+    // ── detect_stagnation: NLopt stagnation-guard unit tests ─────────────────
+
+    /// Build a minimal `NloptState` for `detect_stagnation` unit tests.
+    /// The non-stagnation fields (`cached_etas`, `cached_h_mats`, `prev_x`)
+    /// are left empty because `detect_stagnation` reads only the
+    /// `*_evals` / `*_improvement` / `stagnation_stopped` fields.
+    fn fresh_state() -> NloptState {
+        NloptState {
+            cached_etas: Vec::new(),
+            cached_h_mats: Vec::new(),
+            best_ofv: 0.0,
+            n_evals: 0,
+            n_grad_evals: 0,
+            prev_x: Vec::new(),
+            last_improvement_eval: 0,
+            best_at_last_improvement: f64::INFINITY,
+            stagnation_stopped: false,
+        }
+    }
+
+    /// `detect_stagnation(enabled=false)` is a no-op: it never latches, never
+    /// fires, even after a window of zero improvement.  Replaces the
+    /// end-to-end `stagnation_guard_toggle_runs_to_natural_termination` test
+    /// (removed from `tests/new_optimizers.rs`), which became unreliable
+    /// after SLSQP's own xtol fires before the guard window elapses on the
+    /// warfarin example (both guard-on and guard-off now exit at exactly
+    /// 100 evals via NLopt `XtolReached`, so the e2e toggle comparison no
+    /// longer discriminates).
+    #[test]
+    fn test_detect_stagnation_disabled_never_fires() {
+        let mut state = fresh_state();
+        state.best_ofv = -100.0;
+        state.best_at_last_improvement = -100.0;
+        // Far past the stagnation window (n=7 → window = max(3*8, 50) = 50)
+        // with zero improvement: still must not fire when disabled.
+        for n_evals in 0..200 {
+            state.n_evals = n_evals;
+            assert!(
+                !detect_stagnation(&mut state, 7, false),
+                "enabled=false must never fire (n_evals={n_evals})"
+            );
+        }
+        assert!(
+            !state.stagnation_stopped,
+            "disabled path must not latch `stagnation_stopped`"
+        );
+    }
+
+    /// `detect_stagnation(enabled=true)` fires once `n_evals - last_improvement`
+    /// reaches the stagnation window and latches sticky thereafter.
+    #[test]
+    fn test_detect_stagnation_enabled_fires_at_window_and_latches() {
+        let mut state = fresh_state();
+        state.best_ofv = -100.0;
+        state.best_at_last_improvement = -100.0; // identical → no improvement
+        state.last_improvement_eval = 0;
+
+        let n = 7usize;
+        let window = (3 * (n + 1)).max(50); // = 50
+
+        // Within the window, no firing.
+        for n_evals in 1..window {
+            state.n_evals = n_evals;
+            assert!(
+                !detect_stagnation(&mut state, n, true),
+                "must not fire inside window (n_evals={n_evals}, window={window})"
+            );
+            assert!(!state.stagnation_stopped);
+        }
+
+        // At the window, fires and latches.
+        state.n_evals = window;
+        assert!(
+            detect_stagnation(&mut state, n, true),
+            "must fire at window (n_evals={window})"
+        );
+        assert!(
+            state.stagnation_stopped,
+            "first firing must latch `stagnation_stopped`"
+        );
+
+        // Latched: subsequent calls keep returning `true` without re-checking
+        // the window arithmetic.  Drop n_evals well below the window to prove
+        // the short-circuit is on `stagnation_stopped`, not on the counter.
+        state.n_evals = 1;
+        assert!(
+            detect_stagnation(&mut state, n, true),
+            "latched state must stay sticky-true regardless of n_evals"
+        );
+    }
+
+    /// `detect_stagnation` resets the improvement counter when OFV moves down
+    /// by more than the 1e-3 threshold — so a long run of fruitful descent
+    /// never triggers the guard.
+    #[test]
+    fn test_detect_stagnation_resets_on_improvement() {
+        let mut state = fresh_state();
+        state.best_ofv = -100.0;
+        state.best_at_last_improvement = -100.0;
+        state.last_improvement_eval = 0;
+
+        let n = 7usize;
+        // Walk almost up to the window with zero improvement…
+        state.n_evals = 49;
+        assert!(!detect_stagnation(&mut state, n, true));
+
+        // …then improve OFV by > 1e-3.  Improvement must reset the
+        // last-improvement counter so the next 50 evals start fresh.
+        state.best_ofv = -100.5;
+        state.n_evals = 50;
+        assert!(
+            !detect_stagnation(&mut state, n, true),
+            "improvement must reset the counter"
+        );
+        assert_eq!(
+            state.last_improvement_eval, 50,
+            "last_improvement_eval must advance to the improving eval"
+        );
+        assert_eq!(
+            state.best_at_last_improvement, -100.5,
+            "best_at_last_improvement must update to the new best"
+        );
+
+        // Now we need another full window of zero improvement before firing.
+        state.n_evals = 99;
+        assert!(!detect_stagnation(&mut state, n, true));
+        state.n_evals = 100;
+        assert!(detect_stagnation(&mut state, n, true));
+    }
+
+    /// Improvement *below* the 1e-3 threshold counts as stagnation — the
+    /// guard is deliberately noise-tolerant.  Without this, OFV noise of a
+    /// few ULPs would constantly reset the counter and the guard would
+    /// never fire.
+    #[test]
+    fn test_detect_stagnation_subthreshold_improvement_does_not_reset() {
+        let mut state = fresh_state();
+        state.best_ofv = -100.0;
+        state.best_at_last_improvement = -100.0;
+        state.last_improvement_eval = 0;
+
+        let n = 7usize;
+        // Improve OFV by 5e-4 — below the 1e-3 threshold.  Counter must
+        // NOT reset.
+        state.best_ofv = -100.0005;
+        state.n_evals = 25;
+        assert!(!detect_stagnation(&mut state, n, true));
+        assert_eq!(
+            state.last_improvement_eval, 0,
+            "sub-threshold improvement must not advance the counter"
+        );
+
+        // 50 evals after the original last_improvement_eval (= 0), it fires.
+        state.n_evals = 50;
+        assert!(detect_stagnation(&mut state, n, true));
+    }
+
     #[test]
     fn test_reconverge_this_eval_schedule() {
         let mut opts = FitOptions::default();

--- a/tests/new_optimizers.rs
+++ b/tests/new_optimizers.rs
@@ -156,50 +156,21 @@ fn slsqp_stops_via_stagnation_well_before_a_generous_maxeval() {
     );
 }
 
-#[test]
-fn stagnation_guard_toggle_runs_to_natural_termination() {
-    // With `stagnation_guard = false` the SLSQP run should NOT cut off
-    // early via the guard. The pair complements
-    // `slsqp_stops_via_stagnation_well_before_a_generous_maxeval`: with
-    // the guard on, NLopt terminates well below a `outer_maxiter * (n+1)`
-    // ceiling; with it off, eval counts climb noticeably higher (or hit
-    // maxeval) because only NLopt's own xtol/ftol can stop it.
-    let (model, population) = data_and_model();
-
-    let mut opts_on = base_options();
-    opts_on.optimizer = Optimizer::Slsqp;
-    opts_on.outer_maxiter = 1000;
-    opts_on.stagnation_guard = true;
-    let r_on = fit(&model, &population, &model.default_params, &opts_on)
-        .expect("slsqp fit with guard on must succeed");
-
-    let mut opts_off = base_options();
-    opts_off.optimizer = Optimizer::Slsqp;
-    opts_off.outer_maxiter = 1000;
-    opts_off.stagnation_guard = false;
-    let r_off = fit(&model, &population, &model.default_params, &opts_off)
-        .expect("slsqp fit with guard off must succeed");
-
-    assert!(r_on.ofv.is_finite() && r_off.ofv.is_finite());
-    // Both fits should land on roughly the same OFV — the guard only
-    // affects *when* SLSQP stops, not the converged value.
-    assert!(
-        (r_on.ofv - r_off.ofv).abs() < 1.0,
-        "guard on OFV {} vs off OFV {} should agree within 1 unit",
-        r_on.ofv,
-        r_off.ofv,
-    );
-    // The guard exists precisely because SLSQP can grind past the
-    // numerically-flat OFV plateau. With it off, expect a meaningfully
-    // higher eval count. Assert strictly more — anything else suggests
-    // the toggle didn't take effect.
-    assert!(
-        r_off.n_iterations > r_on.n_iterations,
-        "guard off should run more evals than guard on (off = {}, on = {})",
-        r_off.n_iterations,
-        r_on.n_iterations,
-    );
-}
+// `stagnation_guard_toggle_runs_to_natural_termination` was removed:
+// SLSQP's own `XtolReached` now fires on warfarin at ~eval 100 — well
+// before the guard window (~50 evals past the last improvement at ~eval
+// 65, so eval ~115).  Both guard-on and guard-off therefore exit with
+// identical OFV at exactly the same eval count, so the toggle no longer
+// discriminates and the e2e test cannot tell whether the guard wired
+// through.  The guard's mechanism is now verified directly by the
+// `detect_stagnation_*` unit tests in `src/estimation/outer_optimizer.rs`,
+// which is stricter coverage than the e2e ever provided (every branch of
+// the `detect_stagnation` predicate is exercised).
+//
+// The companion test
+// `slsqp_stops_via_stagnation_well_before_a_generous_maxeval` (above) is
+// retained: it still passes and provides end-to-end coverage that the
+// outer loop terminates well below the maxeval ceiling.
 
 #[test]
 fn final_ofv_no_worse_than_best_seen_during_trace() {

--- a/tests/saem_omega_burnin.rs
+++ b/tests/saem_omega_burnin.rs
@@ -110,6 +110,15 @@ fn simulate_into(model: &ferx_core::types::CompiledModel, template: &Population)
 }
 
 /// Run SAEM with the given burn-in and return the recovered trace(Ω).
+///
+/// `saem_n_mh_steps` is pinned at 3 (the pre-PR #148 default) so the
+/// cold-start collapse this test guards against is reproducible.  The new
+/// default of 10 MH steps mixes the chain well enough on its own that the
+/// no-burn-in run no longer collapses Ω substantially below the burn-in
+/// run — so the new default masks the burn-in fix without removing the
+/// underlying problem.  Anchoring to the pre-#148 default keeps the test
+/// guarding the burn-in mechanism rather than the (orthogonal) MH-step
+/// improvement.
 fn fit_trace(
     model: &ferx_core::types::CompiledModel,
     population: &Population,
@@ -119,6 +128,7 @@ fn fit_trace(
     opts.method = EstimationMethod::Saem;
     opts.saem_n_exploration = 120;
     opts.saem_n_convergence = 120;
+    opts.saem_n_mh_steps = 3;
     opts.saem_omega_burnin = omega_burnin;
     opts.saem_seed = Some(7);
     opts.run_covariance_step = false;


### PR DESCRIPTION
## Why

Two slow tests on `main` had become unreliable as side effects of unrelated improvements that pushed the underlying behaviour past the threshold each test was written to detect. Both are *test-invariant* breakages, not algorithmic regressions — discovered while working on #144.

| Test | Reported state | Root cause |
|---|---|---|
| `saem_omega_burnin::saem_burnin_recovers_omega_on_sparse_data` | `no_burnin=0.1382` vs threshold `< 0.6 * 0.1546 = 0.0928` | PR #148 bumped `saem_n_mh_steps` 3 → 10; 10 MH steps mix the chain well enough that no-burnin Ω no longer collapses |
| `new_optimizers::stagnation_guard_toggle_runs_to_natural_termination` | `off = 100, on = 100` (expected `off > on`) | SLSQP's `XtolReached` now fires at eval ~100 on warfarin — before the stagnation window (~eval 115) — so both runs exit at the same eval count |

## What changed

### 1. SAEM burn-in test

Pin `saem_n_mh_steps = 3` (the pre-#148 default) in the test `fit_trace` helper.  Verified the test invariant holds at 3 MH steps and *not* at 10:

```
n_mh=3:  burnin=0.1411  no_burnin=0.0477  ratio=0.338  (passes the <0.6 assertion)
n_mh=10: burnin=0.1546  no_burnin=0.1382  ratio=0.894  (fails — what we see on main)
```

The burn-in fix is still real and still valuable at the old MH-step default. The new default just masks the no-burnin collapse without removing it. Anchoring to the failure-mode scenario keeps the test guarding the burn-in mechanism rather than the (orthogonal) MH-step improvement.

### 2. Stagnation-guard toggle test

Delete the obsolete e2e (kept a tombstone comment explaining the removal), add four Tier-1 unit tests for `detect_stagnation` directly:

- `test_detect_stagnation_disabled_never_fires` — `enabled=false` is a no-op past the window
- `test_detect_stagnation_enabled_fires_at_window_and_latches` — fires exactly at the boundary; latch is sticky
- `test_detect_stagnation_resets_on_improvement` — a >1e-3 improvement resets the counter
- `test_detect_stagnation_subthreshold_improvement_does_not_reset` — <1e-3 improvement is treated as noise

This is **stricter** coverage than the e2e provided: every branch of the predicate is now exercised directly, with no dependence on SLSQP's internal xtol behaviour.

The companion e2e test `slsqp_stops_via_stagnation_well_before_a_generous_maxeval` (which checks the outer loop terminates well below the maxeval ceiling) is retained — it still passes and remains useful.

## Alternatives considered

For the SAEM test: could have loosened the `< 0.6 * burnin` threshold to `< 0.95 * burnin`. Rejected — the test would then accept noise as a "collapse" and not catch a real regression of the burn-in fix.

For the stagnation test: could have switched to a model where SLSQP genuinely grinds (e.g. a γ-bearing FOCEI scenario). Rejected — would require a new fixture, and the unit-test approach is simpler and provides better branch coverage.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None

## Numerical validation

- [x] All affected tests now pass:

```
cargo test --no-default-features --features "slow-tests,ci" --release \
    --test saem_omega_burnin --test new_optimizers
test saem_burnin_recovers_omega_on_sparse_data ... ok
test result: ok. 1 passed; 0 failed

test result: ok. 10 passed; 0 failed   # was 10 passed, 1 failed

cargo test --no-default-features --features ci --lib detect_stagnation
test result: ok. 4 passed; 0 failed
```

- [x] Lib-test count is unchanged otherwise (3 pre-existing failures on `main` remain — bytecode conditional/logic, inline-if param assignment, gauss_newton pop_grad analytical — none of them touched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
