### PR TITLE
test(types): round-trip every engine warning message through classify_warning

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -2432,6 +2432,166 @@ mod tests {
         assert_eq!(w.category, "general");
     }
 
+    /// Round-trip table covering every literal warning message emitted by the
+    /// engine, with the (severity, category) it should classify to.
+    ///
+    /// This protects the classifier contract from quiet regressions when a
+    /// message gets a typo fix or a wording change. If you edit a message
+    /// string in `outer_optimizer.rs`, `saem.rs`, `gauss_newton.rs`,
+    /// `trust_region.rs`, or `api.rs`, mirror the edit here so the test
+    /// keeps reflecting the engine's actual output.
+    ///
+    /// Messages built by `format!(..)` are exercised with a representative
+    /// instantiation: the substrings the classifier matches on must remain
+    /// present after interpolation.
+    #[test]
+    fn classify_warning_roundtrips_every_engine_message() {
+        use WarningSeverity::*;
+        let table: &[(&str, WarningSeverity, &str)] = &[
+            // -- outer_optimizer.rs ----------------------------------------
+            (
+                "Outer optimization did not converge",
+                Critical,
+                "convergence",
+            ),
+            ("Covariance step failed", Critical, "covariance_step"),
+            // global_search has two arms: explicit "disabled" is a runtime
+            // failure (Warning); a bare mention without "disabled" is
+            // informational.
+            (
+                "global_search disabled: bad seed",
+                Warning,
+                "optimizer_config",
+            ),
+            ("global_search reached eval cap", Info, "optimizer_config"),
+            ("cancelled by user", Info, "cancelled"),
+            // -- gauss_newton.rs -------------------------------------------
+            (
+                "Gauss-Newton: trust radius collapsed",
+                Warning,
+                "optimizer_health",
+            ),
+            (
+                "Gauss-Newton: degenerate BHHH Hessian, trust radius collapsed",
+                Warning,
+                "optimizer_health",
+            ),
+            (
+                "Gauss-Newton: max iterations reached without convergence",
+                Critical,
+                "convergence",
+            ),
+            // -- saem.rs ---------------------------------------------------
+            (
+                "Covariance step failed \u{2014} SEs not available",
+                Critical,
+                "covariance_step",
+            ),
+            (
+                "saem_n_leapfrog > 0 but HMC is unavailable (requires `autodiff` feature)",
+                Info,
+                "gradient_fallback",
+            ),
+            // -- trust_region.rs ------------------------------------------
+            (
+                "Trust-region did not converge: line search stalled",
+                Critical,
+                "convergence",
+            ),
+            // -- api.rs ----------------------------------------------------
+            (
+                "Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).",
+                Warning,
+                "dw_autocorrelation",
+            ),
+            (
+                "Negative IWRES autocorrelation detected (Durbin-Watson = 2.80).",
+                Warning,
+                "dw_autocorrelation",
+            ),
+            (
+                "M3 BLOQ handling requires FOCEI semantics",
+                Warning,
+                "bloq_method",
+            ),
+            (
+                "SIR failed: covariance not positive definite",
+                Warning,
+                "sir",
+            ),
+            (
+                "SIR requested but covariance matrix is not available",
+                Warning,
+                "sir",
+            ),
+            (
+                "IMP: 2 subject(s) had ESS = 0 (proposal collapse)",
+                Warning,
+                "importance_sampling",
+            ),
+            (
+                "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",
+                Warning,
+                "data_quality",
+            ),
+            (
+                "block omega: ETA_CL x ETA_V have mixed lognormal / additive parameterisations",
+                Warning,
+                "omega_structure",
+            ),
+            ("mu-ref: CL, V, KA", Info, "mu_referencing"),
+            (
+                "Multi-start: best result from start 3/8",
+                Info,
+                "multi_start",
+            ),
+            (
+                "12 threads configured but only 10 subject(s)",
+                Info,
+                "threads",
+            ),
+            ("SAEM with more threads than subjects/2", Info, "threads"),
+            (
+                "Covariance step: 35 parameters \u{2192} n\u{00b2} OFV evaluations",
+                Info,
+                "covariance_step",
+            ),
+            (
+                "Covariance step: 35 parameters -> n^2 OFV evaluations",
+                Info,
+                "covariance_step",
+            ),
+            // -- chain-prefixed (multi-stage) -----------------------------
+            (
+                "[FOCEI] Covariance step failed",
+                Critical,
+                "covariance_step",
+            ),
+            ("[SAEM] mu-ref: CL", Info, "mu_referencing"),
+            (
+                "[FOCEI] Outer optimization did not converge",
+                Critical,
+                "convergence",
+            ),
+        ];
+
+        let mut failures: Vec<String> = Vec::new();
+        for (msg, want_sev, want_cat) in table {
+            let got = classify_warning(msg);
+            if got.severity != *want_sev || got.category != *want_cat {
+                failures.push(format!(
+                    "  {msg:?} -> expected ({:?}, {:?}), got ({:?}, {:?})",
+                    want_sev, want_cat, got.severity, got.category
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "classify_warning round-trip failures:\n{}",
+            failures.join("\n")
+        );
+    }
+
     #[test]
     fn is_ode_based_false_for_analytical() {
         let m = test_helpers::analytical_model(GradientMethod::Auto);


### PR DESCRIPTION
## Why

Follow-up to the polish I flagged on my review of #152 — a safety net for the classifier.

`classify_warning()` matches messages on lowercase substrings of the strings that estimators construct via `format!`. The original test set covered 5 representative cases plus the fallback. The literal message vocabulary has since grown (e.g. SAEM, LTBS, IMP, multi-start, the new "global_search disabled" runtime-failure arm) and the classifier itself now has 19 explicit match arms, but no test pins down which engine message maps to which.

A wording fix or a typo correction in any of those `format!` strings could silently re-classify a warning at runtime — for instance, changing `"M3 BLOQ handling"` to `"M3 BLOQ method note"` would quietly demote it from `Warning/bloq_method` to `Warning/general` with no test failure.

## What changed

One new test: `classify_warning_roundtrips_every_engine_message`. It walks a table of literal warning strings emitted by `outer_optimizer.rs`, `saem.rs`, `gauss_newton.rs`, `trust_region.rs`, and `api.rs`, and asserts each classifies to the expected `(WarningSeverity, category)`. Failures are collected and reported in a single panic so a wording drift surfaces every affected message at once, not one-at-a-time.

The table also pins:

- The **two distinct `global_search` arms** — `"global_search disabled: ..."` (runtime failure → `Warning/optimizer_config`) vs a bare `"global_search ..."` mention (informational → `Info/optimizer_config`). This subtlety was *not* covered before and is exactly the kind of thing the round-trip prevents from silently flipping.
- **Multi-stage chain prefixes** — e.g. `"[FOCEI] Covariance step failed"` strips into `source_method = "FOCEI"` and still classifies as `Critical/covariance_step`.
- Both the **Unicode** (`n²`, `→`) and **ASCII** (`n^2`, `->`) forms of the covariance-step note, since estimators sometimes emit one or the other.

While writing the table I caught one drift between my expectation and the live classifier (the `"global_search disabled"` Warning vs Info distinction) — exactly the use case this test is meant to catch. Updated the table accordingly, and that case is now pinned.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] None — pure test addition.

## Numerical validation
- [x] Not applicable (test-only change).

## Performance
- [x] No impact (test runs in well under 1 ms).

## Tests
- [x] `cargo test --lib --features ci --no-default-features classify_warning` — 7/7 pass.

## Reviewer hints

- Single test, single file. The table is the documentation: maintainers editing a warning message in any of the listed files should mirror the edit here.
- Failures collect into a single panic message listing every mis-classified row, so when the table needs a refresh the reviewer sees the full delta in one go.