### PR TITLE
fix(api): error early when IOV model has no occasion labels in dataset

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -340,7 +340,28 @@ pub fn check_model_data(model: &CompiledModel, population: &Population) -> Vec<D
     let mut diags = check_covariates(model, population);
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
+    diags.extend(check_iov_occasions(model, population));
     diags
+}
+
+/// IOV models require occasion labels in the dataset. When `n_kappa > 0` but
+/// every subject has an empty `occasions` vector the kappa random effects are
+/// silently ignored — catch this early instead.
+fn check_iov_occasions(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
+    if model.n_kappa == 0 {
+        return Vec::new();
+    }
+    let all_empty = population.subjects.iter().all(|s| s.occasions.is_empty());
+    if !all_empty {
+        return Vec::new();
+    }
+    vec![Diagnostic::error(
+        "E_IOV_MISSING_OCC",
+        "Model declares kappa (IOV) parameters but no occasion labels were found in the \
+         dataset. Set `iov_column = \"OCC\"` (or the relevant column name) in \
+         [fit_options] so that per-occasion kappas can be estimated.",
+    )
+    .with_block("fit_options")]
 }
 
 /// Model + estimation-option *compatibility* checks that don't depend on data:
@@ -2786,6 +2807,47 @@ mod iov_integration {
             msg.contains("trust_region") && msg.contains("IOV"),
             "error message should mention trust_region and IOV, got: {msg}"
         );
+    }
+
+    // When a model has kappa declarations but the dataset carries no occasion
+    // labels, `fit()` must return an error and `check_model_data` must surface
+    // E_IOV_MISSING_OCC — rather than silently ignoring the kappas.
+    #[test]
+    fn test_iov_missing_occ_returns_err() {
+        let model = make_iov_model();
+        // Population built without occasion labels (empty `occasions` vectors).
+        let mut pop = make_iov_population();
+        for subj in &mut pop.subjects {
+            subj.occasions.clear();
+            subj.dose_occasions.clear();
+        }
+        let opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+        let result = fit(&model, &pop, &model.default_params, &opts);
+        assert!(
+            result.is_err(),
+            "IOV model without occasion labels must error"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("iov_column") || msg.contains("OCC") || msg.contains("occasion"),
+            "error message should mention the missing occasion column, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_check_model_data_flags_missing_occ() {
+        let model = make_iov_model();
+        let mut pop = make_iov_population();
+        for subj in &mut pop.subjects {
+            subj.occasions.clear();
+            subj.dose_occasions.clear();
+        }
+        let diags = super::check_model_data(&model, &pop);
+        let d = diags
+            .iter()
+            .find(|d| d.code == "E_IOV_MISSING_OCC")
+            .expect("expected E_IOV_MISSING_OCC diagnostic");
+        assert!(d.message.contains("iov_column") || d.message.contains("kappa"));
     }
 
     // `ferx check` must surface the same trust_region+IOV incompatibility that

--- a/src/api.rs
+++ b/src/api.rs
@@ -335,7 +335,8 @@ fn check_per_cmt_error_model(model: &CompiledModel, population: &Population) -> 
 /// a dataset, collected into one diagnostic list. Shared by `fit()` (which
 /// stops at the first error via [`first_error`]) and `ferx check` (which
 /// reports every finding). Check order matches the historical inline order in
-/// `fit()` so the first error is unchanged: covariates, scaling, error model.
+/// `fit()` so the first error is unchanged: covariates, scaling, error model,
+/// iov occasions.
 pub fn check_model_data(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
     let mut diags = check_covariates(model, population);
     diags.extend(check_per_cmt_scaling(model, population));
@@ -351,7 +352,10 @@ fn check_iov_occasions(model: &CompiledModel, population: &Population) -> Vec<Di
     if model.n_kappa == 0 {
         return Vec::new();
     }
-    let all_empty = population.subjects.iter().all(|s| s.occasions.is_empty());
+    // `all()` on an empty iterator is vacuously true; an empty population is not
+    // a missing-OCC problem so skip the check when there are no subjects.
+    let all_empty = !population.subjects.is_empty()
+        && population.subjects.iter().all(|s| s.occasions.is_empty());
     if !all_empty {
         return Vec::new();
     }
@@ -2819,7 +2823,6 @@ mod iov_integration {
         let mut pop = make_iov_population();
         for subj in &mut pop.subjects {
             subj.occasions.clear();
-            subj.dose_occasions.clear();
         }
         let opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
         let result = fit(&model, &pop, &model.default_params, &opts);
@@ -2836,18 +2839,20 @@ mod iov_integration {
 
     #[test]
     fn test_check_model_data_flags_missing_occ() {
+        use crate::diagnostics::Severity;
         let model = make_iov_model();
         let mut pop = make_iov_population();
         for subj in &mut pop.subjects {
             subj.occasions.clear();
-            subj.dose_occasions.clear();
         }
         let diags = super::check_model_data(&model, &pop);
         let d = diags
             .iter()
             .find(|d| d.code == "E_IOV_MISSING_OCC")
             .expect("expected E_IOV_MISSING_OCC diagnostic");
+        assert_eq!(d.severity, Severity::Error);
         assert!(d.message.contains("iov_column") || d.message.contains("kappa"));
+        assert_eq!(d.block.as_deref(), Some("fit_options"));
     }
 
     // `ferx check` must surface the same trust_region+IOV incompatibility that


### PR DESCRIPTION
## Why

When a model declares `kappa` (IOV) parameters but the dataset has no occasion column — either because `iov_column` was never set in `[fit_options]`, or the user forgot to include the OCC column — `subjects[i].occasions` is empty for every subject. The inner optimiser checks `!subject.occasions.is_empty()` before entering the IOV path, so kappas are silently ignored and the fit runs as if IOV were not declared at all. There is no warning or error.

## What changed

Added `check_iov_occasions` (called from `check_model_data`) that fires `E_IOV_MISSING_OCC` when `n_kappa > 0` but every subject carries an empty `occasions` vector. Both `fit()` (via `first_error`) and `ferx check` now surface this immediately.

Two regression tests added in `iov_integration`:
- `test_iov_missing_occ_returns_err` — `fit()` must return `Err` containing "iov_column"/"OCC"/"occasion"
- `test_check_model_data_flags_missing_occ` — `check_model_data` must produce `E_IOV_MISSING_OCC`

## Alternatives considered

Could warn rather than error, but silently proceeding gives the user a result that ignores their declared IOV structure entirely — that is misleading enough to warrant a hard stop.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] Public Rust API (`api.rs` / `types.rs`) — `check_model_data` now returns an additional error code `E_IOV_MISSING_OCC`; callers that pattern-match on diagnostics need to handle it.

## Numerical validation
- [x] Not applicable (validation / error-path only)

## Performance
- [x] No significant impact expected

## Tests
- [x] Regression test added that fails without this fix

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] No user-visible change (error message is self-describing: "Set `iov_column = \"OCC\"` in [fit_options]")

## Checklist
- [x] `cargo clippy` — not run locally (enzyme toolchain); CI will catch
- [x] `cargo check --features ci` passes locally

## Reviewer hints
The entire change is in `src/api.rs`: one new private function `check_iov_occasions`, one line wiring it into `check_model_data`, and two tests in `iov_integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)