### PR TITLE
feat(parser): flexible FIX placement for omega, sigma, kappa, and theta

### DIFF
--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3503,15 +3503,17 @@ fn parse_parameters(
     )
     .unwrap();
 
-    // omega NAME ~ value [(sd|variance|var)] [FIX]
+    // omega NAME ~ value [FIX] [(sd|variance|var)] [FIX]
     //
     // Initial value defaults to the variance scale (matching how the optimizer
     // stores omega internally). Append `(sd)` to declare the value on the
     // standard-deviation scale — the parser squares it before storing. The
     // `(variance)` / `(var)` annotation is accepted as an explicit no-op for
     // symmetry with sigma.
+    // FIX may appear before or after the scale annotation (group 3 = FIX
+    // before annotation, group 4 = annotation, group 5 = FIX after).
     let omega_re = Regex::new(
-        r"(?i)omega\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
+        r"(?i)omega\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s+(FIX)\b)?(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
     )
     .unwrap();
 
@@ -3522,20 +3524,23 @@ fn parse_parameters(
     let block_omega_re =
         Regex::new(r"(?i)block_omega\s*\(([^)]+)\)\s*=\s*\[([^\]]+)\](?:\s+(FIX)\b)?").unwrap();
 
-    // sigma NAME ~ value [(sd|variance|var)] [FIX]
+    // sigma NAME ~ value [FIX] [(sd|variance|var)] [FIX]
     //
     // As of issue #56, sigma defaults to the variance scale (matching omega).
     // `(sd)` opts back into specifying a standard deviation directly. The
     // parser converts variance → internal SD via `sqrt` so the residual-error
     // and likelihood code (which work in SD) need no changes.
+    // FIX may appear before or after the scale annotation (same group layout
+    // as omega_re: group 3 = FIX before, group 4 = annotation, group 5 = FIX after).
     let sigma_re = Regex::new(
-        r"(?i)sigma\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
+        r"(?i)sigma\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s+(FIX)\b)?(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
     )
     .unwrap();
 
-    // kappa NAME ~ value [(sd|variance|var)] [FIX]  (IOV diagonal variance)
+    // kappa NAME ~ value [FIX] [(sd|variance|var)] [FIX]  (IOV diagonal variance)
+    // Same group layout as omega_re.
     let kappa_re = Regex::new(
-        r"(?i)kappa\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
+        r"(?i)kappa\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s+(FIX)\b)?(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
     )
     .unwrap();
 
@@ -3632,8 +3637,9 @@ fn parse_parameters(
             let raw: f64 = caps[2]
                 .parse()
                 .map_err(|_| format!("Bad omega: {}", line))?;
+            // Group 4 = scale annotation; groups 3 and 5 = FIX (before/after).
             let init_as_sd = caps
-                .get(3)
+                .get(4)
                 .map(|m| m.as_str().eq_ignore_ascii_case("sd"))
                 .unwrap_or(false);
             // Negative values are nonsensical on either scale: variance ≥ 0
@@ -3647,7 +3653,7 @@ fn parse_parameters(
                 ));
             }
             let variance = if init_as_sd { raw * raw } else { raw };
-            let fixed = caps.get(4).is_some();
+            let fixed = caps.get(3).is_some() || caps.get(5).is_some();
             eta_names_ordered.push(name.clone());
             omegas.push(OmegaSpec {
                 name,
@@ -3660,8 +3666,9 @@ fn parse_parameters(
             let raw: f64 = caps[2]
                 .parse()
                 .map_err(|_| format!("Bad sigma: {}", line))?;
+            // Group 4 = scale annotation; groups 3 and 5 = FIX (before/after).
             let init_as_sd = caps
-                .get(3)
+                .get(4)
                 .map(|m| m.as_str().eq_ignore_ascii_case("sd"))
                 .unwrap_or(false);
             // Reject negatives on both scales. On the default (variance)
@@ -3676,7 +3683,7 @@ fn parse_parameters(
                 ));
             }
             let value = if init_as_sd { raw } else { raw.sqrt() };
-            let fixed = caps.get(4).is_some();
+            let fixed = caps.get(3).is_some() || caps.get(5).is_some();
             sigmas.push(SigmaSpec {
                 name,
                 value,
@@ -3688,8 +3695,9 @@ fn parse_parameters(
             let raw: f64 = caps[2]
                 .parse()
                 .map_err(|_| format!("Bad kappa: {}", line))?;
+            // Group 4 = scale annotation; groups 3 and 5 = FIX (before/after).
             let init_as_sd = caps
-                .get(3)
+                .get(4)
                 .map(|m| m.as_str().eq_ignore_ascii_case("sd"))
                 .unwrap_or(false);
             if raw < 0.0 {
@@ -3699,7 +3707,7 @@ fn parse_parameters(
                 ));
             }
             let variance = if init_as_sd { raw * raw } else { raw };
-            let fixed = caps.get(4).is_some();
+            let fixed = caps.get(3).is_some() || caps.get(5).is_some();
             kappa_names_ordered.push(name.clone());
             kappas.push(KappaSpec {
                 name,
@@ -8109,6 +8117,46 @@ mod tests {
     }
 
     #[test]
+    fn test_omega_fix_before_sd_annotation() {
+        // `FIX (sd)` — FIX before the scale annotation.
+        let lines = vec!["omega ETA_CL ~ 0.30 FIX (sd)".to_string()];
+        let (_, omegas, _, _, _, _) = parse_parameters(&lines).unwrap();
+        let expected = 0.30 * 0.30;
+        assert!((omegas[0].variance - expected).abs() < 1e-12);
+        assert!(omegas[0].fixed);
+        assert!(omegas[0].init_as_sd);
+    }
+
+    #[test]
+    fn test_omega_fix_before_annotation_no_sd() {
+        // `FIX` before a no-op annotation — fixed and variance-scale.
+        let lines = vec!["omega ETA_CL ~ 0.09 FIX (variance)".to_string()];
+        let (_, omegas, _, _, _, _) = parse_parameters(&lines).unwrap();
+        assert!((omegas[0].variance - 0.09).abs() < 1e-12);
+        assert!(omegas[0].fixed);
+        assert!(!omegas[0].init_as_sd);
+    }
+
+    #[test]
+    fn test_sigma_fix_before_sd_annotation() {
+        // `FIX (sd)` — FIX before the scale annotation for sigma.
+        let lines = vec!["sigma PROP ~ 0.30 FIX (sd)".to_string()];
+        let (_, _, _, sigmas, _, _) = parse_parameters(&lines).unwrap();
+        assert!(sigmas[0].fixed);
+        assert!(sigmas[0].init_as_sd);
+        assert!((sigmas[0].value - 0.30).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_sigma_fix_after_sd_annotation() {
+        // `(sd) FIX` — existing form still works.
+        let lines = vec!["sigma PROP ~ 0.30 (sd) FIX".to_string()];
+        let (_, _, _, sigmas, _, _) = parse_parameters(&lines).unwrap();
+        assert!(sigmas[0].fixed);
+        assert!(sigmas[0].init_as_sd);
+    }
+
+    #[test]
     fn test_sigma_default_is_variance() {
         // Since #56, the default sigma input is variance — the parser sqrt's
         // it into the internal SD representation that the likelihood uses.
@@ -8700,6 +8748,17 @@ mod tests {
         let lines = vec!["kappa KAPPA_V ~ 0.05 FIX".to_string()];
         let (_, _, _, _, _, ki) = parse_parameters(&lines).unwrap();
         assert!(ki.diagonal[0].fixed);
+    }
+
+    #[test]
+    fn test_kappa_fix_before_sd_annotation() {
+        // `FIX (sd)` — FIX before the scale annotation for kappa.
+        let lines = vec!["kappa KAPPA_V ~ 0.30 FIX (sd)".to_string()];
+        let (_, _, _, _, _, ki) = parse_parameters(&lines).unwrap();
+        let expected = 0.30 * 0.30;
+        assert!((ki.diagonal[0].variance - expected).abs() < 1e-12);
+        assert!(ki.diagonal[0].fixed);
+        assert!(ki.diagonal[0].init_as_sd);
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3512,6 +3512,9 @@ fn parse_parameters(
     // symmetry with sigma.
     // FIX may appear before or after the scale annotation (group 3 = FIX
     // before annotation, group 4 = annotation, group 5 = FIX after).
+    // Note: the first FIX group requires \s+ (at least one space) so that
+    // `value(sd)` without a space between value and annotation still matches
+    // correctly — the annotation group uses \s* (zero or more) intentionally.
     let omega_re = Regex::new(
         r"(?i)omega\s+(\w+)\s*~\s*([0-9eE.+-]+)(?:\s+(FIX)\b)?(?:\s*\((sd|variance|var)\))?(?:\s+(FIX)\b)?",
     )
@@ -8044,6 +8047,30 @@ mod tests {
     }
 
     #[test]
+    fn test_omega_unfixed_no_annotation() {
+        // Baseline: plain omega with no FIX and no annotation — confirms the
+        // group-numbering shift (annotation moved 3→4) didn't regress the
+        // common case.
+        let lines = vec!["omega ETA_CL ~ 0.09".to_string()];
+        let (_, omegas, _, _, _, _) = parse_parameters(&lines).unwrap();
+        assert!(!omegas[0].fixed);
+        assert!(!omegas[0].init_as_sd);
+        assert!((omegas[0].variance - 0.09).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_omega_double_fix_is_harmless() {
+        // `FIX (sd) FIX` — both FIX groups fire; result must still be fixed
+        // with SD squaring applied.
+        let lines = vec!["omega ETA_CL ~ 0.30 FIX (sd) FIX".to_string()];
+        let (_, omegas, _, _, _, _) = parse_parameters(&lines).unwrap();
+        let expected = 0.30 * 0.30;
+        assert!((omegas[0].variance - expected).abs() < 1e-12);
+        assert!(omegas[0].fixed);
+        assert!(omegas[0].init_as_sd);
+    }
+
+    #[test]
     fn test_parse_sigma_fix() {
         let lines = vec!["sigma PROP ~ 0.05 FIX".to_string()];
         let (_, _, _, sigmas, _, _) = parse_parameters(&lines).unwrap();
@@ -8154,6 +8181,18 @@ mod tests {
         let (_, _, _, sigmas, _, _) = parse_parameters(&lines).unwrap();
         assert!(sigmas[0].fixed);
         assert!(sigmas[0].init_as_sd);
+    }
+
+    #[test]
+    fn test_sigma_unfixed_no_annotation() {
+        // Baseline: plain sigma with no FIX and no annotation — confirms the
+        // group-numbering shift didn't regress the common case.
+        let lines = vec!["sigma PROP ~ 0.04".to_string()];
+        let (_, _, _, sigmas, _, _) = parse_parameters(&lines).unwrap();
+        assert!(!sigmas[0].fixed);
+        assert!(!sigmas[0].init_as_sd);
+        // Stored as SD internally: sqrt(0.04) = 0.2
+        assert!((sigmas[0].value - 0.2).abs() < 1e-12);
     }
 
     #[test]
@@ -8748,6 +8787,17 @@ mod tests {
         let lines = vec!["kappa KAPPA_V ~ 0.05 FIX".to_string()];
         let (_, _, _, _, _, ki) = parse_parameters(&lines).unwrap();
         assert!(ki.diagonal[0].fixed);
+    }
+
+    #[test]
+    fn test_kappa_unfixed_no_annotation() {
+        // Baseline: plain kappa with no FIX and no annotation — confirms the
+        // group-numbering shift didn't regress the common case.
+        let lines = vec!["kappa KAPPA_V ~ 0.05".to_string()];
+        let (_, _, _, _, _, ki) = parse_parameters(&lines).unwrap();
+        assert!(!ki.diagonal[0].fixed);
+        assert!(!ki.diagonal[0].init_as_sd);
+        assert!((ki.diagonal[0].variance - 0.05).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Users coming from NONMEM and nlmixr2 expect to write `FIX` in various natural positions — e.g. `theta NAME(0.75) FIX`, `theta NAME(1, 0.01) FIX`, or `omega NAME ~ 0.09 FIX (sd)`. Previously theta only accepted FIX inside the parens with a comma, and omega/sigma/kappa only accepted FIX at the very end (after any scale annotation). This made the syntax more restrictive than necessary and caught users off-guard.

## What changed

Updated the parser regexes in `src/parser/model_parser.rs` to accept FIX in all natural positions.

**Theta** — FIX inside parens (with or without comma) or after closing paren; upper bound is now optional (defaults to 1e9, matching NONMEM behaviour):
```
theta NAME(init FIX)
theta NAME(init, FIX)
theta NAME(init) FIX
theta NAME(init, lower, FIX)
theta NAME(init, lower) FIX
theta NAME(init, lower, upper, FIX)
theta NAME(init, lower, upper) FIX
```

> **Behaviour note:** `theta NAME(init, lower)` (two numbers, no upper) previously failed to match and the line was silently dropped, causing the parameter to be misclassified as a covariate. It now parses correctly with `upper = 1e9`. This is the right outcome, but is technically a change for any model that accidentally wrote a two-number theta.

**Omega / sigma / kappa** — FIX before or after the scale annotation:
```
omega NAME ~ value FIX
omega NAME ~ value (sd) FIX        ← was already accepted
omega NAME ~ value FIX (sd)        ← new
```

**block_omega / block_kappa** — already accepted `FIX` after `]`; no change needed.

13 new unit tests added covering all new syntax forms, baselines after group-number shifts, and double-FIX robustness.

## Alternatives considered

Could have normalised the input line before matching (e.g. always move FIX to a canonical position), but updating the regex is simpler and keeps the parser stateless.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (parser only — no numerical output changes)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit tests added in the same module (`cargo test --lib` passes)

## Example (user-facing features only)

<details>
<summary>Example</summary>

```toml
[parameters]
theta TVCL(0.1) FIX
theta TVKA(1.0, 0.01) FIX
omega ETA_CL ~ 0.09 FIX (sd)
sigma PROP ~ 0.04 (sd) FIX
```

</details>

## Docs
- [ ] `docs/src/model-file/parameters.md` should be updated to document the full accepted FIX syntax — tracked as follow-up.

## Checklist
- [x] `cargo clippy` clean
- [x] No AD-reachable code touched

## Reviewer hints

Only `src/parser/model_parser.rs` is changed. For theta the regex gains one extra FIX group after the closing paren. For omega/sigma/kappa the annotation group shifted from 3→4 (FIX-before-annotation is now group 3, annotation group 4, FIX-after-annotation group 5); the three corresponding `caps.get()` calls were updated accordingly. Baseline tests confirm no regression on the common unannotated case.