### PR TITLE
feat(parser): warn on declared-but-unused parameters

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -647,7 +647,12 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
 
     let mut diags: Vec<Diagnostic> = Vec::new();
 
-    // 2. Model / estimation-option compatibility (data-independent): catches
+    // 2a. Parse-time warnings (e.g. unused parameters) collected during parsing.
+    for w in &parsed.model.parse_warnings {
+        diags.push(Diagnostic::warning("W_UNUSED_PARAM", w.clone()).with_block("parameters"));
+    }
+
+    // 2b. Model / estimation-option compatibility (data-independent): catches
     //    method/model combinations that `fit()` rejects before fitting, so a
     //    clean check and a fit agree. Uses the parsed `[fit_options]`, mirroring
     //    what the CLI fit path (`run_model_with_data`) passes to `fit()`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -647,9 +647,17 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
 
     let mut diags: Vec<Diagnostic> = Vec::new();
 
-    // 2a. Parse-time warnings (e.g. unused parameters) collected during parsing.
+    // 2a. Parse-time warnings collected during parsing (unused parameters,
+    //     mu-referencing diagnostics, etc.). Each warning embeds its own block
+    //     context in the message text; we use W_PARSE as the generic code here
+    //     rather than a narrower code that would mislabel unrelated warnings.
     for w in &parsed.model.parse_warnings {
-        diags.push(Diagnostic::warning("W_UNUSED_PARAM", w.clone()).with_block("parameters"));
+        let code = if w.contains("declared in [parameters] but not referenced") {
+            "W_UNUSED_PARAM"
+        } else {
+            "W_PARSE"
+        };
+        diags.push(Diagnostic::warning(code, w.clone()));
     }
 
     // 2b. Model / estimation-option compatibility (data-independent): catches

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13078,10 +13078,19 @@ method = foce
 "#
         );
         let parsed = parse_full_model(&src).expect("parse ok");
+        // The conditional model legitimately triggers a mu-referencing warning
+        // for CL — that is unrelated to our check. Assert only that no
+        // unused-parameter warning is emitted for WT_POW or any other parameter.
+        let unused: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("declared in [parameters] but not referenced"))
+            .collect();
         assert!(
-            parsed.model.parse_warnings.is_empty(),
-            "WT_POW used inside if-branch must not warn; got: {:?}",
-            parsed.model.parse_warnings
+            unused.is_empty(),
+            "WT_POW used inside if-branch must not trigger unused-param warning; got: {:?}",
+            unused
         );
     }
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13005,4 +13005,168 @@ method = foce
         );
         assert!(warns[0].contains("kappa"), "warning should mention 'kappa'");
     }
+
+    #[test]
+    fn test_derived_variable_no_false_positive() {
+        // ke = CL / V is a derived variable — no theta/eta directly.
+        // But CL = TVCL * exp(ETA_CL) and V = TVV * exp(ETA_V) ARE in
+        // indiv_stmts and ARE walked, so TVCL/ETA_CL/TVV/ETA_V are found
+        // through those statements. No spurious "unused" warnings expected.
+        let src = format!(
+            r#"
+[parameters]
+  theta TVCL(0.1)
+  theta TVV(10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.04
+  sigma PROP ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  ke = CL / V
+  KA = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  method = foce
+"#
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(
+            parsed.model.parse_warnings.is_empty(),
+            "derived variable ke=CL/V must not trigger false positives; \
+             got: {:?}",
+            parsed.model.parse_warnings
+        );
+    }
+
+    #[test]
+    fn test_theta_used_only_in_conditional_branch_no_warn() {
+        // WT_POW is only referenced inside an if-branch — it must still be
+        // found because collect_theta_eta_in_stmts recurses into if-bodies.
+        let src = format!(
+            r#"
+[parameters]
+  theta TVCL(0.1)
+  theta WT_POW(0.75)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01
+
+[individual_parameters]
+  if (WT > 0) {{
+    CL = TVCL * (WT / 70)^WT_POW * exp(ETA_CL)
+  }} else {{
+    CL = TVCL * exp(ETA_CL)
+  }}
+  V  = 10.0
+  KA = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  method = foce
+"#
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(
+            parsed.model.parse_warnings.is_empty(),
+            "WT_POW used inside if-branch must not warn; got: {:?}",
+            parsed.model.parse_warnings
+        );
+    }
+
+    #[test]
+    fn test_block_omega_one_unused_warns() {
+        // block_omega declares ETA_CL and ETA_V together; only ETA_CL is used.
+        // ETA_V should produce a warning even though it's part of a block.
+        let src = format!(
+            r#"
+[parameters]
+  theta TVCL(0.1)
+  block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04]
+  sigma PROP ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = 10.0
+  KA = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  method = foce
+"#
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("ETA_V"))
+            .collect();
+        assert_eq!(
+            warns.len(),
+            1,
+            "ETA_V unused in block_omega should warn; got: {:?}",
+            warns
+        );
+        assert!(warns[0].contains("omega"), "warning should mention 'omega'");
+        // ETA_CL IS used — must not appear in warnings
+        assert!(
+            !parsed
+                .model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("ETA_CL")),
+            "ETA_CL is used and must not warn"
+        );
+    }
+
+    #[test]
+    fn test_block_omega_all_used_no_warn() {
+        // Both etas in a block_omega are used — no warnings expected.
+        let src = format!(
+            r#"
+[parameters]
+  theta TVCL(0.1)
+  theta TVV(10.0)
+  block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04]
+  sigma PROP ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  method = foce
+"#
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(
+            parsed.model.parse_warnings.is_empty(),
+            "all block_omega etas used — no warnings expected; got: {:?}",
+            parsed.model.parse_warnings
+        );
+    }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1137,6 +1137,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // For per-CMT (multi-endpoint) models this maps each endpoint's sigma
     // names to indices into this flat vector and enforces the ODE-only
     // restriction.
+    // Capture referenced sigma names before `parsed_error_model` is consumed.
+    let used_sigmas_in_error = used_sigma_names(&parsed_error_model);
     let (error_model, error_spec) = build_error_spec(parsed_error_model, &sigma_names, is_ode)?;
     let sigma = SigmaVector {
         values: sigma_values,
@@ -1366,8 +1368,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         n_kappa,
         n_epsilon,
         theta_names,
-        eta_names: eta_names_bsv,
-        kappa_names,
+        eta_names: eta_names_bsv.clone(),
+        kappa_names: kappa_names.clone(),
         indiv_param_names: indiv_var_names.clone(),
         indiv_param_partials,
         default_params,
@@ -1610,6 +1612,21 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             ));
         }
     }
+
+    // Warn about declared-but-unused parameters. These are not errors because a
+    // user may intentionally comment out expressions (e.g. during model
+    // development), but the warning makes clear that such parameters have no
+    // effect on predictions and will not be meaningfully estimated.
+    let unused_warnings = check_unused_parameters(
+        &thetas,
+        &eta_names_bsv,
+        &kappa_names,
+        n_eta,
+        &model.default_params.sigma.names,
+        &indiv_stmts,
+        &used_sigmas_in_error,
+    );
+    model.parse_warnings.extend(unused_warnings);
 
     Ok(ParsedModel {
         model,
@@ -4546,6 +4563,167 @@ fn collect_covariates_in_stmts(stmts: &[Statement], out: &mut std::collections::
             }
         }
     }
+}
+
+fn collect_theta_eta(
+    expr: &Expression,
+    thetas: &mut std::collections::HashSet<usize>,
+    etas: &mut std::collections::HashSet<usize>,
+) {
+    match expr {
+        Expression::Theta(i) => {
+            thetas.insert(*i);
+        }
+        Expression::Eta(i) => {
+            etas.insert(*i);
+        }
+        Expression::BinOp(lhs, _, rhs) => {
+            collect_theta_eta(lhs, thetas, etas);
+            collect_theta_eta(rhs, thetas, etas);
+        }
+        Expression::UnaryFn(_, arg) => collect_theta_eta(arg, thetas, etas),
+        Expression::Power(base, exp) => {
+            collect_theta_eta(base, thetas, etas);
+            collect_theta_eta(exp, thetas, etas);
+        }
+        Expression::Conditional(cond, t, e) => {
+            collect_theta_eta_in_condition(cond, thetas, etas);
+            collect_theta_eta(t, thetas, etas);
+            collect_theta_eta(e, thetas, etas);
+        }
+        _ => {}
+    }
+}
+
+fn collect_theta_eta_in_condition(
+    cond: &Condition,
+    thetas: &mut std::collections::HashSet<usize>,
+    etas: &mut std::collections::HashSet<usize>,
+) {
+    match cond {
+        Condition::Compare(l, _, r) => {
+            collect_theta_eta(l, thetas, etas);
+            collect_theta_eta(r, thetas, etas);
+        }
+        Condition::And(l, r) | Condition::Or(l, r) => {
+            collect_theta_eta_in_condition(l, thetas, etas);
+            collect_theta_eta_in_condition(r, thetas, etas);
+        }
+        Condition::Not(c) => collect_theta_eta_in_condition(c, thetas, etas),
+    }
+}
+
+fn collect_theta_eta_in_stmts(
+    stmts: &[Statement],
+    thetas: &mut std::collections::HashSet<usize>,
+    etas: &mut std::collections::HashSet<usize>,
+) {
+    for s in stmts {
+        match s {
+            Statement::Assign(_, e)
+            | Statement::AssignIdx(_, e)
+            | Statement::DiffEq(_, e)
+            | Statement::DiffEqIdx(_, e) => collect_theta_eta(e, thetas, etas),
+            Statement::AssignBc(_, _) | Statement::DiffEqBc(_, _) => {}
+            Statement::If {
+                branches,
+                else_body,
+            } => {
+                for (cond, body) in branches {
+                    collect_theta_eta_in_condition(cond, thetas, etas);
+                    collect_theta_eta_in_stmts(body, thetas, etas);
+                }
+                if let Some(eb) = else_body {
+                    collect_theta_eta_in_stmts(eb, thetas, etas);
+                }
+            }
+        }
+    }
+}
+
+/// Collect the sigma names referenced in a `ParsedErrorModel` (before index resolution).
+fn used_sigma_names(parsed: &ParsedErrorModel) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    match parsed {
+        ParsedErrorModel::Single(_, names) => {
+            for n in names {
+                out.insert(n.clone());
+            }
+        }
+        ParsedErrorModel::PerCmt(entries) => {
+            for (_, _, names) in entries {
+                for n in names {
+                    out.insert(n.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Warn about parameters declared in `[parameters]` that are not referenced in
+/// any expression. Returns one warning string per unused parameter; the caller
+/// appends these to `CompiledModel.parse_warnings`.
+///
+/// Only user-declared thetas (indices `0..n_theta_user`) are checked; thetas
+/// added automatically (NN weights, diffusion) are excluded.
+fn check_unused_parameters(
+    thetas: &[ThetaSpec],
+    eta_names_bsv: &[String],
+    kappa_names: &[String],
+    n_eta: usize,
+    sigma_names: &[String],
+    indiv_stmts: &[Statement],
+    used_sigmas: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let mut used_thetas = std::collections::HashSet::new();
+    let mut used_etas = std::collections::HashSet::new();
+    collect_theta_eta_in_stmts(indiv_stmts, &mut used_thetas, &mut used_etas);
+
+    let mut warnings = Vec::new();
+
+    for (i, t) in thetas.iter().enumerate() {
+        if !used_thetas.contains(&i) {
+            warnings.push(format!(
+                "theta '{}' is declared in [parameters] but not referenced in \
+                 [individual_parameters] — it will not affect predictions or be \
+                 meaningfully estimated",
+                t.name
+            ));
+        }
+    }
+    for (i, name) in eta_names_bsv.iter().enumerate() {
+        if !used_etas.contains(&i) {
+            warnings.push(format!(
+                "omega '{}' is declared in [parameters] but not referenced in \
+                 [individual_parameters] — it will not affect predictions or be \
+                 meaningfully estimated",
+                name
+            ));
+        }
+    }
+    for (i, name) in kappa_names.iter().enumerate() {
+        if !used_etas.contains(&(n_eta + i)) {
+            warnings.push(format!(
+                "kappa '{}' is declared in [parameters] but not referenced in \
+                 [individual_parameters] — it will not affect predictions or be \
+                 meaningfully estimated",
+                name
+            ));
+        }
+    }
+    for name in sigma_names {
+        if !used_sigmas.contains(name) {
+            warnings.push(format!(
+                "sigma '{}' is declared in [parameters] but not referenced in \
+                 [error_model] — it will not affect predictions or be \
+                 meaningfully estimated",
+                name
+            ));
+        }
+    }
+
+    warnings
 }
 
 fn eval_expression(
@@ -12632,6 +12810,150 @@ if (1 > 0) {
         assert!(
             (sym - expected).abs() < 1e-12 * expected.abs().max(1.0),
             "∂KA/∂TVKAM: sym={sym}, expected={expected}",
+        );
+    }
+
+    // ── unused-parameter warning tests ──────────────────────────────────────
+
+    fn minimal_model(parameters: &str, individual_parameters: &str, error_model: &str) -> String {
+        format!(
+            r#"
+[parameters]
+{parameters}
+
+[individual_parameters]
+{individual_parameters}
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+DV ~ proportional({error_model})
+
+[fit_options]
+method = foce
+"#
+        )
+    }
+
+    #[test]
+    fn test_all_used_no_warnings() {
+        let src = minimal_model(
+            "theta TVCL(0.1)\nomega ETA_CL ~ 0.09\nsigma PROP ~ 0.01",
+            "CL = TVCL * exp(ETA_CL)\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(
+            parsed.model.parse_warnings.is_empty(),
+            "unexpected warnings: {:?}",
+            parsed.model.parse_warnings
+        );
+    }
+
+    #[test]
+    fn test_unused_theta_warns() {
+        let src = minimal_model(
+            "theta TVCL(0.1)\ntheta UNUSED(0.5)\nomega ETA_CL ~ 0.09\nsigma PROP ~ 0.01",
+            "CL = TVCL * exp(ETA_CL)\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("UNUSED"))
+            .collect();
+        assert_eq!(
+            warns.len(),
+            1,
+            "expected exactly one warning for UNUSED theta"
+        );
+        assert!(warns[0].contains("theta"), "warning should mention 'theta'");
+    }
+
+    #[test]
+    fn test_unused_omega_warns() {
+        let src = minimal_model(
+            "theta TVCL(0.1)\nomega ETA_CL ~ 0.09\nomega ETA_UNUSED ~ 0.04\nsigma PROP ~ 0.01",
+            "CL = TVCL * exp(ETA_CL)\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("ETA_UNUSED"))
+            .collect();
+        assert_eq!(
+            warns.len(),
+            1,
+            "expected exactly one warning for ETA_UNUSED omega"
+        );
+        assert!(warns[0].contains("omega"), "warning should mention 'omega'");
+    }
+
+    #[test]
+    fn test_unused_sigma_warns() {
+        let src = minimal_model(
+            "theta TVCL(0.1)\nomega ETA_CL ~ 0.09\nsigma PROP ~ 0.01\nsigma ADD_UNUSED ~ 0.01",
+            "CL = TVCL * exp(ETA_CL)\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("ADD_UNUSED"))
+            .collect();
+        assert_eq!(
+            warns.len(),
+            1,
+            "expected exactly one warning for ADD_UNUSED sigma"
+        );
+        assert!(warns[0].contains("sigma"), "warning should mention 'sigma'");
+    }
+
+    #[test]
+    fn test_commented_out_usage_warns() {
+        // Simulates: CL = TVCL #* exp(ETA_CL) — ETA_CL is commented away
+        let src = minimal_model(
+            "theta TVCL(0.1)\nomega ETA_CL ~ 0.09\nsigma PROP ~ 0.01",
+            "CL = TVCL\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("ETA_CL"))
+            .collect();
+        assert_eq!(warns.len(), 1, "ETA_CL not used → should warn");
+    }
+
+    #[test]
+    fn test_multiple_unused_all_reported() {
+        let src = minimal_model(
+            "theta TVCL(0.1)\ntheta TH_UNUSED(0.5)\nomega ETA_CL ~ 0.09\nomega ETA_UNUSED ~ 0.04\nsigma PROP ~ 0.01\nsigma SIG_UNUSED ~ 0.01",
+            "CL = TVCL * exp(ETA_CL)\nV = 10.0\nKA = 1.0",
+            "PROP",
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let unused: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("UNUSED"))
+            .collect();
+        assert_eq!(
+            unused.len(),
+            3,
+            "expected warnings for TH_UNUSED, ETA_UNUSED, SIG_UNUSED; got: {:?}",
+            unused
         );
     }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4667,6 +4667,11 @@ fn used_sigma_names(parsed: &ParsedErrorModel) -> std::collections::HashSet<Stri
 ///
 /// Only user-declared thetas (indices `0..n_theta_user`) are checked; thetas
 /// added automatically (NN weights, diffusion) are excluded.
+///
+/// Scanning `indiv_stmts` is sufficient for ODE models too: `build_ode_spec`
+/// uses `ParseCtx::ode` which sets `theta_names = []`, so raw theta/eta names
+/// cannot appear in `[odes]` RHS expressions — they must be routed through
+/// `[individual_parameters]` first.
 fn check_unused_parameters(
     thetas: &[ThetaSpec],
     eta_names_bsv: &[String],
@@ -12955,5 +12960,49 @@ method = foce
             "expected warnings for TH_UNUSED, ETA_UNUSED, SIG_UNUSED; got: {:?}",
             unused
         );
+    }
+
+    #[test]
+    fn test_unused_kappa_warns() {
+        // KAPPA_CL declared but not used in any expression (index arithmetic:
+        // Eta(n_eta + i), distinct from BSV etas).
+        let src = format!(
+            r#"
+[parameters]
+  theta TVCL(0.1)
+  omega ETA_CL ~ 0.09
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = 10.0
+  KA = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  method = foce
+  iov_column = OCC
+"#
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let warns: Vec<_> = parsed
+            .model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("KAPPA_CL"))
+            .collect();
+        assert_eq!(
+            warns.len(),
+            1,
+            "expected one warning for unused KAPPA_CL; got: {:?}",
+            warns
+        );
+        assert!(warns[0].contains("kappa"), "warning should mention 'kappa'");
     }
 }


### PR DESCRIPTION
## Why

Parameters declared in `[parameters]` that are never referenced in `[individual_parameters]` or `[error_model]` silently enter the optimizer with no effect on predictions — they inflate the parameter space and produce meaningless estimates. This is easy to hit when a line is commented out during model development:

```
CL = TVCL #* exp(ETA_CL + KAPPA_CL) * (WT/70)^TVCLS
```

In this example `ETA_CL`, `KAPPA_CL`, and `TVCLS` are all declared but inert — previously no feedback was given.

## What changed

- **`src/parser/model_parser.rs`**: three new helpers (`collect_theta_eta`, `collect_theta_eta_in_stmts`, `used_sigma_names`) walk the parsed expression AST to collect referenced theta/eta indices and sigma names. A fourth function `check_unused_parameters` compares declared vs. referenced sets and returns one warning string per unused parameter. Called at the end of `parse_full_model`; results appended to `CompiledModel.parse_warnings`.
- **`src/api.rs`**: `validate_model_file` now forwards `parse_warnings` as `Diagnostic::warning("W_UNUSED_PARAM", ...)` entries so `ferx check` surfaces them without needing a full fit.
- Warnings are **not errors** — commented-out expressions are a valid workflow. The warning simply makes clear the parameter is inert.

Covers all four parameter kinds: `theta`, `omega` (BSV eta), `kappa` (IOV), and `sigma`.

Only user-declared thetas (indices `0..thetas.len()`) are checked; automatically injected thetas (NN weights, diffusion) are excluded by index bound.

## Alternatives considered

**Error instead of warning**: rejected — a user may deliberately comment out expressions while iterating on a model. An error would break that workflow.

**Auto-fix to FIX**: rejected — silently mutating declared parameters would surprise users reading YAML output and could mask intent.

**Check inside `fit()` only**: rejected — the check belongs at parse time since it is a structural model issue, not an estimation issue. Placing it in `CompiledModel.parse_warnings` means library callers and `ferx check` also see it.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (parser / warning only — no change to estimation or predictions)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit tests added in `src/parser/model_parser.rs` (`#[cfg(test)]`):
  - `test_all_used_no_warnings` — baseline: a fully-wired model produces no warnings
  - `test_unused_theta_warns` — extra declared theta → warning naming the theta
  - `test_unused_omega_warns` — extra declared omega → warning naming the eta
  - `test_unused_sigma_warns` — extra declared sigma → warning naming the sigma
  - `test_commented_out_usage_warns` — simulates `CL = TVCL #* exp(ETA_CL)` pattern
  - `test_multiple_unused_all_reported` — all three kinds unused at once → three warnings

## Example

```toml
[parameters]
  theta TVCL(0.1)
  theta TVCLS(0.25)      # referenced in a commented-out line below
  omega ETA_CL ~ 0.09
  sigma PROP ~ 0.01

[individual_parameters]
  CL = TVCL #* exp(ETA_CL) * (WT/70)^TVCLS
  V  = 10.0
  KA = 1.0
```

Expected warnings (in console, YAML, and `ferx check`):
```
WARNING: theta 'TVCLS' is declared in [parameters] but not referenced in [individual_parameters] — it will not affect predictions or be meaningfully estimated
WARNING: omega 'ETA_CL' is declared in [parameters] but not referenced in [individual_parameters] — it will not affect predictions or be meaningfully estimated
```

## Docs
- [x] No user-visible DSL change — warning only; no new syntax or fit options

## Checklist
- [x] `cargo clippy` clean (pre-existing warnings only, unrelated to this PR)
- [x] `cargo check --tests` clean

## Reviewer hints

The core logic is entirely in the four new functions starting at the `collect_theta_eta` block in `model_parser.rs`. The `api.rs` change is three lines. The `eta_names_bsv.clone()` / `kappa_names.clone()` in the `CompiledModel` constructor are the only changes to existing code paths (both were moved — same values, now kept alive past the `model` struct move).

## Open questions

None.