### PR TITLE
feat(api): compute kappa shrinkage for IOV models

### DIFF
--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -112,6 +112,17 @@ Both formulas use the **uncentered second moment with `n` divisor**, matching th
 
 Values of `NaN` indicate a zero-variance omega component (ETA) or fewer than two valid residuals (EPS).
 
+**Kappa shrinkage** (IOV models only — `shrinkage_kappa: Vec<f64>` and `shrinkage_kappa_by_occ: Vec<Vec<f64>>`):
+
+When the model contains `kappa` or `block_kappa` declarations, two additional shrinkage metrics are computed using the same uncentered-moment convention.
+
+*Pooled* — one value per kappa parameter, averaged over every (subject, occasion) pair:
+\\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_{\text{subj}} \cdot K}\sum_i \sum_k \hat{\kappa}_{ijk}^2}}{\sqrt{\omega_{\text{iov},jj}}} \\]
+
+*Per-occasion* — the same formula restricted to occasion index `occ_idx` (0-based order of first appearance), stored in `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`. Only reported when two or more occasions are present. Useful for identifying sparse occasions (high shrinkage in a single occasion suggests that occasion has little information on kappa).
+
+Both metrics are `NaN` when `omega_iov` diagonal is zero or fewer than two (subject, occasion) observations are available for that occasion slot.
+
 ### IWRES Autocorrelation
 
 Two pooled autocorrelation diagnostics are reported after every fit:

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -116,12 +116,15 @@ Values of `NaN` indicate a zero-variance omega component (ETA) or fewer than two
 
 When the model contains `kappa` or `block_kappa` declarations, two additional shrinkage metrics are computed using the same uncentered-moment convention.
 
-*Pooled* — one value per kappa parameter, averaged over every (subject, occasion) pair:
-\\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_{\text{subj}} \cdot K}\sum_i \sum_k \hat{\kappa}_{ijk}^2}}{\sqrt{\omega_{\text{iov},jj}}} \\]
+*Pooled* — one value per kappa parameter `j`, averaged over all `N_\text{pairs}` (subject, occasion) pairs:
+\\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_{\text{pairs}}}\sum_i \sum_{q} \hat{\kappa}_{iqj}^2}}{\sqrt{\omega_{\text{iov},jj}}} \\]
+where `q` indexes occasions and `N_\text{pairs} = \sum_i K_i` (total subject-occasion pairs; equals `N_\text{subj} \cdot K` only for balanced designs).
 
-*Per-occasion* — the same formula restricted to occasion index `occ_idx` (0-based order of first appearance), stored in `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`. Only reported when two or more occasions are present. Useful for identifying sparse occasions (high shrinkage in a single occasion suggests that occasion has little information on kappa).
+*Per-occasion slot* — the same formula restricted to occasion slot `occ_idx`, stored in `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`. Only reported when two or more occasions are present. Useful for identifying sparse occasions (high shrinkage in one slot suggests that occasion has little information on kappa).
 
-Both metrics are `NaN` when `omega_iov` diagonal is zero or fewer than two (subject, occasion) observations are available for that occasion slot.
+> **Note on unbalanced designs:** `occ_idx` is the 0-based position within each subject's own occasion list (order of first appearance in that subject's rows), *not* the raw `OCC` column value. When subjects have different `OCC` sequences (e.g., a late-entry subject whose data begins at OCC 2), a given slot may pool kappas from different occasions across subjects. In that case, use the pooled `shrinkage_kappa` and interpret per-slot values with caution.
+
+Both metrics are `NaN` when `omega_iov` diagonal is zero or fewer than two subject-occasion observations are available for that slot.
 
 ### IWRES Autocorrelation
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1463,6 +1463,15 @@ fn fit_inner(
     // Shrinkage
     let shrinkage_eta = compute_eta_shrinkage(&subjects, &result.params.omega.matrix);
     let shrinkage_eps = compute_eps_shrinkage(&subjects);
+    let (shrinkage_kappa, shrinkage_kappa_by_occ) =
+        if let Some(ref omega_iov) = result.params.omega_iov {
+            (
+                compute_kappa_shrinkage(&result.kappas, &omega_iov.matrix),
+                compute_kappa_shrinkage_by_occ(&result.kappas, &omega_iov.matrix),
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
 
     if let Some(w) = eps_shrinkage_warning(shrinkage_eps) {
         warnings.push(w);
@@ -1594,7 +1603,8 @@ fn fit_inner(
         kappa_fixed: result.params.kappa_fixed.clone(),
         kappa_init_as_sd: model.kappa_init_as_sd.clone(),
         se_kappa,
-        shrinkage_kappa: Vec::new(),
+        shrinkage_kappa,
+        shrinkage_kappa_by_occ,
         ebe_kappas: result.kappas.clone(),
         saem_mu_ref_m_step_evals_saved: result.saem_mu_ref_m_step_evals_saved,
         saem_n_subjects_hmc: result.saem_n_subjects_hmc,
@@ -1929,6 +1939,85 @@ fn compute_subject_results(
         .collect()
 }
 
+/// Kappa shrinkage pooled across all subject-occasion pairs.
+///
+/// `1 - sqrt(mean(κ̂²)) / sqrt(omega_iov_kk)` for each kappa k, where the mean
+/// runs over every (subject, occasion) pair.  Returns NaN for a given kappa when
+/// the corresponding diagonal of `omega_iov` is non-positive or when fewer than
+/// two (subject, occasion) observations are available.
+pub(crate) fn compute_kappa_shrinkage(
+    kappas_per_subject: &[Vec<DVector<f64>>],
+    omega_iov: &DMatrix<f64>,
+) -> Vec<f64> {
+    let n_kappa = omega_iov.nrows();
+    if n_kappa == 0 {
+        return vec![];
+    }
+    // Flatten all per-subject per-occasion kappa vectors into one iterator.
+    let all_kappas: Vec<&DVector<f64>> = kappas_per_subject
+        .iter()
+        .flat_map(|occ_kappas| occ_kappas.iter())
+        .collect();
+    let n = all_kappas.len();
+    if n < 2 {
+        return vec![f64::NAN; n_kappa];
+    }
+    (0..n_kappa)
+        .map(|k| {
+            let var = omega_iov[(k, k)];
+            if var <= 0.0 {
+                return f64::NAN;
+            }
+            let ms = all_kappas.iter().map(|kv| kv[k].powi(2)).sum::<f64>() / n as f64;
+            1.0 - ms.sqrt() / var.sqrt()
+        })
+        .collect()
+}
+
+/// Kappa shrinkage broken out by occasion index.
+///
+/// Returns `shrinkage_by_occ[occ_idx][kappa_idx]` where `occ_idx` is the
+/// 0-based occasion position (order in which occasions were first seen).
+/// Returns an empty outer vec when fewer than two distinct occasions are present
+/// or no kappa parameters exist.
+pub(crate) fn compute_kappa_shrinkage_by_occ(
+    kappas_per_subject: &[Vec<DVector<f64>>],
+    omega_iov: &DMatrix<f64>,
+) -> Vec<Vec<f64>> {
+    let n_kappa = omega_iov.nrows();
+    if n_kappa == 0 {
+        return vec![];
+    }
+    // Determine max number of occasions across subjects.
+    let n_occ = kappas_per_subject
+        .iter()
+        .map(|v| v.len())
+        .max()
+        .unwrap_or(0);
+    if n_occ < 2 {
+        return vec![];
+    }
+    (0..n_occ)
+        .map(|occ_idx| {
+            let occ_kappas: Vec<&DVector<f64>> = kappas_per_subject
+                .iter()
+                .filter_map(|occ_vecs| occ_vecs.get(occ_idx))
+                .collect();
+            let n = occ_kappas.len();
+            (0..n_kappa)
+                .map(|k| {
+                    let var = omega_iov[(k, k)];
+                    if var <= 0.0 || n < 2 {
+                        return f64::NAN;
+                    }
+                    let ms = occ_kappas.iter().map(|kv| kv[k].powi(2)).sum::<f64>() / n as f64;
+                    1.0 - ms.sqrt() / var.sqrt()
+                })
+                .collect()
+        })
+        .collect()
+}
+
 /// ETA shrinkage: `1 - sqrt(mean(eta_hat_k^2)) / sqrt(omega_kk)` for each random effect k.
 ///
 /// Uses the uncentered second moment with `n` divisor (NONMEM / PsN / Monolix
@@ -2139,6 +2228,91 @@ mod tests {
         assert!(eps_shrinkage_warning(-0.05).is_none());
         // NaN — no warning.
         assert!(eps_shrinkage_warning(f64::NAN).is_none());
+    }
+
+    // ── kappa shrinkage ──────────────────────────────────────────────────────
+
+    fn make_kappas(vals: Vec<Vec<f64>>) -> Vec<Vec<DVector<f64>>> {
+        // vals[subj_idx][occ_idx] = single-kappa value
+        vals.into_iter()
+            .map(|occ_vals| {
+                occ_vals
+                    .into_iter()
+                    .map(|v| DVector::from_vec(vec![v]))
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_pooled_zero_when_rms_matches_omega_sd() {
+        // omega_iov = 1.0; kappas = [+1, -1] across 2 subjects × 1 occasion
+        // mean(κ²) = 1 → shrinkage = 0
+        let omega = DMatrix::from_diagonal_element(1, 1, 1.0);
+        let kappas = make_kappas(vec![vec![1.0], vec![-1.0]]);
+        let sh = compute_kappa_shrinkage(&kappas, &omega);
+        assert_eq!(sh.len(), 1);
+        assert!((sh[0]).abs() < 1e-10, "expected ~0, got {}", sh[0]);
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_pooled_positive_when_shrunk() {
+        // kappas near zero → shrinkage > 0
+        let omega = DMatrix::from_diagonal_element(1, 1, 1.0);
+        let kappas = make_kappas(vec![
+            vec![0.01, 0.02],
+            vec![-0.01, -0.02],
+            vec![0.01, 0.02],
+            vec![-0.01, -0.02],
+        ]);
+        let sh = compute_kappa_shrinkage(&kappas, &omega);
+        assert!(sh[0] > 0.9, "expected high shrinkage, got {}", sh[0]);
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_pooled_nan_when_omega_zero() {
+        let omega = DMatrix::zeros(1, 1);
+        let kappas = make_kappas(vec![vec![0.1], vec![-0.1]]);
+        let sh = compute_kappa_shrinkage(&kappas, &omega);
+        assert!(sh[0].is_nan());
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_pooled_nan_when_fewer_than_2_obs() {
+        let omega = DMatrix::from_diagonal_element(1, 1, 1.0);
+        let kappas = make_kappas(vec![vec![0.5]]);
+        let sh = compute_kappa_shrinkage(&kappas, &omega);
+        assert!(sh[0].is_nan());
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_by_occ_returns_empty_for_single_occasion() {
+        let omega = DMatrix::from_diagonal_element(1, 1, 1.0);
+        let kappas = make_kappas(vec![vec![0.5], vec![-0.5]]);
+        let sh = compute_kappa_shrinkage_by_occ(&kappas, &omega);
+        assert!(sh.is_empty(), "expected empty for 1 occasion, got {:?}", sh);
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_by_occ_values() {
+        // 4 subjects, 2 occasions.
+        // OCC 1: kappas = [+1, -1, +1, -1] → mean(κ²) = 1 → shrinkage = 0 with omega=1
+        // OCC 2: kappas = [0.1, -0.1, 0.1, -0.1] → mean(κ²) = 0.01 → high shrinkage
+        let omega = DMatrix::from_diagonal_element(1, 1, 1.0);
+        let kappas = make_kappas(vec![
+            vec![1.0, 0.1],
+            vec![-1.0, -0.1],
+            vec![1.0, 0.1],
+            vec![-1.0, -0.1],
+        ]);
+        let sh = compute_kappa_shrinkage_by_occ(&kappas, &omega);
+        assert_eq!(sh.len(), 2, "expected 2 occasions");
+        assert!(
+            (sh[0][0]).abs() < 1e-10,
+            "occ 1 shrinkage ~0, got {}",
+            sh[0][0]
+        );
+        assert!(sh[1][0] > 0.8, "occ 2 shrinkage high, got {}", sh[1][0]);
     }
 
     #[test]
@@ -3475,6 +3649,7 @@ mod simulate_with_uncertainty_tests {
             kappa_init_as_sd: vec![],
             se_kappa: None,
             shrinkage_kappa: vec![],
+            shrinkage_kappa_by_occ: vec![],
             ebe_kappas: vec![],
             saem_mu_ref_m_step_evals_saved: None,
             saem_n_subjects_hmc: None,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1977,7 +1977,19 @@ pub(crate) fn compute_kappa_shrinkage(
 /// Kappa shrinkage broken out by occasion index.
 ///
 /// Returns `shrinkage_by_occ[occ_idx][kappa_idx]` where `occ_idx` is the
-/// 0-based occasion position (order in which occasions were first seen).
+/// **0-based position within each subject's own occasion list** — i.e. the
+/// order in which distinct OCC values were first encountered in that subject's
+/// rows (matching `split_obs_by_occasion`).
+///
+/// **Important limitation for unbalanced designs:** `occ_idx` is a position
+/// index, *not* the raw OCC column value.  When subjects have different OCC
+/// sequences (e.g., a late-entry subject whose data begins at OCC 2), their
+/// position 0 maps to OCC 2 while other subjects' position 0 maps to OCC 1.
+/// Pooling across position 0 then mixes kappas from different occasions.
+/// For unbalanced designs use the pooled `shrinkage_kappa` instead, and
+/// interpret per-occasion values only when the OCC column is aligned across
+/// all subjects.
+///
 /// Returns an empty outer vec when fewer than two distinct occasions are present
 /// or no kappa parameters exist.
 pub(crate) fn compute_kappa_shrinkage_by_occ(
@@ -2313,6 +2325,27 @@ mod tests {
             sh[0][0]
         );
         assert!(sh[1][0] > 0.8, "occ 2 shrinkage high, got {}", sh[1][0]);
+    }
+
+    #[test]
+    fn test_kappa_shrinkage_two_kappas_independent() {
+        // n_kappa = 2: each kappa parameter should be computed independently.
+        // kappa 0: RMS = 1.0 → shrinkage = 0 with omega_00 = 1.0
+        // kappa 1: RMS = 0.1 → shrinkage = 1 - 0.1/1.0 = 0.9 with omega_11 = 1.0
+        let omega = DMatrix::from_diagonal(&DVector::from_vec(vec![1.0, 1.0]));
+        // Each subject has 1 occasion; kappa vector is [k0_val, k1_val].
+        let kappas: Vec<Vec<DVector<f64>>> = vec![
+            vec![DVector::from_vec(vec![1.0, 0.1])],
+            vec![DVector::from_vec(vec![-1.0, -0.1])],
+        ];
+        let sh = compute_kappa_shrinkage(&kappas, &omega);
+        assert_eq!(sh.len(), 2);
+        assert!((sh[0]).abs() < 1e-10, "kappa 0 shrinkage ~0, got {}", sh[0]);
+        assert!(
+            (sh[1] - 0.9).abs() < 1e-10,
+            "kappa 1 shrinkage ~0.9, got {}",
+            sh[1]
+        );
     }
 
     #[test]

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -370,6 +370,7 @@ mod tests {
             kappa_init_as_sd: vec![],
             se_kappa: None,
             shrinkage_kappa: vec![],
+            shrinkage_kappa_by_occ: vec![],
             ebe_kappas: vec![],
             saem_mu_ref_m_step_evals_saved: None,
             saem_n_subjects_hmc: None,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -265,6 +265,10 @@ struct IovWire {
     se_kappa: Option<Vec<f64>>,
     #[serde(with = "vec_f64_nan_as_null")]
     shrinkage_kappa: Vec<f64>,
+    /// Per-occasion kappa shrinkage: `[occ_idx][kappa_idx]`.
+    /// Defaulted for backward compatibility with older .fitrx files.
+    #[serde(default)]
+    shrinkage_kappa_by_occ: Vec<Vec<f64>>,
     omega_iov: MatrixWire,
     omega_iov_param_corr: Option<MatrixWire>,
     /// Per-kappa SD-init flag. Defaulted for backward compatibility with
@@ -641,6 +645,7 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
             kappa_fixed: r.kappa_fixed.clone(),
             se_kappa: r.se_kappa.clone(),
             shrinkage_kappa: r.shrinkage_kappa.clone(),
+            shrinkage_kappa_by_occ: r.shrinkage_kappa_by_occ.clone(),
             omega_iov: MatrixWire::from(m),
             omega_iov_param_corr: r.omega_iov_param_corr.as_ref().map(MatrixWire::from),
             kappa_init_as_sd: r.kappa_init_as_sd.clone(),
@@ -1325,6 +1330,7 @@ fn wire_to_fit_result(
         kappa_init_as_sd,
         se_kappa,
         shrinkage_kappa,
+        shrinkage_kappa_by_occ,
         omega_iov_param_corr,
     ) = match w.iov {
         Some(iov) => {
@@ -1345,6 +1351,7 @@ fn wire_to_fit_result(
                 init_as_sd,
                 iov.se_kappa,
                 iov.shrinkage_kappa,
+                iov.shrinkage_kappa_by_occ,
                 iov.omega_iov_param_corr
                     .map(|m| m.into_dmatrix())
                     .transpose()?,
@@ -1356,6 +1363,7 @@ fn wire_to_fit_result(
             Vec::new(),
             Vec::new(),
             None,
+            Vec::new(),
             Vec::new(),
             None,
         ),
@@ -1439,6 +1447,7 @@ fn wire_to_fit_result(
         kappa_init_as_sd,
         se_kappa,
         shrinkage_kappa,
+        shrinkage_kappa_by_occ,
         ebe_kappas,
         saem_mu_ref_m_step_evals_saved: w.saem_mu_ref_m_step_evals_saved,
         saem_n_subjects_hmc: w.saem_n_subjects_hmc,
@@ -1601,6 +1610,7 @@ mod tests {
             kappa_init_as_sd: vec![],
             se_kappa: None,
             shrinkage_kappa: vec![],
+            shrinkage_kappa_by_occ: vec![],
             ebe_kappas: vec![],
             saem_mu_ref_m_step_evals_saved: None,
             saem_n_subjects_hmc: None,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -76,6 +76,42 @@ mod vec_f64_nan_as_null {
     }
 }
 
+mod vec_vec_f64_nan_as_null {
+    use serde::{de::Deserialize, ser::SerializeSeq, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Vec<Vec<f64>>, ser: S) -> Result<S::Ok, S::Error> {
+        let mut outer = ser.serialize_seq(Some(value.len()))?;
+        for inner in value {
+            // Delegate each inner Vec<f64> to the same NaN-as-null logic.
+            struct NanSafeSlice<'a>(&'a [f64]);
+            impl serde::Serialize for NanSafeSlice<'_> {
+                fn serialize<S2: Serializer>(&self, s: S2) -> Result<S2::Ok, S2::Error> {
+                    use serde::ser::SerializeSeq as _;
+                    let mut seq = s.serialize_seq(Some(self.0.len()))?;
+                    for v in self.0 {
+                        if v.is_finite() {
+                            seq.serialize_element(v)?;
+                        } else {
+                            seq.serialize_element(&Option::<f64>::None)?;
+                        }
+                    }
+                    seq.end()
+                }
+            }
+            outer.serialize_element(&NanSafeSlice(inner))?;
+        }
+        outer.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<Vec<f64>>, D::Error> {
+        let outer: Vec<Vec<Option<f64>>> = Vec::deserialize(de)?;
+        Ok(outer
+            .into_iter()
+            .map(|inner| inner.into_iter().map(|o| o.unwrap_or(f64::NAN)).collect())
+            .collect())
+    }
+}
+
 mod opt_f64_nan_as_null {
     use serde::{de::Deserialize, Deserializer, Serializer};
 
@@ -267,7 +303,7 @@ struct IovWire {
     shrinkage_kappa: Vec<f64>,
     /// Per-occasion kappa shrinkage: `[occ_idx][kappa_idx]`.
     /// Defaulted for backward compatibility with older .fitrx files.
-    #[serde(default)]
+    #[serde(default, with = "vec_vec_f64_nan_as_null")]
     shrinkage_kappa_by_occ: Vec<Vec<f64>>,
     omega_iov: MatrixWire,
     omega_iov_param_corr: Option<MatrixWire>,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -433,7 +433,7 @@ pub fn print_results(result: &FitResult) {
                         }
                     })
                     .collect();
-                eprintln!("    OCC {}: {}", occ_idx + 1, parts.join(", "));
+                eprintln!("    Occasion slot {}: {}", occ_idx + 1, parts.join(", "));
             }
         }
     }

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -400,6 +400,43 @@ pub fn print_results(result: &FitResult) {
             eprintln!("  EPS shrinkage:  {:.1}%", result.shrinkage_eps * 100.0);
         }
     }
+    if !result.shrinkage_kappa.is_empty() {
+        eprintln!("\n--- Kappa Shrinkage (pooled) ---");
+        for (k, &sh) in result.shrinkage_kappa.iter().enumerate() {
+            let name = result
+                .kappa_names
+                .get(k)
+                .map(|s| s.as_str())
+                .unwrap_or("KAPPA");
+            if sh.is_finite() {
+                eprintln!("  {} shrinkage: {:.1}%", name, sh * 100.0);
+            } else {
+                eprintln!("  {} shrinkage: NaN", name);
+            }
+        }
+        if !result.shrinkage_kappa_by_occ.is_empty() {
+            eprintln!("  Per-occasion:");
+            for (occ_idx, occ_sh) in result.shrinkage_kappa_by_occ.iter().enumerate() {
+                let parts: Vec<String> = occ_sh
+                    .iter()
+                    .enumerate()
+                    .map(|(k, &sh)| {
+                        let name = result
+                            .kappa_names
+                            .get(k)
+                            .map(|s| s.as_str())
+                            .unwrap_or("KAPPA");
+                        if sh.is_finite() {
+                            format!("{} {:.1}%", name, sh * 100.0)
+                        } else {
+                            format!("{} NaN", name)
+                        }
+                    })
+                    .collect();
+                eprintln!("    OCC {}: {}", occ_idx + 1, parts.join(", "));
+            }
+        }
+    }
 
     // Run info
     eprintln!("\n--- Run Info ---");
@@ -1006,6 +1043,7 @@ mod tests {
             kappa_init_as_sd: Vec::new(),
             se_kappa: None,
             shrinkage_kappa: Vec::new(),
+            shrinkage_kappa_by_occ: Vec::new(),
             ebe_kappas: Vec::new(),
             saem_mu_ref_m_step_evals_saved: None,
             saem_n_subjects_hmc: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1613,7 +1613,14 @@ pub struct FitResult {
     /// `kappa NAME ~ X (sd)`. Always `false` for block_kappa entries.
     pub kappa_init_as_sd: Vec<bool>,
     pub se_kappa: Option<Vec<f64>>,
+    /// Pooled kappa shrinkage: one value per kappa parameter, averaged over all
+    /// subject-occasion pairs.  Empty when `n_kappa == 0`.
     pub shrinkage_kappa: Vec<f64>,
+    /// Per-occasion kappa shrinkage: `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`.
+    /// `occ_idx` is the 0-based position in which occasions were first seen across
+    /// subjects (occasion-index order, not raw OCC column values).
+    /// Empty when `n_kappa == 0` or only one occasion is present.
+    pub shrinkage_kappa_by_occ: Vec<Vec<f64>>,
     /// Per-subject, per-occasion kappa EBEs.
     /// `ebe_kappas[i][k]` is the kappa vector for subject i, occasion k.
     /// Outer vec is empty when `n_kappa == 0`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1617,8 +1617,11 @@ pub struct FitResult {
     /// subject-occasion pairs.  Empty when `n_kappa == 0`.
     pub shrinkage_kappa: Vec<f64>,
     /// Per-occasion kappa shrinkage: `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`.
-    /// `occ_idx` is the 0-based position in which occasions were first seen across
-    /// subjects (occasion-index order, not raw OCC column values).
+    /// `occ_idx` is the 0-based position within each subject's own occasion list
+    /// (order in which distinct OCC values first appear in that subject's rows),
+    /// **not** the raw OCC column value.  For unbalanced designs where subjects
+    /// have different OCC sequences, a given `occ_idx` may map to different OCC
+    /// values across subjects — use `shrinkage_kappa` (pooled) in that case.
     /// Empty when `n_kappa == 0` or only one occasion is present.
     pub shrinkage_kappa_by_occ: Vec<Vec<f64>>,
     /// Per-subject, per-occasion kappa EBEs.


### PR DESCRIPTION
## Why

`FitResult.shrinkage_kappa` has existed since IOV was introduced but was always initialised as an empty `Vec` — kappa shrinkage was never actually computed. This makes it impossible to assess how informative the data are about each occasion's kappa random effects, which is the primary diagnostic for IOV model adequacy (analogous to ETA shrinkage for BSV).

## What changed

- **`compute_kappa_shrinkage`** — new function in `api.rs`. Pooled kappa shrinkage, one value per kappa parameter, averaged over all (subject, occasion) pairs:
  \\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_\text{subj}\cdot K}\sum_i\sum_k \hat\kappa_{ijk}^2}}{\sqrt{\omega_{\text{iov},jj}}} \\]
  Uses the same uncentered-second-moment / `n`-divisor convention as ETA shrinkage (NONMEM/PsN).

- **`compute_kappa_shrinkage_by_occ`** — per-occasion variant. Returns `shrinkage_kappa_by_occ[occ_idx][kappa_idx]` where `occ_idx` is 0-based occasion-index order. Useful for spotting data-sparse occasions. Empty when only one occasion is present.

- **`FitResult.shrinkage_kappa_by_occ: Vec<Vec<f64>>`** — new field added to `types.rs`.

- **`IovWire.shrinkage_kappa_by_occ`** — persisted in the `.fitrx` bundle (`#[serde(default)]` for backward compatibility with older files).

- **Console output** (`io/output.rs`) — a new "Kappa Shrinkage (pooled)" section is printed after every IOV fit, followed by a per-occasion breakdown when two or more occasions exist.

- **Docs** (`docs/src/output.md`) — both metrics documented with formula and interpretation.

- **Unit tests** (7 new tests in `api.rs`) covering: zero shrinkage when RMS matches omega SD, high shrinkage when kappas are near zero, NaN on zero omega, NaN when fewer than 2 observations, empty by-occ when single occasion, and per-occasion values.

## Alternatives considered

- **Normality check per occasion** (Shapiro-Wilk / skewness) — rejected. With typical NLME datasets (10–200 subjects), per-occasion samples are too small for meaningful normality tests; shrinkage already captures the key diagnostic question.
- **Centered / n-1 estimator** — rejected for consistency with ETA shrinkage and NONMEM convention.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

The new field is additive; the R wrapper does not currently surface `shrinkage_kappa` so no ferx-r change is required.

## Breaking changes
- [x] `FitResult` / sdtab fields changed — `shrinkage_kappa_by_occ` is a new field. Existing code compiled against the old struct will need recompilation; no behavioural change for non-IOV models (field is always empty).
- [x] Public Rust API (`types.rs`) — struct field added.

<details>
<summary>Migration notes</summary>

Add `shrinkage_kappa_by_occ: vec![]` to any manual `FitResult` constructions outside this repo.

</details>

## Numerical validation
- [x] Not applicable — this PR only computes and surfaces an existing diagnostic; it does not change estimates, OFV, or EBE values.

The `shrinkage_kappa` field was previously always empty, so there is no "before" reference value. The unit tests verify the formula directly against hand-computed values.

## Performance
- [x] No significant impact expected — O(N·K·n_kappa) over the already-computed EBE kappas.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] No regression test needed (no prior behaviour to regress against — field was always empty)

## Example (user-facing features only)

IOV model console output now includes:

```
--- Kappa Shrinkage (pooled) ---
  KAPPA_CL shrinkage: 34.2%
  KAPPA_V  shrinkage: 28.7%
  Per-occasion:
    OCC 1: KAPPA_CL 21.5%, KAPPA_V 18.3%
    OCC 2: KAPPA_CL 47.0%, KAPPA_V 39.1%
```

High per-occasion shrinkage (e.g. OCC 2 above) would prompt a user to check whether that occasion has sufficient sampling to estimate kappa.

## Docs
- [x] `docs/src/output.md` updated — kappa shrinkage section added with formulae and interpretation.
- [ ] `mdbook build` run — not committed (CI deploys from source).
- [ ] No user-visible change — N/A.

## Checklist
- [x] `cargo clippy` clean (only pre-existing dead-code warnings in `hmc.rs`)
- [x] `cargo check --features autodiff` — no AD-reachable code touched
- [x] `Cargo.toml` version not bumped — additive field, no API removal

## Reviewer hints

All changes are confined to the post-fit diagnostics path. The numerical core (EBE optimisation, likelihood, predictions) is untouched. The key files:

- `src/api.rs` — two new `pub(crate)` functions + wiring in `fit()` + 7 unit tests
- `src/types.rs` — one new field on `FitResult`
- `src/io/fitrx.rs` — round-trip serialisation (new field with `#[serde(default)]`)
- `src/io/output.rs` — console display
- `docs/src/output.md` — documentation

## Open questions

None.