### PR TITLE
chore: add CodeFactor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Slow tests](https://github.com/FeRx-NLME/ferx-core/actions/workflows/slow-tests.yml/badge.svg)](https://github.com/FeRx-NLME/ferx-core/actions/workflows/slow-tests.yml)
 [![Docs](https://github.com/FeRx-NLME/ferx-core/actions/workflows/docs.yml/badge.svg)](https://github.com/FeRx-NLME/ferx-core/actions/workflows/docs.yml)
 [![codecov](https://codecov.io/gh/FeRx-NLME/ferx-core/branch/main/graph/badge.svg)](https://codecov.io/gh/FeRx-NLME/ferx-core)
+[![CodeFactor](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core/badge)](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A high-performance Nonlinear Mixed Effects (NLME) modeling engine for population pharmacokinetics, written in Rust. Implements FOCE/FOCEI estimation with analytical PK solutions and an optional ODE solver, similar to NONMEM.


### PR DESCRIPTION
## Why

CodeFactor is now connected to `FeRx-NLME/ferx-core`. This PR adds the
badge so the current grade is visible on the project's GitHub front
page next to the existing CI / Slow tests / Docs / codecov / License
badges.

## What changed

`README.md`: one line, inserted between the existing `codecov` and
`License: MIT` badges. Verified the badge URL responds with HTTP 200
(SVG content):

```
[![CodeFactor](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core/badge)](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core)
```

## Breaking changes

- [x] None

## Tests

- [x] No new tests needed (docs-only)

## Docs

- [x] Not applicable (badge is a doc itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)