### PR TITLE
fix(ad): resolve Enzyme type-analysis phi-node failure

### DIFF
--- a/src/ad/ad_gradients.rs
+++ b/src/ad/ad_gradients.rs
@@ -13,6 +13,17 @@ use std::autodiff::{autodiff_forward, autodiff_reverse};
 /// dependency and Enzyme sees a plain literal.
 const LTBS_FLOOR_AD: f64 = 1e-12;
 
+/// Identity function that Enzyme can see through for type deduction but LLVM
+/// cannot inline away. Provides an unambiguous `f64 -> f64` type boundary at
+/// phi-node merge points where Enzyme's type-analysis would otherwise deadlock.
+/// Currently unused (the `read_volatile` approach was chosen), kept as a
+/// documented utility for future phi-node issues in AD-instrumented code.
+#[inline(never)]
+#[allow(dead_code)]
+fn ad_type_fence(x: f64) -> f64 {
+    x
+}
+
 // ─── Individual NLL: reverse-mode AD for gradient w.r.t. eta ────────────────
 
 #[autodiff_reverse(
@@ -91,10 +102,10 @@ pub fn individual_nll_ad(
         pk[idx] = tv[i] * eta_contrib.exp();
     }
 
-    // Lagtime shifts the effective start of every dose. Default 0.0 (no
-    // shift) so models that don't declare LAGTIME behave identically to
-    // the pre-feature path. AD-safe: only adds + and <= on scalars.
-    let lagtime = pk[PK_IDX_LAGTIME];
+    // Volatile load prevents LLVM from merging this value with the array's
+    // zero-initializer into a phi node that Enzyme cannot type-analyze.
+    // Safety: `pk` is a stack-local [f64; MAX_PK_PARAMS] at a valid index.
+    let lagtime = unsafe { core::ptr::read_volatile(&pk[PK_IDX_LAGTIME]) };
 
     // Predictions + data likelihood
     let mut data_ll = 0.0;
@@ -102,25 +113,22 @@ pub fn individual_nll_ad(
         let t = obs_times[obs_idx];
         let mut conc = 0.0;
         for d in 0..n_doses {
-            let t_eff = dose_times[d] + lagtime;
-            if t_eff <= t {
-                let tau = t - t_eff;
-                conc += single_dose_ad(
-                    pk_model_id,
-                    tau,
-                    dose_amts[d],
-                    dose_rates[d],
-                    dose_durations[d],
-                    pk[PK_IDX_CL],
-                    pk[PK_IDX_V],
-                    pk[PK_IDX_Q],
-                    pk[PK_IDX_V2],
-                    pk[PK_IDX_KA],
-                    pk[PK_IDX_F],
-                    pk[PK_IDX_Q3],
-                    pk[PK_IDX_V3],
-                );
-            }
+            let tau = t - dose_times[d] - lagtime;
+            conc += single_dose_ad(
+                pk_model_id,
+                tau,
+                dose_amts[d],
+                dose_rates[d],
+                dose_durations[d],
+                pk[PK_IDX_CL],
+                pk[PK_IDX_V],
+                pk[PK_IDX_Q],
+                pk[PK_IDX_V2],
+                pk[PK_IDX_KA],
+                pk[PK_IDX_F],
+                pk[PK_IDX_Q3],
+                pk[PK_IDX_V3],
+            );
         }
         if conc < 0.0 {
             conc = 0.0;
@@ -245,33 +253,29 @@ pub fn predict_all_ad(
         pk[idx] = tv[i] * eta_contrib.exp();
     }
 
-    // Lagtime shifts the effective start of every dose. See
-    // `individual_nll_ad` for the matching path on the NLL side.
-    let lagtime = pk[PK_IDX_LAGTIME];
+    // Volatile load — see matching comment in `individual_nll_ad`.
+    let lagtime = unsafe { core::ptr::read_volatile(&pk[PK_IDX_LAGTIME]) };
 
     for obs_idx in 0..n_obs {
         let t = obs_times[obs_idx];
         let mut conc = 0.0;
         for d in 0..n_doses {
-            let t_eff = dose_times[d] + lagtime;
-            if t_eff <= t {
-                let tau = t - t_eff;
-                conc += single_dose_ad(
-                    pk_id,
-                    tau,
-                    dose_amts[d],
-                    dose_rates[d],
-                    dose_durations[d],
-                    pk[PK_IDX_CL],
-                    pk[PK_IDX_V],
-                    pk[PK_IDX_Q],
-                    pk[PK_IDX_V2],
-                    pk[PK_IDX_KA],
-                    pk[PK_IDX_F],
-                    pk[PK_IDX_Q3],
-                    pk[PK_IDX_V3],
-                );
-            }
+            let tau = t - dose_times[d] - lagtime;
+            conc += single_dose_ad(
+                pk_id,
+                tau,
+                dose_amts[d],
+                dose_rates[d],
+                dose_durations[d],
+                pk[PK_IDX_CL],
+                pk[PK_IDX_V],
+                pk[PK_IDX_Q],
+                pk[PK_IDX_V2],
+                pk[PK_IDX_KA],
+                pk[PK_IDX_F],
+                pk[PK_IDX_Q3],
+                pk[PK_IDX_V3],
+            );
         }
         let positive = if conc > 0.0 { conc } else { 0.0 };
         let scaled = positive / obs_scale[obs_idx];


### PR DESCRIPTION
## Why

When building with `--features autodiff` using the Enzyme-enabled nightly toolchain, compilation fails:

```
Enzyme: Cannot deduce type of phi %59 = phi double [...], [0.0, ...]
```

This is a deterministic compiler-level failure (not machine- or environment-specific) caused by a three-layer interaction:

1. **LLVM lowering:** The `pk` array (`[f64; MAX_PK_PARAMS]`) initialized with `[0.0f64; ...]` is lowered to a byte-addressed alloca (`[128 x i8]`), not a typed `[N x double]`.
2. **LLVM optimizer:** Hoists the `pk[PK_IDX_LAGTIME]` load out of the `if t_eff <= t` branch and merges it with the array's zero-initializer into a phi node.
3. **Enzyme type-analysis:** The phi merges type `{}` (unknown, from the untyped alloca) with `Anything` (all-zero literal) — neither resolves to `f64`, so Enzyme gives up.

## What changed

Two complementary fixes applied to both `individual_nll_ad` (reverse-mode) and `predict_all_ad` (forward-mode):

1. **Volatile lagtime load** — `core::ptr::read_volatile(&pk[PK_IDX_LAGTIME])` emits a load that LLVM cannot optimize, move, or merge into a phi node. Forces Enzyme to see an unambiguous `f64`.

2. **Remove conditional branch** — The `if t_eff <= t { ... }` guard around dose accumulation is removed, eliminating the control-flow merge point where LLVM created the problematic phi. This is safe because `single_dose_ad` already returns `0.0` for negative `tau` (line 310).

Additionally defines `ad_type_fence` (`#[inline(never)] fn(f64) -> f64`) as a documented defense-in-depth utility for future phi-node issues — defined but not currently used.

## Alternatives considered

- **`ad_type_fence` wrapper around the load**: Works but adds a function call overhead per subject per iteration. `read_volatile` is lighter (single non-elided load instruction).
- **Restructuring the array initialization**: Would require changing `[0.0f64; N]` to element-by-element assignment — invasive change for a compiler workaround.
- **Waiting for upstream Enzyme fix**: The type-analysis limitation is long-standing and no fix is imminent.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

This is a compile-time fix only. No runtime behavior changes — `single_dose_ad` already handles negative `tau` by returning `0.0`, making the removed branch semantically redundant.

## Performance
- [x] No significant impact expected

One non-elided load per subject per iteration (volatile). The branch removal saves a comparison per dose per observation, roughly offsetting.

## Tests
- [x] No new tests needed (why: compile-time fix verified by `cargo check --features autodiff`; no behavioral change)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo check --features autodiff` still compiles (verified locally with enzyme toolchain)
- [ ] `cargo clippy` clean (clippy unavailable on custom enzyme toolchain; no logic changes to lint)
- [ ] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site
- [x] No update needed

### ferx-book
- [x] No update needed

### Example execution
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

The `unsafe` is trivially sound: `read_volatile` on a stack-local `[f64; 16]` at index 8. The only effect is preventing LLVM from optimizing the load — no UB path exists.

The removed `if t_eff <= t` branch was belt-and-suspenders: `single_dose_ad` line 310 already early-returns `0.0` for `tau < 0.0`. Removing it is the second half of the fix (eliminates the phi merge point) and has no semantic effect.

## Open questions

- Should we gate the `ad_type_fence` utility behind `#[cfg(feature = "autodiff")]`? Currently it's always compiled (with `#[allow(dead_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)