### PR TITLE
feat(pk)!: unify *_iv_bolus / *_infusion into *_iv; RATE drives route per dose [closes #176]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ Models are defined in a simple DSL. Here is a one-compartment oral PK model for 
 
 | Model | Syntax |
 |-------|--------|
-| 1-compartment IV bolus | `pk one_cpt_iv_bolus(cl=CL, v=V)` |
+| 1-compartment IV (bolus and/or infusion) | `pk one_cpt_iv(cl=CL, v=V)` |
 | 1-compartment oral | `pk one_cpt_oral(cl=CL, v=V, ka=KA)` |
-| 1-compartment infusion | `pk one_cpt_infusion(cl=CL, v=V)` |
-| 2-compartment IV bolus | `pk two_cpt_iv_bolus(cl=CL, v1=V1, q=Q, v2=V2)` |
+| 2-compartment IV (bolus and/or infusion) | `pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)` |
 | 2-compartment oral | `pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2, ka=KA)` |
-| 2-compartment infusion | `pk two_cpt_infusion(cl=CL, v1=V1, q=Q, v2=V2)` |
+| 3-compartment IV (bolus and/or infusion) | `pk three_cpt_iv(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)` |
+| 3-compartment oral | `pk three_cpt_oral(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3, ka=KA)` |
 | ODE-based | Define equations in an `[odes]` block |
+
+For IV models, the closed form (bolus vs infusion) is chosen per dose event from the `RATE` column — a subject can mix bolus and infusion records.
 
 ## Estimation Methods
 

--- a/docs/src/api/parsing.md
+++ b/docs/src/api/parsing.md
@@ -32,7 +32,7 @@ let model_str = r#"
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ additive(ADD_ERR)

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -162,11 +162,14 @@ pub struct SubjectResult {
 
 ```rust
 pub enum EstimationMethod { Foce, FoceI, Saem }
-pub enum PkModel { OneCptIvBolus, OneCptOral, OneCptInfusion,
-                   TwoCptIvBolus, TwoCptOral, TwoCptInfusion }
+pub enum PkModel { OneCptIv, OneCptOral,
+                   TwoCptIv, TwoCptOral,
+                   ThreeCptIv, ThreeCptOral }
 pub enum ErrorModel { Additive, Proportional, Combined }
 pub enum Optimizer { Bfgs, Lbfgs, Slsqp, NloptLbfgs, Mma }
 ```
+
+The IV variants cover both bolus and infusion administration — the route is chosen per dose from the data's `RATE` column (`RATE=0` ⇒ bolus, `RATE>0` ⇒ infusion), so one model handles either or a mix within a single subject.
 
 ## DoseEvent
 

--- a/docs/src/data-format.md
+++ b/docs/src/data-format.md
@@ -60,14 +60,11 @@ Covariate names in the data file are matched case-insensitively to names used in
 
 Time-varying covariates are supported for **all** analytical structural models and ODE-defined models:
 
-- 1-compartment IV bolus (`one_cpt_iv_bolus`)
-- 1-compartment infusion (`one_cpt_infusion`)
+- 1-compartment IV (`one_cpt_iv`) — bolus and/or infusion per dose
 - 1-compartment oral (`one_cpt_oral`)
-- 2-compartment IV bolus (`two_cpt_iv_bolus`)
-- 2-compartment infusion (`two_cpt_infusion`)
+- 2-compartment IV (`two_cpt_iv`) — bolus and/or infusion per dose
 - 2-compartment oral (`two_cpt_oral`)
-- 3-compartment IV bolus (`three_cpt_iv_bolus`)
-- 3-compartment infusion (`three_cpt_infusion`)
+- 3-compartment IV (`three_cpt_iv`) — bolus and/or infusion per dose
 - 3-compartment oral (`three_cpt_oral`)
 - All ODE-defined models (via `[odes]`)
 

--- a/docs/src/examples/two-cpt-iv.md
+++ b/docs/src/examples/two-cpt-iv.md
@@ -27,7 +27,7 @@ This example fits a two-compartment IV bolus model with four random effects.
   V2 = TVV2 * exp(ETA_V2)
 
 [structural_model]
-  pk two_cpt_iv_bolus(cl=CL, v1=V1, q=Q, v2=V2)
+  pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/docs/src/model-file/README.md
+++ b/docs/src/model-file/README.md
@@ -29,7 +29,7 @@ ferx-core models are defined in `.ferx` files using a declarative DSL. Each file
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ additive(ADD_ERR)

--- a/docs/src/model-file/structural-model.md
+++ b/docs/src/model-file/structural-model.md
@@ -14,17 +14,18 @@ pk MODEL_NAME(param=VALUE, param=VALUE, ...)
 
 | Model Function | Compartments | Route | Required Parameters |
 |---------------|--------------|-------|---------------------|
-| `one_cpt_iv_bolus` | 1 | IV bolus | `cl`, `v` |
+| `one_cpt_iv` | 1 | IV (bolus and/or infusion) | `cl`, `v` |
 | `one_cpt_oral` | 1 | Oral | `cl`, `v`, `ka` |
-| `one_cpt_infusion` | 1 | IV infusion | `cl`, `v` |
-| `two_cpt_iv_bolus` | 2 | IV bolus | `cl`, `v1`, `q`, `v2` |
+| `two_cpt_iv` | 2 | IV (bolus and/or infusion) | `cl`, `v1`, `q`, `v2` |
 | `two_cpt_oral` | 2 | Oral | `cl`, `v1`, `q`, `v2`, `ka` |
-| `two_cpt_infusion` | 2 | IV infusion | `cl`, `v1`, `q`, `v2` |
-| `three_cpt_iv_bolus` | 3 | IV bolus | `cl`, `v1`, `q2`, `v2`, `q3`, `v3` |
+| `three_cpt_iv` | 3 | IV (bolus and/or infusion) | `cl`, `v1`, `q2`, `v2`, `q3`, `v3` |
 | `three_cpt_oral` | 3 | Oral | `cl`, `v1`, `q2`, `v2`, `q3`, `v3`, `ka` |
-| `three_cpt_infusion` | 3 | IV infusion | `cl`, `v1`, `q2`, `v2`, `q3`, `v3` |
 
-Each model has a `three_compartment_*` long-form alias (e.g. `three_compartment_iv_bolus`); the short and long names are interchangeable.
+Each model has a `*_compartment_*` long-form alias (e.g. `three_compartment_iv`); the short and long names are interchangeable.
+
+There is no separate bolus or infusion variant: every IV model selects the closed form per dose from the `RATE` column (`RATE=0` ⇒ bolus, `RATE>0` ⇒ infusion). A single subject can mix the two. This matches NONMEM, nlmixr2, and Monolix.
+
+The earlier `*_iv_bolus` and `*_infusion` model names were retired in #176. The parser now rejects them with a migration message pointing at the unified `*_iv` name.
 
 ### Examples
 
@@ -34,10 +35,10 @@ One-compartment oral:
   pk one_cpt_oral(cl=CL, v=V, ka=KA)
 ```
 
-Two-compartment IV bolus:
+Two-compartment IV (bolus, infusion, or a mix — driven by RATE):
 ```
 [structural_model]
-  pk two_cpt_iv_bolus(cl=CL, v1=V1, q=Q, v2=V2)
+  pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)
 ```
 
 Two-compartment oral:
@@ -46,10 +47,10 @@ Two-compartment oral:
   pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2, ka=KA)
 ```
 
-Three-compartment IV bolus (note that `q2`/`q3` and `v2`/`v3` distinguish the two peripheral compartments):
+Three-compartment IV (note that `q2`/`q3` and `v2`/`v3` distinguish the two peripheral compartments):
 ```
 [structural_model]
-  pk three_cpt_iv_bolus(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)
+  pk three_cpt_iv(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)
 ```
 
 ### Bioavailability
@@ -64,9 +65,10 @@ All `pk` models accept an optional `lagtime=` parameter (or its NONMEM-style ali
 
 ### Dose Handling
 
-Analytical models support:
-- **Bolus doses**: Instantaneous input (default when `RATE=0` in data)
+Analytical IV models support:
+- **Bolus doses**: Instantaneous input (when `RATE=0` in data)
 - **Infusions**: Zero-order input (when `RATE>0` in data)
+- **Mixed**: A single subject may receive both bolus and infusion doses; the route is read per event from `RATE`
 - **Steady-state**: Pre-computed steady-state concentrations (when `SS=1` and `II>0` in data)
 - **Dose superposition**: Multiple doses are handled by summing contributions from each dose event
 

--- a/examples/one_cpt_infusion.ferx
+++ b/examples/one_cpt_infusion.ferx
@@ -1,6 +1,8 @@
-# One-compartment IV infusion PK model (analytical).
+# One-compartment IV PK model (analytical) — dataset uses infusion doses.
 #
-# Drug is administered as a constant-rate infusion (RATE column in data).
+# Drug is administered as a constant-rate infusion (RATE>0 in the data).
+# The same `one_cpt_iv` model also handles bolus doses (RATE=0) and can
+# mix the two within a single subject; the route is read per-event.
 # CL/F → CL for IV; F is fixed at 1.
 
 [parameters]
@@ -17,7 +19,7 @@
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_infusion(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/examples/one_cpt_iv.ferx
+++ b/examples/one_cpt_iv.ferx
@@ -1,4 +1,7 @@
-# One-compartment IV bolus PK model (analytical)
+# One-compartment IV PK model (analytical).
+#
+# The bolus-vs-infusion choice is per dose (RATE column): RATE=0 ⇒
+# bolus, RATE>0 ⇒ infusion. A subject may mix the two.
 #
 # True parameters: CL=5 L/h, V=50 L
 
@@ -16,7 +19,7 @@
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/examples/one_cpt_iv_renamed.ferx
+++ b/examples/one_cpt_iv_renamed.ferx
@@ -1,4 +1,4 @@
-# 1-cpt IV bolus model with non-standard theta names.
+# 1-cpt IV model with non-standard theta names.
 #
 # Tests that suggest_start is independent of how the user names their TV
 # thetas: the slot lookup proceeds through mu_refs (ETA_CL → CLEARANCE,
@@ -18,7 +18,7 @@
   V  = DISTRIB   * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/examples/scaling_expression.ferx
+++ b/examples/scaling_expression.ferx
@@ -26,7 +26,7 @@
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [scaling]
   obs_scale = V                 # per-subject volume-normalised DV scale

--- a/examples/three_cpt_iv.ferx
+++ b/examples/three_cpt_iv.ferx
@@ -1,4 +1,4 @@
-# Three-compartment IV bolus PK model
+# Three-compartment IV PK model — RATE column drives bolus vs infusion per dose.
 
 [parameters]
   theta TVCL(5.0, 0.1, 100.0)
@@ -26,7 +26,7 @@
   V3 = TVV3 * exp(ETA_V3)
 
 [structural_model]
-  pk three_cpt_iv_bolus(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)
+  pk three_cpt_iv(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/examples/two_cpt_iv.ferx
+++ b/examples/two_cpt_iv.ferx
@@ -1,4 +1,4 @@
-# Two-compartment IV bolus PK model
+# Two-compartment IV PK model — RATE column drives bolus vs infusion per dose.
 
 [parameters]
   theta TVCL(4.0, 0.1, 100.0)
@@ -20,7 +20,7 @@
   V2 = TVV2 * exp(ETA_V2)
 
 [structural_model]
-  pk two_cpt_iv_bolus(cl=CL, v1=V1, q=Q, v2=V2)
+  pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/src/ad/ad_gradients.rs
+++ b/src/ad/ad_gradients.rs
@@ -68,8 +68,8 @@ pub fn individual_nll_ad(
     let n_tv = tv.len();
     let n_doses = dose_times.len();
     let n_obs = obs_times.len();
-    // LTBS is packed as a +100 offset on the model id (pk_model_id ≤ 8 ⇒ base
-    // ≤ 82, so the offset is unambiguous). Under LTBS the effective prediction
+    // LTBS is packed as a +100 offset on the model id (pk_model_id ≤ 5 ⇒ base
+    // ≤ 52, so the offset is unambiguous). Under LTBS the effective prediction
     // is log(conc) and the error model is additive on the log scale.
     let ltbs = (pk_and_err_model as i32) >= 100;
     let base = (pk_and_err_model as i32) % 100;
@@ -315,11 +315,23 @@ fn single_dose_ad(
         return 0.0;
     }
 
+    // Per issue #176, IV variants no longer split by administration type at
+    // the model level. Each IV branch below handles bolus and infusion via
+    // the per-dose `dur` (and `rate`) — the `dur <= 0.0` fall-through is
+    // exactly the bolus closed form. ID mapping (see `pk_model_to_id`):
+    //   0 OneCptIv, 1 OneCptOral, 2 TwoCptIv, 3 TwoCptOral,
+    //   4 ThreeCptIv, 5 ThreeCptOral.
     match pk_model_id {
         0 => {
-            // OneCptIvBolus
+            // OneCptIv — bolus when dur<=0, infusion otherwise.
             let k = cl / v;
-            (amt / v) * (-k * tau).exp()
+            if dur <= 0.0 {
+                (amt / v) * (-k * tau).exp()
+            } else if tau <= dur {
+                (rate / cl) * (1.0 - (-k * tau).exp())
+            } else {
+                (rate / cl) * (1.0 - (-k * dur).exp()) * (-k * (tau - dur)).exp()
+            }
         }
         1 => {
             // OneCptOral
@@ -332,28 +344,29 @@ fn single_dose_ad(
             }
         }
         2 => {
-            // OneCptInfusion
-            let k = cl / v;
+            // TwoCptIv — bolus when dur<=0, infusion otherwise.
+            // The previous `.abs() < 1e-12` diff guards produced NaN
+            // gradients under Enzyme reverse-mode (branching on .abs()
+            // poisons the adjoint), and were dead for physical params.
+            let (alpha, beta, k21) = macro_rates(cl, v, q, v2);
+            let diff = alpha - beta;
             if dur <= 0.0 {
-                (amt / v) * (-k * tau).exp()
-            } else if tau <= dur {
-                (rate / cl) * (1.0 - (-k * tau).exp())
+                let a = (amt / v) * (alpha - k21) / diff;
+                let b = (amt / v) * (k21 - beta) / diff;
+                a * (-alpha * tau).exp() + b * (-beta * tau).exp()
             } else {
-                (rate / cl) * (1.0 - (-k * dur).exp()) * (-k * (tau - dur)).exp()
+                let a_c = (rate / v) * (alpha - k21) / (diff * alpha);
+                let b_c = (rate / v) * (k21 - beta) / (diff * beta);
+                if tau <= dur {
+                    a_c * (1.0 - (-alpha * tau).exp()) + b_c * (1.0 - (-beta * tau).exp())
+                } else {
+                    let dt = tau - dur;
+                    a_c * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp()
+                        + b_c * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp()
+                }
             }
         }
         3 => {
-            // TwoCptIvBolus
-            let (alpha, beta, k21) = macro_rates(cl, v, q, v2);
-            let diff = alpha - beta;
-            if diff.abs() < 1e-12 {
-                return 0.0;
-            }
-            let a = (amt / v) * (alpha - k21) / diff;
-            let b = (amt / v) * (k21 - beta) / diff;
-            a * (-alpha * tau).exp() + b * (-beta * tau).exp()
-        }
-        4 => {
             // TwoCptOral
             let (alpha, beta, k21) = macro_rates(cl, v, q, v2);
             let diff = alpha - beta;
@@ -378,79 +391,8 @@ fn single_dose_ad(
             };
             p + q_val + r
         }
-        5 => {
-            // TwoCptInfusion
-            let (alpha, beta, k21) = macro_rates(cl, v, q, v2);
-            // For any positive (cl, v, q, v2) we have alpha > 0 and
-            // alpha - beta = disc > 0, and beta = d/alpha >= 0. The previous
-            // `.abs() < 1e-12` guards produced NaN gradients under Enzyme
-            // reverse-mode (branching on .abs() poisons the adjoint), and were
-            // dead for physical params — remove them.
-            let diff = alpha - beta;
-            if dur <= 0.0 {
-                let a = (amt / v) * (alpha - k21) / diff;
-                let b = (amt / v) * (k21 - beta) / diff;
-                a * (-alpha * tau).exp() + b * (-beta * tau).exp()
-            } else {
-                let a_c = (rate / v) * (alpha - k21) / (diff * alpha);
-                let b_c = (rate / v) * (k21 - beta) / (diff * beta);
-                if tau <= dur {
-                    a_c * (1.0 - (-alpha * tau).exp()) + b_c * (1.0 - (-beta * tau).exp())
-                } else {
-                    let dt = tau - dur;
-                    a_c * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp()
-                        + b_c * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp()
-                }
-            }
-        }
-        6 => {
-            // ThreeCptIvBolus
-            let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt_ad(cl, v, q, v2, q3, v3);
-            let ab = alpha - beta;
-            let ag = alpha - gamma;
-            let bg = beta - gamma;
-            if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
-                return 0.0;
-            }
-            let d = amt / v;
-            let a = d * (alpha - k21) * (alpha - k31) / (ab * ag);
-            let b = d * (beta - k21) * (beta - k31) / (-ab * bg);
-            let g = d * (gamma - k21) * (gamma - k31) / (ag * bg);
-            a * (-alpha * tau).exp() + b * (-beta * tau).exp() + g * (-gamma * tau).exp()
-        }
-        7 => {
-            // ThreeCptOral
-            let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt_ad(cl, v, q, v2, q3, v3);
-            let ab = alpha - beta;
-            let ag = alpha - gamma;
-            let bg = beta - gamma;
-            if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
-                return 0.0;
-            }
-            let coeff = f_bio * amt * ka / v;
-            let a_c = (alpha - k21) * (alpha - k31) / (ab * ag);
-            let b_c = (beta - k21) * (beta - k31) / (-ab * bg);
-            let g_c = (gamma - k21) * (gamma - k31) / (ag * bg);
-
-            let bateman_a = if (ka - alpha).abs() < 1e-6 {
-                tau * (-alpha * tau).exp()
-            } else {
-                ((-alpha * tau).exp() - (-ka * tau).exp()) / (ka - alpha)
-            };
-            let bateman_b = if (ka - beta).abs() < 1e-6 {
-                tau * (-beta * tau).exp()
-            } else {
-                ((-beta * tau).exp() - (-ka * tau).exp()) / (ka - beta)
-            };
-            let bateman_g = if (ka - gamma).abs() < 1e-6 {
-                tau * (-gamma * tau).exp()
-            } else {
-                ((-gamma * tau).exp() - (-ka * tau).exp()) / (ka - gamma)
-            };
-            coeff * (a_c * bateman_a + b_c * bateman_b + g_c * bateman_g)
-        }
-        8 => {
-            // ThreeCptInfusion
+        4 => {
+            // ThreeCptIv — bolus when dur<=0, infusion otherwise.
             let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt_ad(cl, v, q, v2, q3, v3);
             let ab = alpha - beta;
             let ag = alpha - gamma;
@@ -486,6 +428,37 @@ fn single_dose_ad(
                         + g_c * (1.0 - (-gamma * dur).exp()) * (-gamma * dt).exp()
                 }
             }
+        }
+        5 => {
+            // ThreeCptOral
+            let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt_ad(cl, v, q, v2, q3, v3);
+            let ab = alpha - beta;
+            let ag = alpha - gamma;
+            let bg = beta - gamma;
+            if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
+                return 0.0;
+            }
+            let coeff = f_bio * amt * ka / v;
+            let a_c = (alpha - k21) * (alpha - k31) / (ab * ag);
+            let b_c = (beta - k21) * (beta - k31) / (-ab * bg);
+            let g_c = (gamma - k21) * (gamma - k31) / (ag * bg);
+
+            let bateman_a = if (ka - alpha).abs() < 1e-6 {
+                tau * (-alpha * tau).exp()
+            } else {
+                ((-alpha * tau).exp() - (-ka * tau).exp()) / (ka - alpha)
+            };
+            let bateman_b = if (ka - beta).abs() < 1e-6 {
+                tau * (-beta * tau).exp()
+            } else {
+                ((-beta * tau).exp() - (-ka * tau).exp()) / (ka - beta)
+            };
+            let bateman_g = if (ka - gamma).abs() < 1e-6 {
+                tau * (-gamma * tau).exp()
+            } else {
+                ((-gamma * tau).exp() - (-ka * tau).exp()) / (ka - gamma)
+            };
+            coeff * (a_c * bateman_a + b_c * bateman_b + g_c * bateman_g)
         }
         _ => 0.0,
     }
@@ -602,15 +575,12 @@ fn residual_variance_ad(error_model_id: i32, f_pred: f64, sigma: &[f64]) -> f64 
 
 pub fn pk_model_to_id(m: PkModel) -> i32 {
     match m {
-        PkModel::OneCptIvBolus => 0,
+        PkModel::OneCptIv => 0,
         PkModel::OneCptOral => 1,
-        PkModel::OneCptInfusion => 2,
-        PkModel::TwoCptIvBolus => 3,
-        PkModel::TwoCptOral => 4,
-        PkModel::TwoCptInfusion => 5,
-        PkModel::ThreeCptIvBolus => 6,
-        PkModel::ThreeCptOral => 7,
-        PkModel::ThreeCptInfusion => 8,
+        PkModel::TwoCptIv => 2,
+        PkModel::TwoCptOral => 3,
+        PkModel::ThreeCptIv => 4,
+        PkModel::ThreeCptOral => 5,
     }
 }
 
@@ -794,7 +764,7 @@ mod ltbs_ad_tests {
             &obs_times,
             &observations,
             &cens,
-            PkModel::OneCptIvBolus,
+            PkModel::OneCptIv,
             ErrorModel::Additive,
             &pk_idx_f64,
             &sel_flat,

--- a/src/ad/ad_gradients.rs
+++ b/src/ad/ad_gradients.rs
@@ -345,9 +345,17 @@ fn single_dose_ad(
         }
         2 => {
             // TwoCptIv — bolus when dur<=0, infusion otherwise.
-            // The previous `.abs() < 1e-12` diff guards produced NaN
-            // gradients under Enzyme reverse-mode (branching on .abs()
-            // poisons the adjoint), and were dead for physical params.
+            //
+            // No `diff.abs() < 1e-12 ⇒ 0.0` guard on either branch:
+            // branching on `.abs()` of a continuous argument poisons the
+            // Enzyme reverse-mode adjoint, and the old `TwoCptInfusion`
+            // arm explicitly removed it for that reason. For physical
+            // positive (cl, v, q, v2) the 2-cpt discriminant is
+            // strictly positive, so `diff = α - β = √disc > 0` and the
+            // divisions never blow up in finite precision. The old
+            // `TwoCptIvBolus` arm carried the guard but it was dead in
+            // practice — keeping the bolus and infusion branches
+            // symmetric here matches that prior author's decision.
             let (alpha, beta, k21) = macro_rates(cl, v, q, v2);
             let diff = alpha - beta;
             if dur <= 0.0 {
@@ -393,26 +401,39 @@ fn single_dose_ad(
         }
         4 => {
             // ThreeCptIv — bolus when dur<=0, infusion otherwise.
+            //
+            // The guards differ between the two branches: the bolus
+            // formula only divides by `ab·ag`, `ab·bg`, `ag·bg`, so it
+            // only needs `ab/ag/bg ≈ 0` checks. The infusion formula
+            // additionally divides by `α`, `β`, `γ` in the rate-input
+            // coefficients, so it needs the three extra eigenvalue
+            // checks. Folding all six into a shared guard (as a prior
+            // revision did) collapses physically-valid bolus answers
+            // to zero whenever a slowly-equilibrating 3-cpt has one of
+            // α/β/γ near zero — see issue #176 review.
             let (alpha, beta, gamma, k21, k31) = macro_rates_three_cpt_ad(cl, v, q, v2, q3, v3);
             let ab = alpha - beta;
             let ag = alpha - gamma;
             let bg = beta - gamma;
-            if ab.abs() < 1e-12
-                || ag.abs() < 1e-12
-                || bg.abs() < 1e-12
-                || alpha.abs() < 1e-12
-                || beta.abs() < 1e-12
-                || gamma.abs() < 1e-12
-            {
-                return 0.0;
-            }
             if dur <= 0.0 {
+                if ab.abs() < 1e-12 || ag.abs() < 1e-12 || bg.abs() < 1e-12 {
+                    return 0.0;
+                }
                 let d = amt / v;
                 let a = d * (alpha - k21) * (alpha - k31) / (ab * ag);
                 let b = d * (beta - k21) * (beta - k31) / (-ab * bg);
                 let g = d * (gamma - k21) * (gamma - k31) / (ag * bg);
                 a * (-alpha * tau).exp() + b * (-beta * tau).exp() + g * (-gamma * tau).exp()
             } else {
+                if ab.abs() < 1e-12
+                    || ag.abs() < 1e-12
+                    || bg.abs() < 1e-12
+                    || alpha.abs() < 1e-12
+                    || beta.abs() < 1e-12
+                    || gamma.abs() < 1e-12
+                {
+                    return 0.0;
+                }
                 let rv = rate / v;
                 let a_c = rv * (alpha - k21) * (alpha - k31) / (ab * ag * alpha);
                 let b_c = rv * (beta - k21) * (beta - k31) / (-ab * bg * beta);
@@ -572,15 +593,29 @@ fn residual_variance_ad(error_model_id: i32, f_pred: f64, sigma: &[f64]) -> f64 
 }
 
 // ─── Enum → ID converters ───────────────────────────────────────────────────
+//
+// `pk_model_id` is passed across the autodiff FFI boundary as `f64` (Enzyme
+// cannot carry the Rust enum directly), and the dispatch chains in
+// `event_driven_ad.rs` / `event_driven_ad_jac.rs` compare against literal
+// numbers. Defining the IDs as named constants here means a future
+// renumbering — or a variant rename like #176 — propagates to every dispatch
+// site through the type system rather than silently misrouting.
+
+pub const PK_ID_ONE_CPT_IV: i32 = 0;
+pub const PK_ID_ONE_CPT_ORAL: i32 = 1;
+pub const PK_ID_TWO_CPT_IV: i32 = 2;
+pub const PK_ID_TWO_CPT_ORAL: i32 = 3;
+pub const PK_ID_THREE_CPT_IV: i32 = 4;
+pub const PK_ID_THREE_CPT_ORAL: i32 = 5;
 
 pub fn pk_model_to_id(m: PkModel) -> i32 {
     match m {
-        PkModel::OneCptIv => 0,
-        PkModel::OneCptOral => 1,
-        PkModel::TwoCptIv => 2,
-        PkModel::TwoCptOral => 3,
-        PkModel::ThreeCptIv => 4,
-        PkModel::ThreeCptOral => 5,
+        PkModel::OneCptIv => PK_ID_ONE_CPT_IV,
+        PkModel::OneCptOral => PK_ID_ONE_CPT_ORAL,
+        PkModel::TwoCptIv => PK_ID_TWO_CPT_IV,
+        PkModel::TwoCptOral => PK_ID_TWO_CPT_ORAL,
+        PkModel::ThreeCptIv => PK_ID_THREE_CPT_IV,
+        PkModel::ThreeCptOral => PK_ID_THREE_CPT_ORAL,
     }
 }
 
@@ -722,6 +757,46 @@ pub fn compute_jacobian_ad(
     }
 
     jac
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::*;
+
+    /// `pk_model_to_id` and the named `PK_ID_*` constants must stay in
+    /// lockstep — every dispatch chain in `event_driven_ad.rs` and
+    /// `event_driven_ad_jac.rs` compares the AD `pk_model_id: f64`
+    /// argument against these constants. A silent renumbering (e.g.
+    /// adding a variant in the middle of the enum) would misroute
+    /// every fit under the `autodiff` feature without a compile error,
+    /// since the comparisons are on `f64` literals. This test catches
+    /// that drift.
+    #[test]
+    fn pk_model_to_id_matches_named_constants() {
+        assert_eq!(pk_model_to_id(PkModel::OneCptIv), PK_ID_ONE_CPT_IV);
+        assert_eq!(pk_model_to_id(PkModel::OneCptOral), PK_ID_ONE_CPT_ORAL);
+        assert_eq!(pk_model_to_id(PkModel::TwoCptIv), PK_ID_TWO_CPT_IV);
+        assert_eq!(pk_model_to_id(PkModel::TwoCptOral), PK_ID_TWO_CPT_ORAL);
+        assert_eq!(pk_model_to_id(PkModel::ThreeCptIv), PK_ID_THREE_CPT_IV);
+        assert_eq!(pk_model_to_id(PkModel::ThreeCptOral), PK_ID_THREE_CPT_ORAL);
+    }
+
+    /// The LTBS packing `pk_id * 10 + err_id + 100` must not collide
+    /// with the +100 LTBS-offset boundary. With six PK models (max id
+    /// 5) and three error models (max id 2), the base range is [0, 52]
+    /// and the offset-equipped range is [100, 152] — unambiguous.
+    /// Verify the bound is actually met.
+    #[test]
+    fn ltbs_packing_does_not_collide_with_offset_boundary() {
+        let max_pk = pk_model_to_id(PkModel::ThreeCptOral);
+        let max_err = error_model_to_id(ErrorModel::Combined);
+        let max_base = max_pk * 10 + max_err;
+        assert!(
+            max_base < 100,
+            "pk_model_id * 10 + error_model_id overflows the +100 LTBS offset; \
+             got {max_base} from pk={max_pk}, err={max_err}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/ad/event_driven_ad.rs
+++ b/src/ad/event_driven_ad.rs
@@ -27,6 +27,10 @@
 //!     Const branches get constant-folded by LLVM and don't poison the
 //!     reverse-mode adjoint.
 
+use crate::ad::ad_gradients::{
+    PK_ID_ONE_CPT_IV, PK_ID_ONE_CPT_ORAL, PK_ID_THREE_CPT_IV, PK_ID_THREE_CPT_ORAL,
+    PK_ID_TWO_CPT_IV, PK_ID_TWO_CPT_ORAL,
+};
 use crate::types::*;
 use std::autodiff::autodiff_reverse;
 
@@ -54,7 +58,7 @@ pub struct FlatEventData {
     pub dose_amts: Vec<f64>,
     pub dose_rates: Vec<f64>,
     pub dose_durations: Vec<f64>,
-    /// Per-dose compartment number as f64 (1-based, matches NONMEM).
+    /// Per-dose compartment number (1-based, matches NONMEM).
     /// Used by the 2-/3-cpt AD propagators to route an infusion's
     /// steady-state contribution to the correct channel (central vs
     /// periph1 vs periph2). Const through the AD macros.
@@ -72,7 +76,7 @@ impl FlatEventData {
         // (time, kind_order, orig_idx). Tie-break order at the same time:
         //   dose (0) < pk-only (1) < obs (2)
         // — see analytical `event_driven::event_driven_predictions` for
-        // the rationale. Stored kind is encoded as f64 for the AD macros:
+        // the rationale. Stored kind is encoded for the AD macros:
         //   0.0 = dose, 1.0 = obs, 2.0 = pk-only. The kind_order used for
         // sorting is computed from these.
         for (k, d) in subject.doses.iter().enumerate() {
@@ -385,7 +389,10 @@ pub fn individual_nll_event_driven_ad(
         //   IV models (1- 2- 3-cpt): central = state0
         //   Oral models (1- 2- 3-cpt): central = state1 (state0 is depot)
         // Const branch on pk_model_id constant-folds.
-        let central_amt = if pk_model_id == 1 || pk_model_id == 4 || pk_model_id == 7 {
+        let central_amt = if pk_model_id == PK_ID_ONE_CPT_ORAL
+            || pk_model_id == PK_ID_TWO_CPT_ORAL
+            || pk_model_id == PK_ID_THREE_CPT_ORAL
+        {
             state1
         } else {
             state0
@@ -488,8 +495,11 @@ fn propagate_state_ad(
     // (mirrors `pk::event_driven::propagate_with_bounds`). Oral
     // propagators take no doses internally — bolus into depot is
     // handled in the main event loop with `f_bio` applied there.
-    if pk_model_id == 0 || pk_model_id == 2 {
-        // 1-cpt IV bolus / infusion: state = [central].
+    // Per issue #176, IV bolus and infusion share one model ID (the bolus
+    // vs infusion route is picked per dose inside the propagator from
+    // RATE), so each IV branch below matches a single ID.
+    if pk_model_id == PK_ID_ONE_CPT_IV {
+        // 1-cpt IV (bolus and/or infusion): state = [central].
         let s0 = propagate_one_cpt_ad(
             state0,
             t_from,
@@ -503,12 +513,12 @@ fn propagate_state_ad(
             n_doses,
         );
         (s0, state1, state2, state3)
-    } else if pk_model_id == 1 {
+    } else if pk_model_id == PK_ID_ONE_CPT_ORAL {
         // 1-cpt oral: state = [depot, central]. No infusion support.
         let (s0, s1) = propagate_one_cpt_oral_ad(state0, state1, t_from, t_to, cl, v, ka);
         (s0, s1, state2, state3)
-    } else if pk_model_id == 3 || pk_model_id == 5 {
-        // 2-cpt IV bolus / infusion: state = [central, periph].
+    } else if pk_model_id == PK_ID_TWO_CPT_IV {
+        // 2-cpt IV (bolus and/or infusion): state = [central, periph].
         let (s0, s1) = propagate_two_cpt_ad(
             state0,
             state1,
@@ -526,13 +536,13 @@ fn propagate_state_ad(
             n_doses,
         );
         (s0, s1, state2, state3)
-    } else if pk_model_id == 4 {
+    } else if pk_model_id == PK_ID_TWO_CPT_ORAL {
         // 2-cpt oral: state = [depot, central, periph].
         let (s0, s1, s2) =
             propagate_two_cpt_oral_ad(state0, state1, state2, t_from, t_to, cl, v, q, v2, ka);
         (s0, s1, s2, state3)
-    } else if pk_model_id == 6 || pk_model_id == 8 {
-        // 3-cpt IV bolus / infusion: state = [central, periph1, periph2].
+    } else if pk_model_id == PK_ID_THREE_CPT_IV {
+        // 3-cpt IV (bolus and/or infusion): state = [central, periph1, periph2].
         let (s0, s1, s2) = propagate_three_cpt_ad(
             state0,
             state1,
@@ -553,7 +563,7 @@ fn propagate_state_ad(
             n_doses,
         );
         (s0, s1, s2, state3)
-    } else if pk_model_id == 7 {
+    } else if pk_model_id == PK_ID_THREE_CPT_ORAL {
         // 3-cpt oral: state = [depot, central, periph1, periph2].
         propagate_three_cpt_oral_ad(
             state0, state1, state2, state3, t_from, t_to, cl, v, q, v2, q3, v3, ka,

--- a/src/ad/event_driven_ad.rs
+++ b/src/ad/event_driven_ad.rs
@@ -1153,14 +1153,11 @@ pub fn supports_event_driven_ad(pk_model: PkModel) -> bool {
     // dispatch.
     matches!(
         pk_model,
-        PkModel::OneCptIvBolus
-            | PkModel::OneCptInfusion
+        PkModel::OneCptIv
             | PkModel::OneCptOral
-            | PkModel::TwoCptIvBolus
-            | PkModel::TwoCptInfusion
+            | PkModel::TwoCptIv
             | PkModel::TwoCptOral
-            | PkModel::ThreeCptIvBolus
-            | PkModel::ThreeCptInfusion
+            | PkModel::ThreeCptIv
             | PkModel::ThreeCptOral
     )
 }

--- a/src/ad/event_driven_ad_jac.rs
+++ b/src/ad/event_driven_ad_jac.rs
@@ -15,6 +15,10 @@
 //! Enzyme issue is fixed they should be merged back; until then,
 //! changes to one MUST be mirrored in the other.
 
+use crate::ad::ad_gradients::{
+    PK_ID_ONE_CPT_IV, PK_ID_ONE_CPT_ORAL, PK_ID_THREE_CPT_IV, PK_ID_THREE_CPT_ORAL,
+    PK_ID_TWO_CPT_IV, PK_ID_TWO_CPT_ORAL,
+};
 use crate::ad::event_driven_ad::{FlatEventData, FlatEventTv};
 use crate::types::*;
 use std::autodiff::autodiff_forward;
@@ -165,7 +169,13 @@ pub fn predict_all_event_driven_ad(
         };
         state0 += is_dose * is_bolus * dose_amts[dose_idx] * ev_f;
 
-        let central_amt = if pk_model_id == 1 || pk_model_id == 4 || pk_model_id == 7 {
+        // Central-compartment slot: oral models put depot in state0 and
+        // central in state1; IV models put central in state0. See the
+        // matching dispatch in `event_driven_ad.rs`.
+        let central_amt = if pk_model_id == PK_ID_ONE_CPT_ORAL
+            || pk_model_id == PK_ID_TWO_CPT_ORAL
+            || pk_model_id == PK_ID_THREE_CPT_ORAL
+        {
             state1
         } else {
             state0
@@ -228,7 +238,10 @@ fn propagate_state_jac(
     dose_cmts_f64: &[f64],
     n_doses: usize,
 ) -> (f64, f64, f64, f64) {
-    if pk_model_id == 0 || pk_model_id == 2 {
+    // ID dispatch — mirrors `event_driven_ad.rs::propagate_state_ad`. Per
+    // issue #176, IV bolus and infusion share a single ID; the route is
+    // chosen per dose inside the propagator from RATE.
+    if pk_model_id == PK_ID_ONE_CPT_IV {
         let s0 = propagate_one_cpt_jac(
             state0,
             t_from,
@@ -242,10 +255,10 @@ fn propagate_state_jac(
             n_doses,
         );
         (s0, state1, state2, state3)
-    } else if pk_model_id == 1 {
+    } else if pk_model_id == PK_ID_ONE_CPT_ORAL {
         let (s0, s1) = propagate_one_cpt_oral_jac(state0, state1, t_from, t_to, cl, v, ka);
         (s0, s1, state2, state3)
-    } else if pk_model_id == 3 || pk_model_id == 5 {
+    } else if pk_model_id == PK_ID_TWO_CPT_IV {
         let (s0, s1) = propagate_two_cpt_jac(
             state0,
             state1,
@@ -263,11 +276,11 @@ fn propagate_state_jac(
             n_doses,
         );
         (s0, s1, state2, state3)
-    } else if pk_model_id == 4 {
+    } else if pk_model_id == PK_ID_TWO_CPT_ORAL {
         let (s0, s1, s2) =
             propagate_two_cpt_oral_jac(state0, state1, state2, t_from, t_to, cl, v, q, v2, ka);
         (s0, s1, s2, state3)
-    } else if pk_model_id == 6 || pk_model_id == 8 {
+    } else if pk_model_id == PK_ID_THREE_CPT_IV {
         let (s0, s1, s2) = propagate_three_cpt_jac(
             state0,
             state1,
@@ -288,7 +301,7 @@ fn propagate_state_jac(
             n_doses,
         );
         (s0, s1, s2, state3)
-    } else if pk_model_id == 7 {
+    } else if pk_model_id == PK_ID_THREE_CPT_ORAL {
         propagate_three_cpt_oral_jac(
             state0, state1, state2, state3, t_from, t_to, cl, v, q, v2, q3, v3, ka,
         )

--- a/src/ad/event_driven_ad_jac.rs
+++ b/src/ad/event_driven_ad_jac.rs
@@ -948,7 +948,7 @@ mod tests {
         // 1-cpt IV infusion: dose split across a finite duration so the
         // propagator's per-dose `f_bio * dose_rates[d]` path runs (not the
         // main loop's bolus step).
-        let pk_model_id = pk_model_to_id(PkModel::OneCptInfusion) as f64;
+        let pk_model_id = pk_model_to_id(PkModel::OneCptIv) as f64;
         let event_times = vec![0.0_f64, 0.5, 1.0, 2.0, 4.0, 8.0];
         let event_kinds = vec![0.0_f64, 1.0, 1.0, 1.0, 1.0, 1.0];
         let event_orig = vec![0.0_f64, 0.0, 1.0, 2.0, 3.0, 4.0];

--- a/src/api.rs
+++ b/src/api.rs
@@ -2796,7 +2796,7 @@ mod iov_integration {
         };
         CompiledModel {
             name: "iov_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             // pk_param_fn: eta[0]=BSV for CL, eta[1]=KAPPA_CL (appended by IOV path)
@@ -3644,7 +3644,7 @@ mod simulate_with_uncertainty_tests {
         };
         CompiledModel {
             name: "uncertainty_smoke".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
@@ -4348,7 +4348,7 @@ mod tests_sdtab_tv_cov {
         };
         let model = CompiledModel {
             name: "tv_cov_sdtab_regression".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             // CL = TVCL · exp(η_CL) · (WT/70) — reads WT from the covariate map

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -293,7 +293,7 @@ fn generate_two_cpt_iv() {
         });
     let model = CompiledModel {
         name: "two_cpt_iv".into(),
-        pk_model: PkModel::TwoCptIvBolus,
+        pk_model: PkModel::TwoCptIv,
         error_model: ErrorModel::Proportional,
         error_spec: ferx_core::types::ErrorSpec::Single(ErrorModel::Proportional),
         pk_param_fn,

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1598,7 +1598,7 @@ mod tests {
         };
         CompiledModel {
             name: "gn_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
@@ -2499,7 +2499,7 @@ mod tests {
         };
         let model = CompiledModel {
             name: "gn_block_omega_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
@@ -2771,7 +2771,7 @@ mod tests {
         };
         CompiledModel {
             name: "iov_gn_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1455,7 +1455,7 @@ mod iov_tests {
         };
         CompiledModel {
             name: "iov_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
@@ -1566,7 +1566,7 @@ mod iov_tests {
         };
         let model = CompiledModel {
             name: "no_iov".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2484,7 +2484,7 @@ mod tests {
         };
         CompiledModel {
             name: "outer_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
@@ -2670,7 +2670,7 @@ mod tests {
         };
         let model = CompiledModel {
             name: "block_test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -748,7 +748,7 @@ mod tests {
         };
         CompiledModel {
             name: "test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|_, _, _| PkParams::default()),

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3898,15 +3898,43 @@ fn parse_structural_model(lines: &[String]) -> Result<(PkModel, HashMap<String, 
         if let Some(caps) = pk_re.captures(line) {
             let model_name = &caps[1];
             let pk_model = match model_name {
-                "one_cpt_iv_bolus" | "one_compartment_iv_bolus" => PkModel::OneCptIvBolus,
+                "one_cpt_iv" | "one_compartment_iv" => PkModel::OneCptIv,
                 "one_cpt_oral" | "one_compartment_oral" => PkModel::OneCptOral,
-                "one_cpt_infusion" | "one_compartment_infusion" => PkModel::OneCptInfusion,
-                "two_cpt_iv_bolus" | "two_compartment_iv_bolus" => PkModel::TwoCptIvBolus,
+                "two_cpt_iv" | "two_compartment_iv" => PkModel::TwoCptIv,
                 "two_cpt_oral" | "two_compartment_oral" => PkModel::TwoCptOral,
-                "two_cpt_infusion" | "two_compartment_infusion" => PkModel::TwoCptInfusion,
-                "three_cpt_iv_bolus" | "three_compartment_iv_bolus" => PkModel::ThreeCptIvBolus,
+                "three_cpt_iv" | "three_compartment_iv" => PkModel::ThreeCptIv,
                 "three_cpt_oral" | "three_compartment_oral" => PkModel::ThreeCptOral,
-                "three_cpt_infusion" | "three_compartment_infusion" => PkModel::ThreeCptInfusion,
+                // Retired names (issue #176): bolus and infusion are no longer
+                // separate model variants — the route is read per-dose from the
+                // RATE column. Emit a migration error so users update their
+                // model files explicitly rather than relying on a silent alias.
+                retired @ ("one_cpt_iv_bolus"
+                | "one_compartment_iv_bolus"
+                | "one_cpt_infusion"
+                | "one_compartment_infusion"
+                | "two_cpt_iv_bolus"
+                | "two_compartment_iv_bolus"
+                | "two_cpt_infusion"
+                | "two_compartment_infusion"
+                | "three_cpt_iv_bolus"
+                | "three_compartment_iv_bolus"
+                | "three_cpt_infusion"
+                | "three_compartment_infusion") => {
+                    let n = if retired.starts_with("one") {
+                        "one"
+                    } else if retired.starts_with("two") {
+                        "two"
+                    } else {
+                        "three"
+                    };
+                    return Err(format!(
+                        "`{retired}` was removed in #176; use `{n}_cpt_iv` instead. \
+                         Bolus and infusion administration are now driven by the \
+                         RATE column in the dataset (RATE=0 for bolus, RATE>0 for \
+                         infusion), so a single `{n}_cpt_iv` model handles either \
+                         or a mix of both within the same subject."
+                    ));
+                }
                 other => return Err(format!("Unknown PK model: {}", other)),
             };
 
@@ -7139,6 +7167,49 @@ fn parse_if_statement(
 mod tests {
     use super::*;
 
+    // Issue #176 retired the split `*_iv_bolus` / `*_infusion` model names
+    // in favour of a single `*_iv` per compartment count. The parser must
+    // reject the old names with a migration message rather than silently
+    // accept or emit a generic "unknown model" error.
+    #[test]
+    fn test_retired_iv_bolus_and_infusion_names_emit_migration_error() {
+        let retired = [
+            ("one_cpt_iv_bolus", "one"),
+            ("one_compartment_iv_bolus", "one"),
+            ("one_cpt_infusion", "one"),
+            ("two_cpt_iv_bolus", "two"),
+            ("two_compartment_infusion", "two"),
+            ("three_cpt_iv_bolus", "three"),
+            ("three_cpt_infusion", "three"),
+        ];
+        for (name, n) in retired {
+            let lines = vec![format!("pk {}(cl=CL, v=V)", name)];
+            let err = parse_structural_model(&lines)
+                .expect_err(&format!("expected retired name `{name}` to error"));
+            assert!(
+                err.contains("#176") && err.contains(&format!("{n}_cpt_iv")),
+                "missing migration hint for `{name}`: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unified_iv_names_parse_to_iv_variant() {
+        // The new spelling must compile to the unified IV variant.
+        let cases = [
+            ("one_cpt_iv", PkModel::OneCptIv),
+            ("one_compartment_iv", PkModel::OneCptIv),
+            ("two_cpt_iv", PkModel::TwoCptIv),
+            ("three_cpt_iv", PkModel::ThreeCptIv),
+        ];
+        for (name, expected) in cases {
+            let lines = vec![format!("pk {}(cl=CL, v=V, q=Q, v2=V2, q2=Q2, v3=V3)", name)];
+            let (pk_model, _) = parse_structural_model(&lines)
+                .unwrap_or_else(|e| panic!("`{name}` failed to parse: {e}"));
+            assert_eq!(pk_model, expected, "wrong variant for `{name}`");
+        }
+    }
+
     #[test]
     fn test_parse_method_single() {
         let opts = parse_fit_options(&["method = focei".to_string()]).unwrap();
@@ -7890,7 +7961,7 @@ mod tests {
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9024,7 +9095,7 @@ mod tests {
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9115,7 +9186,7 @@ mod tests {
   V  = TVV  * exp(ETA_V + KAPPA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9329,7 +9400,7 @@ if (X < 10) {
   V = TVV * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9363,7 +9434,7 @@ if (X < 10) {
   V = TVV * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9398,7 +9469,7 @@ if (X < 10) {
   V = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9496,7 +9567,7 @@ if (X < 10) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -9755,7 +9826,7 @@ if (1 > 0) {
 {}
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(EPS)
@@ -9776,7 +9847,7 @@ if (1 > 0) {
   F = inv_logit(THETA_F + ETA_F)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=1, v=1)
+  pk one_cpt_iv(cl=1, v=1)
 
 [error_model]
   DV ~ proportional(EPS)
@@ -9833,7 +9904,7 @@ if (1 > 0) {
   CL = TVCL * exp(ETA_CL + KAPPA_CL)
   V  = TVV  * exp(ETA_V)
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 [error_model]
   DV ~ proportional(EPS)
 [fit_options]
@@ -9894,7 +9965,7 @@ if (1 > 0) {
   CL = TVCL * (WT / 70)^0.75 * exp(ETA_CL)
   V  = TVV  * exp(ETA_V)
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 [error_model]
   DV ~ proportional(EPS)
 ";
@@ -9966,7 +10037,7 @@ if (1 > 0) {
   F = inv_logit(logit(THETA_F) + ETA_F)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=1, v=1)
+  pk one_cpt_iv(cl=1, v=1)
 
 [error_model]
   DV ~ proportional(EPS)
@@ -9995,7 +10066,7 @@ if (1 > 0) {
   F = inv_logit(logit(THETA_F) + ETA_F)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=1, v=1)
+  pk one_cpt_iv(cl=1, v=1)
 
 [error_model]
   DV ~ proportional(EPS)
@@ -10210,7 +10281,7 @@ if (1 > 0) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(NO_SUCH_SIGMA)
@@ -10234,7 +10305,7 @@ if (1 > 0) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   CMT=1: DV ~ proportional(PROP_ERR_PK)
@@ -10763,7 +10834,7 @@ if (1 > 0) {
   CL = TVCL * exp(ETA_CL)
   V  = TVV
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 [diffusion]
   central ~ 0.01
 [error_model]
@@ -10797,7 +10868,7 @@ if (1 > 0) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ additive(ADD)
@@ -11231,7 +11302,7 @@ if (1 > 0) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)
@@ -11713,7 +11784,7 @@ if (1 > 0) {
     #[test]
     fn test_parse_scaling_per_cmt_scalar() {
         // Use the analytical template but layer a per-CMT scaling block on
-        // top. Even though one_cpt_iv_bolus only emits CMT=1 observations,
+        // top. Even though one_cpt_iv only emits CMT=1 observations,
         // the parser doesn't validate coverage (that happens at fit time),
         // so this exercises the parse path cleanly.
         let mut src = String::from(
@@ -11729,7 +11800,7 @@ if (1 > 0) {
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -232,14 +232,11 @@ fn compute_propagation_bounds(
 pub fn supports_event_driven(pk_model: PkModel) -> bool {
     matches!(
         pk_model,
-        PkModel::OneCptIvBolus
-            | PkModel::OneCptInfusion
+        PkModel::OneCptIv
             | PkModel::OneCptOral
-            | PkModel::TwoCptIvBolus
-            | PkModel::TwoCptInfusion
+            | PkModel::TwoCptIv
             | PkModel::TwoCptOral
-            | PkModel::ThreeCptIvBolus
-            | PkModel::ThreeCptInfusion
+            | PkModel::ThreeCptIv
             | PkModel::ThreeCptOral
     )
 }
@@ -248,11 +245,11 @@ pub fn supports_event_driven(pk_model: PkModel) -> bool {
 /// pk_model. Central is where the observation read-out reads from.
 fn state_layout(pk_model: PkModel) -> (usize, usize) {
     match pk_model {
-        PkModel::OneCptIvBolus | PkModel::OneCptInfusion => (1, 0),
+        PkModel::OneCptIv => (1, 0),
         PkModel::OneCptOral => (2, 1), // [depot, central]
-        PkModel::TwoCptIvBolus | PkModel::TwoCptInfusion => (2, 0),
+        PkModel::TwoCptIv => (2, 0),
         PkModel::TwoCptOral => (3, 1), // [depot, central, periph]
-        PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion => (3, 0),
+        PkModel::ThreeCptIv => (3, 0),
         PkModel::ThreeCptOral => (4, 1), // [depot, central, periph1, periph2]
     }
 }
@@ -664,14 +661,14 @@ fn propagate_with_bounds(
             if d.rate > 0.0 && d.duration > 0.0 && t_start <= mid && t_end >= mid {
                 let r = f_bio * d.rate;
                 match (pk_model, d.cmt) {
-                    (PkModel::OneCptIvBolus | PkModel::OneCptInfusion, 1) => rate_central += r,
+                    (PkModel::OneCptIv, 1) => rate_central += r,
                     (PkModel::OneCptOral, 2) => rate_central += r,
-                    (PkModel::TwoCptIvBolus | PkModel::TwoCptInfusion, 1) => rate_central += r,
-                    (PkModel::TwoCptIvBolus | PkModel::TwoCptInfusion, 2) => rate_periph1 += r,
+                    (PkModel::TwoCptIv, 1) => rate_central += r,
+                    (PkModel::TwoCptIv, 2) => rate_periph1 += r,
                     (PkModel::TwoCptOral, 2) => rate_central += r,
-                    (PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion, 1) => rate_central += r,
-                    (PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion, 2) => rate_periph1 += r,
-                    (PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion, 3) => rate_periph2 += r,
+                    (PkModel::ThreeCptIv, 1) => rate_central += r,
+                    (PkModel::ThreeCptIv, 2) => rate_periph1 += r,
+                    (PkModel::ThreeCptIv, 3) => rate_periph2 += r,
                     (PkModel::ThreeCptOral, 2) => rate_central += r,
                     _ => panic!(
                         "event-driven PK: infusion into compartment {} not supported \
@@ -685,19 +682,19 @@ fn propagate_with_bounds(
         }
 
         match pk_model {
-            PkModel::OneCptIvBolus | PkModel::OneCptInfusion => {
+            PkModel::OneCptIv => {
                 propagate_one_cpt(state, dt, pk, rate_central);
             }
             PkModel::OneCptOral => {
                 propagate_one_cpt_oral(state, dt, pk);
             }
-            PkModel::TwoCptIvBolus | PkModel::TwoCptInfusion => {
+            PkModel::TwoCptIv => {
                 propagate_two_cpt(state, dt, pk, rate_central, rate_periph1);
             }
             PkModel::TwoCptOral => {
                 propagate_two_cpt_oral(state, dt, pk);
             }
-            PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion => {
+            PkModel::ThreeCptIv => {
                 propagate_three_cpt(state, dt, pk, rate_central, rate_periph1, rate_periph2);
             }
             PkModel::ThreeCptOral => {
@@ -1195,7 +1192,7 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         assert!(preds[0] > 0.0, "pre-reset obs should be positive");
         assert_relative_eq!(preds[1], 0.0, epsilon = 1e-12);
         assert_relative_eq!(preds[2], 0.0, epsilon = 1e-12);
@@ -1217,11 +1214,11 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
 
         let fresh = vec![DoseEvent::new(10.0, 500.0, 1, 0.0, false, 0.0)];
         for (i, &t) in obs_times.iter().enumerate() {
-            let expected = crate::pk::predict_concentration(PkModel::OneCptIvBolus, &fresh, t, &pk);
+            let expected = crate::pk::predict_concentration(PkModel::OneCptIv, &fresh, t, &pk);
             assert_relative_eq!(preds[i], expected, epsilon = 1e-10, max_relative = 1e-10);
         }
     }
@@ -1238,8 +1235,7 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::OneCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         assert!(
             preds[0] > 0.0,
             "mid-infusion pre-reset obs should be positive"
@@ -1290,10 +1286,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::TwoCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::TwoCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let fresh = vec![DoseEvent::new(20.0, 1000.0, 1, 0.0, false, 0.0)];
         for (i, &t) in obs_times.iter().enumerate() {
-            let expected = crate::pk::predict_concentration(PkModel::TwoCptIvBolus, &fresh, t, &pk);
+            let expected = crate::pk::predict_concentration(PkModel::TwoCptIv, &fresh, t, &pk);
             assert_relative_eq!(preds[i], expected, epsilon = 1e-9, max_relative = 1e-9);
         }
     }
@@ -1309,10 +1305,10 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIvBolus, &subj.doses, t, &pk))
+            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIv, &subj.doses, t, &pk))
             .collect();
         for (a, e) in preds.iter().zip(expected.iter()) {
             assert_relative_eq!(*a, *e, epsilon = 1e-10);
@@ -1332,10 +1328,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIvBolus, &subj.doses, t, &pk))
+            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-10, max_relative = 1e-10);
@@ -1354,13 +1350,10 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::OneCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| {
-                crate::pk::predict_concentration(PkModel::OneCptInfusion, &subj.doses, t, &pk)
-            })
+            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIv, &subj.doses, t, &pk))
             .collect();
         for (a, e) in preds.iter().zip(expected.iter()) {
             assert_relative_eq!(*a, *e, epsilon = 1e-9, max_relative = 1e-9);
@@ -1379,10 +1372,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::TwoCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::TwoCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| crate::pk::predict_concentration(PkModel::TwoCptIvBolus, &subj.doses, t, &pk))
+            .map(|&t| crate::pk::predict_concentration(PkModel::TwoCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-9, max_relative = 1e-9,);
@@ -1403,13 +1396,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::TwoCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::TwoCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| {
-                crate::pk::predict_concentration(PkModel::TwoCptInfusion, &subj.doses, t, &pk)
-            })
+            .map(|&t| crate::pk::predict_concentration(PkModel::TwoCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-8, max_relative = 1e-8,);
@@ -1438,7 +1428,7 @@ mod tests {
         let pk_dose = vec![pk_low];
         let pk_obs = vec![pk_low, pk_high]; // pk changes at obs2
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
 
         // [0, 1] uses pk_low (= pk at obs1):
         //   A1(1) = 1000 * exp(-0.05) ≈ 951.23
@@ -1475,7 +1465,7 @@ mod tests {
         let pk_dose = vec![pk_low, pk_high];
         let pk_obs = vec![pk_low, pk_high];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
 
         // [0, 5] uses pk_low (pk at obs1):
         //   A1(5) = 1000 * exp(-0.05*5) = 778.80, C = 7.788
@@ -1498,14 +1488,11 @@ mod tests {
     #[test]
     fn supports_event_driven_gates_supported_models_only() {
         // Now covers all analytical PK models.
-        assert!(supports_event_driven(PkModel::OneCptIvBolus));
-        assert!(supports_event_driven(PkModel::OneCptInfusion));
+        assert!(supports_event_driven(PkModel::OneCptIv));
         assert!(supports_event_driven(PkModel::OneCptOral));
-        assert!(supports_event_driven(PkModel::TwoCptIvBolus));
-        assert!(supports_event_driven(PkModel::TwoCptInfusion));
+        assert!(supports_event_driven(PkModel::TwoCptIv));
         assert!(supports_event_driven(PkModel::TwoCptOral));
-        assert!(supports_event_driven(PkModel::ThreeCptIvBolus));
-        assert!(supports_event_driven(PkModel::ThreeCptInfusion));
+        assert!(supports_event_driven(PkModel::ThreeCptIv));
         assert!(supports_event_driven(PkModel::ThreeCptOral));
     }
 
@@ -1675,18 +1662,11 @@ mod tests {
         pk.values[crate::types::PK_IDX_F] = 1.0;
         let pk_dose_unit = vec![pk; 1];
         let pk_obs_unit = vec![pk; obs_times.len()];
-        let preds_unit = event_driven_predictions(
-            PkModel::OneCptInfusion,
-            &subj,
-            &pk_dose_unit,
-            &pk_obs_unit,
-            &[],
-        );
+        let preds_unit =
+            event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose_unit, &pk_obs_unit, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| {
-                crate::pk::predict_concentration(PkModel::OneCptInfusion, &subj.doses, t, &pk)
-            })
+            .map(|&t| crate::pk::predict_concentration(PkModel::OneCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds_unit.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-9, max_relative = 1e-8);
@@ -1698,7 +1678,7 @@ mod tests {
         let pk_dose_f = vec![pk_f; 1];
         let pk_obs_f = vec![pk_f; obs_times.len()];
         let preds_f =
-            event_driven_predictions(PkModel::OneCptInfusion, &subj, &pk_dose_f, &pk_obs_f, &[]);
+            event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose_f, &pk_obs_f, &[]);
         for (a_f, a_1) in preds_f.iter().zip(preds_unit.iter()) {
             assert_relative_eq!(*a_f, 0.4 * *a_1, epsilon = 1e-9, max_relative = 1e-9);
         }
@@ -1738,13 +1718,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::ThreeCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::ThreeCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| {
-                crate::pk::predict_concentration(PkModel::ThreeCptIvBolus, &subj.doses, t, &pk)
-            })
+            .map(|&t| crate::pk::predict_concentration(PkModel::ThreeCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-9, max_relative = 1e-8);
@@ -1765,13 +1742,10 @@ mod tests {
         let pk_dose = vec![pk; subj.doses.len()];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::ThreeCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::ThreeCptIv, &subj, &pk_dose, &pk_obs, &[]);
         let expected: Vec<f64> = obs_times
             .iter()
-            .map(|&t| {
-                crate::pk::predict_concentration(PkModel::ThreeCptInfusion, &subj.doses, t, &pk)
-            })
+            .map(|&t| crate::pk::predict_concentration(PkModel::ThreeCptIv, &subj.doses, t, &pk))
             .collect();
         for (i, (a, e)) in preds.iter().zip(expected.iter()).enumerate() {
             assert_relative_eq!(*a, *e, epsilon = 1e-7, max_relative = 1e-7);
@@ -1792,8 +1766,7 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::ThreeCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::ThreeCptIv, &subj, &pk_dose, &pk_obs, &[]);
 
         for (i, &p) in preds.iter().enumerate() {
             assert!(p.is_finite(), "obs {} should be finite, got {}", i, p);
@@ -1819,8 +1792,7 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::ThreeCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::ThreeCptIv, &subj, &pk_dose, &pk_obs, &[]);
         for &p in &preds {
             assert!(p.is_finite() && p >= 0.0, "got {}", p);
         }
@@ -1874,8 +1846,7 @@ mod tests {
         let pk_obs = vec![pk_high];
         let pk_only = vec![pk_high];
 
-        let preds =
-            event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &pk_only);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &pk_only);
 
         //   A(5⁻) = 1000 * exp(-0.10*5) = 606.53   (uses pk_high — end-of-interval)
         //   A(10) = A(5⁻) * exp(-0.10*5) = 367.88
@@ -1950,7 +1921,7 @@ mod tests {
         let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
         let obs_times = vec![0.0, 1.0]; // first obs at t=0, same as dose
         let subj = make_subject(doses, obs_times);
-        let schedule = EventSchedule::for_subject(&subj, PkModel::OneCptIvBolus, &[]);
+        let schedule = EventSchedule::for_subject(&subj, PkModel::OneCptIv, &[]);
 
         assert_eq!(schedule.events.len(), 3);
         assert!(matches!(schedule.events[0].kind, EventKind::Dose));
@@ -1967,7 +1938,7 @@ mod tests {
         let doses = vec![DoseEvent::new(0.0, 1000.0, 1, 500.0, false, 2.0)];
         let obs_times = vec![10.0];
         let subj = make_subject(doses, obs_times);
-        let schedule = EventSchedule::for_subject(&subj, PkModel::OneCptInfusion, &[]);
+        let schedule = EventSchedule::for_subject(&subj, PkModel::OneCptIv, &[]);
 
         // Two events (dose at 0, obs at 10) → one interval (0, 10).
         assert_eq!(schedule.bounds_per_interval.len(), 1);
@@ -2005,11 +1976,10 @@ mod tests {
             pk_obs.push(pk_two(5.0 + 0.1 * i as f64, 50.0, 2.0, 100.0));
         }
 
-        let direct =
-            event_driven_predictions(PkModel::TwoCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
-        let schedule = EventSchedule::for_subject(&subj, PkModel::TwoCptInfusion, &[]);
+        let direct = event_driven_predictions(PkModel::TwoCptIv, &subj, &pk_dose, &pk_obs, &[]);
+        let schedule = EventSchedule::for_subject(&subj, PkModel::TwoCptIv, &[]);
         let with_sched = event_driven_predictions_with_schedule(
-            PkModel::TwoCptInfusion,
+            PkModel::TwoCptIv,
             &subj,
             &schedule,
             &pk_dose,
@@ -2043,7 +2013,7 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         for (j, &t) in obs_times.iter().enumerate() {
             let expected = one_cpt_iv_bolus_ss(&dose, t, cl, v);
             assert_relative_eq!(preds[j], expected, epsilon = 1e-9, max_relative = 1e-7);
@@ -2065,8 +2035,7 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds =
-            event_driven_predictions(PkModel::OneCptInfusion, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         for (j, &t) in obs_times.iter().enumerate() {
             let expected = one_cpt_infusion_ss(&dose, t, cl, v);
             assert_relative_eq!(preds[j], expected, epsilon = 1e-9, max_relative = 1e-7);
@@ -2130,7 +2099,7 @@ mod tests {
         let pk_dose = vec![pk; 1];
         let pk_obs = vec![pk; obs_times.len()];
 
-        let preds = event_driven_predictions(PkModel::OneCptIvBolus, &subj, &pk_dose, &pk_obs, &[]);
+        let preds = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
         for (j, &(_t, pred)) in nonmem.iter().enumerate() {
             assert_relative_eq!(preds[j], pred, max_relative = 1e-4);
         }

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -462,35 +462,48 @@ pub fn predict_concentration(
 
 /// Concentration contribution from a single dose at elapsed time tau.
 ///
+/// For IV variants the bolus-vs-infusion closed form is chosen per dose
+/// from `dose.is_infusion()` (RATE>0 ⇒ infusion). This lets a single
+/// subject mix bolus and infusion doses without changing the model
+/// declaration (issue #176). Oral routes always go through the oral
+/// closed form regardless of RATE.
+///
 /// When `dose.ss` is true and `dose.ii > 0`, the SS closed-form variant
-/// is dispatched for every analytical PK model (1-/2-/3-cpt IV bolus,
-/// oral, and infusion). The malformed SS configurations that the
-/// closed forms don't handle — `ii <= 0` and `T_inf > ii` for infusion —
-/// fall through to the single-dose formula and are flagged by the
-/// data-validation warning in `api.rs`.
+/// is dispatched. The malformed SS configurations the closed forms
+/// don't handle — `ii <= 0` and `T_inf > ii` for infusion — fall through
+/// to the single-dose formula and are flagged by the data-validation
+/// warning in `api.rs`.
 fn single_dose_concentration(pk_model: PkModel, dose: &DoseEvent, tau: f64, p: &PkParams) -> f64 {
     let cl = p.cl();
     let v = p.v();
+    let infusion = dose.is_infusion();
 
     if dose.ss && dose.ii > 0.0 {
         match pk_model {
-            PkModel::OneCptIvBolus => return one_cpt_iv_bolus_ss(dose, tau, cl, v),
-            PkModel::OneCptInfusion => return one_cpt_infusion_ss(dose, tau, cl, v),
-            PkModel::OneCptOral => return one_cpt_oral_f_ss(dose, tau, cl, v, p.ka(), p.f_bio()),
-            PkModel::TwoCptIvBolus => {
-                return two_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2());
+            PkModel::OneCptIv => {
+                return if infusion {
+                    one_cpt_infusion_ss(dose, tau, cl, v)
+                } else {
+                    one_cpt_iv_bolus_ss(dose, tau, cl, v)
+                };
             }
-            PkModel::TwoCptInfusion => {
-                return two_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2());
+            PkModel::OneCptOral => return one_cpt_oral_f_ss(dose, tau, cl, v, p.ka(), p.f_bio()),
+            PkModel::TwoCptIv => {
+                return if infusion {
+                    two_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2())
+                } else {
+                    two_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2())
+                };
             }
             PkModel::TwoCptOral => {
                 return two_cpt_oral_f_ss(dose, tau, cl, v, p.q(), p.v2(), p.ka(), p.f_bio());
             }
-            PkModel::ThreeCptIvBolus => {
-                return three_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3());
-            }
-            PkModel::ThreeCptInfusion => {
-                return three_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3());
+            PkModel::ThreeCptIv => {
+                return if infusion {
+                    three_cpt_infusion_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+                } else {
+                    three_cpt_iv_bolus_ss(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+                };
             }
             PkModel::ThreeCptOral => {
                 return three_cpt_oral_f_ss(
@@ -510,17 +523,28 @@ fn single_dose_concentration(pk_model: PkModel, dose: &DoseEvent, tau: f64, p: &
     }
 
     match pk_model {
-        PkModel::OneCptIvBolus => one_cpt_iv_bolus(dose, tau, cl, v),
-        PkModel::OneCptInfusion => one_cpt_infusion(dose, tau, cl, v),
-        PkModel::OneCptOral => one_cpt_oral_f(dose, tau, cl, v, p.ka(), p.f_bio()),
-        PkModel::TwoCptIvBolus => two_cpt_iv_bolus(dose, tau, cl, v, p.q(), p.v2()),
-        PkModel::TwoCptInfusion => two_cpt_infusion(dose, tau, cl, v, p.q(), p.v2()),
-        PkModel::TwoCptOral => two_cpt_oral_f(dose, tau, cl, v, p.q(), p.v2(), p.ka(), p.f_bio()),
-        PkModel::ThreeCptIvBolus => {
-            three_cpt_iv_bolus(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+        PkModel::OneCptIv => {
+            if infusion {
+                one_cpt_infusion(dose, tau, cl, v)
+            } else {
+                one_cpt_iv_bolus(dose, tau, cl, v)
+            }
         }
-        PkModel::ThreeCptInfusion => {
-            three_cpt_infusion(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+        PkModel::OneCptOral => one_cpt_oral_f(dose, tau, cl, v, p.ka(), p.f_bio()),
+        PkModel::TwoCptIv => {
+            if infusion {
+                two_cpt_infusion(dose, tau, cl, v, p.q(), p.v2())
+            } else {
+                two_cpt_iv_bolus(dose, tau, cl, v, p.q(), p.v2())
+            }
+        }
+        PkModel::TwoCptOral => two_cpt_oral_f(dose, tau, cl, v, p.q(), p.v2(), p.ka(), p.f_bio()),
+        PkModel::ThreeCptIv => {
+            if infusion {
+                three_cpt_infusion(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+            } else {
+                three_cpt_iv_bolus(dose, tau, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+            }
         }
         PkModel::ThreeCptOral => three_cpt_oral_f(
             dose,
@@ -749,7 +773,7 @@ mod tests {
     fn test_superposition_single_dose() {
         let doses = vec![bolus_dose(0.0, 1000.0)];
         let pk = make_pk_params(10.0, 100.0);
-        let c = predict_concentration(PkModel::OneCptIvBolus, &doses, 0.0, &pk);
+        let c = predict_concentration(PkModel::OneCptIv, &doses, 0.0, &pk);
         assert_relative_eq!(c, 10.0, epsilon = 1e-10);
     }
 
@@ -760,7 +784,7 @@ mod tests {
         let k: f64 = 10.0 / 100.0;
 
         // At t=10, first dose has decayed, second dose just given
-        let c = predict_concentration(PkModel::OneCptIvBolus, &doses, 10.0, &pk);
+        let c = predict_concentration(PkModel::OneCptIv, &doses, 10.0, &pk);
         let expected = (1000.0_f64 / 100.0) * (-k * 10.0).exp() + 1000.0 / 100.0;
         assert_relative_eq!(c, expected, epsilon = 1e-10);
     }
@@ -772,8 +796,8 @@ mod tests {
 
         // At t=5, second dose hasn't happened yet
         let c_single =
-            predict_concentration(PkModel::OneCptIvBolus, &[bolus_dose(0.0, 1000.0)], 5.0, &pk);
-        let c_two = predict_concentration(PkModel::OneCptIvBolus, &doses, 5.0, &pk);
+            predict_concentration(PkModel::OneCptIv, &[bolus_dose(0.0, 1000.0)], 5.0, &pk);
+        let c_two = predict_concentration(PkModel::OneCptIv, &doses, 5.0, &pk);
         assert_relative_eq!(c_single, c_two, epsilon = 1e-12);
     }
 
@@ -799,7 +823,7 @@ mod tests {
             dose_occasions: Vec::new(),
         };
         let pk = make_pk_params(10.0, 100.0);
-        let preds = compute_predictions(PkModel::OneCptIvBolus, &subj, &pk);
+        let preds = compute_predictions(PkModel::OneCptIv, &subj, &pk);
         assert!(preds[0] > 0.0);
         assert_relative_eq!(preds[1], 0.0, epsilon = 1e-12);
     }
@@ -839,7 +863,7 @@ mod tests {
         };
         CompiledModel {
             name: "cl_from_cr".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Additive,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Additive),
             pk_param_fn: Box::new(|theta, _eta, cov| {
@@ -956,7 +980,7 @@ mod tests {
             dose_occasions: Vec::new(),
         };
         let pk = make_pk_params(10.0, 100.0);
-        let preds = compute_predictions(PkModel::OneCptIvBolus, &subject, &pk);
+        let preds = compute_predictions(PkModel::OneCptIv, &subject, &pk);
         assert_eq!(preds.len(), 4);
         // Predictions should be monotonically decreasing for IV bolus
         for i in 1..preds.len() {
@@ -1029,15 +1053,15 @@ mod tests {
         pk.values[crate::types::PK_IDX_LAGTIME] = 0.5;
 
         // (a) Before lagged start: still zero.
-        let c_pre = predict_concentration(PkModel::OneCptInfusion, &doses, 0.6, &pk);
+        let c_pre = predict_concentration(PkModel::OneCptIv, &doses, 0.6, &pk);
         assert_eq!(c_pre, 0.0);
 
         // (b) Mid-infusion (lagged): pre-lag conc at tau = t - (dose.time + lag) = t - 2.5.
         // Compare against unlagged infusion at tau via the same formula.
         let pk_nolag = make_pk_params(10.0, 100.0);
-        let c_lag = predict_concentration(PkModel::OneCptInfusion, &doses, 2.6, &pk);
+        let c_lag = predict_concentration(PkModel::OneCptIv, &doses, 2.6, &pk);
         let c_no = predict_concentration(
-            PkModel::OneCptInfusion,
+            PkModel::OneCptIv,
             &[DoseEvent::new(0.1, 100.0, 1, 100.0, false, 0.0)],
             0.2,
             &pk_nolag,
@@ -1046,9 +1070,9 @@ mod tests {
         assert_relative_eq!(c_lag, c_no, epsilon = 1e-10);
 
         // (c) Post-infusion (lagged window ends at 3.5).
-        let c_post = predict_concentration(PkModel::OneCptInfusion, &doses, 3.6, &pk);
+        let c_post = predict_concentration(PkModel::OneCptIv, &doses, 3.6, &pk);
         let c_post_nolag = predict_concentration(
-            PkModel::OneCptInfusion,
+            PkModel::OneCptIv,
             &[DoseEvent::new(0.0, 100.0, 1, 100.0, false, 0.0)],
             1.1,
             &pk_nolag,
@@ -1067,7 +1091,7 @@ mod tests {
         let pk = make_pk_params(10.0, 100.0);
         let k = 10.0_f64 / 100.0;
         for &t in &[0.0, 3.0, 11.9, 24.0] {
-            let c = predict_concentration(PkModel::OneCptIvBolus, &doses, t, &pk);
+            let c = predict_concentration(PkModel::OneCptIv, &doses, t, &pk);
             let expected = (1000.0 / 100.0) * (-k * t).exp() / (1.0 - (-k * ii).exp());
             assert_relative_eq!(c, expected, epsilon = 1e-10);
         }
@@ -1088,9 +1112,8 @@ mod tests {
 
         // Sample several t > lagtime so both curves are defined.
         for &t in &[2.0, 5.0, 11.0, 13.5] {
-            let c_lag = predict_concentration(PkModel::OneCptIvBolus, &doses, t, &pk_lag);
-            let c_no =
-                predict_concentration(PkModel::OneCptIvBolus, &doses, t - lagtime, &pk_nolag);
+            let c_lag = predict_concentration(PkModel::OneCptIv, &doses, t, &pk_lag);
+            let c_no = predict_concentration(PkModel::OneCptIv, &doses, t - lagtime, &pk_nolag);
             assert_relative_eq!(c_lag, c_no, epsilon = 1e-12);
         }
     }
@@ -1509,5 +1532,96 @@ mod tests {
         assert_eq!(arr[0], 1000.0);
         assert!(arr[1].is_nan());
         assert_eq!(arr[2], 1000.0);
+    }
+
+    // ── Mixed bolus + infusion within a single subject (issue #176) ─────────
+    //
+    // Regression guard for the silent-wrong-answer bug on the superposition
+    // path: before #176, `single_dose_concentration` branched on the model
+    // enum (`OneCptIvBolus` vs `OneCptInfusion`), so an infusion event under
+    // an IV-bolus model was treated as an instantaneous bolus of `AMT`,
+    // ignoring the duration entirely. After #176 the dispatch picks per
+    // dose from `dose.is_infusion()`, so both routes coexist in one record.
+
+    #[test]
+    fn test_mixed_bolus_and_infusion_in_single_subject_superposition() {
+        // Same `OneCptIv` model, two doses with different administration:
+        //   t=0:  bolus     AMT=100, RATE=0
+        //   t=4:  infusion  AMT=500, RATE=50 → duration=10
+        // The superposition prediction must equal the sum of the two
+        // single-dose closed forms (one bolus, one infusion).
+        let bolus = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0);
+        let infusion = DoseEvent::new(4.0, 500.0, 1, 50.0, false, 0.0);
+        debug_assert!(!bolus.is_infusion() && infusion.is_infusion());
+        debug_assert!((infusion.duration - 10.0).abs() < 1e-12);
+        let doses = vec![bolus.clone(), infusion.clone()];
+        let pk = make_pk_params(10.0, 100.0);
+
+        // Probe times that fall in three regimes:
+        //   t = 2.0  → only the bolus has been given
+        //   t = 8.0  → both active, infusion still running
+        //   t = 20.0 → infusion has ended, post-infusion decay
+        for &t in &[2.0, 8.0, 20.0] {
+            let combined = predict_concentration(PkModel::OneCptIv, &doses, t, &pk);
+            let from_bolus = predict_concentration(PkModel::OneCptIv, &[bolus.clone()], t, &pk);
+            let from_infusion =
+                predict_concentration(PkModel::OneCptIv, &[infusion.clone()], t, &pk);
+            assert_relative_eq!(combined, from_bolus + from_infusion, epsilon = 1e-12);
+        }
+    }
+
+    #[test]
+    fn test_mixed_dose_superposition_matches_event_driven_path() {
+        // Cross-check: the analytical superposition path and the
+        // event-driven analytical path must agree to roundoff on a
+        // mixed-administration record. Before #176 the superposition path
+        // was silently wrong (bolus formula applied to the infusion dose),
+        // while the event-driven path was already correct — so these two
+        // would have disagreed materially.
+        use crate::pk::event_driven::event_driven_predictions;
+        use crate::types::Subject;
+
+        let doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0), // bolus
+            DoseEvent::new(4.0, 500.0, 1, 50.0, false, 0.0), // infusion (dur=10)
+        ];
+        let obs_times = vec![1.0_f64, 3.0, 6.0, 10.0, 14.0, 20.0];
+        let pk = make_pk_params(10.0, 100.0);
+
+        let analytical: Vec<f64> = obs_times
+            .iter()
+            .map(|&t| predict_concentration(PkModel::OneCptIv, &doses, t, &pk))
+            .collect();
+
+        let n_obs = obs_times.len();
+        let subject = Subject {
+            id: "mixed".into(),
+            doses: doses.clone(),
+            obs_times: obs_times.clone(),
+            observations: vec![0.0; n_obs],
+            obs_cmts: vec![1; n_obs],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n_obs],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+        };
+        let pk_dose: Vec<PkParams> = vec![pk.clone(); doses.len()];
+        let pk_obs: Vec<PkParams> = vec![pk.clone(); obs_times.len()];
+        let event_driven =
+            event_driven_predictions(PkModel::OneCptIv, &subject, &pk_dose, &pk_obs, &[]);
+
+        for (i, (&a, &e)) in analytical.iter().zip(event_driven.iter()).enumerate() {
+            let diff = (a - e).abs();
+            assert!(
+                diff < 1e-10,
+                "mismatch at obs[{i}] t={}: superposition {a} vs event-driven {e} (|Δ|={diff})",
+                obs_times[i]
+            );
+        }
     }
 }

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -985,7 +985,7 @@ mod tests {
     fn make_model() -> CompiledModel {
         CompiledModel {
             name: "test".into(),
-            pk_model: PkModel::OneCptIvBolus,
+            pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
             error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
             pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -379,12 +379,9 @@ fn run_nca(model: &CompiledModel, population: &Population) -> (PopNca, Vec<Strin
             .map(nca_one_cpt_oral)
             .collect(),
 
-        PkModel::OneCptIvBolus
-        | PkModel::TwoCptIvBolus
-        | PkModel::ThreeCptIvBolus
-        | PkModel::OneCptInfusion
-        | PkModel::TwoCptInfusion
-        | PkModel::ThreeCptInfusion => population.subjects.par_iter().map(nca_one_cpt_iv).collect(),
+        PkModel::OneCptIv | PkModel::TwoCptIv | PkModel::ThreeCptIv => {
+            population.subjects.par_iter().map(nca_one_cpt_iv).collect()
+        }
     };
 
     // Count how many subjects had valid CL estimates.
@@ -400,10 +397,10 @@ fn run_nca(model: &CompiledModel, population: &Population) -> (PopNca, Vec<Strin
     // For 2-cpt/3-cpt models, attempt biexponential peeling on the pooled curve.
     let mut pop = pool_nca(&per_subject);
     match model.pk_model {
-        PkModel::TwoCptIvBolus | PkModel::TwoCptInfusion | PkModel::TwoCptOral => {
+        PkModel::TwoCptIv | PkModel::TwoCptOral => {
             try_biexp_peel(model, population, &mut pop, &mut warnings);
         }
-        PkModel::ThreeCptIvBolus | PkModel::ThreeCptInfusion => {
+        PkModel::ThreeCptIv => {
             try_biexp_peel(model, population, &mut pop, &mut warnings);
             warnings.push(
                 "inits_from_nca: 3-cpt distribution parameters from biexponential peeling are unreliable; consider the nca_sweep method".into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -544,18 +544,23 @@ impl ModelParameters {
     }
 }
 
-/// Supported PK structural models
+/// Supported PK structural models.
+///
+/// IV (bolus and/or infusion) administration is represented by a single
+/// variant per compartment count; the bolus-vs-infusion choice is made
+/// per dose event from the dataset's RATE column (see
+/// `DoseEvent::is_infusion`). This mirrors NONMEM, nlmixr2, and Monolix
+/// and lets a subject mix bolus and infusion doses in one record.
+/// Oral routes remain a separate variant because they have a distinct
+/// model structure (absorption rate constant KA, bioavailability F).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PkModel {
-    OneCptIvBolus,
+    OneCptIv,
     OneCptOral,
-    OneCptInfusion,
-    TwoCptIvBolus,
+    TwoCptIv,
     TwoCptOral,
-    TwoCptInfusion,
-    ThreeCptIvBolus,
+    ThreeCptIv,
     ThreeCptOral,
-    ThreeCptInfusion,
 }
 
 /// Supported residual error models

--- a/tests/saem_omega_burnin.rs
+++ b/tests/saem_omega_burnin.rs
@@ -43,7 +43,7 @@ const MODEL: &str = r#"
   V  = TVV  * exp(ETA_V)
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)

--- a/tests/scaling_block.rs
+++ b/tests/scaling_block.rs
@@ -53,7 +53,7 @@ const ANALYTICAL_BASE: &str = "\
   V  = TVV
 
 [structural_model]
-  pk one_cpt_iv_bolus(cl=CL, v=V)
+  pk one_cpt_iv(cl=CL, v=V)
 
 [error_model]
   DV ~ proportional(PROP_ERR)


### PR DESCRIPTION
## Why

Closes #176.

Before this PR, model files had to declare administration up front (`pk one_cpt_iv_bolus(...)` vs `pk one_cpt_infusion(...)`). A subject with both bolus and infusion records under a single declaration was **silently mis-evaluated on the superposition path**: the infusion dose was treated as an instantaneous bolus of `AMT`, ignoring duration. This mirrored neither NONMEM, nlmixr2, nor Monolix, where the administration type is read per event from the `RATE` column.

## What changed

* Collapse the nine `PkModel` variants to six: `{One,Two,Three}Cpt{Iv,Oral}`. There is no longer a separate bolus or infusion variant — every IV model selects the closed form per dose from `DoseEvent::is_infusion()` (`RATE>0 ⇒ infusion`).
* Rewrite `single_dose_concentration()` in `src/pk/mod.rs` to dispatch per dose in both the single-dose and SS branches.
* The event-driven analytical path already did this (it treated `OneCptIvBolus | OneCptInfusion` identically); the match arms there are now mechanically collapsed to the unified variant.
* The AD `single_dose_ad` dispatch table is collapsed from 9 ids to 6. The unified IV body reuses the existing infusion closed form, which falls through to bolus when `dur <= 0` — same numerics as before for either pure case.
* The parser rejects the 12 retired names (`one_cpt_iv_bolus`, `one_cpt_infusion`, …, plus their `*_compartment_*` long forms) with a migration error pointing at the unified `*_iv` name. **No silent aliases** per the design decision.

## Alternatives considered

Keeping the old names as silent aliases — rejected because future readers of the codebase and users skimming examples would be confused by two spellings doing the same thing. A clean-break parse-time error with the migration hint is the smallest forcing function that gets users onto one set of names.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet opened | after — any embedded `.ferx` templates / R helpers that emit model names need the rename |

This PR is **not blocked by** ferx-r; the R package's Rust glue picks up ferx-core changes automatically via the local `[patch]` in its `src/rust/.cargo/config.toml`. The ferx-r follow-up is the migration of any user-facing R templates.

## Breaking changes

- [x] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed
- [x] Public Rust API (`api.rs` / `types.rs`) — `PkModel` enum variants renamed; downstream Rust callers must update
- [ ] None

<details>
<summary>Migration notes</summary>

In any `.ferx` file:

| Before | After |
|--------|-------|
| `pk one_cpt_iv_bolus(...)` | `pk one_cpt_iv(...)` |
| `pk one_cpt_infusion(...)` | `pk one_cpt_iv(...)` |
| `pk two_cpt_iv_bolus(...)` | `pk two_cpt_iv(...)` |
| `pk two_cpt_infusion(...)` | `pk two_cpt_iv(...)` |
| `pk three_cpt_iv_bolus(...)` | `pk three_cpt_iv(...)` |
| `pk three_cpt_infusion(...)` | `pk three_cpt_iv(...)` |

The same applies to the `*_compartment_*` long-form aliases. The parser emits an error pointing at the unified name on any retired spelling.

In Rust code calling `ferx_core`:

| Before | After |
|--------|-------|
| `PkModel::OneCptIvBolus` / `PkModel::OneCptInfusion` | `PkModel::OneCptIv` |
| `PkModel::TwoCptIvBolus` / `PkModel::TwoCptInfusion` | `PkModel::TwoCptIv` |
| `PkModel::ThreeCptIvBolus` / `PkModel::ThreeCptInfusion` | `PkModel::ThreeCptIv` |

</details>

## Numerical validation

- [x] All bundled example fits unchanged. Smoke runs on the renamed examples:

```
# examples/one_cpt_iv.ferx (was iv_bolus; data unchanged)
OFV: -387.0717   TVCL = 4.915952   TVV = 52.056423

# examples/one_cpt_infusion.ferx (model line now `pk one_cpt_iv(...)`; data unchanged)
OFV: -660.5913   TVCL = 5.142030   TVV = 51.595989
```

Both match the pre-PR numbers (the unified IV body reuses the infusion math, which falls through to bolus when `dur <= 0` — i.e., it's the same closed form per case).

- [x] **Mixed bolus + infusion**: a new dedicated regression test
  (`test_mixed_dose_superposition_matches_event_driven_path`) checks
  that on a subject with both a bolus and an infusion dose, the
  superposition path and the event-driven analytical path agree to
  1e-10. They would have disagreed **materially** before this PR
  (the superposition path silently dropped the infusion duration).
- [ ] NONMEM cross-check for mixed bolus+infusion in one record: not run because there is no out-of-the-box NONMEM run in this repo using a mixed-administration design; the engine-internal cross-check between the analytical and event-driven paths (both validated against NONMEM separately) substitutes for now. Happy to add a hand-built warfarin-style mixed-record NM run if a reviewer wants one — flag it.

## Performance

- [x] No significant impact expected. The dispatch is a per-dose branch on `dose.is_infusion()` (a single float comparison) replacing what used to be a per-model branch; the analytical math is identical to the previous bolus or infusion path. Event-driven path is unchanged.

## Tests

- [x] **Regression test added** — three new unit tests in `src/pk/mod.rs` and `src/parser/model_parser.rs`:
  - `test_mixed_bolus_and_infusion_in_single_subject_superposition` — fails on `main` (silent wrong answer)
  - `test_mixed_dose_superposition_matches_event_driven_path` — fails on `main` (paths disagree)
  - `test_retired_iv_bolus_and_infusion_names_emit_migration_error` + `test_unified_iv_names_parse_to_iv_variant` — guard the parser migration
- [x] All 811 lib + integration tests green under `cargo test --tests --no-default-features --features ci --release`.

## Example (user-facing features only)

- [x] Existing `examples/*.ferx` updated to the unified syntax. `examples/one_cpt_infusion.ferx` keeps its filename (it's a *dataset* example for infusion administration) but now declares `pk one_cpt_iv(...)` — demonstrating that the same model handles infusion records when `RATE>0`.

## Docs

- [x] `docs/src/model-file/structural-model.md`, `docs/src/data-format.md`, `docs/src/api/parsing.md`, `docs/src/examples/two-cpt-iv.md`, `docs/src/model-file/README.md`, `README.md` all updated. The structural-model table is collapsed and the per-dose RATE semantics are called out.

## Checklist

- [x] `cargo +nightly fmt --check` clean
- [x] `cargo check --tests --no-default-features --features ci` clean
- [x] `cargo test --tests --no-default-features --features ci --release` — 811 passed, 0 failed
- [ ] `cargo check --features autodiff` — AD codegen ICEs locally on the worktree's enzyme toolchain (pre-existing); needs CI to validate the full AD path

## Reviewer hints

- The substantive logic change is `single_dose_concentration` in `src/pk/mod.rs` (the SS branch and the single-dose branch both now switch on `dose.is_infusion()` per IV variant). Worth a careful read.
- The AD-side change in `src/ad/ad_gradients.rs` is a numbering collapse (9 ids → 6) plus body unification; each IV body now reuses what used to be the `*Infusion` math. The infusion closed form is exactly the bolus form when `dur <= 0`, so per-case numerics are unchanged.
- Everywhere else (~13 files) the changes are mechanical match-arm collapse from `OneCptIvBolus | OneCptInfusion` patterns to `OneCptIv`.

## Open questions

- Do we want a dedicated NONMEM cross-check for a mixed bolus+infusion record committed alongside this PR (analogous to the SS-lagtime cross-check in `src/pk/mod.rs:test_ss_oral_with_lagtime_matches_nonmem`)? The internal analytical-vs-event-driven check covers the math but doesn't anchor against an independent reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)