### PR TITLE
feat(types,api,io): add input_columns to Population and FitResult

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -180,6 +180,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         subjects,
         covariate_names: vec![],
         dv_column: "dv".into(),
+        input_columns: vec![],
     };
 
     // Simulate
@@ -1729,6 +1730,7 @@ fn fit_inner(
             .to_string()
         }),
         covariate_names: population.covariate_names.clone(),
+        input_columns: population.input_columns.clone(),
         #[cfg(feature = "nn")]
         neural_networks: build_neural_network_infos(model),
     };
@@ -2884,6 +2886,7 @@ mod iov_integration {
             subjects,
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 
@@ -3714,6 +3717,7 @@ mod simulate_with_uncertainty_tests {
             subjects,
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 
@@ -3819,6 +3823,7 @@ mod simulate_with_uncertainty_tests {
             outer_gtol: 0.0,
             inits_from_nca: None,
             covariate_names: Vec::new(),
+            input_columns: vec![],
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
         }
@@ -4039,6 +4044,7 @@ mod sde_integration {
             subjects,
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 
@@ -4162,6 +4168,7 @@ mod sde_integration {
                 subjects: vec![subj],
                 covariate_names: Vec::new(),
                 dv_column: "DV".into(),
+                input_columns: vec![],
             }
         };
 
@@ -4442,6 +4449,7 @@ mod tests_sdtab_tv_cov {
             subjects: vec![subject.clone()],
             covariate_names: vec!["WT".into()],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         // Fixed EBE at η = 0; H matrix is irrelevant for the IPRED check but

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -113,6 +113,7 @@ fn simulate_subjects(
         subjects: subjects.clone(),
         covariate_names: vec![],
         dv_column: "dv".into(),
+        input_columns: vec![],
     };
 
     let sim = simulate_with_seed(model, &pop, params, 1, seed);
@@ -505,6 +506,7 @@ fn generate_two_cpt_oral_cov() {
         subjects,
         covariate_names: vec!["wt".into(), "crcl".into()],
         dv_column: "dv".into(),
+        input_columns: vec![],
     };
     let sim = simulate_with_seed(&model, &pop, &params, 1, 456);
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1667,6 +1667,7 @@ mod tests {
             subjects,
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 
@@ -2839,6 +2840,7 @@ mod tests {
             subjects: vec![subject],
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1411,6 +1411,7 @@ mod iov_tests {
             subjects: vec![make_iov_subject()],
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
         // `requested` is the user's FitOptions value, passed independently of
         // model.gradient_method (which compatibility rules may have mutated).

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2560,6 +2560,7 @@ mod tests {
             subjects,
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
+            input_columns: vec![],
         }
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2179,6 +2179,7 @@ mod tests {
             subjects: vec![subj],
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let flag = CancelFlag::new();
@@ -2275,6 +2276,7 @@ mod tests {
             ],
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let theta = vec![1.5f64, 20.0]; // CL, V
@@ -2426,6 +2428,7 @@ mod tests {
             subjects: vec![make_subj("1", 1.0), make_subj("2", 1.1)],
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let theta = vec![1.0f64, 10.0, 0.5];

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -422,6 +422,7 @@ mod tests {
             outer_gtol: 0.0,
             inits_from_nca: None,
             covariate_names: Vec::new(),
+            input_columns: vec![],
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
         }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -691,4 +691,22 @@ mod tests {
         // Obs 2 (t=3, CR missing) → LOCF → 2.0.
         assert_eq!(subj.obs_covariates[2]["CR"], 2.0);
     }
+
+    #[test]
+    fn test_input_columns_preserves_full_header_order() {
+        // input_columns must carry every column in original order and case,
+        // including standard columns (ID, TIME, DV, …) that are excluded from
+        // covariate_names, and IOV columns.
+        let csv = "ID,TIME,DV,EVID,AMT,OCC,WT\n\
+                   1,0,.,1,100,1,70\n\
+                   1,1,5.0,0,.,1,70\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv(f.path(), None, Some("OCC")).unwrap();
+        assert_eq!(
+            pop.input_columns,
+            vec!["ID", "TIME", "DV", "EVID", "AMT", "OCC", "WT"]
+        );
+        // Standard and IOV columns must not appear in covariate_names.
+        assert_eq!(pop.covariate_names, vec!["WT"]);
+    }
 }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -141,6 +141,7 @@ pub fn read_nonmem_csv(
         subjects,
         covariate_names: cov_names,
         dv_column: "dv".to_string(),
+        input_columns: headers,
     })
 }
 

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -271,6 +271,8 @@ struct FitWire {
     inits_from_nca: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     covariate_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    input_columns: Vec<String>,
     /// `[covariate_nn]` block metadata. Absent (None) on bundles produced
     /// before this field existed or when ferx-core was built without
     /// `--features nn`. Loaders gracefully default to an empty Vec.
@@ -759,6 +761,7 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
         outer_gtol: r.outer_gtol,
         inits_from_nca: r.inits_from_nca.clone(),
         covariate_names: r.covariate_names.clone(),
+        input_columns: r.input_columns.clone(),
         #[cfg(feature = "nn")]
         neural_networks: if r.neural_networks.is_empty() {
             None
@@ -1602,6 +1605,7 @@ fn wire_to_fit_result(
         outer_gtol: w.outer_gtol,
         inits_from_nca: w.inits_from_nca,
         covariate_names: w.covariate_names,
+        input_columns: w.input_columns,
         #[cfg(feature = "nn")]
         neural_networks: w.neural_networks.unwrap_or_default(),
     })
@@ -1682,6 +1686,7 @@ mod tests {
             subjects,
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         }
     }
 
@@ -1799,6 +1804,7 @@ mod tests {
             outer_gtol: 1e-4,
             inits_from_nca: None,
             covariate_names: vec!["WT".into(), "AGE".into()],
+            input_columns: vec![],
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
         }

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -2177,4 +2177,22 @@ mod tests {
             vec!["WT".to_string(), "AGE".to_string()]
         );
     }
+
+    #[test]
+    fn input_columns_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ic-roundtrip.fitrx");
+        let mut r = minimal_fit_result();
+        r.input_columns = vec![
+            "ID".into(),
+            "TIME".into(),
+            "DV".into(),
+            "AMT".into(),
+            "WT".into(),
+        ];
+        let p = dummy_population(&["S1", "S2"], 3);
+        save_fit(&r, &p, "src\n", &path, SaveFitOptions::default()).unwrap();
+        let loaded = load_fit(&path).unwrap();
+        assert_eq!(loaded.fit.input_columns, r.input_columns);
+    }
 }

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1104,6 +1104,7 @@ mod tests {
             outer_gtol: 0.0,
             inits_from_nca: None,
             covariate_names: Vec::new(),
+            input_columns: vec![],
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
         }
@@ -1423,6 +1424,7 @@ mod tests {
             outer_gtol: 0.0,
             inits_from_nca: None,
             covariate_names: Vec::new(),
+            input_columns: vec![],
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
         }
@@ -1446,6 +1448,7 @@ mod tests {
             ],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1472,6 +1475,7 @@ mod tests {
             subjects: vec![sdtab_subject("1", 2, vec![1, 2])],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1491,6 +1495,7 @@ mod tests {
             subjects: vec![sdtab_subject("1", 2, vec![1, 1])],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1520,6 +1525,7 @@ mod tests {
             ],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
 
         let cols = sdtab(&result, &population);

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -805,6 +805,7 @@ mod tests {
             subjects: vec![],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
         let result = inits_from_nca(&model, &empty_pop, NcaInit::Nca);
         // Must not panic and should warn.

--- a/src/suggest_start/sweep.rs
+++ b/src/suggest_start/sweep.rs
@@ -381,6 +381,7 @@ mod tests {
             subjects: vec![],
             covariate_names: vec![],
             dv_column: "DV".into(),
+            input_columns: vec![],
         };
         let r = rrmse(&model, &empty_pop, &model.default_params);
         assert!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -279,6 +279,10 @@ pub struct Population {
     pub subjects: Vec<Subject>,
     pub covariate_names: Vec<String>,
     pub dv_column: String,
+    /// All column headers from the data CSV in original order (ID, TIME, DV, AMT, ...,
+    /// covariates). Preserved verbatim so downstream consumers can echo a NONMEM-style
+    /// `$INPUT` line. Empty for in-memory `Population` values that were not read from a file.
+    pub input_columns: Vec<String>,
 }
 
 impl Population {
@@ -1789,6 +1793,9 @@ pub struct FitResult {
     /// requiring the caller to re-read the CSV.  Empty for in-memory `fit()`
     /// calls that never touch a file.
     pub covariate_names: Vec<String>,
+    /// All column headers from the data CSV in original order (ID, TIME, DV, AMT, ...,
+    /// covariates), analogous to NONMEM `$INPUT`. Empty for in-memory `fit()` calls.
+    pub input_columns: Vec<String>,
     /// One entry per `[covariate_nn NAME]` block in the model, populated by
     /// `fit()` from `CompiledModel.covariate_nns`. Empty when the `nn`
     /// feature is off or no block is declared. Output writers

--- a/tests/multi_endpoint.rs
+++ b/tests/multi_endpoint.rs
@@ -62,6 +62,7 @@ fn pkpd_pop() -> Population {
     Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
+        input_columns: vec![],
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],

--- a/tests/saem_omega_burnin.rs
+++ b/tests/saem_omega_burnin.rs
@@ -83,6 +83,7 @@ fn sparse_population(n: usize) -> Population {
         subjects,
         covariate_names: vec![],
         dv_column: "dv".into(),
+        input_columns: vec![],
     }
 }
 

--- a/tests/scaling_block.rs
+++ b/tests/scaling_block.rs
@@ -22,6 +22,7 @@ fn one_subject_pop() -> Population {
     Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
+        input_columns: vec![],
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
@@ -259,6 +260,7 @@ fn two_cmt_pop() -> Population {
     Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
+        input_columns: vec![],
         subjects: vec![mk_subject("1"), mk_subject("2")],
     }
 }

--- a/tests/suggest_start.rs
+++ b/tests/suggest_start.rs
@@ -118,6 +118,7 @@ fn test_suggest_start_empty_population() {
         subjects: vec![],
         covariate_names: vec![],
         dv_column: "DV".into(),
+        input_columns: vec![],
     };
     let result = inits_from_nca(&model, &empty, NcaInit::Nca);
     assert!(!result.warnings.is_empty(), "must warn on empty population");


### PR DESCRIPTION
## Why

`FitResult` only carried `covariate_names` (the non-standard columns). There was no way for `ferx_runlog()` — or any downstream consumer — to echo a NONMEM-style `$INPUT` line showing the complete dataset column list without re-reading the CSV.

## What changed

- `Population` and `FitResult` each gain `pub input_columns: Vec<String>`: the full ordered list of CSV header names as they appear in the file (ID, TIME, DV, AMT, CMT, EVID, RATE, MDV, any covariates, …).
- `datareader.rs`: populates `input_columns` from `headers` (already available; zero extra parsing).
- `api.rs`: copies `population.input_columns` into `FitResult` on the production fit path.
- `io/fitrx.rs`: wire struct gains `#[serde(default)] input_columns: Vec<String>` so older `.fitrx` bundles deserialise cleanly (field defaults to empty vec).
- All other `Population` / `FitResult` construction sites (test helpers, simulate path, etc.) get `input_columns: vec![]`.

## Alternatives considered

Could reconstruct the column list on the R side, but that only recovers the covariates — we'd never know which optional standard columns (RATE, MDV, II, SS, CENS) were actually in the file.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#TBD | open | after |

## Breaking changes

- [x] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [x] Public Rust API (`api.rs` / `types.rs`)

Adding a field to `FitResult` and `Population` is additive; existing callers that construct these in tests needed `input_columns: vec![]` added, which this PR does.

## Numerical validation

- [x] Not applicable (docs / refactor / CI only)

No estimation code changed. `input_columns` is metadata copied from the CSV reader, not used in any computation.

## Performance

- [x] No significant impact expected

`headers` is already allocated in `datareader.rs`; we clone it once.

## Tests

- [x] No new tests needed — the fitrx roundtrip test (`covariate_names_roundtrip`) exercises the same serde path; `input_columns` follows the same pattern and is covered by the existing `#[serde(default)]` contract.

## Example (user-facing features only)

- [x] Not applicable (internal / refactor / fix with no new API surface)

The surface is in ferx-r (`ferx_runlog()`); see the ferx-r PR.

## Docs

- [x] No user-visible change at this layer (the runlog output is in ferx-r)

## Checklist

- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo check --features autodiff` still compiles — no AD-reachable code touched
- [x] `Cargo.toml` version not bumped (additive field, no breakage for existing callers)

## Reviewer hints

The bulk of the diff is mechanical: every `Population { ..., dv_column: ..., }` literal gains an `input_columns: vec![],` line, and every `FitResult { ..., covariate_names: ..., }` literal gains the same. The substantive lines are in `types.rs` (two field declarations), `datareader.rs` (one assignment), `api.rs` line 1733 (the production wire-up), and `fitrx.rs` (wire struct field + two roundtrip assignments).