### PR TITLE
docs(install): note the R package auto-runs the AD toolchain self-test

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -136,6 +136,8 @@ rustc +enzyme -Zautodiff=Enable -Clto=fat -Copt-level=2 /tmp/ad_check.rs -o /tmp
 
 Expected: the compile finishes **in a few seconds** and prints `autodiff OK: f=22.3355, df/dx=43.1711`. If `rustc` instead **hangs** (pins a core at 100% CPU and never returns), your toolchain has the LLVM/Enzyme mismatch described in the warning at the top — rebuild from source with `--set llvm.download-ci-llvm=false`.
 
+> **The ferx R package runs this check for you.** Installing [ferx-r](https://github.com/FeRx-NLME/ferx-r) on the autodiff path runs the same compile-and-run self-test automatically (under a timeout) before the long fat-LTO build, and aborts with a pointer back here if the toolchain hangs — so a broken toolchain fails fast instead of wedging `rustc`. You only need to run the check above by hand when setting the toolchain up outside the R package (e.g. for the `ferx` CLI). Set `FERX_AD_PREFLIGHT_SKIP=1` to skip it once verified.
+
 ### Make the toolchain permanent
 
 The clone lives in `/tmp/rust-src`, and `rustup toolchain link enzyme build/host/stage1` points the `enzyme` toolchain *into* that tree. macOS periodically purges `/tmp`, which would silently break the toolchain. Relocate the stage-1 build (~640 MB once pruned) to a permanent path and re-link:


### PR DESCRIPTION
## Why

The matching ferx-r PR (FeRx-NLME/ferx-r#119, closing FeRx-NLME/ferx-r#111) makes the package's autodiff build run the same compile-and-run autodiff self-test automatically — under a timeout, before the long fat-LTO link — and abort with a pointer back to this page if the toolchain hangs in `llvm::Constant::getNullValue`. The install docs should tell readers that, so R-package users don't think they must run step 4 by hand, while CLI / from-source users still know they do.

## What changed

One note added to `docs/src/installation.md` step 4 (Verify the toolchain): the ferx R package runs this self-test for you on install; the manual check is only needed when setting up the toolchain outside the package (e.g. for the `ferx` CLI); and `FERX_AD_PREFLIGHT_SKIP=1` bypasses it once verified. Docs-only — no code, no behaviour change.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#119 | open | before / together — the doc describes behaviour added there |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs only)

## Tests
- [x] Not applicable (docs only) — prose renders in mdBook; no new SUMMARY.md entry needed (edit to an existing page)

## Reviewer hints

Single paragraph added after the step-4 "Expected:" line. Check the wording matches the ferx-r behaviour: auto-run on the autodiff install path, timeout-guarded, aborts with a redirect here, `FERX_AD_PREFLIGHT_SKIP=1` to bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)