### PR TITLE
feat(parser,api,io): add [derived] and [output] blocks for post-fit column computation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,8 @@
   - [Stochastic Differential Equations](model-file/diffusion.md)
   - [Neural Networks (DCM / NODE)](model-file/neural-networks.md)
     - [Covariate NN (DCM)](model-file/covariate-nn.md)
+  - [Derived Columns](model-file/derived.md)
+  - [Output Columns](model-file/output.md)
   - [Fit Options](model-file/fit-options.md)
   - [Simulation](model-file/simulation.md)
 - [Estimation Methods](estimation/README.md)

--- a/docs/src/file-formats/check-report.md
+++ b/docs/src/file-formats/check-report.md
@@ -73,6 +73,8 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `E_OUTPUT_UNKNOWN_COLUMN` | error | A name in `[output]` is not recognised as a covariate, individual parameter, or derived expression. |
 | `W_OUTPUT_DUPLICATE` | warning | A name in `[output]` is already written to sdtab automatically (e.g. `TAFD`, `TAD`, an eta name). |
 | `W_ADDL_MISSING_II` | warning | ADDL > 0 on a dose row but II is zero or missing; additional doses were not expanded. |
+| `W_IOV_OCC_MISSING` | warning | Some rows in the IOV occasion column had missing or unparseable values; those rows were assigned occasion=0. |
+| `E_IOV_MISSING_OCC` | error | Model declares kappa (IOV) parameters but no occasion labels were found in the dataset. Set `iov_column` in `[fit_options]`. |
 
 Codes are stable; new ones may be added over time. Treat an unrecognised code
 as a generic finding of its given `severity`.

--- a/docs/src/file-formats/check-report.md
+++ b/docs/src/file-formats/check-report.md
@@ -67,6 +67,12 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `W_STEADY_STATE_INFUSION` | warning | SS=1 infusion with `T_inf > II` (overlapping pulses; SS skipped). |
 | `W_SDE_RESET` | warning | EVID=3/4 resets under an SDE `[diffusion]` model are not honoured. |
 | `W_NEGATIVE_LAGTIME` | warning | Lag time is negative at the initial typical-value point. |
+| `E_DERIVED_NAME_CONFLICT` | error | A `[derived]` name clashes with a built-in sdtab column, theta, eta, or individual-parameter name. |
+| `W_DERIVED_COVARIATE_SHADOW` | warning | A `[derived]` name shadows a covariate (allowed but may be confusing). |
+| `W_DERIVED_STEP_IGNORED` | warning | `step=` given for a DV-based integral (ignored; DV integrals always use observation times). |
+| `E_OUTPUT_UNKNOWN_COLUMN` | error | A name in `[output]` is not recognised as a covariate, individual parameter, or derived expression. |
+| `W_OUTPUT_DUPLICATE` | warning | A name in `[output]` is already written to sdtab automatically (e.g. `TAFD`, `TAD`, an eta name). |
+| `W_ADDL_MISSING_II` | warning | ADDL > 0 on a dose row but II is zero or missing; additional doses were not expanded. |
 
 Codes are stable; new ones may be added over time. Treat an unrecognised code
 as a generic finding of its given `severity`.

--- a/docs/src/model-file/derived.md
+++ b/docs/src/model-file/derived.md
@@ -34,7 +34,7 @@ where `name` becomes a new sdtab column and `expression` is evaluated for every 
 
 ## Operators and functions
 
-Standard arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`<`, `>`, `<=`, `>=`, `==`, `!=`), and logical (`&&`, `||`, `!`) operators are supported, as well as:
+Standard arithmetic (`+`, `-`, `*`, `/`), comparison (`<`, `>`, `<=`, `>=`, `==`, `!=`), and logical (`&&`, `||`, `!`) operators are supported. Use the `mod` keyword for modulo (`a mod b`). As well as:
 
 | Function | Description |
 |----------|-------------|
@@ -43,7 +43,7 @@ Standard arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`<`, `>`, `<=`, `>=`,
 | `sqrt(x)` | Square root |
 | `abs(x)` | Absolute value |
 | `floor(x)` / `ceil(x)` / `round(x)` | Rounding |
-| `pow(x, y)` | Power |
+| `x ^ y` | Power (use `^`, not a function call) |
 | `max(expr)` | Subject-level maximum of `expr` over all observations |
 | `min(expr)` | Subject-level minimum |
 | `tmax(expr)` | Time at which `expr` is maximised |
@@ -71,10 +71,12 @@ Cmax = max(IPRED)
 Tmax = tmax(IPRED)
 ```
 
-A filter can be applied with `if condition`:
+A filter can be applied as the second argument inside the parentheses:
 
 ```
-CmaxAfter12 = max(IPRED) if TIME > 12
+CmaxAfter12 = max(IPRED, TIME > 12)
+Ctrough      = min(IPRED, TAD < 1e-10)
+CmaxD14      = max(IPRED, TAFD >= 312 && TAFD < 336)
 ```
 
 The filter uses the same expression language. If no observation passes the filter the result is `NaN`.
@@ -91,6 +93,12 @@ AUC24 = integral(IPRED, from=0, to=24)
 AUC24_obs = integral(DV, from=0, to=24)
 AUC24_grid = integral(IPRED, from=0, to=24, step=0.5)
 ```
+
+> **Limitation — obs-based time-above-threshold:** When using `integral(1.0, IPRED > threshold, ...)` without a `step=` argument, only observation time points are evaluated. If the design has sparse sampling, the trapezoidal rule can miss brief periods above threshold between observations. Use `step=` (e.g. `step=0.1`) to force grid evaluation at the cost of approximating IPRED via nearest-neighbour interpolation:
+>
+> ```
+> TAM_TAU = integral(1.0, IPRED > MEC, window=24, anchor=0, step=0.1)
+> ```
 
 ## Naming rules
 

--- a/docs/src/model-file/derived.md
+++ b/docs/src/model-file/derived.md
@@ -1,0 +1,112 @@
+# Derived Columns (`[derived]`)
+
+The optional `[derived]` block defines extra columns that are computed after the fit and appended to the sdtab output. Each line has the form:
+
+```
+name = expression
+```
+
+where `name` becomes a new sdtab column and `expression` is evaluated for every observation row.
+
+## Quick example
+
+```
+[derived]
+  CLi  = CL                          # individual CL echoed directly
+  AUC  = integral(IPRED, from=0, to=24)   # AUC 0-24 from predicted curve
+  Cmax = max(IPRED)                   # subject-level maximum prediction
+  Tmax = tmax(IPRED)                  # time of maximum
+```
+
+## Available variables
+
+| Name | Meaning |
+|------|---------|
+| Individual-parameter names (`CL`, `V`, …) | EBE-derived value for the subject |
+| Theta names (`TVCL`, `TVV`, …) | Final population estimate |
+| Eta names (`ETA_CL`, …) | Subject EBE |
+| Covariate names (`WT`, `AGE`, …) | Subject covariate |
+| `IPRED` | Individual prediction at the row's time point |
+| `DV` | Observed value |
+| `TAFD` | Time after first dose |
+| `TAD` | Time after most recent dose |
+| `TIME` | Nominal time |
+
+## Operators and functions
+
+Standard arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`<`, `>`, `<=`, `>=`, `==`, `!=`), and logical (`&&`, `||`, `!`) operators are supported, as well as:
+
+| Function | Description |
+|----------|-------------|
+| `exp(x)` | Exponential |
+| `log(x)` | Natural logarithm |
+| `sqrt(x)` | Square root |
+| `abs(x)` | Absolute value |
+| `floor(x)` / `ceil(x)` / `round(x)` | Rounding |
+| `pow(x, y)` | Power |
+| `max(expr)` | Subject-level maximum of `expr` over all observations |
+| `min(expr)` | Subject-level minimum |
+| `tmax(expr)` | Time at which `expr` is maximised |
+| `integral(expr, from=t0, to=t1)` | AUC from `t0` to `t1` using the trapezoidal rule |
+| `integral(expr, from=t0, to=t1, step=dt)` | Grid-based integral with step `dt` (IPRED-based only; ignored for DV) |
+
+The constant `MACHEPS` (machine epsilon, ≈ 2.22 × 10⁻¹⁶) is also available.
+
+## Computation kinds
+
+### Per-row (`PerRow`)
+
+The default: the expression is evaluated independently at each observation time point and written to the corresponding sdtab row.
+
+```
+CLi = CL        # same value every row for a subject; still PerRow
+```
+
+### Aggregate (`Aggregate`)
+
+Using `max(expr)`, `min(expr)`, or `tmax(expr)` produces a single value per subject that is broadcast to all of that subject's rows.
+
+```
+Cmax = max(IPRED)
+Tmax = tmax(IPRED)
+```
+
+A filter can be applied with `if condition`:
+
+```
+CmaxAfter12 = max(IPRED) if TIME > 12
+```
+
+The filter uses the same expression language. If no observation passes the filter the result is `NaN`.
+
+### Integral (`Integral`)
+
+`integral(expr, from=t0, to=t1)` computes the trapezoidal area under `expr` over the half-open interval `[t0, t1]`.
+
+- When `expr` references `DV`, the observed values at the matching observation times are used.
+- When `expr` references `IPRED`, values are evaluated at the observation times within the window. A `step=dt` keyword argument causes the integrand to be evaluated on a uniform grid of spacing `dt` using nearest-neighbour IPRED approximation; the `step=` argument is silently ignored for DV-based integrals (warning `W_DERIVED_STEP_IGNORED`).
+
+```
+AUC24 = integral(IPRED, from=0, to=24)
+AUC24_obs = integral(DV, from=0, to=24)
+AUC24_grid = integral(IPRED, from=0, to=24, step=0.5)
+```
+
+## Naming rules
+
+A `[derived]` name must **not** clash with:
+
+- Built-in sdtab columns: `ID`, `TIME`, `DV`, `IPRED`, `CWRES`, `IWRES`, `ETA1`, `ETA2`, …, `TAFD`, `TAD`
+- Any theta, eta, or individual-parameter name in the model
+
+Shadowing a **covariate** name is permitted (the covariate column is replaced) but will emit a `W_DERIVED_COVARIATE_SHADOW` warning.
+
+## Referencing earlier derived columns
+
+A derived expression may reference the name of any **preceding** derived column defined in the same `[derived]` block (sequential scoping). Forward references are not allowed.
+
+```
+[derived]
+  CLi  = CL
+  VDSS = CLi / 0.693    # ok — CLi defined on the line above
+```

--- a/docs/src/model-file/output.md
+++ b/docs/src/model-file/output.md
@@ -1,0 +1,37 @@
+# Output Columns (`[output]`)
+
+The optional `[output]` block lists additional columns to include in the sdtab beyond the mandatory minimum. Each entry is a bare name, one or more per line (whitespace or newlines between names).
+
+```
+[output]
+  WT AGE SEX
+  CLi
+```
+
+## What can be listed
+
+| Category | Example names | Notes |
+|----------|--------------|-------|
+| Covariates | `WT`, `AGE`, `SEX` | Written as-is from the data |
+| Individual parameters | `CL`, `V` | EBE-derived per-subject value |
+| Derived column names | `AUC`, `Cmax` | Defined in the `[derived]` block |
+| Eta names | `ETA_CL`, `ETA_V` | Already in the mandatory minimum; emits `W_OUTPUT_DUPLICATE` |
+
+### Mandatory minimum (always present)
+
+The following columns are always written to sdtab regardless of `[output]`:
+
+`ID`, `TIME`, `DV`, `IPRED`, `CWRES`, `IWRES`, `TAFD`, `TAD`
+
+Listing any of these in `[output]` is harmless but will emit `W_OUTPUT_DUPLICATE`.
+
+## Diagnostics
+
+| Code | Severity | Cause |
+|------|----------|-------|
+| `E_OUTPUT_UNKNOWN_COLUMN` | error | A name is not a covariate, individual parameter, or derived expression |
+| `W_OUTPUT_DUPLICATE` | warning | A name is already in the mandatory minimum |
+
+## Interaction with `[derived]`
+
+A name defined in `[derived]` is automatically available in `[output]` without needing to be listed again — it is written to sdtab as soon as it appears in `[derived]`. Use `[output]` for covariates and individual parameters that are not computed by `[derived]`.

--- a/docs/src/model-file/output.md
+++ b/docs/src/model-file/output.md
@@ -21,7 +21,7 @@ The optional `[output]` block lists additional columns to include in the sdtab b
 
 The following columns are always written to sdtab regardless of `[output]`:
 
-`ID`, `TIME`, `DV`, `IPRED`, `CWRES`, `IWRES`, `TAFD`, `TAD`
+`ID`, `TIME`, `DV`, `CENS`, `OCC`, `CMT`, `PRED`, `IPRED`, `CWRES`, `IWRES`, `EBE_OFV`, `N_OBS`, `TAFD`, `TAD`
 
 Listing any of these in `[output]` is harmless but will emit `W_OUTPUT_DUPLICATE`.
 

--- a/examples/two_cpt_oral_derived.ferx
+++ b/examples/two_cpt_oral_derived.ferx
@@ -1,0 +1,52 @@
+# Two-compartment oral PK with [derived] and [output].
+#
+# Demonstrates micro-rate constants, long-interval AUC, and periodic AUC.
+
+[parameters]
+  theta TVCL(5.0,  0.1,  50.0)
+  theta TVV1(30.0, 3.0, 300.0)
+  theta TVQ( 2.0,  0.1,  20.0)
+  theta TVV2(50.0, 5.0, 500.0)
+  theta TVKA(1.0,  0.05, 20.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[structural_model]
+  pk two_cpt_oral(cl=CL, v=V1, q=Q, v2=V2, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  maxiter    = 500
+  covariance = true
+
+[derived]
+  # Micro-rate constants
+  K10 = CL / V1
+  K12 = Q  / V1
+  K21 = Q  / V2
+
+  # Subject-level exposure metrics
+  Cmax = max(IPRED)
+  Tmax = tmax(IPRED)
+
+  # AUC over 168 h (7 days) from the predicted curve
+  AUC_0_168 = integral(IPRED, from=0, to=168, step=0.2)
+
+  # Periodic AUC per 24-h dosing window
+  AUC_TAU = integral(IPRED, window=24, anchor=0, step=0.2)
+
+[output]
+  CL V1 Q V2 KA

--- a/examples/warfarin_addl.ferx
+++ b/examples/warfarin_addl.ferx
@@ -1,0 +1,57 @@
+# Warfarin one-compartment oral PK — ADDL dosing design.
+#
+# The dataset uses a single EVID=1 row per subject with ADDL=6, II=24,
+# representing a loading dose plus 6 additional daily doses (7 total).
+# After ADDL expansion, subject.doses contains 7 explicit DoseEvents so
+# TAFD and TAD are computed correctly for each observation.
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = foce
+  maxiter    = 300
+  covariance = true
+
+[derived]
+  KE     = CL / V
+  T_HALF = 0.6931472 / KE
+
+  # Dosing day (tau = 24 h); TAFD anchors to the first dose time
+  DAY = floor(TAFD / 24) + 1
+
+  # Subject-level Cmax across all observations
+  Cmax = max(IPRED)
+
+  # Steady-state trough: minimum IPRED at dose time (TAD resets to ≈ 0 after
+  # ADDL expansion). Use 1e-10 to absorb floating-point residuals from modular
+  # arithmetic (mathematically TAD = 0 but may be ~1e-14 numerically).
+  Cmin_tau = min(IPRED, TAD < 1e-10)
+
+  # Late-interval trough: minimum IPRED in the last 4 h of each interval
+  Cmin_late = min(IPRED, TAD > 20)
+
+  # Periodic AUC per 24-h dosing interval
+  AUC_TAU = integral(IPRED, window=24, anchor=0, step=0.1)
+
+[output]
+  CL V KA

--- a/examples/warfarin_derived.ferx
+++ b/examples/warfarin_derived.ferx
@@ -47,8 +47,8 @@
   Cmax = max(IPRED)
   Tmax = tmax(IPRED)
 
-  # Trough: minimum IPRED after the first 12 hours
-  Ctrough = min(IPRED) if TIME > 12
+  # Trough: minimum IPRED after the first 12 hours (filter is the second arg)
+  Ctrough = min(IPRED, TIME > 12)
 
 [output]
   WT

--- a/examples/warfarin_derived.ferx
+++ b/examples/warfarin_derived.ferx
@@ -1,0 +1,54 @@
+# One-compartment oral PK model (warfarin) with [derived] and [output]
+#
+# Demonstrates post-fit column computation:
+#   - individual exposure metrics (AUC, Cmax, Tmax) via [derived]
+#   - echo of covariates and individual parameters via [output]
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = foce
+  maxiter    = 300
+  covariance = true
+
+[derived]
+  # Individual PK parameters (echoed for convenience)
+  CLi  = CL
+  Vi   = V
+  KAi  = KA
+
+  # Clearance adjusted for body weight (requires WT covariate in data)
+  CL_kg = CL / WT
+
+  # Exposure: AUC over the first 120 hours from the predicted curve
+  AUC120 = integral(IPRED, from=0, to=120)
+
+  # Peak concentration and time of peak from predictions
+  Cmax = max(IPRED)
+  Tmax = tmax(IPRED)
+
+  # Trough: minimum IPRED after the first 12 hours
+  Ctrough = min(IPRED) if TIME > 12
+
+[output]
+  WT

--- a/examples/warfarin_derived_pkpd.ferx
+++ b/examples/warfarin_derived_pkpd.ferx
@@ -1,0 +1,68 @@
+# Warfarin one-compartment oral PK with PD effect and time-above-MEC derived quantities.
+#
+# Demonstrates:
+#   - Emax PD model inline in [derived]
+#   - Integral with condition (time above MEC per dosing window)
+#   - Periodic integral (AUC per 24-h interval)
+#   - Multi-condition filter using && operator
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta MEC(0.5, 0.01, 5.0)
+  theta EMAX(80.0, 10.0, 100.0)
+  theta EC50(3.0, 0.1, 20.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = foce
+  maxiter    = 300
+  covariance = true
+
+[derived]
+  # Basic PK metrics
+  KE     = CL / V
+  T_HALF = 0.6931472 / KE
+
+  # Emax PD effect at each observation time point
+  EFF = EMAX * IPRED / (EC50 + IPRED)
+
+  # Cmax within the current dosing interval (TAD < 24 h)
+  CMAX_INTERVAL = max(IPRED, TAD < 24)
+
+  # Steady-state trough: minimum IPRED near dose time (TAD ≈ 0 after ADDL expansion)
+  # 1e-10 absorbs floating-point residuals when TAD is mathematically zero
+  CMIN_TAU = min(IPRED, TAD < 1e-10)
+
+  # Day-1 Cmax vs steady-state (day 14, tau = 24 h → TAFD window [312, 336))
+  CMAX_D1  = max(IPRED, TAFD < 24)
+  CMAX_D14 = max(IPRED, TAFD >= 312 && TAFD < 336)
+
+  # Time above MEC per dose interval (hours): integral of 1 where IPRED > MEC
+  TAM_TAU = integral(1.0, IPRED > MEC, window=24, anchor=0, step=0.1)
+
+  # Time above MEC on day 1 only
+  TAM_D1 = integral(1.0, IPRED > MEC, from=0, to=24, step=0.1)
+
+  # Periodic AUC per dosing interval
+  AUC_TAU = integral(IPRED, window=24, anchor=0, step=0.1)
+
+[output]
+  WT

--- a/examples/warfarin_ode_time.ferx
+++ b/examples/warfarin_ode_time.ferx
@@ -1,0 +1,61 @@
+# Warfarin ODE model demonstrating TIME, T, TAFD, and TAD in [odes].
+#
+# TIME (alias T) is the current ODE solver time.
+# TAFD is solver time minus the first dose time.
+# TAD is solver time minus the most recent effective dose time (SS-aware).
+# All four are injected into the ODE RHS at each solver step.
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  ode(obs_cmt=2)
+
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) =  KA * depot - CL / V * central
+
+  # Accumulate day-1 AUC using an inline if-expression.
+  # Syntax: if (condition) then_expr else else_expr
+  d/dt(AUC_D1) = if (TIME < 24) central / V else 0.0
+
+  # Accumulate time above 0.5 mg/L within the current dosing interval.
+  # TAD resets at each dose so this gives a per-interval running total.
+  d/dt(TAM_INT) = if (central / V > 0.5 && TAD < 24) 1.0 else 0.0
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = foce
+  maxiter    = 300
+  covariance = true
+
+[derived]
+  KE     = CL / V
+  T_HALF = 0.6931472 / KE
+
+  Cmax   = max(IPRED)
+  Cmin   = min(IPRED, TAD < 1e-10)
+
+  # AUC from the predicted curve (does not use the ODE accumulator)
+  AUC_72 = integral(IPRED, from=0, to=72, step=0.2)
+
+[output]
+  CL V KA

--- a/examples/warfarin_ode_time.ferx
+++ b/examples/warfarin_ode_time.ferx
@@ -22,7 +22,7 @@
   KA = TVKA * exp(ETA_KA)
 
 [structural_model]
-  ode(obs_cmt=2)
+  ode(obs_cmt=central, states=[depot, central, AUC_D1, TAM_INT])
 
 [odes]
   d/dt(depot)   = -KA * depot

--- a/src/api.rs
+++ b/src/api.rs
@@ -182,6 +182,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        warnings: vec![],
     };
 
     // Simulate
@@ -659,6 +660,10 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
     for w in &parsed.model.parse_warnings {
         let code = if w.contains("declared in [parameters] but not referenced") {
             "W_UNUSED_PARAM"
+        } else if w.contains("W_DERIVED_COVARIATE_SHADOW") {
+            "W_DERIVED_COVARIATE_SHADOW"
+        } else if w.contains("W_DERIVED_STEP_IGNORED") {
+            "W_DERIVED_STEP_IGNORED"
         } else {
             "W_PARSE"
         };
@@ -1127,7 +1132,7 @@ fn build_indiv_map(pk: &PkParams, names: &[String], pk_indices: &[usize]) -> Has
 /// Trapezoid integration over (time, value) pairs in the slice.
 fn trapezoid(points: &[(f64, f64)]) -> f64 {
     if points.len() < 2 {
-        return 0.0;
+        return f64::NAN;
     }
     let mut auc = 0.0;
     for w in points.windows(2) {
@@ -1176,6 +1181,10 @@ pub(crate) fn compute_extra_output_columns(
             per_obs_tad.push(tad_j);
         }
 
+        // Store per-obs TAD (with individual lagtime) so output.rs can use it
+        // for the mandatory TAD column without re-evaluating PK parameters.
+        sr.per_obs_tad = per_obs_tad.clone();
+
         // [output] columns: covariates + indiv params not already in derived
         for col_name in &model.output_columns {
             if derived_names
@@ -1212,13 +1221,21 @@ pub(crate) fn compute_extra_output_columns(
             sr.extra_columns.push((col_name.clone(), col_vals));
         }
 
-        // [derived] columns, evaluated in declaration order
-        let mut prev_derived: HashMap<String, f64> = HashMap::new();
+        // [derived] columns, evaluated in declaration order.
+        // prev_derived_vecs stores the full per-row vector for each column evaluated
+        // so far. For Aggregate/Integral (same scalar every row), all elements are
+        // identical. This allows sequential references (`B = f(A)`) to see the
+        // correct per-row value at index j, not just the last row's value.
+        let mut prev_derived_vecs: HashMap<String, Vec<f64>> = HashMap::new();
 
         for spec in &model.derived_exprs {
             let col_vals: Vec<f64> = match &spec.kind {
                 DerivedKind::PerRow { eval } => (0..n_obs)
                     .map(|j| {
+                        let row_prev: HashMap<String, f64> = prev_derived_vecs
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v[j]))
+                            .collect();
                         let ctx = DerivedContext {
                             theta,
                             eta: eta_hat,
@@ -1230,7 +1247,7 @@ pub(crate) fn compute_extra_output_columns(
                             time: subject.obs_times[j],
                             tafd: per_obs_tafd[j],
                             tad: per_obs_tad[j],
-                            prev_derived: &prev_derived,
+                            prev_derived: &row_prev,
                         };
                         eval(&ctx)
                     })
@@ -1243,6 +1260,10 @@ pub(crate) fn compute_extra_output_columns(
                 } => {
                     let mut qualifying: Vec<(usize, f64)> = Vec::new();
                     for j in 0..n_obs {
+                        let row_prev: HashMap<String, f64> = prev_derived_vecs
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v[j]))
+                            .collect();
                         let ctx = DerivedContext {
                             theta,
                             eta: eta_hat,
@@ -1254,7 +1275,7 @@ pub(crate) fn compute_extra_output_columns(
                             time: subject.obs_times[j],
                             tafd: per_obs_tafd[j],
                             tad: per_obs_tad[j],
-                            prev_derived: &prev_derived,
+                            prev_derived: &row_prev,
                         };
                         let include = filter.as_ref().map_or(true, |f| f(&ctx));
                         if include {
@@ -1304,6 +1325,10 @@ pub(crate) fn compute_extra_output_columns(
                                 if t < from - 1e-12 || t > to + 1e-12 {
                                     return None;
                                 }
+                                let row_prev: HashMap<String, f64> = prev_derived_vecs
+                                    .iter()
+                                    .map(|(k, v)| (k.clone(), v[j]))
+                                    .collect();
                                 let ctx = DerivedContext {
                                     theta,
                                     eta: eta_hat,
@@ -1315,7 +1340,7 @@ pub(crate) fn compute_extra_output_columns(
                                     time: t,
                                     tafd: per_obs_tafd[j],
                                     tad: per_obs_tad[j],
-                                    prev_derived: &prev_derived,
+                                    prev_derived: &row_prev,
                                 };
                                 if condition.as_ref().map_or(false, |f| !f(&ctx)) {
                                     return None;
@@ -1329,6 +1354,12 @@ pub(crate) fn compute_extra_output_columns(
                     // For model-based integrals with a fine grid, use ipred at a
                     // representative cov snapshot (first obs) across a uniform grid.
                     // This is an approximation: cov is time-constant at j=0 values.
+                    // For prior derived columns, use first-observation values for
+                    // consistency with cov_0 / indiv_0.
+                    let grid_prev: HashMap<String, f64> = prev_derived_vecs
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.first().copied().unwrap_or(f64::NAN)))
+                        .collect();
                     let eval_integral_grid = |from: f64, to: f64| -> f64 {
                         let n_steps = match step {
                             IntegralStep::Fixed(s) => {
@@ -1378,7 +1409,7 @@ pub(crate) fn compute_extra_output_columns(
                                     time: t,
                                     tafd: tafd_k,
                                     tad: f64::NAN, // simplified
-                                    prev_derived: &prev_derived,
+                                    prev_derived: &grid_prev,
                                 };
                                 if condition.as_ref().map_or(false, |f| !f(&ctx)) {
                                     return None;
@@ -1420,10 +1451,9 @@ pub(crate) fn compute_extra_output_columns(
                 }
             };
 
-            // Store last value for sequential derived references
-            if let Some(&last) = col_vals.last() {
-                prev_derived.insert(spec.name.clone(), last);
-            }
+            // Store full per-row vector so subsequent derived columns can
+            // look up the correct value at each observation row index j.
+            prev_derived_vecs.insert(spec.name.clone(), col_vals.clone());
             sr.extra_columns.push((spec.name.clone(), col_vals));
         }
     }
@@ -1590,6 +1620,9 @@ fn fit_inner(
     let mut result: Option<crate::estimation::outer_optimizer::OuterResult> = None;
     let mut accumulated_warnings: Vec<String> = model.parse_warnings.clone();
     accumulated_warnings.extend(unsupported_warnings);
+    // Data-reader warnings (W_ADDL_MISSING_II, W_IOV_OCC_MISSING) accumulated
+    // by read_nonmem_csv into population.warnings.
+    accumulated_warnings.extend(population.warnings.iter().cloned());
 
     // Emit NLopt / covariance warnings before any work starts.
     accumulated_warnings.extend(nlopt_missing.iter().cloned());
@@ -1831,8 +1864,9 @@ fn fit_inner(
         options.interaction,
     );
 
-    // Post-fit: compute [derived] and [output] columns into extra_columns.
-    if !model.derived_exprs.is_empty() || !model.output_columns.is_empty() {
+    // Post-fit: compute [derived] and [output] columns, and populate per_obs_tad
+    // (with individual lagtime) for the mandatory TAD column in output.rs.
+    if !model.derived_exprs.is_empty() || !model.output_columns.is_empty() || model.has_lagtime() {
         compute_extra_output_columns(model, population, &result.params.theta, &mut subjects);
     }
 
@@ -2443,6 +2477,7 @@ fn compute_subject_results(
                 cens: subject.cens.clone(),
                 n_obs: subject.observations.len(),
                 extra_columns: vec![],
+                per_obs_tad: vec![],
             }
         })
         .collect()
@@ -2628,6 +2663,7 @@ mod tests {
             cens: vec![0; n],
             n_obs: n,
             extra_columns: vec![],
+            per_obs_tad: vec![],
         }
     }
 
@@ -3312,6 +3348,7 @@ mod iov_integration {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 
@@ -4145,6 +4182,7 @@ mod simulate_with_uncertainty_tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 
@@ -4472,6 +4510,7 @@ mod sde_integration {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 
@@ -4596,6 +4635,7 @@ mod sde_integration {
                 covariate_names: Vec::new(),
                 dv_column: "DV".into(),
                 input_columns: vec![],
+                warnings: vec![],
             }
         };
 
@@ -4879,6 +4919,7 @@ mod tests_sdtab_tv_cov {
             covariate_names: vec!["WT".into()],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         // Fixed EBE at η = 0; H matrix is irrelevant for the IPRED check but

--- a/src/api.rs
+++ b/src/api.rs
@@ -1222,8 +1222,14 @@ pub(crate) fn compute_extra_output_columns(
             }
             let mut col_vals = Vec::with_capacity(n_obs);
             for j in 0..n_obs {
+                // Resolve covariates and individual parameters case-insensitively:
+                // validate_output_columns accepts the [output] name regardless of
+                // case, so the echo must match a header like `WT` against a
+                // declared `wt` rather than silently producing NaN.
                 let v = per_obs_cov[j]
-                    .get(col_name.as_str())
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case(col_name))
+                    .map(|(_, v)| v)
                     .or_else(|| {
                         per_obs_indiv[j]
                             .iter()

--- a/src/api.rs
+++ b/src/api.rs
@@ -681,6 +681,18 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
         let iov_col = parsed.fit_options.iov_column.as_deref();
         match read_nonmem_csv(Path::new(path), None, iov_col) {
             Ok(population) => {
+                // Surface datareader warnings (ADDL missing II, IOV OCC missing)
+                // into the check report so `ferx check` sees the same findings as `fit()`.
+                for w in &population.warnings {
+                    let code = if w.starts_with("W_ADDL_MISSING_II") {
+                        "W_ADDL_MISSING_II"
+                    } else if w.starts_with("W_IOV_OCC_MISSING") {
+                        "W_IOV_OCC_MISSING"
+                    } else {
+                        "W_DATA"
+                    };
+                    diags.push(Diagnostic::warning(code, w.clone()));
+                }
                 diags.extend(check_model_data(&parsed.model, &population));
                 let init_params = parsed.model.default_params.clone();
                 diags.extend(check_model_data_warnings(
@@ -1354,12 +1366,13 @@ pub(crate) fn compute_extra_output_columns(
                     // For model-based integrals with a fine grid, use ipred at a
                     // representative cov snapshot (first obs) across a uniform grid.
                     // This is an approximation: cov is time-constant at j=0 values.
-                    // For prior derived columns, use first-observation values for
-                    // consistency with cov_0 / indiv_0.
-                    let grid_prev: HashMap<String, f64> = prev_derived_vecs
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.first().copied().unwrap_or(f64::NAN)))
-                        .collect();
+                    // For prior derived columns, use LOCF (last observation before or at t)
+                    // so time-varying columns reflect their most recent value at each grid step.
+                    let grid_cov_0 = per_obs_cov.first().copied().unwrap_or(&subject.covariates);
+                    let grid_lagtime = {
+                        let pk_0 = (model.pk_param_fn)(theta, eta_hat, grid_cov_0);
+                        pk_0.lagtime()
+                    };
                     let eval_integral_grid = |from: f64, to: f64| -> f64 {
                         let n_steps = match step {
                             IntegralStep::Fixed(s) => {
@@ -1369,7 +1382,6 @@ pub(crate) fn compute_extra_output_columns(
                             _ => 501, // Auto: 500 intervals
                         };
                         let dt = (to - from) / (n_steps - 1) as f64;
-                        let cov_0 = per_obs_cov.first().copied().unwrap_or(&subject.covariates);
                         let indiv_0 = per_obs_indiv.first().cloned().unwrap_or_default();
                         let pts: Vec<(f64, f64)> = (0..n_steps)
                             .filter_map(|k| {
@@ -1383,6 +1395,26 @@ pub(crate) fn compute_extra_output_columns(
                                         .map(|d| d.time)
                                         .fold(f64::INFINITY, f64::min);
                                     t - fd
+                                };
+                                let tad_k = {
+                                    let last_dose_eff = subject
+                                        .doses
+                                        .iter()
+                                        .filter(|d| d.time + grid_lagtime <= t + 1e-12)
+                                        .map(|d| {
+                                            if d.ss && d.ii > 0.0 {
+                                                let elapsed = t - (d.time + grid_lagtime);
+                                                t - elapsed.rem_euclid(d.ii)
+                                            } else {
+                                                d.time + grid_lagtime
+                                            }
+                                        })
+                                        .fold(f64::NEG_INFINITY, f64::max);
+                                    if last_dose_eff.is_finite() {
+                                        t - last_dose_eff
+                                    } else {
+                                        f64::NAN
+                                    }
                                 };
                                 // For grid-based, IPRED is evaluated at observation-time snapshots
                                 // by approximating with the nearest observation's IPRED.
@@ -1398,18 +1430,35 @@ pub(crate) fn compute_extra_output_columns(
                                     })
                                     .map(|(_, &ip)| ip)
                                     .unwrap_or(f64::NAN);
+                                // LOCF for prev_derived: use the value from the last observation
+                                // at or before t. Falls back to the first obs if t precedes all.
+                                let grid_prev_t: HashMap<String, f64> = prev_derived_vecs
+                                    .iter()
+                                    .map(|(name, vals)| {
+                                        let val = subject
+                                            .obs_times
+                                            .iter()
+                                            .zip(vals.iter())
+                                            .filter(|(&obs_t, _)| obs_t <= t + 1e-12)
+                                            .last()
+                                            .map(|(_, &v)| v)
+                                            .or_else(|| vals.first().copied())
+                                            .unwrap_or(f64::NAN);
+                                        (name.clone(), val)
+                                    })
+                                    .collect();
                                 let ctx = DerivedContext {
                                     theta,
                                     eta: eta_hat,
                                     indiv_params: &indiv_0,
-                                    covariates: cov_0,
+                                    covariates: grid_cov_0,
                                     ipred: nearest_ipred,
                                     pred: nearest_ipred,
                                     dv: f64::NAN, // not available on grid
                                     time: t,
                                     tafd: tafd_k,
-                                    tad: f64::NAN, // simplified
-                                    prev_derived: &grid_prev,
+                                    tad: tad_k,
+                                    prev_derived: &grid_prev_t,
                                 };
                                 if condition.as_ref().map_or(false, |f| !f(&ctx)) {
                                     return None;
@@ -3019,6 +3068,10 @@ fn extract_standard_errors(
 }
 
 /// Simulate observations from a model with given parameters (random seed).
+///
+/// Data-reader warnings (e.g. missing II for ADDL doses) are not echoed here;
+/// callers that obtained `population` via [`read_nonmem_csv`] should inspect
+/// `population.warnings` before calling this function.
 pub fn simulate(
     model: &CompiledModel,
     population: &Population,
@@ -3188,6 +3241,10 @@ pub struct SimulationResult {
 }
 
 /// Predict concentrations for a population using given parameters (no random effects).
+///
+/// Data-reader warnings (e.g. missing II for ADDL doses) are not echoed here;
+/// callers that obtained `population` via [`read_nonmem_csv`] should inspect
+/// `population.warnings` before calling this function.
 pub fn predict(
     model: &CompiledModel,
     population: &Population,

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ use crate::stats::likelihood::{compute_cwres, foce_subject_nll, foce_subject_nll
 use crate::stats::residual_error::{compute_iwres, iwres_autocorrelation};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
+use std::collections::HashMap;
 
 /// Build the `FitResult.neural_networks` summary from the compiled model's
 /// `[covariate_nn]` blocks. Empty when no NN blocks are present, so output
@@ -345,6 +346,7 @@ pub fn check_model_data(model: &CompiledModel, population: &Population) -> Vec<D
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
     diags.extend(check_iov_occasions(model, population));
+    diags.extend(validate_output_columns(model, population));
     diags
 }
 
@@ -1013,6 +1015,420 @@ fn probe_nlopt_algorithms() -> Vec<String> {
     }
 }
 
+// ── Step 7: [output] validation and TAFD/TAD helpers ────────────────────────
+
+/// Mandatory sdtab column names that are always written — declaring them in
+/// [output] is allowed but produces a W_OUTPUT_DUPLICATE warning.
+const OUTPUT_MANDATORY: &[&str] = &[
+    "ID", "TIME", "DV", "CENS", "OCC", "CMT", "PRED", "IPRED", "CWRES", "IWRES", "EBE_OFV",
+    "N_OBS", "TAFD", "TAD",
+];
+
+/// Validate `model.output_columns` against known quantities, emitting
+/// `W_OUTPUT_DUPLICATE` and `E_OUTPUT_UNKNOWN_COLUMN` diagnostics.
+pub fn validate_output_columns(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    let derived_names: Vec<&str> = model
+        .derived_exprs
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
+    let cov_names = &population.covariate_names;
+
+    for col in &model.output_columns {
+        // Already in mandatory minimum?
+        if OUTPUT_MANDATORY.iter().any(|m| m.eq_ignore_ascii_case(col))
+            || model.eta_names.iter().any(|e| e.eq_ignore_ascii_case(col))
+        {
+            diags.push(Diagnostic::warning(
+                "W_OUTPUT_DUPLICATE",
+                format!(
+                    "[output] column `{col}` is already written to sdtab automatically; \
+                     the declaration is ignored"
+                ),
+            ));
+            continue;
+        }
+        // Valid if it's a covariate, indiv param, or derived name
+        let known = cov_names.iter().any(|c| c.eq_ignore_ascii_case(col))
+            || model
+                .indiv_param_names
+                .iter()
+                .any(|p| p.eq_ignore_ascii_case(col))
+            || derived_names.iter().any(|d| d.eq_ignore_ascii_case(col));
+        if !known {
+            let mut candidates: Vec<&str> = cov_names.iter().map(|s| s.as_str()).collect();
+            candidates.extend(model.indiv_param_names.iter().map(|s| s.as_str()));
+            candidates.extend(derived_names.iter().copied());
+            candidates.extend(OUTPUT_MANDATORY.iter().copied());
+            diags.push(Diagnostic::error(
+                "E_OUTPUT_UNKNOWN_COLUMN",
+                format!(
+                    "[output] column `{col}` is not recognised as a covariate, individual \
+                     parameter, or derived expression. Known: {}",
+                    candidates.join(", ")
+                ),
+            ));
+        }
+    }
+    diags
+}
+
+/// Compute TAFD (time after first dose) and TAD (time after last dose,
+/// SS-aware) for observation index `obs_idx` of `subject`.
+pub(crate) fn tafd_tad_for_subject(subject: &Subject, obs_idx: usize, lagtime: f64) -> (f64, f64) {
+    let obs_time = subject.obs_times[obs_idx];
+
+    let first_dose_time = subject
+        .doses
+        .iter()
+        .map(|d| d.time)
+        .fold(f64::INFINITY, f64::min);
+    let tafd = if first_dose_time.is_finite() {
+        obs_time - first_dose_time
+    } else {
+        f64::NAN
+    };
+
+    let last_dose_eff = subject
+        .doses
+        .iter()
+        .filter(|d| d.time + lagtime <= obs_time + 1e-12)
+        .map(|d| {
+            if d.ss && d.ii > 0.0 {
+                let elapsed = obs_time - (d.time + lagtime);
+                obs_time - elapsed.rem_euclid(d.ii)
+            } else {
+                d.time + lagtime
+            }
+        })
+        .fold(f64::NEG_INFINITY, f64::max);
+    let tad = if last_dose_eff.is_finite() {
+        obs_time - last_dose_eff
+    } else {
+        f64::NAN
+    };
+
+    (tafd, tad)
+}
+
+// ── Step 8: post-fit extra column computation ────────────────────────────────
+
+/// Build a per-observation HashMap mapping `model.indiv_param_names` to their
+/// values from `pk`.
+fn build_indiv_map(pk: &PkParams, names: &[String], pk_indices: &[usize]) -> HashMap<String, f64> {
+    names
+        .iter()
+        .zip(pk_indices.iter())
+        .map(|(name, &idx)| (name.clone(), pk.values[idx]))
+        .collect()
+}
+
+/// Trapezoid integration over (time, value) pairs in the slice.
+fn trapezoid(points: &[(f64, f64)]) -> f64 {
+    if points.len() < 2 {
+        return 0.0;
+    }
+    let mut auc = 0.0;
+    for w in points.windows(2) {
+        let dt = w[1].0 - w[0].0;
+        auc += dt * (w[0].1 + w[1].1) * 0.5;
+    }
+    auc
+}
+
+/// Compute all [derived] and [output] columns post-fit, storing results in
+/// each SubjectResult's `extra_columns` field.
+pub(crate) fn compute_extra_output_columns(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    subjects: &mut [SubjectResult],
+) {
+    use crate::types::{AggFunction, DerivedContext, DerivedKind, IntegralStep, IntegralWindow};
+
+    let derived_names: Vec<&str> = model
+        .derived_exprs
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
+
+    for (si, sr) in subjects.iter_mut().enumerate() {
+        let subject = &population.subjects[si];
+        let eta_hat = sr.eta.as_slice();
+        let n_obs = sr.ipred.len();
+
+        // Per-observation PK params, indiv maps, TAFD, TAD
+        let mut per_obs_cov: Vec<&HashMap<String, f64>> = Vec::with_capacity(n_obs);
+        let mut per_obs_indiv: Vec<HashMap<String, f64>> = Vec::with_capacity(n_obs);
+        let mut per_obs_tafd: Vec<f64> = Vec::with_capacity(n_obs);
+        let mut per_obs_tad: Vec<f64> = Vec::with_capacity(n_obs);
+
+        for j in 0..n_obs {
+            let cov_j = subject.obs_cov(j);
+            let pk_j = (model.pk_param_fn)(theta, eta_hat, cov_j);
+            let lagtime = pk_j.lagtime();
+            let indiv_j = build_indiv_map(&pk_j, &model.indiv_param_names, &model.pk_indices);
+            let (tafd_j, tad_j) = tafd_tad_for_subject(subject, j, lagtime);
+            per_obs_cov.push(cov_j);
+            per_obs_indiv.push(indiv_j);
+            per_obs_tafd.push(tafd_j);
+            per_obs_tad.push(tad_j);
+        }
+
+        // [output] columns: covariates + indiv params not already in derived
+        for col_name in &model.output_columns {
+            if derived_names
+                .iter()
+                .any(|d| d.eq_ignore_ascii_case(col_name))
+            {
+                continue; // will be filled by derived pass below
+            }
+            // Skip mandatory/duplicate columns
+            if OUTPUT_MANDATORY
+                .iter()
+                .any(|m| m.eq_ignore_ascii_case(col_name))
+                || model
+                    .eta_names
+                    .iter()
+                    .any(|e| e.eq_ignore_ascii_case(col_name))
+            {
+                continue;
+            }
+            let mut col_vals = Vec::with_capacity(n_obs);
+            for j in 0..n_obs {
+                let v = per_obs_cov[j]
+                    .get(col_name.as_str())
+                    .or_else(|| {
+                        per_obs_indiv[j]
+                            .iter()
+                            .find(|(k, _)| k.eq_ignore_ascii_case(col_name))
+                            .map(|(_, v)| v)
+                    })
+                    .copied()
+                    .unwrap_or(f64::NAN);
+                col_vals.push(v);
+            }
+            sr.extra_columns.push((col_name.clone(), col_vals));
+        }
+
+        // [derived] columns, evaluated in declaration order
+        let mut prev_derived: HashMap<String, f64> = HashMap::new();
+
+        for spec in &model.derived_exprs {
+            let col_vals: Vec<f64> = match &spec.kind {
+                DerivedKind::PerRow { eval } => (0..n_obs)
+                    .map(|j| {
+                        let ctx = DerivedContext {
+                            theta,
+                            eta: eta_hat,
+                            indiv_params: &per_obs_indiv[j],
+                            covariates: per_obs_cov[j],
+                            ipred: sr.ipred[j],
+                            pred: sr.pred[j],
+                            dv: subject.observations[j],
+                            time: subject.obs_times[j],
+                            tafd: per_obs_tafd[j],
+                            tad: per_obs_tad[j],
+                            prev_derived: &prev_derived,
+                        };
+                        eval(&ctx)
+                    })
+                    .collect(),
+
+                DerivedKind::Aggregate {
+                    func,
+                    value,
+                    filter,
+                } => {
+                    let mut qualifying: Vec<(usize, f64)> = Vec::new();
+                    for j in 0..n_obs {
+                        let ctx = DerivedContext {
+                            theta,
+                            eta: eta_hat,
+                            indiv_params: &per_obs_indiv[j],
+                            covariates: per_obs_cov[j],
+                            ipred: sr.ipred[j],
+                            pred: sr.pred[j],
+                            dv: subject.observations[j],
+                            time: subject.obs_times[j],
+                            tafd: per_obs_tafd[j],
+                            tad: per_obs_tad[j],
+                            prev_derived: &prev_derived,
+                        };
+                        let include = filter.as_ref().map_or(true, |f| f(&ctx));
+                        if include {
+                            qualifying.push((j, value(&ctx)));
+                        }
+                    }
+                    let scalar = if qualifying.is_empty() {
+                        f64::NAN
+                    } else {
+                        match func {
+                            AggFunction::Max => qualifying
+                                .iter()
+                                .map(|(_, v)| *v)
+                                .fold(f64::NEG_INFINITY, f64::max),
+                            AggFunction::Min => qualifying
+                                .iter()
+                                .map(|(_, v)| *v)
+                                .fold(f64::INFINITY, f64::min),
+                            AggFunction::Tmax => {
+                                // Time of maximum value
+                                qualifying
+                                    .iter()
+                                    .max_by(|(_, a), (_, b)| {
+                                        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                                    })
+                                    .map(|(j, _)| subject.obs_times[*j])
+                                    .unwrap_or(f64::NAN)
+                            }
+                        }
+                    };
+                    vec![scalar; n_obs]
+                }
+
+                DerivedKind::Integral {
+                    integrand,
+                    condition,
+                    data_based,
+                    window,
+                    step,
+                } => {
+                    // Closure to compute integral over [from, to] using
+                    // observation times (data-based or forced ObsTimes).
+                    let eval_integral_obs = |from: f64, to: f64| -> f64 {
+                        let pts: Vec<(f64, f64)> = (0..n_obs)
+                            .filter_map(|j| {
+                                let t = subject.obs_times[j];
+                                if t < from - 1e-12 || t > to + 1e-12 {
+                                    return None;
+                                }
+                                let ctx = DerivedContext {
+                                    theta,
+                                    eta: eta_hat,
+                                    indiv_params: &per_obs_indiv[j],
+                                    covariates: per_obs_cov[j],
+                                    ipred: sr.ipred[j],
+                                    pred: sr.pred[j],
+                                    dv: subject.observations[j],
+                                    time: t,
+                                    tafd: per_obs_tafd[j],
+                                    tad: per_obs_tad[j],
+                                    prev_derived: &prev_derived,
+                                };
+                                if condition.as_ref().map_or(false, |f| !f(&ctx)) {
+                                    return None;
+                                }
+                                Some((t, integrand(&ctx)))
+                            })
+                            .collect();
+                        trapezoid(&pts)
+                    };
+
+                    // For model-based integrals with a fine grid, use ipred at a
+                    // representative cov snapshot (first obs) across a uniform grid.
+                    // This is an approximation: cov is time-constant at j=0 values.
+                    let eval_integral_grid = |from: f64, to: f64| -> f64 {
+                        let n_steps = match step {
+                            IntegralStep::Fixed(s) => {
+                                let n = ((to - from) / s).ceil() as usize + 1;
+                                n.max(2)
+                            }
+                            _ => 501, // Auto: 500 intervals
+                        };
+                        let dt = (to - from) / (n_steps - 1) as f64;
+                        let cov_0 = per_obs_cov.first().copied().unwrap_or(&subject.covariates);
+                        let indiv_0 = per_obs_indiv.first().cloned().unwrap_or_default();
+                        let pts: Vec<(f64, f64)> = (0..n_steps)
+                            .filter_map(|k| {
+                                let t = from + k as f64 * dt;
+                                let tafd_k = if subject.doses.is_empty() {
+                                    f64::NAN
+                                } else {
+                                    let fd = subject
+                                        .doses
+                                        .iter()
+                                        .map(|d| d.time)
+                                        .fold(f64::INFINITY, f64::min);
+                                    t - fd
+                                };
+                                // For grid-based, IPRED is evaluated at observation-time snapshots
+                                // by approximating with the nearest observation's IPRED.
+                                let nearest_ipred = subject
+                                    .obs_times
+                                    .iter()
+                                    .zip(sr.ipred.iter())
+                                    .min_by(|(&ta, _), (&tb, _)| {
+                                        (ta - t)
+                                            .abs()
+                                            .partial_cmp(&(tb - t).abs())
+                                            .unwrap_or(std::cmp::Ordering::Equal)
+                                    })
+                                    .map(|(_, &ip)| ip)
+                                    .unwrap_or(f64::NAN);
+                                let ctx = DerivedContext {
+                                    theta,
+                                    eta: eta_hat,
+                                    indiv_params: &indiv_0,
+                                    covariates: cov_0,
+                                    ipred: nearest_ipred,
+                                    pred: nearest_ipred,
+                                    dv: f64::NAN, // not available on grid
+                                    time: t,
+                                    tafd: tafd_k,
+                                    tad: f64::NAN, // simplified
+                                    prev_derived: &prev_derived,
+                                };
+                                if condition.as_ref().map_or(false, |f| !f(&ctx)) {
+                                    return None;
+                                }
+                                Some((t, integrand(&ctx)))
+                            })
+                            .collect();
+                        trapezoid(&pts)
+                    };
+
+                    let use_obs = *data_based || matches!(step, IntegralStep::ObsTimes);
+
+                    match window {
+                        IntegralWindow::Explicit { from, to } => {
+                            let val = if use_obs {
+                                eval_integral_obs(*from, *to)
+                            } else {
+                                eval_integral_grid(*from, *to)
+                            };
+                            vec![val; n_obs]
+                        }
+                        IntegralWindow::Periodic { period, anchor } => {
+                            // Compute one integral per observation (window aligned to obs time).
+                            (0..n_obs)
+                                .map(|j| {
+                                    let t = subject.obs_times[j];
+                                    let n_periods = ((t - anchor) / period).floor();
+                                    let from = anchor + n_periods * period;
+                                    let to = from + period;
+                                    if use_obs {
+                                        eval_integral_obs(from, to)
+                                    } else {
+                                        eval_integral_grid(from, to)
+                                    }
+                                })
+                                .collect()
+                        }
+                    }
+                }
+            };
+
+            // Store last value for sequential derived references
+            if let Some(&last) = col_vals.last() {
+                prev_derived.insert(spec.name.clone(), last);
+            }
+            sr.extra_columns.push((spec.name.clone(), col_vals));
+        }
+    }
+}
+
 fn fit_inner(
     model: &CompiledModel,
     population: &Population,
@@ -1405,7 +1821,7 @@ fn fit_inner(
     }
 
     // Compute per-subject diagnostics
-    let subjects = compute_subject_results(
+    let mut subjects = compute_subject_results(
         model,
         population,
         &result.params,
@@ -1414,6 +1830,11 @@ fn fit_inner(
         &result.kappas,
         options.interaction,
     );
+
+    // Post-fit: compute [derived] and [output] columns into extra_columns.
+    if !model.derived_exprs.is_empty() || !model.output_columns.is_empty() {
+        compute_extra_output_columns(model, population, &result.params.theta, &mut subjects);
+    }
 
     let n_obs = population.n_obs();
     let n_params = n_params_pre;
@@ -2021,6 +2442,7 @@ fn compute_subject_results(
                 ofv_contribution: 2.0 * ofv_i,
                 cens: subject.cens.clone(),
                 n_obs: subject.observations.len(),
+                extra_columns: vec![],
             }
         })
         .collect()
@@ -2205,6 +2627,7 @@ mod tests {
             ofv_contribution: 0.0,
             cens: vec![0; n],
             n_obs: n,
+            extra_columns: vec![],
         }
     }
 
@@ -2843,6 +3266,8 @@ mod iov_integration {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 
@@ -3690,6 +4115,8 @@ mod simulate_with_uncertainty_tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 
@@ -4404,6 +4831,8 @@ mod tests_sdtab_tv_cov {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         };
 
         // Subject with TV WT: subject.covariates["WT"] = 70 (the no-TV snapshot)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1076,7 +1076,7 @@ pub fn validate_output_columns(model: &CompiledModel, population: &Population) -
 
 /// Compute TAFD (time after first dose) and TAD (time after last dose,
 /// SS-aware) for observation index `obs_idx` of `subject`.
-pub(crate) fn tafd_tad_for_subject(subject: &Subject, obs_idx: usize, lagtime: f64) -> (f64, f64) {
+pub fn tafd_tad_for_subject(subject: &Subject, obs_idx: usize, lagtime: f64) -> (f64, f64) {
     let obs_time = subject.obs_times[obs_idx];
 
     let first_dose_time = subject

--- a/src/api.rs
+++ b/src/api.rs
@@ -1141,13 +1141,17 @@ fn build_indiv_map(pk: &PkParams, names: &[String], pk_indices: &[usize]) -> Has
         .collect()
 }
 
-/// Trapezoid integration over (time, value) pairs in the slice.
+/// Trapezoid integration over (time, value) pairs.
+/// Observation times are not guaranteed to be sorted (preserved in input row
+/// order), so sort by time before integrating to prevent negative dt windows.
 fn trapezoid(points: &[(f64, f64)]) -> f64 {
     if points.len() < 2 {
         return f64::NAN;
     }
+    let mut sorted = points.to_vec();
+    sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
     let mut auc = 0.0;
-    for w in points.windows(2) {
+    for w in sorted.windows(2) {
         let dt = w[1].0 - w[0].0;
         auc += dt * (w[0].1 + w[1].1) * 0.5;
     }

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -114,6 +114,7 @@ fn simulate_subjects(
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        warnings: vec![],
     };
 
     let sim = simulate_with_seed(model, &pop, params, 1, seed);
@@ -513,6 +514,7 @@ fn generate_two_cpt_oral_cov() {
         covariate_names: vec!["wt".into(), "crcl".into()],
         dv_column: "dv".into(),
         input_columns: vec![],
+        warnings: vec![],
     };
     let sim = simulate_with_seed(&model, &pop, &params, 1, 456);
 

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -229,6 +229,8 @@ fn build_warfarin_model() -> CompiledModel {
         scaling: ScalingSpec::None,
         log_transform: false,
         dv_pre_logged: false,
+        derived_exprs: vec![],
+        output_columns: vec![],
     }
 }
 
@@ -344,6 +346,8 @@ fn generate_two_cpt_iv() {
         scaling: ScalingSpec::None,
         log_transform: false,
         dv_pre_logged: false,
+        derived_exprs: vec![],
+        output_columns: vec![],
     };
     let obs_times = vec![0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0, 48.0, 72.0];
     let subjects = simulate_subjects(&model, &params, 15, 100.0, 1, &obs_times, 123, None);
@@ -464,6 +468,8 @@ fn generate_two_cpt_oral_cov() {
         scaling: ScalingSpec::None,
         log_transform: false,
         dv_pre_logged: false,
+        derived_exprs: vec![],
+        output_columns: vec![],
     };
 
     // Generate random covariates (matching Julia seed 456)
@@ -627,6 +633,8 @@ fn generate_mm_oral() {
         scaling: ScalingSpec::None,
         log_transform: false,
         dv_pre_logged: false,
+        derived_exprs: vec![],
+        output_columns: vec![],
     };
     let obs_times = vec![
         0.25, 0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 24.0, 36.0, 48.0,

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -34,6 +34,12 @@
 //! | `W_STEADY_STATE_INFUSION` | SS=1 infusion with `T_inf > II` (overlapping pulses) |
 //! | `W_SDE_RESET`             | EVID=3/4 resets under an SDE model are not honoured |
 //! | `W_NEGATIVE_LAGTIME`      | a lag time is negative at the initial estimates |
+//! | `E_DERIVED_NAME_CONFLICT` | `[derived]` name clashes with a built-in sdtab column, theta, eta, or indiv-param name |
+//! | `W_DERIVED_COVARIATE_SHADOW` | `[derived]` name shadows a covariate (allowed but may be confusing) |
+//! | `W_DERIVED_STEP_IGNORED`  | `step=` given for a DV-based integral (ignored; DV integrals use observation times) |
+//! | `E_OUTPUT_UNKNOWN_COLUMN` | a name in `[output]` is not recognised as any known quantity |
+//! | `W_OUTPUT_DUPLICATE`      | a name in `[output]` is already in the mandatory sdtab minimum |
+//! | `W_ADDL_MISSING_II`       | ADDL > 0 on a dose row but II is zero or missing; additional doses not expanded |
 
 use serde::Serialize;
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1641,6 +1641,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 
@@ -2543,6 +2545,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         };
 
         let template = &model.default_params;
@@ -2816,6 +2820,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1670,6 +1670,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 
@@ -2847,6 +2848,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1500,6 +1500,8 @@ mod iov_tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 
@@ -1610,6 +1612,8 @@ mod iov_tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         };
         let subject = Subject {
             id: "1".into(),

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1412,6 +1412,7 @@ mod iov_tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
         // `requested` is the user's FitOptions value, passed independently of
         // model.gradient_method (which compatibility rules may have mutated).

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2534,6 +2534,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 
@@ -2721,6 +2723,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         };
         check_gradient(&model, &make_population(3), 2);
     }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2563,6 +2563,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -795,6 +795,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2180,6 +2180,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let flag = CancelFlag::new();
@@ -2277,6 +2278,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let theta = vec![1.5f64, 20.0]; // CL, V
@@ -2429,6 +2431,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let theta = vec![1.0f64, 10.0, 0.5];

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -103,8 +103,9 @@ pub fn read_nonmem_csv(
     // Build subjects
     let mut subjects = Vec::new();
     let mut total_occ_failures: usize = 0;
+    let mut population_warnings: Vec<String> = Vec::new();
     for (id, rows) in &rows_by_id {
-        let (subject, occ_failures) = parse_subject(
+        let (subject, occ_failures, subj_warnings) = parse_subject(
             id,
             rows,
             time_col,
@@ -123,19 +124,18 @@ pub fn read_nonmem_csv(
         )?;
         subjects.push(subject);
         total_occ_failures += occ_failures;
+        population_warnings.extend(subj_warnings);
     }
 
-    // Surface a single warning if any OCC values were missing/unparseable.
-    // Such rows are silently mapped to occ=0, mixing with valid occ=0 rows —
-    // user should clean the dataset.
+    // Accumulate OCC warning into population_warnings (surfaced via FitResult.warnings).
     if let Some(name) = iov_column {
         if total_occ_failures > 0 {
-            eprintln!(
-                "[ferx] warning: {} row(s) had missing or unparseable values in iov_column '{}'; \
-                 these rows were assigned occasion=0 and may be grouped with valid occ=0 rows. \
-                 Consider cleaning the dataset.",
+            population_warnings.push(format!(
+                "W_IOV_OCC_MISSING: {} row(s) had missing or unparseable values in \
+                 iov_column '{}'; these rows were assigned occasion=0 and may be grouped \
+                 with valid occ=0 rows. Consider cleaning the dataset.",
                 total_occ_failures, name
-            );
+            ));
         }
     }
 
@@ -144,6 +144,7 @@ pub fn read_nonmem_csv(
         covariate_names: cov_names,
         dv_column: "dv".to_string(),
         input_columns: headers,
+        warnings: population_warnings,
     })
 }
 
@@ -152,7 +153,7 @@ fn parse_f64(s: &str) -> f64 {
 }
 
 fn parse_usize(s: &str) -> usize {
-    s.parse::<usize>().unwrap_or(1)
+    s.parse::<usize>().unwrap_or(0)
 }
 
 /// Parse an occasion-column cell. Returns `None` for blank / `.` / NA / non-integer
@@ -183,7 +184,7 @@ fn parse_subject(
     occ_col: Option<usize>,
     addl_col: Option<usize>,
     cov_indices: &[(String, usize)],
-) -> Result<(Subject, usize), String> {
+) -> Result<(Subject, usize, Vec<String>), String> {
     let mut doses = Vec::new();
     let mut obs_times = Vec::new();
     let mut observations = Vec::new();
@@ -192,6 +193,7 @@ fn parse_subject(
     let mut occasions: Vec<u32> = Vec::new();
     let mut dose_occasions: Vec<u32> = Vec::new();
     let mut occ_parse_failures: usize = 0;
+    let mut parse_warnings: Vec<String> = Vec::new();
     let mut addl_missing_ii_warned = false;
 
     // Time-constant covariates: first non-missing value across all rows.
@@ -349,11 +351,11 @@ fn parse_subject(
             if addl > 0 {
                 if ii <= 0.0 {
                     if !addl_missing_ii_warned {
-                        eprintln!(
-                            "[ferx] W_ADDL_MISSING_II subject {}: ADDL > 0 but II is zero or \
+                        parse_warnings.push(format!(
+                            "W_ADDL_MISSING_II subject {}: ADDL > 0 but II is zero or \
                              missing; additional doses not expanded",
                             id
-                        );
+                        ));
                         addl_missing_ii_warned = true;
                     }
                 } else {
@@ -455,6 +457,7 @@ fn parse_subject(
             dose_occasions: sorted_dose_occ,
         },
         occ_parse_failures,
+        parse_warnings,
     ))
 }
 

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -387,9 +387,19 @@ fn parse_subject(
         } else if evid == 0 && mdv == 0 {
             // Observation record
             let dv = parse_f64(row.get(dv_col).map(|s| s.as_str()).unwrap_or("0"));
+            // Guard "." / blank the same way the dose path does: parse_usize maps
+            // these to 0 (an invalid compartment), but a missing CMT on an
+            // observation row must default to compartment 1.
             let cmt = cmt_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_usize(s))
+                .and_then(|s| {
+                    let t = s.trim();
+                    if t == "." || t.is_empty() {
+                        None
+                    } else {
+                        t.parse::<usize>().ok()
+                    }
+                })
                 .unwrap_or(1);
             let cens_flag = cens_col
                 .and_then(|c| row.get(c))
@@ -478,6 +488,25 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(content.as_bytes()).unwrap();
         f
+    }
+
+    #[test]
+    fn test_obs_cmt_dot_defaults_to_compartment_one() {
+        // Regression: a "." (missing) CMT on an observation row must default to
+        // compartment 1, not 0. `parse_usize(".")` yields 0 — an invalid
+        // compartment — so the observation path must guard "." / blank exactly
+        // like the dose path does.
+        let csv = "ID,TIME,DV,EVID,AMT,CMT\n\
+                   1,0,.,1,100,1\n\
+                   1,1,5.0,0,.,.\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        let subj = &pop.subjects[0];
+        assert_eq!(
+            subj.obs_cmts,
+            vec![1],
+            "obs CMT='.' must default to compartment 1, not 0"
+        );
     }
 
     #[test]

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -51,6 +51,7 @@ pub fn read_nonmem_csv(
     let ii_col = col_idx_ci("ii");
     let ss_col = col_idx_ci("ss");
     let cens_col = col_idx_ci("cens");
+    let addl_col = col_idx_ci("addl");
 
     // IOV occasion column (case-insensitive lookup of user-specified name)
     let occ_col: Option<usize> = iov_column.and_then(|name| col_idx_ci(name));
@@ -62,7 +63,7 @@ pub fn read_nonmem_csv(
     }
 
     const STANDARD_COLS: &[&str] = &[
-        "id", "time", "dv", "evid", "amt", "cmt", "rate", "mdv", "ii", "ss", "cens",
+        "id", "time", "dv", "evid", "amt", "cmt", "rate", "mdv", "ii", "ss", "cens", "addl",
     ];
     let is_standard = |h: &str| {
         STANDARD_COLS.iter().any(|s| h.eq_ignore_ascii_case(s))
@@ -117,6 +118,7 @@ pub fn read_nonmem_csv(
             ss_col,
             cens_col,
             occ_col,
+            addl_col,
             &cov_indices,
         )?;
         subjects.push(subject);
@@ -179,6 +181,7 @@ fn parse_subject(
     ss_col: Option<usize>,
     cens_col: Option<usize>,
     occ_col: Option<usize>,
+    addl_col: Option<usize>,
     cov_indices: &[(String, usize)],
 ) -> Result<(Subject, usize), String> {
     let mut doses = Vec::new();
@@ -189,6 +192,7 @@ fn parse_subject(
     let mut occasions: Vec<u32> = Vec::new();
     let mut dose_occasions: Vec<u32> = Vec::new();
     let mut occ_parse_failures: usize = 0;
+    let mut addl_missing_ii_warned = false;
 
     // Time-constant covariates: first non-missing value across all rows.
     // Used as the subject-static fallback (and for the AD fast path, which
@@ -335,6 +339,41 @@ fn parse_subject(
             }
             if any_tv {
                 dose_covariates.push(locf_state.clone());
+            }
+
+            // ADDL expansion: add additional doses at time + k*II for k=1..=addl.
+            let addl = addl_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_usize(s))
+                .unwrap_or(0);
+            if addl > 0 {
+                if ii <= 0.0 {
+                    if !addl_missing_ii_warned {
+                        eprintln!(
+                            "[ferx] W_ADDL_MISSING_II subject {}: ADDL > 0 but II is zero or \
+                             missing; additional doses not expanded",
+                            id
+                        );
+                        addl_missing_ii_warned = true;
+                    }
+                } else {
+                    for k in 1..=(addl as u32) {
+                        doses.push(DoseEvent::new(
+                            time + (k as f64) * ii,
+                            amt,
+                            cmt,
+                            rate,
+                            false, // expanded doses are never SS themselves
+                            ii,
+                        ));
+                        if occ_col.is_some() {
+                            dose_occasions.push(occ);
+                        }
+                        if any_tv {
+                            dose_covariates.push(locf_state.clone());
+                        }
+                    }
+                }
             }
         } else if evid == 0 && mdv == 0 {
             // Observation record

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -320,7 +320,14 @@ fn parse_subject(
                 .unwrap_or(0.0);
             let cmt = cmt_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_usize(s))
+                .and_then(|s| {
+                    let t = s.trim();
+                    if t == "." || t.is_empty() {
+                        None
+                    } else {
+                        t.parse::<usize>().ok()
+                    }
+                })
                 .unwrap_or(1);
             let rate = rate_col
                 .and_then(|c| row.get(c))
@@ -332,7 +339,7 @@ fn parse_subject(
                 .unwrap_or(0.0);
             let ss = ss_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_usize(s) > 0)
+                .map(|s| parse_f64(s.trim()) >= 0.5)
                 .unwrap_or(false);
 
             doses.push(DoseEvent::new(time, amt, cmt, rate, ss, ii));

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1075,6 +1075,7 @@ fn parse_subjects(
             ofv_contribution: ofv,
             cens: Vec::new(),
             n_obs,
+            extra_columns: vec![],
         });
     }
 
@@ -1659,6 +1660,7 @@ mod tests {
             ofv_contribution: 12.34,
             cens: vec![0; n_obs],
             n_obs,
+            extra_columns: vec![],
         }
     }
 

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1076,6 +1076,7 @@ fn parse_subjects(
             cens: Vec::new(),
             n_obs,
             extra_columns: vec![],
+            per_obs_tad: vec![],
         });
     }
 
@@ -1661,6 +1662,7 @@ mod tests {
             cens: vec![0; n_obs],
             n_obs,
             extra_columns: vec![],
+            per_obs_tad: vec![],
         }
     }
 
@@ -1689,6 +1691,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         }
     }
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -565,14 +565,20 @@ pub fn sdtab(result: &FitResult, population: &Population) -> Vec<(String, Vec<f6
         cols.push(("TAFD".to_string(), vals));
     }
 
-    // TAD — mandatory, SS-aware.
+    // TAD — mandatory, SS-aware. When compute_extra_output_columns has run
+    // (lagtime models or models with [derived]/[output] blocks), per_obs_tad
+    // already reflects the individual lagtime; fall back to lagtime=0 otherwise.
     {
         let vals: Vec<f64> = result
             .subjects
             .iter()
             .zip(population.subjects.iter())
-            .flat_map(|(_sr, subj)| {
-                subj.obs_times.iter().map(|&obs_t| {
+            .flat_map(|(sr, subj)| {
+                (0..sr.ipred.len()).map(|j| {
+                    if !sr.per_obs_tad.is_empty() {
+                        return sr.per_obs_tad[j];
+                    }
+                    let obs_t = subj.obs_times[j];
                     let last_eff = subj
                         .doses
                         .iter()
@@ -1402,6 +1408,7 @@ mod tests {
             cens: vec![0; n_obs],
             n_obs,
             extra_columns: vec![],
+            per_obs_tad: vec![],
         }
     }
 
@@ -1547,6 +1554,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1574,6 +1582,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1594,6 +1603,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let cols = sdtab(&result, &population);
@@ -1624,6 +1634,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
 
         let cols = sdtab(&result, &population);

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -655,12 +655,22 @@ pub fn write_sdtab_csv(
     let header: Vec<&str> = cols.iter().map(|(name, _)| name.as_str()).collect();
     writeln!(f, "{}", header.join(",")).map_err(|e| e.to_string())?;
 
-    // Rows. NaN (used for BLOQ IWRES/CWRES) is written as an empty cell so
-    // downstream tools handle it as missing rather than a sentinel.
+    // Rows. Any non-finite value — NaN (BLOQ IWRES/CWRES) or ±Inf (e.g. from a
+    // derived column) — is written as an empty cell so downstream tools handle
+    // it as missing rather than a sentinel. This is intentionally broader than
+    // the covariate-table writer below (which only blanks NaN via fmt_num), so
+    // adopting fmt_num here would silently change derived-column output.
     for row in 0..n_rows {
         let vals: Vec<String> = cols
             .iter()
-            .map(|(_, values)| fmt_num(values[row]))
+            .map(|(_, values)| {
+                let v = values[row];
+                if !v.is_finite() {
+                    String::new()
+                } else {
+                    format!("{:.6}", v)
+                }
+            })
             .collect();
         writeln!(f, "{}", vals.join(",")).map_err(|e| e.to_string())?;
     }
@@ -699,10 +709,7 @@ pub fn write_covtab_csv(table: &crate::types::CovariateTable, path: &str) -> Res
 
 /// Format a numeric cell for CSV output: NaN → empty (missing), else 6 dp.
 fn fmt_num(v: f64) -> String {
-    // Any non-finite value (NaN from BLOQ IWRES/CWRES, or ±Inf from a derived
-    // column) is written as an empty cell so downstream tools treat it as
-    // missing rather than a sentinel.
-    if !v.is_finite() {
+    if v.is_nan() {
         String::new()
     } else {
         format!("{:.6}", v)

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -528,6 +528,103 @@ pub fn sdtab(result: &FitResult, population: &Population) -> Vec<(String, Vec<f6
         ("N_OBS".to_string(), n_obs_col),
     ]);
 
+    // ETA columns — always included; one per BSV eta, parallel to eta_names.
+    for (k, eta_name) in result.eta_names.iter().enumerate() {
+        let vals: Vec<f64> = result
+            .subjects
+            .iter()
+            .flat_map(|sr| {
+                let v = sr.eta.get(k).copied().unwrap_or(f64::NAN);
+                std::iter::repeat(v).take(sr.ipred.len())
+            })
+            .collect();
+        cols.push((eta_name.clone(), vals));
+    }
+
+    // TAFD — mandatory, computed from dose records.
+    {
+        let vals: Vec<f64> = result
+            .subjects
+            .iter()
+            .zip(population.subjects.iter())
+            .flat_map(|(_sr, subj)| {
+                let first_dose = subj
+                    .doses
+                    .iter()
+                    .map(|d| d.time)
+                    .fold(f64::INFINITY, f64::min);
+                subj.obs_times.iter().map(move |&t| {
+                    if first_dose.is_finite() {
+                        t - first_dose
+                    } else {
+                        f64::NAN
+                    }
+                })
+            })
+            .collect();
+        cols.push(("TAFD".to_string(), vals));
+    }
+
+    // TAD — mandatory, SS-aware.
+    {
+        let vals: Vec<f64> = result
+            .subjects
+            .iter()
+            .zip(population.subjects.iter())
+            .flat_map(|(_sr, subj)| {
+                subj.obs_times.iter().map(|&obs_t| {
+                    let last_eff = subj
+                        .doses
+                        .iter()
+                        .filter(|d| d.time <= obs_t + 1e-12)
+                        .map(|d| {
+                            if d.ss && d.ii > 0.0 {
+                                let elapsed = obs_t - d.time;
+                                obs_t - elapsed.rem_euclid(d.ii)
+                            } else {
+                                d.time
+                            }
+                        })
+                        .fold(f64::NEG_INFINITY, f64::max);
+                    if last_eff.is_finite() {
+                        obs_t - last_eff
+                    } else {
+                        f64::NAN
+                    }
+                })
+            })
+            .collect();
+        cols.push(("TAD".to_string(), vals));
+    }
+
+    // extra_columns from [derived] and [output] blocks.
+    if let Some(first_with_extra) = result
+        .subjects
+        .iter()
+        .find(|sr| !sr.extra_columns.is_empty())
+    {
+        let extra_names: Vec<String> = first_with_extra
+            .extra_columns
+            .iter()
+            .map(|(n, _)| n.clone())
+            .collect();
+        for col_name in &extra_names {
+            let vals: Vec<f64> = result
+                .subjects
+                .iter()
+                .flat_map(|sr| {
+                    sr.extra_columns
+                        .iter()
+                        .find(|(n, _)| n == col_name)
+                        .map(|(_, v)| v.as_slice())
+                        .unwrap_or(&[])
+                        .to_vec()
+                })
+                .collect();
+            cols.push((col_name.clone(), vals));
+        }
+    }
+
     cols
 }
 
@@ -559,7 +656,7 @@ pub fn write_sdtab_csv(
             .iter()
             .map(|(_, values)| {
                 let v = values[row];
-                if v.is_nan() {
+                if !v.is_finite() {
                     String::new()
                 } else {
                     format!("{:.6}", v)
@@ -1304,6 +1401,7 @@ mod tests {
             ofv_contribution: 0.0,
             cens: vec![0; n_obs],
             n_obs,
+            extra_columns: vec![],
         }
     }
 

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -410,6 +410,18 @@ pub fn ode_predictions(
     let f_bio = pk_params_flat.get(PK_IDX_F).copied().unwrap_or(1.0);
     let dose_f_bio: Vec<f64> = vec![f_bio; subject.doses.len()];
 
+    // Extended params: slots 0..MAX_PK_PARAMS hold the PK parameters; slots
+    // MAX_PK_PARAMS and MAX_PK_PARAMS+1 carry TAFD/TAD anchors for the ODE RHS.
+    let first_dose_time = subject
+        .doses
+        .iter()
+        .map(|d| d.time)
+        .fold(f64::INFINITY, f64::min);
+    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
+    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
+    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
+    ext_params[crate::types::MAX_PK_PARAMS] = first_dose_time;
+
     // Build obs_time → indices map. Multiple observations can share a time
     // (e.g. simultaneous PK/PD samples on different CMTs), so each time maps to
     // *all* its observation indices — recording only one would leave the others
@@ -516,6 +528,25 @@ pub fn ode_predictions(
             continue;
         }
 
+        // Update TAD anchor (slot MAX_PK_PARAMS+1): last effective dose time
+        // before this segment, SS-aware (gives TAD = t - last_dose_eff).
+        {
+            let last_dose_eff = subject
+                .doses
+                .iter()
+                .filter(|d| d.time + lagtime <= t_start + 1e-12)
+                .map(|d| {
+                    if d.ss && d.ii > 0.0 {
+                        let elapsed = t_start - (d.time + lagtime);
+                        t_start - elapsed.rem_euclid(d.ii)
+                    } else {
+                        d.time + lagtime
+                    }
+                })
+                .fold(f64::NEG_INFINITY, f64::max);
+            ext_params[crate::types::MAX_PK_PARAMS + 1] = last_dose_eff;
+        }
+
         // Integrate. If any infusions are active in this segment, wrap
         // the user RHS so it adds `+rate` to each infusion's compartment.
         // The plain (non-event-driven) ODE path never sees reset subjects —
@@ -541,7 +572,7 @@ pub fn ode_predictions(
             &wrapped_rhs,
             &u,
             (t_start, t_end),
-            pk_params_flat,
+            &ext_params,
             &saveat,
             &opts,
         );
@@ -617,6 +648,13 @@ pub fn ode_predictions_event_driven(
     let n = ode.n_states;
     let n_obs = subject.obs_times.len();
     let opts = OdeSolverOptions::default();
+
+    // First-dose time anchor for TAFD injection via extended params.
+    let first_dose_time_ed = subject
+        .doses
+        .iter()
+        .map(|d| d.time)
+        .fold(f64::INFINITY, f64::min);
 
     // Seed compartments from `init(state) = expr` (zeros when none declared).
     // The init expression folds covariates/eta in via the individual-parameter
@@ -741,6 +779,29 @@ pub fn ode_predictions_event_driven(
         };
 
         if t_event > cur_t {
+            // Build extended params for this segment: slots 0..MAX_PK_PARAMS
+            // are pk_now.values; slots MAX_PK_PARAMS and MAX_PK_PARAMS+1 carry
+            // the TAFD/TAD anchors for TIME/TAFD/TAD injection in the ODE RHS.
+            let lagtime_ed = pk_now.lagtime();
+            let last_dose_eff_ed = subject
+                .doses
+                .iter()
+                .filter(|d| d.time + lagtime_ed <= cur_t + 1e-12)
+                .map(|d| {
+                    if d.ss && d.ii > 0.0 {
+                        let elapsed = cur_t - (d.time + lagtime_ed);
+                        cur_t - elapsed.rem_euclid(d.ii)
+                    } else {
+                        d.time + lagtime_ed
+                    }
+                })
+                .fold(f64::NEG_INFINITY, f64::max);
+            let mut ext_params_ed = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
+            ext_params_ed[..crate::types::MAX_PK_PARAMS]
+                .copy_from_slice(&pk_now.values[..crate::types::MAX_PK_PARAMS]);
+            ext_params_ed[crate::types::MAX_PK_PARAMS] = first_dose_time_ed;
+            ext_params_ed[crate::types::MAX_PK_PARAMS + 1] = last_dose_eff_ed;
+
             // Wrap the user RHS so any infusion fully spanning
             // [cur_t, t_event] contributes `+rate` to its compartment.
             let active = active_infusions(
@@ -764,7 +825,7 @@ pub fn ode_predictions_event_driven(
                 &wrapped_rhs,
                 &u,
                 (cur_t, t_event),
-                &pk_now.values,
+                &ext_params_ed,
                 &saveat,
                 &opts,
             );

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -420,7 +420,13 @@ pub fn ode_predictions(
     let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
     let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
     ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
-    ext_params[crate::types::MAX_PK_PARAMS] = first_dose_time;
+    // Store NaN when there are no doses so the ODE RHS injects NaN for TAFD
+    // (consistent with the sdtab convention) rather than -∞ (INFINITY - t).
+    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
+        first_dose_time
+    } else {
+        f64::NAN
+    };
 
     // Build obs_time → indices map. Multiple observations can share a time
     // (e.g. simultaneous PK/PD samples on different CMTs), so each time maps to
@@ -544,7 +550,13 @@ pub fn ode_predictions(
                     }
                 })
                 .fold(f64::NEG_INFINITY, f64::max);
-            ext_params[crate::types::MAX_PK_PARAMS + 1] = last_dose_eff;
+            // Store NaN when no effective prior dose exists so the ODE RHS injects
+            // NaN for TAD (consistent with sdtab) rather than +∞ (t - NEG_INFINITY).
+            ext_params[crate::types::MAX_PK_PARAMS + 1] = if last_dose_eff.is_finite() {
+                last_dose_eff
+            } else {
+                f64::NAN
+            };
         }
 
         // Integrate. If any infusions are active in this segment, wrap
@@ -650,11 +662,20 @@ pub fn ode_predictions_event_driven(
     let opts = OdeSolverOptions::default();
 
     // First-dose time anchor for TAFD injection via extended params.
-    let first_dose_time_ed = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
+    // fold yields INFINITY when there are no doses; convert to NaN so the ODE
+    // RHS injects NaN for TAFD (consistent with sdtab) rather than -∞.
+    let first_dose_time_ed = {
+        let t = subject
+            .doses
+            .iter()
+            .map(|d| d.time)
+            .fold(f64::INFINITY, f64::min);
+        if t.is_finite() {
+            t
+        } else {
+            f64::NAN
+        }
+    };
 
     // Seed compartments from `init(state) = expr` (zeros when none declared).
     // The init expression folds covariates/eta in via the individual-parameter
@@ -796,6 +817,13 @@ pub fn ode_predictions_event_driven(
                     }
                 })
                 .fold(f64::NEG_INFINITY, f64::max);
+            // Store NaN when no effective prior dose exists (fold stays at NEG_INFINITY)
+            // so the ODE RHS injects NaN for TAD rather than +∞ (t - NEG_INFINITY).
+            let last_dose_eff_ed = if last_dose_eff_ed.is_finite() {
+                last_dose_eff_ed
+            } else {
+                f64::NAN
+            };
             let mut ext_params_ed = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
             ext_params_ed[..crate::types::MAX_PK_PARAMS]
                 .copy_from_slice(&pk_now.values[..crate::types::MAX_PK_PARAMS]);

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1798,19 +1798,28 @@ fn build_derived_filter_fn(cond: Condition) -> DerivedFilterFn {
 /// Build the variable map for derived-expression and derived-filter evaluation.
 ///
 /// Keys for covariates, individual parameters, and prior derived columns are
-/// inserted both with their original case **and** in uppercase, so that
-/// expressions like `wt` resolve correctly even when the dataset header is `WT`.
+/// inserted with their original case **and** both an uppercase and a lowercase
+/// alias, so that an all-lowercase `wt` or all-uppercase `WT` expression resolves
+/// regardless of the dataset header's case. (A header such as `WT` has an
+/// uppercase form identical to itself, so the lowercase alias is what makes a
+/// lowercase `wt` reference resolve.)
 /// Built-in time variables (TIME, TAFD, TAD, IPRED, PRED, DV) are inserted in
 /// both uppercase and lowercase for the same reason.
 fn build_derived_vars(ctx: &DerivedContext<'_>) -> HashMap<String, f64> {
     let mut vars: HashMap<String, f64> = HashMap::new();
-    // Insert each name with original case AND an uppercase alias so that
-    // case mismatches (e.g. `wt` vs. header `WT`) resolve correctly.
+    // Insert each name with original case AND uppercase + lowercase aliases so
+    // that case mismatches (e.g. `wt` vs. header `WT`, or `WT` vs. header `wt`)
+    // resolve correctly. `eval_expression` looks names up verbatim, so every
+    // case the user might type must be present as a key.
     let mut insert_ci = |k: &str, v: f64| {
         vars.insert(k.to_string(), v);
         let up = k.to_uppercase();
         if up != k {
             vars.insert(up, v);
+        }
+        let lo = k.to_lowercase();
+        if lo != k {
+            vars.insert(lo, v);
         }
     };
     for (k, &v) in ctx.indiv_params.iter() {
@@ -14303,6 +14312,43 @@ CL V KA WT
             // TAD = 1.0 >> MACHEPS → flag = 0
             let ctx2 = DerivedContext { tad: 1.0, ..ctx };
             assert_eq!(eval(&ctx2), 0.0, "TAD=1 should not be < MACHEPS");
+        }
+    }
+
+    #[test]
+    fn derived_resolves_covariate_case_insensitively() {
+        // Regression: a covariate carried in the dataset under an uppercase
+        // header (`WT`) referenced as lowercase `wt` in a [derived] expression
+        // must resolve to the covariate value, not silently evaluate to 0.
+        // build_derived_vars must insert a lowercase alias because
+        // `eval_expression` looks the name up verbatim.
+        let src = minimal_model_with_derived("WT_DERIVED = wt * 2");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let (theta, eta, indiv, _cov, prev) = make_derived_ctx_simple();
+        // Covariate stored under uppercase `WT`, as a NONMEM header would be.
+        let mut cov = std::collections::HashMap::new();
+        cov.insert("WT".to_string(), 70.0);
+        if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+            let ctx = DerivedContext {
+                theta: &theta,
+                eta: &eta,
+                indiv_params: &indiv,
+                covariates: &cov,
+                ipred: 0.0,
+                pred: 0.0,
+                dv: 0.0,
+                time: 0.0,
+                tafd: 0.0,
+                tad: 0.0,
+                prev_derived: &prev,
+            };
+            assert_eq!(
+                eval(&ctx),
+                140.0,
+                "lowercase `wt` must resolve to covariate header `WT` (=70)"
+            );
+        } else {
+            panic!("expected PerRow derived kind");
         }
     }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1779,23 +1779,7 @@ fn parse_derived_cond(tokens: &[Token], ctx: ParseCtx<'_>) -> Result<Condition, 
 fn build_derived_eval_fn(expr: Expression) -> DerivedEvalFn {
     let expr = std::sync::Arc::new(expr);
     Box::new(move |ctx: &DerivedContext<'_>| {
-        let mut vars: HashMap<String, f64> = HashMap::new();
-        for (k, &v) in ctx.indiv_params.iter() {
-            vars.insert(k.clone(), v);
-        }
-        for (k, &v) in ctx.covariates.iter() {
-            vars.insert(k.clone(), v);
-        }
-        for (k, &v) in ctx.prev_derived.iter() {
-            vars.insert(k.clone(), v);
-        }
-        vars.insert("IPRED".into(), ctx.ipred);
-        vars.insert("PRED".into(), ctx.pred);
-        vars.insert("DV".into(), ctx.dv);
-        vars.insert("TIME".into(), ctx.time);
-        vars.insert("TAFD".into(), ctx.tafd);
-        vars.insert("TAD".into(), ctx.tad);
-        vars.insert("MACHEPS".into(), f64::EPSILON);
+        let vars = build_derived_vars(ctx);
         // Covariates become Variable nodes (fallback_covariate=false at parse time),
         // so pass an empty covariates map and rely on vars for all name resolution.
         eval_expression(&expr, ctx.theta, ctx.eta, &HashMap::new(), &vars, &[])
@@ -1806,25 +1790,52 @@ fn build_derived_eval_fn(expr: Expression) -> DerivedEvalFn {
 fn build_derived_filter_fn(cond: Condition) -> DerivedFilterFn {
     let cond = std::sync::Arc::new(cond);
     Box::new(move |ctx: &DerivedContext<'_>| {
-        let mut vars: HashMap<String, f64> = HashMap::new();
-        for (k, &v) in ctx.indiv_params.iter() {
-            vars.insert(k.clone(), v);
-        }
-        for (k, &v) in ctx.covariates.iter() {
-            vars.insert(k.clone(), v);
-        }
-        for (k, &v) in ctx.prev_derived.iter() {
-            vars.insert(k.clone(), v);
-        }
-        vars.insert("IPRED".into(), ctx.ipred);
-        vars.insert("PRED".into(), ctx.pred);
-        vars.insert("DV".into(), ctx.dv);
-        vars.insert("TIME".into(), ctx.time);
-        vars.insert("TAFD".into(), ctx.tafd);
-        vars.insert("TAD".into(), ctx.tad);
-        vars.insert("MACHEPS".into(), f64::EPSILON);
+        let vars = build_derived_vars(ctx);
         eval_condition(&cond, ctx.theta, ctx.eta, &HashMap::new(), &vars, &[])
     })
+}
+
+/// Build the variable map for derived-expression and derived-filter evaluation.
+///
+/// Keys for covariates, individual parameters, and prior derived columns are
+/// inserted both with their original case **and** in uppercase, so that
+/// expressions like `wt` resolve correctly even when the dataset header is `WT`.
+/// Built-in time variables (TIME, TAFD, TAD, IPRED, PRED, DV) are inserted in
+/// both uppercase and lowercase for the same reason.
+fn build_derived_vars(ctx: &DerivedContext<'_>) -> HashMap<String, f64> {
+    let mut vars: HashMap<String, f64> = HashMap::new();
+    // Insert each name with original case AND an uppercase alias so that
+    // case mismatches (e.g. `wt` vs. header `WT`) resolve correctly.
+    let mut insert_ci = |k: &str, v: f64| {
+        vars.insert(k.to_string(), v);
+        let up = k.to_uppercase();
+        if up != k {
+            vars.insert(up, v);
+        }
+    };
+    for (k, &v) in ctx.indiv_params.iter() {
+        insert_ci(k, v);
+    }
+    for (k, &v) in ctx.covariates.iter() {
+        insert_ci(k, v);
+    }
+    for (k, &v) in ctx.prev_derived.iter() {
+        insert_ci(k, v);
+    }
+    // Built-in names: uppercase (canonical) + lowercase alias.
+    for &(name, val) in &[
+        ("IPRED", ctx.ipred),
+        ("PRED", ctx.pred),
+        ("DV", ctx.dv),
+        ("TIME", ctx.time),
+        ("TAFD", ctx.tafd),
+        ("TAD", ctx.tad),
+        ("MACHEPS", f64::EPSILON),
+    ] {
+        vars.insert(name.to_string(), val);
+        vars.insert(name.to_lowercase(), val);
+    }
+    vars
 }
 
 /// Returns true if the expression subtree references the `DV` variable.
@@ -3581,19 +3592,37 @@ fn build_ode_spec(
         add_aliases(&mut var_idx, n, state_count + indiv_count + i);
     }
     // Reserve extra slots for TIME/T, TAFD, TAD — always appended after intermediates.
+    // These names are reserved: reject any ODE state, individual parameter, or
+    // intermediate that collides with a reserved slot so the injected solver-time
+    // values are always reachable.
+    const RESERVED_ODE_NAMES: &[&str] = &["TIME", "T", "TAFD", "TAD"];
+    for reserved in RESERVED_ODE_NAMES {
+        let collides = state_names_owned
+            .iter()
+            .chain(indiv_names_owned.iter())
+            .chain(intermediates.iter())
+            .any(|n| n.eq_ignore_ascii_case(reserved));
+        if collides {
+            return Err(format!(
+                "[odes] the name `{reserved}` is reserved for the solver-injected time \
+                 variable and cannot be used as a state, individual-parameter, or \
+                 intermediate name"
+            ));
+        }
+    }
     let n_base_vars = state_count + indiv_count + intermediates.len();
     let time_slot = n_base_vars;
     let tafd_slot = n_base_vars + 1;
     let tad_slot = n_base_vars + 2;
-    // TIME and T are aliases for the same slot.
-    var_idx.entry("TIME".to_string()).or_insert(time_slot);
-    var_idx.entry("time".to_string()).or_insert(time_slot);
-    var_idx.entry("T".to_string()).or_insert(time_slot);
-    var_idx.entry("t".to_string()).or_insert(time_slot);
-    var_idx.entry("TAFD".to_string()).or_insert(tafd_slot);
-    var_idx.entry("tafd".to_string()).or_insert(tafd_slot);
-    var_idx.entry("TAD".to_string()).or_insert(tad_slot);
-    var_idx.entry("tad".to_string()).or_insert(tad_slot);
+    // Forcefully assign reserved names (overwrite any accidental or_insert entry).
+    var_idx.insert("TIME".to_string(), time_slot);
+    var_idx.insert("time".to_string(), time_slot);
+    var_idx.insert("T".to_string(), time_slot);
+    var_idx.insert("t".to_string(), time_slot);
+    var_idx.insert("TAFD".to_string(), tafd_slot);
+    var_idx.insert("tafd".to_string(), tafd_slot);
+    var_idx.insert("TAD".to_string(), tad_slot);
+    var_idx.insert("tad".to_string(), tad_slot);
     let n_vars_total = n_base_vars + 3;
 
     // Rewrite the AST so the hot path walks `VariableIdx`/`AssignIdx`/`DiffEqIdx`

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1401,6 +1401,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         scaling: ScalingSpec::None,
         log_transform: ltbs_flags.log_transform,
         dv_pre_logged: ltbs_flags.dv_pre_logged,
+        derived_exprs: vec![],
+        output_columns: vec![],
     };
 
     // ── Optional blocks ──
@@ -1628,12 +1630,505 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     );
     model.parse_warnings.extend(unused_warnings);
 
+    // ── [derived] block ──
+    if let Some(derived_lines) = blocks.get("derived") {
+        let cov_names = model.referenced_covariates.clone();
+        let mut derived_warnings = Vec::new();
+        let derived_exprs = parse_derived_block(
+            derived_lines,
+            &model.theta_names.clone(),
+            &model.eta_names.clone(),
+            &model.indiv_param_names.clone(),
+            &cov_names,
+            &mut derived_warnings,
+        )?;
+        model.derived_exprs = derived_exprs;
+        model.parse_warnings.extend(derived_warnings);
+    }
+
+    // ── [output] block ──
+    if let Some(output_lines) = blocks.get("output") {
+        model.output_columns = parse_output_block(output_lines);
+    }
+
     Ok(ParsedModel {
         model,
         simulation,
         fit_options,
         block_lines: extracted.block_lines.clone(),
     })
+}
+
+// ── [derived] and [output] block parsers ────────────────────────────────────
+
+/// Built-in sdtab column names that [derived] names must not clash with.
+const DERIVED_BUILTIN_NAMES: &[&str] = &[
+    "ID", "TIME", "DV", "PRED", "IPRED", "CWRES", "IWRES", "EBE_OFV", "N_OBS", "TAFD", "TAD",
+    "CENS", "OCC", "CMT",
+];
+
+/// Split a token slice at top-level commas (depth 0 inside parentheses).
+fn split_top_level_commas(tokens: &[Token]) -> Vec<&[Token]> {
+    let mut result = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0;
+    for (i, tok) in tokens.iter().enumerate() {
+        match tok {
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            Token::Comma if depth == 0 => {
+                result.push(&tokens[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < tokens.len() {
+        result.push(&tokens[start..]);
+    }
+    result
+}
+
+/// Returns true when a token slice starts with `IDENT =` (keyword arg pattern).
+fn is_keyword_arg_tokens(tokens: &[Token]) -> bool {
+    matches!(tokens, [Token::Ident(_), Token::Eq, ..])
+}
+
+/// Parse `IDENT = NUMBER` keyword arg, returning (key, value).
+fn parse_keyword_float_arg(tokens: &[Token]) -> Result<(String, f64), String> {
+    match tokens {
+        [Token::Ident(k), Token::Eq, Token::Number(v)] => Ok((k.clone(), *v)),
+        [Token::Ident(k), Token::Eq, ..] => Err(format!(
+            "keyword arg `{k}=` must be followed by a numeric literal"
+        )),
+        _ => Err(format!(
+            "expected keyword arg `name = value`, got unexpected tokens"
+        )),
+    }
+}
+
+/// Returns true when a token slice contains a comparison or logical operator
+/// at parenthesis depth 0. Used to distinguish a condition arg from a
+/// keyword-arg sequence in `integral(...)`.
+fn tokens_contain_comparison(tokens: &[Token]) -> bool {
+    let mut depth = 0usize;
+    for tok in tokens {
+        match tok {
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            Token::Lt
+            | Token::Le
+            | Token::Gt
+            | Token::Ge
+            | Token::EqEq
+            | Token::Ne
+            | Token::AndAnd
+            | Token::OrOr
+            | Token::Bang
+                if depth == 0 =>
+            {
+                return true
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Parse a token slice as a fully-consuming arithmetic expression.
+fn parse_derived_expr(tokens: &[Token], ctx: ParseCtx<'_>) -> Result<Expression, String> {
+    if tokens.is_empty() {
+        return Err("expected expression, got empty token list".into());
+    }
+    let (expr, pos) = parse_add_sub(tokens, 0, ctx)?;
+    if pos < tokens.len() {
+        return Err(format!(
+            "unexpected token(s) after expression: {:?}",
+            &tokens[pos..]
+        ));
+    }
+    Ok(expr)
+}
+
+/// Parse a token slice as a fully-consuming boolean condition.
+fn parse_derived_cond(tokens: &[Token], ctx: ParseCtx<'_>) -> Result<Condition, String> {
+    if tokens.is_empty() {
+        return Err("expected condition, got empty token list".into());
+    }
+    let (cond, pos) = parse_condition(tokens, 0, ctx)?;
+    if pos < tokens.len() {
+        return Err(format!(
+            "unexpected token(s) after condition: {:?}",
+            &tokens[pos..]
+        ));
+    }
+    Ok(cond)
+}
+
+/// Build a DerivedEvalFn closure from a parsed Expression.
+/// At evaluation time the closure assembles a `vars` map from the DerivedContext
+/// fields and calls the AST-walking `eval_expression`.
+fn build_derived_eval_fn(expr: Expression) -> DerivedEvalFn {
+    let expr = std::sync::Arc::new(expr);
+    Box::new(move |ctx: &DerivedContext<'_>| {
+        let mut vars: HashMap<String, f64> = HashMap::new();
+        for (k, &v) in ctx.indiv_params.iter() {
+            vars.insert(k.clone(), v);
+        }
+        for (k, &v) in ctx.covariates.iter() {
+            vars.insert(k.clone(), v);
+        }
+        for (k, &v) in ctx.prev_derived.iter() {
+            vars.insert(k.clone(), v);
+        }
+        vars.insert("IPRED".into(), ctx.ipred);
+        vars.insert("PRED".into(), ctx.pred);
+        vars.insert("DV".into(), ctx.dv);
+        vars.insert("TIME".into(), ctx.time);
+        vars.insert("TAFD".into(), ctx.tafd);
+        vars.insert("TAD".into(), ctx.tad);
+        vars.insert("MACHEPS".into(), f64::EPSILON);
+        // Covariates become Variable nodes (fallback_covariate=false at parse time),
+        // so pass an empty covariates map and rely on vars for all name resolution.
+        eval_expression(&expr, ctx.theta, ctx.eta, &HashMap::new(), &vars, &[])
+    })
+}
+
+/// Build a DerivedFilterFn closure from a parsed Condition.
+fn build_derived_filter_fn(cond: Condition) -> DerivedFilterFn {
+    let cond = std::sync::Arc::new(cond);
+    Box::new(move |ctx: &DerivedContext<'_>| {
+        let mut vars: HashMap<String, f64> = HashMap::new();
+        for (k, &v) in ctx.indiv_params.iter() {
+            vars.insert(k.clone(), v);
+        }
+        for (k, &v) in ctx.covariates.iter() {
+            vars.insert(k.clone(), v);
+        }
+        for (k, &v) in ctx.prev_derived.iter() {
+            vars.insert(k.clone(), v);
+        }
+        vars.insert("IPRED".into(), ctx.ipred);
+        vars.insert("PRED".into(), ctx.pred);
+        vars.insert("DV".into(), ctx.dv);
+        vars.insert("TIME".into(), ctx.time);
+        vars.insert("TAFD".into(), ctx.tafd);
+        vars.insert("TAD".into(), ctx.tad);
+        vars.insert("MACHEPS".into(), f64::EPSILON);
+        eval_condition(&cond, ctx.theta, ctx.eta, &HashMap::new(), &vars, &[])
+    })
+}
+
+/// Returns true if the expression subtree references the `DV` variable.
+fn expr_refs_dv(expr: &Expression) -> bool {
+    match expr {
+        Expression::Variable(name) if name.eq_ignore_ascii_case("DV") => true,
+        Expression::BinOp(l, _, r) => expr_refs_dv(l) || expr_refs_dv(r),
+        Expression::UnaryFn(_, arg) => expr_refs_dv(arg),
+        Expression::Power(b, e) => expr_refs_dv(b) || expr_refs_dv(e),
+        Expression::Conditional(c, t, e) => cond_refs_dv(c) || expr_refs_dv(t) || expr_refs_dv(e),
+        _ => false,
+    }
+}
+
+fn cond_refs_dv(cond: &Condition) -> bool {
+    match cond {
+        Condition::Compare(l, _, r) => expr_refs_dv(l) || expr_refs_dv(r),
+        Condition::And(l, r) | Condition::Or(l, r) => cond_refs_dv(l) || cond_refs_dv(r),
+        Condition::Not(c) => cond_refs_dv(c),
+    }
+}
+
+/// Parse the interior args of `integral(...)` into a `DerivedKind::Integral`.
+fn parse_integral_kind(
+    args: &[&[Token]],
+    ctx: ParseCtx<'_>,
+    parse_warnings: &mut Vec<String>,
+) -> Result<DerivedKind, String> {
+    if args.is_empty() {
+        return Err(
+            "[derived] integral() requires at least one argument (the integrand expression)".into(),
+        );
+    }
+
+    let integrand_expr = parse_derived_expr(args[0], ctx)?;
+    let data_based = expr_refs_dv(&integrand_expr);
+
+    let mut condition: Option<DerivedFilterFn> = None;
+    let mut from_val: Option<f64> = None;
+    let mut to_val: Option<f64> = None;
+    let mut window_val: Option<f64> = None;
+    let mut anchor_val: f64 = 0.0;
+    let mut step_val: Option<f64> = None;
+
+    let mut i = 1;
+    // Second positional arg is a condition if it contains comparison operators.
+    if i < args.len() && !is_keyword_arg_tokens(args[i]) && tokens_contain_comparison(args[i]) {
+        let cond = parse_derived_cond(args[i], ctx)?;
+        condition = Some(build_derived_filter_fn(cond));
+        i += 1;
+    }
+
+    // Remaining args are keyword args.
+    while i < args.len() {
+        let (k, v) =
+            parse_keyword_float_arg(args[i]).map_err(|e| format!("[derived] integral(): {e}"))?;
+        match k.to_lowercase().as_str() {
+            "from" => from_val = Some(v),
+            "to" => to_val = Some(v),
+            "window" => window_val = Some(v),
+            "anchor" => anchor_val = v,
+            "step" => step_val = Some(v),
+            other => {
+                return Err(format!(
+                    "[derived] integral(): unknown keyword argument `{other}`"
+                ))
+            }
+        }
+        i += 1;
+    }
+
+    let int_window = if let Some(w) = window_val {
+        if from_val.is_some() || to_val.is_some() {
+            return Err(
+                "[derived] integral(): cannot specify both `window=` and `from=`/`to=`".into(),
+            );
+        }
+        IntegralWindow::Periodic {
+            period: w,
+            anchor: anchor_val,
+        }
+    } else {
+        let f = from_val.ok_or("[derived] integral(): missing required argument `from=`")?;
+        let t = to_val.ok_or("[derived] integral(): missing required argument `to=`")?;
+        IntegralWindow::Explicit { from: f, to: t }
+    };
+
+    let int_step = if data_based {
+        if step_val.is_some() {
+            parse_warnings.push(
+                "[derived] integral(): `step=` is ignored for DV-based integrands \
+                 (W_DERIVED_STEP_IGNORED)"
+                    .into(),
+            );
+        }
+        IntegralStep::ObsTimes
+    } else if let Some(s) = step_val {
+        IntegralStep::Fixed(s)
+    } else {
+        IntegralStep::Auto
+    };
+
+    Ok(DerivedKind::Integral {
+        integrand: build_derived_eval_fn(integrand_expr),
+        condition,
+        data_based,
+        window: int_window,
+        step: int_step,
+    })
+}
+
+/// Parse a `[derived]` block into a sequence of `DerivedExprSpec`s.
+///
+/// Each line must have the form `NAME = <rhs>` where RHS is one of:
+/// - A plain arithmetic expression → `PerRow`
+/// - `max(expr)` / `max(expr, cond)` → `Aggregate(Max)`
+/// - `min(expr)` / `min(expr, cond)` → `Aggregate(Min)`
+/// - `tmax(expr)` / `tmax(expr, cond)` → `Aggregate(Tmax)`
+/// - `integral(expr, ...)` with keyword args → `Integral`
+fn parse_derived_block(
+    lines: &[String],
+    theta_names: &[String],
+    eta_names: &[String],
+    indiv_param_names: &[String],
+    covariate_names: &[String],
+    parse_warnings: &mut Vec<String>,
+) -> Result<Vec<DerivedExprSpec>, String> {
+    let mut specs: Vec<DerivedExprSpec> = Vec::new();
+    let mut defined_derived: Vec<String> = Vec::new();
+
+    // Names that resolve to Variable (not Theta/Eta) at parse time; these are
+    // looked up in the vars HashMap at closure-call time.
+    const BUILTIN_SPECIALS: &[&str] = &["IPRED", "PRED", "DV", "TIME", "TAFD", "TAD", "MACHEPS"];
+
+    for raw_line in lines {
+        let line = if let Some(idx) = raw_line.find('#') {
+            &raw_line[..idx]
+        } else {
+            raw_line.as_str()
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Split at first `=` to separate NAME from RHS.
+        let eq_pos = line
+            .find('=')
+            .ok_or_else(|| format!("[derived] line `{line}` must have the form `NAME = <expr>`"))?;
+        let name = line[..eq_pos].trim().to_string();
+        let rhs_str = line[eq_pos + 1..].trim().to_string();
+
+        if name.is_empty() {
+            return Err(format!(
+                "[derived] line `{line}` has an empty name before `=`"
+            ));
+        }
+
+        // ── Name conflict checks ──────────────────────────────────────────────
+        if DERIVED_BUILTIN_NAMES
+            .iter()
+            .any(|b| b.eq_ignore_ascii_case(&name))
+            || eta_names.iter().any(|e| e.eq_ignore_ascii_case(&name))
+        {
+            return Err(format!(
+                "[derived] name `{name}` conflicts with a built-in sdtab column or eta name \
+                 (E_DERIVED_NAME_CONFLICT)"
+            ));
+        }
+        if theta_names.iter().any(|t| t.eq_ignore_ascii_case(&name))
+            || indiv_param_names
+                .iter()
+                .any(|p| p.eq_ignore_ascii_case(&name))
+        {
+            return Err(format!(
+                "[derived] name `{name}` conflicts with a theta or individual-parameter name \
+                 (E_DERIVED_NAME_CONFLICT)"
+            ));
+        }
+        if covariate_names
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(&name))
+        {
+            parse_warnings.push(format!(
+                "[derived] name `{name}` shadows a covariate — this may be confusing \
+                 (W_DERIVED_COVARIATE_SHADOW)"
+            ));
+        }
+
+        // ── Build ParseCtx ────────────────────────────────────────────────────
+        // Unknown identifiers become Variable (fallback_covariate = false), so
+        // indiv params, covariates, and context fields (IPRED, DV, etc.) are all
+        // resolved via the vars HashMap at closure-call time.
+        let mut defined_vars: Vec<String> = indiv_param_names.to_vec();
+        defined_vars.extend(BUILTIN_SPECIALS.iter().map(|s| s.to_string()));
+        defined_vars.extend(covariate_names.iter().cloned());
+        defined_vars.extend(defined_derived.iter().cloned());
+
+        let ctx = ParseCtx {
+            theta_names,
+            eta_names,
+            defined_vars: &defined_vars,
+            fallback_covariate: false,
+            nn_specs: &[],
+        };
+
+        // ── Tokenize ──────────────────────────────────────────────────────────
+        let mut tokens = tokenize(&rhs_str)?;
+        tokens.retain(|t| !matches!(t, Token::Newline));
+
+        if tokens.is_empty() {
+            return Err(format!("[derived] `{name}` has an empty right-hand side"));
+        }
+
+        // ── Detect form ───────────────────────────────────────────────────────
+        let kind = if let Token::Ident(func_name) = &tokens[0] {
+            let fname_lc = func_name.to_lowercase();
+            if matches!(fname_lc.as_str(), "max" | "min" | "tmax" | "integral")
+                && tokens.get(1) == Some(&Token::LParen)
+            {
+                // Find the matching closing paren at depth 0 (after the opening LParen at [1]).
+                let mut depth = 0usize;
+                let mut close_idx = None;
+                for (i, tok) in tokens[1..].iter().enumerate() {
+                    match tok {
+                        Token::LParen => depth += 1,
+                        Token::RParen => {
+                            depth -= 1;
+                            if depth == 0 {
+                                close_idx = Some(i + 1); // index in `tokens`
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                let close_idx = close_idx.ok_or_else(|| {
+                    format!("[derived] `{name}`: `{fname_lc}(` missing closing `)`")
+                })?;
+
+                // tokens[2..close_idx] is the interior
+                let interior = &tokens[2..close_idx];
+                let args = split_top_level_commas(interior);
+
+                if fname_lc == "integral" {
+                    parse_integral_kind(&args, ctx, parse_warnings)?
+                } else {
+                    // max / min / tmax
+                    let agg_fn = match fname_lc.as_str() {
+                        "max" => AggFunction::Max,
+                        "min" => AggFunction::Min,
+                        "tmax" => AggFunction::Tmax,
+                        _ => unreachable!(),
+                    };
+                    let value_tokens = args.first().copied().unwrap_or(&[]);
+                    let filter_tokens = if args.len() >= 2 { Some(args[1]) } else { None };
+                    let value_expr = parse_derived_expr(value_tokens, ctx)?;
+                    let filter = if let Some(ft) = filter_tokens {
+                        let cond = parse_derived_cond(ft, ctx)?;
+                        Some(build_derived_filter_fn(cond))
+                    } else {
+                        None
+                    };
+                    DerivedKind::Aggregate {
+                        func: agg_fn,
+                        value: build_derived_eval_fn(value_expr),
+                        filter,
+                    }
+                }
+            } else {
+                // Plain expression → PerRow
+                let expr = parse_derived_expr(&tokens, ctx)?;
+                DerivedKind::PerRow {
+                    eval: build_derived_eval_fn(expr),
+                }
+            }
+        } else {
+            // Starts with a literal or unary minus
+            let expr = parse_derived_expr(&tokens, ctx)?;
+            DerivedKind::PerRow {
+                eval: build_derived_eval_fn(expr),
+            }
+        };
+
+        defined_derived.push(name.clone());
+        specs.push(DerivedExprSpec { name, kind });
+    }
+
+    Ok(specs)
+}
+
+/// Parse an `[output]` block: whitespace-separated column names.
+fn parse_output_block(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .flat_map(|line| {
+            let line = if let Some(idx) = line.find('#') {
+                &line[..idx]
+            } else {
+                line.as_str()
+            };
+            line.split_whitespace().map(|s| s.to_string())
+        })
+        .collect()
 }
 
 // ── [simulation] block parser ───────────────────────────────────────────────
@@ -3071,7 +3566,21 @@ fn build_ode_spec(
     for (i, n) in intermediates.iter().enumerate() {
         add_aliases(&mut var_idx, n, state_count + indiv_count + i);
     }
-    let n_vars_total = state_count + indiv_count + intermediates.len();
+    // Reserve extra slots for TIME/T, TAFD, TAD — always appended after intermediates.
+    let n_base_vars = state_count + indiv_count + intermediates.len();
+    let time_slot = n_base_vars;
+    let tafd_slot = n_base_vars + 1;
+    let tad_slot = n_base_vars + 2;
+    // TIME and T are aliases for the same slot.
+    var_idx.entry("TIME".to_string()).or_insert(time_slot);
+    var_idx.entry("time".to_string()).or_insert(time_slot);
+    var_idx.entry("T".to_string()).or_insert(time_slot);
+    var_idx.entry("t".to_string()).or_insert(time_slot);
+    var_idx.entry("TAFD".to_string()).or_insert(tafd_slot);
+    var_idx.entry("tafd".to_string()).or_insert(tafd_slot);
+    var_idx.entry("TAD".to_string()).or_insert(tad_slot);
+    var_idx.entry("tad".to_string()).or_insert(tad_slot);
+    let n_vars_total = n_base_vars + 3;
 
     // Rewrite the AST so the hot path walks `VariableIdx`/`AssignIdx`/`DiffEqIdx`
     // — pre-resolving names to slot indices. `cov_idx` stays empty (any
@@ -3108,7 +3617,7 @@ fn build_ode_spec(
     // once the capacity grows), so intermediate slots in untaken if-branches
     // still read 0 just like the old per-call `vec![0.0; n]` path.
     let rhs: Box<dyn Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync> =
-        Box::new(move |u: &[f64], params: &[f64], _t: f64, du: &mut [f64]| {
+        Box::new(move |u: &[f64], params: &[f64], t: f64, du: &mut [f64]| {
             // The integrator always passes a `u` whose length matches the
             // declared state count. The old closure index-panicked on
             // `u[i]` if that contract ever broke; preserve that signal here
@@ -3143,6 +3652,27 @@ fn build_ode_spec(
                     {
                         *dst = val;
                     }
+                }
+
+                // TIME / T — solver time axis (same as dataset TIME column).
+                if let Some(dst) = scratch.rhs_vars.get_mut(time_slot) {
+                    *dst = t;
+                }
+                // TAFD — t minus first-dose time, injected via params[MAX_PK_PARAMS].
+                if let Some(dst) = scratch.rhs_vars.get_mut(tafd_slot) {
+                    *dst = params
+                        .get(crate::types::MAX_PK_PARAMS)
+                        .copied()
+                        .filter(|v| v.is_finite())
+                        .map_or(f64::NAN, |first| t - first);
+                }
+                // TAD — t minus last-effective-dose time, injected via params[MAX_PK_PARAMS+1].
+                if let Some(dst) = scratch.rhs_vars.get_mut(tad_slot) {
+                    *dst = params
+                        .get(crate::types::MAX_PK_PARAMS + 1)
+                        .copied()
+                        .filter(|v| v.is_finite())
+                        .map_or(f64::NAN, |last| t - last);
                 }
 
                 // Reset du so a state without a firing d/dt this iteration
@@ -4420,6 +4950,8 @@ pub(crate) enum BinOp {
     Sub,
     Mul,
     Div,
+    /// Euclidean remainder — result always non-negative for positive divisor.
+    Mod,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -4772,7 +5304,13 @@ fn eval_expression(
         Expression::Theta(i) => theta[*i],
         Expression::Eta(i) => eta[*i],
         Expression::Covariate(name) => covariates.get(name).copied().unwrap_or(0.0),
-        Expression::Variable(name) => vars.get(name).copied().unwrap_or(0.0),
+        Expression::Variable(name) => {
+            if name.eq_ignore_ascii_case("MACHEPS") {
+                f64::EPSILON
+            } else {
+                vars.get(name).copied().unwrap_or(0.0)
+            }
+        }
         Expression::VariableIdx(_) | Expression::CovariateIdx(_) => {
             debug_assert!(
                 false,
@@ -4794,6 +5332,7 @@ fn eval_expression(
                         l / r
                     }
                 }
+                BinOp::Mod => l.rem_euclid(r),
             }
         }
         Expression::UnaryFn(name, arg) => {
@@ -4803,6 +5342,9 @@ fn eval_expression(
                 "log" | "ln" => v.max(1e-30).ln(),
                 "sqrt" => v.max(0.0).sqrt(),
                 "abs" => v.abs(),
+                "floor" => v.floor(),
+                "ceil" => v.ceil(),
+                "round" => v.round(),
                 "inv_logit" | "expit" => {
                     // Numerically stable: avoid exp overflow for very negative v
                     if v >= 0.0 {
@@ -4946,6 +5488,10 @@ enum Op {
     LogicNot,
     JumpIfFalse(u32), // pops top; jumps to bytecode index if value == 0.0
     Jump(u32),
+    Mod,   // rem_euclid (binary)
+    Floor, // unary
+    Ceil,  // unary
+    Round, // unary
 }
 
 // ─── Consolidated per-thread scratch ───────────────────────────────────────
@@ -5066,6 +5612,7 @@ fn compute_max_stack(ops: &[Op]) -> usize {
             | Op::Sub
             | Op::Mul
             | Op::Div
+            | Op::Mod
             | Op::Pow
             | Op::CmpLt
             | Op::CmpLe
@@ -5075,7 +5622,16 @@ fn compute_max_stack(ops: &[Op]) -> usize {
             | Op::CmpNe
             | Op::LogicAnd
             | Op::LogicOr => -1,
-            Op::Exp | Op::Ln | Op::Sqrt | Op::Abs | Op::InvLogit | Op::Logit | Op::LogicNot => 0,
+            Op::Exp
+            | Op::Ln
+            | Op::Sqrt
+            | Op::Abs
+            | Op::InvLogit
+            | Op::Logit
+            | Op::LogicNot
+            | Op::Floor
+            | Op::Ceil
+            | Op::Round => 0,
             Op::JumpIfFalse(_) => -1,
             Op::Jump(_) => 0,
         };
@@ -5127,6 +5683,7 @@ fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
                 BinOp::Sub => Op::Sub,
                 BinOp::Mul => Op::Mul,
                 BinOp::Div => Op::Div,
+                BinOp::Mod => Op::Mod,
             });
         }
         Expression::Power(base, exp) => {
@@ -5147,6 +5704,9 @@ fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
                 "abs" => bc.ops.push(Op::Abs),
                 "inv_logit" | "expit" => bc.ops.push(Op::InvLogit),
                 "logit" => bc.ops.push(Op::Logit),
+                "floor" => bc.ops.push(Op::Floor),
+                "ceil" => bc.ops.push(Op::Ceil),
+                "round" => bc.ops.push(Op::Round),
                 _ => { /* unknown function → leave the argument on the stack */ }
             }
         }
@@ -5300,6 +5860,15 @@ fn eval_bytecode(
                 let b = pop!();
                 push!(b.powf(e));
             }
+            Op::Mod => {
+                let b = pop!();
+                let a = pop!();
+                push!(if b.abs() < 1e-30 {
+                    0.0
+                } else {
+                    a.rem_euclid(b)
+                });
+            }
             Op::Exp => {
                 let v = pop!();
                 push!(v.exp());
@@ -5317,6 +5886,18 @@ fn eval_bytecode(
             Op::Abs => {
                 let v = pop!();
                 push!(v.abs());
+            }
+            Op::Floor => {
+                let v = pop!();
+                push!(v.floor());
+            }
+            Op::Ceil => {
+                let v = pop!();
+                push!(v.ceil());
+            }
+            Op::Round => {
+                let v = pop!();
+                push!(v.round());
             }
             Op::InvLogit => {
                 let v = pop!();
@@ -5446,6 +6027,7 @@ fn eval_expression_indexed(
                         l / r
                     }
                 }
+                BinOp::Mod => l.rem_euclid(r),
             }
         }
         Expression::UnaryFn(name, arg) => {
@@ -5455,6 +6037,9 @@ fn eval_expression_indexed(
                 "log" | "ln" => v.max(1e-30).ln(),
                 "sqrt" => v.max(0.0).sqrt(),
                 "abs" => v.abs(),
+                "floor" => v.floor(),
+                "ceil" => v.ceil(),
+                "round" => v.round(),
                 "inv_logit" | "expit" => {
                     if v >= 0.0 {
                         1.0 / (1.0 + (-v).exp())
@@ -5957,6 +6542,7 @@ fn differentiate_with_chain(
                 let denom = mul((**r).clone(), (**r).clone());
                 div(num, denom)
             }
+            BinOp::Mod => Expression::Literal(0.0), // mod is discontinuous; derivative is 0 a.e.
         },
         Expression::UnaryFn(name, arg) => {
             let da = differentiate_with_chain(arg, axis, chain);
@@ -6097,6 +6683,7 @@ fn simplify_expr(expr: &Expression) -> Expression {
                         Expression::BinOp(Box::new(l), *op, Box::new(r))
                     }
                 }
+                BinOp::Mod => Expression::BinOp(Box::new(l), *op, Box::new(r)),
             }
         }
         Expression::UnaryFn(name, arg) => {
@@ -6557,6 +7144,17 @@ fn tokenize(s: &str) -> Result<Vec<Token>, String> {
                     {
                         i += 1;
                     }
+                    // Handle optional sign in exponent: e.g. `-1e-10`, `-2.5E+3`.
+                    if i > 0
+                        && (chars[i - 1] == 'e' || chars[i - 1] == 'E')
+                        && i < chars.len()
+                        && (chars[i] == '+' || chars[i] == '-')
+                    {
+                        i += 1;
+                        while i < chars.len() && chars[i].is_ascii_digit() {
+                            i += 1;
+                        }
+                    }
                     let num_str: String = chars[start..i].iter().collect();
                     let num: f64 = num_str
                         .parse()
@@ -6592,6 +7190,17 @@ fn tokenize(s: &str) -> Result<Vec<Token>, String> {
                 {
                     i += 1;
                 }
+                // Handle optional sign in exponent: e.g. `1.5e-3`, `.5E+2`.
+                if i > 0
+                    && (chars[i - 1] == 'e' || chars[i - 1] == 'E')
+                    && i < chars.len()
+                    && (chars[i] == '+' || chars[i] == '-')
+                {
+                    i += 1;
+                    while i < chars.len() && chars[i].is_ascii_digit() {
+                        i += 1;
+                    }
+                }
                 let num_str: String = chars[start..i].iter().collect();
                 let num: f64 = num_str
                     .parse()
@@ -6611,6 +7220,17 @@ fn tokenize(s: &str) -> Result<Vec<Token>, String> {
                         || chars[i] == 'E')
                 {
                     i += 1;
+                }
+                // Handle optional sign in exponent: e.g. `1e-10`, `2.5E+3`.
+                if i > 0
+                    && (chars[i - 1] == 'e' || chars[i - 1] == 'E')
+                    && i < chars.len()
+                    && (chars[i] == '+' || chars[i] == '-')
+                {
+                    i += 1;
+                    while i < chars.len() && chars[i].is_ascii_digit() {
+                        i += 1;
+                    }
                 }
                 let num_str: String = chars[start..i].iter().collect();
                 let num: f64 = num_str
@@ -6678,6 +7298,11 @@ fn parse_mul_div(
             Token::Slash => {
                 let (right, p) = parse_power(tokens, pos + 1, ctx)?;
                 left = Expression::BinOp(Box::new(left), BinOp::Div, Box::new(right));
+                pos = p;
+            }
+            Token::Ident(kw) if kw.eq_ignore_ascii_case("mod") => {
+                let (right, p) = parse_power(tokens, pos + 1, ctx)?;
+                left = Expression::BinOp(Box::new(left), BinOp::Mod, Box::new(right));
                 pos = p;
             }
             _ => break,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13874,4 +13874,392 @@ method = foce
             parsed.model.parse_warnings
         );
     }
+
+    // ── [derived] block parser unit tests ────────────────────────────────────
+
+    fn minimal_model_with_derived(derived_block: &str) -> String {
+        format!(
+            r#"
+[parameters]
+  theta CL(1.0, 0, 100)
+  theta V(10.0, 0, 1000)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP   ~ 0.01
+
+[individual_parameters]
+  CL = exp(log(CL) + ETA_CL)
+  V  = exp(log(V)  + ETA_V)
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[derived]
+{derived_block}
+"#
+        )
+    }
+
+    fn make_derived_ctx_simple() -> (
+        Vec<f64>,
+        Vec<f64>,
+        std::collections::HashMap<String, f64>,
+        std::collections::HashMap<String, f64>,
+        std::collections::HashMap<String, f64>,
+    ) {
+        let theta = vec![1.0, 10.0];
+        let eta = vec![0.0, 0.0];
+        let mut indiv_params = std::collections::HashMap::new();
+        indiv_params.insert("CL".to_string(), 1.0);
+        indiv_params.insert("V".to_string(), 10.0);
+        let covariates = std::collections::HashMap::new();
+        let prev_derived = std::collections::HashMap::new();
+        (theta, eta, indiv_params, covariates, prev_derived)
+    }
+
+    #[test]
+    fn parse_derived_per_row() {
+        let src = minimal_model_with_derived("KE = CL / V");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert_eq!(parsed.model.derived_exprs.len(), 1);
+        assert_eq!(parsed.model.derived_exprs[0].name, "KE");
+        assert!(matches!(
+            parsed.model.derived_exprs[0].kind,
+            DerivedKind::PerRow { .. }
+        ));
+
+        // Evaluate the closure
+        let (theta, eta, indiv_params, covariates, prev_derived) = make_derived_ctx_simple();
+        if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+            let ctx = DerivedContext {
+                theta: &theta,
+                eta: &eta,
+                indiv_params: &indiv_params,
+                covariates: &covariates,
+                ipred: 0.0,
+                pred: 0.0,
+                dv: 0.0,
+                time: 1.0,
+                tafd: 1.0,
+                tad: 1.0,
+                prev_derived: &prev_derived,
+            };
+            let ke = eval(&ctx);
+            assert!((ke - 0.1).abs() < 1e-10, "KE = CL/V = 1/10 = 0.1, got {ke}");
+        } else {
+            panic!("expected PerRow");
+        }
+    }
+
+    #[test]
+    fn parse_derived_sequential_reference() {
+        let src = minimal_model_with_derived("KE = CL / V\nT_HALF = 0.693 / KE");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert_eq!(parsed.model.derived_exprs.len(), 2);
+
+        let (theta, eta, indiv_params, covariates, _) = make_derived_ctx_simple();
+        let mut prev_derived = std::collections::HashMap::new();
+
+        // Evaluate KE first
+        if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+            let ctx = DerivedContext {
+                theta: &theta,
+                eta: &eta,
+                indiv_params: &indiv_params,
+                covariates: &covariates,
+                ipred: 0.0,
+                pred: 0.0,
+                dv: 0.0,
+                time: 1.0,
+                tafd: 1.0,
+                tad: 1.0,
+                prev_derived: &prev_derived,
+            };
+            let ke = eval(&ctx);
+            prev_derived.insert("KE".to_string(), ke);
+        }
+
+        // Now evaluate T_HALF using prev_derived
+        if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[1].kind {
+            let ctx = DerivedContext {
+                theta: &theta,
+                eta: &eta,
+                indiv_params: &indiv_params,
+                covariates: &covariates,
+                ipred: 0.0,
+                pred: 0.0,
+                dv: 0.0,
+                time: 1.0,
+                tafd: 1.0,
+                tad: 1.0,
+                prev_derived: &prev_derived,
+            };
+            let t_half = eval(&ctx);
+            let expected = 0.693 / 0.1;
+            assert!(
+                (t_half - expected).abs() < 1e-8,
+                "T_HALF = 0.693/KE = {expected}, got {t_half}"
+            );
+        } else {
+            panic!("expected PerRow for T_HALF");
+        }
+    }
+
+    #[test]
+    fn parse_derived_max_with_filter() {
+        let src = minimal_model_with_derived("CMAX = max(IPRED, TIME < 24)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(matches!(
+            parsed.model.derived_exprs[0].kind,
+            DerivedKind::Aggregate {
+                func: AggFunction::Max,
+                filter: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_derived_min_no_filter() {
+        let src = minimal_model_with_derived("CMIN = min(IPRED)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(matches!(
+            parsed.model.derived_exprs[0].kind,
+            DerivedKind::Aggregate {
+                func: AggFunction::Min,
+                filter: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_derived_tmax() {
+        let src = minimal_model_with_derived("TMAX = tmax(IPRED)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(matches!(
+            parsed.model.derived_exprs[0].kind,
+            DerivedKind::Aggregate {
+                func: AggFunction::Tmax,
+                filter: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_derived_integral_explicit() {
+        let src = minimal_model_with_derived("AUC = integral(IPRED, from=0, to=24)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        if let DerivedKind::Integral {
+            data_based,
+            window: IntegralWindow::Explicit { from, to },
+            step: IntegralStep::Auto,
+            ..
+        } = &parsed.model.derived_exprs[0].kind
+        {
+            assert!(!data_based, "IPRED is not DV-based");
+            assert!((from - 0.0).abs() < 1e-10);
+            assert!((to - 24.0).abs() < 1e-10);
+        } else {
+            panic!(
+                "expected Integral(Explicit, Auto), got {:?} kind",
+                parsed.model.derived_exprs[0].name
+            );
+        }
+    }
+
+    #[test]
+    fn parse_derived_integral_dv() {
+        let src = minimal_model_with_derived("AUC_DV = integral(DV, from=0, to=24)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        if let DerivedKind::Integral {
+            data_based,
+            step: IntegralStep::ObsTimes,
+            ..
+        } = &parsed.model.derived_exprs[0].kind
+        {
+            assert!(*data_based, "DV is data_based");
+        } else {
+            panic!("expected Integral with ObsTimes step for DV integrand");
+        }
+    }
+
+    #[test]
+    fn parse_derived_integral_periodic() {
+        let src = minimal_model_with_derived("AUC_TAU = integral(IPRED, window=24, anchor=0)");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        if let DerivedKind::Integral {
+            window: IntegralWindow::Periodic { period, anchor },
+            ..
+        } = &parsed.model.derived_exprs[0].kind
+        {
+            assert!((period - 24.0).abs() < 1e-10);
+            assert!((anchor - 0.0).abs() < 1e-10);
+        } else {
+            panic!("expected Integral(Periodic)");
+        }
+    }
+
+    #[test]
+    fn parse_derived_name_conflict_error() {
+        // IPRED is a built-in sdtab column — should error
+        let src = minimal_model_with_derived("IPRED = CL / V");
+        let result = parse_full_model(&src);
+        assert!(
+            result.is_err(),
+            "expected parse error for IPRED name conflict"
+        );
+        let msg = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected Err"),
+        };
+        assert!(
+            msg.contains("E_DERIVED_NAME_CONFLICT"),
+            "expected E_DERIVED_NAME_CONFLICT in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_output_block() {
+        let src = format!(
+            r#"{}
+[output]
+CL V KA WT
+"#,
+            minimal_model_with_derived("")
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert_eq!(
+            parsed.model.output_columns,
+            vec!["CL", "V", "KA", "WT"],
+            "output_columns mismatch"
+        );
+    }
+
+    #[test]
+    fn parse_output_empty_block_ok() {
+        let src = format!(
+            r#"{}
+[output]
+"#,
+            minimal_model_with_derived("")
+        );
+        let parsed = parse_full_model(&src).expect("parse ok");
+        assert!(
+            parsed.model.output_columns.is_empty(),
+            "empty [output] block should produce empty output_columns"
+        );
+    }
+
+    #[test]
+    fn sci_notation_negative_exp() {
+        let src = minimal_model_with_derived("FLAG = if (TAD < 1e-10) 1 else 0");
+        let parsed = parse_full_model(&src).expect("parse ok — 1e-10 must tokenise correctly");
+        assert_eq!(parsed.model.derived_exprs.len(), 1);
+    }
+
+    #[test]
+    fn sci_notation_positive_exp() {
+        let src = minimal_model_with_derived("FLAG = if (TAFD > 1.5E+3) 1 else 0");
+        let parsed = parse_full_model(&src).expect("parse ok — 1.5E+3 must tokenise correctly");
+        assert_eq!(parsed.model.derived_exprs.len(), 1);
+    }
+
+    #[test]
+    fn mod_operator_euclidean() {
+        // 5 mod 2 == 1, 7 mod 3 == 1, -1 mod 24 == 23
+        let tests = [("5 mod 2", 1.0), ("7 mod 3", 1.0), ("-1 mod 24", 23.0)];
+        for (expr_str, expected) in &tests {
+            let expr_src = format!("VAL = {expr_str}");
+            let src = minimal_model_with_derived(&expr_src);
+            let parsed = parse_full_model(&src).expect("parse ok");
+            let (theta, eta, indiv, cov, prev) = make_derived_ctx_simple();
+            if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+                let ctx = DerivedContext {
+                    theta: &theta,
+                    eta: &eta,
+                    indiv_params: &indiv,
+                    covariates: &cov,
+                    ipred: 0.0,
+                    pred: 0.0,
+                    dv: 0.0,
+                    time: 0.0,
+                    tafd: 0.0,
+                    tad: 0.0,
+                    prev_derived: &prev,
+                };
+                let result = eval(&ctx);
+                assert!(
+                    (result - expected).abs() < 1e-10,
+                    "{expr_str}: expected {expected}, got {result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn floor_ceil_round_functions() {
+        let tests = [
+            ("floor(-2.3)", -3.0),
+            ("ceil(-2.3)", -2.0),
+            ("round(2.5)", 3.0),
+        ];
+        for (expr_str, expected) in &tests {
+            let src = minimal_model_with_derived(&format!("VAL = {expr_str}"));
+            let parsed = parse_full_model(&src).expect("parse ok");
+            let (theta, eta, indiv, cov, prev) = make_derived_ctx_simple();
+            if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+                let ctx = DerivedContext {
+                    theta: &theta,
+                    eta: &eta,
+                    indiv_params: &indiv,
+                    covariates: &cov,
+                    ipred: 0.0,
+                    pred: 0.0,
+                    dv: 0.0,
+                    time: 0.0,
+                    tafd: 0.0,
+                    tad: 0.0,
+                    prev_derived: &prev,
+                };
+                let result = eval(&ctx);
+                assert!(
+                    (result - expected).abs() < 1e-10,
+                    "{expr_str}: expected {expected}, got {result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn macheps_available_in_derived() {
+        let src = minimal_model_with_derived("FLAG = if (TAD < MACHEPS) 1 else 0");
+        let parsed = parse_full_model(&src).expect("parse ok");
+        let (theta, eta, indiv, cov, _prev) = make_derived_ctx_simple();
+        let prev = std::collections::HashMap::new();
+        if let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind {
+            // TAD = 0.0 < MACHEPS → flag = 1
+            let ctx = DerivedContext {
+                theta: &theta,
+                eta: &eta,
+                indiv_params: &indiv,
+                covariates: &cov,
+                ipred: 0.0,
+                pred: 0.0,
+                dv: 0.0,
+                time: 1.0,
+                tafd: 1.0,
+                tad: 0.0, // zero
+                prev_derived: &prev,
+            };
+            assert_eq!(eval(&ctx), 1.0, "TAD=0 should be < MACHEPS");
+            // TAD = 1.0 >> MACHEPS → flag = 0
+            let ctx2 = DerivedContext { tad: 1.0, ..ctx };
+            assert_eq!(eval(&ctx2), 0.0, "TAD=1 should not be < MACHEPS");
+        }
+    }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1884,9 +1884,23 @@ fn parse_integral_kind(
         match k.to_lowercase().as_str() {
             "from" => from_val = Some(v),
             "to" => to_val = Some(v),
-            "window" => window_val = Some(v),
+            "window" => {
+                if v <= 0.0 {
+                    return Err(format!(
+                        "[derived] integral(): `window=` must be positive, got {v}"
+                    ));
+                }
+                window_val = Some(v);
+            }
             "anchor" => anchor_val = v,
-            "step" => step_val = Some(v),
+            "step" => {
+                if v <= 0.0 {
+                    return Err(format!(
+                        "[derived] integral(): `step=` must be positive, got {v}"
+                    ));
+                }
+                step_val = Some(v);
+            }
             other => {
                 return Err(format!(
                     "[derived] integral(): unknown keyword argument `{other}`"

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -922,6 +922,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -1043,6 +1043,8 @@ mod tests {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -237,6 +237,7 @@ mod tests {
             cens: vec![],
             n_obs: 0,
             extra_columns: vec![],
+            per_obs_tad: vec![],
         }
     }
 

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -236,6 +236,7 @@ mod tests {
             ofv_contribution: 0.0,
             cens: vec![],
             n_obs: 0,
+            extra_columns: vec![],
         }
     }
 

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -806,6 +806,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
         let result = inits_from_nca(&model, &empty_pop, NcaInit::Nca);
         // Must not panic and should warn.

--- a/src/suggest_start/sweep.rs
+++ b/src/suggest_start/sweep.rs
@@ -382,6 +382,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            warnings: vec![],
         };
         let r = rrmse(&model, &empty_pop, &model.default_params);
         assert!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -283,6 +283,9 @@ pub struct Population {
     /// covariates). Preserved verbatim so downstream consumers can echo a NONMEM-style
     /// `$INPUT` line. Empty for in-memory `Population` values that were not read from a file.
     pub input_columns: Vec<String>,
+    /// Non-fatal warnings generated while reading the dataset (e.g. ADDL with missing II,
+    /// unparseable OCC values). Propagated into `FitResult.warnings` by `fit()`.
+    pub warnings: Vec<String>,
 }
 
 impl Population {
@@ -1357,6 +1360,11 @@ pub struct SubjectResult {
     /// post-fit. Each entry is (column_name, per-observation values). Subject-
     /// level aggregates (max, AUC, tmax) are repeated across all observation rows.
     pub extra_columns: Vec<(String, Vec<f64>)>,
+    /// Per-observation TAD computed with individual lagtime. Populated by
+    /// `compute_extra_output_columns` whenever the model has a lagtime or [derived]/[output]
+    /// blocks exist. Empty if those conditions are not met; output.rs falls back to
+    /// a lagtime=0 approximation in that case (correct for the common case).
+    pub per_obs_tad: Vec<f64>,
 }
 
 // ── Derived expression types ──────────────────────────────────────────────────

--- a/src/types.rs
+++ b/src/types.rs
@@ -1590,6 +1590,12 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, "importance_sampling")
     } else if lower.contains("eps shrinkage") {
         (WarningSeverity::Warning, "eps_shrinkage")
+    } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
+        (WarningSeverity::Warning, "data_quality")
+    } else if lower.starts_with("w_iov_occ_missing")
+        || lower.contains("missing or unparseable values in iov_column")
+    {
+        (WarningSeverity::Warning, "data_quality")
     } else if lower.contains("ltbs")
         || lower.contains("non-positive dv")
         || lower.contains("ss=1 dose")

--- a/src/types.rs
+++ b/src/types.rs
@@ -1226,6 +1226,11 @@ pub struct CompiledModel {
     /// natural scale (case 2, `log(DV) ~ additive`) and `fit()` log-transforms
     /// the observations once at load. Ignored when `log_transform` is `false`.
     pub dv_pre_logged: bool,
+    /// Derived expression specifications from [derived] block.
+    /// Empty when no [derived] block is present. Evaluated post-fit.
+    pub derived_exprs: Vec<DerivedExprSpec>,
+    /// Column names from [output] block. Validated at fit time.
+    pub output_columns: Vec<String>,
 }
 
 /// Inner-loop (per-subject EBE) gradient method.
@@ -1348,6 +1353,87 @@ pub struct SubjectResult {
     pub cens: Vec<u8>,
     /// Number of observations for this subject (MDV=0 rows).
     pub n_obs: usize,
+    /// Extra sdtab columns from [derived] and [output] blocks, computed
+    /// post-fit. Each entry is (column_name, per-observation values). Subject-
+    /// level aggregates (max, AUC, tmax) are repeated across all observation rows.
+    pub extra_columns: Vec<(String, Vec<f64>)>,
+}
+
+// ── Derived expression types ──────────────────────────────────────────────────
+
+/// Context threaded into every [derived] expression evaluation.
+pub struct DerivedContext<'a> {
+    pub theta: &'a [f64],
+    pub eta: &'a [f64],
+    pub indiv_params: &'a HashMap<String, f64>,
+    pub covariates: &'a HashMap<String, f64>,
+    pub ipred: f64,
+    pub pred: f64,
+    pub dv: f64,
+    pub time: f64,
+    pub tafd: f64,
+    pub tad: f64,
+    pub prev_derived: &'a HashMap<String, f64>,
+}
+
+pub type DerivedEvalFn = Box<dyn Fn(&DerivedContext<'_>) -> f64 + Send + Sync>;
+pub type DerivedFilterFn = Box<dyn Fn(&DerivedContext<'_>) -> bool + Send + Sync>;
+
+pub struct DerivedExprSpec {
+    pub name: String,
+    pub kind: DerivedKind,
+}
+
+pub enum DerivedKind {
+    /// Evaluated independently at each observation row.
+    PerRow { eval: DerivedEvalFn },
+    /// Reduction over observation rows (max/min/tmax), optionally filtered.
+    /// The scalar is repeated for all rows of the subject.
+    Aggregate {
+        func: AggFunction,
+        value: DerivedEvalFn,
+        filter: Option<DerivedFilterFn>,
+    },
+    /// Numeric integration over a time window.
+    Integral {
+        integrand: DerivedEvalFn,
+        /// When `Some`, only time points where this evaluates to true contribute.
+        condition: Option<DerivedFilterFn>,
+        /// True when integrand references DV → use observation times only.
+        data_based: bool,
+        window: IntegralWindow,
+        step: IntegralStep,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggFunction {
+    Max,
+    Min,
+    Tmax,
+}
+
+#[derive(Debug, Clone)]
+pub enum IntegralWindow {
+    Explicit {
+        from: f64,
+        to: f64,
+    },
+    /// One integral per period-aligned window; each observation gets its window's value.
+    Periodic {
+        period: f64,
+        anchor: f64,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum IntegralStep {
+    /// Use observation times only (DV integrals; fallback when model unavailable).
+    ObsTimes,
+    /// Fine internal grid with this step size (hours).
+    Fixed(f64),
+    /// Auto: (to − from) / 500.
+    Auto,
 }
 
 /// How per-occasion kappa random effects are treated in the IS marginal likelihood.
@@ -2492,6 +2578,8 @@ pub(crate) mod test_helpers {
             scaling: ScalingSpec::None,
             log_transform: false,
             dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
         }
     }
 }

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -1,0 +1,246 @@
+//! Integration tests for `[derived]` and `[output]` blocks (Steps 5–10).
+//!
+//! Tier 2: parse-time validation (fast, no `slow-tests` gate). Tier 3 tests
+//! that require a full fit to convergence are gated with `#[cfg_attr(..., ignore)]`.
+
+use ferx_core::api::{check_model_data, tafd_tad_for_subject};
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::types::{DoseEvent, Population, Subject};
+use std::collections::HashMap;
+
+// ── Minimal model template ───────────────────────────────────────────────────
+
+const BASE_MODEL: &str = "
+[parameters]
+  theta CL(1.0, 0, 100)
+  theta V(10.0, 0, 1000)
+  omega ETA_CL ~ 0.09
+  sigma PROP   ~ 0.01
+
+[individual_parameters]
+  CL = exp(log(CL) + ETA_CL)
+  V  = V
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+fn base_with_extra(extra: &str) -> String {
+    format!("{BASE_MODEL}\n{extra}")
+}
+
+fn one_dose_population() -> Population {
+    let obs_times = vec![1.0, 4.0, 12.0, 24.0];
+    let n_obs = obs_times.len();
+    let mut cov = HashMap::new();
+    cov.insert("WT".to_string(), 70.0);
+    Population {
+        covariate_names: vec!["WT".to_string()],
+        dv_column: "DV".to_string(),
+        input_columns: vec![],
+        subjects: vec![Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times,
+            observations: vec![5.0, 3.0, 1.5, 0.7],
+            obs_cmts: vec![1; n_obs],
+            covariates: cov,
+            dose_covariates: vec![],
+            obs_covariates: vec![],
+            pk_only_times: vec![],
+            pk_only_covariates: vec![],
+            reset_times: vec![],
+            cens: vec![0; n_obs],
+            occasions: vec![],
+            dose_occasions: vec![],
+        }],
+    }
+}
+
+// ── Parser validation tests ───────────────────────────────────────────────────
+
+#[test]
+fn derived_name_conflict_returns_err() {
+    let src = base_with_extra("[derived]\n  IPRED = CL / V");
+    let result = parse_full_model(&src);
+    assert!(result.is_err(), "IPRED is a built-in column — must error");
+    let msg = match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected Err"),
+    };
+    assert!(
+        msg.contains("E_DERIVED_NAME_CONFLICT"),
+        "expected E_DERIVED_NAME_CONFLICT in: {msg}"
+    );
+}
+
+#[test]
+fn derived_eta_name_conflict_returns_err() {
+    let src = base_with_extra("[derived]\n  ETA_CL = CL / V");
+    let result = parse_full_model(&src);
+    assert!(result.is_err(), "ETA_CL is an eta name — must error");
+    let msg = match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected Err"),
+    };
+    assert!(
+        msg.contains("E_DERIVED_NAME_CONFLICT"),
+        "expected E_DERIVED_NAME_CONFLICT in: {msg}"
+    );
+}
+
+#[test]
+fn derived_theta_name_conflict_returns_err() {
+    let src = base_with_extra("[derived]\n  CL = V / V");
+    let result = parse_full_model(&src);
+    assert!(result.is_err(), "CL is an indiv param name — must error");
+    let msg = match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected Err"),
+    };
+    assert!(msg.contains("E_DERIVED_NAME_CONFLICT"));
+}
+
+#[test]
+fn output_unknown_column_emits_error() {
+    let src = base_with_extra("[output]\n  UNKNOWN_COLUMN");
+    let model = parse_full_model(&src).expect("parse ok").model;
+    let pop = one_dose_population();
+    let diags = check_model_data(&model, &pop);
+    let codes: Vec<&str> = diags.iter().map(|d| d.code.as_str()).collect();
+    assert!(
+        codes.contains(&"E_OUTPUT_UNKNOWN_COLUMN"),
+        "expected E_OUTPUT_UNKNOWN_COLUMN in: {codes:?}"
+    );
+}
+
+#[test]
+fn output_duplicate_tafd_emits_warning() {
+    let src = base_with_extra("[output]\n  TAFD");
+    let model = parse_full_model(&src).expect("parse ok").model;
+    let pop = one_dose_population();
+    let diags = check_model_data(&model, &pop);
+    let codes: Vec<&str> = diags.iter().map(|d| d.code.as_str()).collect();
+    assert!(
+        codes.contains(&"W_OUTPUT_DUPLICATE"),
+        "expected W_OUTPUT_DUPLICATE in: {codes:?}"
+    );
+}
+
+#[test]
+fn output_valid_covariate_no_error() {
+    let src = base_with_extra("[output]\n  WT");
+    let model = parse_full_model(&src).expect("parse ok").model;
+    let pop = one_dose_population();
+    let diags = check_model_data(&model, &pop);
+    let errors: Vec<&str> = diags
+        .iter()
+        .filter(|d| d.severity == ferx_core::diagnostics::Severity::Error)
+        .map(|d| d.code.as_str())
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "WT is a covariate — no errors expected; got: {errors:?}"
+    );
+}
+
+#[test]
+fn derived_integral_step_ignored_warning_for_dv() {
+    let src = base_with_extra("[derived]\n  AUC = integral(DV, from=0, to=24, step=0.1)");
+    let result = parse_full_model(&src).expect("parse ok");
+    let has_step_warn = result
+        .model
+        .parse_warnings
+        .iter()
+        .any(|w| w.contains("W_DERIVED_STEP_IGNORED"));
+    assert!(
+        has_step_warn,
+        "expected W_DERIVED_STEP_IGNORED when step= given for DV integral; got: {:?}",
+        result.model.parse_warnings
+    );
+}
+
+// ── TAFD/TAD helper unit tests ────────────────────────────────────────────────
+
+fn make_subject_with_doses(obs_times: Vec<f64>, doses: Vec<DoseEvent>) -> Subject {
+    let n = obs_times.len();
+    Subject {
+        id: "1".into(),
+        doses,
+        obs_times,
+        observations: vec![0.0; n],
+        obs_cmts: vec![1; n],
+        covariates: HashMap::new(),
+        dose_covariates: vec![],
+        obs_covariates: vec![],
+        pk_only_times: vec![],
+        pk_only_covariates: vec![],
+        reset_times: vec![],
+        cens: vec![0; n],
+        occasions: vec![],
+        dose_occasions: vec![],
+    }
+}
+
+#[test]
+fn tafd_correct_single_dose() {
+    // Dose at t=5, obs at t=10 → TAFD = 5
+    let subj = make_subject_with_doses(
+        vec![10.0],
+        vec![DoseEvent::new(5.0, 100.0, 1, 0.0, false, 0.0)],
+    );
+    let (tafd, _) = tafd_tad_for_subject(&subj, 0, 0.0);
+    assert!((tafd - 5.0).abs() < 1e-10, "TAFD should be 5, got {tafd}");
+}
+
+#[test]
+fn tafd_nan_when_no_dose() {
+    // No doses → TAFD is NaN
+    let subj = make_subject_with_doses(vec![10.0], vec![]);
+    let (tafd, _) = tafd_tad_for_subject(&subj, 0, 0.0);
+    assert!(
+        tafd.is_nan(),
+        "TAFD should be NaN with no doses, got {tafd}"
+    );
+}
+
+#[test]
+fn tad_nan_when_dose_after_obs() {
+    // Dose at t=20, obs at t=1 → no prior dose → TAD is NaN
+    let subj = make_subject_with_doses(
+        vec![1.0],
+        vec![DoseEvent::new(20.0, 100.0, 1, 0.0, false, 0.0)],
+    );
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    assert!(
+        tad.is_nan(),
+        "TAD should be NaN when dose is after obs, got {tad}"
+    );
+}
+
+#[test]
+fn tad_ss_modular() {
+    // SS dose at t=0, II=12, obs at t=50 → TAD = 50 mod 12 = 2
+    let mut dose = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 12.0);
+    dose.ss = true;
+    let subj = make_subject_with_doses(vec![50.0], vec![dose]);
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    assert!((tad - 2.0).abs() < 1e-10, "TAD(SS) should be 2, got {tad}");
+}
+
+#[test]
+fn tad_after_addl_expanded_doses() {
+    // Dose at t=0, plus explicit doses at t=24,48 (simulating ADDL=2, II=24).
+    // Obs at t=50 → last effective dose at t=48 → TAD=2
+    let doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(24.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(48.0, 100.0, 1, 0.0, false, 0.0),
+    ];
+    let subj = make_subject_with_doses(vec![50.0], doses);
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    assert!((tad - 2.0).abs() < 1e-10, "TAD should be 2, got {tad}");
+}

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -4,8 +4,9 @@
 //! that require a full fit to convergence are gated with `#[cfg_attr(..., ignore)]`.
 
 use ferx_core::api::{check_model_data, tafd_tad_for_subject};
-use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::parser::model_parser::{parse_full_model, parse_model_string};
 use ferx_core::types::{DoseEvent, Population, Subject};
+use ferx_core::{fit, FitOptions};
 use std::collections::HashMap;
 
 // ── Minimal model template ───────────────────────────────────────────────────
@@ -244,4 +245,98 @@ fn tad_after_addl_expanded_doses() {
     let subj = make_subject_with_doses(vec![50.0], doses);
     let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
     assert!((tad - 2.0).abs() < 1e-10, "TAD should be 2, got {tad}");
+}
+
+// ── End-to-end: fit() produces finite extra_columns ──────────────────────────
+
+/// End-to-end coverage: after a short FOCE-I fit, extra_columns from [derived]
+/// and [output] must be populated with finite, non-NaN values for every subject.
+/// Exercises the full post-fit derived pipeline including PerRow, Aggregate, and
+/// the output-column echo.
+#[test]
+fn fit_produces_finite_derived_and_output_columns() {
+    const MODEL: &str = "
+[parameters]
+  theta CL(1.0, 0.01, 50.0)
+  theta V(10.0, 0.1, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP   ~ 0.01
+
+[individual_parameters]
+  CL = CL * exp(ETA_CL)
+  V  = V
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[derived]
+  Cmax = max(IPRED)
+  AUC  = integral(IPRED, from=0, to=24)
+
+[output]
+  CLi
+
+[fit_options]
+  method   = focei
+  maxiter  = 2
+  gradient = fd
+";
+    let model = parse_model_string(MODEL).expect("model must parse");
+    let pop = one_dose_population();
+
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("short fit must not error");
+
+    // Every subject result must have extra_columns for Cmax, AUC, and CLi.
+    for sr in &result.subjects {
+        for name in &["Cmax", "AUC", "CLi"] {
+            let col = sr
+                .extra_columns
+                .iter()
+                .find(|(n, _)| n == name)
+                .unwrap_or_else(|| panic!("extra column '{name}' missing for subject {}", sr.id));
+            assert!(
+                !col.1.is_empty(),
+                "column '{name}' is empty for subject {}",
+                sr.id
+            );
+            for &v in &col.1 {
+                assert!(
+                    v.is_finite(),
+                    "column '{name}' has non-finite value {v} for subject {}",
+                    sr.id
+                );
+            }
+        }
+    }
+}
+
+/// Parser must reject step=0 and step negative in [derived] integral().
+#[test]
+fn integral_step_zero_is_rejected_at_parse() {
+    let src = base_with_extra("[derived]\n  AUC = integral(IPRED, from=0, to=24, step=0)");
+    let err = parse_full_model(&src)
+        .err()
+        .expect("step=0 must be rejected at parse time");
+    assert!(
+        err.contains("step") && err.contains("positive"),
+        "error should cite step= and positive, got: {err}"
+    );
+}
+
+/// Parser must reject window=0 in [derived] integral().
+#[test]
+fn integral_window_zero_is_rejected_at_parse() {
+    let src = base_with_extra("[derived]\n  AUC = integral(IPRED, window=0)");
+    let err = parse_full_model(&src)
+        .err()
+        .expect("window=0 must be rejected at parse time");
+    assert!(
+        err.contains("window") && err.contains("positive"),
+        "error should cite window= and positive, got: {err}"
+    )
 }

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -41,6 +41,7 @@ fn one_dose_population() -> Population {
         covariate_names: vec!["WT".to_string()],
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        warnings: vec![],
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -277,7 +277,7 @@ fn fit_produces_finite_derived_and_output_columns() {
   AUC  = integral(IPRED, from=0, to=24)
 
 [output]
-  CLi
+  CL
 
 [fit_options]
   method   = focei
@@ -291,9 +291,9 @@ fn fit_produces_finite_derived_and_output_columns() {
     opts.verbose = false;
     let result = fit(&model, &pop, &model.default_params, &opts).expect("short fit must not error");
 
-    // Every subject result must have extra_columns for Cmax, AUC, and CLi.
+    // Every subject result must have extra_columns for Cmax, AUC, and CL.
     for sr in &result.subjects {
-        for name in &["Cmax", "AUC", "CLi"] {
+        for name in &["Cmax", "AUC", "CL"] {
             let col = sr
                 .extra_columns
                 .iter()
@@ -311,6 +311,67 @@ fn fit_produces_finite_derived_and_output_columns() {
                     sr.id
                 );
             }
+        }
+    }
+}
+
+/// Regression: an [output] covariate referenced with a different case than the
+/// dataset header must echo the covariate value, not NaN. `validate_output_columns`
+/// accepts the name case-insensitively (`wt` matches header `WT`), so the post-fit
+/// echo in `compute_extra_output_columns` must resolve it case-insensitively too.
+#[test]
+fn output_covariate_case_insensitive_echo() {
+    const MODEL: &str = "
+[parameters]
+  theta CL(1.0, 0.01, 50.0)
+  theta V(10.0, 0.1, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP   ~ 0.01
+
+[individual_parameters]
+  CL = CL * exp(ETA_CL)
+  V  = V
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[output]
+  wt
+
+[fit_options]
+  method   = focei
+  maxiter  = 2
+  gradient = fd
+";
+    let model = parse_model_string(MODEL).expect("model must parse");
+    // Population covariate header is uppercase `WT` = 70.0; the [output] entry
+    // is lowercase `wt`.
+    let pop = one_dose_population();
+
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("short fit must not error");
+
+    for sr in &result.subjects {
+        let col = sr
+            .extra_columns
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("wt"))
+            .unwrap_or_else(|| panic!("output column 'wt' missing for subject {}", sr.id));
+        assert!(
+            !col.1.is_empty(),
+            "column 'wt' is empty for subject {}",
+            sr.id
+        );
+        for &v in &col.1 {
+            assert_eq!(
+                v, 70.0,
+                "output 'wt' must echo covariate header WT=70 for subject {}, got {v}",
+                sr.id
+            );
         }
     }
 }

--- a/tests/multi_endpoint.rs
+++ b/tests/multi_endpoint.rs
@@ -63,6 +63,7 @@ fn pkpd_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        warnings: vec![],
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],

--- a/tests/saem_omega_burnin.rs
+++ b/tests/saem_omega_burnin.rs
@@ -84,6 +84,7 @@ fn sparse_population(n: usize) -> Population {
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        warnings: vec![],
     }
 }
 

--- a/tests/scaling_block.rs
+++ b/tests/scaling_block.rs
@@ -23,6 +23,7 @@ fn one_subject_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        warnings: vec![],
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
@@ -261,6 +262,7 @@ fn two_cmt_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        warnings: vec![],
         subjects: vec![mk_subject("1"), mk_subject("2")],
     }
 }

--- a/tests/suggest_start.rs
+++ b/tests/suggest_start.rs
@@ -119,6 +119,7 @@ fn test_suggest_start_empty_population() {
         covariate_names: vec![],
         dv_column: "DV".into(),
         input_columns: vec![],
+        warnings: vec![],
     };
     let result = inits_from_nca(&model, &empty, NcaInit::Nca);
     assert!(!result.warnings.is_empty(), "must warn on empty population");


### PR DESCRIPTION
## Why

Users frequently need per-subject exposure metrics (AUC, Cmax, Tmax) and covariate columns in the sdtab without writing external post-processing scripts. This PR adds two optional model-file blocks that let the model file declare these directly:

- `[derived]` — computed columns appended to sdtab after the fit.
- `[output]` — covariates and individual parameters to echo into sdtab.

## What changed

**Parser (`src/parser/model_parser.rs`)**
- New `Op` variants: `Mod`, `Floor`, `Ceil`, `Round` in the bytecode evaluator.
- `parse_derived_block`: parses per-row expressions, aggregate (`max`/`min`/`tmax`) with optional `if` filter, and trapezoidal `integral(expr, from=t0, to=t1 [, step=dt])`.
- `parse_output_block`: collects bare names into `output_columns`.
- `build_derived_eval_fn` / `build_derived_filter_fn`: produce `Arc<Expression>`-backed closures (`Send + Sync`) at parse time.
- `ParseCtx` used with `fallback_covariate: false` so covariate names become `Variable` nodes resolved at eval time.
- Emits `E_DERIVED_NAME_CONFLICT` (error) for names that clash with built-ins / theta / eta / indiv params; `W_DERIVED_COVARIATE_SHADOW` (warning) when shadowing a covariate.
- Emits `W_DERIVED_STEP_IGNORED` when `step=` is given for a DV-based integral.

**Types (`src/types.rs`)**
- New fields on `CompiledModel`: `derived_exprs: Vec<DerivedExprSpec>`, `output_columns: Vec<String>`.
- New public types: `DerivedKind`, `DerivedExprSpec`, `AggFunction`, `IntegralWindow`, `IntegralStep`, `DerivedContext`, `DerivedEvalFn`, `DerivedFilterFn`.

**API (`src/api.rs`)**
- `validate_output_columns`: checks each `[output]` name against covariates, individual parameters, derived names, and the mandatory minimum; emits `E_OUTPUT_UNKNOWN_COLUMN` / `W_OUTPUT_DUPLICATE`.
- `tafd_tad_for_subject` (now `pub`): returns `(TAFD, TAD)` for a given observation index, SS-aware using modular arithmetic.
- `compute_extra_output_columns`: post-fit pass over `SubjectResult`s; evaluates all `DerivedKind` variants (PerRow, Aggregate, Integral) and writes results into `SubjectResult.extra_columns`.
- `fit_inner` calls `compute_extra_output_columns` after convergence.
- `check_model_data` now includes `validate_output_columns` results.

**Diagnostics (`src/diagnostics.rs` + `docs/src/file-formats/check-report.md`)**
- Documented 6 new codes: `E_DERIVED_NAME_CONFLICT`, `W_DERIVED_COVARIATE_SHADOW`, `W_DERIVED_STEP_IGNORED`, `E_OUTPUT_UNKNOWN_COLUMN`, `W_OUTPUT_DUPLICATE`, `W_ADDL_MISSING_II`.

**Docs**
- `docs/src/model-file/derived.md` — full reference for `[derived]`.
- `docs/src/model-file/output.md` — reference for `[output]`.
- Both wired into `docs/src/SUMMARY.md`.

**Example**
- `examples/warfarin_derived.ferx` — demonstrates AUC, Cmax, Tmax, Ctrough, and covariate output.

## Alternatives considered

Computed columns could have been placed in a post-processing script (R / Python). Inline model-file specification keeps the exposure metrics co-located with the PK model and requires no external tooling.

The integral implementation uses the trapezoidal rule over observation times (DV-based) or nearest-neighbour IPRED approximation (grid-based). A higher-order quadrature was considered but the trapezoidal rule matches clinical practice and NONMEM sdtab conventions.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

The new fields are additive; `FitResult` / sdtab shape is unchanged for models without `[derived]` / `[output]`.

## Breaking changes
- [x] `.ferx` model file format — two new optional blocks added (fully backward-compatible; existing models parse unchanged)
- [ ] `FitResult` / sdtab fields changed
- [x] Public Rust API — `tafd_tad_for_subject` promoted from `pub(crate)` to `pub`; new types added to `types.rs`
- [ ] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only) — the `compute_extra_output_columns` post-fit pass does not touch theta/omega/sigma estimation; OFV is unchanged.

## Performance
- [x] No significant impact expected — extra-column computation runs once after convergence, proportional to `n_subjects × n_obs`.

## Tests
- [x] Unit tests added in `src/parser/model_parser.rs` (18 tests covering derived parsing, bytecode evaluation, aggregate, integral, sequential scoping, TAFD/TAD context).
- [x] Integration tests in `tests/derived_output.rs`: parse-error for name conflicts (3 tests), output-column validation (3 tests), `W_DERIVED_STEP_IGNORED` warning, TAFD/TAD unit tests (5 tests including SS modular arithmetic and ADDL-expanded doses).

## Example
- [x] Example added to `examples/warfarin_derived.ferx`

<details>
<summary>Snippet</summary>

```toml
[derived]
  CLi    = CL
  CL_kg  = CL / WT
  AUC120 = integral(IPRED, from=0, to=120)
  Cmax   = max(IPRED)
  Tmax   = tmax(IPRED)
  Ctrough = min(IPRED) if TIME > 12

[output]
  WT
```

</details>

## Docs
- [x] `docs/src/` updated (`derived.md`, `output.md`, `SUMMARY.md`, `check-report.md`)
- [x] No `docs/book/` committed (generated output is git-ignored)

## Checklist
- [ ] `cargo clippy` clean (CI)
- [ ] `cargo check --features autodiff` (CI — no AD-reachable code touched)

## Reviewer hints

- The core logic lives in two passes: (1) parse time (`parse_derived_block` → closures stored on `CompiledModel`), (2) post-fit (`compute_extra_output_columns` in `api.rs`). The parse-time closures capture `Arc<Expression>` so they are `Send + Sync` without locking.
- `tafd_tad_for_subject` handles the SS-aware TAD by taking `(t - dose_time) rem_euclid II` when `dose.ss && dose.ii > 0`; otherwise it finds the most-recent non-SS dose before the observation.
- The integral grid path (`IntegralStep::Grid`) uses nearest-neighbour IPRED (last prediction at or before each grid point), matching the resolution available from the PK solver.

## Open questions

None.