### PR TITLE
feat(io): add [data_selection] block with IGNORE/ACCEPT record filtering

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Stochastic Differential Equations](model-file/diffusion.md)
   - [Neural Networks (DCM / NODE)](model-file/neural-networks.md)
     - [Covariate NN (DCM)](model-file/covariate-nn.md)
+  - [Data Selection](model-file/data-selection.md)
   - [Fit Options](model-file/fit-options.md)
   - [Simulation](model-file/simulation.md)
 - [Estimation Methods](estimation/README.md)

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -278,7 +278,7 @@ only when the expression passes (equivalent to NONMEM's `$DATA ACCEPT=`).
 |--------|------|
 | `$DATA IGNORE=(BW.GT.80)` | `ignore = BW > 80` |
 | `$DATA ACCEPT=(DV.GE.0.001)` | `accept = DV >= 0.001` |
-| `$DATA IGNORE=@ 3,17` | `ignore_subjects = [3, 17]` |
+| `$DATA IGNORE=(ID.EQ.3) IGNORE=(ID.EQ.17)` | `ignore_subjects = [3, 17]` |
 
 Multiple `ignore` lines mean "exclude if any condition matches"; multiple
 `accept` lines mean "exclude unless all conditions pass".  Conditions within a

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -260,3 +260,34 @@ than parsing prose. The exit code is `0` when no errors are found, `1` when
 there are errors. See the [check report reference](file-formats/check-report.md)
 for the JSON schema and the full code table.
 
+## How do I exclude records or subjects, like NONMEM's `$DATA IGNORE=`?
+
+Use the `[data_selection]` block:
+
+```
+[data_selection]
+  ignore = DV < 0.001          # drop any obs where DV is below detection
+  ignore_subjects = [3, 17]    # drop subjects 3 and 17 entirely
+```
+
+The `ignore` key works like NONMEM's `$DATA IGNORE=`: a record is excluded when
+the expression is true.  The `accept` key is the complement: a record is kept
+only when the expression passes (equivalent to NONMEM's `$DATA ACCEPT=`).
+
+| NONMEM | ferx |
+|--------|------|
+| `$DATA IGNORE=(BW.GT.80)` | `ignore = BW > 80` |
+| `$DATA ACCEPT=(DV.GE.0.001)` | `accept = DV >= 0.001` |
+| `$DATA IGNORE=@ 3,17` | `ignore_subjects = [3, 17]` |
+
+Multiple `ignore` lines mean "exclude if any condition matches"; multiple
+`accept` lines mean "exclude unless all conditions pass".  Conditions within a
+single line can be joined with `&&` (both must hold to trigger the rule).
+`||` within a single expression is not supported — use two separate lines
+instead.
+
+After the fit, the CLI prints a `--- Data Selection ---` block and the YAML
+output file includes an `exclusions:` section with record counts and the
+expressions that fired.  See [Data Selection](model-file/data-selection.md) for
+the full reference.
+

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -127,7 +127,7 @@ After reading the data, ferx reports what was dropped:
 
 ```
 --- Data Selection ---
-  Records read: 420  Obs excluded: 12  Doses excluded: 0
+  Records read: 420  Obs excluded: 12  Doses excluded: 0  Other excluded: 0
   Fired ignore conditions:
     * ignore: DV < 0.001
 ```
@@ -140,9 +140,20 @@ exclusions:
   n_records_total: 420
   n_obs_excluded: 12
   n_dose_excluded: 0
+  n_other_excluded: 0
   fired_ignore:
     - "ignore: DV < 0.001"
 ```
+
+`Other excluded` (`n_other_excluded`) counts excluded records that are neither a
+scored observation nor a dose — EVID 2 (other event), EVID 3 (reset), and
+missing-DV observation rows (EVID 0 with MDV 1). The three counts together
+account for every excluded record.
+
+Each fired condition is listed once. Because checks short-circuit on the first
+match (see *Evaluation order*), a record is attributed to the **first** rule
+that excludes it — so a condition that only ever matches records already removed
+by an earlier rule will not appear in the fired list.
 
 ---
 

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -101,6 +101,12 @@ of the CSV).  An entirely excluded subject does not appear in any output.
 
 Column names in expressions are case-insensitive.
 
+A record whose value for a referenced column is **missing** (`.`, blank, `NA`)
+never matches a comparison on that column. For example, `ignore = DV < 0.001`
+does **not** exclude dose rows, whose `DV` is `.`; only observation rows with a
+real `DV` below the threshold are dropped. (You can still write
+`ignore = EVID == 0 && DV < 0.001` to be explicit.)
+
 ---
 
 ## Evaluation order

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -163,8 +163,16 @@ by an earlier rule will not appear in the fired list.
   instead — each line is already an independent "any of these reasons"
   condition.
 - `AND` / `OR` keywords are not supported; use `&&` within a line.
-- String comparisons are limited to `==` and `!=`; `<`, `<=`, `>`, `>=` on
-  string values have no effect.
+- String comparisons are limited to `==` and `!=`. Ordered comparisons
+  (`<`, `<=`, `>`, `>=`) on `ID` are rejected at parse time, since `ID` is a
+  string label — use `==`/`!=` or `ignore_subjects`.
+- `ADDL` and the occasion / IOV column are **not** filter targets; a condition
+  referencing them is an inert no-op. Filter on the columns in the table above
+  (or expand `ADDL` rows beforehand if you must select on dose number).
+- Covariate values seen by a condition reflect the subject's full record
+  history (last-observation-carried-forward across all rows), independent of
+  which records the filter removes. This matters only when filtering on a
+  time-varying covariate whose value differs on the rows being excluded.
 - A column name that is not present in the dataset always evaluates to false
   (never fires), so a typo silently has no effect — check the exclusion summary
   if a condition is not being applied. (Covariate columns referenced by a

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -185,7 +185,7 @@ See the ferx-r documentation for `ferx_selection()` and `ferx_fit()`.
 | `$DATA IGNORE=C` | `[data_selection]  ignore = C == 1` |
 | `$DATA IGNORE=(BW.GT.80)` | `[data_selection]  ignore = BW > 80` |
 | `$DATA ACCEPT=(DV.GE.0.001)` | `[data_selection]  accept = DV >= 0.001` |
-| `$DATA IGNORE=@ 3,17` | `[data_selection]  ignore_subjects = [3, 17]` |
+| `$DATA IGNORE=(ID.EQ.3) IGNORE=(ID.EQ.17)` | `[data_selection]  ignore_subjects = [3, 17]` |
 
 ferx uses standard inequality operators (`>`, `>=`, `<`, `<=`, `==`, `!=`)
 instead of NONMEM's Fortran-style `.GT.`, `.GE.`, etc.

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -1,0 +1,178 @@
+# Data Selection
+
+The optional `[data_selection]` block lets you exclude records from the dataset
+at read time without modifying the CSV file.  It is the ferx equivalent of
+NONMEM's `$DATA IGNORE=` / `$DATA ACCEPT=`.
+
+## Syntax
+
+```
+[data_selection]
+  ignore = <expression>
+  accept = <expression>
+  ignore_subjects = [<id>, ...]
+```
+
+All three keys are optional and may be repeated.  Missing the block entirely
+means "use all records".
+
+---
+
+## `ignore`
+
+A record is **excluded** when the expression is true.
+
+```
+[data_selection]
+  ignore = DV < 0.001
+  ignore = EVID != 0
+```
+
+Multiple `ignore` lines are independent: a record is excluded when **any one**
+of them matches.  That means each line is a separate reason to drop the record;
+the lines do not combine with OR into a single expression.
+
+Within a single line you can join sub-conditions with `&&` (all must hold):
+
+```
+[data_selection]
+  ignore = EVID == 0 && DV < 0.001
+```
+
+Use `ignore` when you want to flag specific outlier values or dose rows with
+no matching observation.
+
+---
+
+## `accept`
+
+A record is **kept** only when the expression is true; it is excluded otherwise.
+
+```
+[data_selection]
+  accept = BW >= 30 && BW < 48
+```
+
+Multiple `accept` lines are independent; a record is excluded when **any one**
+accept condition fails.
+
+Use `accept` when it is easier to state what the valid range is rather than
+listing each invalid condition.
+
+---
+
+## `ignore_subjects`
+
+Exclude all records for one or more subjects, given by their ID values:
+
+```
+[data_selection]
+  ignore_subjects = [3, 17]
+```
+
+Single-subject shorthand (no brackets):
+
+```
+[data_selection]
+  ignore_subjects = 3
+```
+
+Subject IDs are matched as strings (the same way they appear in the ID column
+of the CSV).  An entirely excluded subject does not appear in any output.
+
+---
+
+## Supported columns
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `ID`   | string equality / inequality | `ID == "3"` or `ID == 3` |
+| `TIME` | numeric | |
+| `DV`   | numeric | |
+| `EVID` | numeric (0/1/2/3/4) | |
+| `AMT`  | numeric | |
+| `CMT`  | numeric | |
+| `RATE` | numeric | |
+| `MDV`  | numeric | |
+| `CENS` | numeric | |
+| `II`   | numeric | |
+| `SS`   | numeric | |
+| any covariate column | numeric | case-insensitive (`BW`, `bw`, `Bw` all match) |
+
+Column names in expressions are case-insensitive.
+
+---
+
+## Evaluation order
+
+For each record, the checks run in this order:
+
+1. `ignore_subjects` — if the record's ID is in the list, exclude immediately.
+2. `ignore` clauses — if **any** clause matches, exclude.
+3. `accept` clauses — if **any** clause does **not** match, exclude.
+
+A record must pass all three stages to be included.
+
+---
+
+## Exclusion summary
+
+After reading the data, ferx reports what was dropped:
+
+```
+--- Data Selection ---
+  Records read: 420  Obs excluded: 12  Doses excluded: 0
+  Fired ignore conditions:
+    * ignore: DV < 0.001
+```
+
+The same information appears in the `exclusions:` block of the YAML output file
+(`*-fit.yaml`):
+
+```yaml
+exclusions:
+  n_records_total: 420
+  n_obs_excluded: 12
+  n_dose_excluded: 0
+  fired_ignore:
+    - "ignore: DV < 0.001"
+```
+
+---
+
+## Limitations
+
+- `||` (OR) within a single expression is not supported. Use multiple lines
+  instead — each line is already an independent "any of these reasons"
+  condition.
+- `AND` / `OR` keywords are not supported; use `&&` within a line.
+- String comparisons are limited to `==` and `!=`; `<`, `<=`, `>`, `>=` on
+  string values have no effect.
+- An unknown column name always evaluates to false (never fires), so a typo
+  silently has no effect — check the exclusion summary if a condition is not
+  being applied.
+
+---
+
+## Merging with R call conditions
+
+When you also supply `ignore` or `accept` conditions via the R function
+`ferx_selection()`, the model-file conditions and the R-call conditions are
+**merged** (not replaced).  Exact-duplicate expressions are deduplicated
+automatically; a condition specified in both places is only evaluated once.
+
+See the ferx-r documentation for `ferx_selection()` and `ferx_fit()`.
+
+---
+
+## NONMEM equivalent
+
+| NONMEM | ferx |
+|--------|------|
+| `$DATA IGNORE=C` | `[data_selection]  ignore = C == 1` |
+| `$DATA IGNORE=(BW.GT.80)` | `[data_selection]  ignore = BW > 80` |
+| `$DATA ACCEPT=(DV.GE.0.001)` | `[data_selection]  accept = DV >= 0.001` |
+| `$DATA IGNORE=@ 3,17` | `[data_selection]  ignore_subjects = [3, 17]` |
+
+ferx uses standard inequality operators (`>`, `>=`, `<`, `<=`, `==`, `!=`)
+instead of NONMEM's Fortran-style `.GT.`, `.GE.`, etc.

--- a/plans/data-selection.md
+++ b/plans/data-selection.md
@@ -1,0 +1,553 @@
+# Plan: `[data_selection]` — IGNORE / ACCEPT support
+
+**Branch:** `feat/data-selection` (to be cut)  
+**Scope:** ferx-core (primary) + ferx-r (follow-up PR)
+
+---
+
+## Background
+
+NONMEM's `$DATA IGNORE=` / `$DATA ACCEPT=` let users exclude or include records based on
+per-row boolean conditions. ferx has no equivalent. The goal is to add:
+
+1. A `[data_selection]` block in the `.ferx` model file (permanent, model-level exclusions).
+2. A `ferx_selection()` R function for interactive/piped use.
+3. Clear exclusion reporting in `ferx_runlog()`.
+
+---
+
+## Style decisions
+
+### Expression syntax
+
+Expressions use **bare (unquoted) comparisons** in the `.ferx` file, consistent with
+how `[individual_parameters]` already writes `if (WT > 70) { ... }`. The `[data_selection]`
+key=value parser splits on the first `=` and treats everything to the right as the raw
+value string, so the `<`, `>` operators cause no ambiguity.
+
+```toml
+[data_selection]
+ignore = DV < 0.001
+ignore = EXCL == 1
+accept = BW >= 30
+```
+
+Operators: `==`, `!=`, `>`, `>=`, `<`, `<=`.  
+Column names are case-insensitive. Values are parsed as `f64`; string equality is
+supported for non-numeric covariate columns.
+
+**Why not NONMEM-style `.GT.`?** Less readable and no precedent in ferx syntax.
+
+### R-side API (base-R, quoted strings + `c()` for multiples)
+
+On the R side expressions are R character strings — not because of a design choice,
+but because that is how R strings work. ferx-r has no rlang/dplyr dependency and uses
+base-R throughout; there is no tidy-eval. Unquoted expressions would require
+`substitute()`/`match.call()` for single conditions but break down for multiples
+(`c(DV < 0.001, EXCL == 1)` would try to evaluate both in the calling environment).
+
+Multiple conditions use a plain **character vector** with `c()`, which is the standard
+base-R pattern for passing multiple string values to a function:
+
+```r
+# Single condition
+ferx_selection(data, ignore = "DV < 0.001")
+
+# Multiple ignore conditions (OR logic)
+ferx_selection(data, ignore = c("DV < 0.001", "EXCL == 1"))
+
+# Multiple accept conditions (AND logic)
+ferx_selection(data, accept = c("BW >= 30", "AGE >= 18"))
+
+# Combined
+ferx_selection(data,
+  ignore     = c("DV < 0.001", "EXCL == 1"),
+  accept     = "BW >= 30",
+  ignore_ids = c(3, 17))
+
+# In a pipe into ferx_fit
+data |>
+  ferx_selection(ignore = c("DV < 0.001", "EXCL == 1"), accept = "BW >= 30") |>
+  ferx_fit(model)
+
+# Or directly on ferx_fit, skipping the explicit ferx_selection step
+ferx_fit(model, data,
+  ignore     = c("DV < 0.001", "EXCL == 1"),
+  accept     = "BW >= 30",
+  ignore_ids = c(3, 17))
+```
+
+The same expression — `DV < 0.001` — is bare in the `.ferx` file and wrapped in `""`
+in R. The Rust parser strips surrounding quotes if present so both forms are accepted.
+
+No tidy-eval. No new package dependencies.
+
+---
+
+## ignore vs accept semantics
+
+### Inclusion rule
+
+A record is **included** if and only if:
+
+```
+!any(ignore_i(row))  AND  all(accept_j(row))
+```
+
+Both independently contribute to exclusion. There is no logical conflict between them.
+The implementation evaluates ignore first, then accept — this matters only for the
+exclusion log (which condition is credited per record).
+
+### User-facing description (docs / runlog — avoid OR/AND framing)
+
+Do **not** describe this as "OR logic" and "AND logic" in documentation or error
+messages — that framing is confusing in a pharmacometric context. Use behavioural
+language, consistent with how NONMEM describes IGNORE/ACCEPT:
+
+- **`ignore`**: "a record is excluded if it matches any ignore condition; each
+  condition is an independent reason to exclude."
+- **`accept`**: "a record is included only if it satisfies all accept conditions."
+
+The key example to put front-and-centre in the docs and R function examples is the
+**range filter**, because it is non-obvious and directly shows why multiple `accept`
+conditions compose usefully:
+
+```r
+# Include only subjects within the protocol weight range
+ferx_selection(data, accept = c("BW >= 30", "BW < 48"))
+```
+
+```toml
+# .ferx equivalent
+[data_selection]
+accept = BW >= 30
+accept = BW < 48
+```
+
+This is consistent with NONMEM, where multiple ACCEPT conditions are also all required
+to hold (AND), and multiple IGNORE conditions each independently exclude (any match).
+
+### Evaluation order (per record)
+
+1. Evaluate each `ignore` expression in declaration order; stop at first match.
+   - If any fires → record excluded; log which condition.
+2. If no ignore matched, evaluate each `accept` expression in declaration order;
+   stop at first failure.
+   - If any fails → record excluded; log which condition.
+3. If neither → record included.
+
+### Can ignore and accept clash?
+
+**Logically: no.** Both narrow the included set; combining them is always well-defined.
+
+A user *can* write contradictory intent that empties the data:
+
+| ignore | accept | Effective range included |
+|--------|--------|--------------------------|
+| `"BW > 80"` | `"BW >= 30"` | BW ∈ [30, 80] — fine |
+| `"DV < 0.1"` | `"DV > 0"` | DV ∈ [0.1, ∞) — fine |
+| `"BW > 60"` | `"BW > 60"` | Nothing — user error |
+| `"EVID == 0"` | `"EVID == 0"` | No observations — user error |
+
+User-error cases produce zero subjects or zero observations, which is caught as a fatal
+error during `read_nonmem_csv` (same path as an empty CSV). No silent wrong results.
+
+### Per-record vs per-subject
+
+Both `ignore` and `accept` operate **per record** (per CSV row), identical to NONMEM.
+For time-constant covariates the effect is naturally per-subject. For time-varying
+covariates, partial-subject exclusion is possible and allowed (same as NONMEM).
+
+**Warnings** are emitted for pathological partial exclusions:
+- All dose records removed but observations remain for a subject.
+- All observations removed but dose records remain for a subject.
+- A subject's entire record set is removed.
+
+### `ignore_subjects` shorthand
+
+`ignore_subjects = [3, 17]` is syntactic sugar for `ignore = ID == 3` + `ignore = ID == 17` in the `.ferx` file (or `ignore = "ID == 3"` as an R string).
+IDs are compared as strings (the `Subject.id` field is a `String`). Both numeric and
+string IDs work.
+
+---
+
+## ferx-core changes
+
+### Step 1 — `src/io/filter_expr.rs` (new file)
+
+A two-level expression evaluator. No external parser crate.
+
+**Level 1 — `FilterExpr`**: one `col op value` comparison.
+
+**Level 2 — `FilterClause`**: one or more `FilterExpr` joined by `&&` within a
+single string, consistent with how the existing ferx DSL uses `&&` in
+`[individual_parameters]` and `[structural_model]` (e.g. `if (central / V > 0.5 && TAD < 24)`).
+All sub-expressions must hold for the clause to fire.
+`||` within a string is explicitly not supported — use multiple strings
+(via `c()` in R or repeated lines in `.ferx`) for that.
+`AND` / `OR` keyword forms are not used anywhere in the ferx DSL and are not supported here.
+
+```rust
+pub struct FilterExpr {
+    col: String,   // case-folded to lowercase
+    op:  CmpOp,
+    rhs: FilterValue,
+}
+
+pub enum CmpOp { Eq, Ne, Lt, Le, Gt, Ge }
+pub enum FilterValue { Num(f64), Str(String) }
+
+/// One string from the user, potentially containing && / AND.
+/// All sub-expressions must hold for the clause to evaluate true.
+pub struct FilterClause {
+    exprs: Vec<FilterExpr>,
+}
+
+impl FilterClause {
+    /// Parse "DV < 0.001" or "BW >= 30 && BW < 48".
+    /// Strips surrounding quotes so both bare (.ferx) and quoted (R) forms are accepted.
+    /// `AND`/`OR` keyword forms and `||` are rejected with a clear parse error.
+    pub fn parse(s: &str) -> Result<Self, String>
+
+    pub fn eval(&self, ctx: &RowContext<'_>) -> bool {
+        self.exprs.iter().all(|e| e.eval(ctx))
+    }
+}
+
+pub struct RowContext<'a> {
+    pub id:   &'a str,
+    pub time: f64,
+    pub dv:   f64,
+    pub evid: u32,
+    pub amt:  f64,
+    pub cmt:  usize,
+    pub rate: f64,
+    pub mdv:  u32,
+    pub cens: u8,
+    pub ii:   f64,
+    pub ss:   bool,
+    pub covariates: &'a HashMap<String, f64>,
+}
+```
+
+This gives two composable levels:
+
+| Context | Composition | Effect |
+|---------|-------------|--------|
+| Multiple strings in `c()` / repeated lines | collection-level | independent: any match excludes (ignore) / all must pass (accept) |
+| `&&` / `AND` within one string | clause-level | all must hold within that one clause |
+
+Example showing where the distinction matters for `ignore`:
+
+```r
+# Excludes ALL observations AND any record with DV < 0.001 (including doses)
+ferx_selection(data, ignore = c("EVID == 0", "DV < 0.001"))
+
+# Excludes only observation records where DV < 0.001
+ferx_selection(data, ignore = "EVID == 0 && DV < 0.001")
+```
+
+For `accept` the two forms produce the same result:
+```r
+ferx_selection(data, accept = c("BW >= 30", "BW < 48"))      # equivalent
+ferx_selection(data, accept = "BW >= 30 && BW < 48")          # equivalent
+```
+
+Unit tests cover: all six operators, numeric and string RHS, case-insensitive column
+names, `&&` separator, unknown column → `false` (never fire), `||` in string → parse
+error with message "use multiple conditions instead of ||", `AND`/`OR` keywords →
+parse error, malformed expression → parse error.
+
+### Step 2 — `src/types.rs` — extend `FitOptions`
+
+```rust
+// In FitOptions:
+pub ignore_exprs:    Vec<String>,   // raw strings; compiled to Vec<FilterClause> at read time
+pub accept_exprs:    Vec<String>,
+pub ignore_subjects: Vec<String>,   // compared as strings against Subject.id
+```
+
+Stored as raw strings so they serialise verbatim into `FitResult` / YAML output.
+
+### Step 3 — `src/types.rs` — new `ExclusionSummary` + extend `Population`
+
+```rust
+pub struct ExclusionSummary {
+    /// Subject IDs with zero remaining records after filtering.
+    pub excluded_subject_ids: Vec<String>,
+    /// Number of observation records (EVID==0) excluded.
+    pub n_obs_excluded:       usize,
+    /// Number of dose records (EVID!=0) excluded.
+    pub n_dose_excluded:      usize,
+    /// Total records read before filtering.
+    pub n_records_total:      usize,
+    /// Which ignore expressions fired at least once (in declaration order).
+    pub fired_ignore:         Vec<String>,
+    /// Which accept expressions rejected at least once (in declaration order).
+    pub fired_accept:         Vec<String>,
+}
+
+// Added to Population:
+pub exclusions: Option<ExclusionSummary>,
+```
+
+Also extend `FitResult` to carry `exclusions: Option<ExclusionSummary>`.
+
+### Step 4 — `src/io/datareader.rs` — filter in `parse_subject`
+
+`read_nonmem_csv` receives compiled `Vec<FilterExpr>` for ignore and accept (compiled
+from the raw strings in `FitOptions`).
+
+Inside the per-row loop in `parse_subject`, after parsing all standard fields and
+covariates (but before the EVID branch that builds doses/obs), evaluate:
+
+```rust
+let ctx = RowContext { id, time, dv, evid, amt, cmt, rate, mdv, cens, ii, ss,
+                       covariates: &cov_snapshot };
+
+// ignore_subjects is pre-expanded into ignore_exprs as "ID == <id>" entries
+let ignored = ignore_exprs.iter().any(|e| e.eval(&ctx));
+if !ignored {
+    let rejected = accept_exprs.iter().any(|e| !e.eval(&ctx));
+    if rejected { /* log which accept expr */ } else { /* include row */ }
+} else { /* log which ignore expr */ }
+```
+
+Track per-subject and aggregate into `ExclusionSummary`.
+
+After building all subjects, emit warnings for pathological cases (doses-without-obs,
+obs-without-doses, fully excluded subjects).
+
+### Step 5 — `src/parser/model_parser.rs` — parse `[data_selection]`
+
+New block type alongside `[fit_options]`. Parsed into the same `FitOptions` struct
+(via the same `apply_fit_option` dispatcher for the new keys `ignore`, `accept`,
+`ignore_subjects`).
+
+`ignore_subjects` accepts a bracketed integer list: `[3, 17, 42]` → each ID is
+appended to `ignore_subjects` as a string.
+
+Repeated `ignore =` lines append to `ignore_exprs` (not override).
+Repeated `accept =` lines append to `accept_exprs`.
+
+### Step 6 — `src/io/output.rs` — CLI output
+
+After the data line, print:
+
+```
+Data: warfarin.csv (32 subjects, 251 records total)
+  Data selection applied:
+    ignore: "DV < 0.001"    → 20 observations excluded
+    ignore: subjects [3]    → subject 3 excluded (2 doses, 8 obs)
+    accept: "BW >= 30"      → 0 records excluded
+  Included: 31 subjects, 221 observations
+```
+
+If no selection is applied, the block is omitted.
+
+### Step 7 — YAML output
+
+The `fit.yaml` output gains an `exclusions:` key:
+
+```yaml
+exclusions:
+  n_records_total: 251
+  n_obs_excluded: 28
+  n_dose_excluded: 2
+  excluded_subject_ids: ["3"]
+  fired_ignore: ["DV < 0.001", "ID == 3"]
+  fired_accept: []
+```
+
+---
+
+## ferx-r changes
+
+### `ferx_selection()` (new, `R/exclude.R`)
+
+```r
+ferx_selection <- function(data, ignore = NULL, accept = NULL, ignore_ids = NULL)
+```
+
+- `data`: character path to CSV, or data.frame already in memory.
+- `ignore`, `accept`: character vector of expression strings.
+- `ignore_ids`: numeric or character vector of subject IDs.
+
+**Behaviour:**
+1. If `data` is a path, read it with `utils::read.csv()`.
+2. Evaluate each expression using base-R on the data.frame columns (parse the same
+   simple grammar: `col op value`). This is a thin R reimplementation of `FilterExpr`
+   for the preview step — the canonical evaluation still happens in Rust at fit time.
+3. Apply ignore-then-accept logic, producing a logical include-vector.
+4. Return a `ferx_data` object: the filtered data.frame plus attributes:
+   - `"source_path"` — original path (if given)
+   - `"exclusions"` — named list: n_total, n_excluded_obs, n_excluded_dose,
+     excluded_ids, fired_ignore, fired_accept
+   - `"ignore"` / `"accept"` — the expression strings (passed to Rust)
+   - `"ignore_ids"` — the ID vector
+
+`ferx_fit()` accepts `ferx_data` objects as its `data` argument. When a `ferx_data`
+is received, the exclusion expressions stored in its attributes are injected into the
+Rust `settings` vectors (`ignore`/`accept`/`ignore_subjects` keys), and the filtered
+data is written to a temp CSV that is passed to Rust. The Rust side re-evaluates
+(so the canonical filtering is always in Rust), but the R preview lets users inspect
+what will be excluded before committing to a fit.
+
+### `ferx_selection_excluded(fit_or_data)` (new)
+
+Returns a data.frame of the records that were excluded, reconstructed by re-reading
+the source CSV and anti-joining against the included records.
+
+```r
+ferx_selection_excluded <- function(x) UseMethod("ferx_selection_excluded")
+ferx_selection_excluded.ferx_data <- function(x) attr(x, "excluded_rows")
+ferx_selection_excluded.ferx_fit  <- function(x) {
+  # re-read source CSV, filter by exclusion summary stored in fit object
+}
+```
+
+### `ferx_runlog()` update (`R/runlog.R`)
+
+Add an exclusion block after the Data line, drawn from `fit$exclusions`:
+
+```
+── Data selection ─────────────────────────────────────────────────
+  ignore: "DV < 0.001"    →  20 obs excluded
+  ignore: IDs [3]         →  subject 3 excluded (8 obs, 2 doses)
+  accept: "BW >= 30"      →  0 records excluded
+  Included: 31 subjects, 221 observations / 32 subjects, 251 total
+```
+
+Block is omitted when `fit$exclusions` is NULL (no selection applied).
+
+### `ferx_fit()` update (`R/fit.R`)
+
+- Add `ignore = NULL`, `accept = NULL`, `ignore_ids = NULL` parameters.
+- Validate: must be character (ignore/accept), numeric or character (ignore_ids).
+- Merge with any expressions from a `ferx_data` object passed as `data`.
+- Inject as `settings` key/value pairs before the Rust call (same pathway as other
+  settings). These are merged (OR'd / AND'd) with any `[data_selection]` block in
+  the `.ferx` file — not overriding it.
+
+### Rust glue (`src/rust/src/lib.rs`)
+
+- `ignore` / `accept` / `ignore_subjects` are **not** on the RESERVED list (they
+  go through `apply_fit_option` like other settings).
+- Repeated `ignore` keys in the settings vectors append to `ignore_exprs` using
+  `push_unique` — exact-string deduplication prevents the same condition appearing
+  twice when both the `.ferx` file and the R call specify it.
+- Expose `fit$exclusions` as a named list mirroring `ExclusionSummary`.
+
+---
+
+## Priority: `.ferx` file vs R call
+
+Conditions from both sources are **merged** (appended), not overriding:
+- `ignore` conditions from `.ferx` `[data_selection]` and from `ferx_fit()` /
+  `ferx_selection()` are OR'd together.
+- `accept` conditions from both sources are AND'd together.
+
+This is additive: the model file expresses permanent analysis-level exclusions;
+the R call adds run-specific ones. Neither silently drops the other.
+
+### Deduplication of identical expressions
+
+If the same expression string appears in both the `.ferx` file and the R call (e.g.
+both specify `ignore = "DV < 0.001"`), appending naively causes the condition to be
+evaluated twice per record. The result is still correct (row excluded once), but the
+exclusion log would list the condition twice and counts would appear doubled.
+
+**Rule:** when collecting expressions from all sources into the final `Vec<String>`,
+deduplicate on exact string match after trimming leading/trailing whitespace. The
+second occurrence of an already-present string is silently dropped.
+
+```rust
+fn push_unique(vec: &mut Vec<String>, s: String) {
+    let trimmed = s.trim().to_string();
+    if !vec.iter().any(|e| e == &trimmed) {
+        vec.push(trimmed);
+    }
+}
+```
+
+Textually different but semantically equivalent expressions (e.g. `"DV<0.001"` vs
+`"DV < 0.001"`, or different operator spacing) are **not** deduplicated — normalising
+expressions is not worth the added complexity. Both would evaluate; the result is
+correct (identical rows excluded) and the log clearly shows both strings.
+
+For scalar settings (e.g., `maxiter`), R call continues to override the `.ferx` file.
+
+---
+
+## Tests required
+
+### ferx-core (unit, Tier 1)
+
+- `FilterExpr::parse`: all six operators, numeric + string RHS, case-insensitive
+  column, bad syntax → error.
+- `FilterExpr::eval`: truth table across operators.
+- `parse_subject` with ignore conditions: excluded obs count, dose count, partial
+  subject warning.
+- Pathological cases: all subjects excluded → error; contradictory ignore+accept
+  → all excluded → error.
+
+### ferx-core (integration, Tier 2)
+
+- `fit()` with `ignore_exprs` set: returns Ok after a few iterations, `FitResult`
+  carries correct `exclusions`.
+- `ignore_subjects` shorthand: equivalent to equivalent `ignore` expression.
+
+### ferx-r (unit)
+
+- `ferx_selection()`: returns `ferx_data`, correct attributes, base-R evaluation
+  matches Rust evaluation on a small synthetic CSV.
+- `ferx_selection_excluded.ferx_data()`: returns correct rows.
+
+---
+
+## Docs
+
+- `docs/src/model-file/` — new page `data-selection.md` describing `[data_selection]`
+  block, both keywords, expression syntax, worked examples.
+- `docs/src/SUMMARY.md` — add entry.
+- `docs/src/faq.md` — NONMEM equivalence table row: `$DATA IGNORE=` → `[data_selection] ignore =`.
+
+### ferx-r package docs (`man/ferx_selection.Rd`)
+
+The `ferx_selection()` roxygen examples must include:
+
+1. **Single ignore** — excluding below-LLOQ observations:
+   ```r
+   ferx_selection(data, ignore = "DV < 0.001")
+   ```
+
+2. **Multiple ignore** — each condition independently excludes:
+   ```r
+   ferx_selection(data, ignore = c("DV < 0.001", "EXCL == 1"))
+   ```
+
+3. **Range filter with accept** — the primary example showing why multiple
+   `accept` conditions are useful; do not describe as "AND logic", use:
+   *"a record is included only if it satisfies all accept conditions"*:
+   ```r
+   # Include only subjects within the protocol weight range [30, 48)
+   ferx_selection(data, accept = c("BW >= 30", "BW < 48"))
+   ```
+
+4. **Combined ignore + accept** — excludes flagged records and restricts range:
+   ```r
+   ferx_selection(data,
+     ignore = "EXCL == 1",
+     accept = c("BW >= 30", "BW < 48"))
+   ```
+
+5. **Pipe into ferx_fit**:
+   ```r
+   data |>
+     ferx_selection(ignore = "DV < 0.001", accept = c("BW >= 30", "BW < 48")) |>
+     ferx_fit(model)
+   ```
+
+The `@description` section must state: *"Behaviour is consistent with NONMEM's
+`$DATA IGNORE=` / `$DATA ACCEPT=`: each ignore condition independently excludes
+matching records; all accept conditions must hold for a record to be included."*

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,9 @@ use crate::estimation::outer_optimizer::optimize_population;
 use crate::estimation::parameterization::theta_packs_log;
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv, read_nonmem_csv_with_covariates, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
+    read_nonmem_csv, read_nonmem_csv_filtered, read_nonmem_csv_with_covariates,
+    read_nonmem_csv_with_covariates_filtered, SelectionFilter, ERR_COV_MISSING_COLUMNS,
+    ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::stats::likelihood::{compute_cwres, foce_subject_nll, foce_subject_nll_iov};
@@ -110,12 +112,14 @@ pub fn run_model_with_data_inits(
     eprintln!("Model: {}", parsed.model.name);
 
     let iov_col = parsed.fit_options.iov_column.as_deref();
+    let sel_filter = build_selection_filter(&parsed.fit_options)?;
     let (population, covariate_table) = read_population_for(
         &parsed.model,
         &parsed.covariate_decls,
         data_path,
         None,
         iov_col,
+        sel_filter.as_ref(),
     )?;
     eprintln!(
         "Data:  {} subjects, {} observations from {}",
@@ -190,6 +194,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        exclusions: None,
     };
 
     // Simulate
@@ -312,6 +317,58 @@ fn undeclared_referenced(model: &CompiledModel, decls: &[CovariateDecl]) -> Vec<
 
 /// Single covariate-aware reader used by every file-based entry point (`fit`
 /// wrappers and `ferx check`), so they all apply identical covariate validation.
+/// Build a `SelectionFilter` from a model file's `FitOptions` alone.
+/// Returns `None` when no selection rules are set.
+fn build_selection_filter(opts: &FitOptions) -> Result<Option<SelectionFilter>, String> {
+    if opts.ignore_exprs.is_empty()
+        && opts.accept_exprs.is_empty()
+        && opts.ignore_subjects.is_empty()
+    {
+        return Ok(None);
+    }
+    SelectionFilter::from_opts(
+        &opts.ignore_exprs,
+        &opts.accept_exprs,
+        &opts.ignore_subjects,
+    )
+    .map(Some)
+}
+
+/// Build a `SelectionFilter` merging the model file's rules with a caller-supplied
+/// `FitOptions` (e.g. from the R wrapper). Conditions from both sources are
+/// deduplicated and OR'd (ignore) / AND'd (accept) together.
+fn build_selection_filter_merged(
+    model_opts: &FitOptions,
+    call_opts: &FitOptions,
+) -> Result<Option<SelectionFilter>, String> {
+    // Merge by accumulating unique strings from both sources.
+    let mut ignore = model_opts.ignore_exprs.clone();
+    let mut accept = model_opts.accept_exprs.clone();
+    let mut subjects = model_opts.ignore_subjects.clone();
+    for s in &call_opts.ignore_exprs {
+        let t = s.trim().to_string();
+        if !ignore.iter().any(|e| e == &t) {
+            ignore.push(t);
+        }
+    }
+    for s in &call_opts.accept_exprs {
+        let t = s.trim().to_string();
+        if !accept.iter().any(|e| e == &t) {
+            accept.push(t);
+        }
+    }
+    for s in &call_opts.ignore_subjects {
+        let t = s.trim().to_string();
+        if !subjects.iter().any(|e| e == &t) {
+            subjects.push(t);
+        }
+    }
+    if ignore.is_empty() && accept.is_empty() && subjects.is_empty() {
+        return Ok(None);
+    }
+    SelectionFilter::from_opts(&ignore, &accept, &subjects).map(Some)
+}
+
 ///
 /// When the model declares a `[covariates]` block this routes through the strict
 /// reader (validates declared columns exist + are numeric, builds the table, and
@@ -324,15 +381,31 @@ fn read_population_for(
     data_path: &str,
     fallback_columns: Option<&[&str]>,
     iov_column: Option<&str>,
+    filter: Option<&SelectionFilter>,
 ) -> Result<(Population, Option<CovariateTable>), String> {
-    match covariate_decls {
-        Some(decls) => {
+    match (covariate_decls, filter) {
+        (Some(decls), Some(sel)) => {
+            let extra = undeclared_referenced(model, decls);
+            let (pop, table) = read_nonmem_csv_with_covariates_filtered(
+                Path::new(data_path),
+                decls,
+                &extra,
+                iov_column,
+                sel,
+            )?;
+            Ok((pop, Some(table)))
+        }
+        (Some(decls), None) => {
             let extra = undeclared_referenced(model, decls);
             let (pop, table) =
                 read_nonmem_csv_with_covariates(Path::new(data_path), decls, &extra, iov_column)?;
             Ok((pop, Some(table)))
         }
-        None => Ok((
+        (None, Some(sel)) => Ok((
+            read_nonmem_csv_filtered(Path::new(data_path), fallback_columns, iov_column, sel)?,
+            None,
+        )),
+        (None, None) => Ok((
             read_nonmem_csv(Path::new(data_path), fallback_columns, iov_column)?,
             None,
         )),
@@ -744,7 +817,14 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
     //    diagnostic rather than a generic read error.
     if let Some(path) = data_path {
         let iov_col = parsed.fit_options.iov_column.as_deref();
-        match read_population_for(&parsed.model, &parsed.covariate_decls, path, None, iov_col) {
+        match read_population_for(
+            &parsed.model,
+            &parsed.covariate_decls,
+            path,
+            None,
+            iov_col,
+            None,
+        ) {
             Ok((population, _table)) => {
                 diags.extend(check_model_data(&parsed.model, &population));
                 let init_params = parsed.model.default_params.clone();
@@ -789,14 +869,16 @@ pub fn fit_from_files(
     // A `[covariates]` declaration takes precedence over the explicit
     // `covariate_columns` argument; otherwise fall back to the argument (or
     // legacy auto-detect when both are absent).
+    let opts = options.unwrap_or_default();
+    let sel_filter_fit = build_selection_filter_merged(&parsed.fit_options, &opts)?;
     let (population, covariate_table) = read_population_for(
         &model,
         &parsed.covariate_decls,
         data_path,
         covariate_columns,
         None,
+        sel_filter_fit.as_ref(),
     )?;
-    let opts = options.unwrap_or_default();
     model.bloq_method = opts.bloq_method;
     // SDE models cannot use autodiff — force FD.
     model.gradient_method =
@@ -2974,6 +3056,7 @@ mod iov_integration {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 
@@ -3805,6 +3888,7 @@ mod simulate_with_uncertainty_tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 
@@ -4133,6 +4217,7 @@ mod sde_integration {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 
@@ -4257,6 +4342,7 @@ mod sde_integration {
                 covariate_names: Vec::new(),
                 dv_column: "DV".into(),
                 input_columns: vec![],
+                exclusions: None,
             }
         };
 
@@ -4538,6 +4624,7 @@ mod tests_sdtab_tv_cov {
             covariate_names: vec!["WT".into()],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         // Fixed EBE at η = 0; H matrix is irrelevant for the IPRED check but

--- a/src/api.rs
+++ b/src/api.rs
@@ -360,8 +360,17 @@ fn build_selection_filter_merged(
         }
     }
     for s in &call_opts.ignore_subjects {
-        let t = s.trim().to_string();
-        if !subjects.iter().any(|e| e == &t) {
+        // Strip surrounding quotes so a caller-supplied `"3"` matches the same
+        // subject as a `.ferx` `ignore_subjects = 3` (the model-file parser
+        // already quote-strips). Without this the two sources disagree and a
+        // duplicate across them fails to dedup.
+        let t = s
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim()
+            .to_string();
+        if !t.is_empty() && !subjects.iter().any(|e| e == &t) {
             subjects.push(t);
         }
     }
@@ -960,6 +969,13 @@ fn perturb_init(
 /// pool of `n` workers, so this setting is per-call (different fits in the
 /// same process can use different thread counts). When `None`, rayon's
 /// global pool is used (one worker per logical CPU).
+///
+/// `[data_selection]` filtering (`options.ignore_exprs` / `accept_exprs` /
+/// `ignore_subjects`) is **not** applied here: it happens at CSV read time in
+/// the file-based entry points (`run_model_with_data`, `fit_from_files`). This
+/// function expects an already-filtered `Population` and simply echoes its
+/// `exclusions` summary onto the result. Callers building a `Population` in
+/// memory should filter their records beforehand.
 pub fn fit(
     model: &CompiledModel,
     population: &Population,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1902,6 +1902,7 @@ fn fit_inner(
         // `run_model_with_data`) when the model declares a `[covariates]`
         // block; the in-memory `fit()` path has no raw rows to echo.
         covariate_table: None,
+        exclusions: population.exclusions.clone(),
     };
 
     if time_gradients {
@@ -3998,6 +3999,7 @@ mod simulate_with_uncertainty_tests {
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
             covariate_table: None,
+            exclusions: None,
         }
     }
 

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -114,6 +114,7 @@ fn simulate_subjects(
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        exclusions: None,
     };
 
     let sim = simulate_with_seed(model, &pop, params, 1, seed);
@@ -507,6 +508,7 @@ fn generate_two_cpt_oral_cov() {
         covariate_names: vec!["wt".into(), "crcl".into()],
         dv_column: "dv".into(),
         input_columns: vec![],
+        exclusions: None,
     };
     let sim = simulate_with_seed(&model, &pop, &params, 1, 456);
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1668,6 +1668,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 
@@ -2841,6 +2842,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1412,6 +1412,7 @@ mod iov_tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
         // `requested` is the user's FitOptions value, passed independently of
         // model.gradient_method (which compatibility rules may have mutated).

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2561,6 +2561,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".to_string(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2180,6 +2180,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let flag = CancelFlag::new();
@@ -2277,6 +2278,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let theta = vec![1.5f64, 20.0]; // CL, V
@@ -2429,6 +2431,7 @@ mod tests {
             covariate_names: Vec::new(),
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let theta = vec![1.0f64, 10.0, 0.5];

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -426,6 +426,7 @@ mod tests {
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
             covariate_table: None,
+            exclusions: None,
         }
     }
 

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -62,6 +62,11 @@ impl SelectionFilter {
     /// Returns `(excluded, which)`:
     /// - `excluded = true` when the row should be dropped.
     /// - `which` is the source string of the first clause that fired (for logging).
+    ///
+    /// Checks short-circuit on the first match, so a record is attributed to the
+    /// first rule that excludes it. A rule that only ever matches records already
+    /// removed by an earlier rule therefore never appears in the fired-condition
+    /// summary — see `docs/src/model-file/data-selection.md`.
     pub fn should_exclude(&self, ctx: &RowContext<'_>) -> (bool, Option<String>) {
         // 1. ignore_subjects shorthand.
         if self.ignore_subject_ids.iter().any(|id| id == ctx.id) {
@@ -87,6 +92,9 @@ impl SelectionFilter {
 pub(crate) struct SubjectExclusion {
     pub n_obs_excluded: usize,
     pub n_dose_excluded: usize,
+    /// Records excluded that are neither scored obs nor doses (EVID 2/3, or
+    /// missing-DV obs).
+    pub n_other_excluded: usize,
     /// Sources that matched at least one row ("ignore: DV < 0.001", etc.).
     pub fired: Vec<String>,
 }
@@ -409,6 +417,7 @@ fn read_nonmem_csv_impl(
         // Accumulate filter statistics.
         excl_summary.n_obs_excluded += subj_excl.n_obs_excluded;
         excl_summary.n_dose_excluded += subj_excl.n_dose_excluded;
+        excl_summary.n_other_excluded += subj_excl.n_other_excluded;
         for src in subj_excl.fired {
             if !excl_summary.fired_ignore.contains(&src)
                 && !excl_summary.fired_accept.contains(&src)
@@ -575,6 +584,7 @@ fn parse_subject(
     let mut occ_parse_failures: usize = 0;
     let mut excl_n_obs: usize = 0;
     let mut excl_n_dose: usize = 0;
+    let mut excl_n_other: usize = 0;
     let mut excl_fired: Vec<String> = Vec::new();
     let mut parse_warnings: Vec<String> = Vec::new();
     let mut addl_missing_ii_warned = false;
@@ -738,11 +748,15 @@ fn parse_subject(
                         excl_fired.push(src);
                     }
                 }
-                // Count by record type for the summary.
+                // Count by record type for the summary. The catch-all `other`
+                // bucket (EVID 2/3, missing-DV obs) ensures every excluded
+                // record is reflected in some counter.
                 if evid == 1 || evid == 4 {
                     excl_n_dose += 1;
                 } else if evid == 0 && mdv == 0 {
                     excl_n_obs += 1;
+                } else {
+                    excl_n_other += 1;
                 }
                 continue; // skip this row
             }
@@ -922,6 +936,7 @@ fn parse_subject(
         SubjectExclusion {
             n_obs_excluded: excl_n_obs,
             n_dose_excluded: excl_n_dose,
+            n_other_excluded: excl_n_other,
             fired: excl_fired,
         },
         parse_warnings,
@@ -986,6 +1001,35 @@ mod tests {
         // One dose (t=0), two observations (t=1, t=6) — the reset row is neither.
         assert_eq!(subj.doses.len(), 1);
         assert_eq!(subj.obs_times, vec![1.0, 6.0]);
+    }
+
+    #[test]
+    fn test_filter_on_undeclared_covariate_via_declared_path() {
+        // Regression: a `[data_selection]` condition on a covariate that the
+        // `[covariates]` block did NOT declare must still fire on the declared
+        // read path. Here only WT is declared; `ignore = STUDY == 2` references
+        // the undeclared STUDY column. `referenced_covariate_columns()` must
+        // pull STUDY into the read union so it lands in each subject's covariate
+        // map — otherwise the condition would silently never match.
+        let csv = "ID,TIME,DV,EVID,AMT,CMT,WT,STUDY\n\
+                   1,0,.,1,100,1,70,1\n\
+                   1,1,5.0,0,.,1,70,1\n\
+                   2,0,.,1,100,1,80,2\n\
+                   2,1,4.0,0,.,1,80,2\n";
+        let f = write_csv(csv);
+        let decls = vec![CovariateDecl {
+            name: "WT".to_string(),
+            kind: CovariateKind::Continuous,
+        }];
+        let filter = SelectionFilter::from_opts(&["STUDY == 2".to_string()], &[], &[]).unwrap();
+        let (pop, _table) =
+            read_nonmem_csv_with_covariates_filtered(f.path(), &decls, &[], None, &filter).unwrap();
+        // Subject 2 (STUDY==2) is excluded entirely; only subject 1 survives.
+        assert_eq!(pop.subjects.len(), 1, "subject 2 should be filtered out");
+        assert_eq!(pop.subjects[0].id, "1");
+        let excl = pop.exclusions.as_ref().expect("exclusions present");
+        assert_eq!(excl.excluded_subject_ids, vec!["2".to_string()]);
+        assert!(excl.fired_ignore.iter().any(|s| s.contains("STUDY == 2")));
     }
 
     #[test]

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1,6 +1,77 @@
-use crate::types::{CovariateDecl, CovariateRow, CovariateTable, DoseEvent, Population, Subject};
+use crate::io::filter_expr::{FilterClause, RowContext};
+use crate::types::{
+    CovariateDecl, CovariateRow, CovariateTable, DoseEvent, ExclusionSummary, Population, Subject,
+};
 use std::collections::HashMap;
 use std::path::Path;
+
+/// Compiled data-selection filter built from `FitOptions` ignore/accept fields.
+/// Passed into `read_nonmem_csv_impl` so filtering happens at read time.
+pub struct SelectionFilter {
+    pub ignore: Vec<FilterClause>,
+    pub accept: Vec<FilterClause>,
+    /// Subject IDs to exclude wholesale (from `ignore_subjects`).
+    pub ignore_subject_ids: Vec<String>,
+}
+
+impl SelectionFilter {
+    /// Build from the raw expression strings stored in `FitOptions`.
+    /// Returns `Err` if any expression fails to parse.
+    pub fn from_opts(
+        ignore_exprs: &[String],
+        accept_exprs: &[String],
+        ignore_subjects: &[String],
+    ) -> Result<Self, String> {
+        let ignore = ignore_exprs
+            .iter()
+            .map(|s| FilterClause::parse(s))
+            .collect::<Result<Vec<_>, _>>()?;
+        let accept = accept_exprs
+            .iter()
+            .map(|s| FilterClause::parse(s))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(SelectionFilter {
+            ignore,
+            accept,
+            ignore_subject_ids: ignore_subjects.to_vec(),
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ignore.is_empty() && self.accept.is_empty() && self.ignore_subject_ids.is_empty()
+    }
+
+    /// Returns `(excluded, which)`:
+    /// - `excluded = true` when the row should be dropped.
+    /// - `which` is the source string of the first clause that fired (for logging).
+    pub fn should_exclude(&self, ctx: &RowContext<'_>) -> (bool, Option<String>) {
+        // 1. ignore_subjects shorthand.
+        if self.ignore_subject_ids.iter().any(|id| id == ctx.id) {
+            return (true, Some(format!("ignore_subjects: {}", ctx.id)));
+        }
+        // 2. ignore clauses (any match → excluded).
+        for clause in &self.ignore {
+            if clause.eval(ctx) {
+                return (true, Some(format!("ignore: {}", clause.source)));
+            }
+        }
+        // 3. accept clauses (all must pass → if any fails, excluded).
+        for clause in &self.accept {
+            if !clause.eval(ctx) {
+                return (true, Some(format!("accept: {}", clause.source)));
+            }
+        }
+        (false, None)
+    }
+}
+
+/// Per-subject exclusion counts returned by `parse_subject` when a filter is active.
+pub(crate) struct SubjectExclusion {
+    pub n_obs_excluded: usize,
+    pub n_dose_excluded: usize,
+    /// Sources that matched at least one row ("ignore: DV < 0.001", etc.).
+    pub fired: Vec<String>,
+}
 
 /// Leading text of the "declared covariate column absent from data" error.
 /// Shared so the `ferx check` layer can classify the reader's error into the
@@ -35,7 +106,7 @@ pub fn read_nonmem_csv(
     covariate_columns: Option<&[&str]>,
     iov_column: Option<&str>,
 ) -> Result<Population, String> {
-    read_nonmem_csv_impl(path, covariate_columns, iov_column, None).map(|(pop, _)| pop)
+    read_nonmem_csv_impl(path, covariate_columns, iov_column, None, None).map(|(pop, _)| pop)
 }
 
 /// Read a NONMEM-format CSV with a `[covariates]` declaration.
@@ -66,7 +137,48 @@ pub fn read_nonmem_csv_with_covariates(
         }
     }
     let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
-    let (pop, table) = read_nonmem_csv_impl(path, Some(&union_refs), iov_column, Some(decls))?;
+    let (pop, table) =
+        read_nonmem_csv_impl(path, Some(&union_refs), iov_column, Some(decls), None)?;
+    Ok((
+        pop,
+        table.expect("covariate table is built whenever table_decls is Some"),
+    ))
+}
+
+/// Like [`read_nonmem_csv`] but applies `[data_selection]` filtering at read time.
+/// Called from `api::read_population_for` when `FitOptions` carries selection rules.
+pub fn read_nonmem_csv_filtered(
+    path: &Path,
+    covariate_columns: Option<&[&str]>,
+    iov_column: Option<&str>,
+    filter: &SelectionFilter,
+) -> Result<Population, String> {
+    read_nonmem_csv_impl(path, covariate_columns, iov_column, None, Some(filter))
+        .map(|(pop, _)| pop)
+}
+
+/// Like [`read_nonmem_csv_with_covariates`] but applies `[data_selection]` filtering.
+pub fn read_nonmem_csv_with_covariates_filtered(
+    path: &Path,
+    decls: &[CovariateDecl],
+    extra_columns: &[String],
+    iov_column: Option<&str>,
+    filter: &SelectionFilter,
+) -> Result<(Population, CovariateTable), String> {
+    let mut union: Vec<String> = decls.iter().map(|d| d.name.clone()).collect();
+    for c in extra_columns {
+        if !union.iter().any(|n| n == c) {
+            union.push(c.clone());
+        }
+    }
+    let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
+    let (pop, table) = read_nonmem_csv_impl(
+        path,
+        Some(&union_refs),
+        iov_column,
+        Some(decls),
+        Some(filter),
+    )?;
     Ok((
         pop,
         table.expect("covariate table is built whenever table_decls is Some"),
@@ -84,6 +196,7 @@ fn read_nonmem_csv_impl(
     covariate_columns: Option<&[&str]>,
     iov_column: Option<&str>,
     table_decls: Option<&[CovariateDecl]>,
+    filter: Option<&SelectionFilter>,
 ) -> Result<(Population, Option<CovariateTable>), String> {
     let mut rdr = csv::ReaderBuilder::new()
         .flexible(true)
@@ -232,11 +345,16 @@ fn read_nonmem_csv_impl(
         rows_by_id.last_mut().unwrap().1.push(fields);
     }
 
-    // Build subjects
+    // Build subjects, applying selection filter if present.
     let mut subjects = Vec::new();
     let mut total_occ_failures: usize = 0;
+    let n_records_total: usize = rows_by_id.iter().map(|(_, rows)| rows.len()).sum();
+    let mut excl_summary = ExclusionSummary {
+        n_records_total,
+        ..Default::default()
+    };
     for (id, rows) in &rows_by_id {
-        let (subject, occ_failures) = parse_subject(
+        let (subject, occ_failures, subj_excl) = parse_subject(
             id,
             rows,
             time_col,
@@ -251,9 +369,51 @@ fn read_nonmem_csv_impl(
             cens_col,
             occ_col,
             &cov_indices,
+            filter,
         )?;
-        subjects.push(subject);
         total_occ_failures += occ_failures;
+
+        // Accumulate filter statistics.
+        excl_summary.n_obs_excluded += subj_excl.n_obs_excluded;
+        excl_summary.n_dose_excluded += subj_excl.n_dose_excluded;
+        for src in subj_excl.fired {
+            if !excl_summary.fired_ignore.contains(&src)
+                && !excl_summary.fired_accept.contains(&src)
+            {
+                if src.starts_with("accept:") {
+                    excl_summary.fired_accept.push(src);
+                } else {
+                    excl_summary.fired_ignore.push(src);
+                }
+            }
+        }
+
+        // Warn about pathological partial exclusions.
+        let has_doses = !subject.doses.is_empty();
+        let has_obs = !subject.observations.is_empty();
+        let excluded_doses = subj_excl.n_dose_excluded > 0;
+        let excluded_obs = subj_excl.n_obs_excluded > 0;
+
+        if excluded_doses && !has_doses && has_obs {
+            eprintln!(
+                "[ferx] warning: subject {id}: all dose records were excluded by \
+                 [data_selection] but observations remain — predictions will be undefined."
+            );
+        }
+        if excluded_obs && !has_obs && has_doses {
+            eprintln!(
+                "[ferx] warning: subject {id}: all observation records were excluded by \
+                 [data_selection] but dose records remain — subject contributes nothing to \
+                 the likelihood."
+            );
+        }
+
+        if subject.doses.is_empty() && subject.observations.is_empty() {
+            // Subject entirely excluded — do not add to subjects list.
+            excl_summary.excluded_subject_ids.push(id.clone());
+            continue;
+        }
+        subjects.push(subject);
     }
 
     // Surface a single warning if any OCC values were missing/unparseable.
@@ -269,6 +429,12 @@ fn read_nonmem_csv_impl(
             );
         }
     }
+
+    let exclusions = if filter.is_some() {
+        Some(excl_summary)
+    } else {
+        None
+    };
 
     let table = if let Some(decls) = table_decls {
         // `table_indices` (and hence each row's `values`) is in declaration
@@ -297,6 +463,7 @@ fn read_nonmem_csv_impl(
             covariate_names: existing_cov_names,
             dv_column: "dv".to_string(),
             input_columns: headers,
+            exclusions,
         },
         table,
     ))
@@ -348,7 +515,8 @@ fn parse_subject(
     cens_col: Option<usize>,
     occ_col: Option<usize>,
     cov_indices: &[(String, usize)],
-) -> Result<(Subject, usize), String> {
+    filter: Option<&SelectionFilter>,
+) -> Result<(Subject, usize, SubjectExclusion), String> {
     let mut doses = Vec::new();
     let mut obs_times = Vec::new();
     let mut observations = Vec::new();
@@ -357,6 +525,9 @@ fn parse_subject(
     let mut occasions: Vec<u32> = Vec::new();
     let mut dose_occasions: Vec<u32> = Vec::new();
     let mut occ_parse_failures: usize = 0;
+    let mut excl_n_obs: usize = 0;
+    let mut excl_n_dose: usize = 0;
+    let mut excl_fired: Vec<String> = Vec::new();
 
     // Time-constant covariates: first non-missing value across all rows.
     // Used as the subject-static fallback (and for the AD fast path, which
@@ -464,6 +635,66 @@ fn parse_subject(
         } else {
             0
         };
+
+        // ── Data selection filter ─────────────────────────────────────────────
+        // Evaluated after LOCF update so the filter sees current covariate
+        // values, matching NONMEM's per-record semantics.
+        if let Some(sel) = filter {
+            let dv_for_ctx = parse_f64(row.get(dv_col).map(|s| s.as_str()).unwrap_or("0"));
+            let amt_for_ctx = amt_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_f64(s))
+                .unwrap_or(0.0);
+            let cmt_for_ctx = cmt_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_usize(s))
+                .unwrap_or(1);
+            let rate_for_ctx = rate_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_f64(s))
+                .unwrap_or(0.0);
+            let ii_for_ctx = ii_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_f64(s))
+                .unwrap_or(0.0);
+            let ss_for_ctx = ss_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_usize(s) > 0)
+                .unwrap_or(false);
+            let cens_for_ctx = cens_col
+                .and_then(|c| row.get(c))
+                .map(|s| parse_usize(s))
+                .unwrap_or(0);
+            let ctx = RowContext {
+                id,
+                time,
+                dv: dv_for_ctx,
+                evid,
+                amt: amt_for_ctx,
+                cmt: cmt_for_ctx,
+                rate: rate_for_ctx,
+                mdv: mdv as u32,
+                cens: if cens_for_ctx > 0 { 1u8 } else { 0u8 },
+                ii: ii_for_ctx,
+                ss: ss_for_ctx,
+                covariates: &locf_state,
+            };
+            let (excluded, which) = sel.should_exclude(&ctx);
+            if excluded {
+                if let Some(src) = which {
+                    if !excl_fired.contains(&src) {
+                        excl_fired.push(src);
+                    }
+                }
+                // Count by record type for the summary.
+                if evid == 1 || evid == 4 {
+                    excl_n_dose += 1;
+                } else if evid == 0 && mdv == 0 {
+                    excl_n_obs += 1;
+                }
+                continue; // skip this row
+            }
+        }
 
         // EVID=3 (reset) and EVID=4 (reset + dose) both zero the compartment
         // state at this time. Record the reset before the dose arm runs so
@@ -584,6 +815,11 @@ fn parse_subject(
             dose_occasions: sorted_dose_occ,
         },
         occ_parse_failures,
+        SubjectExclusion {
+            n_obs_excluded: excl_n_obs,
+            n_dose_excluded: excl_n_dose,
+            fired: excl_fired,
+        },
     ))
 }
 

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -506,6 +506,20 @@ fn parse_f64(s: &str) -> f64 {
     s.parse::<f64>().unwrap_or(0.0)
 }
 
+/// Parse a numeric cell for the data-selection filter, mapping missing/blank
+/// cells (`.`, `NA`, empty) to `NaN`. Because every IEEE comparison against
+/// `NaN` is false (see `cmp_f64`), a record whose value for a referenced column
+/// is missing never matches that condition — so `ignore = DV < 0.001` skips
+/// dose rows (where `DV` is `.`) instead of silently treating them as `0`.
+fn parse_f64_or_nan(s: &str) -> f64 {
+    let t = s.trim();
+    if is_missing_cell(t) {
+        f64::NAN
+    } else {
+        t.parse::<f64>().unwrap_or(f64::NAN)
+    }
+}
+
 fn parse_usize(s: &str) -> usize {
     s.parse::<usize>().unwrap_or(0)
 }
@@ -676,23 +690,25 @@ fn parse_subject(
         // Evaluated after LOCF update so the filter sees current covariate
         // values, matching NONMEM's per-record semantics.
         if let Some(sel) = filter {
-            let dv_for_ctx = parse_f64(row.get(dv_col).map(|s| s.as_str()).unwrap_or("0"));
+            // Missing-sensitive numeric columns map `.`/blank to NaN so the
+            // filter never matches them (see `parse_f64_or_nan`).
+            let dv_for_ctx = parse_f64_or_nan(row.get(dv_col).map(|s| s.as_str()).unwrap_or(""));
             let amt_for_ctx = amt_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_f64(s))
-                .unwrap_or(0.0);
+                .map(|s| parse_f64_or_nan(s))
+                .unwrap_or(f64::NAN);
             let cmt_for_ctx = cmt_col
                 .and_then(|c| row.get(c))
                 .map(|s| parse_usize(s))
                 .unwrap_or(1);
             let rate_for_ctx = rate_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_f64(s))
-                .unwrap_or(0.0);
+                .map(|s| parse_f64_or_nan(s))
+                .unwrap_or(f64::NAN);
             let ii_for_ctx = ii_col
                 .and_then(|c| row.get(c))
-                .map(|s| parse_f64(s))
-                .unwrap_or(0.0);
+                .map(|s| parse_f64_or_nan(s))
+                .unwrap_or(f64::NAN);
             let ss_for_ctx = ss_col
                 .and_then(|c| row.get(c))
                 .map(|s| parse_usize(s) > 0)

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -313,7 +313,15 @@ fn read_nonmem_csv_impl(
     };
     let cov_indices: Vec<(String, usize)> = cov_names
         .iter()
-        .filter_map(|name| col_idx_cs(name).map(|idx| (name.clone(), idx)))
+        .filter_map(|name| {
+            // Prefer an exact header match; fall back to case-insensitive so a
+            // filter-injected lowercase name (e.g. "study" from
+            // `referenced_covariate_columns`) still resolves to a "STUDY" header.
+            // Store the actual header name so covariate keys match the dataset.
+            col_idx_cs(name)
+                .or_else(|| col_idx_ci(name))
+                .map(|idx| (headers[idx].clone(), idx))
+        })
         .collect();
 
     // Optional covariate table over the *declared* covariates. Every declared

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -179,7 +179,24 @@ pub fn read_nonmem_csv_filtered(
     iov_column: Option<&str>,
     filter: &SelectionFilter,
 ) -> Result<Population, String> {
-    read_nonmem_csv_impl(path, covariate_columns, iov_column, None, Some(filter))
+    // When an explicit covariate list is supplied, make sure every covariate the
+    // filter references is in it — otherwise a filtered column outside the list
+    // would not be read and the condition would silently never fire. (With
+    // `None`, the auto-detect path already reads every non-standard column, so no
+    // augmentation is needed.) Symmetric with the `[covariates]` reader.
+    let augmented: Option<Vec<String>> = covariate_columns.map(|cols| {
+        let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
+        for c in filter.referenced_covariate_columns() {
+            if !v.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
+                v.push(c);
+            }
+        }
+        v
+    });
+    let cols_ref: Option<Vec<&str>> = augmented
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    read_nonmem_csv_impl(path, cols_ref.as_deref(), iov_column, None, Some(filter))
         .map(|(pop, _)| pop)
 }
 
@@ -451,8 +468,17 @@ fn read_nonmem_csv_impl(
             ));
         }
 
-        if subject.doses.is_empty() && subject.observations.is_empty() {
-            // Subject entirely excluded — do not add to subjects list.
+        // Only drop a subject as "excluded by data selection" when the filter
+        // actually removed at least one of its records and that left it empty.
+        // Without this guard we would also drop subjects that are empty for
+        // unrelated reasons (e.g. only EVID=2/3 rows) on the no-filter path,
+        // which is a behavior change vs. the pre-feature reader (it pushed every
+        // subject unconditionally). `had_exclusions` is only ever > 0 when a
+        // filter is active.
+        let had_exclusions =
+            subj_excl.n_obs_excluded + subj_excl.n_dose_excluded + subj_excl.n_other_excluded > 0;
+        if had_exclusions && subject.doses.is_empty() && subject.observations.is_empty() {
+            // Subject entirely excluded by the filter — do not add to the list.
             excl_summary.excluded_subject_ids.push(id.clone());
             continue;
         }
@@ -1030,6 +1056,28 @@ mod tests {
         let excl = pop.exclusions.as_ref().expect("exclusions present");
         assert_eq!(excl.excluded_subject_ids, vec!["2".to_string()]);
         assert!(excl.fired_ignore.iter().any(|s| s.contains("STUDY == 2")));
+    }
+
+    #[test]
+    fn test_no_filter_keeps_subject_with_only_other_events() {
+        // Regression: without a [data_selection] filter, a subject made up solely
+        // of EVID=2 (other-event) rows has empty doses+observations but must
+        // still be retained — matching the pre-feature reader, which pushed every
+        // subject unconditionally. The empty-subject skip must be gated on the
+        // filter actually having excluded records.
+        let csv = "ID,TIME,DV,EVID,AMT,CMT\n\
+                   1,0,.,1,100,1\n\
+                   1,1,5.0,0,.,1\n\
+                   2,0,.,2,.,1\n\
+                   2,1,.,2,.,1\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        let ids: Vec<&str> = pop.subjects.iter().map(|s| s.id.as_str()).collect();
+        assert!(
+            ids.contains(&"2"),
+            "subject with only EVID=2 rows must be retained when no filter is active; got {ids:?}"
+        );
+        assert!(pop.exclusions.is_none(), "no filter → no exclusion summary");
     }
 
     #[test]

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1045,11 +1045,19 @@ mod tests {
         // the undeclared STUDY column. `referenced_covariate_columns()` must
         // pull STUDY into the read union so it lands in each subject's covariate
         // map — otherwise the condition would silently never match.
+        // STUDY is a covariate independent of ID: subjects 1 & 2 are in STUDY 1,
+        // subjects 3 & 4 in STUDY 2. Filtering on STUDY (not ID) must drop a whole
+        // study (3 and 4) while keeping the other (1 and 2). The not-1:1 mapping
+        // ensures the test exercises covariate filtering, not ID matching.
         let csv = "ID,TIME,DV,EVID,AMT,CMT,WT,STUDY\n\
                    1,0,.,1,100,1,70,1\n\
                    1,1,5.0,0,.,1,70,1\n\
-                   2,0,.,1,100,1,80,2\n\
-                   2,1,4.0,0,.,1,80,2\n";
+                   2,0,.,1,100,1,72,1\n\
+                   2,1,4.5,0,.,1,72,1\n\
+                   3,0,.,1,100,1,80,2\n\
+                   3,1,4.0,0,.,1,80,2\n\
+                   4,0,.,1,100,1,85,2\n\
+                   4,1,3.5,0,.,1,85,2\n";
         let f = write_csv(csv);
         let decls = vec![CovariateDecl {
             name: "WT".to_string(),
@@ -1058,11 +1066,14 @@ mod tests {
         let filter = SelectionFilter::from_opts(&["STUDY == 2".to_string()], &[], &[]).unwrap();
         let (pop, _table) =
             read_nonmem_csv_with_covariates_filtered(f.path(), &decls, &[], None, &filter).unwrap();
-        // Subject 2 (STUDY==2) is excluded entirely; only subject 1 survives.
-        assert_eq!(pop.subjects.len(), 1, "subject 2 should be filtered out");
-        assert_eq!(pop.subjects[0].id, "1");
+        // Both STUDY==2 subjects (3 and 4) are excluded; STUDY==1 subjects remain.
+        let ids: Vec<&str> = pop.subjects.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["1", "2"], "only STUDY==1 subjects should remain");
         let excl = pop.exclusions.as_ref().expect("exclusions present");
-        assert_eq!(excl.excluded_subject_ids, vec!["2".to_string()]);
+        assert_eq!(
+            excl.excluded_subject_ids,
+            vec!["3".to_string(), "4".to_string()]
+        );
         assert!(excl.fired_ignore.iter().any(|s| s.contains("STUDY == 2")));
     }
 

--- a/src/io/filter_expr.rs
+++ b/src/io/filter_expr.rs
@@ -50,6 +50,13 @@ impl FilterExpr {
                     || (rhs_raw.starts_with('\'') && rhs_raw.ends_with('\''))
                 {
                     FilterValue::Str(rhs_raw[1..rhs_raw.len() - 1].to_string())
+                } else if col == "id" {
+                    // ID is a string label, so it is always compared as a string —
+                    // even when written bare (`ID == 3`). Without this, a bare
+                    // numeric would be parsed as `Num`, and `eval` short-circuits
+                    // every numeric comparison against `id` to `false`, so
+                    // `ID == 3` would silently never match.
+                    FilterValue::Str(rhs_raw.to_string())
                 } else if let Ok(n) = rhs_raw.parse::<f64>() {
                     FilterValue::Num(n)
                 } else {
@@ -363,6 +370,28 @@ mod tests {
     fn test_unknown_column_never_fires() {
         // Unknown column: no-op (does not exclude).
         assert!(!eval("NOSUCHCOL == 1", "1", 0.0, 0, 70.0));
+    }
+
+    // ── Missing value (NaN) never matches ────────────────────────────────────
+
+    #[test]
+    fn test_missing_dv_never_matches() {
+        // A missing DV is carried as NaN; every comparison against it is false,
+        // so e.g. a dose row (DV='.') is not caught by `DV < 0.001`.
+        assert!(!eval("DV < 0.001", "1", f64::NAN, 1, 70.0));
+        assert!(!eval("DV > 0.001", "1", f64::NAN, 1, 70.0));
+        assert!(!eval("DV == 0", "1", f64::NAN, 1, 70.0));
+        // `!=` must also not fire on a missing value.
+        assert!(!eval("DV != 0", "1", f64::NAN, 1, 70.0));
+    }
+
+    #[test]
+    fn test_missing_dv_does_not_break_guarded_clause() {
+        // `EVID == 0 && DV < 0.001` on a dose row (NaN DV): the DV term is false,
+        // so the whole && clause is false — dose row retained.
+        assert!(!eval("EVID == 0 && DV < 0.001", "1", f64::NAN, 1, 70.0));
+        // On a real low observation it still fires.
+        assert!(eval("EVID == 0 && DV < 0.001", "1", 0.0005, 0, 70.0));
     }
 
     // ── Parse errors ─────────────────────────────────────────────────────────

--- a/src/io/filter_expr.rs
+++ b/src/io/filter_expr.rs
@@ -1,0 +1,373 @@
+use std::collections::HashMap;
+
+/// A single comparison: `column op value`.
+#[derive(Debug, Clone)]
+pub struct FilterExpr {
+    col: String, // lowercase
+    op: CmpOp,
+    rhs: FilterValue,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+#[derive(Debug, Clone)]
+enum FilterValue {
+    Num(f64),
+    Str(String),
+}
+
+impl FilterExpr {
+    fn parse_one(s: &str) -> Result<Self, String> {
+        // Try each two-char operator first (order matters: `>=` before `>`).
+        let ops: &[(&str, CmpOp)] = &[
+            ("==", CmpOp::Eq),
+            ("!=", CmpOp::Ne),
+            (">=", CmpOp::Ge),
+            ("<=", CmpOp::Le),
+            (">", CmpOp::Gt),
+            ("<", CmpOp::Lt),
+        ];
+        for (sym, op) in ops {
+            if let Some(pos) = s.find(sym) {
+                let col = s[..pos].trim().to_lowercase();
+                let rhs_raw = s[pos + sym.len()..].trim();
+                if col.is_empty() || rhs_raw.is_empty() {
+                    return Err(format!(
+                        "malformed filter expression '{}': column or value is empty",
+                        s.trim()
+                    ));
+                }
+                // String RHS: `"A"` or `'A'`.
+                let rhs = if (rhs_raw.starts_with('"') && rhs_raw.ends_with('"'))
+                    || (rhs_raw.starts_with('\'') && rhs_raw.ends_with('\''))
+                {
+                    FilterValue::Str(rhs_raw[1..rhs_raw.len() - 1].to_string())
+                } else if let Ok(n) = rhs_raw.parse::<f64>() {
+                    FilterValue::Num(n)
+                } else {
+                    return Err(format!(
+                        "malformed filter expression '{}': right-hand side '{}' is not a \
+                         number or quoted string",
+                        s.trim(),
+                        rhs_raw
+                    ));
+                };
+                return Ok(FilterExpr { col, op: *op, rhs });
+            }
+        }
+        Err(format!(
+            "malformed filter expression '{}': no comparison operator found (==, !=, >=, <=, >, <)",
+            s.trim()
+        ))
+    }
+
+    fn eval(&self, ctx: &RowContext<'_>) -> bool {
+        let col = self.col.as_str();
+        match &self.rhs {
+            FilterValue::Num(rhs) => {
+                let lhs = match col {
+                    "id" => return false, // numeric comparison against ID string: never match
+                    "time" => ctx.time,
+                    "dv" => ctx.dv,
+                    "evid" => ctx.evid as f64,
+                    "amt" => ctx.amt,
+                    "cmt" => ctx.cmt as f64,
+                    "rate" => ctx.rate,
+                    "mdv" => ctx.mdv as f64,
+                    "cens" => ctx.cens as f64,
+                    "ii" => ctx.ii,
+                    "ss" => ctx.ss as u8 as f64,
+                    // Case-insensitive lookup so `BW >= 30` matches a "BW" or "bw" column.
+                    _ => match ctx
+                        .covariates
+                        .iter()
+                        .find(|(k, _)| k.to_lowercase() == col)
+                        .map(|(_, &v)| v)
+                    {
+                        Some(v) => v,
+                        // Unknown column: never fires (safe default).
+                        None => return false,
+                    },
+                };
+                cmp_f64(lhs, *rhs, self.op)
+            }
+            FilterValue::Str(rhs) => {
+                let lhs: &str = match col {
+                    "id" => ctx.id,
+                    // String comparison against numeric columns is not meaningful.
+                    _ => return false,
+                };
+                match self.op {
+                    CmpOp::Eq => lhs == rhs,
+                    CmpOp::Ne => lhs != rhs,
+                    _ => false, // <, <=, >, >= on strings not supported
+                }
+            }
+        }
+    }
+}
+
+fn cmp_f64(lhs: f64, rhs: f64, op: CmpOp) -> bool {
+    match op {
+        CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
+        CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+        CmpOp::Lt => lhs < rhs,
+        CmpOp::Le => lhs <= rhs,
+        CmpOp::Gt => lhs > rhs,
+        CmpOp::Ge => lhs >= rhs,
+    }
+}
+
+/// A single user-supplied expression string, which may contain one or more
+/// `FilterExpr`s joined by `&&`. All sub-expressions must hold for the clause
+/// to evaluate to `true`. Consistent with the existing ferx DSL which uses `&&`
+/// (not `AND`/`OR` keywords) for boolean composition.
+///
+/// `||` within a string is rejected at parse time with a clear error message;
+/// use multiple strings (via `c()` in R or repeated lines in `.ferx`) instead.
+#[derive(Debug, Clone)]
+pub struct FilterClause {
+    exprs: Vec<FilterExpr>,
+    /// Original string, preserved verbatim for logging.
+    pub source: String,
+}
+
+impl FilterClause {
+    /// Parse a user-supplied expression string.
+    ///
+    /// Accepts:
+    /// - `"DV < 0.001"` (bare, from `.ferx` file) or `"\"DV < 0.001\""` (R
+    ///   quoted string) — surrounding quotes are stripped.
+    /// - `"BW >= 30 && BW < 48"` — `&&`-joined clauses; all must hold.
+    ///
+    /// Rejects:
+    /// - `||` — parse error: use multiple strings instead.
+    /// - `AND` / `OR` keyword forms — parse error: use `&&` / multiple strings.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        // Strip surrounding quotes (R passes "DV < 0.001" with quotes intact).
+        let s = raw.trim();
+        let s = if (s.starts_with('"') && s.ends_with('"'))
+            || (s.starts_with('\'') && s.ends_with('\''))
+        {
+            &s[1..s.len() - 1]
+        } else {
+            s
+        };
+
+        // Reject || early with a clear message.
+        if s.contains("||") {
+            return Err(format!(
+                "filter expression '{}' contains '||': OR within a single expression is not \
+                 supported. Use multiple ignore/accept conditions (c() in R, or repeated lines \
+                 in [data_selection]) — each is an independent reason to exclude.",
+                s
+            ));
+        }
+
+        // Reject AND / OR keyword forms.
+        {
+            let upper = s.to_uppercase();
+            for keyword in &[" AND ", " OR "] {
+                if upper.contains(keyword) {
+                    return Err(format!(
+                        "filter expression '{}' contains keyword '{}': use '&&' for AND, \
+                         or multiple conditions for OR.",
+                        s,
+                        keyword.trim()
+                    ));
+                }
+            }
+        }
+
+        let source = s.to_string();
+        let parts: Vec<&str> = s.split("&&").collect();
+        let mut exprs = Vec::with_capacity(parts.len());
+        for part in parts {
+            exprs.push(FilterExpr::parse_one(part.trim())?);
+        }
+        Ok(FilterClause { exprs, source })
+    }
+
+    /// Returns `true` when all sub-expressions hold for the given row.
+    pub fn eval(&self, ctx: &RowContext<'_>) -> bool {
+        self.exprs.iter().all(|e| e.eval(ctx))
+    }
+}
+
+/// Per-row context passed to `FilterClause::eval`.
+pub struct RowContext<'a> {
+    pub id: &'a str,
+    pub time: f64,
+    pub dv: f64,
+    pub evid: u32,
+    pub amt: f64,
+    pub cmt: usize,
+    pub rate: f64,
+    pub mdv: u32,
+    pub cens: u8,
+    pub ii: f64,
+    pub ss: bool,
+    /// Covariate values for this row (case-folded keys).
+    pub covariates: &'a HashMap<String, f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn ctx(id: &str, _dv: f64, _evid: u32, bw: f64) -> (String, HashMap<String, f64>) {
+        let mut cov = HashMap::new();
+        cov.insert("bw".to_string(), bw);
+        (id.to_string(), cov)
+    }
+
+    fn eval(expr: &str, id: &str, dv: f64, evid: u32, bw: f64) -> bool {
+        let (_, cov) = ctx(id, dv, evid, bw);
+        let clause = FilterClause::parse(expr).expect("parse ok");
+        clause.eval(&RowContext {
+            id,
+            time: 0.0,
+            dv,
+            evid,
+            amt: 0.0,
+            cmt: 1,
+            rate: 0.0,
+            mdv: 0,
+            cens: 0,
+            ii: 0.0,
+            ss: false,
+            covariates: &cov,
+        })
+    }
+
+    // ── Operator tests ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_op_eq() {
+        assert!(eval("EVID == 0", "1", 1.0, 0, 70.0));
+        assert!(!eval("EVID == 0", "1", 1.0, 1, 70.0));
+    }
+
+    #[test]
+    fn test_op_ne() {
+        assert!(eval("EVID != 0", "1", 1.0, 1, 70.0));
+        assert!(!eval("EVID != 0", "1", 1.0, 0, 70.0));
+    }
+
+    #[test]
+    fn test_op_lt() {
+        assert!(eval("DV < 0.001", "1", 0.0005, 0, 70.0));
+        assert!(!eval("DV < 0.001", "1", 1.0, 0, 70.0));
+    }
+
+    #[test]
+    fn test_op_le() {
+        assert!(eval("DV <= 1.0", "1", 1.0, 0, 70.0));
+        assert!(!eval("DV <= 1.0", "1", 1.1, 0, 70.0));
+    }
+
+    #[test]
+    fn test_op_gt() {
+        assert!(eval("BW > 80", "1", 0.0, 0, 90.0));
+        assert!(!eval("BW > 80", "1", 0.0, 0, 70.0));
+    }
+
+    #[test]
+    fn test_op_ge() {
+        assert!(eval("BW >= 30", "1", 0.0, 0, 30.0));
+        assert!(eval("BW >= 30", "1", 0.0, 0, 35.0));
+        assert!(!eval("BW >= 30", "1", 0.0, 0, 29.0));
+    }
+
+    // ── Case-insensitive column names ────────────────────────────────────────
+
+    #[test]
+    fn test_case_insensitive_column() {
+        assert!(eval("bw >= 30", "1", 0.0, 0, 30.0));
+        assert!(eval("BW >= 30", "1", 0.0, 0, 30.0));
+        assert!(eval("Bw >= 30", "1", 0.0, 0, 30.0));
+    }
+
+    // ── Quoted strings stripped (R-style) ────────────────────────────────────
+
+    #[test]
+    fn test_quoted_string_stripped() {
+        assert!(eval("\"DV < 0.001\"", "1", 0.0005, 0, 70.0));
+        assert!(eval("'DV < 0.001'", "1", 0.0005, 0, 70.0));
+    }
+
+    // ── ID string equality ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_id_eq_string() {
+        assert!(eval("ID == 3", "3", 0.0, 0, 70.0));
+        assert!(!eval("ID == 3", "1", 0.0, 0, 70.0));
+    }
+
+    #[test]
+    fn test_id_ne_string() {
+        assert!(eval("ID != 3", "1", 0.0, 0, 70.0));
+        assert!(!eval("ID != 3", "3", 0.0, 0, 70.0));
+    }
+
+    // ── && composition ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_and_composition() {
+        // Both must hold.
+        assert!(eval("BW >= 30 && BW < 48", "1", 0.0, 0, 35.0));
+        assert!(!eval("BW >= 30 && BW < 48", "1", 0.0, 0, 25.0));
+        assert!(!eval("BW >= 30 && BW < 48", "1", 0.0, 0, 50.0));
+    }
+
+    #[test]
+    fn test_and_evid_dv() {
+        assert!(eval("EVID == 0 && DV < 0.001", "1", 0.0005, 0, 70.0));
+        assert!(!eval("EVID == 0 && DV < 0.001", "1", 0.0005, 1, 70.0));
+        assert!(!eval("EVID == 0 && DV < 0.001", "1", 1.0, 0, 70.0));
+    }
+
+    // ── Unknown column ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_unknown_column_never_fires() {
+        // Unknown column: no-op (does not exclude).
+        assert!(!eval("NOSUCHCOL == 1", "1", 0.0, 0, 70.0));
+    }
+
+    // ── Parse errors ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_pipe_or_rejected() {
+        assert!(FilterClause::parse("DV < 0.001 || EVID == 0").is_err());
+    }
+
+    #[test]
+    fn test_and_keyword_rejected() {
+        assert!(FilterClause::parse("DV < 0.001 AND EVID == 0").is_err());
+    }
+
+    #[test]
+    fn test_or_keyword_rejected() {
+        assert!(FilterClause::parse("DV < 0.001 OR EVID == 0").is_err());
+    }
+
+    #[test]
+    fn test_missing_operator_rejected() {
+        assert!(FilterClause::parse("DV 0.001").is_err());
+    }
+
+    #[test]
+    fn test_empty_column_rejected() {
+        assert!(FilterClause::parse("== 1").is_err());
+    }
+}

--- a/src/io/filter_expr.rs
+++ b/src/io/filter_expr.rs
@@ -45,10 +45,22 @@ impl FilterExpr {
                         s.trim()
                     ));
                 }
-                // String RHS: `"A"` or `'A'`.
-                let rhs = if (rhs_raw.starts_with('"') && rhs_raw.ends_with('"'))
-                    || (rhs_raw.starts_with('\'') && rhs_raw.ends_with('\''))
-                {
+                // ID is a string label; ordered comparisons on it are not
+                // meaningful and would otherwise silently evaluate to false.
+                // Reject them up front with a clear message.
+                if col == "id" && !matches!(op, CmpOp::Eq | CmpOp::Ne) {
+                    return Err(format!(
+                        "filter expression '{}': ordered comparisons (<, <=, >, >=) are not \
+                         supported on ID (a string label); use == / != or ignore_subjects.",
+                        s.trim()
+                    ));
+                }
+                // String RHS: `"A"` or `'A'`. Require length >= 2 so a lone quote
+                // (`\"` / `'`) does not underflow the `[1..len-1]` slice below.
+                let is_quoted = rhs_raw.len() >= 2
+                    && ((rhs_raw.starts_with('"') && rhs_raw.ends_with('"'))
+                        || (rhs_raw.starts_with('\'') && rhs_raw.ends_with('\'')));
+                let rhs = if is_quoted {
                     FilterValue::Str(rhs_raw[1..rhs_raw.len() - 1].to_string())
                 } else if col == "id" {
                     // ID is a string label, so it is always compared as a string —
@@ -92,11 +104,13 @@ impl FilterExpr {
                     "cens" => ctx.cens as f64,
                     "ii" => ctx.ii,
                     "ss" => ctx.ss as u8 as f64,
-                    // Case-insensitive lookup so `BW >= 30` matches a "BW" or "bw" column.
+                    // Case-insensitive lookup so `BW >= 30` matches a "BW" or "bw"
+                    // column. `col` is already lowercased; `eq_ignore_ascii_case`
+                    // avoids allocating a lowercased key per row in the read loop.
                     _ => match ctx
                         .covariates
                         .iter()
-                        .find(|(k, _)| k.to_lowercase() == col)
+                        .find(|(k, _)| k.eq_ignore_ascii_case(col))
                         .map(|(_, &v)| v)
                     {
                         Some(v) => v,
@@ -123,9 +137,15 @@ impl FilterExpr {
 }
 
 fn cmp_f64(lhs: f64, rhs: f64, op: CmpOp) -> bool {
+    // Exact comparison. LHS (a CSV cell) and RHS (an expression literal) are both
+    // parsed from decimal text, so `STUDY == 2` / `WT == 70.5` match exactly; an
+    // absolute EPSILON band would instead wrongly equate small nonzero values to
+    // zero and adjacent large integers to each other. A missing value arrives as
+    // NaN and must never match: `==`/`<`/`<=`/`>`/`>=` against NaN are already
+    // false, and `!=` is guarded so NaN does not spuriously satisfy it.
     match op {
-        CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
-        CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+        CmpOp::Eq => lhs == rhs,
+        CmpOp::Ne => !lhs.is_nan() && lhs != rhs,
         CmpOp::Lt => lhs < rhs,
         CmpOp::Le => lhs <= rhs,
         CmpOp::Gt => lhs > rhs,
@@ -160,9 +180,11 @@ impl FilterClause {
     /// - `AND` / `OR` keyword forms — parse error: use `&&` / multiple strings.
     pub fn parse(raw: &str) -> Result<Self, String> {
         // Strip surrounding quotes (R passes "DV < 0.001" with quotes intact).
+        // Require length >= 2 so a lone quote does not underflow the slice.
         let s = raw.trim();
-        let s = if (s.starts_with('"') && s.ends_with('"'))
-            || (s.starts_with('\'') && s.ends_with('\''))
+        let s = if s.len() >= 2
+            && ((s.starts_with('"') && s.ends_with('"'))
+                || (s.starts_with('\'') && s.ends_with('\'')))
         {
             &s[1..s.len() - 1]
         } else {
@@ -221,12 +243,27 @@ impl FilterClause {
     }
 }
 
-/// True for the fixed NONMEM columns handled directly in [`RowContext`]
-/// (case-insensitive; `col` is expected already lowercased).
+/// True for the fixed NONMEM columns the reader handles specially, so they are
+/// not mistaken for covariates by `covariate_columns()` (case-insensitive; `col`
+/// is expected already lowercased). `addl` is included — it is a reader-standard
+/// column, not a covariate, even though it has no [`RowContext`] field and so is
+/// not a usable filter target (a condition on it is an inert no-op). The dynamic
+/// occasion / IOV column cannot be listed here; filtering on it is likewise
+/// unsupported (see `docs/src/model-file/data-selection.md`).
 pub fn is_standard_column(col: &str) -> bool {
     matches!(
         col,
-        "id" | "time" | "dv" | "evid" | "amt" | "cmt" | "rate" | "mdv" | "cens" | "ii" | "ss"
+        "id" | "time"
+            | "dv"
+            | "evid"
+            | "amt"
+            | "cmt"
+            | "rate"
+            | "mdv"
+            | "cens"
+            | "ii"
+            | "ss"
+            | "addl"
     )
 }
 
@@ -243,7 +280,9 @@ pub struct RowContext<'a> {
     pub cens: u8,
     pub ii: f64,
     pub ss: bool,
-    /// Covariate values for this row (case-folded keys).
+    /// Covariate values for this row, keyed by the original CSV header name
+    /// (NOT case-folded). `FilterExpr::eval` matches case-insensitively via
+    /// `eq_ignore_ascii_case`, so callers must not assume lowercased keys.
     pub covariates: &'a HashMap<String, f64>,
 }
 
@@ -419,5 +458,37 @@ mod tests {
     #[test]
     fn test_empty_column_rejected() {
         assert!(FilterClause::parse("== 1").is_err());
+    }
+
+    #[test]
+    fn test_lone_quote_does_not_panic() {
+        // A lone quote char must return Err (no comparison operator), not panic
+        // on a `[1..len-1]` slice underflow.
+        assert!(FilterClause::parse("\"").is_err());
+        assert!(FilterClause::parse("'").is_err());
+        // A lone quote as the RHS must not panic either (parses as a 1-char
+        // string label for ID; the point is simply that it does not crash).
+        let _ = FilterClause::parse("ID == \"");
+    }
+
+    #[test]
+    fn test_id_ordered_comparison_rejected() {
+        // Ordered comparisons on ID are a parse error (not a silent no-op).
+        assert!(FilterClause::parse("ID >= 3").is_err());
+        assert!(FilterClause::parse("ID < 10").is_err());
+        assert!(FilterClause::parse("ID > 0").is_err());
+        assert!(FilterClause::parse("ID <= 5").is_err());
+        // == / != still allowed.
+        assert!(FilterClause::parse("ID == 3").is_ok());
+        assert!(FilterClause::parse("ID != 3").is_ok());
+    }
+
+    #[test]
+    fn test_exact_equality_small_and_large() {
+        // Near-zero nonzero value must NOT equal 0 (no EPSILON band).
+        assert!(!eval("DV == 0", "1", 1e-20, 0, 70.0));
+        assert!(eval("DV != 0", "1", 1e-20, 0, 70.0));
+        // Exact integer-coded match still works.
+        assert!(eval("DV == 5", "1", 5.0, 0, 70.0));
     }
 }

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1690,6 +1690,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         }
     }
 

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1611,6 +1611,7 @@ fn wire_to_fit_result(
         // The covariate table is not persisted in the .fitrx bundle (yet); a
         // round-tripped result therefore has no covariate table.
         covariate_table: None,
+        exclusions: None,
     })
 }
 
@@ -1812,6 +1813,7 @@ mod tests {
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
             covariate_table: None,
+            exclusions: None,
         }
     }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,5 @@
 pub mod datareader;
+pub mod filter_expr;
 pub mod fitrx;
 pub mod hash;
 pub mod output;

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1482,6 +1482,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let cols = sdtab(&result, &population);
@@ -1509,6 +1510,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let cols = sdtab(&result, &population);
@@ -1529,6 +1531,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let cols = sdtab(&result, &population);
@@ -1559,6 +1562,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
 
         let cols = sdtab(&result, &population);

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -449,6 +449,33 @@ pub fn print_results(result: &FitResult) {
     eprintln!("  Wall time:  {:.1}s", result.wall_time_secs);
     eprintln!("  ferx v{}", result.ferx_version);
 
+    // Data selection exclusions
+    if let Some(excl) = &result.exclusions {
+        eprintln!("\n--- Data Selection ---");
+        eprintln!(
+            "  Records read: {}  Obs excluded: {}  Doses excluded: {}",
+            excl.n_records_total, excl.n_obs_excluded, excl.n_dose_excluded
+        );
+        if !excl.excluded_subject_ids.is_empty() {
+            eprintln!(
+                "  Subjects excluded entirely: {}",
+                excl.excluded_subject_ids.join(", ")
+            );
+        }
+        if !excl.fired_ignore.is_empty() {
+            eprintln!("  Fired ignore conditions:");
+            for c in &excl.fired_ignore {
+                eprintln!("    * {}", c);
+            }
+        }
+        if !excl.fired_accept.is_empty() {
+            eprintln!("  Fired accept conditions (failed):");
+            for c in &excl.fired_accept {
+                eprintln!("    * {}", c);
+            }
+        }
+    }
+
     // Warnings
     if !result.warnings.is_empty() {
         eprintln!("\n--- Warnings ---");
@@ -967,6 +994,31 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         }
     }
 
+    if let Some(excl) = &result.exclusions {
+        writeln!(f, "\nexclusions:").map_err(|e| e.to_string())?;
+        writeln!(f, "  n_records_total: {}", excl.n_records_total).map_err(|e| e.to_string())?;
+        writeln!(f, "  n_obs_excluded: {}", excl.n_obs_excluded).map_err(|e| e.to_string())?;
+        writeln!(f, "  n_dose_excluded: {}", excl.n_dose_excluded).map_err(|e| e.to_string())?;
+        if !excl.excluded_subject_ids.is_empty() {
+            writeln!(f, "  excluded_subject_ids:").map_err(|e| e.to_string())?;
+            for id in &excl.excluded_subject_ids {
+                writeln!(f, "    - \"{}\"", id).map_err(|e| e.to_string())?;
+            }
+        }
+        if !excl.fired_ignore.is_empty() {
+            writeln!(f, "  fired_ignore:").map_err(|e| e.to_string())?;
+            for c in &excl.fired_ignore {
+                writeln!(f, "    - \"{}\"", c).map_err(|e| e.to_string())?;
+            }
+        }
+        if !excl.fired_accept.is_empty() {
+            writeln!(f, "  fired_accept:").map_err(|e| e.to_string())?;
+            for c in &excl.fired_accept {
+                writeln!(f, "    - \"{}\"", c).map_err(|e| e.to_string())?;
+            }
+        }
+    }
+
     if !result.warnings.is_empty() {
         writeln!(f, "\nwarnings:").map_err(|e| e.to_string())?;
         for w in &result.warnings {
@@ -1139,6 +1191,7 @@ mod tests {
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
             covariate_table: None,
+            exclusions: None,
         }
     }
 
@@ -1460,6 +1513,7 @@ mod tests {
             #[cfg(feature = "nn")]
             neural_networks: Vec::new(),
             covariate_table: None,
+            exclusions: None,
         }
     }
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -453,8 +453,8 @@ pub fn print_results(result: &FitResult) {
     if let Some(excl) = &result.exclusions {
         eprintln!("\n--- Data Selection ---");
         eprintln!(
-            "  Records read: {}  Obs excluded: {}  Doses excluded: {}",
-            excl.n_records_total, excl.n_obs_excluded, excl.n_dose_excluded
+            "  Records read: {}  Obs excluded: {}  Doses excluded: {}  Other excluded: {}",
+            excl.n_records_total, excl.n_obs_excluded, excl.n_dose_excluded, excl.n_other_excluded
         );
         if !excl.excluded_subject_ids.is_empty() {
             eprintln!(
@@ -1104,6 +1104,7 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         writeln!(f, "  n_records_total: {}", excl.n_records_total).map_err(|e| e.to_string())?;
         writeln!(f, "  n_obs_excluded: {}", excl.n_obs_excluded).map_err(|e| e.to_string())?;
         writeln!(f, "  n_dose_excluded: {}", excl.n_dose_excluded).map_err(|e| e.to_string())?;
+        writeln!(f, "  n_other_excluded: {}", excl.n_other_excluded).map_err(|e| e.to_string())?;
         if !excl.excluded_subject_ids.is_empty() {
             writeln!(f, "  excluded_subject_ids:").map_err(|e| e.to_string())?;
             for id in &excl.excluded_subject_ids {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1408,11 +1408,35 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .get("simulation")
         .map(|lines| parse_simulation_block(lines))
         .transpose()?;
-    let fit_options = if let Some(lines) = blocks.get("fit_options") {
+    let mut fit_options = if let Some(lines) = blocks.get("fit_options") {
         parse_fit_options(lines)?
     } else {
         FitOptions::default()
     };
+
+    // ── [data_selection] block ────────────────────────────────────────────────
+    // Parsed after [fit_options] and merged into the same FitOptions so the
+    // read-time filtering code has a single place to look.
+    if let Some(lines) = blocks.get("data_selection") {
+        for line in lines {
+            let parts: Vec<&str> = line.splitn(2, '=').map(|s| s.trim()).collect();
+            if parts.len() != 2 {
+                continue;
+            }
+            let key = parts[0];
+            let value = parts[1];
+            if key != "ignore" && key != "accept" && key != "ignore_subjects" {
+                return Err(format!(
+                    "[data_selection]: unknown key `{key}` — valid keys are \
+                     ignore, accept, ignore_subjects"
+                ));
+            }
+            match apply_fit_option(&mut fit_options, key, value) {
+                Ok(_) => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
 
     // Mirror fit-level BLOQ method onto the compiled model so the likelihood
     // functions can branch without threading bloq_method through every call.
@@ -2106,10 +2130,55 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
                 }
             };
         }
+        // ── [data_selection] keys ─────────────────────────────────────────────
+        "ignore" => {
+            // Validate the expression parses correctly; store verbatim for logging.
+            crate::io::filter_expr::FilterClause::parse(value)
+                .map_err(|e| format!("[data_selection] ignore: {e}"))?;
+            push_unique_expr(&mut opts.ignore_exprs, value);
+            // user_set_keys intentionally not pushed for selection keys — they
+            // are not estimation options and should not trigger "unused key" warnings.
+            return Ok(true);
+        }
+        "accept" => {
+            crate::io::filter_expr::FilterClause::parse(value)
+                .map_err(|e| format!("[data_selection] accept: {e}"))?;
+            push_unique_expr(&mut opts.accept_exprs, value);
+            return Ok(true);
+        }
+        "ignore_subjects" => {
+            // Accept `[3, 17, 42]` or `3` (single value).
+            let raw = value.trim().trim_start_matches('[').trim_end_matches(']');
+            for part in raw.split(',') {
+                let id = part.trim().to_string();
+                if id.is_empty() {
+                    continue;
+                }
+                // Validate it looks like a number or quoted string.
+                let bare = id.trim_matches('"').trim_matches('\'');
+                if bare.is_empty() {
+                    return Err(format!(
+                        "[data_selection] ignore_subjects: empty ID entry in '{value}'"
+                    ));
+                }
+                push_unique_expr(&mut opts.ignore_subjects, bare);
+            }
+            return Ok(true);
+        }
         _ => return Ok(false),
     }
     opts.user_set_keys.push(key.to_string());
     Ok(true)
+}
+
+/// Append `s` (trimmed) to `vec` only if not already present (case-sensitive).
+/// Prevents duplicate conditions when the same expression appears in both the
+/// `.ferx` file and the R call.
+fn push_unique_expr(vec: &mut Vec<String>, s: &str) {
+    let trimmed = s.trim().to_string();
+    if !vec.iter().any(|e| e == &trimmed) {
+        vec.push(trimmed);
+    }
 }
 
 // ── [scaling] block parser ──────────────────────────────────────────────────

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -806,6 +806,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
         let result = inits_from_nca(&model, &empty_pop, NcaInit::Nca);
         // Must not panic and should warn.

--- a/src/suggest_start/sweep.rs
+++ b/src/suggest_start/sweep.rs
@@ -382,6 +382,7 @@ mod tests {
             covariate_names: vec![],
             dv_column: "DV".into(),
             input_columns: vec![],
+            exclusions: None,
         };
         let r = rrmse(&model, &empty_pop, &model.default_params);
         assert!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1893,6 +1893,10 @@ pub struct FitResult {
     /// (which has no raw rows) or when no `[covariates]` block is declared.
     /// Missing values are `f64::NAN`. See [`CovariateTable`].
     pub covariate_table: Option<CovariateTable>,
+    /// Record-level exclusion statistics; `Some` when `[data_selection]` rules
+    /// were active during the fit (or the caller supplied `ignore`/`accept`
+    /// expressions).  `None` means no filtering was requested.
+    pub exclusions: Option<ExclusionSummary>,
 }
 
 /// Minimal per-NN metadata carried on `FitResult` so output writers can

--- a/src/types.rs
+++ b/src/types.rs
@@ -273,6 +273,24 @@ impl Subject {
     }
 }
 
+/// Summary of records excluded by `[data_selection]` `ignore`/`accept` rules.
+#[derive(Debug, Clone, Default)]
+pub struct ExclusionSummary {
+    /// Subject IDs that had all records removed (zero doses and observations remaining).
+    pub excluded_subject_ids: Vec<String>,
+    /// Number of observation records (EVID==0, MDV==0) excluded.
+    pub n_obs_excluded: usize,
+    /// Number of dose records (EVID 1/4) excluded.
+    pub n_dose_excluded: usize,
+    /// Total CSV records read before any filtering.
+    pub n_records_total: usize,
+    /// `ignore` / `ignore_subjects` clauses that matched at least one record,
+    /// in declaration order.
+    pub fired_ignore: Vec<String>,
+    /// `accept` clauses that rejected at least one record, in declaration order.
+    pub fired_accept: Vec<String>,
+}
+
 /// A collection of subjects
 #[derive(Debug, Clone)]
 pub struct Population {
@@ -283,6 +301,9 @@ pub struct Population {
     /// covariates). Preserved verbatim so downstream consumers can echo a NONMEM-style
     /// `$INPUT` line. Empty for in-memory `Population` values that were not read from a file.
     pub input_columns: Vec<String>,
+    /// Present when `[data_selection]` rules were applied; `None` when no filtering
+    /// was requested or the population was constructed in-memory.
+    pub exclusions: Option<ExclusionSummary>,
 }
 
 impl Population {
@@ -2110,6 +2131,17 @@ pub struct FitOptions {
     /// values from the data. Useful when the model file's defaults are far from
     /// the truth. `None` (the default) disables it.
     pub inits_from_nca: Option<crate::suggest_start::NcaInit>,
+    /// Expression strings for `[data_selection] ignore = ...` / `ignore_subjects`.
+    /// Each string may contain `&&`-joined sub-expressions (all must hold).
+    /// A record is excluded when any clause evaluates to `true`.
+    /// Stored verbatim for logging; compiled to `FilterClause` at read time.
+    pub ignore_exprs: Vec<String>,
+    /// Expression strings for `[data_selection] accept = ...`.
+    /// A record is excluded when any clause evaluates to `false`.
+    pub accept_exprs: Vec<String>,
+    /// Subject IDs to exclude wholesale (syntactic sugar for `ignore = ID == X`).
+    /// Compared as strings against `Subject::id`.
+    pub ignore_subjects: Vec<String>,
 }
 
 impl Default for FitOptions {
@@ -2182,6 +2214,9 @@ impl Default for FitOptions {
             min_obs_for_convergence_check: 2,
             stagnation_guard: true,
             inits_from_nca: None,
+            ignore_exprs: Vec::new(),
+            accept_exprs: Vec::new(),
+            ignore_subjects: Vec::new(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,6 +282,12 @@ pub struct ExclusionSummary {
     pub n_obs_excluded: usize,
     /// Number of dose records (EVID 1/4) excluded.
     pub n_dose_excluded: usize,
+    /// Number of other records excluded that are neither a scored observation
+    /// nor a dose — EVID==2 (other event), EVID==3 (reset), and missing-DV
+    /// observation rows (EVID==0, MDV==1). Tracked so the reported counts sum to
+    /// every excluded record and the summary can't read all-zeros while rows
+    /// were dropped.
+    pub n_other_excluded: usize,
     /// Total CSV records read before any filtering.
     pub n_records_total: usize,
     /// `ignore` / `ignore_subjects` clauses that matched at least one record,

--- a/tests/data_selection.rs
+++ b/tests/data_selection.rs
@@ -204,6 +204,11 @@ fn read_filtered_population_excludes_low_dv_obs() {
         excl.n_obs_excluded > 0,
         "at least one obs row with DV < 1.0 must be excluded"
     );
+    // Dose rows carry DV='.' (missing → NaN), so `DV < 1.0` must NOT catch them.
+    assert_eq!(
+        excl.n_dose_excluded, 0,
+        "dose rows have missing DV and must not match a DV comparison"
+    );
     assert!(
         filtered.n_obs() < n_obs_all,
         "filtered population has fewer observations"

--- a/tests/data_selection.rs
+++ b/tests/data_selection.rs
@@ -1,0 +1,265 @@
+//! Tier-2 integration tests for `[data_selection]` — IGNORE/ACCEPT filtering.
+//!
+//! Tests exercise the full parse → filter → fit boundary via the public API.
+//! They return quickly (a small `fit()` with a handful of outer iterations) and
+//! do not need the `slow-tests` gate.
+
+use ferx_core::io::datareader::{read_nonmem_csv_filtered, SelectionFilter};
+use ferx_core::io::filter_expr::RowContext;
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{fit, read_nonmem_csv, FitOptions};
+use std::collections::HashMap;
+use std::path::Path;
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const ONE_CPT_IV_DATA: &str = "data/one_cpt_iv.csv";
+
+/// Minimal 1-cpt IV model — 3 outer iterations so the tests are fast.
+const MODEL_SRC: &str = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method  = focei
+  maxiter = 3
+  gradient = fd
+";
+
+// ─── Parser tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn parser_populates_ignore_exprs() {
+    let src = format!(
+        "{}\n[data_selection]\n  ignore = DV < 1.0\n  ignore = EVID != 0\n",
+        MODEL_SRC
+    );
+    let parsed = parse_full_model(&src).expect("parse ok");
+    assert_eq!(
+        parsed.fit_options.ignore_exprs,
+        vec!["DV < 1.0", "EVID != 0"]
+    );
+    assert!(parsed.fit_options.accept_exprs.is_empty());
+}
+
+#[test]
+fn parser_populates_accept_exprs() {
+    let src = format!("{}\n[data_selection]\n  accept = DV >= 1.0\n", MODEL_SRC);
+    let parsed = parse_full_model(&src).expect("parse ok");
+    assert_eq!(parsed.fit_options.accept_exprs, vec!["DV >= 1.0"]);
+    assert!(parsed.fit_options.ignore_exprs.is_empty());
+}
+
+#[test]
+fn parser_populates_ignore_subjects() {
+    let src = format!(
+        "{}\n[data_selection]\n  ignore_subjects = [1, 3]\n",
+        MODEL_SRC
+    );
+    let parsed = parse_full_model(&src).expect("parse ok");
+    assert_eq!(parsed.fit_options.ignore_subjects, vec!["1", "3"]);
+}
+
+#[test]
+fn parser_deduplicates_identical_exprs() {
+    let src = format!(
+        "{}\n[data_selection]\n  ignore = DV < 1.0\n  ignore = DV < 1.0\n",
+        MODEL_SRC
+    );
+    let parsed = parse_full_model(&src).expect("parse ok");
+    // Second identical line must be silently deduplicated.
+    assert_eq!(parsed.fit_options.ignore_exprs, vec!["DV < 1.0"]);
+}
+
+#[test]
+fn parser_rejects_pipe_or() {
+    let src = format!(
+        "{}\n[data_selection]\n  ignore = DV < 1.0 || EVID == 0\n",
+        MODEL_SRC
+    );
+    assert!(
+        parse_full_model(&src).is_err(),
+        "expected parse error for ||"
+    );
+}
+
+#[test]
+fn parser_rejects_unknown_key() {
+    let src = format!("{}\n[data_selection]\n  bad_key = something\n", MODEL_SRC);
+    assert!(
+        parse_full_model(&src).is_err(),
+        "expected parse error for unknown key"
+    );
+}
+
+// ─── SelectionFilter unit tests ──────────────────────────────────────────────
+
+fn empty_cov() -> HashMap<String, f64> {
+    HashMap::new()
+}
+
+fn obs_ctx<'a>(id: &'a str, dv: f64, cov: &'a HashMap<String, f64>) -> RowContext<'a> {
+    RowContext {
+        id,
+        time: 1.0,
+        dv,
+        evid: 0,
+        amt: 0.0,
+        cmt: 1,
+        rate: 0.0,
+        mdv: 0,
+        cens: 0,
+        ii: 0.0,
+        ss: false,
+        covariates: cov,
+    }
+}
+
+#[test]
+fn filter_ignore_excludes_matching_row() {
+    let f = SelectionFilter::from_opts(&["DV < 1.0".to_string()], &[], &[]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, which) = f.should_exclude(&obs_ctx("1", 0.5, &cov));
+    assert!(excluded);
+    assert!(which.unwrap().contains("DV < 1.0"));
+}
+
+#[test]
+fn filter_ignore_passes_non_matching_row() {
+    let f = SelectionFilter::from_opts(&["DV < 1.0".to_string()], &[], &[]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, _) = f.should_exclude(&obs_ctx("1", 2.0, &cov));
+    assert!(!excluded);
+}
+
+#[test]
+fn filter_accept_excludes_row_that_fails_condition() {
+    let f = SelectionFilter::from_opts(&[], &["DV >= 1.0".to_string()], &[]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, which) = f.should_exclude(&obs_ctx("1", 0.5, &cov));
+    assert!(excluded);
+    assert!(which.unwrap().contains("DV >= 1.0"));
+}
+
+#[test]
+fn filter_accept_passes_row_that_meets_condition() {
+    let f = SelectionFilter::from_opts(&[], &["DV >= 1.0".to_string()], &[]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, _) = f.should_exclude(&obs_ctx("1", 2.0, &cov));
+    assert!(!excluded);
+}
+
+#[test]
+fn filter_ignore_subjects_excludes_whole_subject() {
+    let f = SelectionFilter::from_opts(&[], &[], &["5".to_string()]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, _) = f.should_exclude(&obs_ctx("5", 1.0, &cov));
+    assert!(excluded);
+}
+
+#[test]
+fn filter_ignore_subjects_passes_other_subject() {
+    let f = SelectionFilter::from_opts(&[], &[], &["5".to_string()]).expect("ok");
+    let cov = empty_cov();
+    let (excluded, _) = f.should_exclude(&obs_ctx("1", 1.0, &cov));
+    assert!(!excluded);
+}
+
+// ─── End-to-end: read with filter → fit ─────────────────────────────────────
+
+#[test]
+fn read_filtered_population_excludes_low_dv_obs() {
+    let path = Path::new(ONE_CPT_IV_DATA);
+    if !path.exists() {
+        eprintln!("Skipping: {} not found", ONE_CPT_IV_DATA);
+        return;
+    }
+
+    // Without filter: 90 obs rows across 10 subjects.
+    let unfiltered = read_nonmem_csv(path, None, None).expect("read ok");
+    let n_obs_all = unfiltered.n_obs();
+
+    // With ignore = DV < 1.0: should exclude several obs rows.
+    let filter =
+        SelectionFilter::from_opts(&["DV < 1.0".to_string()], &[], &[]).expect("filter ok");
+    let filtered = read_nonmem_csv_filtered(path, None, None, &filter).expect("filtered read ok");
+
+    let excl = filtered.exclusions.as_ref().expect("exclusions present");
+    // one_cpt_iv.csv has 100 non-header rows.
+    assert_eq!(excl.n_records_total, 100);
+    assert!(
+        excl.n_obs_excluded > 0,
+        "at least one obs row with DV < 1.0 must be excluded"
+    );
+    assert!(
+        filtered.n_obs() < n_obs_all,
+        "filtered population has fewer observations"
+    );
+    assert!(
+        excl.fired_ignore.iter().any(|s| s.contains("DV < 1.0")),
+        "fired_ignore must record the matching clause"
+    );
+}
+
+#[test]
+fn ignore_subject_removes_subject_entirely() {
+    let path = Path::new(ONE_CPT_IV_DATA);
+    if !path.exists() {
+        eprintln!("Skipping: {} not found", ONE_CPT_IV_DATA);
+        return;
+    }
+
+    let unfiltered = read_nonmem_csv(path, None, None).expect("read ok");
+    let n_subjects_all = unfiltered.subjects.len();
+
+    let filter = SelectionFilter::from_opts(&[], &[], &["3".to_string()]).expect("ok");
+    let filtered = read_nonmem_csv_filtered(path, None, None, &filter).expect("read ok");
+
+    assert_eq!(
+        filtered.subjects.len(),
+        n_subjects_all - 1,
+        "one fewer subject after ignore_subjects = [3]"
+    );
+    let excl = filtered.exclusions.as_ref().expect("exclusions present");
+    assert!(
+        excl.excluded_subject_ids.contains(&"3".to_string()),
+        "excluded_subject_ids must contain '3'"
+    );
+}
+
+#[test]
+fn fit_result_carries_exclusions() {
+    let path = Path::new(ONE_CPT_IV_DATA);
+    if !path.exists() {
+        eprintln!("Skipping: {} not found", ONE_CPT_IV_DATA);
+        return;
+    }
+
+    let model = ferx_core::parse_model_string(MODEL_SRC).expect("parse ok");
+    let filter =
+        SelectionFilter::from_opts(&["DV < 1.0".to_string()], &[], &[]).expect("filter ok");
+    let pop = read_nonmem_csv_filtered(path, None, None, &filter).expect("read ok");
+
+    let mut opts = FitOptions::default();
+    opts.outer_maxiter = 2;
+
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("fit ok");
+    let excl = result.exclusions.as_ref().expect("exclusions on FitResult");
+    assert!(
+        excl.n_obs_excluded > 0,
+        "fit result carries positive obs exclusion count"
+    );
+}

--- a/tests/multi_endpoint.rs
+++ b/tests/multi_endpoint.rs
@@ -63,6 +63,7 @@ fn pkpd_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        exclusions: None,
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],

--- a/tests/saem_omega_burnin.rs
+++ b/tests/saem_omega_burnin.rs
@@ -84,6 +84,7 @@ fn sparse_population(n: usize) -> Population {
         covariate_names: vec![],
         dv_column: "dv".into(),
         input_columns: vec![],
+        exclusions: None,
     }
 }
 

--- a/tests/scaling_block.rs
+++ b/tests/scaling_block.rs
@@ -23,6 +23,7 @@ fn one_subject_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        exclusions: None,
         subjects: vec![Subject {
             id: "1".into(),
             doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
@@ -261,6 +262,7 @@ fn two_cmt_pop() -> Population {
         covariate_names: Vec::new(),
         dv_column: "DV".to_string(),
         input_columns: vec![],
+        exclusions: None,
         subjects: vec![mk_subject("1"), mk_subject("2")],
     }
 }

--- a/tests/suggest_start.rs
+++ b/tests/suggest_start.rs
@@ -119,6 +119,7 @@ fn test_suggest_start_empty_population() {
         covariate_names: vec![],
         dv_column: "DV".into(),
         input_columns: vec![],
+        exclusions: None,
     };
     let result = inits_from_nca(&model, &empty, NcaInit::Nca);
     assert!(!result.warnings.is_empty(), "must warn on empty population");


### PR DESCRIPTION
## Why

NONMEM users routinely use `$DATA IGNORE=` and `$DATA ACCEPT=` to exclude outlier records, below-LLOQ observations, or specific subjects without editing the CSV. ferx had no equivalent; users had to pre-filter their data externally. This PR adds a `[data_selection]` block to the `.ferx` DSL covering the same use cases.

## What changed

New `[data_selection]` block in `.ferx` model files:

```
[data_selection]
  ignore = DV < 0.001          # drop obs below detection limit
  ignore = EVID != 0           # second independent reason; either one excludes
  accept = BW >= 30 && BW < 48 # keep only records in this weight range
  ignore_subjects = [3, 17]    # exclude subjects entirely
```

Key design decisions:
- `ignore` lines: any match → exclude (independent OR semantics across lines)
- `accept` lines: all must pass → exclude if any fails
- `&&` within a line: both sub-conditions must hold to trigger the rule
- `||` and `AND`/`OR` keywords are rejected at parse time with a clear error; use multiple lines instead (consistent with the rest of the ferx DSL)
- Column names are case-insensitive; unknown columns evaluate to `false` (safe default)
- Surrounding quotes are stripped, so R-style quoted strings work without changes in `.ferx` files
- Identical expressions are deduplicated automatically (both within `[data_selection]` and when merging `.ferx` conditions with R-call conditions)

**New files:**
- `src/io/filter_expr.rs` — `FilterExpr` (single comparison), `FilterClause` (`&&`-joined), `RowContext`
- `src/io/datareader.rs` — `SelectionFilter`, `SubjectExclusion`, filtered reader variants
- `docs/src/model-file/data-selection.md` — full reference page
- `tests/data_selection.rs` — Tier-2 integration tests

**Modified:**
- `src/parser/model_parser.rs` — `[data_selection]` block parsed; `push_unique_expr` deduplication helper
- `src/api.rs` — `build_selection_filter`, `build_selection_filter_merged` (merges model-file + caller conditions)
- `src/types.rs` — `ExclusionSummary` on `Population`; `ignore_exprs`/`accept_exprs`/`ignore_subjects` on `FitOptions`; `exclusions: Option<ExclusionSummary>` on `FitResult`
- `src/io/output.rs` — `--- Data Selection ---` block in CLI output; `exclusions:` block in YAML

## Alternatives considered

- **`[fit_options]` keys instead of a separate block** — rejected; data selection is a data concern, not an estimation concern. Separate block also makes it easy to grep/document.
- **OR within a string** — rejected for consistency with the ferx DSL which does not use `||` as a keyword; multiple lines achieve the same effect and are clearer to read.
- **Storing ExclusionSummary only on Population** — rejected; putting it on FitResult as well lets the R binding and YAML output surface it without needing access to the Population object.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet opened | after |

The ferx-r PR will add `ferx_selection()`, `ferx_fit(ignore=, accept=, ignore_ids=)`, and expose `fit$exclusions` via Rust glue. This PR is self-contained and does not break the existing R binding.

## Breaking changes
- [x] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
  - Added `exclusions: Option<ExclusionSummary>` to `FitResult`. The YAML output gains an optional `exclusions:` top-level key when filtering was active; absent otherwise. Old YAML files without the key are unaffected.
- [x] Public Rust API (`api.rs` / `types.rs`)
  - Added three fields to `FitOptions` (all `Vec::new()` by default — no existing code breaks).
  - Added `exclusions: Option<ExclusionSummary>` to `Population` (defaults to `None` — 25+ literal sites patched).

<details>
<summary>Migration notes</summary>

No migration required for existing `.ferx` files or calling code. The `[data_selection]` block is entirely optional; omitting it preserves existing behaviour. The new `FitOptions` fields default to empty vecs.

If you construct `Population { ... }` literals directly in Rust, add `exclusions: None` to the struct initialiser.

</details>

## Numerical validation
- [x] Not applicable — this is a pre-fit data filter; it does not change any estimation algorithm. Records excluded before the fit are simply absent from the likelihood; the fit on the remaining records is numerically identical to running on a manually pre-filtered CSV.

## Performance
- [x] No significant impact expected — filtering is O(n_records × n_clauses) at read time, before any estimation. A typical filter with 2–3 clauses over 500 records adds < 1 ms.

## Tests
- [x] Unit tests in `src/io/filter_expr.rs` (all 6 operators, `&&`, case-insensitivity, `||`/keyword rejection, unknown column, ID equality)
- [x] Tier-2 integration tests in `tests/data_selection.rs`: parser round-trip, deduplication, error cases, `SelectionFilter` API, `read_nonmem_csv_filtered`, end-to-end `fit()` with exclusion propagation

## Example

```
[parameters]
  theta TVCL(2.0, 0.1, 20.0)
  theta TVV(40.0, 5.0, 200.0)
  omega ETA_CL ~ 0.09
  sigma PROP_ERR ~ 0.05 (sd)

[individual_parameters]
  CL = TVCL * exp(ETA_CL)
  V  = TVV

[structural_model]
  pk one_cpt_oral(cl=CL, v=V, ka=KA)

[error_model]
  DV ~ proportional(PROP_ERR)

[data_selection]
  ignore = DV < 0.001
  ignore_subjects = [12]
```

CLI output (excerpt):
```
--- Data Selection ---
  Records read: 420  Obs excluded: 8  Doses excluded: 0
  Subjects excluded entirely: 12
  Fired ignore conditions:
    * ignore: DV < 0.001
```

YAML output (excerpt):
```yaml
exclusions:
  n_records_total: 420
  n_obs_excluded: 8
  n_dose_excluded: 0
  excluded_subject_ids:
    - "12"
  fired_ignore:
    - "ignore: DV < 0.001"
```

## Docs
- [x] `docs/src/model-file/data-selection.md` — full reference page added
- [x] `docs/src/SUMMARY.md` — new page linked
- [x] `docs/src/faq.md` — NONMEM equivalence table added

## Checklist
- [x] `cargo check --tests --no-default-features --features ci` clean
- [x] No AD-reachable code touched (filter runs at read time, before any gradient computation)

## Reviewer hints

The core of the feature is two new files:
- [`src/io/filter_expr.rs`](src/io/filter_expr.rs) — the two-level grammar (trivial, ~370 lines including tests)
- [`src/io/datareader.rs`](src/io/datareader.rs) — `SelectionFilter`, `parse_subject` changes, and the new filtered reader entry points (look for the `filter: Option<&SelectionFilter>` parameter added to `read_nonmem_csv_impl`)

Everything else is plumbing: adding the field to structs, propagating it through the API, and wiring up output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-review update (merge with `main` + fixes found in verification)

Rebased onto current `main` (resolved conflicts from #184/#185 `[covariates]`/`[derived]`/`[output]` and the datareader-warnings work). `Population` now carries **both** `exclusions` (this PR) and `warnings` (main); `parse_subject` returns a 4-tuple threading per-subject warnings and exclusion counts together.

Bugs caught and fixed while verifying:

1. **`ID == 3` never matched.** A bare numeric RHS was parsed as a number, but the `id` column short-circuits every numeric comparison to `false`, so `ignore = ID == 3` silently did nothing (and the `test_id_eq_string` unit test would have failed). IDs are string labels, so a bare numeric RHS for `id` is now stored as a string.
2. **Missing values matched comparisons.** Dose rows carry `DV = '.'`, which parsed to `0.0`, so `ignore = DV < 0.001` excluded *every dose row*. Missing-sensitive numeric columns (DV/AMT/RATE/II) now map `.`/blank/NA to `NaN`; because every IEEE comparison against `NaN` is false, a missing value never matches a condition. (`n_dose_excluded == 0` is now asserted in the integration test.)
3. **Filtering on an undeclared covariate no-op'd** on the declared-`[covariates]` read path (the column was absent from each subject's covariate map). `SelectionFilter::referenced_covariate_columns()` now feeds referenced columns into the read union.
4. **Warning-convention fix.** Pathological partial-exclusion messages (all doses or all obs of a subject excluded) now go into `Population.warnings` → `FitResult.warnings` instead of `eprintln!`.

Documented intentional behaviors (not bugs): the covariate-table echo (`*-covtab.csv`) reflects the raw input and is **not** filtered (the fit, `*-sdtab.csv`, and `[output]` columns are); `.fitrx` does not persist the exclusion summary (consistent with `covariate_table`).

All CI green (Test, Clippy, Check, Format).
