### PR TITLE
fix(output): remove ETA columns from sdtab (regression from #185)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1136,17 +1136,23 @@ pub fn validate_output_columns(model: &CompiledModel, population: &Population) -
     let cov_names = &population.covariate_names;
 
     for col in &model.output_columns {
-        // Already in mandatory minimum?
-        if OUTPUT_MANDATORY.iter().any(|m| m.eq_ignore_ascii_case(col))
-            || model.eta_names.iter().any(|e| e.eq_ignore_ascii_case(col))
-        {
-            diags.push(Diagnostic::warning(
-                "W_OUTPUT_DUPLICATE",
+        // Already in mandatory minimum, or an ETA (reported via ebe_etas, not sdtab)?
+        let is_eta = model.eta_names.iter().any(|e| e.eq_ignore_ascii_case(col));
+        if OUTPUT_MANDATORY.iter().any(|m| m.eq_ignore_ascii_case(col)) || is_eta {
+            let msg = if is_eta {
+                // sdtab is per-observation only; per-subject EBEs live in
+                // `ebe_etas` on the R side, so an ETA can't be an sdtab column.
+                format!(
+                    "[output] column `{col}` is an ETA estimate, reported via `ebe_etas` \
+                     rather than as an sdtab column; the declaration is ignored"
+                )
+            } else {
                 format!(
                     "[output] column `{col}` is already written to sdtab automatically; \
                      the declaration is ignored"
-                ),
-            ));
+                )
+            };
+            diags.push(Diagnostic::warning("W_OUTPUT_DUPLICATE", msg));
             continue;
         }
         // Valid if it's a covariate, indiv param, or derived name

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -528,18 +528,10 @@ pub fn sdtab(result: &FitResult, population: &Population) -> Vec<(String, Vec<f6
         ("N_OBS".to_string(), n_obs_col),
     ]);
 
-    // ETA columns — always included; one per BSV eta, parallel to eta_names.
-    for (k, eta_name) in result.eta_names.iter().enumerate() {
-        let vals: Vec<f64> = result
-            .subjects
-            .iter()
-            .flat_map(|sr| {
-                let v = sr.eta.get(k).copied().unwrap_or(f64::NAN);
-                std::iter::repeat(v).take(sr.ipred.len())
-            })
-            .collect();
-        cols.push((eta_name.clone(), vals));
-    }
+    // NOTE: sdtab intentionally does NOT emit ETA1..ETAn columns. Per-subject
+    // EBEs live in `fit$ebe_etas` on the R side; sdtab is strictly
+    // per-observation diagnostic data (see tests/map_estimates_outputs.rs::
+    // sdtab_omits_eta_columns_after_fit).
 
     // TAFD — mandatory, computed from dose records.
     {


### PR DESCRIPTION
## Why
The `Slow tests` workflow went red on `main` immediately after #185 merged ([run 27069348085](https://github.com/FeRx-NLME/ferx-core/actions/runs/27069348085)). The failing test is `tests/map_estimates_outputs.rs::sdtab_omits_eta_columns_after_fit`.

Root cause: #185 (`feat/derived-output`) and #180 (`input-columns-runlog`) were developed in parallel. #180 deliberately **removed** `ETA1..ETAn` columns from `sdtab()` (per-subject EBEs live in `fit$ebe_etas` on the R side; sdtab is strictly per-observation diagnostic data). #185 independently **added** an "ETA columns — always included" block to `sdtab()`. The textual merge didn't conflict, so #185 silently re-introduced the columns. The guarding test only runs in slow-tests (not PR CI), so it surfaced only after the merge to `main`.

## What changed
- Removed the vestigial ETA-columns block from `output::sdtab()` (`src/io/output.rs`).
- Left a `NOTE` referencing the design and the guarding test so it can't be re-added by accident.

## Alternatives considered
- **Update the test to allow ETA columns** — rejected. That would revert #180's deliberate architecture and break the R FFI contract, which reads per-subject EBEs from `fit$ebe_etas`, not sdtab.

## Cross-repo dependency
None. This restores the sdtab shape `ferx-r` already expects (no ETA columns; EBEs via `ebe_etas`), so no matching `ferx-r` PR is needed.

## Breaking changes
- [x] `FitResult` / sdtab fields changed — sdtab no longer carries `ETA*` columns. This **restores** the intended post-#180 contract; the only window where ETA columns appeared was the brief period since #185 merged.

## Numerical validation
- [x] Not applicable (output-shape only; no estimation / OFV change).

## Performance
- [x] No significant impact expected (removes a per-subject column build).

## Tests
- [x] Regression test that fails without this fix: `sdtab_omits_eta_columns_after_fit` (pre-existing slow-tests guard from #180) failed on `main` and passes with this change. Verified via a `workflow_dispatch` slow-tests run on this branch.

## Example
- [x] Not applicable (fix, no new API surface).

## Docs
- [x] Not applicable.