### PR TITLE
perf(estimation): AD inner gradients through EVID=3/4 resets + lagtime

### DIFF
--- a/src/ad/event_driven_ad.rs
+++ b/src/ad/event_driven_ad.rs
@@ -48,11 +48,21 @@ const LTBS_FLOOR_AD: f64 = 1e-12;
 pub struct FlatEventData {
     /// Sorted merged event times.
     pub event_times: Vec<f64>,
-    /// 0.0 for dose, 1.0 for observation.
+    /// Event kind tag: 0.0 = dose, 1.0 = obs, 2.0 = pk-only, 3.0 = reset
+    /// (EVID=3/4). Reset events sort first at a given time so they zero the
+    /// state before a same-time dose lands (EVID=4).
     pub event_kinds: Vec<f64>,
     /// Original index back into `subject.doses` (when kind=0) or
-    /// `subject.obs_times` (when kind=1).
+    /// `subject.obs_times` (when kind=1). Unused for reset (kind=3) events.
     pub event_orig_idx_f64: Vec<f64>,
+    /// Per-event reset floor: the time of the most recent system reset
+    /// strictly *before* this event, or `f64::NEG_INFINITY` when none.
+    /// Applied to the propagation interval ending at this event — infusions
+    /// whose start is `< event_reset_floor[i]` are turned off (a reset stops
+    /// ongoing infusions, just as it zeros the compartments). Mirrors the
+    /// scalar `reset_floor` in `pk::event_driven::event_driven_predictions`.
+    /// Const w.r.t. eta, so it threads through the AD kernels untouched.
+    pub event_reset_floor: Vec<f64>,
     /// Dose-level arrays (parallel to `subject.doses`).
     pub dose_times: Vec<f64>,
     pub dose_amts: Vec<f64>,
@@ -66,21 +76,49 @@ pub struct FlatEventData {
 }
 
 impl FlatEventData {
-    pub fn from_subject(subject: &Subject) -> Self {
+    /// Build the flat event timeline for `subject`.
+    ///
+    /// `dose_lagtimes` (length `subject.doses.len()`, or empty for no lag)
+    /// shifts each dose's effective start to `doses[k].time + lag[k]` — for
+    /// both its merged-timeline event (where the bolus injects and the
+    /// propagation boundary lands) and the `dose_times` array the propagators
+    /// use for infusion-window overlap. Resets/obs/pk-only keep their record
+    /// times. Mirrors `pk::event_driven::EventSchedule::for_subject`.
+    ///
+    /// The lags are treated as Const w.r.t. eta in the AD kernels: exact for
+    /// the usual eta-independent lagtime (a `THETA`, optionally covariate-
+    /// scaled), and a documented approximation (drops `∂lag/∂η`) for the rare
+    /// eta-dependent case — the marginal NLL value itself is still computed by
+    /// the exact analytical path, so only the inner-loop gradient / FOCE `|H|`
+    /// see the frozen lag.
+    pub fn from_subject(subject: &Subject, dose_lagtimes: &[f64]) -> Self {
         let n_obs = subject.obs_times.len();
         let n_dose = subject.doses.len();
         let n_pk_only = subject.pk_only_times.len();
-        let n_events = n_obs + n_dose + n_pk_only;
+        let n_reset = subject.reset_times.len();
+        let n_events = n_obs + n_dose + n_pk_only + n_reset;
+
+        debug_assert!(
+            dose_lagtimes.is_empty() || dose_lagtimes.len() == n_dose,
+            "dose_lagtimes length {} != n_dose {}",
+            dose_lagtimes.len(),
+            n_dose
+        );
+        let lag = |k: usize| -> f64 { dose_lagtimes.get(k).copied().unwrap_or(0.0) };
 
         let mut events: Vec<(f64, f64, f64)> = Vec::with_capacity(n_events);
-        // (time, kind_order, orig_idx). Tie-break order at the same time:
-        //   dose (0) < pk-only (1) < obs (2)
-        // — see analytical `event_driven::event_driven_predictions` for
-        // the rationale. Stored kind is encoded for the AD macros:
-        //   0.0 = dose, 1.0 = obs, 2.0 = pk-only. The kind_order used for
-        // sorting is computed from these.
+        // (time, kind_tag, orig_idx). Tie-break order at the same time:
+        //   reset (3) < dose (0) < pk-only (2) < obs (1)
+        // — a reset zeros the state before a same-time dose lands (EVID=4),
+        // matching `event_driven::event_driven_predictions`. Stored kind tag
+        // is encoded for the AD macros:
+        //   0.0 = dose, 1.0 = obs, 2.0 = pk-only, 3.0 = reset. The sort
+        // ordinal is computed from these by `kind_order`.
+        // Dose events use the *lagged* time so the bolus injects and the
+        // infusion window opens at `time + lag` (a lagged dose may re-sort
+        // after later obs — correct, it genuinely happens later).
         for (k, d) in subject.doses.iter().enumerate() {
-            events.push((d.time, 0.0, k as f64));
+            events.push((d.time + lag(k), 0.0, k as f64));
         }
         for (j, &t) in subject.obs_times.iter().enumerate() {
             events.push((t, 1.0, j as f64));
@@ -88,15 +126,20 @@ impl FlatEventData {
         for (m, &t) in subject.pk_only_times.iter().enumerate() {
             events.push((t, 2.0, m as f64));
         }
-        // Sort: by time, then by tie-break order (dose=0 < pk-only=2-mapped
-        // to 1 < obs=1-mapped to 2). Encode the tie-break ordinal directly.
+        for (r, &t) in subject.reset_times.iter().enumerate() {
+            events.push((t, 3.0, r as f64));
+        }
+        // Sort: by time, then by tie-break ordinal (reset first so an EVID=4
+        // zeros the state before its same-time dose; then dose < pk-only < obs).
         let kind_order = |k: f64| -> u8 {
-            if k < 0.5 {
-                0 // dose
+            if k > 2.5 {
+                0 // reset
+            } else if k < 0.5 {
+                1 // dose
             } else if k > 1.5 {
-                1 // pk-only
+                2 // pk-only
             } else {
-                2 // obs
+                3 // obs
             }
         };
         events.sort_by(|a, b| {
@@ -114,11 +157,34 @@ impl FlatEventData {
             event_orig_idx_f64.push(idx);
         }
 
+        // Per-event reset floor. Walk the sorted events tracking the most
+        // recent reset time; each event records the floor in effect *before*
+        // it (resets at strictly earlier positions). The reset event's own
+        // interval still uses the previous floor — its infusions are turned
+        // off only from the next interval on, exactly as the non-AD path
+        // `continue`s past a reset after setting `reset_floor = ev.time`.
+        let mut event_reset_floor = Vec::with_capacity(n_events);
+        let mut running_floor = f64::NEG_INFINITY;
+        for i in 0..n_events {
+            event_reset_floor.push(running_floor);
+            if event_kinds[i] > 2.5 {
+                running_floor = event_times[i];
+            }
+        }
+
         Self {
             event_times,
             event_kinds,
             event_orig_idx_f64,
-            dose_times: subject.doses.iter().map(|d| d.time).collect(),
+            event_reset_floor,
+            // Lagged start times — the propagators' infusion-window overlap
+            // must use the same `time + lag` as the merged-timeline events.
+            dose_times: subject
+                .doses
+                .iter()
+                .enumerate()
+                .map(|(k, d)| d.time + lag(k))
+                .collect(),
             dose_amts: subject.doses.iter().map(|d| d.amt).collect(),
             dose_rates: subject.doses.iter().map(|d| d.rate).collect(),
             dose_durations: subject.doses.iter().map(|d| d.duration).collect(),
@@ -137,19 +203,31 @@ pub struct FlatEventTv {
 }
 
 impl FlatEventTv {
-    pub fn from_subject(model: &CompiledModel, subject: &Subject, theta: &[f64]) -> Self {
+    /// `dose_lagtimes` must match the slice passed to
+    /// [`FlatEventData::from_subject`] so the two timelines sort identically
+    /// (a lagged dose may re-order relative to obs).
+    pub fn from_subject(
+        model: &CompiledModel,
+        subject: &Subject,
+        theta: &[f64],
+        dose_lagtimes: &[f64],
+    ) -> Self {
         let tv_fn = model
             .tv_fn
             .as_ref()
             .expect("FlatEventTv::from_subject: model.tv_fn required for AD path");
+        let lag = |k: usize| -> f64 { dose_lagtimes.get(k).copied().unwrap_or(0.0) };
 
         // Re-derive the same event order used by FlatEventData::from_subject.
-        // Triplet kind tags: 0 = dose, 1 = obs, 2 = pk-only (EVID=2).
+        // Kind tags: 0 = dose, 1 = obs, 2 = pk-only (EVID=2), 3 = reset.
         let mut events: Vec<(f64, f64, usize, u8)> = Vec::with_capacity(
-            subject.doses.len() + subject.obs_times.len() + subject.pk_only_times.len(),
+            subject.doses.len()
+                + subject.obs_times.len()
+                + subject.pk_only_times.len()
+                + subject.reset_times.len(),
         );
         for (k, d) in subject.doses.iter().enumerate() {
-            events.push((d.time, 0.0, k, 0));
+            events.push((d.time + lag(k), 0.0, k, 0));
         }
         for (j, &t) in subject.obs_times.iter().enumerate() {
             events.push((t, 1.0, j, 1));
@@ -157,13 +235,19 @@ impl FlatEventTv {
         for (m, &t) in subject.pk_only_times.iter().enumerate() {
             events.push((t, 2.0, m, 2));
         }
+        for (r, &t) in subject.reset_times.iter().enumerate() {
+            events.push((t, 3.0, r, 3));
+        }
+        // Must match FlatEventData::from_subject exactly (reset first).
         let kind_order = |k: f64| -> u8 {
-            if k < 0.5 {
+            if k > 2.5 {
                 0
-            } else if k > 1.5 {
+            } else if k < 0.5 {
                 1
-            } else {
+            } else if k > 1.5 {
                 2
+            } else {
+                3
             }
         };
         events.sort_by(|a, b| {
@@ -177,10 +261,16 @@ impl FlatEventTv {
 
         let mut tv = Vec::with_capacity(n_events * n_tv);
         for (_, _, orig, kind_tag) in &events {
+            // Reset events carry no per-record covariate snapshot — use the
+            // subject-static map (LOCF-correct for time-constant covariates).
+            // Their PK params only drive the propagation into the reset, whose
+            // result is immediately zeroed, so the exact value never reaches a
+            // prediction; a valid (finite, positive) row just avoids NaN.
             let cov = match kind_tag {
                 0 => subject.dose_cov(*orig),
                 1 => subject.obs_cov(*orig),
-                _ => subject.pk_only_cov(*orig),
+                2 => subject.pk_only_cov(*orig),
+                _ => &subject.covariates,
             };
             let row = tv_fn(theta, cov);
             assert_eq!(row.len(), n_tv, "tv_fn returned wrong length");
@@ -205,6 +295,7 @@ impl FlatEventTv {
     Const,      // event_times
     Const,      // event_kinds
     Const,      // event_orig_idx_f64
+    Const,      // event_reset_floor
     Const,      // dose_times
     Const,      // dose_amts
     Const,      // dose_rates
@@ -225,8 +316,12 @@ pub fn individual_nll_event_driven_ad(
     log_det_omega: f64,
     sigma_values: &[f64],
     event_times: &[f64],
-    event_kinds: &[f64], // 0=dose, 1=obs
+    event_kinds: &[f64], // 0=dose, 1=obs, 2=pk-only, 3=reset
     event_orig_idx_f64: &[f64],
+    // Per-event reset floor (length n_events): time of the most recent reset
+    // strictly before each event, else NEG_INFINITY. Infusions starting before
+    // it are masked off in the propagators. Const w.r.t. eta.
+    event_reset_floor: &[f64],
     dose_times: &[f64],
     dose_amts: &[f64],
     dose_rates: &[f64],
@@ -351,6 +446,7 @@ pub fn individual_nll_event_driven_ad(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            event_reset_floor[ev_idx],
         );
         state0 = s0_new;
         state1 = s1_new;
@@ -359,6 +455,18 @@ pub fn individual_nll_event_driven_ad(
 
         let kind = event_kinds[ev_idx];
         let orig = event_orig_idx_f64[ev_idx] as usize;
+
+        // ── Reset branch (EVID=3/4, kind=3.0). Zero every compartment after
+        // propagating into the reset time — the interval's drug is discarded,
+        // matching `pk::event_driven`'s reset that zeros state and `continue`s.
+        // `keep` is a Const mask (0 at a reset, 1 elsewhere) so the multiply is
+        // phi-free and Enzyme-safe. is_dose / is_obs are both 0 for a reset
+        // (kind=3.0), so the dose and obs branches below skip it naturally.
+        let keep = if kind > 2.5 { 0.0 } else { 1.0 };
+        state0 *= keep;
+        state1 *= keep;
+        state2 *= keep;
+        state3 *= keep;
         // `orig` is an index into doses (kind=0), obs (kind=1), or
         // pk_only events (kind=2). For each side-array access we
         // clamp to a safe fallback index when the event isn't of
@@ -488,6 +596,10 @@ fn propagate_state_ad(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    // Most-recent reset time strictly before this interval (or NEG_INFINITY).
+    // Infusions whose start is `< reset_floor` are masked off inside the IV
+    // propagators. Const w.r.t. eta; oral propagators ignore it (bolus only).
+    reset_floor: f64,
 ) -> (f64, f64, f64, f64) {
     // Const-only branch on pk_model_id — constant-folds under LLVM. Only
     // the relevant arm contains real adjoint flow per build. `f_bio`
@@ -511,6 +623,7 @@ fn propagate_state_ad(
             dose_rates,
             dose_durations,
             n_doses,
+            reset_floor,
         );
         (s0, state1, state2, state3)
     } else if pk_model_id == PK_ID_ONE_CPT_ORAL {
@@ -534,6 +647,7 @@ fn propagate_state_ad(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            reset_floor,
         );
         (s0, s1, state2, state3)
     } else if pk_model_id == PK_ID_TWO_CPT_ORAL {
@@ -561,6 +675,7 @@ fn propagate_state_ad(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            reset_floor,
         );
         (s0, s1, s2, state3)
     } else if pk_model_id == PK_ID_THREE_CPT_ORAL {
@@ -591,6 +706,7 @@ fn propagate_one_cpt_ad(
     dose_rates: &[f64],
     dose_durations: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> f64 {
     let v_safe = v.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -611,8 +727,13 @@ fn propagate_one_cpt_ad(
         let diff = tau_total_raw - tau_to;
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
         let r = f_bio * dose_rates[d];
+        // Infusions that started before the most recent reset are off
+        // (Const mask on dose_times[d], mirrors `reset_floor` in the non-AD
+        // path). `s_i < reset_floor` strictly so an infusion starting *at*
+        // the reset time (e.g. an EVID=4's own infusion) stays active.
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let contribution = (r / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
-        s0 += contribution;
+        s0 += active * contribution;
     }
     s0
 }
@@ -638,6 +759,7 @@ fn propagate_two_cpt_ad(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> (f64, f64) {
     let v1_safe = v1.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -685,6 +807,8 @@ fn propagate_two_cpt_ad(
         // convention as the bolus injection step in the event loop.
         let cmt = dose_cmts_f64[d] as i32;
         let r = f_bio * dose_rates[d];
+        // Infusions started before the most recent reset are off (Const mask).
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let (a_ss_1, a_ss_2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -707,8 +831,8 @@ fn propagate_two_cpt_ad(
             c1_ss * (k21 - alpha) * (e_a_to - e_a_tot) + c2_ss * (k21 - beta) * (e_b_to - e_b_tot);
         let a2_contrib = k12 * (c1_ss * (e_a_to - e_a_tot) + c2_ss * (e_b_to - e_b_tot));
 
-        s0 += a1_contrib;
-        s1 += a2_contrib;
+        s0 += active * a1_contrib;
+        s1 += active * a2_contrib;
     }
     (s0, s1)
 }
@@ -943,6 +1067,7 @@ fn propagate_three_cpt_ad(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> (f64, f64, f64) {
     let v1_safe = v1.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -985,6 +1110,8 @@ fn propagate_three_cpt_ad(
         // rate so dur→0 limits to a bolus of amount F·AMT.
         let cmt = dose_cmts_f64[d] as i32;
         let r = f_bio * dose_rates[d];
+        // Infusions started before the most recent reset are off (Const mask).
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let (a_ss_c, a_ss_p1, a_ss_p2) = if cmt == 2 {
             // Channel 2 (periph1).
             (
@@ -1025,9 +1152,9 @@ fn propagate_three_cpt_ad(
             gamma, a_ss_c, a_ss_p1, a_ss_p2, k12, k13, k21, k31, tau_total,
         );
 
-        s0 += (ca_to - ca_tot) + (cb_to - cb_tot) + (cg_to - cg_tot);
-        s1 += (p1a_to - p1a_tot) + (p1b_to - p1b_tot) + (p1g_to - p1g_tot);
-        s2 += (p2a_to - p2a_tot) + (p2b_to - p2b_tot) + (p2g_to - p2g_tot);
+        s0 += active * ((ca_to - ca_tot) + (cb_to - cb_tot) + (cg_to - cg_tot));
+        s1 += active * ((p1a_to - p1a_tot) + (p1b_to - p1b_tot) + (p1g_to - p1g_tot));
+        s2 += active * ((p2a_to - p2a_tot) + (p2b_to - p2b_tot) + (p2g_to - p2g_tot));
     }
     (s0, s1, s2)
 }
@@ -1259,6 +1386,7 @@ pub fn compute_nll_gradient_event_driven_ad(
         &event_data.event_times,
         &event_data.event_kinds,
         &event_data.event_orig_idx_f64,
+        &event_data.event_reset_floor,
         dose_times_padded,
         dose_amts_padded,
         dose_rates_padded,

--- a/src/ad/event_driven_ad.rs
+++ b/src/ad/event_driven_ad.rs
@@ -75,6 +75,69 @@ pub struct FlatEventData {
     pub dose_cmts_f64: Vec<f64>,
 }
 
+/// Same-time tie-break ordinal: `reset (0) < dose (1) < pk-only (2) < obs (3)`.
+/// A reset must sort before a same-time dose so an EVID=4 zeros the state before
+/// its own dose lands — matching `pk::event_driven::event_driven_predictions`.
+/// `kind_tag` is the encoded event kind (0.0=dose, 1.0=obs, 2.0=pk-only,
+/// 3.0=reset).
+fn event_kind_order(kind_tag: f64) -> u8 {
+    if kind_tag > 2.5 {
+        0 // reset
+    } else if kind_tag < 0.5 {
+        1 // dose
+    } else if kind_tag > 1.5 {
+        2 // pk-only
+    } else {
+        3 // obs
+    }
+}
+
+/// Merged, sorted event timeline shared by [`FlatEventData`] and [`FlatEventTv`]
+/// so the two are guaranteed to order events identically (a single source for
+/// the reset insertion, lag shift, and tie-break). Returns one
+/// `(time, kind_tag, orig_idx)` per event, where `kind_tag` is 0.0=dose,
+/// 1.0=obs, 2.0=pk-only, 3.0=reset and dose events carry the per-dose lag
+/// (`doses[k].time + lag(k)`; a lagged dose may re-sort past a later obs —
+/// correct, it genuinely happens later). Resets/obs/pk-only keep their record
+/// times.
+///
+/// Panics if `dose_lagtimes` is non-empty and not length `subject.doses.len()`
+/// (hard assert, matching `pk::event_driven::EventSchedule::for_subject`).
+fn build_sorted_events(subject: &Subject, dose_lagtimes: &[f64]) -> Vec<(f64, f64, usize)> {
+    assert!(
+        dose_lagtimes.is_empty() || dose_lagtimes.len() == subject.doses.len(),
+        "dose_lagtimes length {} != n_dose {}",
+        dose_lagtimes.len(),
+        subject.doses.len()
+    );
+    let lag = |k: usize| -> f64 { dose_lagtimes.get(k).copied().unwrap_or(0.0) };
+
+    let mut events: Vec<(f64, f64, usize)> = Vec::with_capacity(
+        subject.doses.len()
+            + subject.obs_times.len()
+            + subject.pk_only_times.len()
+            + subject.reset_times.len(),
+    );
+    for (k, d) in subject.doses.iter().enumerate() {
+        events.push((d.time + lag(k), 0.0, k));
+    }
+    for (j, &t) in subject.obs_times.iter().enumerate() {
+        events.push((t, 1.0, j));
+    }
+    for (m, &t) in subject.pk_only_times.iter().enumerate() {
+        events.push((t, 2.0, m));
+    }
+    for (r, &t) in subject.reset_times.iter().enumerate() {
+        events.push((t, 3.0, r));
+    }
+    events.sort_by(|a, b| {
+        a.0.partial_cmp(&b.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| event_kind_order(a.1).cmp(&event_kind_order(b.1)))
+    });
+    events
+}
+
 impl FlatEventData {
     /// Build the flat event timeline for `subject`.
     ///
@@ -90,63 +153,12 @@ impl FlatEventData {
     /// scaled), and a documented approximation (drops `∂lag/∂η`) for the rare
     /// eta-dependent case — the marginal NLL value itself is still computed by
     /// the exact analytical path, so only the inner-loop gradient / FOCE `|H|`
-    /// see the frozen lag.
+    /// see the frozen lag. (The FOCEI inner loop routes eta-dependent lagtime
+    /// to FD instead — see `inner_optimizer::resolve_gradient_method`.)
     pub fn from_subject(subject: &Subject, dose_lagtimes: &[f64]) -> Self {
-        let n_obs = subject.obs_times.len();
-        let n_dose = subject.doses.len();
-        let n_pk_only = subject.pk_only_times.len();
-        let n_reset = subject.reset_times.len();
-        let n_events = n_obs + n_dose + n_pk_only + n_reset;
-
-        debug_assert!(
-            dose_lagtimes.is_empty() || dose_lagtimes.len() == n_dose,
-            "dose_lagtimes length {} != n_dose {}",
-            dose_lagtimes.len(),
-            n_dose
-        );
+        let events = build_sorted_events(subject, dose_lagtimes);
+        let n_events = events.len();
         let lag = |k: usize| -> f64 { dose_lagtimes.get(k).copied().unwrap_or(0.0) };
-
-        let mut events: Vec<(f64, f64, f64)> = Vec::with_capacity(n_events);
-        // (time, kind_tag, orig_idx). Tie-break order at the same time:
-        //   reset (3) < dose (0) < pk-only (2) < obs (1)
-        // — a reset zeros the state before a same-time dose lands (EVID=4),
-        // matching `event_driven::event_driven_predictions`. Stored kind tag
-        // is encoded for the AD macros:
-        //   0.0 = dose, 1.0 = obs, 2.0 = pk-only, 3.0 = reset. The sort
-        // ordinal is computed from these by `kind_order`.
-        // Dose events use the *lagged* time so the bolus injects and the
-        // infusion window opens at `time + lag` (a lagged dose may re-sort
-        // after later obs — correct, it genuinely happens later).
-        for (k, d) in subject.doses.iter().enumerate() {
-            events.push((d.time + lag(k), 0.0, k as f64));
-        }
-        for (j, &t) in subject.obs_times.iter().enumerate() {
-            events.push((t, 1.0, j as f64));
-        }
-        for (m, &t) in subject.pk_only_times.iter().enumerate() {
-            events.push((t, 2.0, m as f64));
-        }
-        for (r, &t) in subject.reset_times.iter().enumerate() {
-            events.push((t, 3.0, r as f64));
-        }
-        // Sort: by time, then by tie-break ordinal (reset first so an EVID=4
-        // zeros the state before its same-time dose; then dose < pk-only < obs).
-        let kind_order = |k: f64| -> u8 {
-            if k > 2.5 {
-                0 // reset
-            } else if k < 0.5 {
-                1 // dose
-            } else if k > 1.5 {
-                2 // pk-only
-            } else {
-                3 // obs
-            }
-        };
-        events.sort_by(|a, b| {
-            a.0.partial_cmp(&b.0)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| kind_order(a.1).cmp(&kind_order(b.1)))
-        });
 
         let mut event_times = Vec::with_capacity(n_events);
         let mut event_kinds = Vec::with_capacity(n_events);
@@ -154,7 +166,7 @@ impl FlatEventData {
         for (t, k, idx) in events {
             event_times.push(t);
             event_kinds.push(k);
-            event_orig_idx_f64.push(idx);
+            event_orig_idx_f64.push(idx as f64);
         }
 
         // Per-event reset floor. Walk the sorted events tracking the most
@@ -216,61 +228,29 @@ impl FlatEventTv {
             .tv_fn
             .as_ref()
             .expect("FlatEventTv::from_subject: model.tv_fn required for AD path");
-        let lag = |k: usize| -> f64 { dose_lagtimes.get(k).copied().unwrap_or(0.0) };
 
-        // Re-derive the same event order used by FlatEventData::from_subject.
-        // Kind tags: 0 = dose, 1 = obs, 2 = pk-only (EVID=2), 3 = reset.
-        let mut events: Vec<(f64, f64, usize, u8)> = Vec::with_capacity(
-            subject.doses.len()
-                + subject.obs_times.len()
-                + subject.pk_only_times.len()
-                + subject.reset_times.len(),
-        );
-        for (k, d) in subject.doses.iter().enumerate() {
-            events.push((d.time + lag(k), 0.0, k, 0));
-        }
-        for (j, &t) in subject.obs_times.iter().enumerate() {
-            events.push((t, 1.0, j, 1));
-        }
-        for (m, &t) in subject.pk_only_times.iter().enumerate() {
-            events.push((t, 2.0, m, 2));
-        }
-        for (r, &t) in subject.reset_times.iter().enumerate() {
-            events.push((t, 3.0, r, 3));
-        }
-        // Must match FlatEventData::from_subject exactly (reset first).
-        let kind_order = |k: f64| -> u8 {
-            if k > 2.5 {
-                0
-            } else if k < 0.5 {
-                1
-            } else if k > 1.5 {
-                2
-            } else {
-                3
-            }
-        };
-        events.sort_by(|a, b| {
-            a.0.partial_cmp(&b.0)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| kind_order(a.1).cmp(&kind_order(b.1)))
-        });
-
+        // Same sorted timeline FlatEventData walks — built by the shared helper
+        // so the per-event tv rows stay aligned with the event_* arrays.
+        let events = build_sorted_events(subject, dose_lagtimes);
         let n_events = events.len();
         let n_tv = model.pk_idx_f64.len();
 
         let mut tv = Vec::with_capacity(n_events * n_tv);
-        for (_, _, orig, kind_tag) in &events {
-            // Reset events carry no per-record covariate snapshot — use the
+        for (_, kind_tag, orig) in &events {
+            // Covariate snapshot per event kind (0=dose, 1=obs, 2=pk-only).
+            // Reset events (3) carry no per-record snapshot — use the
             // subject-static map (LOCF-correct for time-constant covariates).
             // Their PK params only drive the propagation into the reset, whose
             // result is immediately zeroed, so the exact value never reaches a
             // prediction; a valid (finite, positive) row just avoids NaN.
-            let cov = match kind_tag {
-                0 => subject.dose_cov(*orig),
-                1 => subject.obs_cov(*orig),
-                2 => subject.pk_only_cov(*orig),
-                _ => &subject.covariates,
+            let cov = if *kind_tag < 0.5 {
+                subject.dose_cov(*orig)
+            } else if *kind_tag < 1.5 {
+                subject.obs_cov(*orig)
+            } else if *kind_tag < 2.5 {
+                subject.pk_only_cov(*orig)
+            } else {
+                &subject.covariates
             };
             let row = tv_fn(theta, cov);
             assert_eq!(row.len(), n_tv, "tv_fn returned wrong length");

--- a/src/ad/event_driven_ad_jac.rs
+++ b/src/ad/event_driven_ad_jac.rs
@@ -38,6 +38,7 @@ const LTBS_FLOOR_AD: f64 = 1e-12;
     Const,      // event_times
     Const,      // event_kinds
     Const,      // event_orig_idx_f64
+    Const,      // event_reset_floor
     Const,      // dose_times
     Const,      // dose_amts
     Const,      // dose_rates
@@ -55,6 +56,8 @@ pub fn predict_all_event_driven_ad(
     event_times: &[f64],
     event_kinds: &[f64],
     event_orig_idx_f64: &[f64],
+    // Per-event reset floor (length n_events); see sibling `event_driven_ad.rs`.
+    event_reset_floor: &[f64],
     dose_times: &[f64],
     dose_amts: &[f64],
     dose_rates: &[f64],
@@ -148,6 +151,7 @@ pub fn predict_all_event_driven_ad(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            event_reset_floor[ev_idx],
         );
         state0 = s0_new;
         state1 = s1_new;
@@ -157,6 +161,15 @@ pub fn predict_all_event_driven_ad(
         let kind = event_kinds[ev_idx];
         let orig = event_orig_idx_f64[ev_idx] as usize;
         let dose_idx = if kind < 0.5 { orig } else { 0 };
+
+        // Reset branch (kind=3.0): zero every compartment after propagating
+        // into the reset time. `keep` is a Const mask (0 at a reset). Mirrors
+        // the reverse-mode kernel in `event_driven_ad.rs`.
+        let keep = if kind > 2.5 { 0.0 } else { 1.0 };
+        state0 *= keep;
+        state1 *= keep;
+        state2 *= keep;
+        state3 *= keep;
 
         // is_dose=0 for obs (kind=1) and pk-only (kind=2), so their
         // state0 is unchanged regardless of dose_*[dose_idx]. `ev_f`
@@ -237,6 +250,7 @@ fn propagate_state_jac(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> (f64, f64, f64, f64) {
     // ID dispatch — mirrors `event_driven_ad.rs::propagate_state_ad`. Per
     // issue #176, IV bolus and infusion share a single ID; the route is
@@ -253,6 +267,7 @@ fn propagate_state_jac(
             dose_rates,
             dose_durations,
             n_doses,
+            reset_floor,
         );
         (s0, state1, state2, state3)
     } else if pk_model_id == PK_ID_ONE_CPT_ORAL {
@@ -274,6 +289,7 @@ fn propagate_state_jac(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            reset_floor,
         );
         (s0, s1, state2, state3)
     } else if pk_model_id == PK_ID_TWO_CPT_ORAL {
@@ -299,6 +315,7 @@ fn propagate_state_jac(
             dose_durations,
             dose_cmts_f64,
             n_doses,
+            reset_floor,
         );
         (s0, s1, s2, state3)
     } else if pk_model_id == PK_ID_THREE_CPT_ORAL {
@@ -322,6 +339,7 @@ fn propagate_one_cpt_jac(
     dose_rates: &[f64],
     dose_durations: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> f64 {
     let v_safe = v.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -342,8 +360,10 @@ fn propagate_one_cpt_jac(
         let diff = tau_total_raw - tau_to;
         let tau_total = tau_to + (diff + diff.abs()) * 0.5;
         let r = f_bio * dose_rates[d];
+        // Infusions started before the most recent reset are off (Const mask).
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let contribution = (r / ke) * ((-ke * tau_to).exp() - (-ke * tau_total).exp());
-        s0 += contribution;
+        s0 += active * contribution;
     }
     s0
 }
@@ -364,6 +384,7 @@ fn propagate_two_cpt_jac(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> (f64, f64) {
     let v1_safe = v1.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -405,6 +426,8 @@ fn propagate_two_cpt_jac(
 
         let cmt = dose_cmts_f64[d] as i32;
         let r = f_bio * dose_rates[d];
+        // Infusions started before the most recent reset are off (Const mask).
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let (a_ss_1, a_ss_2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -426,8 +449,8 @@ fn propagate_two_cpt_jac(
             c1_ss * (k21 - alpha) * (e_a_to - e_a_tot) + c2_ss * (k21 - beta) * (e_b_to - e_b_tot);
         let a2_contrib = k12 * (c1_ss * (e_a_to - e_a_tot) + c2_ss * (e_b_to - e_b_tot));
 
-        s0 += a1_contrib;
-        s1 += a2_contrib;
+        s0 += active * a1_contrib;
+        s1 += active * a2_contrib;
     }
     (s0, s1)
 }
@@ -626,6 +649,7 @@ fn propagate_three_cpt_jac(
     dose_durations: &[f64],
     dose_cmts_f64: &[f64],
     n_doses: usize,
+    reset_floor: f64,
 ) -> (f64, f64, f64) {
     let v1_safe = v1.abs() + 1e-30;
     let cl_safe = cl.abs() + 1e-30;
@@ -660,6 +684,8 @@ fn propagate_three_cpt_jac(
 
         let cmt = dose_cmts_f64[d] as i32;
         let r = f_bio * dose_rates[d];
+        // Infusions started before the most recent reset are off (Const mask).
+        let active = if s_i < reset_floor { 0.0 } else { 1.0 };
         let (a_ss_c, a_ss_p1, a_ss_p2) = if cmt == 2 {
             (
                 r * v1_safe / cl_safe,
@@ -696,9 +722,9 @@ fn propagate_three_cpt_jac(
             gamma, a_ss_c, a_ss_p1, a_ss_p2, k12, k13, k21, k31, tau_total,
         );
 
-        s0 += (ca_to - ca_tot) + (cb_to - cb_tot) + (cg_to - cg_tot);
-        s1 += (p1a_to - p1a_tot) + (p1b_to - p1b_tot) + (p1g_to - p1g_tot);
-        s2 += (p2a_to - p2a_tot) + (p2b_to - p2b_tot) + (p2g_to - p2g_tot);
+        s0 += active * ((ca_to - ca_tot) + (cb_to - cb_tot) + (cg_to - cg_tot));
+        s1 += active * ((p1a_to - p1a_tot) + (p1b_to - p1b_tot) + (p1g_to - p1g_tot));
+        s2 += active * ((p2a_to - p2a_tot) + (p2b_to - p2b_tot) + (p2g_to - p2g_tot));
     }
     (s0, s1, s2)
 }
@@ -831,6 +857,7 @@ pub fn compute_jacobian_event_driven_ad(
             &event_data.event_times,
             &event_data.event_kinds,
             &event_data.event_orig_idx_f64,
+            &event_data.event_reset_floor,
             dose_times_padded,
             dose_amts_padded,
             dose_rates_padded,
@@ -862,7 +889,234 @@ pub fn compute_jacobian_event_driven_ad(
 mod tests {
     use super::*;
     use crate::ad::ad_gradients::pk_model_to_id;
+    use crate::ad::event_driven_ad::FlatEventData;
+    use crate::pk::event_driven::event_driven_predictions;
     use approx::assert_relative_eq;
+    use std::collections::HashMap;
+
+    // ── Reset (EVID=3/4) AD-vs-analytical regression ───────────────────
+    //
+    // The event-driven AD forward kernel must reproduce the reset-aware
+    // analytical path (`pk::event_driven::event_driven_predictions`) for
+    // subjects carrying system resets: state zeroed at the reset and any
+    // infusion that started before the reset turned off. We drive the REAL
+    // `FlatEventData::from_subject` timeline (so the reset-event insertion,
+    // tie-break ordering, and `event_reset_floor` computation are all under
+    // test) and feed constant PK params per event (no covariates), then
+    // compare obs-slot predictions to the analytical reference.
+
+    fn subject_with_resets(
+        doses: Vec<DoseEvent>,
+        obs_times: Vec<f64>,
+        reset_times: Vec<f64>,
+    ) -> Subject {
+        let n_obs = obs_times.len();
+        Subject {
+            id: "1".into(),
+            doses,
+            obs_times,
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; n_obs],
+            obs_cmts: vec![1; n_obs],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times,
+            cens: vec![0; n_obs],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        }
+    }
+
+    /// Run the event-driven AD forward kernel for `subject` with constant
+    /// PK params `values` (covering `pk_idx`), returning per-observation
+    /// predictions in obs order. Uses the production `FlatEventData`.
+    fn ad_event_driven_preds(
+        pk_model: PkModel,
+        subject: &Subject,
+        pk_idx: &[usize],
+        values: &[f64],
+        dose_lagtimes: &[f64],
+    ) -> Vec<f64> {
+        let ed = FlatEventData::from_subject(subject, dose_lagtimes);
+        let n_events = ed.event_times.len();
+        let n_obs = subject.obs_times.len();
+
+        let pk_idx_f64: Vec<f64> = pk_idx.iter().map(|&i| i as f64).collect();
+        let n_tv = pk_idx.len();
+        let eta = vec![0.0_f64]; // single eta, zero effect
+        let sel_flat = vec![0.0_f64; n_tv]; // n_tv * n_eta (n_eta = 1), all zero
+        let tv = build_tv_constant(pk_idx, values, n_events);
+        let obs_scale = vec![1.0_f64; n_events]; // readout = central / V
+        let pk_model_id = pk_model_to_id(pk_model) as f64;
+
+        let mut out = vec![0.0_f64; n_events];
+        predict_all_event_driven_ad(
+            &eta,
+            &tv,
+            &ed.event_times,
+            &ed.event_kinds,
+            &ed.event_orig_idx_f64,
+            &ed.event_reset_floor,
+            &ed.dose_times,
+            &ed.dose_amts,
+            &ed.dose_rates,
+            &ed.dose_durations,
+            &ed.dose_cmts_f64,
+            &pk_idx_f64,
+            &sel_flat,
+            pk_model_id,
+            &obs_scale,
+            &mut out,
+        );
+
+        let mut preds = vec![0.0_f64; n_obs];
+        for ev in 0..n_events {
+            let k = ed.event_kinds[ev];
+            if k > 0.5 && k < 1.5 {
+                let oi = ed.event_orig_idx_f64[ev] as usize;
+                preds[oi] = out[ev];
+            }
+        }
+        preds
+    }
+
+    fn pk_one_iv(cl: f64, v: f64) -> PkParams {
+        let mut p = PkParams::default();
+        p.values[PK_IDX_CL] = cl;
+        p.values[PK_IDX_V] = v;
+        p
+    }
+
+    fn pk_three_iv(cl: f64, v1: f64, q2: f64, v2: f64, q3: f64, v3: f64) -> PkParams {
+        let mut p = PkParams::default();
+        p.values[PK_IDX_CL] = cl;
+        p.values[PK_IDX_V] = v1;
+        p.values[PK_IDX_Q] = q2;
+        p.values[PK_IDX_V2] = v2;
+        p.values[PK_IDX_Q3] = q3;
+        p.values[PK_IDX_V3] = v3;
+        p
+    }
+
+    #[test]
+    fn ad_reset_turns_off_ongoing_infusion_matches_analytical() {
+        // 1-cpt IV: infusion 0–8 h (rate 125), reset at t=4 mid-infusion.
+        // Obs at t=3 (pre-reset, > 0) and t=6 (post-reset). The reset zeros
+        // the state AND turns the infusion off, so t=6 must read ~0.
+        let doses = vec![DoseEvent::new(0.0, 1000.0, 1, 125.0, false, 0.0)];
+        let obs_times = vec![3.0, 6.0];
+        let subj = subject_with_resets(doses, obs_times.clone(), vec![4.0]);
+        let pk = pk_one_iv(10.0, 100.0);
+        let pk_dose = vec![pk; subj.doses.len()];
+        let pk_obs = vec![pk; obs_times.len()];
+
+        let reference = event_driven_predictions(PkModel::OneCptIv, &subj, &pk_dose, &pk_obs, &[]);
+        let ad = ad_event_driven_preds(
+            PkModel::OneCptIv,
+            &subj,
+            &[PK_IDX_CL, PK_IDX_V],
+            &[10.0, 100.0],
+            &[],
+        );
+
+        assert!(reference[0] > 0.0 && ad[0] > 0.0, "pre-reset obs positive");
+        assert_relative_eq!(ad[1], 0.0, epsilon = 1e-9);
+        for (a, r) in ad.iter().zip(reference.iter()) {
+            assert_relative_eq!(*a, *r, epsilon = 1e-9, max_relative = 1e-9);
+        }
+    }
+
+    #[test]
+    fn ad_three_cpt_two_occasion_reset_matches_analytical() {
+        // Propofol-shaped: two infusion occasions separated by an EVID=4
+        // reset on a 3-cpt IV model. Occasion 1: infusion at t=0 (rate 343,
+        // dur 0.27 ≈ a 92.6 mg bolus-like push) + a maintenance infusion at
+        // t=60. Reset at t=120 zeros the system; occasion 2 repeats. Every
+        // obs prediction must match the reset-aware analytical path.
+        let doses = vec![
+            DoseEvent::new(0.0, 92.6, 1, 343.0, false, 0.0),
+            DoseEvent::new(60.0, 89.4, 1, 1.49, false, 0.0),
+            DoseEvent::new(120.0, 92.6, 1, 343.0, false, 0.0),
+            DoseEvent::new(180.0, 89.4, 1, 1.49, false, 0.0),
+        ];
+        let obs_times = vec![2.0, 8.0, 30.0, 90.0, 122.0, 128.0, 150.0, 210.0];
+        let subj = subject_with_resets(doses, obs_times.clone(), vec![120.0]);
+        let pk = pk_three_iv(2.0, 6.0, 1.0, 25.0, 0.5, 250.0);
+        let pk_dose = vec![pk; subj.doses.len()];
+        let pk_obs = vec![pk; obs_times.len()];
+
+        let reference =
+            event_driven_predictions(PkModel::ThreeCptIv, &subj, &pk_dose, &pk_obs, &[]);
+        let ad = ad_event_driven_preds(
+            PkModel::ThreeCptIv,
+            &subj,
+            &[
+                PK_IDX_CL, PK_IDX_V, PK_IDX_Q, PK_IDX_V2, PK_IDX_Q3, PK_IDX_V3,
+            ],
+            &[2.0, 6.0, 1.0, 25.0, 0.5, 250.0],
+            &[],
+        );
+
+        // Occasion-2 obs (t≥120) must be positive — the reset+redose rebuilds
+        // the profile — and the early occasion-2 point must NOT carry residual
+        // occasion-1 drug (that's the reset/infusion-off invariant).
+        assert!(ad[4] > 0.0, "post-reset redose obs positive");
+        for (a, r) in ad.iter().zip(reference.iter()) {
+            assert_relative_eq!(*a, *r, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
+
+    #[test]
+    fn ad_reset_plus_lagtime_matches_analytical() {
+        // Lagtime + reset on the same subject (the route that previously fell
+        // back to FD). 2-cpt IV: bolus at t=0 with ALAG=1.5 h (so drug enters
+        // at t=1.5), a long infusion at t=5 (ALAG shifts its window to
+        // [6.5, 16.5], so it is still running when the reset hits), and a reset
+        // at t=12 that must zero the state AND turn that infusion off. The
+        // lagged dose timeline + reset/infusion-off must all match the
+        // analytical path, which lags via `EventSchedule`.
+        let doses = vec![
+            DoseEvent::new(0.0, 1000.0, 1, 0.0, false, 0.0), // bolus, lagged to 1.5
+            DoseEvent::new(5.0, 600.0, 1, 60.0, false, 0.0), // 10-h infusion → [6.5, 16.5]
+            DoseEvent::new(12.0, 800.0, 1, 0.0, false, 0.0), // post-reset bolus, lagged to 13.5
+        ];
+        let obs_times = vec![1.0, 3.0, 8.0, 11.0, 13.0, 16.0, 24.0];
+        let subj = subject_with_resets(doses, obs_times.clone(), vec![12.0]);
+
+        let lag = 1.5_f64;
+        let mut pk = PkParams::default();
+        pk.values[PK_IDX_CL] = 4.0;
+        pk.values[PK_IDX_V] = 30.0;
+        pk.values[PK_IDX_Q] = 2.0;
+        pk.values[PK_IDX_V2] = 40.0;
+        pk.values[PK_IDX_LAGTIME] = lag;
+        let pk_dose = vec![pk; subj.doses.len()];
+        let pk_obs = vec![pk; obs_times.len()];
+
+        // Analytical reference lags internally from `pk.lagtime()`.
+        let reference = event_driven_predictions(PkModel::TwoCptIv, &subj, &pk_dose, &pk_obs, &[]);
+        // AD path takes the lags explicitly (Const per-dose).
+        let dose_lagtimes = vec![lag; subj.doses.len()];
+        let ad = ad_event_driven_preds(
+            PkModel::TwoCptIv,
+            &subj,
+            &[PK_IDX_CL, PK_IDX_V, PK_IDX_Q, PK_IDX_V2],
+            &[4.0, 30.0, 2.0, 40.0],
+            &dose_lagtimes,
+        );
+
+        // Obs at t=1.0 is before the lagged bolus entry (t=1.5) → ~0.
+        assert_relative_eq!(ad[0], 0.0, epsilon = 1e-9);
+        assert!(ad[1] > 0.0, "obs after lagged bolus entry positive");
+        for (a, r) in ad.iter().zip(reference.iter()) {
+            assert_relative_eq!(*a, *r, epsilon = 1e-7, max_relative = 1e-7);
+        }
+    }
 
     // Helper: build the minimum tv_per_event row layout the kernel needs.
     // `pk_idx_f64` declares which PK indices the row covers (and in what
@@ -916,12 +1170,15 @@ mod tests {
             let tv = build_tv_constant(&pk_idx, &[cl, v, ka, f], event_times.len());
             let mut out = vec![0.0_f64; event_times.len()];
             let obs_scale = vec![1.0_f64; event_times.len()];
+            // No resets in these fixtures — floor is NEG_INFINITY everywhere.
+            let event_reset_floor = vec![f64::NEG_INFINITY; event_times.len()];
             predict_all_event_driven_ad(
                 &eta,
                 &tv,
                 &event_times,
                 &event_kinds,
                 &event_orig,
+                &event_reset_floor,
                 &dose_times,
                 &dose_amts,
                 &dose_rates,
@@ -985,12 +1242,15 @@ mod tests {
             let tv = build_tv_constant(&pk_idx, &[cl, v, f], event_times.len());
             let mut out = vec![0.0_f64; event_times.len()];
             let obs_scale = vec![1.0_f64; event_times.len()];
+            // No resets in these fixtures — floor is NEG_INFINITY everywhere.
+            let event_reset_floor = vec![f64::NEG_INFINITY; event_times.len()];
             predict_all_event_driven_ad(
                 &eta,
                 &tv,
                 &event_times,
                 &event_kinds,
                 &event_orig,
+                &event_reset_floor,
                 &dose_times,
                 &dose_amts,
                 &dose_rates,

--- a/src/api.rs
+++ b/src/api.rs
@@ -130,6 +130,16 @@ pub fn run_model_with_data_inits(
     );
 
     let init_params = build_init_params(&parsed);
+    // Sync the resolved gradient method from fit_options onto the model so
+    // `resolve_gradient_method` (which reads `model.gradient_method`) honours
+    // the file's `gradient = ...` key. Mirrors `fit_from_files` (SDE forces FD).
+    parsed.model.gradient_method = if parsed.model.is_sde()
+        && parsed.fit_options.gradient_method != crate::types::GradientMethod::Fd
+    {
+        crate::types::GradientMethod::Fd
+    } else {
+        parsed.fit_options.gradient_method
+    };
     let mut result = fit(
         &parsed.model,
         &population,

--- a/src/estimation/hmc.rs
+++ b/src/estimation/hmc.rs
@@ -97,8 +97,15 @@ pub fn leapfrog(
 ///   - the model uses an ODE (`model.ode_spec.is_some()`)
 ///   - the model has no analytical PK path (`model.tv_fn.is_none()`)
 ///   - `omega.log_det` is non-finite (degenerate variance matrix)
-///   - the subject has time-varying covariates on an unsupported PK model
-///     or a model with lag time (event-driven AD path prerequisite)
+///   - [`inner_optimizer::resolve_gradient_method`] resolves the subject to
+///     `Fd` (no AD path consistent with the analytical objective): SS doses,
+///     an oral model with a zero-order infusion dose, eta-dependent lagtime, or
+///     a TV-covariate / reset subject on a PK model the event-driven AD path
+///     doesn't support.
+///
+/// Reset (EVID=3/4), TV-covariate, and lagtime subjects take the event-driven
+/// AD path; plain subjects take the single-snapshot path — the same routing as
+/// the FOCEI inner loop.
 #[cfg(feature = "autodiff")]
 #[allow(clippy::too_many_arguments)]
 pub fn hmc_step(
@@ -149,91 +156,111 @@ pub fn hmc_step(
     // leapfrog, `last_nll.get()` == NLL(η_proposal) without an extra AD call.
     let last_nll = Cell::new(nll_current);
 
-    // Build the gradient closure for leapfrog.  Two paths depending on whether
-    // the subject has time-varying covariates.
-    let (p_init, eta_prop, p_prop, nll_prop) = if subject.has_tv_covariates() {
-        // Event-driven AD path — required for TV-covariate subjects.
-        if !event_driven_ad::supports_event_driven_ad(model.pk_model) || model.has_lagtime() {
-            return None;
+    // Route by the SAME policy as the FOCEI inner loop
+    // (`inner_optimizer::resolve_gradient_method`) so the two estimators stay
+    // consistent: reset / TV-covariate / lagtime subjects take the event-driven
+    // AD path, and subjects where AD would be inconsistent with the analytical
+    // objective (SS doses, oral + zero-order infusion, eta-dependent lagtime,
+    // unsupported models) resolve to `Fd` — for which HMC has no path, so we
+    // return `None` and the caller falls back to its non-gradient sampler.
+    use crate::estimation::inner_optimizer::{resolve_gradient_method, InnerGradientMethod};
+
+    // Build the gradient closure for leapfrog, dispatching on the resolved route.
+    let (p_init, eta_prop, p_prop, nll_prop) = match resolve_gradient_method(model, subject) {
+        InnerGradientMethod::Fd => return None,
+        InnerGradientMethod::AdEventDriven => {
+            // Per-dose lagtimes (eta-independent part) baked into the event
+            // timeline — same source as `find_ebe`. Empty for non-lagtime models.
+            let dose_lagtimes: Vec<f64> = if model.has_lagtime() {
+                let zeros = vec![0.0; n_eta];
+                crate::pk::compute_event_pk_params(model, subject, theta, &zeros)
+                    .dose
+                    .iter()
+                    .map(|p| p.lagtime())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let event_data = event_driven_ad::FlatEventData::from_subject(subject, &dose_lagtimes);
+            let tv_per_event =
+                event_driven_ad::FlatEventTv::from_subject(model, subject, theta, &dose_lagtimes);
+            let obs = subject.observations.clone();
+
+            let grad_fn = |q: &[f64]| -> Vec<f64> {
+                // Per-event scale array — q is the eta proposal, matches the
+                // pattern in `inner_optimizer::find_ebe`.
+                let event_scale =
+                    crate::estimation::inner_optimizer::build_event_scale_array_for_ad(
+                        model,
+                        subject,
+                        &event_data,
+                        theta,
+                        q,
+                    );
+                let (nll, g) = event_driven_ad::compute_nll_gradient_event_driven_ad(
+                    q,
+                    &tv_per_event,
+                    &omega_inv_flat,
+                    log_det_omega,
+                    sigma_values,
+                    &event_data,
+                    &obs,
+                    &cens_f64,
+                    model.pk_model,
+                    model.error_model,
+                    &model.pk_idx_f64,
+                    &model.sel_flat,
+                    &event_scale,
+                    model.log_transform,
+                );
+                last_nll.set(nll);
+                g
+            };
+
+            let p_init: Vec<f64> = (0..n_eta).map(|_| rng.sample(StandardNormal)).collect();
+            let (qp, pp) = leapfrog(eta, &p_init, &grad_fn, step_size, n_leapfrog);
+            let nll_p = last_nll.get();
+            (p_init, qp, pp, nll_p)
         }
-        // No lag: the `has_lagtime()` guard above already excluded lagtime
-        // models from the HMC event-driven path.
-        let event_data = event_driven_ad::FlatEventData::from_subject(subject, &[]);
-        let tv_per_event = event_driven_ad::FlatEventTv::from_subject(model, subject, theta, &[]);
-        let obs = subject.observations.clone();
+        InnerGradientMethod::AdSingleSnapshot => {
+            // Single-snapshot AD path — no TV covariates, no resets.
+            let tv_fn = model.tv_fn.as_ref().unwrap();
+            let tv_adjusted = tv_fn(theta, &subject.covariates);
+            let dose_data = FlatDoseData::from_subject(subject);
+            let obs = subject.observations.clone();
+            let obs_times = subject.obs_times.clone();
 
-        let grad_fn = |q: &[f64]| -> Vec<f64> {
-            // Per-event scale array — q is the eta proposal, matches the
-            // pattern in `inner_optimizer::find_ebe`.
-            let event_scale = crate::estimation::inner_optimizer::build_event_scale_array_for_ad(
-                model,
-                subject,
-                &event_data,
-                theta,
-                q,
-            );
-            let (nll, g) = event_driven_ad::compute_nll_gradient_event_driven_ad(
-                q,
-                &tv_per_event,
-                &omega_inv_flat,
-                log_det_omega,
-                sigma_values,
-                &event_data,
-                &obs,
-                &cens_f64,
-                model.pk_model,
-                model.error_model,
-                &model.pk_idx_f64,
-                &model.sel_flat,
-                &event_scale,
-                model.log_transform,
-            );
-            last_nll.set(nll);
-            g
-        };
+            let grad_fn = |q: &[f64]| -> Vec<f64> {
+                // Per-observation scale array (single-snapshot AD path).
+                let obs_scale = crate::estimation::inner_optimizer::build_scale_array_for_ad(
+                    model, subject, theta, q,
+                );
+                let (nll, g) = compute_nll_gradient_ad(
+                    q,
+                    &tv_adjusted,
+                    &omega_inv_flat,
+                    log_det_omega,
+                    sigma_values,
+                    &dose_data,
+                    &obs_times,
+                    &obs,
+                    &cens_f64,
+                    model.pk_model,
+                    model.error_model,
+                    &model.pk_idx_f64,
+                    &model.sel_flat,
+                    &obs_scale,
+                    model.log_transform,
+                );
+                last_nll.set(nll);
+                g
+            };
 
-        let p_init: Vec<f64> = (0..n_eta).map(|_| rng.sample(StandardNormal)).collect();
-        let (qp, pp) = leapfrog(eta, &p_init, &grad_fn, step_size, n_leapfrog);
-        let nll_p = last_nll.get();
-        (p_init, qp, pp, nll_p)
-    } else {
-        // Single-snapshot AD path — no TV covariates.
-        let tv_fn = model.tv_fn.as_ref().unwrap();
-        let tv_adjusted = tv_fn(theta, &subject.covariates);
-        let dose_data = FlatDoseData::from_subject(subject);
-        let obs = subject.observations.clone();
-        let obs_times = subject.obs_times.clone();
-
-        let grad_fn = |q: &[f64]| -> Vec<f64> {
-            // Per-observation scale array (single-snapshot AD path).
-            let obs_scale = crate::estimation::inner_optimizer::build_scale_array_for_ad(
-                model, subject, theta, q,
-            );
-            let (nll, g) = compute_nll_gradient_ad(
-                q,
-                &tv_adjusted,
-                &omega_inv_flat,
-                log_det_omega,
-                sigma_values,
-                &dose_data,
-                &obs_times,
-                &obs,
-                &cens_f64,
-                model.pk_model,
-                model.error_model,
-                &model.pk_idx_f64,
-                &model.sel_flat,
-                &obs_scale,
-                model.log_transform,
-            );
-            last_nll.set(nll);
-            g
-        };
-
-        let p_init: Vec<f64> = (0..n_eta).map(|_| rng.sample(StandardNormal)).collect();
-        let (qp, pp) = leapfrog(eta, &p_init, &grad_fn, step_size, n_leapfrog);
-        let nll_p = last_nll.get();
-        (p_init, qp, pp, nll_p)
+            let p_init: Vec<f64> = (0..n_eta).map(|_| rng.sample(StandardNormal)).collect();
+            let (qp, pp) = leapfrog(eta, &p_init, &grad_fn, step_size, n_leapfrog);
+            let nll_p = last_nll.get();
+            (p_init, qp, pp, nll_p)
+        }
     };
 
     // Metropolis accept/reject on ΔH = H_curr − H_prop.

--- a/src/estimation/hmc.rs
+++ b/src/estimation/hmc.rs
@@ -97,8 +97,9 @@ pub fn leapfrog(
 ///   - the model uses an ODE (`model.ode_spec.is_some()`)
 ///   - the model has no analytical PK path (`model.tv_fn.is_none()`)
 ///   - `omega.log_det` is non-finite (degenerate variance matrix)
-///   - [`inner_optimizer::resolve_gradient_method`] resolves the subject to
-///     `Fd` (no AD path consistent with the analytical objective): SS doses,
+///   - [`crate::estimation::inner_optimizer::resolve_gradient_method`] resolves
+///     the subject to `Fd` (no AD path consistent with the analytical
+///     objective): SS doses,
 ///     an oral model with a zero-order infusion dose, eta-dependent lagtime, or
 ///     a TV-covariate / reset subject on a PK model the event-driven AD path
 ///     doesn't support.

--- a/src/estimation/hmc.rs
+++ b/src/estimation/hmc.rs
@@ -156,8 +156,10 @@ pub fn hmc_step(
         if !event_driven_ad::supports_event_driven_ad(model.pk_model) || model.has_lagtime() {
             return None;
         }
-        let event_data = event_driven_ad::FlatEventData::from_subject(subject);
-        let tv_per_event = event_driven_ad::FlatEventTv::from_subject(model, subject, theta);
+        // No lag: the `has_lagtime()` guard above already excluded lagtime
+        // models from the HMC event-driven path.
+        let event_data = event_driven_ad::FlatEventData::from_subject(subject, &[]);
+        let tv_per_event = event_driven_ad::FlatEventTv::from_subject(model, subject, theta, &[]);
         let obs = subject.observations.clone();
 
         let grad_fn = |q: &[f64]| -> Vec<f64> {

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -103,9 +103,12 @@ pub(crate) fn build_event_scale_array_for_ad(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InnerGradientMethod {
     /// Finite differences. Used when AD is unavailable/disabled, when the
-    /// model has no `tv_fn`, or when a TV-covariate / reset subject is on a
-    /// structural model the event-driven AD path doesn't support
-    /// (`supports_event_driven_ad` == false, e.g. ODE models).
+    /// model has no `tv_fn`, on a structural model the event-driven AD path
+    /// doesn't support (`supports_event_driven_ad` == false, e.g. ODE models),
+    /// or when AD would be inconsistent with the analytical objective:
+    /// SS doses, an oral model with a zero-order (infusion) dose (the AD oral
+    /// propagators are bolus-only), or eta-dependent lagtime (the AD paths
+    /// freeze lag w.r.t. eta).
     Fd,
     /// Reverse-mode AD with a single per-subject `tv_adjusted` vector
     /// — the legacy fast path. Correct only when the subject has no
@@ -115,6 +118,45 @@ enum InnerGradientMethod {
     /// time-varying covariates and/or system resets (EVID=3/4) to be
     /// reflected in gradients.
     AdEventDriven,
+}
+
+/// True for the extravascular (oral / first-order absorption) analytical PK
+/// models, whose AD propagators are bolus-only (see the oral-infusion guard in
+/// [`resolve_gradient_method`]).
+#[cfg(feature = "autodiff")]
+fn is_oral_model(pk_model: PkModel) -> bool {
+    matches!(
+        pk_model,
+        PkModel::OneCptOral | PkModel::TwoCptOral | PkModel::ThreeCptOral
+    )
+}
+
+/// True when any BSV eta acts on the lagtime parameter, i.e. the model declares
+/// `lagtime`/`ALAG` with between-subject variability. Detected from the one-hot
+/// eta selector `sel_flat` (row-major `n_tv × n_eta`, parallel to `pk_indices`):
+/// a nonzero entry on the `PK_IDX_LAGTIME` row means eta moves the lag.
+///
+/// The AD paths freeze lagtime w.r.t. eta, so an eta-dependent lag makes the AD
+/// gradient inconsistent with the analytical objective — those subjects route
+/// to FD (see [`resolve_gradient_method`]).
+#[cfg(feature = "autodiff")]
+fn lagtime_depends_on_eta(model: &CompiledModel) -> bool {
+    let n_eta = model.n_eta;
+    if n_eta == 0 {
+        return false;
+    }
+    model
+        .pk_indices
+        .iter()
+        .enumerate()
+        .filter(|(_, &pk_idx)| pk_idx == crate::types::PK_IDX_LAGTIME)
+        .any(|(row, _)| {
+            let base = row * n_eta;
+            model
+                .sel_flat
+                .get(base..base + n_eta)
+                .is_some_and(|r| r.iter().any(|&c| c != 0.0))
+        })
 }
 
 fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGradientMethod {
@@ -144,6 +186,25 @@ fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGra
         // gradients (computed against the single-dose response) would not
         // match the SS-aware predictions from `predict_concentration`.
         if subject.has_ss_doses() {
+            return InnerGradientMethod::Fd;
+        }
+        // Oral models with a zero-order (infusion, RATE>0) dose: every AD oral
+        // propagator — both the single-snapshot superposition (`ad_gradients`)
+        // and the event-driven (`event_driven_ad`) path — is bolus-only. They
+        // inject `amt` into the depot and ignore the infusion rate, whereas the
+        // analytical value path (`event_driven::propagate_with_bounds`) applies
+        // the zero-order input. Differentiating that mismatch yields a gradient
+        // inconsistent with the objective, so route these subjects to FD.
+        if is_oral_model(model.pk_model) && subject.doses.iter().any(|d| d.rate > 0.0) {
+            return InnerGradientMethod::Fd;
+        }
+        // Eta-dependent lagtime: the AD paths treat lagtime as Const w.r.t. eta
+        // (the event-driven path bakes a per-dose lag frozen at eta=0 into the
+        // timeline; the single-snapshot path reads it `volatile`), so `∂lag/∂η`
+        // is dropped and the AD gradient disagrees with the analytical
+        // (current-eta) objective the inner loop minimizes. Exact only when no
+        // eta acts on lagtime — fall back to FD when one does.
+        if lagtime_depends_on_eta(model) {
             return InnerGradientMethod::Fd;
         }
         // System resets (EVID=3/4) and time-varying covariates both need the
@@ -1683,6 +1744,68 @@ mod iov_tests {
             "mu shift not applied: r1.eta={}, r2.eta={}",
             r1.eta[0],
             r2.eta[0],
+        );
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn is_oral_model_classifies_extravascular_models() {
+        assert!(is_oral_model(PkModel::OneCptOral));
+        assert!(is_oral_model(PkModel::TwoCptOral));
+        assert!(is_oral_model(PkModel::ThreeCptOral));
+        assert!(!is_oral_model(PkModel::OneCptIv));
+        assert!(!is_oral_model(PkModel::TwoCptIv));
+        assert!(!is_oral_model(PkModel::ThreeCptIv));
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn lagtime_depends_on_eta_detects_bsv_on_lag() {
+        // Base model has no lagtime row (pk_indices = [CL, V]).
+        let mut model = make_iov_model();
+        assert!(!lagtime_depends_on_eta(&model), "no lag row -> false");
+
+        // Add a lagtime tv-row carrying eta (nonzero sel entry).
+        model.pk_indices = vec![0, 1, crate::types::PK_IDX_LAGTIME];
+        model.sel_flat = vec![1.0, 0.0, 1.0]; // 3 rows x n_eta=1; lag row has eta
+        assert!(lagtime_depends_on_eta(&model), "lag row with eta -> true");
+
+        // Same lagtime row but eta-independent (zero sel) -> false.
+        model.sel_flat = vec![1.0, 0.0, 0.0];
+        assert!(
+            !lagtime_depends_on_eta(&model),
+            "eta-independent lag -> false"
+        );
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn oral_infusion_subject_routes_to_fd() {
+        // tv_fn = Some so the AD branches are reachable; pk_model oral.
+        let mut model = make_iov_model();
+        model.tv_fn = Some(Box::new(
+            |_t: &[f64], _c: &std::collections::HashMap<String, f64>| vec![0.0, 0.0],
+        ));
+        model.pk_model = PkModel::OneCptOral;
+
+        // Oral *bolus* subject (RATE=0): AD is fine -> not FD.
+        let bolus = make_iov_subject();
+        assert!(bolus.doses.iter().all(|d| d.rate == 0.0));
+        assert_ne!(
+            resolve_gradient_method(&model, &bolus),
+            InnerGradientMethod::Fd,
+            "oral bolus should still take an AD route"
+        );
+
+        // Add a zero-order (infusion) dose -> guard routes to FD.
+        let mut infusion = make_iov_subject();
+        infusion
+            .doses
+            .push(DoseEvent::new(0.0, 100.0, 1, 50.0, false, 0.0)); // RATE>0
+        assert_eq!(
+            resolve_gradient_method(&model, &infusion),
+            InnerGradientMethod::Fd,
+            "oral + infusion must route to FD (AD oral propagators are bolus-only)"
         );
     }
 }

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -101,7 +101,7 @@ pub(crate) fn build_event_scale_array_for_ad(
 /// the single-snapshot AD path can't honour per-event covariate values or
 /// resets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InnerGradientMethod {
+pub(crate) enum InnerGradientMethod {
     /// Finite differences. Used when AD is unavailable/disabled, when the
     /// model has no `tv_fn`, on a structural model the event-driven AD path
     /// doesn't support (`supports_event_driven_ad` == false, e.g. ODE models),
@@ -159,7 +159,10 @@ fn lagtime_depends_on_eta(model: &CompiledModel) -> bool {
         })
 }
 
-fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGradientMethod {
+pub(crate) fn resolve_gradient_method(
+    model: &CompiledModel,
+    subject: &Subject,
+) -> InnerGradientMethod {
     #[cfg(not(feature = "autodiff"))]
     {
         let _ = model;
@@ -1775,6 +1778,27 @@ mod iov_tests {
         assert!(
             !lagtime_depends_on_eta(&model),
             "eta-independent lag -> false"
+        );
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn reset_only_subject_routes_to_event_driven() {
+        // A subject with a system reset but no TV covariates must take the
+        // reset-aware event-driven AD path (not single-snapshot, which can't
+        // express resets). Both find_ebe and hmc_step dispatch on this.
+        let mut model = make_iov_model();
+        model.tv_fn = Some(Box::new(
+            |_t: &[f64], _c: &std::collections::HashMap<String, f64>| vec![0.0, 0.0],
+        ));
+        model.pk_model = PkModel::OneCptIv; // supports event-driven AD
+        let mut subj = make_iov_subject();
+        assert!(!subj.has_tv_covariates(), "fixture has no TV covariates");
+        subj.reset_times = vec![3.5];
+        assert_eq!(
+            resolve_gradient_method(&model, &subj),
+            InnerGradientMethod::AdEventDriven,
+            "reset-only subject must take the event-driven AD path"
         );
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -93,24 +93,27 @@ pub(crate) fn build_event_scale_array_for_ad(
 /// (b) the model to have `tv_fn` populated (analytical PK path only).
 /// ODE models have no AD path, so `Auto` resolves to FD there.
 ///
-/// For subjects with time-varying covariates, the *event-driven* AD path
-/// is used when the structural model is in
-/// [`crate::ad::event_driven_ad::supports_event_driven_ad`] (currently
-/// 1- and 2-cpt IV bolus + infusion). Other models with TV covariates
-/// fall back to FD — the single-snapshot AD path can't honour per-event
-/// covariate values.
+/// For subjects with time-varying covariates *or* system resets (EVID=3/4),
+/// the *event-driven* AD path is used when the structural model is in
+/// [`crate::ad::event_driven_ad::supports_event_driven_ad`] (all six
+/// analytical PK models). Lagtime is handled there too (a Const per-dose lag
+/// baked into the event timeline). Models outside that set fall back to FD —
+/// the single-snapshot AD path can't honour per-event covariate values or
+/// resets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InnerGradientMethod {
-    /// Finite differences. Used when AD is unavailable/disabled, when
-    /// the model has no `tv_fn`, or when the subject has TV covariates
-    /// on a model the event-driven AD path doesn't support yet.
+    /// Finite differences. Used when AD is unavailable/disabled, when the
+    /// model has no `tv_fn`, or when a TV-covariate / reset subject is on a
+    /// structural model the event-driven AD path doesn't support
+    /// (`supports_event_driven_ad` == false, e.g. ODE models).
     Fd,
     /// Reverse-mode AD with a single per-subject `tv_adjusted` vector
     /// — the legacy fast path. Correct only when the subject has no
-    /// time-varying covariates.
+    /// time-varying covariates and no system resets.
     AdSingleSnapshot,
     /// Reverse-mode AD with per-event `tv` arrays — required for
-    /// time-varying covariates to be reflected in gradients.
+    /// time-varying covariates and/or system resets (EVID=3/4) to be
+    /// reflected in gradients.
     AdEventDriven,
 }
 
@@ -143,25 +146,16 @@ fn resolve_gradient_method(model: &CompiledModel, subject: &Subject) -> InnerGra
         if subject.has_ss_doses() {
             return InnerGradientMethod::Fd;
         }
-        // System resets (EVID=3/4) zero the compartment state mid-record.
-        // The AD-instrumented propagators have no reset event, so their
-        // gradients wouldn't match the reset-aware predictions from the
-        // event-driven path. Fall back to FD until the AD path learns
-        // resets — the FD path routes through the reset-aware analytical
-        // propagator (see `pk::compute_predictions`).
-        if subject.has_resets() {
-            return InnerGradientMethod::Fd;
-        }
-        // Lagtime in the event-driven AD path would require threading
-        // per-dose `lagtime` through the AD-instrumented propagators and
-        // their infusion-window checks. The single-snapshot AD path
-        // already handles lagtime (see `ad_gradients.rs::predict_all_ad`).
-        // Until the event-driven AD path is updated, fall back to FD when
-        // a TV-cov subject is paired with a lagtime-bearing model.
-        if subject.has_tv_covariates() {
-            if crate::ad::event_driven_ad::supports_event_driven_ad(model.pk_model)
-                && !model.has_lagtime()
-            {
+        // System resets (EVID=3/4) and time-varying covariates both need the
+        // event-driven AD path: a reset zeros the compartment state mid-record
+        // (and turns off ongoing infusions), neither of which the
+        // single-snapshot superposition path in `ad_gradients.rs` can express.
+        // The event-driven AD kernel handles resets via a per-event reset-floor
+        // mask (mirrors `pk::event_driven`'s `reset_floor`) and lagtime via a
+        // Const per-dose lag baked into the event timeline (see
+        // `FlatEventData::from_subject`).
+        if subject.has_resets() || subject.has_tv_covariates() {
+            if crate::ad::event_driven_ad::supports_event_driven_ad(model.pk_model) {
                 InnerGradientMethod::AdEventDriven
             } else {
                 InnerGradientMethod::Fd
@@ -497,17 +491,37 @@ pub fn find_ebe(
             InnerGradientMethod::AdSingleSnapshot => {
                 (Some(tv_fn(&params.theta, &subject.covariates)), None, None)
             }
-            InnerGradientMethod::AdEventDriven => (
-                None,
-                Some(crate::ad::event_driven_ad::FlatEventData::from_subject(
-                    subject,
-                )),
-                Some(crate::ad::event_driven_ad::FlatEventTv::from_subject(
-                    model,
-                    subject,
-                    &params.theta,
-                )),
-            ),
+            InnerGradientMethod::AdEventDriven => {
+                // Per-dose lagtimes for the lagged event timeline, evaluated at
+                // (theta, covariate) with eta = 0 so they're Const w.r.t. the
+                // gradient. Exact for the usual eta-independent lagtime; the
+                // rare eta-dependent case drops ∂lag/∂η (documented in
+                // `FlatEventData::from_subject`). Empty when the model declares
+                // no lagtime — `from_subject` then applies zero shift.
+                let dose_lagtimes: Vec<f64> = if model.has_lagtime() {
+                    let zeros = vec![0.0; n_eta];
+                    crate::pk::compute_event_pk_params(model, subject, &params.theta, &zeros)
+                        .dose
+                        .iter()
+                        .map(|p| p.lagtime())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                (
+                    None,
+                    Some(crate::ad::event_driven_ad::FlatEventData::from_subject(
+                        subject,
+                        &dose_lagtimes,
+                    )),
+                    Some(crate::ad::event_driven_ad::FlatEventTv::from_subject(
+                        model,
+                        subject,
+                        &params.theta,
+                        &dose_lagtimes,
+                    )),
+                )
+            }
             InnerGradientMethod::Fd => (None, None, None),
         };
         (


### PR DESCRIPTION
## Why
On `propofol_schnider` (3-cpt IV, FOCEI), ferx took **~65 s** vs NONMEM's **~2.3 s**. Root cause: every subject has stacked `EVID=4` reset occasions, and the Enzyme AD inner-gradient path didn't support resets, so `resolve_gradient_method` fell back to **finite differences for every subject**. FD is both costlier (`2·n_eta` extra solves per gradient) and noisier — the FD gradients stalled the outer loop early, leaving the fit ~3.8 OFV short of NONMEM.

This PR teaches the event-driven AD path about resets (and lagtime), so reset/occasion data takes the AD fast path.

## What changed
**Reset (EVID=3/4) support in the event-driven AD kernels** (reverse-mode NLL + forward-mode Jacobian):
- `FlatEventData`/`FlatEventTv` insert reset events (`kind=3.0`, sorted first so an `EVID=4` zeros state before its same-time dose) and precompute a per-event `event_reset_floor` array — the AD analogue of the non-AD scalar `reset_floor`.
- Both kernels zero state at a reset via a Const `keep` mask, and mask each infusion contribution by `dose_times[d] < reset_floor` (strict `<`, so an `EVID=4`'s own infusion stays active). All branch-free / phi-safe for Enzyme.
- Gate (`resolve_gradient_method`) routes reset **or** TV-cov subjects to `AdEventDriven`.

**Lagtime support**: per-dose lag (eta-independent part, from `compute_event_pk_params(...).dose[k].lagtime()`) is baked into the dose event times and the propagators' `dose_times`, mirroring `EventSchedule::for_subject`.

**Correctness guards** (route to FD where AD would disagree with the analytical objective): oral models with a zero-order infusion dose (the AD oral propagators are bolus-only), and eta-dependent lagtime (the AD paths freeze lag w.r.t. eta).

**Consistency / cleanup**: `hmc_step` now dispatches on the same `resolve_gradient_method` as the FOCEI inner loop (fixes a gap where reset-only subjects bypassed the reset-aware path in HMC, and removes its bespoke routing); the merged event-timeline build is shared via `build_sorted_events` so the two `FlatEvent*` builders can't desync.

**Bug fix**: `run_model_with_data_inits` (CLI / ferx-r path) never synced `model.gradient_method` from the file's `[fit_options]`, so `gradient = ad|fd` was silently ignored — now mirrors `fit_from_files`.

## Alternatives considered
Hand-coded closed-form ∂f/∂η through resets (NONMEM-style) was rejected: Enzyme already produces the exact analytic derivative for the non-reset case, so extending the existing event-driven kernel with a reset event reuses all that math rather than duplicating a second derivative surface. Eta-dependent lagtime could have been approximated (frozen lag) instead of routed to FD, but FD keeps the gradient consistent with the objective for that rare case.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API or `FitResult`/sdtab change; the ferx-r `[patch]` picks this up automatically.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: NONMEM `ADVAN11 TRANS4` and prior ferx FD path, on `propofol_schnider`

```
# NONMEM (run1.ext)        OFV -3039.287   TVV1 5.761 TVV2 26.089 TVV3 309.366 TVCL 1.921 TVQ2 1.343 TVQ3 0.867
# ferx FD (prior)          OFV -3035.071   (65 s, stalled on noisy FD gradients)
# ferx AD (this PR)        OFV -3038.843   (~3 s) TVV1 5.827 TVV2 26.495 TVV3 315.603 TVCL 1.913 TVQ2 1.338 TVQ3 0.868
```
All thetas within ~2% of NONMEM; OFV within 0.45 (FD was 3.8 short). Reset-path AD predictions are validated against the analytical `event_driven_predictions` to ≤1e-7 (1-cpt infusion-cut-by-reset, 3-cpt two-occasion, 2-cpt lagtime+reset).

## Performance
- [x] Faster — `propofol_schnider` FOCEI, single thread: **65 s → ~7 s (~9×)**; banner now `AD (event-driven)`, 0 FD gradient calls.

## Tests
- [x] Unit/regression tests added (`cargo test --lib`): reset AD vs analytical (3 cases incl. lagtime+reset); routing guards (oral classification, lagtime-eta detection, oral-bolus→AD vs oral+infusion→FD, reset-only→event-driven). Full lib suite: **886 pass**.

## Docs
- [x] No user-visible change (internal estimation routing; same fit options, same outputs — just faster/more accurate on reset data)

## Checklist
- [x] `cargo check --features autodiff` compiles (built clean with `RUSTFLAGS="-Z autodiff=Enable"`)
- [ ] `cargo clippy` — not runnable on the AD path locally (the `enzyme` toolchain has no clippy component; the autodiff-gated code only builds there). The non-autodiff (`ci`) clippy surface is clean for the changed files apart from pre-existing autodiff-gating dead-code warnings.

## Reviewer hints
Focus on `event_driven_ad.rs` (reset state-zero `keep` mask + `event_reset_floor` infusion mask) and its **mirror** in `event_driven_ad_jac.rs` — the two AD kernels are deliberate copy-paste (Enzyme IR isolation) and must stay in sync. The reset-first sort tie-break and the strict `<` infusion comparison are the subtle bits; both match the analytical `pk::event_driven` path the kernels are differentiating. `hmc.rs` is a mechanical re-dispatch onto the shared router.

This PR builds on the (already-merged) `EVID=4` segmentation from #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
