### PR TITLE
fix(docs): make warfarin --simulate work and fix verify-build step [closes #199]

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -272,10 +272,12 @@ The `ci` feature is the right choice for development on machines without the ful
 ### Verify the build
 
 ```bash
-RUSTFLAGS="-Z autodiff=Enable" cargo run --release --features autodiff --bin ferx -- examples/warfarin.ferx --simulate
+RUSTFLAGS="-Z autodiff=Enable" cargo run --release --features autodiff --bin ferx -- examples/warfarin.ferx --data data/warfarin.csv
 ```
 
-Should print a successful model fit with parameter estimates.
+Should print a successful model fit with parameter estimates. Fitting against
+the bundled `data/warfarin.csv` exercises the autodiff gradient path, so it
+also confirms Enzyme is working end-to-end (not just that the binary links).
 
 ---
 

--- a/examples/warfarin.ferx
+++ b/examples/warfarin.ferx
@@ -26,3 +26,10 @@
   method     = foce
   maxiter    = 300
   covariance = true
+
+[simulation]
+  n_subjects = 10
+  dose_amt   = 100.0
+  dose_cmt   = 1
+  times      = [0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0, 48.0, 72.0, 96.0, 120.0]
+  seed       = 1


### PR DESCRIPTION
## Why

In #199 a user (on Linux) reported the dev toolchain wouldn't install per the docs. But the paste shows the build actually succeeded — the binary compiled and ran:

```
Finished `release` profile [optimized] target(s) in 0.08s
Running `target/release/ferx examples/warfarin.ferx --simulate`
Error: Model file has no [simulation] block — use --data instead
```

That last line is the binary running correctly and rejecting the model — not a toolchain failure. The `cargo is unavailable for the active toolchain` info line above it is the expected stage-1 fallback.

The real bug is in the docs: the **"Verify the build"** command in `installation.md` runs `examples/warfarin.ferx --simulate`, but `examples/warfarin.ferx` had **no `[simulation]` block** (only `mm_multistart.ferx` did). So the verify step always failed at the last hop, regardless of Enzyme health — making a working autodiff build look like an install failure. The same broken `warfarin.ferx --simulate` invocation also appears in `README.md`, `docs/src/cli.md`, and `CLAUDE.md`.

## What changed

1. **Added a `[simulation]` block to `examples/warfarin.ferx`** (10 subjects, 100 mg into cmt 1, the warfarin sampling schedule). This makes `--simulate` work as-written in every doc that references it — README, cli.md, CLAUDE.md (the README even claims "uses [simulation] block", now actually true).
2. **Changed the `installation.md` verify step to `--data data/warfarin.csv`** instead of `--simulate`. Its surrounding text promises "a successful model fit with parameter estimates," which a simulation doesn't produce — and fitting real data exercises the **autodiff gradient path**, so it confirms Enzyme works end-to-end rather than just that the binary links.

## Numerical validation

- [x] `warfarin.ferx --simulate` runs and recovers the true params: TVCL 0.2→0.215, TVV 10→10.23, TVKA 1.5→1.39 (OFV -211.87).
- [x] `warfarin.ferx --data data/warfarin.csv` fits cleanly (OFV -280.18).
- [x] Both verified with a `--no-default-features --features ci` build (CLI behavior is identical to the autodiff build; only the gradient backend differs).

## Breaking changes
- [x] None — the `[simulation]` block is purely additive; existing `--data` usage of `warfarin.ferx` is unaffected.

## Docs
- [x] `docs/src/installation.md` updated.

## Tests
- [x] No new tests needed — docs/example-only change; the example is itself exercised by the verify command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)