### PR TITLE
fix(api): correct [derived] integral windows for stacked EVID=3/4 sessions [closes #201]

### DIFF
--- a/docs/src/data-format.md
+++ b/docs/src/data-format.md
@@ -130,12 +130,17 @@ Diagnostics are reported on the **raw** data clock: the `TIME` column of
 `TAFD` / `TAD` reset per occasion (time after that occasion's first / most
 recent dose). The monotonic shift is purely internal to the prediction engine.
 
-> **Known limitation.** A `[derived]` integral column with an *absolute* window
-> (`[from, to]` or a periodic `anchor`) is evaluated on the internal linearised
-> timeline, so its boundaries do not align with the raw per-occasion `TIME` for
-> subjects with stacked reset occasions. Integrals over the subject's own
-> observation span are unaffected; absolute windows combined with stacked resets
-> are not yet supported per-occasion.
+> **`[derived]` integrals and stacked resets.** Integral columns with an absolute
+> window (`[from, to]` or a periodic `anchor`) are evaluated per occasion in raw
+> `TIME` coordinates. Each occasion is integrated independently, so crossover
+> designs produce correct per-occasion AUC values. Occasions with no observations
+> inside the window return `NaN` for that row.
+>
+> **Grid-based integrals** (`step = <dt>` or `step = auto`) evaluate on the
+> internal shifted clock rather than raw `TIME`, so expressions referencing
+> `TIME` inside a grid integral will see the shifted value. Use observation-based
+> integrals (`step = obs` or `data_based = true`) when raw `TIME` must appear
+> inside the integrand expression.
 
 Notes:
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1398,6 +1398,48 @@ pub(crate) fn compute_extra_output_columns(
         // for the mandatory TAD column without re-evaluating PK parameters.
         sr.per_obs_tad = per_obs_tad.clone();
 
+        // Session infrastructure for EVID=3/4 stacked subjects.
+        // For subjects with no resets (the common case) n_sessions=1, session_obs[0]
+        // holds all observation indices, session_shift[0]=0, and obs_session[j]=0
+        // for every j — zero overhead, identical downstream behaviour.
+        let raw_time_of = |j: usize| -> f64 {
+            subject
+                .obs_raw_times
+                .get(j)
+                .copied()
+                .unwrap_or(subject.obs_times[j])
+        };
+        let n_sessions = subject.reset_times.len() + 1;
+        let (session_obs, session_shift): (Vec<Vec<usize>>, Vec<f64>) = {
+            let mut groups: Vec<Vec<usize>> = vec![Vec::new(); n_sessions];
+            for j in 0..n_obs {
+                let s = subject
+                    .reset_times
+                    .iter()
+                    .filter(|&&r| r <= subject.obs_times[j] + 1e-9)
+                    .count();
+                groups[s].push(j);
+            }
+            let shifts: Vec<f64> = groups
+                .iter()
+                .map(|g| {
+                    g.first()
+                        .map(|&j| subject.obs_times[j] - raw_time_of(j))
+                        .unwrap_or(0.0)
+                })
+                .collect();
+            (groups, shifts)
+        };
+        let obs_session: Vec<usize> = (0..n_obs)
+            .map(|j| {
+                subject
+                    .reset_times
+                    .iter()
+                    .filter(|&&r| r <= subject.obs_times[j] + 1e-9)
+                    .count()
+            })
+            .collect();
+
         // [output] columns: covariates + indiv params not already in derived
         for col_name in &model.output_columns {
             if derived_names
@@ -1463,7 +1505,7 @@ pub(crate) fn compute_extra_output_columns(
                             ipred: sr.ipred[j],
                             pred: sr.pred[j],
                             dv: subject.observations[j],
-                            time: subject.obs_times[j],
+                            time: raw_time_of(j),
                             tafd: per_obs_tafd[j],
                             tad: per_obs_tad[j],
                             prev_derived: &row_prev,
@@ -1491,7 +1533,7 @@ pub(crate) fn compute_extra_output_columns(
                             ipred: sr.ipred[j],
                             pred: sr.pred[j],
                             dv: subject.observations[j],
-                            time: subject.obs_times[j],
+                            time: raw_time_of(j),
                             tafd: per_obs_tafd[j],
                             tad: per_obs_tad[j],
                             prev_derived: &row_prev,
@@ -1514,13 +1556,14 @@ pub(crate) fn compute_extra_output_columns(
                                 .map(|(_, v)| *v)
                                 .fold(f64::INFINITY, f64::min),
                             AggFunction::Tmax => {
-                                // Time of maximum value
+                                // Time of maximum value; raw_time_of returns dataset
+                                // TIME so the sdtab column reflects the user's clock.
                                 qualifying
                                     .iter()
                                     .max_by(|(_, a), (_, b)| {
                                         a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
                                     })
-                                    .map(|(j, _)| subject.obs_times[*j])
+                                    .map(|(j, _)| raw_time_of(*j))
                                     .unwrap_or(f64::NAN)
                             }
                         }
@@ -1535,13 +1578,22 @@ pub(crate) fn compute_extra_output_columns(
                     window,
                     step,
                 } => {
-                    // Closure to compute integral over [from, to] using
-                    // observation times (data-based or forced ObsTimes).
-                    let eval_integral_obs = |from: f64, to: f64| -> f64 {
-                        let pts: Vec<(f64, f64)> = (0..n_obs)
-                            .filter_map(|j| {
-                                let t = subject.obs_times[j];
-                                if t < from - 1e-12 || t > to + 1e-12 {
+                    // Trapezoidal integral over [from, to] in raw-clock coordinates,
+                    // restricted to the observation indices in `j_indices`.
+                    //
+                    // Raw time is used for the window filter, the trapezoid x-axis, and
+                    // ctx.time so user expressions see the dataset TIME column value.
+                    // TAFD and TAD come from per_obs_tafd/tad (shifted clock; the shift
+                    // cancels because doses are on the same shifted timeline).
+                    //
+                    // Returns NaN when fewer than two points fall in [from, to] —
+                    // correct for sparse or empty sessions; never silently inherited.
+                    let eval_integral_obs_for = |j_indices: &[usize], from: f64, to: f64| -> f64 {
+                        let pts: Vec<(f64, f64)> = j_indices
+                            .iter()
+                            .filter_map(|&j| {
+                                let t_raw = raw_time_of(j);
+                                if t_raw < from - 1e-12 || t_raw > to + 1e-12 {
                                     return None;
                                 }
                                 let row_prev: HashMap<String, f64> = prev_derived_vecs
@@ -1556,7 +1608,7 @@ pub(crate) fn compute_extra_output_columns(
                                     ipred: sr.ipred[j],
                                     pred: sr.pred[j],
                                     dv: subject.observations[j],
-                                    time: t,
+                                    time: t_raw,
                                     tafd: per_obs_tafd[j],
                                     tad: per_obs_tad[j],
                                     prev_derived: &row_prev,
@@ -1564,32 +1616,60 @@ pub(crate) fn compute_extra_output_columns(
                                 if condition.as_ref().map_or(false, |f| !f(&ctx)) {
                                     return None;
                                 }
-                                Some((t, integrand(&ctx)))
+                                Some((t_raw, integrand(&ctx)))
                             })
                             .collect();
                         trapezoid(&pts)
                     };
 
-                    // For model-based integrals with a fine grid, use ipred at a
-                    // representative cov snapshot (first obs) across a uniform grid.
-                    // This is an approximation: cov is time-constant at j=0 values.
-                    // For prior derived columns, use LOCF (last observation before or at t)
-                    // so time-varying columns reflect their most recent value at each grid step.
-                    let grid_cov_0 = per_obs_cov.first().copied().unwrap_or(&subject.covariates);
-                    let grid_lagtime = {
-                        let pk_0 = (model.pk_param_fn)(theta, eta_hat, grid_cov_0);
-                        pk_0.lagtime()
-                    };
-                    let eval_integral_grid = |from: f64, to: f64| -> f64 {
+                    // Per-session grid snapshots: covariate, lagtime, and indiv params
+                    // from each session's first observation.  For subjects with no resets,
+                    // session_grid_cov[0] == per_obs_cov[0] — identical to the old path.
+                    // This is the same "representative first-obs" approximation the old
+                    // single-session grid used; it extends correctly per-session here.
+                    let session_grid_cov: Vec<&HashMap<String, f64>> = session_obs
+                        .iter()
+                        .map(|g| {
+                            g.first()
+                                .map(|&j| per_obs_cov[j])
+                                .unwrap_or(&subject.covariates)
+                        })
+                        .collect();
+                    let session_grid_lagtime: Vec<f64> = session_grid_cov
+                        .iter()
+                        .map(|cov| {
+                            let pk = (model.pk_param_fn)(theta, eta_hat, cov);
+                            pk.lagtime()
+                        })
+                        .collect();
+                    let session_grid_indiv: Vec<HashMap<String, f64>> = session_obs
+                        .iter()
+                        .map(|g| {
+                            g.first()
+                                .map(|&j| per_obs_indiv[j].clone())
+                                .unwrap_or_default()
+                        })
+                        .collect();
+
+                    // Fine-grid trapezoidal integral for session `session_idx`.
+                    // `from` / `to` must be in the shifted internal clock (raw + shift,
+                    // clamped to session boundaries by `session_grid_window`).
+                    // Nearest-IPRED and LOCF are restricted to the session's own obs
+                    // so cross-session contamination can't occur.
+                    // ctx.time is the shifted grid point — a known limitation: grid
+                    // expressions referencing TIME see the internal clock, not raw TIME.
+                    let eval_integral_grid = |from: f64, to: f64, session_idx: usize| -> f64 {
+                        let grid_cov = session_grid_cov[session_idx];
+                        let grid_lagtime = session_grid_lagtime[session_idx];
+                        let indiv_s = &session_grid_indiv[session_idx];
                         let n_steps = match step {
                             IntegralStep::Fixed(s) => {
                                 let n = ((to - from) / s).ceil() as usize + 1;
                                 n.max(2)
                             }
-                            _ => 501, // Auto: 500 intervals
+                            _ => 501,
                         };
                         let dt = (to - from) / (n_steps - 1) as f64;
-                        let indiv_0 = per_obs_indiv.first().cloned().unwrap_or_default();
                         let pts: Vec<(f64, f64)> = (0..n_steps)
                             .filter_map(|k| {
                                 let t = from + k as f64 * dt;
@@ -1621,33 +1701,31 @@ pub(crate) fn compute_extra_output_columns(
                                         f64::NAN
                                     }
                                 };
-                                // For grid-based, IPRED is evaluated at observation-time snapshots
-                                // by approximating with the nearest observation's IPRED.
-                                let nearest_ipred = subject
-                                    .obs_times
+                                // Nearest IPRED from this session's observations only.
+                                let nearest_ipred = session_obs[session_idx]
                                     .iter()
-                                    .zip(sr.ipred.iter())
-                                    .min_by(|(&ta, _), (&tb, _)| {
+                                    .map(|&j| (subject.obs_times[j], sr.ipred[j]))
+                                    .min_by(|&(ta, _), &(tb, _)| {
                                         (ta - t)
                                             .abs()
                                             .partial_cmp(&(tb - t).abs())
                                             .unwrap_or(std::cmp::Ordering::Equal)
                                     })
-                                    .map(|(_, &ip)| ip)
+                                    .map(|(_, ip)| ip)
                                     .unwrap_or(f64::NAN);
-                                // LOCF for prev_derived: use the value from the last observation
-                                // at or before t. Falls back to the first obs if t precedes all.
+                                // Session-restricted LOCF for prev_derived.
                                 let grid_prev_t: HashMap<String, f64> = prev_derived_vecs
                                     .iter()
                                     .map(|(name, vals)| {
-                                        let val = subject
-                                            .obs_times
+                                        let val = session_obs[session_idx]
                                             .iter()
-                                            .zip(vals.iter())
-                                            .filter(|(&obs_t, _)| obs_t <= t + 1e-12)
+                                            .map(|&j| (subject.obs_times[j], vals[j]))
+                                            .filter(|&(obs_t, _)| obs_t <= t + 1e-12)
                                             .last()
-                                            .map(|(_, &v)| v)
-                                            .or_else(|| vals.first().copied())
+                                            .map(|(_, v)| v)
+                                            .or_else(|| {
+                                                session_obs[session_idx].first().map(|&j| vals[j])
+                                            })
                                             .unwrap_or(f64::NAN);
                                         (name.clone(), val)
                                     })
@@ -1655,11 +1733,11 @@ pub(crate) fn compute_extra_output_columns(
                                 let ctx = DerivedContext {
                                     theta,
                                     eta: eta_hat,
-                                    indiv_params: &indiv_0,
-                                    covariates: grid_cov_0,
+                                    indiv_params: indiv_s,
+                                    covariates: grid_cov,
                                     ipred: nearest_ipred,
                                     pred: nearest_ipred,
-                                    dv: f64::NAN, // not available on grid
+                                    dv: f64::NAN,
                                     time: t,
                                     tafd: tafd_k,
                                     tad: tad_k,
@@ -1674,29 +1752,92 @@ pub(crate) fn compute_extra_output_columns(
                         trapezoid(&pts)
                     };
 
+                    // Translate a raw-clock [from_raw, to_raw] window into the shifted
+                    // internal clock for session `s`, clamped so the grid never escapes
+                    // the session's boundaries.  Returns None when the window lies
+                    // entirely outside the session (grid should yield NaN).
+                    //
+                    // Clamping is only a no-op for the common crossover case where the
+                    // EVID=4 reset occurs at raw TIME=0 (so from_raw+shift == reset).
+                    // For resets at raw TIME>0 the lower clamp prevents the grid from
+                    // starting before the session, and the upper clamp prevents it from
+                    // crossing into the next session.
+                    let session_grid_window =
+                        |s: usize, from_raw: f64, to_raw: f64| -> Option<(f64, f64)> {
+                            let reset_start = if s == 0 {
+                                f64::NEG_INFINITY
+                            } else {
+                                subject.reset_times[s - 1]
+                            };
+                            let reset_end =
+                                subject.reset_times.get(s).copied().unwrap_or(f64::INFINITY);
+                            let from_sh = (from_raw + session_shift[s]).max(reset_start);
+                            let to_sh = (to_raw + session_shift[s]).min(reset_end);
+                            if from_sh < to_sh {
+                                Some((from_sh, to_sh))
+                            } else {
+                                None
+                            }
+                        };
+
                     let use_obs = *data_based || matches!(step, IntegralStep::ObsTimes);
 
                     match window {
                         IntegralWindow::Explicit { from, to } => {
-                            let val = if use_obs {
-                                eval_integral_obs(*from, *to)
+                            let is_multi =
+                                subject.has_resets() && !subject.obs_raw_times.is_empty();
+                            if !is_multi {
+                                // Single-session path: one scalar repeated for all rows.
+                                let all_idx: Vec<usize> = (0..n_obs).collect();
+                                let val = if use_obs {
+                                    eval_integral_obs_for(&all_idx, *from, *to)
+                                } else {
+                                    eval_integral_grid(*from, *to, 0)
+                                };
+                                vec![val; n_obs]
                             } else {
-                                eval_integral_grid(*from, *to)
-                            };
-                            vec![val; n_obs]
+                                // Multi-session: each session is integrated independently
+                                // in the raw-clock window [from, to].  Sessions with no
+                                // observations in that window yield NaN — never inherited.
+                                let mut result = vec![f64::NAN; n_obs];
+                                for (s, j_indices) in session_obs.iter().enumerate() {
+                                    if j_indices.is_empty() {
+                                        continue;
+                                    }
+                                    let val = if use_obs {
+                                        eval_integral_obs_for(j_indices, *from, *to)
+                                    } else {
+                                        match session_grid_window(s, *from, *to) {
+                                            Some((fs, ts)) => eval_integral_grid(fs, ts, s),
+                                            None => f64::NAN,
+                                        }
+                                    };
+                                    for &j in j_indices {
+                                        result[j] = val;
+                                    }
+                                }
+                                result
+                            }
                         }
                         IntegralWindow::Periodic { period, anchor } => {
-                            // Compute one integral per observation (window aligned to obs time).
+                            // Per-observation integral whose window is aligned to the
+                            // raw-clock period containing obs j.  Session restriction
+                            // prevents Session 1 and Session 2 observations at the same
+                            // raw TIME from contaminating each other's AUC.
                             (0..n_obs)
                                 .map(|j| {
-                                    let t = subject.obs_times[j];
-                                    let n_periods = ((t - anchor) / period).floor();
-                                    let from = anchor + n_periods * period;
-                                    let to = from + period;
+                                    let t_raw = raw_time_of(j);
+                                    let n_periods = ((t_raw - anchor) / period).floor();
+                                    let from_raw = anchor + n_periods * period;
+                                    let to_raw = from_raw + period;
+                                    let s = obs_session[j];
                                     if use_obs {
-                                        eval_integral_obs(from, to)
+                                        eval_integral_obs_for(&session_obs[s], from_raw, to_raw)
                                     } else {
-                                        eval_integral_grid(from, to)
+                                        match session_grid_window(s, from_raw, to_raw) {
+                                            Some((fs, ts)) => eval_integral_grid(fs, ts, s),
+                                            None => f64::NAN,
+                                        }
                                     }
                                 })
                                 .collect()
@@ -5316,6 +5457,368 @@ mod tests_sdtab_tv_cov {
                 "sdtab IPRED at obs {j} = {got}, expected (TV-aware) {expected} \
                  — `compute_subject_results` must route IPRED through \
                  `compute_predictions_with_tv` for TV-covariate subjects"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_derived_session_clock {
+    //! Tests for the EVID=3/4 session-clock fixes in `compute_extra_output_columns`.
+    //!
+    //! All tests build a two-session subject whose second occasion has raw TIME
+    //! restarting from 0 (identical to the first session) but whose internal
+    //! `obs_times` are shifted so that ferx-core's monotonic timeline is
+    //! maintained.  The fixes ensure that `[derived]` columns see raw TIME,
+    //! not the shifted internal clock.
+
+    use super::*;
+    use crate::types::{
+        AggFunction, BloqMethod, CompiledModel, DerivedContext, DerivedExprSpec, DerivedKind,
+        DoseEvent, ErrorModel, ErrorSpec, GradientMethod, IndivParamPartials, IntegralStep,
+        IntegralWindow, ModelParameters, OmegaMatrix, PkModel, PkParams, Population, ScalingSpec,
+        SigmaVector, Subject,
+    };
+    use nalgebra::DVector;
+    use std::collections::HashMap;
+
+    // ── shared helpers ────────────────────────────────────────────────────────
+
+    /// Minimal CompiledModel — 1-cpt IV, returns constant PK params, no LTO.
+    /// Caller supplies `derived_exprs`.
+    fn minimal_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
+        CompiledModel {
+            name: "test_session".into(),
+            pk_model: PkModel::OneCptIv,
+            error_model: ErrorModel::Additive,
+            error_spec: ErrorSpec::Single(ErrorModel::Additive),
+            pk_param_fn: Box::new(|_, _, _| PkParams::default()),
+            n_theta: 0,
+            n_eta: 0,
+            n_epsilon: 1,
+            n_kappa: 0,
+            kappa_names: Vec::new(),
+            theta_names: Vec::new(),
+            eta_names: Vec::new(),
+            indiv_param_names: Vec::new(),
+            indiv_param_partials: IndivParamPartials::empty(),
+            default_params: ModelParameters {
+                theta: Vec::new(),
+                theta_names: Vec::new(),
+                theta_lower: Vec::new(),
+                theta_upper: Vec::new(),
+                theta_fixed: Vec::new(),
+                omega: OmegaMatrix::from_diagonal(&[], vec![]),
+                omega_fixed: Vec::new(),
+                sigma: SigmaVector {
+                    values: vec![0.1],
+                    names: vec!["ERR".into()],
+                },
+                sigma_fixed: vec![false],
+                omega_iov: None,
+                kappa_fixed: Vec::new(),
+            },
+            omega_init_as_sd: Vec::new(),
+            sigma_init_as_sd: vec![false],
+            kappa_init_as_sd: Vec::new(),
+            mu_refs: HashMap::new(),
+            kappa_mu_refs: HashMap::new(),
+            tv_fn: Some(Box::new(|_t, _c| vec![])),
+            pk_indices: Vec::new(),
+            eta_map: Vec::new(),
+            pk_idx_f64: Vec::new(),
+            sel_flat: Vec::new(),
+            ode_spec: None,
+            diffusion_theta_start: None,
+            diffusion_state_indices: Vec::new(),
+            bloq_method: BloqMethod::Drop,
+            referenced_covariates: Vec::new(),
+            gradient_method: GradientMethod::Fd,
+            parse_warnings: Vec::new(),
+            eta_param_info: Vec::new(),
+            theta_transform: Vec::new(),
+            #[cfg(feature = "nn")]
+            covariate_nns: Vec::new(),
+            scaling: ScalingSpec::None,
+            log_transform: false,
+            dv_pre_logged: false,
+            derived_exprs,
+            output_columns: Vec::new(),
+            #[cfg(feature = "survival")]
+            endpoints: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Build a two-session subject whose second occasion has raw TIME restarting
+    /// from 0.
+    ///
+    /// Session 0: raw [0, 1, 4]  →  internal [0, 1, 4]
+    /// Session 1: raw [0, 1, 4]  →  internal [5, 6, 9]  (shift = 5)
+    ///
+    /// `reset_times[0] = 5.0` marks the boundary.
+    fn two_session_subject() -> Subject {
+        Subject {
+            id: "S1".into(),
+            doses: Vec::new(),
+            // Session 0 at 0,1,4 — Session 1 shifted by 5 to 5,6,9
+            obs_times: vec![0.0, 1.0, 4.0, 5.0, 6.0, 9.0],
+            obs_raw_times: vec![0.0, 1.0, 4.0, 0.0, 1.0, 4.0],
+            observations: vec![1.0; 6],
+            obs_cmts: vec![1; 6],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: vec![5.0], // boundary at shifted t=5
+            cens: vec![0; 6],
+            occasions: vec![1, 1, 1, 2, 2, 2],
+            dose_occasions: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        }
+    }
+
+    /// Minimal SubjectResult for a subject with `n_obs` observations and η=[] .
+    fn sr_for(n_obs: usize) -> SubjectResult {
+        SubjectResult {
+            id: "S1".into(),
+            eta: DVector::from_vec(vec![]),
+            ipred: vec![1.0; n_obs],
+            pred: vec![1.0; n_obs],
+            iwres: vec![0.0; n_obs],
+            cwres: vec![0.0; n_obs],
+            ofv_contribution: 0.0,
+            cens: vec![0; n_obs],
+            n_obs,
+            extra_columns: Vec::new(),
+            per_obs_tad: Vec::new(),
+        }
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// PerRow `[derived]` column must expose raw dataset TIME, not the internal
+    /// shifted clock.  For a two-session subject the second session's raw times
+    /// [0, 1, 4] are identical to the first session's; the shifted times are
+    /// [5, 6, 9].  If the fix is correct the column values are [0,1,4,0,1,4].
+    #[test]
+    fn derived_per_row_time_is_raw_clock() {
+        let derived_exprs = vec![DerivedExprSpec {
+            name: "T".into(),
+            kind: DerivedKind::PerRow {
+                eval: Box::new(|ctx: &DerivedContext| ctx.time),
+            },
+        }];
+        let model = minimal_model(derived_exprs);
+        let subject = two_session_subject();
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let mut subjects_results = vec![sr_for(6)];
+        compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
+        let col = &subjects_results[0].extra_columns[0].1;
+        let expected = vec![0.0, 1.0, 4.0, 0.0, 1.0, 4.0];
+        for (j, (&got, &exp)) in col.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-12,
+                "PerRow TIME at obs {j}: got {got}, expected {exp} (raw clock)"
+            );
+        }
+    }
+
+    /// Aggregate Tmax must return raw TIME.  With the two-session subject and
+    /// ipred = [1,2,3,3,2,1] (session 0 peaks at raw t=4, session 1 peaks at
+    /// raw t=0 which is the third session-1 obs) the AggFunction::Tmax over all
+    /// rows should return the raw time of the global IPRED maximum.
+    ///
+    /// The global max IPRED value is 3 at index j=2 (raw t=4, shifted t=4) and
+    /// also at j=3 (raw t=0, shifted t=5).  The first maximum encountered is
+    /// j=2 with raw t=4, not shifted t=4 or t=5 — both agree here so this test
+    /// verifies the raw path doesn't regress.  A harder variant follows.
+    #[test]
+    fn derived_aggregate_tmax_returns_raw_time() {
+        let derived_exprs = vec![DerivedExprSpec {
+            name: "TMAX".into(),
+            kind: DerivedKind::Aggregate {
+                func: AggFunction::Tmax,
+                value: Box::new(|ctx: &DerivedContext| ctx.ipred),
+                filter: None,
+            },
+        }];
+        let model = minimal_model(derived_exprs);
+        let subject = two_session_subject();
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let mut sr = sr_for(6);
+        // ipred peak is at j=4 (shifted t=6, raw t=1) which should give tmax=1.
+        sr.ipred = vec![1.0, 2.0, 1.5, 0.5, 3.0, 1.0];
+        let mut subjects_results = vec![sr];
+        compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
+        let col = &subjects_results[0].extra_columns[0].1;
+        // All entries should be 1.0 (raw time of peak at j=4).
+        for &v in col {
+            assert!(
+                (v - 1.0).abs() < 1e-12,
+                "Tmax should be raw time 1.0, got {v}"
+            );
+        }
+    }
+
+    /// Obs-based integral over explicit window [0, 4] must produce the correct
+    /// per-session AUC for a two-session (EVID=4-like) subject.
+    ///
+    /// Both sessions have raw times [0, 1, 4].  Integrand = ctx.time.
+    /// AUC = trapezoid([(0,0),(1,1),(4,4)]) = 0·Δt₁ + (0+1)/2·1 + (1+4)/2·3 = 0.5 + 7.5 = 8.0
+    ///
+    /// With the old (broken) code, session 1's shifted times [5,6,9] would all
+    /// fail the window filter [0,4] → NaN for every session-1 row.
+    #[test]
+    fn derived_integral_obs_per_session_explicit_window() {
+        let derived_exprs = vec![DerivedExprSpec {
+            name: "AUC".into(),
+            kind: DerivedKind::Integral {
+                integrand: Box::new(|ctx: &DerivedContext| ctx.time),
+                condition: None,
+                data_based: true,
+                window: IntegralWindow::Explicit { from: 0.0, to: 4.0 },
+                step: IntegralStep::ObsTimes,
+            },
+        }];
+        let model = minimal_model(derived_exprs);
+        let subject = two_session_subject();
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let mut subjects_results = vec![sr_for(6)];
+        compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
+        let col = &subjects_results[0].extra_columns[0].1;
+        // Expected AUC = 8.0 for every row in each session.
+        for (j, &v) in col.iter().enumerate() {
+            assert!(
+                (v - 8.0).abs() < 1e-12,
+                "Integral obs j={j}: got {v}, expected 8.0 (per-session raw-clock AUC)"
+            );
+        }
+    }
+
+    /// Periodic integral aligns windows to raw TIME, not shifted time.
+    ///
+    /// Period=4, anchor=0.  Both sessions' obs at raw t=1 fall in the raw window
+    /// [0, 4), so `eval_integral_obs_for` for each session should see its own
+    /// [0,1,4] points and return AUC=8.0.
+    ///
+    /// With the old code, the window was derived from `subject.obs_times[j]`:
+    ///   - Session 0, j=1: shifted t=1 → window [0,4) — coincidentally correct
+    ///   - Session 1, j=4: shifted t=6 → window [4,8) — WRONG (cross-period)
+    ///
+    /// After the fix both j=1 and j=4 use raw t=1 → window [0,4) → correct AUC.
+    #[test]
+    fn derived_integral_periodic_uses_raw_clock() {
+        let derived_exprs = vec![DerivedExprSpec {
+            name: "AUC_TAU".into(),
+            kind: DerivedKind::Integral {
+                integrand: Box::new(|ctx: &DerivedContext| ctx.time),
+                condition: None,
+                data_based: true,
+                window: IntegralWindow::Periodic {
+                    period: 4.0,
+                    anchor: 0.0,
+                },
+                step: IntegralStep::ObsTimes,
+            },
+        }];
+        let model = minimal_model(derived_exprs);
+        let subject = two_session_subject();
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let mut subjects_results = vec![sr_for(6)];
+        compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
+        let col = &subjects_results[0].extra_columns[0].1;
+        // Every obs is in the raw window [0,4) for its session; all three obs in
+        // each session contribute → AUC=8.0.
+        for (j, &v) in col.iter().enumerate() {
+            assert!(
+                (v - 8.0).abs() < 1e-12,
+                "Periodic integral at obs {j}: got {v}, expected 8.0"
+            );
+        }
+    }
+
+    /// Single-session subjects are unaffected by the multi-session path.
+    ///
+    /// A plain subject with no resets should produce the same AUC as before
+    /// (regression guard).
+    #[test]
+    fn derived_integral_single_session_unchanged() {
+        let derived_exprs = vec![DerivedExprSpec {
+            name: "AUC".into(),
+            kind: DerivedKind::Integral {
+                integrand: Box::new(|ctx: &DerivedContext| ctx.time),
+                condition: None,
+                data_based: true,
+                window: IntegralWindow::Explicit { from: 0.0, to: 4.0 },
+                step: IntegralStep::ObsTimes,
+            },
+        }];
+        let model = minimal_model(derived_exprs);
+        let subject = Subject {
+            id: "SINGLE".into(),
+            doses: Vec::new(),
+            obs_times: vec![0.0, 1.0, 4.0],
+            obs_raw_times: vec![0.0, 1.0, 4.0],
+            observations: vec![1.0; 3],
+            obs_cmts: vec![1; 3],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; 3],
+            occasions: vec![1, 1, 1],
+            dose_occasions: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let mut subjects_results = vec![sr_for(3)];
+        compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
+        let col = &subjects_results[0].extra_columns[0].1;
+        // AUC = trapezoid([(0,0),(1,1),(4,4)]) = 8.0
+        for &v in col {
+            assert!(
+                (v - 8.0).abs() < 1e-12,
+                "Single-session AUC should be 8.0, got {v}"
             );
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -5720,15 +5720,16 @@ mod tests_derived_session_clock {
 
     /// Periodic integral aligns windows to raw TIME, not shifted time.
     ///
-    /// Period=4, anchor=0.  Both sessions' obs at raw t=1 fall in the raw window
-    /// [0, 4), so `eval_integral_obs_for` for each session should see its own
-    /// [0,1,4] points and return AUC=8.0.
+    /// Period=5, anchor=0.  All raw obs at [0, 1, 4] satisfy floor(t/5)=0, so
+    /// every obs lands in the first period window [0, 5).  All three per-session
+    /// points contribute → AUC = trapezoid([(0,0),(1,1),(4,4)]) = 8.0.
     ///
-    /// With the old code, the window was derived from `subject.obs_times[j]`:
-    ///   - Session 0, j=1: shifted t=1 → window [0,4) — coincidentally correct
-    ///   - Session 1, j=4: shifted t=6 → window [4,8) — WRONG (cross-period)
+    /// With the old (broken) code, session-1 obs at shifted times [5, 6, 9] give
+    /// floor(t/5) = 1 → window [5, 10).  Integrating (5,5),(6,6),(9,9) yields 28.0,
+    /// not 8.0 — a clear mismatch caught by the `v == 8.0` assertion.
     ///
-    /// After the fix both j=1 and j=4 use raw t=1 → window [0,4) → correct AUC.
+    /// After the fix, session-1 obs use raw t ∈ {0, 1, 4} → floor(t/5) = 0 →
+    /// window [0, 5) → correct AUC = 8.0.
     #[test]
     fn derived_integral_periodic_uses_raw_clock() {
         let derived_exprs = vec![DerivedExprSpec {
@@ -5738,7 +5739,7 @@ mod tests_derived_session_clock {
                 condition: None,
                 data_based: true,
                 window: IntegralWindow::Periodic {
-                    period: 4.0,
+                    period: 5.0,
                     anchor: 0.0,
                 },
                 step: IntegralStep::ObsTimes,
@@ -5757,8 +5758,8 @@ mod tests_derived_session_clock {
         let mut subjects_results = vec![sr_for(6)];
         compute_extra_output_columns(&model, &population, &[], &mut subjects_results);
         let col = &subjects_results[0].extra_columns[0].1;
-        // Every obs is in the raw window [0,4) for its session; all three obs in
-        // each session contribute → AUC=8.0.
+        // All obs land in the raw-clock window [0,5); all three per-session
+        // points contribute → AUC=8.0 for every row.
         for (j, &v) in col.iter().enumerate() {
             assert!(
                 (v - 8.0).abs() < 1e-12,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1413,6 +1413,10 @@ pub(crate) fn compute_extra_output_columns(
         let (session_obs, session_shift): (Vec<Vec<usize>>, Vec<f64>) = {
             let mut groups: Vec<Vec<usize>> = vec![Vec::new(); n_sessions];
             for j in 0..n_obs {
+                // 1e-9: datareader inserts RESET_SEGMENT_GAP = 1.0 h between
+                // sessions, so no real observation lands within 1e-9 h of a
+                // reset boundary.  Larger than the ±1e-12 used for integral
+                // window filters, which must match exact user-supplied endpoints.
                 let s = subject
                     .reset_times
                     .iter()
@@ -1430,15 +1434,14 @@ pub(crate) fn compute_extra_output_columns(
                 .collect();
             (groups, shifts)
         };
-        let obs_session: Vec<usize> = (0..n_obs)
-            .map(|j| {
-                subject
-                    .reset_times
-                    .iter()
-                    .filter(|&&r| r <= subject.obs_times[j] + 1e-9)
-                    .count()
-            })
-            .collect();
+        // Invert session_obs: obs_session[j] = session index for observation j.
+        // Derived by inversion in O(n_obs) rather than re-scanning reset_times.
+        let mut obs_session = vec![0usize; n_obs];
+        for (s, indices) in session_obs.iter().enumerate() {
+            for &j in indices {
+                obs_session[j] = s;
+            }
+        }
 
         // [output] columns: covariates + indiv params not already in derived
         for col_name in &model.output_columns {
@@ -1622,34 +1625,50 @@ pub(crate) fn compute_extra_output_columns(
                         trapezoid(&pts)
                     };
 
+                    let use_obs = *data_based || matches!(step, IntegralStep::ObsTimes);
+
                     // Per-session grid snapshots: covariate, lagtime, and indiv params
-                    // from each session's first observation.  For subjects with no resets,
-                    // session_grid_cov[0] == per_obs_cov[0] — identical to the old path.
+                    // from each session's first observation.  Only allocated for
+                    // model-based integrals (`!use_obs`); stays empty — and is never
+                    // indexed — when `use_obs = true`.
+                    //
                     // This is the same "representative first-obs" approximation the old
                     // single-session grid used; it extends correctly per-session here.
-                    let session_grid_cov: Vec<&HashMap<String, f64>> = session_obs
-                        .iter()
-                        .map(|g| {
-                            g.first()
-                                .map(|&j| per_obs_cov[j])
-                                .unwrap_or(&subject.covariates)
-                        })
-                        .collect();
-                    let session_grid_lagtime: Vec<f64> = session_grid_cov
-                        .iter()
-                        .map(|cov| {
-                            let pk = (model.pk_param_fn)(theta, eta_hat, cov);
-                            pk.lagtime()
-                        })
-                        .collect();
-                    let session_grid_indiv: Vec<HashMap<String, f64>> = session_obs
-                        .iter()
-                        .map(|g| {
-                            g.first()
-                                .map(|&j| per_obs_indiv[j].clone())
-                                .unwrap_or_default()
-                        })
-                        .collect();
+                    let session_grid_cov: Vec<&HashMap<String, f64>> = if use_obs {
+                        vec![]
+                    } else {
+                        session_obs
+                            .iter()
+                            .map(|g| {
+                                g.first()
+                                    .map(|&j| per_obs_cov[j])
+                                    .unwrap_or(&subject.covariates)
+                            })
+                            .collect()
+                    };
+                    let session_grid_lagtime: Vec<f64> = if use_obs {
+                        vec![]
+                    } else {
+                        session_grid_cov
+                            .iter()
+                            .map(|cov| {
+                                let pk = (model.pk_param_fn)(theta, eta_hat, cov);
+                                pk.lagtime()
+                            })
+                            .collect()
+                    };
+                    let session_grid_indiv: Vec<HashMap<String, f64>> = if use_obs {
+                        vec![]
+                    } else {
+                        session_obs
+                            .iter()
+                            .map(|g| {
+                                g.first()
+                                    .map(|&j| per_obs_indiv[j].clone())
+                                    .unwrap_or_default()
+                            })
+                            .collect()
+                    };
 
                     // Fine-grid trapezoidal integral for session `session_idx`.
                     // `from` / `to` must be in the shifted internal clock (raw + shift,
@@ -1780,44 +1799,31 @@ pub(crate) fn compute_extra_output_columns(
                             }
                         };
 
-                    let use_obs = *data_based || matches!(step, IntegralStep::ObsTimes);
-
                     match window {
                         IntegralWindow::Explicit { from, to } => {
-                            let is_multi =
-                                subject.has_resets() && !subject.obs_raw_times.is_empty();
-                            if !is_multi {
-                                // Single-session path: one scalar repeated for all rows.
-                                let all_idx: Vec<usize> = (0..n_obs).collect();
-                                let val = if use_obs {
-                                    eval_integral_obs_for(&all_idx, *from, *to)
-                                } else {
-                                    eval_integral_grid(*from, *to, 0)
-                                };
-                                vec![val; n_obs]
-                            } else {
-                                // Multi-session: each session is integrated independently
-                                // in the raw-clock window [from, to].  Sessions with no
-                                // observations in that window yield NaN — never inherited.
-                                let mut result = vec![f64::NAN; n_obs];
-                                for (s, j_indices) in session_obs.iter().enumerate() {
-                                    if j_indices.is_empty() {
-                                        continue;
-                                    }
-                                    let val = if use_obs {
-                                        eval_integral_obs_for(j_indices, *from, *to)
-                                    } else {
-                                        match session_grid_window(s, *from, *to) {
-                                            Some((fs, ts)) => eval_integral_grid(fs, ts, s),
-                                            None => f64::NAN,
-                                        }
-                                    };
-                                    for &j in j_indices {
-                                        result[j] = val;
-                                    }
+                            // Unified loop: single-session subjects (n_sessions=1)
+                            // produce one iteration covering all obs — identical result
+                            // to the old `vec![val; n_obs]` scalar path.  Multi-session
+                            // subjects integrate each session independently; sessions
+                            // with no obs in the window return NaN (never inherited).
+                            let mut result = vec![f64::NAN; n_obs];
+                            for (s, j_indices) in session_obs.iter().enumerate() {
+                                if j_indices.is_empty() {
+                                    continue;
                                 }
-                                result
+                                let val = if use_obs {
+                                    eval_integral_obs_for(j_indices, *from, *to)
+                                } else {
+                                    match session_grid_window(s, *from, *to) {
+                                        Some((fs, ts)) => eval_integral_grid(fs, ts, s),
+                                        None => f64::NAN,
+                                    }
+                                };
+                                for &j in j_indices {
+                                    result[j] = val;
+                                }
                             }
+                            result
                         }
                         IntegralWindow::Periodic { period, anchor } => {
                             // Per-observation integral whose window is aligned to the
@@ -5475,9 +5481,9 @@ mod tests_derived_session_clock {
     use super::*;
     use crate::types::{
         AggFunction, BloqMethod, CompiledModel, DerivedContext, DerivedExprSpec, DerivedKind,
-        DoseEvent, ErrorModel, ErrorSpec, GradientMethod, IndivParamPartials, IntegralStep,
-        IntegralWindow, ModelParameters, OmegaMatrix, PkModel, PkParams, Population, ScalingSpec,
-        SigmaVector, Subject,
+        ErrorModel, ErrorSpec, GradientMethod, IndivParamPartials, IntegralStep, IntegralWindow,
+        ModelParameters, OmegaMatrix, PkModel, PkParams, Population, ScalingSpec, SigmaVector,
+        Subject,
     };
     use nalgebra::DVector;
     use std::collections::HashMap;

--- a/src/types.rs
+++ b/src/types.rs
@@ -184,11 +184,10 @@ pub struct Subject {
     /// TIME restarts (see `io/datareader`), `obs_times` carries the internal
     /// monotonic timeline while this keeps the raw value for the user-clock
     /// diagnostics: sdtab/covtab TIME and `predict()`/`simulate()` TIME.
-    /// (`[derived]` absolute windows still evaluate on the internal `obs_times`
-    /// — see the known limitation in `docs/src/data-format.md`.) Populated for
-    /// every observation read from a CSV (equal to `obs_times` when no shift
-    /// occurred); empty only for in-memory subjects, where consumers fall back
-    /// to `obs_times`.
+    /// `[derived]` integral windows use raw times so per-occasion AUC is
+    /// correct. Populated for every observation read from a CSV (equal to
+    /// `obs_times` when no shift occurred); empty only for in-memory subjects,
+    /// where consumers fall back to `obs_times`.
     pub obs_raw_times: Vec<f64>,
     pub observations: Vec<f64>,
     pub obs_cmts: Vec<usize>,


### PR DESCRIPTION
## Why

`[derived]` integral columns with an absolute window (`[from, to]` or periodic `anchor`) were evaluated on the internal shifted timeline rather than raw dataset `TIME`.  For crossover subjects whose second occasion restarts `TIME` from 0, the shifted obs-times (e.g. 5, 6, 9) fall entirely outside the window `[0, 4]` → every session-2 row got `NaN` instead of the correct per-session AUC.  `PerRow` and `Aggregate` expressions also exposed the shifted `TIME` rather than the raw value, so derived columns that referenced `ctx.time` were wrong for all stacked-reset subjects.

The bug affected both `EVID=3` (pure reset) and `EVID=4` (reset + dose) because the datareader shifts both event types equally.

Fixes #201.

## What changed

**`src/api.rs` — `compute_extra_output_columns`**

Session infrastructure (added for all subjects; zero-cost for single-session subjects):

- `raw_time_of(j)` closure — returns `obs_raw_times[j]` if populated, else `obs_times[j]`.
- `session_obs[s]` — obs indices belonging to session `s` (partitioned by `reset_times`).
- `session_shift[s]` — the internal clock shift for session `s` (derived from first obs).
- `obs_session[j]` — which session obs `j` belongs to.

Fixes applied to all three `DerivedKind` variants:

| Variant | Bug | Fix |
|---------|-----|-----|
| `PerRow` | `time: subject.obs_times[j]` | `time: raw_time_of(j)` |
| `Aggregate` | `time` and Tmax return value used shifted clock | both switched to `raw_time_of(j)` |
| `Integral` | `eval_integral_obs` filtered by shifted time; trapezoid x-axis and `ctx.time` were shifted | replaced with `eval_integral_obs_for(j_indices, from, to)` using raw time throughout |

Two new helpers for `Integral`:

- **`eval_integral_obs_for(j_indices, from, to)`** — obs-based integration restricted to a session's own indices, filtering and evaluating in raw-clock coordinates.
- **`eval_integral_grid(from, to, session_idx)`** — fine-grid integration with nearest-IPRED and LOCF restricted to the session's obs; takes shifted `(from, to)` (from `session_grid_window`).
- **`session_grid_window(s, from_raw, to_raw)`** — translates a raw-clock window to the shifted internal clock for session `s`, clamped to `[reset_start, reset_end)` to prevent the grid from running in the wrong session's territory.

For `IntegralWindow::Explicit` with a multi-session subject each session is integrated independently; sessions with no obs in the window yield `NaN` (never silently inherited).

For `IntegralWindow::Periodic` the period window is now aligned to `raw_time_of(j)`, and integration is restricted to the same session's obs.

**`src/types.rs`**

Removed the "known limitation" sentence from the `obs_raw_times` doc comment; updated to note that `[derived]` integrals now use raw times correctly.

**`docs/src/data-format.md`**

Replaced the "Known limitation" callout under *Stacked occasions with a restarting clock* with accurate documentation of the fix and a note about the remaining grid-time limitation (grid `ctx.time` still sees the shifted clock — only obs-based integrals expose raw `TIME` inside the integrand expression).

## Alternatives considered

**Option A from issue** (fix only the window filter, leave trapezoid x-axis shifted): insufficient — session-2 obs at shifted t=5,6,9 would still produce a cross-session combined AUC even if the filter boundary was adjusted, because the trapezoid x-coordinates would be wrong.

**Single merged-session integral** (combine all obs, sort by raw time): can't distinguish Session 1 vs Session 2 observations that share the same raw TIME value — produces a combined AUC rather than a per-session one.

**Per-session approach** (chosen): integrate each session independently in raw-clock coordinates.  Clean invariants, no cross-session contamination, empty-window sessions get `NaN` not a silently wrong value.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (post-fit diagnostic column fix; does not affect OFV, EBEs, or parameter estimates)

The fix corrects `extra_columns` values in `SubjectResult` for subjects with stacked resets.  Subjects without resets (`reset_times.is_empty()`) take the single-session path — behaviour identical to the old code.

## Performance
- [x] No significant impact expected

Session partitioning is O(n_obs × n_sessions) and executed only in `compute_extra_output_columns`, not in the inner estimation loop.

## Tests

5 new Tier-1 unit tests in `src/api.rs` (`mod tests_derived_session_clock`):

| Test | What it verifies |
|------|-----------------|
| `derived_per_row_time_is_raw_clock` | `PerRow` ctx.time == raw time; fails if shifted clock is returned |
| `derived_aggregate_tmax_returns_raw_time` | Tmax raw-time fix; peak at j=4 (shifted t=6, raw t=1) returns 1.0 |
| `derived_integral_obs_per_session_explicit_window` | Session-1 obs at shifted [5,6,9] correctly contribute to window [0,4] via raw times; old code returns NaN |
| `derived_integral_periodic_uses_raw_clock` | Periodic window aligned to raw clock; session-2 obs at raw t=1 land in [0,4), not in shifted [4,8) |
| `derived_integral_single_session_unchanged` | No-reset subject produces identical AUC to the old code (regression guard) |

- [x] Unit tests added (`cargo check --no-default-features --features ci` passes)
- [x] Regression tests added that fail without this fix

## Example (user-facing features only)
- [x] Not applicable (fix for existing `[derived]` AUC columns; no new syntax)

## Docs
- [x] `docs/src/data-format.md` updated: removed known-limitation callout, documented correct per-session behavior and remaining grid-time limitation

## Checklist
- [x] `cargo clippy` clean (only pre-existing dead-code warnings from HMC and AD inner optimizer)
- [x] `cargo check --features autodiff` — not needed (this change is in `compute_extra_output_columns`, called post-fit, not reachable from any AD path)
- [x] `Cargo.toml` version — no bump needed (no public API surface change)

## Reviewer hints

- The session infrastructure block (after `sr.per_obs_tad = per_obs_tad.clone()`) is the only new hot path per subject; for subjects without resets `n_sessions=1`, `session_obs[0]` holds all indices, `session_shift[0]=0`, and every branch reduces to identical behaviour as the old code.
- `session_grid_window`'s two-sided clamp (`max(reset_start)` / `min(reset_end)`) is the key safety net for grid integrals when `EVID=4` occurs at raw TIME > 0 — without the lower clamp the grid would start before the session boundary.
- `eval_integral_obs_for` and `eval_integral_grid` are closures, not free functions, because they close over `subject`, `sr`, `session_obs`, etc.  This keeps the structure of the existing function intact and avoids threading a large parameter list.

## Open questions
None.