### PR TITLE
docs: clarify ferx-r CI builds from a pinned Cargo.lock, not latest main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ ferx-core is a Rust-based Nonlinear Mixed Effects (NLME) modeling engine for pop
 
 ## Sibling repositories
 
-The R wrapper package lives at `../ferx-r` (sibling directory). The R package's Rust glue depends on `ferx-core` via git, but its `src/rust/.cargo/config.toml` carries a `[patch]` that auto-swaps in `../../../ferx-core` (this repo) when the sibling checkout exists. So changes here are picked up by an R-package build automatically — no Cargo.toml edits needed on either side. When a change to a `pub` API in `ferx-core` lands, expect to follow up with a matching PR in `ferx-r`.
+The R wrapper package lives at `../ferx-r` (sibling directory). The R package's Rust glue depends on `ferx-core` via git, but its `src/rust/.cargo/config.toml` carries a `[patch]` that auto-swaps in `../../../ferx-core` (this repo) when the sibling checkout exists. So **local** R-package builds pick up changes here automatically — no Cargo.toml edits needed on either side. When a change to a `pub` API in `ferx-core` lands, expect to follow up with a matching PR in `ferx-r`.
+
+Note that ferx-r's **CI** does not get the change automatically: it builds from the ferx-core commit pinned in `ferx-r/src/rust/Cargo.lock` (the patch only applies locally). A ferx-r PR that needs a new ferx-core commit — e.g. a newly-`pub` API — must bump that lock, via `ferx-r/tools/update-ferx-core-lock.sh` (never a bare `cargo update`, which the patch will unpin). Otherwise CI fails with `error[E0603]: ... is private`.
 
 ## First-time setup
 


### PR DESCRIPTION
## Why

The "Sibling repositories" note in `CLAUDE.md` said ferx-core changes are "picked up by an R-package build automatically." That's true for *local* ferx-r builds (the `[patch]` in `src/rust/.cargo/config.toml` redirects to the sibling checkout), but **not** for ferx-r CI, which builds from the ferx-core commit pinned in `ferx-r/src/rust/Cargo.lock`. As written, the note implied no follow-up lock bump was needed.

This bit us in practice: ferx-r PR FeRx-NLME/ferx-r#134 failed CI with `error[E0603]: function read_population_for is private` because its lock still pinned a ferx-core commit predating the `pub` promotion (#192), even though `Cargo.toml` tracks `branch = "main"`.

## What changed

One clause in the Sibling repositories section: distinguish local builds (auto-pickup via patch) from ferx-r CI (pinned `Cargo.lock`), and point at `ferx-r/tools/update-ferx-core-lock.sh` as the safe way to bump — with the warning that a bare `cargo update` unpins it via the patch. A matching, longer note was added on the ferx-r side (FeRx-NLME/ferx-r#134).

Docs-only.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#134 | open | — (independent; same theme) |

## Breaking changes
- [x] None

## Tests
- [x] No new tests needed (docs-only)

## Docs
- [x] `docs/src/` — n/a (this is the repo-guidance `CLAUDE.md`, not the mdBook)
- [x] No user-visible change
