### PR TITLE
docs: add combined ferx-core + ferx-r SDLC, Contributing page, and CHANGELOG

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -85,7 +85,8 @@
 
 ## Docs
 - [ ] `docs/src/` updated for user-visible changes
-- [ ] `mdbook build` run and `docs/book/` committed
+- [ ] New pages linked in `docs/src/SUMMARY.md` (do **not** commit `docs/book/` — it is git-ignored; CI builds & deploys it)
+- [ ] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
 - [ ] No user-visible change
 
 ## Checklist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to **ferx-core** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the [Releases](https://ferx-nlme.github.io/ferx-core/development/sdlc.html#9-releases)
+section of the SDLC for the versioning policy).
+
+<!--
+  HOW TO MAINTAIN THIS FILE
+  - Add an entry under [Unreleased] in the same PR as your change, in the right
+    category (Added / Changed / Deprecated / Removed / Fixed / Security /
+    Performance). One bullet, user-facing language, reference the issue/PR (#NN).
+  - At release time: rename [Unreleased] to the new version + date, then start a
+    fresh empty [Unreleased] and update the compare links at the bottom.
+  - The R wrapper (ferx-r) tracks its own user-facing changes in NEWS.md.
+-->
+
+## [Unreleased]
+
+### Added
+- Time-to-event / survival modelling (Phase 1): `[event_model]` block, TTE
+  datareader, likelihood, and API wiring, behind the `survival` feature
+  (#191, #192).
+- `[data_selection]` block with NONMEM-style `IGNORE`/`ACCEPT` record filtering,
+  plus an `ExclusionSummary` on `FitResult` surfaced in the CLI and YAML output.
+- Combined ferx-core + ferx-r development documentation: a Development Lifecycle
+  (SDLC) page and a Contributing page in the book.
+
+### Fixed
+- IOV FOCEI marginal likelihood now matches NONMEM after the Almquist Laplace
+  correction (#109, #203).
+- SAEM no longer collapses a block Ω to a rank-1 (near-unit-correlation)
+  solution (#191).
+- Stacked `EVID=4` reset occasions are segmented onto a monotonic timeline
+  (#195, #197).
+- `sdtab` no longer emits stray ETA columns (regression from #185).
+- `warfarin --simulate` works again, and the docs `verify-build` step is fixed
+  (#199, #200).
+
+### Performance
+- Autodiff inner gradients now flow through `EVID=3/4` resets and lag time,
+  removing a large finite-difference fallback slowdown (#198).
+
+## [0.1.5] - 2026-06-01
+
+Released before this changelog was started. See the
+[GitHub release](https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.5)
+and `git log v0.1.0..v0.1.5` for details.
+
+## [0.1.0] - 2026-05-29
+
+Initial tagged release. See the
+[GitHub release](https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0).
+
+[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.0...v0.1.5
+[0.1.0]: https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,24 @@ The same restriction applies to any helper the AD code calls transitively — `m
 
 This restriction will go away once Enzyme upstream adds rules for the newer intrinsics — track at https://github.com/EnzymeAD/Enzyme/issues. When removing the workaround, re-enable a representative test under CI with the `autodiff` feature to catch regressions.
 
+## Changelog
+
+User-facing changes are tracked in `CHANGELOG.md` at the repo root, in
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with
+[semantic versioning](https://semver.org/).
+
+**In the same PR as any user-facing change, add a one-line entry under the
+`## [Unreleased]` heading** in the correct category (`Added`, `Changed`,
+`Deprecated`, `Removed`, `Fixed`, `Security`, or `Performance`). Write it in
+user-facing language and reference the issue/PR number (`#NN`). A PR that only
+touches internal refactors, tests, or CI does not need an entry.
+
+At release time (not per-PR), `## [Unreleased]` is renamed to the new version
+with a date, a fresh empty `## [Unreleased]` is started, and the compare links
+at the bottom are updated. The R wrapper (`../ferx-r`) tracks its own
+user-facing changes in `NEWS.md`, so a cross-repo change may need an entry in
+both.
+
 ## Pull Requests
 
 When creating a PR in this repo, always read `.github/PULL_REQUEST_TEMPLATE.md` and fill every section before calling `gh pr create`.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -62,3 +62,6 @@
   - [Simulation](api/simulation.md)
   - [Parsing](api/parsing.md)
 - [FAQ](faq.md)
+- [Development](development/README.md)
+  - [Contributing to FeRx development](development/contributing.md)
+  - [Development Lifecycle (SDLC)](development/sdlc.md)

--- a/docs/src/development/README.md
+++ b/docs/src/development/README.md
@@ -1,0 +1,13 @@
+# Development
+
+Process and contributor documentation for the FeRx project, spanning both
+**ferx-core** (the Rust engine) and **ferx-r** (the R wrapper).
+
+- [Contributing to FeRx development](contributing.md) — how to help, whether by
+  testing and reporting, opening Issues, or opening PRs.
+- [Development Lifecycle (SDLC)](sdlc.md) — governance, the issue→PR→merge→release
+  flow, the trunk-based git model, cross-repo synchronization, the testing
+  pyramid, NONMEM validation, CI quality gates, releases & versioning,
+  maintenance & support, and security.
+
+For the low-level build/test/style rules of each repo, see its `CLAUDE.md`.

--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -1,0 +1,79 @@
+# Contributing to FeRx development
+
+You don't need to be on the core team to move FeRx forward. There are three
+ways to contribute, in increasing order of involvement — pick whichever fits
+your time and expertise. **All three start or end as a GitHub Issue or PR**, so
+the work stays visible to everyone (see [Communication](sdlc.md#3-communication)).
+
+For the full process behind any of this, see the
+[Development Lifecycle (SDLC)](sdlc.md).
+
+## Test it and tell us what breaks
+
+The single most valuable thing most users can do is **run FeRx on real models
+and data and report where it disagrees** with NONMEM / Monolix / nlmixr2 — or
+where it is slow, unclear, or crashes. Parity with established tools is our top
+priority (see [Gold-standard validation](sdlc.md#7-gold-standard-validation)),
+so a concrete, reproducible mismatch is gold.
+
+- Install per the [Installation](../installation.md) page, then run your model
+  via the CLI or the R package (`ferx_fit()`).
+- Compare the key outputs — **OFV, theta, omega, sigma, ETAs, CWRES/IWRES** —
+  against your reference tool.
+- If something is off, capture the two output sets and the versions, and open
+  an Issue (next section). Even "it ran but the OFV is 30 points off NONMEM" is
+  a useful report.
+
+## Open an Issue
+
+Issues are where all work starts (see [the development
+workflow](sdlc.md#4-the-development-workflow-with-ai)): bug reports, parity
+gaps, feature requests, and docs problems all belong here.
+
+How to write a good one:
+
+- **Search existing issues first** to avoid duplicates.
+- **Bug:** a minimal `.ferx` model + a small data subset that reproduces it,
+  what you expected vs. what you got, and the ferx-core / ferx-r versions.
+- **Parity gap:** attach the NONMEM (or other tool) output and the ferx output
+  side by side, plus the model and data.
+- **Feature:** state **Why, How, and the design choices**, and who benefits.
+  Expect push-back or deferral if it serves a niche of one — see the
+  "Christmas tree" guardrail in [Philosophy and quality
+  bar](sdlc.md#1-philosophy-and-quality-bar).
+- Add it to the GitHub **Project view** so the team has visibility and can
+  triage it.
+
+You don't have to fix what you file — a well-described Issue is a complete
+contribution on its own.
+
+## Open a Pull Request
+
+Ready to write code or docs? The full process is in the
+[SDLC](sdlc.md#4-the-development-workflow-with-ai); the short version for a
+contributor:
+
+1. **Claim the work.** Comment on the Issue you want to take (or open one
+   first) so effort isn't duplicated.
+2. **Branch off the latest `main`** (trunk-based — see [Git
+   workflow](sdlc.md#5-git-workflow)); keep it focused on one issue.
+3. **Test it.** Add a test at the right tier (see the [testing
+   pyramid](sdlc.md#8-cicd-and-quality-gates)); for anything numerical add a
+   NONMEM comparison ([Gold-standard
+   validation](sdlc.md#7-gold-standard-validation)). Every feature needs a
+   test; every bug fix needs a regression test that fails without it.
+4. **Keep both sides in sync.** ferx-core ↔ ferx-r ([Cross-repo
+   synchronization](sdlc.md#10-cross-repo-synchronization)) and docs updated;
+   on the R side, regenerate `man/` and keep `R/*.R` ASCII-only (see [Pull
+   requests](sdlc.md#6-pull-requests)).
+5. **Fill every section of the PR template**, including the cross-repo table.
+6. **Expect review.** Run `/code-review` on large/numerical PRs; anything
+   touching design, the DSL, or estimation also gets a human core-team review.
+7. **Finish the [Definition-of-done checklist](sdlc.md#12-definition-of-done)**
+   before marking it ready.
+
+**Good first contributions:** add a NONMEM-comparison test for a model we don't
+cover yet, improve a docs page, or fix a reproducible bug with a regression
+test. Small, well-tested PRs are the easiest to merge. Large or experimental
+features should be discussed in an Issue first and developed on a long-lived
+feature branch rather than merged in half-working.

--- a/docs/src/development/sdlc.md
+++ b/docs/src/development/sdlc.md
@@ -1,0 +1,495 @@
+# Development Lifecycle (SDLC)
+
+This page describes how the FeRx project is developed across its two coupled
+repositories — **ferx-core** (the Rust NLME engine) and **ferx-r** (the R
+wrapper package) — from idea to release. It is the canonical process document
+for contributors and AI agents working on either repo.
+
+FeRx follows an **iterative, trunk-based continuous-delivery** model (close to
+Agile): small changes flow continuously to `main`, releases are tags, and the
+loop repeats. The scarcest planning/feasibility input is often not engineering
+time but **AI token budget** — treat it as first-class when scoping and
+sequencing work (a heavy multi-agent review or a large refactor is a *cost* to
+plan for, see [§4](#4-the-development-workflow-with-ai)).
+
+> **Scope.** This covers governance, the issue→PR→merge→release flow, the
+> git model, cross-repo synchronization, the testing pyramid, NONMEM
+> validation, and the quality gates enforced by CI. It complements (does not
+> replace) each repo's `CLAUDE.md`, which carries the low-level
+> build/test/style rules.
+>
+> **Want to help?** You don't need to be on the core team — see
+> [Contributing to FeRx development](contributing.md).
+
+---
+
+## 1. Philosophy and quality bar
+
+FeRx is a numerical estimation engine. A wrong answer that *looks* right is
+worse than a crash. Because the project is openly AI-assisted, it is
+(fairly or not) perceived as an "AI-generated" product, which raises — not
+lowers — the bar we hold ourselves to.
+
+**Principles**
+
+- **High quality bar, especially for core numerics.** Aim *higher* than
+  comparable tools on testing and validation. Every numerical result must be
+  reproducible and validated (see [§7](#7-gold-standard-validation)).
+- **Match dev speed to risk.** Fast iteration is welcome for simple,
+  non-core features and fixes. **Deliberately slow down** for anything that
+  touches estimation, likelihood, PK/ODE math, or the `.ferx`/DSL surface.
+- **Parity first, novelty second.** The initial priority is parity with
+  **NONMEM**, then Monolix / nlmixr2. Novel features (copula-IIV, neural ODEs,
+  FREM, …) come *after* the core is trusted. The emphasis will shift toward
+  novel features as the foundation matures.
+- **Avoid FeRx becoming a "Christmas tree"** Not every request belongs in FeRx. Evaluate
+  each issue/PR against the design philosophy and **prioritize the majority of users**.
+  It is fine — expected — to push back, defer, or decline, even for PRs from well-known developers. 
+  Deferral is a valid outcome if feature is not a priority: log it as a backlog issue.
+
+**Gate questions for any incoming issue or PR**
+
+1. Does it fit the design philosophy, or does it bloat the tool?
+2. Does it serve the majority of users, or a niche of one?
+3. For a PR: is the code well-designed, well-documented, and well-tested?
+4. Can it be deferred to a future cycle without harm?
+
+---
+
+## 2. Team and governance
+
+| Role | Members | Responsibility |
+|------|----------------------|----------------|
+| **Core team** (≤ ~5) | TBD | Direction, design authority, merge rights, releases |
+| **Power users / developers** (10+) | TBD |Feature contributions, domain review |
+| **Advisory board** | TBD | Scientific guidance, validation perspective |
+| **Pharma partners** | — | Real-world use cases, guidance |
+
+**Governance guardrails**
+
+- **No single controlling entity.** Explicitly avoid one organization controlling the project's direction.
+- **Avoid a bloated organization.** Keep the decision-making core small and the process lightweight.
+- Design-level decisions (DSL changes, estimation defaults, breaking API
+  changes) require **core-team** sign-off.
+
+---
+
+## 3. Communication
+
+- **Google Chat** for day-to-day coordination.
+- **(Bi-)weekly meetings** for planning and design discussion.
+- **Technical discussion happens on GitHub** — in the relevant Issue or PR —
+  so it is visible, searchable, and tied to the code. Decisions made in chat
+  or meetings that affect design should be written back into the issue/PR.
+
+---
+
+## 4. The development workflow (with AI)
+
+FeRx is developed with Claude Code (CC) as a primary implementer, with humans
+owning intent, design, and final judgment. The standard loop:
+
+1. **Open a Backlog Issue** in the GitHub Project view. Describe the intent
+   clearly — **Why, How, and the design choices**. This gives visibility to
+   the rest of the team and forces the problem to be laid out before code is
+   written.
+2. **Review the issue and agree the design before coding.** Have CC rewrite the
+   issue for clarity, then settle the *approach*. For anything touching
+   estimation, the numerics, or the `.ferx`/DSL surface, this is an explicit
+   **design gate**: write the chosen approach and the alternatives weighed into
+   the Issue (or a short design note) and get **core-team buy-in first** — don't
+   discover the design in the diff. Simple, non-core changes can skip straight
+   to implementation.
+3. **Have CC implement the issue and open the PR.** Fill every section of the
+   [PR template](#6-pull-requests) — including the cross-repo dependency table.
+4. **For large / complex PRs — especially with numerical consequences — run
+   the multi-agent review** (`/code-review` / "ultrareview", at medium or high 
+   effort with up to ~9 agents),
+   then have CC fix what it finds. This is token-expensive: if the budget is
+   tight, schedule it overnight or hand it to someone with budget.
+5. **Produce a NONMEM comparison** of the fit (see
+   [§7](#7-gold-standard-validation)). Wire it into the test suite at the right tier:
+   a real convergence fit → **slow tests**; a simulation or quick numeric
+   check → **regular tests**.
+6. *(Optional, for complex issues)* have **Copilot** review afterward as a
+   second independent pass.
+7. **Large / complex PRs, or anything affecting design or the DSL, always get
+   a human review** in addition to AI review.
+8. **Log any remaining or deferred work as new Issues** — nothing important
+   should live only in a PR comment.
+9. **Manually test an example fit**, ideally on real data and/or a model not
+   already used by CC. If it misbehaves, have CC fix it.
+10. **Merge.** Before merging, confirm the **Rust and R sides are in sync**,
+    documentation is updated, and the feature/fix is fully tested.
+
+> **Rule of thumb on AI autonomy:** let CC move fast on mechanical and
+> non-core work; insert human checkpoints (design discussion, manual fit,
+> human review) precisely where a subtle numerical error would be expensive.
+
+---
+
+## 5. Git workflow
+
+### 5.1 Branching model — trunk-based
+
+**`main` is always the latest code.**
+
+- New feature/fix work is **branched off `main`**.
+- When done (reviewed, tested, in sync), the branch is **merged into `main`**.
+- A **release is a tag on `main`** (e.g. `v0.3.0`); see [§9](#9-releases).
+
+```
+main ──●──●──●──●──●──▶   tag v0.3.0
+        \   /  \   /
+ feat/x  ●─●    \ /
+ fix/y         ●──●
+```
+
+**Trade-off we accept:** `main` is always newest but is *not guaranteed
+release-stable* between tags. We mitigate this with the CI gates in
+[§8](#8-cicd-and-quality-gates) and by treating tagged releases — not arbitrary
+`main` commits — as what we point users at.
+
+> This is intentionally the simplest model. If instability on `main` becomes a
+> recurring problem, the alternative (`dev` + release branches) can be revisited
+> by the core team — but the default is trunk-based.
+
+**Hygiene**
+
+- **Always pull the latest `main` before starting new work**, and branch off it.
+- Keep branches short-lived and focused on one issue.
+- Branch/PR titles follow `type(scope): short description [closes #N]` — see
+  the PR template header for the allowed `type`/`scope` values.
+
+### 5.2 Experimental / large features
+
+Big experimental features (e.g. copula-IIV, neural ODEs, FREM) are the
+exception to "merge small, merge often":
+
+- Develop them on a **long-lived feature branch** until production-ready —
+  **do not** merge them into `main` piece-by-piece in a half-working state.
+- They must be **documented with multiple examples**.
+- They must be **referenced to the literature** (or carry a vignette, if the
+  method is genuinely new).
+
+### 5.3 Git worktrees
+
+By default git checks out one revision per folder, so you work one issue at a
+time. **Worktrees** let you check out multiple branches at once, so CC can work
+several issues in parallel. The cost: local testing is harder (e.g. for the R
+package you must install from the worktree folder).
+
+- **Avoid worktrees** unless you have **two or more complex issues** that can't
+  each be finished quickly.
+- **Always create the worktree off `main`.**
+- **In ferx-r specifically**, use `EnterWorktree` at the start of any session on
+  a non-`main` branch — it stops uncommitted WIP from one chat contaminating
+  another chat that shares the same checkout directory.
+
+---
+
+## 6. Pull requests
+
+Every PR uses `.github/PULL_REQUEST_TEMPLATE.md` and must fill **every**
+section before `gh pr create`. Key sections that exist specifically because of
+how FeRx is built:
+
+- **Cross-repo dependency table** — record the matching ferx-r (or ferx-core)
+  PR and whether it must merge *before / after / together*. If a sibling PR is
+  required but not yet open, mark the PR **Draft**. See [§10](#10-cross-repo-synchronization).
+- **Numerical validation** — reference values vs NONMEM / nlmixr2 / a prior
+  ferx commit (see [§7](#7-gold-standard-validation)).
+- **Breaking changes** — `.ferx` format, `FitResult`/sdtab fields, or public
+  Rust API. sdtab/`FitResult` changes are parsed by ferx-r → link the R PR.
+- **Tests**, **Docs**, **Example**, and the **example-execution checklist**
+  (build ferx-core, rebuild ferx-r against it, run affected examples).
+
+**R-side pre-PR gates (ferx-r)**
+
+- Run `roxygen2::roxygenize()` and **commit the regenerated `man/*.Rd`** — they
+  are checked into the repo and must stay in sync with the `#'` comments in
+  `R/`. Never hand-edit the auto-generated `R/extendr-wrappers.R`.
+- **No non-ASCII characters in `R/*.R`** — `R CMD check --as-cran` requires pure
+  ASCII (use `-` / `...`, not `—` / `…`). Verify before every PR:
+
+  ```bash
+  python3 -c "import glob; [print(f) for f in glob.glob('R/*.R') if any(b>127 for b in open(f,'rb').read())]"
+  ```
+
+**Review requirements**
+
+- All PRs: green CI + at least the AI review pass.
+- Large/complex, numerical, design-, or DSL-affecting PRs: **a human core-team
+  review is mandatory** on top of AI review.
+
+---
+
+## 7. Gold-standard validation
+
+**Every feature that produces numerical results requires a comparison with
+NONMEM output**, and every new feature requires a test (lowest tier that fits).
+
+- NONMEM comparison is **essential for core features**. nlmixr2 parity is a
+  fine *first pass*, but **NONMEM parity is what matters** — unless it's clear
+  nlmixr2 is the better reference.
+- CI has **no NONMEM access**, so commit the **NONMEM output files** alongside
+  the test/docs rather than running NONMEM in CI.
+- Reference NONMEM 7.5+ runs are reproducible in the `pmx` container.
+
+Put the comparison either in the feature's docs page (`docs/src/...`,
+`docs/src/faq.md`, or the relevant `estimation/*.md`) or in the PR description.
+
+---
+
+## 8. CI/CD and quality gates
+
+### 8.1 Testing pyramid
+
+Tests live in three tiers (see `CLAUDE.md` for placement rules). Put a new
+test in the **lowest tier whose constraints it fits**.
+
+| Tier | What | Where | When it runs |
+|------|------|-------|--------------|
+| **1 — Unit** | Smallest helper isolating the behaviour; core functionality, math/predictions, fast numeric checks vs NONMEM (e.g. IPRED for ADVAN1-5). Avoid `fit()`. | inline `#[cfg(test)]` in `src/**` | Every PR. **Whole suite must stay < 10 min** (target seconds). |
+| **2 — Integration** | Public API (`fit()`, `predict()`, …) but returns immediately — `Ok` after a few outer iterations, or an `Err`. **No convergence loops.** | `tests/*.rs` | Compile-checked every PR; run nightly. |
+| **3 — Slow / convergence** | Full population fits to convergence; NONMEM / nlmixr2 fit comparisons. | `tests/*.rs` or `src/`, gated behind `slow-tests` | Nightly (`slow-tests.yml`, 06:00 UTC) + on push to `main` touching estimation code. |
+
+**Real-data tests** are currently **manual** (a handful of models Ron re-runs
+after each major feature) and not yet on GitHub — a known gap to formalize.
+
+### 8.2 CI workflows (ferx-core)
+
+| Workflow | Trigger | Jobs |
+|----------|---------|------|
+| `ci.yml` | PR + push to `main` | `check`, `test` (`--lib --release`), `survival` (TTE feature), `clippy`, `fmt`; **`coverage`** on weekly schedule / manual |
+| `slow-tests.yml` | nightly 06:00 UTC, manual, push to `main` touching estimation paths | Tier-3 fits to convergence (`--features ci,slow-tests --release`, `--no-fail-fast`) |
+| `docs.yml` | push to `main` touching `docs/**` | `mdbook build` → deploy to `gh-pages` |
+| `release.yml` | tag `v*` or manual | GitHub release with generated notes |
+
+> Note: `RAYON_NUM_THREADS=1` is pinned in CI so cargo owns the test
+> parallelism on 2-core runners. Don't remove it.
+
+### 8.3 CI workflows (ferx-r)
+
+`R-CMD-check.yaml` and `test-coverage.yaml`. **ferx-r CI builds ferx-core from
+the commit pinned in `ferx-r/src/rust/Cargo.lock`** — not from latest `main`.
+See [§10](#10-cross-repo-synchronization).
+
+### 8.4 Code-quality thresholds
+
+| Tool | Measures | Target |
+|------|----------|--------|
+| **Codecov** | unit-test line coverage | **>90%**; a PR must not degrade coverage (Codecov comments on PRs) |
+| **CodeFactor** | code quality / smells | **A+** |
+
+`rustfmt` is enforced by the shared pre-commit hook (`git config core.hooksPath
+.githooks`) and by the `fmt` CI job; `clippy` must be clean.
+
+### 8.5 Documentation workflow
+
+Docs are an [mdBook](https://rust-lang.github.io/mdBook/) under `docs/`.
+
+- **Edit only `docs/src/`.** `docs/book/` is generated, git-ignored, and
+  **never committed** — `docs.yml` builds and deploys it to `gh-pages` on every
+  push to `main` touching `docs/**`. Build locally to preview, but leave the
+  output untracked.
+- **New pages must be linked in `docs/src/SUMMARY.md`** or they won't appear in
+  the book.
+- Route user-visible changes to the right page: `model-file/fit-options.md`
+  (`[fit_options]` keys), `model-file/individual-parameters.md` (DSL syntax),
+  `estimation/*.md` (estimator behaviour), `faq.md` (NONMEM / nlmixr2
+  comparisons).
+- On the R side, the `roxygen2`-generated `man/*.Rd` files **are** the docs —
+  regenerate and commit them (see [§6](#6-pull-requests)).
+
+> **To resolve:** the PR template still carries a checkbox "`mdbook build` run
+> and `docs/book/` committed," which contradicts the *never commit `docs/book/`*
+> rule above. The intent is **not** to commit built output — fix the template
+> so the two agree.
+
+### 8.6 Build portability (Enzyme / FD fallback)
+
+ferx-r's autodiff uses the **Enzyme** Rust fork, but the build auto-probes for
+it and **falls back to finite-difference gradients** (`FERX_NO_AUTODIFF=1`) when
+it is absent. Standard-Rust users (Mac / Linux / Windows) and CI rely on this FD
+path to install and run ferx at all.
+
+- **Never silently break or degrade the no-autodiff / FD path.** If a change
+  would, stop and warn. This covers `src/Makevars` (autodiff detection / feature
+  flags), `R/zzz.R`, and any `lib.rs` / `Cargo.toml` / CI change that assumes
+  the Enzyme toolchain is present.
+
+---
+
+## 9. Releases
+
+Trunk-based, so a release is a **tag on `main`**:
+
+1. Confirm `main` is green (CI), ferx-core ↔ ferx-r are in sync, docs are
+   current, and the relevant `Cargo.toml` / `DESCRIPTION` versions are bumped.
+   *(Current: ferx-core `0.1.6`, ferx-r `0.1.5`.)*
+2. Tag `main` with `vX.Y.Z` (e.g. `v0.3.0`). `release.yml` builds the GitHub
+   release and generates notes.
+3. Point users at the **tagged release**, not an arbitrary `main` commit.
+4. For an R-side release, ensure `Cargo.lock` pins the intended ferx-core
+   commit (see below) so the build is reproducible.
+
+**Versioning.** Both repos follow **semantic versioning** (`MAJOR.MINOR.PATCH`).
+A breaking change to the `.ferx` format, the public Rust API, or sdtab /
+`FitResult` fields bumps MAJOR (pre-1.0, bump MINOR); a backward-compatible
+feature bumps MINOR; a fix bumps PATCH. The PR template's *Breaking changes*
+section is what flags that a MAJOR/MINOR bump is due.
+
+**Changelog.** ferx-core keeps a hand-curated `CHANGELOG.md` (Keep a Changelog
+format); add an `[Unreleased]` entry **in the same PR** as any user-facing
+change — `CLAUDE.md` carries the rule. ferx-r keeps the equivalent `NEWS.md`, so
+a cross-repo change may touch both. `release.yml` additionally auto-generates
+GitHub release notes from merged PRs, so keep PR titles in `type(scope): …`
+form. User-facing breaking changes also carry **migration notes** (PR template).
+
+**Distribution.** Releases are **GitHub releases** built by `release.yml` on
+each `vX.Y.Z` tag. Today ferx-core is consumed as a **git dependency** (not
+published to crates.io) and ferx-r is installed from source / GitHub
+(`R CMD INSTALL`, e.g. `remotes::install_github`). If we later publish to
+crates.io or a CRAN-style channel, add that publish step here.
+
+---
+
+## 10. Cross-repo synchronization
+
+The two repos are coupled, and keeping them in sync is a first-class part of
+the lifecycle — **a PR is not "done" until both sides agree.**
+
+**Local builds (automatic).** ferx-r's `src/rust/.cargo/config.toml` carries a
+`[patch]` that swaps in `../../../ferx-core` when this checkout exists, so
+**local** R builds pick up ferx-core changes with no Cargo edits. Verify a
+ferx-core change by rebuilding the R package:
+
+```bash
+cargo build --release                       # ferx-core
+cd ../ferx-r && FERX_NO_AUTODIFF=1 R CMD INSTALL .
+```
+
+> **Never commit a `Cargo.toml` that flips the ferx-core dep to a path
+> dependency.** ferx-r's `src/rust/Cargo.toml` pins ferx-core as a git dep on
+> `main`; the `[patch]` already handles the local swap. A committed path dep
+> breaks reviewers and CI, which build against GitHub `main`.
+
+**ferx-r CI (manual bump required).** CI does **not** get the change
+automatically — it builds from the ferx-core commit pinned in
+`ferx-r/src/rust/Cargo.lock`. A ferx-r PR that needs a new ferx-core commit
+(e.g. a newly-`pub` API) must bump that lock with:
+
+```bash
+ferx-r/tools/update-ferx-core-lock.sh        # never a bare `cargo update`
+```
+
+A bare `cargo update` unpins the patch and CI fails with
+`error[E0603]: ... is private`.
+
+**Checklist when changing a `pub` API or `FitResult`/sdtab field**
+
+- [ ] Open the matching ferx-r PR and record it in the PR cross-repo table.
+- [ ] Bump `Cargo.lock` in ferx-r via `update-ferx-core-lock.sh`.
+- [ ] Confirm the R package compiles against the new ferx-core.
+- [ ] Update docs on both sides.
+- [ ] Coverage not degraded.
+
+---
+
+## 11. Tooling conventions
+
+- **Model:** use **Opus 4.6 or better** for development. **Never Sonnet or
+  Haiku** for code (Sonnet is acceptable only for documentation). _(Newer Opus
+  releases — 4.7, 4.8 — supersede 4.6 under the same rule.)_
+- **Pre-commit hook:** `git config core.hooksPath .githooks` after cloning
+  (blocks commits failing `rustfmt`).
+- **AD-reachable code:** never use `f64::max`/`min` in autodiff-instrumented
+  paths — see the autodiff section of `CLAUDE.md`.
+
+---
+
+## 12. Definition of done
+
+A change is done only when **all** of the following hold:
+
+- [ ] Implements the issue's stated intent; design choices discussed where open.
+- [ ] Tests added at the correct tier; whole fast suite still < 10 min.
+- [ ] NONMEM comparison included for any numerical behaviour.
+- [ ] CI green: `check`, `test`, `survival`, `clippy`, `fmt`; coverage not degraded.
+- [ ] AI review run (and human review for large/numerical/DSL/design PRs).
+- [ ] Docs updated (`docs/src/**`, examples) for any user-visible change.
+- [ ] ferx-core ↔ ferx-r in sync (R package compiles; `Cargo.lock` bumped if needed).
+- [ ] R-side (if touched): `man/` regenerated & committed, `R/*.R` pure ASCII,
+      no-autodiff/FD build path still installs.
+- [ ] Deferred/remaining work logged as new Issues.
+- [ ] Manually tested on an example fit (ideally real / novel data).
+
+---
+
+## 13. Maintenance & support
+
+Work doesn't stop at a release — most of an estimation engine's life is bug
+reports, parity questions, and follow-up fixes.
+
+**Bug triage.** User-reported problems land as GitHub Issues (see
+[Contributing](contributing.md)) and are labelled and prioritized in the Project
+view. Reproduce first; a confirmed bug gets a **failing regression test before
+the fix** (see [§8](#8-cicd-and-quality-gates)). Correctness bugs in the core
+numerics outrank cosmetic issues.
+
+**Patch / hotfix releases.** Trunk-based keeps `main` as the newest code, which
+is the easy case: an urgent fix branches off `main`, merges, and ships as a
+**PATCH tag** (`vX.Y.Z+1`). If `main` already carries unreleased work that
+shouldn't go out yet, cherry-pick the fix onto the **latest release tag** on a
+short-lived `release/vX.Y` branch and tag the patch from there — this is the
+explicit answer to trunk-based's "`main` isn't always release-stable"
+trade-off ([§5](#5-git-workflow)). A cross-repo fix must keep ferx-core ↔ ferx-r
+in sync ([§10](#10-cross-repo-synchronization)).
+
+**Deprecation & breaking changes.** Avoid silent breaks. A breaking change to
+the `.ferx` format, the public API, or sdtab / `FitResult` fields must be
+flagged in the PR template's *Breaking changes* section, carry **migration
+notes**, bump the version ([§9](#9-releases)), and be announced in the release
+notes / `NEWS.md`. Where practical, **deprecate with a warning for one release**
+before removing.
+
+**Supported versions & support channel.** We support the **latest release** and
+encourage users to upgrade; old release lines aren't maintained unless a
+security fix demands it. User-facing support is via **GitHub Issues**; internal
+coordination via Google Chat ([§3](#3-communication)).
+
+---
+
+## 14. Security & dependencies
+
+FeRx is a numerical library, not a network service, so its attack surface is
+small — but it ships native code (FFI via extendr), an unusual toolchain (the
+Enzyme Rust fork), and a tree of crate / R dependencies, all of which need
+hygiene. We aim for a lightweight **DevSecOps** posture: push these checks into
+CI rather than bolt them on later.
+
+**Dependency hygiene.** Keep dependencies current and watch for advisories:
+
+- Run **`cargo audit`** (RUSTSEC advisory DB) over the Rust tree — wired into CI
+  as `.github/workflows/audit.yml` (on dependency-file changes, weekly, and on
+  demand).
+- **Dependabot** (`.github/dependabot.yml`) opens weekly `cargo` and
+  `github-actions` update PRs for ferx-core. *(ferx-r: still to add.)*
+- Treat the **Enzyme toolchain** as supply-chain surface: pin it, and never let
+  a toolchain change silently break the FD-fallback path
+  ([§8](#8-cicd-and-quality-gates)).
+
+**Native / unsafe code.** Review any `unsafe` and the **extendr FFI boundary**
+(`src/rust/src/lib.rs` in ferx-r) with extra care — a memory-safety bug there
+can crash the host R session. Prefer safe abstractions; justify any `unsafe` in
+the PR.
+
+**Vulnerability reporting.** Report suspected vulnerabilities **privately**, not
+in a public Issue — ferx-core's [`SECURITY.md`](https://github.com/FeRx-NLME/ferx-core/security/policy)
+documents the GitHub private-advisory flow. *(ferx-r: `SECURITY.md` still to
+add.)*
+
+**Security-sensitive changes.** For changes that parse untrusted input, do file
+I/O, or touch the FFI boundary, run the **`/security-review`** skill (or request
+a focused human review) before merge.


### PR DESCRIPTION
## Why
The project had no written, shared development process spanning **ferx-core** and **ferx-r**, and no project changelog. This adds both, based on the team's `FeRx_dev_workflow` notes and grounded in the actual CI workflows, PR template, and both repos' `CLAUDE.md` files. It also fills the gaps found when comparing against a canonical 7-phase SDLC.

## What changed
Docs-only + process. New **Development** part of the mdBook:

- **`docs/src/development/sdlc.md`** — Development Lifecycle: philosophy & quality bar, governance, the AI dev workflow (with an explicit *design gate*), trunk-based git model, PRs, gold-standard (NONMEM) validation, the testing pyramid + CI quality gates, **releases & semver**, cross-repo synchronization, tooling conventions, definition of done, **maintenance & support** (incl. the trunk-based hotfix flow), and **security & dependencies**.
- **`docs/src/development/contributing.md`** — contributor on-ramp (test & report, open Issues, open PRs).
- **`docs/src/development/README.md`** + **`SUMMARY.md`** — wire up the new part.
- **`CHANGELOG.md`** — new Keep-a-Changelog / semver file, seeded from real history since `v0.1.5`.
- **`CLAUDE.md`** — new "Changelog" section requiring an `[Unreleased]` entry per user-facing change.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — resolve the `docs/book` "committed vs never-committed" contradiction; add a CHANGELOG checkbox.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r is *described* by this doc but unchanged; a follow-up could link to the published SDLC from ferx-r's README.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / process only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (docs/process only; mdBook builds cleanly)

## Docs
- [x] `docs/src/` updated
- [x] New pages linked in `docs/src/SUMMARY.md` (`docs/book/` not committed)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (the SDLC/Contributing docs themselves)

## Reviewer hints
- Two items in the SDLC are **prescriptive / not yet implemented** and intentionally flagged as such: `cargo audit`/Dependabot/`SECURITY.md` (§14) and a core `CHANGELOG.md` (now added). 
- The git model is documented as **trunk-based** per the team decision; the `dev`+release alternative is noted as a fallback.
- `CHANGELOG.md` `[Unreleased]` is a reasonable seed from history, not an exhaustive audit; issue/PR numbers came from commit messages.

## Open questions
- Placement of Maintenance/Security as §13–14 (after Definition of done) was chosen to avoid renumbering/anchor churn — fine, or prefer them right after Releases?
- Should ferx-r get a matching link to this SDLC, and a `SECURITY.md` in both repos as a quick follow-up?