### PR TITLE
test: raise coverage to >90% (io/output, dual numbers, CLI binaries)

### DIFF
--- a/src/ad/dual.rs
+++ b/src/ad/dual.rs
@@ -149,3 +149,100 @@ impl PartialOrd for Dual {
         self.val.partial_cmp(&other.val)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Dual;
+
+    const TOL: f64 = 1e-9;
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < TOL
+    }
+
+    #[test]
+    fn constructors_set_value_and_seed_derivative() {
+        assert_eq!(Dual::new(2.0, 3.0).deriv, 3.0);
+        assert_eq!(Dual::constant(2.0).deriv, 0.0);
+        assert_eq!(Dual::variable(2.0).deriv, 1.0);
+    }
+
+    #[test]
+    fn exp_ln_sqrt_derivatives() {
+        // d/dx e^x at x=1 → e, e.
+        let e = Dual::variable(1.0).exp();
+        assert!(close(e.val, std::f64::consts::E) && close(e.deriv, std::f64::consts::E));
+        // d/dx ln(x) at x=2 → ln2, 0.5.
+        let l = Dual::variable(2.0).ln();
+        assert!(close(l.val, 2.0_f64.ln()) && close(l.deriv, 0.5));
+        // d/dx sqrt(x) at x=4 → 2, 0.25.
+        let s = Dual::variable(4.0).sqrt();
+        assert!(close(s.val, 2.0) && close(s.deriv, 0.25));
+        // sqrt at 0 → value 0, derivative floored to 0 (no divide-by-zero).
+        let s0 = Dual::variable(0.0).sqrt();
+        assert!(close(s0.val, 0.0) && close(s0.deriv, 0.0));
+        // ln floors the argument at 1e-30 for non-positive input.
+        let lneg = Dual::variable(-1.0).ln();
+        assert!(lneg.val.is_finite());
+    }
+
+    #[test]
+    fn abs_branches() {
+        let pos = Dual::new(3.0, 1.0).abs();
+        assert!(close(pos.val, 3.0) && close(pos.deriv, 1.0));
+        let neg = Dual::new(-3.0, 1.0).abs();
+        assert!(close(neg.val, 3.0) && close(neg.deriv, -1.0));
+    }
+
+    #[test]
+    fn powf_and_powi() {
+        // d/dx x^3 at x=2 → 8, 12 (powf with constant exponent).
+        let p = Dual::variable(2.0).powf(Dual::constant(3.0));
+        assert!(close(p.val, 8.0) && close(p.deriv, 12.0));
+        // non-positive base short-circuits to constant 0.
+        let p0 = Dual::variable(-2.0).powf(Dual::constant(2.0));
+        assert!(close(p0.val, 0.0) && close(p0.deriv, 0.0));
+        // powi: d/dx x^3 at x=2 → 8, 12.
+        let pi = Dual::variable(2.0).powi(3);
+        assert!(close(pi.val, 8.0) && close(pi.deriv, 12.0));
+    }
+
+    #[test]
+    fn max_picks_branch_and_kills_derivative_when_clamped() {
+        let kept = Dual::new(7.0, 1.0).max(5.0);
+        assert!(close(kept.val, 7.0) && close(kept.deriv, 1.0));
+        let clamped = Dual::new(2.0, 1.0).max(5.0);
+        assert!(close(clamped.val, 5.0) && close(clamped.deriv, 0.0));
+    }
+
+    #[test]
+    fn arithmetic_follows_calculus_rules() {
+        let x = Dual::variable(3.0); // val 3, deriv 1
+        let y = Dual::new(2.0, 0.0); // val 2, deriv 0
+        let add = x + y;
+        assert!(close(add.val, 5.0) && close(add.deriv, 1.0));
+        let sub = x - y;
+        assert!(close(sub.val, 1.0) && close(sub.deriv, 1.0));
+        // product rule: d(xy) = x'y + xy' = 1*2 + 3*0 = 2.
+        let mul = x * y;
+        assert!(close(mul.val, 6.0) && close(mul.deriv, 2.0));
+        // quotient rule: d(x/y) = (x'y - xy')/y² = (1*2 - 3*0)/4 = 0.5.
+        let div = x / y;
+        assert!(close(div.val, 1.5) && close(div.deriv, 0.5));
+        // divide-by-(near)zero short-circuits to constant 0.
+        let div0 = x / Dual::constant(0.0);
+        assert!(close(div0.val, 0.0) && close(div0.deriv, 0.0));
+        // negation flips both components.
+        let neg = -x;
+        assert!(close(neg.val, -3.0) && close(neg.deriv, -1.0));
+    }
+
+    #[test]
+    fn eq_and_ord_compare_value_only() {
+        // Equality ignores the derivative component.
+        assert_eq!(Dual::new(2.0, 1.0), Dual::new(2.0, 9.0));
+        assert_ne!(Dual::new(2.0, 1.0), Dual::new(3.0, 1.0));
+        assert!(Dual::new(1.0, 5.0) < Dual::new(2.0, 0.0));
+        assert!(Dual::new(2.0, 0.0) > Dual::new(1.0, 5.0));
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -3187,6 +3187,48 @@ mod iov_integration {
         );
     }
 
+    // ── Test: IMP in a chained methods sequence + IOV exercises the IS IOV path ─
+    // `methods = [foce, imp]` on a kappa-bearing model drives the importance-
+    // sampling marginal-likelihood step through its IOV branch
+    // (`obs_nll_iov_fixed_kappa`, `compute_posterior_hessian`,
+    // `subject_is_estimate`, `build_proposals`). κ is held at its EBE, so the
+    // reported −2LL is a partial marginal (see `KappaTreatment::FixedAtMode`).
+    #[test]
+    fn test_iov_imp_chain_runs_importance_sampling() {
+        let model = make_iov_model();
+        let pop = make_iov_population();
+        let mut opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+        opts.methods = vec![EstimationMethod::Foce, EstimationMethod::Imp];
+        opts.is_samples = 200; // keep the per-subject sampling cheap
+        opts.is_seed = Some(42); // deterministic proposal draws
+        let result = fit(&model, &pop, &model.default_params, &opts);
+        assert!(
+            result.is_ok(),
+            "FOCE→IMP chain with IOV must succeed, got: {:?}",
+            result.err()
+        );
+        let fr = result.unwrap();
+        let is = fr
+            .importance_sampling
+            .as_ref()
+            .expect("importance_sampling result must be populated by the IMP stage");
+        assert!(
+            is.minus2_log_likelihood.is_finite(),
+            "IS marginal −2LL must be finite, got {}",
+            is.minus2_log_likelihood
+        );
+        assert!(
+            is.mc_standard_error.is_finite() && is.mc_standard_error >= 0.0,
+            "IS Monte-Carlo SE must be finite and non-negative, got {}",
+            is.mc_standard_error
+        );
+        assert_eq!(is.n_samples, 200, "n_samples should echo the IS budget");
+        assert!(
+            fr.omega_iov.is_some(),
+            "omega_iov must survive into the IS-augmented result"
+        );
+    }
+
     // ── Test: trust-region optimizer + IOV must return Err ────────────────────
     // trust_region.rs currently passes `&[]` for kappas to pop_nll, which would
     // silently route the OFV through the non-IOV path. Guard at api.rs blocks

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2947,4 +2947,82 @@ mod tests {
             result.ofv,
         );
     }
+
+    // ── built-in BFGS optimizer (non-NLopt path) ─────────────────────────────
+
+    /// Drives the `Optimizer::Bfgs` branch of `optimize_population` for a few
+    /// outer iterations. Exercises `optimize_bfgs`, `bfgs_update`, and
+    /// `backtracking_line_search_warm` end-to-end on a tiny 1-cpt IV problem
+    /// without running to convergence (fast, Tier-1).
+    #[test]
+    fn bfgs_optimizer_runs_and_improves_ofv() {
+        use crate::types::{EstimationMethod, FitOptions, Optimizer};
+        let model = make_model();
+        let population = make_population(4);
+        let opts = FitOptions {
+            method: EstimationMethod::Foce,
+            optimizer: Optimizer::Bfgs,
+            outer_maxiter: 5,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+
+        // OFV at the initial point, for an improvement comparison.
+        let init_ofv = {
+            let init = optimize_population(
+                &model,
+                &population,
+                &model.default_params,
+                &FitOptions {
+                    optimizer: Optimizer::Bfgs,
+                    outer_maxiter: 0,
+                    run_covariance_step: false,
+                    ..opts.clone()
+                },
+            );
+            init.ofv
+        };
+
+        let result = optimize_population(&model, &population, &model.default_params, &opts);
+        assert!(result.ofv.is_finite(), "BFGS produced non-finite OFV");
+        assert_eq!(result.eta_hats.len(), population.subjects.len());
+        // Built-in BFGS does not export a final gradient (NLopt-only field).
+        assert!(result.final_gradient.is_none());
+        // A handful of iterations should not make the OFV worse.
+        assert!(
+            result.ofv <= init_ofv + 1e-6,
+            "BFGS worsened OFV: init={init_ofv:.4} final={:.4}",
+            result.ofv
+        );
+    }
+
+    // ── global pre-search (CRS2-LM) ──────────────────────────────────────────
+
+    /// Exercises the `run_global_presearch` branch. CRS2-LM may be absent from
+    /// the linked NLopt build; in that case the pre-search returns `Err` and a
+    /// `global_search disabled` warning is recorded. Either way the run must
+    /// finish with a finite OFV — this test just ensures the branch is taken
+    /// and handled gracefully (small `global_maxeval` keeps it fast).
+    #[test]
+    fn global_presearch_branch_runs_or_warns() {
+        use crate::types::{EstimationMethod, FitOptions, Optimizer};
+        let model = make_model();
+        let population = make_population(4);
+        let opts = FitOptions {
+            method: EstimationMethod::Foce,
+            optimizer: Optimizer::Bobyqa,
+            outer_maxiter: 3,
+            global_search: true,
+            global_maxeval: 8,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+        let result = optimize_population(&model, &population, &model.default_params, &opts);
+        assert!(
+            result.ofv.is_finite(),
+            "presearch run produced non-finite OFV"
+        );
+    }
 }

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2356,6 +2356,187 @@ mod tests {
         }
     }
 
+    /// IOV M-step gradient (`obs_nll_subject_grad_iov`) must match the forward-FD
+    /// of `obs_nll_subject_into_iov` in log-packed space. This guards the
+    /// analytical gradient that the gradient-based M-step would use — it is not
+    /// exercised by the default BOBYQA M-step (derivative-free), so without this
+    /// direct test the function is untested. Single subject, 2 occasions, κ on CL.
+    #[test]
+    fn obs_nll_subject_grad_iov_matches_fd() {
+        use crate::types::{
+            BloqMethod, CompiledModel, DoseEvent, ErrorModel, ErrorSpec, GradientMethod,
+            ModelParameters, OmegaMatrix, PkModel, PkParams, ScalingSpec, SigmaVector, Subject,
+        };
+        use std::collections::HashMap;
+
+        // Minimal IOV model: CL = TVCL·exp(ETA_CL + KAPPA_CL), V = TVV.
+        let model = CompiledModel {
+            name: "iov_grad_test".into(),
+            pk_model: PkModel::OneCptIv,
+            error_model: ErrorModel::Proportional,
+            error_spec: ErrorSpec::Single(ErrorModel::Proportional),
+            pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
+                let mut p = PkParams::default();
+                let kappa = if eta.len() > 1 { eta[1] } else { 0.0 };
+                p.values[0] = theta[0] * (eta[0] + kappa).exp();
+                p.values[1] = theta[1];
+                p
+            }),
+            n_theta: 2,
+            n_eta: 1,
+            n_epsilon: 1,
+            n_kappa: 1,
+            kappa_names: vec!["KAPPA_CL".into()],
+            theta_names: vec!["TVCL".into(), "TVV".into()],
+            eta_names: vec!["ETA_CL".into()],
+            indiv_param_names: vec!["CL".into(), "V".into()],
+            indiv_param_partials: crate::types::IndivParamPartials::empty(),
+            default_params: ModelParameters {
+                theta: vec![5.0, 50.0],
+                theta_names: vec!["TVCL".into(), "TVV".into()],
+                theta_lower: vec![0.1, 5.0],
+                theta_upper: vec![50.0, 500.0],
+                theta_fixed: vec![false; 2],
+                omega: OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]),
+                omega_fixed: vec![false],
+                sigma: SigmaVector {
+                    values: vec![0.05],
+                    names: vec!["PROP_ERR".into()],
+                },
+                sigma_fixed: vec![false],
+                omega_iov: Some(OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()])),
+                kappa_fixed: vec![false],
+            },
+            omega_init_as_sd: vec![false],
+            sigma_init_as_sd: vec![false],
+            kappa_init_as_sd: vec![false],
+            mu_refs: HashMap::new(),
+            kappa_mu_refs: HashMap::new(),
+            tv_fn: None,
+            pk_indices: vec![0, 1],
+            eta_map: vec![0],
+            pk_idx_f64: vec![0.0, 1.0],
+            sel_flat: vec![1.0, 0.0],
+            ode_spec: None,
+            diffusion_theta_start: None,
+            diffusion_state_indices: Vec::new(),
+            bloq_method: BloqMethod::Drop,
+            referenced_covariates: Vec::new(),
+            gradient_method: GradientMethod::Fd,
+            parse_warnings: Vec::new(),
+            eta_param_info: Vec::new(),
+            theta_transform: Vec::new(),
+            #[cfg(feature = "nn")]
+            covariate_nns: Vec::new(),
+            scaling: ScalingSpec::None,
+            log_transform: false,
+            dv_pre_logged: false,
+        };
+
+        // One subject, 2 occasions (times 1–3 occ 1, 4–6 occ 2), one dose each.
+        let subject = Subject {
+            id: "S1".into(),
+            doses: vec![
+                DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+                DoseEvent::new(3.5, 100.0, 1, 0.0, false, 0.0),
+            ],
+            obs_times: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            observations: vec![36.0, 28.0, 21.0, 34.0, 26.0, 19.0],
+            obs_cmts: vec![1; 6],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; 6],
+            occasions: vec![1, 1, 1, 2, 2, 2],
+            dose_occasions: vec![1, 2],
+        };
+
+        let theta = vec![5.0f64, 50.0];
+        let sigma = vec![0.05f64];
+        let eta = vec![0.1f64];
+        let kappas: Vec<Vec<f64>> = vec![vec![0.05], vec![-0.05]]; // one per occasion
+        let n_theta = 2;
+        let n_sigma = 1;
+        let n = n_theta + n_sigma;
+
+        let mut scratch = EventPkParams::default();
+        let (nll, grad) = obs_nll_subject_grad_iov(
+            &model,
+            &subject,
+            &theta,
+            &sigma,
+            &eta,
+            &kappas,
+            &[true, true, true],
+            &[-1e30; 3],
+            &[1e30; 3],
+            n_theta,
+            n_sigma,
+            &mut scratch,
+        );
+
+        // Reference: forward-FD of obs_nll_subject_into_iov in log-packed space.
+        let f0 = obs_nll_subject_into_iov(
+            &model,
+            &subject,
+            &theta,
+            &sigma,
+            &eta,
+            &kappas,
+            &mut scratch,
+        );
+        assert!((nll - f0).abs() < 1e-10, "nll mismatch: {nll} vs {f0}");
+
+        let h = 1e-6;
+        let mut ref_grad = vec![0.0f64; n];
+        for i in 0..n_theta {
+            let mut tp = theta.clone();
+            tp[i] += h;
+            let fp = obs_nll_subject_into_iov(
+                &model,
+                &subject,
+                &tp,
+                &sigma,
+                &eta,
+                &kappas,
+                &mut scratch,
+            );
+            ref_grad[i] = theta[i] * (fp - f0) / h; // d/d_log = theta · d/d_theta
+        }
+        {
+            let mut sp = sigma.clone();
+            sp[0] += h;
+            let fp = obs_nll_subject_into_iov(
+                &model,
+                &subject,
+                &theta,
+                &sp,
+                &eta,
+                &kappas,
+                &mut scratch,
+            );
+            ref_grad[n_theta] = sigma[0] * (fp - f0) / h;
+        }
+
+        for j in 0..n {
+            let rel = if ref_grad[j].abs() > 1e-8 {
+                (grad[j] - ref_grad[j]).abs() / ref_grad[j].abs()
+            } else {
+                (grad[j] - ref_grad[j]).abs()
+            };
+            assert!(
+                rel < 1e-4,
+                "grad[{j}]: analytical={:.6e}, fd={:.6e}, rel={:.2e}",
+                grad[j],
+                ref_grad[j],
+                rel
+            );
+        }
+    }
+
     /// Per-CMT (multi-endpoint) M-step gradient must match the forward-FD of
     /// `obs_nll_sum` — the correctness gate for the per-CMT `dvar_df` /
     /// `dvar_dlogsigma` score terms. Two endpoints with *different* error

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1576,4 +1576,320 @@ mod tests {
             id_col
         );
     }
+
+    // ── fmt_num / fixed_label: pure formatting helpers ───────────────────────
+
+    #[test]
+    fn fmt_num_nan_is_blank_finite_is_six_dp() {
+        assert_eq!(fmt_num(f64::NAN), "");
+        assert_eq!(fmt_num(1.5), "1.500000");
+        assert_eq!(fmt_num(0.0), "0.000000");
+        assert_eq!(fmt_num(-2.25), "-2.250000");
+    }
+
+    #[test]
+    fn fixed_label_appends_fix_tag() {
+        assert_eq!(fixed_label("CL"), "CL [FIX]");
+    }
+
+    // ── write_sdtab_csv: round-trips through the file writer ──────────────────
+
+    #[test]
+    fn write_sdtab_csv_emits_header_and_blanks_nan_residuals() {
+        // One subject, two observations; the second observation is BLOQ, so its
+        // CWRES/IWRES are NaN and must serialize to an empty cell, not "NaN".
+        let sr = SubjectResult {
+            id: "7".to_string(),
+            eta: nalgebra::DVector::zeros(0),
+            ipred: vec![10.0, 5.0],
+            pred: vec![11.0, 6.0],
+            iwres: vec![0.25, f64::NAN],
+            cwres: vec![-0.5, f64::NAN],
+            ofv_contribution: 3.0,
+            cens: vec![0, 1],
+            n_obs: 2,
+        };
+        let result = minimal_sdtab_result(vec![sr]);
+        let population = Population {
+            subjects: vec![sdtab_subject("7", 2, vec![1, 1])],
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("sdtab.csv");
+        write_sdtab_csv(&result, &population, path.to_str().unwrap()).expect("sdtab write");
+        let csv = std::fs::read_to_string(&path).expect("sdtab read");
+
+        let mut lines = csv.lines();
+        let header = lines.next().expect("header line");
+        assert!(header.starts_with("ID,TIME,DV"), "header={header}");
+        // Subject is BLOQ on one row → CENS column appears.
+        assert!(header.contains("CENS"), "CENS column expected: {header}");
+        assert!(header.contains("CWRES") && header.contains("IWRES"));
+
+        let rows: Vec<&str> = lines.collect();
+        assert_eq!(rows.len(), 2, "two observation rows expected");
+        // Numeric ID is preserved verbatim (parses to 7.0).
+        assert!(rows[0].starts_with("7.000000,"));
+        // BLOQ row: trailing CWRES/IWRES cells are blank (empty between commas).
+        assert!(
+            rows[1].contains(",,"),
+            "NaN residuals should be blank cells, got: {}",
+            rows[1]
+        );
+    }
+
+    // ── write_covtab_csv: CSV escaping + NaN-as-blank ────────────────────────
+
+    #[test]
+    fn write_covtab_csv_escapes_ids_and_blanks_missing() {
+        use crate::types::{CovariateKind, CovariateRow, CovariateTable};
+        let table = CovariateTable {
+            names: vec!["WT".to_string(), "SEX".to_string()],
+            kinds: vec![CovariateKind::Continuous, CovariateKind::Categorical],
+            rows: vec![
+                CovariateRow {
+                    id: "A,1".to_string(), // comma must be quoted by the csv writer
+                    time: 0.0,
+                    evid: 1,
+                    values: vec![70.0, 1.0],
+                },
+                CovariateRow {
+                    id: "B".to_string(),
+                    time: 1.5,
+                    evid: 0,
+                    values: vec![f64::NAN, 0.0], // missing WT → blank cell
+                },
+            ],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("covtab.csv");
+        write_covtab_csv(&table, path.to_str().unwrap()).expect("covtab write");
+        let csv = std::fs::read_to_string(&path).expect("covtab read");
+
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(lines[0], "ID,TIME,EVID,WT,SEX");
+        // ID with a comma is quoted, not split across columns.
+        assert!(
+            lines[1].starts_with("\"A,1\",0.000000,1,70.000000,1.000000"),
+            "row 1 escaping wrong: {}",
+            lines[1]
+        );
+        // Missing WT serializes to an empty cell.
+        assert_eq!(lines[2], "B,1.500000,0,,0.000000");
+    }
+
+    // ── parameter_table: theta / omega / sigma rows ──────────────────────────
+
+    fn full_param_result(se_theta: Option<Vec<f64>>) -> FitResult {
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.theta = vec![2.0, 0.0];
+        r.theta_names = vec!["CL".to_string(), "ZERO".to_string()];
+        r.theta_fixed = vec![false, true];
+        r.se_theta = se_theta;
+        r.omega = DMatrix::from_row_slice(2, 2, &[0.09, 0.01, 0.01, 0.04]);
+        r.eta_names = vec!["ETA_CL".to_string(), "ETA_V".to_string()];
+        r
+    }
+
+    #[test]
+    fn parameter_table_lists_theta_omega_sigma_with_se() {
+        let table = parameter_table(&full_param_result(Some(vec![0.2, 0.0])));
+        assert!(table.contains("Parameter") && table.contains("Type"));
+        // THETA row carries an SE and a finite %RSE.
+        let cl = table.lines().find(|l| l.starts_with("CL")).expect("CL row");
+        assert!(cl.contains("THETA") && cl.contains("0.200000"), "{cl}");
+        // OMEGA lower triangle: (1,1),(2,1),(2,2).
+        assert!(table.contains("OMEGA(1,1)"));
+        assert!(table.contains("OMEGA(2,1)"));
+        assert!(table.contains("OMEGA(2,2)"));
+        assert!(table.contains("SIGMA(1)"));
+    }
+
+    #[test]
+    fn parameter_table_dashes_se_when_absent() {
+        let table = parameter_table(&full_param_result(None));
+        let cl = table.lines().find(|l| l.starts_with("CL")).expect("CL row");
+        // No covariance run → SE/%RSE rendered as "---".
+        assert!(cl.contains("---"), "{cl}");
+    }
+
+    // ── print_results: stderr smoke test (exercises both header branches) ────
+
+    #[test]
+    fn print_results_smoke_single_and_chain() {
+        // Single-method, with SEs and a fixed theta.
+        print_results(&full_param_result(Some(vec![0.2, 0.0])));
+        // Method chain (>1) + no SEs → the alternate header + "N/A" branch.
+        let mut chained = full_param_result(None);
+        chained.method_chain = vec![EstimationMethod::Saem, EstimationMethod::FoceI];
+        chained.converged = false;
+        print_results(&chained);
+    }
+
+    // ── comprehensive report fixtures: exercise every optional section ────────
+
+    use crate::types::{ImportanceSamplingResult, KappaTreatment};
+
+    /// A FitResult with *every* optional reporting section populated: free +
+    /// fixed thetas with SEs, a 2×2 block omega (off-diagonal correlation),
+    /// a combined (proportional + additive) sigma, a 2×2 block omega_iov,
+    /// importance-sampling results with a low-ESS subject, SIR CIs for
+    /// theta/omega/sigma, eta/eps/kappa shrinkage (with a NaN entry), a
+    /// computed covariance, and a warning. Drives the maximal branch coverage
+    /// of both `print_results` and `write_estimates_yaml` in one pass.
+    fn comprehensive_result() -> FitResult {
+        let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.1, 0.5]);
+        // theta: one free (with SE), one fixed.
+        r.theta = vec![2.0, 0.0];
+        r.theta_names = vec!["CL".into(), "BASE".into()];
+        r.theta_fixed = vec![false, true];
+        r.se_theta = Some(vec![0.2, 0.0]);
+        // omega: 2×2 block with an off-diagonal; second eta fixed; param_corr
+        // left None so the correlation fallback path is taken.
+        r.omega = DMatrix::from_row_slice(2, 2, &[0.09, 0.02, 0.02, 0.04]);
+        r.eta_names = vec!["ETA_CL".into(), "ETA_V".into()];
+        r.omega_fixed = vec![false, true];
+        r.se_omega = Some(vec![0.01, 0.0]);
+        r.omega_param_corr = None;
+        // sigma: combined → [Proportional, Additive]; one fixed.
+        r.sigma_fixed = vec![false, true];
+        r.se_sigma = Some(vec![0.01, 0.02]);
+        // omega_iov: 2×2 block kappa with an off-diagonal; second kappa fixed.
+        r.omega_iov = Some(DMatrix::from_row_slice(2, 2, &[0.05, 0.01, 0.01, 0.03]));
+        r.kappa_names = vec!["KAPPA_CL".into(), "KAPPA_V".into()];
+        r.kappa_fixed = vec![false, true];
+        r.se_kappa = Some(vec![0.005, 0.0]);
+        r.omega_iov_param_corr = None;
+        // importance sampling, with a low-ESS subject.
+        r.importance_sampling = Some(ImportanceSamplingResult {
+            minus2_log_likelihood: -1234.5,
+            mc_standard_error: 1.2,
+            low_ess_subjects: vec![("S3".into(), 0.05)],
+            n_samples: 500,
+            proposal_df: 5.0,
+            ess_min: 0.05,
+            ess_median: 0.6,
+            kappa_treatment: KappaTreatment::FixedAtMode,
+        });
+        // SIR CIs for theta/omega/sigma.
+        r.sir_ess = Some(123.4);
+        r.sir_ci_theta = Some(vec![(1.8, 2.2), (-0.1, 0.1)]);
+        r.sir_ci_omega = Some(vec![(0.07, 0.11), (0.03, 0.05)]);
+        r.sir_ci_sigma = Some(vec![(0.08, 0.12), (0.4, 0.6)]);
+        // Shrinkage (a NaN entry exercises the is_finite guard).
+        r.shrinkage_eta = vec![0.12, f64::NAN];
+        r.shrinkage_eps = 0.05;
+        r.shrinkage_kappa = vec![0.20, f64::NAN];
+        r.shrinkage_kappa_by_occ = vec![vec![0.10, f64::NAN]];
+        r.covariance_status = CovarianceStatus::Computed;
+        r.warnings = vec!["example warning".into()];
+        r
+    }
+
+    #[test]
+    fn write_estimates_yaml_emits_all_sections() {
+        let r = comprehensive_result();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        // Theta: free with SE, and fixed entry.
+        assert!(yaml.contains("  CL:") && yaml.contains("    se: 0.200000"));
+        assert!(yaml.contains("  BASE:") && yaml.contains("    fixed: true"));
+        // Omega diagonal + off-diagonal covariance block.
+        assert!(yaml.contains("\nomega:"));
+        assert!(yaml.contains("  ETA_V__ETA_CL:"));
+        assert!(yaml.contains("    covariance: 0.020000"));
+        // Sigma: combined → proportional emits cv_pct, additive does not.
+        assert!(yaml.contains("error model: combined"));
+        assert!(yaml.contains("    type: proportional") && yaml.contains("    type: additive"));
+        // IOV block + kappa off-diagonal.
+        assert!(yaml.contains("\nomega_iov:"));
+        assert!(yaml.contains("  KAPPA_V__KAPPA_CL:"));
+        // Importance sampling block.
+        assert!(yaml.contains("\nimportance_sampling:"));
+        assert!(yaml.contains("  kappa_treatment: fixed_at_mode"));
+        assert!(yaml.contains("  low_ess_subjects:") && yaml.contains("- id: \"S3\""));
+        // SIR section with all three CI blocks.
+        assert!(yaml.contains("\nsir:"));
+        assert!(
+            yaml.contains("  ci_theta:")
+                && yaml.contains("  ci_omega:")
+                && yaml.contains("  ci_sigma:")
+        );
+        // Warnings.
+        assert!(yaml.contains("\nwarnings:") && yaml.contains("- \"example warning\""));
+    }
+
+    #[test]
+    fn print_results_smoke_comprehensive() {
+        // Exercises the maximal-section path of the stderr printer.
+        print_results(&comprehensive_result());
+    }
+
+    #[test]
+    fn write_yaml_and_print_handle_no_se_and_failed_covariance() {
+        // No SEs on any non-fixed parameter (→ `se: ~` / N/A arms), a failed
+        // covariance step (→ show_cv=false / "FAILED"), an IS block with the
+        // Marginalized κ treatment and no low-ESS subjects, and no SIR /
+        // shrinkage / warnings.
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.theta = vec![2.0];
+        r.theta_names = vec!["CL".into()];
+        r.theta_fixed = vec![false];
+        r.se_theta = None;
+        r.omega = DMatrix::from_row_slice(1, 1, &[0.09]);
+        r.eta_names = vec!["ETA_CL".into()];
+        r.omega_fixed = vec![false];
+        r.se_omega = None;
+        r.sigma_fixed = vec![false];
+        r.se_sigma = None;
+        r.omega_iov = Some(DMatrix::from_row_slice(1, 1, &[0.04]));
+        r.kappa_names = vec!["KAPPA_CL".into()];
+        r.kappa_fixed = vec![false];
+        r.se_kappa = None;
+        r.importance_sampling = Some(ImportanceSamplingResult {
+            minus2_log_likelihood: -10.0,
+            mc_standard_error: 0.5,
+            low_ess_subjects: Vec::new(),
+            n_samples: 100,
+            proposal_df: 4.0,
+            ess_min: 0.9,
+            ess_median: 0.95,
+            kappa_treatment: KappaTreatment::Marginalized,
+        });
+        r.covariance_status = CovarianceStatus::Failed;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(
+            yaml.contains("    se: ~"),
+            "missing-SE entries render as `se: ~`"
+        );
+        assert!(yaml.contains("  kappa_treatment: marginalized"));
+        assert!(yaml.contains("  low_ess_subjects: []"));
+
+        // print_results: failed-covariance branch (no CV%, "FAILED").
+        print_results(&r);
+
+        // Flip the IS κ treatment to NotApplicable to cover that match arm too.
+        if let Some(is) = r.importance_sampling.as_mut() {
+            is.kappa_treatment = KappaTreatment::NotApplicable;
+        }
+        print_results(&r);
+    }
+
+    #[cfg(feature = "nn")]
+    #[test]
+    fn print_results_smoke_with_neural_network_block() {
+        // Covers the `--- NEURAL NETWORKS ---` print branch.
+        print_results(&make_nn_result());
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2998,4 +2998,166 @@ mod tests {
              for the basin-trap regression rationale before adjusting."
         );
     }
+
+    // ── small pure helpers ───────────────────────────────────────────────────
+
+    /// Bare subject with no doses/observations; tests mutate the fields they
+    /// exercise.
+    fn bare_subject(id: &str) -> Subject {
+        Subject {
+            id: id.to_string(),
+            doses: Vec::new(),
+            obs_times: Vec::new(),
+            observations: Vec::new(),
+            obs_cmts: Vec::new(),
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: Vec::new(),
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+        }
+    }
+
+    fn dose(ss: bool) -> DoseEvent {
+        DoseEvent {
+            time: 0.0,
+            amt: 100.0,
+            cmt: 1,
+            rate: 0.0,
+            duration: 0.0,
+            ss,
+            ii: 0.0,
+        }
+    }
+
+    #[test]
+    fn subject_has_bloq_reflects_cens_flags() {
+        let mut s = bare_subject("1");
+        s.cens = vec![0, 0];
+        assert!(!s.has_bloq());
+        s.cens = vec![0, 1];
+        assert!(s.has_bloq());
+    }
+
+    #[test]
+    fn subject_has_ss_doses_detects_steady_state_flag() {
+        let mut s = bare_subject("1");
+        s.doses = vec![dose(false), dose(false)];
+        assert!(!s.has_ss_doses());
+        s.doses.push(dose(true));
+        assert!(s.has_ss_doses());
+    }
+
+    #[test]
+    fn subject_pk_only_cov_falls_back_to_static_map() {
+        let mut s = bare_subject("1");
+        s.covariates.insert("WT".to_string(), 70.0);
+        // No per-EVID-2 snapshots → static map.
+        assert_eq!(s.pk_only_cov(0).get("WT"), Some(&70.0));
+        // With a snapshot at index 0 → that snapshot.
+        let mut snap = HashMap::new();
+        snap.insert("WT".to_string(), 80.0);
+        s.pk_only_covariates = vec![snap];
+        assert_eq!(s.pk_only_cov(0).get("WT"), Some(&80.0));
+        // Out-of-range index → fall back to static map.
+        assert_eq!(s.pk_only_cov(5).get("WT"), Some(&70.0));
+    }
+
+    #[test]
+    fn prune_irrelevant_tv_covariates_clears_only_constant_referenced_covs() {
+        // Subject A: the referenced covariate (WT) is constant across snapshots
+        // but an unreferenced one (DAY) varies → snapshots should be pruned.
+        let mut a = bare_subject("A");
+        a.covariates = HashMap::from([("WT".to_string(), 70.0), ("DAY".to_string(), 1.0)]);
+        a.obs_covariates = vec![
+            HashMap::from([("WT".to_string(), 70.0), ("DAY".to_string(), 1.0)]),
+            HashMap::from([("WT".to_string(), 70.0), ("DAY".to_string(), 2.0)]),
+        ];
+        // Subject B: the referenced covariate (WT) genuinely varies → keep.
+        let mut b = bare_subject("B");
+        b.covariates = HashMap::from([("WT".to_string(), 70.0)]);
+        b.obs_covariates = vec![
+            HashMap::from([("WT".to_string(), 70.0)]),
+            HashMap::from([("WT".to_string(), 90.0)]),
+        ];
+
+        let mut pop = Population {
+            subjects: vec![a, b],
+            covariate_names: vec!["WT".to_string(), "DAY".to_string()],
+            dv_column: "DV".to_string(),
+            input_columns: Vec::new(),
+        };
+        let pruned = pop.prune_irrelevant_tv_covariates(&["WT".to_string()]);
+        assert_eq!(pruned, 1, "only subject A should be pruned");
+        assert!(
+            pop.subjects[0].obs_covariates.is_empty(),
+            "A pruned to fast path"
+        );
+        assert!(
+            !pop.subjects[1].obs_covariates.is_empty(),
+            "B keeps TV snapshots"
+        );
+    }
+
+    #[test]
+    fn covariate_kind_label_strings() {
+        assert_eq!(CovariateKind::Continuous.label(), "continuous");
+        assert_eq!(CovariateKind::Categorical.label(), "categorical");
+    }
+
+    #[test]
+    fn scaling_spec_requires_fd_is_always_false() {
+        assert!(!ScalingSpec::None.requires_fd());
+        assert!(!ScalingSpec::ScalarScale(1000.0).requires_fd());
+        assert!(!ScalingSpec::PerCmt(HashMap::new()).requires_fd());
+    }
+
+    #[test]
+    fn estimation_method_label_covers_all_variants() {
+        assert_eq!(EstimationMethod::Foce.label(), "FOCE");
+        assert_eq!(EstimationMethod::FoceI.label(), "FOCEI");
+        assert_eq!(EstimationMethod::FoceGn.label(), "FOCE-GN");
+        assert_eq!(EstimationMethod::FoceGnHybrid.label(), "FOCE-GN-Hybrid");
+        assert_eq!(EstimationMethod::Saem.label(), "SAEM");
+        assert_eq!(EstimationMethod::Imp.label(), "IMP");
+    }
+
+    #[test]
+    fn model_parameters_has_any_fixed_tracks_every_flag_vec() {
+        let mut mp = test_helpers::analytical_model(GradientMethod::Fd).default_params;
+        mp.theta_fixed = vec![false];
+        mp.omega_fixed = vec![false];
+        mp.sigma_fixed = vec![false];
+        mp.kappa_fixed = Vec::new();
+        assert!(!mp.has_any_fixed());
+        mp.sigma_fixed = vec![true];
+        assert!(mp.has_any_fixed());
+    }
+
+    #[test]
+    fn pk_params_from_hashmap_maps_named_fields_and_aliases() {
+        let map = HashMap::from([
+            ("cl".to_string(), 5.0),
+            ("v1".to_string(), 30.0), // v1 alias → V index
+            ("q".to_string(), 2.0),
+            ("v2".to_string(), 50.0),
+            ("ka".to_string(), 1.2),
+            ("f".to_string(), 0.8),
+            ("q3".to_string(), 0.5),
+            ("v3".to_string(), 100.0),
+        ]);
+        let p = PkParams::from_hashmap(&map);
+        assert_eq!(p.values[PK_IDX_CL], 5.0);
+        assert_eq!(p.values[PK_IDX_V], 30.0);
+        assert_eq!(p.values[PK_IDX_Q], 2.0);
+        assert_eq!(p.values[PK_IDX_V2], 50.0);
+        assert_eq!(p.values[PK_IDX_KA], 1.2);
+        assert_eq!(p.values[PK_IDX_F], 0.8);
+        assert_eq!(p.values[PK_IDX_Q3], 0.5);
+        assert_eq!(p.values[PK_IDX_V3], 100.0);
+    }
 }

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -1,0 +1,266 @@
+//! End-to-end coverage for the two CLI binaries (`ferx` and `generate_data`).
+//!
+//! These run the built binaries as subprocesses. Cargo exposes their paths via
+//! the `CARGO_BIN_EXE_<name>` env vars. The `check` subcommand and the data
+//! generator are both fast (no model fitting), so these stay in the default
+//! test job rather than the slow tier.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+// ── generate_data: writes the four example datasets into ./data ──────────────
+
+#[test]
+fn generate_data_writes_all_datasets() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // The generator writes to relative `data/<name>.csv`, so it needs a `data`
+    // subdirectory in its working directory.
+    std::fs::create_dir(tmp.path().join("data")).expect("mkdir data");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_generate_data"))
+        .current_dir(tmp.path())
+        .status()
+        .expect("run generate_data");
+    assert!(status.success(), "generate_data exited with {status:?}");
+
+    for name in [
+        "warfarin.csv",
+        "two_cpt_iv.csv",
+        "two_cpt_oral_cov.csv",
+        "mm_oral.csv",
+    ] {
+        let p = tmp.path().join("data").join(name);
+        let meta = std::fs::metadata(&p)
+            .unwrap_or_else(|e| panic!("expected {} to exist: {e}", p.display()));
+        assert!(meta.len() > 0, "{} is empty", p.display());
+        // First line should be the NONMEM-style header.
+        let contents = std::fs::read_to_string(&p).unwrap();
+        let header = contents.lines().next().unwrap_or("");
+        assert!(
+            header.starts_with("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV"),
+            "unexpected header in {}: {header}",
+            p.display()
+        );
+    }
+}
+
+// ── ferx check: validate a model with/without data, JSON and human output ────
+
+fn ferx() -> Command {
+    let mut c = Command::new(env!("CARGO_BIN_EXE_ferx"));
+    c.current_dir(repo_root());
+    c
+}
+
+#[test]
+fn check_json_reports_valid_model() {
+    let out = ferx()
+        .args(["check", "examples/one_cpt_iv.ferx", "--json"])
+        .output()
+        .expect("run ferx check --json");
+    assert!(
+        out.status.success(),
+        "check should exit 0 for a valid model"
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    // Output is a JSON CheckReport.
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    assert_eq!(v["valid"], serde_json::Value::Bool(true));
+}
+
+#[test]
+fn check_human_output_runs() {
+    let out = ferx()
+        .args(["check", "examples/one_cpt_iv.ferx"])
+        .output()
+        .expect("run ferx check");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("ok:"),
+        "human check summary missing: {stdout}"
+    );
+}
+
+#[test]
+fn check_with_data_runs_data_dependent_checks() {
+    let out = ferx()
+        .args([
+            "check",
+            "examples/one_cpt_iv.ferx",
+            "--data",
+            "data/one_cpt_iv.csv",
+        ])
+        .output()
+        .expect("run ferx check --data");
+    // Exit code is 0 (valid) or 1 (warnings/errors) — both exercise the data
+    // path; only a usage/serialization failure (2) would be wrong here.
+    assert_ne!(out.status.code(), Some(2), "should not be a usage error");
+}
+
+#[test]
+fn check_missing_model_is_usage_error() {
+    let out = ferx().arg("check").output().expect("run ferx check");
+    assert_eq!(out.status.code(), Some(2), "missing model → usage exit 2");
+}
+
+#[test]
+fn check_data_flag_without_value_is_usage_error() {
+    let out = ferx()
+        .args(["check", "examples/one_cpt_iv.ferx", "--data"])
+        .output()
+        .expect("run ferx check --data (no value)");
+    assert_eq!(out.status.code(), Some(2), "--data without value → exit 2");
+}
+
+#[test]
+fn no_arguments_prints_usage_and_exits_one() {
+    let out = ferx().output().expect("run ferx with no args");
+    assert_eq!(out.status.code(), Some(1), "no args → usage exit 1");
+}
+
+// ── ferx fit: full success path (writes sdtab/yaml/timing + .fitrx bundle) ────
+
+/// Drives the fit half of `main`: a small 10-subject 1-cpt IV FOCEI fit with
+/// `--threads` and `--output` (so the thread-pool and .fitrx-bundle branches
+/// are covered too). All outputs land in a tempdir, so the repo tree is left
+/// untouched. Fast (analytical PK, ~1s) — stays in the default test tier.
+#[test]
+fn fit_with_data_writes_outputs_and_bundle() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let model = repo_root().join("examples/one_cpt_iv.ferx");
+    let data = repo_root().join("data/one_cpt_iv.csv");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_ferx"))
+        .current_dir(tmp.path())
+        .arg(&model)
+        .arg("--data")
+        .arg(&data)
+        .args(["--threads", "2", "--output", "run.fitrx", "--include-data"])
+        .output()
+        .expect("run ferx fit");
+    assert!(
+        out.status.success(),
+        "fit should succeed; stderr=\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("Fit completed!"),
+        "summary missing: {stdout}"
+    );
+    assert!(stdout.contains("OFV:"));
+
+    // Output files are named from the model stem and written to cwd (the tmp).
+    for name in ["one_cpt_iv-fit.yaml", "one_cpt_iv-sdtab.csv", "run.fitrx"] {
+        let p = tmp.path().join(name);
+        assert!(p.exists(), "expected output {} to be written", p.display());
+    }
+}
+
+/// Drives the `--simulate` half of `main` (no data file). Uses a tiny inline
+/// analytical 1-cpt model with a `[simulation]` block written to the tempdir,
+/// so `run_model_simulate` generates synthetic data and the output-writing path
+/// runs — fast (analytical PK, 5 subjects), unlike the ODE example models.
+#[test]
+fn simulate_writes_outputs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let model_src = "\
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[simulation]
+  n_subjects = 5
+  dose_amt   = 100.0
+  dose_cmt   = 1
+  times      = [0.5, 1.0, 2.0, 4.0, 8.0]
+  seed       = 1
+";
+    let model = tmp.path().join("sim_model.ferx");
+    std::fs::write(&model, model_src).expect("write model");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_ferx"))
+        .current_dir(tmp.path())
+        .arg(&model)
+        .arg("--simulate")
+        .output()
+        .expect("run ferx --simulate");
+    assert!(
+        out.status.success(),
+        "simulate should succeed; stderr=\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(tmp.path().join("sim_model-fit.yaml").exists());
+}
+
+/// Covers the arg-parsing error exits in `main` (each calls `process::exit(1)`
+/// before any fitting, so these are fast). One subprocess per bad flag.
+#[test]
+fn bad_flags_exit_with_error() {
+    // --threads with a non-numeric value.
+    let out = ferx()
+        .args(["examples/one_cpt_iv.ferx", "--threads", "notanumber"])
+        .output()
+        .expect("run");
+    assert_eq!(out.status.code(), Some(1), "bad --threads → exit 1");
+
+    // --output present but missing its value.
+    let out = ferx()
+        .args([
+            "examples/one_cpt_iv.ferx",
+            "--data",
+            "data/one_cpt_iv.csv",
+            "--output",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "--output without value → exit 1"
+    );
+
+    // --inits-from-nca with an unknown method.
+    let out = ferx()
+        .args([
+            "examples/one_cpt_iv.ferx",
+            "--data",
+            "data/one_cpt_iv.csv",
+            "--inits-from-nca=bogus",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(out.status.code(), Some(1), "bad --inits-from-nca → exit 1");
+}
+
+/// A fit that fails (model file does not exist) takes the `Err` arm of `main`
+/// and exits non-zero with an `Error:` message.
+#[test]
+fn fit_with_missing_files_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = Command::new(env!("CARGO_BIN_EXE_ferx"))
+        .current_dir(tmp.path())
+        .args(["does_not_exist.ferx", "--data", "nope.csv"])
+        .output()
+        .expect("run ferx fit on missing files");
+    assert!(!out.status.success(), "missing files should fail the fit");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("Error:"),
+        "expected an Error: message on stderr"
+    );
+}


### PR DESCRIPTION
## Why
Coverage gaps left several modules under-tested. Overall line coverage was 84.9%; the worst offenders were `io/output.rs` (40%), the CLI binaries (`generate_data` 0%, `run_model` 39%), and `ad/dual.rs` (0%). This raises overall line coverage to **90.0%** (region 91.2%).

## What changed
Test-only additions — **no production code touched** (1142 insertions across 6 src files + a new integration test).

- **`io/output.rs` 40% → 90%**: `write_sdtab_csv` / `write_covtab_csv` (NaN→blank, CSV escaping of commas in IDs), `parameter_table`, `fmt_num`/`fixed_label`, and a maximal-section `FitResult` fixture driving both `print_results` and `write_estimates_yaml` through every optional block (block omega/kappa correlations, combined sigma, IOV, importance-sampling, SIR CIs, shrinkage, warnings), plus no-SE / failed-covariance / `KappaTreatment` variants.
- **`ad/dual.rs` 0% → 100%**: dual-number arithmetic checked against hand-computed derivatives (exp/ln/sqrt/abs/powf/powi/max, operators, eq/ord).
- **`bin/generate_data.rs` 0% → 99.8%**, **`bin/run_model.rs` 39% → 88%**: new `tests/cli_binaries.rs` runs both binaries as subprocesses (cargo-llvm-cov captures child coverage) — the `check` subcommand (JSON/human/error paths), a fast 10-subject fit with `.fitrx` bundle + `--threads`, an inline-model `--simulate`, and the arg-error exit branches.
- **`types.rs` helpers**: `Subject::has_bloq`/`has_ss_doses`/`pk_only_cov`, `prune_irrelevant_tv_covariates`, `ScalingSpec::requires_fd`, `CovariateKind::label`, `EstimationMethod::label`, `PkParams::from_hashmap`, `ModelParameters::has_any_fixed`.
- **estimation**: built-in BFGS + global presearch (`outer_optimizer`), the IS IOV path via a FOCE→IMP chain (`api`), and an FD-validation test for the otherwise-unexercised `obs_nll_subject_grad_iov` M-step gradient (`saem`).

## Alternatives considered
`obs_nll_subject_grad_iov` is dead code under the default BOBYQA (derivative-free) M-step, so it's covered with a direct finite-difference validation test rather than an end-to-end fit — same value as the existing non-IOV gradient test, guarding correctness if a gradient-based M-step is ever enabled.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (tests only — no estimator/PK/stats behaviour changed)

## Performance
- [x] No significant impact expected (new tests run in <1s; the slow mm_multistart `--simulate` was avoided in favour of a fast inline model)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression-style FD validation added for `obs_nll_subject_grad_iov`

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo fmt --check` clean
- [ ] `cargo clippy` clean (not re-run; changes are test-only)

## Reviewer hints
- Stacks on `feat/covariates-dsl-section-182` (the covtab/`CovariateTable` tests depend on that feature); base is set to that branch — merge it first.
- Coverage was measured with stock nightly + `--features ci,nn`; the pinned `enzyme` toolchain lacks the profiler runtime.
- Pre-existing baseline failures on this branch (`test_subject_nll_pop_grad_analytical_matches_fd`, `bytecode_matches_ast_on_conditional_and_logic`, `test_inline_if_in_parameter_assignment`) are unrelated and were skipped during coverage runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)