### PR TITLE
chore(security): add SECURITY.md, Dependabot, and cargo-audit CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  # Rust crate dependencies (Cargo.toml / Cargo.lock at the repo root).
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Batch low-risk minor/patch bumps into one PR to cut review noise;
+      # major bumps still come as individual PRs.
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions pinned in .github/workflows/*.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,37 @@
+name: Security audit
+
+# Runs `cargo audit` (RUSTSEC advisory DB) against the committed Cargo.lock.
+# Kept off the per-PR critical path (only fires when dependency files change,
+# weekly, or on demand) so a newly-published advisory can't block unrelated
+# PRs, while still catching vulnerable dependencies promptly when the lockfile
+# changes. Scheduled runs open a tracking issue for any new advisory.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/audit.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported versions
+
+ferx-core is pre-1.0 and under active development. Security fixes are applied to
+the **latest release** (and `main`); older release lines are not maintained.
+Please upgrade to the latest tagged release before reporting an issue.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub Issue for security vulnerabilities.**
+
+Report privately via GitHub's
+[**Report a vulnerability**](https://github.com/FeRx-NLME/ferx-core/security/advisories/new)
+flow (Security → Advisories → Report a vulnerability). If you can't use that,
+contact a maintainer directly.
+
+Please include:
+
+- a description of the issue and its impact,
+- steps to reproduce (a minimal `.ferx` model / data subset if relevant),
+- the affected version(s) or commit, and
+- any suggested fix.
+
+We aim to acknowledge a report within a few business days, agree on a disclosure
+timeline, and credit reporters who wish to be named once a fix ships.
+
+## Scope
+
+ferx-core is a numerical library, not a network service, so its main security
+surface is:
+
+- **Native / FFI code** — the Rust engine is consumed from R (ferx-r) through
+  the extendr FFI boundary; memory-safety bugs there can crash the host process.
+- **Dependencies** — Rust crates (monitored by `cargo audit` and Dependabot) and
+  the Enzyme toolchain used for autodiff builds.
+- **Untrusted input** — parsing `.ferx` model files and NONMEM-format CSV data.
+
+See the [Security & dependencies](https://ferx-nlme.github.io/ferx-core/development/sdlc.html#14-security--dependencies)
+section of the development docs for how this fits into the wider process.


### PR DESCRIPTION
## Why
The SDLC (§14, added in #227) flagged that ferx-core had **no dependency/security hygiene tooling** — no `cargo audit`, no Dependabot, no `SECURITY.md`. This adds all three. Small, self-contained, no code changes.

## What changed
- **`SECURITY.md`** — supported-versions policy (latest release), **private** vulnerability reporting via GitHub Security Advisories, and the project's security scope (FFI/native, dependencies, untrusted `.ferx`/CSV input).
- **`.github/dependabot.yml`** — weekly `cargo` + `github-actions` updates; minor/patch crate bumps grouped into one PR to cut noise; major bumps stay individual.
- **`.github/workflows/audit.yml`** — `cargo audit` (RUSTSEC advisory DB) via `rustsec/audit-check`, triggered on `Cargo.toml`/`Cargo.lock` changes, weekly, and on demand. Deliberately **off the per-PR critical path** so a newly-published advisory can't block unrelated PRs.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed here | — |

The same `SECURITY.md` + Dependabot would be worth adding to **ferx-r** as a follow-up (separate repo/PR).

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CI / policy only)

## Tests
- [x] No new tests needed. YAML validated locally; `Cargo.lock` is committed so `cargo audit` has a lockfile to scan.

## Docs
- [x] No user-visible runtime change. `SECURITY.md` links to the SDLC §14 section (published once #227 merges).

## Reviewer hints
- First scheduled `audit.yml` run may surface **pre-existing** advisories in current dependencies — that's the tool working, not a regression from this PR; triage separately.
- Relationship to **#227**: that PR documents these as "to add"; this PR adds them. Either merge order is fine — I'll update #227's §14 wording to drop the "not configured yet" caveats.

## Open questions
- Want the audit job to also run on the **per-PR** path (blocking), or keep it scheduled/dependency-triggered as here?
- Add matching `SECURITY.md` + Dependabot to **ferx-r** now, or later?