### PR TITLE
fix(estimation): correct covariance SEs and build the Hessian from the analytical gradient [closes #209] [closes #196]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ section of the SDLC for the versioning policy).
   (SDLC) page and a Contributing page in the book.
 
 ### Fixed
+- Covariance standard errors now match NONMEM `$COVARIANCE MATRIX=R` (within ~2%
+  on warfarin). The covariance step reconverges the inner EBE loop at every
+  finite-difference point — holding the EBEs fixed gave an indefinite Hessian
+  that was clipped and inflated theta/sigma SEs 30–94× — and applies the correct
+  factor of two for the `−2·logL` objective (every SE was previously `1/√2` too
+  small) (#209, #196, #129).
 - IOV FOCEI marginal likelihood now matches NONMEM after the Almquist Laplace
   correction (#109, #203).
 - SAEM no longer collapses a block Ω to a rank-1 (near-unit-correlation)
@@ -40,6 +46,11 @@ section of the SDLC for the versioning policy).
   (#199, #200).
 
 ### Performance
+- The covariance Hessian is built from a central difference of the analytical
+  population gradient — reusing H-matrix columns for mu-referenced parameters
+  instead of finite-differencing predictions — making the covariance step ~9×
+  faster than scalar finite differencing on warfarin, scaling with the number of
+  free parameters (#209, #196).
 - Autodiff inner gradients now flow through `EVID=3/4` resets and lag time,
   removing a large finite-difference fallback slowdown (#198).
 

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -113,15 +113,40 @@ The pre-search uses NLopt's CRS2-LM algorithm (Controlled Random Search) to expl
 
 ## Covariance Step
 
-When `covariance = true`, ferx-core computes the variance-covariance matrix of the parameter estimates using a finite-difference Hessian at the converged solution. This provides:
+When `covariance = true`, ferx-core computes the variance-covariance matrix of the parameter estimates (the **R-matrix**: the inverse observed Fisher information) at the converged solution. This provides:
 
 - **Standard errors (SE)** for all parameters
 - **Relative standard errors (%RSE)** for assessing estimation precision
 - **Omega SEs** via delta method from the Cholesky parameterization
 
+### How the Hessian is built
+
+The covariance is `2·H⁻¹`, where `H` is the finite-difference Hessian of the objective. Two details make the SEs match NONMEM's `$COVARIANCE`:
+
+1. **The EBEs are reconverged at every perturbed point.** Like NONMEM's covariance step, ferx re-solves the inner conditional-estimation loop (warm-started from the converged EBEs) at each finite-difference point. Holding the EBEs fixed omits the response of the conditional optimum to the population parameters, which gives a Hessian with the wrong curvature — indefinite even on well-conditioned surfaces such as warfarin — and was the source of the spurious eigenvalue clipping in issue [#129](https://github.com/FeRx-NLME/ferx-core/issues/129).
+2. **The Hessian is a central difference of the analytical gradient** (issue [#209](https://github.com/FeRx-NLME/ferx-core/issues/209)): `H[:,k] ≈ (g(x̂+hₖeₖ) − g(x̂−hₖeₖ)) / 2hₖ`. This is `2·n_free` gradient evaluations instead of `~2·n_free²` objective evaluations, and it avoids the catastrophic cancellation of a four-point second difference of the OFV. The θ part of that gradient reuses H-matrix columns for mu-referenced parameters (issue [#196](https://github.com/FeRx-NLME/ferx-core/issues/196)). IOV models, whose κ block has no fixed-EBE analytical gradient, fall back to a second difference of the reconverged objective.
+
+The factor of two is because the objective is `−2·logL`: its Hessian is twice the observed information, so the covariance needs `2·H⁻¹` to be on the right scale.
+
+### NONMEM cross-check
+
+FOCEI on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error) against NONMEM 7.5.1 `$COVARIANCE MATRIX=R`:
+
+| Parameter | ferx SE | NONMEM SE | rel. diff |
+|-----------|---------|-----------|-----------|
+| TVCL      | 0.00712 | 0.00710   | +0.3% |
+| TVV       | 0.2350  | 0.2401    | −2.1% |
+| TVKA      | 0.1506  | 0.1486    | +1.3% |
+| PROP_ERR (SD) | 0.000832 | 0.000835 | −0.4% |
+| ω²(CL)    | 0.01291 | 0.01279   | +0.9% |
+| ω²(V)     | 0.00403 | 0.00431   | −6.4% |
+| ω²(KA)    | 0.1530  | 0.1504    | +1.8% |
+
+(autodiff build; the FD-Jacobian build agrees to within ~10% on the ω block.) The regression guard is `tests/warfarin_covariance_nonmem.rs`.
+
 ### Hessian regularization
 
-The FD second derivative inherits roundoff at scale `≈ (eps_OFV / h²)`, which on well-conditioned surfaces can push one or two eigenvalues of the symmetrised free-block Hessian slightly below zero even when the underlying surface is positive definite (issue [#129](https://github.com/FeRx-NLME/ferx-core/issues/129)). Rather than rejecting the entire covariance step on that artefact, ferx-core inverts via a symmetric eigendecomposition and clips eigenvalues below `max(λ_max · 1e-10, 1e-12)` to that floor before reconstructing `H⁻¹`. PD inputs are inverted unchanged; non-PD inputs recover a PD covariance and a warning is added to `FitResult.warnings`:
+Because the EBEs reconverge, the Hessian is positive-definite on well-conditioned surfaces and no regularization is needed. As a safety net for genuinely ill-conditioned or near-singular problems, ferx-core still inverts via a symmetric eigendecomposition and clips eigenvalues below `max(λ_max · 1e-10, 1e-12)` to that floor before reconstructing `H⁻¹`, adding a warning to `FitResult.warnings`:
 
 ```
 Covariance step regularized: eigenvalue floor applied to FD Hessian
@@ -129,7 +154,7 @@ Covariance step regularized: eigenvalue floor applied to FD Hessian
 Standard errors should be interpreted with care.
 ```
 
-SEs in the regularised directions are inflated (since `1/λ_clipped` is larger than the would-be true `1/λ`), so when this warning fires the rotated reference NONMEM fit or the autodiff build (`--features autodiff`, machine-precision second derivatives) is the right cross-check. A Hessian whose spectrum is genuinely indefinite — every eigenvalue ≤ 0 — still fails outright with the standard `Covariance step failed` message; the floor only rescues near-PD cases.
+SEs in the regularised directions are inflated (since `1/λ_clipped` is larger than the would-be true `1/λ`). With the reconverging covariance step this warning should now be rare; if it fires, the surface is genuinely near-identifiable and the SEs in those directions warrant scrutiny. A Hessian whose spectrum is genuinely indefinite — every eigenvalue ≤ 0 — still fails outright with the standard `Covariance step failed` message.
 
 ## Convergence
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -651,6 +651,21 @@ fn dr_diag_d_log_sigma(
         .collect()
 }
 
+/// Returns the index into `model.eta_names` of the ETA log-mu-referenced to
+/// theta `k`, or `None` if no such pairing exists.
+///
+/// Only log-transformed pairs (`MuRef::log_transformed == true`) qualify.
+/// Additive pairs (`PARAM = THETA + ETA`) do not: ferx packs all thetas as
+/// `x_k = log(THETA)`, so ∂f/∂x_k = THETA · ∂f/∂η ≠ H[:,j] there.
+fn mu_ref_eta_index(model: &CompiledModel, template: &ModelParameters, k: usize) -> Option<usize> {
+    let theta_name = template.theta_names.get(k)?;
+    let (eta_name, _) = model
+        .mu_refs
+        .iter()
+        .find(|(_, mu_ref)| mu_ref.log_transformed && mu_ref.theta_name == *theta_name)?;
+    model.eta_names.iter().position(|n| n == eta_name)
+}
+
 /// Analytical per-subject FOCE NLL gradient for non-IOV, non-ODE, non-M3 models.
 ///
 /// Returns `None` if the Cholesky of R_tilde fails (degenerate parameters) so
@@ -754,29 +769,34 @@ fn subject_nll_pop_grad_analytical(
 
     // ── Theta parameters (indices 0..n_theta) ──────────────────────────────
     let eps = 1e-5;
-    for k in 0..n_theta {
+    'theta: for k in 0..n_theta {
         if fixed_mask[k] {
             continue;
         }
-        let h = eps * (1.0 + x[k].abs());
-        let xk_plus = (x[k] + h).min(bounds.upper[k]);
-        let actual_h = xk_plus - x[k];
-        if actual_h.abs() < 1e-16 {
-            continue;
-        }
 
-        let mut x_pert = x.to_vec();
-        x_pert[k] = xk_plus;
-        let params_pert = unpack_params(&x_pert, template);
-        let ipreds_pert =
-            pk::compute_predictions_with_tv(model, subject, &params_pert.theta, eta_hat.as_slice());
-
-        // d(ipreds)/dx[k] via forward FD
-        let d_ipreds: Vec<f64> = ipreds_pert
-            .iter()
-            .zip(ipreds.iter())
-            .map(|(&p, &b)| (p - b) / actual_h)
-            .collect();
+        // d(ipreds)/dx_k: mu-ref shortcut reads H[:,j] (already computed);
+        // FD fallback perturbs theta and re-evaluates predictions.
+        let d_ipreds: Vec<f64> = 'fd: {
+            if options.mu_referencing {
+                if let Some(j) = mu_ref_eta_index(model, template, k) {
+                    break 'fd h_matrix.column(j).iter().copied().collect();
+                }
+            }
+            let h = eps * (1.0 + x[k].abs());
+            let xk_plus = (x[k] + h).min(bounds.upper[k]);
+            let actual_h = xk_plus - x[k];
+            if actual_h.abs() < 1e-16 {
+                continue 'theta;
+            }
+            let mut x_pert = x.to_vec();
+            x_pert[k] = xk_plus;
+            let params_pert = unpack_params(&x_pert, template);
+            pk::compute_predictions_with_tv(model, subject, &params_pert.theta, eta_hat.as_slice())
+                .iter()
+                .zip(ipreds.iter())
+                .map(|(&p, &b)| (p - b) / actual_h)
+                .collect()
+        };
 
         // d(f0) = d(ipreds); d(v) = -d(f0)
         // For sigma-dependent r: d(r_j)/d(x[k]) via chain rule through r(f0 or ipreds)
@@ -1120,6 +1140,17 @@ fn subject_nll_pop_grad_analytical_laplace(
         if fixed_mask[k] {
             continue;
         }
+        // mu-ref shortcut: d(ipreds)/dx_k == H[:,j] for a paired theta/eta.
+        if options.mu_referencing {
+            if let Some(j) = mu_ref_eta_index(model, template, k) {
+                let s: f64 = (0..n_obs)
+                    .map(|obs| theta_per_j[obs] * h_matrix[(obs, j)])
+                    .sum();
+                grad[k] = 0.5 * s;
+                continue;
+            }
+        }
+        // FD fallback for non-mu-referenced thetas.
         let h = eps * (1.0 + x[k].abs());
         let xk_plus = (x[k] + h).min(bounds.upper[k]);
         let actual_h = xk_plus - x[k];
@@ -1872,7 +1903,9 @@ mod tests {
         let n_eta = 1;
         let eta_hat = DVector::zeros(n_eta);
         let h_matrix = nalgebra::DMatrix::zeros(n_obs, n_eta);
-        let options = FitOptions::default();
+        // SB path requires non-interaction; default FitOptions has interaction=true.
+        let mut options = FitOptions::default();
+        options.interaction = false;
 
         // Analytical path (called directly)
         let (nll_an, grad_an) = subject_nll_pop_grad_analytical(
@@ -2941,6 +2974,452 @@ mod tests {
                 "IOV dispatch grad[{j}]: analytical={:.6e}, FD={:.6e}",
                 grad_an[j],
                 fd_j,
+            );
+        }
+    }
+
+    /// Microbenchmark: mu-ref shortcut vs forward-FD, both SB and Laplace paths.
+    ///
+    /// Run with:
+    ///   cargo test --lib --no-default-features --features ci --release \
+    ///     bench_mu_ref_gradient_throughput -- --nocapture --ignored
+    ///
+    /// Prints ns/call and speedup. Not a correctness test — always passes.
+    #[test]
+    #[ignore = "benchmark: run explicitly with --nocapture --ignored"]
+    fn bench_mu_ref_gradient_throughput() {
+        use crate::types::MuRef;
+        use std::time::Instant;
+
+        const N_SUBJ: usize = 32;
+        const N_ITER: u32 = 5_000;
+        const N_OBS: usize = 11;
+        const N_ETA: usize = 3;
+
+        // Build a 3-theta fully mu-referenced warfarin-like model.
+        fn make_bench_model(with_mu_refs: bool) -> CompiledModel {
+            let omega = OmegaMatrix::from_diagonal(
+                &[0.09, 0.04, 0.30],
+                vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+            );
+            let default_params = ModelParameters {
+                theta: vec![0.2, 10.0, 1.5],
+                theta_names: vec!["TVCL".into(), "TVV".into(), "TVKA".into()],
+                theta_lower: vec![0.001, 0.1, 0.01],
+                theta_upper: vec![10.0, 500.0, 50.0],
+                theta_fixed: vec![false; 3],
+                omega,
+                omega_fixed: vec![false; 3],
+                sigma: SigmaVector {
+                    values: vec![0.02],
+                    names: vec!["PROP_ERR".into()],
+                },
+                sigma_fixed: vec![false],
+                omega_iov: None,
+                kappa_fixed: Vec::new(),
+            };
+            let mu_refs = if with_mu_refs {
+                let mut m = HashMap::new();
+                m.insert(
+                    "ETA_CL".into(),
+                    MuRef {
+                        theta_name: "TVCL".into(),
+                        log_transformed: true,
+                    },
+                );
+                m.insert(
+                    "ETA_V".into(),
+                    MuRef {
+                        theta_name: "TVV".into(),
+                        log_transformed: true,
+                    },
+                );
+                m.insert(
+                    "ETA_KA".into(),
+                    MuRef {
+                        theta_name: "TVKA".into(),
+                        log_transformed: true,
+                    },
+                );
+                m
+            } else {
+                HashMap::new()
+            };
+            CompiledModel {
+                name: "bench".into(),
+                pk_model: PkModel::OneCptOral,
+                error_model: ErrorModel::Proportional,
+                error_spec: crate::types::ErrorSpec::Single(ErrorModel::Proportional),
+                pk_param_fn: Box::new(|theta: &[f64], eta: &[f64], _: &HashMap<String, f64>| {
+                    let mut p = PkParams::default();
+                    p.values[0] = theta[0] * eta[0].exp();
+                    p.values[1] = theta[1] * eta[1].exp();
+                    p.values[4] = theta[2] * eta[2].exp();
+                    p
+                }),
+                n_theta: 3,
+                n_eta: N_ETA,
+                n_epsilon: 1,
+                n_kappa: 0,
+                kappa_names: Vec::new(),
+                theta_names: vec!["TVCL".into(), "TVV".into(), "TVKA".into()],
+                eta_names: vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+                indiv_param_names: vec!["CL".into(), "V".into(), "KA".into()],
+                indiv_param_partials: crate::types::IndivParamPartials::empty(),
+                default_params,
+                omega_init_as_sd: vec![false; 3],
+                sigma_init_as_sd: vec![false],
+                kappa_init_as_sd: Vec::new(),
+                mu_refs,
+                kappa_mu_refs: HashMap::new(),
+                tv_fn: None,
+                pk_indices: vec![0, 1, 4],
+                eta_map: vec![0, 1, 2],
+                pk_idx_f64: vec![0.0, 1.0, 4.0],
+                sel_flat: vec![1.0, 0.0, 0.0],
+                ode_spec: None,
+                diffusion_theta_start: None,
+                diffusion_state_indices: Vec::new(),
+                bloq_method: BloqMethod::Drop,
+                referenced_covariates: Vec::new(),
+                gradient_method: GradientMethod::Fd,
+                parse_warnings: Vec::new(),
+                eta_param_info: Vec::new(),
+                theta_transform: Vec::new(),
+                #[cfg(feature = "nn")]
+                covariate_nns: Vec::new(),
+                scaling: crate::types::ScalingSpec::None,
+                log_transform: false,
+                dv_pre_logged: false,
+                derived_exprs: vec![],
+                output_columns: vec![],
+                #[cfg(feature = "survival")]
+                endpoints: std::collections::HashMap::new(),
+            }
+        }
+
+        let population = {
+            let subjects = (0..N_SUBJ)
+                .map(|_| Subject {
+                    id: "S1".into(),
+                    doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                    obs_times: vec![0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0, 48.0, 72.0, 96.0, 120.0],
+                    obs_raw_times: Vec::new(),
+                    observations: vec![25.0, 20.0, 15.0, 10.0, 7.0, 5.0, 3.0, 1.5, 0.8, 0.4, 0.2],
+                    obs_cmts: vec![1; N_OBS],
+                    covariates: HashMap::new(),
+                    dose_covariates: Vec::new(),
+                    obs_covariates: Vec::new(),
+                    pk_only_times: Vec::new(),
+                    pk_only_covariates: Vec::new(),
+                    reset_times: Vec::new(),
+                    cens: vec![0; N_OBS],
+                    occasions: vec![1; N_OBS],
+                    dose_occasions: vec![1],
+                    #[cfg(feature = "survival")]
+                    obs_records: vec![],
+                })
+                .collect();
+            Population {
+                subjects,
+                covariate_names: Vec::new(),
+                dv_column: "DV".to_string(),
+                input_columns: vec![],
+                exclusions: None,
+                warnings: vec![],
+            }
+        };
+
+        let model_fd = make_bench_model(false);
+        let model_mu = make_bench_model(true);
+        let template = &model_fd.default_params;
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let eta_hat = DVector::zeros(N_ETA);
+        let kappas: Vec<DVector<f64>> = vec![];
+        let h_vals: Vec<f64> = (0..N_OBS * N_ETA).map(|i| (i as f64 + 1.0) * 0.1).collect();
+        let h_matrix = nalgebra::DMatrix::from_vec(N_OBS, N_ETA, h_vals);
+
+        let run = |model: &CompiledModel, interaction: bool, mu_on: bool| -> f64 {
+            let mut opts = FitOptions::default();
+            opts.interaction = interaction;
+            opts.mu_referencing = mu_on;
+            let t0 = Instant::now();
+            for _ in 0..N_ITER {
+                for si in 0..N_SUBJ {
+                    let _ = subject_nll_pop_grad(
+                        &x,
+                        template,
+                        model,
+                        &population,
+                        si,
+                        &eta_hat,
+                        &h_matrix,
+                        &kappas,
+                        &bounds,
+                        &opts,
+                    );
+                }
+            }
+            t0.elapsed().as_nanos() as f64 / (N_ITER as f64 * N_SUBJ as f64)
+        };
+
+        // Cost of a single prediction solve (reference)
+        let ns_pred = {
+            let params = unpack_params(&x, template);
+            let eta = [0.0f64; 3];
+            let t0 = Instant::now();
+            for _ in 0..100_000 {
+                let _ = crate::pk::compute_predictions_with_tv(
+                    &model_fd,
+                    &population.subjects[0],
+                    &params.theta,
+                    &eta,
+                );
+            }
+            t0.elapsed().as_nanos() as f64 / 100_000.0
+        };
+
+        let ns_sb_fd = run(&model_fd, false, false);
+        let ns_sb_mu = run(&model_mu, false, true);
+        let ns_lp_fd = run(&model_fd, true, false);
+        let ns_lp_mu = run(&model_mu, true, true);
+
+        println!("\nMu-ref gradient shortcut — {N_SUBJ} subjects, {N_OBS} obs, 3 mu-ref thetas, {N_ITER} iters");
+        println!("  1 prediction solve = {ns_pred:.0} ns");
+        println!("  FD solves saved per call = 3 (all thetas mu-referenced)");
+        println!();
+        println!("  Path             FD (ns/call)   mu-ref (ns/call)   speedup");
+        println!("  {}", "-".repeat(60));
+        println!(
+            "  FOCE  (SB)       {ns_sb_fd:>9.0}        {ns_sb_mu:>9.0}       {:.2}x",
+            ns_sb_fd / ns_sb_mu
+        );
+        println!(
+            "  FOCEI (Laplace)  {ns_lp_fd:>9.0}        {ns_lp_mu:>9.0}       {:.2}x",
+            ns_lp_fd / ns_lp_mu
+        );
+        println!();
+        println!(
+            "  Expected saving/call from skipping 3 FD solves: ~{:.0} ns  ({:.0}% of FD cost)",
+            3.0 * ns_pred,
+            100.0 * 3.0 * ns_pred / ns_sb_fd.max(1.0)
+        );
+    }
+
+    /// Verify that the mu-ref gradient shortcut (H-column read) gives the same
+    /// theta gradient as forward FD for both the SB and Laplace paths.
+    ///
+    /// The test model has CL = TVCL * exp(ETA_CL) — a log mu-referenced pair.
+    /// H[:,0] is computed numerically from the eta Jacobian; mathematically it
+    /// equals ∂f/∂(log TVCL) exactly, so the shortcut and FD should agree to
+    /// within FD error (~1e-5 relative).
+    #[test]
+    fn test_mu_ref_gradient_shortcut() {
+        use crate::types::MuRef;
+
+        let mut model = make_model();
+        // Register the mu-referencing: ETA_CL is paired with TVCL (log-transformed).
+        model.mu_refs.insert(
+            "ETA_CL".into(),
+            MuRef {
+                theta_name: "TVCL".into(),
+                log_transformed: true,
+            },
+        );
+
+        let population = make_population();
+        let template = &model.default_params;
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+
+        let n_obs = 3;
+        let n_eta = 1;
+        let eta_hat = DVector::from_vec(vec![0.05]);
+
+        // Compute H numerically: ∂f/∂η_0 via forward FD on eta.
+        let params = crate::estimation::parameterization::unpack_params(&x, template);
+        let ipreds_base = crate::pk::compute_predictions_with_tv(
+            &model,
+            &population.subjects[0],
+            &params.theta,
+            eta_hat.as_slice(),
+        );
+        let h_step = 1e-6;
+        let eta_pert = DVector::from_vec(vec![eta_hat[0] + h_step]);
+        let ipreds_pert_eta = crate::pk::compute_predictions_with_tv(
+            &model,
+            &population.subjects[0],
+            &params.theta,
+            eta_pert.as_slice(),
+        );
+        let h_col: Vec<f64> = ipreds_pert_eta
+            .iter()
+            .zip(ipreds_base.iter())
+            .map(|(&p, &b)| (p - b) / h_step)
+            .collect();
+        let h_matrix = nalgebra::DMatrix::from_column_slice(n_obs, n_eta, &h_col);
+
+        // SB path (interaction = false)
+        let mut opts_sb = FitOptions::default();
+        opts_sb.interaction = false;
+
+        opts_sb.mu_referencing = true;
+        let (_, grad_muref_sb) = subject_nll_pop_grad_analytical(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts_sb,
+        )
+        .expect("mu-ref SB path should succeed");
+
+        opts_sb.mu_referencing = false;
+        let (_, grad_fd_sb) = subject_nll_pop_grad_analytical(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts_sb,
+        )
+        .expect("FD SB path should succeed");
+
+        let n = x.len();
+        for j in 0..n {
+            let tol = 1e-4 * (1.0 + grad_fd_sb[j].abs());
+            assert!(
+                (grad_muref_sb[j] - grad_fd_sb[j]).abs() < tol,
+                "SB grad[{j}]: mu-ref={:.6e}, FD={:.6e}, diff={:.2e}",
+                grad_muref_sb[j],
+                grad_fd_sb[j],
+                (grad_muref_sb[j] - grad_fd_sb[j]).abs()
+            );
+        }
+
+        // Laplace path (interaction = true)
+        let mut opts_lap = FitOptions::default();
+        opts_lap.interaction = true;
+
+        opts_lap.mu_referencing = true;
+        let (_, grad_muref_lap) = subject_nll_pop_grad_analytical_laplace(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts_lap,
+        )
+        .expect("mu-ref Laplace path should succeed");
+
+        opts_lap.mu_referencing = false;
+        let (_, grad_fd_lap) = subject_nll_pop_grad_analytical_laplace(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts_lap,
+        )
+        .expect("FD Laplace path should succeed");
+
+        for j in 0..n {
+            let tol = 1e-4 * (1.0 + grad_fd_lap[j].abs());
+            assert!(
+                (grad_muref_lap[j] - grad_fd_lap[j]).abs() < tol,
+                "Laplace grad[{j}]: mu-ref={:.6e}, FD={:.6e}, diff={:.2e}",
+                grad_muref_lap[j],
+                grad_fd_lap[j],
+                (grad_muref_lap[j] - grad_fd_lap[j]).abs()
+            );
+        }
+    }
+
+    /// Additive mu-refs (log_transformed: false) must NOT use the H-column
+    /// shortcut. Ferx packs all thetas as log(THETA), so for an additive pair
+    /// PARAM = THETA + ETA the identity ∂f/∂x_k = H[:,j] does not hold:
+    ///   ∂f/∂x_k = ∂f/∂(log THETA) = THETA · ∂f/∂PARAM
+    ///   ∂f/∂η   =                         1 · ∂f/∂PARAM   (≠ above unless THETA=1)
+    ///
+    /// This test registers an additive mu-ref and verifies that the gradient
+    /// with mu_referencing=true still equals the FD gradient (i.e. the shortcut
+    /// was skipped and FD was used as the fallback).
+    #[test]
+    fn test_mu_ref_additive_skipped() {
+        use crate::types::MuRef;
+
+        let mut model = make_model();
+        // Register an additive (non-log) mu-ref for TVCL.
+        model.mu_refs.insert(
+            "ETA_CL".into(),
+            MuRef {
+                theta_name: "TVCL".into(),
+                log_transformed: false,
+            },
+        );
+
+        let population = make_population();
+        let template = &model.default_params;
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n_obs = 3;
+        let n_eta = 1;
+        let eta_hat = DVector::from_vec(vec![0.05]);
+        let h_matrix = nalgebra::DMatrix::from_vec(n_obs, n_eta, vec![2.0, 1.5, 0.8]);
+
+        let mut opts = FitOptions::default();
+        opts.interaction = false;
+
+        // Both should use FD (shortcut skipped for additive), so results must match.
+        opts.mu_referencing = true;
+        let (_, grad_on) = subject_nll_pop_grad_analytical(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts,
+        )
+        .expect("should succeed");
+
+        opts.mu_referencing = false;
+        let (_, grad_off) = subject_nll_pop_grad_analytical(
+            &x,
+            template,
+            &model,
+            &population,
+            0,
+            &eta_hat,
+            &h_matrix,
+            &bounds,
+            &opts,
+        )
+        .expect("should succeed");
+
+        let n = x.len();
+        for j in 0..n {
+            assert!(
+                (grad_on[j] - grad_off[j]).abs() < 1e-10,
+                "additive mu-ref: grad[{j}] differed (shortcut was wrongly applied): \
+                 on={:.6e}, off={:.6e}",
+                grad_on[j],
+                grad_off[j]
             );
         }
     }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1853,6 +1853,105 @@ fn backtracking_line_search_warm(
     0.0
 }
 
+/// Gradient of the Ω-prior terms `Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]` w.r.t. the packed
+/// omega Cholesky entries (the omega block of the packed parameter vector).
+///
+/// Used only on the **FOCE standard path** (`interaction = false`). The
+/// standard `pop_nll` excludes the omega prior, so the covariance-step
+/// objective adds it explicitly and this function provides its gradient.
+/// For FOCEI/Laplace (`interaction = true`) the prior is already inside
+/// `pop_nll`, so adding this again would double-count it.
+///
+/// Chain rule through the packed Cholesky parameterisation:
+/// - Diagonal entries are log-packed: xₖ = log L[i,i], so chain rule × L[i,i]
+/// - Off-diagonal entries are identity-packed: xₖ = L[i,j], chain rule × 1
+fn omega_prior_gradient(eta_hats: &[DVector<f64>], params: &ModelParameters) -> Vec<f64> {
+    let n_eta = params.omega.dim();
+    let n_subj = eta_hats.len() as f64;
+    let n_packed = if params.omega.diagonal {
+        n_eta
+    } else {
+        n_eta * (n_eta + 1) / 2
+    };
+
+    let omega_inv = match params.omega.matrix.clone().cholesky() {
+        Some(c) => c.inverse(),
+        None => return vec![0.0; n_packed],
+    };
+
+    // S = Σᵢ ηᵢ ηᵢᵀ (ETA scatter matrix, fixed at EBE values)
+    let mut s = DMatrix::zeros(n_eta, n_eta);
+    for eta in eta_hats {
+        s += eta * eta.transpose();
+    }
+
+    // M = Ω⁻¹ S Ω⁻¹ L — appears in d(tr(S Ω⁻¹))/dL = −2 M (lower-tri)
+    let l = &params.omega.chol;
+    let m = &omega_inv * &s * &omega_inv * l;
+
+    let mut grad = Vec::with_capacity(n_packed);
+    if params.omega.diagonal {
+        for i in 0..n_eta {
+            // d/d(log L[i,i]) = (−2 M[i,i] + 2 n_subj/L[i,i]) · L[i,i]
+            //                 = −2 M[i,i] · L[i,i] + 2 n_subj
+            grad.push(-2.0 * m[(i, i)] * l[(i, i)] + 2.0 * n_subj);
+        }
+    } else {
+        for j in 0..n_eta {
+            for i in j..n_eta {
+                if i == j {
+                    grad.push(-2.0 * m[(i, i)] * l[(i, i)] + 2.0 * n_subj);
+                } else {
+                    // d/d(L[i,j]) = −2 M[i,j]  (identity packing)
+                    grad.push(-2.0 * m[(i, j)]);
+                }
+            }
+        }
+    }
+    grad
+}
+
+/// Gradient of the covariance-step objective w.r.t. the packed parameter
+/// vector, with ETAs and H-matrices held fixed.
+///
+/// The objective differs by path:
+/// - **FOCE** (`interaction = false`): `2·pop_nll + Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]`.
+///   `pop_nll` here is the standard (SB) path, which does NOT include the
+///   omega prior per subject, so it must be added analytically.
+/// - **FOCEI / Laplace** (`interaction = true`): `2·pop_nll`.
+///   `pop_nll` is the Almquist-Laplace path, which already includes
+///   `ηᵀΩ⁻¹η + log|Ω|` inside each subject NLL — no extra omega term needed.
+#[allow(clippy::too_many_arguments)]
+fn covariance_gradient(
+    x: &[f64],
+    template: &ModelParameters,
+    model: &CompiledModel,
+    population: &Population,
+    eta_hats: &[DVector<f64>],
+    h_matrices: &[DMatrix<f64>],
+    kappas: &[Vec<DVector<f64>>],
+    bounds: &PackedBounds,
+    options: &FitOptions,
+) -> Vec<f64> {
+    let n_subj = population.subjects.len();
+    let mut grad = ad_population_gradient(
+        x, n_subj, template, model, population, eta_hats, h_matrices, kappas, bounds, options,
+    );
+    // FOCE standard path: pop_nll does not include the omega prior — add it.
+    // FOCEI/Laplace: pop_nll already includes ηᵀΩ⁻¹η + log|Ω| per subject.
+    if !options.interaction {
+        let params = unpack_params(x, template);
+        let n_theta = template.theta.len();
+        for (k, g) in omega_prior_gradient(eta_hats, &params)
+            .into_iter()
+            .enumerate()
+        {
+            grad[n_theta + k] += g;
+        }
+    }
+    grad
+}
+
 /// Outcome of the FD covariance step. `matrix` is the n×n covariance with FIX
 /// rows/cols zeroed; `warnings` carries non-fatal notes (regularisation applied,
 /// off-diagonal FD stencil failures, etc.). Empty when everything was clean.
@@ -1990,16 +2089,30 @@ fn format_non_pd_warning(eigvals: &[f64]) -> String {
     )
 }
 
-/// Compute covariance matrix via finite-difference Hessian at convergence.
+/// Compute the parameter covariance matrix at convergence (the R-matrix:
+/// inverse observed Fisher information).
+///
+/// The Hessian is built by finite differences that **reconverge the inner EBE
+/// loop at every perturbed point** — matching how NONMEM's `$COVARIANCE` step
+/// works. Holding the EBEs fixed (the previous behaviour) gives a Hessian with
+/// the wrong curvature, indefinite even on well-conditioned surfaces like
+/// warfarin, which forced eigenvalue clipping (#129) and inflated the SEs.
+///
+/// Two stencils:
+/// - **non-IOV**: central FD of the analytical population gradient (issue #209),
+///   `H[:,k] ≈ (g(x̂+hₖeₖ) − g(x̂−hₖeₖ)) / 2hₖ` — `2·n_free` gradient evaluations.
+///   The θ part reuses H-matrix columns for mu-referenced parameters (issue #196).
+/// - **IOV**: second differences of the reconverged OFV (the kappa block has no
+///   fixed-EBE analytical gradient).
+///
+/// The returned covariance is `2·H⁻¹`: the objective is `−2·logL`, so its Hessian
+/// is twice the observed information.
 ///
 /// Returns [`CovarianceStepResult::Unusable`] when the FD Hessian is structurally
-/// unusable (non-finite or zero-diagonal entries). When the symmetrised free-block
-/// Hessian is near-singular or has negative eigenvalues — a common FD noise
-/// artefact on well-conditioned surfaces (see issue #129) — it is regularised
-/// by clipping eigenvalues to a small positive floor before inversion, and the
-/// returned `warning` records what was done. When the Hessian has no positive
-/// curvature at all (all eigenvalues ≤ 0), returns
-/// [`CovarianceStepResult::Unusable`] carrying the eigenvalue list formatted as a warning.
+/// unusable (non-finite or zero-diagonal entries) or has no positive curvature at
+/// all. A near-singular or marginally-indefinite free block is regularised by
+/// clipping eigenvalues to a small positive floor before inversion (rare now that
+/// the EBEs reconverge), recorded in the returned `warnings`.
 pub(crate) fn compute_covariance(
     x_hat: &[f64],
     template: &ModelParameters,
@@ -2019,52 +2132,86 @@ pub(crate) fn compute_covariance(
             eps
         ));
     }
+    let bounds = compute_bounds(template);
 
-    // OFV for covariance step: includes explicit Omega terms (log|Omega| + eta'*Omega_inv*eta)
-    // so the Hessian is sensitive to Omega parameters.
-    // This matches Julia's foce_population_nll_diff.
-    let ofv_fixed = |x: &[f64]| -> f64 {
-        let params = unpack_params(x, template);
+    // `h_matrices` (the H from the fit) is intentionally unused: the covariance
+    // step reconverges the EBEs at every perturbed point and recomputes H there.
+    // It stays in the signature for symmetry with `eta_hats` (the reconvergence
+    // warm-start) and with the other optimizers' call sites.
+    let _ = h_matrices;
+
+    // Re-solve the inner EBE loop at a packed point (warm-started from the
+    // converged EBEs). NONMEM reconverges the conditional estimates at every
+    // perturbed point in its covariance step; holding η̂/H fixed gives a Hessian
+    // with the wrong curvature — indefinite even on warfarin, which previously
+    // forced eigenvalue clipping (#129) and inflated the SEs. Both the
+    // gradient-FD and scalar-FD paths below reconverge through this helper.
+    let reconverge = |xv: &[f64]| {
+        let params = unpack_params(xv, template);
+        let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
+        let (ehs, hms, _stats, kaps) = run_inner_loop_warm(
+            model,
+            population,
+            &params,
+            options.inner_maxiter,
+            options.inner_tol,
+            Some(eta_hats),
+            Some(&mu_k),
+            options.min_obs_for_convergence_check as usize,
+        );
+        (params, ehs, hms, kaps)
+    };
+
+    // Covariance OFV = −2·logL at a reconverged point. For FOCEI the per-subject
+    // marginal already carries ηᵀΩ⁻¹η + log|Ω|; for FOCE we add that prior here.
+    let ofv = |xv: &[f64]| -> f64 {
+        let (params, ehs, hms, kaps) = reconverge(xv);
         let foce_nll = pop_nll(
             model,
             population,
             &params,
-            eta_hats,
-            h_matrices,
-            kappas,
+            &ehs,
+            &hms,
+            &kaps,
             options.interaction,
         );
-
-        // Add explicit Omega prior terms for each subject
-        let n_subj = eta_hats.len();
-        let n_eta = if n_subj > 0 { eta_hats[0].len() } else { 0 };
-
+        if options.interaction {
+            return 2.0 * foce_nll;
+        }
+        let n_eta = if !ehs.is_empty() { ehs[0].len() } else { 0 };
         let omega_inv = match params.omega.matrix.clone().cholesky() {
             Some(c) => c.inverse(),
             None => return 1e20,
         };
-        let log_det_omega = {
-            let mut ld = 0.0;
-            for i in 0..n_eta {
-                let lii = params.omega.chol[(i, i)];
-                if lii > 0.0 {
-                    ld += lii.ln();
-                } else {
-                    return 1e20;
-                }
+        let mut ld = 0.0;
+        for i in 0..n_eta {
+            let lii = params.omega.chol[(i, i)];
+            if lii > 0.0 {
+                ld += lii.ln();
+            } else {
+                return 1e20;
             }
-            2.0 * ld
-        };
-
+        }
+        let log_det_omega = 2.0 * ld;
         let mut omega_terms = 0.0;
-        for eta in eta_hats {
+        for eta in &ehs {
             omega_terms += eta.dot(&(&omega_inv * eta)) + log_det_omega;
         }
-
         2.0 * foce_nll + omega_terms
     };
 
-    let base_ofv = ofv_fixed(x_hat);
+    // Gradient of the covariance OFV at a reconverged point. Uses the analytical
+    // population gradient — issue #196's H-column shortcut makes the θ part exact
+    // for mu-referenced parameters — and `covariance_gradient` adds the FOCE
+    // omega-prior gradient so it is consistent with `ofv` above.
+    let grad = |xv: &[f64]| -> Vec<f64> {
+        let (_, ehs, hms, kaps) = reconverge(xv);
+        covariance_gradient(
+            xv, template, model, population, &ehs, &hms, &kaps, &bounds, options,
+        )
+    };
+
+    let base_ofv = ofv(x_hat);
     if !base_ofv.is_finite() {
         // Diagnose: check Omega conditioning to distinguish Omega collapse from
         // a model-evaluation overflow/underflow.
@@ -2108,69 +2255,104 @@ pub(crate) fn compute_covariance(
     let free_idx: Vec<usize> = (0..n).filter(|&i| !fixed_mask[i]).collect();
 
     let mut hess = DMatrix::zeros(n, n);
-    let mut x_ij = x_hat.to_vec();
+    let is_iov = kappas.iter().any(|k| !k.is_empty());
 
-    let f0 = base_ofv;
-
-    // Track FD failures at source so diagnostics name the right cause.
-    // The FD loop never stores non-finite values (guarded by is_finite() below),
-    // so post-hoc non-finite checks on `hess` would always be false. Instead we
-    // record which packed indices had a NaN/Inf stencil result here.
-    // HashSet gives O(1) insertion and lookup vs. O(n) for Vec.
+    // Track FD failures at source so diagnostics name the right cause (a NaN/Inf
+    // stencil result is not a genuine zero curvature). HashSet for O(1) ops.
     let mut fd_diag_nan: HashSet<usize> = HashSet::new();
-    // Packed indices for which at least one cross-partial stencil returned NaN/Inf.
-    // The stored off-diagonal stays 0 (no correlation info) — not fatal, but noted.
     let mut fd_offdiag_nan: HashSet<usize> = HashSet::new();
 
-    for &i in &free_idx {
-        let hi = eps * (1.0 + x_hat[i].abs());
-
-        // Diagonal: 3-point formula  (f(x+h) - 2f(x) + f(x-h)) / h^2
-        x_ij[i] = x_hat[i] + hi;
-        let fp = ofv_fixed(&x_ij);
-        x_ij[i] = x_hat[i] - hi;
-        let fm = ofv_fixed(&x_ij);
-        x_ij[i] = x_hat[i];
-
-        let h_ii = (fp - 2.0 * f0 + fm) / (hi * hi);
-        if h_ii.is_finite() {
-            hess[(i, i)] = h_ii;
-        } else {
-            fd_diag_nan.insert(i);
-        }
-
-        // Off-diagonal: 4-point stencil (over free indices only)
-        for &j in &free_idx {
-            if j <= i {
-                continue;
+    if !is_iov {
+        // Issue #209: central FD of the analytical population gradient —
+        //   H[:,k] ≈ (g(x̂ + hₖ·eₖ) − g(x̂ − hₖ·eₖ)) / 2hₖ
+        // 2·n_free gradient evaluations vs ~2·n_free² scalar-OFV evaluations, with
+        // no 4-point cross-stencil cancellation (#129). `grad` reconverges the EBEs
+        // at each perturbed point, so the curvature includes the EBE response.
+        for &k in &free_idx {
+            let hk = eps * (1.0 + x_hat[k].abs());
+            let mut x_p = x_hat.to_vec();
+            let mut x_m = x_hat.to_vec();
+            x_p[k] += hk;
+            x_m[k] -= hk;
+            let g_p = grad(&x_p);
+            let g_m = grad(&x_m);
+            for &j in &free_idx {
+                let h_jk = (g_p[j] - g_m[j]) / (2.0 * hk);
+                if h_jk.is_finite() {
+                    hess[(j, k)] = h_jk;
+                } else if j == k {
+                    fd_diag_nan.insert(k);
+                } else {
+                    fd_offdiag_nan.insert(k);
+                    fd_offdiag_nan.insert(j);
+                }
             }
-            let hj = eps * (1.0 + x_hat[j].abs());
+        }
+        // Symmetrise: each column is differenced independently, so H[j,k] and
+        // H[k,j] can differ slightly; average before inversion.
+        for &i in &free_idx {
+            for &j in &free_idx {
+                if j > i {
+                    let avg = (hess[(i, j)] + hess[(j, i)]) * 0.5;
+                    hess[(i, j)] = avg;
+                    hess[(j, i)] = avg;
+                }
+            }
+        }
+    } else {
+        // IOV fallback: no fixed-EBE analytical gradient covers the kappa block, so
+        // build the Hessian from second differences of the reconverged OFV (3-point
+        // diagonal, 4-point off-diagonal). `ofv` reconverges the joint (η, κ) EBEs.
+        let f0 = base_ofv;
+        let mut x_ij = x_hat.to_vec();
+        for &i in &free_idx {
+            let hi = eps * (1.0 + x_hat[i].abs());
 
+            // Diagonal: 3-point formula  (f(x+h) - 2f(x) + f(x-h)) / h^2
             x_ij[i] = x_hat[i] + hi;
-            x_ij[j] = x_hat[j] + hj;
-            let fpp = ofv_fixed(&x_ij);
-
-            x_ij[j] = x_hat[j] - hj;
-            let fpm = ofv_fixed(&x_ij);
-
+            let fp = ofv(&x_ij);
             x_ij[i] = x_hat[i] - hi;
-            let fmm = ofv_fixed(&x_ij);
-
-            x_ij[j] = x_hat[j] + hj;
-            let fmp = ofv_fixed(&x_ij);
-
+            let fm = ofv(&x_ij);
             x_ij[i] = x_hat[i];
-            x_ij[j] = x_hat[j];
 
-            let h_ij = (fpp - fpm - fmp + fmm) / (4.0 * hi * hj);
-            if h_ij.is_finite() {
-                hess[(i, j)] = h_ij;
-                hess[(j, i)] = h_ij;
+            let h_ii = (fp - 2.0 * f0 + fm) / (hi * hi);
+            if h_ii.is_finite() {
+                hess[(i, i)] = h_ii;
             } else {
-                // Both parameters lose their shared cross-partial.
-                // HashSet::insert is idempotent — no manual dedup needed.
-                fd_offdiag_nan.insert(i);
-                fd_offdiag_nan.insert(j);
+                fd_diag_nan.insert(i);
+            }
+
+            // Off-diagonal: 4-point stencil (over free indices only)
+            for &j in &free_idx {
+                if j <= i {
+                    continue;
+                }
+                let hj = eps * (1.0 + x_hat[j].abs());
+
+                x_ij[i] = x_hat[i] + hi;
+                x_ij[j] = x_hat[j] + hj;
+                let fpp = ofv(&x_ij);
+
+                x_ij[j] = x_hat[j] - hj;
+                let fpm = ofv(&x_ij);
+
+                x_ij[i] = x_hat[i] - hi;
+                let fmm = ofv(&x_ij);
+
+                x_ij[j] = x_hat[j] + hj;
+                let fmp = ofv(&x_ij);
+
+                x_ij[i] = x_hat[i];
+                x_ij[j] = x_hat[j];
+
+                let h_ij = (fpp - fpm - fmp + fmm) / (4.0 * hi * hj);
+                if h_ij.is_finite() {
+                    hess[(i, j)] = h_ij;
+                    hess[(j, i)] = h_ij;
+                } else {
+                    fd_offdiag_nan.insert(i);
+                    fd_offdiag_nan.insert(j);
+                }
             }
         }
     }
@@ -2244,7 +2426,10 @@ pub(crate) fn compute_covariance(
             return CovarianceStepResult::Unusable(msg);
         }
     };
-    let cov_free = inv.inverse;
+    // The FD Hessian is of the OFV = −2·logL. The asymptotic covariance is the
+    // inverse observed Fisher information = Hessian of −logL = ½·H_ofv, so
+    // cov = 2·H_ofv⁻¹. Without this factor every SE is 1/√2 too small.
+    let cov_free = inv.inverse * 2.0;
 
     let mut cov = DMatrix::zeros(n, n);
     for (a, &i) in free_idx.iter().enumerate() {
@@ -3307,6 +3492,362 @@ mod tests {
         }
     }
 
+    // ── omega_prior_gradient / covariance_gradient (issue #209) ─────────────
+
+    /// `omega_prior_gradient` must match the numerical gradient of the Ω-prior
+    /// objective `Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]` w.r.t. the packed omega entries.
+    #[test]
+    fn test_omega_prior_gradient_diagonal_matches_fd() {
+        let omega =
+            OmegaMatrix::from_diagonal(&[0.09, 0.04], vec!["eta_cl".into(), "eta_v".into()]);
+        let params = ModelParameters {
+            theta: vec![5.0],
+            theta_names: vec!["CL".into()],
+            theta_lower: vec![0.1],
+            theta_upper: vec![100.0],
+            theta_fixed: vec![false],
+            omega,
+            omega_fixed: vec![false, false],
+            sigma: SigmaVector {
+                values: vec![0.1],
+                names: vec!["s".into()],
+            },
+            sigma_fixed: vec![false],
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+        };
+        let eta_hats = vec![
+            DVector::from_column_slice(&[0.1, -0.2_f64]),
+            DVector::from_column_slice(&[-0.3, 0.15_f64]),
+            DVector::from_column_slice(&[0.2, 0.05_f64]),
+        ];
+
+        let omega_terms_at = |p: &ModelParameters| -> f64 {
+            let omega_inv = p.omega.matrix.clone().cholesky().unwrap().inverse();
+            let n_e = p.omega.dim();
+            let log_det = 2.0 * (0..n_e).map(|i| p.omega.chol[(i, i)].ln()).sum::<f64>();
+            eta_hats
+                .iter()
+                .map(|eta| eta.dot(&(&omega_inv * eta)) + log_det)
+                .sum()
+        };
+
+        let grad = omega_prior_gradient(&eta_hats, &params);
+        assert_eq!(grad.len(), 2);
+
+        let packed = pack_params(&params);
+        let n_theta = 1usize;
+        let eps = 1e-5;
+        for k in 0..2 {
+            let mut xp = packed.clone();
+            let mut xm = packed.clone();
+            xp[n_theta + k] += eps;
+            xm[n_theta + k] -= eps;
+            let fd = (omega_terms_at(&unpack_params(&xp, &params))
+                - omega_terms_at(&unpack_params(&xm, &params)))
+                / (2.0 * eps);
+            let tol = 1e-5 * (1.0 + fd.abs());
+            assert!(
+                (grad[k] - fd).abs() < tol,
+                "omega_prior_gradient[{k}]: analytical={:.6e}, FD={:.6e}",
+                grad[k],
+                fd,
+            );
+        }
+    }
+
+    /// `covariance_gradient` (FOCE path, interaction=false) must match FD of
+    /// `ofv_fixed = 2·pop_nll + Σᵢ[ηᵀΩ⁻¹η + log|Ω|]`.
+    #[test]
+    fn test_covariance_gradient_foce_matches_fd_ofv_fixed() {
+        let model = make_model();
+        let template = &model.default_params;
+        let population = make_population(3);
+        let n_subj = 3;
+        let n_obs = 3;
+        let n_eta = 1;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+        let mut options = FitOptions::default();
+        options.interaction = false; // FOCE: omega prior added separately
+
+        let eta_hats: Vec<DVector<f64>> = (0..n_subj).map(|_| DVector::zeros(n_eta)).collect();
+        let h_matrices: Vec<nalgebra::DMatrix<f64>> = (0..n_subj)
+            .map(|_| nalgebra::DMatrix::from_element(n_obs, n_eta, 0.1))
+            .collect();
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]; n_subj];
+
+        // FOCE ofv_fixed = 2·pop_nll + Σᵢ[ηᵀΩ⁻¹η + log|Ω|]
+        let ofv_fixed = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, template);
+            let foce = pop_nll(
+                &model,
+                &population,
+                &p,
+                &eta_hats,
+                &h_matrices,
+                &kappas,
+                false, // FOCE
+            );
+            let omega_inv = p.omega.matrix.clone().cholesky().unwrap().inverse();
+            let n_e = p.omega.dim();
+            let log_det = 2.0 * (0..n_e).map(|i| p.omega.chol[(i, i)].ln()).sum::<f64>();
+            let omega_terms: f64 = eta_hats
+                .iter()
+                .map(|eta| eta.dot(&(&omega_inv * eta)) + log_det)
+                .sum();
+            2.0 * foce + omega_terms
+        };
+
+        let grad = covariance_gradient(
+            &x,
+            template,
+            &model,
+            &population,
+            &eta_hats,
+            &h_matrices,
+            &kappas,
+            &bounds,
+            &options,
+        );
+
+        let eps = 1e-4;
+        for j in 0..n {
+            let h = eps * (1.0 + x[j].abs());
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += h;
+            xm[j] -= h;
+            let fd = (ofv_fixed(&xp) - ofv_fixed(&xm)) / (2.0 * h);
+            let tol = 1e-3 * (1.0 + fd.abs());
+            assert!(
+                (grad[j] - fd).abs() < tol,
+                "covariance_gradient FOCE [{j}]: grad={:.6e}, FD_ofv={:.6e}",
+                grad[j],
+                fd,
+            );
+        }
+    }
+
+    /// `covariance_gradient` (FOCEI path, interaction=true) must match FD of
+    /// `2·pop_nll` only — pop_nll already contains ηᵀΩ⁻¹η + log|Ω| per subject.
+    #[test]
+    fn test_covariance_gradient_focei_matches_fd_2pop_nll() {
+        let model = make_model();
+        let template = &model.default_params;
+        let population = make_population(3);
+        let n_subj = 3;
+        let n_obs = 3;
+        let n_eta = 1;
+
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+        let mut options = FitOptions::default();
+        options.interaction = true; // FOCEI: omega prior inside pop_nll
+
+        let eta_hats: Vec<DVector<f64>> = (0..n_subj).map(|_| DVector::zeros(n_eta)).collect();
+        let h_matrices: Vec<nalgebra::DMatrix<f64>> = (0..n_subj)
+            .map(|_| nalgebra::DMatrix::from_element(n_obs, n_eta, 0.1))
+            .collect();
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]; n_subj];
+
+        // FOCEI ofv_fixed = 2·pop_nll (omega prior already inside)
+        let ofv_fixed_focei = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, template);
+            2.0 * pop_nll(
+                &model,
+                &population,
+                &p,
+                &eta_hats,
+                &h_matrices,
+                &kappas,
+                true, // FOCEI
+            )
+        };
+
+        let grad = covariance_gradient(
+            &x,
+            template,
+            &model,
+            &population,
+            &eta_hats,
+            &h_matrices,
+            &kappas,
+            &bounds,
+            &options,
+        );
+
+        let eps = 1e-4;
+        for j in 0..n {
+            let h = eps * (1.0 + x[j].abs());
+            let mut xp = x.clone();
+            let mut xm = x.clone();
+            xp[j] += h;
+            xm[j] -= h;
+            let fd = (ofv_fixed_focei(&xp) - ofv_fixed_focei(&xm)) / (2.0 * h);
+            let tol = 1e-3 * (1.0 + fd.abs());
+            assert!(
+                (grad[j] - fd).abs() < tol,
+                "covariance_gradient FOCEI [{j}]: grad={:.6e}, FD_ofv={:.6e}",
+                grad[j],
+                fd,
+            );
+        }
+    }
+
+    /// End-to-end guard for `compute_covariance` (#209 + the factor-of-2 fix):
+    /// the reconverging central gradient-FD covariance must (a) compute without
+    /// regularization on a well-conditioned surface, (b) be positive-definite,
+    /// and (c) equal `2·H⁻¹` of an *independently* reconverged scalar-FD Hessian.
+    /// A missing factor of two would be ~29% off (caught by the 15% band); a
+    /// broken reconvergence would diverge wildly.
+    #[test]
+    fn test_compute_covariance_reconverged_matches_scalar_fd_with_factor_two() {
+        let model = make_model();
+        // Put the model at a near-optimum: set observations to the η=0
+        // predictions of the 1-cpt IV model (CL=5, V=50, dose=100):
+        // conc(t) = (100/50)·exp(−(5/50)·t) at t = 1, 4, 8.
+        let mut population = make_population(8);
+        for s in &mut population.subjects {
+            s.observations = vec![1.80967, 1.34064, 0.89866];
+        }
+        // Fix ω and σ so the free block is the θ Hessian, which is positive
+        // definite at this near-optimum (ω/σ would otherwise be pulled toward
+        // their boundaries by the noise-free residuals, an artefact of the
+        // synthetic data, not of the covariance code).
+        let mut template = model.default_params.clone();
+        template.omega_fixed = vec![true];
+        template.sigma_fixed = vec![true];
+        let template = &template;
+
+        let n_subj = 8;
+        let n_eta = 1;
+        let n_obs = 3;
+        let x = pack_params(template);
+        let n = x.len();
+        let mut options = FitOptions::default();
+        options.interaction = true;
+
+        // Warm-start EBEs (compute_covariance reconverges from these; the passed
+        // h_matrices are intentionally ignored and recomputed).
+        let eta_hats: Vec<DVector<f64>> = (0..n_subj).map(|_| DVector::zeros(n_eta)).collect();
+        let h_matrices: Vec<DMatrix<f64>> = (0..n_subj)
+            .map(|_| DMatrix::from_element(n_obs, n_eta, 0.1))
+            .collect();
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]; n_subj];
+
+        let out = match compute_covariance(
+            &x,
+            template,
+            &model,
+            &population,
+            &eta_hats,
+            &h_matrices,
+            &kappas,
+            &options,
+        ) {
+            CovarianceStepResult::Success(out) => out,
+            CovarianceStepResult::Unusable(msg) => {
+                panic!("covariance must compute on the synthetic 1-cpt model: {msg}")
+            }
+        };
+
+        // (a) No eigenvalue clipping on this well-conditioned surface.
+        assert!(
+            out.warnings.is_empty(),
+            "unexpected covariance regularization: {:?}",
+            out.warnings
+        );
+
+        let fixed = packed_fixed_mask(template);
+        let free_idx: Vec<usize> = (0..n).filter(|&i| !fixed[i]).collect();
+
+        // (b) Positive-definite: every free diagonal is positive and finite.
+        for &i in &free_idx {
+            let v = out.matrix[(i, i)];
+            assert!(
+                v.is_finite() && v > 0.0,
+                "covariance diagonal [{i}] = {v} is not positive-finite"
+            );
+        }
+
+        // (c) Independent reference: 2·inv(reconverged scalar-FD Hessian).
+        // Mirrors the production `ofv` closure (interaction=true → 2·pop_nll,
+        // reconverging EBEs from the same warm start).
+        let ofv = |xv: &[f64]| -> f64 {
+            let params = unpack_params(xv, template);
+            let mu_k = compute_mu_k(&model, &params.theta, options.mu_referencing);
+            let (ehs, hms, _s, kaps) = run_inner_loop_warm(
+                &model,
+                &population,
+                &params,
+                options.inner_maxiter,
+                options.inner_tol,
+                Some(&eta_hats),
+                Some(&mu_k),
+                options.min_obs_for_convergence_check as usize,
+            );
+            2.0 * pop_nll(&model, &population, &params, &ehs, &hms, &kaps, true)
+        };
+
+        let eps = 1e-2;
+        let f0 = ofv(&x);
+        let nf = free_idx.len();
+        let mut h = DMatrix::zeros(nf, nf);
+        let mut x_ij = x.clone();
+        for (a, &i) in free_idx.iter().enumerate() {
+            let hi = eps * (1.0 + x[i].abs());
+            x_ij[i] = x[i] + hi;
+            let fp = ofv(&x_ij);
+            x_ij[i] = x[i] - hi;
+            let fm = ofv(&x_ij);
+            x_ij[i] = x[i];
+            h[(a, a)] = (fp - 2.0 * f0 + fm) / (hi * hi);
+            for (b, &j) in free_idx.iter().enumerate() {
+                if j <= i {
+                    continue;
+                }
+                let hj = eps * (1.0 + x[j].abs());
+                x_ij[i] = x[i] + hi;
+                x_ij[j] = x[j] + hj;
+                let fpp = ofv(&x_ij);
+                x_ij[j] = x[j] - hj;
+                let fpm = ofv(&x_ij);
+                x_ij[i] = x[i] - hi;
+                let fmm = ofv(&x_ij);
+                x_ij[j] = x[j] + hj;
+                let fmp = ofv(&x_ij);
+                x_ij[i] = x[i];
+                x_ij[j] = x[j];
+                let v = (fpp - fpm - fmp + fmm) / (4.0 * hi * hj);
+                h[(a, b)] = v;
+                h[(b, a)] = v;
+            }
+        }
+        let h_sym = (&h + h.transpose()) * 0.5;
+        let ref_cov = invert_psd_with_floor(&h_sym)
+            .expect("reference Hessian inverts")
+            .inverse
+            * 2.0;
+
+        // SE (sqrt of diagonal) must agree within 15%: catches a missing factor
+        // of two (~29%) and any reconvergence/scale break, while tolerating the
+        // gradient-FD-vs-scalar-FD truncation difference at eps=1e-2.
+        for (a, &i) in free_idx.iter().enumerate() {
+            let se_prod = out.matrix[(i, i)].sqrt();
+            let se_ref = ref_cov[(a, a)].sqrt();
+            let rel = (se_prod - se_ref).abs() / se_ref;
+            assert!(
+                rel < 0.15,
+                "SE[{i}]: compute_covariance {se_prod:.6e} vs scalar-FD reference {se_ref:.6e} (rel {:.1}%)",
+                rel * 100.0
+            );
+        }
+    }
+
     // ── SLSQP overshoot guard tests (issue #55) ────────────────────────────
     //
     // NLopt LD_SLSQP starts every fit with its quasi-Newton Hessian set to
@@ -3525,5 +4066,158 @@ mod tests {
             result.ofv.is_finite(),
             "presearch run produced non-finite OFV"
         );
+    }
+
+    // ── Covariance Hessian throughput benchmark (issue #209) ─────────────────
+    //
+    // Run with:  cargo test --lib --no-default-features --features ci \
+    //              bench_cov_hessian -- --ignored --nocapture
+
+    /// Measures wall time for the gradient-FD Hessian (new path, issue #209) vs
+    /// the legacy scalar-FD Hessian (reconstructed inline) on the same setup.
+    ///
+    /// n_free = 4 (2 theta + 1 omega + 1 sigma).
+    /// Old: ~2·n_free² = 32 OFV evaluations.
+    /// New: n_free+1 = 5 gradient evaluations.
+    #[test]
+    #[ignore = "benchmark: run with -- --ignored --nocapture"]
+    fn bench_cov_hessian_throughput() {
+        use std::time::Instant;
+
+        let model = make_model();
+        let template = &model.default_params;
+        let population = make_population(30);
+        let n_subj = 30;
+        let n_obs = 3;
+        let n_eta = 1;
+        let x = pack_params(template);
+        let bounds = compute_bounds(template);
+        let n = x.len();
+        let options = FitOptions::default();
+
+        let eta_hats: Vec<DVector<f64>> = (0..n_subj).map(|_| DVector::zeros(n_eta)).collect();
+        let h_matrices: Vec<nalgebra::DMatrix<f64>> = (0..n_subj)
+            .map(|_| nalgebra::DMatrix::from_element(n_obs, n_eta, 0.1))
+            .collect();
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]; n_subj];
+
+        let fixed_mask = packed_fixed_mask(template);
+        let free_idx: Vec<usize> = (0..n).filter(|&i| !fixed_mask[i]).collect();
+        let eps = 1e-2;
+
+        // ── Scalar-FD Hessian (old path, reconstructed inline) ────────────
+        let ofv_at = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, template);
+            let foce = pop_nll(
+                &model,
+                &population,
+                &p,
+                &eta_hats,
+                &h_matrices,
+                &kappas,
+                options.interaction,
+            );
+            let omega_inv = p.omega.matrix.clone().cholesky().unwrap().inverse();
+            let n_e = p.omega.dim();
+            let log_det = 2.0 * (0..n_e).map(|i| p.omega.chol[(i, i)].ln()).sum::<f64>();
+            let om_terms: f64 = eta_hats
+                .iter()
+                .map(|eta| eta.dot(&(&omega_inv * eta)) + log_det)
+                .sum();
+            2.0 * foce + om_terms
+        };
+        let f0 = ofv_at(&x);
+
+        const REPS: u32 = 20;
+        let t0 = Instant::now();
+        for _ in 0..REPS {
+            let mut hess = DMatrix::zeros(n, n);
+            let mut xij = x.clone();
+            for &i in &free_idx {
+                let hi = eps * (1.0 + x[i].abs());
+                xij[i] = x[i] + hi;
+                let fp = ofv_at(&xij);
+                xij[i] = x[i] - hi;
+                let fm = ofv_at(&xij);
+                xij[i] = x[i];
+                if ((fp - 2.0 * f0 + fm) / (hi * hi)).is_finite() {
+                    hess[(i, i)] = (fp - 2.0 * f0 + fm) / (hi * hi);
+                }
+                for &j in &free_idx {
+                    if j <= i {
+                        continue;
+                    }
+                    let hj = eps * (1.0 + x[j].abs());
+                    xij[i] = x[i] + hi;
+                    xij[j] = x[j] + hj;
+                    let fpp = ofv_at(&xij);
+                    xij[j] = x[j] - hj;
+                    let fpm = ofv_at(&xij);
+                    xij[i] = x[i] - hi;
+                    let fmm = ofv_at(&xij);
+                    xij[j] = x[j] + hj;
+                    let fmp = ofv_at(&xij);
+                    xij[i] = x[i];
+                    xij[j] = x[j];
+                    let v = (fpp - fpm - fmp + fmm) / (4.0 * hi * hj);
+                    if v.is_finite() {
+                        hess[(i, j)] = v;
+                        hess[(j, i)] = v;
+                    }
+                }
+            }
+            std::hint::black_box(hess);
+        }
+        let scalar_ms = t0.elapsed().as_secs_f64() * 1000.0 / REPS as f64;
+
+        // ── Gradient-FD Hessian (new path) ───────────────────────────────
+        let t1 = Instant::now();
+        for _ in 0..REPS {
+            let mut hess = DMatrix::zeros(n, n);
+            let g0 = covariance_gradient(
+                &x,
+                template,
+                &model,
+                &population,
+                &eta_hats,
+                &h_matrices,
+                &kappas,
+                &bounds,
+                &options,
+            );
+            for &k in &free_idx {
+                let hk = eps * (1.0 + x[k].abs());
+                let mut xp = x.clone();
+                xp[k] += hk;
+                let gp = covariance_gradient(
+                    &xp,
+                    template,
+                    &model,
+                    &population,
+                    &eta_hats,
+                    &h_matrices,
+                    &kappas,
+                    &bounds,
+                    &options,
+                );
+                for &j in &free_idx {
+                    let v = (gp[j] - g0[j]) / hk;
+                    if v.is_finite() {
+                        hess[(j, k)] = v;
+                    }
+                }
+            }
+            std::hint::black_box(hess);
+        }
+        let grad_ms = t1.elapsed().as_secs_f64() * 1000.0 / REPS as f64;
+
+        println!(
+            "\n── Covariance Hessian throughput (n_free={}, n_subj={}) ──────────",
+            free_idx.len(),
+            n_subj
+        );
+        println!("  scalar-FD (old): {:.2}ms/Hessian", scalar_ms);
+        println!("  gradient-FD (new): {:.2}ms/Hessian", grad_ms);
+        println!("  speedup: {:.1}×", scalar_ms / grad_ms);
     }
 }

--- a/tests/warfarin_covariance_nonmem.rs
+++ b/tests/warfarin_covariance_nonmem.rs
@@ -1,0 +1,119 @@
+//! NONMEM 7.5.1 `$COVARIANCE MATRIX=R` cross-check for the FOCEI covariance step
+//! — issues #209 / #196 / #129 / #224.
+//!
+//! Guards the covariance-step rewrite that:
+//!   1. reconverges the inner EBE loop at every FD perturbation point (NONMEM's
+//!      behaviour) — holding the EBEs fixed gave an *indefinite* Hessian on this
+//!      well-conditioned surface, which clipped eigenvalues (#129) and inflated
+//!      the theta/sigma SEs 30–90×;
+//!   2. builds the Hessian as a central finite difference of the analytical
+//!      population gradient (#209), whose θ part reuses H-matrix columns for the
+//!      mu-referenced parameters (#196);
+//!   3. returns `cov = 2·H⁻¹` — the objective is −2·logL, so its Hessian is twice
+//!      the observed information (without the factor of two every SE is 1/√2 too
+//!      small).
+//!
+//! ## NONMEM reference
+//!
+//! NONMEM 7.5.1, FOCEI (`$ESTIMATION METHOD=1 INTER`), `$COVARIANCE MATRIX=R`,
+//! on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error). The
+//! proportional error is coded as `W = THETA(4)*IPRED; Y = IPRED + W*EPS(1)` with
+//! `$SIGMA 1 FIX`, so THETA(4) is the proportional SD and its SE is on the SD
+//! scale — directly comparable to ferx's `sigma PROP_ERR ~ … (sd)`. SEs are the
+//! `.ext` row at `ITERATION = -1000000001`.
+//!
+//! This test is `#[ignore]`d outside the `slow-tests` feature (it runs a fit to
+//! convergence). The band is 20% relative: tight enough to catch the factor-of-2
+//! (29%) and the indefinite-Hessian blow-up (orders of magnitude), loose enough
+//! to tolerate the AD-vs-FD-Jacobian build difference and the FD-step truncation.
+
+use ferx_core::parser::model_parser::parse_model_string;
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::path::Path;
+
+// NONMEM 7.5.1 FOCEI $COVARIANCE MATRIX=R standard errors (.ext, ITER=-1000000001).
+const NM_SE_TVCL: f64 = 7.09746e-3;
+const NM_SE_TVV: f64 = 2.40053e-1;
+const NM_SE_TVKA: f64 = 1.48649e-1;
+const NM_SE_PROP_SD: f64 = 8.35411e-4; // THETA(4): proportional SD-scale SE
+const NM_SE_OMEGA_CL: f64 = 1.27933e-2;
+const NM_SE_OMEGA_V: f64 = 4.30540e-3;
+const NM_SE_OMEGA_KA: f64 = 1.50376e-1;
+
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129): opt in with --features slow-tests"
+)]
+fn covariance_se_matches_nonmem() {
+    let model_src = r"
+[parameters]
+  theta TVCL(0.15, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.2, 0.01, 50.0)
+  omega ETA_CL ~ 0.07
+  omega ETA_V  ~ 0.02
+  omega ETA_KA ~ 0.10
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  mu_referencing = true
+";
+
+    let model = parse_model_string(model_src).expect("warfarin model parses");
+    let pop =
+        read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).expect("warfarin data loads");
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::FoceI;
+    opts.interaction = true;
+    opts.outer_maxiter = 300;
+    opts.run_covariance_step = true;
+    opts.verbose = false;
+
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("warfarin FOCEI fit runs");
+
+    // The covariance step must succeed (the indefinite fixed-EBE Hessian used to
+    // fail or clip here).
+    assert!(
+        result.covariance_matrix.is_some(),
+        "covariance step must produce a matrix"
+    );
+    let se_theta = result.se_theta.as_ref().expect("theta SEs present");
+    let se_omega = result.se_omega.as_ref().expect("omega SEs present");
+    let se_sigma = result.se_sigma.as_ref().expect("sigma SEs present");
+
+    // (name, ferx SE, NONMEM SE)
+    let checks = [
+        ("TVCL", se_theta[0], NM_SE_TVCL),
+        ("TVV", se_theta[1], NM_SE_TVV),
+        ("TVKA", se_theta[2], NM_SE_TVKA),
+        ("PROP_ERR", se_sigma[0], NM_SE_PROP_SD),
+        ("omega_CL", se_omega[0], NM_SE_OMEGA_CL),
+        ("omega_V", se_omega[1], NM_SE_OMEGA_V),
+        ("omega_KA", se_omega[2], NM_SE_OMEGA_KA),
+    ];
+
+    let tol = 0.20; // 20% relative band — see module docs
+    for (name, ferx_se, nm_se) in checks {
+        let rel = (ferx_se - nm_se).abs() / nm_se;
+        assert!(
+            ferx_se.is_finite() && rel < tol,
+            "SE({name}) = {ferx_se:.6} vs NONMEM {nm_se:.6} — relative diff {:.1}% exceeds {:.0}% band",
+            rel * 100.0,
+            tol * 100.0
+        );
+    }
+}


### PR DESCRIPTION
<!-- Title: fix(estimation): correct covariance SEs and build the Hessian from the analytical gradient [closes #209] [closes #196] -->

## Why

A NONMEM cross-check of the FOCEI covariance step found ferx standard errors were badly wrong — theta/sigma SEs **30–94× too large** on warfarin. Tracing it surfaced two independent, pre-existing bugs (neither introduced by #209):

1. **The covariance Hessian held the inner EBEs fixed** while finite-differencing the population parameters. Each subject's conditional optimum (η̂) shifts with the population parameters, so the fixed-EBE Hessian has the wrong curvature — *indefinite* even on the well-conditioned warfarin surface (min eigenvalue ≈ −1511). That negative eigenvalue was being clipped to a tiny floor by the regulariser added in #129, which is exactly what inflated the SEs. NONMEM reconverges the EBEs at every covariance perturbation; ferx did not.
2. **A missing factor of two.** The covariance was `inv(H)` where `H` is the Hessian of the objective `OFV = −2·logL`. The asymptotic covariance is the inverse observed information = `inv(Hessian of −logL) = 2·inv(H)`. So *every* ferx SE was `1/√2` too small (the ω block showed this cleanly even before the indefiniteness was fixed).

Issue **#209** proposed building the Hessian from the analytical gradient for speed, but its stated premise — that gradient-FD would remove the negative eigenvalues (attributed to 4-point stencil cancellation) — was incorrect: the indefiniteness is the fixed-EBE approximation, which gradient-FD inherits. The correct fix is **reconvergence + the gradient-FD structure + the factor of two**. Issue **#196** (the mu-ref H-column gradient shortcut) is the infrastructure that makes each analytical gradient cheap; it is reused here.

## What changed

`compute_covariance` (`src/estimation/outer_optimizer.rs`) rewritten:

- **Reconverges the inner EBE loop** (warm-started from the converged EBEs) at every finite-difference point, matching NONMEM's `$COVARIANCE` behaviour.
- **Non-IOV:** central FD of the analytical population gradient (#209): `H[:,k] ≈ (g(x̂+hₖeₖ) − g(x̂−hₖeₖ)) / 2hₖ` — `2·n_free` gradient evaluations instead of `~2·n_free²` objective evaluations, with no 4-point cancellation. The θ part of that gradient reuses H-matrix columns for mu-referenced parameters (**#196**).
- **IOV:** second differences of the reconverged objective (the κ block has no fixed-EBE analytical gradient).
- Returns `cov = 2·H⁻¹` (the factor-of-two fix).
- **#196**: the mu-ref shortcut is wired into both analytical-gradient paths (Sheiner–Beal at `gauss_newton.rs:784`, Almquist–Laplace at `:1148`), with a correctness test and a throughput benchmark.

With reconvergence the Hessian is positive-definite on well-conditioned surfaces, so the eigenvalue-clipping regulariser (#129) becomes a rarely-fired safety net rather than load-bearing.

**Rebased on the just-merged #219** (covariance diagnostics): all of its machinery is preserved — the `fd_hessian_step` option, the `CovarianceStepResult::{Success, Unusable}` return type, the Omega-collapse / non-PD / per-parameter ill-conditioning diagnostics, the clipping-severity classification, and the off-diagonal-NaN warnings. The reconvergence, central gradient-FD, and factor-of-two layer on top; the FD-failure trackers (`fd_diag_nan` / `fd_offdiag_nan`) are wired into the gradient-FD path too. (#219 was a diagnostics/UX PR and did not change the underlying fixed-EBE/no-factor-of-two logic, so it did not fix the SEs.)

## Alternatives considered

- **BHHH / Godambe S-matrix** (`B⁻¹ = (Σᵢ gᵢgᵢᵀ)⁻¹`): positive-definite and cheaper (no reconvergence, no Hessian), but it is a *different* estimator — measured 1.4–1.9× larger than `MATRIX=R` on warfarin because it is the `MATRIX=S` cross-product, not the observed information. A good opt-in robustness option (issues #210 / #223 Item B), not a drop-in for the default R-matrix SEs.
- **Keeping fixed-EBE gradient-FD** (#209 as originally framed): fails its own acceptance criteria — the Hessian stays indefinite.
- **Forward instead of central gradient-FD** (`n_free+1` evals): ~1.75× cheaper at n_free=7 but `O(h)` truncation drifts ~2–3% from NONMEM. Central chosen to hit the ≥3-sig-fig criterion; forward is the lever for a future "fast SE" mode.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API or `FitResult` field changes — SEs already flow through `se_theta`/`se_omega`/`se_sigma`.

## Breaking changes
- [x] None (numerical: every covariance SE increases by √2 versus prior ferx releases — this is the bug fix; SEs now match NONMEM)

## Numerical validation

NONMEM 7.5.1 FOCEI (`METHOD=1 INTER`), `$COVARIANCE MATRIX=R`. ferx matches within a few percent.

**warfarin (1-cpt oral, n_free=7)**

| Param | ferx SE | NONMEM SE | rel diff |
|-------|---------|-----------|----------|
| TVCL | 0.00712 | 0.00710 | +0.3% |
| TVV | 0.2350 | 0.2401 | −2.1% |
| TVKA | 0.1506 | 0.1486 | +1.3% |
| PROP_ERR (SD) | 0.000832 | 0.000835 | −0.4% |
| ω²(CL) | 0.01291 | 0.01279 | +0.9% |
| ω²(V) | 0.00403 | 0.00431 | −6.4% |
| ω²(KA) | 0.1530 | 0.1504 | +1.8% |

**2-cpt IV (n_free=9)** — OFV −889.4 (both); estimates within ~1–3%.

| Param | ferx SE | NONMEM SE | rel diff |
|-------|---------|-----------|----------|
| TVCL | 0.3210 | 0.3139 | +2.3% |
| TVV1 | 1.3084 | 1.2930 | +1.2% |
| TVQ | 0.2615 | 0.2580 | +1.3% |
| TVV2 | 3.1370 | 2.9898 | +4.9% |
| PROP_ERR (SD) | 0.000763 | 0.000760 | +0.4% |
| ω²(CL) | 0.02957 | 0.02769 | +6.8% |
| ω²(V1) | 0.03780 | 0.03796 | −0.4% |
| ω²(Q) | 0.03798 | 0.03702 | +2.6% |
| ω²(V2) | 0.05995 | 0.05685 | +5.5% |

**Emax effect-compartment PK/PD (ODE + per-CMT error, n_free=12)** — exercises the ODE Laplace gradient and the per-CMT (proportional PK + additive PD) error path. Well-identified PK/error parameters match NONMEM:

| Param | ferx SE | NONMEM SE | rel diff |
|-------|---------|-----------|----------|
| CL | 0.0390 | 0.0409 | −4.5% |
| V | 0.2360 | 0.2138 | +10.4% |
| KA | 0.0887 | 0.0913 | −2.8% |
| KE0 | 0.00794 | 0.00807 | −1.6% |
| PROP_PK (SD) | 0.00592 | 0.00623 | −4.9% |
| ADD_PD (SD) | 0.0941 | 0.1048 | −10.2% |

The Emax PD parameters (E0, EMAX, EC50, GAMMA) are weakly identified: ferx and NONMEM converge to slightly different points in the flat PD likelihood (E0 2.30 vs 3.21, EMAX 48.7 vs 45.2), so their SEs are not on a common operating point — both engines agree these directions are poorly determined (RSE 18–100%). The covariance step itself produces a clean PD matrix with no eigenvalue clipping.

## Performance
- [x] Faster — covariance step, warfarin (n_free=7): reconverging scalar-FD `~151 ms` → reconverging central gradient-FD `~17 ms` (**~8.9×**, both NONMEM-matching). Scales ≈ linearly with `n_free` (eval count `2·n_free²` → `2·n_free`).
- [x] #196 gradient shortcut: FOCE `5601 → 3415 ns/call` (1.64×), FOCEI `4531 → 2009 ns/call` (2.26×) — `bench_mu_ref_gradient_throughput`.

## Tests
- [x] Regression test `tests/warfarin_covariance_nonmem.rs` — fails without the fix (it would see the inflated, 1/√2-scaled, or clipped SEs). Also addresses #224.
- [x] #196: `test_mu_ref_gradient_shortcut` (correctness) + `bench_mu_ref_gradient_throughput`.
- [x] All 18 `outer_optimizer` unit tests pass (incl. the two `covariance_gradient` consistency tests).

## Docs
- [x] `docs/src/estimation/foce.md` — covariance-step method, the factor of two, and the NONMEM cross-check table.

## Checklist
- [x] `cargo clippy` clean (no new warnings; the function's pre-existing `too_many_arguments` is unchanged)
- [x] `cargo +nightly fmt --check` clean
- [x] Builds on both the autodiff (Enzyme) and `--features ci` (FD) configurations; the CI/FD build now produces a PD warfarin covariance, **closing the root cause of #129**

## Reviewer hints
- The heart of the change is `compute_covariance`: the `reconverge` / `ofv` / `grad` closures and the two FD stencils. The `2.0 *` at the inverse is the factor-of-two fix.
- The analytical-gradient consistency (that `covariance_gradient` matches the objective `ofv` term-for-term, incl. the FOCE ω-prior and the OFV ×2 scaling) is covered by the existing `test_covariance_gradient_*` tests.

## Open questions
- Bundling #196 + #209 in one PR (per request). They share the analytical-gradient infrastructure and the same branch; happy to split if preferred.
