### PR TITLE
test(estimation): add FOCE + IOV covariance SE NONMEM cross-checks

### DIFF
--- a/tests/warfarin_covariance_nonmem.rs
+++ b/tests/warfarin_covariance_nonmem.rs
@@ -241,3 +241,152 @@ fn covariance_se_matches_nonmem() {
 fn covariance_se_matches_nonmem_foce() {
     assert_covariance_se_matches_nonmem(EstimationMethod::Foce, false);
 }
+
+// ── IOV covariance (the `is_iov` second-difference Hessian branch) ───────────
+
+/// Warfarin with inter-occasion variability on CL (one κ per occasion sharing a
+/// single variance). Mirrors `examples/warfarin_iov.ferx` and the NONMEM
+/// reference `tests/nonmem/warfarin_iov.ctl`.
+const IOV_MODEL_SRC: &str = r"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP_ERR ~ 0.2 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  iov_column = OCC
+";
+
+/// FOCEI covariance with IOV — the only end-to-end guard for the `is_iov` branch
+/// of `compute_covariance`, which (lacking a fixed-EBE analytical κ gradient)
+/// builds the Hessian from second differences of the reconverged objective
+/// rather than the central-gradient stencil used for the non-IOV path.
+///
+/// NONMEM 7.5.1 FOCEI (`$EST METHOD=1 INTER`) `$COVARIANCE MATRIX=R` on
+/// `data/warfarin_iov.csv` (10 subjects, 2 occasions), from `warfarin_iov.ctl`
+/// with `MATRIX=R` added. SEs are the `.ext` row at `ITERATION = -1000000001`.
+///
+/// NONMEM reports OMEGA/SIGMA SEs on the variance scale; ferx's ω SEs are also
+/// variance-scale (compared directly), but its PROP_ERR SE is SD-scale, so the
+/// NONMEM `$SIGMA` variance SE is delta-method converted: with σ² = 0.0353876
+/// and SE(σ²) = 0.00381432, SE(σ) = SE(σ²)/(2·σ) = 0.00381432/(2·0.188116) =
+/// 1.0138e-2.
+///
+/// theta + residual-error + ω all match NONMEM within ~8% (20% band). The **κ**
+/// (IOV) SE is held to a 40% band: with only two occasions the IOV variance is
+/// weakly identified, so ferx (OFV 307.9) and NONMEM (308.8) settle at different
+/// κ optima — the κ *estimate* differs ~27%, and its SE tracks that. This guards
+/// that the IOV covariance step runs, succeeds, and lands in the NONMEM
+/// neighbourhood; it is not a tight κ-SE anchor.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129): opt in with --features slow-tests"
+)]
+fn covariance_se_matches_nonmem_iov() {
+    let model = parse_model_string(IOV_MODEL_SRC).expect("warfarin IOV model parses");
+    let pop = read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, Some("OCC"))
+        .expect("warfarin_iov data loads");
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::FoceI;
+    opts.interaction = true;
+    opts.outer_maxiter = 300;
+    opts.run_covariance_step = true;
+    opts.verbose = false;
+
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("warfarin IOV fit runs");
+
+    assert!(
+        result.covariance_matrix.is_some(),
+        "IOV covariance step must produce a matrix"
+    );
+    let se_theta = result.se_theta.as_ref().expect("theta SEs present");
+    let se_omega = result.se_omega.as_ref().expect("omega SEs present");
+    let se_sigma = result.se_sigma.as_ref().expect("sigma SEs present");
+    let se_kappa = result.se_kappa.as_ref().expect("kappa SEs present");
+
+    // NONMEM 7.5.1 FOCEI $COVARIANCE MATRIX=R SEs (.ext, ITER=-1000000001);
+    // PROP_ERR converted from the variance-scale $SIGMA SE (see fn docs).
+    let refs = [
+        SeRef {
+            name: "TVCL",
+            nm: 1.33623e-2,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "TVV",
+            nm: 3.41267e-1,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "TVKA",
+            nm: 9.32221e-2,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "PROP_ERR",
+            nm: 1.0138e-2,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "omega_CL",
+            nm: 2.80628e-2,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "omega_V",
+            nm: 6.44076e-3,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "omega_KA",
+            nm: 2.79920e-2,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "kappa_CL",
+            nm: 1.76108e-2,
+            tol: 0.40,
+        },
+    ];
+    let ferx = [
+        se_theta[0],
+        se_theta[1],
+        se_theta[2],
+        se_sigma[0],
+        se_omega[0],
+        se_omega[1],
+        se_omega[2],
+        se_kappa[0],
+    ];
+
+    for (r, &ferx_se) in refs.iter().zip(ferx.iter()) {
+        let rel = (ferx_se - r.nm).abs() / r.nm;
+        assert!(
+            ferx_se.is_finite() && rel < r.tol,
+            "SE({}) = {ferx_se:.6} vs NONMEM {:.6} — relative diff {:.1}% exceeds {:.0}% band",
+            r.name,
+            r.nm,
+            rel * 100.0,
+            r.tol * 100.0
+        );
+    }
+}

--- a/tests/warfarin_covariance_nonmem.rs
+++ b/tests/warfarin_covariance_nonmem.rs
@@ -1,5 +1,5 @@
-//! NONMEM 7.5.1 `$COVARIANCE MATRIX=R` cross-check for the FOCEI covariance step
-//! — issues #209 / #196 / #129 / #224.
+//! NONMEM 7.5.1 `$COVARIANCE MATRIX=R` cross-check for the FOCE/FOCEI covariance
+//! step — issues #209 / #196 / #129 / #224.
 //!
 //! Guards the covariance-step rewrite that:
 //!   1. reconverges the inner EBE loop at every FD perturbation point (NONMEM's
@@ -13,40 +13,41 @@
 //!      the observed information (without the factor of two every SE is 1/√2 too
 //!      small).
 //!
+//! Two cases run the same warfarin model through the two covariance-OFV paths:
+//!   - **FOCEI** (`interaction = true`): the per-subject marginal already carries
+//!     `ηᵀΩ⁻¹η + log|Ω|`, so the covariance OFV is just `2·pop_nll`.
+//!   - **FOCE** (`interaction = false`): `pop_nll` (Sheiner–Beal) omits that prior,
+//!     so `compute_covariance` adds it back analytically via `omega_prior_gradient`.
+//!     This is the only end-to-end guard for that FOCE-specific gradient branch.
+//!
 //! ## NONMEM reference
 //!
-//! NONMEM 7.5.1, FOCEI (`$ESTIMATION METHOD=1 INTER`), `$COVARIANCE MATRIX=R`,
-//! on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error). The
-//! proportional error is coded as `W = THETA(4)*IPRED; Y = IPRED + W*EPS(1)` with
-//! `$SIGMA 1 FIX`, so THETA(4) is the proportional SD and its SE is on the SD
-//! scale — directly comparable to ferx's `sigma PROP_ERR ~ … (sd)`. SEs are the
-//! `.ext` row at `ITERATION = -1000000001`.
+//! NONMEM 7.5.1 on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional
+//! error), `$COVARIANCE MATRIX=R`. The proportional error is coded as
+//! `W = THETA(4)*IPRED; Y = IPRED + W*EPS(1)` with `$SIGMA 1 FIX`, so THETA(4) is
+//! the proportional SD and its SE is on the SD scale — directly comparable to
+//! ferx's `sigma PROP_ERR ~ … (sd)`. SEs are the `.ext` row at
+//! `ITERATION = -1000000001`. FOCEI uses `$EST METHOD=1 INTER`, FOCE drops `INTER`.
 //!
-//! This test is `#[ignore]`d outside the `slow-tests` feature (it runs a fit to
-//! convergence). The band is 20% relative: tight enough to catch the factor-of-2
-//! (29%) and the indefinite-Hessian blow-up (orders of magnitude), loose enough
-//! to tolerate the AD-vs-FD-Jacobian build difference and the FD-step truncation.
+//! These tests are `#[ignore]`d outside the `slow-tests` feature (they run a fit
+//! to convergence). The band on the structural (theta) and residual-error (sigma)
+//! SEs is 20% relative: tight enough to catch the factor-of-2 (29%) and the
+//! indefinite-Hessian blow-up (orders of magnitude), loose enough to tolerate the
+//! AD-vs-FD-Jacobian build difference and the FD-step truncation.
+//!
+//! The omega-block band is method-dependent. FOCEI matches NONMEM tightly (20%),
+//! but FOCE runs the Sheiner–Beal objective, whose omega-block curvature differs
+//! from NONMEM's FOCE: on this model ferx's FOCE omega SEs sit ~25–36% below
+//! NONMEM (the theta/sigma SEs still match within ~3%, and the omega *estimates*
+//! agree within ~6%). That is the SB-vs-NONMEM approximation gap, not a fault in
+//! the covariance machinery — so the FOCE omega band is widened to 45%. Tightening
+//! it is tracked with the planned FOCE Sheiner–Beal → Almquist–Laplace switch.
 
 use ferx_core::parser::model_parser::parse_model_string;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
 use std::path::Path;
 
-// NONMEM 7.5.1 FOCEI $COVARIANCE MATRIX=R standard errors (.ext, ITER=-1000000001).
-const NM_SE_TVCL: f64 = 7.09746e-3;
-const NM_SE_TVV: f64 = 2.40053e-1;
-const NM_SE_TVKA: f64 = 1.48649e-1;
-const NM_SE_PROP_SD: f64 = 8.35411e-4; // THETA(4): proportional SD-scale SE
-const NM_SE_OMEGA_CL: f64 = 1.27933e-2;
-const NM_SE_OMEGA_V: f64 = 4.30540e-3;
-const NM_SE_OMEGA_KA: f64 = 1.50376e-1;
-
-#[test]
-#[cfg_attr(
-    not(feature = "slow-tests"),
-    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129): opt in with --features slow-tests"
-)]
-fn covariance_se_matches_nonmem() {
-    let model_src = r"
+const MODEL_SRC: &str = r"
 [parameters]
   theta TVCL(0.15, 0.001, 10.0)
   theta TVV(8.0, 0.1, 500.0)
@@ -68,22 +69,120 @@ fn covariance_se_matches_nonmem() {
   DV ~ proportional(PROP_ERR)
 
 [fit_options]
-  method     = focei
   mu_referencing = true
 ";
 
-    let model = parse_model_string(model_src).expect("warfarin model parses");
+/// One parameter's NONMEM SE and the relative band ferx must fall within.
+struct SeRef {
+    name: &'static str,
+    nm: f64,
+    tol: f64,
+}
+
+const TIGHT: f64 = 0.20; // theta + residual-error: NONMEM-anchored
+const OMEGA_FOCEI: f64 = 0.20; // FOCEI omega matches NONMEM tightly
+const OMEGA_FOCE: f64 = 0.45; // FOCE omega: Sheiner–Beal gap (see module docs)
+
+/// NONMEM 7.5.1 `$COVARIANCE MATRIX=R` SEs (.ext, ITER=-1000000001), in the
+/// order [TVCL, TVV, TVKA, PROP_SD, ωCL, ωV, ωKA].
+fn nonmem_refs(focei: bool) -> [SeRef; 7] {
+    let omega_tol = if focei { OMEGA_FOCEI } else { OMEGA_FOCE };
+    if focei {
+        // FOCEI: $EST METHOD=1 INTER.
+        [
+            SeRef {
+                name: "TVCL",
+                nm: 7.09746e-3,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "TVV",
+                nm: 2.40053e-1,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "TVKA",
+                nm: 1.48649e-1,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "PROP_ERR",
+                nm: 8.35411e-4,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "omega_CL",
+                nm: 1.27933e-2,
+                tol: omega_tol,
+            },
+            SeRef {
+                name: "omega_V",
+                nm: 4.30540e-3,
+                tol: omega_tol,
+            },
+            SeRef {
+                name: "omega_KA",
+                nm: 1.50376e-1,
+                tol: omega_tol,
+            },
+        ]
+    } else {
+        // FOCE: $EST METHOD=1 (no INTER).
+        [
+            SeRef {
+                name: "TVCL",
+                nm: 6.62683e-3,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "TVV",
+                nm: 2.34041e-1,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "TVKA",
+                nm: 1.24489e-1,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "PROP_ERR",
+                nm: 9.41384e-4,
+                tol: TIGHT,
+            },
+            SeRef {
+                name: "omega_CL",
+                nm: 1.27958e-2,
+                tol: omega_tol,
+            },
+            SeRef {
+                name: "omega_V",
+                nm: 4.29747e-3,
+                tol: omega_tol,
+            },
+            SeRef {
+                name: "omega_KA",
+                nm: 1.60641e-1,
+                tol: omega_tol,
+            },
+        ]
+    }
+}
+
+/// Fit warfarin with the requested conditional method and assert every
+/// covariance SE matches the NONMEM `MATRIX=R` reference within 20%.
+fn assert_covariance_se_matches_nonmem(method: EstimationMethod, interaction: bool) {
+    let model = parse_model_string(MODEL_SRC).expect("warfarin model parses");
     let pop =
         read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).expect("warfarin data loads");
 
     let mut opts = FitOptions::default();
-    opts.method = EstimationMethod::FoceI;
-    opts.interaction = true;
+    opts.method = method;
+    opts.interaction = interaction;
     opts.outer_maxiter = 300;
     opts.run_covariance_step = true;
     opts.verbose = false;
 
-    let result = fit(&model, &pop, &model.default_params, &opts).expect("warfarin FOCEI fit runs");
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("warfarin fit runs");
 
     // The covariance step must succeed (the indefinite fixed-EBE Hessian used to
     // fail or clip here).
@@ -95,25 +194,50 @@ fn covariance_se_matches_nonmem() {
     let se_omega = result.se_omega.as_ref().expect("omega SEs present");
     let se_sigma = result.se_sigma.as_ref().expect("sigma SEs present");
 
-    // (name, ferx SE, NONMEM SE)
-    let checks = [
-        ("TVCL", se_theta[0], NM_SE_TVCL),
-        ("TVV", se_theta[1], NM_SE_TVV),
-        ("TVKA", se_theta[2], NM_SE_TVKA),
-        ("PROP_ERR", se_sigma[0], NM_SE_PROP_SD),
-        ("omega_CL", se_omega[0], NM_SE_OMEGA_CL),
-        ("omega_V", se_omega[1], NM_SE_OMEGA_V),
-        ("omega_KA", se_omega[2], NM_SE_OMEGA_KA),
+    let refs = nonmem_refs(interaction);
+    // ferx SEs in the same order as `refs`.
+    let ferx = [
+        se_theta[0],
+        se_theta[1],
+        se_theta[2],
+        se_sigma[0],
+        se_omega[0],
+        se_omega[1],
+        se_omega[2],
     ];
 
-    let tol = 0.20; // 20% relative band — see module docs
-    for (name, ferx_se, nm_se) in checks {
-        let rel = (ferx_se - nm_se).abs() / nm_se;
+    for (r, &ferx_se) in refs.iter().zip(ferx.iter()) {
+        let rel = (ferx_se - r.nm).abs() / r.nm;
         assert!(
-            ferx_se.is_finite() && rel < tol,
-            "SE({name}) = {ferx_se:.6} vs NONMEM {nm_se:.6} — relative diff {:.1}% exceeds {:.0}% band",
+            ferx_se.is_finite() && rel < r.tol,
+            "SE({}) = {ferx_se:.6} vs NONMEM {:.6} — relative diff {:.1}% exceeds {:.0}% band",
+            r.name,
+            r.nm,
             rel * 100.0,
-            tol * 100.0
+            r.tol * 100.0
         );
     }
+}
+
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129): opt in with --features slow-tests"
+)]
+fn covariance_se_matches_nonmem() {
+    assert_covariance_se_matches_nonmem(EstimationMethod::FoceI, true);
+}
+
+/// FOCE (non-interaction) covariance: exercises the Sheiner–Beal path where
+/// `compute_covariance` adds the Ω-prior gradient (`omega_prior_gradient`) that
+/// FOCEI gets for free from the marginal — the only end-to-end guard for that
+/// branch (the unit test `test_covariance_gradient_foce_matches_fd_ofv_fixed`
+/// checks the gradient in isolation).
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129): opt in with --features slow-tests"
+)]
+fn covariance_se_matches_nonmem_foce() {
+    assert_covariance_se_matches_nonmem(EstimationMethod::Foce, false);
 }


### PR DESCRIPTION
<!-- Title: test(estimation): add FOCE + IOV covariance SE NONMEM cross-checks -->

## Why

The covariance-step rewrite in #234 has two branches with **no end-to-end coverage**, only isolated unit tests:

1. **FOCE (Sheiner–Beal):** `pop_nll` omits the `ηᵀΩ⁻¹η + log|Ω|` prior, so `compute_covariance` adds it back via `omega_prior_gradient` (FOCEI gets it free from the Almquist–Laplace marginal). The existing slow test only ran FOCEI.
2. **IOV (`is_iov`):** the κ block has no fixed-EBE analytical gradient, so the Hessian is built from second differences of the reconverged objective rather than the central-gradient stencil the non-IOV paths use.

This closes follow-ups #1 and #2 from the #234 review.

## What changed

`tests/warfarin_covariance_nonmem.rs`:
- Refactored the shared fit+assert body into `assert_covariance_se_matches_nonmem`, with each parameter a `SeRef { name, nm, tol }`.
- **`covariance_se_matches_nonmem_foce`** — FOCE (`method = foce`), anchored to NONMEM `$EST METHOD=1` (no `INTER`), `$COV MATRIX=R`.
- **`covariance_se_matches_nonmem_iov`** — FOCEI + IOV on CL, anchored to NONMEM `$EST METHOD=1 INTER`, `$COV MATRIX=R` on `data/warfarin_iov.csv` (from `warfarin_iov.ctl` + `MATRIX=R`).

All three tests are gated `#[cfg_attr(not(feature = "slow-tests"), ignore)]` and run in `slow-tests.yml`.

## Depends on #234

The FOCE/IOV covariance paths only exist on #234. This branch is rebased on current `main` **with #234's two commits included**, so the diff here shows them too — review the last two commits (the FOCE and IOV tests) in isolation. **Merge #234 first**, then I'll rebase and the #234 commits drop out, leaving only the tests.

## Numerical validation

All vs NONMEM 7.5.1 `$COVARIANCE MATRIX=R`.

**FOCE** (`data/warfarin.csv`, OFV ferx −280.15 / NM −280.36):

| Param | ferx SE | NM SE | rel | band |
|---|---|---|---|---|
| TVCL / TVV / TVKA | 0.00640 / 0.2389 / 0.1213 | 0.00663 / 0.2340 / 0.1245 | −3.4 / +2.1 / −2.6% | 20% |
| PROP_ERR (SD) | 0.000925 | 0.000941 | −1.7% | 20% |
| ω²(CL/V/KA) | 0.0083 / 0.0033 / 0.1024 | 0.0128 / 0.0043 / 0.1606 | −35 / −24 / −36% | **45%** |

FOCE omega band is widened to 45% — the **Sheiner–Beal vs NONMEM-FOCE approximation gap** (theta/sigma match within 3%, omega *estimates* within 6%), not a covariance-step fault; FOCEI omega matches NONMEM within 20%. Tightens with the planned FOCE SB → Almquist–Laplace switch.

**IOV (FOCEI)** (`data/warfarin_iov.csv`, OFV ferx 307.9 / NM 308.8):

| Param | ferx SE | NM SE | rel | band |
|---|---|---|---|---|
| TVCL / TVV / TVKA | 0.01365 / 0.3510 / 0.0869 | 0.01336 / 0.3413 / 0.0932 | +2.2 / +2.8 / −6.8% | 20% |
| PROP_ERR (SD) | 0.01032 | 0.01014¹ | +1.8% | 20% |
| ω²(CL/V/KA) | 0.0303 / 0.0068 / 0.0284 | 0.0281 / 0.0064 / 0.0280 | +7.8 / +4.9 / +1.5% | 20% |
| κ²(CL) | 0.02220 | 0.01761 | +26% | **40%** |

¹ NONMEM reports `$SIGMA` on the variance scale; delta-method converted to the SD scale ferx reports: SE(σ)=SE(σ²)/(2σ)=0.00381/(2·0.1881).

κ band is 40% — with only two occasions the IOV variance is weakly identified, so ferx and NONMEM settle at different κ optima (estimate also ~27% apart). The test guards that the IOV covariance step runs, succeeds, and lands in the NONMEM neighbourhood; it is not a tight κ-SE anchor.

- [x] Compared against: NONMEM 7.5.1 `$COVARIANCE MATRIX=R`

## Performance
- [x] No significant impact (test-only; the three fits run in <0.3 s total)

## Tests
- [x] Regression tests added — `covariance_se_matches_nonmem_foce`, `covariance_se_matches_nonmem_iov`. Both fail without #234's reconvergence + factor-of-two (+ `omega_prior_gradient` for FOCE).

## Breaking changes
- [x] None (tests only)

## Docs
- [x] No user-visible change (the covariance-step NONMEM table already lives in `docs/src/estimation/foce.md` via #234).

## Reviewer hints
- Two deliberate band decisions: the **45% FOCE omega** band (SB gap) and the **40% IOV κ** band (weakly-identified IOV variance). Both are documented in the module/test docs with the underlying ferx-vs-NONMEM numbers. If you'd rather treat either gap as a defect to fix before merging the guard, say so.
- NONMEM control streams: 1-cpt oral `ADVAN2 TRANS2`, `CMT=DROP`, `$COV MATRIX=R UNCONDITIONAL`; FOCE drops `INTER`; IOV uses `$OMEGA BLOCK(1) … SAME` for the per-occasion κ.
