### PR TITLE
fix(io): rename var_ to log_chol_ for packed omega diagonal labels; fix CHANGELOG issue ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ section of the SDLC for the versioning policy).
 - `covariance_matrix:` block in `*-fit.yaml`: the full optimizer-space parameter
   covariance matrix (log-theta, Cholesky-omega, log-sigma; kappa appended for IOV
   models), parameter-labelled, emitted when the covariance step succeeds or is
-  regularised (#240).
+  regularised (#236).
 - Time-to-event / survival modelling (Phase 1): `[event_model]` block, TTE
   datareader, likelihood, and API wiring, behind the `survival` feature
   (#191, #192).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ section of the SDLC for the versioning policy).
 - `covariance_matrix:` block in `*-fit.yaml`: the full optimizer-space parameter
   covariance matrix (log-theta, Cholesky-omega, log-sigma; kappa appended for IOV
   models), parameter-labelled, emitted when the covariance step succeeds or is
-  regularised (#236).
+  regularised. Omega/kappa diagonal entries are keyed `log_chol_<eta>` (packed
+  value is `log(L_ii)`); off-diagonal entries are keyed `chol_<row>_<col>`
+  (`L_ij`, not log-transformed) (#236).
 - Time-to-event / survival modelling (Phase 1): `[event_model]` block, TTE
   datareader, likelihood, and API wiring, behind the `survival` feature
   (#191, #192).

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -134,11 +134,11 @@ covariance_matrix:
   # (identity otherwise), sigma log-transformed, omega/kappa Cholesky-factored
   parameters: [TVCL, TVV, log_chol_ETA_CL, log_chol_ETA_V, sigma_1]
   rows:
-    TVCL:           [1.234567e-4, 2.345678e-5, 0.000000e+0, 0.000000e+0, 0.000000e+0]
-    TVV:            [2.345678e-5, 1.456789e-3, 0.000000e+0, 0.000000e+0, 0.000000e+0]
+    TVCL:            [1.234567e-4, 2.345678e-5, 0.000000e+0, 0.000000e+0, 0.000000e+0]
+    TVV:             [2.345678e-5, 1.456789e-3, 0.000000e+0, 0.000000e+0, 0.000000e+0]
     log_chol_ETA_CL: [0.000000e+0, 0.000000e+0, 5.678901e-5, 0.000000e+0, 0.000000e+0]
     log_chol_ETA_V:  [0.000000e+0, 0.000000e+0, 0.000000e+0, 2.345678e-6, 0.000000e+0]
-    sigma_1:   [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
+    sigma_1:         [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
 ```
 
 The `covariance_matrix:` block is only present when the covariance step ran

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -132,12 +132,12 @@ sigma:
 covariance_matrix:
   # optimizer parameterization: theta log-transformed when lower bound >= 0
   # (identity otherwise), sigma log-transformed, omega/kappa Cholesky-factored
-  parameters: [TVCL, TVV, var_ETA_CL, var_ETA_V, sigma_1]
+  parameters: [TVCL, TVV, log_chol_ETA_CL, log_chol_ETA_V, sigma_1]
   rows:
-    TVCL:      [1.234567e-4, 2.345678e-5, 0.000000e+0, 0.000000e+0, 0.000000e+0]
-    TVV:       [2.345678e-5, 1.456789e-3, 0.000000e+0, 0.000000e+0, 0.000000e+0]
-    var_ETA_CL: [0.000000e+0, 0.000000e+0, 5.678901e-5, 0.000000e+0, 0.000000e+0]
-    var_ETA_V:  [0.000000e+0, 0.000000e+0, 0.000000e+0, 2.345678e-6, 0.000000e+0]
+    TVCL:           [1.234567e-4, 2.345678e-5, 0.000000e+0, 0.000000e+0, 0.000000e+0]
+    TVV:            [2.345678e-5, 1.456789e-3, 0.000000e+0, 0.000000e+0, 0.000000e+0]
+    log_chol_ETA_CL: [0.000000e+0, 0.000000e+0, 5.678901e-5, 0.000000e+0, 0.000000e+0]
+    log_chol_ETA_V:  [0.000000e+0, 0.000000e+0, 0.000000e+0, 2.345678e-6, 0.000000e+0]
     sigma_1:   [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
 ```
 
@@ -145,9 +145,11 @@ The `covariance_matrix:` block is only present when the covariance step ran
 successfully or was regularised. The values are in **optimizer space** — thetas
 and sigma are on the log scale (or identity scale when the lower bound is
 negative), omega and kappa are Cholesky-factored. The `parameters:` list gives
-the canonical column order; `rows:` keys match that order. Omega diagonal
-entries appear as `var_<eta>` and off-diagonal Cholesky entries as
-`chol_<eta_row>_<eta_col>`.
+the canonical column order; `rows:` keys match that order. Omega and kappa
+diagonal entries appear as `log_chol_<eta>` — the packed value is `log(L_ii)`
+where `omega = L Lᵀ` (log of the Cholesky diagonal, **not** the variance).
+Off-diagonal Cholesky entries appear as `chol_<eta_row>_<eta_col>` (`L_ij`,
+not log-transformed).
 
 ### Key Fields
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -764,9 +764,11 @@ fn fmt_cov_entry(v: f64) -> String {
 /// Build the ordered parameter name list that matches `pack_params` layout:
 /// `[theta..., omega_packed..., sigma..., kappa_packed...]`.
 ///
-/// For a diagonal omega/kappa each entry is `var_{eta_name}`.
+/// For a diagonal omega/kappa each entry is `log_chol_{eta_name}` — the packed
+/// value is `log(L_ii)` where `omega = L Lᵀ` (Cholesky diagonal, log-transformed).
 /// For a full-block omega/kappa the column-major lower-triangle entries are
-/// `var_{eta_i}` on the diagonal and `chol_{eta_i}_{eta_j}` (i > j) off-diagonal.
+/// `log_chol_{eta_i}` on the diagonal (`log(L_ii)`) and `chol_{eta_i}_{eta_j}`
+/// (i > j) off-diagonal (`L_ij`, not log-transformed).
 fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     let n_theta = result.theta_names.len();
     let n_eta = result.omega.nrows();
@@ -811,13 +813,13 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
 
     if omega_diagonal {
         for name in &result.eta_names {
-            names.push(format!("var_{name}"));
+            names.push(format!("log_chol_{name}"));
         }
     } else {
         for j in 0..n_eta {
             for i in j..n_eta {
                 if i == j {
-                    names.push(format!("var_{}", result.eta_names[i]));
+                    names.push(format!("log_chol_{}", result.eta_names[i]));
                 } else {
                     names.push(format!(
                         "chol_{}_{}",
@@ -833,13 +835,13 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     if n_kappa > 0 {
         if kappa_diagonal {
             for name in &result.kappa_names {
-                names.push(format!("var_{name}"));
+                names.push(format!("log_chol_{name}"));
             }
         } else {
             for j in 0..n_kappa {
                 for i in j..n_kappa {
                     if i == j {
-                        names.push(format!("var_{}", result.kappa_names[i]));
+                        names.push(format!("log_chol_{}", result.kappa_names[i]));
                     } else {
                         names.push(format!(
                             "chol_{}_{}",
@@ -2202,7 +2204,7 @@ mod tests {
             "covariance_matrix block missing"
         );
         assert!(
-            yaml.contains("  parameters: [CL, BASE, var_ETA_CL, chol_ETA_V_ETA_CL, var_ETA_V, EPS_1, EPS_2, var_KAPPA_CL, chol_KAPPA_V_KAPPA_CL, var_KAPPA_V]"),
+            yaml.contains("  parameters: [CL, BASE, log_chol_ETA_CL, chol_ETA_V_ETA_CL, log_chol_ETA_V, EPS_1, EPS_2, log_chol_KAPPA_CL, chol_KAPPA_V_KAPPA_CL, log_chol_KAPPA_V]"),
             "covariance_matrix parameter list wrong:\n{yaml}"
         );
         // Warnings.
@@ -2271,7 +2273,7 @@ mod tests {
 
     #[test]
     fn write_yaml_emits_covariance_matrix_block() {
-        // Diagonal omega (1 eta), 1 theta, 1 sigma → packed: [CL, var_ETA_CL, EPS_1]
+        // Diagonal omega (1 eta), 1 theta, 1 sigma → packed: [CL, log_chol_ETA_CL, EPS_1]
         let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
         r.theta = vec![2.0];
         r.theta_names = vec!["CL".into()];
@@ -2293,11 +2295,14 @@ mod tests {
             "block header missing"
         );
         assert!(
-            yaml.contains("  parameters: [CL, var_ETA_CL, EPS_1]"),
+            yaml.contains("  parameters: [CL, log_chol_ETA_CL, EPS_1]"),
             "parameter list wrong:\n{yaml}"
         );
         assert!(yaml.contains("    CL: ["), "CL row missing");
-        assert!(yaml.contains("    var_ETA_CL: ["), "var_ETA_CL row missing");
+        assert!(
+            yaml.contains("    log_chol_ETA_CL: ["),
+            "log_chol_ETA_CL row missing"
+        );
         assert!(yaml.contains("    EPS_1: ["), "EPS_1 row missing");
         // Identity matrix: diagonal 1 → "1.000000e+0", off-diagonal 0 → "0.000000e+0"
         assert!(
@@ -2326,7 +2331,9 @@ mod tests {
         let yaml2 = std::fs::read_to_string(&path2).expect("yaml read");
 
         assert!(
-            yaml2.contains("  parameters: [CL, var_ETA_CL, chol_ETA_V_ETA_CL, var_ETA_V, EPS_1]"),
+            yaml2.contains(
+                "  parameters: [CL, log_chol_ETA_CL, chol_ETA_V_ETA_CL, log_chol_ETA_V, EPS_1]"
+            ),
             "full-block omega parameter list wrong:\n{yaml2}"
         );
         // No covariance_matrix block when covariance_matrix is None


### PR DESCRIPTION
<!-- Title format: type(scope): short description  [closes #N] -->

## Why

Copilot review on #240 flagged four issues after the PR was merged; three were not addressed. This PR resolves them.

**Finding 2 & 4 — `var_*` label is factually wrong.**
The packed covariance diagonal entry for omega/kappa stores `log(L_ii)` where `omega = L Lᵀ` (log of the Cholesky diagonal), not the variance. Labelling it `var_ETA_CL` is inconsistent with `chol_ETA_V_ETA_CL` for off-diagonal entries and would mislead any consumer that reads the label and tries to back-transform by name.

**Finding 3 — CHANGELOG referenced the PR (#240) instead of the originating issue (#236).**

**Finding 1 — `packed_param_names` ambiguity for mixed diagonal/block models** is already documented in the code comment (added in #240) and requires a structural fix (`omega_is_block`/`kappa_is_block` on `FitResult`). Not changed here.

## What changed

- Renamed all `var_<eta>` / `var_<kappa>` packed-covariance labels to `log_chol_<eta>` / `log_chol_<kappa>`:  `log_chol_` makes the log-Cholesky encoding explicit and is consistent with `chol_` used for off-diagonal entries.
- Updated: docstring on `packed_param_names`, all four `format!()` call-sites, all test assertions, `docs/src/output.md` YAML example, and the prose description.
- Fixed CHANGELOG `(#240)` → `(#236)`.

## Alternatives considered

Keeping `var_` as a "parameter type hint" rather than a value description — rejected because off-diagonal entries already use `chol_` as their prefix, and that prefix accurately reflects the encoding. Uniformity and accuracy win over brevity.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

The label change affects the YAML output format. Any ferx-r code that parses `covariance_matrix:` by key name would need updating, but that code does not yet exist (the R reader has not been wired up to this block).

## Breaking changes
- [x] `FitResult` / sdtab fields changed — the `covariance_matrix:` YAML block now emits `log_chol_*` keys instead of `var_*` for diagonal omega/kappa entries. Any downstream parser relying on `var_` key names must update.
- [ ] None

## Numerical validation
- [x] Not applicable (label rename only — values are unchanged)

## Performance
- [x] No significant impact expected

## Tests
- [x] All existing unit tests updated to the new label format; no new tests needed (the rename is mechanical and fully covered by existing assertions).

## Example (user-facing features only)

Before:
```yaml
covariance_matrix:
  parameters: [TVCL, TVV, var_ETA_CL, var_ETA_V, sigma_1]
  rows:
    var_ETA_CL: [...]
```

After:
```yaml
covariance_matrix:
  parameters: [TVCL, TVV, log_chol_ETA_CL, log_chol_ETA_V, sigma_1]
  rows:
    log_chol_ETA_CL: [...]
```

## Docs
- [x] `docs/src/output.md` updated — YAML example and prose description both use `log_chol_*`
- [x] `CHANGELOG.md` `[Unreleased]` issue reference corrected (#240 → #236)

## Checklist
- [x] `cargo check --no-default-features --features ci` clean (no new warnings)
- [x] `cargo fmt` passes (pre-commit hook passes)
- [ ] `cargo clippy` clean
- [x] No AD-reachable code touched

## Reviewer hints

Only `src/io/output.rs`, `docs/src/output.md`, and `CHANGELOG.md` change. The diff is mechanical: every `var_` label in the covariance-matrix emission path becomes `log_chol_`. The values themselves are unchanged.

## Open questions

None.