### PR TITLE
docs(api): label feature maturity and warn on experimental features [closes #175]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Feature maturity labels (`stable` / `beta` / `experimental`) documented for
+  every major feature: a new *Feature Maturity* docs page with definitions and a
+  per-feature table, plus a maturity banner on each feature reference page.
+  Experimental features (`[diffusion]` / SDE, `[covariate_nn]` / neural networks)
+  now emit a runtime warning at fit time (`W_EXPERIMENTAL_SDE`,
+  `W_EXPERIMENTAL_NN`), also surfaced by `ferx check` (#175).
 - `covariance_matrix:` block in `*-fit.yaml`: the full optimizer-space parameter
   covariance matrix (log-theta, Cholesky-omega, log-sigma; kappa appended for IOV
   models), parameter-labelled, emitted when the covariance step succeeds or is

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Introduction](introduction.md)
+- [Feature Maturity](maturity.md)
 - [Getting Started](getting-started.md)
   - [Installation](installation.md)
   - [Quick Start](quick-start.md)

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -1,5 +1,7 @@
 # FOCE / FOCEI
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 First-Order Conditional Estimation (FOCE) and its interaction variant (FOCEI) are the primary estimation methods in ferx-core. They use a two-level nested optimization to find maximum likelihood estimates of population parameters.
 
 ## Algorithm Overview

--- a/docs/src/estimation/gauss-newton.md
+++ b/docs/src/estimation/gauss-newton.md
@@ -1,5 +1,7 @@
 # Gauss-Newton (BHHH)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The Gauss-Newton optimizer is an alternative to the standard FOCE/FOCEI approach that exploits the nonlinear-least-squares structure of the FOCE objective. It uses the BHHH (Berndt-Hall-Hall-Hausman) approximation to the Hessian and typically converges in 10-30 iterations, compared to 100+ evaluations for gradient-based methods like SLSQP.
 
 This approach mirrors NONMEM's modified Gauss-Newton algorithm.

--- a/docs/src/estimation/importance-sampling.md
+++ b/docs/src/estimation/importance-sampling.md
@@ -1,5 +1,7 @@
 # Importance Sampling (IMP)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `imp` stage estimates the marginal log-likelihood
 
 \\[

--- a/docs/src/estimation/optimizers.md
+++ b/docs/src/estimation/optimizers.md
@@ -1,5 +1,7 @@
 # Outer Optimizers
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The **outer optimizer** is the algorithm that minimises the population objective function (OFV) over the transformed parameter vector `[log θ, chol(Ω), log σ]`.
 
 It only applies to methods that *have* a single outer-loop minimisation over that vector:

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -1,5 +1,7 @@
 # SAEM
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 Stochastic Approximation Expectation-Maximization (SAEM) is an alternative estimation method that uses MCMC sampling for random effects instead of MAP optimization. It is more robust to local minima and can handle complex random effect structures, including models with **inter-occasion variability (IOV)**.
 
 ## Algorithm Overview

--- a/docs/src/estimation/sir.md
+++ b/docs/src/estimation/sir.md
@@ -1,5 +1,7 @@
 # Sampling Importance Resampling (SIR)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 SIR is an optional post-estimation step that provides non-parametric parameter uncertainty estimates. It produces 95% confidence intervals that are more robust than the asymptotic covariance matrix, particularly for models with:
 
 - Non-normal parameter distributions

--- a/docs/src/estimation/tte.md
+++ b/docs/src/estimation/tte.md
@@ -1,5 +1,7 @@
 # Time-to-Event (TTE) Models
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 > **Phase 1 (current):** Parametric TTE with exponential, Weibull, and Gompertz hazard
 > families; right-censored, exact, and interval-censored observations; left truncation
 > via `TENTRY`; FOCEI and SAEM estimation; fixed-effects (`n_eta = 0`) and random-effects

--- a/docs/src/file-formats/check-report.md
+++ b/docs/src/file-formats/check-report.md
@@ -66,6 +66,8 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `W_STEADY_STATE_II` | warning | SS=1 doses with missing / non-positive `II` (treated as non-SS). |
 | `W_STEADY_STATE_INFUSION` | warning | SS=1 infusion with `T_inf > II` (overlapping pulses; SS skipped). |
 | `W_SDE_RESET` | warning | EVID=3/4 resets under an SDE `[diffusion]` model are not honoured. |
+| `W_EXPERIMENTAL_SDE` | warning | The model uses stochastic differential equations (`[diffusion]`), an [experimental](../maturity.md) feature. |
+| `W_EXPERIMENTAL_NN` | warning | The model uses neural-network components (`[covariate_nn]`), an [experimental](../maturity.md) feature. |
 | `W_NEGATIVE_LAGTIME` | warning | Lag time is negative at the initial typical-value point. |
 | `E_DERIVED_NAME_CONFLICT` | error | A `[derived]` name clashes with a built-in sdtab column, theta, eta, or individual-parameter name. |
 | `W_DERIVED_COVARIATE_SHADOW` | warning | A `[derived]` name shadows a covariate (allowed but may be confusing). |

--- a/docs/src/maturity.md
+++ b/docs/src/maturity.md
@@ -1,0 +1,86 @@
+# Feature Maturity
+
+Not every feature in ferx-core is equally battle-tested. Some — like FOCE/FOCEI
+estimation and the analytical PK solutions — have been validated against gold
+standard engines across many datasets. Others are newer and have only been
+exercised on a handful of examples. To make this explicit, every major feature
+carries a **maturity label**.
+
+Where a feature has its own dedicated reference page, that page repeats its label
+in a banner at the top, e.g.:
+
+> **Maturity: beta** — see [Feature Maturity](maturity.md) for what this means.
+
+The table below is the authoritative list; a few features documented inside a
+shared reference page (e.g. autodiff under [Fit Options](model-file/fit-options.md))
+or only in an example carry their label here rather than in a per-page banner.
+
+## Maturity levels
+
+| Label | Meaning |
+|-------|---------|
+| **stable** | Well-tested functionality with proven stability across diverse datasets and estimation options. Performance is comparable to (or better than) gold standard NLME engines (NONMEM, Monolix). Safe for production use. |
+| **beta** | Stable in limited testing and across a range of fit settings, but some caution is warranted before relying on it in production on unseen datasets. Validate against a reference where you can. |
+| **experimental** | New functionality tested only on a single example or a small handful of (often toy) examples. Behaviour and syntax may change. Results should be treated as provisional and validated carefully. |
+
+These labels describe ferx-core's *current* state and will move upward as
+features accumulate testing and cross-validation. Most of ferx-core is currently
+**beta**, with a mature core approaching **stable**; a few features remain
+**experimental**.
+
+## Runtime warnings
+
+**Experimental** features emit a warning at fit time (surfaced in
+`FitResult.warnings`, the CLI output, and `ferx check`) so their status is
+visible at the point of use:
+
+| Feature | Warning code |
+|---------|--------------|
+| Stochastic differential equations (`[diffusion]`) | `W_EXPERIMENTAL_SDE` |
+| Neural networks (`[covariate_nn]`) | `W_EXPERIMENTAL_NN` |
+
+**Beta** and **stable** features do not emit a maturity warning.
+
+## Feature reference
+
+### Model file features
+
+| Feature | Maturity | Reference |
+|---------|----------|-----------|
+| Parameters (theta / omega / sigma, block omega) | **stable** | [Parameters](model-file/parameters.md) |
+| Inter-occasion variability (IOV) | **stable** | [IOV](model-file/iov.md) |
+| Covariates | **stable** | [Covariates](model-file/covariates.md) |
+| Structural model — analytical PK (1/2/3-cpt) | **stable** | [Structural Model](model-file/structural-model.md) |
+| Lag time | **stable** | [Lagtime](model-file/lagtime.md) |
+| Steady-state doses (SS) | **stable** | [Steady-State Doses](model-file/steady-state.md) |
+| Multiple dosing (ADDL / II) | **stable** | [Multiple Dosing](examples/multiple-dosing.md) |
+| Error model (additive / proportional / combined) | **stable** | [Error Model](model-file/error-model.md) |
+| Simulation | **stable** | [Simulation](model-file/simulation.md) |
+| Individual parameters DSL | **beta** | [Individual Parameters](model-file/individual-parameters.md) |
+| BLOQ / censored observations (M3) | **beta** | [BLOQ](model-file/bloq.md) |
+| ODE models (Dormand-Prince RK45) | **beta** | [ODE Models](model-file/ode-models.md) |
+| Scaling | **beta** | [Scaling](model-file/scaling.md) |
+| Data selection | **beta** | [Data Selection](model-file/data-selection.md) |
+| Derived columns | **beta** | [Derived Columns](model-file/derived.md) |
+| Output columns | **beta** | [Output Columns](model-file/output.md) |
+| Time-to-event endpoints (TTE) | **beta** | [Time-to-Event Endpoints](model-file/event-model.md) |
+| Stochastic differential equations (SDE) | **experimental** | [SDE](model-file/diffusion.md) |
+| Neural networks (DCM / NODE) | **experimental** | [Neural Networks](model-file/neural-networks.md) |
+
+### Estimation features
+
+| Feature | Maturity | Reference |
+|---------|----------|-----------|
+| FOCE / FOCEI | **stable** | [FOCE / FOCEI](estimation/foce.md) |
+| Gauss-Newton (BHHH) — `gn`, `gn_hybrid` | **beta** | [Gauss-Newton](estimation/gauss-newton.md) |
+| SAEM | **beta** | [SAEM](estimation/saem.md) |
+| SIR | **beta** | [SIR](estimation/sir.md) |
+| Importance sampling (IMP) | **beta** | [Importance Sampling](estimation/importance-sampling.md) |
+| Outer optimizers (BOBYQA, SLSQP, L-BFGS, MMA, trust-region) | **beta** | [Outer Optimizers](estimation/optimizers.md) |
+| Time-to-event estimation (TTE) | **beta** | [Time-to-Event](estimation/tte.md) |
+| Automatic differentiation (`gradient_method = ad`) | **beta** | [Fit Options](model-file/fit-options.md) |
+
+> The label reflects the engine's overall confidence in a feature, not the
+> presence or absence of tests — a beta feature may still have extensive
+> automated tests; "stable" additionally requires broad cross-validation against
+> reference engines across diverse datasets.

--- a/docs/src/model-file/bloq.md
+++ b/docs/src/model-file/bloq.md
@@ -1,5 +1,7 @@
 # BLOQ / Below Limit of Quantification
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 Observations below the lower limit of quantification (LLOQ) cannot be treated as ordinary data: they carry only the information that the true concentration is somewhere below the detection threshold. Ignoring them (dropping rows) biases parameter estimates; treating the reported value (e.g. LLOQ/2) as a real observation is also biased. The statistically correct approach is to integrate the likelihood over the censored region.
 
 ferx-core supports two strategies, selected via `bloq_method` in `[fit_options]`.

--- a/docs/src/model-file/covariate-nn.md
+++ b/docs/src/model-file/covariate-nn.md
@@ -1,5 +1,7 @@
 # `[covariate_nn]` — Deep Compartment Models (DCM)
 
+> **Maturity: experimental** — see [Feature Maturity](../maturity.md) for what this means.
+
 A `[covariate_nn]` block replaces the **typical-value covariate model** with
 a small feed-forward neural network. Instead of writing
 

--- a/docs/src/model-file/covariates.md
+++ b/docs/src/model-file/covariates.md
@@ -1,5 +1,7 @@
 # Covariates
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[covariates]` block declares which dataset columns are
 covariates and whether each is **continuous** or **categorical**. This is a
 declaration of *availability* — it does **not** mean the covariate is used in

--- a/docs/src/model-file/data-selection.md
+++ b/docs/src/model-file/data-selection.md
@@ -1,5 +1,7 @@
 # Data Selection
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[data_selection]` block lets you exclude records from the dataset
 at read time without modifying the CSV file.  It is the ferx equivalent of
 NONMEM's `$DATA IGNORE=` / `$DATA ACCEPT=`.

--- a/docs/src/model-file/derived.md
+++ b/docs/src/model-file/derived.md
@@ -1,5 +1,7 @@
 # Derived Columns (`[derived]`)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[derived]` block defines extra columns that are computed after the fit and appended to the sdtab output. Each line has the form:
 
 ```

--- a/docs/src/model-file/diffusion.md
+++ b/docs/src/model-file/diffusion.md
@@ -1,5 +1,7 @@
 # Stochastic Differential Equations (SDE / Diffusion)
 
+> **Maturity: experimental** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[diffusion]` block adds continuous stochastic noise to ODE state variables.
 This models *system noise* — structural uncertainty that accumulates between
 observations — as opposed to measurement noise (sigma) or inter-individual

--- a/docs/src/model-file/error-model.md
+++ b/docs/src/model-file/error-model.md
@@ -1,5 +1,7 @@
 # Error Model
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[error_model]` block defines the residual error structure, specifying how observed data (DV) relates to model predictions.
 
 ## Syntax

--- a/docs/src/model-file/event-model.md
+++ b/docs/src/model-file/event-model.md
@@ -1,5 +1,7 @@
 # Time-to-Event Endpoints (`[event_model]`)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[event_model]` block registers a CMT column as a TTE (time-to-event)
 endpoint.  Observations on that CMT are routed to a parametric survival
 likelihood rather than the Gaussian residual-error model.

--- a/docs/src/model-file/individual-parameters.md
+++ b/docs/src/model-file/individual-parameters.md
@@ -1,5 +1,7 @@
 # Individual Parameters
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[individual_parameters]` block defines how population parameters (theta), random effects (eta), and covariates combine to produce individual PK parameters.
 
 ## Syntax

--- a/docs/src/model-file/iov.md
+++ b/docs/src/model-file/iov.md
@@ -1,5 +1,7 @@
 # Inter-Occasion Variability (IOV)
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 Inter-Occasion Variability (IOV) models the fact that a subject's PK parameters may shift between occasions (treatment periods, study visits, dosing intervals). Unlike between-subject variability (BSV), which is fixed for a subject across the whole study, IOV is a random effect that is re-drawn for each occasion.
 
 ## Concepts

--- a/docs/src/model-file/lagtime.md
+++ b/docs/src/model-file/lagtime.md
@@ -1,5 +1,7 @@
 # Lagtime
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 A `lagtime` PK parameter shifts the effective start of every dose record by
 a fixed amount. This is the standard way to model delayed-onset oral
 absorption: even after the dose is administered at clock time `t_dose`,

--- a/docs/src/model-file/neural-networks.md
+++ b/docs/src/model-file/neural-networks.md
@@ -1,5 +1,7 @@
 # Neural Networks
 
+> **Maturity: experimental** — see [Feature Maturity](../maturity.md) for what this means.
+
 ferx-core is gaining two complementary neural-network extensions. Both are
 gated behind the `nn` cargo feature (off by default) and are being built
 incrementally — see [`plans/dcm-and-low-dim-node.md`][plan] in the source

--- a/docs/src/model-file/ode-models.md
+++ b/docs/src/model-file/ode-models.md
@@ -1,5 +1,7 @@
 # ODE Models
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 For pharmacokinetic models without analytical solutions (e.g., saturable elimination, target-mediated drug disposition), ferx-core provides an ODE solver.
 
 ## Structural Model Declaration

--- a/docs/src/model-file/output.md
+++ b/docs/src/model-file/output.md
@@ -1,5 +1,7 @@
 # Output Columns (`[output]`)
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[output]` block lists additional columns to include in the sdtab beyond the mandatory minimum. Each entry is a bare name, one or more per line (whitespace or newlines between names).
 
 ```

--- a/docs/src/model-file/parameters.md
+++ b/docs/src/model-file/parameters.md
@@ -1,5 +1,7 @@
 # Parameters
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[parameters]` block defines all model parameters: fixed effects (theta), between-subject variability (omega), and residual error (sigma).
 
 ## Theta (Fixed Effects)

--- a/docs/src/model-file/scaling.md
+++ b/docs/src/model-file/scaling.md
@@ -1,5 +1,7 @@
 # Scaling
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[scaling]` block declares how the structural model's raw
 output maps to the observed `DV`. It exists so the user does not have to
 fold unit conversion or amount-to-concentration arithmetic into the

--- a/docs/src/model-file/simulation.md
+++ b/docs/src/model-file/simulation.md
@@ -1,5 +1,7 @@
 # Simulation
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 The optional `[simulation]` block defines a virtual clinical trial design for generating simulated data. This is useful for model validation and testing.
 
 ## Syntax

--- a/docs/src/model-file/steady-state.md
+++ b/docs/src/model-file/steady-state.md
@@ -1,5 +1,7 @@
 # Steady-State Doses (SS=1)
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 A dose record with `SS=1` and `II > 0` tells ferx-core that, at the time
 of the record, the compartmental state is at steady state under repeated
 dosing of that amount/rate every `II` time units. The record itself is

--- a/docs/src/model-file/structural-model.md
+++ b/docs/src/model-file/structural-model.md
@@ -1,5 +1,7 @@
 # Structural Model
 
+> **Maturity: stable** — see [Feature Maturity](../maturity.md) for what this means.
+
 The `[structural_model]` block specifies the pharmacokinetic model used to generate predictions.
 
 ## Analytical PK Models

--- a/src/api.rs
+++ b/src/api.rs
@@ -727,6 +727,10 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
 /// non-fatal — `fit()` pushes their messages into `FitResult.warnings` and
 /// proceeds; `ferx check` reports them as `Warning` diagnostics. Message text
 /// is identical to the historical inline strings.
+///
+/// Feature-presence (data-independent) notices such as the experimental-feature
+/// warnings live in [`check_experimental_features`] instead, so `ferx check`
+/// surfaces them even without a `--data` file.
 pub fn check_model_data_warnings(
     model: &CompiledModel,
     population: &Population,
@@ -824,6 +828,46 @@ pub fn check_model_data_warnings(
     diags
 }
 
+/// Feature-presence (data-independent) *warning*-level checks for experimental
+/// features (issue #175). Stochastic differential equations and neural-network
+/// components are classified `experimental` in the Feature Maturity docs: tested
+/// only on a handful of toy examples. We emit a warning whenever they are used
+/// so results are applied with appropriate caution.
+///
+/// Kept separate from [`check_model_data_warnings`] because these depend only on
+/// the compiled `model`, not on the dataset — so `ferx check model.ferx` (no
+/// `--data`) and `fit()` both surface them. Non-fatal: `fit()` pushes the
+/// messages into `FitResult.warnings`; `ferx check` reports them as warnings.
+pub fn check_experimental_features(model: &CompiledModel) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+
+    if model.is_sde() {
+        diags.push(Diagnostic::warning(
+            "W_EXPERIMENTAL_SDE",
+            "Stochastic differential equations ([diffusion] / Extended Kalman \
+             Filter) are an EXPERIMENTAL feature: validated only on a small set \
+             of toy examples, with estimator support limited to FOCE/FOCEI. \
+             Standard errors and convergence behaviour are not yet proven across \
+             diverse datasets — validate results carefully before relying on \
+             them. See the Feature Maturity page in the documentation.",
+        ));
+    }
+    #[cfg(feature = "nn")]
+    if !model.covariate_nns.is_empty() {
+        diags.push(Diagnostic::warning(
+            "W_EXPERIMENTAL_NN",
+            "Neural-network model components ([covariate_nn] / deep compartment \
+             models) are an EXPERIMENTAL feature: validated only on a small set \
+             of toy examples. Standard errors for network weights are not \
+             reliable and the syntax may still change — validate results \
+             carefully before relying on them. See the Feature Maturity page in \
+             the documentation.",
+        ));
+    }
+
+    diags
+}
+
 /// Map a free-text parser error string to a single structured [`Diagnostic`].
 /// Recognises the `"Missing [X] block"` shape (→ `E_MISSING_BLOCK`, with the
 /// block name attached) and the `--features nn` gate (→ `E_NN_FEATURE_DISABLED`);
@@ -896,6 +940,11 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
     //    clean check and a fit agree. Uses the parsed `[fit_options]`, mirroring
     //    what the CLI fit path (`run_model_with_data`) passes to `fit()`.
     diags.extend(check_model_options(&parsed.model, &parsed.fit_options));
+
+    // 2c. Experimental-feature notices (data-independent): these depend only on
+    //    the model, so they surface from `ferx check model.ferx` even without a
+    //    `--data` file.
+    diags.extend(check_experimental_features(&parsed.model));
 
     // 3. Data-dependent checks (only when a dataset is supplied). Read through
     //    the same covariate-aware chokepoint the fit uses, so `ferx check` and
@@ -2178,6 +2227,10 @@ fn fit_inner(
     // message text is unchanged. Probed against `population` (not the pruned
     // copy) and `init_params`, matching the historical inline checks.
     for d in check_model_data_warnings(model, population, init_params) {
+        accumulated_warnings.push(d.message);
+    }
+    // Experimental-feature notices (data-independent; see check_experimental_features).
+    for d in check_experimental_features(model) {
         accumulated_warnings.push(d.message);
     }
     if options.run_covariance_step && n_params_pre > 30 {
@@ -5522,6 +5575,34 @@ mod sde_integration {
                 "error message should mention gn: {msg}"
             );
         }
+    }
+
+    /// Issue #175: an SDE ([diffusion]) model must surface the experimental
+    /// feature warning, classified into the `experimental` category. The check
+    /// is data-independent (`check_experimental_features` takes only the model),
+    /// so `ferx check` reports it even without a `--data` file. Fast — no fit.
+    #[test]
+    fn sde_emits_experimental_warning() {
+        let parsed = parse_full_model(SDE_MODEL_SRC).expect("SDE model should parse");
+        let diags = super::check_experimental_features(&parsed.model);
+        let exp = diags
+            .iter()
+            .find(|d| d.code == "W_EXPERIMENTAL_SDE")
+            .expect("SDE model should emit W_EXPERIMENTAL_SDE");
+        assert_eq!(exp.severity, crate::diagnostics::Severity::Warning);
+        assert_eq!(
+            crate::types::classify_warning(&exp.message).category,
+            "experimental"
+        );
+
+        // Sanity: a non-SDE model must NOT emit the experimental warning.
+        let base = parse_full_model(BASE_MODEL_SRC).expect("base model should parse");
+        assert!(
+            super::check_experimental_features(&base.model)
+                .iter()
+                .all(|d| d.code != "W_EXPERIMENTAL_SDE"),
+            "non-SDE model should not emit W_EXPERIMENTAL_SDE"
+        );
     }
 }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -33,6 +33,8 @@
 //! | `W_STEADY_STATE_II`       | SS=1 dose with missing / non-positive II |
 //! | `W_STEADY_STATE_INFUSION` | SS=1 infusion with `T_inf > II` (overlapping pulses) |
 //! | `W_SDE_RESET`             | EVID=3/4 resets under an SDE model are not honoured |
+//! | `W_EXPERIMENTAL_SDE`      | an SDE (`[diffusion]`) model uses an experimental feature (see Feature Maturity docs) |
+//! | `W_EXPERIMENTAL_NN`       | a neural-network (`[covariate_nn]`) model uses an experimental feature (see Feature Maturity docs) |
 //! | `W_NEGATIVE_LAGTIME`      | a lag time is negative at the initial estimates |
 //! | `E_DERIVED_NAME_CONFLICT` | `[derived]` name clashes with a built-in sdtab column, theta, eta, or indiv-param name |
 //! | `W_DERIVED_COVARIATE_SHADOW` | `[derived]` name shadows a covariate (allowed but may be confusing) |

--- a/src/types.rs
+++ b/src/types.rs
@@ -1836,8 +1836,8 @@ pub enum WarningSeverity {
 /// `bloq_method`, `sir`, `importance_sampling`, `data_quality`,
 /// `omega_structure`, `ebe_convergence`, `gradient_fallback`,
 /// `mu_referencing`, `optimizer_config`, `multi_start`, `cancelled`,
-/// `threads`, `condition_number`, `eta_normality`, `eps_shrinkage`, `general`
-/// (fallback for unrecognised messages).
+/// `threads`, `condition_number`, `eta_normality`, `eps_shrinkage`,
+/// `experimental`, `general` (fallback for unrecognised messages).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WarningEntry {
     pub severity: WarningSeverity,
@@ -1914,6 +1914,10 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, "dw_autocorrelation")
     } else if lower.contains("shapiro") || lower.contains("non-normal") {
         (WarningSeverity::Warning, "eta_normality")
+    } else if lower.contains("experimental feature") {
+        // Experimental-feature notices (issue #175): SDE and neural-network
+        // components emit a runtime warning so results are applied with caution.
+        (WarningSeverity::Warning, "experimental")
     } else if lower.contains("m3 bloq") || lower.contains("bloq handling") {
         (WarningSeverity::Warning, "bloq_method")
     } else if lower.contains("sir failed") || lower.contains("sir requested") {
@@ -3126,6 +3130,18 @@ mod tests {
                 "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",
                 Warning,
                 "data_quality",
+            ),
+            (
+                "Stochastic differential equations ([diffusion] / Extended Kalman \
+                 Filter) are an EXPERIMENTAL feature: validated only on a small set",
+                Warning,
+                "experimental",
+            ),
+            (
+                "Neural-network model components ([covariate_nn] / deep compartment \
+                 models) are an EXPERIMENTAL feature: validated only on a small set",
+                Warning,
+                "experimental",
             ),
             (
                 "block omega: ETA_CL x ETA_V have mixed lognormal / additive parameterisations",


### PR DESCRIPTION
## Why
Feature maturity wasn't visible to users — there was no way to tell, from the docs, whether a feature is production-ready or an early experiment. Issue #175 asks for explicit maturity labels (stable / beta / experimental), with experimental features warning at runtime.

## What changed
Maturity is calibrated conservatively, following the framing in #175: a mature core is **stable**, most features are **beta**, and neural networks (DCM/NODE) + SDE are **experimental**.

**Docs**
- New **Feature Maturity** page (`docs/src/maturity.md`): level definitions (verbatim from #175), a runtime-warning note, and per-feature tables for model-file and estimation features. Linked from `SUMMARY.md`.
- A maturity banner added to the top of every feature reference page (`model-file/*`, `estimation/*`).
- Two new warning codes documented in `file-formats/check-report.md`.

**Code**
- Experimental features now emit a runtime warning, surfaced in `FitResult.warnings`, the CLI, and `ferx check`:
  - `W_EXPERIMENTAL_SDE` — `[diffusion]` / SDE models
  - `W_EXPERIMENTAL_NN` — `[covariate_nn]` models (gated on the `nn` cargo feature)
- Both are emitted from the shared `check_model_data_warnings`, so `fit()` and `ferx check` report identically.
- New `experimental` warning category in `classify_warning` + registry entry in `diagnostics.rs`.

## Alternatives considered
A code-signal-based calibration (treating any feature with NONMEM cross-checks / slow convergence tests as stable) would have marked most of the engine stable. Rejected in favour of the conservative, author-aligned framing in #175 — "stable" requires broad cross-validation, not just the presence of tests.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

No signature changes to public APIs. `classify_warning` gains a new `experimental` category *value* (additive); the R wrapper consumes structured warnings and won't break.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs + warnings only; no estimation/PK/stats numerics changed)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added: `sde_emits_experimental_warning` (fast, no fit) asserts `W_EXPERIMENTAL_SDE` is emitted and classified `experimental`; both experimental messages added to the `classify_warning` round-trip table.

> Note: 3 pre-existing lib failures in `src/parser/model_parser.rs` (bytecode conditional/logic) are unrelated to this PR — that file is untouched here.

## Docs
- [x] `docs/src/` updated for user-visible changes
- [x] New page linked in `docs/src/SUMMARY.md` (`docs/book/` not committed)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings introduced)
- [x] `cargo check --no-default-features --features ci,nn` compiles (nn-gated branch)

## Reviewer hints
- The maturity calls themselves are the main thing to sanity-check — see the tables in `docs/src/maturity.md`. Two I'd especially flag: **autodiff** (labeled beta, table row points at `fit-options.md`) and the **individual-parameters DSL** (labeled beta).
- The `[dynamics_nn]` block isn't implemented yet (Phase B), so the NN warning currently covers `[covariate_nn]` only.

## Open questions
- Should beta features also emit an informational notice at runtime? #175 floats it; this PR keeps runtime warnings to experimental only.