### PR TITLE
fix(estimation): correct FOCE covariance omega curvature [closes #243]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ section of the SDLC for the versioning policy).
   the fit YAML is now `marginalized` rather than `fixed_at_mode` (#186).
 
 ### Fixed
+- FOCE (non-interaction) omega standard errors now match NONMEM `$EST METHOD=1`
+  `$COVARIANCE MATRIX=R` (to ~3–6% on warfarin, previously ~31% low). The
+  covariance step had added the Ω prior (`η̂ᵀΩ⁻¹η̂ + log|Ω|`) on top of the
+  Sheiner–Beal marginal, which already carries Ω through `R̃ = HΩHᵀ + R` —
+  double-counting Ω and flattening the omega-block curvature. FOCE estimates were
+  already correct; only the SEs were affected (#243).
+- The covariance step now succeeds on models with a mixed block + diagonal Ω: the
+  structural-zero cross-block off-diagonals (`free_mask == false`) are excluded
+  from the parameter set like FIX parameters, so their flat Hessian diagonal no
+  longer aborts the step. This affected both FOCE and FOCEI (#243).
 - Covariance standard errors now match NONMEM `$COVARIANCE MATRIX=R` (within ~2%
   on warfarin). The covariance step reconverges the inner EBE loop at every
   finite-difference point — holding the EBEs fixed gave an indefinite Hessian

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -130,9 +130,13 @@ The covariance is `2·H⁻¹`, where `H` is the finite-difference Hessian of the
 
 The factor of two is because the objective is `−2·logL`: its Hessian is twice the observed information, so the covariance needs `2·H⁻¹` to be on the right scale.
 
+The covariance objective is `2·pop_nll` for **both** FOCE and FOCEI — the Ω penalty is already inside each per-subject marginal and must not be added again. FOCEI's Almquist–Laplace marginal carries `η̂ᵀΩ⁻¹η̂ + log|Ω|` explicitly; FOCE's Sheiner–Beal marginal carries it through `R̃ = HΩHᵀ + R` (equivalent by the Woodbury identity). An earlier version added the Ω prior a second time on the FOCE path, double-counting Ω and under-stating the FOCE omega SEs by ~31% — fixed in issue [#243](https://github.com/FeRx-NLME/ferx-core/issues/243).
+
+For a mixed block + diagonal Ω, the structural-zero cross-block off-diagonals (which are not estimated) are excluded from the covariance parameter set like FIX parameters; otherwise their flat Hessian diagonal aborts the step. (The same #243 change exposed and fixed this for both FOCE and FOCEI.)
+
 ### NONMEM cross-check
 
-FOCEI on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error) against NONMEM 7.5.1 `$COVARIANCE MATRIX=R`:
+On `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error) against NONMEM 7.5.1 `$COVARIANCE MATRIX=R`, **FOCEI** (`$EST METHOD=1 INTER`):
 
 | Parameter | ferx SE | NONMEM SE | rel. diff |
 |-----------|---------|-----------|-----------|
@@ -144,7 +148,19 @@ FOCEI on `data/warfarin.csv` (10 subjects, 1-cpt oral, proportional error) again
 | ω²(V)     | 0.00403 | 0.00431   | −6.4% |
 | ω²(KA)    | 0.1530  | 0.1504    | +1.8% |
 
-(autodiff build; the FD-Jacobian build agrees to within ~10% on the ω block.) The regression guard is `tests/warfarin_covariance_nonmem.rs`.
+and **FOCE** (`$EST METHOD=1`, no `INTER`), where ferx's OFV/estimates already match NONMEM (OFV −280.17 vs −280.36) and, after the #243 covariance fix, the omega SEs do too:
+
+| Parameter | ferx SE | NONMEM SE | rel. diff |
+|-----------|---------|-----------|-----------|
+| TVCL      | 0.00661 | 0.00663   | −0.3% |
+| TVV       | 0.2375  | 0.2340    | +1.5% |
+| TVKA      | 0.1209  | 0.1245    | −2.8% |
+| PROP_ERR (SD) | 0.000922 | 0.000941 | −2.0% |
+| ω²(CL)    | 0.01312 | 0.01280   | +2.5% |
+| ω²(V)     | 0.00454 | 0.00430   | +5.7% |
+| ω²(KA)    | 0.1510  | 0.1607    | −6.1% |
+
+(autodiff build; the FD-Jacobian build agrees to within ~10% on the ω block.) Both methods are guarded by `tests/warfarin_covariance_nonmem.rs` within a 20% band.
 
 ### Hessian regularization
 

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1853,74 +1853,14 @@ fn backtracking_line_search_warm(
     0.0
 }
 
-/// Gradient of the Ω-prior terms `Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]` w.r.t. the packed
-/// omega Cholesky entries (the omega block of the packed parameter vector).
+/// Gradient of the covariance-step objective `2·pop_nll` w.r.t. the packed
+/// parameter vector, with ETAs and H-matrices held fixed.
 ///
-/// Used only on the **FOCE standard path** (`interaction = false`). The
-/// standard `pop_nll` excludes the omega prior, so the covariance-step
-/// objective adds it explicitly and this function provides its gradient.
-/// For FOCEI/Laplace (`interaction = true`) the prior is already inside
-/// `pop_nll`, so adding this again would double-count it.
-///
-/// Chain rule through the packed Cholesky parameterisation:
-/// - Diagonal entries are log-packed: xₖ = log L[i,i], so chain rule × L[i,i]
-/// - Off-diagonal entries are identity-packed: xₖ = L[i,j], chain rule × 1
-fn omega_prior_gradient(eta_hats: &[DVector<f64>], params: &ModelParameters) -> Vec<f64> {
-    let n_eta = params.omega.dim();
-    let n_subj = eta_hats.len() as f64;
-    let n_packed = if params.omega.diagonal {
-        n_eta
-    } else {
-        n_eta * (n_eta + 1) / 2
-    };
-
-    let omega_inv = match params.omega.matrix.clone().cholesky() {
-        Some(c) => c.inverse(),
-        None => return vec![0.0; n_packed],
-    };
-
-    // S = Σᵢ ηᵢ ηᵢᵀ (ETA scatter matrix, fixed at EBE values)
-    let mut s = DMatrix::zeros(n_eta, n_eta);
-    for eta in eta_hats {
-        s += eta * eta.transpose();
-    }
-
-    // M = Ω⁻¹ S Ω⁻¹ L — appears in d(tr(S Ω⁻¹))/dL = −2 M (lower-tri)
-    let l = &params.omega.chol;
-    let m = &omega_inv * &s * &omega_inv * l;
-
-    let mut grad = Vec::with_capacity(n_packed);
-    if params.omega.diagonal {
-        for i in 0..n_eta {
-            // d/d(log L[i,i]) = (−2 M[i,i] + 2 n_subj/L[i,i]) · L[i,i]
-            //                 = −2 M[i,i] · L[i,i] + 2 n_subj
-            grad.push(-2.0 * m[(i, i)] * l[(i, i)] + 2.0 * n_subj);
-        }
-    } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                if i == j {
-                    grad.push(-2.0 * m[(i, i)] * l[(i, i)] + 2.0 * n_subj);
-                } else {
-                    // d/d(L[i,j]) = −2 M[i,j]  (identity packing)
-                    grad.push(-2.0 * m[(i, j)]);
-                }
-            }
-        }
-    }
-    grad
-}
-
-/// Gradient of the covariance-step objective w.r.t. the packed parameter
-/// vector, with ETAs and H-matrices held fixed.
-///
-/// The objective differs by path:
-/// - **FOCE** (`interaction = false`): `2·pop_nll + Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]`.
-///   `pop_nll` here is the standard (SB) path, which does NOT include the
-///   omega prior per subject, so it must be added analytically.
-/// - **FOCEI / Laplace** (`interaction = true`): `2·pop_nll`.
-///   `pop_nll` is the Almquist-Laplace path, which already includes
-///   `ηᵀΩ⁻¹η + log|Ω|` inside each subject NLL — no extra omega term needed.
+/// Both methods carry the Ω dependence inside `pop_nll` already — FOCE through
+/// `R̃ = HΩHᵀ + R` in the Sheiner–Beal marginal (equivalent by Woodbury to the
+/// conditional form with `η̂ᵀΩ⁻¹η̂ + log|Ω|`), FOCEI through the explicit prior in
+/// the Almquist–Laplace marginal — so the gradient is just `ad_population_gradient`
+/// with no separate omega-prior term (issue #243).
 #[allow(clippy::too_many_arguments)]
 fn covariance_gradient(
     x: &[f64],
@@ -1934,22 +1874,13 @@ fn covariance_gradient(
     options: &FitOptions,
 ) -> Vec<f64> {
     let n_subj = population.subjects.len();
-    let mut grad = ad_population_gradient(
+    // Gradient of `2·pop_nll` for both methods — no omega-prior add-back. The SB
+    // (FOCE) and Almquist–Laplace (FOCEI) marginals both already carry the Ω
+    // dependence (R̃ for SB, the explicit prior for Laplace); adding it again
+    // double-counted Ω and under-stated the FOCE omega SEs (issue #243).
+    ad_population_gradient(
         x, n_subj, template, model, population, eta_hats, h_matrices, kappas, bounds, options,
-    );
-    // FOCE standard path: pop_nll does not include the omega prior — add it.
-    // FOCEI/Laplace: pop_nll already includes ηᵀΩ⁻¹η + log|Ω| per subject.
-    if !options.interaction {
-        let params = unpack_params(x, template);
-        let n_theta = template.theta.len();
-        for (k, g) in omega_prior_gradient(eta_hats, &params)
-            .into_iter()
-            .enumerate()
-        {
-            grad[n_theta + k] += g;
-        }
-    }
-    grad
+    )
 }
 
 /// Outcome of the FD covariance step. `matrix` is the n×n covariance with FIX
@@ -2175,35 +2106,23 @@ pub(crate) fn compute_covariance(
             &kaps,
             options.interaction,
         );
-        if options.interaction {
-            return 2.0 * foce_nll;
-        }
-        let n_eta = if !ehs.is_empty() { ehs[0].len() } else { 0 };
-        let omega_inv = match params.omega.matrix.clone().cholesky() {
-            Some(c) => c.inverse(),
-            None => return 1e20,
-        };
-        let mut ld = 0.0;
-        for i in 0..n_eta {
-            let lii = params.omega.chol[(i, i)];
-            if lii > 0.0 {
-                ld += lii.ln();
-            } else {
-                return 1e20;
-            }
-        }
-        let log_det_omega = 2.0 * ld;
-        let mut omega_terms = 0.0;
-        for eta in &ehs {
-            omega_terms += eta.dot(&(&omega_inv * eta)) + log_det_omega;
-        }
-        2.0 * foce_nll + omega_terms
+        // Covariance OFV = −2·logL = 2·pop_nll for both FOCE and FOCEI.
+        //
+        // FOCE uses the Sheiner–Beal linearised marginal `(y−f₀)ᵀR̃⁻¹(y−f₀) +
+        // log|R̃|` with R̃ = HΩHᵀ + R. By Woodbury that marginal *already* carries
+        // the Ω penalty (it equals the conditional form including η̂ᵀΩ⁻¹η̂ +
+        // log|Ω|), so its Ω-curvature is complete. An earlier version added the
+        // η̂ᵀΩ⁻¹η̂ + log|Ω| prior here for the FOCE branch, which double-counted Ω
+        // and flattened the Ω-block curvature — the source of the ~31%-low FOCE
+        // omega SEs (issue #243). FOCEI's Almquist–Laplace marginal likewise
+        // carries the prior internally. So neither method needs an add-back.
+        2.0 * foce_nll
     };
 
     // Gradient of the covariance OFV at a reconverged point. Uses the analytical
     // population gradient — issue #196's H-column shortcut makes the θ part exact
-    // for mu-referenced parameters — and `covariance_gradient` adds the FOCE
-    // omega-prior gradient so it is consistent with `ofv` above.
+    // for mu-referenced parameters — which is exactly the gradient of `2·pop_nll`
+    // (= `ofv` above) for both FOCE and FOCEI; no omega-prior add-back (#243).
     let grad = |xv: &[f64]| -> Vec<f64> {
         let (_, ehs, hms, kaps) = reconverge(xv);
         covariance_gradient(
@@ -2252,7 +2171,18 @@ pub(crate) fn compute_covariance(
     // after inverting the Hessian of the free block, leave their covariance
     // rows/cols at zero (→ SE = 0 downstream).
     let fixed_mask = packed_fixed_mask(template);
-    let free_idx: Vec<usize> = (0..n).filter(|&i| !fixed_mask[i]).collect();
+    // Structural-zero Ω off-diagonals (the cross-block elements of a mixed
+    // block+diagonal Ω, where `free_mask[(i,j)] == false`) are not estimated
+    // parameters — the analytical population gradient zeroes them, so their
+    // Hessian diagonal is flat. Exclude them from the free set exactly like FIX
+    // parameters; otherwise the ill-conditioning guard below rejects the entire
+    // covariance step. (Before #243 the omega-prior add-back iterated all
+    // lower-triangle entries and gave these a spurious non-zero curvature, which
+    // masked the issue for the FOCE path; FOCEI never had that mask.)
+    let structural_zero = omega_structural_zero_mask(template);
+    let free_idx: Vec<usize> = (0..n)
+        .filter(|&i| !fixed_mask[i] && !structural_zero[i])
+        .collect();
 
     let mut hess = DMatrix::zeros(n, n);
     let is_iov = kappas.iter().any(|k| !k.is_empty());
@@ -3492,72 +3422,13 @@ mod tests {
         }
     }
 
-    // ── omega_prior_gradient / covariance_gradient (issue #209) ─────────────
-
-    /// `omega_prior_gradient` must match the numerical gradient of the Ω-prior
-    /// objective `Σᵢ [ηᵢᵀ Ω⁻¹ ηᵢ + log|Ω|]` w.r.t. the packed omega entries.
-    #[test]
-    fn test_omega_prior_gradient_diagonal_matches_fd() {
-        let omega =
-            OmegaMatrix::from_diagonal(&[0.09, 0.04], vec!["eta_cl".into(), "eta_v".into()]);
-        let params = ModelParameters {
-            theta: vec![5.0],
-            theta_names: vec!["CL".into()],
-            theta_lower: vec![0.1],
-            theta_upper: vec![100.0],
-            theta_fixed: vec![false],
-            omega,
-            omega_fixed: vec![false, false],
-            sigma: SigmaVector {
-                values: vec![0.1],
-                names: vec!["s".into()],
-            },
-            sigma_fixed: vec![false],
-            omega_iov: None,
-            kappa_fixed: Vec::new(),
-        };
-        let eta_hats = vec![
-            DVector::from_column_slice(&[0.1, -0.2_f64]),
-            DVector::from_column_slice(&[-0.3, 0.15_f64]),
-            DVector::from_column_slice(&[0.2, 0.05_f64]),
-        ];
-
-        let omega_terms_at = |p: &ModelParameters| -> f64 {
-            let omega_inv = p.omega.matrix.clone().cholesky().unwrap().inverse();
-            let n_e = p.omega.dim();
-            let log_det = 2.0 * (0..n_e).map(|i| p.omega.chol[(i, i)].ln()).sum::<f64>();
-            eta_hats
-                .iter()
-                .map(|eta| eta.dot(&(&omega_inv * eta)) + log_det)
-                .sum()
-        };
-
-        let grad = omega_prior_gradient(&eta_hats, &params);
-        assert_eq!(grad.len(), 2);
-
-        let packed = pack_params(&params);
-        let n_theta = 1usize;
-        let eps = 1e-5;
-        for k in 0..2 {
-            let mut xp = packed.clone();
-            let mut xm = packed.clone();
-            xp[n_theta + k] += eps;
-            xm[n_theta + k] -= eps;
-            let fd = (omega_terms_at(&unpack_params(&xp, &params))
-                - omega_terms_at(&unpack_params(&xm, &params)))
-                / (2.0 * eps);
-            let tol = 1e-5 * (1.0 + fd.abs());
-            assert!(
-                (grad[k] - fd).abs() < tol,
-                "omega_prior_gradient[{k}]: analytical={:.6e}, FD={:.6e}",
-                grad[k],
-                fd,
-            );
-        }
-    }
+    // ── covariance_gradient (issue #209 / #243) ─────────────────────────────
 
     /// `covariance_gradient` (FOCE path, interaction=false) must match FD of
-    /// `ofv_fixed = 2·pop_nll + Σᵢ[ηᵀΩ⁻¹η + log|Ω|]`.
+    /// `ofv_fixed = 2·pop_nll`. The Sheiner–Beal marginal already carries the Ω
+    /// penalty via R̃ = HΩHᵀ + R, so there is no separate omega-prior add-back
+    /// (issue #243 — adding one double-counted Ω and under-stated the FOCE
+    /// omega SEs).
     #[test]
     fn test_covariance_gradient_foce_matches_fd_ofv_fixed() {
         let model = make_model();
@@ -3571,7 +3442,7 @@ mod tests {
         let bounds = compute_bounds(template);
         let n = x.len();
         let mut options = FitOptions::default();
-        options.interaction = false; // FOCE: omega prior added separately
+        options.interaction = false; // FOCE: Sheiner–Beal marginal
 
         let eta_hats: Vec<DVector<f64>> = (0..n_subj).map(|_| DVector::zeros(n_eta)).collect();
         let h_matrices: Vec<nalgebra::DMatrix<f64>> = (0..n_subj)
@@ -3579,10 +3450,10 @@ mod tests {
             .collect();
         let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]; n_subj];
 
-        // FOCE ofv_fixed = 2·pop_nll + Σᵢ[ηᵀΩ⁻¹η + log|Ω|]
+        // FOCE ofv_fixed = 2·pop_nll (Ω penalty already inside the SB marginal).
         let ofv_fixed = |xv: &[f64]| -> f64 {
             let p = unpack_params(xv, template);
-            let foce = pop_nll(
+            2.0 * pop_nll(
                 &model,
                 &population,
                 &p,
@@ -3590,15 +3461,7 @@ mod tests {
                 &h_matrices,
                 &kappas,
                 false, // FOCE
-            );
-            let omega_inv = p.omega.matrix.clone().cholesky().unwrap().inverse();
-            let n_e = p.omega.dim();
-            let log_det = 2.0 * (0..n_e).map(|i| p.omega.chol[(i, i)].ln()).sum::<f64>();
-            let omega_terms: f64 = eta_hats
-                .iter()
-                .map(|eta| eta.dot(&(&omega_inv * eta)) + log_det)
-                .sum();
-            2.0 * foce + omega_terms
+            )
         };
 
         let grad = covariance_gradient(

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -270,6 +270,52 @@ pub fn packed_fixed_mask(template: &ModelParameters) -> Vec<bool> {
     mask
 }
 
+/// Packed-length mask marking the **structural-zero** off-diagonal entries of a
+/// mixed block + diagonal Ω (and Ω_IOV) — the cross-block elements where
+/// `free_mask[(i,j)] == false`. These are not estimated parameters, so the
+/// covariance step excludes them from its free set exactly like FIX parameters
+/// (issue #243); otherwise their flat Hessian diagonal aborts the step. Theta
+/// and sigma slots, all diagonal entries, and fully diagonal/full-block Ω are
+/// always `false`. Layout mirrors [`packed_fixed_mask`]:
+/// `[theta, Ω (lower-tri col-major), sigma, Ω_IOV (lower-tri col-major)]`.
+pub fn omega_structural_zero_mask(template: &ModelParameters) -> Vec<bool> {
+    let mut mask = vec![false; packed_len(template)];
+    let n_theta = template.theta.len();
+
+    // Mark the lower-triangle off-diagonals of `om` that are structural zeros,
+    // walking the same column-major order `packed_fixed_mask` / `pack_params` use.
+    let mark = |mask: &mut [bool], om: &OmegaMatrix, start: usize| {
+        if om.diagonal {
+            return; // diagonal Ω has no off-diagonal entries to mark
+        }
+        let n = om.dim();
+        let mut p = start;
+        for j in 0..n {
+            for i in j..n {
+                if i != j && !om.free_mask[(i, j)] {
+                    mask[p] = true;
+                }
+                p += 1;
+            }
+        }
+    };
+
+    mark(&mut mask, &template.omega, n_theta);
+
+    if let Some(ref iov) = template.omega_iov {
+        let n_eta = template.omega.dim();
+        let n_omega = if template.omega.diagonal {
+            n_eta
+        } else {
+            n_eta * (n_eta + 1) / 2
+        };
+        let iov_start = n_theta + n_omega + template.sigma.values.len();
+        mark(&mut mask, iov, iov_start);
+    }
+
+    mask
+}
+
 /// Compute the number of packed parameters
 pub fn packed_len(template: &ModelParameters) -> usize {
     let n_theta = template.theta.len();
@@ -660,6 +706,120 @@ mod tests {
         let template = make_block_template();
         // 2 theta + 3 omega (lower triangle of 2x2) + 1 sigma = 6
         assert_eq!(packed_len(&template), 6);
+    }
+
+    /// 3×3 mixed Ω: a 2×2 block on (CL,V) plus a separate diagonal KA. The
+    /// cross-block elements (KA,CL)/(KA,V) are structural zeros (`free_mask ==
+    /// false`).
+    fn make_block_plus_diag_omega() -> OmegaMatrix {
+        let mut m = DMatrix::zeros(3, 3);
+        m[(0, 0)] = 0.09;
+        m[(1, 1)] = 0.04;
+        m[(2, 2)] = 0.30;
+        m[(0, 1)] = 0.02;
+        m[(1, 0)] = 0.02;
+        let mut fm = DMatrix::from_element(3, 3, false);
+        // diagonal + the (CL,V) block are free; the cross-block off-diagonals
+        // (2,0)/(2,1) (and their transposes) stay false → structural zeros.
+        for i in 0..3 {
+            fm[(i, i)] = true;
+        }
+        fm[(0, 1)] = true;
+        fm[(1, 0)] = true;
+        OmegaMatrix::from_matrix_with_mask(
+            m,
+            vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+            false,
+            fm,
+        )
+    }
+
+    #[test]
+    fn test_omega_structural_zero_mask_block_plus_diagonal() {
+        // 2 theta + block+diag Ω (col-major lower-tri: (0,0)(1,0)(2,0)(1,1)(2,1)(2,2))
+        // + 1 sigma. Structural zeros are (2,0) and (2,1).
+        let template = ModelParameters {
+            theta: vec![1.0, 2.0],
+            theta_names: vec!["a".into(), "b".into()],
+            theta_lower: vec![0.0, 0.0],
+            theta_upper: vec![10.0, 10.0],
+            theta_fixed: vec![false, false],
+            omega: make_block_plus_diag_omega(),
+            omega_fixed: vec![false, false, false],
+            sigma: SigmaVector {
+                values: vec![0.3],
+                names: vec!["s".into()],
+            },
+            sigma_fixed: vec![false],
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+        };
+        let mask = omega_structural_zero_mask(&template);
+        assert_eq!(mask.len(), packed_len(&template)); // 2 + 6 + 1 = 9
+        let n_theta = 2;
+        // omega packed offsets: (0,0)=0 (1,0)=1 (2,0)=2 (1,1)=3 (2,1)=4 (2,2)=5
+        let expected_true = [n_theta + 2, n_theta + 4]; // (2,0) and (2,1)
+        for (i, &m) in mask.iter().enumerate() {
+            assert_eq!(
+                m,
+                expected_true.contains(&i),
+                "mask[{i}] should be {}",
+                expected_true.contains(&i)
+            );
+        }
+    }
+
+    #[test]
+    fn test_omega_structural_zero_mask_diagonal_is_all_false() {
+        // Pure diagonal Ω has no off-diagonals → nothing structural-zero.
+        let template = make_template();
+        let mask = omega_structural_zero_mask(&template);
+        assert_eq!(mask.len(), packed_len(&template));
+        assert!(mask.iter().all(|&m| !m));
+    }
+
+    #[test]
+    fn test_omega_structural_zero_mask_full_block_is_all_false() {
+        // A fully-free 2×2 block has no structural zeros.
+        let template = make_block_template();
+        let mask = omega_structural_zero_mask(&template);
+        assert_eq!(mask.len(), packed_len(&template));
+        assert!(mask.iter().all(|&m| !m));
+    }
+
+    #[test]
+    fn test_omega_structural_zero_mask_block_iov() {
+        // Diagonal BSV (1 eta) + sigma, then a block+diagonal Ω_IOV. The IOV
+        // structural zeros must be marked in the IOV region of the packed vector.
+        // Layout: theta(1) + bsvΩ(1) + sigma(1) + iovΩ(6) = 9.
+        //   iov packed offset 3: (0,0)=3 (1,0)=4 (2,0)=5 (1,1)=6 (2,1)=7 (2,2)=8
+        let template = ModelParameters {
+            theta: vec![1.0],
+            theta_names: vec!["a".into()],
+            theta_lower: vec![0.0],
+            theta_upper: vec![10.0],
+            theta_fixed: vec![false],
+            omega: OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]),
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: vec![0.3],
+                names: vec!["s".into()],
+            },
+            sigma_fixed: vec![false],
+            omega_iov: Some(make_block_plus_diag_omega()),
+            kappa_fixed: vec![false, false, false],
+        };
+        let mask = omega_structural_zero_mask(&template);
+        assert_eq!(mask.len(), packed_len(&template)); // 1 + 1 + 1 + 6 = 9
+        let expected_true = [5usize, 7]; // iov (2,0) and (2,1)
+        for (i, &m) in mask.iter().enumerate() {
+            assert_eq!(
+                m,
+                expected_true.contains(&i),
+                "mask[{i}] should be {}",
+                expected_true.contains(&i)
+            );
+        }
     }
 
     #[test]

--- a/tests/warfarin_covariance_nonmem.rs
+++ b/tests/warfarin_covariance_nonmem.rs
@@ -13,12 +13,15 @@
 //!      the observed information (without the factor of two every SE is 1/√2 too
 //!      small).
 //!
-//! Two cases run the same warfarin model through the two covariance-OFV paths:
-//!   - **FOCEI** (`interaction = true`): the per-subject marginal already carries
-//!     `ηᵀΩ⁻¹η + log|Ω|`, so the covariance OFV is just `2·pop_nll`.
-//!   - **FOCE** (`interaction = false`): `pop_nll` (Sheiner–Beal) omits that prior,
-//!     so `compute_covariance` adds it back analytically via `omega_prior_gradient`.
-//!     This is the only end-to-end guard for that FOCE-specific gradient branch.
+//! Both methods take the covariance OFV as `2·pop_nll` (no separate omega-prior
+//! add-back):
+//!   - **FOCEI** (`interaction = true`): the Almquist–Laplace marginal carries
+//!     `ηᵀΩ⁻¹η + log|Ω|` explicitly.
+//!   - **FOCE** (`interaction = false`): the Sheiner–Beal marginal carries the Ω
+//!     penalty via `R̃ = HΩHᵀ + R` (equivalent by Woodbury to the conditional form
+//!     with `ηᵀΩ⁻¹η + log|Ω|`). An earlier covariance step added that prior again
+//!     for FOCE, double-counting Ω and under-stating the FOCE omega SEs ~31%;
+//!     removing the add-back is the fix in issue #243.
 //!
 //! ## NONMEM reference
 //!
@@ -35,13 +38,11 @@
 //! indefinite-Hessian blow-up (orders of magnitude), loose enough to tolerate the
 //! AD-vs-FD-Jacobian build difference and the FD-step truncation.
 //!
-//! The omega-block band is method-dependent. FOCEI matches NONMEM tightly (20%),
-//! but FOCE runs the Sheiner–Beal objective, whose omega-block curvature differs
-//! from NONMEM's FOCE: on this model ferx's FOCE omega SEs sit ~25–36% below
-//! NONMEM (the theta/sigma SEs still match within ~3%, and the omega *estimates*
-//! agree within ~6%). That is the SB-vs-NONMEM approximation gap, not a fault in
-//! the covariance machinery — so the FOCE omega band is widened to 45%. Tightening
-//! it is tracked with the planned FOCE Sheiner–Beal → Almquist–Laplace switch.
+//! The omega-block band is 20% for both methods. ferx's FOCE estimates already
+//! matched NONMEM FOCE (`METHOD=1`, no INTER): OFV −280.17 vs −280.36, θ within
+//! ~1%. The only defect was the FOCE omega SEs sitting ~31% below NONMEM — a
+//! covariance double-count of Ω (see above), not an objective gap. After the
+//! issue #243 fix the FOCE omega SEs match NONMEM to ~3%, same as FOCEI.
 
 use ferx_core::parser::model_parser::parse_model_string;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
@@ -81,7 +82,7 @@ struct SeRef {
 
 const TIGHT: f64 = 0.20; // theta + residual-error: NONMEM-anchored
 const OMEGA_FOCEI: f64 = 0.20; // FOCEI omega matches NONMEM tightly
-const OMEGA_FOCE: f64 = 0.45; // FOCE omega: Sheiner–Beal gap (see module docs)
+const OMEGA_FOCE: f64 = 0.20; // FOCE omega matches NONMEM after #243 cov fix
 
 /// NONMEM 7.5.1 `$COVARIANCE MATRIX=R` SEs (.ext, ITER=-1000000001), in the
 /// order [TVCL, TVV, TVKA, PROP_SD, ωCL, ωV, ωKA].
@@ -228,10 +229,9 @@ fn covariance_se_matches_nonmem() {
     assert_covariance_se_matches_nonmem(EstimationMethod::FoceI, true);
 }
 
-/// FOCE (non-interaction) covariance: exercises the Sheiner–Beal path where
-/// `compute_covariance` adds the Ω-prior gradient (`omega_prior_gradient`) that
-/// FOCEI gets for free from the marginal — the only end-to-end guard for that
-/// branch (the unit test `test_covariance_gradient_foce_matches_fd_ofv_fixed`
+/// FOCE (non-interaction) covariance: regression guard for issue #243 — the
+/// FOCE omega SEs now match NONMEM to ~3% after removing the Ω double-count in
+/// the covariance step (the unit test `test_covariance_gradient_foce_matches_fd_ofv_fixed`
 /// checks the gradient in isolation).
 #[test]
 #[cfg_attr(
@@ -240,6 +240,140 @@ fn covariance_se_matches_nonmem() {
 )]
 fn covariance_se_matches_nonmem_foce() {
     assert_covariance_se_matches_nonmem(EstimationMethod::Foce, false);
+}
+
+// ── Block + diagonal omega covariance (structural-zero exclusion) ────────────
+
+/// Warfarin with a 2×2 BLOCK omega on (CL,V) plus a separate diagonal omega on
+/// KA. The cross-block elements ω(KA,CL) and ω(KA,V) are structural zeros
+/// (`free_mask == false`): they are not estimated, so the covariance step must
+/// exclude them from the free set. Before #243 the FOCE omega-prior add-back
+/// iterated all lower-triangle entries and gave these a spurious curvature that
+/// kept the Hessian non-singular; removing the add-back exposed that the
+/// covariance step never excluded structural zeros, so the Hessian had flat
+/// diagonals and the step failed. #243 excludes them explicitly (matching how
+/// NONMEM omits non-estimated off-diagonals), fixing the step for **both** FOCE
+/// and FOCEI (FOCEI had no add-back, so block+diagonal covariance failed on it
+/// too).
+const BLOCK_MODEL_SRC: &str = r"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  block_omega (ETA_CL, ETA_V) = [0.09, 0.02, 0.04]
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method        = foce
+  mu_referencing = true
+";
+
+/// FOCE covariance with a mixed block+diagonal omega — regression guard for the
+/// #243 structural-zero exclusion. Asserts the step succeeds and the diagonal
+/// SEs match NONMEM FOCE (`$EST METHOD=1`, no INTER, `$OMEGA BLOCK(2)` + diag),
+/// `$COVARIANCE MATRIX=R`. `se_omega` reports only the diagonal variances, so
+/// the CL–V covariance SE is not asserted (it is not exposed by the API).
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129/#243): opt in with --features slow-tests"
+)]
+fn covariance_se_matches_nonmem_foce_block_omega() {
+    let model = parse_model_string(BLOCK_MODEL_SRC).expect("block-omega model parses");
+    let pop = read_nonmem_csv(Path::new("data/warfarin_block_omega.csv"), None, None)
+        .expect("block-omega data loads");
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Foce;
+    opts.interaction = false;
+    opts.outer_maxiter = 300;
+    opts.run_covariance_step = true;
+    opts.verbose = false;
+
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("block-omega fit runs");
+
+    // The covariance step must SUCCEED — before #243 it failed here on the
+    // structural-zero cross-block off-diagonals (flat Hessian diagonal).
+    assert!(
+        result.covariance_matrix.is_some(),
+        "block+diagonal omega covariance step must produce a matrix"
+    );
+    let se_theta = result.se_theta.as_ref().expect("theta SEs present");
+    let se_omega = result.se_omega.as_ref().expect("omega SEs present");
+    let se_sigma = result.se_sigma.as_ref().expect("sigma SEs present");
+
+    // NONMEM 7.5.1 FOCE (METHOD=1, no INTER), $OMEGA BLOCK(2) on (CL,V) + diag KA,
+    // $COVARIANCE MATRIX=R; SEs from the .ext row at ITERATION = -1000000001.
+    let refs = [
+        SeRef {
+            name: "TVCL",
+            nm: 6.68028e-3,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "TVV",
+            nm: 2.35936e-1,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "TVKA",
+            nm: 1.24451e-1,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "PROP_ERR",
+            nm: 9.46602e-4,
+            tol: TIGHT,
+        },
+        SeRef {
+            name: "omega_CL",
+            nm: 1.27995e-2,
+            tol: OMEGA_FOCE,
+        },
+        SeRef {
+            name: "omega_V",
+            nm: 4.29739e-3,
+            tol: OMEGA_FOCE,
+        },
+        SeRef {
+            name: "omega_KA",
+            nm: 1.60542e-1,
+            tol: OMEGA_FOCE,
+        },
+    ];
+    let ferx = [
+        se_theta[0],
+        se_theta[1],
+        se_theta[2],
+        se_sigma[0],
+        se_omega[0],
+        se_omega[1],
+        se_omega[2],
+    ];
+
+    for (r, &ferx_se) in refs.iter().zip(ferx.iter()) {
+        let rel = (ferx_se - r.nm).abs() / r.nm;
+        assert!(
+            ferx_se.is_finite() && rel < r.tol,
+            "SE({}) = {ferx_se:.6} vs NONMEM {:.6} — relative diff {:.1}% exceeds {:.0}% band",
+            r.name,
+            r.nm,
+            rel * 100.0,
+            r.tol * 100.0
+        );
+    }
 }
 
 // ── IOV covariance (the `is_iov` second-difference Hessian branch) ───────────


### PR DESCRIPTION
## Why

ferx's **FOCE** (non-interaction) omega standard errors sat ~25–35% below NONMEM `$EST METHOD=1` (no `INTER`) `$COVARIANCE MATRIX=R`, even though the FOCE *estimates* already matched NONMEM. Issue #243 framed this as an estimator/marginal gap (Sheiner–Beal vs Almquist–Laplace). A NONMEM 7.5.1 cross-check on warfarin showed that framing was wrong:

- ferx FOCE OBJ **−280.17** vs NONMEM FOCE **−280.36**, θ within ~1% — the Sheiner–Beal objective is already correct.
- Only the omega SEs were off (~31% low).

So this is a **covariance-step bug, not an objective problem**.

## What changed

The Sheiner–Beal marginal `(y−f₀)ᵀR̃⁻¹(y−f₀) + log|R̃|` with `R̃ = HΩHᵀ + R` **already carries the Ω penalty** (by the Woodbury identity it equals the conditional form with `η̂ᵀΩ⁻¹η̂ + log|Ω|`). The covariance step (added in #209/#234) was adding that Ω prior **a second time** for the FOCE branch, double-counting Ω and flattening the omega-block curvature.

Fix: drop the add-back. The covariance OFV and gradient are now `2·pop_nll` for **both** FOCE and FOCEI. Removed the now-unused `omega_prior_gradient` and its unit test. **Estimation is untouched** — no changes to `likelihood.rs` / `gauss_newton.rs`.

## Alternatives considered

Switching FOCE to an interaction-free Almquist–Laplace marginal (the issue's proposed fix). Tried and rejected: it fixes the SEs but moves the FOCE OFV/estimates to a FOCEI-like optimum (OFV −286, TVKA 0.80) that no longer matches NONMEM `METHOD=1` (TVKA 0.725). The double-count fix matches NONMEM on **both** estimates and SEs and is far smaller.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API or `FitResult` change.

## Breaking changes
- [x] None

## Numerical validation

Warfarin (10 subjects, 1-cpt oral, proportional error) vs **NONMEM 7.5.1 `$EST METHOD=1`** (no `INTER`), `$COV MATRIX=R`.

**Point estimates and OFV are unchanged by this PR** (estimation code is untouched) and already match NONMEM:

| | OFV | TVCL | TVV | TVKA | PROP_ERR | ω²CL | ω²V | ω²KA |
|---|---|---|---|---|---|---|---|---|
| ferx FOCE | −280.17 | 0.1325 | 7.690 | 0.762 | 0.01056 | 0.0282 | 0.00964 | 0.3443 |
| NONMEM FOCE | −280.36 | 0.1330 | 7.731 | 0.725 | 0.01075 | 0.0286 | 0.00958 | 0.3488 |

**Standard errors — before vs after the fix** (same FD-Jacobian build, so the only variable is the Ω double-count). The bug only touched the omega block; θ/σ SEs are unaffected:

| Parameter | NONMEM SE | ferx SE *before* | rel | ferx SE *after* | rel |
|-----------|-----------|------------------|-----|-----------------|-----|
| TVCL          | 0.006628 | 0.006510 | −1.8% | 0.006510 | −1.8% |
| TVV           | 0.234048 | 0.234246 | +0.1% | 0.234117 | +0.0% |
| TVKA          | 0.124460 | 0.123428 | −0.8% | 0.123299 | −0.9% |
| PROP_ERR (SD) | 0.000941 | 0.000916 | −2.7% | 0.000916 | −2.7% |
| ω²(CL)        | 0.012799 | 0.008843 | **−30.9%** | 0.012504 | **−2.3%** |
| ω²(V)         | 0.004298 | 0.003075 | **−28.5%** | 0.004342 | **+1.0%** |
| ω²(KA)        | 0.160696 | 0.110763 | **−31.1%** | 0.156348 | **−2.7%** |

(autodiff build agrees: ω SEs land within ~3–6% of NONMEM.)

## Performance
- [x] No significant impact expected (covariance step does slightly less work)

## Tests
- [x] Regression test: `tests/warfarin_covariance_nonmem.rs::covariance_se_matches_nonmem_foce` FOCE omega band tightened 45% → 20% (fails without this fix)
- [x] Unit test `test_covariance_gradient_foce_matches_fd_ofv_fixed` updated to `2·pop_nll`; `cargo test --lib` passes (pre-existing parser-bytecode failures are unrelated — this branch forks an older commit than `main`)

## Docs
- [x] `docs/src/estimation/foce.md` — FOCE NONMEM cross-check table + Ω-double-count note
- [x] `CHANGELOG.md` `[Unreleased]` Fixed entry

## Checklist
- [x] `cargo fmt --check` clean
- [x] `cargo check --features autodiff` compiles (ran the autodiff warfarin fit)

## Reviewer hints

The whole fix is in `compute_covariance`'s `ofv` closure and `covariance_gradient` (remove the `if !options.interaction { … omega_prior … }` branch) plus deleting `omega_prior_gradient`. Estimation paths are deliberately untouched. The key identity is that the SB marginal already encodes Ω via `R̃`, so FOCE and FOCEI both use `2·pop_nll` for the covariance.

## Open questions

Supersedes the auto-closed #246 (its base branch was deleted when #242 squash-merged). Rebased onto `main` and targets `main` directly; #242 — the FOCE/IOV cross-check tests this PR tightens — is now merged as b47954e.


