### PR TITLE
feat(estimation): allow standalone importance sampling (method = imp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Importance sampling can now run **standalone** (`method = imp`), evaluating the
+  IS log-likelihood at the initial parameters — IMP derives the EBEs/Jacobian it
+  needs via a FOCE inner loop at those parameters instead of requiring a
+  preceding estimator. Useful for scoring imported/fixed parameter sets. IMP
+  still may appear at most once and must be the terminal stage of a chain.
 - Feature maturity labels (`stable` / `beta` / `experimental`) documented for
   every major feature: a new *Feature Maturity* docs page with definitions and a
   per-feature table, plus a maturity banner on each feature reference page.

--- a/docs/src/estimation/importance-sampling.md
+++ b/docs/src/estimation/importance-sampling.md
@@ -36,28 +36,38 @@ much-lower-bias estimate at extra MC cost.
 
 ## How it runs
 
-`imp` is a chain stage, not a standalone method:
+`imp` is usually the terminal stage of a chain, but can also run on its own:
 
 ```
 [fit_options]
-  method        = [focei, imp]
-  is_samples    = 2000     # K, samples per subject
-  is_proposal_df = 5       # ν, Student-t tail weight
+  method        = [focei, imp]   # estimate with FOCEI, then evaluate the IS-LL
+  is_samples    = 2000           # K, samples per subject
+  is_proposal_df = 5             # ν, Student-t tail weight
   is_seed       = 12345
+```
+
+```
+[fit_options]
+  method = imp                   # standalone: IS-LL at the initial parameters
 ```
 
 Rules:
 
-- **Must follow another stage.** `methods = [imp]` and
-  `methods = [imp, focei]` are rejected — IMP needs the previous stage's
-  EBEs and per-subject Jacobian as the proposal centre/scale.
+- **Standalone is allowed.** `method = imp` evaluates the IS-LL at the
+  **initial parameters** — IMP derives the EBEs and per-subject Jacobian it
+  needs (the proposal centre/scale) at those parameters via a FOCE inner loop,
+  rather than from a preceding estimator. It does not estimate the parameters;
+  it reports the −2 log L there (handy for scoring imported/fixed parameter
+  sets). When chained after an estimator (`[focei, imp]`), it uses that stage's
+  EBEs/Jacobian instead.
 - **Must appear at most once.**
-- **Should be terminal.** A non-terminal `imp` produces a warning — the
-  next stage updates parameters and the IS result becomes meaningless.
+- **Must be terminal.** `methods = [imp, focei]` (or any `imp` mid-chain) is
+  rejected — a following stage would overwrite the parameters and make the IS
+  result meaningless.
 
-When IMP runs, `FitResult.method` still reports the previous estimating
-stage (e.g. `FOCEI`), and `FitResult.method_chain` preserves the full
-chain (`[FoceI, Imp]`). The IS-LL itself lands on
+When IMP runs after an estimator, `FitResult.method` reports that estimating
+stage (e.g. `FOCEI`); for a standalone `imp` it reports `IMP`. Either way
+`FitResult.method_chain` preserves the full chain and the IS-LL lands on
 `FitResult.importance_sampling`.
 
 ## Algorithm

--- a/docs/src/file-formats/check-report.md
+++ b/docs/src/file-formats/check-report.md
@@ -61,7 +61,7 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `E_DATA` | error | The `--data` file could not be read or parsed. |
 | `E_SDE_INCOMPATIBLE` | error | An SDE (`[diffusion]`) model used with an incompatible method (`saem`, `gn`, `gn_hybrid`) or `gradient_method = ad`. |
 | `E_AD_UNAVAILABLE` | error | `gradient_method = ad` requested, but the binary was built without the `autodiff` feature. Use `auto`/`fd`, or rebuild with the Enzyme toolchain. Only emitted by non-autodiff builds. |
-| `E_IMP_CHAIN` | error | `imp` is mis-placed in a method chain — first stage, repeated, or not the terminal stage. |
+| `E_IMP_CHAIN` | error | `imp` is mis-placed in a method chain — repeated, or not the terminal stage. (`imp` alone is allowed: it evaluates the IS-LL at the initial parameters.) |
 | `E_OPTIMIZER_IOV` | error | `optimizer = trust_region` used with an IOV model (`n_kappa > 0`). |
 | `W_STEADY_STATE_II` | warning | SS=1 doses with missing / non-positive `II` (treated as non-SS). |
 | `W_STEADY_STATE_INFUSION` | warning | SS=1 infusion with `T_inf > II` (overlapping pulses; SS skipped). |

--- a/src/api.rs
+++ b/src/api.rs
@@ -665,20 +665,12 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
         );
     }
 
-    // IMP is a likelihood evaluation, not an estimator: it must follow a
-    // parameter-estimating stage, appear at most once, and be the terminal stage.
+    // IMP is a likelihood evaluation, not an estimator: it may appear at most
+    // once and must be the terminal stage. It may run standalone (as the only
+    // stage), in which case the EBEs/Hessians it consumes are evaluated at the
+    // initial parameters — IMP then reports the −2 log L at those parameters
+    // without estimating them.
     if chain.iter().any(|&m| m == EstimationMethod::Imp) {
-        if chain.first().copied() == Some(EstimationMethod::Imp) {
-            diags.push(
-                Diagnostic::error(
-                    "E_IMP_CHAIN",
-                    "method `imp` cannot be the first stage in a chain — it consumes \
-                     EBEs and Hessians from a preceding estimator. Try `methods = [focei, imp]` \
-                     or `methods = [saem, imp]`.",
-                )
-                .with_block("fit_options"),
-            );
-        }
         let n_imp = chain
             .iter()
             .filter(|&&m| m == EstimationMethod::Imp)
@@ -2327,9 +2319,57 @@ fn fit_inner(
         // params/result update at the bottom of the loop so the preceding
         // stage's `OuterResult` continues to be the canonical one.
         if method == EstimationMethod::Imp {
+            // Standalone IMP (no preceding estimator): evaluate the EBEs/Hessians
+            // at the initial parameters so IMP can report the −2 log L there.
+            // This synthetic stage also becomes the canonical `OuterResult` so
+            // the rest of the fit (sdtab, FitResult) sees the (unchanged) params.
+            if result.is_none() {
+                let mu_k = crate::estimation::parameterization::compute_mu_k(
+                    model,
+                    &stage_params.theta,
+                    stage_opts.mu_referencing,
+                );
+                let (eta_hats, h_matrices, _stats, kappas) =
+                    crate::estimation::inner_optimizer::run_inner_loop_warm(
+                        model,
+                        population,
+                        &stage_params,
+                        stage_opts.inner_maxiter,
+                        stage_opts.inner_tol,
+                        None,
+                        Some(&mu_k),
+                        stage_opts.min_obs_for_convergence_check as usize,
+                    );
+                let nll = crate::estimation::outer_optimizer::pop_nll(
+                    model,
+                    population,
+                    &stage_params,
+                    &eta_hats,
+                    &h_matrices,
+                    &kappas,
+                    stage_opts.interaction,
+                );
+                result = Some(crate::estimation::outer_optimizer::OuterResult {
+                    params: stage_params.clone(),
+                    ofv: 2.0 * nll,
+                    converged: true,
+                    n_iterations: 0,
+                    eta_hats,
+                    h_matrices,
+                    kappas,
+                    covariance_matrix: None,
+                    warnings: Vec::new(),
+                    saem_mu_ref_m_step_evals_saved: None,
+                    saem_n_subjects_hmc: None,
+                    ebe_convergence_warnings: 0,
+                    max_unconverged_subjects: 0,
+                    total_ebe_fallbacks: 0,
+                    final_gradient: None,
+                    sir_fallback_proposal: None,
+                });
+            }
             let prev = result.as_ref().expect(
-                "IMP guard above should have rejected an IMP-first chain — \
-                 prior stage's OuterResult must exist here",
+                "IMP stage: prior OuterResult must exist (synthesised above when standalone)",
             );
             match crate::estimation::importance_sampling::run_importance_sampling(
                 model,

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -28,7 +28,7 @@
 //! | `E_DATA`                  | the `--data` file could not be read or parsed |
 //! | `E_SDE_INCOMPATIBLE`      | an SDE (`[diffusion]`) model used with SAEM / GN / AD |
 //! | `E_AD_UNAVAILABLE`        | `gradient_method = ad` requested on a build without the `autodiff` feature |
-//! | `E_IMP_CHAIN`             | `imp` mis-placed in a method chain (first / repeated / non-terminal) |
+//! | `E_IMP_CHAIN`             | `imp` mis-placed in a method chain (repeated / non-terminal) |
 //! | `E_OPTIMIZER_IOV`         | `optimizer = trust_region` used with an IOV model |
 //! | `W_STEADY_STATE_II`       | SS=1 dose with missing / non-positive II |
 //! | `W_STEADY_STATE_INFUSION` | SS=1 infusion with `T_inf > II` (overlapping pulses) |

--- a/tests/importance_sampling_api.rs
+++ b/tests/importance_sampling_api.rs
@@ -30,28 +30,36 @@ fn warfarin_setup() -> (
 }
 
 #[test]
-fn imp_only_chain_is_rejected() {
+fn imp_only_chain_runs_standalone() {
+    // Standalone IMP: no preceding estimator. Evaluates the EBEs/Hessians at the
+    // initial parameters and reports the −2 log L there.
     let (model, population, mut opts) = warfarin_setup();
     opts.methods = vec![EstimationMethod::Imp];
-    let err = fit(&model, &population, &model.default_params, &opts)
-        .err()
-        .expect("methods = [imp] must be rejected");
+    let result = fit(&model, &population, &model.default_params, &opts)
+        .expect("methods = [imp] (standalone) must produce a fit");
+    let imp = result
+        .importance_sampling
+        .as_ref()
+        .expect("importance_sampling field should be populated for a standalone imp fit");
     assert!(
-        err.contains("first stage"),
-        "expected `first stage` in error, got: {err}"
+        imp.minus2_log_likelihood.is_finite(),
+        "-2 LL must be finite, got {}",
+        imp.minus2_log_likelihood
     );
+    assert_eq!(result.method_chain, vec![EstimationMethod::Imp]);
 }
 
 #[test]
-fn imp_first_in_chain_is_rejected() {
+fn imp_before_estimator_is_rejected() {
+    // `imp` first but not terminal — caught by the "must be the final stage" rule.
     let (model, population, mut opts) = warfarin_setup();
     opts.methods = vec![EstimationMethod::Imp, EstimationMethod::FoceI];
     let err = fit(&model, &population, &model.default_params, &opts)
         .err()
         .expect("methods = [imp, focei] must be rejected");
     assert!(
-        err.contains("first stage"),
-        "expected `first stage` in error, got: {err}"
+        err.contains("final stage"),
+        "expected `final stage` in error, got: {err}"
     );
 }
 


### PR DESCRIPTION
## Why
Importance sampling (`imp`) could only run as the terminal stage **after** another estimator, because it consumes that stage's EBEs/Hessians as the proposal centre/scale. `method = imp` (and any `[imp, ...]`) was rejected with `E_IMP_CHAIN`. But IMP is fundamentally a likelihood *evaluator*, and a common need is to compute the IS −2 log L at a **known/imported/fixed** parameter set (e.g. NONMEM estimates) without re-estimating — which previously forced users to run a throwaway estimator first.

## What changed
`method = imp` now runs standalone. When IMP is the first (only) stage, the EBEs/Hessians it needs are evaluated at the **initial parameters** via a FOCE inner loop (`run_inner_loop_warm` + `pop_nll`), and that synthetic evaluation becomes the canonical `OuterResult` so the rest of the fit (sdtab, `FitResult`) sees the unchanged parameters. IMP then reports the −2 log L at those parameters; the IS-LL lands on `FitResult.importance_sampling` and `FitResult.method` reports `IMP`.

The other chain rules are unchanged: `imp` may appear **at most once** and **must be terminal**. So `[imp, focei]` is still rejected — now via the terminal rule rather than a dedicated first-stage rule.

## Alternatives considered
Reusing `optimize_population` with `outer_maxiter = 0` to produce the init-params result — rejected because NLopt treats `maxeval = 0` as *unlimited*, so it would fully optimize rather than evaluate at the initial parameters. Building the EBE/H evaluation directly is exact and cheap.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

`method = "imp"` already flows through the R wrapper; it's simply no longer rejected. No `FitResult`/glue changes.

## Breaking changes
- [x] None (purely relaxes a previously-rejected configuration; all prior chains behave identically)

## Numerical validation
- [x] Not applicable in the NONMEM-comparison sense — this enables a configuration, it doesn't change any estimator's math. Standalone IMP reproduces the same IS machinery used after FOCEI; covered by tests below.

## Performance
- [x] No significant impact expected (standalone path runs one FOCE inner loop at the initial parameters, same as the inner loop any FOCEI fit already does).

## Tests
- [x] Unit/integration tests updated in `tests/importance_sampling_api.rs`:
  - `imp_only_chain_runs_standalone` — `method = imp` now produces a fit with `importance_sampling` populated and `method_chain == [Imp]`.
  - `imp_before_estimator_is_rejected` — `[imp, focei]` still rejected (terminal rule).
  - Existing `imp_non_terminal_in_chain_is_rejected`, `imp_duplicated_in_chain_is_rejected`, and the `focei → imp` / `saem → imp` tests still pass.
- [x] `cargo test --lib` / IMP integration tests pass (8/8).

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[fit_options]
  method = imp          # standalone: IS-LL at the initial parameters
  is_samples = 2000
  is_proposal_df = 5
  is_seed = 12345
```

`fit$importance_sampling$minus2_log_likelihood` (R) / `FitResult.importance_sampling` (Rust) holds the IS −2 log L evaluated at the initial parameters; the parameters are not changed.
</details>

## Docs
- [x] `docs/src/estimation/importance-sampling.md` updated (standalone usage + rules)
- [x] `docs/src/file-formats/check-report.md` `E_IMP_CHAIN` description updated
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo check --no-default-features --features ci` compiles; mdBook builds

## Reviewer hints
Two spots: (1) the relaxed validation in `check_model_options` (dropped the first-stage error, kept at-most-once + terminal), and (2) the standalone branch in the fit loop that synthesises the init-params `OuterResult`. The synthetic result mirrors how SAEM builds its final `OuterResult` (inner loop + `pop_nll`), with `converged = true`, `n_iterations = 0`, no covariance step.

## Open questions
None.