### PR TITLE
feat(estimation): add IMPMAP estimator (importance_sampling_map) [closes #270]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- New `importance_sampling_map` (alias `impmap`) estimation method: a Monte-Carlo
+  EM estimator equivalent to NONMEM `METHOD=IMPMAP`. Each iteration re-centers a
+  per-subject importance-sampling proposal on the conditional mode (MAP) and
+  updates θ/Ω/σ from the importance-weighted posterior moments. Runs standalone
+  or chained (`methods = [focei, impmap]`); multivariate-normal proposal by
+  default (`impmap_proposal_df = normal`), Student-t optional. Validated against
+  FOCEI on warfarin. IOV and SDE models are not yet supported (#270).
 - Feature maturity labels (`stable` / `beta` / `experimental`) documented for
   every major feature: a new *Feature Maturity* docs page with definitions and a
   per-feature table, plus a maturity banner on each feature reference page.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -32,6 +32,7 @@
   - [SAEM](estimation/saem.md)
   - [SIR](estimation/sir.md)
   - [Importance Sampling (IMP)](estimation/importance-sampling.md)
+  - [IMPMAP](estimation/impmap.md)
   - [Outer Optimizers](estimation/optimizers.md)
   - [Time-to-Event (TTE)](estimation/tte.md)
 - [Data Format](data-format.md)

--- a/docs/src/estimation/README.md
+++ b/docs/src/estimation/README.md
@@ -10,6 +10,8 @@ ferx-core separates two orthogonal choices: the **statistical method** (how rand
 
 - **[SAEM](saem.md)** — Stochastic Approximation Expectation-Maximization. Uses MCMC sampling for random effects, providing more robust convergence on complex models with many random effects.
 
+- **[IMPMAP](impmap.md)** — Importance Sampling assisted by Mode A Posteriori (NONMEM `METHOD=IMPMAP`). A Monte-Carlo EM estimator that re-centers a per-subject importance-sampling proposal on the conditional mode every iteration. Targets high-dimensional, rich-data models where a non-MAP importance-sampling EM stalls. Runs standalone (`method = impmap`) or chained (`methods = [focei, impmap]`).
+
 ## Post-estimation steps
 
 These chain after a primary method via `methods = [...]` and refine the result rather than re-estimating from scratch:

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -85,6 +85,16 @@ The reported estimate is the running mean of the parameter vector over the final
 `impmap_averaging` iterations. A FOCE-Laplace `ofv` is computed at the final
 parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM.
 
+> **Mu-referencing is required.** The closed-form `log θ += mean(η)` shift is the
+> EM-correct typical-value update for log-normal random effects, so it is always
+> applied for log-mu-referenced parameters (`CL = TVCL * exp(ETA_CL)`),
+> independent of the `mu_referencing` fit option — that option only governs
+> inner-loop centering. Like NONMEM's EM methods, IMPMAP needs a mu-referenced
+> parameterization: a model with random effects whose typical values are *not*
+> log-mu-referenced emits a warning and may estimate those typical values poorly
+> (θ and the η mean are confounded over the importance samples). Use FOCEI for
+> such models.
+
 ## Validation against NONMEM
 
 On the bundled warfarin example (1-cpt oral, proportional error, 3 mu-referenced

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -1,0 +1,135 @@
+# IMPMAP — Importance Sampling assisted by Mode A Posteriori
+
+> **Maturity: beta** — see [Feature Maturity](../maturity.md) for what this means.
+
+`impmap` (alias `importance_sampling_map`) is a **Monte-Carlo EM (MCEM)
+estimator**, equivalent to NONMEM `$EST METHOD=IMPMAP`. It estimates the
+population parameters θ/Ω/σ by maximizing the importance-sampled marginal
+likelihood.
+
+It is the estimating counterpart to the [`imp`](importance-sampling.md) stage:
+`imp` only *evaluates* `−2 log L` at fixed parameters, whereas `impmap` *updates*
+the parameters each iteration.
+
+> **NONMEM's description.** *"Sometimes for highly dimensioned PK/PD problems
+> with very rich data the importance sampling method does not advance the
+> objective function well or even diverges. For this the IMPMAP method may be
+> used. At each iteration, conditional modes and conditional first-order
+> variances are evaluated as in the ITS or FOCE method, not just on the first
+> iteration as is done with IMP method. These are then used as parameters to the
+> multivariate normal proposal density for the Monte Carlo importance sampling
+> step."*
+
+## When to use it
+
+IMPMAP targets the regime where a plain importance-sampling EM stalls or
+diverges: **high-dimensional models with rich data**, where the individual
+posteriors are sharp and a proposal not re-centered on the mode samples the
+likelihood poorly. Re-evaluating the conditional mode and first-order variance
+**every** iteration keeps the proposal aligned with the posterior throughout.
+
+For routine 1–3 compartment PK with a few random effects, FOCEI is faster and
+deterministic — reach for IMPMAP when FOCEI struggles or you want a
+sampling-based cross-check that does not rely on the Laplace approximation.
+
+## How it runs
+
+Standalone, or as a chain stage warm-started by a preceding estimator:
+
+```
+[fit_options]
+  method             = importance_sampling_map   # or: impmap
+  impmap_iterations  = 200
+  impmap_samples     = 300
+  impmap_proposal_df = normal      # multivariate normal (NONMEM default)
+  impmap_seed        = 12345
+```
+
+```
+[fit_options]
+  method = [focei, impmap]         # FOCEI warm-start, then IMPMAP refine
+```
+
+Because `impmap` is an estimator, in a chain like `[focei, impmap]` the reported
+`FitResult.method` is `IMPMAP` and `method_chain` preserves the full sequence.
+
+## Algorithm
+
+Each MCEM iteration, at the current parameters θ⁽ᵗ⁾, Ω⁽ᵗ⁾, σ⁽ᵗ⁾:
+
+1. **MAP re-center (E-step A).** Run the FOCE inner loop for every subject to get
+   the conditional mode η̂ᵢ and Jacobian Jᵢ, and form the first-order-variance
+   Hessian \\(H_i = J_i^\\top R_i^{-1} J_i + \\Omega^{-1}\\).
+
+2. **Importance sampling (E-step B).** Draw `K = impmap_samples` samples
+   \\(\\eta_{ik} \\sim q(\\hat\\eta_i, H_i^{-1})\\) — a multivariate normal by
+   default (`impmap_proposal_df = normal`), or a Student-t for heavier tails —
+   with self-normalized weights
+   \\(\\tilde w_{ik} \\propto p(y_i\\mid\\eta_{ik},\\theta)\\,p(\\eta_{ik}\\mid\\Omega)/q(\\eta_{ik})\\).
+
+3. **M-step.**
+   - **Ω** (closed form): \\(\\Omega = \\tfrac1N \\sum_i \\sum_k \\tilde w_{ik}\\,\\eta_{ik}\\eta_{ik}^\\top\\),
+     then structural off-diagonals zeroed, FIX entries restored, free diagonals
+     floored to stay positive-definite.
+   - **θ** (mu-referenced): the log-typical value is shifted by the
+     importance-weighted population mean random effect,
+     \\(\\log\\theta \\mathrel{+}= \\tfrac1N\\sum_i \\sum_k \\tilde w_{ik}\\,\\eta_{ik}\\).
+     Re-MAPing at the new θ drives the mean random effect toward zero, so this
+     fixed-point iteration resolves the θ–η confounding that would otherwise
+     inflate Ω.
+   - **θ** (non-mu-ref) and **σ**: maximize the importance-weighted observation
+     likelihood \\(\\sum_i \\sum_k \\tilde w_{ik}\\log p(y_i\\mid\\eta_{ik},\\theta,\\sigma)\\)
+     with a derivative-free NLopt BOBYQA step.
+
+The reported estimate is the running mean of the parameter vector over the final
+`impmap_averaging` iterations. A FOCE-Laplace `ofv` is computed at the final
+parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM.
+
+## Validation against NONMEM
+
+On the bundled warfarin example (1-cpt oral, proportional error, 3 mu-referenced
+ETAs), ferx IMPMAP (`impmap_iterations = 150`, `impmap_samples = 500`, MVN
+proposal, seed 12345) matches NONMEM 7.5.1 `METHOD=IMPMAP` on the same
+model/data (`tests/nonmem/warfarin_impmap.ctl`):
+
+| Parameter | NONMEM IMPMAP | ferx IMPMAP |
+|-----------|--------------:|------------:|
+| TVCL | 0.135 | 0.1327 |
+| TVV | 7.89 | 7.737 |
+| TVKA | 0.730 | 0.811 |
+| ω²(ETA_CL) | 0.0291 | 0.0286 |
+| ω²(ETA_V) | 0.0101 | 0.0096 |
+| ω²(ETA_KA) | 0.340 | 0.336 |
+| σ (PROP, SD) | 0.01034 | 0.01056 |
+| −2 log L | −284.92 | −286.00 |
+
+The well-determined CL/V structure and all three variance components agree to a
+few percent; TVKA is the least-identified parameter on this 10-subject extract
+(ETA_KA variance ≈ 0.34, high shrinkage) and carries the loosest band. The OFVs
+(NONMEM "without constant" vs ferx's Laplace OFV) agree to ~1 unit, the usual
+cross-engine margin. This comparison is asserted by the gated
+`ferx_impmap_matches_nonmem_impmap_on_warfarin` test (nightly, `slow-tests`); a
+companion `impmap_converges_to_focei_on_warfarin` test checks agreement with
+ferx's own FOCEI.
+
+## Cost
+
+Per iteration ≈ one MAP inner loop (parallel over subjects) plus
+`K × n_subjects` predicts for the IS step plus a short weighted BOBYQA M-step.
+Total cost is roughly `impmap_iterations ×` the cost of a single `imp`
+evaluation. Everything is parallelized over subjects via the shared Rayon pool.
+
+## Not yet supported
+
+- **IOV (`[iov]` / `kappa`)** — the κ sufficient statistics and Ω_iov update are
+  a planned follow-up. IOV models are refused; use SAEM or FOCEI.
+- **SDE / `[diffusion]`** — refused for the same reason `imp` refuses them (the
+  EKF process-noise variance is not threaded through the IS observation
+  likelihood). Use FOCE / FOCEI.
+
+## See also
+
+- [Importance Sampling (IMP)](importance-sampling.md) — the evaluation-only
+  marginal-likelihood stage that shares IMPMAP's per-subject IS kernel.
+- [SAEM](saem.md) — the other sampling-based estimator; a common warm-start
+  (`methods = [saem, impmap]`).

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -13,7 +13,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
-| `method` | `foce`, `focei`, `saem`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). |
+| `method` | `foce`, `focei`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). |
 | `maxiter` | integer | `500` | Maximum outer loop iterations |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
 | `covariance_method` | `r`, `s`, `rsr` | `r` | Which covariance estimator to assemble, mirroring NONMEM `$COVARIANCE MATRIX=`. `r` = inverse Hessian `R⁻¹` (model-based; the default). `s` = inverse score cross-product `S⁻¹` (empirical information). `rsr` = the Huber–White sandwich `R⁻¹SR⁻¹` (robust to model mis-specification; NONMEM's default). **ferx defaults to `r`, but NONMEM's `$COVARIANCE` default is `rsr`** — set `covariance_method = rsr` when reconciling SEs against a NONMEM run that used the default `$COV`. `s`/`rsr` are currently supported for FOCEI and IOV fits (they need the per-subject score, whose Ω-prior term is only consistent under interaction). All three require a positive-definite FD Hessian: if the Hessian is non-PD the covariance step fails for every method (a non-PD Hessian is not yet routed to the `s` cross-product). Requires `covariance = true`. |
@@ -122,6 +122,39 @@ PK). Use it as a final chain stage:
 
 See [Importance Sampling documentation](../estimation/importance-sampling.md)
 for the algorithm, IOV caveats, and tuning guidance.
+
+## IMPMAP (`importance_sampling_map`)
+
+Unlike `imp` (which only *evaluates* the marginal likelihood), `impmap` is a
+full **estimator** — a Monte-Carlo EM loop equivalent to NONMEM
+`METHOD=IMPMAP`. Each iteration re-centers a per-subject importance-sampling
+proposal at the freshly-computed conditional mode (MAP) and updates θ/Ω/σ from
+the importance-weighted posterior moments. It runs standalone or as a chain
+stage:
+
+```
+[fit_options]
+  method             = importance_sampling_map   # alias: impmap
+  impmap_iterations  = 200
+  impmap_samples     = 300
+  impmap_proposal_df = normal     # multivariate normal (NONMEM default)
+  impmap_seed        = 12345
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `impmap_iterations` | `200` | Number of MCEM iterations (parameter updates). |
+| `impmap_samples` | `300` | Importance samples K per subject per iteration. Larger K reduces Monte-Carlo noise at linear cost. |
+| `impmap_proposal_df` | `normal` | Proposal degrees of freedom. `normal` (or `mvn`) gives a multivariate-normal proposal (NONMEM's default); a finite value ≥ 1 gives a heavier-tailed Student-t. |
+| `impmap_averaging` | `50` | Final iterations whose parameters are averaged into the reported estimate (Monte-Carlo variance reduction). |
+| `impmap_seed` | `12345` | RNG seed. Same seed → identical estimates. |
+| `impmap_low_ess_threshold` | `0.1` | Subjects with normalized ESS below this fraction are flagged as poorly sampled. |
+
+`impmap` reuses `inner_maxiter` / `inner_tol` for the per-iteration MAP step.
+Inter-occasion variability (`[iov]` / `kappa`) and SDE (`[diffusion]`) models
+are not yet supported and are refused up front. See the
+[IMPMAP documentation](../estimation/impmap.md) for the algorithm and the
+NONMEM comparison.
 
 ## Optimizer Choices
 

--- a/examples/warfarin_impmap.ferx
+++ b/examples/warfarin_impmap.ferx
@@ -1,0 +1,32 @@
+# One-compartment oral PK model (warfarin) — IMPMAP estimation
+# (Importance Sampling assisted by Mode A Posteriori; NONMEM METHOD=IMPMAP).
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method             = importance_sampling_map
+  impmap_iterations  = 40
+  impmap_samples     = 200
+  impmap_averaging   = 15
+  impmap_seed        = 12345
+  covariance         = false

--- a/src/api.rs
+++ b/src/api.rs
@@ -2134,6 +2134,7 @@ fn fit_inner(
                     | EstimationMethod::FoceGn
                     | EstimationMethod::FoceGnHybrid
                     | EstimationMethod::Imp
+                    | EstimationMethod::Impmap
             )
         });
         if uses_gradient_route {
@@ -2391,6 +2392,18 @@ fn fit_inner(
         let stage_result = match method {
             EstimationMethod::Saem => {
                 saem::run_saem(model, population, &stage_params, &stage_opts)?
+            }
+            EstimationMethod::Impmap => {
+                // Warm-start the first MAP inner loop from the preceding stage's
+                // EBEs when chained (e.g. [focei, impmap] / [saem, impmap]).
+                let warm = result.as_ref().map(|r| r.eta_hats.as_slice());
+                crate::estimation::impmap::run_impmap(
+                    model,
+                    population,
+                    &stage_params,
+                    warm,
+                    &stage_opts,
+                )?
             }
             EstimationMethod::FoceGn | EstimationMethod::FoceGnHybrid => {
                 crate::estimation::gauss_newton::run_foce_gn(

--- a/src/api.rs
+++ b/src/api.rs
@@ -634,6 +634,17 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 .with_block("fit_options"),
             );
         }
+        if chain.iter().any(|&m| m == EstimationMethod::Impmap) {
+            diags.push(
+                Diagnostic::error(
+                    "E_SDE_INCOMPATIBLE",
+                    "method = impmap is not compatible with a [diffusion] block. \
+                     The EKF process-noise variance is not threaded through the IMPMAP \
+                     importance-sampling likelihood. Use method = foce or method = focei.",
+                )
+                .with_block("fit_options"),
+            );
+        }
         if options.gradient_method == crate::types::GradientMethod::Ad {
             diags.push(
                 Diagnostic::error(
@@ -644,6 +655,21 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 .with_block("fit_options"),
             );
         }
+    }
+
+    // IMPMAP does not yet support inter-occasion variability (κ / [iov]); the κ
+    // sufficient statistics and Ω_iov M-step are a planned follow-up. Surface it
+    // at check time so `ferx check` rejects it rather than the fit failing at
+    // runtime (possibly after a chained warm-up stage has already run).
+    if model.n_kappa > 0 && chain.iter().any(|&m| m == EstimationMethod::Impmap) {
+        diags.push(
+            Diagnostic::error(
+                "E_IMPMAP_IOV_UNSUPPORTED",
+                "method = impmap does not yet support inter-occasion variability \
+                 (κ / [iov]). Use method = saem or method = focei for IOV models.",
+            )
+            .with_block("fit_options"),
+        );
     }
 
     // Explicit `gradient_method = ad` on a build compiled WITHOUT the `autodiff`
@@ -2894,6 +2920,10 @@ fn fit_inner(
             EstimationMethod::Saem => "saem",
             EstimationMethod::FoceGn => "gn",
             EstimationMethod::FoceGnHybrid => "gn",
+            // IMPMAP never runs the outer optimizer — its M-step uses an internal
+            // BOBYQA regardless of `options.optimizer`, so report that rather than
+            // a setting that had no effect.
+            EstimationMethod::Impmap => "impmap-bobyqa",
             _ => options.optimizer.label(),
         }
         .to_string(),
@@ -4583,6 +4613,20 @@ mod iov_integration {
         // A compatible optimizer produces no compatibility diagnostics.
         let ok_opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
         assert!(super::check_model_options(&model, &ok_opts).is_empty());
+    }
+
+    // IMPMAP does not yet support IOV; `ferx check` must flag it up front rather
+    // than letting the fit fail at runtime (review finding #3).
+    #[test]
+    fn test_check_model_options_flags_impmap_iov() {
+        let model = make_iov_model();
+        let opts = fast_opts(EstimationMethod::Impmap, Optimizer::Bobyqa, false);
+        let diags = super::check_model_options(&model, &opts);
+        let d = diags
+            .iter()
+            .find(|d| d.code == "E_IMPMAP_IOV_UNSUPPORTED")
+            .expect("expected E_IMPMAP_IOV_UNSUPPORTED diagnostic");
+        assert!(d.is_error() && d.message.contains("inter-occasion"));
     }
 
     // On a build without the `autodiff` feature, explicitly requesting AD must

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -88,7 +88,9 @@ pub fn gradient_method_outer(
     optimizer: Optimizer,
 ) -> GradientMethodKind {
     match method {
-        EstimationMethod::Saem | EstimationMethod::Imp => GradientMethodKind::NotApplicable,
+        EstimationMethod::Saem | EstimationMethod::Imp | EstimationMethod::Impmap => {
+            GradientMethodKind::NotApplicable
+        }
         EstimationMethod::FoceGn | EstimationMethod::FoceGnHybrid => {
             GradientMethodKind::FiniteDifferences
         }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -1,0 +1,649 @@
+//! IMPMAP — Importance Sampling assisted by Mode A Posteriori (NONMEM
+//! `METHOD=IMPMAP`).
+//!
+//! A Monte-Carlo EM (MCEM) **estimator**. Each iteration:
+//!
+//! 1. **E-step part A (MAP):** re-evaluate every subject's conditional mode η̂ᵢ
+//!    and first-order-variance Hessian `Hᵢ = Jᵢᵀ Rᵢ⁻¹ Jᵢ + Ω⁻¹` at the current
+//!    parameters (the FOCE/ITS inner loop). This re-centering each iteration —
+//!    rather than only on the first, as plain `IMP` does — is what makes IMPMAP
+//!    robust on high-dimensional, rich-data problems where IMP can stall.
+//! 2. **E-step part B (IS):** draw `K` importance samples ηᵢₖ from a proposal
+//!    centred at η̂ᵢ with scale `Σᵢ = Hᵢ⁻¹` (multivariate normal by default;
+//!    Student-t with `impmap_proposal_df`), with self-normalized weights w̃ᵢₖ.
+//! 3. **M-step:** update parameters from the importance-weighted complete-data
+//!    expectation:
+//!    - **Ω** closed form: `Ω = (1/N) Σᵢ Σₖ w̃ᵢₖ ηᵢₖ ηᵢₖᵀ`.
+//!    - **θ, σ** by maximizing the weighted observation likelihood
+//!      `Σᵢ Σₖ w̃ᵢₖ log p(yᵢ | ηᵢₖ, θ, σ)` (derivative-free NLopt BOBYQA in
+//!      packed log-space, warm-started from the previous iteration).
+//!
+//! The reported estimate is the running mean of the parameter vector over the
+//! final `impmap_averaging` iterations (Monte-Carlo variance reduction). The
+//! returned [`OuterResult`] carries the final EBEs / Jacobians and a FOCE
+//! Laplace `ofv` for AIC/BIC comparability, identical in shape to SAEM's, so the
+//! covariance step and chained-stage handoff in `api.rs` need no special casing.
+//!
+//! ## Scope (v1)
+//!
+//! Inter-occasion variability (`κ` / `[iov]`) is **not yet supported** by the
+//! IMPMAP M-step (the κ sufficient statistics and Ω_iov update are a follow-up);
+//! such models are refused up front. SDE / `[diffusion]` models are refused for
+//! the same reason `IMP` refuses them. Use SAEM or FOCEI for those.
+
+use crate::estimation::importance_sampling::{compute_posterior_hessian, subject_is_draws};
+use crate::estimation::inner_optimizer::run_inner_loop_warm;
+use crate::estimation::outer_optimizer::{
+    compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
+};
+use crate::estimation::parameterization::{compute_mu_k, pack_params, theta_packs_log};
+use crate::pk::EventPkParams;
+use crate::stats::likelihood::obs_nll_subject_into;
+use crate::types::*;
+use nalgebra::{DMatrix, DVector};
+use rayon::prelude::*;
+
+/// Floor the free Ω diagonal to keep the proposal/prior positive-definite.
+/// Mirrors SAEM's `floor_omega_diagonal`: FIX-ed diagonals are left untouched.
+fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
+    for i in 0..omega_mat.nrows() {
+        if omega_fixed.get(i).copied().unwrap_or(false) {
+            continue;
+        }
+        if omega_mat[(i, i)] < floor {
+            omega_mat[(i, i)] = floor;
+        }
+    }
+}
+
+/// Positive-definite floor for free Ω diagonals (matches the SAEM constant).
+const OMEGA_DIAG_FLOOR: f64 = 1e-6;
+
+/// Log-transformed mu-referencing pairs `(theta_idx, eta_idx)`. For these the
+/// typical value satisfies `log(P_i) = log(θ) + η_i`, so the EM M-step shifts
+/// `log(θ) += mean(η)` in closed form — without it θ and the η mean are
+/// confounded and the variance Ω absorbs the misfit instead. Mirrors SAEM's
+/// `get_mu_ref_pairs`.
+fn mu_ref_log_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
+    let mut pairs = Vec::new();
+    for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
+        if let Some(mu_ref) = model.mu_refs.get(eta_name) {
+            if !mu_ref.log_transformed {
+                continue;
+            }
+            if let Some(theta_idx) = model
+                .theta_names
+                .iter()
+                .position(|n| n == &mu_ref.theta_name)
+            {
+                pairs.push((theta_idx, eta_idx));
+            }
+        }
+    }
+    pairs
+}
+
+/// Run IMPMAP. `warm_etas`, when supplied by a preceding chain stage, seed the
+/// first MAP inner loop; otherwise the inner loop cold-starts from η = 0.
+pub fn run_impmap(
+    model: &CompiledModel,
+    population: &Population,
+    init_params: &ModelParameters,
+    warm_etas: Option<&[DVector<f64>]>,
+    options: &FitOptions,
+) -> Result<OuterResult, String> {
+    let n_subjects = population.subjects.len();
+    let n_eta = model.n_eta;
+    let n_theta = init_params.theta.len();
+    let n_sigma = init_params.sigma.values.len();
+
+    // ---- Validation ----
+    if n_eta == 0 {
+        return Err("IMPMAP requires at least one random effect (n_eta = 0). \
+             Use FOCE/FOCEI for fixed-effects-only models."
+            .to_string());
+    }
+    if model.is_sde() {
+        return Err("IMPMAP is not yet supported for SDE / [diffusion] models \
+             (the EKF process-noise variance is not threaded through the IS \
+             observation likelihood). Use FOCE / FOCEI instead."
+            .to_string());
+    }
+    if model.n_kappa > 0 {
+        return Err(
+            "IMPMAP does not yet support inter-occasion variability (κ / [iov]); \
+             the IOV M-step is a planned follow-up. Use SAEM or FOCEI for IOV models."
+                .to_string(),
+        );
+    }
+    if !init_params.omega.log_det.is_finite() {
+        return Err(
+            "IMPMAP: initial Ω log-determinant is not finite — check the \
+             [parameters] Ω block."
+                .to_string(),
+        );
+    }
+
+    let n_iter = options.impmap_iterations.max(1);
+    let k_samples = options.impmap_samples.max(2);
+    let nu = options.impmap_proposal_df;
+    let n_avg = options.impmap_averaging.min(n_iter);
+    let seed = options.impmap_seed.unwrap_or(12345);
+    let threshold = options.impmap_low_ess_threshold;
+    let verbose = options.verbose;
+    let cancel = &options.cancel;
+
+    if verbose {
+        let prop = if nu.is_finite() {
+            format!("t_{nu}")
+        } else {
+            "normal".to_string()
+        };
+        eprintln!(
+            "IMPMAP: {} subjects, {} ETAs, {} iters, K={}/subject, {} proposal, seed={}",
+            n_subjects, n_eta, n_iter, k_samples, prop, seed
+        );
+    }
+
+    // ---- Packing scaffolding (mirrors SAEM) ----
+    // Per-theta packing: log for `theta_lower >= 0`, identity otherwise (so
+    // covariate exponents with negative lower bounds are not pinned to ~0).
+    let theta_packs_log_mask: Vec<bool> = init_params
+        .theta_lower
+        .iter()
+        .map(|&lo| theta_packs_log(lo))
+        .collect();
+    let pack_theta = |i: usize, t: f64| -> f64 {
+        if theta_packs_log_mask[i] {
+            t.max(1e-10).ln()
+        } else {
+            t
+        }
+    };
+
+    let mut log_theta: Vec<f64> = (0..n_theta)
+        .map(|i| pack_theta(i, init_params.theta[i]))
+        .collect();
+    let mut log_sigma: Vec<f64> = init_params
+        .sigma
+        .values
+        .iter()
+        .map(|&s| s.max(1e-10).ln())
+        .collect();
+
+    let mut log_theta_lower: Vec<f64> = (0..n_theta)
+        .map(|i| {
+            if theta_packs_log_mask[i] {
+                init_params.theta_lower[i].max(1e-10).ln()
+            } else {
+                init_params.theta_lower[i]
+            }
+        })
+        .collect();
+    let mut log_theta_upper: Vec<f64> = (0..n_theta)
+        .map(|i| {
+            if theta_packs_log_mask[i] {
+                init_params.theta_upper[i].min(1e9).ln()
+            } else {
+                init_params.theta_upper[i]
+            }
+        })
+        .collect();
+    let mut log_sigma_lower = vec![-8.0f64; n_sigma];
+    let mut log_sigma_upper = vec![5.0f64; n_sigma];
+
+    // Pin FIX parameters: lower == upper == packed value.
+    for i in 0..n_theta {
+        if init_params.theta_fixed.get(i).copied().unwrap_or(false) {
+            log_theta_lower[i] = log_theta[i];
+            log_theta_upper[i] = log_theta[i];
+        }
+    }
+    for i in 0..n_sigma {
+        if init_params.sigma_fixed.get(i).copied().unwrap_or(false) {
+            log_sigma_lower[i] = log_sigma[i];
+            log_sigma_upper[i] = log_sigma[i];
+        }
+    }
+
+    // Closed-form mu-referencing M-step: shift `log(θ) += mean(η)` for
+    // log-mu-ref pairs (essential — without it θ and the η mean are confounded
+    // and Ω inflates to absorb the misfit). When active, those θ are pinned out
+    // of the NLopt weighted M-step, which then fits only σ and non-mu-ref θ.
+    let mu_ref_pairs = mu_ref_log_pairs(model);
+    let use_closed_form = options.mu_referencing && !mu_ref_pairs.is_empty();
+
+    // ---- Iteration state ----
+    let mut theta_cur = init_params.theta.clone();
+    let mut sigma_cur = init_params.sigma.values.clone();
+    let mut omega_mat = init_params.omega.matrix.clone();
+    let mut prev_etas: Option<Vec<DVector<f64>>> = warm_etas.map(|e| e.to_vec());
+
+    // Running mean of parameters over the final `n_avg` iterations.
+    let mut acc_theta = vec![0.0f64; n_theta];
+    let mut acc_sigma = vec![0.0f64; n_sigma];
+    let mut acc_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
+    let mut n_acc = 0usize;
+
+    let mut warnings: Vec<String> = Vec::new();
+    let mut last_eta_hats: Vec<DVector<f64>> = Vec::new();
+
+    for k in 1..=n_iter {
+        if crate::cancel::is_cancelled(cancel) {
+            if verbose {
+                eprintln!("IMPMAP: cancelled at iteration {}", k);
+            }
+            break;
+        }
+
+        // Assemble current params for the inner loop / E-step.
+        let omega_k = OmegaMatrix::from_matrix(
+            omega_mat.clone(),
+            init_params.omega.eta_names.clone(),
+            init_params.omega.diagonal,
+        );
+        let params_k = ModelParameters {
+            theta: theta_cur.clone(),
+            theta_names: init_params.theta_names.clone(),
+            theta_lower: init_params.theta_lower.clone(),
+            theta_upper: init_params.theta_upper.clone(),
+            theta_fixed: init_params.theta_fixed.clone(),
+            omega: omega_k,
+            omega_fixed: init_params.omega_fixed.clone(),
+            sigma: SigmaVector {
+                values: sigma_cur.clone(),
+                names: init_params.sigma.names.clone(),
+            },
+            sigma_fixed: init_params.sigma_fixed.clone(),
+            omega_iov: None,
+            kappa_fixed: init_params.kappa_fixed.clone(),
+        };
+
+        // ---- E-step A: MAP recenter (conditional mode + Jacobian) ----
+        let mu_k = compute_mu_k(model, &params_k.theta, options.mu_referencing);
+        let (eta_hats, h_matrices, _stats, _kappas) = run_inner_loop_warm(
+            model,
+            population,
+            &params_k,
+            options.inner_maxiter,
+            options.inner_tol,
+            prev_etas.as_deref(),
+            Some(&mu_k),
+            0,
+        );
+
+        let omega_inv = params_k.omega.inv.clone();
+        let log_det_omega = params_k.omega.log_det;
+
+        // ---- E-step B: importance sampling around each mode ----
+        let draws: Vec<_> = population
+            .subjects
+            .par_iter()
+            .enumerate()
+            .map_init(EventPkParams::default, |scratch, (i, subject)| {
+                let h_post = compute_posterior_hessian(
+                    model,
+                    subject,
+                    &params_k.theta,
+                    &eta_hats[i],
+                    &params_k.sigma.values,
+                    &h_matrices[i],
+                    &omega_inv,
+                    n_eta,
+                    scratch,
+                );
+                subject_is_draws(
+                    model,
+                    subject,
+                    &params_k.theta,
+                    &params_k.sigma.values,
+                    &eta_hats[i],
+                    &h_post,
+                    &omega_inv,
+                    log_det_omega,
+                    n_eta,
+                    k_samples,
+                    nu,
+                    seed.wrapping_add(i as u64).wrapping_add((k as u64) << 32),
+                    scratch,
+                )
+            })
+            .collect();
+
+        // ESS diagnostics + marginal log-likelihood for the trace.
+        let mut ll = 0.0f64;
+        let mut n_low_ess = 0usize;
+        for d in &draws {
+            ll += d.log_marginal;
+            if d.ess_fraction < threshold {
+                n_low_ess += 1;
+            }
+        }
+        let minus2ll = -2.0 * ll;
+
+        // ---- M-step Ω: weighted second moment, structurally masked + floored ----
+        let mut new_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
+        for d in &draws {
+            new_omega += &d.second_moment;
+        }
+        new_omega /= n_subjects as f64;
+        for i in 0..n_eta {
+            for j in 0..n_eta {
+                if !init_params.omega.free_mask[(i, j)] {
+                    new_omega[(i, j)] = 0.0;
+                }
+                let fi = init_params.omega_fixed.get(i).copied().unwrap_or(false);
+                let fj = init_params.omega_fixed.get(j).copied().unwrap_or(false);
+                if fi || fj {
+                    new_omega[(i, j)] = init_params.omega.matrix[(i, j)];
+                }
+            }
+        }
+        floor_omega_diagonal(&mut new_omega, &init_params.omega_fixed, OMEGA_DIAG_FLOOR);
+        omega_mat = new_omega;
+
+        // ---- M-step σ + non-mu-ref θ: maximize weighted observation likelihood ----
+        // Pin the log-mu-ref θ (handled by the closed-form shift below) so NLopt
+        // optimizes only σ and any non-mu-ref θ, using the θ_old-centered samples.
+        let mut mstep_theta_lower = log_theta_lower.clone();
+        let mut mstep_theta_upper = log_theta_upper.clone();
+        if use_closed_form {
+            for &(t, _e) in &mu_ref_pairs {
+                mstep_theta_lower[t] = log_theta[t];
+                mstep_theta_upper[t] = log_theta[t];
+            }
+        }
+        let mstep_maxiter: u32 = if k <= n_iter / 2 { 4 } else { 8 };
+        let (new_log_theta, new_log_sigma) = theta_sigma_weighted_mstep(
+            model,
+            population,
+            &draws,
+            &log_theta,
+            &log_sigma,
+            &mstep_theta_lower,
+            &mstep_theta_upper,
+            &log_sigma_lower,
+            &log_sigma_upper,
+            n_theta,
+            n_sigma,
+            mstep_maxiter,
+            &theta_packs_log_mask,
+        );
+        log_theta = new_log_theta;
+        log_sigma = new_log_sigma;
+
+        // ---- Closed-form mu-ref θ shift: log(θ) += population mean(η) ----
+        if use_closed_form {
+            let mut eta_bar = vec![0.0f64; n_eta];
+            for d in &draws {
+                for (acc, &m) in eta_bar.iter_mut().zip(d.mean.iter()) {
+                    *acc += m;
+                }
+            }
+            for acc in eta_bar.iter_mut() {
+                *acc /= n_subjects as f64;
+            }
+            for &(t, e) in &mu_ref_pairs {
+                log_theta[t] =
+                    (log_theta[t] + eta_bar[e]).clamp(log_theta_lower[t], log_theta_upper[t]);
+            }
+        }
+
+        theta_cur = (0..n_theta)
+            .map(|i| {
+                if theta_packs_log_mask[i] {
+                    log_theta[i].exp()
+                } else {
+                    log_theta[i]
+                }
+            })
+            .collect();
+        sigma_cur = log_sigma.iter().map(|&s| s.exp()).collect();
+
+        // Warm-start next iteration's inner loop from this iteration's modes.
+        prev_etas = Some(eta_hats.clone());
+        last_eta_hats = eta_hats;
+
+        // ---- Parameter averaging over the final n_avg iterations ----
+        if k > n_iter - n_avg {
+            for i in 0..n_theta {
+                acc_theta[i] += theta_cur[i];
+            }
+            for i in 0..n_sigma {
+                acc_sigma[i] += sigma_cur[i];
+            }
+            acc_omega += &omega_mat;
+            n_acc += 1;
+        }
+
+        if verbose && (k <= 5 || k % 10 == 0 || k == n_iter) {
+            eprintln!(
+                "  iter {:4}: -2logL(IS) = {:.4}  (low-ESS subjects: {})",
+                k, minus2ll, n_low_ess
+            );
+        }
+    }
+
+    if crate::cancel::is_cancelled(cancel) {
+        return Err("cancelled by user".to_string());
+    }
+
+    // ---- Final (averaged) parameters ----
+    let (final_theta, final_sigma, final_omega_mat) = if n_acc > 0 {
+        let t: Vec<f64> = acc_theta.iter().map(|&v| v / n_acc as f64).collect();
+        let s: Vec<f64> = acc_sigma.iter().map(|&v| v / n_acc as f64).collect();
+        let o = acc_omega / n_acc as f64;
+        (t, s, o)
+    } else {
+        (theta_cur.clone(), sigma_cur.clone(), omega_mat.clone())
+    };
+
+    let final_omega = OmegaMatrix::from_matrix(
+        final_omega_mat,
+        init_params.omega.eta_names.clone(),
+        init_params.omega.diagonal,
+    );
+    let final_params = ModelParameters {
+        theta: final_theta,
+        theta_names: init_params.theta_names.clone(),
+        theta_lower: init_params.theta_lower.clone(),
+        theta_upper: init_params.theta_upper.clone(),
+        theta_fixed: init_params.theta_fixed.clone(),
+        omega: final_omega,
+        omega_fixed: init_params.omega_fixed.clone(),
+        sigma: SigmaVector {
+            values: final_sigma,
+            names: init_params.sigma.names.clone(),
+        },
+        sigma_fixed: init_params.sigma_fixed.clone(),
+        omega_iov: None,
+        kappa_fixed: init_params.kappa_fixed.clone(),
+    };
+
+    // ---- Final EBEs (warm-started) + FOCE Laplace OFV for comparability ----
+    let warm = if last_eta_hats.is_empty() {
+        None
+    } else {
+        Some(last_eta_hats.as_slice())
+    };
+    let final_mu_k = compute_mu_k(model, &final_params.theta, options.mu_referencing);
+    let (eta_hats, h_matrices, _stats, final_kappas) = run_inner_loop_warm(
+        model,
+        population,
+        &final_params,
+        options.inner_maxiter,
+        options.inner_tol,
+        warm,
+        Some(&final_mu_k),
+        0,
+    );
+
+    let ofv = 2.0
+        * pop_nll(
+            model,
+            population,
+            &final_params,
+            &eta_hats,
+            &h_matrices,
+            &final_kappas,
+            options.interaction,
+        );
+
+    // ---- Covariance step ----
+    let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let covariance_matrix =
+        if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
+            let packed = pack_params(&final_params);
+            match compute_covariance(
+                &packed,
+                &final_params,
+                model,
+                population,
+                &eta_hats,
+                &h_matrices,
+                &final_kappas,
+                options,
+            ) {
+                CovarianceStepResult::Success(out) => {
+                    warnings.extend(out.warnings);
+                    Some(out.matrix)
+                }
+                CovarianceStepResult::Unusable(msg) => {
+                    warnings.push(msg);
+                    None
+                }
+                CovarianceStepResult::FailedNonPd {
+                    reason,
+                    fallback_proposal,
+                } => {
+                    warnings.push(reason);
+                    sir_fallback_proposal = Some(fallback_proposal);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+    if verbose {
+        eprintln!("IMPMAP completed. Final OFV (Laplace) = {:.4}", ofv);
+    }
+
+    Ok(OuterResult {
+        params: final_params,
+        ofv,
+        converged: true,
+        n_iterations: n_iter,
+        eta_hats,
+        h_matrices,
+        kappas: final_kappas,
+        covariance_matrix,
+        warnings,
+        saem_mu_ref_m_step_evals_saved: None,
+        saem_n_subjects_hmc: None,
+        ebe_convergence_warnings: 0,
+        max_unconverged_subjects: 0,
+        total_ebe_fallbacks: 0,
+        final_gradient: None,
+        sir_fallback_proposal,
+    })
+}
+
+/// Weighted θ/σ M-step: minimize the importance-weighted observation NLL
+/// `Σᵢ Σₖ w̃ᵢₖ · obs_nll(yᵢ | ηᵢₖ, θ, σ)` over the per-subject sample sets, using
+/// derivative-free NLopt BOBYQA in packed log-space, warm-started from the
+/// current parameters. Mirrors SAEM's `theta_sigma_mstep_light` but sums over
+/// the `K` weighted samples per subject instead of a single EBE.
+#[allow(clippy::too_many_arguments)]
+fn theta_sigma_weighted_mstep(
+    model: &CompiledModel,
+    population: &Population,
+    draws: &[crate::estimation::importance_sampling::SubjectDraws],
+    log_theta_init: &[f64],
+    log_sigma_init: &[f64],
+    log_theta_lower: &[f64],
+    log_theta_upper: &[f64],
+    log_sigma_lower: &[f64],
+    log_sigma_upper: &[f64],
+    n_theta: usize,
+    n_sigma: usize,
+    maxiter: u32,
+    theta_packs_log_mask: &[bool],
+) -> (Vec<f64>, Vec<f64>) {
+    let n = n_theta + n_sigma;
+
+    let mut x: Vec<f64> = Vec::with_capacity(n);
+    x.extend_from_slice(log_theta_init);
+    x.extend_from_slice(log_sigma_init);
+
+    let mut lower: Vec<f64> = Vec::with_capacity(n);
+    lower.extend_from_slice(log_theta_lower);
+    lower.extend_from_slice(log_sigma_lower);
+    let mut upper: Vec<f64> = Vec::with_capacity(n);
+    upper.extend_from_slice(log_theta_upper);
+    upper.extend_from_slice(log_sigma_upper);
+
+    for i in 0..n {
+        x[i] = x[i].clamp(lower[i], upper[i]);
+    }
+
+    let unpack_thetas = |packed: &[f64]| -> Vec<f64> {
+        (0..n_theta)
+            .map(|i| {
+                if theta_packs_log_mask[i] {
+                    packed[i].exp()
+                } else {
+                    packed[i]
+                }
+            })
+            .collect()
+    };
+
+    // Weighted observation NLL, parallel over subjects. Each subject contributes
+    // Σₖ w̃ₖ · obs_nll(yᵢ | ηᵢₖ, θ, σ).
+    let obj = |xv: &[f64], _: Option<&mut [f64]>, _: &mut ()| -> f64 {
+        let th: Vec<f64> = unpack_thetas(&xv[..n_theta]);
+        let sg: Vec<f64> = xv[n_theta..].iter().map(|&v| v.exp()).collect();
+        let val: f64 = population
+            .subjects
+            .par_iter()
+            .zip(draws.par_iter())
+            .map_init(EventPkParams::default, |scratch, (subject, d)| {
+                let mut s = 0.0f64;
+                for (w, eta) in d.weights.iter().zip(d.etas.iter()) {
+                    if *w == 0.0 {
+                        continue;
+                    }
+                    s += w * obs_nll_subject_into(model, subject, &th, &sg, eta, scratch);
+                }
+                s
+            })
+            .sum();
+        if val.is_finite() {
+            val
+        } else {
+            1e20
+        }
+    };
+
+    let mut opt = nlopt::Nlopt::new(
+        nlopt::Algorithm::Bobyqa,
+        n,
+        obj,
+        nlopt::Target::Minimize,
+        (),
+    );
+    opt.set_lower_bounds(&lower).unwrap();
+    opt.set_upper_bounds(&upper).unwrap();
+    opt.set_maxeval(maxiter * (n as u32 + 1)).unwrap();
+    opt.set_ftol_rel(1e-4).unwrap();
+
+    let mut xs = x.clone();
+    match opt.optimize(&mut xs) {
+        Ok(_) | Err(_) => {}
+    }
+
+    let log_theta_new = xs[..n_theta].to_vec();
+    let log_sigma_new = xs[n_theta..].to_vec();
+    (log_theta_new, log_sigma_new)
+}

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -126,7 +126,16 @@ pub fn run_impmap(
 
     let n_iter = options.impmap_iterations.max(1);
     let k_samples = options.impmap_samples.max(2);
+    // `INFINITY` selects the multivariate-normal proposal; any finite value must
+    // be a valid Student-t DoF (>= 1). Guard here so a programmatic caller that
+    // bypasses the parser's range check can't reach the `ChiSquared::new(nu)`
+    // panic in `subject_is_draws`. Mirrors `run_importance_sampling`.
     let nu = options.impmap_proposal_df;
+    if nu.is_finite() && nu < 1.0 {
+        return Err(format!(
+            "IMPMAP: impmap_proposal_df must be >= 1.0 (or +inf for a normal proposal), got {nu}"
+        ));
+    }
     let n_avg = options.impmap_averaging.min(n_iter);
     let seed = options.impmap_seed.unwrap_or(12345);
     let threshold = options.impmap_low_ess_threshold;
@@ -532,7 +541,12 @@ pub fn run_impmap(
     Ok(OuterResult {
         params: final_params,
         ofv,
-        converged: true,
+        // IMPMAP runs a fixed iteration schedule (no parameter-stabilization
+        // stopping test yet), so the only convergence signal we can honestly
+        // report is a finite final objective — a non-finite OFV means the MCEM
+        // diverged. Matches SAEM's `converged: ofv.is_finite()`; importantly it
+        // keeps a diverged run from being preferred in multi-start selection.
+        converged: ofv.is_finite(),
         n_iterations: n_iter,
         eta_hats,
         h_matrices,

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -215,12 +215,29 @@ pub fn run_impmap(
         }
     }
 
-    // Closed-form mu-referencing M-step: shift `log(θ) += mean(η)` for
-    // log-mu-ref pairs (essential — without it θ and the η mean are confounded
-    // and Ω inflates to absorb the misfit). When active, those θ are pinned out
-    // of the NLopt weighted M-step, which then fits only σ and non-mu-ref θ.
+    // Closed-form mu-referencing M-step: shift `log(θ) += mean(η)` for log-mu-ref
+    // pairs, with those θ pinned out of the NLopt weighted M-step (which then fits
+    // only σ and non-mu-ref θ). This is the EM-correct typical-value update for
+    // log-normal random effects, NOT an optional refinement: without it θ and the
+    // η mean are confounded over the fixed importance samples, so θ stays at its
+    // start and Ω inflates to absorb the misfit. It is therefore applied whenever
+    // log-mu-ref pairs exist, independent of `options.mu_referencing` (which only
+    // governs inner-loop `compute_mu_k` centering, a separate concern). NONMEM's
+    // EM methods likewise require mu-referencing.
+    let mut warnings: Vec<String> = Vec::new();
     let mu_ref_pairs = mu_ref_log_pairs(model);
-    let use_closed_form = options.mu_referencing && !mu_ref_pairs.is_empty();
+    let use_closed_form = !mu_ref_pairs.is_empty();
+    if !use_closed_form {
+        // No log-mu-ref parameter: every typical value goes through the weighted
+        // M-step, which cannot resolve the θ/η-mean confounding on its own. Flag
+        // it — estimates may be unreliable (see the docs caveat).
+        warnings.push(
+            "IMPMAP: no log-mu-referenced parameters found (e.g. `CL = TVCL*exp(ETA)`); \
+             typical-value estimation relies on the weighted M-step alone and may converge \
+             poorly. Prefer a log-mu-referenced parameterization, or use FOCEI."
+                .to_string(),
+        );
+    }
 
     // ---- Iteration state ----
     let mut theta_cur = init_params.theta.clone();
@@ -234,7 +251,6 @@ pub fn run_impmap(
     let mut acc_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
     let mut n_acc = 0usize;
 
-    let mut warnings: Vec<String> = Vec::new();
     let mut last_eta_hats: Vec<DVector<f64>> = Vec::new();
 
     for k in 1..=n_iter {

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -510,6 +510,174 @@ fn subject_is_estimate(
 }
 
 // ---------------------------------------------------------------------------
+// IMPMAP: MAP-centered draws with retained samples + weighted moments
+// ---------------------------------------------------------------------------
+
+/// Per-subject output of one IMPMAP E-step: the retained importance samples and
+/// their normalized weights (consumed by the θ/σ M-step), the weighted posterior
+/// moments (the Ω sufficient statistic and conditional mean), and the same
+/// marginal-LL / ESS diagnostics the `Imp` kernel reports.
+pub(crate) struct SubjectDraws {
+    /// IS-estimated marginal log-likelihood `log p̂(yᵢ | θ)` (for the OFV trace).
+    pub log_marginal: f64,
+    /// Normalized effective sample size ESS/K (proposal-quality diagnostic).
+    pub ess_fraction: f64,
+    /// The `K` sampled η vectors (each length `d`).
+    pub etas: Vec<Vec<f64>>,
+    /// Self-normalized importance weights `w̃ᵢₖ` (length `K`, sums to 1).
+    pub weights: Vec<f64>,
+    /// Weighted posterior mean `Σₖ w̃ᵢₖ ηᵢₖ` (length `d`) — drives the closed-form
+    /// mu-referencing θ shift.
+    pub mean: Vec<f64>,
+    /// Weighted second moment `Σₖ w̃ᵢₖ ηᵢₖ ηᵢₖᵀ` (d×d) — the per-subject Ω
+    /// sufficient statistic.
+    pub second_moment: DMatrix<f64>,
+}
+
+/// Draw `K` importance samples for one subject from a proposal centered at the
+/// conditional mode `η̂` with first-order-variance scale `Σ = (H + λI)⁻¹`, and
+/// return the retained samples, self-normalized weights, and weighted second
+/// moment for the IMPMAP M-step.
+///
+/// `nu = f64::INFINITY` selects a multivariate-normal proposal (NONMEM IMPMAP
+/// default); a finite `nu ≥ 1` selects a multivariate Student-t. The marginal-LL
+/// and weight math is otherwise identical to [`subject_is_estimate`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn subject_is_draws(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    sigma: &[f64],
+    eta_hat: &DVector<f64>,
+    h: &DMatrix<f64>,
+    omega_inv: &DMatrix<f64>,
+    log_det_omega: f64,
+    d: usize,
+    k_samples: usize,
+    nu: f64,
+    seed: u64,
+    scratch: &mut EventPkParams,
+) -> SubjectDraws {
+    let mvn = !nu.is_finite();
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let proposal = match build_proposal(h, omega_inv, d) {
+        Some(p) => p,
+        None => {
+            return SubjectDraws {
+                log_marginal: 0.0,
+                ess_fraction: 0.0,
+                etas: Vec::new(),
+                weights: Vec::new(),
+                mean: vec![0.0; d],
+                second_moment: DMatrix::zeros(d, d),
+            };
+        }
+    };
+
+    let normal = StandardNormal;
+    // Student-t scale mixing variable; unused for the MVN branch.
+    let chi_sq = if mvn {
+        None
+    } else {
+        Some(ChiSquared::new(nu).expect("ChiSquared requires nu > 0; checked by caller"))
+    };
+
+    let half_d = 0.5 * d as f64;
+    let log_p_eta_const = -half_d * TWO_PI.ln() - 0.5 * log_det_omega;
+    // Constant term of log q(η): MVN uses −d/2·log(2π)+½log|Σ⁻¹|; Student-t adds
+    // the Γ-ratio / ν-scaling pieces.
+    let log_q_const = if mvn {
+        -half_d * TWO_PI.ln() + 0.5 * proposal.log_det_inv_scale
+    } else {
+        ln_gamma(0.5 * (nu + d as f64)) - ln_gamma(0.5 * nu) + 0.5 * proposal.log_det_inv_scale
+            - half_d * (nu * std::f64::consts::PI).ln()
+    };
+
+    let mut log_w: Vec<f64> = Vec::with_capacity(k_samples);
+    let mut etas: Vec<Vec<f64>> = Vec::with_capacity(k_samples);
+    let mut z = vec![0.0_f64; d];
+    let mut diff = vec![0.0_f64; d];
+
+    for _ in 0..k_samples {
+        for zi in z.iter_mut() {
+            *zi = normal.sample(&mut rng);
+        }
+        let scale = match &chi_sq {
+            Some(c) => {
+                let cc: f64 = c.sample(&mut rng).max(1e-300);
+                (nu / cc).sqrt()
+            }
+            None => 1.0,
+        };
+        let mut eta_sample = vec![0.0_f64; d];
+        proposal.apply_l_sigma(&z, &mut eta_sample, scale);
+        for (j, e) in eta_sample.iter_mut().enumerate() {
+            *e += eta_hat[j];
+        }
+
+        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, &eta_sample, scratch);
+        let log_p_y = -obs_nll;
+
+        let mut quad_form = 0.0_f64;
+        for i in 0..d {
+            let mut row = 0.0_f64;
+            for j in 0..d {
+                row += omega_inv[(i, j)] * eta_sample[j];
+            }
+            quad_form += row * eta_sample[i];
+        }
+        let log_p_eta = log_p_eta_const - 0.5 * quad_form;
+
+        for (k, d_slot) in diff.iter_mut().enumerate() {
+            *d_slot = eta_sample[k] - eta_hat[k];
+        }
+        let mahal = proposal.mahalanobis(&diff);
+        let log_q = if mvn {
+            log_q_const - 0.5 * mahal
+        } else {
+            log_q_const - 0.5 * (nu + d as f64) * (1.0 + mahal / nu).ln()
+        };
+
+        log_w.push(log_p_y + log_p_eta - log_q);
+        etas.push(eta_sample);
+    }
+
+    let (lse, weights) = logsumexp_with_normalised(&log_w);
+    let log_marginal = lse - (k_samples as f64).ln();
+    let ess = {
+        let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
+        if sum_sq > 0.0 {
+            1.0 / sum_sq
+        } else {
+            0.0
+        }
+    };
+    let ess_fraction = ess / (k_samples as f64);
+
+    // Weighted first and second moments Σₖ w̃ₖ ηₖ and Σₖ w̃ₖ ηₖ ηₖᵀ.
+    let mut mean = vec![0.0_f64; d];
+    let mut second_moment = DMatrix::<f64>::zeros(d, d);
+    for (w, eta) in weights.iter().zip(etas.iter()) {
+        for i in 0..d {
+            mean[i] += w * eta[i];
+            for j in 0..d {
+                second_moment[(i, j)] += w * eta[i] * eta[j];
+            }
+        }
+    }
+
+    SubjectDraws {
+        log_marginal,
+        ess_fraction,
+        etas,
+        weights,
+        mean,
+        second_moment,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Joint (eta, kappa) sampling for IOV models
 // ---------------------------------------------------------------------------
 
@@ -937,7 +1105,7 @@ fn logsumexp_with_normalised(xs: &[f64]) -> (f64, Vec<f64>) {
 /// variance evaluated at η̂. This is the matrix the IS proposal scales against
 /// — it's the Laplace covariance's inverse.
 #[allow(clippy::too_many_arguments)]
-fn compute_posterior_hessian(
+pub(crate) fn compute_posterior_hessian(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -1,5 +1,6 @@
 pub mod gauss_newton;
 pub(crate) mod hmc;
+pub mod impmap;
 pub mod importance_sampling;
 pub mod inner_optimizer;
 pub mod outer_optimizer;

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -423,6 +423,7 @@ fn method_to_str(m: EstimationMethod) -> &'static str {
         EstimationMethod::FoceGnHybrid => "foce_gn_hybrid",
         EstimationMethod::Saem => "saem",
         EstimationMethod::Imp => "imp",
+        EstimationMethod::Impmap => "impmap",
     }
 }
 
@@ -430,6 +431,7 @@ fn method_from_str(s: &str) -> Result<EstimationMethod, FitrxError> {
     Ok(match s {
         "foce" => EstimationMethod::Foce,
         "focei" => EstimationMethod::FoceI,
+        "impmap" => EstimationMethod::Impmap,
         "foce_gn" => EstimationMethod::FoceGn,
         "foce_gn_hybrid" => EstimationMethod::FoceGnHybrid,
         "saem" => EstimationMethod::Saem,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2873,6 +2873,11 @@ fn parse_method_token(token: &str) -> Result<EstimationMethod, String> {
         .to_lowercase();
     if val == "saem" {
         Ok(EstimationMethod::Saem)
+    } else if val == "impmap"
+        || val == "importance_sampling_map"
+        || val == "importance-sampling-map"
+    {
+        Ok(EstimationMethod::Impmap)
     } else if val == "imp" || val == "importance_sampling" || val == "importance-sampling" {
         Ok(EstimationMethod::Imp)
     } else if val.contains("hybrid") || val == "gn_hybrid" || val == "gn-hybrid" {
@@ -3097,6 +3102,47 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
                 ));
             }
             opts.is_low_ess_threshold = v;
+        }
+        "impmap_iterations" => {
+            let v = parse_usize("impmap_iterations")?;
+            if v < 1 {
+                return Err(format!("impmap_iterations must be >= 1, got {v}"));
+            }
+            opts.impmap_iterations = v;
+        }
+        "impmap_samples" => {
+            let v = parse_usize("impmap_samples")?;
+            if v < 2 {
+                return Err(format!("impmap_samples must be >= 2, got {v}"));
+            }
+            opts.impmap_samples = v;
+        }
+        "impmap_proposal_df" => {
+            // `normal` / `mvn` (or a very large df) select a multivariate-normal
+            // proposal — NONMEM's IMPMAP default. A finite value gives Student-t.
+            let tok = value.trim().trim_matches(|c| c == '"' || c == '\'');
+            if tok.eq_ignore_ascii_case("normal") || tok.eq_ignore_ascii_case("mvn") {
+                opts.impmap_proposal_df = f64::INFINITY;
+            } else {
+                let v = parse_f64("impmap_proposal_df")?;
+                if v < 1.0 {
+                    return Err(format!(
+                        "impmap_proposal_df must be >= 1.0 or `normal`, got {v}"
+                    ));
+                }
+                opts.impmap_proposal_df = v;
+            }
+        }
+        "impmap_seed" => opts.impmap_seed = parse_u64_opt("impmap_seed")?,
+        "impmap_averaging" => opts.impmap_averaging = parse_usize("impmap_averaging")?,
+        "impmap_low_ess_threshold" => {
+            let v = parse_f64("impmap_low_ess_threshold")?;
+            if !(0.0..=1.0).contains(&v) {
+                return Err(format!(
+                    "impmap_low_ess_threshold must be in [0.0, 1.0], got {v}"
+                ));
+            }
+            opts.impmap_low_ess_threshold = v;
         }
         "mu_referencing" => opts.mu_referencing = parse_bool("mu_referencing")?,
         "bloq_method" | "bloq" => {
@@ -8916,6 +8962,65 @@ mod tests {
         assert!(apply_fit_option(&mut opts, "is_low_ess_threshold", "-0.1").is_err()); // < 0
                                                                                        // Defaults preserved after a failed apply.
         assert_eq!(opts.is_samples, 1000);
+    }
+
+    #[test]
+    fn test_impmap_method_tokens_parse() {
+        for tok in [
+            "impmap",
+            "importance_sampling_map",
+            "importance-sampling-map",
+        ] {
+            let opts = parse_fit_options(&[format!("method = {tok}")]).expect("parse must succeed");
+            assert_eq!(
+                opts.method,
+                EstimationMethod::Impmap,
+                "token `{tok}` must map to Impmap"
+            );
+        }
+        // `imp` must still resolve to the evaluation-only stage, not Impmap.
+        let opts = parse_fit_options(&["method = imp".to_string()]).expect("parse");
+        assert_eq!(opts.method, EstimationMethod::Imp);
+    }
+
+    #[test]
+    fn test_impmap_options_parse_and_validate() {
+        let opts = parse_fit_options(&[
+            "method = importance_sampling_map".to_string(),
+            "impmap_iterations = 80".to_string(),
+            "impmap_samples = 250".to_string(),
+            "impmap_proposal_df = 8.0".to_string(),
+            "impmap_averaging = 30".to_string(),
+            "impmap_seed = 77".to_string(),
+            "impmap_low_ess_threshold = 0.2".to_string(),
+            "covariance = false".to_string(),
+        ])
+        .expect("parse must succeed");
+        assert_eq!(opts.method, EstimationMethod::Impmap);
+        assert_eq!(opts.impmap_iterations, 80);
+        assert_eq!(opts.impmap_samples, 250);
+        assert_eq!(opts.impmap_proposal_df, 8.0);
+        assert_eq!(opts.impmap_averaging, 30);
+        assert_eq!(opts.impmap_seed, Some(77));
+        assert_eq!(opts.impmap_low_ess_threshold, 0.2);
+        // All keys are method-specific to Impmap and Impmap is selected.
+        assert!(opts.unsupported_keys_warnings().is_empty());
+
+        // `normal` / `mvn` select the multivariate-normal proposal (df = +inf).
+        for kw in ["normal", "mvn", "NORMAL"] {
+            let mut o = FitOptions::default();
+            assert!(apply_fit_option(&mut o, "impmap_proposal_df", kw).is_ok());
+            assert!(o.impmap_proposal_df.is_infinite());
+        }
+
+        // Range validation.
+        let mut o = FitOptions::default();
+        assert!(apply_fit_option(&mut o, "impmap_samples", "1").is_err()); // < 2
+        assert!(apply_fit_option(&mut o, "impmap_iterations", "0").is_err()); // < 1
+        assert!(apply_fit_option(&mut o, "impmap_proposal_df", "0.5").is_err()); // < 1
+        assert!(apply_fit_option(&mut o, "impmap_low_ess_threshold", "1.5").is_err()); // > 1
+                                                                                       // Default (MVN) preserved after the failed applies.
+        assert!(o.impmap_proposal_df.is_infinite());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2419,6 +2419,29 @@ pub struct FitOptions {
     /// (ESS / K) are flagged in the result. Default 0.1. Set to 0 to silence
     /// the flag entirely.
     pub is_low_ess_threshold: f64,
+    // IMPMAP (Importance Sampling assisted by Mode A Posteriori) options,
+    // consumed by the `Impmap` estimating stage. IMPMAP runs a Monte-Carlo EM
+    // loop: each iteration re-centers a per-subject importance-sampling proposal
+    // at the freshly-computed conditional mode (MAP) and first-order variance,
+    // then updates θ/Ω/σ from the importance-weighted posterior moments.
+    /// Number of MCEM iterations (M-step parameter updates). Default 200.
+    pub impmap_iterations: usize,
+    /// Importance samples drawn per subject per iteration (K). Default 300.
+    /// Larger K reduces Monte-Carlo noise in the M-step at linear cost.
+    pub impmap_samples: usize,
+    /// Proposal degrees of freedom. `f64::INFINITY` selects a multivariate
+    /// normal proposal (NONMEM's IMPMAP default; parsed from `normal`); a finite
+    /// value selects a heavier-tailed Student-t. Default `INFINITY` (MVN).
+    pub impmap_proposal_df: f64,
+    /// RNG seed for the IMPMAP sampling. `None` falls back to a fixed default so
+    /// runs are reproducible across invocations.
+    pub impmap_seed: Option<u64>,
+    /// Number of terminal iterations whose parameters are averaged to form the
+    /// reported estimate (Monte-Carlo variance reduction). Default 50.
+    pub impmap_averaging: usize,
+    /// Subjects whose normalized effective sample size (ESS / K) falls below
+    /// this fraction are flagged as poorly-sampled. Default 0.1.
+    pub impmap_low_ess_threshold: f64,
     /// How BLOQ (Below Limit of Quantification) observations are handled.
     /// See [`BloqMethod`]. Defaults to `Drop` (backward-compatible: no effect
     /// when the data has no CENS column).
@@ -2613,6 +2636,12 @@ impl Default for FitOptions {
             is_proposal_df: 5.0,
             is_seed: None,
             is_low_ess_threshold: 0.1,
+            impmap_iterations: 200,
+            impmap_samples: 300,
+            impmap_proposal_df: f64::INFINITY,
+            impmap_seed: None,
+            impmap_averaging: 50,
+            impmap_low_ess_threshold: 0.1,
             bloq_method: BloqMethod::Drop,
             steihaug_max_iters: None,
             mu_referencing: true,
@@ -2721,6 +2750,13 @@ pub enum EstimationMethod {
     /// scale) and is typically terminal. Reports `−2 log L_IS` on
     /// `FitResult.importance_sampling`, distinct from the Laplace OFV on `ofv`.
     Imp,
+    /// Importance Sampling assisted by Mode A Posteriori (NONMEM `METHOD=IMPMAP`).
+    /// Unlike [`Imp`](Self::Imp), this *is* an estimator: a Monte-Carlo EM loop
+    /// whose E-step re-evaluates each subject's conditional mode and first-order
+    /// variance every iteration (as in FOCE/ITS) to center a multivariate-normal
+    /// importance-sampling proposal, and whose M-step updates θ/Ω/σ from the
+    /// importance-weighted posterior moments.
+    Impmap,
 }
 
 impl EstimationMethod {
@@ -2732,6 +2768,7 @@ impl EstimationMethod {
             EstimationMethod::FoceGnHybrid => "FOCE-GN-Hybrid",
             EstimationMethod::Saem => "SAEM",
             EstimationMethod::Imp => "IMP",
+            EstimationMethod::Impmap => "IMPMAP",
         }
     }
 }
@@ -2894,6 +2931,16 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "is_proposal_df",
             "is_seed",
             "is_low_ess_threshold",
+        ],
+        EstimationMethod::Impmap => &[
+            "inner_maxiter",
+            "inner_tol",
+            "impmap_iterations",
+            "impmap_samples",
+            "impmap_proposal_df",
+            "impmap_seed",
+            "impmap_averaging",
+            "impmap_low_ess_threshold",
         ],
     }
 }

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -98,6 +98,23 @@ fn impmap_rejects_iov_models() {
     );
 }
 
+#[test]
+fn impmap_rejects_invalid_proposal_df() {
+    // A programmatic caller can set impmap_proposal_df directly, bypassing the
+    // parser's range check. A finite df < 1 must return a clean Err, not panic
+    // in the ChiSquared proposal sampler.
+    let (model, population, mut opts) = warfarin_setup();
+    opts.method = EstimationMethod::Impmap;
+    opts.impmap_proposal_df = 0.0;
+    let err = fit(&model, &population, &model.default_params, &opts)
+        .err()
+        .expect("impmap_proposal_df = 0 must be rejected");
+    assert!(
+        err.contains("impmap_proposal_df"),
+        "expected impmap_proposal_df error, got: {err}"
+    );
+}
+
 /// Tier 3 — full convergence. IMPMAP should recover the FOCEI solution on
 /// warfarin (the Laplace approximation is accurate for this well-sampled model,
 /// so the MCEM marginal and the FOCEI Laplace estimates agree). Gated behind

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -1,0 +1,165 @@
+//! Integration tests for the IMPMAP estimator (`method = importance_sampling_map`).
+//!
+//! Tier 2 (fast, default PR job): wire-up and validation — IMPMAP runs standalone
+//! and as a chain stage, returns finite estimates, and refuses IOV models. These
+//! cap iterations aggressively; convergence *quality* is asserted in the Tier-3
+//! slow suite below.
+
+use ferx_core::parser::model_parser::parse_model_file;
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::path::Path;
+
+fn warfarin_setup() -> (
+    ferx_core::types::CompiledModel,
+    ferx_core::types::Population,
+    FitOptions,
+) {
+    let model =
+        parse_model_file(Path::new("examples/warfarin.ferx")).expect("warfarin model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+        .expect("warfarin data must load");
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    opts.run_covariance_step = false;
+    // Aggressively capped — Tier 2 tests wire-up, not convergence quality.
+    opts.impmap_iterations = 12;
+    opts.impmap_samples = 100;
+    opts.impmap_averaging = 4;
+    opts.impmap_seed = Some(7);
+    opts.inner_maxiter = 30;
+    (model, population, opts)
+}
+
+#[test]
+fn impmap_standalone_produces_finite_estimates() {
+    let (model, population, mut opts) = warfarin_setup();
+    opts.method = EstimationMethod::Impmap;
+    let result = fit(&model, &population, &model.default_params, &opts)
+        .expect("standalone impmap must produce a fit");
+
+    assert_eq!(result.method, EstimationMethod::Impmap);
+    assert_eq!(result.method_chain, vec![EstimationMethod::Impmap]);
+    assert!(
+        result.ofv.is_finite(),
+        "OFV must be finite, got {}",
+        result.ofv
+    );
+    for (name, v) in result.theta_names.iter().zip(result.theta.iter()) {
+        assert!(
+            v.is_finite() && *v > 0.0,
+            "theta {name} must be finite > 0, got {v}"
+        );
+    }
+    // Ω diagonals stay positive & finite (the diagonal floor guards this).
+    for i in 0..model.n_eta {
+        let w = result.omega[(i, i)];
+        assert!(
+            w.is_finite() && w > 0.0,
+            "omega[{i},{i}] must be finite > 0, got {w}"
+        );
+    }
+}
+
+#[test]
+fn focei_then_impmap_chain_runs() {
+    let (model, population, mut opts) = warfarin_setup();
+    opts.methods = vec![EstimationMethod::FoceI, EstimationMethod::Impmap];
+    opts.outer_maxiter = 25; // bound the FOCEI warm-up stage too
+    let result = fit(&model, &population, &model.default_params, &opts)
+        .expect("focei → impmap chain must produce a fit");
+
+    // IMPMAP is an estimator, so it is the final reported method.
+    assert_eq!(result.method, EstimationMethod::Impmap);
+    assert_eq!(
+        result.method_chain,
+        vec![EstimationMethod::FoceI, EstimationMethod::Impmap]
+    );
+    assert!(result.ofv.is_finite());
+}
+
+#[test]
+fn impmap_rejects_iov_models() {
+    let model = parse_model_file(Path::new("examples/warfarin_iov.ferx"))
+        .expect("warfarin_iov model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, None)
+        .expect("warfarin_iov data must load");
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    opts.run_covariance_step = false;
+    opts.method = EstimationMethod::Impmap;
+    opts.impmap_iterations = 3;
+
+    let err = fit(&model, &population, &model.default_params, &opts)
+        .err()
+        .expect("impmap on an IOV model must be rejected (v1)");
+    assert!(
+        err.to_lowercase().contains("inter-occasion") || err.contains("IOV"),
+        "expected IOV-not-supported error, got: {err}"
+    );
+}
+
+/// Tier 3 — full convergence. IMPMAP should recover the FOCEI solution on
+/// warfarin (the Laplace approximation is accurate for this well-sampled model,
+/// so the MCEM marginal and the FOCEI Laplace estimates agree). Gated behind
+/// `slow-tests`; run nightly.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn impmap_converges_to_focei_on_warfarin() {
+    let model =
+        parse_model_file(Path::new("examples/warfarin.ferx")).expect("warfarin model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+        .expect("warfarin data must load");
+
+    // Reference: FOCEI.
+    let mut focei = FitOptions::default();
+    focei.method = EstimationMethod::FoceI;
+    focei.run_covariance_step = false;
+    focei.outer_maxiter = 300;
+    let r_focei = fit(&model, &population, &model.default_params, &focei)
+        .expect("FOCEI reference fit must succeed");
+
+    // IMPMAP.
+    let mut imp = FitOptions::default();
+    imp.method = EstimationMethod::Impmap;
+    imp.run_covariance_step = false;
+    imp.impmap_iterations = 150;
+    imp.impmap_samples = 500;
+    imp.impmap_averaging = 50;
+    imp.impmap_seed = Some(12345);
+    let r_imp =
+        fit(&model, &population, &model.default_params, &imp).expect("IMPMAP fit must succeed");
+
+    // Thetas within 10% (MCEM is stochastic; the band absorbs MC noise).
+    for ((name, ti), tf) in r_imp
+        .theta_names
+        .iter()
+        .zip(r_imp.theta.iter())
+        .zip(r_focei.theta.iter())
+    {
+        let rel = (ti - tf).abs() / tf.abs().max(1e-8);
+        assert!(
+            rel < 0.10,
+            "theta {name}: IMPMAP {ti} vs FOCEI {tf} (rel {rel:.3})"
+        );
+    }
+    // Ω diagonals within 25% (variance components are noisier).
+    for i in 0..model.n_eta {
+        let wi = r_imp.omega[(i, i)];
+        let wf = r_focei.omega[(i, i)];
+        let rel = (wi - wf).abs() / wf.abs().max(1e-8);
+        assert!(
+            rel < 0.25,
+            "omega[{i},{i}]: IMPMAP {wi} vs FOCEI {wf} (rel {rel:.3})"
+        );
+    }
+    // OFV (both Laplace) within a few units.
+    assert!(
+        (r_imp.ofv - r_focei.ofv).abs() < 5.0,
+        "OFV: IMPMAP {} vs FOCEI {}",
+        r_imp.ofv,
+        r_focei.ofv
+    );
+}

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -99,6 +99,37 @@ fn impmap_rejects_iov_models() {
 }
 
 #[test]
+fn impmap_converges_with_mu_referencing_off() {
+    // Regression: the closed-form log-mu-ref θ shift is the EM-correct typical-
+    // value update and must apply regardless of `mu_referencing`. When it was
+    // gated on `mu_referencing`, turning it off left θ stuck at its start (TVCL
+    // ≈ 0.198, init 0.2) and Ω inflated (ETA_CL ≈ 0.19) — the θ/η-mean
+    // confounding. With the fix, mu_referencing = false recovers the same well-
+    // identified estimates (TVCL ≈ 0.13, ETA_CL ≈ 0.03).
+    let (model, population, mut opts) = warfarin_setup();
+    opts.method = EstimationMethod::Impmap;
+    opts.mu_referencing = false;
+    opts.impmap_iterations = 40;
+    opts.impmap_samples = 150;
+    opts.impmap_averaging = 15;
+    let r = fit(&model, &population, &model.default_params, &opts)
+        .expect("impmap with mu_referencing=false must fit");
+
+    // The broken (confounded) result had TVCL ≈ 0.198 and ω²(CL) ≈ 0.19; these
+    // thresholds cleanly separate the fixed result (≈0.13 / ≈0.03) from it.
+    assert!(
+        r.theta[0] < 0.18,
+        "TVCL should move off its 0.2 start toward ~0.13, got {} (θ/η confounding regressed?)",
+        r.theta[0]
+    );
+    assert!(
+        r.omega[(0, 0)] < 0.10,
+        "ω²(ETA_CL) should be ~0.03, not inflated ~0.19, got {}",
+        r.omega[(0, 0)]
+    );
+}
+
+#[test]
 fn impmap_rejects_invalid_proposal_df() {
     // A programmatic caller can set impmap_proposal_df directly, bypassing the
     // parser's range check. A finite df < 1 must return a clean Err, not panic

--- a/tests/nonmem/warfarin_impmap.ctl
+++ b/tests/nonmem/warfarin_impmap.ctl
@@ -1,0 +1,23 @@
+$PROBLEM Warfarin 1-cpt oral - ferx-core IMPMAP cross-check (issue #270)
+$DATA warfarin.csv IGNORE=@
+$INPUT ID TIME DV EVID AMT CMT=DROP RATE MDV
+$SUBROUTINES ADVAN2 TRANS2
+$PK
+  CL = THETA(1)*EXP(ETA(1))
+  V  = THETA(2)*EXP(ETA(2))
+  KA = THETA(3)*EXP(ETA(3))
+  S2 = V
+$ERROR
+  IPRED = F
+  Y = IPRED*(1 + EPS(1))
+$THETA (0, 0.2)   ; TVCL
+$THETA (0, 10.0)  ; TVV
+$THETA (0, 1.5)   ; TVKA
+$OMEGA 0.09       ; ETA_CL
+$OMEGA 0.04       ; ETA_V
+$OMEGA 0.30       ; ETA_KA
+$SIGMA 0.0004     ; proportional variance (= 0.02 SD, matching the .ferx init)
+; IMPMAP (Importance Sampling assisted by Mode A Posteriori).
+$ESTIMATION METHOD=IMPMAP INTERACTION NITER=200 ISAMPLE=300 PRINT=10 SEED=12345 NOABORT
+$COVARIANCE UNCONDITIONAL
+$TABLE ID TIME NOPRINT ONEHEADER FILE=sdtab_impmap

--- a/tests/warfarin_impmap_nonmem.rs
+++ b/tests/warfarin_impmap_nonmem.rs
@@ -1,0 +1,119 @@
+//! NONMEM 7.5.1 `METHOD=IMPMAP` cross-check for ferx's IMPMAP estimator.
+//!
+//! Runs ferx IMPMAP standalone on warfarin and asserts the converged estimates
+//! match NONMEM's `METHOD=IMPMAP` reference on the same model/data. This is the
+//! cross-engine validation required for a new estimator (CLAUDE.md): IMPMAP is
+//! NONMEM's method, so the anchor is NONMEM itself, not just ferx's FOCEI.
+//!
+//! Gated behind `slow-tests` (runs the full 150-iteration MCEM); skipped in the
+//! default PR job, run nightly via `slow-tests.yml`.
+//!
+//! ## Reference values
+//!
+//! From `tests/nonmem/warfarin_impmap.ctl` run on `data/warfarin.csv` with
+//! NONMEM 7.5.1 (`METHOD=IMPMAP INTERACTION NITER=200 ISAMPLE=300 SEED=12345`):
+//!
+//! | Parameter | NONMEM IMPMAP | ferx IMPMAP |
+//! |-----------|--------------:|------------:|
+//! | TVCL      | 0.135         | 0.1327      |
+//! | TVV       | 7.89          | 7.737       |
+//! | TVKA      | 0.730         | 0.811       |
+//! | ω²(CL)    | 0.0291        | 0.0286      |
+//! | ω²(V)     | 0.0101        | 0.0096      |
+//! | ω²(KA)    | 0.340         | 0.336       |
+//! | σ (SD)    | 0.01034       | 0.01056     |
+//! | OFV       | −284.92       | −286.00     |
+//!
+//! TVKA is the least-identified parameter on this 10-subject extract (ETA_KA
+//! variance ≈ 0.34, high shrinkage), so it carries the loosest band; the
+//! well-determined CL/V structure and the variance components agree to a few
+//! percent. The OFVs are on a comparable scale (NONMEM "without constant" and
+//! ferx's Laplace OFV) and agree to ~1 unit, the usual cross-engine margin.
+
+use ferx_core::parser::model_parser::parse_model_file;
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::path::Path;
+
+// NONMEM 7.5.1 METHOD=IMPMAP reference (see module docstring / .ctl).
+const NM_TVCL: f64 = 0.135;
+const NM_TVV: f64 = 7.89;
+const NM_TVKA: f64 = 0.730;
+const NM_OMEGA_CL: f64 = 0.0291;
+const NM_OMEGA_V: f64 = 0.0101;
+const NM_OMEGA_KA: f64 = 0.340;
+const NM_SIGMA_SD: f64 = 0.010344; // sqrt(1.07e-4)
+const NM_OFV: f64 = -284.917;
+
+fn rel(a: f64, b: f64) -> f64 {
+    (a - b).abs() / b.abs().max(1e-8)
+}
+
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn ferx_impmap_matches_nonmem_impmap_on_warfarin() {
+    let model =
+        parse_model_file(Path::new("examples/warfarin.ferx")).expect("warfarin model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+        .expect("warfarin data must load");
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Impmap;
+    opts.run_covariance_step = false;
+    opts.impmap_iterations = 150;
+    opts.impmap_samples = 500;
+    opts.impmap_averaging = 50;
+    opts.impmap_seed = Some(12345);
+    let r =
+        fit(&model, &population, &model.default_params, &opts).expect("IMPMAP fit must succeed");
+
+    // Thetas: CL/V well-identified (5%), KA poorly-identified (15%).
+    assert!(
+        rel(r.theta[0], NM_TVCL) < 0.05,
+        "TVCL {} vs NM {NM_TVCL}",
+        r.theta[0]
+    );
+    assert!(
+        rel(r.theta[1], NM_TVV) < 0.05,
+        "TVV {} vs NM {NM_TVV}",
+        r.theta[1]
+    );
+    assert!(
+        rel(r.theta[2], NM_TVKA) < 0.15,
+        "TVKA {} vs NM {NM_TVKA}",
+        r.theta[2]
+    );
+
+    // Variance components (NONMEM prints 3 sig figs; allow 15%).
+    assert!(
+        rel(r.omega[(0, 0)], NM_OMEGA_CL) < 0.15,
+        "omega_CL {}",
+        r.omega[(0, 0)]
+    );
+    assert!(
+        rel(r.omega[(1, 1)], NM_OMEGA_V) < 0.15,
+        "omega_V {}",
+        r.omega[(1, 1)]
+    );
+    assert!(
+        rel(r.omega[(2, 2)], NM_OMEGA_KA) < 0.15,
+        "omega_KA {}",
+        r.omega[(2, 2)]
+    );
+
+    // Residual error (ferx reports the proportional SD).
+    assert!(
+        rel(r.sigma[0], NM_SIGMA_SD) < 0.10,
+        "sigma_SD {} vs NM {NM_SIGMA_SD}",
+        r.sigma[0]
+    );
+
+    // OFV within the cross-engine margin.
+    assert!(
+        (r.ofv - NM_OFV).abs() < 3.0,
+        "OFV {} vs NONMEM {NM_OFV}",
+        r.ofv
+    );
+}


### PR DESCRIPTION
## Why

Implements #270 — IMPMAP (Importance Sampling assisted by Mode A Posteriori), NONMEM's `METHOD=IMPMAP`. ferx already had an evaluation-only `imp` stage (reports `−2 log L` at fixed parameters); IMPMAP is the **estimating** counterpart — a Monte-Carlo EM that actually updates θ/Ω/σ. It targets the regime NONMEM documents for it: high-dimensional, rich-data models where a non-MAP importance-sampling EM stalls or diverges, fixed by re-centering the proposal on the conditional mode *every* iteration.

## What changed

Each MCEM iteration: (1) re-run the FOCE inner loop for every subject to get the conditional mode η̂ᵢ and first-order-variance Hessian; (2) draw `K` importance samples from a multivariate-normal proposal centered there (NONMEM's default; Student-t optional); (3) M-step — closed-form Ω from the weighted second moment, a **closed-form mu-referencing shift** `log θ += mean(η)` for log-mu-ref pairs, and a weighted BOBYQA step for σ and non-mu-ref θ. Reported estimate is the average over the final `impmap_averaging` iterations.

- `EstimationMethod::Impmap`; parser tokens `impmap` / `importance_sampling_map`; six `impmap_*` fit options (`impmap_proposal_df = normal` selects MVN).
- `estimation/impmap.rs::run_impmap` returns `OuterResult`, so the covariance step and `[focei, impmap]` chaining work without special-casing.
- New moments-returning `subject_is_draws` in `importance_sampling.rs` reuses the IMP per-subject kernel (proposal build, weights, ESS) and adds MVN support + weighted moments. **IMP output is unchanged** — its 8 regression tests still pass.
- Dispatch in `api.rs`; IOV (`[iov]`/κ) and SDE (`[diffusion]`) models are refused (v1 scope, documented).

The closed-form mu-ref shift was the crux: without it θ and the η mean are confounded given fixed samples, so Ω inflated to absorb the misfit (TVCL stuck at the init 0.20 instead of 0.13). Re-MAPing at the shifted θ drives the mean η → 0, a stable EM fixed point.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API signature changed; the new `method` token + `impmap_*` keys flow through the existing model-file path. A `ferx-r` `NEWS.md` note can follow separately.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: **NONMEM 7.5.1 `METHOD=IMPMAP`** (`tests/nonmem/warfarin_impmap.ctl`) and ferx FOCEI
- [x] Reference values:

```
                NONMEM IMPMAP   ferx IMPMAP
TVCL              0.135           0.1327
TVV               7.89            7.737
TVKA              0.730           0.811     (least-identified param, 10-subj extract)
omega^2 CL        0.0291          0.0286
omega^2 V         0.0101          0.0096
omega^2 KA        0.340           0.336
sigma (SD)        0.01034         0.01056
OFV              -284.92         -286.00    (~1u cross-engine margin)
```

Well-determined CL/V structure and all variance components agree to a few percent; TVKA (high shrinkage here) carries the loosest band.

## Performance
- [x] No significant impact expected (new method; ~`iterations ×` one IMP eval, parallel over subjects)

## Tests
- [x] Unit tests added (`parser::model_parser::tests::test_impmap_*` — token + option parsing/validation, MVN `normal` keyword)
- [x] Tier-2 integration (`tests/impmap_api.rs`): standalone, `[focei, impmap]` chain, IOV-rejection
- [x] Tier-3 gated (`slow-tests`): `impmap_converges_to_focei_on_warfarin` and `ferx_impmap_matches_nonmem_impmap_on_warfarin`

## Example (user-facing features only)
- [x] Example added: `examples/warfarin_impmap.ferx`

```
[fit_options]
  method             = importance_sampling_map   # alias: impmap
  impmap_iterations  = 150
  impmap_samples     = 500
  impmap_proposal_df = normal      # multivariate normal (NONMEM default)
  impmap_seed        = 12345
```

## Docs
- [x] `docs/src/estimation/impmap.md` (new), linked in `SUMMARY.md`; `estimation/README.md` + `model-file/fit-options.md` updated
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean on the new code
- [ ] `cargo check --features autodiff` — not run locally (env hits a pre-existing Enzyme codegen ICE unrelated to this change; built & tested with `--no-default-features --features ci`, and no AD-reachable code is touched). CI will exercise the autodiff path.

## Reviewer hints

- `estimation/impmap.rs` is the core — focus on the M-step (closed-form mu-ref shift + weighted BOBYQA) and the Ω update masking/floor (mirrors SAEM).
- `subject_is_draws` in `importance_sampling.rs` — confirm IMP's existing kernel is untouched (the new fn is additive).
- v1 deliberately defers IOV and SDE (refused up front); the κ sufficient statistics / Ω_iov update are a planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
