### PR TITLE
fix(api): per-dose-occasion absorption lag in TAD [follow-up to #238]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,13 @@ section of the SDLC for the versioning policy).
   silently treating every kappa as zero. Post-fit diagnostic columns that depend
   on a κ-varying parameter (e.g. `CL`, `V`, `KA`) were wrong for IOV subjects;
   the fitted estimates, OFV, and IPRED/IWRES were unaffected (#238).
-- IOV models with inter-occasion variability on the **absorption lag**: the
-  `sdtab` TAD column now shifts each dose by its own occasion's lag, rather than
-  applying the observation's occasion lag to every dose. This only changed TAD
-  when the lag carries IOV and dosing spans occasions (e.g. BID across two
-  occasions); models without IOV-on-lag are unaffected (follow-up to #238).
+- The `sdtab` TAD column now shifts each dose by **its own** absorption lag —
+  evaluated with that dose's occasion kappa and that dose's covariate snapshot —
+  rather than applying the observation's lag to every dose. This changes TAD only
+  when the absorption lag varies across doses, i.e. when it carries IOV (kappa) or
+  depends on a time-varying covariate, *and* dosing spans the differing values
+  (e.g. BID across two occasions); models with a constant lag are unaffected
+  (follow-up to #238).
 - FOCE (non-interaction) omega standard errors now match NONMEM `$EST METHOD=1`
   `$COVARIANCE MATRIX=R` (to ~3–6% on warfarin, previously ~31% low). The
   covariance step had added the Ω prior (`η̂ᵀΩ⁻¹η̂ + log|Ω|`) on top of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ section of the SDLC for the versioning policy).
   silently treating every kappa as zero. Post-fit diagnostic columns that depend
   on a κ-varying parameter (e.g. `CL`, `V`, `KA`) were wrong for IOV subjects;
   the fitted estimates, OFV, and IPRED/IWRES were unaffected (#238).
+- IOV models with inter-occasion variability on the **absorption lag**: the
+  `sdtab` TAD column now shifts each dose by its own occasion's lag, rather than
+  applying the observation's occasion lag to every dose. This only changed TAD
+  when the lag carries IOV and dosing spans occasions (e.g. BID across two
+  occasions); models without IOV-on-lag are unaffected (follow-up to #238).
 - FOCE (non-interaction) omega standard errors now match NONMEM `$EST METHOD=1`
   `$COVARIANCE MATRIX=R` (to ~3–6% on warfarin, previously ~31% low). The
   covariance step had added the Ω prior (`η̂ᵀΩ⁻¹η̂ + log|Ω|`) on top of the

--- a/src/api.rs
+++ b/src/api.rs
@@ -6638,9 +6638,9 @@ mod tests_derived_iov_kappa {
 
     use super::*;
     use crate::types::{
-        BloqMethod, CompiledModel, DerivedContext, DerivedExprSpec, DerivedKind, ErrorModel,
-        ErrorSpec, GradientMethod, IndivParamPartials, ModelParameters, OmegaMatrix, PkModel,
-        PkParams, Population, ScalingSpec, SigmaVector, Subject,
+        BloqMethod, CompiledModel, DerivedContext, DerivedExprSpec, DerivedKind, DoseEvent,
+        ErrorModel, ErrorSpec, GradientMethod, IndivParamPartials, ModelParameters, OmegaMatrix,
+        PkModel, PkParams, Population, ScalingSpec, SigmaVector, Subject, PK_IDX_LAGTIME,
     };
     use nalgebra::DVector;
     use std::collections::HashMap;
@@ -6864,5 +6864,81 @@ mod tests_derived_iov_kappa {
                 "CL_OUT[{j}] with missing kappa should fall back to κ=0 → 10, got {v}"
             );
         }
+    }
+
+    /// Caller-level regression for the per-dose-occasion absorption lag
+    /// (follow-up to #238). `compute_extra_output_columns` must build TAD using
+    /// each *dose's* occasion lag, not the observation's. The model puts IOV on
+    /// the lag (`lag = 1.0 + κ`); a subject is dosed BID across two occasions:
+    ///   morning dose @0  (occasion 1, κ=0.0 → lag 1.0)
+    ///   evening dose @12 (occasion 2, κ=0.5 → lag 1.5)
+    /// with observations @2 (occ 1) and @13 (occ 2). At obs @13 the evening dose
+    /// arrives at 13.5 — not yet absorbed — so TAD counts from the morning dose's
+    /// arrival at 1.0 → 12.0. Applying the obs-occasion lag (1.5) to every dose,
+    /// as before this follow-up, would give 11.5.
+    #[test]
+    fn tad_uses_per_dose_occasion_lag() {
+        let mut model = minimal_iov_model(vec![]);
+        // Drive the absorption lag (slot PK_IDX_LAGTIME) from the occasion kappa.
+        model.pk_param_fn = Box::new(|_theta: &[f64], eta: &[f64], _cov: &HashMap<String, f64>| {
+            let kappa = eta.get(1).copied().unwrap_or(0.0);
+            let mut p = PkParams::default();
+            p.values[PK_IDX_LAGTIME] = 1.0 + kappa;
+            p
+        });
+
+        let subject = Subject {
+            id: "S1".into(),
+            doses: vec![
+                DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+                DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+            ],
+            obs_times: vec![2.0, 13.0],
+            obs_raw_times: vec![2.0, 13.0],
+            observations: vec![1.0, 1.0],
+            obs_cmts: vec![1, 1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0],
+            occasions: vec![1, 2],
+            dose_occasions: vec![1, 2],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        // ebe_kappas in split_obs_by_occasion order: occ 1 → idx 0 (κ=0.0),
+        // occ 2 → idx 1 (κ=0.5).
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![
+            DVector::from_vec(vec![0.0]),
+            DVector::from_vec(vec![0.5]),
+        ]];
+        let mut subjects_results = vec![sr_iov(2)];
+
+        compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+
+        let tad = &subjects_results[0].per_obs_tad;
+        assert!(
+            (tad[0] - 1.0).abs() < 1e-9,
+            "obs@2 TAD: morning dose arrives @1.0 → 1.0, got {}",
+            tad[0]
+        );
+        assert!(
+            (tad[1] - 12.0).abs() < 1e-9,
+            "obs@13 TAD must be 12.0 (evening dose uses its own occ-2 lag 1.5 → arrives \
+             @13.5, excluded; counts from morning @1.0). The pre-follow-up obs-occasion \
+             lag would give 11.5. Got {}",
+            tad[1]
+        );
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1418,7 +1418,21 @@ pub fn validate_output_columns(model: &CompiledModel, population: &Population) -
 
 /// Compute TAFD (time after first dose) and TAD (time after last dose,
 /// SS-aware) for observation index `obs_idx` of `subject`.
-pub fn tafd_tad_for_subject(subject: &Subject, obs_idx: usize, lagtime: f64) -> (f64, f64) {
+///
+/// `dose_lagtimes[d]` is the absorption lag for dose `d`, evaluated with that
+/// dose's occasion kappa (see [`crate::pk::predict_iov`]). Each dose's effective
+/// arrival is `dose.time + dose_lagtimes[d]`, so under IOV-on-lag a dose given in
+/// one occasion is shifted by its *own* lag rather than the observation's — which
+/// matters for the most-recent-dose pick when occasions have different lags (e.g.
+/// BID dosing spanning two occasions). Missing entries (`dose_lagtimes` shorter
+/// than `subject.doses`, or `&[]`) default to a zero lag, so callers with no
+/// IOV-on-lag can pass `&[]`. TAFD is unaffected — it is measured from the raw
+/// first-dose time, not the lagged arrival.
+pub fn tafd_tad_for_subject(
+    subject: &Subject,
+    obs_idx: usize,
+    dose_lagtimes: &[f64],
+) -> (f64, f64) {
     let obs_time = subject.obs_times[obs_idx];
 
     let first_dose_time = subject.occasion_first_dose_time(obs_time);
@@ -1431,14 +1445,19 @@ pub fn tafd_tad_for_subject(subject: &Subject, obs_idx: usize, lagtime: f64) -> 
     let last_dose_eff = subject
         .doses
         .iter()
-        .filter(|d| d.time + lagtime <= obs_time + 1e-12)
-        .map(|d| {
-            if d.ss && d.ii > 0.0 {
-                let elapsed = obs_time - (d.time + lagtime);
-                obs_time - elapsed.rem_euclid(d.ii)
-            } else {
-                d.time + lagtime
+        .enumerate()
+        .filter_map(|(d, dose)| {
+            let lag = dose_lagtimes.get(d).copied().unwrap_or(0.0);
+            if dose.time + lag > obs_time + 1e-12 {
+                return None;
             }
+            let eff = if dose.ss && dose.ii > 0.0 {
+                let elapsed = obs_time - (dose.time + lag);
+                obs_time - elapsed.rem_euclid(dose.ii)
+            } else {
+                dose.time + lag
+            };
+            Some(eff)
         })
         .fold(f64::NEG_INFINITY, f64::max);
     let tad = if last_dose_eff.is_finite() {
@@ -1536,6 +1555,21 @@ pub(crate) fn compute_extra_output_columns(
             .map(|j| combined_for(subject.occasions.get(j).copied().unwrap_or(0)))
             .collect();
 
+        // Per-dose absorption lag, each evaluated with that dose's occasion kappa
+        // (mirrors predict_iov's per-dose PK params). TAD shifts every dose by its
+        // own lag, so a dose given in one occasion is not mis-shifted by the
+        // observation's occasion lag — matters only when the lag carries IOV and
+        // dosing spans occasions (e.g. BID across two occasions). Computed once per
+        // subject (dose-indexed, not obs-indexed); for non-IOV every entry equals
+        // the single lag, leaving TAD unchanged.
+        let dose_lagtimes: Vec<f64> = (0..subject.doses.len())
+            .map(|d| {
+                let occ = subject.dose_occasions.get(d).copied().unwrap_or(0);
+                let eta_d = combined_for(occ);
+                (model.pk_param_fn)(theta, &eta_d, subject.dose_cov(d)).lagtime()
+            })
+            .collect();
+
         // Per-observation PK params, indiv maps, TAFD, TAD
         let mut per_obs_cov: Vec<&HashMap<String, f64>> = Vec::with_capacity(n_obs);
         let mut per_obs_indiv: Vec<HashMap<String, f64>> = Vec::with_capacity(n_obs);
@@ -1545,9 +1579,8 @@ pub(crate) fn compute_extra_output_columns(
         for (j, eta_full) in per_obs_eta_full.iter().enumerate() {
             let cov_j = subject.obs_cov(j);
             let pk_j = (model.pk_param_fn)(theta, eta_full, cov_j);
-            let lagtime = pk_j.lagtime();
             let indiv_j = build_indiv_map(&pk_j, &model.indiv_param_names, &model.pk_indices);
-            let (tafd_j, tad_j) = tafd_tad_for_subject(subject, j, lagtime);
+            let (tafd_j, tad_j) = tafd_tad_for_subject(subject, j, &dose_lagtimes);
             per_obs_cov.push(cov_j);
             per_obs_indiv.push(indiv_j);
             per_obs_tafd.push(tafd_j);

--- a/src/api.rs
+++ b/src/api.rs
@@ -1416,56 +1416,62 @@ pub fn validate_output_columns(model: &CompiledModel, population: &Population) -
     diags
 }
 
-/// Compute TAFD (time after first dose) and TAD (time after last dose,
-/// SS-aware) for observation index `obs_idx` of `subject`.
-///
-/// `dose_lagtimes[d]` is the absorption lag for dose `d`, evaluated with that
-/// dose's occasion kappa (see [`crate::pk::predict_iov`]). Each dose's effective
-/// arrival is `dose.time + dose_lagtimes[d]`, so under IOV-on-lag a dose given in
-/// one occasion is shifted by its *own* lag rather than the observation's — which
-/// matters for the most-recent-dose pick when occasions have different lags (e.g.
-/// BID dosing spanning two occasions). Missing entries (`dose_lagtimes` shorter
-/// than `subject.doses`, or `&[]`) default to a zero lag, so callers with no
-/// IOV-on-lag can pass `&[]`. TAFD is unaffected — it is measured from the raw
-/// first-dose time, not the lagged arrival.
-pub fn tafd_tad_for_subject(
-    subject: &Subject,
-    obs_idx: usize,
-    dose_lagtimes: &[f64],
-) -> (f64, f64) {
-    let obs_time = subject.obs_times[obs_idx];
-
-    let first_dose_time = subject.occasion_first_dose_time(obs_time);
-    let tafd = if first_dose_time.is_finite() {
-        obs_time - first_dose_time
-    } else {
-        f64::NAN
-    };
-
+/// Time after the most recent **absorbed** dose at time `t` (SS-aware), shifting
+/// each dose by its own lag from `dose_lagtimes`. Missing entries — a slice
+/// shorter than `subject.doses`, or `&[]` — default to zero lag. Returns NaN when
+/// no dose has been absorbed by `t`. Shared by the per-observation TAD column and
+/// the model-based integral grid so both apply identical per-dose-lag logic.
+fn tad_at_time(subject: &Subject, t: f64, dose_lagtimes: &[f64]) -> f64 {
     let last_dose_eff = subject
         .doses
         .iter()
         .enumerate()
         .filter_map(|(d, dose)| {
             let lag = dose_lagtimes.get(d).copied().unwrap_or(0.0);
-            if dose.time + lag > obs_time + 1e-12 {
+            if dose.time + lag > t + 1e-12 {
                 return None;
             }
             let eff = if dose.ss && dose.ii > 0.0 {
-                let elapsed = obs_time - (dose.time + lag);
-                obs_time - elapsed.rem_euclid(dose.ii)
+                let elapsed = t - (dose.time + lag);
+                t - elapsed.rem_euclid(dose.ii)
             } else {
                 dose.time + lag
             };
             Some(eff)
         })
         .fold(f64::NEG_INFINITY, f64::max);
-    let tad = if last_dose_eff.is_finite() {
-        obs_time - last_dose_eff
+    if last_dose_eff.is_finite() {
+        t - last_dose_eff
+    } else {
+        f64::NAN
+    }
+}
+
+/// Compute TAFD (time after first dose) and TAD (time after last dose, SS-aware)
+/// for observation index `obs_idx` of `subject`.
+///
+/// `dose_lagtimes[d]` is the absorption lag for dose `d`, evaluated with that
+/// dose's occasion kappa and covariate snapshot (see [`crate::pk::predict_iov`]).
+/// Each dose's effective arrival is `dose.time + dose_lagtimes[d]`, so under a lag
+/// that varies across doses — IOV on the lag, or a time-varying covariate — a dose
+/// given in one occasion is shifted by its *own* lag rather than the observation's,
+/// which matters for the most-recent-dose pick (e.g. BID dosing spanning two
+/// occasions). Missing entries default to zero lag, so callers with no lag can
+/// pass `&[]`. TAFD is unaffected — measured from the raw first-dose time, not the
+/// lagged arrival.
+pub fn tafd_tad_for_subject(
+    subject: &Subject,
+    obs_idx: usize,
+    dose_lagtimes: &[f64],
+) -> (f64, f64) {
+    let obs_time = subject.obs_times[obs_idx];
+    let first_dose_time = subject.occasion_first_dose_time(obs_time);
+    let tafd = if first_dose_time.is_finite() {
+        obs_time - first_dose_time
     } else {
         f64::NAN
     };
-
+    let tad = tad_at_time(subject, obs_time, dose_lagtimes);
     (tafd, tad)
 }
 
@@ -1556,19 +1562,25 @@ pub(crate) fn compute_extra_output_columns(
             .collect();
 
         // Per-dose absorption lag, each evaluated with that dose's occasion kappa
-        // (mirrors predict_iov's per-dose PK params). TAD shifts every dose by its
-        // own lag, so a dose given in one occasion is not mis-shifted by the
-        // observation's occasion lag — matters only when the lag carries IOV and
-        // dosing spans occasions (e.g. BID across two occasions). Computed once per
-        // subject (dose-indexed, not obs-indexed); for non-IOV every entry equals
-        // the single lag, leaving TAD unchanged.
-        let dose_lagtimes: Vec<f64> = (0..subject.doses.len())
-            .map(|d| {
-                let occ = subject.dose_occasions.get(d).copied().unwrap_or(0);
-                let eta_d = combined_for(occ);
-                (model.pk_param_fn)(theta, &eta_d, subject.dose_cov(d)).lagtime()
-            })
-            .collect();
+        // and covariate snapshot (mirrors predict_iov's per-dose PK params). TAD
+        // shifts every dose by its own lag, so a dose given in one occasion is not
+        // mis-shifted by the observation's lag — matters when the lag varies across
+        // doses (IOV on the lag, or a time-varying covariate) and dosing spans the
+        // differing values (e.g. BID across two occasions). Computed once per
+        // subject (dose-indexed). Skipped entirely when the model declares no lag:
+        // `dose_lagtimes` stays empty and `tad_at_time` falls back to zero lag,
+        // so the common no-lag case pays nothing for this per-dose pass.
+        let dose_lagtimes: Vec<f64> = if model.has_lagtime() {
+            (0..subject.doses.len())
+                .map(|d| {
+                    let occ = subject.dose_occasions.get(d).copied().unwrap_or(0);
+                    let eta_d = combined_for(occ);
+                    (model.pk_param_fn)(theta, &eta_d, subject.dose_cov(d)).lagtime()
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         // Per-observation PK params, indiv maps, TAFD, TAD
         let mut per_obs_cov: Vec<&HashMap<String, f64>> = Vec::with_capacity(n_obs);
@@ -1880,18 +1892,6 @@ pub(crate) fn compute_extra_output_columns(
                             })
                             .collect()
                     };
-                    let session_grid_lagtime: Vec<f64> = if use_obs {
-                        vec![]
-                    } else {
-                        session_grid_cov
-                            .iter()
-                            .zip(session_grid_eta_full.iter())
-                            .map(|(cov, eta_full)| {
-                                let pk = (model.pk_param_fn)(theta, eta_full, cov);
-                                pk.lagtime()
-                            })
-                            .collect()
-                    };
                     let session_grid_indiv: Vec<HashMap<String, f64>> = if use_obs {
                         vec![]
                     } else {
@@ -1914,7 +1914,6 @@ pub(crate) fn compute_extra_output_columns(
                     // expressions referencing TIME see the internal clock, not raw TIME.
                     let eval_integral_grid = |from: f64, to: f64, session_idx: usize| -> f64 {
                         let grid_cov = session_grid_cov[session_idx];
-                        let grid_lagtime = session_grid_lagtime[session_idx];
                         let indiv_s = &session_grid_indiv[session_idx];
                         let grid_eta_full = session_grid_eta_full[session_idx];
                         let n_steps = match step {
@@ -1994,26 +1993,11 @@ pub(crate) fn compute_extra_output_columns(
                                         f64::NAN
                                     }
                                 };
-                                let tad_k = {
-                                    let last_dose_eff = subject
-                                        .doses
-                                        .iter()
-                                        .filter(|d| d.time + grid_lagtime <= t + 1e-12)
-                                        .map(|d| {
-                                            if d.ss && d.ii > 0.0 {
-                                                let elapsed = t - (d.time + grid_lagtime);
-                                                t - elapsed.rem_euclid(d.ii)
-                                            } else {
-                                                d.time + grid_lagtime
-                                            }
-                                        })
-                                        .fold(f64::NEG_INFINITY, f64::max);
-                                    if last_dose_eff.is_finite() {
-                                        t - last_dose_eff
-                                    } else {
-                                        f64::NAN
-                                    }
-                                };
+                                // Same per-dose-lag TAD as the per-observation column
+                                // (shared `tad_at_time`), so a `[derived]` integral over
+                                // TAD agrees with the `sdtab` TAD column under IOV/TV-cov
+                                // lag — not the old session-representative scalar lag.
+                                let tad_k = tad_at_time(subject, t, &dose_lagtimes);
                                 // Nearest IPRED from this session's observations only.
                                 let nearest_ipred = session_obs[session_idx]
                                     .iter()
@@ -6879,6 +6863,11 @@ mod tests_derived_iov_kappa {
     #[test]
     fn tad_uses_per_dose_occasion_lag() {
         let mut model = minimal_iov_model(vec![]);
+        // Declare an absorption lag (ALAG → PK_IDX_LAGTIME) so `model.has_lagtime()`
+        // holds; compute_extra_output_columns only builds per-dose lags for models
+        // that declare a lag.
+        model.indiv_param_names = vec!["CL".into(), "ALAG".into()];
+        model.pk_indices = vec![0, PK_IDX_LAGTIME];
         // Drive the absorption lag (slot PK_IDX_LAGTIME) from the occasion kappa.
         model.pk_param_fn = Box::new(|_theta: &[f64], eta: &[f64], _cov: &HashMap<String, f64>| {
             let kappa = eta.get(1).copied().unwrap_or(0.0);
@@ -6939,6 +6928,70 @@ mod tests_derived_iov_kappa {
              @13.5, excluded; counts from morning @1.0). The pre-follow-up obs-occasion \
              lag would give 11.5. Got {}",
             tad[1]
+        );
+    }
+
+    /// Caller-level regression: the per-dose lag uses each dose's *covariate*
+    /// snapshot (`dose_cov`), not the observation's — so a lag depending on a
+    /// time-varying covariate is shifted by conditions at dosing, matching
+    /// `predict_iov`. Lag = `LAGCOV`: the dose sees `LAGCOV=1` (lag 1.0), the
+    /// observation sees `LAGCOV=5` (lag 5.0). With a dose @0 and obs @3, the dose
+    /// covariate gives arrival @1.0 → TAD 2.0; the obs covariate would push arrival
+    /// to @5.0 (after the obs) → TAD NaN. Asserting TAD = 2.0 proves `dose_cov` is
+    /// used. (No IOV here — this isolates the covariate basis, not kappa.)
+    #[test]
+    fn tad_lag_uses_dose_covariate_not_obs() {
+        let mut model = minimal_iov_model(vec![]);
+        model.indiv_param_names = vec!["CL".into(), "ALAG".into()];
+        model.pk_indices = vec![0, PK_IDX_LAGTIME];
+        // Lag = LAGCOV covariate (time-varying); independent of eta/kappa.
+        model.pk_param_fn = Box::new(|_theta: &[f64], _eta: &[f64], cov: &HashMap<String, f64>| {
+            let mut p = PkParams::default();
+            p.values[PK_IDX_LAGTIME] = cov.get("LAGCOV").copied().unwrap_or(0.0);
+            p
+        });
+
+        let cov_dose = HashMap::from([("LAGCOV".to_string(), 1.0)]);
+        let cov_obs = HashMap::from([("LAGCOV".to_string(), 5.0)]);
+        let subject = Subject {
+            id: "S1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![3.0],
+            obs_raw_times: vec![3.0],
+            observations: vec![1.0],
+            obs_cmts: vec![1],
+            covariates: HashMap::new(),
+            dose_covariates: vec![cov_dose],
+            obs_covariates: vec![cov_obs],
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0],
+            occasions: vec![1],
+            dose_occasions: vec![1],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: vec!["LAGCOV".into()],
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let kappas: Vec<Vec<DVector<f64>>> = vec![vec![DVector::from_vec(vec![0.0])]];
+        let mut subjects_results = vec![sr_iov(1)];
+
+        compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+
+        let tad = &subjects_results[0].per_obs_tad;
+        assert!(
+            (tad[0] - 2.0).abs() < 1e-9,
+            "TAD must use the dose covariate (LAGCOV=1 → lag 1.0 → arrival @1.0 → TAD 2.0); \
+             the obs covariate (LAGCOV=5) would push arrival to @5.0 (after the obs) → NaN. \
+             Got {}",
+            tad[0]
         );
     }
 }

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -201,7 +201,7 @@ fn tafd_correct_single_dose() {
         vec![10.0],
         vec![DoseEvent::new(5.0, 100.0, 1, 0.0, false, 0.0)],
     );
-    let (tafd, _) = tafd_tad_for_subject(&subj, 0, 0.0);
+    let (tafd, _) = tafd_tad_for_subject(&subj, 0, &[]);
     assert!((tafd - 5.0).abs() < 1e-10, "TAFD should be 5, got {tafd}");
 }
 
@@ -209,7 +209,7 @@ fn tafd_correct_single_dose() {
 fn tafd_nan_when_no_dose() {
     // No doses → TAFD is NaN
     let subj = make_subject_with_doses(vec![10.0], vec![]);
-    let (tafd, _) = tafd_tad_for_subject(&subj, 0, 0.0);
+    let (tafd, _) = tafd_tad_for_subject(&subj, 0, &[]);
     assert!(
         tafd.is_nan(),
         "TAFD should be NaN with no doses, got {tafd}"
@@ -223,7 +223,7 @@ fn tad_nan_when_dose_after_obs() {
         vec![1.0],
         vec![DoseEvent::new(20.0, 100.0, 1, 0.0, false, 0.0)],
     );
-    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, &[]);
     assert!(
         tad.is_nan(),
         "TAD should be NaN when dose is after obs, got {tad}"
@@ -236,7 +236,7 @@ fn tad_ss_modular() {
     let mut dose = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 12.0);
     dose.ss = true;
     let subj = make_subject_with_doses(vec![50.0], vec![dose]);
-    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, &[]);
     assert!((tad - 2.0).abs() < 1e-10, "TAD(SS) should be 2, got {tad}");
 }
 
@@ -250,8 +250,84 @@ fn tad_after_addl_expanded_doses() {
         DoseEvent::new(48.0, 100.0, 1, 0.0, false, 0.0),
     ];
     let subj = make_subject_with_doses(vec![50.0], doses);
-    let (_, tad) = tafd_tad_for_subject(&subj, 0, 0.0);
+    let (_, tad) = tafd_tad_for_subject(&subj, 0, &[]);
     assert!((tad - 2.0).abs() < 1e-10, "TAD should be 2, got {tad}");
+}
+
+// ── Per-dose-occasion absorption lag (BID across occasions; follow-up to #238) ──
+
+#[test]
+fn tad_bid_explicit_no_lag() {
+    // Explicit q12h BID, no lag: TAD = time since the most recent dose.
+    let doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(24.0, 100.0, 1, 0.0, false, 0.0),
+    ];
+    let subj = make_subject_with_doses(vec![6.0, 14.0, 26.0], doses);
+    let tad: Vec<f64> = (0..3)
+        .map(|j| tafd_tad_for_subject(&subj, j, &[]).1)
+        .collect();
+    assert_eq!(
+        tad,
+        vec![6.0, 2.0, 2.0],
+        "BID TAD = time since the most recent q12h dose"
+    );
+}
+
+#[test]
+fn tad_bid_uniform_lag_excludes_unabsorbed_dose() {
+    // Uniform lag = 1h (no IOV on lag). A dose whose lagged arrival is after the
+    // observation is excluded from the "most recent dose" pick.
+    let doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+    ];
+    // obs @12.5: evening dose @12 arrives @13 — not yet → from morning (arrived @1).
+    let subj_a = make_subject_with_doses(vec![12.5], doses.clone());
+    let tad_a = tafd_tad_for_subject(&subj_a, 0, &[1.0, 1.0]).1;
+    assert!(
+        (tad_a - 11.5).abs() < 1e-12,
+        "evening dose not yet absorbed: TAD {tad_a}"
+    );
+    // obs @13.5: evening dose arrived @13 → TAD = 0.5.
+    let subj_b = make_subject_with_doses(vec![13.5], doses);
+    let tad_b = tafd_tad_for_subject(&subj_b, 0, &[1.0, 1.0]).1;
+    assert!(
+        (tad_b - 0.5).abs() < 1e-12,
+        "evening dose absorbed: TAD {tad_b}"
+    );
+}
+
+#[test]
+fn tad_bid_per_dose_occasion_lag() {
+    // BID spanning two IOV occasions with IOV on the absorption lag:
+    //   morning dose @0  (occasion 1, lag 1.0)
+    //   evening dose @12 (occasion 2, lag 1.5)
+    //   obs @13          (occasion 2)
+    // The evening dose arrives at 13.5 — not yet absorbed at obs 13 — so TAD must
+    // count from the morning dose's arrival at 1.0 → 12.0.
+    let doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+    ];
+    let subj = make_subject_with_doses(vec![13.0], doses);
+
+    // Correct: each dose shifted by its own occasion's lag.
+    let tad_per_dose = tafd_tad_for_subject(&subj, 0, &[1.0, 1.5]).1;
+    assert!(
+        (tad_per_dose - 12.0).abs() < 1e-12,
+        "per-dose lag must pick the morning dose @1.0 → TAD 12.0, got {tad_per_dose}"
+    );
+
+    // Regression contrast: a single obs-occasion scalar (1.5) applied to both
+    // doses mis-shifts the morning dose → 11.5, the behaviour this follow-up
+    // removes. (Pre-#238, the zero-lag scalar gave 1.0 — the wrong dose entirely.)
+    let tad_uniform = tafd_tad_for_subject(&subj, 0, &[1.5, 1.5]).1;
+    assert!(
+        (tad_uniform - 11.5).abs() < 1e-12,
+        "single obs-occasion lag mis-shifts the morning dose, got {tad_uniform}"
+    );
 }
 
 // ── End-to-end: fit() produces finite extra_columns ──────────────────────────


### PR DESCRIPTION
> **Stacked on #271** (base branch is `worktree-fix-238-iov-extra-output-kappas`, not `main`). Merge #271 first; GitHub will retarget this to `main` afterwards. The diff here is only the TAD delta.

## Why

Follow-up to the #271 review. `tafd_tad_for_subject` applied a **single** `lagtime` to every dose. When the absorption lag carries IOV and dosing spans occasions (e.g. BID across two occasions), a dose given in one occasion was shifted by the *observation's* occasion lag instead of its own — which can select the wrong "most recent dose".

Concretely (morning dose @0 occ 1 lag 1.0, evening dose @12 occ 2 lag 1.5, obs @13 occ 2): the evening dose arrives at 13.5, so at obs 13 it hasn't absorbed and TAD should count from the morning dose's arrival at 1.0 → **TAD = 12.0**. The single-scalar approach gave 11.5 (morning dose mis-shifted by the occ-2 lag); pre-#238 it gave 1.0 (wrong dose entirely). #271 narrowed the error; this closes it.

This only matters with **IOV on the lag** *and* dosing across occasions — F (bioavailability) is unaffected (it scales amount, not timing, and is already per-dose-occasion in `predict_iov`).

## What changed

`tafd_tad_for_subject` now takes per-dose lagtimes (`dose_lagtimes: &[f64]`, dose-indexed) instead of one scalar; each dose's effective arrival is `dose.time + dose_lagtimes[d]`. The caller (`compute_extra_output_columns`) computes each dose's lag with that dose's occasion kappa — mirroring `predict_iov`'s per-dose PK params, reusing the `combined_for` closure from #271. Missing/`&[]` entries default to zero lag. **TAFD is unchanged** (raw first-dose time). For any model without IOV-on-lag, all entries are equal, so TAD is identical to before.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`tafd_tad_for_subject` is `pub` but only consumed internally + in tests; ferx-r does not reference it (verified).

## Breaking changes
- [x] Public Rust API (`api.rs`): `tafd_tad_for_subject` signature `lagtime: f64` → `dose_lagtimes: &[f64]`. No external consumers; callers pass `&[]` for the no-lag case.

## Numerical validation
- [x] Reference values (per-dose lag, BID across occasions):

```
doses: @0 (lag 1.0), @12 (lag 1.5);  obs @13
per-dose  [1.0, 1.5] -> TAD = 12.0   (correct: morning dose, its own lag)
scalar    [1.5, 1.5] -> TAD = 11.5   (#271 behaviour, morning mis-shifted)
pre-#238  [0.0, 0.0] -> TAD = 1.0    (wrong dose: evening counted as arrived)
```

## Tests
- [x] Regression test added that fails without this fix (`tad_bid_per_dose_occasion_lag`, plus `tad_bid_explicit_no_lag` and `tad_bid_uniform_lag_excludes_unabsorbed_dose`). Existing TAD tests updated to `&[]` (behaviour-identical). `cargo test --test derived_output` → 19 pass; IOV unit + e2e cross-check still green.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (Fixed, follow-up to #238)
- [x] No new DSL/option surface

## Checklist
- [x] `cargo clippy --no-default-features --features ci` adds no warnings in changed code
- [x] `cargo +nightly fmt --check` clean
- [x] Not breaking for ferx-r (no version bump)

## Reviewer hints
The per-dose lag computation in `compute_extra_output_columns` is the exact analogue of `predict_iov`'s `dose_params` (per-dose occasion kappa via `combined_for(dose_occasions[d])`). It is dose-indexed and computed once per subject. The grid-integral TAD path is deliberately left on the session-representative lag — consistent with the grid's existing first-obs approximation for covariates/indiv params.
