### PR TITLE
test(estimation): extract + unit-test the SIR-fallback wiring [closes #264]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2780,36 +2780,18 @@ fn fit_inner(
 
     // SIR fallback: when the FD Hessian is non-PD and covariance_fallback = sir,
     // run SIR with the rectified |eigenvalue| proposal built inside compute_covariance.
-    let sir_fallback_result = if options.covariance_fallback == CovarianceFallback::Sir
-        && result.covariance_matrix.is_none()
-        && sir_result.is_none()
-        && !crate::cancel::is_cancelled(&options.cancel)
-    {
-        if let Some(ref proposal) = result.sir_fallback_proposal {
-            if options.verbose {
-                eprintln!("\nRunning SIR fallback (non-PD Hessian)...");
-            }
-            match crate::estimation::sir::run_sir_core(
-                model,
-                population,
-                &result.params,
-                &result.eta_hats,
-                proposal,
-                result.ofv,
-                options,
-            ) {
-                Ok(sir) => Some(sir),
-                Err(e) => {
-                    warnings.push(format!("SIR fallback failed: {}", e));
-                    None
-                }
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let sir_fallback_result = resolve_sir_fallback(
+        options,
+        result.covariance_matrix.is_some(),
+        sir_result.is_some(),
+        result.sir_fallback_proposal.as_ref(),
+        model,
+        population,
+        &result.params,
+        &result.eta_hats,
+        result.ofv,
+        &mut warnings,
+    );
 
     // `final_method` reports the last *estimating* stage — IMP is a likelihood
     // evaluation and doesn't produce parameters, so a chain like `[saem, imp]`
@@ -3231,6 +3213,71 @@ fn resolve_covariance_status(
         CovarianceStatus::SirFallback
     } else {
         CovarianceStatus::Failed
+    }
+}
+
+/// Pure gate for the non-PD-Hessian SIR fallback: should it run? It fires only
+/// when the user opted in (`covariance_fallback = sir`), the FD-Hessian
+/// covariance did **not** succeed (`!has_covariance_matrix`), a normal
+/// `sir = true` run did **not** already produce intervals (`!normal_sir_ran`),
+/// and `compute_covariance` actually handed back a fallback proposal
+/// (`has_fallback_proposal`). Split out of [`resolve_sir_fallback`] so the
+/// decision is unit-testable without driving a fit to a non-PD Hessian (#264).
+fn should_run_sir_fallback(
+    fallback_is_sir: bool,
+    has_covariance_matrix: bool,
+    normal_sir_ran: bool,
+    has_fallback_proposal: bool,
+) -> bool {
+    fallback_is_sir && !has_covariance_matrix && !normal_sir_ran && has_fallback_proposal
+}
+
+/// Run the non-PD-Hessian SIR fallback when [`should_run_sir_fallback`] permits.
+///
+/// Returns `Some(SirResult)` when the fallback fired and SIR succeeded; `None`
+/// when the gate declined, the run was cancelled, or SIR itself failed (the
+/// failure case pushes a `"SIR fallback failed: …"` warning). Extracted from
+/// `fit_inner` so the gate → `run_sir_core` → warning wiring is exercised by a
+/// unit test with a controlled (tame) proposal, rather than relying on a real
+/// non-PD fit — which the optimizer's fixed warmup budget cannot reach and a
+/// degenerate fixture cannot reliably survive in SIR (#264).
+#[allow(clippy::too_many_arguments)]
+fn resolve_sir_fallback(
+    options: &FitOptions,
+    has_covariance_matrix: bool,
+    normal_sir_ran: bool,
+    fallback_proposal: Option<&DMatrix<f64>>,
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[DVector<f64>],
+    ofv: f64,
+    warnings: &mut Vec<String>,
+) -> Option<crate::estimation::sir::SirResult> {
+    if crate::cancel::is_cancelled(&options.cancel) {
+        return None;
+    }
+    if !should_run_sir_fallback(
+        options.covariance_fallback == CovarianceFallback::Sir,
+        has_covariance_matrix,
+        normal_sir_ran,
+        fallback_proposal.is_some(),
+    ) {
+        return None;
+    }
+    let proposal =
+        fallback_proposal.expect("should_run_sir_fallback guarantees a proposal is present");
+    if options.verbose {
+        eprintln!("\nRunning SIR fallback (non-PD Hessian)...");
+    }
+    match crate::estimation::sir::run_sir_core(
+        model, population, params, eta_hats, proposal, ofv, options,
+    ) {
+        Ok(sir) => Some(sir),
+        Err(e) => {
+            warnings.push(format!("SIR fallback failed: {}", e));
+            None
+        }
     }
 }
 
@@ -5155,6 +5202,150 @@ mod tests_cov_diagnostics {
         assert_eq!(
             resolve_covariance_status(true, false, false),
             CovarianceStatus::Failed
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_sir_fallback {
+    use super::*;
+    use std::path::Path;
+
+    // ── should_run_sir_fallback (pure gate, #264) ────────────────────────────
+
+    #[test]
+    fn sir_fallback_gate_fires_only_when_all_conditions_hold() {
+        // Opted in, no real covariance, no normal SIR, proposal present.
+        assert!(should_run_sir_fallback(true, false, false, true));
+    }
+
+    #[test]
+    fn sir_fallback_gate_blocked_by_each_condition() {
+        // Each single deviation from the firing case blocks the fallback.
+        assert!(!should_run_sir_fallback(false, false, false, true)); // covariance_fallback != sir
+        assert!(!should_run_sir_fallback(true, true, false, true)); // a real H⁻¹ covariance exists
+        assert!(!should_run_sir_fallback(true, false, true, true)); // a normal sir=true run already produced CIs
+        assert!(!should_run_sir_fallback(true, false, false, false)); // compute_covariance produced no proposal
+    }
+
+    // ── resolve_sir_fallback (gate + run_sir_core + status, #264) ─────────────
+
+    fn warfarin_fixture() -> (
+        CompiledModel,
+        Population,
+        ModelParameters,
+        Vec<DVector<f64>>,
+        DMatrix<f64>,
+    ) {
+        let model =
+            crate::parser::model_parser::parse_model_file(Path::new("examples/warfarin.ferx"))
+                .expect("warfarin model parses");
+        let pop = crate::read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+            .expect("warfarin data loads");
+        let params = model.default_params.clone();
+        let eta_hats: Vec<DVector<f64>> = (0..pop.subjects.len())
+            .map(|_| DVector::zeros(params.omega.dim()))
+            .collect();
+        // Tame fallback-style proposal: small PD diagonal in packed space, so
+        // draws stay near valid parameters (positive θ/σ, PD Ω) and SIR yields
+        // finite weights. A real non-PD fixture risks a wide proposal whose draws
+        // overflow `exp(...)` → "all invalid weights" → status `Failed`.
+        let n_packed = crate::estimation::parameterization::pack_params(&params).len();
+        let proposal = DMatrix::from_diagonal(&DVector::from_element(n_packed, 0.01));
+        (model, pop, params, eta_hats, proposal)
+    }
+
+    /// `resolve_sir_fallback` short-circuits to `None` (without touching the SIR
+    /// machinery) when the gate declines — here because `covariance_fallback`
+    /// defaults to `none`. No warning is emitted for a simple decline.
+    #[test]
+    fn resolve_sir_fallback_is_none_when_option_off() {
+        let (model, pop, params, eta_hats, proposal) = warfarin_fixture();
+        let opts = FitOptions::default(); // covariance_fallback = None
+        let mut warnings = Vec::new();
+        let result = resolve_sir_fallback(
+            &opts,
+            false,
+            false,
+            Some(&proposal),
+            &model,
+            &pop,
+            &params,
+            &eta_hats,
+            0.0,
+            &mut warnings,
+        );
+        assert!(
+            result.is_none(),
+            "fallback must not fire when covariance_fallback = none"
+        );
+        assert!(
+            warnings.is_empty(),
+            "no warning when the gate simply declines: {warnings:?}"
+        );
+    }
+
+    /// End-to-end fallback wiring (#264): with `covariance_fallback = sir`, no
+    /// real covariance, and a tame PD proposal (the part a real non-PD fit can't
+    /// reliably deliver), `resolve_sir_fallback` runs SIR and returns a result
+    /// whose θ/Ω/σ credible intervals are populated and finite — and the status
+    /// the caller derives from it is `SirFallback`. Slow: a full SIR pass
+    /// (sampling + per-draw population likelihood).
+    #[test]
+    #[cfg_attr(
+        not(feature = "slow-tests"),
+        ignore = "slow: full SIR pass; opt in with --features slow-tests"
+    )]
+    fn resolve_sir_fallback_fires_and_yields_finite_cis() {
+        let (model, pop, params, eta_hats, proposal) = warfarin_fixture();
+        let mut opts = FitOptions::default();
+        opts.covariance_fallback = CovarianceFallback::Sir;
+        opts.verbose = false;
+        opts.sir_samples = 400;
+        opts.sir_resamples = 200;
+
+        let mut warnings = Vec::new();
+        let result = resolve_sir_fallback(
+            &opts,
+            false,
+            false,
+            Some(&proposal),
+            &model,
+            &pop,
+            &params,
+            &eta_hats,
+            0.0,
+            &mut warnings,
+        );
+
+        let fired = result.is_some();
+        let sir = result.expect("fallback should fire and SIR should succeed with a tame proposal");
+
+        assert!(!sir.ci_theta.is_empty(), "theta CIs must be populated");
+        for (lo, hi) in sir
+            .ci_theta
+            .iter()
+            .chain(&sir.ci_omega)
+            .chain(&sir.ci_sigma)
+        {
+            assert!(
+                lo.is_finite() && hi.is_finite() && lo <= hi,
+                "SIR-fallback CI must be finite and ordered, got ({lo}, {hi})"
+            );
+        }
+        assert!(
+            sir.effective_sample_size.is_finite() && sir.effective_sample_size > 0.0,
+            "ESS must be finite and positive, got {}",
+            sir.effective_sample_size
+        );
+        assert!(
+            !warnings.iter().any(|w| w.contains("SIR fallback failed")),
+            "no failure warning expected on the success path: {warnings:?}"
+        );
+        // The status the caller derives from a fired fallback is SirFallback.
+        assert_eq!(
+            resolve_covariance_status(true, false, fired),
+            CovarianceStatus::SirFallback
         );
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -5324,7 +5324,12 @@ mod tests_sir_fallback {
             &mut warnings,
         );
 
-        let fired = result.is_some();
+        // Derive the reported status from the actual outcome, *before* unwrapping,
+        // so this checks the real fire→status mapping rather than a constant.
+        assert_eq!(
+            resolve_covariance_status(true, false, result.is_some()),
+            CovarianceStatus::SirFallback
+        );
         let sir = result.expect("fallback should fire and SIR should succeed with a tame proposal");
 
         assert!(!sir.ci_theta.is_empty(), "theta CIs must be populated");
@@ -5347,11 +5352,6 @@ mod tests_sir_fallback {
         assert!(
             !warnings.iter().any(|w| w.contains("SIR fallback failed")),
             "no failure warning expected on the success path: {warnings:?}"
-        );
-        // The status the caller derives from a fired fallback is SirFallback.
-        assert_eq!(
-            resolve_covariance_status(true, false, fired),
-            CovarianceStatus::SirFallback
         );
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -5303,6 +5303,10 @@ mod tests_sir_fallback {
         opts.verbose = false;
         opts.sir_samples = 400;
         opts.sir_resamples = 200;
+        // Own the determinism explicitly rather than leaning on run_sir_core's
+        // `None => fixed seed` fallback, so a future change to that fallback can't
+        // silently make this sampling test flaky.
+        opts.sir_seed = Some(20240612);
 
         let mut warnings = Vec::new();
         let result = resolve_sir_fallback(
@@ -5314,6 +5318,8 @@ mod tests_sir_fallback {
             &pop,
             &params,
             &eta_hats,
+            // ofv_hat cancels in the SIR log-sum-exp weight normalisation, so any
+            // finite value yields identical CIs — 0.0 keeps the fixture simple.
             0.0,
             &mut warnings,
         );


### PR DESCRIPTION
## Why
`covariance_fallback = sir` (#245) runs SIR when the FD Hessian is non-PD: `compute_covariance → FailedNonPd { proposal } → run_sir_core → covariance_status = SirFallback`. Every branch was unit-tested **in isolation** (the proposal builder, `resolve_covariance_status`, `select_fd_step`, and a Tier-2 *inert* test), but the api.rs glue that **decides whether to fire the fallback** and **wires the SIR result into the status** had no test. #264.

## What changed
Extracted that glue out of `fit_inner` and tested it at the seam:
- `should_run_sir_fallback(fallback_is_sir, has_covariance_matrix, normal_sir_ran, has_fallback_proposal) -> bool` — the pure gate.
- `resolve_sir_fallback(...) -> Option<SirResult>` — gate + cancel check + `run_sir_core` + the `"SIR fallback failed"` warning. `fit_inner`'s ~30-line inline block becomes one call.
- Tests: the gate exhaustively (fires iff opted-in + no real covariance + no normal SIR + a proposal present); a decline path (`covariance_fallback = none` → `None`, no warning, no SIR machinery touched); and a **slow firing test** — with a tame PD proposal on warfarin, `resolve_sir_fallback` runs SIR and returns finite θ/Ω/σ CIs + positive ESS, and the derived status is `SirFallback`.

## Alternatives considered
**A full `fit()` end-to-end test (the literal issue title) is not achievable and not worth faking:**
1. A real non-PD FD Hessian is unreachable through `fit()` — BOBYQA's budget is `outer_maxiter·(n+1) + 40·(n+1)`, so even `outer_maxiter = 0` runs a fixed `40·(n+1)` warmup and walks to the PD minimum. You can't park the optimizer on a concave point.
2. `FailedNonPd` requires the free-block Hessian to be negative-semidefinite in *every* direction (`invert_psd_with_floor` returns `None` only when `max_eig ≤ 0`) — a degenerate "minimum" that's hard to construct and arch-sensitive.
3. Even then, a wide fallback proposal makes SIR draws overflow `exp(...)` → `"all invalid weights"` → status `Failed`, not `SirFallback`. The two constraints (non-PD enough / SIR-survivable) may have no joint solution.

A **controlled tame proposal at the seam** exercises the same real wiring (`run_sir_core` + status) deterministically, without that brittleness. The matrix-level non-PD detection is already unit-tested, so the integration gap is fully closed.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None — `should_run_sir_fallback` / `resolve_sir_fallback` are private; no public API or output-field change.

## Numerical validation
- [x] Not applicable (test + internal refactor).

## Performance
- [x] No significant impact expected (pure extraction; identical runtime behaviour).

## Tests
- [x] Unit tests added in `api.rs` (`tests_sir_fallback`): gate logic (fast) + a slow-gated firing test (`--features slow-tests`).
- [x] No CHANGELOG entry — internal refactor + tests only (per CLAUDE.md).

## Reviewer hints
The firing test is slow-gated, so PR `Test` only **compiles** it — I'm running a Slow tests pass on the branch to confirm the tame proposal actually yields finite CIs (will link). The interesting question is just whether `resolve_sir_fallback` faithfully reproduces the old inline block (it does — same conditions, same warning, same `run_sir_core` call).
