### PR TITLE
ci(coverage): per-PR coverage gate + weekly 90% floor; gate ad::dual to autodiff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,12 @@ jobs:
             "https://codecov.io/api/v2/github/FeRx-NLME/repos/ferx-core/totals/" \
             | python3 -c "import json,sys; print(json.load(sys.stdin)['totals']['coverage'])" 2>/dev/null || true)
           if [ -z "${cov:-}" ]; then echo "no coverage figure; skipping nudge"; exit 0; fi
-          below=$(python3 -c "print('1' if float('$cov') < 90 else '0')")
-          existing=$(gh api "repos/$REPO/issues/$PR/comments" \
-            --jq "[.[] | select(.body | contains(\"$marker\"))][0].id" 2>/dev/null || true)
+          below=$(python3 -c "import sys; print('1' if float(sys.argv[1]) < 90 else '0')" "$cov")
+          # `// empty` so a no-match yields an empty string (-> POST a new
+          # comment) instead of the literal `null`; `--paginate` so the marker
+          # isn't missed past the first page of comments.
+          existing=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\"))][0].id // empty" 2>/dev/null || true)
           if [ "$below" = "1" ]; then
             body=$(printf '%s\n📉 **Coverage floor not yet met.** Project coverage is **%s%%**, below the **90%%** floor enforced on the weekly full-coverage run (see #286).\n\nThis PR is **not blocked**. If it adds code, please make sure the new lines are covered — the `patch` check (target 90%%) grades exactly your changed lines, and the Codecov report below shows the gaps. Thanks for helping clear the floor. 🙏' "$marker" "$cov")
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: cargo fmt -- --check
 
   coverage:
-    name: Coverage
+    name: Coverage (full, nightly)
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
@@ -137,9 +137,83 @@ jobs:
         # (mirrors the same flag in slow-tests.yml).
         run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,slow-tests --release --lcov --output-path lcov.info
 
-      - name: Upload to Codecov
+      - name: Upload to Codecov (slow flag)
         uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          flags: slow
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage-pr:
+    name: Coverage (fast, patch)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write # for the below-floor nudge comment
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Own cache key: the instrumented build can't share artifacts with the
+          # normal `ci` cache (different RUSTFLAGS).
+          shared-key: ci-cov
+      - name: Install cargo-llvm-cov
+        # Prebuilt binary (no compile) so the per-PR job stays fast.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate fast coverage report
+        # Fast tier only: `--features ci` (no `slow-tests`, no `survival`). This
+        # is the per-PR patch gate; the full `ci,slow-tests` run is nightly (the
+        # `coverage` job above). Runs in parallel with the other PR jobs and
+        # fits inside the existing Survival-job wall-clock, so PR feedback time
+        # is unchanged. `--tests` so the integration tests count (same rationale
+        # as the nightly job).
+        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --release --lcov --output-path lcov.info
+
+      - name: Upload to Codecov (fast flag)
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: fast
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Nudge the author while the project is below the floor
+        # Informational, non-blocking. If the project (full, slow-inclusive)
+        # coverage on `main` is below the 90% floor the weekly run enforces,
+        # post/update ONE sticky PR comment so the author is nudged to cover new
+        # lines. Self-resolves once the backfill clears 90%. Never fails the PR
+        # (continue-on-error); skipped on forks (read-only token).
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -u
+          marker='<!-- coverage-floor-nudge -->'
+          cov=$(curl -s --max-time 20 \
+            "https://codecov.io/api/v2/github/FeRx-NLME/repos/ferx-core/totals/" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['totals']['coverage'])" 2>/dev/null || true)
+          if [ -z "${cov:-}" ]; then echo "no coverage figure; skipping nudge"; exit 0; fi
+          below=$(python3 -c "print('1' if float('$cov') < 90 else '0')")
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\"))][0].id" 2>/dev/null || true)
+          if [ "$below" = "1" ]; then
+            body=$(printf '%s\n📉 **Coverage floor not yet met.** Project coverage is **%s%%**, below the **90%%** floor enforced on the weekly full-coverage run (see #286).\n\nThis PR is **not blocked**. If it adds code, please make sure the new lines are covered — the `patch` check (target 90%%) grades exactly your changed lines, and the Codecov report below shows the gaps. Thanks for helping clear the floor. 🙏' "$marker" "$cov")
+          else
+            body=$(printf '%s\n✅ Project coverage is at or above the 90%% floor — thanks for keeping it green!' "$marker")
+          fi
+          if [ -n "${existing:-}" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+          elif [ "$below" = "1" ]; then
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+          fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,98 @@
+# Coverage policy for ferx-core. Rule: CLAUDE.md. Work: #286. Discussion: #285.
+#
+# Sustainability model: coverage is enforced where it's fair, informational
+# where it isn't.
+#   patch                -> every PR's own changed lines must be tested (ENFORCED)
+#   project/default      -> per-PR no-regression context (informational, non-blocking)
+#   project/floor        -> per-PR 90% gap shown to the author (informational)
+#   project/floor_weekly -> 90% floor ENFORCED on the weekly main run (goes red
+#                           below 90%); never evaluated on PRs, so it blocks no one
+# Slow-tests NEVER run on PRs: per-PR upload = `fast` flag (--features ci);
+# nightly upload = `slow` flag (--features ci,slow-tests). carryforward lets the
+# nightly `slow` data augment the project number on PRs without re-running it.
+
+coverage:
+  range: 85..95
+  precision: 2
+  round: down
+  status:
+    project:
+      # Per-PR project statuses are INFORMATIONAL: they never block a
+      # contributor and never show a red X on a PR. (They also read low on a
+      # PR until carryforward is seeded, since the per-PR job is fast-only —
+      # another reason not to gate on them.) The teeth live on `patch` (per
+      # PR) and `floor_weekly` (the weekly main run).
+      #
+      # No-regression context, relative to base.
+      default:
+        target: auto
+        threshold: 0.5%
+        informational: true
+        flags:
+          - fast
+          - slow
+      # The explicit 90% gap, shown on every PR so the author sees how far
+      # under the floor they are — informational, so it challenges without
+      # gatekeeping.
+      floor:
+        target: 90%
+        threshold: 0%
+        informational: true
+        flags:
+          - fast
+          - slow
+      # The teeth: ENFORCED on the weekly full-coverage run on `main` only, so
+      # the project status genuinely goes RED there while we're below 90%.
+      # Never evaluated on PRs (branches: main), so it blocks no one. No later
+      # flip needed — it's enforcing now and turns green on its own once the
+      # backfill clears 90%.
+      floor_weekly:
+        target: 90%
+        threshold: 0%
+        informational: false
+        branches:
+          - main
+        flags:
+          - fast
+          - slow
+    patch:
+      default:
+        target: 90% # new/changed lines must be tested
+        threshold: 0%
+        flags:
+          - fast
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: fast
+      carryforward: false
+    - name: slow
+      carryforward: true
+
+comment:
+  layout: "header, diff, flags, files"
+  require_changes: true
+
+# Ignore policy: scope by what the code IS, never by how red it is.
+#   tests/**, build.rs        -> don't measure coverage OF test/build code.
+#   src/bin/generate_data.rs  -> maintainer tool that writes example-data
+#       fixtures; not library, not the user-facing CLI. Guarded at the right
+#       altitude by the e2e smoke test in tests/cli_binaries.rs. Ignorable on
+#       its role (would be even at 100%), not to pad the number.
+#
+# Deliberately NOT ignored:
+#   src/bin/run_model.rs      -> the `ferx` CLI (arg parsing, dispatch, error
+#       exits) is user-facing logic -> refactored into a lib run() and
+#       unit-tested, not excluded (#286).
+#
+# Handled at the source, not here:
+#   src/ad/dual.rs            -> autodiff-only infra. `pub mod dual` is gated
+#       behind feature="autodiff" (like the rest of ad/), so the FD-only `ci`
+#       coverage build no longer compiles or reports it. Re-enters measurement
+#       when the Enzyme coverage job lands (#281).
+ignore:
+  - "tests/**"
+  - "**/build.rs"
+  - "src/bin/generate_data.rs"

--- a/src/ad/mod.rs
+++ b/src/ad/mod.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "autodiff")]
 pub mod ad_gradients;
+#[cfg(feature = "autodiff")]
 pub mod dual;
 #[cfg(feature = "autodiff")]
 pub mod event_driven_ad;
 #[cfg(feature = "autodiff")]
 pub mod event_driven_ad_jac;
 
+#[cfg(feature = "autodiff")]
 pub use dual::Dual;


### PR DESCRIPTION
## Why

Coverage on `main` is **86.9%** and only measured weekly (schedule/manual) with **no PR enforcement** — nothing stops a PR adding untested lines, so the number drifts. This makes coverage a **per-PR gate** (enforced where fair, informational where not) plus a **weekly hard floor** — the sustainable mechanism agreed in #285 (Proposal C). Epic/backfill tracked in #286.

## What changed

**`codecov.yml`** (new):
- **`patch` ≥ 90% — ENFORCED.** A PR's own changed lines must be covered. The fair, scoped challenge to each author.
- **`project/default` (auto) + `project/floor` (90%) — INFORMATIONAL on PRs.** Never block a contributor; they surface the gap via the status + Codecov comment without gatekeeping (and read low until the `slow` flag is seeded, since the per-PR job is fast-only).
- **`project/floor_weekly` (90%, `branches: [main]`) — ENFORCED.** The weekly full-coverage run goes **red below 90%**; self-resolves once the backfill clears 90% (no manual flip).
- `fast` (per-PR) / `slow` (nightly) flags with carryforward.
- **Ignores scoped by role, not coverage %:** `generate_data` (fixture-generator dev tool, guarded by the `cli_binaries` smoke test) is ignored; `run_model` (user-facing CLI) deliberately is **not** — pending a `main()`→lib `run()` refactor (#286).

**`.github/workflows/ci.yml`:**
- Nightly `Coverage (full, nightly)` job → uploads the `slow` flag (`--features ci,slow-tests`).
- New PR-only `coverage-pr` job → `cargo llvm-cov --features ci` (fast tier; **no slow-tests, no survival**), uploads `fast` flag, prebuilt `cargo-llvm-cov`, runs in parallel within the existing ~8-min Survival wall-clock (no added PR latency).
- A **non-blocking sticky PR comment** that nudges the author when `main`'s project coverage is below the 90% floor (self-resolves over 90%; skipped on forks).

**`src/ad/mod.rs`:** gate `pub mod dual` + `pub use Dual` behind `feature = "autodiff"` — it is autodiff-only infra, unused in the FD-only `ci` build where it previously reported a misleading 0%. Re-enters measurement under #281.

## Alternatives considered

- **`ignore:` the binaries and `dual.rs` to lift the %** — rejected: that games the denominator, not coverage. Binaries get a real refactor (#286); `dual` is gated for scope-coherence, not to pad the number.
- **Full coverage (with slow-tests) per PR** — rejected: minutes-long, would slow PR feedback. Fast tier per-PR + nightly full keeps PRs fast.
- **`project auto` alone as the floor** — rejected: it's relative and its threshold permits slow drift below 90%; hence the explicit, absolute `project/floor_weekly`.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`ad::Dual` stays available in default (`autodiff`) builds, which is what ferx-r uses — no public-API change for its build.

## Breaking changes
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

`ad::Dual` is now `#[cfg(feature = "autodiff")]`. It remains available in every default build (autodiff is a default feature). Only the CI-internal `--no-default-features --features ci` build no longer exposes it, and nothing consumes it there.

</details>

## Numerical validation
- [x] Not applicable (CI / config only; the AD-module gating changes no numerics)

## Performance
- [x] No significant impact expected — `coverage-pr` runs in parallel and fits inside the existing Survival-job envelope; recent PR runs are ~8 min, bounded by Survival, not by the coverage job.

## Tests
- [x] No new tests needed (why: this change *is* test/coverage infrastructure + an AD-module `cfg` gate. The FD `ci` build was verified locally with `cargo check --no-default-features --features ci`.)

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry — N/A (CI / internal)
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — *CI verifies; the `ad/mod.rs` change is `cfg` attributes only.*
- [ ] `cargo check --features autodiff` still compiles — **cannot run locally or in CI (Enzyme unavailable; see #281).** Gating is logically sound: `dual` now compiles under `autodiff` alongside its only consumer `ad_gradients` (also `autodiff`-gated). FD-only `ci` build verified.
- [x] `Cargo.toml` version bump — not needed (no breaking change)

## Docs & examples

### ferx-site
- [x] No new DSL / fit option / example / data file — N/A

### ferx-book
- [x] No estimator / DSL / fit-option change — N/A

### Example execution
- [x] No example execution step needed (CI-only / no user-visible change)

## Reviewer hints

The substance is **`codecov.yml`** (the status model) and the **`coverage-pr`** job. Key design points:
- `patch` enforced (fair, scoped to the author's lines); project statuses **informational on PRs** (non-blocking); the floor enforced **only on the weekly `main` run**.
- **First-run caveat:** until the `slow` flag is seeded (one `workflow_dispatch` of `Coverage (full, nightly)` on `main`), per-PR project numbers read fast-only/low — harmless because those statuses are informational. The nudge comment uses the public Codecov API's `main` total, so it reports the accurate (slow-inclusive) figure regardless.
- The nudge step is `continue-on-error` + fork-guarded, so it can never fail a PR.

## Open questions

- OK to **seed the `slow` flag** by manually dispatching `Coverage (full, nightly)` right after merge, so per-PR carryforward is accurate from the next PR?
- Branch name is the worktree-generated `worktree-coverage-gate` — happy to rename to `ci/coverage-gate` if you prefer.
