### PR TITLE
feat(api): propensity-score-matched simulation for RWD VPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ section of the SDLC for the versioning policy).
   subject's observed dosing/sampling design is paired with a similar drawn eta.
   This corrects VPC bias from treatment adaptation in real-world data (longer
   intervals for high-clearance patients, etc.). Operates on observed data;
-  returns the usual simulation rows for the caller to build the VPC.
+  returns the usual simulation rows for the caller to build the VPC (#288).
 - New `importance_sampling_map` (alias `impmap`) estimation method: a Monte-Carlo
   EM estimator equivalent to NONMEM `METHOD=IMPMAP`. Each iteration re-centers a
   per-subject importance-sampling proposal on the conditional mode (MAP) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Propensity-score-matched simulation: `simulate_with_options()` with a new
+  `SimulateOptions { seed, propensity_match }`. When `propensity_match` is set,
+  each replicate's drawn etas are reassigned to subjects by optimal Mahalanobis
+  matching (under the model Ω) against the subjects' fitted (posthoc) etas, so a
+  subject's observed dosing/sampling design is paired with a similar drawn eta.
+  This corrects VPC bias from treatment adaptation in real-world data (longer
+  intervals for high-clearance patients, etc.). Operates on observed data;
+  returns the usual simulation rows for the caller to build the VPC.
 - New `importance_sampling_map` (alias `impmap`) estimation method: a Monte-Carlo
   EM estimator equivalent to NONMEM `METHOD=IMPMAP`. Each iteration re-centers a
   per-subject importance-sampling proposal on the conditional mode (MAP) and

--- a/docs/src/api/simulation.md
+++ b/docs/src/api/simulation.md
@@ -49,6 +49,90 @@ pub fn simulate_with_seed(
 ) -> Vec<SimulationResult>
 ```
 
+## `simulate_with_options()` — propensity-score matching
+
+Same outputs as `simulate()`, with options for a seed and for **propensity-score
+matching** of the simulated random effects.
+
+```rust
+pub fn simulate_with_options(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    n_sim: usize,
+    opts: &SimulateOptions,
+) -> Result<Vec<SimulationResult>, String>
+
+pub struct SimulateOptions {
+    pub seed: Option<u64>,        // None draws from entropy
+    pub propensity_match: bool,   // default false
+}
+```
+
+With `propensity_match = false` this is identical to `simulate_with_seed()` (or
+`simulate()` when `seed` is `None`).
+
+### Why match?
+
+In real-world data, therapy is often **adapted in response to a patient's own
+PK** — e.g. high-clearance patients are given longer dosing intervals or more
+frequent sampling. A standard VPC draws each subject's `eta` *independently* of
+its dosing/sampling design, so this design↔eta association is lost and the VPC
+can show spurious model misspecification even when the model is correct.
+
+Propensity-score matching restores the association. For each replicate:
+
+1. Draw a pool of `N` etas from \\( N(0, \Omega) \\) (`N` = number of subjects).
+2. **Optimally** match the `N` drawn etas 1:1 (without replacement) to the `N`
+   subjects' **fitted (posthoc) etas**, minimising the total **Mahalanobis**
+   distance under the model \\( \Omega \\):
+   \\( d^2(a,b) = (a-b)^\top \Omega^{-1} (a-b) \\)
+   (a linear assignment problem; mirrors `MatchIt(method = "optimal",
+   distance = "mahalanobis")`).
+3. Each subject keeps its own observed design but is simulated with the drawn
+   eta that matched its fitted eta — so a high-clearance draw lands on a subject
+   whose adaptive design reflects high clearance.
+
+The fitted etas are computed once via a posthoc (MAP) inner-loop pass over the
+observed `population` at `params`; only the drawn pool and the matching change
+across replicates.
+
+**Requires observed data**: every subject must carry observations (so its
+posthoc eta is defined). The function returns `Err` if the population is empty
+or any subject has no observations. The matching is the only correction applied;
+binning and plotting the VPC is left to the caller (e.g. the `vpc` R package).
+
+### Validation against R
+
+The matching numerics were cross-checked against R on a fixed 8-subject,
+2-eta scenario:
+
+- the Mahalanobis cost matrix matches R's `mahalanobis()` under Ω to `2e-11`;
+- ferx-core's optimal assignment is **identical** to two independent optimal
+  solvers — `clue::solve_LSAP` and `optmatch::pairmatch` (the engine
+  `MatchIt(method = "optimal")` uses) — with the same total cost to 10 dp.
+
+A direct `MatchIt(method = "optimal", distance = "mahalanobis")` call (as in the
+PAGE-poster workflow) returns a slightly different *pairing*, because MatchIt
+scales the Mahalanobis metric by the *empirical* covariance of the combined
+etas rather than the model Ω. The optimal-matching algorithm is the same
+(optmatch); only the metric differs, which is the documented modelling choice
+here (Ω is exact for draws from `N(0, Ω)` and needs no extra estimation).
+
+**Example:**
+```rust
+let pop = read_nonmem_csv(Path::new("rwd.csv"), None)?;   // observed data
+let fit = fit(&model, &pop, &model.default_params, &opts)?;
+
+// Recover the fitted ModelParameters (theta/Omega/sigma) from the result.
+let params = fitted_params_from_result(&fit, &model);
+let sims = simulate_with_options(
+    &model, &pop, &params, 200,
+    &SimulateOptions { seed: Some(42), propensity_match: true },
+)?;
+// → 200 replicates; build the pmVPC from `sims` as usual.
+```
+
 ## `predict()`
 
 Population predictions without random effects (eta = 0). No simulation noise is added.

--- a/plans/propensity-score-matched-simulation.md
+++ b/plans/propensity-score-matched-simulation.md
@@ -1,0 +1,154 @@
+# Plan: Simulate with propensity-score matching (`match` flag)
+
+## Goal
+
+Add a `match = true|false` (default `false`) argument to the simulation API. When
+`true`, each replicate's freshly drawn etas are **reassigned to subjects by
+propensity-score matching against the subjects' fitted (posthoc) etas**, instead
+of each subject simply using its own freshly drawn eta. This corrects VPC bias
+from treatment adaptation (interval/dose/sampling adaptation) in real-world data.
+
+Scope is intentionally narrow: **just the simulation numerics.** No VPC binning,
+no plotting, no new output dataset format — the caller (ferx-r / user) handles
+the VPC from the returned `Vec<SimulationResult>`.
+
+## Background / what "matched" means
+
+Reference: `~/projects/insightrx/vpc_and_rwd/README.md` and
+`R/example_poster_nonmem.R` (PAGE poster, Keizer/Bergstrand/Hughes).
+
+Per replicate `j` (current behaviour draws one eta per subject and simulates on
+that subject's own design):
+
+1. Draw `N` etas from `N(0, Ω)` (`N` = number of observed subjects) — the
+   "simulated subjects" pool.
+2. Match the `N` drawn etas (type 0) 1:1 to the `N` fitted etas (type 1) by
+   **optimal matching without replacement** using **Mahalanobis distance** in
+   eta-space (R script: `MatchIt::matchit(method="optimal", distance="mahalanobis")`).
+3. Each subject `i` (keeping its observed dosing + sampling design) is simulated
+   with the drawn eta that matched to subject `i`'s fitted eta — so e.g. a
+   high-CL draw lands on a subject whose adaptive design (longer interval)
+   reflects high CL.
+4. Simulate PK/(PD) + residual error as today.
+
+In ferx, `eta` is already the random-effect deviation (covariate effects live in
+the structural model, not in eta), so `fit_result.subjects[i].eta` /
+`find_ebe()` output is exactly the "ETA, not EBE" quantity the README wants.
+
+## Design decisions (defaults; flag-able later if needed)
+
+- **Matching metric: Ω-based Mahalanobis**, `d²(a,b) = (a−b)ᵀ Ω⁻¹ (a−b)`.
+  Principled (both pools are ~`N(0,Ω)`), deterministic, and free —
+  `params.omega.inv` is already precomputed (`OmegaMatrix.inv`). This differs
+  slightly from MatchIt's empirical-pooled-covariance default; we use the model
+  Ω. (Empirical pooled covariance could be added behind an option later.)
+- **Assignment: optimal (global min total cost)** via an in-repo Kuhn–Munkres
+  (Hungarian) solver — no new dependency. `N×N`, O(N³) per replicate; fine for
+  typical N (a few hundred). Replicates run independently (parallelizable).
+- **Match on BSV etas only** (length `n_eta`); IOV kappas excluded from matching.
+- **Fitted etas computed once** (they depend only on observed data + params, not
+  on the replicate) via the existing batch inner loop; only the drawn pool and
+  assignment change per replicate.
+- **`match` requires observed data** (subjects must carry `observations` to get
+  posthoc etas). The synthetic `[simulation]` block has no observed data, so the
+  flag lives on the **programmatic simulate API only**, not the DSL block. Calling
+  with `match=true` on a population without observations → `Err`.
+- **`match=false` path is left byte-for-byte unchanged** so existing seeded
+  simulations / regression tests reproduce exactly (same RNG draw order).
+
+## Implementation
+
+### 1. New module: `src/propensity_match.rs`
+- `fn mahalanobis_sq(a: &[f64], b: &[f64], omega_inv: &DMatrix<f64>) -> f64`.
+- `fn optimal_assignment(cost: &DMatrix<f64>) -> Vec<usize>` — Kuhn–Munkres on a
+  square cost matrix; returns, for each subject (column), the matched drawn-eta
+  row (or row→col; pick one orientation and document it).
+- `fn match_draws_to_fitted(pool: &[DVector<f64>], fitted: &[DVector<f64>], omega_inv) -> Vec<usize>`
+  — builds the cost matrix and returns subject→pool-index assignment.
+- Register `mod propensity_match;` in `src/lib.rs`.
+
+### 2. API surface in `src/api.rs`
+Introduce `SimulateOptions { seed: Option<u64>, propensity_match: bool }` and a
+single entry point, keeping existing functions as non-breaking wrappers:
+
+```rust
+pub struct SimulateOptions { pub seed: Option<u64>, pub propensity_match: bool }
+
+pub fn simulate_with_options(
+    model: &CompiledModel, population: &Population, params: &ModelParameters,
+    n_sim: usize, opts: &SimulateOptions,
+) -> Result<Vec<SimulationResult>, String>;
+
+// unchanged behaviour, delegate with propensity_match=false:
+pub fn simulate(...) -> Vec<SimulationResult>           // thread_rng
+pub fn simulate_with_seed(...) -> Vec<SimulationResult> // seeded
+```
+
+(`match` is a Rust keyword, so the field is `propensity_match`; ferx-r exposes it
+to R as `match`.)
+
+### 3. Matched path in the simulate core
+- When `propensity_match`:
+  - Compute fitted etas once: run the existing batch posthoc inner loop
+    (`estimation::inner_optimizer::run_inner_loop_warm`) over `population` with
+    `params` → `Vec<DVector<f64>>` of length `N` (BSV etas).
+  - Error if any subject has zero observations (no posthoc eta) or `N == 0`.
+  - Per replicate: draw `N` pool etas (`L·z`), call `match_draws_to_fitted`,
+    then for each subject `i` simulate with `pool[assignment[i]]` instead of a
+    per-subject fresh draw. Residual-error sampling unchanged.
+- When `!propensity_match`: call the existing `simulate_inner_with_draw`
+  untouched.
+
+### 4. ferx-r follow-up (separate PR, per CLAUDE.md)
+- `simulate_with_options` is a new `pub` API → bump `ferx-r` Cargo.lock via
+  `tools/update-ferx-core-lock.sh` and surface a `match` argument on the R
+  simulate wrapper. Note in PR.
+
+## Tests (per CLAUDE.md tiers)
+
+- **Tier 1 (unit, `src/propensity_match.rs`)**
+  - `optimal_assignment` vs brute-force min-cost permutation for small N
+    (e.g. N≤7), including ties and asymmetric costs.
+  - `mahalanobis_sq` against hand-computed values; identity-Ω reduces to squared
+    Euclidean.
+  - Degenerate check: if drawn pool == fitted etas, optimal assignment is the
+    identity permutation.
+- **Tier 2 (integration, `tests/`)** — `simulate_with_options(match=true)` on a
+  tiny 2–3 subject population returns `Ok` with the expected row count and finite
+  DVs; `match=true` on a population with no observations returns `Err`.
+- **Regression** — `simulate_with_seed` output is unchanged (matched path not
+  taken) for a fixed seed.
+
+## NONMEM / external comparison (per CLAUDE.md)
+
+The new numeric kernel is the *matching*, not an estimator. Validate the Rust
+optimal-Mahalanobis assignment against the R reference: dump a fixed set of
+observed etas + drawn etas + Ω, run `MatchIt::matchit(method="optimal",
+distance="mahalanobis")` (and the poster's NONMEM workflow), and confirm the Rust
+assignment reproduces the same matched pairs (or same total cost on ties). Record
+in the PR description / a short `docs/src` note.
+
+## Docs & changelog
+
+- `docs/src` — document the `match` simulate argument (a simulation/FAQ page; add
+  to `SUMMARY.md` if a new page). Explain the pmVPC use case and that matching
+  requires observed designs + fitted etas.
+- `CHANGELOG.md` `## [Unreleased]` → `Added`: propensity-score-matched simulation
+  (`match`) for VPCs on adaptively-dosed real-world data (`#NN`).
+
+## Files touched
+
+- `src/propensity_match.rs` (new) — Mahalanobis + Hungarian + match orchestration.
+- `src/lib.rs` — register module.
+- `src/api.rs` — `SimulateOptions`, `simulate_with_options`, matched branch.
+- `tests/*.rs` — integration test.
+- `docs/src/...` + `SUMMARY.md`, `CHANGELOG.md`.
+- (Follow-up) `ferx-r` — lock bump + R `match` argument.
+
+## Open questions for reviewer
+
+- Metric default: Ω-based Mahalanobis (proposed) vs MatchIt-style empirical
+  pooled covariance — OK to default to Ω and add empirical later?
+- Should `match=true` reuse `fit_result` etas when a `FitResult` is in hand
+  (faster) instead of always recomputing posthoc? Current plan recomputes for a
+  self-contained signature.

--- a/src/api.rs
+++ b/src/api.rs
@@ -4031,10 +4031,31 @@ pub fn simulate_with_options(
     }
 
     // Fitted (posthoc) BSV etas depend only on the observed data + params, so
-    // compute them once and reuse across replicates.
+    // compute them once and reuse across replicates. The inner-loop budget here
+    // is a self-contained MAP pass (this entry point takes no FitOptions); the
+    // tolerances only need to localize each EBE well enough to match on, not to
+    // reproduce a specific fit's inner settings.
     let (eta_hats, _h, _stats, _kappas) = crate::estimation::inner_optimizer::run_inner_loop_warm(
         model, population, params, 100, 1e-6, None, None, 1,
     );
+
+    // A divergent EBE can come back non-finite (`find_ebe` only gates its
+    // `converged` flag on a finite nll, not the returned eta). A NaN/Inf eta
+    // would poison the Mahalanobis cost matrix and make the optimal-assignment
+    // solver spin forever (NaN compares false against every candidate), so fail
+    // loudly here instead.
+    if let Some((i, _)) = eta_hats
+        .iter()
+        .enumerate()
+        .find(|(_, e)| e.iter().any(|x| !x.is_finite()))
+    {
+        return Err(format!(
+            "propensity-score matching: the posthoc eta for subject '{}' is \
+             non-finite (its EBE did not converge); cannot match",
+            population.subjects[i].id
+        ));
+    }
+
     let omega_inv = &params.omega.inv;
     Ok(simulate_inner_with_draw(
         model,

--- a/src/api.rs
+++ b/src/api.rs
@@ -3966,6 +3966,87 @@ pub fn simulate_with_seed(
     simulate_inner(model, population, params, n_sim, &mut rng)
 }
 
+/// Options controlling [`simulate_with_options`].
+#[derive(Debug, Clone, Default)]
+pub struct SimulateOptions {
+    /// Seed for reproducibility. `None` draws from entropy.
+    pub seed: Option<u64>,
+    /// When `true`, reassign each replicate's drawn etas to subjects by
+    /// **propensity-score matching** against the subjects' fitted (posthoc)
+    /// etas — optimal Mahalanobis matching under the model `Ω`. This restores
+    /// the design↔eta association present in adaptively-dosed real-world data
+    /// and corrects the resulting VPC bias (see [`crate::propensity_match`]).
+    ///
+    /// Requires `population` to be observed data: every subject must carry
+    /// observations so its posthoc eta can be computed. Has no effect for the
+    /// synthetic `[simulation]` block (no observed designs to match against).
+    pub propensity_match: bool,
+}
+
+/// Simulate observations, optionally with propensity-score matching.
+///
+/// With `opts.propensity_match == false` this is identical to
+/// [`simulate_with_seed`] (or [`simulate`] when `opts.seed` is `None`). With it
+/// `true`, the freshly drawn etas of each replicate are reassigned to subjects
+/// so each subject's observed design is paired with a drawn eta close (under the
+/// model `Ω` Mahalanobis metric) to that subject's fitted eta. The fitted
+/// (posthoc) etas are computed once from `params` + the observed `population`.
+///
+/// Returns `Err` if matching is requested but the population is empty or any
+/// subject has no observations.
+pub fn simulate_with_options(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    n_sim: usize,
+    opts: &SimulateOptions,
+) -> Result<Vec<SimulationResult>, String> {
+    use rand::SeedableRng;
+    let mut rng: rand::rngs::StdRng = match opts.seed {
+        Some(s) => rand::rngs::StdRng::seed_from_u64(s),
+        None => rand::rngs::StdRng::from_entropy(),
+    };
+
+    if !opts.propensity_match {
+        return Ok(simulate_inner_with_draw(
+            model, population, params, n_sim, 1, None, &mut rng,
+        ));
+    }
+
+    if population.subjects.is_empty() {
+        return Err(
+            "propensity-score matching requires a non-empty observed population".to_string(),
+        );
+    }
+    if let Some(s) = population
+        .subjects
+        .iter()
+        .find(|s| s.observations.is_empty())
+    {
+        return Err(format!(
+            "propensity-score matching requires observations for every subject \
+             (to compute posthoc etas); subject '{}' has none",
+            s.id
+        ));
+    }
+
+    // Fitted (posthoc) BSV etas depend only on the observed data + params, so
+    // compute them once and reuse across replicates.
+    let (eta_hats, _h, _stats, _kappas) = crate::estimation::inner_optimizer::run_inner_loop_warm(
+        model, population, params, 100, 1e-6, None, None, 1,
+    );
+    let omega_inv = &params.omega.inv;
+    Ok(simulate_inner_with_draw(
+        model,
+        population,
+        params,
+        n_sim,
+        1,
+        Some((&eta_hats, omega_inv)),
+        &mut rng,
+    ))
+}
+
 fn simulate_inner<R: rand::Rng>(
     model: &CompiledModel,
     population: &Population,
@@ -3973,15 +4054,80 @@ fn simulate_inner<R: rand::Rng>(
     n_sim: usize,
     rng: &mut R,
 ) -> Vec<SimulationResult> {
-    simulate_inner_with_draw(model, population, params, n_sim, 1, rng)
+    simulate_inner_with_draw(model, population, params, n_sim, 1, None, rng)
 }
 
+/// Emit all observation rows for one subject given a fully-formed `eta_slice`
+/// (length `n_eta + n_kappa`). Draws only residual epsilons from `rng`; the eta
+/// is supplied by the caller (freshly sampled, or propensity-matched).
+#[allow(clippy::too_many_arguments)]
+fn emit_subject_rows<R: rand::Rng>(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta_slice: &[f64],
+    draw: usize,
+    sim: usize,
+    normal: rand_distr::Normal<f64>,
+    rng: &mut R,
+    results: &mut Vec<SimulationResult>,
+) {
+    // Compute individual parameters
+    let pk_params = (model.pk_param_fn)(&params.theta, eta_slice, &subject.covariates);
+
+    // Predict concentrations
+    let ipreds = model_preds(model, subject, &pk_params, &params.theta, eta_slice);
+
+    // Add residual error (Gaussian path)
+    for (j, &ipred) in ipreds.iter().enumerate() {
+        let var = model.residual_variance_at(subject.obs_cmts[j], ipred, &params.sigma.values);
+        let eps: f64 = rng.sample(normal);
+        let value = ipred + var.sqrt() * eps;
+
+        results.push(SimulationResult {
+            draw,
+            sim,
+            id: subject.id.clone(),
+            // Raw data TIME (matches sdtab / input); `obs_times` may be
+            // the internal shifted clock for stacked reset occasions.
+            time: subject
+                .obs_raw_times
+                .get(j)
+                .copied()
+                .unwrap_or(subject.obs_times[j]),
+            cmt: subject.obs_cmts[j],
+            ipred,
+            outcome: SimOutcome::Continuous { value },
+        });
+    }
+
+    // TTE simulation path (requires survival feature)
+    #[cfg(feature = "survival")]
+    crate::survival::simulate_tte(
+        model,
+        subject,
+        &params.theta,
+        eta_slice,
+        draw,
+        sim,
+        rng,
+        results,
+    );
+}
+
+/// `matched`, when `Some((fitted_etas, omega_inv))`, reassigns each replicate's
+/// drawn etas to subjects by propensity-score matching against `fitted_etas`
+/// (optimal Mahalanobis matching under `omega_inv`; see `crate::propensity_match`).
+/// `None` is the standard per-subject independent draw and reproduces the
+/// previous behaviour byte-for-byte (same RNG draw order).
+#[allow(clippy::too_many_arguments)]
 fn simulate_inner_with_draw<R: rand::Rng>(
     model: &CompiledModel,
     population: &Population,
     params: &ModelParameters,
     n_sim: usize,
     draw: usize,
+    matched: Option<(&[DVector<f64>], &nalgebra::DMatrix<f64>)>,
     rng: &mut R,
 ) -> Vec<SimulationResult> {
     use rand_distr::Normal;
@@ -3992,56 +4138,58 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     let mut results = Vec::new();
 
     for sim_idx in 0..n_sim {
-        for subject in &population.subjects {
-            // Sample eta from N(0, Omega); append zero kappas for IOV models.
-            let z: Vec<f64> = (0..n_eta).map(|_| rng.sample(normal)).collect();
-            let z_vec = DVector::from_column_slice(&z);
-            let eta = &params.omega.chol * z_vec;
-            let mut eta_slice: Vec<f64> = eta.iter().copied().collect();
-            eta_slice.resize(n_eta + model.n_kappa, 0.0);
-
-            // Compute individual parameters
-            let pk_params = (model.pk_param_fn)(&params.theta, &eta_slice, &subject.covariates);
-
-            // Predict concentrations
-            let ipreds = model_preds(model, subject, &pk_params, &params.theta, &eta_slice);
-
-            // Add residual error (Gaussian path)
-            for (j, &ipred) in ipreds.iter().enumerate() {
-                let var =
-                    model.residual_variance_at(subject.obs_cmts[j], ipred, &params.sigma.values);
-                let eps: f64 = rng.sample(normal);
-                let value = ipred + var.sqrt() * eps;
-
-                results.push(SimulationResult {
-                    draw,
-                    sim: sim_idx + 1,
-                    id: subject.id.clone(),
-                    // Raw data TIME (matches sdtab / input); `obs_times` may be
-                    // the internal shifted clock for stacked reset occasions.
-                    time: subject
-                        .obs_raw_times
-                        .get(j)
-                        .copied()
-                        .unwrap_or(subject.obs_times[j]),
-                    cmt: subject.obs_cmts[j],
-                    ipred,
-                    outcome: SimOutcome::Continuous { value },
-                });
+        let sim = sim_idx + 1;
+        match matched {
+            Some((fitted, omega_inv)) => {
+                // Draw a pool of one eta per subject for this replicate, then
+                // reassign the draws to subjects by matching them to the fitted
+                // (posthoc) etas. Each subject keeps its own observed design.
+                let n = population.subjects.len();
+                let pool: Vec<DVector<f64>> = (0..n)
+                    .map(|_| {
+                        let z: Vec<f64> = (0..n_eta).map(|_| rng.sample(normal)).collect();
+                        &params.omega.chol * DVector::from_column_slice(&z)
+                    })
+                    .collect();
+                let assign =
+                    crate::propensity_match::match_draws_to_fitted(&pool, fitted, omega_inv);
+                for (i, subject) in population.subjects.iter().enumerate() {
+                    let mut eta_slice: Vec<f64> = pool[assign[i]].iter().copied().collect();
+                    eta_slice.resize(n_eta + model.n_kappa, 0.0);
+                    emit_subject_rows(
+                        model,
+                        subject,
+                        params,
+                        &eta_slice,
+                        draw,
+                        sim,
+                        normal,
+                        rng,
+                        &mut results,
+                    );
+                }
             }
-
-            // TTE simulation path (requires survival feature)
-            #[cfg(feature = "survival")]
-            crate::survival::simulate_tte(
-                model,
-                subject,
-                &params.theta,
-                &eta_slice,
-                draw,
-                sim_idx + 1,
-                rng,
-                &mut results,
-            );
+            None => {
+                for subject in &population.subjects {
+                    // Sample eta from N(0, Omega); append zero kappas for IOV models.
+                    let z: Vec<f64> = (0..n_eta).map(|_| rng.sample(normal)).collect();
+                    let z_vec = DVector::from_column_slice(&z);
+                    let eta = &params.omega.chol * z_vec;
+                    let mut eta_slice: Vec<f64> = eta.iter().copied().collect();
+                    eta_slice.resize(n_eta + model.n_kappa, 0.0);
+                    emit_subject_rows(
+                        model,
+                        subject,
+                        params,
+                        &eta_slice,
+                        draw,
+                        sim,
+                        normal,
+                        rng,
+                        &mut results,
+                    );
+                }
+            }
         }
     }
 
@@ -4108,6 +4256,7 @@ pub fn simulate_with_uncertainty(
             params,
             opts.n_sim_per_draw,
             k + 1,
+            None,
             &mut rng,
         );
         results.append(&mut rows);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod nn;
 pub mod ode;
 pub mod parser;
 pub mod pk;
+pub mod propensity_match;
 pub mod stats;
 pub mod suggest_start;
 #[cfg(feature = "survival")]
@@ -30,8 +31,8 @@ pub mod types;
 pub use api::{
     check_model_data, check_model_data_warnings, check_model_options, fit, fit_from_files, predict,
     run_from_file, run_model_simulate, run_model_with_data, run_model_with_data_inits, simulate,
-    simulate_with_seed, simulate_with_uncertainty, validate_model_file, PredictionResult,
-    SimulateUncertaintyOptions, SimulationResult,
+    simulate_with_options, simulate_with_seed, simulate_with_uncertainty, validate_model_file,
+    PredictionResult, SimulateOptions, SimulateUncertaintyOptions, SimulationResult,
 };
 pub use cancel::CancelFlag;
 pub use diagnostics::{CheckReport, Diagnostic, Severity};

--- a/src/propensity_match.rs
+++ b/src/propensity_match.rs
@@ -1,0 +1,258 @@
+//! Propensity-score matching of simulated random effects to fitted (posthoc)
+//! random effects, for VPCs on adaptively-dosed real-world data.
+//!
+//! Background: in real-world data, therapy is often adapted in response to a
+//! patient's own PK (e.g. longer dosing intervals for high-clearance patients).
+//! A standard VPC draws each subject's `eta` independently of its design, so the
+//! design↔eta association present in the observed data is lost and the VPC shows
+//! spurious misspecification. Propensity-score matching restores that
+//! association: per replicate, freshly drawn etas are reassigned to subjects so
+//! that each subject's *design* is paired with a drawn eta close (in eta-space)
+//! to that subject's *fitted* eta. See the PAGE poster "Visual Predictive Checks
+//! for Real-World Data using Propensity-Score Matching" (Keizer, Bergstrand,
+//! Hughes).
+//!
+//! The metric is the Mahalanobis distance under the model `Ω`,
+//! `d²(a,b) = (a−b)ᵀ Ω⁻¹ (a−b)`, and matching is **optimal** (global minimum of
+//! the total matched distance, i.e. the linear assignment problem) and 1:1
+//! without replacement, mirroring `MatchIt(method = "optimal")`.
+
+use nalgebra::{DMatrix, DVector};
+
+/// Squared Mahalanobis distance between two eta vectors under `Ω⁻¹`.
+///
+/// `omega_inv` must be `d × d` where `d == a.len() == b.len()`.
+pub fn mahalanobis_sq(a: &[f64], b: &[f64], omega_inv: &DMatrix<f64>) -> f64 {
+    let d = a.len();
+    debug_assert_eq!(b.len(), d);
+    debug_assert_eq!(omega_inv.nrows(), d);
+    debug_assert_eq!(omega_inv.ncols(), d);
+    let mut acc = 0.0;
+    for i in 0..d {
+        let di = a[i] - b[i];
+        // Symmetric quadratic form; accumulate over the full matrix.
+        let mut row = 0.0;
+        for j in 0..d {
+            row += omega_inv[(i, j)] * (a[j] - b[j]);
+        }
+        acc += di * row;
+    }
+    acc
+}
+
+/// Solve the square linear assignment problem: given an `n × n` cost matrix,
+/// return `assign` of length `n` where `assign[i] = j` pairs row `i` with
+/// column `j`, minimising `Σ_i cost[(i, assign[i])]`.
+///
+/// Uses the O(n³) Hungarian algorithm with potentials (Jonker–Volgenant-style
+/// shortest augmenting paths). Costs are finite `f64`; ties are broken
+/// arbitrarily but deterministically.
+pub fn optimal_assignment(cost: &DMatrix<f64>) -> Vec<usize> {
+    let n = cost.nrows();
+    assert_eq!(
+        cost.ncols(),
+        n,
+        "optimal_assignment requires a square matrix"
+    );
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // 1-indexed working arrays (index 0 is a sentinel), following the classic
+    // potentials formulation. `p[j]` is the row currently matched to column j.
+    let inf = f64::INFINITY;
+    let mut u = vec![0.0f64; n + 1];
+    let mut v = vec![0.0f64; n + 1];
+    let mut p = vec![0usize; n + 1];
+    let mut way = vec![0usize; n + 1];
+
+    for i in 1..=n {
+        p[0] = i;
+        let mut j0 = 0usize;
+        let mut minv = vec![inf; n + 1];
+        let mut used = vec![false; n + 1];
+        loop {
+            used[j0] = true;
+            let i0 = p[j0];
+            let mut delta = inf;
+            let mut j1 = 0usize;
+            for j in 1..=n {
+                if !used[j] {
+                    // cost is 0-indexed; working arrays are 1-indexed.
+                    let cur = cost[(i0 - 1, j - 1)] - u[i0] - v[j];
+                    if cur < minv[j] {
+                        minv[j] = cur;
+                        way[j] = j0;
+                    }
+                    if minv[j] < delta {
+                        delta = minv[j];
+                        j1 = j;
+                    }
+                }
+            }
+            for j in 0..=n {
+                if used[j] {
+                    u[p[j]] += delta;
+                    v[j] -= delta;
+                } else {
+                    minv[j] -= delta;
+                }
+            }
+            j0 = j1;
+            if p[j0] == 0 {
+                break;
+            }
+        }
+        // Augment along the alternating path.
+        loop {
+            let j1 = way[j0];
+            p[j0] = p[j1];
+            j0 = j1;
+            if j0 == 0 {
+                break;
+            }
+        }
+    }
+
+    // p[j] = row matched to column j; invert to row -> column.
+    let mut assign = vec![0usize; n];
+    for j in 1..=n {
+        assign[p[j] - 1] = j - 1;
+    }
+    assign
+}
+
+/// For each subject (indexed by `fitted`), pick the drawn pool index whose eta
+/// optimally matches the subject's fitted eta under the `Ω⁻¹` metric.
+///
+/// `pool` and `fitted` must have equal length `n`; the return value `assign`
+/// has length `n` with `assign[i]` the `pool` index assigned to subject `i`
+/// (a permutation of `0..n`).
+pub fn match_draws_to_fitted(
+    pool: &[DVector<f64>],
+    fitted: &[DVector<f64>],
+    omega_inv: &DMatrix<f64>,
+) -> Vec<usize> {
+    let n = fitted.len();
+    assert_eq!(pool.len(), n, "pool and fitted must have equal length");
+    // Rows = subjects (fitted), columns = drawn pool.
+    let mut cost = DMatrix::zeros(n, n);
+    for i in 0..n {
+        for j in 0..n {
+            cost[(i, j)] = mahalanobis_sq(fitted[i].as_slice(), pool[j].as_slice(), omega_inv);
+        }
+    }
+    optimal_assignment(&cost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Brute-force minimum-cost permutation for small n, for cross-checking.
+    fn brute_force(cost: &DMatrix<f64>) -> f64 {
+        let n = cost.nrows();
+        let mut idx: Vec<usize> = (0..n).collect();
+        let mut best = f64::INFINITY;
+        permute(&mut idx, 0, cost, &mut best);
+        best
+    }
+    fn permute(idx: &mut [usize], k: usize, cost: &DMatrix<f64>, best: &mut f64) {
+        let n = idx.len();
+        if k == n {
+            let total: f64 = (0..n).map(|i| cost[(i, idx[i])]).sum();
+            if total < *best {
+                *best = total;
+            }
+            return;
+        }
+        for s in k..n {
+            idx.swap(k, s);
+            permute(idx, k + 1, cost, best);
+            idx.swap(k, s);
+        }
+    }
+
+    fn total_cost(cost: &DMatrix<f64>, assign: &[usize]) -> f64 {
+        (0..assign.len()).map(|i| cost[(i, assign[i])]).sum()
+    }
+
+    #[test]
+    fn mahalanobis_identity_is_squared_euclidean() {
+        let omega_inv = DMatrix::identity(2, 2);
+        let d = mahalanobis_sq(&[1.0, 2.0], &[-1.0, 0.0], &omega_inv);
+        assert!((d - (4.0 + 4.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mahalanobis_diagonal_scales_each_axis() {
+        // Ω⁻¹ = diag(1/4, 1) ⇒ d² = (Δ0)²/4 + (Δ1)².
+        let omega_inv = DMatrix::from_diagonal(&DVector::from_vec(vec![0.25, 1.0]));
+        let d = mahalanobis_sq(&[2.0, 3.0], &[0.0, 0.0], &omega_inv);
+        assert!((d - (4.0 * 0.25 + 9.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn assignment_identity_when_diagonal_cheapest() {
+        // Cheapest to match i->i.
+        let cost = DMatrix::from_row_slice(3, 3, &[0.0, 5.0, 5.0, 5.0, 0.0, 5.0, 5.0, 5.0, 0.0]);
+        let a = optimal_assignment(&cost);
+        assert_eq!(a, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn assignment_finds_off_diagonal_optimum() {
+        // Optimal is the anti-diagonal (total 0), not the diagonal (total 3).
+        let cost = DMatrix::from_row_slice(3, 3, &[1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0]);
+        let a = optimal_assignment(&cost);
+        assert_eq!(total_cost(&cost, &a), 0.0);
+        assert_eq!(a, vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn assignment_matches_brute_force_on_varied_matrices() {
+        // A handful of deterministic, irregular matrices up to n = 7.
+        let sizes = [1usize, 2, 3, 4, 5, 6, 7];
+        for &n in &sizes {
+            let mut cost = DMatrix::zeros(n, n);
+            for i in 0..n {
+                for j in 0..n {
+                    // Deterministic pseudo-random-ish values with ties.
+                    let v = ((i * 7 + j * 3 + (i * j) % 5) % 11) as f64;
+                    cost[(i, j)] = v;
+                }
+            }
+            let a = optimal_assignment(&cost);
+            // Valid permutation.
+            let mut seen = vec![false; n];
+            for &j in &a {
+                assert!(!seen[j]);
+                seen[j] = true;
+            }
+            let got = total_cost(&cost, &a);
+            let want = brute_force(&cost);
+            assert!((got - want).abs() < 1e-9, "n={n}: got {got}, want {want}");
+        }
+    }
+
+    #[test]
+    fn matching_is_identity_when_pool_equals_fitted() {
+        // If the drawn pool equals the fitted etas, optimal matching is the
+        // identity (each subject gets its own value, distance 0).
+        let omega_inv = DMatrix::identity(2, 2);
+        let fitted = vec![
+            DVector::from_vec(vec![0.0, 0.0]),
+            DVector::from_vec(vec![1.5, -0.5]),
+            DVector::from_vec(vec![-2.0, 1.0]),
+        ];
+        let pool = fitted.clone();
+        let assign = match_draws_to_fitted(&pool, &fitted, &omega_inv);
+        assert_eq!(assign, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn empty_assignment() {
+        let cost = DMatrix::<f64>::zeros(0, 0);
+        assert!(optimal_assignment(&cost).is_empty());
+    }
+}

--- a/src/propensity_match.rs
+++ b/src/propensity_match.rs
@@ -27,15 +27,15 @@ pub fn mahalanobis_sq(a: &[f64], b: &[f64], omega_inv: &DMatrix<f64>) -> f64 {
     debug_assert_eq!(b.len(), d);
     debug_assert_eq!(omega_inv.nrows(), d);
     debug_assert_eq!(omega_inv.ncols(), d);
+    // Form the difference once, then evaluate the quadratic form diffᵀ Ω⁻¹ diff.
+    let diff: Vec<f64> = (0..d).map(|k| a[k] - b[k]).collect();
     let mut acc = 0.0;
     for i in 0..d {
-        let di = a[i] - b[i];
-        // Symmetric quadratic form; accumulate over the full matrix.
         let mut row = 0.0;
         for j in 0..d {
-            row += omega_inv[(i, j)] * (a[j] - b[j]);
+            row += omega_inv[(i, j)] * diff[j];
         }
-        acc += di * row;
+        acc += diff[i] * row;
     }
     acc
 }
@@ -53,6 +53,13 @@ pub fn optimal_assignment(cost: &DMatrix<f64>) -> Vec<usize> {
         cost.ncols(),
         n,
         "optimal_assignment requires a square matrix"
+    );
+    // Non-finite costs would make the shortest-path search never terminate (a
+    // NaN compares false against every candidate). Callers must screen them out
+    // (e.g. `simulate_with_options` rejects non-finite posthoc etas upstream).
+    debug_assert!(
+        cost.iter().all(|x| x.is_finite()),
+        "optimal_assignment requires all costs to be finite"
     );
     if n == 0 {
         return Vec::new();

--- a/tests/propensity_matched_sim.rs
+++ b/tests/propensity_matched_sim.rs
@@ -1,0 +1,211 @@
+//! Integration tests for propensity-score-matched simulation
+//! (`simulate_with_options` with `propensity_match = true`).
+//!
+//! The matching *math* (Mahalanobis + optimal assignment) is unit-tested in
+//! `src/propensity_match.rs`; these tests exercise the public-API wiring on a
+//! real compiled model: shape, finiteness, the error path, reproducibility of
+//! the unmatched path, and that the matched path is actually distinct.
+
+use ferx_core::{
+    parse_model_string, simulate_with_options, simulate_with_seed, DoseEvent, Population,
+    SimulateOptions, Subject,
+};
+use std::collections::HashMap;
+
+const MODEL: &str = r#"
+[parameters]
+  theta TVCL(8.66, 0.1, 150.0)
+  theta TVV(100.0, 1.0, 2000.0)
+  omega ETA_CL ~ 0.25
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.2 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV * exp(ETA_V)
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+fn template_population(n: usize) -> Population {
+    let grid = [0.5_f64, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0];
+    let subjects: Vec<Subject> = (1..=n)
+        .map(|i| {
+            // Phase-shift the (5-point) grid per subject so designs vary.
+            let times: Vec<f64> = (0..5).map(|j| grid[(i + j) % grid.len()]).collect();
+            let n_obs = times.len();
+            Subject {
+                id: format!("{i}"),
+                doses: vec![DoseEvent::new(0.0, 1000.0, 1, 0.0, false, 0.0)],
+                obs_times: times,
+                obs_raw_times: Vec::new(),
+                observations: vec![0.0; n_obs],
+                obs_cmts: vec![1; n_obs],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0; n_obs],
+                occasions: Vec::new(),
+                dose_occasions: Vec::new(),
+                #[cfg(feature = "survival")]
+                obs_records: vec![],
+            }
+        })
+        .collect();
+    Population {
+        subjects,
+        covariate_names: vec![],
+        dv_column: "dv".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+/// Fill in observations by simulating once from the true params, so the
+/// population looks like real observed data (needed for posthoc etas).
+fn observed_population(model: &ferx_core::types::CompiledModel, n: usize) -> Population {
+    let template = template_population(n);
+    let sim = simulate_with_seed(model, &template, &model.default_params, 1, 42);
+    let mut pop = template;
+    for subj in pop.subjects.iter_mut() {
+        subj.observations = sim
+            .iter()
+            .filter(|s| s.id == subj.id)
+            .map(|s| s.outcome.continuous_value().max(1e-6))
+            .collect();
+    }
+    pop
+}
+
+#[test]
+fn matched_simulation_has_expected_shape_and_finite_dvs() {
+    let model = parse_model_string(MODEL).expect("model parses");
+    let pop = observed_population(&model, 12);
+    let n_sim = 4;
+    let n_obs: usize = pop.subjects.iter().map(|s| s.obs_times.len()).sum();
+
+    let opts = SimulateOptions {
+        seed: Some(2024),
+        propensity_match: true,
+    };
+    let rows = simulate_with_options(&model, &pop, &model.default_params, n_sim, &opts)
+        .expect("matched simulation succeeds");
+
+    assert_eq!(rows.len(), n_obs * n_sim, "one row per obs per replicate");
+    assert!(rows
+        .iter()
+        .all(|r| r.outcome.continuous_value().is_finite()));
+    // Replicate indices span 1..=n_sim.
+    let mut sims: Vec<usize> = rows.iter().map(|r| r.sim).collect();
+    sims.sort_unstable();
+    sims.dedup();
+    assert_eq!(sims, (1..=n_sim).collect::<Vec<_>>());
+}
+
+#[test]
+fn matched_simulation_is_reproducible_and_distinct_from_unmatched() {
+    let model = parse_model_string(MODEL).expect("model parses");
+    let pop = observed_population(&model, 10);
+
+    let matched = SimulateOptions {
+        seed: Some(7),
+        propensity_match: true,
+    };
+    let a = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
+    let b = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
+    let dv = |rs: &[ferx_core::SimulationResult]| {
+        rs.iter()
+            .map(|r| r.outcome.continuous_value())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        dv(&a),
+        dv(&b),
+        "matched path must be reproducible under a seed"
+    );
+
+    // The matched path takes a different branch (pool draw + reassignment), so
+    // its output must differ from the unmatched path on the same seed.
+    let unmatched = SimulateOptions {
+        seed: Some(7),
+        propensity_match: false,
+    };
+    let c = simulate_with_options(&model, &pop, &model.default_params, 3, &unmatched).unwrap();
+    assert_ne!(dv(&a), dv(&c), "matched should differ from unmatched");
+}
+
+#[test]
+fn unmatched_options_path_equals_simulate_with_seed() {
+    let model = parse_model_string(MODEL).expect("model parses");
+    let pop = observed_population(&model, 8);
+
+    let opts = SimulateOptions {
+        seed: Some(99),
+        propensity_match: false,
+    };
+    let via_opts = simulate_with_options(&model, &pop, &model.default_params, 2, &opts).unwrap();
+    let via_seed = simulate_with_seed(&model, &pop, &model.default_params, 2, 99);
+
+    let dv = |rs: &[ferx_core::SimulationResult]| {
+        rs.iter()
+            .map(|r| r.outcome.continuous_value())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        dv(&via_opts),
+        dv(&via_seed),
+        "unmatched simulate_with_options must reproduce simulate_with_seed byte-for-byte"
+    );
+}
+
+#[test]
+fn matching_requires_observations() {
+    let model = parse_model_string(MODEL).expect("model parses");
+    // A subject with no observation records → posthoc eta undefined.
+    let obsless = Subject {
+        id: "1".into(),
+        doses: vec![DoseEvent::new(0.0, 1000.0, 1, 0.0, false, 0.0)],
+        obs_times: Vec::new(),
+        obs_raw_times: Vec::new(),
+        observations: Vec::new(),
+        obs_cmts: Vec::new(),
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: Vec::new(),
+        occasions: Vec::new(),
+        dose_occasions: Vec::new(),
+        #[cfg(feature = "survival")]
+        obs_records: vec![],
+    };
+    let pop = Population {
+        subjects: vec![obsless],
+        covariate_names: vec![],
+        dv_column: "dv".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    };
+
+    let opts = SimulateOptions {
+        seed: Some(1),
+        propensity_match: true,
+    };
+    let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
+        .expect_err("matching without observations must error");
+    assert!(
+        err.contains("observations"),
+        "error should mention the missing observations: {err}"
+    );
+}


### PR DESCRIPTION
## Why

Visual predictive checks built from **real-world data** are systematically biased
when therapy is adapted in response to a patient's own PK (e.g. high-clearance
patients given longer dosing intervals). A standard VPC draws each subject's
`eta` independently of its design, so the design↔eta association present in the
observed data is lost and the VPC shows spurious model misspecification even when
the model is correct. This implements the **propensity-score-matched VPC** (pmVPC)
correction from the PAGE poster *"Visual Predictive Checks for Real-World Data
using Propensity-Score Matching"* (Keizer, Bergstrand, Hughes), so the numerics
run on the Rust side and callers (ferx-r / the `vpc` package) just consume the
simulated rows.

## What changed

- New `simulate_with_options()` + `SimulateOptions { seed, propensity_match }`.
  With `propensity_match` set, each replicate draws an `N`-eta pool, **optimally
  matches** it 1:1 (Mahalanobis, without replacement) to the subjects' fitted
  (posthoc) etas, and simulates each subject's own observed design with its
  matched draw.
- New `src/propensity_match.rs`: Ω⁻¹ Mahalanobis distance + an in-repo
  Kuhn–Munkres (Hungarian) optimal linear-assignment solver (no new dependency).
- `simulate_inner_with_draw` refactored into a shared `emit_subject_rows` helper
  plus a matched/unmatched branch. The fitted etas + `Ω⁻¹` are computed once
  (via the existing inner loop) and reused across replicates; non-finite EBEs are
  rejected up front so a divergent posthoc eta can't hang the solver.
- `propensity_match = false` is **byte-for-byte identical** to `simulate_with_seed`
  (same RNG draw order); `simulate` / `simulate_with_seed` /
  `simulate_with_uncertainty` are unchanged.

## Alternatives considered

- **Metric** — model `Ω` Mahalanobis (chosen: principled since both pools are
  `~N(0,Ω)`, deterministic, `Ω⁻¹` already precomputed) vs MatchIt's empirical
  pooled covariance. Left as a possible future option.
- **ETA source** — recompute posthoc EBEs internally (chosen: self-contained,
  takes no `FitResult`) vs reuse `fit_result.subjects[i].eta`.
- **Matching** — optimal/Hungarian (chosen, mirrors `MatchIt(method="optimal")`)
  vs a cheaper rank pairing (dropped after discussion).
- **Surface** — programmatic API only. The synthetic `[simulation]` DSL block has
  no observed designs to match against, so the flag would be meaningless there.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#160 | open | after (CI needs this commit for the `Cargo.lock` bump) |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

> Additive only: new `pub` `simulate_with_options` / `SimulateOptions`. Existing
> simulate APIs keep their signatures and behaviour.

## Numerical validation

The new numeric kernel is the **matching**, validated against R on a fixed
8-subject / 2-eta scenario:

- [x] Compared against: R `mahalanobis()`, `clue::solve_LSAP`,
  `optmatch::pairmatch` (the engine `MatchIt(method="optimal")` uses), and a
  literal `MatchIt(method="optimal", distance="mahalanobis")` call.
- [x] Reference values:

```
max |cost_R - cost_rust| under Ω        = 2.2e-11   (validates mahalanobis_sq)
clue::solve_LSAP    assignment           = 2 5 6 4 8 7 1 3   total cost 16.8857815075
optmatch::pairmatch assignment           = 2 5 6 4 8 7 1 3   (identical)
ferx-core           assignment           = 2 5 6 4 8 7 1 3   total cost 16.8857815075  ✓

MatchIt(optimal, mahalanobis) assignment = 4 1 6 7 2 3 8 5   (differs: MatchIt scales by the
  empirical covariance, not Ω — the documented metric choice; same optimal-matching engine)
```

## Performance
- [x] No significant impact expected (existing paths unchanged; unmatched path
  byte-identical).
- Matched path adds an `O(n³)` assignment per replicate (`O(n_sim·n³)` total,
  single-threaded). Fitted etas / `Ω⁻¹` are hoisted out of the replicate loop.
  Per-replicate rayon parallelisation is a deliberate follow-up (it would change
  RNG consumption and break the seeded-reproducibility guarantee).

## Tests
- [x] Unit tests added (`src/propensity_match.rs`): Mahalanobis values, optimal
  assignment vs brute force up to n=7, identity/degenerate cases (7 tests).
- [x] Regression test added: `simulate_with_options(match=false)` reproduces
  `simulate_with_seed` byte-for-byte; matched path reproducible and distinct;
  error path when a subject has no observations (`tests/propensity_matched_sim.rs`).

## Example (user-facing features only)
- [x] Not applicable (no new `.ferx` syntax). Programmatic API example in
  `docs/src/api/simulation.md`:

```rust
let pop  = read_nonmem_csv(Path::new("rwd.csv"), None)?;        // observed data
let fit  = fit(&model, &pop, &model.default_params, &opts)?;
let params = fitted_params_from_result(&fit, &model);
let sims = simulate_with_options(
    &model, &pop, &params, 200,
    &SimulateOptions { seed: Some(42), propensity_match: true },
)?;  // 200 replicates → build the pmVPC from `sims`
```

## Docs
- [x] `docs/src/api/simulation.md` updated (new section + R-validation note)
- [x] No new pages (existing page, no `SUMMARY.md` change)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo +nightly clippy` clean on the changed files
- [x] Not AD-reachable — the change is on the simulation path, not the
  gradient/AD path; `cargo check --features autodiff` unaffected
- [x] No version bump (additive, non-breaking)

## Docs & examples

### ferx-site / ferx-book
- [x] No new `.ferx` DSL syntax / `[fit_options]` key
- [x] No new example `.ferx` file or `data/` file
- [x] No estimator / DSL / fit-option change for the book

### Example execution
- [x] No example execution step needed (programmatic API; no user-visible DSL /
  example / data change). ferx-r glue was `cargo check`-verified against this
  branch; full `R CMD INSTALL` is deferred to the ferx-r PR after this merges.

## Reviewer hints

Focus on `src/propensity_match.rs` (the Hungarian solver — cross-checked exactly
against `clue`/`optmatch`) and the matched branch in `simulate_inner_with_draw`
(`src/api.rs`) — the key invariant is that the **unmatched** path keeps the exact
prior RNG draw order, which is covered by the byte-for-byte regression test.

## Open questions

- Default metric is model `Ω`; happy to add an empirical-covariance option to
  match MatchIt exactly if reviewers prefer.
- Per-replicate rayon parallelisation intentionally deferred (RNG/reproducibility
  implications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
