### PR TITLE
ci(build): no-LTO ci-test profile to speed up Test/Survival/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
-      # `--release` pays an extra ~3-5 min compile vs default once, then runs
-      # the population-fit tests (SDE, IOV, FOCEI, GN-hybrid) 5-10× faster.
-      # Net: replaces the >80 min debug test wall with a single-digit-minute
-      # release wall on average.
+      # `--profile ci-test` keeps release-level optimisation (population-fit
+      # tests — SDE, IOV, FOCEI, GN-hybrid — run 5-10× faster than debug) but
+      # drops fat LTO, whose whole-program link dominated these jobs. Net:
+      # avoids the >80 min debug wall without paying the LTO compile tax.
       - name: cargo test
-        run: cargo test --lib --no-default-features --features ci --release
+        run: cargo test --lib --no-default-features --features ci --profile ci-test
 
       # The NONMEM-anchored per-(ID,OCC) CL cross-check for IOV (issue #238)
       # lives in an integration test, which `--lib` above does not build or run.
@@ -59,7 +59,7 @@ jobs:
       # convergence loop, sub-second — and self-contained (reference fixture
       # committed at tests/nonmem/warfarin_iov_cl_reference.csv).
       - name: cargo test (NONMEM IOV CL cross-check, issue #238)
-        run: cargo test --test warfarin_iov_nonmem --no-default-features --features ci --release
+        run: cargo test --test warfarin_iov_nonmem --no-default-features --features ci --profile ci-test
 
   survival:
     name: Survival (TTE)
@@ -78,7 +78,7 @@ jobs:
       # `tte_smoke` integration tests are Tier-2 (a handful of outer iterations),
       # so `--tests` stays fast.
       - name: cargo test (survival)
-        run: cargo test --tests --no-default-features --features ci,survival --release
+        run: cargo test --tests --no-default-features --features ci,survival --profile ci-test
 
   clippy:
     name: Clippy
@@ -135,7 +135,7 @@ jobs:
         # `--no-fail-fast` so a single test-binary failure doesn't abort
         # cargo's run and silently drop coverage from every later binary
         # (mirrors the same flag in slow-tests.yml).
-        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,slow-tests --release --lcov --output-path lcov.info
+        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,slow-tests --profile ci-test --lcov --output-path lcov.info
 
       - name: Upload to Codecov (slow flag)
         uses: codecov/codecov-action@v7
@@ -171,11 +171,11 @@ jobs:
       - name: Generate fast coverage report
         # Fast tier only: `--features ci` (no `slow-tests`, no `survival`). This
         # is the per-PR patch gate; the full `ci,slow-tests` run is nightly (the
-        # `coverage` job above). Runs in parallel with the other PR jobs and
-        # fits inside the existing Survival-job wall-clock, so PR feedback time
-        # is unchanged. `--tests` so the integration tests count (same rationale
-        # as the nightly job).
-        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --release --lcov --output-path lcov.info
+        # `coverage` job above). Runs in parallel with the other PR jobs and,
+        # like them, builds with `--profile ci-test` (no fat LTO), so it stays
+        # within the PR wall-clock. `--tests` so the integration tests count
+        # (same rationale as the nightly job).
+        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --profile ci-test --lcov --output-path lcov.info
 
       - name: Upload to Codecov (fast flag)
         uses: codecov/codecov-action@v7

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -42,7 +42,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci-slow
-      - name: cargo test (release + slow-tests)
+      - name: cargo test (ci-test profile + slow-tests)
+        # `--profile ci-test` (defined in Cargo.toml) keeps release-level
+        # optimisation so the heavy fits run fast, but drops fat LTO — the
+        # whole-program link tax that otherwise dominates this build.
+        #
         # `--lib` is intentionally omitted so integration tests in `tests/`
         # are compiled and run here. Gated slow tests (the `slow-tests` feature
         # removes their `#[ignore]`) and ungated integration tests both execute.
@@ -51,4 +55,4 @@ jobs:
         # fails. Without it, cargo aborts at the first failed binary and the
         # remaining ~15 integration-test binaries (alphabetically after the
         # failing one) silently never run, masking concurrent regressions.
-        run: cargo test --no-default-features --features ci,slow-tests --release --no-fail-fast
+        run: cargo test --no-default-features --features ci,slow-tests --profile ci-test --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,11 @@ approx = "0.5"
 
 [profile.release]
 lto = "fat"
+
+# Used by the CI test/coverage jobs: release-level optimisation (so the
+# population-fit tests stay fast) but NO fat LTO, whose whole-program link
+# dominated the Test/Survival/coverage jobs (the ~8 min Survival job was ~96%
+# LTO compile, ~20 s of actual tests). The shipped `release` keeps `lto = "fat"`.
+[profile.ci-test]
+inherits = "release"
+lto = false


### PR DESCRIPTION
## Why

The `Survival (TTE)` job is the long pole on PR CI at **~8m23s** — but step-level timing shows **~96% of that is compilation and only ~20s is the tests** (9.91s for the 991 lib unit tests + ~10s across the integration binaries). The cost is `[profile.release] lto = "fat"` combined with `--tests`: every integration-test binary (~38 of them) gets a whole-program fat-LTO link, on a 2-core runner. LTO buys nothing for correctness tests that run once.

## What changed

- **`Cargo.toml`:** add `[profile.ci-test]` — `inherits = "release"`, `lto = false`. Keeps `opt-level = 3` (so the population-fit tests stay fast, which is the *actual* reason `--release` was used) but drops the fat-LTO link tax. The shipped `release` profile is untouched (still `lto = "fat"`).
- **`.github/workflows/ci.yml`:** switch the five `--release` test/coverage invocations to `--profile ci-test` — `Test` (both steps: `--lib` and the NONMEM IOV cross-check), `Survival`, the nightly `Coverage`, and `coverage-pr`.

## Alternatives considered

- **Drop `--release` entirely (debug) on Survival** — rejected: the job also runs the 991 lib unit tests, some of which are population fits that are 5-10× slower in debug. `ci-test` keeps opt-level, so those stay fast.
- **`lto = "thin"`** — still much slower to compile than `false`, and tests don't need any LTO. `false` is the right call for a test profile.
- **Narrow Survival to `--test tte_smoke`** (compile fewer binaries) — rejected for now: it trades away the feature-interaction coverage of running the whole suite with `survival` on. Reachable later if more speed is needed.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Custom profiles are inert unless invoked with `--profile`; no effect on ferx-r or the shipped artifact.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable to behaviour — **but** dropping LTO changes cross-crate inlining/FMA, so floating-point results shift at the ULP level. The NONMEM-anchored tests (`warfarin_iov_nonmem`, the `compartment_states_nonmem` / covariance suites) are tolerance-based and should absorb it. **This PR's own CI run is the validation** — if a tight assertion trips, that's the signal.

## Performance
- [x] **Faster (this is the point).** Expected: `Survival` ~8m → ~3m-ish, `Test` ~2m → ~1m, `coverage-pr` faster too (so it can't become the new PR pole once Survival shrinks). Real before/after will be in this PR's run vs `main`.

## Tests
- [x] No new tests (CI build-profile change). The existing suite — especially the NONMEM-anchored tests — is the validation that no-LTO doesn't perturb results past tolerance.

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] `CHANGELOG.md` — N/A (CI / internal; no user-facing change)
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — *CI verifies; no source touched.*
- [x] `cargo check --features autodiff` — N/A (no AD-reachable code touched)
- [x] `Cargo.toml` version bump — not needed

## Docs & examples
- [x] No DSL / fit-option / example / data change — all N/A

## Reviewer hints

- Profile only affects CI; the **shipped `release` stays fat-LTO**.
- The two things to eyeball: (1) the FP/tolerance caveat above — watch the NONMEM-anchored jobs in this run; (2) **coverage is re-measured under `ci-test`** (no LTO → less inlining → if anything slightly more accurate line attribution). That's a one-time baseline shift; doing it now is clean because the gate's `slow` flag isn't seeded yet.
- `cargo`/`cargo-llvm-cov` both accept `--profile <name>`; manifest validated with `cargo metadata`.

## Open questions

- Comfortable re-baselining **coverage** under `ci-test` (I switched both coverage jobs for fast/slow consistency and to keep `coverage-pr` fast), or would you rather keep the coverage jobs on `--release` and only speed up `Test`/`Survival`?
