### PR TITLE
test(io,bin): cover data-reader error paths + CLI check subcommand

### DIFF
--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -350,7 +350,7 @@ fn parse_inits_from_nca_flag(args: &[String]) -> Result<Option<NcaInit>, String>
 mod tests {
     use super::{
         parse_check_args, parse_inits_from_nca_flag, parse_output_flag, parse_threads_flag,
-        run_check, CheckArgsError,
+        print_check_human, run_check, CheckArgsError,
     };
     use ferx_core::NcaInit;
 
@@ -527,5 +527,36 @@ mod tests {
         let bad_path = bad.to_str().unwrap();
         assert_eq!(run_check(&args(&["check", bad_path])), 1);
         assert_eq!(run_check(&args(&["check", bad_path, "--json"])), 1);
+    }
+
+    #[test]
+    fn print_check_human_covers_all_diagnostic_shapes() {
+        // Drive `print_check_human` directly over diagnostics that hit every arm:
+        // both severities, all three `loc` shapes (block+line / block-only /
+        // none), and suggestion present/absent — branches the model-file fixtures
+        // above don't deterministically reach.
+        use ferx_core::{CheckReport, Diagnostic};
+        let invalid = CheckReport::new(
+            "m.ferx",
+            Some("d.csv".to_string()),
+            vec![
+                Diagnostic::warning("W_X", "a warning")
+                    .with_block("error_model")
+                    .with_line(7)
+                    .with_suggestion("try this instead"),
+                Diagnostic::error("E_Y", "block-scoped error").with_block("odes"),
+                Diagnostic::error("E_Z", "locationless error"),
+            ],
+        );
+        // Must not panic; output is captured by the test harness.
+        print_check_human(&invalid);
+        assert!(!invalid.valid);
+        assert_eq!(invalid.error_count(), 2);
+        assert_eq!(invalid.warning_count(), 1);
+
+        // A clean report exercises the valid-summary branch through the same printer.
+        let ok = CheckReport::new("m.ferx", None, vec![]);
+        print_check_human(&ok);
+        assert!(ok.valid);
     }
 }

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -350,7 +350,7 @@ fn parse_inits_from_nca_flag(args: &[String]) -> Result<Option<NcaInit>, String>
 mod tests {
     use super::{
         parse_check_args, parse_inits_from_nca_flag, parse_output_flag, parse_threads_flag,
-        CheckArgsError,
+        run_check, CheckArgsError,
     };
     use ferx_core::NcaInit;
 
@@ -473,5 +473,59 @@ mod tests {
             parse_check_args(&args(&["check", "model.ferx", "--data", "--json"])),
             Err(CheckArgsError::MissingDataValue)
         );
+    }
+
+    // ── run_check: in-process coverage of the `check` subcommand ──────────────
+    // `run_check` (and, through it, `print_check_human`) is otherwise exercised
+    // only by the `cli_binaries.rs` end-to-end tests, which spawn `ferx` as a
+    // child process — coverage the instrumented build does not capture. Driving
+    // it in-process with absolute fixture paths (so CWD is irrelevant) registers
+    // the coverage and pins the documented exit-code contract: 0 = valid,
+    // 1 = errors found, 2 = usage / bad arguments.
+
+    const VALID_MODEL: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/one_cpt_iv.ferx");
+    const VALID_DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/data/one_cpt_iv.csv");
+
+    #[test]
+    fn run_check_usage_errors_return_2() {
+        // No model path, and a flag where the model should be — both usage (2).
+        assert_eq!(run_check(&args(&["check"])), 2);
+        assert_eq!(run_check(&args(&["check", "--json"])), 2);
+    }
+
+    #[test]
+    fn run_check_missing_data_value_returns_2() {
+        assert_eq!(run_check(&args(&["check", VALID_MODEL, "--data"])), 2);
+    }
+
+    #[test]
+    fn run_check_valid_model_human_and_json_return_0() {
+        // A clean example model has no errors → valid → 0. Covers both the human
+        // (`print_check_human`) and `--json` (serde) rendering branches.
+        assert_eq!(run_check(&args(&["check", VALID_MODEL])), 0);
+        assert_eq!(run_check(&args(&["check", VALID_MODEL, "--json"])), 0);
+    }
+
+    #[test]
+    fn run_check_with_data_runs_data_path_without_usage_error() {
+        // 0 (valid) or 1 (data-dependent findings) — never 2. Exercises the
+        // data-dependent branch of `validate_model_file`.
+        assert_ne!(
+            run_check(&args(&["check", VALID_MODEL, "--data", VALID_DATA])),
+            2
+        );
+    }
+
+    #[test]
+    fn run_check_invalid_model_returns_1() {
+        // An unparseable model → errors → invalid → 1. Covers the invalid-summary
+        // and error-diagnostic branches of `print_check_human`, plus `--json` on
+        // an invalid report.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bad = dir.path().join("bad.ferx");
+        std::fs::write(&bad, "this is not a valid ferx model\n").expect("write bad model");
+        let bad_path = bad.to_str().unwrap();
+        assert_eq!(run_check(&args(&["check", bad_path])), 1);
+        assert_eq!(run_check(&args(&["check", bad_path, "--json"])), 1);
     }
 }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1308,6 +1308,86 @@ mod tests {
         f
     }
 
+    // ── "no happy paths": malformed-input rejection ──────────────────────────
+    // The reader's validation surface — branches where a bug silently corrupts
+    // (or crashes on) real NONMEM datasets. All deterministic and fit-free:
+    // feed malformed CSV, assert the exact error or warning. These error paths
+    // are otherwise exercised only indirectly, if at all.
+
+    #[test]
+    fn missing_required_columns_are_rejected() {
+        // ID / TIME / DV are mandatory; each missing one is a hard error that
+        // names the absent column.
+        let f = write_csv("TIME,DV,EVID,AMT\n0,.,1,100\n");
+        let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
+        assert!(err.contains("Missing ID column"), "{err}");
+
+        let f = write_csv("ID,DV,EVID,AMT\n1,.,1,100\n");
+        let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
+        assert!(err.contains("Missing TIME column"), "{err}");
+
+        let f = write_csv("ID,TIME,EVID,AMT\n1,0,1,100\n");
+        let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
+        assert!(err.contains("Missing DV column"), "{err}");
+    }
+
+    #[test]
+    fn unknown_iov_column_is_rejected() {
+        // A requested IOV column that isn't in the header is a hard error, not a
+        // silent "no occasions" — otherwise an IOV model would quietly collapse.
+        let f = write_csv("ID,TIME,DV,EVID,AMT\n1,0,.,1,100\n1,1,5.0,0,.\n");
+        let err = read_nonmem_csv(f.path(), None, Some("OCC")).unwrap_err();
+        assert!(
+            err.contains("iov_column 'OCC'") && err.contains("not found"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn declared_covariate_column_missing_is_rejected() {
+        // `[covariates]` declares WT but the dataset has no WT column → hard
+        // error (a silently-vanished covariate would evaluate to nothing).
+        let f = write_csv("ID,TIME,DV,EVID,AMT\n1,0,.,1,100\n1,1,5.0,0,.\n");
+        let decls = vec![CovariateDecl {
+            name: "WT".to_string(),
+            kind: CovariateKind::Continuous,
+        }];
+        let err = read_nonmem_csv_with_covariates(f.path(), &decls, &[], None).unwrap_err();
+        assert!(err.contains(ERR_COV_MISSING_COLUMNS), "{err}");
+        assert!(err.contains("WT"), "missing column should be named: {err}");
+    }
+
+    #[test]
+    fn declared_covariate_non_numeric_value_is_rejected() {
+        // A declared covariate must be numerically coded; a text value is a hard
+        // error rather than a silent 0.0 that would bias the fit.
+        let f = write_csv("ID,TIME,DV,EVID,AMT,WT\n1,0,.,1,100,heavy\n1,1,5.0,0,.,heavy\n");
+        let decls = vec![CovariateDecl {
+            name: "WT".to_string(),
+            kind: CovariateKind::Continuous,
+        }];
+        let err = read_nonmem_csv_with_covariates(f.path(), &decls, &[], None).unwrap_err();
+        assert!(err.contains(ERR_COV_NON_NUMERIC), "{err}");
+        assert!(
+            err.contains("WT"),
+            "offending covariate should be named: {err}"
+        );
+    }
+
+    #[test]
+    fn unparseable_iov_occasion_values_warn_not_fail() {
+        // A non-numeric occasion value doesn't abort the read: the row is
+        // assigned occ=0 and surfaced as a W_IOV_OCC_MISSING population warning
+        // so the user can clean the data (a hard error here would be too brittle).
+        let f = write_csv("ID,TIME,DV,EVID,AMT,OCC\n1,0,.,1,100,x\n1,1,5.0,0,.,x\n");
+        let pop = read_nonmem_csv(f.path(), None, Some("OCC")).unwrap();
+        assert!(
+            pop.warnings.iter().any(|w| w.contains("W_IOV_OCC_MISSING")),
+            "expected an IOV-occasion warning, got {:?}",
+            pop.warnings
+        );
+    }
+
     #[test]
     fn test_obs_cmt_dot_defaults_to_compartment_one() {
         // Regression: a "." (missing) CMT on an observation row must default to


### PR DESCRIPTION
## Why

#286 backfill, "no happy paths" slice. After #290's no-LTO measurement fix the project is already at **90.48%** (the old 86.9% was a fat-LTO attribution artifact), so this is **robustness-first**: it covers the deterministic, fit-free *failure* surfaces where a bug silently corrupts — or crashes on — real input. Buffer over the thin 0.48% floor margin is a side effect, not the goal.

## What changed (tests only, no behavior change)

**`src/io/datareader.rs`** — malformed-NONMEM-CSV rejection (the data-input failure surface, 32 `Err`/warning sites):
- missing required `ID` / `TIME` / `DV` column → named hard error
- unknown `iov_column` → hard error (not a silent "no occasions")
- `[covariates]`-declared column absent from data → hard error (`ERR_COV_MISSING_COLUMNS`)
- declared covariate with a non-numeric value → hard error (`ERR_COV_NON_NUMERIC`), not a silent `0.0`
- unparseable IOV occasion value → `W_IOV_OCC_MISSING` population *warning* (lenient path), asserted via `Population.warnings`

**`src/bin/run_model.rs`** — in-process `run_check` tests for the `check` subcommand (and, through it, `print_check_human`): usage→2, invalid model→1, valid→0, plus `--json` and `--data`. These paths are otherwise reached only by `cli_binaries.rs` as a **subprocess**, whose coverage the instrumented build doesn't capture; driving them in-process with **absolute** fixture paths (so CWD is irrelevant — the exact thing that broke the subprocess coverage) registers it.

## Alternatives considered

- **`output.rs`** (was the headline 28% gap) — skipped: under no-LTO it's already **93.5%**; the 28% was a fat-LTO artifact.
- **`outer_optimizer` / `gauss_newton` / `saem`** (the largest missed-line counts) — skipped: their uncovered branches are *fit-triggered* fallbacks (line-search failure, non-PD damping, non-convergence), reachable only through a fit → Tier-3 slow-tests territory, not fast deterministic unit work.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (tests only; no estimation/output code changed)

## Performance
- [x] No impact — all new tests are fit-free and run in milliseconds (fast tier)

## Tests
- [x] Unit tests added in the same modules. Deterministic, fit-free; assert exact error/warning substrings read from the source. `cargo check --tests --no-default-features --features ci` passes; `cargo +nightly fmt` clean.

## Example (user-facing features only)
- [x] Not applicable (internal / tests)

## Docs
- [x] `CHANGELOG.md` — N/A (tests only, no user-facing change)
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — *CI verifies.*
- [x] `cargo check --features autodiff` — N/A (no AD-reachable code touched)
- [x] `Cargo.toml` version bump — not needed

## Docs & examples
- [x] No DSL / fit-option / example / data change — all N/A

## Reviewer hints

- The assertions match **literal** error/warning strings from the source (`Missing ID column`, the `ERR_COV_*` consts, `W_IOV_OCC_MISSING`), so they're tight but not brittle.
- `run_check` tests use `concat!(env!("CARGO_MANIFEST_DIR"), …)` absolute paths → CWD-independent, unlike the subprocess `cli_binaries.rs`.
- Context: this is the first "no happy paths" increment; the `datareader` error surface is the highest-impact one (bad data → silently wrong science). `model_parser.rs` error branches are the natural next slice.

## Open questions

- None blocking. Broader: #286's "reach ≥90%" line is already satisfied by the #290 measurement fix — remaining backfill is now buffer/robustness, not a gate requirement.
