### PR TITLE
test(io): cover TTE-aware reader wrappers in the FD build

### DIFF
--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1990,11 +1990,11 @@ mod tests {
         // delegation lines. (The cfg(survival) row-routing inside the impl is
         // exercised by the survival job, not here.)
         let no_tte = std::collections::HashSet::new();
-        let csv = "ID,TIME,DV,EVID,AMT,WT,STUDY\n\
-                   1,0,.,1,100,70,1\n\
-                   1,1,5.0,0,.,70,1\n\
-                   2,0,.,1,100,80,2\n\
-                   2,1,4.0,0,.,80,2\n";
+        let csv = "ID,TIME,DV,EVID,AMT,WT,STUDY,AGE\n\
+                   1,0,.,1,100,70,1,30\n\
+                   1,1,5.0,0,.,70,1,30\n\
+                   2,0,.,1,100,80,2,40\n\
+                   2,1,4.0,0,.,80,2,40\n";
         let f = write_csv(csv);
 
         // filtered_tte: explicit covariate list, augmented by a filter that
@@ -2013,14 +2013,25 @@ mod tests {
             "STUDY==2 subject should be filtered out via the augmented column"
         );
 
-        // with_covariates_tte: declared covariates + table building, no filter.
+        // with_covariates_tte: declared WT + an undeclared `extra` (STUDY) + a
+        // filter referencing a *third* column (AGE) — exercises BOTH the
+        // extra-columns dedup loop and the filter-referenced-column merge. The
+        // filter matches no row, so both subjects are retained.
         let decls = vec![CovariateDecl {
             name: "WT".to_string(),
             kind: CovariateKind::Continuous,
         }];
-        let (pop2, _table) =
-            read_nonmem_csv_with_covariates_tte(f.path(), &decls, &[], None, None, &no_tte)
-                .unwrap();
-        assert_eq!(pop2.subjects.len(), 2);
+        let extra = ["STUDY".to_string()];
+        let nomatch = SelectionFilter::from_opts(&["AGE == 999".to_string()], &[], &[]).unwrap();
+        let (pop2, _table) = read_nonmem_csv_with_covariates_tte(
+            f.path(),
+            &decls,
+            &extra,
+            None,
+            Some(&nomatch),
+            &no_tte,
+        )
+        .unwrap();
+        assert_eq!(pop2.subjects.len(), 2, "AGE==999 matches no row");
     }
 }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1979,4 +1979,48 @@ mod tests {
         // Standard and IOV columns must not appear in covariate_names.
         assert_eq!(pop.covariate_names, vec!["WT"]);
     }
+
+    #[test]
+    fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
+        // `read_nonmem_csv_filtered_tte` / `_with_covariates_tte` (used by
+        // api::read_population_for for [event_model] models) are always compiled
+        // but only *called* on the TTE path, so they read as uncovered in the
+        // FD-only build. With an empty tte_cmts set they delegate to the Gaussian
+        // reader; drive them directly to cover the column-augmentation / union /
+        // delegation lines. (The cfg(survival) row-routing inside the impl is
+        // exercised by the survival job, not here.)
+        let no_tte = std::collections::HashSet::new();
+        let csv = "ID,TIME,DV,EVID,AMT,WT,STUDY\n\
+                   1,0,.,1,100,70,1\n\
+                   1,1,5.0,0,.,70,1\n\
+                   2,0,.,1,100,80,2\n\
+                   2,1,4.0,0,.,80,2\n";
+        let f = write_csv(csv);
+
+        // filtered_tte: explicit covariate list, augmented by a filter that
+        // references an out-of-list column (STUDY) — exercises the augmentation
+        // branch; the filter then drops STUDY==2 (subject 2).
+        let cols: &[&str] = &["WT"];
+        let filter = SelectionFilter::from_opts(&["STUDY == 2".to_string()], &[], &[]).unwrap();
+        let pop = read_nonmem_csv_filtered_tte(f.path(), Some(cols), None, Some(&filter), &no_tte)
+            .unwrap();
+        assert_eq!(
+            pop.subjects
+                .iter()
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1"],
+            "STUDY==2 subject should be filtered out via the augmented column"
+        );
+
+        // with_covariates_tte: declared covariates + table building, no filter.
+        let decls = vec![CovariateDecl {
+            name: "WT".to_string(),
+            kind: CovariateKind::Continuous,
+        }];
+        let (pop2, _table) =
+            read_nonmem_csv_with_covariates_tte(f.path(), &decls, &[], None, None, &no_tte)
+                .unwrap();
+        assert_eq!(pop2.subjects.len(), 2);
+    }
 }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -2015,23 +2015,33 @@ mod tests {
 
         // with_covariates_tte: declared WT + an undeclared `extra` (STUDY) + a
         // filter referencing a *third* column (AGE) — exercises BOTH the
-        // extra-columns dedup loop and the filter-referenced-column merge. The
-        // filter matches no row, so both subjects are retained.
+        // extra-columns dedup loop and the filter-referenced-column merge, and
+        // *validates* the merge: AGE==40 can only drop subject 2 if AGE was
+        // actually pulled into the read union, so the assertion fails if the
+        // merge regresses.
         let decls = vec![CovariateDecl {
             name: "WT".to_string(),
             kind: CovariateKind::Continuous,
         }];
         let extra = ["STUDY".to_string()];
-        let nomatch = SelectionFilter::from_opts(&["AGE == 999".to_string()], &[], &[]).unwrap();
+        let drop_age40 = SelectionFilter::from_opts(&["AGE == 40".to_string()], &[], &[]).unwrap();
         let (pop2, _table) = read_nonmem_csv_with_covariates_tte(
             f.path(),
             &decls,
             &extra,
             None,
-            Some(&nomatch),
+            Some(&drop_age40),
             &no_tte,
         )
         .unwrap();
-        assert_eq!(pop2.subjects.len(), 2, "AGE==999 matches no row");
+        // Subject 2 (AGE=40) is dropped via the merged AGE column; subject 1 remains.
+        assert_eq!(
+            pop2.subjects
+                .iter()
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1"],
+            "AGE==40 must drop subject 2 — proving AGE was pulled into the read union"
+        );
     }
 }


### PR DESCRIPTION
## Why

#286 backfill, final coverable slice — and a finding on what's left.

`read_nonmem_csv_filtered_tte` / `read_nonmem_csv_with_covariates_tte` are **always compiled** (`pub(crate)`, not feature-gated) but only **called** on the `[event_model]` TTE path, so in the FD-only (`--features ci`) coverage build they read as fully uncovered (~66 lines). With an empty `tte_cmts` set they simply delegate to the Gaussian reader, so they're directly unit-testable.

## What changed (tests only)

One test (`tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts`) drives both wrappers directly:
- `filtered_tte` with an explicit covariate list + a filter referencing an out-of-list column (`STUDY`) — exercises the column-augmentation branch, then asserts the filter drops `STUDY==2`.
- `with_covariates_tte` with declared covariates — exercises union-building + table construction.

## Finding: the remaining "misses" are mostly not real gaps

I pulled **line-level** Codecov data for the candidates. The big "gaps" are largely artifacts, not testable code:

| file | cov | missed | reality |
|---|---|---|---|
| `model_parser.rs` | 93.4% | 607 | **270 scattered 2-line clusters** (largest 31) — low ROI |
| `datareader.rs` | 84.8% | 200 | biggest block (95 lines, 1101–1195) is **`cfg(survival)`** — not compiled in the coverage build, exercised by the `survival` job (like `ad/dual.rs`). This PR covers the real ~66-line wrapper gap. |
| `outer_optimizer` / `gauss_newton` | 85% / 83% | 447 / 396 | **fit-triggered** fallback branches → slow-tests tier, not fast unit tests |

So after this slice the high-value, fast-unit-testable backfill is **done**. What remains is (a) feature-gated code measured by the `survival` job but not the coverage flag, (b) fit-triggered estimation fallbacks, (c) scattered edge cases. The 90.55% is actually an **undercount** of the true `ci+survival` surface — a future option is a `survival` coverage flag, but that's separate from #286.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (tests only)

## Performance
- [x] No impact — one fit-free, millisecond test

## Tests
- [x] Unit test added in `src/io/datareader.rs`. Deterministic, fit-free; reuses the module's `write_csv` + `SelectionFilter` patterns. `cargo check --tests --no-default-features --features ci` passes; `cargo +nightly fmt` clean.

## Docs
- [x] `CHANGELOG.md` — N/A (tests only)
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — *CI verifies.*
- [x] `cargo check --features autodiff` — N/A (no AD-reachable code touched)
- [x] `Cargo.toml` version bump — not needed

## Reviewer hints

- The empty `tte_cmts` set is the trick: the wrappers run their always-compiled bodies and delegate to the Gaussian path, while the `cfg(survival)` row-routing they'd normally trigger stays compiled-out (covered by the `survival` job).
- This is intended as the **last** #286 backfill PR — see the finding above. The coverage gate goal (≥90%) was already met by #290's measurement fix; #291 + this add robustness buffer.

## Open questions

- Recommend treating #286's coverage line as **closed** after this. Worth a separate ticket: a `survival` coverage flag so feature-gated code is measured (would lift the reported number toward the true ci+survival coverage)?
