### PR TITLE
ci(coverage): measure the survival surface via a dedicated codecov flag [closes #293]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,18 +67,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal
+        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-survival
-      # All TTE/survival code is behind `#[cfg(feature = "survival")]`, so the
-      # default `ci` jobs above neither compile nor exercise it. Build and run
-      # the feature explicitly here so a break can't land with CI green. The
-      # `tte_smoke` integration tests are Tier-2 (a handful of outer iterations),
-      # so `--tests` stays fast.
-      - name: cargo test (survival)
-        run: cargo test --tests --no-default-features --features ci,survival --profile ci-test
+          # Instrumented build (coverage RUSTFLAGS) can't share the plain `ci`
+          # caches; own key, like the other coverage jobs (`coverage-pr` -> ci-cov).
+          shared-key: ci-cov-survival
+      - name: Install cargo-llvm-cov
+        # Prebuilt binary (no compile) so this job stays fast.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      # All TTE/survival code is behind `#[cfg(feature = "survival")]`, so neither
+      # the default `ci` jobs nor the FD coverage jobs (`fast`/`slow` flags)
+      # compile it — Codecov reports those lines as missed even though they're
+      # exercised here, undercounting the true surface (#293). So this job both
+      # GATES the survival code (a break still fails it) and MEASURES it: it runs
+      # under `cargo llvm-cov` and uploads the `survival` flag, which Codecov
+      # merges with `fast`/`slow`. `tte_smoke` is Tier-2 (a handful of outer
+      # iterations), so `--tests` stays fast; `--profile ci-test` (no fat LTO)
+      # keeps it cheap. `--no-fail-fast` mirrors the other coverage jobs.
+      - name: Generate survival coverage report
+        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,survival --profile ci-test --lcov --output-path lcov.info
+
+      - name: Upload to Codecov (survival flag)
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: survival
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   clippy:
     name: Clippy

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,9 @@
 # Slow-tests NEVER run on PRs: per-PR upload = `fast` flag (--features ci);
 # nightly upload = `slow` flag (--features ci,slow-tests). carryforward lets the
 # nightly `slow` data augment the project number on PRs without re-running it.
+# Feature-gated TTE/survival code is compiled OUT of the `fast`/`slow` FD builds,
+# so the `survival` job uploads a `survival` flag (--features ci,survival) that
+# Codecov merges in — counting those lines where they're actually exercised (#293).
 
 coverage:
   range: 85..95
@@ -31,6 +34,7 @@ coverage:
         flags:
           - fast
           - slow
+          - survival
       # The explicit 90% gap, shown on every PR so the author sees how far
       # under the floor they are — informational, so it challenges without
       # gatekeeping.
@@ -41,6 +45,7 @@ coverage:
         flags:
           - fast
           - slow
+          - survival
       # The teeth: ENFORCED on the weekly full-coverage run on `main` only, so
       # the project status genuinely goes RED there while we're below 90%.
       # Never evaluated on PRs (branches: main), so it blocks no one. No later
@@ -55,12 +60,19 @@ coverage:
         flags:
           - fast
           - slow
+          - survival
     patch:
       default:
         target: 90% # new/changed lines must be tested
         threshold: 0%
+        # `fast` + `survival` are the two FRESH per-PR coverage sources, so they
+        # grade the changed lines. `survival` is required here: survival-gated
+        # changes are compiled out of the `fast` build, so without it a survival
+        # PR's own new lines would read as uncovered. `slow` stays excluded — it's
+        # carryforward (stale for brand-new code).
         flags:
           - fast
+          - survival
 
 flag_management:
   default_rules:
@@ -69,6 +81,11 @@ flag_management:
     - name: fast
       carryforward: false
     - name: slow
+      carryforward: true
+    - name: survival
+      # The `survival` job runs on PRs, main pushes, AND the weekly schedule, so it
+      # normally uploads fresh. carryforward is a safety net: the flag still
+      # contributes on any run where that job didn't upload (fresh data overrides).
       carryforward: true
 
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,12 +7,12 @@
 #   project/floor        -> per-PR 90% gap shown to the author (informational)
 #   project/floor_weekly -> 90% floor ENFORCED on the weekly main run (goes red
 #                           below 90%); never evaluated on PRs, so it blocks no one
-# Slow-tests NEVER run on PRs: per-PR upload = `fast` flag (--features ci);
-# nightly upload = `slow` flag (--features ci,slow-tests). carryforward lets the
-# nightly `slow` data augment the project number on PRs without re-running it.
-# Feature-gated TTE/survival code is compiled OUT of the `fast`/`slow` FD builds,
-# so the `survival` job uploads a `survival` flag (--features ci,survival) that
-# Codecov merges in — counting those lines where they're actually exercised (#293).
+# Slow-tests NEVER run on PRs. Per-PR uploads = `fast` (--features ci) + `survival`
+# (--features ci,survival); nightly upload = `slow` flag (--features ci,slow-tests).
+# carryforward lets the nightly `slow` data augment the project number on PRs without
+# re-running it. The `survival` flag exists because feature-gated TTE/survival code is
+# compiled OUT of the `fast`/`slow` FD builds — Codecov merges `survival` in so those
+# lines are counted where they're actually exercised (#293).
 
 coverage:
   range: 85..95


### PR DESCRIPTION
## Why

The coverage builds compile only the FD `ci` surface — `coverage-pr` uses `--features ci` (`fast` flag), the nightly `coverage` uses `--features ci,slow-tests` (`slow` flag). Everything behind `#[cfg(feature = "survival")]` — TTE / survival / categorical endpoints, **~121 cfg sites across 20 source files** (`datareader.rs`, `api.rs`, `model_parser.rs`, `stats/likelihood.rs`, …) — is **never compiled** in those builds, so Codecov reports it as **missed** even though the `survival` CI job actually exercises it.

Net effect: the reported number **undercounts** the true `ci+survival` surface and manufactures phantom "gaps" no test can close. (During #292 backfill, `datareader.rs`'s single biggest "gap", lines ~1101–1195, turned out to be a survival-gated TTE-routing block — uncoverable in the `ci` build.) Same root cause as `ad/dual.rs`, which #287 gated out of the report.

Closes #293 (survival scope). `nn` is split to a follow-up — #295.

## What changed

- **`.github/workflows/ci.yml`** — convert the existing `survival` job to run under `cargo llvm-cov` (install `llvm-tools-preview` + prebuilt `cargo-llvm-cov`, own cache key `ci-cov-survival`) and upload a **`survival`** flag (`--features ci,survival --profile ci-test`). It still **gates** survival code (a break fails it) and now also **measures** it. Kept ungated (push + PR + schedule) so the weekly `main` run — which enforces `project/floor_weekly` — sees *fresh* survival data instead of relying on carryforward.
- **`codecov.yml`** — register `survival` (carryforward as a safety net); add it to `project/default`, `project/floor`, `project/floor_weekly`; add it to `patch` alongside `fast`, so survival-gated changed lines (compiled out of the fast build) aren't graded as uncovered on a future survival PR.

## Alternatives considered

A separate per-PR `coverage-survival` job mirroring `coverage-pr`, leaving the plain `survival` job intact. Rejected: it would run the survival suite **twice** per PR and, being PR-only, would not refresh the `survival` flag on the weekly `main` run that enforces the floor — forcing reliance on stale carryforward. Converting the existing job avoids the duplicate run and keeps the enforced floor honest. No gate is lost: `check`/`clippy` use `--features ci` and don't compile survival, so this job remains the only thing that builds it, instrumented or not.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

CI/coverage-only; no `pub` API change.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected — an existing Tier-2 job becomes instrumented (`ci-test` profile, no fat LTO); no new job is added.

## Tests
- [x] No new tests needed (CI-config change). Validated by the `Survival (TTE)` job running green on this PR and Codecov showing the new `survival` flag + a project-coverage rise.

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] No user-visible change
- `CHANGELOG.md`: N/A — internal/CI per CLAUDE.md.

## Checklist
- [x] `cargo clippy` clean — no Rust touched
- [x] `cargo check --features autodiff` — no Rust touched
- [x] `Cargo.toml` version bump — N/A

## Docs & examples

### ferx-site
- [x] N/A — no DSL / `[fit_options]` / example / data changes

### ferx-book
- [x] N/A — no estimator / DSL / fit-option changes

### Example execution
- [x] No example execution step needed (CI-only; no user-visible change)

## Reviewer hints

- The behavioural change is entirely the `survival` job in `ci.yml` plus the flag wiring in `codecov.yml`.
- Subtle bit: `patch` must include `survival`, else a future survival-only PR fails the enforced patch gate on its own new lines (absent from the `fast` lcov).
- Expect a **one-time re-baseline**: project % rises as previously-"missed" survival lines flip to hits; `project/floor_weekly` (90%) absorbs it. **After merge**, dispatch CI on `main` (`workflow_dispatch`) to re-seed the `slow` + `survival` flags.

## Open questions

- None. `nn` intentionally deferred to #295 (needs a nightly `ci,nn,slow-tests` measurement — a per-PR nn build would lower coverage).