### PR TITLE
ci(coverage): scope the patch status to PRs only (only_pulls) [#300]

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -65,6 +65,12 @@ coverage:
       default:
         target: 90% # new/changed lines must be tested
         threshold: 0%
+        # Patch is a pull-request concept — grade changed lines only on PRs.
+        # On a push to `main` the `fast` flag is absent (its job is PR-only), so
+        # patch falls back to `survival` alone and mis-grades the merge commit's
+        # diff against a stale base: a false red on `main` that blocks nothing.
+        # `only_pulls` confines the status to PR comparisons. (#300)
+        only_pulls: true
         # `fast` + `survival` are the two FRESH per-PR coverage sources, so they
         # grade the changed lines. `survival` is required here: survival-gated
         # changes are compiled out of the `fast` build, so without it a survival


### PR DESCRIPTION
## Why

`codecov/patch` is a pull-request concept, but Codecov evaluates it on **every** commit — including pushes to `main`. On a `main` push the `fast` flag is absent (its job, `coverage-pr`, is PR-only), so `patch` falls back to grading the diff on `survival` alone, against whatever base Codecov picks for the merge commit. After a merge train or a Codecov outage that base goes stale, so the merge commit shows a **false-red patch** — observed on #296's merge commit as `86.66% of diff hit (target 90.00%)`, grading unrelated PRs' lines (the merge brought in #283/#288/#289…), not #296 (which was YAML-only and passed its own PR patch at 96.77%). It blocks nothing, but it makes `main` look like it's failing the coverage gate when it isn't.

## What changed

One line in `codecov.yml`: `only_pulls: true` on the `patch.default` status, so it's computed **only on PR comparisons** — where `fast` is present and the base is correct. The per-PR gate is unchanged (PRs still require 90% patch on `fast`+`survival`); this only stops the status from posting on `main` pushes, where it can't be computed correctly.

## Alternatives considered

Leaving it: the false red ages out as `main` advances, but it recurs on every merge train / Codecov hiccup. Scoping to PRs fixes it at the root. (The companion fragility — `slow` going stale so the *project* number false-reds — is tracked separately in #300.)

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CI only)

## Performance
- [x] No significant impact expected (Codecov-config only; no CI jobs added/changed)

## Tests
- [x] No new tests needed — Codecov-config change. Validated by behavior: `patch` will no longer post on `main` pushes; PR `patch` is unchanged (this PR's own `codecov/patch` still runs and must pass).

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] No user-visible change
- `CHANGELOG.md`: N/A — internal/CI per CLAUDE.md.

## Checklist
- [x] `cargo clippy` clean — no Rust touched
- [x] `cargo check --features autodiff` — no Rust touched
- [x] `Cargo.toml` version bump — N/A

## Docs & examples
- [x] N/A — no DSL / example / data / estimator changes
- [x] No example execution step needed (CI-only)

## Reviewer hints

- Single-line semantic change: `only_pulls: true` under `coverage.status.patch.default`.
- Confirms the intent that `patch` grades *changed lines on PRs*; on `main` there is no diff-to-grade in the PR sense, and `fast` isn't even uploaded there.

## Open questions

- None. Companion hardening for the `slow`/project false-red is #300.