### PR TITLE
chore(ci): Enzyme autodiff CI — toolchain image + AD-vs-FD consistency job [#281]

### DIFF
--- a/.github/docker/enzyme-toolchain.Dockerfile
+++ b/.github/docker/enzyme-toolchain.Dockerfile
@@ -88,6 +88,37 @@ RUN rustup toolchain link enzyme /opt/enzyme-toolchain \
     && chmod -R a+rX /opt/enzyme-toolchain \
     && rustc +enzyme --version --verbose
 
+# Functional autodiff smoke test — `rustc +enzyme --version` only proves the
+# toolchain LOADS; a mismatched-LLVM Enzyme passes --version yet HANGS in
+# llvm::Constant::getNullValue the moment it differentiates anything
+# (docs/src/installation.md §4). This compiles + runs a real #[autodiff_forward]
+# function under fat LTO (the autodiff link mode) so a broken monthly rebuild
+# FAILS HERE in seconds instead of wedging autodiff.yml for 90 min on a timeout.
+# `timeout` converts the silent getNullValue hang into a hard build failure.
+RUN <<'BASH'
+set -eux
+cat > /tmp/ad_check.rs <<'EOF'
+#![feature(autodiff)]
+use std::autodiff::autodiff_forward;
+
+// d/dx of f(x,y) = exp(x*y) + x*x  is  y*exp(x*y) + 2x.
+#[autodiff_forward(df, Dual, Const, Dual)]
+#[inline(never)]
+fn f(x: f64, y: f64) -> f64 { (x * y).exp() + x * x }
+
+fn main() {
+    let (val, dfdx) = df(1.5, 1.0, 2.0);          // x=1.5, dx=1, y=2
+    let expect = 2.0 * (1.5 * 2.0_f64).exp() + 2.0 * 1.5;
+    assert!((dfdx - expect).abs() < 1e-9);
+    println!("autodiff OK: f={val:.4}, df/dx={dfdx:.4}");
+}
+EOF
+timeout 180 rustc +enzyme -Zautodiff=Enable -Clto=fat -Copt-level=2 \
+    /tmp/ad_check.rs -o /tmp/ad_check
+/tmp/ad_check
+rm -f /tmp/ad_check /tmp/ad_check.rs
+BASH
+
 ENV RUSTUP_TOOLCHAIN=enzyme
 
 # ── Notes ──────────────────────────────────────────────────────────────────
@@ -100,6 +131,6 @@ ENV RUSTUP_TOOLCHAIN=enzyme
 #  * Verification depth: `rustc +enzyme --version` only proves the toolchain
 #    LOADS, not that differentiation WORKS (installation.md warns a
 #    mismatched-LLVM Enzyme can pass --version yet hang on real autodiff). The
-#    real functional check is ferx-core's `autodiff_fd_consistency` suite, run by
-#    autodiff.yml against this image. A future hardening is a tiny inline
-#    #[autodiff] smoke compile+run here to fail the monthly rebuild earlier.
+#    inline #[autodiff_forward] smoke test above (timeout-guarded) catches a
+#    broken toolchain at IMAGE BUILD time; ferx-core's `autodiff_fd_consistency`
+#    suite (run by autodiff.yml against this image) is the deeper functional check.

--- a/.github/docker/enzyme-toolchain.Dockerfile
+++ b/.github/docker/enzyme-toolchain.Dockerfile
@@ -2,7 +2,6 @@
 #
 # Lean Enzyme-enabled Rust toolchain image for ferx-core CI  (issue #281)
 # =======================================================================
-# DRAFT for discussion — not wired into CI yet.
 #
 # Why this exists
 # ---------------
@@ -91,14 +90,16 @@ RUN rustup toolchain link enzyme /opt/enzyme-toolchain \
 
 ENV RUSTUP_TOOLCHAIN=enzyme
 
-# ── OPEN QUESTIONS for the team (validate on first build) ──────────────────
-#  1. cargo-in-toolchain: ferx-r links `build/host/stage1` and runs cargo fine.
-#     If `cargo` complains it's missing from the `enzyme` toolchain, either add
-#     `./x build --stage 1 cargo` in stage 1, or in the consumer job invoke the
-#     enzyme rustc via nightly cargo: `RUSTC=$(rustup which --toolchain enzyme rustc)`.
-#  2. Verification depth: `rustc +enzyme --version` only proves the toolchain
-#     LOADS, not that differentiation WORKS — installation.md warns a
-#     mismatched-LLVM Enzyme passes --version yet hangs on real autodiff. The
-#     REAL functional check is ferx-core's `autodiff_fd_consistency` suite, run
-#     by autodiff.yml against this image. (Could add a tiny inline #[autodiff]
-#     smoke compile+run here to fail the image build earlier.)
+# ── Notes ──────────────────────────────────────────────────────────────────
+#  * cargo-in-toolchain: cargo comes from the nightly proxies installed above;
+#    the `enzyme` toolchain supplies only the Enzyme rustc. This is the proven
+#    ferx-r pattern (link `build/host/stage1` + `rustup default enzyme`). If a
+#    future rust/rustup ever needs cargo inside the linked toolchain, either add
+#    `./x build --stage 1 cargo` in stage 1 or set
+#    `RUSTC=$(rustup which --toolchain enzyme rustc)` in the consumer job.
+#  * Verification depth: `rustc +enzyme --version` only proves the toolchain
+#    LOADS, not that differentiation WORKS (installation.md warns a
+#    mismatched-LLVM Enzyme can pass --version yet hang on real autodiff). The
+#    real functional check is ferx-core's `autodiff_fd_consistency` suite, run by
+#    autodiff.yml against this image. A future hardening is a tiny inline
+#    #[autodiff] smoke compile+run here to fail the monthly rebuild earlier.

--- a/.github/docker/enzyme-toolchain.Dockerfile
+++ b/.github/docker/enzyme-toolchain.Dockerfile
@@ -1,0 +1,104 @@
+# syntax=docker/dockerfile:1.7
+#
+# Lean Enzyme-enabled Rust toolchain image for ferx-core CI  (issue #281)
+# =======================================================================
+# DRAFT for discussion — not wired into CI yet.
+#
+# Why this exists
+# ---------------
+# ferx-core's *default* build uses Enzyme autodiff for inner-loop gradients,
+# but every normal CI job builds `--features ci` (finite differences only) on
+# plain nightly. So the autodiff path — and the `autodiff_fd_consistency`
+# regression guard that protects the whole #278 bug class — are exercised
+# NOWHERE automatically. Enzyme needs a custom rustc+LLVM built from source
+# (no prebuilt rustup channel; the plugin-only shortcut hangs — see
+# docs/src/installation.md), which is far too slow to build inside every run.
+#
+# This image bakes that toolchain ONCE. The per-run `autodiff.yml` job then
+# just pulls it and compiles/tests ferx-core. The slow build runs on a
+# GitHub-hosted runner via `enzyme-toolchain-image.yml`; nobody builds it
+# locally. Published (public) to ghcr.io/ferx-nlme/enzyme-toolchain.
+#
+# Recipe adapted from ferx-r/Dockerfile (the project's proven Enzyme build),
+# stripped of the R / RStudio layers so the CI image stays lean.
+
+# ===========================================================================
+# Stage 1: build a stage-1 rustc with Enzyme + its own matching LLVM.
+# The ~20-30 GB build tree stays in this throwaway stage.
+#   * download-ci-llvm=false is REQUIRED: Enzyme can't be built against CI LLVM.
+#   * llvm.targets=X86 trims LLVM to the host backend (vs ferx-r, which builds
+#     all targets) — cuts build time/size for an x86_64-only CI image. Drop it
+#     if the build misbehaves.
+# ===========================================================================
+FROM ubuntu:24.04 AS enzyme-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake ninja-build build-essential curl git ca-certificates \
+        python3 pkg-config libssl-dev libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/opt/cargo \
+    RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/cargo/bin:/usr/local/bin:/usr/bin:/bin
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain nightly --profile minimal
+
+RUN set -eux; \
+    git clone --depth 1 https://github.com/rust-lang/rust /tmp/rust-src; \
+    cd /tmp/rust-src; \
+    ./configure \
+        --release-channel=nightly \
+        --enable-llvm-enzyme \
+        --enable-llvm-link-shared \
+        --enable-ninja \
+        --disable-docs \
+        --set llvm.download-ci-llvm=false \
+        --set llvm.targets=X86 ; \
+    ./x build --stage 1 library; \
+    rustup toolchain link enzyme build/host/stage1; \
+    rustc +enzyme --version --verbose
+
+# ===========================================================================
+# Stage 2: lean runtime = ubuntu + enzyme toolchain + cargo + ferx-core's
+# C build deps (the `nlopt` crate builds NLopt from source via cmake; `lld`
+# for the fat-LTO autodiff link).
+# ===========================================================================
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake ninja-build lld build-essential curl git ca-certificates \
+        python3 pkg-config libssl-dev libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/opt/cargo \
+    RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/cargo/bin:/usr/local/bin:/usr/bin:/bin
+
+# cargo + the rustup proxies come from a normal nightly; the Enzyme *rustc* is
+# the linked `enzyme` toolchain copied from the builder stage. rust-src is
+# pulled in because some autodiff builds want it.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain nightly --profile minimal \
+    && rustup component add rust-src --toolchain nightly \
+    && chmod -R a+rX /opt/cargo /opt/rustup
+
+COPY --from=enzyme-builder /tmp/rust-src/build/host/stage1 /opt/enzyme-toolchain
+RUN rustup toolchain link enzyme /opt/enzyme-toolchain \
+    && rustup default enzyme \
+    && chmod -R a+rX /opt/enzyme-toolchain \
+    && rustc +enzyme --version --verbose
+
+ENV RUSTUP_TOOLCHAIN=enzyme
+
+# ── OPEN QUESTIONS for the team (validate on first build) ──────────────────
+#  1. cargo-in-toolchain: ferx-r links `build/host/stage1` and runs cargo fine.
+#     If `cargo` complains it's missing from the `enzyme` toolchain, either add
+#     `./x build --stage 1 cargo` in stage 1, or in the consumer job invoke the
+#     enzyme rustc via nightly cargo: `RUSTC=$(rustup which --toolchain enzyme rustc)`.
+#  2. Verification depth: `rustc +enzyme --version` only proves the toolchain
+#     LOADS, not that differentiation WORKS — installation.md warns a
+#     mismatched-LLVM Enzyme passes --version yet hangs on real autodiff. The
+#     REAL functional check is ferx-core's `autodiff_fd_consistency` suite, run
+#     by autodiff.yml against this image. (Could add a tiny inline #[autodiff]
+#     smoke compile+run here to fail the image build earlier.)

--- a/.github/workflows/autodiff.yml
+++ b/.github/workflows/autodiff.yml
@@ -1,21 +1,28 @@
 name: Autodiff (Enzyme)
 
-# DRAFT for discussion (issue #281) — exercises the autodiff (Enzyme) inner-
-# gradient path that the normal FD-only CI never builds. This is the gap that
-# let the whole #278 bug class ship undetected. It runs ferx-core's AD-vs-FD
-# consistency guard inside the prebuilt Enzyme toolchain image
+# Issue #281 — exercises the autodiff (Enzyme) inner-gradient path that the
+# normal FD-only CI (`--features ci`) never builds. ferx-core's *default* build
+# is `default = ["autodiff"]`, so without this job the AD path — and the
+# `autodiff_fd_consistency` guard #280 added — run NOWHERE automatically. That
+# blind spot let the whole #278 bug class ship undetected. This job runs the
+# AD-vs-FD consistency guard inside the prebuilt Enzyme toolchain image
 # (see enzyme-toolchain-image.yml).
 #
-# Heavy (fat-LTO autodiff compile), so it is nightly + path-filtered + manual,
-# NOT a blocking every-PR gate — matching how the repo already treats slow work
-# (slow-tests.yml, the weekly coverage job).
+# Cadence mirrors slow-tests.yml: schedule (daily) + manual dispatch + push to
+# `main` on AD-relevant paths. It is NOT a per-PR gate — the fat-LTO Enzyme
+# compile is heavy, and a per-PR run would (a) go red on fork PRs whose
+# read-only GITHUB_TOKEN can't pull the image until it's public and (b) add
+# noise before the image is proven. Daily + push-to-main still catches AD
+# regressions within a day and on every main merge touching AD code. Future:
+# promote to a PR-path / required check once the job is proven fast and stable.
 
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 5 * * *"            # nightly
-  pull_request:
-    paths:                          # only PRs that can plausibly affect AD
+    - cron: "0 5 * * *"            # daily (offset from slow-tests' 06:00 UTC)
+  push:
+    branches: [main]
+    paths:                          # only main merges that can plausibly affect AD
       - "src/ad/**"
       - "src/estimation/**"
       - "src/pk/**"
@@ -36,7 +43,7 @@ jobs:
     container:
       image: ghcr.io/ferx-nlme/enzyme-toolchain:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # The image provides the rustc; this only caches cargo deps + target.
       # NOTE: image sets CARGO_HOME=/opt/cargo — confirm rust-cache picks that
@@ -48,8 +55,7 @@ jobs:
       # autodiff REQUIRES fat LTO for cross-crate Enzyme correctness
       # (docs/src/installation.md). So use the fat-LTO `release` profile — NOT
       # the no-LTO `ci-test` profile the FD jobs use. `autodiff` is the default
-      # feature; `survival` adds the TTE (Weibull/Gompertz) cases. This is the
-      # SAME 8/8 suite the PR validated locally, now run on every relevant PR.
+      # feature; `survival` adds the TTE (Weibull/Gompertz) cases.
       - name: AD-vs-FD consistency guard
         env:
           RUSTFLAGS: "-Z autodiff=Enable"
@@ -57,12 +63,9 @@ jobs:
           cargo test --release --features autodiff,survival \
             --test autodiff_fd_consistency -- --nocapture
 
-# ── OPEN QUESTIONS for the team ────────────────────────────────────────────
-#  * Profile: `--release` (fat LTO) is the correct/safe choice for Enzyme, but
-#    it's slow. Confirm whether a dedicated `[profile.autodiff-ci]` (release +
-#    fat LTO, maybe codegen-units tuning) is worth adding to Cargo.toml.
-#  * Scope: start with `autodiff_fd_consistency` only. Optionally add the
+# ── Follow-ups (once this job is proven green against the published image) ──
+#  * Scope: starts with `autodiff_fd_consistency` only. Consider adding the
 #    `#[cfg(autodiff)]` *unit* tests (`cargo test --release --lib --features
-#    autodiff,survival`) once the job is proven green and time is acceptable.
-#  * Gate strength: nightly + path-filtered to begin. If it proves fast/stable
-#    enough, consider promoting to a required check on the filtered paths.
+#    autodiff,survival`) once the job is proven green and runtime is acceptable.
+#  * Gate strength: schedule + push-to-main to begin. If it proves fast/stable,
+#    consider promoting to a required check on the filtered paths (per-PR).

--- a/.github/workflows/autodiff.yml
+++ b/.github/workflows/autodiff.yml
@@ -1,0 +1,68 @@
+name: Autodiff (Enzyme)
+
+# DRAFT for discussion (issue #281) — exercises the autodiff (Enzyme) inner-
+# gradient path that the normal FD-only CI never builds. This is the gap that
+# let the whole #278 bug class ship undetected. It runs ferx-core's AD-vs-FD
+# consistency guard inside the prebuilt Enzyme toolchain image
+# (see enzyme-toolchain-image.yml).
+#
+# Heavy (fat-LTO autodiff compile), so it is nightly + path-filtered + manual,
+# NOT a blocking every-PR gate — matching how the repo already treats slow work
+# (slow-tests.yml, the weekly coverage job).
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 5 * * *"            # nightly
+  pull_request:
+    paths:                          # only PRs that can plausibly affect AD
+      - "src/ad/**"
+      - "src/estimation/**"
+      - "src/pk/**"
+      - "tests/autodiff_fd_consistency.rs"
+      - "Cargo.toml"
+
+concurrency:
+  group: autodiff-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consistency:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # The image defaults to the enzyme toolchain (ENV RUSTUP_TOOLCHAIN=enzyme),
+    # so plain `cargo` below uses the Enzyme rustc. Must be a PUBLIC package for
+    # fork-PR pulls to work without auth (see enzyme-toolchain-image.yml).
+    container:
+      image: ghcr.io/ferx-nlme/enzyme-toolchain:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The image provides the rustc; this only caches cargo deps + target.
+      # NOTE: image sets CARGO_HOME=/opt/cargo — confirm rust-cache picks that
+      # up (it keys off CARGO_HOME) or set it explicitly.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: autodiff-enzyme
+
+      # autodiff REQUIRES fat LTO for cross-crate Enzyme correctness
+      # (docs/src/installation.md). So use the fat-LTO `release` profile — NOT
+      # the no-LTO `ci-test` profile the FD jobs use. `autodiff` is the default
+      # feature; `survival` adds the TTE (Weibull/Gompertz) cases. This is the
+      # SAME 8/8 suite the PR validated locally, now run on every relevant PR.
+      - name: AD-vs-FD consistency guard
+        env:
+          RUSTFLAGS: "-Z autodiff=Enable"
+        run: |
+          cargo test --release --features autodiff,survival \
+            --test autodiff_fd_consistency -- --nocapture
+
+# ── OPEN QUESTIONS for the team ────────────────────────────────────────────
+#  * Profile: `--release` (fat LTO) is the correct/safe choice for Enzyme, but
+#    it's slow. Confirm whether a dedicated `[profile.autodiff-ci]` (release +
+#    fat LTO, maybe codegen-units tuning) is worth adding to Cargo.toml.
+#  * Scope: start with `autodiff_fd_consistency` only. Optionally add the
+#    `#[cfg(autodiff)]` *unit* tests (`cargo test --release --lib --features
+#    autodiff,survival`) once the job is proven green and time is acceptable.
+#  * Gate strength: nightly + path-filtered to begin. If it proves fast/stable
+#    enough, consider promoting to a required check on the filtered paths.

--- a/.github/workflows/enzyme-toolchain-image.yml
+++ b/.github/workflows/enzyme-toolchain-image.yml
@@ -1,0 +1,76 @@
+name: Enzyme toolchain image
+
+# DRAFT for discussion (issue #281) — builds the custom rustc+LLVM+Enzyme
+# toolchain ONCE and publishes it to ghcr.io so the per-run autodiff job
+# (autodiff.yml) can just pull it. This is the slow (~1-2 h) build; it runs on
+# a GitHub-hosted runner, never on a developer machine.
+#
+# Cost: both repos are PUBLIC, so standard `ubuntu-latest` minutes and the
+# public ghcr package are free. The only resource risk is runner DISK (handled
+# below), not money.
+
+on:
+  workflow_dispatch: {}            # manual: (re)publish on demand
+  schedule:
+    - cron: "0 4 1 * *"            # monthly refresh — the `nightly` pin drifts
+  push:
+    branches: [main]
+    paths:                          # rebuild when the recipe itself changes
+      - ".github/docker/enzyme-toolchain.Dockerfile"
+      - ".github/workflows/enzyme-toolchain-image.yml"
+
+concurrency:
+  group: enzyme-toolchain-image
+  cancel-in-progress: false        # never cancel a half-finished toolchain build
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300            # the from-source rustc+LLVM build is slow
+    permissions:
+      contents: read
+      packages: write               # push to ghcr.io/<owner>/*
+    steps:
+      - uses: actions/checkout@v4
+
+      # ubuntu-latest ships ~14 GB free; the LLVM+rustc build wants ~30 GB.
+      # This reclaims ~20-30 GB by removing preinstalled SDKs we don't use.
+      - name: Free up runner disk
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          large-packages: true
+          docker-images: false      # we need Docker itself
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/enzyme-toolchain.Dockerfile
+          push: true
+          # ghcr paths must be lowercase; owner is FeRx-NLME -> ferx-nlme.
+          tags: |
+            ghcr.io/ferx-nlme/enzyme-toolchain:latest
+            ghcr.io/ferx-nlme/enzyme-toolchain:${{ github.sha }}
+          # Layer cache so a stage-2-only edit doesn't rebuild LLVM. NOTE: GHA
+          # cache is capped at 10 GB/repo, which the LLVM layers may exceed —
+          # expect cold rebuilds when the cache is evicted.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+# ── AFTER THE FIRST SUCCESSFUL PUBLISH ─────────────────────────────────────
+#  * Make the package PUBLIC (Org -> Packages -> enzyme-toolchain -> Settings ->
+#    visibility). Otherwise autodiff.yml — especially on PRs from forks, whose
+#    GITHUB_TOKEN is read-only — cannot pull the image anonymously.
+#  * If `ubuntu-latest` runs out of disk even after the reclaim step, options:
+#    trim LLVM further, or use a larger runner (BILLED even on public repos), or
+#    do a one-off cloud-VM build and push manually.

--- a/.github/workflows/enzyme-toolchain-image.yml
+++ b/.github/workflows/enzyme-toolchain-image.yml
@@ -1,13 +1,21 @@
 name: Enzyme toolchain image
 
-# DRAFT for discussion (issue #281) — builds the custom rustc+LLVM+Enzyme
-# toolchain ONCE and publishes it to ghcr.io so the per-run autodiff job
-# (autodiff.yml) can just pull it. This is the slow (~1-2 h) build; it runs on
-# a GitHub-hosted runner, never on a developer machine.
+# Issue #281 — builds the custom rustc+LLVM+Enzyme toolchain ONCE and publishes
+# it to ghcr.io so the per-run autodiff job (autodiff.yml) can just pull it.
+# This is the slow (~1-2 h) from-source build; it runs on a GitHub-hosted
+# runner, never on a developer machine. The image is owned by ferx-core (where
+# the autodiff code and its `autodiff_fd_consistency` test live), keeping this
+# repo's CI self-contained; the recipe tracks ferx-r/Dockerfile's enzyme-builder
+# stage (see the Dockerfile header).
 #
-# Cost: both repos are PUBLIC, so standard `ubuntu-latest` minutes and the
-# public ghcr package are free. The only resource risk is runner DISK (handled
-# below), not money.
+# Cost: the repo is PUBLIC, so standard `ubuntu-latest` minutes and the public
+# ghcr package are free. The only resource risk is runner DISK (handled below),
+# not money.
+#
+# Bootstrap: `workflow_dispatch` only works once this file is on the default
+# branch, so the FIRST image build comes from the `push: main` trigger when the
+# PR lands (it touches both paths below). After that first publish, set the ghcr
+# package visibility to PUBLIC (see footer) so autodiff.yml can pull it.
 
 on:
   workflow_dispatch: {}            # manual: (re)publish on demand
@@ -31,7 +39,7 @@ jobs:
       contents: read
       packages: write               # push to ghcr.io/<owner>/*
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ubuntu-latest ships ~14 GB free; the LLVM+rustc build wants ~30 GB.
       # This reclaims ~20-30 GB by removing preinstalled SDKs we don't use.


### PR DESCRIPTION
## Why

ferx-core's **default** Cargo build enables Enzyme autodiff (`default = ["autodiff"]`) — the nominal primary build — yet the autodiff inner-gradient path is exercised **nowhere** in CI: every job builds `--features ci` (finite differences) on plain `nightly`. This is the FD-only coverage gap that let the whole #278 bug class ship undetected, and it means the regression guard #280 added (`tests/autodiff_fd_consistency.rs`, gated `#![cfg(feature = "autodiff")]`) currently runs nowhere automatically. Closes the structural half of #281.

## What changed

Three CI-only files (no product code, no public API):

1. **`.github/docker/enzyme-toolchain.Dockerfile`** — a lean `rustc`+LLVM+Enzyme image, a fork of `../ferx-r/Dockerfile`'s proven `enzyme-builder` stage minus the R/RStudio layers (`llvm.targets=X86` trim for a CI image).
2. **`.github/workflows/enzyme-toolchain-image.yml`** — builds that image **once** on a GitHub-hosted runner (with `jlumbroso/free-disk-space`) and pushes it to `ghcr.io/ferx-nlme/enzyme-toolchain`; manual + monthly + on-recipe-change.
3. **`.github/workflows/autodiff.yml`** — pulls that image and runs `autodiff_fd_consistency` under the fat-LTO `release` profile (Enzyme requires fat LTO for cross-crate correctness).

## Resolved design decisions

- **Image owner = ferx-core.** The image exists to test *ferx-core's* autodiff code; the test and the code under test both live here, so owning the image here keeps this repo's CI self-contained with no cross-repo CI coupling. The recipe tracks ferx-r's `enzyme-builder` stage (documented in the Dockerfile header).
- **Cadence mirrors `slow-tests.yml`:** `schedule` (daily) + `workflow_dispatch` + `push: main` on AD paths. **No per-PR trigger** — the fat-LTO Enzyme compile is heavy; a per-PR run would go red on fork PRs (read-only `GITHUB_TOKEN` can't pull the image until it is public) and add noise before the image is proven. Daily + push-to-main still catches AD regressions within a day and on every main merge touching AD code. Promotion to a required PR-path check is a noted future step once the job is proven stable.

## Bootstrap sequence (after merge — needs org admin)

1. Merge → the `push: main` path filter auto-runs `enzyme-toolchain-image.yml`, building & publishing the image (~1–2 h, one time). (`workflow_dispatch` only works once the workflow is on the default branch, so the first build must come from this push trigger.)
2. **Set the ghcr package visibility to Public** (Org → Packages → enzyme-toolchain → Settings), so `autodiff.yml` — including fork PRs — can pull it anonymously.
3. `workflow_dispatch` `autodiff.yml` once to confirm the suite is green against the published image.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

CI-only; no ferx-core code or public API touched. The Dockerfile is *derived from* ferx-r's but doesn't depend on it at build time.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CI only) — the *purpose* of this PR is to start running the existing `autodiff_fd_consistency` numerical guard (AD-vs-FD objective agreement) in CI, where it currently never runs.

## Performance
- [x] No significant impact expected — the new jobs are isolated (schedule + push:main + dispatch) and don't touch the existing FD CI. The autodiff job is intentionally fat-LTO (slow) for correctness, hence kept off the per-PR critical path.

## Tests
- [x] No new tests needed (this **wires the existing** `tests/autodiff_fd_consistency.rs` guard into CI; it adds no product code).

## Example (user-facing features only)
- [x] Not applicable (internal / CI)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry — N/A (internal/CI, no user-facing change)
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean — N/A (no Rust code changed)
- [x] `cargo check --features autodiff` still compiles — N/A (no Rust code changed)
- [x] `Cargo.toml` version bumped if breaking — N/A (not breaking)

## Docs & examples
- [x] No example execution step needed (CI-only, no user-visible change). All ferx-site / ferx-book / example-execution sub-items N/A.

## Follow-ups (out of scope)
- Optionally widen the job to the `#[cfg(autodiff)]` unit tests and/or promote to a required PR-path check once proven green.
- A `#[autodiff]` smoke compile in the Dockerfile to fail the monthly rebuild earlier if a nightly drift breaks Enzyme.
- Generalizing the analytical AD kernels so the gated classes (non-log-normal η, LTBS, conditional, η-dependent obs_scale, TTE) regain the fast AD path — tracked in #281's comments.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)