### PR TITLE
ci(slow-tests): run heavy fits when the parser changes

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -22,6 +22,11 @@ on:
       - 'src/ode/ekf.rs'
       - 'src/ode/predictions.rs'
       - 'src/ode/solver.rs'
+      # The parser compiles every model the heavy fits run, so a change to model
+      # compilation (e.g. the structural-param binding in #261) can shift a fit's
+      # objective or break it outright — including the NONMEM-anchored slow test
+      # in tests/structural_param_nonmem.rs.
+      - 'src/parser/**'
       - 'src/stats/likelihood.rs'
 
 env:


### PR DESCRIPTION
## Why
The `slow-tests.yml` push-to-`main` path filter lists `src/api.rs`, `src/estimation/**`, `src/ode/*`, and `src/stats/likelihood.rs`, but **not** `src/parser/`. The parser compiles every model the heavy fits run, so a model-compilation change (e.g. the structural-param binding fixed in #261, #308) wouldn't re-run the NONMEM-anchored convergence tests — including the new `tests/structural_param_nonmem.rs` — until the next daily cron. Follow-up to #308.

## What changed
Added `- 'src/parser/**'` to the `push` `paths:` filter in `.github/workflows/slow-tests.yml`, with a comment explaining the rationale. The `schedule` (daily) and `workflow_dispatch` triggers are unaffected (they have no path filter and already run the full slow suite).

## Alternatives considered
`src/parser/model_parser.rs` (the single file) instead of the `**` glob — rejected: any parser file feeds model compilation and thus the fits, so the module-wide glob is the right altitude.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields
- [ ] Public Rust API
- [x] None

## Numerical validation
- [x] Not applicable (CI-only)

## Performance
- [x] No significant impact expected (only widens when the nightly slow-tests re-run on a `main` push; cron cadence unchanged)

## Tests
- [x] No new tests needed (CI workflow trigger change; YAML only)

## Example (user-facing features only)
- [x] Not applicable (internal CI)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean — N/A (no Rust changed)
- [x] `cargo check --features autodiff` — N/A (no Rust changed)
- [x] `Cargo.toml` version bump — N/A

## Docs & examples
### Example execution
- [x] No example execution step needed (CI workflow YAML only)

## Reviewer hints
One-line path-filter addition; the `schedule`/`dispatch` triggers (no path filter) are unchanged, so this only affects which `main` pushes eagerly re-run the slow suite.
