### PR TITLE
fix(estimation): FOCE evaluates residual variance at f(η=0), matching NONMEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ section of the SDLC for the versioning policy).
   (SDLC) page and a Contributing page in the book.
 
 ### Changed
+- FOCE (non-interaction) now evaluates the residual variance at the population
+  prediction `f(η=0)` — NONMEM's `METHOD=1` (no `INTER`) semantics — instead of
+  the linearized `f0 = f(η̂) − H·η̂`. On nonlinear models (e.g. oral absorption)
+  with proportional/combined error, `f0` could extrapolate to near-zero or
+  negative concentrations, collapsing `R(f0) = (f0·σ)²` and making the marginal
+  multimodal with an indefinite covariance Hessian (garbage SEs reported as
+  "likely reliable"). FOCE+proportional fits now converge deterministically,
+  reproduce NONMEM FOCE estimates/SEs (within ~3% on a 1-cpt oral benchmark),
+  and yield a positive-definite covariance. Additive-error FOCE is unchanged
+  (its variance is `f`-independent). The FOCE covariance for `f`-dependent error
+  uses the reconverged-OFV second-difference Hessian (the true objective
+  curvature) rather than the envelope-approximation analytical gradient.
 - IMP (importance sampling) now jointly samples (η, κ) for IOV models,
   integrating over inter-occasion variability so the reported `−2 log L` is
   directly comparable to FOCE/FOCEI and NONMEM `METHOD=IMP`. Previously κ was

--- a/docs/src/estimation/foce.md
+++ b/docs/src/estimation/foce.md
@@ -76,7 +76,15 @@ where \\( H \\) is the Jacobian matrix \\( \partial f / \partial \eta \\). The p
 
 \\[ \text{OFV}_i = (y - f_0)^T \tilde{R}^{-1} (y - f_0) + \log|\tilde{R}| \\]
 
-where \\( \tilde{R} = H \Omega H^T + R(f_0) \\).
+where \\( \tilde{R} = H \Omega H^T + R(f(\eta{=}0)) \\). The residual variance \\( R \\)
+is evaluated at the **population prediction** \\( f(\eta{=}0) \\) — matching NONMEM's
+`METHOD=1` (no `INTER`) semantics — not at the linearized point \\( f_0 \\). On a
+nonlinear model (e.g. oral absorption) the linearization \\( f_0 = f(\hat\eta) - H\hat\eta \\)
+can extrapolate to a near-zero or negative concentration where the true typical-individual
+prediction is healthy; evaluating a proportional variance \\( (f\sigma)^2 \\) there collapses
+the weight and makes the objective multimodal with an indefinite covariance. \\( f(\eta{=}0) \\)
+is always physically sensible, so FOCE+proportional converges deterministically and matches
+NONMEM FOCE. Additive error is unaffected (\\( R \\) does not depend on \\( f \\)).
 
 ### FOCEI (Interaction)
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -750,8 +750,18 @@ fn subject_nll_pop_grad_analytical(
         .map(|(j, &ip)| ip - h_eta[j])
         .collect();
 
-    // r_diag: at f0 (standard) or at ipreds (interaction)
-    let r_pred_point: &[f64] = if options.interaction { &ipreds } else { &f0 };
+    // FOCE (no interaction): evaluate R at the population prediction f(η=0),
+    // matching `foce_subject_nll_standard`. f0 = f(η̂) − H·η̂ can cross zero on
+    // a nonlinear model and make R̃ ill-conditioned; f(η=0) is always sensible.
+    // Additive error is f-independent → keep f0 (bit-identical, no extra eval).
+    let use_pop_var = model.error_spec.has_f_dependent_variance();
+    let zeros_eta = vec![0.0_f64; n_eta];
+    let pop_preds: Vec<f64> = if use_pop_var {
+        pk::compute_predictions_with_tv(model, subject, &params.theta, &zeros_eta)
+    } else {
+        Vec::new()
+    };
+    let r_pred_point: &[f64] = if use_pop_var { &pop_preds } else { &f0 };
     let r_diag = compute_r_diag(
         &model.error_spec,
         r_pred_point,
@@ -818,11 +828,40 @@ fn subject_nll_pop_grad_analytical(
                 .collect()
         };
 
+        // d(f(η=0))/dx_k for the variance chain rule, when R is evaluated at the
+        // population prediction (f-dependent error). No mu-ref shortcut: the
+        // H-column gives ∂f/∂η at η̂, not the θ-derivative of f at η=0, so this
+        // is always FD. Cheap (one extra prediction eval per free θ) and only on
+        // the f-dependent path. For additive error `dr_j == 0`, so it is unused.
+        let d_pop_preds: Vec<f64> = if use_pop_var {
+            let h = eps * (1.0 + x[k].abs());
+            let xk_plus = (x[k] + h).min(bounds.upper[k]);
+            let actual_h = xk_plus - x[k];
+            if actual_h.abs() < 1e-16 {
+                vec![0.0; n_obs]
+            } else {
+                let mut x_pert = x.to_vec();
+                x_pert[k] = xk_plus;
+                let params_pert = unpack_params(&x_pert, template);
+                pk::compute_predictions_with_tv(model, subject, &params_pert.theta, &zeros_eta)
+                    .iter()
+                    .zip(pop_preds.iter())
+                    .map(|(&p, &b)| (p - b) / actual_h)
+                    .collect()
+            }
+        } else {
+            Vec::new()
+        };
+
+        // Variance-point derivative: d(f(η=0)) on the f-dependent path, else
+        // d(f0)=d(ipreds). The mean term below always uses d(f0)=d_ipreds.
+        let d_var_pred: &[f64] = if use_pop_var { &d_pop_preds } else { &d_ipreds };
+
         // d(f0) = d(ipreds); d(v) = -d(f0)
-        // For sigma-dependent r: d(r_j)/d(x[k]) via chain rule through r(f0 or ipreds)
+        // For sigma-dependent r: d(r_j)/d(x[k]) via chain rule through r at r_pred_point
         let dr: Vec<f64> = r_diag
             .iter()
-            .zip(r_pred_point.iter().zip(d_ipreds.iter()))
+            .zip(r_pred_point.iter().zip(d_var_pred.iter()))
             .map(|(&r_j, (&pred_j, &dp_j))| match model.error_model {
                 ErrorModel::Additive => 0.0,
                 ErrorModel::Proportional => {
@@ -1810,6 +1849,21 @@ fn subject_nll_at(
             &[],
         )
     } else {
+        // FOCE (no interaction): evaluate R at the population prediction f(η=0)
+        // for f-dependent error, consistent with the marginal in likelihood.rs
+        // and with `subject_nll_pop_grad_analytical` (so GN's NLL matches its
+        // gradient). Additive error keeps f0 (bit-identical).
+        let pop_preds: Option<Vec<f64>> = if model.error_spec.has_f_dependent_variance() {
+            let zeros = vec![0.0_f64; eta_hat.len()];
+            Some(crate::pk::compute_predictions_with_tv(
+                model,
+                subject,
+                &params.theta,
+                &zeros,
+            ))
+        } else {
+            None
+        };
         foce_subject_nll_standard(
             subject,
             &ipreds,
@@ -1820,6 +1874,7 @@ fn subject_nll_at(
             &model.error_spec,
             model.bloq_method,
             &[],
+            pop_preds.as_deref(),
         )
     }
 }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2485,13 +2485,22 @@ pub(crate) fn compute_covariance(
 
     let mut hess = DMatrix::zeros(n, n);
     let is_iov = kappas.iter().any(|k| !k.is_empty());
+    // Route non-interaction FOCE with f-dependent error (proportional/combined)
+    // through the OFV second-difference stencil (the IOV path), which builds
+    // the true Hessian of the actual marginal. The analytical SB gradient is an
+    // envelope approximation with no EBE-response Δ (that correction exists only
+    // for FOCEI, #274), so its central-FD Hessian comes out indefinite on the
+    // f-dependent FOCE surface. Additive FOCE keeps the cheap analytical path
+    // (the Δ vanishes for f-independent variance, and it already matches NONMEM).
+    let force_ofv_hessian = !options.interaction && model.error_spec.has_f_dependent_variance();
+    let use_analytical = !is_iov && !force_ofv_hessian;
 
     // Track FD failures at source so diagnostics name the right cause (a NaN/Inf
     // stencil result is not a genuine zero curvature). HashSet for O(1) ops.
     let mut fd_diag_nan: HashSet<usize> = HashSet::new();
     let mut fd_offdiag_nan: HashSet<usize> = HashSet::new();
 
-    if !is_iov {
+    if use_analytical {
         // Issue #209 + #256 + #274: central FD of the analytical population
         // gradient, as one flat `par_iter` over the 2·n_free perturbed points.
         //   H[:,k] ≈ (g(x̂ + hₖ·eₖ) − g(x̂ − hₖ·eₖ)) / 2hₖ

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -447,6 +447,20 @@ pub fn foce_subject_nll(
             &p_obs,
         )
     } else {
+        // FOCE (no interaction): evaluate the residual variance R at the
+        // population prediction f(η=0) — NONMEM's no-interaction semantics —
+        // not the SB-linearized f0. f0 = f(η̂) − H·η̂ can extrapolate to
+        // near-zero/negative concentrations on a nonlinear (e.g. oral) model,
+        // collapsing R(f0)=(f0·σ)² to the floor and making R̃ ill-conditioned;
+        // f(η=0) is the physically sensible typical-individual prediction
+        // (always ≥0). Skipped for additive error (variance is f-independent,
+        // so f0 and f(η=0) give the same R) to keep that path bit-identical.
+        let pop_preds: Option<Vec<f64>> = if model.error_spec.has_f_dependent_variance() {
+            let zeros = vec![0.0_f64; eta_hat.len()];
+            Some(model_predictions(model, subject, theta, &zeros))
+        } else {
+            None
+        };
         foce_subject_nll_standard(
             subject,
             &ipreds,
@@ -457,6 +471,7 @@ pub fn foce_subject_nll(
             &model.error_spec,
             model.bloq_method,
             &p_obs,
+            pop_preds.as_deref(),
         )
     }
 }
@@ -475,6 +490,11 @@ pub fn foce_subject_nll_standard(
     error_spec: &ErrorSpec,
     _bloq_method: BloqMethod,
     p_obs: &[f64],
+    // When `Some`, evaluate the residual variance R at these predictions
+    // instead of the SB-linearized f0. Used to evaluate R at the population
+    // prediction f(η=0) — NONMEM's no-interaction semantics — which is always
+    // ≥0, avoiding the f0 zero-crossing pathology on oral proportional models.
+    r_pred_override: Option<&[f64]>,
 ) -> f64 {
     let n_obs = subject.observations.len();
 
@@ -486,8 +506,9 @@ pub fn foce_subject_nll_standard(
         .map(|(j, &ip)| ip - h_eta[j])
         .collect();
 
-    // R diagonal at f0; inflate with EKF process-noise variance for SDE models.
-    let mut r_diag = compute_r_diag(error_spec, &f0, &subject.obs_cmts, sigma_values);
+    // R diagonal; inflate with EKF process-noise variance for SDE models.
+    let r_eval: &[f64] = r_pred_override.unwrap_or(&f0);
+    let mut r_diag = compute_r_diag(error_spec, r_eval, &subject.obs_cmts, sigma_values);
     for (j, r) in r_diag.iter_mut().enumerate() {
         *r += p_obs.get(j).copied().unwrap_or(0.0);
     }
@@ -993,6 +1014,26 @@ pub fn foce_subject_nll_iov(
             &p_obs_iov,
         )
     } else {
+        // FOCE (no interaction): evaluate R at the population prediction with
+        // all random effects zero (η=0, κ=0), matching the non-IOV marginal so
+        // the zero-κ / Ω_iov→0 reduction collapses exactly to the BSV marginal.
+        // Additive error keeps f0 (bit-identical).
+        let pop_preds: Option<Vec<f64>> = if model.error_spec.has_f_dependent_variance() {
+            let zeros_eta = vec![0.0_f64; n_eta];
+            let zero_kappas: Vec<Vec<f64>> = kappa_slices
+                .iter()
+                .map(|k| vec![0.0_f64; k.len()])
+                .collect();
+            Some(pk::predict_iov(
+                model,
+                subject,
+                theta,
+                &zeros_eta,
+                &zero_kappas,
+            ))
+        } else {
+            None
+        };
         foce_subject_nll_standard(
             subject,
             &ipreds,
@@ -1003,6 +1044,7 @@ pub fn foce_subject_nll_iov(
             &model.error_spec,
             model.bloq_method,
             &p_obs_iov,
+            pop_preds.as_deref(),
         )
     }
 }
@@ -1595,6 +1637,65 @@ mod tests {
         assert!(
             (small - large).abs() > 1e-6,
             "Ω_iov must change the marginal OFV (small={small}, large={large})"
+        );
+    }
+
+    /// Regression for the FOCE+proportional fix: the residual variance must be
+    /// evaluated at a supplied population prediction `f(η=0)`, not the
+    /// SB-linearized `f0 = ipred − H·η̂`. When `f0` crosses zero (a nonlinear
+    /// model's linearization undershooting), `R(f0) = (f0·σ)²` collapses to the
+    /// floor and that observation's huge weight blows up the marginal — the
+    /// pathology that made FOCE+proportional multimodal with an indefinite
+    /// covariance. Passing `r_pred_override = Some(positive preds)` must avoid it.
+    #[test]
+    fn foce_standard_variance_uses_override_not_zero_crossing_f0() {
+        let subject = make_simple_subject(); // 6 obs
+        let omega = make_omega(0.09);
+        let sigma = vec![0.2]; // proportional SD
+        let error_spec = ErrorSpec::Single(ErrorModel::Proportional);
+
+        // ipreds all positive; H·η̂ drives the first f0 component to exactly 0.
+        let ipreds = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0];
+        let eta_hat = DVector::from_vec(vec![1.0]);
+        let h_matrix = DMatrix::from_column_slice(6, 1, &[10.0, 5.0, 5.0, 5.0, 5.0, 5.0]);
+        // f0 = ipred − H·η̂ = [0, 15, 25, 35, 45, 55] → first R(f0) hits the floor.
+
+        let nll_f0 = foce_subject_nll_standard(
+            &subject,
+            &ipreds,
+            &eta_hat,
+            &h_matrix,
+            &omega,
+            &sigma,
+            &error_spec,
+            BloqMethod::Drop,
+            &[],
+            None,
+        );
+        let nll_override = foce_subject_nll_standard(
+            &subject,
+            &ipreds,
+            &eta_hat,
+            &h_matrix,
+            &omega,
+            &sigma,
+            &error_spec,
+            BloqMethod::Drop,
+            &[],
+            Some(&ipreds),
+        );
+
+        assert!(nll_override.is_finite() && nll_f0.is_finite());
+        // The f0 path's near-floored first-observation variance inflates the
+        // marginal above the override path (which weights by the true ~positive
+        // prediction). The two differ by a clear, deterministic margin (~56 on
+        // this construction) — confirming R is evaluated at the override, not f0.
+        // (The HΩH' term in R̃ cushions the floored R(f0), so the gap is moderate
+        // rather than catastrophic, but it is well above FP noise.)
+        assert!(
+            nll_f0 - nll_override > 20.0,
+            "override must change the SB marginal (R evaluated at f(η=0), not f0): \
+             nll_f0={nll_f0}, nll_override={nll_override}"
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -889,6 +889,22 @@ impl ErrorSpec {
     /// scaling path. Fit-time validation rejects an uncovered CMT up front,
     /// and `build_error_spec` resolves indices against the real sigma vector,
     /// so a `NaN` here is only reachable via a hand-constructed model.
+    /// Whether the residual variance depends on the prediction `f` for any
+    /// endpoint (proportional or combined). When `false` (purely additive),
+    /// the variance is constant in `f`, so FOCE's choice of evaluation point
+    /// (linearized `f0` vs population `f(η=0)`) is irrelevant and the cheap
+    /// path stays bit-identical. Used to gate the FOCE population-variance
+    /// (`f(η=0)`) treatment in the marginal, analytical gradient, and
+    /// covariance step.
+    pub fn has_f_dependent_variance(&self) -> bool {
+        match self {
+            ErrorSpec::Single(em) => !matches!(em, ErrorModel::Additive),
+            ErrorSpec::PerCmt(map) => map
+                .values()
+                .any(|ep| !matches!(ep.error_model, ErrorModel::Additive)),
+        }
+    }
+
     pub fn variance_at(&self, cmt: usize, f_pred: f64, sigma: &[f64]) -> f64 {
         use crate::stats::residual_error::residual_variance;
         match self {
@@ -3132,6 +3148,30 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn error_spec_has_f_dependent_variance() {
+        use std::collections::HashMap;
+        // Single endpoint: only additive is f-independent.
+        assert!(!ErrorSpec::Single(ErrorModel::Additive).has_f_dependent_variance());
+        assert!(ErrorSpec::Single(ErrorModel::Proportional).has_f_dependent_variance());
+        assert!(ErrorSpec::Single(ErrorModel::Combined).has_f_dependent_variance());
+
+        // PerCmt: f-dependent if ANY endpoint is non-additive.
+        let ep = |em: ErrorModel| EndpointError {
+            error_model: em,
+            sigma_idx: vec![0],
+        };
+        let mut all_additive = HashMap::new();
+        all_additive.insert(1usize, ep(ErrorModel::Additive));
+        all_additive.insert(2usize, ep(ErrorModel::Additive));
+        assert!(!ErrorSpec::PerCmt(all_additive).has_f_dependent_variance());
+
+        let mut mixed = HashMap::new();
+        mixed.insert(1usize, ep(ErrorModel::Additive));
+        mixed.insert(2usize, ep(ErrorModel::Proportional));
+        assert!(ErrorSpec::PerCmt(mixed).has_f_dependent_variance());
+    }
 
     #[test]
     fn classify_warning_convergence_is_critical() {


### PR DESCRIPTION
## Why

FOCE (non-interaction) on proportional/combined error diverged from NONMEM and produced a degenerate covariance. On a 1-cpt oral benchmark (N=50, simulated), FOCE estimates were optimizer- and start-dependent (TVCL anywhere from 0.25 to 0.53), the converged point was a **saddle** (covariance Hessian eigenvalue −2086), and the SEs came back as garbage (TVCL SE 80) behind a "Standard errors are likely reliable" message.

Root cause: the Sheiner–Beal marginal evaluated the residual variance at the **linearized** prediction `f0 = f(η̂) − H·η̂`. On a nonlinear model `f0` can extrapolate to a near-zero or negative concentration where the true typical-individual prediction is healthy; evaluating `R(f0) = (f0·σ)²` there collapses the weight to the variance floor, making the marginal multimodal with an indefinite Hessian. (FOCEI and additive-error FOCE were unaffected and already matched NONMEM.)

## What changed

FOCE now evaluates the residual variance at the **population prediction `f(η=0)`** — the typical-individual concentration, always ≥ 0 — which is NONMEM's actual `METHOD=1` (no `INTER`) semantics. The residual `(y − f0)` stays on the SB-linearized mean; only the variance weight moves. All three sites are gated on `ErrorSpec::has_f_dependent_variance()` so **additive error is bit-identical** (its variance does not depend on `f`).

- `stats/likelihood.rs`: `foce_subject_nll_standard` gains an `r_pred_override`; the non-interaction marginal and the IOV zero-κ reduction path pass `f(η=0)`.
- `estimation/gauss_newton.rs`: the analytical SB gradient evaluates `R` at `f(η=0)` with the chain-rule derivative `d(f(η=0))/dθ` (FD), so slsqp/gn get a consistent descent direction; `subject_nll_at` mirrors it.
- `estimation/outer_optimizer.rs`: the FOCE covariance for `f`-dependent error uses the reconverged-OFV **second-difference Hessian** (the true objective curvature), not the envelope-approximation analytical gradient — which has no EBE-response Δ (that correction exists only for FOCEI, #274).

## Alternatives considered

- **R at `f(η̂)`** (the individual prediction): fixes the numerics but turns FOCE-proportional FOCEI-like (warfarin TVKA 0.756 → 0.815, OBJ → ≈ FOCEI), diverging from NONMEM FOCE on cases that currently match. Rejected.
- **Optimizer/covariance hardening only** (keep R at `f0`): the SB-at-`f0` surface is genuinely multimodal where `f0` crosses zero, so no optimizer fix makes it deterministic. Rejected.

## Breaking changes
- [x] None (no API/format change). FOCE+proportional/combined **estimates change** (toward NONMEM); additive is bit-identical. Documented in CHANGELOG.

## Numerical validation
- [x] Compared against: **NONMEM 7.5.1** (`METHOD=1`, `$COV MATRIX=R`), controlled run, 1-cpt oral, N=50, proportional.

```
                 ferx (this PR)   NONMEM FOCE   diff
TVCL              0.3964          0.3845        +3.1%
TVV              11.274          11.014         +2.4%
TVKA              1.0813          1.0723        +0.8%
omega^2(CL)       0.1354          0.1616        -16%
omega^2(V)        0.0810          0.0796        +1.8%
omega^2(KA)       0.1254          0.1212        +3.5%
(SEs within ~10%; covariance positive-definite; deterministic across
 bobyqa/slsqp and multiple starts.)

before this PR: TVCL 0.25–0.53 (optimizer-dependent), covariance eig −2086
                (clipped), SE(TVCL) 80 reported as "likely reliable".
```

- [x] Warfarin FOCE/FOCEI/IOV `$COVARIANCE MATRIX=R` cross-checks (`tests/warfarin_covariance_nonmem.rs`) still pass.

## Performance
- [x] No significant impact on the default path (bobyqa). The `f`-dependent FOCE covariance uses the OFV second-difference stencil (~n_free× more warm EBE reconvergences than the analytical-gradient stencil), bounded to the one-time covariance step; additive FOCE keeps the cheap analytical path.

## Tests
- [x] Unit tests added (`cargo test --lib` passes): `error_spec_has_f_dependent_variance`, `foce_standard_variance_uses_override_not_zero_crossing_f0`.
- [x] Regression test fails without the fix (the override test pins R to `f(η=0)` vs the `f0` zero-crossing blow-up).

## Docs
- [x] `docs/src/estimation/foce.md` FOCE section updated (R at `f(η=0)`).
- [x] `CHANGELOG.md` `[Unreleased]` entry added.

## Reviewer hints

The behavioural change is the `r_pred_override` in `foce_subject_nll_standard` and the three call sites that now pass `f(η=0)` for `f`-dependent error. The covariance routing change (`force_ofv_hessian`) is the reason the SEs are now PD/honest. Additive bit-identicality rests entirely on `has_f_dependent_variance()` gating every new branch.

## Open questions

A follow-up is planned to **unify all covariance on the reconverged-OFV second difference** (deleting the #274 Δ correction, the `point_grad` analytical-covariance path, and the mu-ref gradient shortcut, which benchmarks show buys no speed). That would subsume the `force_ofv_hessian` special-case and the `d(f(η=0))/dθ` chain rule added here. Tracking separately to keep this fix focused and the FOCEI NONMEM match independently validated.