### PR TITLE
docs(plans): add built-in absorption models roadmap [#322]

### DIFF
--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -58,9 +58,9 @@ now-closed #282). In NONMEM, coded `RATE` is *parameter-driven*, not data-column
 **duration** is modeled (`D1` in `$PK`). Neither reads a data column; duration is the more
 commonly estimated of the two. #324 is scoped to:
 
-- **#324 Phase 0** — safety net: reject coded/malformed `RATE` (`-1`, `-2`, other negatives,
+- **#324 safety net (PR #326)** — reject coded/malformed `RATE` (`-1`, `-2`, other negatives,
   non-finite) on a dose row instead of silently treating it as an IV bolus (today's bug).
-  Ships first, standalone (PR #326).
+  Ships first, standalone.
 - **#324 faithful support** — `RATE=-1` = rate modeled via an `R1`-style `.ferx` DSL
   parameter; `RATE=-2` = duration modeled via a `D1`-style DSL parameter. Both
   runtime/parameter-driven; **no `DURATION` data column**.
@@ -74,7 +74,7 @@ absorption family (`zero_order`, `sequential`, `mixed`) reuses.
   neither involves a zero-order input. The two headline models are unblocked by #324.
 - **Is the foundation** for the zero-order absorption family in Phase 2 below.
 
-Decision: ship #324's Phase 0 safety net first (independently valuable); its `D1`
+Decision: ship #324's safety net first (independently valuable); its `D1`
 modeled-duration path establishes the estimated-duration forcing this plan's Phase 2 then
 reuses. Phase 0/1 of this plan can start in parallel, since they don't depend on it.
 
@@ -361,7 +361,7 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 ## Phasing (one PR each)
 
-- **Phase −1 — issue #324 (NONMEM coded `RATE`), standalone first.** Ship the safety net
+- **Prerequisite — issue #324 (NONMEM coded `RATE`), standalone first.** Ship the safety net
   first (reject coded/malformed `RATE` instead of a silent IV bolus; PR #326). Faithful
   support follows as a parameter-driven DSL feature: `RATE=-1` = rate modeled (`R1`-style),
   `RATE=-2` = duration modeled (`D1`-style) — **no `DURATION` data column**. The

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -2,7 +2,8 @@
 
 **Tracking issue:** [#322](https://github.com/FeRx-NLME/ferx-core/issues/322)
 **Scope:** ferx-core (primary) + ferx-r (follow-up PR once `pub` API lands)
-**Status:** approved roadmap, not yet implemented. Multi-PR / phased.
+**Status:** approved roadmap. Prerequisite #324 safety net (PR #326) **merged 2026-06-14**;
+remaining models not yet implemented. Multi-PR / phased.
 
 ---
 
@@ -58,9 +59,9 @@ now-closed #282). In NONMEM, coded `RATE` is *parameter-driven*, not data-column
 **duration** is modeled (`D1` in `$PK`). Neither reads a data column; duration is the more
 commonly estimated of the two. #324 is scoped to:
 
-- **#324 safety net (PR #326)** — reject coded/malformed `RATE` (`-1`, `-2`, other negatives,
-  non-finite) on a dose row instead of silently treating it as an IV bolus (today's bug).
-  Ships first, standalone.
+- **#324 safety net (PR #326) — ✅ MERGED 2026-06-14.** Rejects coded/malformed `RATE` (`-1`,
+  `-2`, other negatives, non-finite) on a dose row instead of silently treating it as a bolus
+  (the original bug). Shipped standalone.
 - **#324 faithful support** — `RATE=-1` = rate modeled via an `R1`-style `.ferx` DSL
   parameter; `RATE=-2` = duration modeled via a `D1`-style DSL parameter. Both
   runtime/parameter-driven; **no `DURATION` data column**.
@@ -361,8 +362,8 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 ## Phasing (one PR each)
 
-- **Prerequisite — issue #324 (NONMEM coded `RATE`), standalone first.** Ship the safety net
-  first (reject coded/malformed `RATE` instead of a silent IV bolus; PR #326). Faithful
+- **Prerequisite — issue #324 (NONMEM coded `RATE`), standalone first.** Safety net **✅ MERGED**
+  (PR #326, 2026-06-14: rejects coded/malformed `RATE` instead of a silent bolus). Faithful
   support follows as a parameter-driven DSL feature: `RATE=-1` = rate modeled (`R1`-style),
   `RATE=-2` = duration modeled (`D1`-style) — **no `DURATION` data column**. The
   `RATE=-2`/`D1` modeled-duration path establishes the estimated-duration forcing that this

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -1,4 +1,4 @@
-# Plan: Built-in absorption models (`[absorption]` block)
+# Plan: Built-in absorption models (input-rate functions + `ode_template`)
 
 **Tracking issue:** [#322](https://github.com/FeRx-NLME/ferx-core/issues/322)
 **Scope:** ferx-core (primary) + ferx-r (follow-up PR once `pub` API lands)
@@ -19,39 +19,33 @@ and forces the user to do math the engine should do.
 The goal is to compute these **in Rust** as first-class, user-friendly built-ins, with
 **robust handling of edge cases (no happy-path-only code)**. The named anchors are
 **Savic 2007** (transit) and **Freijer & Post** (convection–dispersion ⇒ inverse-Gaussian
-density input). The mechanism is a set of **built-in input-rate functions** (`transit`,
-`igd`, `weibull`, `zero_order`, `first_order`) exposed two ways (see "DSL surface"):
-**Layer 1** — callable directly in the `[odes]` RHS so the user writes the ODE explicitly
-(Ron's proposal: `d/dt(depot) = transit(NTR, MTT) - KA*depot`), and **Layer 2** — an optional
-`[absorption]` block that, on an analytical `pk` model, uses a closed form where one exists
-and otherwise desugars to the Layer-1 ODE with a clear warning.
+density input). The mechanism is a set of **built-in input-rate functions** (`transit`, `igd`, `weibull`,
+`zero_order`, `first_order`) callable in the `[odes]` RHS, so the user writes the ODE
+explicitly (Ron's proposal: `d/dt(depot) = transit(NTR, MTT) - KA*depot`). The disposition is
+supplied explicitly — a hand-written `ode(...)` or a generated `ode_template ...` — never
+invented behind an analytical `pk` request (which errors instead). See "DSL surface".
 
 This is a **large, multi-PR feature**; the plan is phased so each model lands with its own
 tests, NONMEM anchor, and docs.
 
 ## Goals / non-goals
 
-- **Goal:** `[absorption]` block selecting transit / inverse-Gaussian / Weibull /
-  zero-order / sequential / parallel / mixed, with parameters bound to
+- **Goal:** built-in absorption input-rate functions (`transit`, `igd`, `weibull`,
+  `zero_order`, `first_order`) usable in `[odes]`, with arguments bound to
   `[individual_parameters]` (so they carry IIV, covariates, etc. for free).
-- **Goal:** the `[absorption]` type works on **both** analytical (`pk ...`) and ODE
-  (`ode(...)`) disposition models (Ron's review). On ODE models it injects the input as RHS
-  forcing into the dosing compartment; on analytical models it dispatches a **closed form
-  where one exists**, and falls back to numerical integration only where none does.
-- **Goal:** **closed-form-first, not ODE-always.** Most absorption types reduce to
-  superpositions of the analytical building blocks ferx already has (see "Which models stay
-  analytical"), so they stay in the fast analytical engine. Weibull, inverse-Gaussian, and
-  continuous-N transit have no elementary closed form; when one of those is applied to an
-  analytically-specified model ferx integrates numerically **and emits a clear warning**
-  (Ron's requirement) — never a silent ODE swap.
-- **Goal:** **transparency.** Each model's math and its explicit ODE form are documented;
-  `ferx check` surfaces the effective (synthesized) model so the numerical path is
-  inspectable, not a black box. Where both forms exist they are cross-checked under the
-  analytical↔ODE equivalence harness (ferx-r#127 / `tests/analytical_ode_equivalence.rs`).
+- **Goal:** **explicit disposition, no surprises** (Ron). Absorption feeds an ODE supplied by
+  the user — hand-written `ode(...)` or generated `ode_template ...`. Asking for an
+  ODE-only absorption model (transit / IG / Weibull) on an analytical `pk ...` is a clear
+  **error** pointing at `ode_template` — never a silent (or even warned) analytical→ODE swap.
+- **Goal:** `ode_template NAME(...)` generates the standard disposition ODE from the codified
+  analytical↔ODE transforms (ferx-r#127 / `tests/analytical_ode_equivalence.rs`); a general
+  primitive, reusable beyond absorption (TMDD, …).
 - **Goal:** continuous (non-integer) N for the Savic transit model — the key thing the
   current hand-written ODE example cannot do.
+- **Non-goal (this plan):** the declarative `[absorption]` block — **dropped** (see DSL
+  surface); absorption is the input-rate functions plus an explicit ODE disposition.
 - **Non-goal (this plan):** changing the existing analytical `pk` disposition solvers; they
-  keep working unchanged for first-order/IV. Absorption models layer on top.
+  keep working unchanged for the standard closed-form models.
 - **Non-goal (this plan):** the NONMEM coded-`RATE` data path itself (`RATE=-1`/`-2`,
   issue #324) — a separate data-reader feature this plan depends on for its zero-order
   family. See "Relationship to #324".
@@ -84,17 +78,20 @@ Decision: ship #324's Phase 0 safety net first (independently valuable); its `D1
 modeled-duration path establishes the estimated-duration forcing this plan's Phase 2 then
 reuses. Phase 0/1 of this plan can start in parallel, since they don't depend on it.
 
-## DSL surface — two layers over one set of input-rate functions
+## DSL surface
 
-The absorption math lives in **built-in input-rate functions** — `transit(n, mtt)`,
+Absorption is a set of **built-in input-rate functions** — `transit(n, mtt)`,
 `igd(mat, cv2)` (inverse-Gaussian / Freijer & Post), `weibull(td, beta)`, `zero_order(dur)`,
-and `first_order(ka)` (for composition). They are the single source of truth, exposed two
-ways.
+and `first_order(ka)` (for composition) — used **inside an ODE**. The disposition the
+absorption feeds is supplied **explicitly**, never invented behind the user's back. Three
+ways to supply it: a hand-written `ode(...)`, an analytical `pk ...` (closed-form models
+only — see the error rule), or a generated `ode_template ...` (Ron's proposal — ferx writes
+the standard disposition ODE for you). No model is ever *silently* turned into an ODE.
 
-### Layer 1 — input-rate functions in `[odes]` (Ron's proposal; transparent foundation)
+### Absorption: input-rate functions in `[odes]`
 
-The user writes the ODE explicitly and calls the built-in for the input rate — keeping full
-control of the compartment structure and *seeing* that it is an ODE — but without
+The user writes (or generates, below) the ODE and calls the built-in for the input rate —
+keeping full control of the compartment structure and *seeing* that it is an ODE — without
 hand-coding the Stirling gamma density:
 
 ```
@@ -114,8 +111,8 @@ models (Weibull, IG, continuous-N transit) and satisfies Ron's transparency ask 
 
 **Input-rate function for each model.** Each returns the dose-driven appearance rate into the
 compartment it is added to (dose amount × F, superposed over doses). Fractions for parallel /
-biphasic pathways are **plain scalar multipliers** — so no `pathway` grammar is needed in
-Layer 1, and `frac` just splits the dose by linearity.
+biphasic pathways are **plain scalar multipliers** — so no `pathway` grammar is needed, and
+`frac` just splits the dose by linearity.
 
 *Savic transit* — `transit(n, mtt)` into a depot, then first-order `ka` (shown above);
 `ktr = (n+1)/mtt`, continuous `n`.
@@ -174,49 +171,53 @@ function* (it is the chain input) and must **not** also enter as a bolus into th
 compartment — define and test this rule explicitly (it is the classic Savic "dose into the
 virtual transit, not the depot" subtlety).
 
-### Layer 2 — `[absorption]` block (optional convenience; desugars to Layer 1 / closed forms)
+### Disposition: `ode_template` (Ron's proposal) — explicit, no surprises
 
-A one-liner on an analytical disposition for users who don't want to write the ODE. It
-selects the input model declaratively; the engine uses a **closed form where one exists**
-(see "Which models stay analytical") and otherwise auto-builds the equivalent Layer-1 ODE,
-emitting `W_ABSORPTION_NUMERICAL`. Parameters reference `[individual_parameters]` names
-(like `cl=CL` on the pk line):
+Writing the full disposition ODE by hand every time is verbose. `ode_template NAME(...)`
+tells ferx to **generate** the standard disposition ODE for a named model — the codified
+analytical→ODE transforms already specified in ferx-r#127 / `ode-analytical-equivalence.md`
+(e.g. `two_cpt_oral` → `depot`/`central`/`periph` states with the micro-constant RHS and
+`obs_scale = V1`). The user then extends it with absorption input-rate functions:
 
 ```
 [structural_model]
-  pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2)   # NB: no ka= when [absorption] present
+  ode_template two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2)   # ferx writes the 2-cpt oral ODE
 
-[absorption]
-  model = transit
-  mtt   = MTT          # mean transit time
-  n     = NTR          # number of transit compartments (continuous)
-  ka    = KA           # optional; defaults to KTR=(n+1)/mtt
+[odes]
+  # add the Savic transit input into the generated depot
+  d/dt(depot) += transit(NTR, MTT)        # extend the generated RHS (syntax TBD; see Open Qs)
 ```
 
-Multi-pathway models (Freijer sum-of-two-IG, parallel first-order) use repeated
-`pathway` entries with a fraction:
+Because the user typed `ode_template`, they **expect** ferx to write ODEs — there is no
+hidden conversion (Ron's core requirement). The same primitive generalizes beyond
+absorption (e.g. **TMDD**: generate a standard disposition, then add target-binding terms),
+so it is worth building as a general mechanism, not an absorption-specific one (Ron's last
+point).
 
-```
-[absorption]
-  model    = inverse_gaussian
-  pathway  = { mat = MAT1, cv2 = CV2_1, frac = FR1 }
-  pathway  = { mat = MAT2, cv2 = CV2_2 }   # last frac defaults to 1 - sum(others)
-```
+### The error rule (analytical + ODE-only absorption ⇒ error)
 
-> The `pathway = { ... }` inline-record form is a **new grammar construct** (no DSL
-> precedent today). For the common ≤2-pathway case, repeated scalar keys (`mat1=`, `cv2_1=`,
-> `frac1=`, `mat2=`, …) reach parity with zero new grammar; defer the brace form until a
-> >2-pathway need is real.
+If a user writes an **analytical** `pk one/two/three_cpt_oral(...)` and *also* asks for an
+absorption model with no closed form (transit / IG / Weibull), ferx **errors** with a
+message pointing at `ode_template` — it does **not** silently (or even with a warning) build
+an ODE behind an analytical request. This is Ron's "avoid surprises":
 
-Rules (all enforced at parse time, all with negative tests):
-- `[absorption]` present ⇒ the `pk *_oral` line must **not** also map `ka=` (mutually
-  exclusive: first-order is the no-`[absorption]` default). Mapping both is a parse error.
-- `[absorption]` is only valid with an **oral** disposition (`one/two/three_cpt_oral`);
-  combining with an IV-only model, or with a subject carrying `RATE>0` infusion dose rows,
-  is a **parse error** (the dose route is ambiguous — see Robustness).
-- Every referenced name must be a declared individual parameter (reuse the existing
-  "undefined name" machinery — `parser/model_parser.rs` visit_*_nodes); unknown keys for a
-  model are rejected; pathway fractions must be in (0,1] and sum to ≈1.
+> *"transit absorption requires an ODE; replace `pk two_cpt_oral(...)` with
+> `ode_template two_cpt_oral(...)` and add `transit(...)` in `[odes]`."*
+
+### Dropped: the declarative `[absorption]` block
+
+An earlier draft proposed a declarative `[absorption]` block on an analytical `pk` model
+that would pick a closed form or silently desugar to an ODE. **Dropped** — that is exactly
+the silent analytical→ODE conversion Ron objected to, and with `ode_template` + one-line
+input-rate functions it buys almost no convenience for a lot of machinery (closed-form
+dispatch, the `W_ABSORPTION_NUMERICAL` warning, a `pathway = {}` grammar). If a one-liner is
+ever wanted it can return later as pure sugar over `ode_template` — never over `pk`.
+
+Parser rules (enforced, with negative tests): input-rate-function arguments must be declared
+individual parameters (reuse the undefined-name machinery in `parser/model_parser.rs`);
+unknown function names / wrong arity are rejected; an input-rate function combined with an
+analytical `pk` disposition triggers the error rule above; parallel/biphasic fractions must
+be in (0,1].
 
 ## The models (input rate `R_in(t)`, ∫₀^∞ R_in dt = F·Dose)
 
@@ -225,7 +226,7 @@ superposed. `D` = `F·amt`.
 
 | `model =` | `R_in(t)` | Params | Special fn | t→0 edge |
 |---|---|---|---|---|
-| `first_order` (default, no block) | `D·ka·e^{−ka·tad}` | ka | — | finite |
+| `first_order` (default) | `D·ka·e^{−ka·tad}` | ka | — | finite |
 | `zero_order` | `D/Dur` on `[0,Dur]` else 0 | dur | — | step |
 | `sequential` (0→1st) | zero-order fills depot over `dur`, then `ka` out | dur, ka | — | step |
 | `parallel` (dual 1st-order) | `D·Σ fᵢ·kaᵢ·e^{−kaᵢ·tad}` | ka1,ka2,frac | — | finite |
@@ -244,12 +245,16 @@ Notes:
   CV² = relative dispersion of the absorption-time distribution — i.e. the standard
   inverse-Gaussian density with mean `μ=MAT` and shape `λ=MAT/CV²` (implementer mapping).
 
-## Which models stay analytical vs need numerical integration
+## Which models *could* be accelerated with a closed form (internal only)
 
-This is the crux of Ron's review: *does adding an absorption model silently turn an
-analytical model into an ODE?* Mostly **no** — only where the math forces it.
+With the error rule above, the user always specifies their disposition explicitly, so this
+table is **no longer a user-facing dispatch** — it is an internal performance note. Where an
+`ode_template`/`ode` absorption model happens to have a closed form, ferx *may* compute it
+via the fast analytical path instead of integrating, **provided the two are proven identical
+under the equivalence harness** (so there is no behavioural surprise — same numbers, faster).
+Everything else integrates.
 
-| Absorption model | Closed form with linear disposition? | Engine |
+| Absorption model | Closed form with linear disposition? | Can ferx accelerate internally? |
 |---|---|---|
 | `first_order` | yes (Bateman) — already shipped | analytical |
 | `zero_order` | yes (= infusion into depot/central) | analytical |
@@ -261,19 +266,13 @@ analytical model into an ODE?* Mostly **no** — only where the math forces it.
 | `weibull` | **no** elementary closed form | numerical |
 | `inverse_gaussian` (Freijer & Post) | **no** elementary closed form (general multi-cpt) | numerical |
 
-So, will analytical models be made into ODEs? **Not in general.** The
-first-order/zero-order/parallel/sequential/mixed family and integer-N transit reduce to
-**superpositions of the closed forms ferx already has** (e.g. `parallel` = two `two_cpt_oral`
-evaluations weighted by `frac`) and stay analytical. Continuous-N transit stays analytical
-once the incomplete-gamma special function lands (Phase 3, promoted from "optional"). Only
-**Weibull** and **inverse-Gaussian** are inherently numerical — there is no closed-form
-convolution of those input densities with a multi-compartment disposition, so they are
-integrated (ODE / convolution quadrature) regardless of how the disposition was written.
-
-**When the numerical path is used on an analytically-specified model, ferx warns**
-(`W_ABSORPTION_NUMERICAL`, e.g. "absorption=weibull has no closed form with two_cpt_oral;
-predictions use numerical integration (slower)"). A model written as `ode(...)` gets no
-warning — the user already chose numerical integration.
+The first-order / zero-order / parallel / sequential / mixed family and integer-N transit
+are superpositions of closed forms ferx already has (e.g. `parallel` = two `two_cpt_oral`
+evaluations weighted by `frac`); continuous-N transit gains a closed form once the
+incomplete-gamma special function lands (Phase 3). **Weibull** and **inverse-Gaussian** have
+no elementary closed-form convolution with a multi-compartment disposition and always
+integrate. The user-facing model is the ODE they wrote; any closed-form acceleration is an
+equivalence-tested optimization underneath it, not a different code path they can observe.
 
 ## Engine architecture
 
@@ -288,24 +287,23 @@ Decouple **input function** from **disposition**, reusing existing machinery:
    pattern. Honor the `ad/` rule: **no `f64::max`/`min`** — use explicit comparisons (see
    CLAUDE.md). Each model also exposes `validate(θ) -> Result` and the analytic mass
    `∫R_in = F·Dose` (test invariant).
-2. **Disposition — two dispatch modes** (chosen per absorption×disposition combo, per the
-   table above):
-   - **(a) Closed-form (preferred).** Stay in the analytical engine. The first-order /
-     zero-order / parallel / sequential / mixed family and integer-N transit map `R_in` to a
-     **superposition of the existing `pk/` closed forms** (e.g. `parallel` = two
-     `two_cpt_oral` evaluations weighted by `frac`); continuous-N transit uses the
-     incomplete-gamma closed form (Phase 3). No ODE solve, no warning.
-   - **(b) Numerical fallback.** Weibull / inverse-Gaussian / continuous-N transit before the
-     incomplete-gamma path lands: add `+R_in(tad)` forcing into the dosing compartment via the
-     **same RHS-wrapper mechanism that already injects `+rate` for infusions**
-     (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper"). Emit
-     `W_ABSORPTION_NUMERICAL` when the disposition was specified analytically.
-   - **Works on both model kinds.** On an `ode(...)` disposition the absorption type injects
-     the same `R_in(tad)` forcing into the user's dosing compartment (no warning — they chose
-     ODE). On a `pk ...` disposition, mode (a)/(b) is selected by the table.
-   - Shared by both modes: observed value via the existing obs-compartment plumbing; **SS=1**
-     reuses `equilibrate_ss_state`; **lagtime/F** reuse `PK_IDX_LAGTIME` (shift `tad`) and
-     `PK_IDX_F` (scale `D`); multiple doses / ADDL superpose `R_in` per dose.
+2. **Forcing into the user's ODE.** `R_in(tad)` is added into the dosing compartment of the
+   disposition the user supplied (`ode(...)` or the `ode_template`-generated states) via the
+   **same RHS-wrapper mechanism that already injects `+rate` for infusions**
+   (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper"). No silent
+   conversion: an analytical `pk` disposition + an ODE-only absorption model is rejected by the
+   error rule, not forced. Shared plumbing: observed value via the existing obs-compartment
+   path; **SS=1** reuses `equilibrate_ss_state`; **lagtime/F** reuse `PK_IDX_LAGTIME` (shift
+   `tad`) and `PK_IDX_F` (scale `D`); multiple doses / ADDL superpose `R_in` per dose.
+   - **Internal closed-form acceleration (optional):** where the combo has a closed form
+     (first/zero/parallel/sequential/mixed, integer-N transit, continuous-N transit via
+     incomplete gamma), ferx *may* compute it via the `pk/` solvers instead of integrating —
+     **only** when proven identical under the equivalence harness, so the user sees the same
+     numbers, faster. This is an optimization beneath the ODE the user wrote, never a separate
+     observable path.
+   - **`ode_template` generation:** the named-model → ODE transform (states, micro-constant
+     RHS, `obs_scale`) is codified once from `ode-analytical-equivalence.md`; the absorption
+     term is appended to the generated depot/dosing compartment.
 3. **Special functions (`src/stats/special.rs`):** add `ln_gamma` via a **Lanczos** rational
    approximation (AD-safe, following the existing `erf` A&S precedent) — **not** bare Stirling:
    `N` is estimated continuously and transit `N` is commonly 1–10, where Stirling errs ~8% at
@@ -328,9 +326,10 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   `W_NEGATIVE_LAGTIME` pattern in `diagnostics.rs`).
 - **Singularity guards:** `tad ≤ ε ⇒ R_in = 0`; transit `0^N` and `log(tad)` guarded;
   Weibull `β<1` integrable spike capped/handled; IGD essential singularity at `tad→0`.
-- **Mutual exclusivity & route checks:** `[absorption]` + `ka=` ⇒ error; `[absorption]` on
-  IV-only disposition ⇒ error; `[absorption]` + a `RATE>0` infusion dose row ⇒ **parse error**
-  (the dose route is ambiguous; decided over "documented precedence").
+- **Route checks:** an ODE-only absorption input-rate function (`transit`/`igd`/`weibull`) on
+  an analytical `pk` disposition ⇒ **error** pointing at `ode_template` (the error rule); an
+  input-rate function plus a `RATE>0` infusion dose row into the same compartment ⇒ **parse
+  error** (dose route ambiguous).
 - **Mass-balance invariant** `∫R_in dt = F·Dose` as a unit test per model (catches a wrong
   normalization constant — the classic transit/IGD bug).
 - **AD-safety:** no `f64::max`/`min` anywhere reachable from the AD path; re-enable a
@@ -341,9 +340,10 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 - `src/types.rs` — new `AbsorptionSpec` + `AbsorptionModel` enum on `CompiledModel`; oral
   `PkModel` paths gain an optional spec.
-- `src/parser/model_parser.rs` — parse/validate `[absorption]`; reuse undefined-name walker
-  and the `consumes_pk_slot`/"declared-but-unused" census.
-- `src/pk/absorption.rs` (new) — generic input functions + validation + mass.
+- `src/parser/model_parser.rs` — parse `ode_template NAME(...)` + the input-rate function
+  intrinsics; the error rule; reuse the undefined-name walker / "declared-but-unused" census.
+- `src/pk/absorption.rs` (new) — generic input functions + validation + mass; `ode_template`
+  generation reuses the `ode-analytical-equivalence.md` transforms.
 - `src/stats/special.rs` — `ln_gamma` (+ later regularized incomplete gamma).
 - `src/ode/predictions.rs` — synthesized-disposition + `R_in` forcing; SS reuse.
 - prediction dispatcher / `src/estimation/inner_optimizer.rs` — route oral+absorption to the
@@ -361,13 +361,12 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   `RATE=-2`/`D1` modeled-duration path establishes the estimated-duration forcing that this
   plan's Phase 2 zero-order family reuses. Independent of this plan's Phase 0/1, which can
   start in parallel.
-- **Phase 0 — `transit()` input-rate function (Layer 1 first).** Implement the built-in
-  `transit(n, mtt)` intrinsic callable in `[odes]` (Ron's proposal): the input-rate
-  evaluator, dose-context wiring, the dose-routing rule (dose feeds the function, not a
-  bolus), and `ln_gamma`. Anchor against the existing `transit_2cpt` dataset and a NONMEM
-  Savic run — this proves the transparent path end-to-end. The optional `[absorption]` block
-  (Layer 2), the closed-form-vs-numerical dispatch, and the `W_ABSORPTION_NUMERICAL` warning
-  land here or as a Layer-2 follow-up (see Open questions).
+- **Phase 0 — `transit()` input-rate function + `ode_template`.** Implement the built-in
+  `transit(n, mtt)` intrinsic callable in `[odes]` (Ron's proposal): the input-rate evaluator,
+  dose-context wiring, the dose-routing rule (dose feeds the function, not a bolus), `ln_gamma`,
+  and `ode_template` generation for the standard PK models + the analytical-`pk`-plus-absorption
+  **error rule**. Anchor against the existing `transit_2cpt` dataset and a NONMEM Savic run —
+  proves the transparent path end-to-end.
 - **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; **numerical**
   (no closed form). Anchor vs the Freijer & Post paper / a NONMEM `$DES` IG run.
 - **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the
@@ -382,8 +381,9 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 - **Tier 1 (unit):** input-fn values vs hand-computed; mass-balance integral; `ln_gamma` vs
   reference; every param-validation error/warning.
-- **Tier 2 (`tests/*.rs`):** parse `[absorption]` → `CompiledModel`; `fit()` returns
-  immediately / errors on a bad spec (no convergence loop).
+- **Tier 2 (`tests/*.rs`):** parse `ode_template` + input-rate functions → `CompiledModel`;
+  the error rule fires on `pk` + ODE-only absorption; `fit()` returns immediately / errors on a
+  bad spec (no convergence loop).
 - **Tier 3 (slow, gated):** full fits per model to convergence (gate with
   `cfg_attr(not(feature="slow-tests"), ignore)`).
 - **NONMEM comparison** (required for numeric features): transit & IG estimates/OFV vs
@@ -409,11 +409,15 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 ## Open questions
 
-- **Keep Layer 2 (`[absorption]` block) at all, or ship Layer-1 functions only?** Ron's
-  proposal is just the `[odes]` input-rate functions (fully transparent, composable, no
-  silent ODE). The block adds convenience but also the closed-form dispatch + warning
-  machinery. Decision pending: ship Layer 1 first (Phase 0), then decide whether Layer 2
-  earns its complexity once Layer 1 is in users' hands.
+- **`[absorption]` block — decided to drop** (see DSL surface). Recommendation pending your /
+  Ron's sign-off: ship input-rate functions + `ode_template`; if a one-liner is wanted later
+  it returns as sugar over `ode_template`, never over `pk`.
+- **`ode_template` extend-vs-override syntax** — how does the user add the absorption term to
+  a generated RHS? Options: `d/dt(depot) += transit(...)` (append), re-declaring `d/dt(depot)`
+  to override, or a dedicated `[absorption_into = depot]` hint. Needs a decision in Phase 0.
+- **`ode_template` scope** — ship it absorption-only first, or design the general primitive
+  (TMDD etc.) up front? Ron flagged the reuse; lean to designing the generation hook generally
+  but ship the standard PK templates first.
 - **`transit()` argument form** — `transit(n, mtt)` (explicit, recommended) vs `transit(n)`
   reading a conventional `MTT`/`KTR` param. Explicit args avoid magic.
 

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -20,11 +20,11 @@ The goal is to compute these **in Rust** as first-class, user-friendly built-ins
 **robust handling of edge cases (no happy-path-only code)**. The named anchors are
 **Savic 2007** (transit) and **Freijer & Post** (convection–dispersion ⇒ inverse-Gaussian
 density input). The mechanism is a set of **built-in input-rate functions** (`transit`,
-`igd`, `weibull`, `zero_order`) exposed two ways (see "DSL surface"): **Layer 1** — callable
-directly in the `[odes]` RHS so the user writes the ODE explicitly (Ron's proposal:
-`d/dt(depot) = transit(NTR, MTT) - KA*depot`), and **Layer 2** — an optional `[absorption]`
-block that, on an analytical `pk` model, uses a closed form where one exists and otherwise
-desugars to the Layer-1 ODE with a clear warning.
+`igd`, `weibull`, `zero_order`, `first_order`) exposed two ways (see "DSL surface"):
+**Layer 1** — callable directly in the `[odes]` RHS so the user writes the ODE explicitly
+(Ron's proposal: `d/dt(depot) = transit(NTR, MTT) - KA*depot`), and **Layer 2** — an optional
+`[absorption]` block that, on an analytical `pk` model, uses a closed form where one exists
+and otherwise desugars to the Layer-1 ODE with a clear warning.
 
 This is a **large, multi-PR feature**; the plan is phased so each model lands with its own
 tests, NONMEM anchor, and docs.
@@ -87,8 +87,9 @@ reuses. Phase 0/1 of this plan can start in parallel, since they don't depend on
 ## DSL surface — two layers over one set of input-rate functions
 
 The absorption math lives in **built-in input-rate functions** — `transit(n, mtt)`,
-`igd(mat, cv2)` (inverse-Gaussian / Freijer & Post), `weibull(td, beta)`,
-`zero_order(dur)`. They are the single source of truth, exposed two ways.
+`igd(mat, cv2)` (inverse-Gaussian / Freijer & Post), `weibull(td, beta)`, `zero_order(dur)`,
+and `first_order(ka)` (for composition). They are the single source of truth, exposed two
+ways.
 
 ### Layer 1 — input-rate functions in `[odes]` (Ron's proposal; transparent foundation)
 
@@ -108,10 +109,62 @@ hand-coding the Stirling gamma density:
 `transit(NTR, MTT)` returns the Savic transit-chain appearance rate into that compartment,
 evaluated by the engine from time-after-dose and the dose amount (×F), superposed over doses
 — the same dose context the infusion RHS-wrapper already carries. `igd(...)`, `weibull(...)`,
-`zero_order(...)` behave identically. Multi-pathway / parallel absorption is just additional
-RHS terms (`transit(...) + igd(...)`) — no new grammar. This is the natural home for the
-inherently-numerical models (Weibull, IG, continuous-N transit) and satisfies Ron's
-transparency ask directly.
+`zero_order(...)` behave identically. This is the natural home for the inherently-numerical
+models (Weibull, IG, continuous-N transit) and satisfies Ron's transparency ask directly.
+
+**Input-rate function for each model.** Each returns the dose-driven appearance rate into the
+compartment it is added to (dose amount × F, superposed over doses). Fractions for parallel /
+biphasic pathways are **plain scalar multipliers** — so no `pathway` grammar is needed in
+Layer 1, and `frac` just splits the dose by linearity.
+
+*Savic transit* — `transit(n, mtt)` into a depot, then first-order `ka` (shown above);
+`ktr = (n+1)/mtt`, continuous `n`.
+
+*Inverse-Gaussian (Freijer & Post)* — `igd(mat, cv2)` straight into central; the biphasic
+form is two terms split by a fraction:
+```
+[odes]
+  # single IG into 1-cpt
+  d/dt(central) = igd(MAT, CV2) - (CL/V)*central
+  # Freijer biphasic (sum of two IG), fraction FR through pathway 1
+  d/dt(central) = FR*igd(MAT1, CV2_1) + (1-FR)*igd(MAT2, CV2_2) - (CL/V)*central
+```
+
+*Weibull* — `weibull(td, beta)` (td = scale, beta = shape):
+```
+[odes]
+  d/dt(central) = weibull(TD, BETA) - (CL/V)*central
+```
+
+*Zero-order, estimated duration* — `zero_order(dur)` (constant rate over `dur`; this is the
+modeled-duration / #324 `D1` case, reusable as an absorption input):
+```
+[odes]
+  d/dt(central) = zero_order(DUR) - (CL/V)*central
+```
+
+*Parallel / dual first-order* — compose two `first_order(ka)` terms with a fraction (no need
+for two depot compartments or per-compartment F):
+```
+[odes]
+  d/dt(central) = FR*first_order(KA1) + (1-FR)*first_order(KA2) - (CL/V)*central
+```
+
+*Sequential (zero-order then first-order)* — `zero_order` fills the depot, `ka` to central:
+```
+[odes]
+  d/dt(depot)   = zero_order(DUR) - KA*depot
+  d/dt(central) = KA*depot - (CL/V)*central
+```
+
+*Mixed (zero-order + first-order, in parallel)*:
+```
+[odes]
+  d/dt(central) = (1-FZO)*first_order(KA) + FZO*zero_order(DUR) - (CL/V)*central
+```
+
+(`first_order(ka)` is the existing first-order absorption exposed as an input-rate function
+for composition; standalone first-order still uses the analytical `pk *_oral` path.)
 
 Two implementation notes: **(i)** these are **engine intrinsics**, not pure expressions — the
 `[odes]` evaluator must hand them the dose schedule, amount, F, and time-after-dose (extend

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -31,12 +31,24 @@ tests, NONMEM anchor, and docs.
 - **Goal:** `[absorption]` block selecting transit / inverse-Gaussian / Weibull /
   zero-order / sequential / parallel / mixed, with parameters bound to
   `[individual_parameters]` (so they carry IIV, covariates, etc. for free).
-- **Goal:** one engine path that works for **any** input function, reusing the ODE
-  RHS-forcing mechanism already used for infusions.
+- **Goal:** the `[absorption]` type works on **both** analytical (`pk ...`) and ODE
+  (`ode(...)`) disposition models (Ron's review). On ODE models it injects the input as RHS
+  forcing into the dosing compartment; on analytical models it dispatches a **closed form
+  where one exists**, and falls back to numerical integration only where none does.
+- **Goal:** **closed-form-first, not ODE-always.** Most absorption types reduce to
+  superpositions of the analytical building blocks ferx already has (see "Which models stay
+  analytical"), so they stay in the fast analytical engine. Weibull, inverse-Gaussian, and
+  continuous-N transit have no elementary closed form; when one of those is applied to an
+  analytically-specified model ferx integrates numerically **and emits a clear warning**
+  (Ron's requirement) — never a silent ODE swap.
+- **Goal:** **transparency.** Each model's math and its explicit ODE form are documented;
+  `ferx check` surfaces the effective (synthesized) model so the numerical path is
+  inspectable, not a black box. Where both forms exist they are cross-checked under the
+  analytical↔ODE equivalence harness (ferx-r#127 / `tests/analytical_ode_equivalence.rs`).
 - **Goal:** continuous (non-integer) N for the Savic transit model — the key thing the
-  current ODE example cannot do.
-- **Non-goal (this plan):** changing the analytical closed-form `pk` disposition solvers;
-  they keep working unchanged for first-order/IV. Absorption models layer on top.
+  current hand-written ODE example cannot do.
+- **Non-goal (this plan):** changing the existing analytical `pk` disposition solvers; they
+  keep working unchanged for first-order/IV. Absorption models layer on top.
 - **Non-goal (this plan):** the NONMEM coded-`RATE` data path itself (`RATE=-1`/`-2`,
   issue #324) — a separate data-reader feature this plan depends on for its zero-order
   family. See "Relationship to #324".
@@ -137,6 +149,37 @@ Notes:
   CV² = relative dispersion of the absorption-time distribution — i.e. the standard
   inverse-Gaussian density with mean `μ=MAT` and shape `λ=MAT/CV²` (implementer mapping).
 
+## Which models stay analytical vs need numerical integration
+
+This is the crux of Ron's review: *does adding an absorption model silently turn an
+analytical model into an ODE?* Mostly **no** — only where the math forces it.
+
+| Absorption model | Closed form with linear disposition? | Engine |
+|---|---|---|
+| `first_order` | yes (Bateman) — already shipped | analytical |
+| `zero_order` | yes (= infusion into depot/central) | analytical |
+| `parallel` (dual first-order) | yes — superpose two `*_oral` solutions weighted by `frac` | analytical (reuses existing solvers) |
+| `sequential` (0→1st) | yes (piecewise: zero-order fill, then first-order) | analytical |
+| `mixed` (0 + 1st) | yes (superpose zero-order + first-order) | analytical |
+| `transit` (Savic), **integer N** | yes (generalized Bateman / sum of N+1 terms) | analytical |
+| `transit` (Savic), **continuous N** | yes **iff** the lower incomplete gamma `P(a,x)` is implemented; else numerical | analytical (Phase 3) or numerical |
+| `weibull` | **no** elementary closed form | numerical |
+| `inverse_gaussian` (Freijer & Post) | **no** elementary closed form (general multi-cpt) | numerical |
+
+So, will analytical models be made into ODEs? **Not in general.** The
+first-order/zero-order/parallel/sequential/mixed family and integer-N transit reduce to
+**superpositions of the closed forms ferx already has** (e.g. `parallel` = two `two_cpt_oral`
+evaluations weighted by `frac`) and stay analytical. Continuous-N transit stays analytical
+once the incomplete-gamma special function lands (Phase 3, promoted from "optional"). Only
+**Weibull** and **inverse-Gaussian** are inherently numerical — there is no closed-form
+convolution of those input densities with a multi-compartment disposition, so they are
+integrated (ODE / convolution quadrature) regardless of how the disposition was written.
+
+**When the numerical path is used on an analytically-specified model, ferx warns**
+(`W_ABSORPTION_NUMERICAL`, e.g. "absorption=weibull has no closed form with two_cpt_oral;
+predictions use numerical integration (slower)"). A model written as `ode(...)` gets no
+warning — the user already chose numerical integration.
+
 ## Engine architecture
 
 Decouple **input function** from **disposition**, reusing existing machinery:
@@ -150,24 +193,35 @@ Decouple **input function** from **disposition**, reusing existing machinery:
    pattern. Honor the `ad/` rule: **no `f64::max`/`min`** — use explicit comparisons (see
    CLAUDE.md). Each model also exposes `validate(θ) -> Result` and the analytic mass
    `∫R_in = F·Dose` (test invariant).
-2. **Disposition + forcing (`src/ode/predictions.rs`):** synthesize the linear 1/2/3-cpt
-   disposition ODE internally and add `+R_in(tad)` as an appearance term into the depot (or
-   central) compartment — the **same RHS-wrapper mechanism that already injects `+rate` for
-   infusions** (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper").
-   - Observed value = `A_central / V` (reuse existing obs-compartment plumbing).
-   - **SS=1:** reuse `equilibrate_ss_state` (already cycles apply-dose/integrate-II).
-   - **lagtime/F:** reuse `PK_IDX_LAGTIME` (shift `tad`) and `PK_IDX_F` (scale `D`) — already
-     applied to the dose, not the RHS.
-   - Multiple doses / ADDL: superpose `R_in` per dose, same as discrete-dose superposition.
+2. **Disposition — two dispatch modes** (chosen per absorption×disposition combo, per the
+   table above):
+   - **(a) Closed-form (preferred).** Stay in the analytical engine. The first-order /
+     zero-order / parallel / sequential / mixed family and integer-N transit map `R_in` to a
+     **superposition of the existing `pk/` closed forms** (e.g. `parallel` = two
+     `two_cpt_oral` evaluations weighted by `frac`); continuous-N transit uses the
+     incomplete-gamma closed form (Phase 3). No ODE solve, no warning.
+   - **(b) Numerical fallback.** Weibull / inverse-Gaussian / continuous-N transit before the
+     incomplete-gamma path lands: add `+R_in(tad)` forcing into the dosing compartment via the
+     **same RHS-wrapper mechanism that already injects `+rate` for infusions**
+     (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper"). Emit
+     `W_ABSORPTION_NUMERICAL` when the disposition was specified analytically.
+   - **Works on both model kinds.** On an `ode(...)` disposition the absorption type injects
+     the same `R_in(tad)` forcing into the user's dosing compartment (no warning — they chose
+     ODE). On a `pk ...` disposition, mode (a)/(b) is selected by the table.
+   - Shared by both modes: observed value via the existing obs-compartment plumbing; **SS=1**
+     reuses `equilibrate_ss_state`; **lagtime/F** reuse `PK_IDX_LAGTIME` (shift `tad`) and
+     `PK_IDX_F` (scale `D`); multiple doses / ADDL superpose `R_in` per dose.
 3. **Special functions (`src/stats/special.rs`):** add `ln_gamma` via a **Lanczos** rational
    approximation (AD-safe, following the existing `erf` A&S precedent) — **not** bare Stirling:
    `N` is estimated continuously and transit `N` is commonly 1–10, where Stirling errs ~8% at
    N=1 / ~0.8% at N=10, enough to bias the absorption peak. IGD needs only `exp/sqrt`; Weibull
    needs `powf` — both already AD-safe.
-4. **Optional Phase 3 perf fast-path:** transit→1-cpt (and →2-cpt) has a closed-form
-   convolution via the **lower incomplete gamma** `P(a,x)`; implementing that in
-   `special.rs` lets transit skip ODE integration. Deferred — the ODE path is the robust
-   baseline first.
+4. **Incomplete-gamma closed form for transit (Phase 3, promoted from optional):** because
+   keeping continuous-N transit analytical is now a goal (Ron's transparency concern),
+   implement the regularized lower incomplete gamma `P(a,x)` (AD-safe) in `special.rs` so
+   transit→1/2-cpt skips numerical integration. Sequence: ship transit on the numerical
+   fallback first to prove the pipeline, then add the closed form and assert the two agree
+   under the equivalence harness.
 
 ## Robustness ("no happy paths") — explicit requirements
 
@@ -213,14 +267,19 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   plan's Phase 2 zero-order family reuses. Independent of this plan's Phase 0/1, which can
   start in parallel.
 - **Phase 0 — engine + Savic transit.** `[absorption]` grammar, `AbsorptionSpec`, generic
-  input-fn trait, ODE-forcing plumbing, `ln_gamma`, transit end-to-end. Anchor against the
-  existing `transit_2cpt` dataset and a NONMEM Savic run. Proves the architecture.
-- **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; anchor vs the
-  Freijer & Post paper / a NONMEM `$DES` IG run.
+  input-fn trait, the **closed-form-vs-numerical dispatch**, the `W_ABSORPTION_NUMERICAL`
+  warning, and `[absorption]`-on-both-engines (analytical `pk` + `ode(...)`). Ship transit on
+  the numerical fallback first (with `ln_gamma`), anchored against the existing `transit_2cpt`
+  dataset and a NONMEM Savic run. Proves the architecture end-to-end.
+- **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; **numerical**
+  (no closed form). Anchor vs the Freijer & Post paper / a NONMEM `$DES` IG run.
 - **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the
-  catalogue; each with a NONMEM anchor. The zero-order family reuses the estimated-duration
-  forcing from #324 (Phase 2).
-- **Phase 3 (optional) — analytical incomplete-gamma fast path** for transit→1/2-cpt.
+  catalogue; each with a NONMEM anchor. **Closed-form** for zero-order/sequential/parallel/
+  mixed (superpose existing solvers; the zero-order family reuses #324's estimated-duration
+  forcing); **numerical** for Weibull (warned on an analytical disposition).
+- **Phase 3 — analytical incomplete-gamma closed form for transit** (1/2-cpt) so continuous-N
+  transit stays in the analytical engine; assert it matches the Phase-0 numerical form under
+  the equivalence harness.
 
 ## Tests & NONMEM anchoring (CLAUDE.md mandates)
 

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -37,25 +37,34 @@ tests, NONMEM anchor, and docs.
   current ODE example cannot do.
 - **Non-goal (this plan):** changing the analytical closed-form `pk` disposition solvers;
   they keep working unchanged for first-order/IV. Absorption models layer on top.
-- **Non-goal (this plan):** model-estimated zero-order *infusion* via `RATE=-2`
-  (issue #282) — related but a separate data-driven path. See "Relationship to #282".
+- **Non-goal (this plan):** the NONMEM coded-`RATE` data path itself (`RATE=-1`/`-2`,
+  issue #324) — a separate data-reader feature this plan depends on for its zero-order
+  family. See "Relationship to #324".
 
-## Relationship to issue #282 (RATE=-2)
+## Relationship to issue #324 (NONMEM coded RATE values)
 
-#282 = model-estimated zero-order **infusion duration**, triggered by the `RATE`
-column (a NONMEM data convention), distinct from the `[absorption]` block. It shares
-one piece of machinery with this plan: a **zero-order forcing term whose duration is an
-estimated parameter** (`D1`-style plumbing in both analytical and ODE paths).
+#324 adds end-to-end support for NONMEM's coded `RATE` column (consolidating #95 and the
+now-closed #282). It is itself phased:
 
-- **Not a prerequisite** for Phase 0 (transit) or Phase 1 (inverse-Gaussian) — neither
-  involves a zero-order input. The two headline models are unblocked by #282.
-- **Is the foundation** for the zero-order absorption family (`zero_order`,
-  `sequential`, `mixed`) in Phase 2: both need the estimated-duration forcing, so #282
-  is best done **before Phase 2**.
+- **#324 Phase 0** — safety net: reject/warn on negative coded `RATE` instead of silently
+  treating it as an IV bolus (today's bug).
+- **#324 Phase 1** — `RATE=-1` duration-defined infusion (reads a `DURATION` column,
+  `rate = amt/duration`); the most common clinical convention.
+- **#324 Phase 2** — `RATE=-2` model-estimated duration: a `D1`-style `.ferx` DSL parameter
+  controls the infusion duration at runtime.
 
-Decision: do #282 as an early standalone PR (small, self-contained, ships a user win on
-its own) that establishes the estimated-duration forcing Phase 2 then reuses — but start
-Phase 0/1 in parallel, since they don't depend on it.
+The piece this plan depends on is **#324 Phase 2**: a *zero-order forcing term whose
+duration is an estimated model parameter* (`D1`-style plumbing in both analytical and ODE
+paths). That same mechanism is what the zero-order absorption family (`zero_order`,
+`sequential`, `mixed`) reuses.
+
+- **Not a prerequisite** for Phase 0 (transit) or Phase 1 (inverse-Gaussian) of this plan —
+  neither involves a zero-order input. The two headline models are unblocked by #324.
+- **Is the foundation** for the zero-order absorption family in Phase 2 below.
+
+Decision: do #324 first (its Phase 0/1 are independently valuable; its Phase 2 establishes
+the estimated-duration forcing this plan's Phase 2 then reuses) — but start Phase 0/1 of
+this plan in parallel, since they don't depend on it.
 
 ## DSL surface (decided: new `[absorption]` block)
 
@@ -179,18 +188,20 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 ## Phasing (one PR each)
 
-- **Phase −1 — issue #282 (`RATE=-2`), standalone first.** Model-estimated zero-order
-  infusion duration via the `RATE` column + a `D1`-style estimated-duration parameter.
-  Self-contained, ships a user win on its own, and establishes the estimated-duration
-  forcing that Phase 2's zero-order family reuses. Phase 0/1 can start in parallel since
-  they don't depend on it.
+- **Phase −1 — issue #324 (NONMEM coded `RATE`), standalone first.** Support `RATE=-1`
+  (duration-defined, via a `DURATION` column) and `RATE=-2` (model-estimated duration via a
+  `D1`-style DSL parameter), behind a safety net for unsupported coded values. Independently
+  shippable and a user win on its own; its `RATE=-2` part (#324 Phase 2) establishes the
+  estimated-duration forcing that this plan's Phase 2 zero-order family reuses. Phase 0/1
+  here can start in parallel since they don't depend on it.
 - **Phase 0 — engine + Savic transit.** `[absorption]` grammar, `AbsorptionSpec`, generic
   input-fn trait, ODE-forcing plumbing, `ln_gamma`, transit end-to-end. Anchor against the
   existing `transit_2cpt` dataset and a NONMEM Savic run. Proves the architecture.
 - **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; anchor vs the
   Freijer & Post paper / a NONMEM `$DES` IG run.
 - **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the
-  catalogue; each with a NONMEM anchor. Reuses the estimated-duration forcing from #282.
+  catalogue; each with a NONMEM anchor. The zero-order family reuses the estimated-duration
+  forcing from #324 (Phase 2).
 - **Phase 3 (optional) — analytical incomplete-gamma fast path** for transit→1/2-cpt.
 
 ## Tests & NONMEM anchoring (CLAUDE.md mandates)

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -228,6 +228,13 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   `cfg_attr(not(feature="slow-tests"), ignore)`).
 - **NONMEM comparison** (required for numeric features): transit & IG estimates/OFV vs
   equivalent NONMEM models, documented in the example pages or PR descriptions.
+- **Gradient agreement (AD ≡ FD):** per model, a unit test asserting the AD/`Dual` gradient
+  of `individual_nll` w.r.t. the absorption params matches the central-FD gradient to
+  tolerance on a small fixture. It compiles/runs under **both** the default `--features ci`
+  (FD) job and the `--features autodiff` (Enzyme) job — the FD job is the per-PR backstop;
+  the `autodiff` job (#281 cadence) is where the AD path is actually exercised. This is the
+  bridge that stops an AD-only regression (e.g. a wrong `ln_gamma` dual rule) slipping past
+  FD-only PR CI — the #317 failure mode.
 
 ## Verification
 
@@ -236,7 +243,9 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   patch ≥90% on each PR's diff.
 - End-to-end smoke per phase: `ferx examples/transit_savic.ferx --data data/transit_2cpt.csv`
   → converges, `converged: true`, MTT/N estimates near the data-generating values.
-- Mass-balance + AD-invariance unit tests are the fast regression backstop.
+- Per-PR `--features ci` (FD) verifies the FD gradient path; the `--features autodiff` job
+  (#281 cadence) verifies the AD path. Mass-balance and the AD≡FD gradient-agreement test are
+  the fast regression backstop and the bridge between the two.
 
 ## Open risks
 

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -1,0 +1,222 @@
+# Plan: Built-in absorption models (`[absorption]` block)
+
+**Tracking issue:** [#322](https://github.com/FeRx-NLME/ferx-core/issues/322)
+**Scope:** ferx-core (primary) + ferx-r (follow-up PR once `pub` API lands)
+**Status:** approved roadmap, not yet implemented. Multi-PR / phased.
+
+---
+
+## Context
+
+ferx-core today supports exactly one absorption model analytically: **first-order**
+(`ka`), plus an optional lag time (`PK_IDX_LAGTIME`) and bioavailability (`PK_IDX_F`).
+Anything richer — transit-compartment (Savic), Weibull, inverse-Gaussian (Freijer &
+Post), zero-order, sequential/parallel/mixed — is only reachable by the user
+hand-writing an `[odes]` chain (see `examples/transit_2cpt.ferx`). That hand-written
+route is error-prone, **cannot estimate a continuous number of transit compartments**,
+and forces the user to do math the engine should do.
+
+The goal is to compute these **in Rust** as first-class, user-friendly built-ins, with
+**robust handling of edge cases (no happy-path-only code)**. The named anchors are
+**Savic 2007** (transit) and **Freijer & Post** (convection–dispersion ⇒ inverse-Gaussian
+density input). This plan adds a new `[absorption]` block that selects a built-in
+absorption model whose input rate `R_in(t)` is computed analytically in Rust and routed
+into the existing disposition machinery.
+
+This is a **large, multi-PR feature**; the plan is phased so each model lands with its own
+tests, NONMEM anchor, and docs.
+
+## Goals / non-goals
+
+- **Goal:** `[absorption]` block selecting transit / inverse-Gaussian / Weibull /
+  zero-order / sequential / parallel / mixed, with parameters bound to
+  `[individual_parameters]` (so they carry IIV, covariates, etc. for free).
+- **Goal:** one engine path that works for **any** input function, reusing the ODE
+  RHS-forcing mechanism already used for infusions.
+- **Goal:** continuous (non-integer) N for the Savic transit model — the key thing the
+  current ODE example cannot do.
+- **Non-goal (this plan):** changing the analytical closed-form `pk` disposition solvers;
+  they keep working unchanged for first-order/IV. Absorption models layer on top.
+- **Non-goal (this plan):** model-estimated zero-order *infusion* via `RATE=-2`
+  (issue #282) — related but a separate data-driven path. See "Relationship to #282".
+
+## Relationship to issue #282 (RATE=-2)
+
+#282 = model-estimated zero-order **infusion duration**, triggered by the `RATE`
+column (a NONMEM data convention), distinct from the `[absorption]` block. It shares
+one piece of machinery with this plan: a **zero-order forcing term whose duration is an
+estimated parameter** (`D1`-style plumbing in both analytical and ODE paths).
+
+- **Not a prerequisite** for Phase 0 (transit) or Phase 1 (inverse-Gaussian) — neither
+  involves a zero-order input. The two headline models are unblocked by #282.
+- **Is the foundation** for the zero-order absorption family (`zero_order`,
+  `sequential`, `mixed`) in Phase 2: both need the estimated-duration forcing, so #282
+  is best done **before Phase 2**.
+
+Decision: do #282 as an early standalone PR (small, self-contained, ships a user win on
+its own) that establishes the estimated-duration forcing Phase 2 then reuses — but start
+Phase 0/1 in parallel, since they don't depend on it.
+
+## DSL surface (decided: new `[absorption]` block)
+
+Disposition stays on the `pk` line; absorption moves to its own block, mirroring
+`[odes]`/`[error_model]`. Parameters reference names declared in
+`[individual_parameters]` (exactly like `cl=CL` on the pk line):
+
+```
+[structural_model]
+  pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2)   # NB: no ka= when [absorption] present
+
+[absorption]
+  model = transit
+  mtt   = MTT          # mean transit time
+  n     = NTR          # number of transit compartments (continuous)
+  ka    = KA           # optional; defaults to KTR=(n+1)/mtt
+```
+
+Multi-pathway models (Freijer sum-of-two-IG, parallel first-order) use repeated
+`pathway` entries with a fraction:
+
+```
+[absorption]
+  model    = inverse_gaussian
+  pathway  = { mat = MAT1, cv2 = CV2_1, frac = FR1 }
+  pathway  = { mat = MAT2, cv2 = CV2_2 }   # last frac defaults to 1 - sum(others)
+```
+
+Rules (all enforced at parse time, all with negative tests):
+- `[absorption]` present ⇒ the `pk *_oral` line must **not** also map `ka=` (mutually
+  exclusive: first-order is the no-`[absorption]` default). Mapping both is a parse error.
+- `[absorption]` is only valid with an **oral** disposition (`one/two/three_cpt_oral`);
+  combining with an IV-only model or with `RATE>0` infusion dosing is a parse error /
+  warning (see Robustness).
+- Every referenced name must be a declared individual parameter (reuse the existing
+  "undefined name" machinery — `parser/model_parser.rs` visit_*_nodes); unknown keys for a
+  model are rejected; pathway fractions must be in (0,1] and sum to ≈1.
+
+## The models (input rate `R_in(t)`, ∫₀^∞ R_in dt = F·Dose)
+
+`tad = t − dose.time − lagtime`; `R_in = 0` for `tad ≤ 0`. Per-dose contributions are
+superposed. `D` = `F·amt`.
+
+| `model =` | `R_in(t)` | Params | Special fn | t→0 edge |
+|---|---|---|---|---|
+| `first_order` (default, no block) | `D·ka·e^{−ka·tad}` | ka | — | finite |
+| `zero_order` | `D/Dur` on `[0,Dur]` else 0 | dur | — | step |
+| `sequential` (0→1st) | zero-order fills depot over `dur`, then `ka` out | dur, ka | — | step |
+| `parallel` (dual 1st-order) | `D·Σ fᵢ·kaᵢ·e^{−kaᵢ·tad}` | ka1,ka2,frac | — | finite |
+| `mixed` (0 + 1st) | `f_zo·zero(dur) + (1−f_zo)·first(ka)` | dur, ka, frac | — | step |
+| `transit` (**Savic**) | `D·KTR·(KTR·tad)^N·e^{−KTR·tad}/Γ(N+1)` into depot, then `ka`; `KTR=(N+1)/MTT` | mtt, n, [ka] | `ln_gamma` | `0^N`→0 (N>0) |
+| `inverse_gaussian` (**Freijer&Post**) | `D·√(MAT/(2π·CV²·tad³))·exp(−(tad−MAT)²/(2·CV²·MAT·tad))` | mat, cv2 [, pathways] | exp/sqrt | →0, guard |
+| `weibull` | `D·(β/Td)(tad/Td)^{β−1}·exp(−(tad/Td)^β)` | td (scale), beta (shape) | powf | β<1 ⇒ ∞ (integrable), guard |
+
+Notes:
+- **transit:** the gamma density is the chain output; it forces the **depot**, which empties
+  to central via first-order `ka` (defaulting to `KTR`), matching rxode2/PKPDsim's
+  `transit()`. Continuous N via `ln_gamma` (Stirling/Lanczos). This is the headline feature.
+- **inverse_gaussian:** single or sum-of-two (Freijer biphasic). MAT = mean absorption time,
+  CV² = relative dispersion of the absorption-time distribution.
+
+## Engine architecture
+
+Decouple **input function** from **disposition**, reusing existing machinery:
+
+1. **Input function (new `src/pk/absorption.rs`):** `R_in(tad; θ)` per model, written
+   generically over a `Float`-like trait so the **same code serves the f64 path and the AD
+   path** (avoids hand-maintained AD duplicates). Honor the `ad/` rule: **no `f64::max`/`min`**
+   — use explicit comparisons (see CLAUDE.md). Each model also exposes:
+   `validate(θ) -> Result` and the analytic mass `∫R_in = F·Dose` (test invariant).
+2. **Disposition + forcing (`src/ode/predictions.rs`):** synthesize the linear 1/2/3-cpt
+   disposition ODE internally and add `+R_in(tad)` as an appearance term into the depot (or
+   central) compartment — the **same RHS-wrapper mechanism that already injects `+rate` for
+   infusions** (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper").
+   - Observed value = `A_central / V` (reuse existing obs-compartment plumbing).
+   - **SS=1:** reuse `equilibrate_ss_state` (already cycles apply-dose/integrate-II).
+   - **lagtime/F:** reuse `PK_IDX_LAGTIME` (shift `tad`) and `PK_IDX_F` (scale `D`) — already
+     applied to the dose, not the RHS.
+   - Multiple doses / ADDL: superpose `R_in` per dose, same as discrete-dose superposition.
+3. **Special functions (`src/stats/special.rs`):** add `ln_gamma` (AD-safe, following the
+   existing `erf` precedent that is "differentiable by Enzyme"). IGD needs only `exp/sqrt`;
+   Weibull needs `powf` — both already AD-safe.
+4. **Optional Phase 3 perf fast-path:** transit→1-cpt (and →2-cpt) has a closed-form
+   convolution via the **lower incomplete gamma** `P(a,x)`; implementing that in
+   `special.rs` lets transit skip ODE integration. Deferred — the ODE path is the robust
+   baseline first.
+
+## Robustness ("no happy paths") — explicit requirements
+
+Each item needs a negative/edge test so it registers Codecov patch coverage:
+
+- **Parameter-domain validation** at parse + fit-init: `mtt>0`, `n≥0`, `dur>0`, `td>0`,
+  `beta>0`, `mat>0`, `cv2>0`, `0<frac≤1`, `Σfrac≈1`. Parse errors for static violations;
+  `FitResult.warnings` (`W_ABSORPTION_*`) for init-value violations (mirror the existing
+  `W_NEGATIVE_LAGTIME` pattern in `diagnostics.rs`).
+- **Singularity guards:** `tad ≤ ε ⇒ R_in = 0`; transit `0^N` and `log(tad)` guarded;
+  Weibull `β<1` integrable spike capped/handled; IGD essential singularity at `tad→0`.
+- **Mutual exclusivity & route checks:** `[absorption]` + `ka=` ⇒ error; `[absorption]` on
+  IV-only disposition ⇒ error; `[absorption]` + infusion dose rows ⇒ error or documented
+  precedence.
+- **Mass-balance invariant** `∫R_in dt = F·Dose` as a unit test per model (catches a wrong
+  normalization constant — the classic transit/IGD bug).
+- **AD-safety:** no `f64::max`/`min` anywhere reachable from the AD path; re-enable a
+  representative absorption test under the `autodiff` feature (per CLAUDE.md / issue #281
+  CI work).
+
+## Files (representative, not exhaustive)
+
+- `src/types.rs` — new `AbsorptionSpec` + `AbsorptionModel` enum on `CompiledModel`; oral
+  `PkModel` paths gain an optional spec.
+- `src/parser/model_parser.rs` — parse/validate `[absorption]`; reuse undefined-name walker
+  and the `consumes_pk_slot`/"declared-but-unused" census.
+- `src/pk/absorption.rs` (new) — generic input functions + validation + mass.
+- `src/stats/special.rs` — `ln_gamma` (+ later regularized incomplete gamma).
+- `src/ode/predictions.rs` — synthesized-disposition + `R_in` forcing; SS reuse.
+- prediction dispatcher / `src/estimation/inner_optimizer.rs` — route oral+absorption to the
+  forced path; `src/diagnostics.rs` — new `W_ABSORPTION_*`.
+- Docs: new `docs/src/model-file/absorption.md` + `SUMMARY.md`; cross-link
+  `structural-model.md`; new `examples/*.ferx`; `CHANGELOG.md` (`[Unreleased] → Added`).
+- `../ferx-r` follow-up PR for the new `pub` surface (+ `tools/update-ferx-core-lock.sh`).
+
+## Phasing (one PR each)
+
+- **Phase −1 — issue #282 (`RATE=-2`), standalone first.** Model-estimated zero-order
+  infusion duration via the `RATE` column + a `D1`-style estimated-duration parameter.
+  Self-contained, ships a user win on its own, and establishes the estimated-duration
+  forcing that Phase 2's zero-order family reuses. Phase 0/1 can start in parallel since
+  they don't depend on it.
+- **Phase 0 — engine + Savic transit.** `[absorption]` grammar, `AbsorptionSpec`, generic
+  input-fn trait, ODE-forcing plumbing, `ln_gamma`, transit end-to-end. Anchor against the
+  existing `transit_2cpt` dataset and a NONMEM Savic run. Proves the architecture.
+- **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; anchor vs the
+  Freijer & Post paper / a NONMEM `$DES` IG run.
+- **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the
+  catalogue; each with a NONMEM anchor. Reuses the estimated-duration forcing from #282.
+- **Phase 3 (optional) — analytical incomplete-gamma fast path** for transit→1/2-cpt.
+
+## Tests & NONMEM anchoring (CLAUDE.md mandates)
+
+- **Tier 1 (unit):** input-fn values vs hand-computed; mass-balance integral; `ln_gamma` vs
+  reference; every param-validation error/warning.
+- **Tier 2 (`tests/*.rs`):** parse `[absorption]` → `CompiledModel`; `fit()` returns
+  immediately / errors on a bad spec (no convergence loop).
+- **Tier 3 (slow, gated):** full fits per model to convergence (gate with
+  `cfg_attr(not(feature="slow-tests"), ignore)`).
+- **NONMEM comparison** (required for numeric features): transit & IG estimates/OFV vs
+  equivalent NONMEM models, documented in the example pages or PR descriptions.
+
+## Verification
+
+- `cargo check --no-default-features --features ci`; push to CI for the test matrix.
+  Coverage: `cargo +nightly llvm-cov --tests --no-default-features --features ci` to confirm
+  patch ≥90% on each PR's diff.
+- End-to-end smoke per phase: `ferx examples/transit_savic.ferx --data data/transit_2cpt.csv`
+  → converges, `converged: true`, MTT/N estimates near the data-generating values.
+- Mass-balance + AD-invariance unit tests are the fast regression backstop.
+
+## Open risks
+
+- **Speed:** ODE-forcing is slower than closed forms; acceptable baseline, Phase 3 mitigates
+  transit. Quantify on warfarin-sized data.
+- **AD through `ln_gamma` / `powf`:** must verify Enzyme handles them (the `autodiff` CI from
+  issue #281 is the gate); fall back to FD for the absorption params if needed.
+- **DSL ergonomics for multi-pathway** (`pathway = {...}`): new sub-grammar; keep it minimal.

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -19,9 +19,12 @@ and forces the user to do math the engine should do.
 The goal is to compute these **in Rust** as first-class, user-friendly built-ins, with
 **robust handling of edge cases (no happy-path-only code)**. The named anchors are
 **Savic 2007** (transit) and **Freijer & Post** (convection–dispersion ⇒ inverse-Gaussian
-density input). This plan adds a new `[absorption]` block that selects a built-in
-absorption model whose input rate `R_in(t)` is computed analytically in Rust and routed
-into the existing disposition machinery.
+density input). The mechanism is a set of **built-in input-rate functions** (`transit`,
+`igd`, `weibull`, `zero_order`) exposed two ways (see "DSL surface"): **Layer 1** — callable
+directly in the `[odes]` RHS so the user writes the ODE explicitly (Ron's proposal:
+`d/dt(depot) = transit(NTR, MTT) - KA*depot`), and **Layer 2** — an optional `[absorption]`
+block that, on an analytical `pk` model, uses a closed form where one exists and otherwise
+desugars to the Layer-1 ODE with a clear warning.
 
 This is a **large, multi-PR feature**; the plan is phased so each model lands with its own
 tests, NONMEM anchor, and docs.
@@ -81,11 +84,50 @@ Decision: ship #324's Phase 0 safety net first (independently valuable); its `D1
 modeled-duration path establishes the estimated-duration forcing this plan's Phase 2 then
 reuses. Phase 0/1 of this plan can start in parallel, since they don't depend on it.
 
-## DSL surface (decided: new `[absorption]` block)
+## DSL surface — two layers over one set of input-rate functions
 
-Disposition stays on the `pk` line; absorption moves to its own block, mirroring
-`[odes]`/`[error_model]`. Parameters reference names declared in
-`[individual_parameters]` (exactly like `cl=CL` on the pk line):
+The absorption math lives in **built-in input-rate functions** — `transit(n, mtt)`,
+`igd(mat, cv2)` (inverse-Gaussian / Freijer & Post), `weibull(td, beta)`,
+`zero_order(dur)`. They are the single source of truth, exposed two ways.
+
+### Layer 1 — input-rate functions in `[odes]` (Ron's proposal; transparent foundation)
+
+The user writes the ODE explicitly and calls the built-in for the input rate — keeping full
+control of the compartment structure and *seeing* that it is an ODE — but without
+hand-coding the Stirling gamma density:
+
+```
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = transit(NTR, MTT) - KA*depot
+  d/dt(central) = KA*depot - (CL/V)*central
+```
+
+`transit(NTR, MTT)` returns the Savic transit-chain appearance rate into that compartment,
+evaluated by the engine from time-after-dose and the dose amount (×F), superposed over doses
+— the same dose context the infusion RHS-wrapper already carries. `igd(...)`, `weibull(...)`,
+`zero_order(...)` behave identically. Multi-pathway / parallel absorption is just additional
+RHS terms (`transit(...) + igd(...)`) — no new grammar. This is the natural home for the
+inherently-numerical models (Weibull, IG, continuous-N transit) and satisfies Ron's
+transparency ask directly.
+
+Two implementation notes: **(i)** these are **engine intrinsics**, not pure expressions — the
+`[odes]` evaluator must hand them the dose schedule, amount, F, and time-after-dose (extend
+the expression evaluator plus the dose context the RHS-wrapper already holds). **(ii) Dose
+routing:** when a compartment's RHS contains an input-rate function, the dose *feeds that
+function* (it is the chain input) and must **not** also enter as a bolus into the same
+compartment — define and test this rule explicitly (it is the classic Savic "dose into the
+virtual transit, not the depot" subtlety).
+
+### Layer 2 — `[absorption]` block (optional convenience; desugars to Layer 1 / closed forms)
+
+A one-liner on an analytical disposition for users who don't want to write the ODE. It
+selects the input model declaratively; the engine uses a **closed form where one exists**
+(see "Which models stay analytical") and otherwise auto-builds the equivalent Layer-1 ODE,
+emitting `W_ABSORPTION_NUMERICAL`. Parameters reference `[individual_parameters]` names
+(like `cl=CL` on the pk line):
 
 ```
 [structural_model]
@@ -266,11 +308,13 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   `RATE=-2`/`D1` modeled-duration path establishes the estimated-duration forcing that this
   plan's Phase 2 zero-order family reuses. Independent of this plan's Phase 0/1, which can
   start in parallel.
-- **Phase 0 — engine + Savic transit.** `[absorption]` grammar, `AbsorptionSpec`, generic
-  input-fn trait, the **closed-form-vs-numerical dispatch**, the `W_ABSORPTION_NUMERICAL`
-  warning, and `[absorption]`-on-both-engines (analytical `pk` + `ode(...)`). Ship transit on
-  the numerical fallback first (with `ln_gamma`), anchored against the existing `transit_2cpt`
-  dataset and a NONMEM Savic run. Proves the architecture end-to-end.
+- **Phase 0 — `transit()` input-rate function (Layer 1 first).** Implement the built-in
+  `transit(n, mtt)` intrinsic callable in `[odes]` (Ron's proposal): the input-rate
+  evaluator, dose-context wiring, the dose-routing rule (dose feeds the function, not a
+  bolus), and `ln_gamma`. Anchor against the existing `transit_2cpt` dataset and a NONMEM
+  Savic run — this proves the transparent path end-to-end. The optional `[absorption]` block
+  (Layer 2), the closed-form-vs-numerical dispatch, and the `W_ABSORPTION_NUMERICAL` warning
+  land here or as a Layer-2 follow-up (see Open questions).
 - **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; **numerical**
   (no closed form). Anchor vs the Freijer & Post paper / a NONMEM `$DES` IG run.
 - **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the
@@ -309,6 +353,16 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 - Per-PR `--features ci` (FD) verifies the FD gradient path; the `--features autodiff` job
   (#281 cadence) verifies the AD path. Mass-balance and the AD≡FD gradient-agreement test are
   the fast regression backstop and the bridge between the two.
+
+## Open questions
+
+- **Keep Layer 2 (`[absorption]` block) at all, or ship Layer-1 functions only?** Ron's
+  proposal is just the `[odes]` input-rate functions (fully transparent, composable, no
+  silent ODE). The block adds convenience but also the closed-form dispatch + warning
+  machinery. Decision pending: ship Layer 1 first (Phase 0), then decide whether Layer 2
+  earns its complexity once Layer 1 is in users' hands.
+- **`transit()` argument form** — `transit(n, mtt)` (explicit, recommended) vs `transit(n)`
+  reading a conventional `MTT`/`KTR` param. Explicit args avoid magic.
 
 ## Open risks
 

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -93,12 +93,17 @@ Multi-pathway models (Freijer sum-of-two-IG, parallel first-order) use repeated
   pathway  = { mat = MAT2, cv2 = CV2_2 }   # last frac defaults to 1 - sum(others)
 ```
 
+> The `pathway = { ... }` inline-record form is a **new grammar construct** (no DSL
+> precedent today). For the common ≤2-pathway case, repeated scalar keys (`mat1=`, `cv2_1=`,
+> `frac1=`, `mat2=`, …) reach parity with zero new grammar; defer the brace form until a
+> >2-pathway need is real.
+
 Rules (all enforced at parse time, all with negative tests):
 - `[absorption]` present ⇒ the `pk *_oral` line must **not** also map `ka=` (mutually
   exclusive: first-order is the no-`[absorption]` default). Mapping both is a parse error.
 - `[absorption]` is only valid with an **oral** disposition (`one/two/three_cpt_oral`);
-  combining with an IV-only model or with `RATE>0` infusion dosing is a parse error /
-  warning (see Robustness).
+  combining with an IV-only model, or with a subject carrying `RATE>0` infusion dose rows,
+  is a **parse error** (the dose route is ambiguous — see Robustness).
 - Every referenced name must be a declared individual parameter (reuse the existing
   "undefined name" machinery — `parser/model_parser.rs` visit_*_nodes); unknown keys for a
   model are rejected; pathway fractions must be in (0,1] and sum to ≈1.
@@ -120,21 +125,28 @@ superposed. `D` = `F·amt`.
 | `weibull` | `D·(β/Td)(tad/Td)^{β−1}·exp(−(tad/Td)^β)` | td (scale), beta (shape) | powf | β<1 ⇒ ∞ (integrable), guard |
 
 Notes:
-- **transit:** the gamma density is the chain output; it forces the **depot**, which empties
-  to central via first-order `ka` (defaulting to `KTR`), matching rxode2/PKPDsim's
-  `transit()`. Continuous N via `ln_gamma` (Stirling/Lanczos). This is the headline feature.
+- **transit:** `n` counts the transit compartments **excluding** the final absorption (`ka`)
+  compartment, so `KTR=(n+1)/MTT`. The gamma density is the chain output; it forces the
+  **depot**, which empties to central via first-order `ka` (defaulting to `KTR` when omitted),
+  matching rxode2/PKPDsim's `transit()`. Continuous N via `ln_gamma` (Lanczos; see Engine).
+  Headline feature.
 - **inverse_gaussian:** single or sum-of-two (Freijer biphasic). MAT = mean absorption time,
-  CV² = relative dispersion of the absorption-time distribution.
+  CV² = relative dispersion of the absorption-time distribution — i.e. the standard
+  inverse-Gaussian density with mean `μ=MAT` and shape `λ=MAT/CV²` (implementer mapping).
 
 ## Engine architecture
 
 Decouple **input function** from **disposition**, reusing existing machinery:
 
-1. **Input function (new `src/pk/absorption.rs`):** `R_in(tad; θ)` per model, written
-   generically over a `Float`-like trait so the **same code serves the f64 path and the AD
-   path** (avoids hand-maintained AD duplicates). Honor the `ad/` rule: **no `f64::max`/`min`**
-   — use explicit comparisons (see CLAUDE.md). Each model also exposes:
-   `validate(θ) -> Result` and the analytic mass `∫R_in = F·Dose` (test invariant).
+1. **Input function (new `src/pk/absorption.rs`):** `R_in(tad; θ)` per model. `src/ad/dual.rs`'s
+   `Dual` already implements `exp`/`ln`/`sqrt`/`powf`, so the input functions can be written
+   once over a small numeric trait that both `f64` and `Dual` satisfy — sharing one body across
+   the plain-f64, dual-number, and Enzyme (concrete-f64) paths. This needs a **new** shared
+   trait (today's AD path uses hand-written `_ad` duplicates, not generics) plus a `Dual` impl
+   of `ln_gamma`; if either proves awkward, fall back to the existing duplicate-function
+   pattern. Honor the `ad/` rule: **no `f64::max`/`min`** — use explicit comparisons (see
+   CLAUDE.md). Each model also exposes `validate(θ) -> Result` and the analytic mass
+   `∫R_in = F·Dose` (test invariant).
 2. **Disposition + forcing (`src/ode/predictions.rs`):** synthesize the linear 1/2/3-cpt
    disposition ODE internally and add `+R_in(tad)` as an appearance term into the depot (or
    central) compartment — the **same RHS-wrapper mechanism that already injects `+rate` for
@@ -144,9 +156,11 @@ Decouple **input function** from **disposition**, reusing existing machinery:
    - **lagtime/F:** reuse `PK_IDX_LAGTIME` (shift `tad`) and `PK_IDX_F` (scale `D`) — already
      applied to the dose, not the RHS.
    - Multiple doses / ADDL: superpose `R_in` per dose, same as discrete-dose superposition.
-3. **Special functions (`src/stats/special.rs`):** add `ln_gamma` (AD-safe, following the
-   existing `erf` precedent that is "differentiable by Enzyme"). IGD needs only `exp/sqrt`;
-   Weibull needs `powf` — both already AD-safe.
+3. **Special functions (`src/stats/special.rs`):** add `ln_gamma` via a **Lanczos** rational
+   approximation (AD-safe, following the existing `erf` A&S precedent) — **not** bare Stirling:
+   `N` is estimated continuously and transit `N` is commonly 1–10, where Stirling errs ~8% at
+   N=1 / ~0.8% at N=10, enough to bias the absorption peak. IGD needs only `exp/sqrt`; Weibull
+   needs `powf` — both already AD-safe.
 4. **Optional Phase 3 perf fast-path:** transit→1-cpt (and →2-cpt) has a closed-form
    convolution via the **lower incomplete gamma** `P(a,x)`; implementing that in
    `special.rs` lets transit skip ODE integration. Deferred — the ODE path is the robust
@@ -163,8 +177,8 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 - **Singularity guards:** `tad ≤ ε ⇒ R_in = 0`; transit `0^N` and `log(tad)` guarded;
   Weibull `β<1` integrable spike capped/handled; IGD essential singularity at `tad→0`.
 - **Mutual exclusivity & route checks:** `[absorption]` + `ka=` ⇒ error; `[absorption]` on
-  IV-only disposition ⇒ error; `[absorption]` + infusion dose rows ⇒ error or documented
-  precedence.
+  IV-only disposition ⇒ error; `[absorption]` + a `RATE>0` infusion dose row ⇒ **parse error**
+  (the dose route is ambiguous; decided over "documented precedence").
 - **Mass-balance invariant** `∫R_in dt = F·Dose` as a unit test per model (catches a wrong
   normalization constant — the classic transit/IGD bug).
 - **AD-safety:** no `f64::max`/`min` anywhere reachable from the AD path; re-enable a
@@ -230,4 +244,6 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   transit. Quantify on warfarin-sized data.
 - **AD through `ln_gamma` / `powf`:** must verify Enzyme handles them (the `autodiff` CI from
   issue #281 is the gate); fall back to FD for the absorption params if needed.
-- **DSL ergonomics for multi-pathway** (`pathway = {...}`): new sub-grammar; keep it minimal.
+- **DSL ergonomics for multi-pathway** (`pathway = {...}`): a new inline-record sub-grammar
+  with no DSL precedent — deferred in favour of repeated scalar keys for the ≤2-pathway case
+  (see DSL surface).

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -44,27 +44,30 @@ tests, NONMEM anchor, and docs.
 ## Relationship to issue #324 (NONMEM coded RATE values)
 
 #324 adds end-to-end support for NONMEM's coded `RATE` column (consolidating #95 and the
-now-closed #282). It is itself phased:
+now-closed #282). In NONMEM, coded `RATE` is *parameter-driven*, not data-column-driven:
+`RATE=-1` ⇒ the infusion **rate** is modeled (`R1` in `$PK`); `RATE=-2` ⇒ the infusion
+**duration** is modeled (`D1` in `$PK`). Neither reads a data column; duration is the more
+commonly estimated of the two. #324 is scoped to:
 
-- **#324 Phase 0** — safety net: reject/warn on negative coded `RATE` instead of silently
-  treating it as an IV bolus (today's bug).
-- **#324 Phase 1** — `RATE=-1` duration-defined infusion (reads a `DURATION` column,
-  `rate = amt/duration`); the most common clinical convention.
-- **#324 Phase 2** — `RATE=-2` model-estimated duration: a `D1`-style `.ferx` DSL parameter
-  controls the infusion duration at runtime.
+- **#324 Phase 0** — safety net: reject coded/malformed `RATE` (`-1`, `-2`, other negatives,
+  non-finite) on a dose row instead of silently treating it as an IV bolus (today's bug).
+  Ships first, standalone (PR #326).
+- **#324 faithful support** — `RATE=-1` = rate modeled via an `R1`-style `.ferx` DSL
+  parameter; `RATE=-2` = duration modeled via a `D1`-style DSL parameter. Both
+  runtime/parameter-driven; **no `DURATION` data column**.
 
-The piece this plan depends on is **#324 Phase 2**: a *zero-order forcing term whose
-duration is an estimated model parameter* (`D1`-style plumbing in both analytical and ODE
-paths). That same mechanism is what the zero-order absorption family (`zero_order`,
-`sequential`, `mixed`) reuses.
+The piece this plan depends on is the **`RATE=-2` / `D1` modeled-duration** plumbing: a
+*zero-order forcing term whose duration is an estimated model parameter* (`D1`-style
+plumbing in both analytical and ODE paths). That same mechanism is what the zero-order
+absorption family (`zero_order`, `sequential`, `mixed`) reuses.
 
 - **Not a prerequisite** for Phase 0 (transit) or Phase 1 (inverse-Gaussian) of this plan —
   neither involves a zero-order input. The two headline models are unblocked by #324.
 - **Is the foundation** for the zero-order absorption family in Phase 2 below.
 
-Decision: do #324 first (its Phase 0/1 are independently valuable; its Phase 2 establishes
-the estimated-duration forcing this plan's Phase 2 then reuses) — but start Phase 0/1 of
-this plan in parallel, since they don't depend on it.
+Decision: ship #324's Phase 0 safety net first (independently valuable); its `D1`
+modeled-duration path establishes the estimated-duration forcing this plan's Phase 2 then
+reuses. Phase 0/1 of this plan can start in parallel, since they don't depend on it.
 
 ## DSL surface (decided: new `[absorption]` block)
 
@@ -202,12 +205,13 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 
 ## Phasing (one PR each)
 
-- **Phase −1 — issue #324 (NONMEM coded `RATE`), standalone first.** Support `RATE=-1`
-  (duration-defined, via a `DURATION` column) and `RATE=-2` (model-estimated duration via a
-  `D1`-style DSL parameter), behind a safety net for unsupported coded values. Independently
-  shippable and a user win on its own; its `RATE=-2` part (#324 Phase 2) establishes the
-  estimated-duration forcing that this plan's Phase 2 zero-order family reuses. Phase 0/1
-  here can start in parallel since they don't depend on it.
+- **Phase −1 — issue #324 (NONMEM coded `RATE`), standalone first.** Ship the safety net
+  first (reject coded/malformed `RATE` instead of a silent IV bolus; PR #326). Faithful
+  support follows as a parameter-driven DSL feature: `RATE=-1` = rate modeled (`R1`-style),
+  `RATE=-2` = duration modeled (`D1`-style) — **no `DURATION` data column**. The
+  `RATE=-2`/`D1` modeled-duration path establishes the estimated-duration forcing that this
+  plan's Phase 2 zero-order family reuses. Independent of this plan's Phase 0/1, which can
+  start in parallel.
 - **Phase 0 — engine + Savic transit.** `[absorption]` grammar, `AbsorptionSpec`, generic
   input-fn trait, ODE-forcing plumbing, `ln_gamma`, transit end-to-end. Anchor against the
   existing `transit_2cpt` dataset and a NONMEM Savic run. Proves the architecture.

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -177,22 +177,26 @@ Writing the full disposition ODE by hand every time is verbose. `ode_template NA
 tells ferx to **generate** the standard disposition ODE for a named model — the codified
 analytical→ODE transforms already specified in ferx-r#127 / `ode-analytical-equivalence.md`
 (e.g. `two_cpt_oral` → `depot`/`central`/`periph` states with the micro-constant RHS and
-`obs_scale = V1`). The user then extends it with absorption input-rate functions:
+`obs_scale = V1`). The user customises it in `[odes]` using **override semantics** (Ron's
+call): any `d/dt(X)` declared in `[odes]` **replaces** the template's equation for compartment
+`X` (maximum flexibility); compartments left undeclared keep the generated RHS. To add the
+Savic input, re-declare the depot with the transit term:
 
 ```
 [structural_model]
   ode_template two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2)   # ferx writes the 2-cpt oral ODE
 
 [odes]
-  # add the Savic transit input into the generated depot
-  d/dt(depot) += transit(NTR, MTT)        # extend the generated RHS (syntax TBD; see Open Qs)
+  # re-declaring d/dt(depot) OVERRIDES the template's depot equation
+  d/dt(depot) = transit(NTR, MTT) - KA*depot
+  # d/dt(central) and d/dt(periph) keep the generated equations
 ```
 
 Because the user typed `ode_template`, they **expect** ferx to write ODEs — there is no
-hidden conversion (Ron's core requirement). The same primitive generalizes beyond
-absorption (e.g. **TMDD**: generate a standard disposition, then add target-binding terms),
-so it is worth building as a general mechanism, not an absorption-specific one (Ron's last
-point).
+hidden conversion (Ron's core requirement). The same primitive generalizes beyond absorption
+(Ron: future uses such as **TMDD**, **TGI**, **neutropenia** — generate a standard
+disposition, then add the extra terms), so it is worth building generically; this plan keeps
+scope to **absorption first**.
 
 ### The error rule (analytical + ODE-only absorption ⇒ error)
 
@@ -206,12 +210,13 @@ an ODE behind an analytical request. This is Ron's "avoid surprises":
 
 ### Dropped: the declarative `[absorption]` block
 
-An earlier draft proposed a declarative `[absorption]` block on an analytical `pk` model
-that would pick a closed form or silently desugar to an ODE. **Dropped** — that is exactly
-the silent analytical→ODE conversion Ron objected to, and with `ode_template` + one-line
-input-rate functions it buys almost no convenience for a lot of machinery (closed-form
-dispatch, the `W_ABSORPTION_NUMERICAL` warning, a `pathway = {}` grammar). If a one-liner is
-ever wanted it can return later as pure sugar over `ode_template` — never over `pk`.
+An earlier draft proposed a declarative `[absorption]` block. **Dropped** — Ron confirmed it
+is not needed (2026-06-14): the input-rate functions already give a one-line absorption term,
+and keeping the surface generic/simple beats a dedicated block. On an analytical `pk` it would
+be the silent analytical→ODE conversion Ron objected to (the error rule above handles that);
+on `ode_template` it would be a second, redundant way to write what the functions already
+express, plus a `pathway = {}` grammar and closed-form-dispatch machinery for no real gain.
+Absorption = input-rate functions + an explicit ODE disposition (`ode` or `ode_template`).
 
 Parser rules (enforced, with negative tests): input-rate-function arguments must be declared
 individual parameters (reuse the undefined-name machinery in `parser/model_parser.rs`);
@@ -407,17 +412,17 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   (#281 cadence) verifies the AD path. Mass-balance and the AD≡FD gradient-agreement test are
   the fast regression backstop and the bridge between the two.
 
+## Resolved decisions (Ron, 2026-06-14)
+
+- **No `[absorption]` block.** Input-rate functions in `[odes]` suffice; keep the surface
+  generic/simple. Both **A** (hand-written `ode`) and **B** (`ode_template`) ship and coexist.
+- **`ode_template` scope: absorption first.** TMDD / TGI / neutropenia are future uses of the
+  same primitive, out of scope here.
+- **Override semantics:** a `d/dt(X)` re-declared in `[odes]` **overrides** the template's
+  equation for `X` (maximum flexibility) — no `+=` append form.
+
 ## Open questions
 
-- **`[absorption]` block — decided to drop** (see DSL surface). Recommendation pending your /
-  Ron's sign-off: ship input-rate functions + `ode_template`; if a one-liner is wanted later
-  it returns as sugar over `ode_template`, never over `pk`.
-- **`ode_template` extend-vs-override syntax** — how does the user add the absorption term to
-  a generated RHS? Options: `d/dt(depot) += transit(...)` (append), re-declaring `d/dt(depot)`
-  to override, or a dedicated `[absorption_into = depot]` hint. Needs a decision in Phase 0.
-- **`ode_template` scope** — ship it absorption-only first, or design the general primitive
-  (TMDD etc.) up front? Ron flagged the reuse; lean to designing the generation hook generally
-  but ship the standard PK templates first.
 - **`transit()` argument form** — `transit(n, mtt)` (explicit, recommended) vs `transit(n)`
   reading a conventional `MTT`/`KTR` param. Explicit args avoid magic.
 

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -21,7 +21,7 @@ The goal is to compute these **in Rust** as first-class, user-friendly built-ins
 **Savic 2007** (transit) and **Freijer & Post** (convection–dispersion ⇒ inverse-Gaussian
 density input). The mechanism is a set of **built-in input-rate functions** (`transit`, `igd`, `weibull`,
 `zero_order`, `first_order`) callable in the `[odes]` RHS, so the user writes the ODE
-explicitly (Ron's proposal: `d/dt(depot) = transit(NTR, MTT) - KA*depot`). The disposition is
+explicitly (Ron's proposal: `d/dt(depot) = transit(n=NTR, mtt=MTT) - KA*depot`). The disposition is
 supplied explicitly — a hand-written `ode(...)` or a generated `ode_template ...` — never
 invented behind an analytical `pk` request (which errors instead). See "DSL surface".
 
@@ -99,20 +99,22 @@ hand-coding the Stirling gamma density:
   ode(obs_cmt=central, states=[depot, central])
 
 [odes]
-  d/dt(depot)   = transit(NTR, MTT) - KA*depot
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
   d/dt(central) = KA*depot - (CL/V)*central
 ```
 
-`transit(NTR, MTT)` returns the Savic transit-chain appearance rate into that compartment,
+`transit(n=NTR, mtt=MTT)` returns the Savic transit-chain appearance rate into that compartment,
 evaluated by the engine from time-after-dose and the dose amount (×F), superposed over doses
 — the same dose context the infusion RHS-wrapper already carries. `igd(...)`, `weibull(...)`,
 `zero_order(...)` behave identically. This is the natural home for the inherently-numerical
 models (Weibull, IG, continuous-N transit) and satisfies Ron's transparency ask directly.
 
 **Input-rate function for each model.** Each returns the dose-driven appearance rate into the
-compartment it is added to (dose amount × F, superposed over doses). Fractions for parallel /
-biphasic pathways are **plain scalar multipliers** — so no `pathway` grammar is needed, and
-`frac` just splits the dose by linearity.
+compartment it is added to (dose amount × F, superposed over doses). Arguments are **named**
+(matching the `pk(...)` convention): `transit(n=NTR, mtt=MTT)` — order-proof and
+parser-validated, so a swapped or typo'd argument errors instead of silently giving wrong
+numbers. Fractions for parallel / biphasic pathways are **plain scalar multipliers** — so no
+`pathway` grammar is needed, and `frac` just splits the dose by linearity.
 
 *Savic transit* — `transit(n, mtt)` into a depot, then first-order `ka` (shown above);
 `ktr = (n+1)/mtt`, continuous `n`.
@@ -122,42 +124,42 @@ form is two terms split by a fraction:
 ```
 [odes]
   # single IG into 1-cpt
-  d/dt(central) = igd(MAT, CV2) - (CL/V)*central
+  d/dt(central) = igd(mat=MAT, cv2=CV2) - (CL/V)*central
   # Freijer biphasic (sum of two IG), fraction FR through pathway 1
-  d/dt(central) = FR*igd(MAT1, CV2_1) + (1-FR)*igd(MAT2, CV2_2) - (CL/V)*central
+  d/dt(central) = FR*igd(mat=MAT1, cv2=CV2_1) + (1-FR)*igd(mat=MAT2, cv2=CV2_2) - (CL/V)*central
 ```
 
 *Weibull* — `weibull(td, beta)` (td = scale, beta = shape):
 ```
 [odes]
-  d/dt(central) = weibull(TD, BETA) - (CL/V)*central
+  d/dt(central) = weibull(td=TD, beta=BETA) - (CL/V)*central
 ```
 
 *Zero-order, estimated duration* — `zero_order(dur)` (constant rate over `dur`; this is the
 modeled-duration / #324 `D1` case, reusable as an absorption input):
 ```
 [odes]
-  d/dt(central) = zero_order(DUR) - (CL/V)*central
+  d/dt(central) = zero_order(dur=DUR) - (CL/V)*central
 ```
 
 *Parallel / dual first-order* — compose two `first_order(ka)` terms with a fraction (no need
 for two depot compartments or per-compartment F):
 ```
 [odes]
-  d/dt(central) = FR*first_order(KA1) + (1-FR)*first_order(KA2) - (CL/V)*central
+  d/dt(central) = FR*first_order(ka=KA1) + (1-FR)*first_order(ka=KA2) - (CL/V)*central
 ```
 
 *Sequential (zero-order then first-order)* — `zero_order` fills the depot, `ka` to central:
 ```
 [odes]
-  d/dt(depot)   = zero_order(DUR) - KA*depot
+  d/dt(depot)   = zero_order(dur=DUR) - KA*depot
   d/dt(central) = KA*depot - (CL/V)*central
 ```
 
 *Mixed (zero-order + first-order, in parallel)*:
 ```
 [odes]
-  d/dt(central) = (1-FZO)*first_order(KA) + FZO*zero_order(DUR) - (CL/V)*central
+  d/dt(central) = (1-FZO)*first_order(ka=KA) + FZO*zero_order(dur=DUR) - (CL/V)*central
 ```
 
 (`first_order(ka)` is the existing first-order absorption exposed as an input-rate function
@@ -188,7 +190,7 @@ Savic input, re-declare the depot with the transit term:
 
 [odes]
   # re-declaring d/dt(depot) OVERRIDES the template's depot equation
-  d/dt(depot) = transit(NTR, MTT) - KA*depot
+  d/dt(depot) = transit(n=NTR, mtt=MTT) - KA*depot
   # d/dt(central) and d/dt(periph) keep the generated equations
 ```
 
@@ -412,8 +414,9 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   (#281 cadence) verifies the AD path. Mass-balance and the AD≡FD gradient-agreement test are
   the fast regression backstop and the bridge between the two.
 
-## Resolved decisions (Ron, 2026-06-14)
+## Resolved decisions
 
+Ron, 2026-06-14:
 - **No `[absorption]` block.** Input-rate functions in `[odes]` suffice; keep the surface
   generic/simple. Both **A** (hand-written `ode`) and **B** (`ode_template`) ship and coexist.
 - **`ode_template` scope: absorption first.** TMDD / TGI / neutropenia are future uses of the
@@ -421,10 +424,14 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
 - **Override semantics:** a `d/dt(X)` re-declared in `[odes]` **overrides** the template's
   equation for `X` (maximum flexibility) — no `+=` append form.
 
-## Open questions
+Argument convention:
+- **Input-rate functions take named args** — `transit(n=NTR, mtt=MTT)`, not positional and
+  not a conventional-param lookup. Matches the `pk(...)` convention; order-proof and
+  parser-validated (swapped/typo'd args error rather than silently producing wrong results,
+  per the repo's no-silent-wrong-results rule). Reuses the `pk(...)` kwarg-parsing logic,
+  extended into the `[odes]` expression parser (today only `UnaryFn` exists there).
 
-- **`transit()` argument form** — `transit(n, mtt)` (explicit, recommended) vs `transit(n)`
-  reading a conventional `MTT`/`KTR` param. Explicit args avoid magic.
+No open questions outstanding.
 
 ## Open risks
 


### PR DESCRIPTION
## Why
Tracks the design for #322 — built-in absorption models. ferx-core only has first-order
absorption analytically; richer models (Savic transit, Freijer & Post inverse-Gaussian,
Weibull, zero-order family) are reachable only by hand-written `[odes]`, which can't even
estimate a continuous number of transit compartments. This adds the phased roadmap to
`plans/` (matching the existing `plans/*.md` convention) before implementation starts.

## What changed
Adds `plans/absorption-models.md`: a new `[absorption]` block selecting Rust-computed
absorption models; one engine that forces an analytic input rate `R_in(t)` into the
existing infusion RHS-forcing path; "no happy paths" robustness requirements; and a
phased PR breakdown (#282 first → Savic transit → inverse-Gaussian → rest). **Doc only —
no code changes.**

## Alternatives considered
DSL surface: a new `[absorption]` block (chosen) vs an `absorption=` arg on the `pk` line
vs per-disposition model names (`one_cpt_transit`, …). The block parses cleanest and
naturally expresses multi-pathway models (Freijer sum-of-two-IG, parallel first-order).
Captured in the plan.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#— | not needed | — |

(Doc only. Implementation phases will each carry their own ferx-r follow-up for new `pub` API.)

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: documentation only — implementation phases add tests per CLAUDE.md tiers)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] No user-visible change (planning doc under `plans/`, not part of the mdBook)

## Checklist
- [x] `cargo clippy` clean (no code changed)
- [x] `cargo check --features autodiff` still compiles (no code changed)
- [x] `Cargo.toml` version bumped if breaking (N/A)

## Docs & examples
N/A — planning doc only; no DSL/example/data changes in this PR.

### Example execution (run locally before marking ready for review)
- [x] No example execution step needed (docs-only / no user-visible change)

## Reviewer hints
Single new file `plans/absorption-models.md`. Worth a skim for the DSL surface, the
phasing (esp. #282 sequenced first), and the "no happy paths" robustness list. No code.

## Open questions
None blocking — this is the agreed roadmap. Phase-level design questions are noted inline
in the plan's "Open risks" section.