### PR TITLE
feat(stats): add Lanczos ln_gamma; consolidate importance_sampling copy [#322]

### DIFF
--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -26,7 +26,7 @@
 use crate::pk::{compute_predictions_with_tv_into, predict_iov, EventPkParams};
 use crate::stats::likelihood::{obs_nll_subject_into, split_obs_by_occasion};
 use crate::stats::residual_error::compute_r_diag;
-use crate::stats::special::log_normal_cdf;
+use crate::stats::special::{ln_gamma, log_normal_cdf};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rand::rngs::StdRng;
@@ -1042,37 +1042,6 @@ fn build_proposal(h: &DMatrix<f64>, omega_inv: &DMatrix<f64>, d: usize) -> Optio
 // Numerical helpers
 // ---------------------------------------------------------------------------
 
-/// log Γ(x) via the Lanczos approximation. Standard library doesn't expose
-/// `f64::ln_gamma` on stable, so we inline the textbook coefficients.
-fn ln_gamma(x: f64) -> f64 {
-    // Cody's coefficients for Lanczos g=7, n=9. Accuracy ~1e-15 for x > 0.
-    const G: f64 = 7.0;
-    const C: [f64; 9] = [
-        0.999_999_999_999_81,
-        676.520_368_121_885_1,
-        -1_259.139_216_722_402_8,
-        771.323_428_777_653_2,
-        -176.615_029_162_140_6,
-        12.507_343_278_686_905,
-        -0.138_571_095_265_720_1,
-        9.984_369_578_019_572e-6,
-        1.505_632_735_149_311_6e-7,
-    ];
-    if x < 0.5 {
-        // Reflection.
-        return std::f64::consts::PI.ln()
-            - (std::f64::consts::PI * x).sin().ln()
-            - ln_gamma(1.0 - x);
-    }
-    let x = x - 1.0;
-    let mut a = C[0];
-    for (i, &c) in C.iter().enumerate().skip(1) {
-        a += c / (x + i as f64);
-    }
-    let t = x + G + 0.5;
-    0.5 * (TWO_PI).ln() + (x + 0.5) * t.ln() - t + a.ln()
-}
-
 /// Numerically stable `log Σ exp(xᵢ)` plus the normalised weights `wᵢ`.
 fn logsumexp_with_normalised(xs: &[f64]) -> (f64, Vec<f64>) {
     if xs.is_empty() {
@@ -1170,19 +1139,6 @@ mod tests {
         let (lse, w) = logsumexp_with_normalised(&[f64::NEG_INFINITY; 3]);
         assert_eq!(lse, f64::NEG_INFINITY);
         assert_eq!(w, vec![0.0, 0.0, 0.0]);
-    }
-
-    #[test]
-    fn ln_gamma_matches_known_values() {
-        // ln Γ(0.5) = ln √π
-        assert!((ln_gamma(0.5) - 0.5 * std::f64::consts::PI.ln()).abs() < 1e-10);
-        // ln Γ(1) = 0
-        assert!(ln_gamma(1.0).abs() < 1e-10);
-        // ln Γ(5) = ln 24
-        assert!((ln_gamma(5.0) - 24.0_f64.ln()).abs() < 1e-10);
-        // ln Γ(10) = ln 9!
-        let factorial_9: f64 = (1..=9).map(|n| n as f64).product();
-        assert!((ln_gamma(10.0) - factorial_9.ln()).abs() < 1e-9);
     }
 
     #[test]

--- a/src/stats/special.rs
+++ b/src/stats/special.rs
@@ -1,4 +1,5 @@
-//! Special functions for M3 BLOQ likelihood: erf, normal CDF, and log normal CDF.
+//! Special functions: erf, normal CDF, log normal CDF (M3 BLOQ likelihood), and
+//! ln Γ (Lanczos) — the latter for the transit-compartment absorption model.
 //!
 //! These are implemented from polynomial/rational approximations (Abramowitz &
 //! Stegun 7.1.26 for erf) so that they are differentiable by Enzyme without
@@ -68,6 +69,49 @@ pub fn log_normal_cdf(z: f64) -> f64 {
         // z < 0, so -z > 0 and ln(-z) is well-defined; series > 0 for z < -5.
         log_phi - (-z).ln() + series.ln()
     }
+}
+
+/// Natural log of the Gamma function, ln Γ(x), via the Lanczos approximation
+/// (g = 7, n = 9), accurate to ~1e-13 (relative) for x > 0.
+///
+/// Added for the transit-compartment absorption model (Savic et al. 2007): its
+/// gamma-density input rate needs `ln Γ(n + 1)` for a *continuous* number of
+/// transit compartments `n`, where `n!` is undefined. Bare Stirling errs ~8% at
+/// n = 1 — enough to bias the absorption peak — so Lanczos is used instead.
+///
+/// AD/Enzyme-safe: only `+`, `-`, `*`, `/`, `.ln()`, and (on the reflection
+/// branch) `.sin()` — no `f64::max`/`min` intrinsics (see CLAUDE.md). The
+/// reflection branch (x < 0.5) is never exercised by the transit path
+/// (n ≥ 0 ⇒ argument ≥ 1) but keeps the function correct over the whole
+/// domain x > 0.
+pub fn ln_gamma(x: f64) -> f64 {
+    // Lanczos coefficients for g = 7 (n = 9 terms).
+    const G: f64 = 7.0;
+    const COEF: [f64; 9] = [
+        0.999_999_999_999_809_93,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_13,
+        -176.615_029_162_140_59,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_571_6e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+
+    // Reflection for x < 0.5: ln Γ(x) = ln(π / sin(πx)) − ln Γ(1 − x).
+    if x < 0.5 {
+        let pi = std::f64::consts::PI;
+        return (pi / (pi * x).sin()).ln() - ln_gamma(1.0 - x);
+    }
+
+    let x = x - 1.0;
+    let mut a = COEF[0];
+    for (i, &c) in COEF.iter().enumerate().skip(1) {
+        a += c / (x + i as f64);
+    }
+    let t = x + G + 0.5;
+    0.5 * (2.0 * std::f64::consts::PI).ln() + (x + 0.5) * t.ln() - t + a.ln()
 }
 
 #[cfg(test)]
@@ -153,5 +197,64 @@ mod tests {
             );
             prev = v;
         }
+    }
+
+    #[test]
+    fn ln_gamma_integer_factorials() {
+        // ln Γ(n+1) = ln(n!). Includes the near-zero cases (0! = 1! = 1).
+        let cases = [
+            (1.0, 0.0),                    // 0! = 1
+            (2.0, 0.0),                    // 1! = 1
+            (3.0, std::f64::consts::LN_2), // 2! = 2
+            (5.0, 24.0_f64.ln()),          // 4! = 24
+            (6.0, 120.0_f64.ln()),         // 5! = 120
+            (11.0, 3_628_800.0_f64.ln()),  // 10! = 3628800
+        ];
+        for (x, want) in cases {
+            assert_relative_eq!(ln_gamma(x), want, epsilon = 1e-9, max_relative = 1e-10);
+        }
+    }
+
+    #[test]
+    fn ln_gamma_half_integers_closed_form() {
+        // ln Γ(1/2) = ln √π (main branch, x = 0.5 exactly).
+        assert_relative_eq!(
+            ln_gamma(0.5),
+            0.5 * std::f64::consts::PI.ln(),
+            epsilon = 1e-12
+        );
+        // ln Γ(3/2) = ln(√π / 2).
+        assert_relative_eq!(
+            ln_gamma(1.5),
+            (std::f64::consts::PI.sqrt() / 2.0).ln(),
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn ln_gamma_reflection_branch_small_x() {
+        // x < 0.5 exercises the reflection formula. ln Γ(1/4) = 1.2880225246980776.
+        assert_relative_eq!(ln_gamma(0.25), 1.288_022_524_698_077_6, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn ln_gamma_recurrence() {
+        // Functional equation: ln Γ(x+1) = ln Γ(x) + ln x (spans both branches).
+        for &x in &[0.3, 0.7, 1.0, 2.5, 4.2, 9.0] {
+            assert_relative_eq!(
+                ln_gamma(x + 1.0),
+                ln_gamma(x) + x.ln(),
+                epsilon = 1e-9,
+                max_relative = 1e-10
+            );
+        }
+    }
+
+    #[test]
+    fn ln_gamma_large_argument_no_overflow() {
+        // Γ(100) overflows f64, but ln Γ(100) = 359.1342053695754 is finite.
+        let v = ln_gamma(100.0);
+        assert!(v.is_finite());
+        assert_relative_eq!(v, 359.134_205_369_575_4, max_relative = 1e-11);
     }
 }

--- a/src/stats/special.rs
+++ b/src/stats/special.rs
@@ -14,6 +14,8 @@ const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
 /// Smallest probability retained before taking `ln`. Prevents `-inf` contamination
 /// of the likelihood when a BLOQ observation lies many SDs above the prediction.
 const MIN_PROB: f64 = 1e-300;
+/// ½·ln(2π) — the constant term of the Lanczos `ln_gamma` formula.
+const HALF_LN_2PI: f64 = 0.918_938_533_204_672_74;
 
 /// Abramowitz & Stegun 7.1.26 — max error ~1.5e-7 over the whole real line.
 /// Entirely polynomial in t = 1/(1 + p*|x|) and exp(-x²), so Enzyme-safe.
@@ -111,7 +113,7 @@ pub fn ln_gamma(x: f64) -> f64 {
         a += c / (x + i as f64);
     }
     let t = x + G + 0.5;
-    0.5 * (2.0 * std::f64::consts::PI).ln() + (x + 0.5) * t.ln() - t + a.ln()
+    HALF_LN_2PI + (x + 0.5) * t.ln() - t + a.ln()
 }
 
 #[cfg(test)]

--- a/src/stats/special.rs
+++ b/src/stats/special.rs
@@ -257,4 +257,19 @@ mod tests {
         assert!(v.is_finite());
         assert_relative_eq!(v, 359.134_205_369_575_4, max_relative = 1e-11);
     }
+
+    #[test]
+    fn ln_gamma_legendre_duplication() {
+        // Legendre duplication formula — an independent identity that needs no
+        // external reference table and exercises both branches (z = 0.3 takes
+        // the reflection path):
+        //   ln Γ(z) + ln Γ(z+½) = (1−2z)·ln2 + ½·ln π + ln Γ(2z).
+        let ln2 = std::f64::consts::LN_2;
+        let half_ln_pi = 0.5 * std::f64::consts::PI.ln();
+        for &z in &[0.3, 0.7, 1.3, 2.0, 3.5, 6.1] {
+            let lhs = ln_gamma(z) + ln_gamma(z + 0.5);
+            let rhs = (1.0 - 2.0 * z) * ln2 + half_ln_pi + ln_gamma(2.0 * z);
+            assert_relative_eq!(lhs, rhs, epsilon = 1e-9, max_relative = 1e-10);
+        }
+    }
 }


### PR DESCRIPTION
## Why

First building block of the built-in **absorption-models** roadmap (#322; plan
now in `plans/absorption-models.md`). The Savic 2007 transit-compartment model's
gamma-density input rate needs `ln Γ(n + 1)` for a *continuous* number of transit
compartments `n` (where `n!` is undefined). `src/stats/special.rs` had
`erf`/`erfc`/`normal_cdf`/`log_normal_cdf` but **no `ln Γ`**.

Separately, `src/estimation/importance_sampling.rs` carried a *private, identical*
Lanczos `ln_gamma` (for the Student-t proposal normalising constant) — a
duplicate worth consolidating while we add the canonical one.

## What changed

- Added `pub fn ln_gamma(x: f64) -> f64` to `stats::special` — Lanczos
  approximation (g = 7, n = 9), ~1e-13 relative accuracy for x > 0, with
  reflection for x < 0.5. Written **AD/Enzyme-safe**: only `+ - * /`, `.ln()`,
  and `.sin()` (reflection branch only) — no `f64::max`/`min` intrinsics
  (see CLAUDE.md), so the future `transit()` AD path can reuse it.
- Pointed `importance_sampling` at the canonical `stats::special::ln_gamma` and
  removed its private copy (identical algorithm/coefficients) + the now-redundant
  local test.

## Alternatives considered

- **Bare Stirling** for `ln Γ`: rejected — ~8% error at N = 1, enough to bias the
  absorption peak. Lanczos is smooth and accurate.
- **Leaving the two `ln_gamma` copies**: rejected (DRY); `stats::special` is the
  natural home for special functions.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`ln_gamma` is new `pub` surface, but ferx-r does not reference it → no lock bump.

## Breaking changes
- [x] None — additive `pub fn` in `stats::special`; the `importance_sampling`
  change is internal and behaviour-preserving.

## Numerical validation

`ln_gamma` validated against exact values + independent identities (unit tests):

```
ln Γ(0.5) = 0.5723649429247001   (= ln √π)
ln Γ(5)   = 3.1780538303479458   (= ln 24)
ln Γ(100) = 359.1342053695754    (Γ(100) itself overflows f64)
recurrence : ln Γ(x+1) = ln Γ(x) + ln x
Legendre   : ln Γ(z) + ln Γ(z+½) = (1−2z)·ln2 + ½·ln π + ln Γ(2z)
```

- [x] Compared against: prior ferx commit — the `importance_sampling` numerics are
  unchanged (the removed copy used the same Lanczos g=7 coefficients); the 8
  `tests/importance_sampling_api.rs` integration tests (standalone IMP with
  Student-t `proposal_df = 5`, which runs through `ln_gamma`) all pass.

## Performance
- [x] No significant impact expected (cheap helper; IS now reaches the same
  algorithm through a shared function).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes) — 6
  `ln_gamma` tests in `stats::special` (factorials, half-integer closed forms,
  reflection branch, recurrence, Legendre duplication, large-arg no-overflow).
- [x] Regression test added that fails without this fix — the identity/reference
  tests pin `ln_gamma`; the IS suite guards the consolidation.

## Example (user-facing features only)
- [x] Not applicable — internal building block, no new user-facing API surface
  (`ln_gamma` is a math helper, no DSL). The user-runnable example + Tier-2/Tier-3
  fit tests land with the `transit()` model that will consume this.

## Docs
- [x] No user-visible change
- [x] `CHANGELOG.md` — N/A (internal building block)

## Checklist
- [x] `cargo clippy` clean
- [ ] `cargo check --features autodiff` — N/A: not AD-reachable yet (the only
  caller, `importance_sampling`, is not autodiff-instrumented); written AD-safe
  for the future `transit()` path. (Enzyme toolchain unavailable locally; CI
  covers the autodiff build.)
- [x] `Cargo.toml` version bump — N/A (not breaking)

## Docs & examples

### ferx-site
- [x] No new `.ferx` DSL syntax or `[fit_options]` key
- [x] No new example `.ferx` file
- [x] No new data file

### ferx-book
- [x] No new estimator / DSL feature / fit option

### Example execution
- [x] No example execution step needed (internal; no user-visible change)

## Reviewer hints

- Focus on the Lanczos coefficients/formula in `special.rs::ln_gamma`, and that
  the `importance_sampling` consolidation is behaviour-preserving (identical
  algorithm — the 8 IS integration tests pass).
- `ln_gamma` is now `pub`, consistent with its siblings (`erf`, `normal_cdf`);
  additive, not breaking.

## Open questions

- I split `ln_gamma` into this small standalone PR (utility + dedup, independently
  valuable) rather than bundling it into the larger `transit()` Phase-0 PR. Happy
  to fold it into a single Phase-0 PR instead if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
