### PR TITLE
fix(parser): don't fire compute_max_stack end-depth assert on conditional bytecode

### DIFF
--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6865,10 +6865,10 @@ fn compute_max_stack(ops: &[Op]) -> usize {
     // stack (the result); this catches off-by-one push/pop emissions in any
     // future `compile_expr_into` change. Bytecode with branches can't be
     // checked this way (the linear scan walks both arms — see
-    // `bytecode_has_branch`), so skip the end-depth check when a jump is
-    // present. `peak` stays a safe over-estimate either way.
+    // `bytecode_has_branch`), so the predicate exempts them. `peak` stays a
+    // safe over-estimate either way.
     debug_assert!(
-        ops.is_empty() || bytecode_has_branch(ops) || depth == 1,
+        ends_at_expected_depth(ops, depth),
         "compute_max_stack: bytecode ends at depth {depth}, expected 1",
     );
     peak.max(1) as usize
@@ -6883,6 +6883,20 @@ fn compute_max_stack(ops: &[Op]) -> usize {
 fn bytecode_has_branch(ops: &[Op]) -> bool {
     ops.iter()
         .any(|op| matches!(op, Op::Jump(_) | Op::JumpIfFalse(_)))
+}
+
+/// Whether a completed linear scan of `ops` ending at `depth` satisfies the
+/// well-formed end-depth invariant: a jump-free expression must leave exactly
+/// one value on the stack. Branchy bytecode is exempt — a `Conditional` emits
+/// both arms inline, so the linear walk ends above depth 1 even though
+/// execution takes one arm (see [`bytecode_has_branch`]). The cheap `depth`
+/// check is tried first so the common jump-free path skips the O(n) scan.
+///
+/// Returned rather than inlined into the `debug_assert!` so the invariant is
+/// exercised even under the `ci-test` profile, where `debug_assert!` is
+/// compiled out and the assertion itself never runs.
+fn ends_at_expected_depth(ops: &[Op], depth: i32) -> bool {
+    depth == 1 || ops.is_empty() || bytecode_has_branch(ops)
 }
 
 fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
@@ -15432,6 +15446,18 @@ if (1 > 0) {
         assert!(!bytecode_has_branch(
             &compile_bytecode(&binop(BinOp::Add, lit(1.0), lit(2.0))).ops
         ));
+
+        // `ends_at_expected_depth` — the returnable predicate the `debug_assert!`
+        // consumes. Exercised directly so the end-depth invariant is covered
+        // even under the `ci-test` profile (debug-assertions off), where the
+        // assertion is compiled out and never runs. Branchy bytecode is exempt
+        // at any end depth; jump-free bytecode must end at depth 1.
+        let cond_ops = compile_bytecode(&expr).ops;
+        let addops = compile_bytecode(&binop(BinOp::Add, lit(1.0), lit(2.0))).ops;
+        assert!(ends_at_expected_depth(&cond_ops, 2)); // branchy: exempt even at depth 2
+        assert!(ends_at_expected_depth(&addops, 1)); // jump-free: depth 1 ok
+        assert!(!ends_at_expected_depth(&addops, 2)); // jump-free: depth 2 rejected
+        assert!(ends_at_expected_depth(&[], 0)); // empty: ok
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6797,11 +6797,11 @@ fn compile_bytecode(expr: &Expression) -> Bytecode {
 ///   Jump        :   0
 ///   JumpIfFalse :  -1
 ///
-/// The single linear scan returns an *upper bound* (not the exact peak):
-/// `Conditional` emits both then- and else-branches inline with a `Jump`
-/// between them, so the linear walk credits BOTH branches' pushes against
-/// running depth even though execution only takes one branch at runtime.
-/// That over-estimate is exactly what `eval_bytecode` wants for its
+/// A single linear scan ([`scan_stack_depth`]) returns an *upper bound* (not
+/// the exact peak): `Conditional` emits both then- and else-branches inline
+/// with a `Jump` between them, so the linear walk credits BOTH branches'
+/// pushes against running depth even though execution only takes one branch at
+/// runtime. That over-estimate is exactly what `eval_bytecode` wants for its
 /// `stack.reserve(max_stack)` call — under-estimating here would let the
 /// unchecked-write hot loop go OOB on the conservative-FD path. The
 /// `depth >= 0` and balanced-end debug asserts catch a future opcode
@@ -6811,6 +6811,30 @@ fn compile_bytecode(expr: &Expression) -> Bytecode {
 /// If backward jumps (e.g. for loops) are ever added, this linear-scan
 /// algorithm no longer holds — fixed-point iteration would be required.
 fn compute_max_stack(ops: &[Op]) -> usize {
+    let (peak, depth) = scan_stack_depth(ops);
+    // A well-formed *jump-free* expression leaves exactly one value on the
+    // stack (the result); this catches off-by-one push/pop emissions in any
+    // future `compile_expr_into` change. Bytecode with branches can't be
+    // checked this way (the linear scan walks both arms — see
+    // `bytecode_has_branch`), so the predicate exempts them. `peak` stays a
+    // safe over-estimate either way.
+    debug_assert!(
+        ends_at_expected_depth(ops, depth),
+        "compute_max_stack: bytecode ends at depth {depth}, expected 1",
+    );
+    peak.max(1) as usize
+}
+
+/// Single linear pass over `ops` returning `(peak, end_depth)`: the maximum
+/// running f64-stack depth and the depth left after the final op. Split out
+/// from [`compute_max_stack`] so the end-depth invariant can be checked on
+/// *real* compiled bytecode from a unit test (see
+/// `compute_max_stack_jumpfree_bytecode_ends_at_depth_one`) even under the
+/// `ci-test` profile, where the `debug_assert!` that normally guards it is
+/// compiled out. Returning `end_depth` — rather than only consuming it inside
+/// that `debug_assert!` — is what lets a future `compile_expr_into` off-by-one
+/// be caught in CI, not just under the local dev profile.
+fn scan_stack_depth(ops: &[Op]) -> (i32, i32) {
     let mut depth: i32 = 0;
     let mut peak: i32 = 0;
     for op in ops {
@@ -6861,17 +6885,7 @@ fn compute_max_stack(ops: &[Op]) -> usize {
             peak = depth;
         }
     }
-    // A well-formed *jump-free* expression leaves exactly one value on the
-    // stack (the result); this catches off-by-one push/pop emissions in any
-    // future `compile_expr_into` change. Bytecode with branches can't be
-    // checked this way (the linear scan walks both arms — see
-    // `bytecode_has_branch`), so the predicate exempts them. `peak` stays a
-    // safe over-estimate either way.
-    debug_assert!(
-        ends_at_expected_depth(ops, depth),
-        "compute_max_stack: bytecode ends at depth {depth}, expected 1",
-    );
-    peak.max(1) as usize
+    (peak, depth)
 }
 
 /// True if `ops` contains a branch (`Jump` / `JumpIfFalse`). The end-of-scan
@@ -15448,16 +15462,74 @@ if (1 > 0) {
         ));
 
         // `ends_at_expected_depth` — the returnable predicate the `debug_assert!`
-        // consumes. Exercised directly so the end-depth invariant is covered
-        // even under the `ci-test` profile (debug-assertions off), where the
-        // assertion is compiled out and never runs. Branchy bytecode is exempt
-        // at any end depth; jump-free bytecode must end at depth 1.
+        // consumes. Exercised directly (with hard-coded depths) so its branching
+        // logic is covered even under the `ci-test` profile (debug-assertions
+        // off), where the assertion is compiled out and never runs. Branchy
+        // bytecode is exempt at any end depth; jump-free bytecode must end at
+        // depth 1. The depth real bytecode actually compiles to is pinned
+        // separately in `compute_max_stack_jumpfree_bytecode_ends_at_depth_one`.
         let cond_ops = compile_bytecode(&expr).ops;
         let addops = compile_bytecode(&binop(BinOp::Add, lit(1.0), lit(2.0))).ops;
         assert!(ends_at_expected_depth(&cond_ops, 2)); // branchy: exempt even at depth 2
         assert!(ends_at_expected_depth(&addops, 1)); // jump-free: depth 1 ok
         assert!(!ends_at_expected_depth(&addops, 2)); // jump-free: depth 2 rejected
         assert!(ends_at_expected_depth(&[], 0)); // empty: ok
+    }
+
+    #[test]
+    fn compute_max_stack_jumpfree_bytecode_ends_at_depth_one() {
+        // Closes the gap the sibling test leaves open. That one feeds
+        // `ends_at_expected_depth` HARD-CODED depths, so it pins the predicate's
+        // branching logic but never the depth a real expression compiles to — a
+        // future `compile_expr_into` off-by-one would slip past it. Here we scan
+        // REAL bytecode and assert the end-depth invariant directly.
+        //
+        // `scan_stack_depth` *returns* the end depth (rather than only feeding it
+        // to the `debug_assert!` in `compute_max_stack`), so these are plain
+        // value assertions that hold under every profile — including `ci-test`,
+        // where debug-assertions are off. That is what makes such a regression
+        // catchable in CI, not only under the local dev profile.
+        for expr in [
+            lit(3.0),
+            binop(BinOp::Add, lit(1.0), lit(2.0)),
+            binop(BinOp::Sub, binop(BinOp::Mul, lit(2.0), lit(3.0)), lit(4.0)),
+            unary("exp", lit(0.5)),
+            unary("ln", binop(BinOp::Div, lit(6.0), lit(2.0))),
+        ] {
+            let ops = compile_bytecode(&expr).ops;
+            assert!(
+                !bytecode_has_branch(&ops),
+                "expr must compile jump-free for this invariant: {ops:?}"
+            );
+            let (peak, end_depth) = scan_stack_depth(&ops);
+            // A well-formed expression leaves exactly one result on the stack.
+            assert_eq!(
+                end_depth, 1,
+                "jump-free expr must end at depth 1, got {end_depth}: {ops:?}"
+            );
+            // `peak` (the reserved stack size) never under-counts the end depth,
+            // and `compute_max_stack` returns exactly `peak.max(1)`.
+            assert!(
+                peak >= end_depth,
+                "peak {peak} < end_depth {end_depth}: {ops:?}"
+            );
+            assert_eq!(compute_max_stack(&ops), peak.max(1) as usize);
+        }
+
+        // Counterpart to the exemption: branchy bytecode genuinely ends ABOVE
+        // depth 1 (the linear scan walks both arms), which is exactly why
+        // `compute_max_stack` skips the end-depth assert when jumps are present.
+        let cond_ops = compile_bytecode(&cond(
+            cmp(lit(2.0), CmpOp::Lt, lit(3.0)),
+            lit(1.0),
+            lit(-1.0),
+        ))
+        .ops;
+        assert!(bytecode_has_branch(&cond_ops));
+        assert!(
+            scan_stack_depth(&cond_ops).1 > 1,
+            "conditional should end above depth 1 (both arms walked): {cond_ops:?}"
+        );
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6861,14 +6861,28 @@ fn compute_max_stack(ops: &[Op]) -> usize {
             peak = depth;
         }
     }
-    // A well-formed expression bytecode leaves exactly one value on the
-    // stack (the result). Catch off-by-one push/pop emissions in any
-    // future compile_expr_into change.
+    // A well-formed *jump-free* expression leaves exactly one value on the
+    // stack (the result); this catches off-by-one push/pop emissions in any
+    // future `compile_expr_into` change. Bytecode with branches can't be
+    // checked this way (the linear scan walks both arms — see
+    // `bytecode_has_branch`), so skip the end-depth check when a jump is
+    // present. `peak` stays a safe over-estimate either way.
     debug_assert!(
-        depth == 1 || ops.is_empty(),
+        ops.is_empty() || bytecode_has_branch(ops) || depth == 1,
         "compute_max_stack: bytecode ends at depth {depth}, expected 1",
     );
     peak.max(1) as usize
+}
+
+/// True if `ops` contains a branch (`Jump` / `JumpIfFalse`). The end-of-scan
+/// depth invariant in [`compute_max_stack`] only holds for branch-free
+/// bytecode: a `Conditional` emits both arms inline, so the linear walk ends
+/// above depth 1 even though execution takes one arm. Extracted (and
+/// unit-tested directly) so the branch check is exercised independently of the
+/// debug-only assertion that consumes it.
+fn bytecode_has_branch(ops: &[Op]) -> bool {
+    ops.iter()
+        .any(|op| matches!(op, Op::Jump(_) | Op::JumpIfFalse(_)))
 }
 
 fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
@@ -15370,6 +15384,54 @@ if (1 > 0) {
     }
     fn cmp(l: Expression, op: CmpOp, r: Expression) -> Condition {
         Condition::Compare(l, op, r)
+    }
+
+    #[test]
+    fn compute_max_stack_allows_branching_bytecode() {
+        // Regression: a `Conditional` compiles to
+        //   cond; JumpIfFalse(else); then; Jump(end); else
+        // so `compute_max_stack`'s linear scan walks BOTH arms and ends above
+        // depth 1 (one extra per branch). The end-depth assertion must be
+        // skipped when jumps are present; before the fix, `compile_bytecode`
+        // panicked here under debug-assertions ("bytecode ends at depth 2").
+        let expr = cond(cmp(lit(2.0), CmpOp::Lt, lit(3.0)), lit(1.0), lit(-1.0));
+        let bc = compile_bytecode(&expr); // would panic pre-fix
+        assert!(
+            bc.max_stack >= 1,
+            "max_stack must be >= 1, got {}",
+            bc.max_stack
+        );
+
+        // The reserved size must actually be sufficient to evaluate correctly:
+        // 2 < 3 ⇒ the `then` arm (1.0).
+        let nn: Vec<Vec<f64>> = Vec::new();
+        let mut stack: Vec<f64> = Vec::new();
+        let by = eval_bytecode(&bc, &[], &[], &[], &[], &nn, &mut stack);
+        assert_eq!(by.to_bits(), 1.0_f64.to_bits());
+
+        // Nested conditionals (deeper branch nesting) must also not trip it,
+        // and a deeper `peak` must still be returned.
+        let nested = cond(
+            cmp(lit(1.0), CmpOp::Gt, lit(0.0)),
+            cond(cmp(lit(2.0), CmpOp::Lt, lit(5.0)), lit(10.0), lit(20.0)),
+            lit(-1.0),
+        );
+        assert!(compute_max_stack(&compile_bytecode(&nested).ops) >= 1);
+
+        // The jump-free path is unchanged: `1 + 2` pushes two operands before
+        // `Add`, so the peak (the returned size) is 2 — and its end-depth of 1
+        // still satisfies the (retained) jump-free assertion.
+        assert_eq!(
+            compute_max_stack(&compile_bytecode(&binop(BinOp::Add, lit(1.0), lit(2.0))).ops),
+            2
+        );
+
+        // `bytecode_has_branch` (which gates the assertion) — true for
+        // conditional bytecode, false for a jump-free arithmetic expression.
+        assert!(bytecode_has_branch(&compile_bytecode(&expr).ops));
+        assert!(!bytecode_has_branch(
+            &compile_bytecode(&binop(BinOp::Add, lit(1.0), lit(2.0))).ops
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Why
`compute_max_stack`'s final `debug_assert!(depth == 1)` wrongly fires for any expression containing a conditional (`if` / ternary). A `Conditional` compiles to `cond; JumpIfFalse(else); then; Jump(end); else`; the helper's **linear** scan sums per-op stack deltas and so counts **both** arms' pushes (+1 each) even though exactly one executes at runtime — ending at depth 2 (more when nested).

This is **debug-only** and pre-existing on `main` (unrelated to any feature work). CI never caught it because the test job uses `--profile ci-test`, which inherits from `release` (debug-assertions off). Under the default dev/test profile four parser tests panic: `bytecode_matches_ast_on_conditional_and_logic`, `test_inline_if_in_parameter_assignment`, `test_ode_rhs_defined_names_ok`, `test_parse_all_example_ferx_files`.

Repro: `cargo test --lib --no-default-features --features ci test_ode_rhs_defined_names_ok` → panics `compute_max_stack: bytecode ends at depth 2, expected 1`.

## What changed
Skip the end-depth assertion when the bytecode contains any `Jump`/`JumpIfFalse`. The off-by-one guard is **retained** for jump-free expressions (the only case where a linear end-depth is meaningful). `peak` — the returned stack size — is unchanged: it is a safe over-estimate for branches (the linear depth dominates whichever single arm runs, so the VM stack is never under-allocated), which is why release has always been correct.

## Alternatives considered
Tracking branch joins to compute an exact end-depth (more machinery for a guard that only needs to catch jump-free off-by-ones); or deleting the guard (loses real protection). Skipping it precisely when jumps are present keeps the protection where it is valid, with no false positives.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (parser / debug-assertion correctness; no numerical output changes)

## Performance
- [x] No significant impact expected (the added jump scan lives inside `debug_assert!` and is compiled out in release)

## Tests
- [x] Regression test added that fails without this fix (`compute_max_stack_allows_branching_bytecode` — compiles conditional + nested-conditional bytecode, asserts a sufficient size with no panic, and that the jump-free path is unchanged)
- [x] **CI-detectable regression test** (`compute_max_stack_jumpfree_bytecode_ends_at_depth_one`, commit `122011e`) — closes the testable gap in review note 1. The scan is extracted into `scan_stack_depth(ops) -> (peak, end_depth)`, so the end-depth invariant can be asserted on **real** compiled bytecode as a plain value (not via the `debug_assert!` that `--profile ci-test` compiles out). Proven: with a stray-push off-by-one injected into `compile_expr_into`, this test **fails under `ci-test`** where `compute_max_stack_allows_branching_bytecode` still passes. (The broad "all `debug_assert!`s are dead in CI" gap remains tracked as #344.)
- [x] `cargo test --lib` passes — full lib suite now **1039 passed, 0 failed under the dev profile** (debug-assertions on); the four previously-panicking tests are green

## Example (user-facing features only)
- [x] Not applicable (internal fix, no API surface)

## Docs
- [x] No user-visible change — release behavior is identical; `CHANGELOG.md` N/A (internal)

## Checklist
- [x] `cargo clippy` clean (no warnings in the changed regions)
- [x] `cargo check --features autodiff` — N/A (no AD-reachable code touched)
- [x] No version bump (non-breaking)

## Reviewer hints
The crux: `peak` (the returned value) is a safe over-estimate for conditionals — the linear scan walks both arms, so it dominates whichever single arm runs — hence the VM stack is never under-allocated and release was always correct. Only the **end-depth** invariant was wrong for branches.

## Open questions
Secondary CI gap (out of scope here): `--profile ci-test` silences **all** `debug_assert!`s, so guards like this are dead in CI. A dedicated debug-assertions job would catch them, but may surface other latent debug-asserts repo-wide — better tracked as its own follow-up issue.
