### PR TITLE
feat(pk): built-in transit-compartment absorption via transit() [#322]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ section of the SDLC for the versioning policy).
   not also as a bolus — so a flexible, continuously-estimable absorption shape
   takes one line instead of a hand-coded transit chain. Honors `F`/lagtime and
   superposes over doses; works with IIV/IOV, resets, and time-varying covariates.
-  Steady-state dosing into a transit compartment, and combining `transit()` with
-  a `[diffusion]` block, are rejected with a clear error (`E_ABSORPTION_SS` /
-  `E_ABSORPTION_DIFFUSION`). New example `examples/transit_savic.ferx` and docs
+  Unsupported combinations are rejected with a clear error rather than silently
+  mis-modeled: steady-state dosing into a transit compartment (`E_ABSORPTION_SS`),
+  an infusion (`RATE>0`) into a transit compartment (`E_ABSORPTION_RATE`, which
+  would double-count the dose), a `[diffusion]` block together with `transit()`
+  (`E_ABSORPTION_DIFFUSION`), and an out-of-domain `mtt`/`n` at typical values
+  (`E_ABSORPTION_DOMAIN`). New example `examples/transit_savic.ferx` and docs
   page *Built-in Absorption Models* (#322).
 - Example `dose_rate.ferx` (+ `data/dose_rate.csv`) demonstrating the supported
   NONMEM `RATE` dosing forms — a bolus (`RATE=0`) and a constant-rate infusion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Built-in **transit-compartment absorption** for ODE models via a `transit(n, mtt)`
+  input-rate function in the `[odes]` block (Savic et al. 2007, continuous `n`):
+  `R_in(tad) = F·Dose·KTR·(KTR·tad)^n·e^(−KTR·tad)/Γ(n+1)`, `KTR=(n+1)/mtt`. The
+  dose is delivered as this appearance rate into the depot (∫R_in dt = F·Dose) —
+  not also as a bolus — so a flexible, continuously-estimable absorption shape
+  takes one line instead of a hand-coded transit chain. Honors `F`/lagtime and
+  superposes over doses; works with IIV/IOV, resets, and time-varying covariates.
+  Steady-state dosing into a transit compartment, and combining `transit()` with
+  a `[diffusion]` block, are rejected with a clear error (`E_ABSORPTION_SS` /
+  `E_ABSORPTION_DIFFUSION`). New example `examples/transit_savic.ferx` and docs
+  page *Built-in Absorption Models* (#322).
 - Example `dose_rate.ferx` (+ `data/dose_rate.csv`) demonstrating the supported
   NONMEM `RATE` dosing forms — a bolus (`RATE=0`) and a constant-rate infusion
   (`RATE>0`) mixed in one dataset (#324).

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Error Model](model-file/error-model.md)
   - [BLOQ / Censored Observations](model-file/bloq.md)
   - [ODE Models](model-file/ode-models.md)
+  - [Built-in Absorption Models](model-file/absorption.md)
   - [Scaling](model-file/scaling.md)
   - [Stochastic Differential Equations](model-file/diffusion.md)
   - [Neural Networks (DCM / NODE)](model-file/neural-networks.md)

--- a/docs/src/examples/transit-absorption.md
+++ b/docs/src/examples/transit-absorption.md
@@ -2,6 +2,8 @@
 
 This example demonstrates a two-compartment model with transit-compartment absorption and allometric scaling on body weight. The complete model file is [`examples/transit_2cpt.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/transit_2cpt.ferx).
 
+> 💡 **Tip:** this page codes the transit chain as **explicit** ODE states (fixed integer `n`). For most models the built-in [`transit(n, mtt)`](../model-file/absorption.md) input-rate function is simpler — one line, with a single **continuous** (estimable) `n` — see `examples/transit_savic.ferx`.
+
 ## When to use
 
 Use a transit-compartment chain when:

--- a/docs/src/model-file/absorption.md
+++ b/docs/src/model-file/absorption.md
@@ -69,12 +69,18 @@ delivers the mass.
   as for ordinary doses — see [Bioavailability](ode-models.md#bioavailability).
   Do **not** multiply `transit(...)` by `F` in the RHS.
 - **Lagtime** shifts `tad` (the input starts at `dose time + lagtime`).
-- **Multiple doses** superpose: `R_in` is summed per dose.
+- **Multiple doses** superpose: `R_in` is summed per dose. With **IOV** on the
+  transit parameters, an absorption tail that is still appearing when the next
+  occasion begins is evaluated with the *current* occasion's `n`/`mtt` — exact
+  when `II` exceeds the absorption window (the usual case) and for IIV-only
+  models, approximate only for overlapping occasions.
 
 ### Parameter domains
 
-Validated at parse / fit time: `mtt > 0` and `n ≥ 0`. A non-finite or
-out-of-domain value is an error, not a silently clamped result.
+Validated at fit time on typical values (η = 0, per subject, so covariate
+relationships are included): `mtt > 0` and `n ≥ 0`. A non-finite or
+out-of-domain value is rejected with `E_ABSORPTION_DOMAIN` — an error, not a
+silently clamped result or an opaque `NaN` fit failure.
 
 ### Not yet supported (Phase 0)
 

--- a/docs/src/model-file/absorption.md
+++ b/docs/src/model-file/absorption.md
@@ -77,22 +77,44 @@ delivers the mass.
 
 ### Parameter domains
 
-Validated at fit time on typical values (η = 0, per subject, so covariate
-relationships are included): `mtt > 0` and `n ≥ 0`. A non-finite or
-out-of-domain value is rejected with `E_ABSORPTION_DOMAIN` — an error, not a
-silently clamped result or an opaque `NaN` fit failure.
+The domain is `mtt > 0` and `n ≥ 0`. It is enforced in two places:
+
+- **Typical values** (η = 0, per subject, so covariate relationships are
+  included) are validated at fit time. A non-finite or out-of-domain typical
+  value is rejected with `E_ABSORPTION_DOMAIN` — a clear error, not an opaque
+  `NaN` fit failure. Constrain the parameter so it stays in range, e.g.
+  `MTT = TVMTT * exp(ETA_MTT)` keeps `MTT > 0`.
+- **Transient mid-fit excursions** are clamped. With an additive
+  parameterisation (`MTT = TVMTT + ETA_MTT`), the inner EBE search or a
+  finite-difference step can momentarily push `mtt ≤ 0` / `n < 0` even though the
+  typical value is in range. There `R_in` is evaluated at the domain boundary
+  (a finite value) rather than producing a `NaN` that would poison the objective.
+  Because the converged optimum is interior, this clamp never affects reported
+  estimates — it only keeps the optimiser numerically stable. (A log-normal
+  parameterisation avoids the excursion entirely and is recommended.)
 
 ### Not yet supported (Phase 0)
 
 These combinations are **rejected with a clear error** rather than silently
 mis-modeled:
 
+- **An infusion (`RATE>0`) into a transit compartment** (`E_ABSORPTION_RATE`) —
+  the dose mass is delivered through `R_in`, computed from the dose *amount*, so
+  an infusion rate on the same record would double-count it. Use a plain bolus
+  record (`RATE=0`) into the absorption compartment; the transit chain provides
+  the input-rate shape.
 - **Steady-state dosing (`SS=1`) into a transit compartment** (`E_ABSORPTION_SS`)
   — periodic steady state with an in-progress absorption tail needs dedicated
   treatment. Expand the run-in with explicit dosing records instead.
 - **A `[diffusion]` block (SDE/EKF) together with `transit()`**
   (`E_ABSORPTION_DIFFUSION`) — the EKF propagation does not yet carry the
   input-rate forcing.
+
+> **Note:** these guards run at `fit()` time (and via `ferx check`), which is
+> where model–data compatibility is validated. The lower-level `predict()` and
+> `simulate()` entry points assume an already-checked model and do not re-run
+> them, so run `ferx check` (or `fit()`) on a new model before relying on
+> `predict`/`simulate` output.
 
 ## Worked example
 

--- a/docs/src/model-file/absorption.md
+++ b/docs/src/model-file/absorption.md
@@ -1,0 +1,114 @@
+# Built-in Absorption Models
+
+ferx provides built-in **absorption input-rate functions** for ODE models — a
+dose-driven appearance rate `R_in(tad)` that is added into the dosing
+compartment instead of treating the dose as an instantaneous bolus. They let you
+write a flexible absorption *shape* (transit-chain delay, etc.) as a single
+intrinsic in the `[odes]` block, rather than hand-coding a chain of physical
+transit compartments.
+
+Phase 0 ships the **transit-compartment** model; more input-rate models
+(inverse-Gaussian, Weibull, zero-order families) are planned — see
+`plans/absorption-models.md`.
+
+## Transit-compartment absorption — `transit(n, mtt)`
+
+The Savic et al. (2007) transit-compartment model with a **continuous** number
+of compartments `n`:
+
+\\[
+R_\text{in}(t_\text{ad}) = F\cdot\text{Dose}\;\cdot\;
+\text{KTR}\;\frac{(\text{KTR}\cdot t_\text{ad})^{n}\,e^{-\text{KTR}\cdot t_\text{ad}}}{\Gamma(n+1)},
+\qquad \text{KTR}=\frac{n+1}{\text{MTT}}
+\\]
+
+where `tad` is time after the dose, `MTT` is the mean transit time, and `KTR` is
+the transit rate constant. The input integrates to the full dose
+(`∫₀^∞ R_in dt = F·Dose`), and `R_in = 0` for `tad ≤ 0`. With `n = 0` it reduces
+to a first-order (Bateman) input with rate `1/MTT`. Because `n` is continuous,
+the absorption *shape* itself is an estimable parameter.
+
+### Syntax
+
+Add `transit(...)` to the right-hand side of the depot compartment's ODE:
+
+```text
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV  * exp(ETA_V)
+  KA  = TVKA
+  MTT = TVMTT          # mean transit time (h)
+  NTR = TVN            # number of transit compartments (continuous)
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot/V - CL/V*central
+```
+
+- **Arguments are named**: `n=<param>` and `mtt=<param>`. Both must be declared
+  `[individual_parameters]` (so they fold in theta/eta/covariates and can carry
+  IIV/IOV exactly like any other individual parameter).
+- `transit(...)` may appear **once** on a `d/dt(...)` line and must not be
+  scaled or combined with other input-rate terms — it is the chain input, not an
+  ordinary expression. (It is split out of the RHS at parse time and evaluated
+  by the engine with dose context; the rest of the RHS — here `- KA*depot` — is
+  the disposition you write normally.)
+
+### Dose routing — the dose feeds the function, not a bolus
+
+A dose into a transit compartment is delivered **entirely** through `R_in` over
+time. ferx therefore does **not** also add it as an instantaneous bolus — doing
+so would double-count the dose. This mirrors NONMEM, where the transit dose
+compartment carries `F1 = 0` for the bolus while the analytical/`$DES` input
+delivers the mass.
+
+- **Bioavailability `F`** scales the delivered mass (`Dose = F · AMT`), exactly
+  as for ordinary doses — see [Bioavailability](ode-models.md#bioavailability).
+  Do **not** multiply `transit(...)` by `F` in the RHS.
+- **Lagtime** shifts `tad` (the input starts at `dose time + lagtime`).
+- **Multiple doses** superpose: `R_in` is summed per dose.
+
+### Parameter domains
+
+Validated at parse / fit time: `mtt > 0` and `n ≥ 0`. A non-finite or
+out-of-domain value is an error, not a silently clamped result.
+
+### Not yet supported (Phase 0)
+
+These combinations are **rejected with a clear error** rather than silently
+mis-modeled:
+
+- **Steady-state dosing (`SS=1`) into a transit compartment** (`E_ABSORPTION_SS`)
+  — periodic steady state with an in-progress absorption tail needs dedicated
+  treatment. Expand the run-in with explicit dosing records instead.
+- **A `[diffusion]` block (SDE/EKF) together with `transit()`**
+  (`E_ABSORPTION_DIFFUSION`) — the EKF propagation does not yet carry the
+  input-rate forcing.
+
+## Worked example
+
+[`examples/transit_savic.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/transit_savic.ferx)
+is a complete one-compartment oral model with built-in transit absorption. Run
+it on simulated data:
+
+```bash
+cargo run --release -- examples/transit_savic.ferx --simulate
+```
+
+For comparison,
+[`examples/transit_2cpt.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/transit_2cpt.ferx)
+codes the same idea as three **explicit** transit ODE states (fixed integer
+`n = 3`); the built-in `transit()` collapses that to one line with a single
+continuous `n`. See [Transit Absorption](../examples/transit-absorption.md) for
+the worked two-compartment example and diagnostics guidance.
+
+## Numerical note
+
+The transit input is integrated numerically through the ODE solver (the same
+RHS-wrapper mechanism that injects `+rate` for infusions). An analytical
+closed form for continuous-`n` transit (via the regularized incomplete gamma
+function) is planned so 1-/2-compartment transit models can stay in the
+analytical engine — see `plans/absorption-models.md`.

--- a/docs/src/model-file/ode-models.md
+++ b/docs/src/model-file/ode-models.md
@@ -168,6 +168,7 @@ The solver automatically adapts step sizes based on local error estimates.
 - **Infusion doses** (`RATE > 0`): Treated as a continuous zero-order input. The integrator's timeline is broken at the infusion's end (`time + amt/rate`), and `F · RATE` is added to the target compartment's derivative for every segment fully spanned by the infusion. Overlapping infusions on the same compartment sum their rates
 - **Compartment indexing**: Compartments are 1-indexed in the data file (`CMT=1` corresponds to the first state in the `states` list)
 - **Multiple doses**: The ODE is integrated in segments between dose events, with state discontinuities at each bolus
+- **Built-in absorption input rates**: A dose can instead be delivered as a dose-driven appearance rate `R_in(tad)` (e.g. transit-compartment absorption) added into the depot over time — see [Built-in Absorption Models](absorption.md)
 
 ### Bioavailability
 

--- a/examples/transit_savic.ferx
+++ b/examples/transit_savic.ferx
@@ -1,0 +1,67 @@
+# Savic transit-compartment absorption — built-in `transit()` input rate
+#
+# One-compartment oral disposition with a Savic et al. (2007) transit-chain
+# absorption delay, expressed with the built-in `transit()` input-rate function
+# instead of a hand-coded chain of physical transit compartments.
+#
+#   R_in(tad) = F·Dose · KTR · (KTR·tad)^N · exp(−KTR·tad) / Γ(N + 1)
+#   KTR = (N + 1) / MTT          (mean transit time MTT, continuous N)
+#
+# `transit(n=NTR, mtt=MTT)` is added into the depot compartment as a dose-driven
+# appearance rate; the oral dose feeds that function and is NOT also added as a
+# bolus (∫ R_in dt = F·Dose). Contrast `examples/transit_2cpt.ferx`, which codes
+# the same idea as three explicit transit ODE states — here N is a single
+# continuous parameter, so the absorption *shape* is itself estimable.
+#
+# ── Unit convention (same as examples/bioavailability_ode.ferx) ──────────────
+#   CMT=1  depot    — oral dose lands here (amount, mg); receives R_in(tad)
+#   CMT=2  central  — concentration (mg/L); C = amount / V
+#
+# Self-contained: the [simulation] block below lets you run it with no data file
+#   cargo run --release -- examples/transit_savic.ferx --simulate
+# which simulates an oral 100 mg dose into CMT=1, observed on CMT=2, and fits it
+# back. True simulation parameters: TVCL=5, TVV=50, TVKA=1.0, TVMTT=1.0, TVN=3,
+#   omega_CL=omega_V=0.09, sigma_prop=0.15.
+
+[parameters]
+  theta TVCL(5.0,   0.1, 100.0)   # typical clearance (L/h)
+  theta TVV(50.0,   5.0, 500.0)   # typical central volume (L)
+  theta TVKA(1.0,  0.05,  24.0)   # typical absorption rate constant (/h)
+  theta TVMTT(1.0, 0.05,  24.0)   # mean transit time (h); KTR = (N+1)/MTT
+  theta TVN(3.0,    0.1,  30.0)   # number of transit compartments (continuous)
+
+  omega ETA_CL ~ 0.09             # IIV on CL (~30% CV)
+  omega ETA_V  ~ 0.09             # IIV on V  (~30% CV)
+
+  sigma PROP_ERR ~ 0.15 (sd)      # proportional residual error (~15% CV)
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV  * exp(ETA_V)
+  KA  = TVKA
+  MTT = TVMTT
+  NTR = TVN
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  # depot  : oral-dose compartment (mg); transit() delivers F·Dose over time
+  # central: concentration compartment (mg/L)
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot/V - CL/V*central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  maxiter    = 500
+  covariance = true
+
+[simulation]
+  n_subjects = 12
+  dose_amt   = 100.0
+  dose_cmt   = 1
+  times      = [0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 16.0, 24.0]
+  seed       = 7

--- a/plans/absorption-models.md
+++ b/plans/absorption-models.md
@@ -2,8 +2,10 @@
 
 **Tracking issue:** [#322](https://github.com/FeRx-NLME/ferx-core/issues/322)
 **Scope:** ferx-core (primary) + ferx-r (follow-up PR once `pub` API lands)
-**Status:** approved roadmap. Prerequisite #324 safety net (PR #326) **merged 2026-06-14**;
-remaining models not yet implemented. Multi-PR / phased.
+**Status:** approved roadmap, in progress. Prerequisite #324 safety net (PR #326) **merged
+2026-06-14**. **Phase 0a — built-in `transit()` absorption — implemented in PR #343 (open,
+2026-06-14)**; `ln_gamma` building block merged (#340). `ode_template` (Phase 0b) and the
+remaining models (Phases 1–3) not yet implemented. Multi-PR / phased.
 
 ---
 
@@ -295,14 +297,24 @@ Decouple **input function** from **disposition**, reusing existing machinery:
    pattern. Honor the `ad/` rule: **no `f64::max`/`min`** — use explicit comparisons (see
    CLAUDE.md). Each model also exposes `validate(θ) -> Result` and the analytic mass
    `∫R_in = F·Dose` (test invariant).
+   - **Phase 0a finding:** the shared numeric trait was **not needed** for transit. ODE models
+     always differentiate via **finite differences** (`model.tv_fn` is `None` for any ODE model,
+     so `gradient = ad` falls back to FD — see `OdeReadout::requires_fd`), and the forcing is
+     evaluated only on the FD/forward path, so no `Dual`/Enzyme path is reachable.
+     `transit_input_rate` is plain `f64` (still kept `max`/`min`-free). Revisit the trait only
+     if/when an autodiff ODE path is added.
 2. **Forcing into the user's ODE.** `R_in(tad)` is added into the dosing compartment of the
    disposition the user supplied (`ode(...)` or the `ode_template`-generated states) via the
    **same RHS-wrapper mechanism that already injects `+rate` for infusions**
    (`ode/predictions.rs` header doc: "adding `+rate` … via an RHS wrapper"). No silent
    conversion: an analytical `pk` disposition + an ODE-only absorption model is rejected by the
    error rule, not forced. Shared plumbing: observed value via the existing obs-compartment
-   path; **SS=1** reuses `equilibrate_ss_state`; **lagtime/F** reuse `PK_IDX_LAGTIME` (shift
-   `tad`) and `PK_IDX_F` (scale `D`); multiple doses / ADDL superpose `R_in` per dose.
+   path; **lagtime/F** reuse `PK_IDX_LAGTIME` (shift `tad`) and `PK_IDX_F` (scale `D`); multiple
+   doses / ADDL superpose `R_in` per dose. **SS=1** was intended to reuse `equilibrate_ss_state`,
+   but Phase 0a **defers and rejects** it (`E_ABSORPTION_SS`): the periodic steady state of a
+   forcing whose `R_in` tail spills across the dosing interval needs dedicated treatment (the
+   per-cycle pulse equilibration is only exact when `II ≫` the absorption window). A later phase
+   adds proper SS-with-forcing.
    - **Internal closed-form acceleration (optional):** where the combo has a closed form
      (first/zero/parallel/sequential/mixed, integer-N transit, continuous-N transit via
      incomplete gamma), ferx *may* compute it via the `pk/` solvers instead of integrating —
@@ -369,12 +381,23 @@ Each item needs a negative/edge test so it registers Codecov patch coverage:
   `RATE=-2`/`D1` modeled-duration path establishes the estimated-duration forcing that this
   plan's Phase 2 zero-order family reuses. Independent of this plan's Phase 0/1, which can
   start in parallel.
-- **Phase 0 — `transit()` input-rate function + `ode_template`.** Implement the built-in
-  `transit(n, mtt)` intrinsic callable in `[odes]` (Ron's proposal): the input-rate evaluator,
-  dose-context wiring, the dose-routing rule (dose feeds the function, not a bolus), `ln_gamma`,
-  and `ode_template` generation for the standard PK models + the analytical-`pk`-plus-absorption
-  **error rule**. Anchor against the existing `transit_2cpt` dataset and a NONMEM Savic run —
-  proves the transparent path end-to-end.
+- **Phase 0a — `transit()` input-rate function. ✅ IMPLEMENTED — PR #343 (open, 2026-06-14).**
+  Built-in `transit(n, mtt)` intrinsic in `[odes]`: log-domain Savic evaluator (`ln_gamma`
+  shipped in #340), dose-context wiring, and the dose-routing rule — the dose feeds `R_in`, its
+  bolus is **suppressed**, `∫R_in dt = F·Dose`. `R_in(tad)` is injected via the infusion
+  RHS-wrapper across **all four** ODE prediction paths (`ode_predictions`, event-driven, and the
+  two compartment-state variants); F scales the mass, lagtime shifts `tad`, multiple doses
+  superpose, and resets turn off pre-reset doses. Not-yet-supported combinations are **rejected
+  loudly** (not silently mis-modeled): SS=1 into a transit compartment (`E_ABSORPTION_SS`) and
+  `transit()` + a `[diffusion]` block (`E_ABSORPTION_DIFFUSION`). Validated by parameter recovery
+  (`examples/transit_savic.ferx --simulate`: TVN 3.0→3.19, MTT 1.0→0.90) + the absorption-
+  independent **AUC∞ = Dose/CL** invariant. **NONMEM Savic anchor still TODO** — does not block
+  #343; flagged for a follow-up (or fold into Phase 3, which adds the analytical form to compare).
+- **Phase 0b — `ode_template` generation + the analytical-`pk`-plus-absorption error rule.**
+  DEFERRED out of #343 (not needed for the raw `[odes]` + `transit()` path that Phase 0a ships).
+  Generate the standard PK disposition ODEs from the codified analytical↔ODE transforms, and
+  reject an analytical `pk` disposition combined with an ODE-only absorption model, pointing the
+  user at `ode_template`. Reuses the undefined-name walker / "declared-but-unused" census.
 - **Phase 1 — inverse-Gaussian (Freijer & Post).** Single + sum-of-two IG; **numerical**
   (no closed form). Anchor vs the Freijer & Post paper / a NONMEM `$DES` IG run.
 - **Phase 2 — Weibull + zero-order + sequential + parallel + mixed.** Round out the

--- a/src/api.rs
+++ b/src/api.rs
@@ -649,6 +649,34 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
         );
     }
 
+    // Parameter-domain validation (data-level): an out-of-domain or non-finite
+    // input-rate parameter (e.g. transit `mtt ≤ 0` or `n < 0`) would otherwise
+    // propagate as a NaN through the ODE RHS and surface only as an opaque fit
+    // failure. Evaluated on typical values (η = 0) per subject, so a covariate
+    // relationship that pushes a subject's typical `mtt`/`n` out of range is
+    // caught too. Reported once — a single fatal error already halts the fit.
+    let zero_eta = vec![0.0_f64; model.n_eta + model.n_kappa];
+    'subjects: for subject in &population.subjects {
+        let pk = (model.pk_param_fn)(&model.default_params.theta, &zero_eta, &subject.covariates);
+        for forcing in &ode.input_rate {
+            if let Err(msg) = forcing.validate(&pk.values) {
+                diags.push(
+                    Diagnostic::error(
+                        "E_ABSORPTION_DOMAIN",
+                        format!(
+                            "Built-in absorption input-rate parameter out of domain at typical \
+                             values (subject {}): {msg}. Constrain the parameter so it stays in \
+                             range (e.g. `MTT = TVMTT * exp(ETA_MTT)` keeps MTT > 0).",
+                            subject.id
+                        ),
+                    )
+                    .with_block("odes"),
+                );
+                break 'subjects;
+            }
+        }
+    }
+
     diags
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -568,6 +568,7 @@ pub fn check_model_data(model: &CompiledModel, population: &Population) -> Vec<D
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
     diags.extend(check_iov_occasions(model, population));
+    diags.extend(check_absorption_dosing(model, population));
     diags.extend(validate_output_columns(model, population));
     diags
 }
@@ -593,6 +594,62 @@ fn check_iov_occasions(model: &CompiledModel, population: &Population) -> Vec<Di
          [fit_options] so that per-occasion kappas can be estimated.",
     )
     .with_block("fit_options")]
+}
+
+/// Built-in absorption input-rate models (e.g. `transit()`) are integrated
+/// through the standard ODE prediction paths. Two combinations are not yet
+/// supported and are rejected here — loudly — rather than silently mis-modeled:
+///   - a steady-state dose (`SS=1`) into an input-rate compartment: periodic
+///     steady state with an unfinished `R_in` tail needs dedicated treatment
+///     (a later phase of `plans/absorption-models.md`);
+///   - an input-rate model combined with a `[diffusion]` block (the SDE/EKF
+///     path), whose Kalman propagation does not carry the `R_in` forcing.
+fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
+    let Some(ode) = &model.ode_spec else {
+        return Vec::new();
+    };
+    if ode.input_rate.is_empty() {
+        return Vec::new();
+    }
+    let mut diags = Vec::new();
+
+    // input-rate + [diffusion]/EKF (model-level): the EKF propagator does not
+    // apply the R_in forcing, so the absorption term would be silently dropped.
+    if !ode.diffusion_var.is_empty() {
+        diags.push(
+            Diagnostic::error(
+                "E_ABSORPTION_DIFFUSION",
+                "A built-in absorption input-rate model (e.g. transit()) cannot yet be \
+                 combined with a [diffusion] block (the SDE/EKF path): the EKF \
+                 propagation does not carry the input-rate forcing. Remove the \
+                 [diffusion] block or the absorption term.",
+            )
+            .with_block("odes"),
+        );
+    }
+
+    // SS=1 dose into an input-rate compartment (data-level): the steady-state
+    // equilibration applies the dose as a bolus pulse, not as R_in over the cycle.
+    use std::collections::BTreeSet;
+    let cmts: BTreeSet<usize> = ode.input_rate.iter().map(|f| f.cmt + 1).collect();
+    let has_ss = population.subjects.iter().any(|s| {
+        s.doses
+            .iter()
+            .any(|d| d.ss && d.ii > 0.0 && cmts.contains(&d.cmt))
+    });
+    if has_ss {
+        diags.push(
+            Diagnostic::error(
+                "E_ABSORPTION_SS",
+                "Steady-state dosing (SS=1) into a built-in absorption input-rate \
+                 compartment (e.g. transit()) is not yet supported. Expand the run-in \
+                 with explicit dosing records, or remove the absorption term.",
+            )
+            .with_block("odes"),
+        );
+    }
+
+    diags
 }
 
 /// Model + estimation-option *compatibility* checks that don't depend on data:

--- a/src/api.rs
+++ b/src/api.rs
@@ -649,6 +649,32 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
         );
     }
 
+    // Infusion (RATE>0) into an input-rate compartment (data-level): the dose
+    // would be delivered twice — once as the `+rate` infusion injection in the
+    // ODE RHS wrapper, and again as `R_in(tad)` superposed by the input-rate
+    // forcing — silently ~doubling exposure. A transit dose carries its mass
+    // through `R_in` from the bolus amount; an infusion rate on that record is
+    // undefined, so reject it loudly. (Coded RATE=-1/-2 is already rejected at
+    // the datareader, so `is_infusion()` is the remaining case.)
+    let has_infusion = population.subjects.iter().any(|s| {
+        s.doses
+            .iter()
+            .any(|d| d.is_infusion() && cmts.contains(&d.cmt))
+    });
+    if has_infusion {
+        diags.push(
+            Diagnostic::error(
+                "E_ABSORPTION_RATE",
+                "An infusion (RATE>0) into a built-in absorption input-rate \
+                 compartment (e.g. transit()) is not supported: the dose mass is \
+                 delivered through the input-rate function R_in computed from the dose \
+                 amount, so an infusion rate would double-count it. Use a plain bolus \
+                 dose record (RATE=0) into the absorption compartment.",
+            )
+            .with_block("odes"),
+        );
+    }
+
     // Parameter-domain validation (data-level): an out-of-domain or non-finite
     // input-rate parameter (e.g. transit `mtt ≤ 0` or `n < 0`) would otherwise
     // propagate as a NaN through the ODE RHS and surface only as an opaque fit

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -609,6 +609,7 @@ fn generate_mm_oral() {
         diffusion_var: Vec::new(),
         init_fn: None,
         solver_opts: ferx_core::ode::OdeSolverOptions::default(),
+        input_rate: Vec::new(),
     };
     let model = CompiledModel {
         name: "mm_oral".into(),

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -408,6 +408,7 @@ mod tests {
             diffusion_var: Vec::new(),
             init_fn: None,
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
         };
         let ode_preds = ode_predictions(&ode_spec, &pk, &[], &[], &subj);
 

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1910,11 +1910,7 @@ mod tests {
         let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
         let subj = make_subject(doses, vec![0.0, 40.0]);
         let preds = ode_predictions(&ode, &pk, &[], &[], &subj);
-        assert!(
-            preds[0].abs() < 1e-9,
-            "bolus not suppressed: got {}",
-            preds[0]
-        );
+        assert!(preds[0].abs() < 1e-9, "bolus not suppressed: {}", preds[0]);
         assert_relative_eq!(preds[1], 100.0, max_relative = 5e-3);
     }
 
@@ -1961,6 +1957,37 @@ mod tests {
             "pre-reset dose R_in leaked past the reset: got {}",
             preds[0]
         );
+    }
+
+    #[test]
+    fn transit_forcing_applied_in_with_states_path() {
+        // The per-compartment states path (`ode_predictions_with_states`, used for
+        // derived-output state extraction) must inject the transit forcing too —
+        // the accumulator state holds ∫R_in = F·amt = 100.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 1.0);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let subj = make_subject(doses, vec![40.0]);
+        let (preds, states) = ode_predictions_with_states(&ode, &pk, &[], &[], &subj);
+        assert_relative_eq!(preds[0], 100.0, max_relative = 5e-3);
+        assert_relative_eq!(states[0][0], 100.0, max_relative = 5e-3);
+    }
+
+    #[test]
+    fn transit_forcing_in_dense_solve_states_skips_other_cmt_dose() {
+        // `ode_dense_solve_states` applies the forcing; a dose targeting a
+        // *non-forcing* compartment is skipped by the superposition loop. State 0
+        // (the forcing cmt ≡ CMT 1) holds only the CMT-1 dose's mass — not the
+        // CMT-2 dose, which never feeds R_in.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 1.0);
+        let doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0), // CMT 1: feeds R_in
+            DoseEvent::new(0.0, 50.0, 2, 0.0, false, 0.0),  // CMT 2: not the forcing cmt
+        ];
+        let subj = make_subject(doses, vec![40.0]);
+        let states = ode_dense_solve_states(&ode, &pk, &[], &[], &subj, &[40.0]);
+        assert_relative_eq!(states[0][0], 100.0, max_relative = 5e-3);
     }
 
     #[test]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -242,6 +242,67 @@ pub(crate) fn active_infusions(
         .collect()
 }
 
+/// True if a built-in absorption input-rate forcing (transit/etc.) feeds the
+/// compartment `cmt_1based` (the data file's 1-based CMT). A dose into such a
+/// compartment delivers its mass via `R_in(tad)` integrated over time
+/// (`∫R_in dt = F·amt`), so its instantaneous **bolus must be suppressed** to
+/// avoid double-counting the dose — the dose feeds the input-rate function, not
+/// the state directly (see `plans/absorption-models.md`).
+#[inline]
+pub(crate) fn input_rate_consumes_cmt(ode: &OdeSpec, cmt_1based: usize) -> bool {
+    !ode.input_rate.is_empty()
+        && ode
+            .input_rate
+            .iter()
+            .any(|f| f.cmt == cmt_1based.saturating_sub(1))
+}
+
+/// Add every built-in absorption input-rate forcing into `dy` at integration
+/// time `t`. For each forcing, sums `R_in(tad)` over all doses targeting its
+/// compartment (Savic superposition), with `tad = t − (dose.time + lag)` and
+/// dose mass `F·amt`. `R_in = 0` for `tad ≤ 0`, so future doses contribute
+/// nothing. `reset_floor` turns off doses delivered before the most recent
+/// EVID=3/4 reset, mirroring [`active_infusions`]. This is the input-rate
+/// analogue of the `+rate` infusion injection in the wrapped RHS.
+#[inline]
+#[allow(clippy::too_many_arguments)] // mirrors the dose context threaded into the RHS wrappers
+fn add_input_rate_forcing(
+    ode: &OdeSpec,
+    doses: &[DoseEvent],
+    dose_lagtimes: &[f64],
+    dose_f_bio: &[f64],
+    reset_floor: f64,
+    params: &[f64],
+    t: f64,
+    dy: &mut [f64],
+) {
+    for forcing in &ode.input_rate {
+        if forcing.cmt >= dy.len() {
+            continue;
+        }
+        let mut acc = 0.0;
+        for (k, d) in doses.iter().enumerate() {
+            if d.cmt.saturating_sub(1) != forcing.cmt {
+                continue;
+            }
+            let lag = dose_lagtimes.get(k).copied().unwrap_or(0.0);
+            let t_eff = d.time + lag;
+            // Doses delivered before the most recent reset are off — the reset
+            // zeroed the compartments, same rule as `active_infusions`.
+            if t_eff < reset_floor - INFUSION_EPS {
+                continue;
+            }
+            let tad = t - t_eff;
+            if tad <= 0.0 {
+                continue;
+            }
+            let dose_mass = dose_f_bio.get(k).copied().unwrap_or(1.0) * d.amt;
+            acc += forcing.rate(tad, dose_mass, params);
+        }
+        dy[forcing.cmt] += acc;
+    }
+}
+
 /// Function that computes the observable from
 /// `(state, pk_params_flat, theta, eta, covariates)`. Used by `[scaling]
 /// y = <expr>` (Form C) to replace the default `u[obs_cmt_idx]` readout
@@ -505,8 +566,11 @@ pub fn ode_predictions(
             if dose.ss && dose.ii > 0.0 {
                 u = equilibrate_ss_state(ode, pk_params_flat, dose, &opts);
             }
-            if !is_real_infusion(dose) {
-                // dose.cmt is 1-based; state indices are 0-based
+            if !is_real_infusion(dose) && !input_rate_consumes_cmt(ode, dose.cmt) {
+                // dose.cmt is 1-based; state indices are 0-based. A dose into a
+                // built-in input-rate compartment (transit/etc.) is delivered as
+                // R_in over time by the wrapped RHS below — not as a bolus — so
+                // it's skipped here to avoid double-counting the dose.
                 let cmt_idx = dose.cmt - 1;
                 if cmt_idx < n {
                     u[cmt_idx] += f_bio * dose.amt;
@@ -592,6 +656,21 @@ pub fn ode_predictions(
                 if cmt_idx < dy.len() {
                     dy[cmt_idx] += rate;
                 }
+            }
+            // Built-in absorption input-rate forcing (transit/etc.): adds
+            // R_in(tad) into its compartment, superposed over doses. No resets
+            // on the plain path (those route to the event-driven walker).
+            if !ode.input_rate.is_empty() {
+                add_input_rate_forcing(
+                    ode,
+                    &subject.doses,
+                    &dose_lagtimes,
+                    &dose_f_bio,
+                    f64::NEG_INFINITY,
+                    p,
+                    t,
+                    dy,
+                );
             }
         };
         let sol = solve_ode(
@@ -861,6 +940,21 @@ pub fn ode_predictions_event_driven(
                         dy[cmt_idx] += rate;
                     }
                 }
+                // Built-in absorption input-rate forcing (transit/etc.): adds
+                // R_in(tad) into its compartment, superposed over doses. Doses
+                // before `reset_floor` (the most recent EVID=3/4) are off.
+                if !ode.input_rate.is_empty() {
+                    add_input_rate_forcing(
+                        ode,
+                        &subject.doses,
+                        &dose_lagtimes,
+                        &dose_f_bio,
+                        reset_floor,
+                        p,
+                        t,
+                        dy,
+                    );
+                }
             };
             let saveat = vec![t_event];
             let sol = solve_ode(
@@ -889,8 +983,10 @@ pub fn ode_predictions_event_driven(
                 }
                 // Boluses: add amt to state. Infusions: no instantaneous
                 // change — handled via the wrapped RHS for segments inside
-                // [d.time, d.time + d.duration].
-                if !is_real_infusion(d) {
+                // [d.time, d.time + d.duration]. A dose into a built-in
+                // input-rate compartment (transit/etc.) is delivered as R_in
+                // over time by the wrapped RHS, so it's skipped here too.
+                if !is_real_infusion(d) && !input_rate_consumes_cmt(ode, d.cmt) {
                     let cmt_idx = d.cmt.saturating_sub(1);
                     if cmt_idx < n {
                         u[cmt_idx] += pk_now.f_bio() * d.amt;
@@ -1164,13 +1260,18 @@ pub fn ode_predictions_with_states(
                     u = equilibrate_ss_state(ode, pk_params_flat, dose, &opts);
                 }
                 if !is_real_infusion(dose) {
-                    // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
-                    if dose.cmt > 0 {
-                        let cmt = dose.cmt - 1;
-                        if cmt < n {
-                            u[cmt] += dose.amt * f;
+                    if !input_rate_consumes_cmt(ode, dose.cmt) {
+                        // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
+                        if dose.cmt > 0 {
+                            let cmt = dose.cmt - 1;
+                            if cmt < n {
+                                u[cmt] += dose.amt * f;
+                            }
                         }
                     }
+                    // else: the dose feeds a built-in input-rate function
+                    // (transit/etc.) and is delivered as R_in over time by the
+                    // wrapped RHS below — no bolus here (would double-count).
                 } else {
                     let end_t = t_eff + dose.duration;
                     active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
@@ -1245,6 +1346,7 @@ pub fn ode_predictions_with_states(
         let wrapped_rhs = {
             let infusions = current_infusions.clone();
             let f_bio_snap = dose_f_bio.clone();
+            let lag_snap = dose_lagtimes.clone();
             move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
                 (ode.rhs)(y, p, t, dy);
                 for &(di, t_start_inf, t_end_inf) in &infusions {
@@ -1263,6 +1365,20 @@ pub fn ode_predictions_with_states(
                             }
                         }
                     }
+                }
+                // Built-in absorption input-rate forcing (transit/etc.):
+                // R_in(tad) superposed over doses. No resets on this path.
+                if !ode.input_rate.is_empty() {
+                    add_input_rate_forcing(
+                        ode,
+                        &subject.doses,
+                        &lag_snap,
+                        &f_bio_snap,
+                        f64::NEG_INFINITY,
+                        p,
+                        t,
+                        dy,
+                    );
                 }
             }
         };
@@ -1478,13 +1594,18 @@ pub fn ode_dense_solve_states(
                     u = equilibrate_ss_state(ode, pk_params_flat, dose, &opts);
                 }
                 if !is_real_infusion(dose) {
-                    // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
-                    if dose.cmt > 0 {
-                        let cmt = dose.cmt - 1;
-                        if cmt < n {
-                            u[cmt] += dose.amt * f;
+                    if !input_rate_consumes_cmt(ode, dose.cmt) {
+                        // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
+                        if dose.cmt > 0 {
+                            let cmt = dose.cmt - 1;
+                            if cmt < n {
+                                u[cmt] += dose.amt * f;
+                            }
                         }
                     }
+                    // else: the dose feeds a built-in input-rate function
+                    // (transit/etc.) and is delivered as R_in over time by the
+                    // wrapped RHS below — no bolus here (would double-count).
                 } else {
                     let end_t = t_eff + dose.duration;
                     active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
@@ -1542,9 +1663,20 @@ pub fn ode_dense_solve_states(
         active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
         let current_infusions = active_infusions.clone();
 
+        // Doses delivered before the most recent reset (EVID=3/4) at or before
+        // this segment are off for the input-rate forcing — mirroring how the
+        // reset clears `active_infusions` and re-seeds `u` above.
+        let reset_floor = subject
+            .reset_times
+            .iter()
+            .cloned()
+            .filter(|&rt| rt <= t_start + 1e-12)
+            .fold(f64::NEG_INFINITY, f64::max);
+
         let wrapped_rhs = {
             let infusions = current_infusions.clone();
             let f_bio_snap = dose_f_bio.clone();
+            let lag_snap = dose_lagtimes.clone();
             move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
                 (ode.rhs)(y, p, t, dy);
                 for &(di, t_start_inf, t_end_inf) in &infusions {
@@ -1562,6 +1694,20 @@ pub fn ode_dense_solve_states(
                             }
                         }
                     }
+                }
+                // Built-in absorption input-rate forcing (transit/etc.):
+                // R_in(tad) superposed over doses, off before `reset_floor`.
+                if !ode.input_rate.is_empty() {
+                    add_input_rate_forcing(
+                        ode,
+                        &subject.doses,
+                        &lag_snap,
+                        &f_bio_snap,
+                        reset_floor,
+                        p,
+                        t,
+                        dy,
+                    );
                 }
             }
         };
@@ -1679,6 +1825,133 @@ mod tests {
         p.values[0] = kin;
         p.values[1] = kout;
         p
+    }
+
+    // ── Built-in absorption input-rate forcing (transit) ──────────────────
+    use crate::pk::absorption::{InputRateForcing, InputRateKind};
+
+    /// Single compartment that only *accumulates* the transit input (`dy = 0`),
+    /// so its amount at large `t` equals the total delivered mass `∫R_in = F·amt`
+    /// — a direct mass-balance probe of the forcing through the real integrator.
+    /// Transit args live at free slots: `n` @ 6, `mtt` @ 7.
+    fn transit_accumulator_spec() -> OdeSpec {
+        OdeSpec {
+            rhs: Box::new(|_y: &[f64], _p: &[f64], _t: f64, dy: &mut [f64]| {
+                dy[0] = 0.0;
+            }),
+            n_states: 1,
+            state_names: vec!["depot".into()],
+            readout: OdeReadout::ObsCmt(0),
+            diffusion_var: Vec::new(),
+            solver_opts: OdeSolverOptions::default(),
+            input_rate: vec![InputRateForcing {
+                cmt: 0,
+                kind: InputRateKind::Transit,
+                arg_slots: vec![6, 7],
+            }],
+            init_fn: None,
+        }
+    }
+
+    fn pk_transit_vec(n: f64, mtt: f64, f: f64) -> Vec<f64> {
+        let mut v = vec![0.0; crate::types::MAX_PK_PARAMS];
+        v[6] = n;
+        v[7] = mtt;
+        v[crate::types::PK_IDX_F] = f;
+        v
+    }
+
+    fn pk_transit_struct(n: f64, mtt: f64, f: f64) -> PkParams {
+        let mut p = PkParams::default();
+        p.values[6] = n;
+        p.values[7] = mtt;
+        p.values[crate::types::PK_IDX_F] = f;
+        p
+    }
+
+    #[test]
+    fn input_rate_consumes_cmt_matches_forcing_compartment() {
+        let ode = transit_accumulator_spec(); // forcing on state 0 ≡ 1-based CMT 1
+        assert!(input_rate_consumes_cmt(&ode, 1));
+        assert!(!input_rate_consumes_cmt(&ode, 2));
+        // A spec with no input-rate term never consumes a dose.
+        assert!(!input_rate_consumes_cmt(&one_cpt_ode_spec(), 1));
+    }
+
+    #[test]
+    fn transit_forcing_delivers_full_dose_mass() {
+        // The accumulator depot should hold ∫R_in = F·amt = 100 once absorption
+        // is complete — NOT 200 (bolus would double-count) and NOT 0 (no forcing).
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 1.0);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let subj = make_subject(doses, vec![40.0]);
+        let preds = ode_predictions(&ode, &pk, &[], &[], &subj);
+        assert_relative_eq!(preds[0], 100.0, max_relative = 5e-3);
+    }
+
+    #[test]
+    fn transit_dose_does_not_enter_as_bolus() {
+        // An observation exactly at the dose time reads ~0: the transit dose is
+        // delivered as R_in over time, never as an instantaneous bolus jump. (A
+        // trailing obs keeps the break-time loop non-empty.) The late obs then
+        // confirms the full mass still arrives.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 1.0);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let subj = make_subject(doses, vec![0.0, 40.0]);
+        let preds = ode_predictions(&ode, &pk, &[], &[], &subj);
+        assert!(
+            preds[0].abs() < 1e-9,
+            "bolus not suppressed: got {}",
+            preds[0]
+        );
+        assert_relative_eq!(preds[1], 100.0, max_relative = 5e-3);
+    }
+
+    #[test]
+    fn transit_forcing_scales_with_bioavailability() {
+        // F = 0.4 ⇒ delivered mass = 0.4·100 = 40.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 0.4);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let subj = make_subject(doses, vec![40.0]);
+        let preds = ode_predictions(&ode, &pk, &[], &[], &subj);
+        assert_relative_eq!(preds[0], 40.0, max_relative = 5e-3);
+    }
+
+    #[test]
+    fn transit_forcing_superposes_over_doses() {
+        // Two doses (100 @ t=0, 50 @ t=10) superpose: ∫R_in = F·(100+50) = 150.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_vec(3.0, 2.0, 1.0);
+        let doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(10.0, 50.0, 1, 0.0, false, 0.0),
+        ];
+        let subj = make_subject(doses, vec![60.0]);
+        let preds = ode_predictions(&ode, &pk, &[], &[], &subj);
+        assert_relative_eq!(preds[0], 150.0, max_relative = 5e-3);
+    }
+
+    #[test]
+    fn transit_forcing_respects_reset_floor() {
+        // Event-driven path: an EVID=3 reset at t=1 zeros the depot AND turns off
+        // the pre-reset dose's input rate. With no post-reset dose, the
+        // accumulator stays at 0 — the t=0 dose's R_in must not resume.
+        let ode = transit_accumulator_spec();
+        let pk = pk_transit_struct(3.0, 2.0, 1.0);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let mut subj = make_subject(doses, vec![40.0]);
+        subj.reset_times = vec![1.0];
+        let dose_pk = vec![pk; subj.doses.len()];
+        let obs_pk = vec![pk; subj.obs_times.len()];
+        let preds = ode_predictions_event_driven(&ode, &subj, &[], &[], &dose_pk, &obs_pk, &[]);
+        assert!(
+            preds[0].abs() < 1e-6,
+            "pre-reset dose R_in leaked past the reset: got {}",
+            preds[0]
+        );
     }
 
     #[test]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -264,6 +264,11 @@ pub(crate) fn input_rate_consumes_cmt(ode: &OdeSpec, cmt_1based: usize) -> bool 
 /// nothing. `reset_floor` turns off doses delivered before the most recent
 /// EVID=3/4 reset, mirroring [`active_infusions`]. This is the input-rate
 /// analogue of the `+rate` infusion injection in the wrapped RHS.
+///
+/// The shape parameters come from `params` (the current segment's snapshot), so
+/// with IOV every superposed dose's tail uses the *current* occasion's `n`/`mtt`.
+/// This is exact for IIV and when `II` exceeds the absorption window; only
+/// overlapping-occasion tails are approximated.
 #[inline]
 #[allow(clippy::too_many_arguments)] // mirrors the dose context threaded into the RHS wrappers
 fn add_input_rate_forcing(
@@ -280,6 +285,10 @@ fn add_input_rate_forcing(
         if forcing.cmt >= dy.len() {
             continue;
         }
+        // Precompute the dose-invariant constants (ln Γ, KTR, …) once per forcing
+        // — not once per dose — so the superposition loop below does only the
+        // tad/dose-dependent arithmetic.
+        let prepared = forcing.prepare(params);
         let mut acc = 0.0;
         for (k, d) in doses.iter().enumerate() {
             if d.cmt.saturating_sub(1) != forcing.cmt {
@@ -297,7 +306,7 @@ fn add_input_rate_forcing(
                 continue;
             }
             let dose_mass = dose_f_bio.get(k).copied().unwrap_or(1.0) * d.amt;
-            acc += forcing.rate(tad, dose_mass, params);
+            acc += prepared.rate(tad, dose_mass);
         }
         dy[forcing.cmt] += acc;
     }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -338,6 +338,12 @@ pub struct OdeSpec {
     /// integration entry point (`ode_predictions*`, EKF) uses the configured
     /// accuracy without threading options through each call.
     pub solver_opts: OdeSolverOptions,
+    /// Built-in absorption input-rate forcing terms (design A,
+    /// `plans/absorption-models.md`). Each adds `R_in(tad)` into its compartment
+    /// during integration, superposed over doses — the same RHS-wrapper layer
+    /// that injects `+rate` for infusions. Empty for models with no built-in
+    /// `transit()`/etc. input-rate term (the historical default).
+    pub input_rate: Vec<crate::pk::absorption::InputRateForcing>,
 }
 
 impl OdeSpec {
@@ -1612,6 +1618,7 @@ mod tests {
             readout: OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
             init_fn: None,
         }
     }
@@ -1659,6 +1666,7 @@ mod tests {
             readout: OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
             init_fn: Some(Box::new(|p: &[f64]| {
                 let (kin, kout) = (p[0], p[1]);
                 vec![if kout > 0.0 { kin / kout } else { 0.0 }]
@@ -1885,6 +1893,7 @@ mod tests {
             readout: OdeReadout::ObsCmt(1),
             diffusion_var: Vec::new(),
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
             init_fn: None,
         }
     }
@@ -2324,6 +2333,7 @@ mod tests {
             )),
             diffusion_var: Vec::new(),
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
             init_fn: None,
         }
     }
@@ -2457,6 +2467,7 @@ mod tests {
             readout: OdeReadout::ObsCmt(0),
             diffusion_var: Vec::new(),
             solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
             init_fn: None,
         };
         let pk = pk_one(1.0, 1.0);

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -114,6 +114,15 @@ fn equilibrate_ss_state(
             }
         } else {
             // Bolus pulse + decay for one cycle.
+            //
+            // NOTE: this applies the SS dose as an instantaneous bolus and does
+            // not route it through an input-rate forcing (`R_in`). That is correct
+            // only because SS dosing into a built-in absorption (e.g. transit())
+            // compartment is rejected upstream by `E_ABSORPTION_SS`
+            // (`api::check_absorption_dosing`). When SS + input-rate is supported
+            // (a later phase of `plans/absorption-models.md`), this pulse must be
+            // suppressed for an input-rate compartment and `R_in` integrated over
+            // the cycle instead.
             u[cmt_idx] += f_bio * dose.amt;
             let sol = solve_ode(
                 &ode.rhs,
@@ -195,6 +204,9 @@ fn ss_state_at_phase(
             }
         }
     } else {
+        // Instantaneous SS bolus (no `R_in` routing) — sound only because SS into
+        // an input-rate compartment is rejected upstream by `E_ABSORPTION_SS`;
+        // see the matching note in `equilibrate_ss_state`.
         u[cmt_idx] += f_bio * dose.amt;
         let sol = solve_ode(&ode.rhs, &u, (0.0, phase), pk_params_flat, &[phase], opts);
         if let Some(last) = sol.last() {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4367,21 +4367,28 @@ fn diffeq_state(line: &str) -> Option<String> {
     Some(rest[..close].trim().to_string())
 }
 
-/// True if the span `[start, end)` in `line` (ASCII) is immediately preceded or
-/// followed (skipping spaces) by `*`, `/`, or `^` — i.e. a scaled call.
-fn adjacent_scales(line: &str, start: usize, end: usize) -> bool {
+/// True if the call spanning `[start, end)` in `line` (ASCII) is **not** a bare,
+/// positively-signed, top-level additive term — i.e. it is scaled (`*` `/` `^`),
+/// negated (a leading `-`), or grouped (`(` immediately before / `)` immediately
+/// after, which can hide an outer scale such as `(transit(...))/V`). The
+/// input-rate forcing is always injected as `+R_in`, unscaled, so only a bare
+/// `+ transit(...)` term is faithful; any other context would silently drop the
+/// sign or scale. Surrounding spaces are skipped; the faithful preceding chars
+/// are `=` (RHS start) and `+`, the faithful following chars are end-of-line,
+/// `+`, and `-` (each starts a new additive term).
+fn call_is_scaled_or_signed(line: &str, start: usize, end: usize) -> bool {
     let b = line.as_bytes();
     let mut i = start;
     while i > 0 && b[i - 1] == b' ' {
         i -= 1;
     }
-    let before = i > 0 && matches!(b[i - 1], b'*' | b'/' | b'^');
+    let before_bad = i > 0 && matches!(b[i - 1], b'*' | b'/' | b'^' | b'-' | b'(');
     let mut j = end;
     while j < b.len() && b[j] == b' ' {
         j += 1;
     }
-    let after = j < b.len() && matches!(b[j], b'*' | b'/' | b'^');
-    before || after
+    let after_bad = j < b.len() && matches!(b[j], b'*' | b'/' | b'^' | b')');
+    before_bad || after_bad
 }
 
 /// Split a string on top-level commas (commas outside nested parentheses).
@@ -4460,10 +4467,13 @@ fn extract_input_rate_terms(
                 raw.trim()
             )
         })?;
-        if adjacent_scales(raw, start, end) {
+        if call_is_scaled_or_signed(raw, start, end) {
             return Err(
-                "[odes]: a scaled transit(...) (e.g. `FR*transit(...)`) is not yet supported; \
-                 use it as a standalone additive input rate"
+                "[odes]: transit(...) must be a standalone, positively-signed additive input \
+                 rate — it cannot be scaled (`* / ^`), negated (a leading `-`), or wrapped in \
+                 parentheses (e.g. `FR*transit(...)`, `-transit(...)`, `(transit(...))/V`), \
+                 since these silently drop the sign/scale. Write it as a bare `+ transit(...)` \
+                 term."
                     .to_string(),
             );
         }
@@ -9311,6 +9321,20 @@ mod tests {
         assert!(go("d/dt(depot) = FR*transit(n=NTR, mtt=MTT)")
             .unwrap_err()
             .contains("scaled"));
+        // Leading unary minus: the forcing is injected `+R_in`, so a negated call
+        // would silently flip the sign of the input rate. Must be rejected.
+        assert!(go("d/dt(depot) = -transit(n=NTR, mtt=MTT) - KA*depot")
+            .unwrap_err()
+            .contains("standalone"));
+        // Subtracted term (wrong sign) even without `*`/`/` scaling.
+        assert!(go("d/dt(depot) = KA*depot - transit(n=NTR, mtt=MTT)")
+            .unwrap_err()
+            .contains("standalone"));
+        // Parenthesised + scaled outside the group: the old adjacency check saw
+        // only the flanking `(`/`)`, so the `/V` was silently dropped — now rejected.
+        assert!(go("d/dt(depot) = (transit(n=NTR, mtt=MTT))/V")
+            .unwrap_err()
+            .contains("standalone"));
         assert!(go("d/dt(depot) = transit(n=NTR, mtt=MTT")
             .unwrap_err()
             .contains("unbalanced"));
@@ -9336,6 +9360,13 @@ mod tests {
         let (cleaned, f) = go("d/dt(depot) = -KA*depot").unwrap();
         assert_eq!(cleaned[0], "d/dt(depot) = -KA*depot");
         assert!(f.is_empty());
+
+        // Positive controls for the tightened sign/scale guard: a bare additive
+        // `transit(...)` is accepted whether it is the only term, the first term
+        // before a `-` disposition term, or a later `+` term.
+        assert!(go("d/dt(depot) = transit(n=NTR, mtt=MTT)").is_ok());
+        assert!(go("d/dt(depot) = transit(n=NTR, mtt=MTT) - KA*depot").is_ok());
+        assert!(go("d/dt(depot) = -KA*depot + transit(n=NTR, mtt=MTT)").is_ok());
     }
 
     // Issue #176 retired the split `*_iv_bolus` / `*_infusion` model names

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4321,6 +4321,191 @@ fn ode_param_slots(names: &[String]) -> Result<Vec<usize>, String> {
     Ok(slots)
 }
 
+/// Find `name(` at a word boundary in `s` (ASCII), returning the index of `name`.
+fn find_word_call(s: &str, name: &str) -> Option<usize> {
+    let pat = format!("{name}(");
+    let b = s.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = s[from..].find(&pat) {
+        let i = from + rel;
+        let before_ok = i == 0 || !(b[i - 1].is_ascii_alphanumeric() || b[i - 1] == b'_');
+        if before_ok {
+            return Some(i);
+        }
+        from = i + 1;
+    }
+    None
+}
+
+/// Given the index of a `(` in `s` (ASCII), return the inner text and the index
+/// just past the matching `)`. `None` if unbalanced.
+fn balanced_parens(s: &str, open: usize) -> Option<(String, usize)> {
+    let b = s.as_bytes();
+    if b.get(open) != Some(&b'(') {
+        return None;
+    }
+    let mut depth = 0i32;
+    for i in open..b.len() {
+        match b[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((s[open + 1..i].to_string(), i + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// State name `X` if `line` is a `d/dt(X) = …` equation, else `None`.
+fn diffeq_state(line: &str) -> Option<String> {
+    let rest = line.trim_start().strip_prefix("d/dt(")?;
+    let close = rest.find(')')?;
+    Some(rest[..close].trim().to_string())
+}
+
+/// True if the span `[start, end)` in `line` (ASCII) is immediately preceded or
+/// followed (skipping spaces) by `*`, `/`, or `^` — i.e. a scaled call.
+fn adjacent_scales(line: &str, start: usize, end: usize) -> bool {
+    let b = line.as_bytes();
+    let mut i = start;
+    while i > 0 && b[i - 1] == b' ' {
+        i -= 1;
+    }
+    let before = i > 0 && matches!(b[i - 1], b'*' | b'/' | b'^');
+    let mut j = end;
+    while j < b.len() && b[j] == b' ' {
+        j += 1;
+    }
+    let after = j < b.len() && matches!(b[j], b'*' | b'/' | b'^');
+    before || after
+}
+
+/// Split a string on top-level commas (commas outside nested parentheses).
+fn split_args_on_commas(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut last = 0;
+    for (i, &c) in s.as_bytes().iter().enumerate() {
+        match c {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(&s[last..i]);
+                last = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&s[last..]);
+    parts
+}
+
+/// Extract built-in absorption input-rate calls (currently `transit(...)`,
+/// design A) from the `[odes]` RHS lines. For each
+/// `d/dt(STATE) = … transit(n=P, mtt=Q) …`, records an [`InputRateForcing`]
+/// (`cmt` ← STATE index; `n`/`mtt` resolved to individual-parameter slots) and
+/// rewrites the call to `0` so the remaining RHS parses as a normal expression.
+/// Returns the cleaned lines and the collected forcing terms.
+///
+/// Validation (negative-tested): `transit(...)` must be the input rate of a
+/// top-level `d/dt(...)` equation; args are exactly `n` and `mtt`, each a
+/// declared individual parameter; a scaled call (`FR*transit(...)`) and more than
+/// one call per equation are rejected (parallel/biphasic comes with later models).
+fn extract_input_rate_terms(
+    rhs_lines: &[String],
+    state_names: &[String],
+    indiv_param_names: &[String],
+    indiv_param_slots: &[usize],
+) -> Result<(Vec<String>, Vec<crate::pk::absorption::InputRateForcing>), String> {
+    use crate::pk::absorption::{InputRateForcing, InputRateKind};
+    let resolve_slot = |val: &str, arg: &str| -> Result<usize, String> {
+        indiv_param_names
+            .iter()
+            .position(|p| p == val)
+            .map(|i| indiv_param_slots[i])
+            .ok_or_else(|| {
+                format!(
+                    "[odes]: transit({arg}={val}): `{val}` is not a declared individual parameter"
+                )
+            })
+    };
+
+    let mut forcings = Vec::new();
+    let mut cleaned = Vec::with_capacity(rhs_lines.len());
+    for raw in rhs_lines {
+        let Some(start) = find_word_call(raw, "transit") else {
+            cleaned.push(raw.clone());
+            continue;
+        };
+        let state = diffeq_state(raw).ok_or_else(|| {
+            format!(
+                "[odes]: transit(...) may only be the input rate of a `d/dt(...)` equation — \
+                 found it in `{}`",
+                raw.trim()
+            )
+        })?;
+        let cmt = state_names
+            .iter()
+            .position(|s| s == &state)
+            .ok_or_else(|| format!("[odes]: d/dt({state}): undeclared state"))?;
+
+        let open = start + "transit".len();
+        let (inner, end) = balanced_parens(raw, open).ok_or_else(|| {
+            format!(
+                "[odes]: transit(...): unbalanced parentheses in `{}`",
+                raw.trim()
+            )
+        })?;
+        if adjacent_scales(raw, start, end) {
+            return Err(
+                "[odes]: a scaled transit(...) (e.g. `FR*transit(...)`) is not yet supported; \
+                 use it as a standalone additive input rate"
+                    .to_string(),
+            );
+        }
+
+        let mut n_slot = None;
+        let mut mtt_slot = None;
+        for part in split_args_on_commas(&inner) {
+            let (name, val) = part.split_once('=').ok_or_else(|| {
+                format!(
+                    "[odes]: transit(...) arguments must be `name=parameter`, got `{}`",
+                    part.trim()
+                )
+            })?;
+            let (name, val) = (name.trim(), val.trim());
+            match name {
+                "n" => n_slot = Some(resolve_slot(val, "n")?),
+                "mtt" => mtt_slot = Some(resolve_slot(val, "mtt")?),
+                other => {
+                    return Err(format!(
+                        "[odes]: transit(...) has no argument `{other}` (expected `n` and `mtt`)"
+                    ))
+                }
+            }
+        }
+        let n_slot = n_slot.ok_or("[odes]: transit(...) missing required argument `n`")?;
+        let mtt_slot = mtt_slot.ok_or("[odes]: transit(...) missing required argument `mtt`")?;
+
+        forcings.push(InputRateForcing {
+            cmt,
+            kind: InputRateKind::Transit,
+            arg_slots: vec![n_slot, mtt_slot],
+        });
+
+        let new_line = format!("{}0{}", &raw[..start], &raw[end..]);
+        if find_word_call(&new_line, "transit").is_some() {
+            return Err("[odes]: at most one transit(...) per d/dt equation (Phase 0)".to_string());
+        }
+        cleaned.push(new_line);
+    }
+    Ok((cleaned, forcings))
+}
+
 fn build_ode_spec(
     lines: &[String],
     state_names: &[String],
@@ -4420,6 +4605,16 @@ fn build_ode_spec(
             rhs_lines.push(raw.clone());
         }
     }
+
+    // Design A: pull built-in input-rate calls (transit(...)) out of each d/dt RHS
+    // into forcing terms before expression parsing, so they never enter the
+    // expression AST / bytecode / symbolic-AD core (each call is rewritten to `0`).
+    let (rhs_lines, input_rate) = extract_input_rate_terms(
+        &rhs_lines,
+        state_names,
+        indiv_param_names,
+        indiv_param_slots,
+    )?;
 
     // For ODE RHS expressions, states + individual params get injected into the
     // `vars` map at eval time, so every bare identifier should resolve to a
@@ -4875,9 +5070,9 @@ fn build_ode_spec(
         // Default tolerances; overwritten from [fit_options] / settings by
         // CompiledModel::sync_ode_solver_opts once fit options are merged.
         solver_opts: crate::ode::OdeSolverOptions::default(),
-        // Populated by the [odes] input-rate parse-split (transit() etc.); empty
-        // until that lands — no built-in absorption forcing for existing models.
-        input_rate: Vec::new(),
+        // Built-in absorption forcing terms split out of the [odes] RHS above
+        // (design A); empty for models with no transit()/etc. input-rate call.
+        input_rate,
     })
 }
 
@@ -9062,6 +9257,65 @@ fn parse_if_statement(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── transit() input-rate parse-split (#322, design A) ────────────────────
+    #[test]
+    fn extract_transit_input_rate_basic() {
+        let lines = vec![
+            "d/dt(depot) = transit(n=NTR, mtt=MTT) - KA*depot".to_string(),
+            "d/dt(central) = KA*depot - (CL/V)*central".to_string(),
+        ];
+        let states = vec!["depot".to_string(), "central".to_string()];
+        let names = vec![
+            "NTR".to_string(),
+            "MTT".to_string(),
+            "KA".to_string(),
+            "CL".to_string(),
+            "V".to_string(),
+        ];
+        let slots = vec![10, 11, 4, 0, 1];
+        let (cleaned, forcings) =
+            extract_input_rate_terms(&lines, &states, &names, &slots).unwrap();
+        // transit(...) replaced by 0; the rest of the RHS is untouched.
+        assert_eq!(cleaned[0], "d/dt(depot) = 0 - KA*depot");
+        assert_eq!(cleaned[1], "d/dt(central) = KA*depot - (CL/V)*central");
+        assert_eq!(forcings.len(), 1);
+        assert_eq!(forcings[0].cmt, 0); // depot
+        assert!(matches!(
+            forcings[0].kind,
+            crate::pk::absorption::InputRateKind::Transit
+        ));
+        assert_eq!(forcings[0].arg_slots, vec![10, 11]); // [n=NTR slot, mtt=MTT slot]
+    }
+
+    #[test]
+    fn extract_transit_input_rate_rejects_bad_specs() {
+        let states = vec!["depot".to_string()];
+        let names = vec!["NTR".to_string(), "MTT".to_string()];
+        let slots = vec![0, 1];
+        let go =
+            |line: &str| extract_input_rate_terms(&[line.to_string()], &states, &names, &slots);
+
+        assert!(go("d/dt(depot) = transit(n=NTR, mtt=ZZZ)")
+            .unwrap_err()
+            .contains("not a declared individual parameter"));
+        assert!(go("d/dt(depot) = transit(n=NTR, foo=MTT)")
+            .unwrap_err()
+            .contains("no argument `foo`"));
+        assert!(go("d/dt(depot) = transit(n=NTR)")
+            .unwrap_err()
+            .contains("missing required argument `mtt`"));
+        assert!(go("x = transit(n=NTR, mtt=MTT)")
+            .unwrap_err()
+            .contains("d/dt"));
+        assert!(go("d/dt(depot) = FR*transit(n=NTR, mtt=MTT)")
+            .unwrap_err()
+            .contains("scaled"));
+        // No transit() → unchanged, no forcings.
+        let (cleaned, f) = go("d/dt(depot) = -KA*depot").unwrap();
+        assert_eq!(cleaned[0], "d/dt(depot) = -KA*depot");
+        assert!(f.is_empty());
+    }
 
     // Issue #176 retired the split `*_iv_bolus` / `*_infusion` model names
     // in favour of a single `*_iv` per compartment count. The parser must

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -9311,6 +9311,27 @@ mod tests {
         assert!(go("d/dt(depot) = FR*transit(n=NTR, mtt=MTT)")
             .unwrap_err()
             .contains("scaled"));
+        assert!(go("d/dt(depot) = transit(n=NTR, mtt=MTT")
+            .unwrap_err()
+            .contains("unbalanced"));
+        assert!(go("d/dt(depot) = transit(NTR, mtt=MTT)")
+            .unwrap_err()
+            .contains("name=parameter"));
+        assert!(
+            go("d/dt(depot) = transit(n=NTR, mtt=MTT) + transit(n=NTR, mtt=MTT)")
+                .unwrap_err()
+                .contains("at most one")
+        );
+        // Nested parens in an arg value are split correctly, then rejected as a
+        // non-parameter (exercises the comma-splitter's paren-depth tracking).
+        assert!(go("d/dt(depot) = transit(n=foo(a,b), mtt=MTT)")
+            .unwrap_err()
+            .contains("not a declared individual parameter"));
+        // A word *ending* in `transit` (e.g. `xtransit(`) is not a transit() call:
+        // left unchanged, no forcing recorded.
+        let (kept, none) = go("d/dt(depot) = xtransit(n=NTR, mtt=MTT) - depot").unwrap();
+        assert_eq!(kept[0], "d/dt(depot) = xtransit(n=NTR, mtt=MTT) - depot");
+        assert!(none.is_empty());
         // No transit() → unchanged, no forcings.
         let (cleaned, f) = go("d/dt(depot) = -KA*depot").unwrap();
         assert_eq!(cleaned[0], "d/dt(depot) = -KA*depot");

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4875,6 +4875,9 @@ fn build_ode_spec(
         // Default tolerances; overwritten from [fit_options] / settings by
         // CompiledModel::sync_ode_solver_opts once fit options are merged.
         solver_opts: crate::ode::OdeSolverOptions::default(),
+        // Populated by the [odes] input-rate parse-split (transit() etc.); empty
+        // until that lands — no built-in absorption forcing for existing models.
+        input_rate: Vec::new(),
     })
 }
 

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -28,18 +28,13 @@ use crate::stats::special::ln_gamma;
 ///
 /// Domain: `mtt > 0`, `n ≥ 0` (enforce upstream with [`validate_transit`]).
 /// Evaluated in the log domain for stability with large `n` / `(KTR·tad)^n`.
+///
+/// This is the readable reference form (used by tests and one-shot callers); the
+/// ODE hot path goes through [`InputRateForcing::prepare`] +
+/// [`PreparedInputRate::rate`], which hoist the dose-invariant constants
+/// (`ln Γ`, `KTR`, `ln KTR`) out of the per-dose superposition loop.
 pub fn transit_input_rate(tad: f64, n: f64, mtt: f64, dose: f64) -> f64 {
-    if tad <= 0.0 || dose <= 0.0 {
-        return 0.0;
-    }
-    let ktr = (n + 1.0) / mtt;
-    let x = ktr * tad; // > 0 (tad > 0, ktr > 0 for valid params)
-
-    // ln R_in = ln dose + ln KTR + n·ln(KTR·tad) − KTR·tad − ln Γ(n + 1).
-    // For n = 0 the middle term is 0·ln x = 0, reducing to the first-order
-    // (Bateman) input dose·KTR·exp(−KTR·tad).
-    let ln_rin = dose.ln() + ktr.ln() + n * x.ln() - x - ln_gamma(n + 1.0);
-    ln_rin.exp()
+    PreparedInputRate::transit(n, mtt).rate(tad, dose)
 }
 
 /// Validate transit parameters: `mtt` strictly positive, `n` non-negative.
@@ -82,19 +77,91 @@ pub struct InputRateForcing {
 }
 
 impl InputRateForcing {
-    /// Appearance rate `R_in(tad)` into [`Self::cmt`] for one dose, where
-    /// `dose = F · amt` and `params` is the flat individual-parameter vector.
-    /// Per-dose contributions are summed by the caller; `tad ≤ 0 ⇒ 0`.
-    pub fn rate(&self, tad: f64, dose: f64, params: &[f64]) -> f64 {
-        let arg = |i: usize, dflt: f64| {
-            self.arg_slots
-                .get(i)
-                .and_then(|&s| params.get(s))
-                .copied()
-                .unwrap_or(dflt)
-        };
+    /// Read this forcing's argument `i` from the flat individual-parameter
+    /// vector `params`, falling back to `dflt` if the slot is absent.
+    #[inline]
+    fn arg(&self, params: &[f64], i: usize, dflt: f64) -> f64 {
+        self.arg_slots
+            .get(i)
+            .and_then(|&s| params.get(s))
+            .copied()
+            .unwrap_or(dflt)
+    }
+
+    /// Precompute the dose-invariant constants for this forcing's parameters
+    /// (read from the flat individual-parameter vector `params`). Call **once**
+    /// per RHS evaluation, then evaluate [`PreparedInputRate::rate`] per dose —
+    /// this keeps the expensive `ln Γ` (and `KTR`, `ln KTR`) out of the per-dose
+    /// superposition loop on the ODE hot path.
+    pub fn prepare(&self, params: &[f64]) -> PreparedInputRate {
         match self.kind {
-            InputRateKind::Transit => transit_input_rate(tad, arg(0, 0.0), arg(1, 1.0), dose),
+            InputRateKind::Transit => {
+                PreparedInputRate::transit(self.arg(params, 0, 0.0), self.arg(params, 1, 1.0))
+            }
+        }
+    }
+
+    /// Validate this forcing's parameters (read from the flat individual-parameter
+    /// vector `params`) against the model's domain, naming the offending value.
+    /// Wired into the fit-time data checks (evaluated on typical values, η = 0) so
+    /// an out-of-domain or non-finite `n`/`mtt` is rejected loudly instead of
+    /// propagating as a `NaN` through the ODE RHS.
+    pub fn validate(&self, params: &[f64]) -> Result<(), String> {
+        match self.kind {
+            InputRateKind::Transit => {
+                validate_transit(self.arg(params, 0, 0.0), self.arg(params, 1, 1.0))
+            }
+        }
+    }
+}
+
+/// An input-rate forcing with its dose-invariant constants precomputed for the
+/// ODE hot path. Built once per RHS evaluation by [`InputRateForcing::prepare`];
+/// [`Self::rate`] then costs only the `tad`/`dose`-dependent arithmetic per dose.
+#[derive(Debug, Clone, Copy)]
+pub enum PreparedInputRate {
+    /// Savic transit constants: `KTR`, `ln KTR`, `n`, and `ln Γ(n + 1)`.
+    Transit {
+        ktr: f64,
+        ln_ktr: f64,
+        n: f64,
+        ln_gamma_np1: f64,
+    },
+}
+
+impl PreparedInputRate {
+    /// Precompute the transit constants for `(n, mtt)`.
+    #[inline]
+    fn transit(n: f64, mtt: f64) -> Self {
+        let ktr = (n + 1.0) / mtt;
+        PreparedInputRate::Transit {
+            ktr,
+            ln_ktr: ktr.ln(),
+            n,
+            ln_gamma_np1: ln_gamma(n + 1.0),
+        }
+    }
+
+    /// Appearance rate `R_in(tad)` for one dose (`dose = F · amt`). Per-dose
+    /// contributions are summed by the caller; `tad ≤ 0` or `dose ≤ 0 ⇒ 0`.
+    #[inline]
+    pub fn rate(&self, tad: f64, dose: f64) -> f64 {
+        if tad <= 0.0 || dose <= 0.0 {
+            return 0.0;
+        }
+        match *self {
+            // ln R_in = ln dose + ln KTR + n·ln(KTR·tad) − KTR·tad − ln Γ(n + 1).
+            // For n = 0 the middle term is 0·ln x = 0, reducing to the first-order
+            // (Bateman) input dose·KTR·exp(−KTR·tad).
+            PreparedInputRate::Transit {
+                ktr,
+                ln_ktr,
+                n,
+                ln_gamma_np1,
+            } => {
+                let x = ktr * tad; // > 0 (tad > 0, ktr > 0 for valid params)
+                (dose.ln() + ln_ktr + n * x.ln() - x - ln_gamma_np1).exp()
+            }
         }
     }
 }
@@ -170,5 +237,50 @@ mod tests {
         assert!(validate_transit(-1.0, 2.0).is_err());
         assert!(validate_transit(f64::NAN, 2.0).is_err());
         assert!(validate_transit(3.0, f64::NAN).is_err());
+    }
+
+    /// `prepare(...).rate(...)` (the hoisted ODE-hot-path form) must agree bit-for-bit
+    /// with the readable reference `transit_input_rate` — guards the two from drifting
+    /// and pins the `arg_slots` wiring in `prepare`.
+    #[test]
+    fn prepared_rate_matches_reference_and_reads_slots() {
+        let forcing = InputRateForcing {
+            cmt: 0,
+            kind: InputRateKind::Transit,
+            arg_slots: vec![6, 7], // n @ 6, mtt @ 7
+        };
+        let mut params = vec![0.0; crate::types::MAX_PK_PARAMS];
+        params[6] = 3.0; // n
+        params[7] = 2.0; // mtt
+        let prepared = forcing.prepare(&params);
+        for &tad in &[0.0, 0.1, 1.0, 4.0, 12.0] {
+            assert_eq!(
+                prepared.rate(tad, 100.0),
+                transit_input_rate(tad, 3.0, 2.0, 100.0)
+            );
+        }
+    }
+
+    /// `InputRateForcing::validate` reads `n`/`mtt` from the right slots and
+    /// surfaces the domain error — the hook the fit-time check relies on.
+    #[test]
+    fn forcing_validate_reads_slots_and_flags_domain() {
+        let forcing = InputRateForcing {
+            cmt: 0,
+            kind: InputRateKind::Transit,
+            arg_slots: vec![6, 7],
+        };
+        let mut ok = vec![0.0; crate::types::MAX_PK_PARAMS];
+        ok[6] = 3.0;
+        ok[7] = 2.0;
+        assert!(forcing.validate(&ok).is_ok());
+
+        let mut bad_mtt = ok.clone();
+        bad_mtt[7] = -1.0; // mtt ≤ 0
+        assert!(forcing.validate(&bad_mtt).unwrap_err().contains("mtt"));
+
+        let mut bad_n = ok.clone();
+        bad_n[6] = -2.0; // n < 0
+        assert!(forcing.validate(&bad_n).unwrap_err().contains("n "));
     }
 }

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -1,0 +1,133 @@
+//! Built-in absorption **input-rate functions** — `R_in(tad)` per model (#322).
+//!
+//! Each returns the dose-driven appearance rate into the compartment it feeds,
+//! normalised so `∫₀^∞ R_in dt = dose`, where the caller folds bioavailability
+//! into `dose = F · amt`. `R_in = 0` for `tad ≤ 0` (the input starts after the
+//! dose); per-dose contributions are superposed by the caller.
+//!
+//! These are the inherently-numerical absorption models that feed an explicit
+//! ODE disposition (see `plans/absorption-models.md`). They are AD/Enzyme-safe
+//! (only `+ − * /`, `.ln()`, `.exp()`; no `f64::max`/`min` intrinsics — see
+//! CLAUDE.md). Written for `f64` for now; a shared numeric trait for the
+//! `Dual`/Enzyme paths follows when these are wired into the autodiff ODE
+//! gradient (the roadmap's escape hatch — duplicate-free generics later).
+
+use crate::stats::special::ln_gamma;
+
+/// Savic et al. (2007) transit-compartment input rate into the **depot**, for a
+/// *continuous* number of transit compartments `n`:
+///
+/// ```text
+/// R_in(tad) = dose · KTR · (KTR·tad)^n · exp(−KTR·tad) / Γ(n + 1),
+///   KTR = (n + 1) / mtt,   dose = F · amt.
+/// ```
+///
+/// The depot then empties to central via first-order `ka` (applied in the ODE,
+/// not here). `∫₀^∞ R_in dt = dose`. Returns `0` for `tad ≤ 0` and for a
+/// non-positive `dose`.
+///
+/// Domain: `mtt > 0`, `n ≥ 0` (enforce upstream with [`validate_transit`]).
+/// Evaluated in the log domain for stability with large `n` / `(KTR·tad)^n`.
+pub fn transit_input_rate(tad: f64, n: f64, mtt: f64, dose: f64) -> f64 {
+    if tad <= 0.0 || dose <= 0.0 {
+        return 0.0;
+    }
+    let ktr = (n + 1.0) / mtt;
+    let x = ktr * tad; // > 0 (tad > 0, ktr > 0 for valid params)
+
+    // ln R_in = ln dose + ln KTR + n·ln(KTR·tad) − KTR·tad − ln Γ(n + 1).
+    // For n = 0 the middle term is 0·ln x = 0, reducing to the first-order
+    // (Bateman) input dose·KTR·exp(−KTR·tad).
+    let ln_rin = dose.ln() + ktr.ln() + n * x.ln() - x - ln_gamma(n + 1.0);
+    ln_rin.exp()
+}
+
+/// Validate transit parameters: `mtt` strictly positive, `n` non-negative.
+/// The negated comparisons also reject `NaN`.
+pub fn validate_transit(n: f64, mtt: f64) -> Result<(), String> {
+    if !(mtt > 0.0) {
+        return Err(format!(
+            "transit: mtt (mean transit time) must be > 0, got {mtt}"
+        ));
+    }
+    if !(n >= 0.0) {
+        return Err(format!(
+            "transit: n (number of transit compartments) must be ≥ 0, got {n}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    /// Coarse trapezoidal `∫₀^upper R_in dt` — enough to check normalisation.
+    fn integrate(n: f64, mtt: f64, dose: f64, upper: f64, dt: f64) -> f64 {
+        let steps = (upper / dt) as usize;
+        let mut sum = 0.0;
+        let mut prev = transit_input_rate(0.0, n, mtt, dose);
+        for i in 1..=steps {
+            let t = i as f64 * dt;
+            let cur = transit_input_rate(t, n, mtt, dose);
+            sum += 0.5 * (prev + cur) * dt;
+            prev = cur;
+        }
+        sum
+    }
+
+    #[test]
+    fn transit_mass_balance_integrates_to_dose() {
+        // ∫₀^∞ R_in dt = dose across a range of (n, mtt) — the invariant that
+        // catches a wrong normalisation constant (the whole point of ln Γ).
+        for &(n, mtt) in &[(0.0, 1.0), (1.0, 2.0), (3.0, 1.5), (7.3, 4.0), (20.0, 6.0)] {
+            let dose = 100.0;
+            let mass = integrate(n, mtt, dose, 80.0, 0.002);
+            assert_relative_eq!(mass, dose, max_relative = 2e-3);
+        }
+    }
+
+    #[test]
+    fn transit_n_zero_is_first_order() {
+        // n = 0 ⇒ R_in = dose·ktr·exp(−ktr·tad) with ktr = 1/mtt (Bateman input).
+        let (mtt, dose) = (2.0_f64, 50.0_f64);
+        let ktr = 1.0 / mtt;
+        for &tad in &[0.1, 0.5, 1.0, 3.0, 8.0] {
+            let want = dose * ktr * (-ktr * tad).exp();
+            assert_relative_eq!(
+                transit_input_rate(tad, 0.0, mtt, dose),
+                want,
+                max_relative = 1e-12
+            );
+        }
+    }
+
+    #[test]
+    fn transit_peaks_at_the_gamma_mode() {
+        // For n > 0 the chain output peaks at KTR·tad = n ⇒ tad = n·mtt/(n+1).
+        let (n, mtt, dose) = (4.0, 3.0, 100.0);
+        let mode = n * mtt / (n + 1.0);
+        let peak = transit_input_rate(mode, n, mtt, dose);
+        assert!(peak > transit_input_rate(mode * 0.5, n, mtt, dose));
+        assert!(peak > transit_input_rate(mode * 1.5, n, mtt, dose));
+    }
+
+    #[test]
+    fn transit_zero_before_dose_and_for_zero_dose() {
+        assert_eq!(transit_input_rate(0.0, 3.0, 2.0, 100.0), 0.0);
+        assert_eq!(transit_input_rate(-1.0, 3.0, 2.0, 100.0), 0.0);
+        assert_eq!(transit_input_rate(1.0, 3.0, 2.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn validate_transit_domain() {
+        assert!(validate_transit(3.0, 2.0).is_ok());
+        assert!(validate_transit(0.0, 1.0).is_ok()); // n = 0 allowed (first-order)
+        assert!(validate_transit(3.0, 0.0).is_err());
+        assert!(validate_transit(3.0, -1.0).is_err());
+        assert!(validate_transit(-1.0, 2.0).is_err());
+        assert!(validate_transit(f64::NAN, 2.0).is_err());
+        assert!(validate_transit(3.0, f64::NAN).is_err());
+    }
+}

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -58,6 +58,47 @@ pub fn validate_transit(n: f64, mtt: f64) -> Result<(), String> {
     Ok(())
 }
 
+/// Which built-in absorption input-rate model a forcing term uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputRateKind {
+    /// Savic transit-compartment chain — `transit(n, mtt)`.
+    Transit,
+}
+
+/// A built-in absorption input-rate term attached to one ODE compartment.
+///
+/// Design A (see `plans/absorption-models.md`): the input-rate function is split
+/// out of the `[odes]` RHS at parse time and evaluated here with dose context,
+/// rather than threaded through the expression AST / bytecode VM / symbolic-AD
+/// machinery. `arg_slots` index the flat individual-parameter vector for this
+/// model's parameters — for [`InputRateKind::Transit`], `[n, mtt]`.
+#[derive(Debug, Clone)]
+pub struct InputRateForcing {
+    /// 0-based ODE compartment that receives `R_in`.
+    pub cmt: usize,
+    pub kind: InputRateKind,
+    /// Indices into the flat individual-parameter vector for this model's args.
+    pub arg_slots: Vec<usize>,
+}
+
+impl InputRateForcing {
+    /// Appearance rate `R_in(tad)` into [`Self::cmt`] for one dose, where
+    /// `dose = F · amt` and `params` is the flat individual-parameter vector.
+    /// Per-dose contributions are summed by the caller; `tad ≤ 0 ⇒ 0`.
+    pub fn rate(&self, tad: f64, dose: f64, params: &[f64]) -> f64 {
+        let arg = |i: usize, dflt: f64| {
+            self.arg_slots
+                .get(i)
+                .and_then(|&s| params.get(s))
+                .copied()
+                .unwrap_or(dflt)
+        };
+        match self.kind {
+            InputRateKind::Transit => transit_input_rate(tad, arg(0, 0.0), arg(1, 1.0), dose),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -130,9 +130,34 @@ pub enum PreparedInputRate {
 }
 
 impl PreparedInputRate {
+    /// Domain floor for `mtt` when clamping a transient mid-fit excursion (see
+    /// [`Self::transit`]). Far below any realistic mean transit time, so it never
+    /// perturbs a converged fit — it only keeps a transient `mtt ≤ 0` from
+    /// turning `ktr.ln()` into a `NaN`.
+    const MIN_MTT: f64 = 1e-8;
+
     /// Precompute the transit constants for `(n, mtt)`.
+    ///
+    /// The arguments are **clamped to the valid domain** (`mtt > 0`, `n ≥ 0`).
+    /// The fit-time guard ([`validate_transit`], wired into
+    /// `check_absorption_dosing`) already rejects an out-of-domain *typical*
+    /// value loudly; but during estimation the inner BFGS perturbs `eta` and the
+    /// outer FD step perturbs `theta`, so an additive parameterisation
+    /// (`MTT = TVMTT + ETA_MTT`) or a wide FD step can drive a transient
+    /// `mtt ≤ 0` / `n < 0` *mid-search*. Left unclamped that yields
+    /// `ktr.ln()` / `ln Γ(n+1) = NaN`, which propagates through the ODE RHS into
+    /// an opaque `NaN` OFV instead of a recoverable step. Clamping keeps `R_in`
+    /// finite at the domain wall so the optimiser can climb back to the interior;
+    /// the converged optimum is interior, so reported estimates are unaffected.
+    /// `NaN` inputs also fall to the floor (every `>`/`>=` is false for `NaN`).
     #[inline]
     fn transit(n: f64, mtt: f64) -> Self {
+        let mtt = if mtt > Self::MIN_MTT {
+            mtt
+        } else {
+            Self::MIN_MTT
+        };
+        let n = if n >= 0.0 { n } else { 0.0 };
         let ktr = (n + 1.0) / mtt;
         PreparedInputRate::Transit {
             ktr,
@@ -237,6 +262,31 @@ mod tests {
         assert!(validate_transit(-1.0, 2.0).is_err());
         assert!(validate_transit(f64::NAN, 2.0).is_err());
         assert!(validate_transit(3.0, f64::NAN).is_err());
+    }
+
+    /// A *transient* domain excursion (`mtt ≤ 0`, `n < 0`, or `NaN`) — reachable
+    /// mid-fit when an additive `eta` or a wide FD step leaves the domain — must
+    /// yield a **finite, non-negative** `R_in`, never a `NaN` that silently
+    /// poisons the ODE RHS / OFV. The loud fit-start `validate_transit` still
+    /// rejects out-of-domain *typical* values; this guards the search path
+    /// (`PreparedInputRate::transit` clamps to the domain).
+    #[test]
+    fn transit_rate_is_finite_for_domain_excursions() {
+        for &(n, mtt) in &[
+            (3.0, 0.0),      // mtt = 0  → ktr = +∞ unclamped
+            (3.0, -1.0),     // mtt < 0  → ktr < 0, ln(ktr) = NaN unclamped
+            (-1.0, 2.0),     // n  < 0
+            (f64::NAN, 2.0), // NaN n
+            (3.0, f64::NAN), // NaN mtt
+        ] {
+            for &tad in &[0.5, 2.0, 10.0] {
+                let r = transit_input_rate(tad, n, mtt, 100.0);
+                assert!(
+                    r.is_finite() && r >= 0.0,
+                    "R_in must be finite & non-negative at n={n}, mtt={mtt}, tad={tad}, got {r}"
+                );
+            }
+        }
     }
 
     /// `prepare(...).rate(...)` (the hoisted ODE-hot-path form) must agree bit-for-bit

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1,3 +1,4 @@
+pub mod absorption;
 pub mod event_driven;
 pub mod one_compartment;
 pub mod three_compartment;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3279,6 +3279,7 @@ pub(crate) mod test_helpers {
                     diffusion_var: Vec::new(),
                     init_fn: None,
                     solver_opts: crate::ode::OdeSolverOptions::default(),
+                    input_rate: Vec::new(),
                 })
             } else {
                 None

--- a/tests/transit_absorption.rs
+++ b/tests/transit_absorption.rs
@@ -90,6 +90,43 @@ const TRANSIT_DIFFUSION_MODEL: &str = r#"
   method = foce
 "#;
 
+/// Transit absorption whose mean transit time is out of domain at typical
+/// values: `MTT = TVMTT` with a *negative* typical `TVMTT`, so `mtt ≤ 0`. Without
+/// the fit-time domain guard this would produce `ktr.ln() = NaN` and propagate a
+/// NaN through the ODE RHS; with it, the model is rejected loudly.
+const TRANSIT_BAD_DOMAIN_MODEL: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVKA(1.0, 0.05,  24.0)
+  theta TVMTT(-1.0, -10.0, 24.0)
+  theta TVN(3.0,   0.1,  30.0)
+
+  omega ETA_CL ~ 0.0
+
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+  KA  = TVKA
+  MTT = TVMTT
+  NTR = TVN
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot/V - CL/V*central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+"#;
+
 /// Single oral bolus of 100 mg into the depot (CMT 1), observed on central
 /// (CMT 2) over a fine grid out to 72 h (~10 elimination half-lives).
 fn pop_single_oral(obs_times: Vec<f64>) -> Population {
@@ -222,6 +259,23 @@ fn transit_with_diffusion_block_is_rejected() {
     assert!(
         diags.iter().any(|d| d.code == "E_ABSORPTION_DIFFUSION"),
         "expected E_ABSORPTION_DIFFUSION, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn out_of_domain_transit_parameter_is_rejected() {
+    // A transit `mtt ≤ 0` at typical values must be rejected at fit time rather
+    // than silently propagating a NaN through the ODE RHS (the `validate_transit`
+    // domain guard, evaluated on η = 0 per subject).
+    let model = parse_full_model(TRANSIT_BAD_DOMAIN_MODEL)
+        .expect("bad-domain transit model still parses")
+        .model;
+    let pop = pop_single_oral(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_ABSORPTION_DOMAIN"),
+        "expected E_ABSORPTION_DOMAIN, got {:?}",
         diags.iter().map(|d| &d.code).collect::<Vec<_>>()
     );
 }

--- a/tests/transit_absorption.rs
+++ b/tests/transit_absorption.rs
@@ -248,6 +248,40 @@ fn ss_dose_into_transit_compartment_is_rejected() {
 }
 
 #[test]
+fn infusion_into_transit_compartment_is_rejected() {
+    // An infusion (RATE>0) into a transit compartment would be delivered twice —
+    // once as the `+rate` infusion injection in the ODE RHS wrapper, once as
+    // R_in(tad) superposed by the forcing — silently ~doubling exposure. The
+    // transit chain already defines the input rate from the dose amount, so an
+    // infusion rate on that record is undefined and must be rejected loudly.
+    let model = parse_full_model(TRANSIT_MODEL)
+        .expect("transit model parses")
+        .model;
+    let inf_dose = DoseEvent::new(0.0, 100.0, 1, 10.0, false, 0.0); // RATE=10>0 into depot (CMT 1)
+    let n = 2;
+    let pop = Population {
+        covariate_names: Vec::new(),
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![common::subject(
+            "1",
+            vec![inf_dose],
+            vec![1.0, 6.0],
+            vec![0.0; n],
+            vec![2; n],
+        )],
+    };
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_ABSORPTION_RATE"),
+        "expected E_ABSORPTION_RATE, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn transit_with_diffusion_block_is_rejected() {
     // A built-in input-rate model + a [diffusion] block (SDE/EKF) is rejected:
     // the EKF propagation does not carry the R_in forcing.

--- a/tests/transit_absorption.rs
+++ b/tests/transit_absorption.rs
@@ -1,0 +1,227 @@
+//! End-to-end tests for built-in **transit-compartment absorption** (#322,
+//! Phase 0). Exercises the `transit()` input-rate forcing through the *public*
+//! API — parse → `predict()` → ODE integration → readout — plus the fit-time
+//! guards that reject the not-yet-supported dosing combinations.
+//!
+//! The centrepiece is an **AUC invariant**: for a one-compartment model the
+//! steady-state exposure is `AUC∞ = F·Dose / CL` *regardless of the absorption
+//! model*. Integrating the predicted transit curve must therefore recover
+//! `Dose/CL` — a model-independent check that the forcing delivers exactly the
+//! dose mass (not zero — forcing missing; not 2×Dose — bolus double-counted)
+//! through the whole pipeline, including the parser's argument-slot wiring.
+
+mod common;
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{check_model_data, predict, DoseEvent, Population};
+
+/// One-compartment oral model with built-in Savic transit absorption.
+/// depot (CMT 1, mg) receives `R_in(tad)`; central (CMT 2, mg/L) is the readout.
+/// η fixed at 0 so `predict()` returns the typical-value curve. CL = 5 ⇒
+/// AUC∞ = 100/5 = 20 mg·h/L. F defaults to 1.0 (no `f=` mapping).
+const TRANSIT_MODEL: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVKA(1.0, 0.05,  24.0)
+  theta TVMTT(1.0, 0.05, 24.0)
+  theta TVN(3.0,   0.1,  30.0)
+
+  omega ETA_CL ~ 0.0
+
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+  KA  = TVKA
+  MTT = TVMTT
+  NTR = TVN
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot/V - CL/V*central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+"#;
+
+/// Same disposition + transit absorption, but with a `[diffusion]` block — the
+/// SDE/EKF path, which cannot carry the input-rate forcing (rejected by guard).
+const TRANSIT_DIFFUSION_MODEL: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVKA(1.0, 0.05,  24.0)
+  theta TVMTT(1.0, 0.05, 24.0)
+  theta TVN(3.0,   0.1,  30.0)
+
+  omega ETA_CL ~ 0.0
+
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+  KA  = TVKA
+  MTT = TVMTT
+  NTR = TVN
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = transit(n=NTR, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot/V - CL/V*central
+
+[diffusion]
+  central ~ 0.01
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = foce
+"#;
+
+/// Single oral bolus of 100 mg into the depot (CMT 1), observed on central
+/// (CMT 2) over a fine grid out to 72 h (~10 elimination half-lives).
+fn pop_single_oral(obs_times: Vec<f64>) -> Population {
+    let n = obs_times.len();
+    let dose = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0);
+    Population {
+        covariate_names: Vec::new(),
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![common::subject(
+            "1",
+            vec![dose],
+            obs_times,
+            vec![0.0; n],
+            vec![2; n],
+        )],
+    }
+}
+
+#[test]
+fn transit_curve_recovers_dose_auc_and_has_delayed_peak() {
+    let model = parse_full_model(TRANSIT_MODEL)
+        .expect("transit model parses")
+        .model;
+
+    // 0, 0.25, …, 72.0 — fine enough for trapezoidal AUC, long enough that the
+    // truncated tail is negligible (ke = CL/V = 0.1 ⇒ t½ ≈ 6.9 h).
+    let obs_times: Vec<f64> = (0..=288).map(|i| i as f64 * 0.25).collect();
+    let pop = pop_single_oral(obs_times);
+    let preds = predict(&model, &pop, &model.default_params);
+
+    // (1) No instantaneous bolus jump: the dose enters as R_in over time, so
+    //     central starts at exactly 0 (initial state) at the dose time.
+    assert_eq!(preds[0].time, 0.0);
+    assert!(
+        preds[0].pred.abs() < 1e-12,
+        "transit dose leaked in as a bolus: central(0) = {}",
+        preds[0].pred
+    );
+
+    // (2) Delayed, interior peak — the hallmark of transit absorption (Tmax is
+    //     pushed out vs first-order). The maximum is neither the first nor the
+    //     last sample.
+    let max_idx = (0..preds.len())
+        .max_by(|&a, &b| preds[a].pred.partial_cmp(&preds[b].pred).unwrap())
+        .unwrap();
+    assert!(
+        max_idx > 1 && max_idx < preds.len() - 1,
+        "expected an interior Tmax, got index {} (t = {})",
+        max_idx,
+        preds[max_idx].time
+    );
+
+    // (3) Mass balance via the absorption-independent invariant AUC∞ = Dose/CL.
+    //     Catches a missing forcing (AUC → 0) or a double-counted bolus
+    //     (AUC → 2·Dose/CL).
+    let auc: f64 = preds
+        .windows(2)
+        .map(|w| 0.5 * (w[0].pred + w[1].pred) * (w[1].time - w[0].time))
+        .sum();
+    let auc_inf = 100.0 / 5.0; // F·Dose/CL with F = 1, CL = 5
+    let rel = (auc - auc_inf).abs() / auc_inf;
+    assert!(
+        rel < 0.02,
+        "transit AUC {:.4} vs Dose/CL {:.4} (rel err {:.2e})",
+        auc,
+        auc_inf,
+        rel
+    );
+}
+
+#[test]
+fn transit_normal_dosing_passes_data_checks() {
+    // Positive control: ordinary (non-SS) dosing into the transit compartment
+    // raises no absorption diagnostic.
+    let model = parse_full_model(TRANSIT_MODEL)
+        .expect("transit model parses")
+        .model;
+    let pop = pop_single_oral(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        !diags.iter().any(|d| d.code.starts_with("E_ABSORPTION")),
+        "unexpected absorption diagnostic: {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ss_dose_into_transit_compartment_is_rejected() {
+    // Steady-state dosing into a transit compartment is not yet supported and
+    // must be rejected loudly rather than silently mis-modeled as a bolus train.
+    let model = parse_full_model(TRANSIT_MODEL)
+        .expect("transit model parses")
+        .model;
+    let ss_dose = DoseEvent::new(0.0, 100.0, 1, 0.0, true, 12.0); // SS=1, II=12
+    let n = 2;
+    let pop = Population {
+        covariate_names: Vec::new(),
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![common::subject(
+            "1",
+            vec![ss_dose],
+            vec![1.0, 6.0],
+            vec![0.0; n],
+            vec![2; n],
+        )],
+    };
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_ABSORPTION_SS"),
+        "expected E_ABSORPTION_SS, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn transit_with_diffusion_block_is_rejected() {
+    // A built-in input-rate model + a [diffusion] block (SDE/EKF) is rejected:
+    // the EKF propagation does not carry the R_in forcing.
+    let model = parse_full_model(TRANSIT_DIFFUSION_MODEL)
+        .expect("transit+diffusion model parses")
+        .model;
+    let pop = pop_single_oral(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_ABSORPTION_DIFFUSION"),
+        "expected E_ABSORPTION_DIFFUSION, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}

--- a/tests/transit_absorption.rs
+++ b/tests/transit_absorption.rs
@@ -264,6 +264,21 @@ fn transit_with_diffusion_block_is_rejected() {
 }
 
 #[test]
+fn transit_model_with_undeclared_param_fails_to_parse() {
+    // The `extract_input_rate_terms` error must propagate all the way out of
+    // `build_ode_spec` / `parse_full_model` (the `?` at the call site), not only
+    // from the unit-level helper. `mtt=NOPE` references an undeclared parameter.
+    let bad = TRANSIT_MODEL.replace("mtt=MTT", "mtt=NOPE");
+    let err = parse_full_model(&bad)
+        .err()
+        .expect("expected a parse error for an undeclared transit parameter");
+    assert!(
+        err.contains("not a declared individual parameter"),
+        "unexpected parse error: {err}"
+    );
+}
+
+#[test]
 fn out_of_domain_transit_parameter_is_rejected() {
     // A transit `mtt ≤ 0` at typical values must be rejected at fit time rather
     // than silently propagating a NaN through the ODE RHS (the `validate_transit`


### PR DESCRIPTION
## Why
Phase 0 of the built-in absorption roadmap (#322 / `plans/absorption-models.md`). ferx-core only had first-order absorption (`ka`) analytically; richer absorption was reachable only by hand-coding a chain of physical transit compartments (`examples/transit_2cpt.ferx`), which cannot estimate a continuous number of compartments. This adds **Savic et al. (2007) transit-compartment absorption** as a built-in `transit(n, mtt)` input-rate function with a **continuous** (estimable) `n`.

## What changed
- New `src/pk/absorption.rs`: `transit_input_rate` (log-domain Savic, `∫R_in dt = F·Dose`), `validate_transit`, and `InputRateForcing`/`InputRateKind` carried on `OdeSpec.input_rate`.
- Parser splits `transit(n=, mtt=)` out of the `[odes]` RHS (named args; must be declared individual parameters) and records the forcing — it never enters the expression AST / bytecode VM / symbolic-AD core.
- **Forcing eval** (this PR's core): `R_in(tad)` is injected into the depot via the same RHS-wrapper that adds `+rate` for infusions, across all four production ODE paths (`ode_predictions`, event-driven, `_with_states`, dense-solve; the event-driven-with-states path delegates to the latter two). The transit dose is delivered **entirely** as `R_in` over time, so its instantaneous bolus is **suppressed** (no double-counting). `F` scales the mass, lagtime shifts `tad`, multiple doses superpose, and `reset_floor` turns off pre-EVID-3/4 doses.
- Fit-time guards (`api::check_absorption_dosing`, wired into `check_model_data`): SS=1 into a transit compartment → `E_ABSORPTION_SS`; `transit()` + a `[diffusion]` block → `E_ABSORPTION_DIFFUSION`. Both rejected loudly (deferred to a later phase) rather than silently mis-modeled.

ODE models always differentiate via **finite differences** (`model.tv_fn` is `None` ⇒ `gradient=ad` falls back to FD), so `transit_input_rate` is f64-only and no Enzyme/Dual path is reachable; it is kept `f64::max`/`min`-free regardless.

## Alternatives considered
Threading `transit()` through the expression AST / bytecode VM / symbolic-AD (rejected: it needs dose schedule/amount/F/TAD context those layers lack — "design A" in the roadmap). `ode_template` generation + the analytical-`pk`+absorption hard-error rule are deferred; Phase 0 uses an explicit `[odes]` disposition.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

The new `pub` surface (`pk::absorption`) is additive and not yet consumed by ferx-r; local builds (patch) and CI (pinned lock) both compile unchanged. Exposing `transit()` in the R wrapper is a separate follow-up.

## Breaking changes
- [x] None (additive; non-transit models are byte-for-byte unaffected)

## Numerical validation
- [x] **Parameter recovery:** `examples/transit_savic.ferx --simulate` recovers its truths under FOCEI — TVCL 5→4.81, TVV 50→55.9, TVKA 1.0→0.84, **TVN 3.0→3.19**, TVMTT 1.0→0.90, prop 0.15→0.155 (covariance computed).
- [x] **AUC invariant:** an end-to-end test integrates the predicted transit curve and recovers AUC∞ = Dose/CL within 2% — an absorption-model-independent check that the forcing delivers exactly the dose mass (not 0 = missing forcing, not 2× = double-counted bolus).
- [ ] **NONMEM anchor pending** — see Open questions.

## Performance
- [x] No significant impact for non-transit models (the forcing loop is gated on `!input_rate.is_empty()`). Transit models integrate numerically through the ODE solver, as documented; an analytical incomplete-gamma fast path is a later phase.

## Tests
- [x] Unit tests (`cargo test --lib` passes): 6 integrator tests (mass balance, bolus suppression, F scaling, superposition, reset_floor) + the absorption-math tests.
- [x] Integration tests (`tests/transit_absorption.rs`): AUC invariant, delayed-peak shape, and both guard rejections.

## Example (user-facing features only)
- [x] Example added: `examples/transit_savic.ferx` (self-contained — runs via `--simulate`).

## Docs
- [x] `docs/src/model-file/absorption.md` added; linked in `SUMMARY.md`; cross-linked from `ode-models.md` and the existing transit example page.
- [x] `CHANGELOG.md` `[Unreleased] → Added` entry.

## Checklist
- [x] `cargo clippy` clean (the new `add_input_rate_forcing` carries a scoped `#[allow(clippy::too_many_arguments)]`, matching the dose context threaded into the RHS wrappers)
- [ ] `cargo check --features autodiff` — absorption code is f64-only and not AD-reachable (ODE path is FD); it compiles under the feature but was not run locally (no Enzyme toolchain) — CI's autodiff job covers it
- [x] No version bump (additive, non-breaking)

## Reviewer hints
- The core is `add_input_rate_forcing` + `input_rate_consumes_cmt` in `src/ode/predictions.rs`, wired at every bolus site (suppression) and RHS wrapper (injection) across the 4 paths.
- The `AUC∞ = Dose/CL` test is the strongest correctness signal; the 6 unit tests pin the individual properties.
- Guards live in `api::check_absorption_dosing`.
- Verified CI-green: full lib suite `1050 passed, 0 failed` under the exact CI profile (`--no-default-features --features ci --profile ci-test`).

## Open questions
- **NONMEM anchor:** I do not have NONMEM; Phase 0 is validated by parameter recovery + the mass-balance / AUC invariant. A NONMEM Savic cross-check is worth doing before or with a later phase — flagging per the repo's "compare with NONMEM" rule. Happy to convert this to a Draft if you would rather gate on that.