### PR TITLE
docs: fix MathJax equations mangled by markdown emphasis (IOV/SAEM/IMP/output)

### DIFF
--- a/docs/src/estimation/importance-sampling.md
+++ b/docs/src/estimation/importance-sampling.md
@@ -4,10 +4,12 @@
 
 The `imp` stage estimates the marginal log-likelihood
 
-\\[
+<div>
+\[
 -2 \\log L(\\theta) \\;=\\; -2 \\sum_i \\log p(y_i \\mid \\theta)
 \\;=\\; -2 \\sum_i \\log \\int p(y_i \\mid \\eta, \\theta)\\, p(\\eta \\mid \\theta)\\, d\\eta
-\\]
+\]
+</div>
 
 by Monte-Carlo importance sampling. The IS Monte-Carlo estimator of
 `p(yᵢ|θ)` is unbiased; the reported `−2 log L` carries a small Jensen
@@ -87,35 +89,43 @@ For each subject *i* with EBE η̂ᵢ and inner-loop Jacobian Jᵢ = ∂f/∂η 
    (multivariate Student-t).
 
 3. **Compute log importance weights:**
-   \\[
+<div>
+   \[
    \\log w_{ik} = \\log p(y_i \\mid \\eta_{ik}, \\theta)
                 + \\log p(\\eta_{ik} \\mid \\theta)
                 - \\log q(\\eta_{ik}).
-   \\]
+   \]
+</div>
 
 4. **Subject marginal LL** via log-sum-exp:
-   \\[
+<div>
+   \[
    \\log \\hat p(y_i \\mid \\theta)
    \\;=\\; \\operatorname{lse}_k \\log w_{ik} - \\log K.
-   \\]
+   \]
+</div>
 
 5. **Per-subject effective sample size:**
-   \\(\\mathrm{ESS}_i = 1 / \\sum_k \\tilde w_{ik}^2\\) (normalised weights).
+   \\(\\mathrm{ESS}\_i = 1 / \\sum\_k \\tilde w\_{ik}^2\\) (normalised weights).
    The result reports the across-subject min and median of ESS/K, plus
    any subjects below `is_low_ess_threshold` (default 10%).
 
 6. **Monte-Carlo standard error.** For a self-normalised IS estimator the
    asymptotic per-subject variance (Geweke 1989) is
-   \\[
+<div>
+   \[
    \\operatorname{Var}\\bigl(\\log \\hat p(y_i \\mid \\theta)\\bigr)
    \\;\\approx\\; \\frac{1}{K}\\left(\\frac{1}{\\mathrm{ESS}_i / K} - 1\\right).
-   \\]
+   \]
+</div>
    Aggregating across subjects (LL is a sum of independent per-subject
    log-marginals) and converting to the `−2 log L` scale,
-   \\[
+<div>
+   \[
    \\operatorname{SE}(-2 \\log L_{IS})
    \\;=\\; 2 \\sqrt{\\sum_i \\operatorname{Var}\\bigl(\\log \\hat p(y_i \\mid \\theta)\\bigr)}.
-   \\]
+   \]
+</div>
    Subjects with degenerate ESS (\\(\\mathrm{ESS}_i / K = 0\\) — complete
    proposal collapse) fall back to a per-subject variance of `1.0`, which
    produces a *finite* but inflated SE rather than a NaN. A separate

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -35,7 +35,9 @@ Each SAEM iteration consists of:
 
 For each subject, sample from the conditional distribution of random effects:
 
-\\[ p(\eta_i | y_i, \theta, \Omega, \sigma) \\]
+<div>
+\[ p(\eta_i | y_i, \theta, \Omega, \sigma) \]
+</div>
 
 Two samplers are available:
 
@@ -49,13 +51,15 @@ Two MH kernels run per subject per SAEM iteration (the mixture of Kuhn & Laviell
 
 Both kernels are symmetric in \\( \eta \\), so the proposal density cancels and the acceptance log-ratio is the difference of `individual_nll` values, which encodes the prior \\( N(0, \Omega) \\) plus the observation likelihood.
 
-**Acceptance**: \\( \min(1, \exp(\text{NLL}_{\text{current}} - \text{NLL}_{\text{prop}})) \\). Target acceptance rate: 40%.
+**Acceptance**: \\( \min(1, \exp(\text{NLL}\_{\text{current}} - \text{NLL}\_{\text{prop}})) \\). Target acceptance rate: 40%.
 
 #### HMC (Hamiltonian Monte Carlo, `n_leapfrog > 0`)
 
 When `n_leapfrog` is set to a positive integer (e.g. `3`), one HMC proposal replaces the `n_mh_steps` MH proposals per subject per iteration. HMC uses the gradient of the individual NLL to make longer, more directed moves through the posterior:
 
-\\[ H(\eta, p) = \text{NLL}(\eta) + \tfrac{1}{2} \|p\|^2 \\]
+<div>
+\[ H(\eta, p) = \text{NLL}(\eta) + \tfrac{1}{2} \|p\|^2 \]
+</div>
 
 with momentum \\( p \sim N(0, I) \\) and a standard velocity Störmer-Verlet (leapfrog) integrator. Acceptance is on \\( \Delta H \\), targeting ~65% acceptance.
 
@@ -77,13 +81,17 @@ The startup banner reports the resolved E-step kernel on a `sampler:` line, e.g.
 
 Update the sufficient statistic for \\( \Omega \\):
 
-\\[ S_2 \leftarrow (1 - \gamma_k^\Omega) \cdot S_2 + \gamma_k^\Omega \cdot \frac{1}{N} \sum_{i=1}^{N} \eta_i \eta_i^T \\]
+<div>
+\[ S_2 \leftarrow (1 - \gamma_k^\Omega) \cdot S_2 + \gamma_k^\Omega \cdot \frac{1}{N} \sum_{i=1}^{N} \eta_i \eta_i^T \]
+</div>
 
 **Damped Ω step.** The θ/σ M-step uses the full \\( \gamma_k \\) (1.0 during exploration), but the Ω sufficient statistic uses a *capped* step \\( \gamma_k^\Omega = \min(\gamma_k, 0.1) \\). With the full \\( \gamma=1 \\), Ω would be overwritten every exploration iteration by a single warm-started, not-yet-equilibrated MCMC draw; for a correlated block that one snapshot is biased toward the chain's current correlation, and the bias feeds back through \\( \mathrm{chol}(\Omega) \\) into the next proposal — the same rank-1 runaway the componentwise kernel guards against, here attacked from the M-step side. Capping the Ω learning rate during exploration averages those draws (Robbins-Monro) and breaks the feedback while θ still moves at full speed. The cap applies during exploration only; in the convergence phase it is lifted and Ω uses the full decaying \\( \gamma_k = 1/(k-K_1) \\) — the same Robbins-Monro schedule as θ — so the SA estimate settles correctly (by then the chain is equilibrated, so the single-draw overwrite risk no longer applies).
 
 ### 3. M-Step for Omega (Closed Form)
 
-\\[ \Omega_k = S_2 \\]
+<div>
+\[ \Omega_k = S_2 \]
+</div>
 
 with structurally-zero entries (cross-block off-diagonals, standalone-vs-block off-diagonals, and all off-diagonals in a fully-diagonal Ω) zeroed out — the SA accumulator \\( (1/N) \sum_i \eta_i \eta_i^T \\) is dense by construction, but the model declares which entries are free parameters. Without this projection the chain feeds spurious sampling correlations into the next iteration's MH proposal Cholesky and Ω drifts toward rank-deficiency. Free diagonals are then floored at `1e-6` to keep them away from zero (which would collapse the per-eta proposal scale `δ·chol(Ω)`); this floor does not by itself guarantee positive-definiteness of a full block Ω.
 
@@ -93,11 +101,15 @@ with structurally-zero entries (cross-block off-diagonals, standalone-vs-block o
 
 Minimize the conditional observation negative log-likelihood with ETAs held fixed:
 
-\\[ \sum_{i=1}^{N} \sum_{j=1}^{n_i} \left[ \frac{1}{2} \log V_{ij} + \frac{1}{2} \frac{(y_{ij} - f_{ij})^2}{V_{ij}} \right] \\]
+<div>
+\[ \sum_{i=1}^{N} \sum_{j=1}^{n_i} \left[ \frac{1}{2} \log V_{ij} + \frac{1}{2} \frac{(y_{ij} - f_{ij})^2}{V_{ij}} \right] \]
+</div>
 
 When `mu_referencing = true` (the default), ferx detects lognormal parameters from the `[individual_parameters]` block and applies the **closed-form EM update** for those thetas instead of running NLopt:
 
-\\[ \log \theta_j \leftarrow \log \theta_j + \gamma_k \cdot \overline{\eta_j} \\]
+<div>
+\[ \log \theta_j \leftarrow \log \theta_j + \gamma_k \cdot \overline{\eta_j} \]
+</div>
 
 where \\( \overline{\eta_j} = (1/N) \sum_i \eta_{i,j} \\) is the empirical mean of the post-MH random effects for the eta paired with \\( \theta_j \\). For a log-mu-referenced model where \\( \log P_i = \log \theta + \eta_i \\) with \\( \eta_i \sim N(0, \omega^2) \\), this is exactly the M-step that maximises the complete-data log-likelihood, scaled by the SA step size \\( \gamma_k \\). After the update the etas are re-centred by the same shift so they remain deviations from the new \\( \log \theta_j \\).
 
@@ -248,7 +260,9 @@ SAEM completed. Final OFV = ...
 
 During the iterations ferx prints `condNLL`, the **conditional** (joint) negative log-likelihood summed over subjects, evaluated at the *current MH/HMC-sampled* etas:
 
-\\[ \text{condNLL} = \sum_{i=1}^{N} \text{NLL}(\eta_i^{\text{sampled}}) \\]
+<div>
+\[ \text{condNLL} = \sum_{i=1}^{N} \text{NLL}(\eta_i^{\text{sampled}}) \]
+</div>
 
 This is a cheap per-iteration progress signal. It is **not** the marginal objective function value (OFV): it is evaluated at one stochastic draw of the random effects rather than integrated over their distribution, so unlike the FOCE/FOCEI outer-loop OFV it is noisy, will not decrease monotonically, and is **not comparable across runs** for model selection.
 

--- a/docs/src/model-file/iov.md
+++ b/docs/src/model-file/iov.md
@@ -14,7 +14,9 @@ An **occasion** is a distinct time window during which the same kappa value appl
 
 **Kappa** (κ) is the IOV random effect, analogous to eta (η) for BSV. Each kappa is drawn independently per occasion:
 
-\\[ \kappa_{ik} \sim \mathcal{N}(0, \Omega_\text{IOV}) \\]
+<div>
+\[ \kappa_{ik} \sim \mathcal{N}(0, \Omega_\text{IOV}) \]
+</div>
 
 where *i* indexes subjects and *k* indexes occasions. The IOV omega matrix Ω_IOV is estimated alongside the BSV omega.
 
@@ -109,18 +111,22 @@ See `examples/warfarin_iov.ferx` for a complete runnable example.
 
 When a model has kappa declarations and the subject has occasion labels, the inner optimizer runs `find_ebe_iov` instead of the standard `find_ebe`. It jointly optimizes over:
 
-\\[ p = [\underbrace{\eta_1, \ldots, \eta_{n_\eta}}_{\text{BSV}},\ \underbrace{\kappa_{1,1}, \ldots, \kappa_{1,n_\kappa}}_{\text{occasion 1}},\ \ldots,\ \underbrace{\kappa_{K,1}, \ldots, \kappa_{K,n_\kappa}}_{\text{occasion K}}] \\]
+<div>
+\[ p = [\underbrace{\eta_1, \ldots, \eta_{n_\eta}}_{\text{BSV}},\ \underbrace{\kappa_{1,1}, \ldots, \kappa_{1,n_\kappa}}_{\text{occasion 1}},\ \ldots,\ \underbrace{\kappa_{K,1}, \ldots, \kappa_{K,n_\kappa}}_{\text{occasion K}}] \]
+</div>
 
 The joint negative log-posterior is:
 
-\\[
+<div>
+\[
 -\log p(p \mid y_i) = \frac{1}{2}\left[
   \eta^T \Omega^{-1} \eta + \log|\Omega|
   + \sum_{k=1}^{K} \kappa_k^T \Omega_\text{IOV}^{-1} \kappa_k
   + K \log|\Omega_\text{IOV}|
   + \sum_{j} \left(\frac{(y_{ij} - f_{ij}^{(k_j)})^2}{V_{ij}} + \log V_{ij}\right)
 \right]
-\\]
+\]
+</div>
 
 where \\( k_j \\) is the occasion of observation *j* and \\( f_{ij}^{(k)} = f(\theta, \eta_i, \kappa_{ik}) \\).
 
@@ -130,23 +136,29 @@ Optimization uses BFGS; the gradient is computed by finite differences (no AD pa
 
 The IOV omega is packed after the sigma block in the optimizer vector. For Option A (diagonal Ω_IOV) only the log-diagonal entries are appended; for Option B the full Cholesky lower triangle is appended (log-diagonals plus off-diagonals as-is), mirroring the BSV omega packing:
 
-\\[
+<div>
+\[
 x = [\log\theta,\ \text{chol}(\Omega_\text{BSV}),\ \log\sigma,\ \text{chol}(\Omega_\text{IOV})]
-\\]
+\]
+</div>
 
 The per-subject FOCE objective is a *proper augmented marginal*: the per-occasion kappas are integrated out through the linearised marginal exactly like the BSV etas. The random-effect vector is \\( b = [\eta,\ \kappa_1, \ldots, \kappa_K] \\) with block-diagonal prior covariance
 
-\\[
+<div>
+\[
 \Sigma_b = \text{blockdiag}(\Omega_\text{BSV},\ \Omega_\text{IOV},\ \ldots,\ \Omega_\text{IOV})
-\\]
+\]
+</div>
 
 (*K* copies of Ω_IOV), and the H-matrix is **augmented** with kappa columns,
 \\( H_\text{full} = [\,\partial f/\partial\eta \mid \partial f/\partial\kappa_1 \mid \cdots \mid \partial f/\partial\kappa_K\,] \\). Because \\( \kappa_k \\) enters only occasion-*k*'s predictions, its columns are non-zero only on that occasion's rows. The objective is then the ordinary Sheiner–Beal form
 
-\\[
+<div>
+\[
 \text{NLL}_i = \tfrac{1}{2}\left[(y - f_0)^T \tilde{R}^{-1} (y - f_0) + \log|\tilde{R}|\right],\qquad
 \tilde{R} = H_\text{full}\,\Sigma_b\,H_\text{full}^T + R
-\\]
+\]
+</div>
 
 with no separate kappa prior added (it is already folded into \\( \tilde{R} \\)). This reduces exactly to the BSV-only FOCE objective when there are no kappas.
 

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -48,11 +48,15 @@ A CSV file with per-observation diagnostics, one row per observation per subject
 ### Residual Definitions
 
 **IWRES** (Individual Weighted Residual):
-\\[ \text{IWRES}_j = \frac{y_j - \text{IPRED}_j}{\sqrt{V_j}} \\]
+<div>
+\[ \text{IWRES}_j = \frac{y_j - \text{IPRED}_j}{\sqrt{V_j}} \]
+</div>
 where \\( V_j \\) is the residual variance evaluated at the individual prediction.
 
 **CWRES** (Conditional Weighted Residual):
-\\[ \text{CWRES}_j = \frac{y_j - f_{0,j}}{\sqrt{\tilde{R}_{jj}}} \\]
+<div>
+\[ \text{CWRES}_j = \frac{y_j - f_{0,j}}{\sqrt{\tilde{R}_{jj}}} \]
+</div>
 where \\( f_0 = f(\hat{\eta}) - H\hat{\eta} \\) is the linearized population prediction and \\( \tilde{R} = H\Omega H^T + R \\) is the conditional variance.
 
 ### Example
@@ -169,12 +173,16 @@ The following fields are populated on the `FitResult` struct returned by `fit()`
 Two shrinkage metrics are reported after every fit:
 
 **ETA shrinkage** (per random effect — `shrinkage_eta: Vec<f64>`):
-\\[ \text{shrinkage}_k = 1 - \frac{\sqrt{\frac{1}{n}\sum_i \hat{\eta}_{k,i}^2}}{\sqrt{\omega_{kk}}} \\]
+<div>
+\[ \text{shrinkage}_k = 1 - \frac{\sqrt{\frac{1}{n}\sum_i \hat{\eta}_{k,i}^2}}{\sqrt{\omega_{kk}}} \]
+</div>
 
 A value near 1 means individual EBEs are all pulled toward zero — the data are not informative about that random effect. A value near 0 means the ETAs are spread consistent with the prior omega.
 
 **EPS shrinkage** (scalar — `shrinkage_eps: f64`):
-\\[ \text{shrinkage}_\varepsilon = 1 - \sqrt{\frac{1}{n}\sum_j \text{IWRES}_j^2} \\]
+<div>
+\[ \text{shrinkage}_\varepsilon = 1 - \sqrt{\frac{1}{n}\sum_j \text{IWRES}_j^2} \]
+</div>
 
 Both formulas use the **uncentered second moment with `n` divisor**, matching the NONMEM / PsN / Monolix convention — the population model assumes `E[η]=0` and `E[IWRES²]=1`, so the natural estimator is `√(Σx²/n)` rather than the unbiased sample SD (which centers on the sample mean and divides by `n-1`). The unbiased form would inflate SD by `√(n/(n-1))` and routinely produce spurious negative shrinkage on small samples.
 
@@ -187,7 +195,9 @@ Values of `NaN` indicate a zero-variance omega component (ETA) or fewer than two
 When the model contains `kappa` or `block_kappa` declarations, two additional shrinkage metrics are computed using the same uncentered-moment convention.
 
 *Pooled* — one value per kappa parameter `j`, averaged over all `N_\text{pairs}` (subject, occasion) pairs:
-\\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_{\text{pairs}}}\sum_i \sum_{q} \hat{\kappa}_{iqj}^2}}{\sqrt{\omega_{\text{iov},jj}}} \\]
+<div>
+\[ \text{shrinkage}_{\kappa,j} = 1 - \frac{\sqrt{\frac{1}{N_{\text{pairs}}}\sum_i \sum_{q} \hat{\kappa}_{iqj}^2}}{\sqrt{\omega_{\text{iov},jj}}} \]
+</div>
 where `q` indexes occasions and `N_\text{pairs} = \sum_i K_i` (total subject-occasion pairs; equals `N_\text{subj} \cdot K` only for balanced designs).
 
 *Per-occasion slot* — the same formula restricted to occasion slot `occ_idx`, stored in `shrinkage_kappa_by_occ[occ_idx][kappa_idx]`. Only reported when two or more occasions are present. Useful for identifying sparse occasions (high shrinkage in one slot suggests that occasion has little information on kappa).
@@ -203,7 +213,9 @@ Two pooled autocorrelation diagnostics are reported after every fit:
 **`iwres_lag1_r`** — pooled lag-1 Pearson correlation of IWRES across subjects. Values near 0 indicate no serial dependence; values approaching ±1 indicate strong autocorrelation.
 
 **`dw_statistic`** — pooled Durbin-Watson statistic:
-\\[ \text{DW} = \frac{\sum_i \sum_t (e_{i,t} - e_{i,t-1})^2}{\sum_i \sum_t e_{i,t}^2} \\]
+<div>
+\[ \text{DW} = \frac{\sum_i \sum_t (e_{i,t} - e_{i,t-1})^2}{\sum_i \sum_t e_{i,t}^2} \]
+</div>
 
 | DW range | Interpretation |
 |----------|---------------|


### PR DESCRIPTION
## Why
The "Algorithm Details → Inner loop / Outer loop" equations on the IOV page rendered as broken LaTeX (reported), and the same root cause affected the SAEM, importance-sampling, and output pages.

The mdbook renders math **client-side** (`docs/mathjax-config.js`, no `mathjax-support`/preprocessor). pulldown-cmark therefore parses `_` inside equations as emphasis *before* MathJax runs. Display equations with flanking-underscore subscripts — e.g. `\underbrace{...}_{...}` pairs — got wrapped in `<em>`, so MathJax received corrupted source and rendered garbage. Equations without paired underscores rendered fine, which is why only *some* equations on a page broke.

## What changed
No new tooling, no CI change, no delimiter migration (kept literal `$INPUT`/`$PK` dollars safe):
- **Display blocks** — wrapped each `\\[ … \\]` in a raw `<div>` (pulldown-cmark passes HTML-block contents through verbatim, skipping emphasis parsing) and switched its delimiters to single-backslash `\[ … \]` (no markdown backslash-unescaping happens inside a raw HTML block). 24 blocks across 4 files.
- **Inline spans** — for the two inline equations that also mangled (`saem.md` acceptance ratio, `importance-sampling.md` ESS), escaped the paired underscores as `\_` so markdown emits a literal `_` while MathJax still reads a subscript.

## Alternatives considered
- mdbook built-in `mathjax-support = true`: tested — does **not** help (mangling is in the markdown pass, not MathJax).
- Server-side `mdbook-katex`: most robust, but needs a CI binary, book.toml preprocessor, and escaping every literal `$` in NONMEM control records (`$INPUT`/`$PK`) to avoid false math. Rejected as too invasive for a rendering bug; noted as a future option.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs only)

## Tests
- [x] No new tests needed (docs rendering; verified by build + scan below)

## Docs
- [x] `docs/src/` updated; no `docs/book/` committed (git-ignored)
- [x] No SUMMARY.md change (no new pages)
- [x] No user-facing code change → no CHANGELOG entry

## Verification
- `mdbook build` succeeds.
- Full-book scan for LaTeX leaking into `<em>` returns **zero** pages (was 5).
- Previously-broken IOV `\underbrace` equation now renders verbatim; post-equation prose intact on all touched pages.

## Reviewer hints
Skim the `<div>` wrapping (mechanical). The subtle part is the single- vs double-backslash rule: outside a raw HTML block markdown eats one backslash (so `\\[` is correct), inside a `<div>` block it does not (so `\[` is correct). Note for future equations: new display math should follow the `<div>` + single-backslash pattern, or paired-underscore subscripts will re-break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)