### PR TITLE
ci: run coverage jobs on stable toolchain to keep instrumented cache warm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,18 @@ jobs:
   survival:
     name: Survival (TTE)
     runs-on: ubuntu-latest
+    # Override the global nightly: this job builds `--features ci,survival`
+    # (autodiff OFF), so it needs no nightly-only code (`feature(autodiff)` in
+    # src/lib.rs is the crate's only nightly attr). Stable's rustc version is
+    # stable for ~6 weeks vs nightly's daily bump, so the instrumented cache
+    # (keyed on rustc version) stays warm instead of cold-rebuilding the whole
+    # dep graph under coverage RUSTFLAGS every run.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
+      - name: Install stable toolchain
+        run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -134,13 +142,17 @@ jobs:
         run: cargo fmt -- --check
 
   coverage:
-    name: Coverage (full, nightly)
+    name: Coverage (full)
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Stable, not nightly: builds `--features ci,slow-tests` (autodiff OFF) so no
+    # nightly-only code. Keeps the instrumented `ci-slow` cache warm. See survival.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
+      - name: Install stable toolchain
+        run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -180,10 +192,15 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # for the below-floor nudge comment
+    # Stable, not nightly: builds `--features ci` (autodiff OFF) so no
+    # nightly-only code. Keeps the instrumented `ci-cov` cache warm across runs
+    # (stable rustc bumps ~6-weekly vs nightly daily). See the survival job.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal -c llvm-tools-preview
+      - name: Install stable toolchain
+        run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Why
The `survival`, fast-patch (`coverage-pr`), and full (`coverage`) CI jobs run `cargo llvm-cov`. The coverage RUSTFLAGS make their build artifacts unshareable with the plain `ci` caches, so each has its own cache key (`ci-cov-survival`, `ci-cov`, `ci-slow`). Those caches are keyed on the rustc version, and the global toolchain is a **floating `nightly`** that bumps daily — so most runs missed the cache and cold-rebuilt the entire dependency graph under coverage instrumentation.

That cold rebuild *was* the cost: on a recent run the Survival job spent **301s of its 324s** in the single "Generate survival coverage report" step; every other step was ~20s combined.

## What changed
Pin the three coverage jobs to the **stable** toolchain (job-level `env: RUSTUP_TOOLCHAIN: stable`, overriding the global `nightly`), and install `stable -c llvm-tools-preview`.

None of these jobs need nightly: they build `--features ci[,survival|,slow-tests]` with **autodiff OFF**, and the crate's only nightly-only item is `#![feature(autodiff)]` (`src/lib.rs:1`), gated behind `feature = "autodiff"`. Stable's rustc version bumps ~6-weekly instead of daily, so the instrumented caches stay warm across runs.

Also renamed the `coverage` job display name "Coverage (full, nightly)" → "Coverage (full)" since it no longer uses the nightly toolchain (it's the weekly Monday-cron job). It's schedule/dispatch-only, never a PR-required check, so no branch-protection impact.

Other jobs (`check`/`test`/`clippy`/`fmt`) stay on nightly — they aren't coverage jobs and are already fast.

## Alternatives considered
- **Drop coverage from the survival PR job, gate-only.** Rejected: `codecov.yml` enforces `patch` (90% on changed lines) with `flags: [fast, survival]`, and survival-gated lines are compiled OUT of the `fast` build — without the `survival` coverage upload, a survival PR's own new lines read as uncovered → patch goes red. The coverage build is load-bearing per-PR.
- **Pin a dated nightly** (`nightly-YYYY-MM-DD`). Stabilizes the cache key too, but stable removes the daily churn entirely with no nightly-only need here.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CI only)

## Performance
- [x] Faster — Survival job's coverage step `~301s` (cold nightly rebuild) → expected `~30s` on a warm stable cache. First post-merge run is cold (new stable cache); benefit lands run 2+.

## Tests
- [x] No new tests needed (CI-config change). Verified locally that `cargo +stable check --tests --no-default-features --features ci,survival` and `--features ci,slow-tests` both compile (stable 1.95.0).

## Docs
- [x] No user-visible change ( `CHANGELOG.md` N/A — CI only, per CLAUDE.md).

## Checklist
- [x] `cargo clippy` clean (unaffected — no source change)
- [x] `cargo check --features autodiff` still compiles (no AD-reachable code touched)

## Reviewer hints
The load-bearing claim is "these jobs need no nightly": confirm `src/lib.rs:1` is the only `#![feature(...)]` and it's `autodiff`-gated, and that all three jobs build `--no-default-features --features ci*`. Real proof of the speedup is CI itself over the next couple of runs (warm cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)