### PR TITLE
fix(api): silence spurious unused-option warning for covariance-family keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- The covariance-family fit options `covariance_method`, `covariance_fallback`,
+  and `covariance_ofv_hessian` no longer emit a spurious "is not used by method
+  `<method>` and will be ignored" warning. They are framework-wide covariance-step
+  options (honoured for every estimator) but were missing from the warning's
+  allowlist; the options were always applied — only the warning was wrong.
 - A missing `DV` (`.`/`NA`/blank) on an `EVID=0` observation row without `MDV=1`
   is no longer silently scored as `DV=0`. Such rows are now treated as `MDV=1`
   (skipped) and a single `W_MISSING_DV` warning reports how many rows were

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -10627,7 +10627,12 @@ mod tests {
         for method in ["foce", "focei", "gn", "gn_hybrid", "saem"] {
             let opts = parse_fit_options(&[
                 format!("method = {method}"),
-                "covariance = false".to_string(),
+                "covariance = true".to_string(),
+                // The whole covariance family is framework-wide — none of these
+                // are method-specific, so none must warn under any method.
+                "covariance_method = s".to_string(),
+                "covariance_fallback = sir".to_string(),
+                "covariance_ofv_hessian = true".to_string(),
                 "verbose = false".to_string(),
                 "sir = true".to_string(),
                 "bloq_method = m3".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3154,6 +3154,9 @@ impl FitOptions {
 pub fn framework_keys() -> &'static [&'static str] {
     &[
         "covariance",
+        "covariance_method",
+        "covariance_fallback",
+        "covariance_ofv_hessian",
         "fd_hessian_step",
         "verbose",
         "sir",


### PR DESCRIPTION
## Why
Setting `covariance_method` (or `covariance_fallback` / `covariance_ofv_hessian`)
under FOCEI/FOCE produced a misleading warning:

```
fit option `covariance_method` is not used by method `FOCEI` and will be ignored.
```

The warning is wrong: these are framework-wide covariance-**step** options,
honoured by every estimator in `outer_optimizer.rs` (e.g.
`combine_covariance(options.covariance_method, …)`). The option was always
applied — only the warning was spurious. It misled users into thinking their
requested covariance estimator (`s`/`rsr`) was being silently dropped.

Root cause: `FitOptions::unsupported_keys_warnings()` checks each user-set key
against `framework_keys()` ∪ `method_specific_keys(method)`. The covariance
family parses four keys (`covariance`, `covariance_fallback`, `covariance_method`,
`covariance_ofv_hessian`) but only `covariance` was in `framework_keys()`, so the
other three triggered the false "unused option" warning. `covariance_method`
dates to #223; `covariance_ofv_hessian` was added in #335.

## What changed
- Added `covariance_method`, `covariance_fallback`, and `covariance_ofv_hessian`
  to `framework_keys()` in `src/types.rs`.
- Extended `test_common_keys_never_warn` to exercise the whole covariance family
  under every method — this fails against the old allowlist (regression guard).

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (warning-text only; covariance numerics unchanged — the
  option was already honoured)

End-to-end confirmation on a FOCEI + `covariance_method = rsr` warfarin run:
the covariance step succeeds and the warnings block no longer contains any
"is not used by method" line (`grep -c` = 0).

## Performance
- [x] No significant impact expected

## Tests
- [x] Regression test added that fails without this fix (`test_common_keys_never_warn`)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added

## Reviewer hints
The fix is a one-line allowlist addition; the substance is confirming these
three keys are genuinely method-agnostic (they are — all consumed in the
covariance assembly in `outer_optimizer.rs`, not in any method-specific path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)