### PR TITLE
refactor(ode): single RHS-wrapper seam + per-segment prepare() hoist [closes #353]

### DIFF
--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -8,6 +8,7 @@
 //! derivative for the duration of the infusion via an RHS wrapper.
 
 use crate::ode::solver::{solve_ode, OdeSolverOptions};
+use crate::pk::absorption::PreparedInputRate;
 use crate::types::{DoseEvent, PkParams, Subject, PK_IDX_F, PK_IDX_LAGTIME};
 use std::collections::HashMap;
 
@@ -269,38 +270,95 @@ pub(crate) fn input_rate_consumes_cmt(ode: &OdeSpec, cmt_1based: usize) -> bool 
             .any(|f| f.cmt == cmt_1based.saturating_sub(1))
 }
 
-/// Add every built-in absorption input-rate forcing into `dy` at integration
-/// time `t`. For each forcing, sums `R_in(tad)` over all doses targeting its
-/// compartment (Savic superposition), with `tad = t − (dose.time + lag)` and
-/// dose mass `F·amt`. `R_in = 0` for `tad ≤ 0`, so future doses contribute
-/// nothing. `reset_floor` turns off doses delivered before the most recent
-/// EVID=3/4 reset, mirroring [`active_infusions`]. This is the input-rate
-/// analogue of the `+rate` infusion injection in the wrapped RHS.
+/// How a segment's infusions are injected as a `+rate` derivative term in the
+/// wrapped RHS. The two shapes mirror how the two families of ODE paths break
+/// their timelines:
 ///
-/// The shape parameters come from `params` (the current segment's snapshot), so
-/// with IOV every superposed dose's tail uses the *current* occasion's `n`/`mtt`.
-/// This is exact for IIV and when `II` exceeds the absorption window; only
-/// overlapping-occasion tails are approximated.
+/// - [`InfusionInput::Spanning`]: a constant `(cmt_idx, rate)` list added on
+///   every RHS evaluation. The prediction paths split the timeline at every
+///   dose/infusion-end, so within a segment each active infusion spans the whole
+///   interval — see [`active_infusions`].
+/// - [`InfusionInput::Gated`]: `(cmt_idx, rate, t_start, t_end)` tuples, each
+///   active only for `t ∈ [t_start − ε, t_end + ε)`. The dense/simulate paths do
+///   **not** split at infusion edges, so an infusion can start or end inside a
+///   segment and must be gated on the integration time.
+///
+/// In both cases `rate` already folds in bioavailability (`F·RATE`).
+enum InfusionInput {
+    Spanning(Vec<(usize, f64)>),
+    Gated(Vec<(usize, f64, f64, f64)>),
+}
+
+/// Resolve the dense-path infusion list (`(dose_idx, t_start, t_end)`) into the
+/// `(cmt_idx, F·rate, t_start, t_end)` tuples the seam's [`InfusionInput::Gated`]
+/// branch injects. Doses with `CMT=0` (no compartment) or a compartment beyond
+/// the state vector are dropped — the same guard the dense paths applied per RHS
+/// evaluation before the seam, lifted out to once per segment.
+fn gated_infusions(
+    active: &[(usize, f64, f64)],
+    doses: &[DoseEvent],
+    dose_f_bio: &[f64],
+    n_states: usize,
+) -> Vec<(usize, f64, f64, f64)> {
+    active
+        .iter()
+        .filter_map(|&(di, t_start_inf, t_end_inf)| {
+            let dose = &doses[di];
+            // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
+            if dose.cmt == 0 {
+                return None;
+            }
+            let cmt = dose.cmt - 1;
+            if cmt >= n_states {
+                return None;
+            }
+            Some((cmt, dose.rate * dose_f_bio[di], t_start_inf, t_end_inf))
+        })
+        .collect()
+}
+
+/// Precompute the per-forcing dose-invariant constants (ln Γ, KTR, ln KTR) for
+/// the segment's PK snapshot `params`, parallel to `ode.input_rate` (#322 #7).
+///
+/// Built **once per segment** and reused across every RK45 stage / step inside
+/// the seam, instead of re-running [`InputRateForcing::prepare`] on each RHS
+/// evaluation. `params` (the segment's `ext_params` snapshot) is constant for
+/// the whole segment, so this is an exact hoist. Returns an empty (non-allocating)
+/// vec when the model has no built-in input-rate forcings.
+fn prepare_input_rates(ode: &OdeSpec, params: &[f64]) -> Vec<PreparedInputRate> {
+    ode.input_rate.iter().map(|f| f.prepare(params)).collect()
+}
+
+/// Add every built-in absorption input-rate forcing into `dy` at integration
+/// time `t`, using the per-segment-hoisted `prepared` constants. For each
+/// forcing, sums `R_in(tad)` over all doses targeting its compartment (Savic
+/// superposition), with `tad = t − (dose.time + lag)` and dose mass `F·amt`.
+/// `R_in = 0` for `tad ≤ 0`, so future doses contribute nothing. `reset_floor`
+/// turns off doses delivered before the most recent EVID=3/4 reset, mirroring
+/// [`active_infusions`]. This is the input-rate analogue of the `+rate` infusion
+/// injection in the wrapped RHS.
+///
+/// `prepared` is parallel to `ode.input_rate` (built by [`prepare_input_rates`]
+/// from the current segment's snapshot), so with IOV every superposed dose's
+/// tail uses the *current* occasion's `n`/`mtt`. This is exact for IIV and when
+/// `II` exceeds the absorption window; only overlapping-occasion tails are
+/// approximated.
 #[inline]
 #[allow(clippy::too_many_arguments)] // mirrors the dose context threaded into the RHS wrappers
-fn add_input_rate_forcing(
+fn add_prepared_input_rate_forcing(
     ode: &OdeSpec,
+    prepared: &[PreparedInputRate],
     doses: &[DoseEvent],
     dose_lagtimes: &[f64],
     dose_f_bio: &[f64],
     reset_floor: f64,
-    params: &[f64],
     t: f64,
     dy: &mut [f64],
 ) {
-    for forcing in &ode.input_rate {
+    for (forcing, prep) in ode.input_rate.iter().zip(prepared) {
         if forcing.cmt >= dy.len() {
             continue;
         }
-        // Precompute the dose-invariant constants (ln Γ, KTR, …) once per forcing
-        // — not once per dose — so the superposition loop below does only the
-        // tad/dose-dependent arithmetic.
-        let prepared = forcing.prepare(params);
         let mut acc = 0.0;
         for (k, d) in doses.iter().enumerate() {
             if d.cmt.saturating_sub(1) != forcing.cmt {
@@ -318,9 +376,72 @@ fn add_input_rate_forcing(
                 continue;
             }
             let dose_mass = dose_f_bio.get(k).copied().unwrap_or(1.0) * d.amt;
-            acc += prepared.rate(tad, dose_mass);
+            acc += prep.rate(tad, dose_mass);
         }
         dy[forcing.cmt] += acc;
+    }
+}
+
+/// The single seam that wraps a model's user RHS with the two dose-driven
+/// forcing terms shared by **all** ODE integration paths: the infusion `+rate`
+/// injection and the built-in absorption input-rate forcing (`R_in`,
+/// transit/etc.).
+///
+/// Before this seam each path hand-copied `(ode.rhs)(…)` + the infusion loop +
+/// `add_input_rate_forcing(…)` into its own closure; a new path or absorption
+/// model had to replicate it in every one, and an omission silently dropped the
+/// forcing (#322 #6). Routing every path through here removes the copy-paste.
+///
+/// `reset_floor` is threaded per call and **intentionally differs** by path: the
+/// two non-reset paths (`ode_predictions`, `ode_predictions_with_states`) pass
+/// `f64::NEG_INFINITY` because the dispatcher routes reset subjects to the
+/// event-driven walker; the two reset-aware paths pass a real floor. `prepared`
+/// is the per-segment hoist from [`prepare_input_rates`].
+fn wrap_rhs_with_forcings<'a>(
+    ode: &'a OdeSpec,
+    doses: &'a [DoseEvent],
+    dose_lagtimes: &'a [f64],
+    dose_f_bio: &'a [f64],
+    reset_floor: f64,
+    prepared: &'a [PreparedInputRate],
+    infusions: InfusionInput,
+) -> impl Fn(&[f64], &[f64], f64, &mut [f64]) + 'a {
+    move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
+        (ode.rhs)(y, p, t, dy);
+        match &infusions {
+            InfusionInput::Spanning(active) => {
+                for &(cmt_idx, rate) in active {
+                    if cmt_idx < dy.len() {
+                        dy[cmt_idx] += rate;
+                    }
+                }
+            }
+            InfusionInput::Gated(active) => {
+                for &(cmt_idx, rate, t_start_inf, t_end_inf) in active {
+                    // +ε on the upper bound (not −ε) so the infusion is active
+                    // right up to t_end_inf — the dynamic gate must not cut off
+                    // the last sub-step.
+                    if t >= t_start_inf - INFUSION_EPS
+                        && t < t_end_inf + INFUSION_EPS
+                        && cmt_idx < dy.len()
+                    {
+                        dy[cmt_idx] += rate;
+                    }
+                }
+            }
+        }
+        if !prepared.is_empty() {
+            add_prepared_input_rate_forcing(
+                ode,
+                prepared,
+                doses,
+                dose_lagtimes,
+                dose_f_bio,
+                reset_floor,
+                t,
+                dy,
+            );
+        }
     }
 }
 
@@ -671,29 +792,18 @@ pub fn ode_predictions(
             &dose_f_bio,
             f64::NEG_INFINITY,
         );
-        let wrapped_rhs = |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
-            (ode.rhs)(y, p, t, dy);
-            for &(cmt_idx, rate) in &active {
-                if cmt_idx < dy.len() {
-                    dy[cmt_idx] += rate;
-                }
-            }
-            // Built-in absorption input-rate forcing (transit/etc.): adds
-            // R_in(tad) into its compartment, superposed over doses. No resets
-            // on the plain path (those route to the event-driven walker).
-            if !ode.input_rate.is_empty() {
-                add_input_rate_forcing(
-                    ode,
-                    &subject.doses,
-                    &dose_lagtimes,
-                    &dose_f_bio,
-                    f64::NEG_INFINITY,
-                    p,
-                    t,
-                    dy,
-                );
-            }
-        };
+        // Hoist the input-rate constants (ln Γ, KTR, …) once per segment; the PK
+        // snapshot `ext_params` is constant across the integration (#322 #7).
+        let prepared = prepare_input_rates(ode, &ext_params);
+        let wrapped_rhs = wrap_rhs_with_forcings(
+            ode,
+            &subject.doses,
+            &dose_lagtimes,
+            &dose_f_bio,
+            f64::NEG_INFINITY,
+            &prepared,
+            InfusionInput::Spanning(active),
+        );
         let sol = solve_ode(
             &wrapped_rhs,
             &u,
@@ -954,29 +1064,18 @@ pub fn ode_predictions_event_driven(
                 &dose_f_bio,
                 reset_floor,
             );
-            let wrapped_rhs = |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
-                (ode.rhs)(y, p, t, dy);
-                for &(cmt_idx, rate) in &active {
-                    if cmt_idx < dy.len() {
-                        dy[cmt_idx] += rate;
-                    }
-                }
-                // Built-in absorption input-rate forcing (transit/etc.): adds
-                // R_in(tad) into its compartment, superposed over doses. Doses
-                // before `reset_floor` (the most recent EVID=3/4) are off.
-                if !ode.input_rate.is_empty() {
-                    add_input_rate_forcing(
-                        ode,
-                        &subject.doses,
-                        &dose_lagtimes,
-                        &dose_f_bio,
-                        reset_floor,
-                        p,
-                        t,
-                        dy,
-                    );
-                }
-            };
+            // Hoist the input-rate constants once per segment (#322 #7); the
+            // segment PK snapshot `ext_params_ed` is constant for the integration.
+            let prepared = prepare_input_rates(ode, &ext_params_ed);
+            let wrapped_rhs = wrap_rhs_with_forcings(
+                ode,
+                &subject.doses,
+                &dose_lagtimes,
+                &dose_f_bio,
+                reset_floor,
+                &prepared,
+                InfusionInput::Spanning(active),
+            );
             let saveat = vec![t_event];
             let sol = solve_ode(
                 &wrapped_rhs,
@@ -1362,47 +1461,20 @@ pub fn ode_predictions_with_states(
         };
 
         active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
-        let current_infusions = active_infusions.clone();
-
-        let wrapped_rhs = {
-            let infusions = current_infusions.clone();
-            let f_bio_snap = dose_f_bio.clone();
-            let lag_snap = dose_lagtimes.clone();
-            move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
-                (ode.rhs)(y, p, t, dy);
-                for &(di, t_start_inf, t_end_inf) in &infusions {
-                    // Use +1e-12 on the upper bound (not -1e-12) so the infusion
-                    // is active right up to t_end_inf. The reference ode_predictions
-                    // applies the rate for the whole segment via active_infusions;
-                    // the dynamic gate here must not cut off the last sub-step.
-                    if t >= t_start_inf - 1e-12 && t < t_end_inf + 1e-12 {
-                        let dose = &subject.doses[di];
-                        let f = f_bio_snap[di];
-                        // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
-                        if dose.cmt > 0 {
-                            let cmt = dose.cmt - 1;
-                            if cmt < n {
-                                dy[cmt] += dose.rate * f;
-                            }
-                        }
-                    }
-                }
-                // Built-in absorption input-rate forcing (transit/etc.):
-                // R_in(tad) superposed over doses. No resets on this path.
-                if !ode.input_rate.is_empty() {
-                    add_input_rate_forcing(
-                        ode,
-                        &subject.doses,
-                        &lag_snap,
-                        &f_bio_snap,
-                        f64::NEG_INFINITY,
-                        p,
-                        t,
-                        dy,
-                    );
-                }
-            }
-        };
+        // Resolve each active infusion to (cmt_idx, F·rate, t_start, t_end) for
+        // the time-gated injection inside the seam (CMT=0 / out-of-range dropped).
+        let gated = gated_infusions(&active_infusions, &subject.doses, &dose_f_bio, n);
+        // Hoist the input-rate constants once per segment (#322 #7).
+        let prepared = prepare_input_rates(ode, &ext_params);
+        let wrapped_rhs = wrap_rhs_with_forcings(
+            ode,
+            &subject.doses,
+            &dose_lagtimes,
+            &dose_f_bio,
+            f64::NEG_INFINITY,
+            &prepared,
+            InfusionInput::Gated(gated),
+        );
 
         let sol = solve_ode(
             &wrapped_rhs,
@@ -1682,7 +1754,9 @@ pub fn ode_dense_solve_states(
         };
 
         active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
-        let current_infusions = active_infusions.clone();
+        // Resolve to (cmt_idx, F·rate, t_start, t_end) for the seam's time-gated
+        // injection (CMT=0 / out-of-range dropped).
+        let gated = gated_infusions(&active_infusions, &subject.doses, &dose_f_bio, n);
 
         // Doses delivered before the most recent reset (EVID=3/4) at or before
         // this segment are off for the input-rate forcing — mirroring how the
@@ -1694,44 +1768,17 @@ pub fn ode_dense_solve_states(
             .filter(|&rt| rt <= t_start + 1e-12)
             .fold(f64::NEG_INFINITY, f64::max);
 
-        let wrapped_rhs = {
-            let infusions = current_infusions.clone();
-            let f_bio_snap = dose_f_bio.clone();
-            let lag_snap = dose_lagtimes.clone();
-            move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
-                (ode.rhs)(y, p, t, dy);
-                for &(di, t_start_inf, t_end_inf) in &infusions {
-                    // Use +1e-12 on the upper bound — same fix as applied to
-                    // ode_predictions_with_states — so the infusion is active
-                    // right up to t_end_inf rather than cutting off 1e-12 early.
-                    if t >= t_start_inf - 1e-12 && t < t_end_inf + 1e-12 {
-                        let dose = &subject.doses[di];
-                        let f = f_bio_snap[di];
-                        // dose.cmt is 1-based; CMT=0 means no compartment — ignore.
-                        if dose.cmt > 0 {
-                            let cmt = dose.cmt - 1;
-                            if cmt < n {
-                                dy[cmt] += dose.rate * f;
-                            }
-                        }
-                    }
-                }
-                // Built-in absorption input-rate forcing (transit/etc.):
-                // R_in(tad) superposed over doses, off before `reset_floor`.
-                if !ode.input_rate.is_empty() {
-                    add_input_rate_forcing(
-                        ode,
-                        &subject.doses,
-                        &lag_snap,
-                        &f_bio_snap,
-                        reset_floor,
-                        p,
-                        t,
-                        dy,
-                    );
-                }
-            }
-        };
+        // Hoist the input-rate constants once per segment (#322 #7).
+        let prepared = prepare_input_rates(ode, &ext_params);
+        let wrapped_rhs = wrap_rhs_with_forcings(
+            ode,
+            &subject.doses,
+            &dose_lagtimes,
+            &dose_f_bio,
+            reset_floor,
+            &prepared,
+            InfusionInput::Gated(gated),
+        );
 
         let sol = solve_ode(
             &wrapped_rhs,
@@ -2000,6 +2047,156 @@ mod tests {
         let subj = make_subject(doses, vec![40.0]);
         let states = ode_dense_solve_states(&ode, &pk, &[], &[], &subj, &[40.0]);
         assert_relative_eq!(states[0][0], 100.0, max_relative = 5e-3);
+    }
+
+    // ── Forcing-seam helpers (#353): the single RHS-wrapper seam + per-segment
+    //    prepare() hoist shared by all four ODE integration paths. ────────────
+
+    #[test]
+    fn prepare_input_rates_parallel_to_forcings_and_empty_without_them() {
+        // Parallel to `ode.input_rate`; empty (non-allocating) when the model has
+        // no built-in input-rate forcing.
+        let ode = transit_accumulator_spec();
+        let params = pk_transit_vec(3.0, 2.0, 1.0);
+        let prepared = prepare_input_rates(&ode, &params);
+        assert_eq!(prepared.len(), 1);
+        // The hoisted constant must match a direct `prepare` on the same params —
+        // the invariant that keeps the #7 hoist from drifting from the per-eval form.
+        assert_eq!(
+            prepared[0].rate(2.5, 100.0),
+            ode.input_rate[0].prepare(&params).rate(2.5, 100.0)
+        );
+        assert!(prepare_input_rates(&one_cpt_ode_spec(), &params).is_empty());
+    }
+
+    #[test]
+    fn gated_infusions_resolves_rate_and_drops_unaddressable() {
+        // (dose_idx, t_start, t_end) → (cmt_idx, F·rate, t_start, t_end); a CMT=0
+        // dose and a compartment beyond the state vector are dropped.
+        let doses = vec![
+            DoseEvent::new(0.0, 0.0, 1, 4.0, false, 0.0), // CMT 1 → state 0
+            DoseEvent::new(0.0, 0.0, 0, 9.0, false, 0.0), // CMT 0 → dropped
+            DoseEvent::new(0.0, 0.0, 5, 9.0, false, 0.0), // CMT 5 → state 4 ≥ n → dropped
+        ];
+        let f_bio = vec![0.5, 1.0, 1.0];
+        let active = vec![(0usize, 1.0, 3.0), (1, 1.0, 3.0), (2, 1.0, 3.0)];
+        let gated = gated_infusions(&active, &doses, &f_bio, 1);
+        assert_eq!(gated, vec![(0usize, 4.0 * 0.5, 1.0, 3.0)]);
+    }
+
+    #[test]
+    fn add_prepared_forcing_superposes_skips_other_cmt_and_respects_floor() {
+        let ode = transit_accumulator_spec(); // forcing on state 0 ≡ CMT 1
+        let params = pk_transit_vec(3.0, 2.0, 1.0);
+        let prepared = prepare_input_rates(&ode, &params);
+        let doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0), // feeds R_in
+            DoseEvent::new(0.0, 50.0, 2, 0.0, false, 0.0),  // other cmt → ignored
+        ];
+        let lags = vec![0.0, 0.0];
+        let f_bio = vec![1.0, 1.0];
+        let t = 1.5;
+
+        // No reset: only the CMT-1 dose contributes its R_in(tad).
+        let mut dy = vec![0.0];
+        add_prepared_input_rate_forcing(
+            &ode,
+            &prepared,
+            &doses,
+            &lags,
+            &f_bio,
+            f64::NEG_INFINITY,
+            t,
+            &mut dy,
+        );
+        let want = prepared[0].rate(t, 100.0);
+        assert!(want > 0.0);
+        assert_relative_eq!(dy[0], want, max_relative = 1e-12);
+
+        // A reset_floor after the dose time turns its forcing off.
+        let mut dy_off = vec![0.0];
+        add_prepared_input_rate_forcing(
+            &ode,
+            &prepared,
+            &doses,
+            &lags,
+            &f_bio,
+            1.0,
+            t,
+            &mut dy_off,
+        );
+        assert_eq!(dy_off[0], 0.0);
+    }
+
+    #[test]
+    fn seam_spanning_adds_base_rhs_and_infusion() {
+        // Spanning infusion is added unconditionally on top of the user RHS; with
+        // no input_rate forcing the forcing branch is skipped.
+        let ode = one_cpt_ode_spec();
+        let params = pk_one(1.0, 1.0).values; // ke = cl/v = 1
+        let prepared: Vec<PreparedInputRate> = Vec::new();
+        let rhs = wrap_rhs_with_forcings(
+            &ode,
+            &[],
+            &[],
+            &[],
+            f64::NEG_INFINITY,
+            &prepared,
+            InfusionInput::Spanning(vec![(0, 7.0)]),
+        );
+        let mut dy = vec![0.0];
+        rhs(&[2.0], &params, 0.0, &mut dy); // base −ke·y = −2, +7 infusion = 5
+        assert_relative_eq!(dy[0], 5.0, max_relative = 1e-12);
+    }
+
+    #[test]
+    fn seam_gated_infusion_active_only_inside_window() {
+        let ode = one_cpt_ode_spec();
+        let params = pk_one(0.0, 1.0).values; // ke = 0 ⇒ base RHS = 0
+        let prepared: Vec<PreparedInputRate> = Vec::new();
+        let rhs = wrap_rhs_with_forcings(
+            &ode,
+            &[],
+            &[],
+            &[],
+            f64::NEG_INFINITY,
+            &prepared,
+            InfusionInput::Gated(vec![(0, 3.0, 2.0, 5.0)]),
+        );
+        let mut before = vec![0.0];
+        rhs(&[0.0], &params, 1.0, &mut before); // before [2,5)
+        assert_eq!(before[0], 0.0);
+        let mut inside = vec![0.0];
+        rhs(&[0.0], &params, 3.0, &mut inside); // inside
+        assert_relative_eq!(inside[0], 3.0, max_relative = 1e-12);
+        let mut after = vec![0.0];
+        rhs(&[0.0], &params, 6.0, &mut after); // past t_end
+        assert_eq!(after[0], 0.0);
+    }
+
+    #[test]
+    fn seam_applies_input_rate_forcing_on_top_of_base_rhs() {
+        // With an input_rate forcing and no infusions, the seam adds R_in(tad)
+        // into the forcing compartment — matching the hoisted prepared constant.
+        let ode = transit_accumulator_spec(); // rhs sets dy[0] = 0
+        let params = pk_transit_vec(3.0, 2.0, 1.0);
+        let prepared = prepare_input_rates(&ode, &params);
+        let doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        let lags = vec![0.0];
+        let f_bio = vec![1.0];
+        let rhs = wrap_rhs_with_forcings(
+            &ode,
+            &doses,
+            &lags,
+            &f_bio,
+            f64::NEG_INFINITY,
+            &prepared,
+            InfusionInput::Spanning(Vec::new()),
+        );
+        let t = 1.5;
+        let mut dy = vec![0.0];
+        rhs(&[0.0], &params, t, &mut dy);
+        assert_relative_eq!(dy[0], prepared[0].rate(t, 100.0), max_relative = 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Why
Follow-up from the #343 review (roninsightrx findings #6 + #7), tracked in #353. Both are cleanup/perf on the same surface — the four ODE integration paths in `src/ode/predictions.rs` — and were deferred from #343 to keep that PR's diff focused on correctness fixes.

- **#6** — `if !ode.input_rate.is_empty() { add_input_rate_forcing(...) }` plus the infusion `+rate` injection was hand-copied into four `wrapped_rhs` closures. A fifth path or a new absorption model had to replicate it in every one; an omission would silently drop the forcing.
- **#7** — `add_input_rate_forcing` called `forcing.prepare(params)` (ln Γ, KTR, ln KTR) on every RHS evaluation, though `params` (the segment PK snapshot) is constant for the whole segment (~7 RK45 stages × many steps × subjects × iterations).

## What changed
- **One seam.** New `wrap_rhs_with_forcings(...)` wraps the user RHS with both dose-driven terms — the infusion `+rate` and the input-rate forcing — and is the single closure all four paths now route through (`ode_predictions`, `ode_predictions_event_driven`, `ode_predictions_with_states`, `ode_dense_solve_states`).
- **`InfusionInput` enum** captures the two genuinely-different infusion shapes the paths use: `Spanning((cmt, rate))` for the prediction paths (timeline pre-split at infusion edges → segment-wide constant) and `Gated((cmt, rate, t_start, t_end))` for the dense/simulate paths (no edge split → time-windowed per RK step). A small `gated_infusions` helper resolves the dense paths' `(dose_idx, t_start, t_end)` list into the gated tuples (CMT=0 / out-of-range dropped) once per segment instead of per RHS eval.
- **`reset_floor` skew preserved exactly.** The two non-reset paths pass `f64::NEG_INFINITY` (the dispatcher routes reset subjects to the event-driven walker); the two reset-aware paths pass a real floor. This is correct by design (per the #353 note) and unchanged.
- **prepare() hoist.** New `prepare_input_rates(ode, params)` builds the `Vec<PreparedInputRate>` once per segment from the segment's `ext_params` snapshot and passes it into the seam; `add_input_rate_forcing` becomes `add_prepared_input_rate_forcing` taking the prepared constants. Exact hoist — the snapshot is constant across the integration.

## Alternatives considered
The issue's suggested signature took a single `active_infusions` list, which fits the two prediction paths but not the dense/simulate paths' time-gated injection. The `InfusionInput` enum unifies both without forcing the dense paths back onto a coarser segment split.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

All touched items are private (`fn` / private `enum`); no `pub` API diff, so no `ferx-r` pin bump.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (refactor — no numerical results change). Behavior is pinned by the existing `tests/transit_absorption.rs` integration tests (all 4 paths via the public API) and the `transit_forcing_*` unit tests, all green.

## Performance
- [x] Faster — `prepare()` (ln Γ via Lanczos, plus KTR/ln KTR) now runs once per segment instead of once per RHS evaluation for transit models. Modest (the per-dose `rate()` ln/exp dominates), no benchmark harness; free once the seam exists.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 1070 passed)
- [x] No new behavior to regress-test beyond the existing integration coverage; new unit tests pin the extracted helpers directly: `prepare_input_rates` (parallel + empty), `gated_infusions` (resolve + drop unaddressable), `add_prepared_input_rate_forcing` (superpose / skip other cmt / reset cutoff), and the seam's `Spanning`/`Gated` injection + forcing-on-top, including a hoist-equals-inline-`prepare` invariant.

## Docs
- [x] No user-visible change (CHANGELOG N/A — internal refactor/perf)

## Checklist
- [x] `cargo clippy` clean (no new warnings from this diff; pre-existing `too_many_arguments`/`type_complexity` elsewhere unchanged)
- [x] `cargo check --features autodiff` — N/A locally (Enzyme CI), but the ODE forcing path is FD-only and AD-unreachable; no AD-instrumented code touched

## Reviewer hints
- The four call-site hunks are mechanical: delete the inline closure, add `let prepared = prepare_input_rates(ode, &ext_params…)` + a `wrap_rhs_with_forcings(...)` call with the right `InfusionInput` variant and `reset_floor`.
- Worth a look: `gated_infusions` reproduces the dense paths' old per-eval `cmt>0 && cmt<n` guard; the `+ε` upper-bound gate in the seam's `Gated` branch matches the original `t < t_end_inf + 1e-12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)