### PR TITLE
refactor(estimation): dedup IMPMAP/SAEM EM scaffolding + cut hot-loop allocs [closes #273]

### DIFF
--- a/src/estimation/em_common.rs
+++ b/src/estimation/em_common.rs
@@ -1,0 +1,176 @@
+//! Helpers shared by the EM-family estimators (SAEM and IMPMAP).
+//!
+//! Both run a Monte-Carlo EM loop with the same Ω M-step invariants and the
+//! same log-mu-referencing closed-form θ shift, so the leaf helpers that encode
+//! those invariants live here and are used from both [`saem`](super::saem) and
+//! [`impmap`](super::impmap). Keeping a single copy means a fix to the Ω-floor
+//! rule or the mu-ref-pair selection cannot silently diverge between the two
+//! estimators (which is exactly how the IMPMAP duplicates were introduced).
+
+use crate::types::CompiledModel;
+use nalgebra::DMatrix;
+
+/// Positive-definite floor for free BSV Ω diagonals in the M-step.
+///
+/// Larger than the IOV floor (1e-8) because the SAEM BSV MH proposal scale is
+/// `step_scale · chol(Ω)`: if a diagonal is allowed near zero the proposal for
+/// that η collapses and the chain can no longer move it, so Ω must stay large
+/// enough to keep the random walk alive. 1e-6 keeps a free η explorable while
+/// being far below any plausible estimated variance. IMPMAP reuses the same
+/// floor to keep its IS proposal `Σᵢ = Hᵢ⁻¹` (and the prior Ω⁻¹) well-conditioned.
+pub(crate) const OMEGA_DIAG_FLOOR: f64 = 1e-6;
+
+/// Raise every *free* diagonal entry of the BSV Ω that has fallen below `floor`
+/// up to `floor`. FIX-ed diagonals (`omega_fixed[i] == true`) are left untouched
+/// — they carry the user's declared variance and must not be perturbed. Missing
+/// `omega_fixed` entries (slice shorter than the matrix) default to free.
+pub(crate) fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
+    for i in 0..omega_mat.nrows() {
+        let fixed = omega_fixed.get(i).copied().unwrap_or(false);
+        if !fixed && omega_mat[(i, i)] < floor {
+            omega_mat[(i, i)] = floor;
+        }
+    }
+}
+
+/// Log-transformed mu-referencing pairs `(theta_idx, eta_idx)`.
+///
+/// Only `log_transformed = true` mu-refs (patterns `THETA*exp(ETA)` and
+/// `exp(log(THETA)+ETA)`) are returned. For these the typical value satisfies
+/// `log(P_i) = log(θ) + η_i`, so the EM M-step can shift `log(θ) += mean(η)` in
+/// closed form (the chain rule gives `d/d_log(theta) = -Σᵢ d/d_eta`). Additive
+/// mu-refs (`THETA + ETA`, `log_transformed = false`) require the extra factor
+/// of `theta` from the log-space chain rule and are deliberately excluded — they
+/// fall through to the regular NLopt M-step.
+pub(crate) fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
+    let mut pairs = Vec::new();
+    for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
+        if let Some(mu_ref) = model.mu_refs.get(eta_name) {
+            if !mu_ref.log_transformed {
+                continue;
+            }
+            if let Some(theta_idx) = model
+                .theta_names
+                .iter()
+                .position(|n| n == &mu_ref.theta_name)
+            {
+                pairs.push((theta_idx, eta_idx));
+            }
+        }
+    }
+    pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::test_helpers::analytical_model;
+    use crate::types::{GradientMethod, MuRef};
+
+    fn model_with_mu_refs(
+        theta_names: &[&str],
+        eta_names: &[&str],
+        mu_refs: &[(&str, &str, bool)],
+    ) -> CompiledModel {
+        let mut m = analytical_model(GradientMethod::Auto);
+        m.theta_names = theta_names.iter().map(|s| (*s).to_string()).collect();
+        m.eta_names = eta_names.iter().map(|s| (*s).to_string()).collect();
+        m.n_theta = theta_names.len();
+        m.n_eta = eta_names.len();
+        m.mu_refs = mu_refs
+            .iter()
+            .map(|(eta, theta, log_t)| {
+                (
+                    (*eta).to_string(),
+                    MuRef {
+                        theta_name: (*theta).to_string(),
+                        log_transformed: *log_t,
+                    },
+                )
+            })
+            .collect();
+        m
+    }
+
+    #[test]
+    fn floor_omega_diagonal_floors_free_entries_only() {
+        // Three etas: a free near-zero diagonal (should be floored), a free
+        // healthy diagonal (untouched), and a FIX-ed near-zero diagonal (kept).
+        let mut omega = DMatrix::<f64>::zeros(3, 3);
+        omega[(0, 0)] = 1e-9; // free, below floor → raised
+        omega[(1, 1)] = 0.2; // free, above floor → unchanged
+        omega[(2, 2)] = 1e-9; // FIX-ed, below floor → preserved
+                              // an off-diagonal that must not be touched by the diagonal floor
+        omega[(0, 1)] = 0.01;
+        omega[(1, 0)] = 0.01;
+
+        let omega_fixed = vec![false, false, true];
+        floor_omega_diagonal(&mut omega, &omega_fixed, 1e-6);
+
+        assert_eq!(
+            omega[(0, 0)],
+            1e-6,
+            "free near-zero diagonal must be floored"
+        );
+        assert_eq!(
+            omega[(1, 1)],
+            0.2,
+            "healthy free diagonal must be unchanged"
+        );
+        assert_eq!(
+            omega[(2, 2)],
+            1e-9,
+            "FIX-ed diagonal must be left exactly as declared"
+        );
+        assert_eq!(omega[(0, 1)], 0.01, "off-diagonals must not be touched");
+    }
+
+    #[test]
+    fn floor_omega_diagonal_treats_missing_fixed_flags_as_free() {
+        // `omega_fixed` shorter than the matrix: missing entries default to free.
+        let mut omega = DMatrix::<f64>::zeros(2, 2);
+        omega[(0, 0)] = 1e-9;
+        omega[(1, 1)] = 1e-9;
+        floor_omega_diagonal(&mut omega, &[], 1e-6);
+        assert_eq!(omega[(0, 0)], 1e-6);
+        assert_eq!(omega[(1, 1)], 1e-6);
+    }
+
+    #[test]
+    fn get_mu_ref_pairs_empty_when_no_mu_refs() {
+        let m = analytical_model(GradientMethod::Auto);
+        assert!(get_mu_ref_pairs(&m).is_empty());
+    }
+
+    #[test]
+    fn get_mu_ref_pairs_returns_log_transformed_pair() {
+        let m = model_with_mu_refs(
+            &["CL", "V"],
+            &["ETA_CL", "ETA_V"],
+            &[("ETA_CL", "CL", true), ("ETA_V", "V", true)],
+        );
+        let mut pairs = get_mu_ref_pairs(&m);
+        pairs.sort();
+        assert_eq!(pairs, vec![(0, 0), (1, 1)]);
+    }
+
+    #[test]
+    fn get_mu_ref_pairs_excludes_additive_mu_refs() {
+        // ETA_CL is lognormal (THETA*exp(ETA)) — included.
+        // ETA_V is additive (THETA+ETA) — excluded because the gradient-step
+        // chain rule used in the EM M-step assumes log-transformed parameters.
+        let m = model_with_mu_refs(
+            &["CL", "V"],
+            &["ETA_CL", "ETA_V"],
+            &[("ETA_CL", "CL", true), ("ETA_V", "V", false)],
+        );
+        assert_eq!(get_mu_ref_pairs(&m), vec![(0, 0)]);
+    }
+
+    #[test]
+    fn get_mu_ref_pairs_skips_orphaned_theta() {
+        // mu_ref points at a theta name that doesn't exist — silently skipped.
+        let m = model_with_mu_refs(&["CL"], &["ETA_CL"], &[("ETA_CL", "MISSING", true)]);
+        assert!(get_mu_ref_pairs(&m).is_empty());
+    }
+}

--- a/src/estimation/em_common.rs
+++ b/src/estimation/em_common.rs
@@ -7,7 +7,8 @@
 //! rule or the mu-ref-pair selection cannot silently diverge between the two
 //! estimators (which is exactly how the IMPMAP duplicates were introduced).
 
-use crate::types::CompiledModel;
+use crate::estimation::parameterization::theta_packs_log;
+use crate::types::{CompiledModel, ModelParameters};
 use nalgebra::DMatrix;
 
 /// Positive-definite floor for free BSV Ω diagonals in the M-step.
@@ -61,36 +62,123 @@ pub(crate) fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
     pairs
 }
 
+/// Unpack a packed θ vector back to natural space, per the packing mask.
+///
+/// `mask[i] == true` means θ_i was log-packed (so unpack with `exp`); `false`
+/// means identity packing (covariate exponents with a negative lower bound,
+/// which must not be forced positive). The SAEM and IMPMAP θ/σ M-steps share
+/// this so the unpack can never drift from the pack in [`PackedThetaSigma`].
+pub(crate) fn unpack_thetas(packed: &[f64], mask: &[bool]) -> Vec<f64> {
+    packed
+        .iter()
+        .zip(mask)
+        .map(|(&p, &is_log)| if is_log { p.exp() } else { p })
+        .collect()
+}
+
+/// Initial θ/σ values and bounds in the packed (log/identity) optimizer space
+/// shared by the SAEM and IMPMAP M-steps.
+///
+/// θ uses log-packing when its lower bound is ≥ 0 (`theta_packs_log`), identity
+/// otherwise — so a covariate exponent with a negative lower bound is not pinned
+/// near 0 by `ln`. σ is always log-packed with fixed `[-8, 5]` bounds. FIX-ed
+/// parameters get `lower == upper == packed value`, so the inner NLopt M-step
+/// treats them as constants (matching the FOCE/FOCEI treatment). Built once from
+/// `init_params`; both estimators then mutate the packed `log_theta`/`log_sigma`
+/// in place across iterations and unpack via [`unpack_thetas`].
+pub(crate) struct PackedThetaSigma {
+    /// Per-θ packing selector: `true` → log, `false` → identity.
+    pub theta_packs_log_mask: Vec<bool>,
+    /// Initial θ in packed space.
+    pub log_theta: Vec<f64>,
+    /// Initial σ in packed space (always log).
+    pub log_sigma: Vec<f64>,
+    pub log_theta_lower: Vec<f64>,
+    pub log_theta_upper: Vec<f64>,
+    pub log_sigma_lower: Vec<f64>,
+    pub log_sigma_upper: Vec<f64>,
+}
+
+impl PackedThetaSigma {
+    pub(crate) fn new(init: &ModelParameters) -> Self {
+        let n_theta = init.theta.len();
+        let n_sigma = init.sigma.values.len();
+
+        let theta_packs_log_mask: Vec<bool> = init
+            .theta_lower
+            .iter()
+            .map(|&lo| theta_packs_log(lo))
+            .collect();
+        let pack_theta = |i: usize, t: f64| -> f64 {
+            if theta_packs_log_mask[i] {
+                t.max(1e-10).ln()
+            } else {
+                t
+            }
+        };
+
+        // Pack initial θ (per-mask) and σ (always log).
+        let log_theta: Vec<f64> = (0..n_theta).map(|i| pack_theta(i, init.theta[i])).collect();
+        let log_sigma: Vec<f64> = init
+            .sigma
+            .values
+            .iter()
+            .map(|&s| s.max(1e-10).ln())
+            .collect();
+
+        // Bounds in packed space — log when log-packed, identity otherwise.
+        let mut log_theta_lower: Vec<f64> = (0..n_theta)
+            .map(|i| {
+                if theta_packs_log_mask[i] {
+                    init.theta_lower[i].max(1e-10).ln()
+                } else {
+                    init.theta_lower[i]
+                }
+            })
+            .collect();
+        let mut log_theta_upper: Vec<f64> = (0..n_theta)
+            .map(|i| {
+                if theta_packs_log_mask[i] {
+                    init.theta_upper[i].min(1e9).ln()
+                } else {
+                    init.theta_upper[i]
+                }
+            })
+            .collect();
+        let mut log_sigma_lower = vec![-8.0f64; n_sigma];
+        let mut log_sigma_upper = vec![5.0f64; n_sigma];
+
+        // Pin FIX parameters: lower == upper == packed value.
+        for i in 0..n_theta {
+            if init.theta_fixed.get(i).copied().unwrap_or(false) {
+                log_theta_lower[i] = log_theta[i];
+                log_theta_upper[i] = log_theta[i];
+            }
+        }
+        for i in 0..n_sigma {
+            if init.sigma_fixed.get(i).copied().unwrap_or(false) {
+                log_sigma_lower[i] = log_sigma[i];
+                log_sigma_upper[i] = log_sigma[i];
+            }
+        }
+
+        PackedThetaSigma {
+            theta_packs_log_mask,
+            log_theta,
+            log_sigma,
+            log_theta_lower,
+            log_theta_upper,
+            log_sigma_lower,
+            log_sigma_upper,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::test_helpers::analytical_model;
-    use crate::types::{GradientMethod, MuRef};
-
-    fn model_with_mu_refs(
-        theta_names: &[&str],
-        eta_names: &[&str],
-        mu_refs: &[(&str, &str, bool)],
-    ) -> CompiledModel {
-        let mut m = analytical_model(GradientMethod::Auto);
-        m.theta_names = theta_names.iter().map(|s| (*s).to_string()).collect();
-        m.eta_names = eta_names.iter().map(|s| (*s).to_string()).collect();
-        m.n_theta = theta_names.len();
-        m.n_eta = eta_names.len();
-        m.mu_refs = mu_refs
-            .iter()
-            .map(|(eta, theta, log_t)| {
-                (
-                    (*eta).to_string(),
-                    MuRef {
-                        theta_name: (*theta).to_string(),
-                        log_transformed: *log_t,
-                    },
-                )
-            })
-            .collect();
-        m
-    }
+    use crate::types::test_helpers::{analytical_model, model_with_mu_refs};
+    use crate::types::GradientMethod;
 
     #[test]
     fn floor_omega_diagonal_floors_free_entries_only() {
@@ -172,5 +260,90 @@ mod tests {
         // mu_ref points at a theta name that doesn't exist — silently skipped.
         let m = model_with_mu_refs(&["CL"], &["ETA_CL"], &[("ETA_CL", "MISSING", true)]);
         assert!(get_mu_ref_pairs(&m).is_empty());
+    }
+
+    #[test]
+    fn unpack_thetas_applies_mask_per_index() {
+        // mask[0]=log → exp; mask[1]=identity → passthrough (negative-bound exponent).
+        let out = unpack_thetas(&[1.0, -0.8], &[true, false]);
+        assert!((out[0] - 1.0_f64.exp()).abs() < 1e-12);
+        assert_eq!(
+            out[1], -0.8,
+            "identity-packed theta must pass through unchanged"
+        );
+    }
+
+    /// Build a minimal ModelParameters with the given theta bounds/fixed flags
+    /// and a single sigma, for exercising PackedThetaSigma.
+    fn params(
+        theta: &[f64],
+        theta_lower: &[f64],
+        theta_upper: &[f64],
+        theta_fixed: &[bool],
+        sigma: &[f64],
+        sigma_fixed: &[bool],
+    ) -> ModelParameters {
+        use crate::types::{OmegaMatrix, SigmaVector};
+        ModelParameters {
+            theta: theta.to_vec(),
+            theta_names: (0..theta.len()).map(|i| format!("T{i}")).collect(),
+            theta_lower: theta_lower.to_vec(),
+            theta_upper: theta_upper.to_vec(),
+            theta_fixed: theta_fixed.to_vec(),
+            omega: OmegaMatrix::from_diagonal(&[0.1], vec!["ETA".into()]),
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: sigma.to_vec(),
+                names: (0..sigma.len()).map(|i| format!("E{i}")).collect(),
+            },
+            sigma_fixed: sigma_fixed.to_vec(),
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn packed_theta_sigma_log_packs_only_nonneg_lower_bound_theta() {
+        // T0: lower 0 → log-packed; T1: lower -1 (covariate exponent) → identity.
+        let p = params(
+            &[2.0, -0.5],
+            &[0.0, -1.0],
+            &[100.0, 5.0],
+            &[false, false],
+            &[0.3],
+            &[false],
+        );
+        let packed = PackedThetaSigma::new(&p);
+        assert_eq!(packed.theta_packs_log_mask, vec![true, false]);
+        assert!((packed.log_theta[0] - 2.0_f64.ln()).abs() < 1e-12);
+        assert_eq!(packed.log_theta[1], -0.5, "identity theta packed as-is");
+        // Sigma is always log-packed with fixed [-8, 5] bounds.
+        assert!((packed.log_sigma[0] - 0.3_f64.ln()).abs() < 1e-12);
+        assert_eq!(packed.log_sigma_lower, vec![-8.0]);
+        assert_eq!(packed.log_sigma_upper, vec![5.0]);
+        // Round-trips back through unpack_thetas.
+        let nat = unpack_thetas(&packed.log_theta, &packed.theta_packs_log_mask);
+        assert!((nat[0] - 2.0).abs() < 1e-12);
+        assert!((nat[1] - (-0.5)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn packed_theta_sigma_pins_fixed_params() {
+        // T1 fixed and sigma fixed → lower == upper == packed value.
+        let p = params(
+            &[2.0, 7.0],
+            &[0.0, 0.0],
+            &[100.0, 100.0],
+            &[false, true],
+            &[0.3],
+            &[true],
+        );
+        let packed = PackedThetaSigma::new(&p);
+        assert_eq!(packed.log_theta_lower[1], packed.log_theta[1]);
+        assert_eq!(packed.log_theta_upper[1], packed.log_theta[1]);
+        assert_eq!(packed.log_sigma_lower[0], packed.log_sigma[0]);
+        assert_eq!(packed.log_sigma_upper[0], packed.log_sigma[0]);
+        // The free theta keeps its real bounds, not pinned.
+        assert!(packed.log_theta_lower[0] < packed.log_theta_upper[0]);
     }
 }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -268,7 +268,9 @@ pub fn run_impmap(
             0,
         );
 
-        let omega_inv = params_k.omega.inv.clone();
+        // Borrow rather than clone: `params_k` is only read for the rest of this
+        // iteration, so the n_eta×n_eta inverse need not be copied per iteration.
+        let omega_inv = &params_k.omega.inv;
         let log_det_omega = params_k.omega.log_det;
 
         // ---- E-step B: importance sampling around each mode ----
@@ -284,7 +286,7 @@ pub fn run_impmap(
                     &eta_hats[i],
                     &params_k.sigma.values,
                     &h_matrices[i],
-                    &omega_inv,
+                    omega_inv,
                     n_eta,
                     scratch,
                 );
@@ -295,7 +297,7 @@ pub fn run_impmap(
                     &params_k.sigma.values,
                     &eta_hats[i],
                     &h_post,
-                    &omega_inv,
+                    omega_inv,
                     log_det_omega,
                     n_eta,
                     k_samples,
@@ -598,7 +600,7 @@ fn theta_sigma_weighted_mstep(
             .zip(draws.par_iter())
             .map_init(EventPkParams::default, |scratch, (subject, d)| {
                 let mut s = 0.0f64;
-                for (w, eta) in d.weights.iter().zip(d.etas.chunks_exact(model.n_eta)) {
+                for (w, eta) in d.weights.iter().zip(d.samples()) {
                     if *w == 0.0 {
                         continue;
                     }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -31,6 +31,7 @@
 //! such models are refused up front. SDE / `[diffusion]` models are refused for
 //! the same reason `IMP` refuses them. Use SAEM or FOCEI for those.
 
+use crate::estimation::em_common::{floor_omega_diagonal, get_mu_ref_pairs, OMEGA_DIAG_FLOOR};
 use crate::estimation::importance_sampling::{compute_posterior_hessian, subject_is_draws};
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
@@ -42,46 +43,6 @@ use crate::stats::likelihood::obs_nll_subject_into;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
-
-/// Floor the free Ω diagonal to keep the proposal/prior positive-definite.
-/// Mirrors SAEM's `floor_omega_diagonal`: FIX-ed diagonals are left untouched.
-fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
-    for i in 0..omega_mat.nrows() {
-        if omega_fixed.get(i).copied().unwrap_or(false) {
-            continue;
-        }
-        if omega_mat[(i, i)] < floor {
-            omega_mat[(i, i)] = floor;
-        }
-    }
-}
-
-/// Positive-definite floor for free Ω diagonals (matches the SAEM constant).
-const OMEGA_DIAG_FLOOR: f64 = 1e-6;
-
-/// Log-transformed mu-referencing pairs `(theta_idx, eta_idx)`. For these the
-/// typical value satisfies `log(P_i) = log(θ) + η_i`, so the EM M-step shifts
-/// `log(θ) += mean(η)` in closed form — without it θ and the η mean are
-/// confounded and the variance Ω absorbs the misfit instead. Mirrors SAEM's
-/// `get_mu_ref_pairs`.
-fn mu_ref_log_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
-    let mut pairs = Vec::new();
-    for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
-        if let Some(mu_ref) = model.mu_refs.get(eta_name) {
-            if !mu_ref.log_transformed {
-                continue;
-            }
-            if let Some(theta_idx) = model
-                .theta_names
-                .iter()
-                .position(|n| n == &mu_ref.theta_name)
-            {
-                pairs.push((theta_idx, eta_idx));
-            }
-        }
-    }
-    pairs
-}
 
 /// Run IMPMAP. `warm_etas`, when supplied by a preceding chain stage, seed the
 /// first MAP inner loop; otherwise the inner loop cold-starts from η = 0.
@@ -225,7 +186,7 @@ pub fn run_impmap(
     // governs inner-loop `compute_mu_k` centering, a separate concern). NONMEM's
     // EM methods likewise require mu-referencing.
     let mut warnings: Vec<String> = Vec::new();
-    let mu_ref_pairs = mu_ref_log_pairs(model);
+    let mu_ref_pairs = get_mu_ref_pairs(model);
     let use_closed_form = !mu_ref_pairs.is_empty();
     if !use_closed_form {
         // No log-mu-ref parameter: every typical value goes through the weighted
@@ -251,7 +212,30 @@ pub fn run_impmap(
     let mut acc_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
     let mut n_acc = 0usize;
 
-    let mut last_eta_hats: Vec<DVector<f64>> = Vec::new();
+    // Reusable per-iteration parameter bundle. Only `theta`, `sigma.values`, and
+    // `omega` change between iterations; the invariant metadata (names, bounds,
+    // fixed masks) is cloned once here and left untouched, instead of rebuilding
+    // the full struct every iteration.
+    let mut params_k = ModelParameters {
+        theta: theta_cur.clone(),
+        theta_names: init_params.theta_names.clone(),
+        theta_lower: init_params.theta_lower.clone(),
+        theta_upper: init_params.theta_upper.clone(),
+        theta_fixed: init_params.theta_fixed.clone(),
+        omega: OmegaMatrix::from_matrix(
+            omega_mat.clone(),
+            init_params.omega.eta_names.clone(),
+            init_params.omega.diagonal,
+        ),
+        omega_fixed: init_params.omega_fixed.clone(),
+        sigma: SigmaVector {
+            values: sigma_cur.clone(),
+            names: init_params.sigma.names.clone(),
+        },
+        sigma_fixed: init_params.sigma_fixed.clone(),
+        omega_iov: None,
+        kappa_fixed: init_params.kappa_fixed.clone(),
+    };
 
     for k in 1..=n_iter {
         if crate::cancel::is_cancelled(cancel) {
@@ -261,28 +245,15 @@ pub fn run_impmap(
             break;
         }
 
-        // Assemble current params for the inner loop / E-step.
-        let omega_k = OmegaMatrix::from_matrix(
+        // Refresh only the three mutated pieces for this iteration (the rest of
+        // `params_k` is invariant — see its construction above).
+        params_k.theta.clone_from(&theta_cur);
+        params_k.sigma.values.clone_from(&sigma_cur);
+        params_k.omega = OmegaMatrix::from_matrix(
             omega_mat.clone(),
             init_params.omega.eta_names.clone(),
             init_params.omega.diagonal,
         );
-        let params_k = ModelParameters {
-            theta: theta_cur.clone(),
-            theta_names: init_params.theta_names.clone(),
-            theta_lower: init_params.theta_lower.clone(),
-            theta_upper: init_params.theta_upper.clone(),
-            theta_fixed: init_params.theta_fixed.clone(),
-            omega: omega_k,
-            omega_fixed: init_params.omega_fixed.clone(),
-            sigma: SigmaVector {
-                values: sigma_cur.clone(),
-                names: init_params.sigma.names.clone(),
-            },
-            sigma_fixed: init_params.sigma_fixed.clone(),
-            omega_iov: None,
-            kappa_fixed: init_params.kappa_fixed.clone(),
-        };
 
         // ---- E-step A: MAP recenter (conditional mode + Jacobian) ----
         let mu_k = compute_mu_k(model, &params_k.theta, options.mu_referencing);
@@ -426,8 +397,8 @@ pub fn run_impmap(
         sigma_cur = log_sigma.iter().map(|&s| s.exp()).collect();
 
         // Warm-start next iteration's inner loop from this iteration's modes.
-        prev_etas = Some(eta_hats.clone());
-        last_eta_hats = eta_hats;
+        // `prev_etas` also carries the final modes out for the post-loop EBE pass.
+        prev_etas = Some(eta_hats);
 
         // ---- Parameter averaging over the final n_avg iterations ----
         if k > n_iter - n_avg {
@@ -463,34 +434,21 @@ pub fn run_impmap(
         (theta_cur.clone(), sigma_cur.clone(), omega_mat.clone())
     };
 
-    let final_omega = OmegaMatrix::from_matrix(
+    // Reuse the per-iteration bundle for the final params — only the three
+    // mutated pieces differ from the invariant metadata already in `params_k`.
+    let mut final_params = params_k;
+    final_params.theta = final_theta;
+    final_params.sigma.values = final_sigma;
+    final_params.omega = OmegaMatrix::from_matrix(
         final_omega_mat,
         init_params.omega.eta_names.clone(),
         init_params.omega.diagonal,
     );
-    let final_params = ModelParameters {
-        theta: final_theta,
-        theta_names: init_params.theta_names.clone(),
-        theta_lower: init_params.theta_lower.clone(),
-        theta_upper: init_params.theta_upper.clone(),
-        theta_fixed: init_params.theta_fixed.clone(),
-        omega: final_omega,
-        omega_fixed: init_params.omega_fixed.clone(),
-        sigma: SigmaVector {
-            values: final_sigma,
-            names: init_params.sigma.names.clone(),
-        },
-        sigma_fixed: init_params.sigma_fixed.clone(),
-        omega_iov: None,
-        kappa_fixed: init_params.kappa_fixed.clone(),
-    };
 
     // ---- Final EBEs (warm-started) + FOCE Laplace OFV for comparability ----
-    let warm = if last_eta_hats.is_empty() {
-        None
-    } else {
-        Some(last_eta_hats.as_slice())
-    };
+    // `prev_etas` holds the final iteration's modes (or the caller's warm start
+    // if `n_iter == 0` never ran the body).
+    let warm = prev_etas.as_deref();
     let final_mu_k = compute_mu_k(model, &final_params.theta, options.mu_referencing);
     let (eta_hats, h_matrices, _stats, final_kappas) = run_inner_loop_warm(
         model,
@@ -640,7 +598,7 @@ fn theta_sigma_weighted_mstep(
             .zip(draws.par_iter())
             .map_init(EventPkParams::default, |scratch, (subject, d)| {
                 let mut s = 0.0f64;
-                for (w, eta) in d.weights.iter().zip(d.etas.iter()) {
+                for (w, eta) in d.weights.iter().zip(d.etas.chunks_exact(model.n_eta)) {
                     if *w == 0.0 {
                         continue;
                     }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -31,13 +31,15 @@
 //! such models are refused up front. SDE / `[diffusion]` models are refused for
 //! the same reason `IMP` refuses them. Use SAEM or FOCEI for those.
 
-use crate::estimation::em_common::{floor_omega_diagonal, get_mu_ref_pairs, OMEGA_DIAG_FLOOR};
+use crate::estimation::em_common::{
+    floor_omega_diagonal, get_mu_ref_pairs, unpack_thetas, PackedThetaSigma, OMEGA_DIAG_FLOOR,
+};
 use crate::estimation::importance_sampling::{compute_posterior_hessian, subject_is_draws};
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
     compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
 };
-use crate::estimation::parameterization::{compute_mu_k, pack_params, theta_packs_log};
+use crate::estimation::parameterization::{compute_mu_k, pack_params};
 use crate::pk::EventPkParams;
 use crate::stats::likelihood::obs_nll_subject_into;
 use crate::types::*;
@@ -115,66 +117,16 @@ pub fn run_impmap(
         );
     }
 
-    // ---- Packing scaffolding (mirrors SAEM) ----
-    // Per-theta packing: log for `theta_lower >= 0`, identity otherwise (so
-    // covariate exponents with negative lower bounds are not pinned to ~0).
-    let theta_packs_log_mask: Vec<bool> = init_params
-        .theta_lower
-        .iter()
-        .map(|&lo| theta_packs_log(lo))
-        .collect();
-    let pack_theta = |i: usize, t: f64| -> f64 {
-        if theta_packs_log_mask[i] {
-            t.max(1e-10).ln()
-        } else {
-            t
-        }
-    };
-
-    let mut log_theta: Vec<f64> = (0..n_theta)
-        .map(|i| pack_theta(i, init_params.theta[i]))
-        .collect();
-    let mut log_sigma: Vec<f64> = init_params
-        .sigma
-        .values
-        .iter()
-        .map(|&s| s.max(1e-10).ln())
-        .collect();
-
-    let mut log_theta_lower: Vec<f64> = (0..n_theta)
-        .map(|i| {
-            if theta_packs_log_mask[i] {
-                init_params.theta_lower[i].max(1e-10).ln()
-            } else {
-                init_params.theta_lower[i]
-            }
-        })
-        .collect();
-    let mut log_theta_upper: Vec<f64> = (0..n_theta)
-        .map(|i| {
-            if theta_packs_log_mask[i] {
-                init_params.theta_upper[i].min(1e9).ln()
-            } else {
-                init_params.theta_upper[i]
-            }
-        })
-        .collect();
-    let mut log_sigma_lower = vec![-8.0f64; n_sigma];
-    let mut log_sigma_upper = vec![5.0f64; n_sigma];
-
-    // Pin FIX parameters: lower == upper == packed value.
-    for i in 0..n_theta {
-        if init_params.theta_fixed.get(i).copied().unwrap_or(false) {
-            log_theta_lower[i] = log_theta[i];
-            log_theta_upper[i] = log_theta[i];
-        }
-    }
-    for i in 0..n_sigma {
-        if init_params.sigma_fixed.get(i).copied().unwrap_or(false) {
-            log_sigma_lower[i] = log_sigma[i];
-            log_sigma_upper[i] = log_sigma[i];
-        }
-    }
+    // ---- Packing scaffolding (shared with SAEM via em_common) ----
+    let PackedThetaSigma {
+        theta_packs_log_mask,
+        mut log_theta,
+        mut log_sigma,
+        log_theta_lower,
+        log_theta_upper,
+        log_sigma_lower,
+        log_sigma_upper,
+    } = PackedThetaSigma::new(init_params);
 
     // Closed-form mu-referencing M-step: shift `log(θ) += mean(η)` for log-mu-ref
     // pairs, with those θ pinned out of the NLopt weighted M-step (which then fits
@@ -387,15 +339,7 @@ pub fn run_impmap(
             }
         }
 
-        theta_cur = (0..n_theta)
-            .map(|i| {
-                if theta_packs_log_mask[i] {
-                    log_theta[i].exp()
-                } else {
-                    log_theta[i]
-                }
-            })
-            .collect();
+        theta_cur = unpack_thetas(&log_theta, &theta_packs_log_mask);
         sigma_cur = log_sigma.iter().map(|&s| s.exp()).collect();
 
         // Warm-start next iteration's inner loop from this iteration's modes.
@@ -448,8 +392,15 @@ pub fn run_impmap(
     );
 
     // ---- Final EBEs (warm-started) + FOCE Laplace OFV for comparability ----
-    // `prev_etas` holds the final iteration's modes (or the caller's warm start
-    // if `n_iter == 0` never ran the body).
+    // `prev_etas` holds the final iteration's modes. `n_iter = ...max(1)` (above)
+    // guarantees the loop body ran at least once and overwrote `prev_etas`, so
+    // this is never the caller's stale seed (or `None`). If a future change ever
+    // lets the body be skipped, this assert flags that the warm start below would
+    // silently fall back to etas computed under the *initial* params.
+    debug_assert!(
+        n_iter >= 1,
+        "IMPMAP final warm-start assumes the iteration loop ran at least once"
+    );
     let warm = prev_etas.as_deref();
     let final_mu_k = compute_mu_k(model, &final_params.theta, options.mu_referencing);
     let (eta_hats, h_matrices, _stats, final_kappas) = run_inner_loop_warm(
@@ -577,22 +528,10 @@ fn theta_sigma_weighted_mstep(
         x[i] = x[i].clamp(lower[i], upper[i]);
     }
 
-    let unpack_thetas = |packed: &[f64]| -> Vec<f64> {
-        (0..n_theta)
-            .map(|i| {
-                if theta_packs_log_mask[i] {
-                    packed[i].exp()
-                } else {
-                    packed[i]
-                }
-            })
-            .collect()
-    };
-
     // Weighted observation NLL, parallel over subjects. Each subject contributes
     // Σₖ w̃ₖ · obs_nll(yᵢ | ηᵢₖ, θ, σ).
     let obj = |xv: &[f64], _: Option<&mut [f64]>, _: &mut ()| -> f64 {
-        let th: Vec<f64> = unpack_thetas(&xv[..n_theta]);
+        let th: Vec<f64> = unpack_thetas(&xv[..n_theta], theta_packs_log_mask);
         let sg: Vec<f64> = xv[n_theta..].iter().map(|&v| v.exp()).collect();
         let val: f64 = population
             .subjects

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -522,8 +522,11 @@ pub(crate) struct SubjectDraws {
     pub log_marginal: f64,
     /// Normalized effective sample size ESS/K (proposal-quality diagnostic).
     pub ess_fraction: f64,
-    /// The `K` sampled η vectors (each length `d`).
-    pub etas: Vec<Vec<f64>>,
+    /// The `K` sampled η vectors stored row-major in one flat buffer of length
+    /// `K·d` (sample `k` is `etas[k*d..(k+1)*d]`). A single allocation per subject
+    /// instead of `K` small `Vec`s — at K=500 this is the hot allocation in the
+    /// E-step. Iterate with `etas.chunks_exact(d)`.
+    pub etas: Vec<f64>,
     /// Self-normalized importance weights `w̃ᵢₖ` (length `K`, sums to 1).
     pub weights: Vec<f64>,
     /// Weighted posterior mean `Σₖ w̃ᵢₖ ηᵢₖ` (length `d`) — drives the closed-form
@@ -570,6 +573,7 @@ pub(crate) fn subject_is_draws(
                 etas: Vec::new(),
                 weights: Vec::new(),
                 mean: vec![0.0; d],
+                // (early-return on a non-PD proposal; no samples retained)
                 second_moment: DMatrix::zeros(d, d),
             };
         }
@@ -595,11 +599,13 @@ pub(crate) fn subject_is_draws(
     };
 
     let mut log_w: Vec<f64> = Vec::with_capacity(k_samples);
-    let mut etas: Vec<Vec<f64>> = Vec::with_capacity(k_samples);
+    // One flat buffer for all K retained samples (row-major, K·d). Filled in
+    // place per sample — no per-sample allocation.
+    let mut etas: Vec<f64> = vec![0.0_f64; k_samples * d];
     let mut z = vec![0.0_f64; d];
     let mut diff = vec![0.0_f64; d];
 
-    for _ in 0..k_samples {
+    for k in 0..k_samples {
         for zi in z.iter_mut() {
             *zi = normal.sample(&mut rng);
         }
@@ -610,13 +616,14 @@ pub(crate) fn subject_is_draws(
             }
             None => 1.0,
         };
-        let mut eta_sample = vec![0.0_f64; d];
-        proposal.apply_l_sigma(&z, &mut eta_sample, scale);
+        let eta_sample = &mut etas[k * d..(k + 1) * d];
+        proposal.apply_l_sigma(&z, eta_sample, scale);
         for (j, e) in eta_sample.iter_mut().enumerate() {
             *e += eta_hat[j];
         }
+        let eta_sample: &[f64] = eta_sample;
 
-        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, &eta_sample, scratch);
+        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, eta_sample, scratch);
         let log_p_y = -obs_nll;
 
         let mut quad_form = 0.0_f64;
@@ -629,8 +636,8 @@ pub(crate) fn subject_is_draws(
         }
         let log_p_eta = log_p_eta_const - 0.5 * quad_form;
 
-        for (k, d_slot) in diff.iter_mut().enumerate() {
-            *d_slot = eta_sample[k] - eta_hat[k];
+        for (j, d_slot) in diff.iter_mut().enumerate() {
+            *d_slot = eta_sample[j] - eta_hat[j];
         }
         let mahal = proposal.mahalanobis(&diff);
         let log_q = if mvn {
@@ -640,7 +647,6 @@ pub(crate) fn subject_is_draws(
         };
 
         log_w.push(log_p_y + log_p_eta - log_q);
-        etas.push(eta_sample);
     }
 
     let (lse, weights) = logsumexp_with_normalised(&log_w);
@@ -658,7 +664,7 @@ pub(crate) fn subject_is_draws(
     // Weighted first and second moments Σₖ w̃ₖ ηₖ and Σₖ w̃ₖ ηₖ ηₖᵀ.
     let mut mean = vec![0.0_f64; d];
     let mut second_moment = DMatrix::<f64>::zeros(d, d);
-    for (w, eta) in weights.iter().zip(etas.iter()) {
+    for (w, eta) in weights.iter().zip(etas.chunks_exact(d)) {
         for i in 0..d {
             mean[i] += w * eta[i];
             for j in 0..d {

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -523,10 +523,15 @@ pub(crate) struct SubjectDraws {
     /// Normalized effective sample size ESS/K (proposal-quality diagnostic).
     pub ess_fraction: f64,
     /// The `K` sampled η vectors stored row-major in one flat buffer of length
-    /// `K·d` (sample `k` is `etas[k*d..(k+1)*d]`). A single allocation per subject
-    /// instead of `K` small `Vec`s — at K=500 this is the hot allocation in the
-    /// E-step. Iterate with `etas.chunks_exact(d)`.
-    pub etas: Vec<f64>,
+    /// `K·n_dim`. A single allocation per subject instead of `K` small `Vec`s —
+    /// at K=500 this is the hot allocation in the E-step. Private so callers
+    /// cannot mis-chunk it; iterate via [`SubjectDraws::samples`], which always
+    /// uses the producer's own stride.
+    etas: Vec<f64>,
+    /// Per-sample η dimension `d` (the stride of `etas`). Carried with the data
+    /// so the chunk width is the one the producer used, not one re-derived at the
+    /// consumption site.
+    n_dim: usize,
     /// Self-normalized importance weights `w̃ᵢₖ` (length `K`, sums to 1).
     pub weights: Vec<f64>,
     /// Weighted posterior mean `Σₖ w̃ᵢₖ ηᵢₖ` (length `d`) — drives the closed-form
@@ -535,6 +540,18 @@ pub(crate) struct SubjectDraws {
     /// Weighted second moment `Σₖ w̃ᵢₖ ηᵢₖ ηᵢₖᵀ` (d×d) — the per-subject Ω
     /// sufficient statistic.
     pub second_moment: DMatrix<f64>,
+}
+
+impl SubjectDraws {
+    /// Iterate the retained samples as `&[f64]` slices of length `n_dim`, the
+    /// stride the producer stored them with. This is the only way to read the
+    /// samples, so a consumer can never pick the wrong chunk width. Yields `K`
+    /// slices (zero for an early-return / non-PD-proposal subject).
+    pub(crate) fn samples(&self) -> std::slice::ChunksExact<'_, f64> {
+        // `n_dim == 0` is impossible: IMPMAP refuses `n_eta == 0` up front, and
+        // `subject_is_draws` always records the `d` it was called with.
+        self.etas.chunks_exact(self.n_dim)
+    }
 }
 
 /// Draw `K` importance samples for one subject from a proposal centered at the
@@ -570,10 +587,12 @@ pub(crate) fn subject_is_draws(
             return SubjectDraws {
                 log_marginal: 0.0,
                 ess_fraction: 0.0,
+                // early-return on a non-PD proposal: no samples retained, but
+                // n_dim still records the stride so `samples()` is well-formed.
                 etas: Vec::new(),
+                n_dim: d,
                 weights: Vec::new(),
                 mean: vec![0.0; d],
-                // (early-return on a non-PD proposal; no samples retained)
                 second_moment: DMatrix::zeros(d, d),
             };
         }
@@ -677,6 +696,7 @@ pub(crate) fn subject_is_draws(
         log_marginal,
         ess_fraction,
         etas,
+        n_dim: d,
         weights,
         mean,
         second_moment,

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod em_common;
 pub mod gauss_newton;
 pub(crate) mod hmc;
 pub mod impmap;

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -6,6 +6,7 @@
 /// Two-phase step-size schedule (Monolix convention):
 ///   Phase 1 (exploration, k ≤ K1):  γₖ = 1          — rapid basin convergence
 ///   Phase 2 (convergence, k > K1):  γₖ = 1/(k−K1)   — almost-sure convergence to MLE
+use crate::estimation::em_common::{floor_omega_diagonal, get_mu_ref_pairs, OMEGA_DIAG_FLOOR};
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
     compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
@@ -39,15 +40,6 @@ pub(crate) const MSTEP_NLOPT_ALGORITHM: nlopt::Algorithm = nlopt::Algorithm::Bob
 // SAEM state
 // ---------------------------------------------------------------------------
 
-/// Positive-definite floor for free BSV Ω diagonals in the M-step.
-///
-/// Larger than the IOV floor (1e-8) because the BSV MH proposal scale is
-/// `step_scale · chol(Ω)`: if a diagonal is allowed near zero the proposal for
-/// that η collapses and the chain can no longer move it, so Ω must stay large
-/// enough to keep the random walk alive. 1e-6 keeps a free η explorable while
-/// being far below any plausible estimated variance.
-const SAEM_OMEGA_DIAG_FLOOR: f64 = 1e-6;
-
 /// Target acceptance rate for the componentwise (1-D) eta kernel. The optimal
 /// scaling result for single-coordinate random-walk Metropolis is ≈0.44
 /// (Roberts & Rosenthal 2001), higher than the block kernel's 0.40 target.
@@ -60,18 +52,6 @@ const CW_TARGET_ACCEPT: f64 = 0.44;
 /// rank-1 collapse feedback. In the convergence phase the cap is lifted and Ω
 /// uses the full decaying γ = 1/(k−k1), the same Robbins-Monro schedule as θ.
 const OMEGA_SA_MAX_STEP: f64 = 0.1;
-
-/// Raise every *free* diagonal entry of the BSV Ω that has fallen below `floor`
-/// up to `floor`. FIX-ed diagonals (`omega_fixed[i] == true`) are left untouched
-/// — they carry the user's declared variance and must not be perturbed.
-fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
-    for i in 0..omega_mat.nrows() {
-        let fixed = omega_fixed.get(i).copied().unwrap_or(false);
-        if !fixed && omega_mat[(i, i)] < floor {
-            omega_mat[(i, i)] = floor;
-        }
-    }
-}
 
 struct SaemState {
     /// Per-subject current ETAs
@@ -995,34 +975,6 @@ fn obs_nll_sum_iov(
         .sum()
 }
 
-/// Build (theta_idx, eta_idx) pairs for log-transformed mu-references only.
-///
-/// Only `log_transformed = true` mu-refs (patterns `THETA*exp(ETA)` and
-/// `exp(log(THETA)+ETA)`) participate in the gradient-step M-step.  For these
-/// the chain rule gives `d/d_log(theta) = -Σᵢ d/d_eta`, which matches the
-/// update applied in the SAEM loop.  Additive mu-refs (`THETA + ETA`,
-/// `log_transformed = false`) require the extra factor of `theta` from the
-/// log-space chain rule and are deliberately excluded — they fall through to
-/// the regular NLopt M-step.
-fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
-    let mut pairs = Vec::new();
-    for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
-        if let Some(mu_ref) = model.mu_refs.get(eta_name) {
-            if !mu_ref.log_transformed {
-                continue;
-            }
-            if let Some(theta_idx) = model
-                .theta_names
-                .iter()
-                .position(|n| n == &mu_ref.theta_name)
-            {
-                pairs.push((theta_idx, eta_idx));
-            }
-        }
-    }
-    pairs
-}
-
 /// One-line description of the SAEM E-step sampler kernel, for the startup
 /// banner. SAEM's estimation is sampling-based (not gradient-driven), so the
 /// banner reports the kernel here instead of a gradient route. HMC is used
@@ -1397,7 +1349,7 @@ pub fn run_saem(
             // diagonal is shared across subjects) rather than per subject inside
             // the parallel kernel. Floored to match the Ω diagonal floor.
             let cw_sd: Vec<f64> = (0..n_eta)
-                .map(|j| omega_k.matrix[(j, j)].max(SAEM_OMEGA_DIAG_FLOOR).sqrt())
+                .map(|j| omega_k.matrix[(j, j)].max(OMEGA_DIAG_FLOOR).sqrt())
                 .collect();
             let cw_sd_ref = &cw_sd;
             // For IOV models, eta proposals must target p(η | κ, θ, data):
@@ -1662,7 +1614,7 @@ pub fn run_saem(
             floor_omega_diagonal(
                 &mut state.omega_mat,
                 &init_params.omega_fixed,
-                SAEM_OMEGA_DIAG_FLOOR,
+                OMEGA_DIAG_FLOOR,
             );
 
             // ---- Step 3b: Omega_iov (analytic, IOV only) ----
@@ -2172,87 +2124,8 @@ mod tests {
         m
     }
 
-    #[test]
-    fn floor_omega_diagonal_floors_free_entries_only() {
-        // Three etas: a free near-zero diagonal (should be floored), a free
-        // healthy diagonal (untouched), and a FIX-ed near-zero diagonal (kept).
-        let mut omega = DMatrix::<f64>::zeros(3, 3);
-        omega[(0, 0)] = 1e-9; // free, below floor → raised
-        omega[(1, 1)] = 0.2; // free, above floor → unchanged
-        omega[(2, 2)] = 1e-9; // FIX-ed, below floor → preserved
-                              // an off-diagonal that must not be touched by the diagonal floor
-        omega[(0, 1)] = 0.01;
-        omega[(1, 0)] = 0.01;
-
-        let omega_fixed = vec![false, false, true];
-        floor_omega_diagonal(&mut omega, &omega_fixed, 1e-6);
-
-        assert_eq!(
-            omega[(0, 0)],
-            1e-6,
-            "free near-zero diagonal must be floored"
-        );
-        assert_eq!(
-            omega[(1, 1)],
-            0.2,
-            "healthy free diagonal must be unchanged"
-        );
-        assert_eq!(
-            omega[(2, 2)],
-            1e-9,
-            "FIX-ed diagonal must be left exactly as declared"
-        );
-        assert_eq!(omega[(0, 1)], 0.01, "off-diagonals must not be touched");
-    }
-
-    #[test]
-    fn floor_omega_diagonal_treats_missing_fixed_flags_as_free() {
-        // `omega_fixed` shorter than the matrix: missing entries default to free.
-        let mut omega = DMatrix::<f64>::zeros(2, 2);
-        omega[(0, 0)] = 1e-9;
-        omega[(1, 1)] = 1e-9;
-        floor_omega_diagonal(&mut omega, &[], 1e-6);
-        assert_eq!(omega[(0, 0)], 1e-6);
-        assert_eq!(omega[(1, 1)], 1e-6);
-    }
-
-    #[test]
-    fn get_mu_ref_pairs_empty_when_no_mu_refs() {
-        let m = analytical_model(GradientMethod::Auto);
-        assert!(get_mu_ref_pairs(&m).is_empty());
-    }
-
-    #[test]
-    fn get_mu_ref_pairs_returns_log_transformed_pair() {
-        let m = model_with_mu_refs(
-            &["CL", "V"],
-            &["ETA_CL", "ETA_V"],
-            &[("ETA_CL", "CL", true), ("ETA_V", "V", true)],
-        );
-        let mut pairs = get_mu_ref_pairs(&m);
-        pairs.sort();
-        assert_eq!(pairs, vec![(0, 0), (1, 1)]);
-    }
-
-    #[test]
-    fn get_mu_ref_pairs_excludes_additive_mu_refs() {
-        // ETA_CL is lognormal (THETA*exp(ETA)) — included.
-        // ETA_V is additive (THETA+ETA) — excluded because the gradient-step
-        // chain rule used in run_saem assumes log-transformed parameters.
-        let m = model_with_mu_refs(
-            &["CL", "V"],
-            &["ETA_CL", "ETA_V"],
-            &[("ETA_CL", "CL", true), ("ETA_V", "V", false)],
-        );
-        assert_eq!(get_mu_ref_pairs(&m), vec![(0, 0)]);
-    }
-
-    #[test]
-    fn get_mu_ref_pairs_skips_orphaned_theta() {
-        // mu_ref points at a theta name that doesn't exist — silently skipped.
-        let m = model_with_mu_refs(&["CL"], &["ETA_CL"], &[("ETA_CL", "MISSING", true)]);
-        assert!(get_mu_ref_pairs(&m).is_empty());
-    }
+    // `floor_omega_diagonal` and `get_mu_ref_pairs` are tested in
+    // `estimation::em_common` (their canonical home, shared with IMPMAP).
 
     // ---- Regression tests for the three SAEM correctness bugs ----
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -6,7 +6,9 @@
 /// Two-phase step-size schedule (Monolix convention):
 ///   Phase 1 (exploration, k ≤ K1):  γₖ = 1          — rapid basin convergence
 ///   Phase 2 (convergence, k > K1):  γₖ = 1/(k−K1)   — almost-sure convergence to MLE
-use crate::estimation::em_common::{floor_omega_diagonal, get_mu_ref_pairs, OMEGA_DIAG_FLOOR};
+use crate::estimation::em_common::{
+    floor_omega_diagonal, get_mu_ref_pairs, unpack_thetas, PackedThetaSigma, OMEGA_DIAG_FLOOR,
+};
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
     compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
@@ -601,20 +603,6 @@ fn theta_sigma_mstep_light(
         x[i] = x[i].clamp(lower[i], upper[i]);
     }
 
-    // Unpack a slice of packed theta values into natural-scale theta.
-    // Closure (not local fn) so it captures `theta_packs_log_mask`.
-    let unpack_thetas = |packed: &[f64]| -> Vec<f64> {
-        (0..n_theta)
-            .map(|i| {
-                if theta_packs_log_mask[i] {
-                    packed[i].exp()
-                } else {
-                    packed[i]
-                }
-            })
-            .collect()
-    };
-
     // Objective operating on the unscaled packed parameters.
     //
     // Gradient strategy: single rayon pass over subjects, each computing its
@@ -629,7 +617,7 @@ fn theta_sigma_mstep_light(
     //  • Pinned dims (lower == upper) are skipped per-subject, saving the
     //    predict calls entirely (same as the old FD guard).
     let obj = |xv: &[f64], grad: Option<&mut [f64]>, _: &mut ()| -> f64 {
-        let th: Vec<f64> = unpack_thetas(&xv[..n_theta]);
+        let th: Vec<f64> = unpack_thetas(&xv[..n_theta], theta_packs_log_mask);
         let sg: Vec<f64> = xv[n_theta..].iter().map(|&v| v.exp()).collect();
 
         if let Some(g) = grad {
@@ -1177,66 +1165,19 @@ pub fn run_saem(
     // `t.max(1e-10).ln()` packing and could never be estimated —
     // visible regression: SAD_SCEN4 SAEM left γ_CL stuck at 0 (truth
     // -0.8), letting the rest of the fit drift to compensate.
-    let theta_packs_log_mask: Vec<bool> = init_params
-        .theta_lower
-        .iter()
-        .map(|&lo| crate::estimation::parameterization::theta_packs_log(lo))
-        .collect();
-    let pack_theta = |i: usize, t: f64| -> f64 {
-        if theta_packs_log_mask[i] {
-            t.max(1e-10).ln()
-        } else {
-            t
-        }
-    };
-    let unpack_theta = |i: usize, packed: f64| -> f64 {
-        if theta_packs_log_mask[i] {
-            packed.exp()
-        } else {
-            packed
-        }
-    };
-
-    // Pack initial theta (per-mask) and sigma (always log).
-    let mut log_theta: Vec<f64> = (0..n_theta).map(|i| pack_theta(i, theta_cur[i])).collect();
-    let mut log_sigma: Vec<f64> = sigma_cur.iter().map(|&s| s.max(1e-10).ln()).collect();
-
-    // Bounds in packed space — log when log-packed, identity otherwise.
-    let mut log_theta_lower: Vec<f64> = (0..n_theta)
-        .map(|i| {
-            if theta_packs_log_mask[i] {
-                init_params.theta_lower[i].max(1e-10).ln()
-            } else {
-                init_params.theta_lower[i]
-            }
-        })
-        .collect();
-    let mut log_theta_upper: Vec<f64> = (0..n_theta)
-        .map(|i| {
-            if theta_packs_log_mask[i] {
-                init_params.theta_upper[i].min(1e9).ln()
-            } else {
-                init_params.theta_upper[i]
-            }
-        })
-        .collect();
-    let mut log_sigma_lower = vec![-8.0f64; n_sigma];
-    let mut log_sigma_upper = vec![5.0f64; n_sigma];
-
-    // Pin FIX parameters: set lower == upper == packed_value so the inner
-    // NLopt M-step treats them as constants. Matches the FOCE/FOCEI treatment.
-    for i in 0..n_theta {
-        if init_params.theta_fixed.get(i).copied().unwrap_or(false) {
-            log_theta_lower[i] = log_theta[i];
-            log_theta_upper[i] = log_theta[i];
-        }
-    }
-    for i in 0..n_sigma {
-        if init_params.sigma_fixed.get(i).copied().unwrap_or(false) {
-            log_sigma_lower[i] = log_sigma[i];
-            log_sigma_upper[i] = log_sigma[i];
-        }
-    }
+    //
+    // The full packed-space scaffolding is shared with IMPMAP via em_common.
+    // `theta_cur`/`sigma_cur` equal `init_params.theta`/`.sigma.values` here
+    // (just cloned, not yet mutated), so packing from `init_params` is identical.
+    let PackedThetaSigma {
+        theta_packs_log_mask,
+        mut log_theta,
+        mut log_sigma,
+        log_theta_lower,
+        log_theta_upper,
+        log_sigma_lower,
+        log_sigma_upper,
+    } = PackedThetaSigma::new(init_params);
 
     let mut state = SaemState {
         etas,
@@ -1755,9 +1696,7 @@ pub fn run_saem(
                 log_sigma = sigma_new;
             }
 
-            state.theta = (0..n_theta)
-                .map(|i| unpack_theta(i, log_theta[i]))
-                .collect();
+            state.theta = unpack_thetas(&log_theta, &theta_packs_log_mask);
             state.sigma_vals = log_sigma.iter().map(|&v| v.exp()).collect();
         }
 
@@ -2044,8 +1983,8 @@ pub fn run_saem(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::test_helpers::analytical_model;
-    use crate::types::{GradientMethod, MuRef};
+    use crate::types::test_helpers::{analytical_model, model_with_mu_refs};
+    use crate::types::GradientMethod;
 
     /// Pin the SAEM M-step optimizer choice.
     ///
@@ -2097,31 +2036,6 @@ mod tests {
             s2.starts_with("HMC"),
             "autodiff build with analytical model + leapfrog steps should use HMC, got: {s2}"
         );
-    }
-
-    fn model_with_mu_refs(
-        theta_names: &[&str],
-        eta_names: &[&str],
-        mu_refs: &[(&str, &str, bool)],
-    ) -> CompiledModel {
-        let mut m = analytical_model(GradientMethod::Auto);
-        m.theta_names = theta_names.iter().map(|s| (*s).to_string()).collect();
-        m.eta_names = eta_names.iter().map(|s| (*s).to_string()).collect();
-        m.n_theta = theta_names.len();
-        m.n_eta = eta_names.len();
-        m.mu_refs = mu_refs
-            .iter()
-            .map(|(eta, theta, log_t)| {
-                (
-                    (*eta).to_string(),
-                    MuRef {
-                        theta_name: (*theta).to_string(),
-                        log_transformed: *log_t,
-                    },
-                )
-            })
-            .collect();
-        m
     }
 
     // `floor_omega_diagonal` and `get_mu_ref_pairs` are tested in

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3337,7 +3337,7 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "impmap_proposal_df" => {
             // `normal` / `mvn` (or a very large df) select a multivariate-normal
             // proposal — NONMEM's IMPMAP default. A finite value gives Student-t.
-            let tok = value.trim().trim_matches(|c| c == '"' || c == '\'');
+            let tok = value.trim_matches(|c| c == '"' || c == '\'');
             if tok.eq_ignore_ascii_case("normal") || tok.eq_ignore_ascii_case("mvn") {
                 opts.impmap_proposal_df = f64::INFINITY;
             } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3295,6 +3295,34 @@ pub(crate) mod test_helpers {
         make_compiled_model(true, gradient_method)
     }
 
+    /// Build an analytical model with the given theta/eta names and mu-references.
+    /// Each `mu_refs` entry is `(eta_name, theta_name, log_transformed)`. Shared by
+    /// the SAEM and IMPMAP / em_common tests that exercise mu-ref-pair selection.
+    pub(crate) fn model_with_mu_refs(
+        theta_names: &[&str],
+        eta_names: &[&str],
+        mu_refs: &[(&str, &str, bool)],
+    ) -> CompiledModel {
+        let mut m = analytical_model(GradientMethod::Auto);
+        m.theta_names = theta_names.iter().map(|s| (*s).to_string()).collect();
+        m.eta_names = eta_names.iter().map(|s| (*s).to_string()).collect();
+        m.n_theta = theta_names.len();
+        m.n_eta = eta_names.len();
+        m.mu_refs = mu_refs
+            .iter()
+            .map(|(eta, theta, log_t)| {
+                (
+                    (*eta).to_string(),
+                    MuRef {
+                        theta_name: (*theta).to_string(),
+                        log_transformed: *log_t,
+                    },
+                )
+            })
+            .collect();
+        m
+    }
+
     fn make_compiled_model(with_ode: bool, gradient_method: GradientMethod) -> CompiledModel {
         CompiledModel {
             name: "test".into(),


### PR DESCRIPTION
## Why
Follow-up cleanup from the IMPMAP code review (#272 / #270), tracked in #273. The
correctness findings were fixed in #272; this PR is the dedicated **maintainability
+ efficiency** refactor (several pieces touch `saem.rs`, so they wanted their own
review).

`impmap.rs` re-implemented several pieces that already exist in `saem.rs`. The SAEM
copies carry unit tests and rationale; the IMPMAP copies had neither, so the shared
invariants (Ω masking/floor, FIX-pinning, log-mu-ref pair selection) were tested in
only one place and could silently drift — a future SAEM fix would not reach IMPMAP,
with no compile error and no test.

## What changed
**Reuse — shared EM-family leaves.** New `pub(crate)` module
`estimation::em_common` holds the exact-copy leaves, used from both `saem.rs` and
`impmap.rs`:
- `floor_omega_diagonal` — Ω diagonal PD floor (FIX-aware)
- `get_mu_ref_pairs` — log-mu-ref `(theta_idx, eta_idx)` pairs (was `mu_ref_log_pairs` in IMPMAP)
- `OMEGA_DIAG_FLOOR = 1e-6` — single constant carrying the MH proposal-collapse rationale

The dedicated unit tests move to `em_common` (their canonical home) and now cover
the path used by both estimators.

**Efficiency — IMPMAP hot loop.**
- `subject_is_draws`: the K retained samples now live in **one flat `Vec<f64>`**
  of length `K·d` per subject, filled in place, instead of K small `vec![0.0; d]`
  allocations (≈7.5M short-lived allocs at K=500, N=100, 150 iters); also improves
  M-step cache locality. Consumers iterate with `chunks_exact(d)`.
- `params_k` is built **once** and only the three changing fields
  (`theta`, `sigma.values`, `omega`) are refreshed in place each iteration, instead
  of rebuilding the full 16-field struct; `final_params` reuses the same bundle.
- Dropped the per-iteration `eta_hats.clone()` + redundant `last_eta_hats` binding;
  a single `prev_etas` carries the modes forward and out to the final EBE pass.

**Simplification.** Removed the redundant `value.trim()` in the
`impmap_proposal_df = normal` parser branch (`value` is already trimmed at the top
of `apply_fit_option`).

## Alternatives considered
The issue also proposes a shared packed-space M-step helper (generalizing
`theta_sigma_mstep_light` / `theta_sigma_weighted_mstep` over a per-subject
sample/weight provider) and threading the mode's `ipreds`/`r_diag` out of
`run_inner_loop_warm` so `compute_posterior_hessian` avoids a redundant re-predict.
Both are **deferred**: the M-step generalization is a larger API reshape, and the
re-predict fix changes `run_inner_loop_warm`'s signature, which is shared by
FOCEI/SAEM (wide blast radius). Kept this PR to the high-value, low-risk subset so
it stays reviewable.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change (`em_common` is `pub(crate)`; `SubjectDraws` is `pub(crate)`).

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: prior ferx commit (same branch, pre-refactor) — results identical
- [x] IMPMAP↔NONMEM warfarin match test (`ferx_impmap_matches_nonmem_impmap_on_warfarin`) passes
- [x] IMPMAP→FOCEI convergence test (`impmap_converges_to_focei_on_warfarin`) passes

This is a behaviour-preserving refactor; the slow IMPMAP tests that assert against
NONMEM output and against the FOCEI fit both pass unchanged under
`--features slow-tests`.

## Performance
- [x] Faster — removes ≈K allocations/subject/iteration in the IMPMAP E-step and
  per-iteration full-`ModelParameters` rebuilds; not separately benchmarked
  (allocation count is structural). No slowdowns.

## Tests
- [x] Unit test(s) added in the same module — the `floor_omega_diagonal` /
  `get_mu_ref_pairs` tests now live in `em_common` and exercise the shared path
- [x] Full suite passes: `cargo test --lib --no-default-features --features ci`
  (192 estimation tests) and the gated `impmap_api` / `warfarin_impmap_nonmem`
  tests under `--features slow-tests`

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor, no user-facing change)
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (touched modules)
- [x] `cargo check --features autodiff` — N/A: no `ad/`-reachable code touched, no
  `f64::max`/`min` added (autodiff build needs the Enzyme toolchain)
- [x] `Cargo.toml` version bump — N/A (non-breaking)

## Docs & examples
- [x] No example execution step needed (internal refactor / no user-visible change)

## Reviewer hints
- `em_common.rs` is the new shared home; the SAEM copies were removed and their
  tests relocated (diff in `saem.rs` is mostly deletions + a 1-line import +
  `SAEM_OMEGA_DIAG_FLOOR` → `OMEGA_DIAG_FLOOR` rename).
- The subtle bits are in `impmap.rs`: `prev_etas` now doubles as the final-mode
  carrier (cancellation still returns `Err` before the final EBE pass, so the
  empty-`last_eta_hats` branch it replaced was unreachable in the success path),
  and `SubjectDraws.etas` is now flat `K·d` — both `chunks_exact(d)` consumers
  (the moment loop in `importance_sampling.rs`, the weighted M-step in `impmap.rs`)
  updated to match. `n_eta == 0` is refused up front, so `chunks_exact` never sees
  a zero chunk size.

## Open questions
None.
