### PR TITLE
fix(parser): resolve branch-only individual parameters in [odes] [closes #357]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,15 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- An individual parameter assigned only inside symmetric `if`/`else` branches in
+  `[individual_parameters]` (the NONMEM-style `IF (cond) CL = ...` /
+  `IF (!cond) CL = ...` construction) on an **ODE model** is no longer rejected
+  by the `[odes]` RHS validator as an undefined name. A name written on every
+  branch is now promoted to a real individual parameter — getting a PK slot,
+  being written back, and resolving in the ODE RHS — provided a downstream block
+  (`[odes]`, `[structural_model]`, `[scaling]`, `[derived]`) actually references
+  it. Purely internal branch helpers stay branch-local and never consume a PK
+  slot (#357).
 - The covariance-family fit options `covariance_method`, `covariance_fallback`,
   and `covariance_ofv_hessian` no longer emit a spurious "is not used by method
   `<method>` and will be ignored" warning. They are framework-wide covariance-step

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -305,8 +305,10 @@ fn unconditional_names_in(stmts: &[Statement]) -> Vec<String> {
             } => {
                 // Without an `else`, no name is guaranteed across all paths.
                 if let Some(eb) = else_body {
-                    let mut sets: Vec<Vec<String>> =
-                        branches.iter().map(|(_, b)| unconditional_names_in(b)).collect();
+                    let mut sets: Vec<Vec<String>> = branches
+                        .iter()
+                        .map(|(_, b)| unconditional_names_in(b))
+                        .collect();
                     sets.push(unconditional_names_in(eb));
                     if let Some((first, rest)) = sets.split_first() {
                         for name in first {
@@ -13221,7 +13223,11 @@ if (WT > 70) {
         let ctx = empty_ctx();
         let stmts = parse_block_statements(block, ctx, StatementMode::Plain).unwrap();
         let uncond = unconditionally_assigned_vars(&stmts);
-        assert_eq!(uncond, vec!["CL"], "V lacks an else branch — not unconditional");
+        assert_eq!(
+            uncond,
+            vec!["CL"],
+            "V lacks an else branch — not unconditional"
+        );
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -238,6 +238,11 @@ fn assigned_vars_in_order(stmts: &[Statement]) -> Vec<String> {
 /// Branch-local helpers (e.g. `SCALE = ...` inside an `if` body) are
 /// intentionally excluded: including them would corrupt the AD inner loop
 /// by placing the helper in a PK slot (typically overwriting CL at slot 0).
+///
+/// These names are *always* individual parameters. `indiv_var_names` is this
+/// set plus the subset of all-branch-assigned names that a downstream block
+/// actually consumes (see `unconditionally_assigned_vars` and the call site in
+/// `parse_full_model`, issue #357).
 fn top_level_assigned_vars(stmts: &[Statement]) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for s in stmts {
@@ -248,6 +253,109 @@ fn top_level_assigned_vars(stmts: &[Statement]) -> Vec<String> {
         }
     }
     out
+}
+
+/// Variable names that are *unconditionally* defined by the end of the block:
+/// every top-level assignment, PLUS any name assigned on EVERY branch of an
+/// `if`/`else` (recursively). Such a name has a definite value on all code
+/// paths, so it *can* be a genuine individual parameter — unlike a branch-local
+/// helper assigned in only some branches.
+///
+/// This is a SUPERSET of `top_level_assigned_vars`. The all-branch extras are
+/// only promoted to actual individual parameters at the call site when a
+/// downstream block consumes them (issue #357) — promoting *every* such name
+/// would slot throwaway intermediates into the PK array (silently hijacking the
+/// reserved F/lagtime slots, aliasing the CL slot in `pk_indices`, or
+/// exhausting the 16-slot layout). See `parse_full_model`.
+///
+/// Motivating case: a PK parameter written only inside symmetric `if`/`else`
+/// branches (the natural NONMEM-style `IF (cond) CL = ...` / `IF (!cond) CL =
+/// ...` construction) must still get a PK slot, be written back by
+/// `pk_param_fn`, and be visible to the `[odes]` RHS name resolver — but only
+/// because `[odes]` references it.
+///
+/// First-occurrence order, deduplicated. An `if` with no `else`, or one where
+/// some branch omits the name, does NOT contribute that name — it could be
+/// undefined on the missing path, so it stays branch-local (matching
+/// `top_level_assigned_vars` for that case).
+fn unconditionally_assigned_vars(stmts: &[Statement]) -> Vec<String> {
+    // `unconditional_names_in` already deduplicates (its `push` closure), so no
+    // second pass is needed here.
+    unconditional_names_in(stmts)
+}
+
+/// Recursive worker for `unconditionally_assigned_vars`. Returns the names
+/// definitely assigned within `stmts`, in first-occurrence order: top-level
+/// `Assign`s, plus the intersection of unconditional names across all branches
+/// of any `if`/`else` (requires an `else`; the intersection preserves the
+/// order in which names first appear in the leading branch).
+fn unconditional_names_in(stmts: &[Statement]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let push = |name: &str, out: &mut Vec<String>| {
+        if !out.iter().any(|n| n == name) {
+            out.push(name.to_string());
+        }
+    };
+    for s in stmts {
+        match s {
+            Statement::Assign(name, _) => push(name, &mut out),
+            Statement::If {
+                branches,
+                else_body,
+            } => {
+                // Without an `else`, no name is guaranteed across all paths.
+                if let Some(eb) = else_body {
+                    let mut sets: Vec<Vec<String>> =
+                        branches.iter().map(|(_, b)| unconditional_names_in(b)).collect();
+                    sets.push(unconditional_names_in(eb));
+                    if let Some((first, rest)) = sets.split_first() {
+                        for name in first {
+                            if rest.iter().all(|s| s.iter().any(|n| n == name)) {
+                                push(name, &mut out);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Collect every identifier-like token (`[A-Za-z_][A-Za-z0-9_]*`) appearing in
+/// `lines`, upper-cased, into `out`. Used to decide whether an all-branch
+/// individual parameter is actually *consumed* by a downstream block (issue
+/// #357): such a name is promoted to a PK-slotted individual parameter only if
+/// some block outside `[individual_parameters]` references it. A purely
+/// internal helper (used only to compute another param within
+/// `[individual_parameters]`) stays branch-local, preserving the pre-#357
+/// behaviour and avoiding spurious PK-slot allocation / reserved-slot hijack.
+///
+/// Deliberately crude (lexical, case-folded, no scope awareness): a false
+/// positive only over-promotes a name that genuinely appears downstream — the
+/// safe direction. Keywords / state names that happen to collide are harmless;
+/// they would only matter if the user *also* named an individual parameter
+/// identically, in which case promoting it is correct anyway. Matched
+/// case-insensitively to mirror the ODE/analytical name resolvers, which alias
+/// both cases.
+fn collect_referenced_identifiers(lines: &[String], out: &mut std::collections::HashSet<String>) {
+    for line in lines {
+        let bytes = line.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'_' || bytes[i].is_ascii_alphabetic() {
+                let start = i;
+                i += 1;
+                while i < bytes.len() && (bytes[i] == b'_' || bytes[i].is_ascii_alphanumeric()) {
+                    i += 1;
+                }
+                out.insert(line[start..i].to_ascii_uppercase());
+            } else {
+                i += 1;
+            }
+        }
+    }
 }
 
 /// Union of eta indices touched by every assignment to `var_name` anywhere in
@@ -930,12 +1038,22 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // full set registered as defined_vars so any in-block reference (forward
     // or backward) resolves as Variable rather than Covariate.
     //
-    // `indiv_var_names` contains only TOP-LEVEL assignments — these are the
-    // individual parameters that map to PK slots and the TV output vector.
-    // Branch-local helpers (assigned only inside if-bodies) are intentionally
-    // excluded to prevent them from corrupting the AD inner-loop slot layout.
-    // The ParseCtx still receives the full set (via assigned_vars_in_order) so
-    // branch-local names parse as Variable rather than Covariate.
+    // `indiv_var_names` — the names that map to PK slots and the TV output
+    // vector. Two tiers (issue #357):
+    //   1. Every top-level assignment is always an individual parameter.
+    //   2. A name assigned on *all* branches of an if/else is promoted ONLY
+    //      when a downstream block ([odes], [structural_model], [scaling],
+    //      [derived]) actually references it — i.e. it is consumed as a PK
+    //      parameter. This is what makes the NONMEM-style `IF (cond) CL = ...`
+    //      / `IF (!cond) CL = ...` construction work: CL appears in [odes], so
+    //      it earns a slot, is written back by pk_param_fn, and resolves in the
+    //      ODE RHS.
+    // Promoting *every* all-branch name (the naive fix) would slot throwaway
+    // intermediates into the PK array — silently hijacking the reserved
+    // F/lagtime slots, aliasing the CL slot in pk_indices, or exhausting the
+    // 16-slot layout. So a branch-only helper used purely to compute another
+    // param stays branch-local. The ParseCtx still receives the full set (via
+    // assigned_vars_in_order) so such helpers parse as Variable, not Covariate.
     let indiv_text = indiv_lines.join("\n");
     // NN-output lookup table for `TYPICAL_PK.CL`-style dot-access in
     // [individual_parameters]. Always present (empty when no [covariate_nn]
@@ -955,7 +1073,22 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     let bare_ctx = ParseCtx::new(&theta_names, &eta_names, &[]).with_nn_specs(&nn_specs_for_ctx);
     let pre_stmts = parse_block_statements(&indiv_text, bare_ctx, StatementMode::Plain)?;
     let all_assigned = assigned_vars_in_order(&pre_stmts);
-    let indiv_var_names = top_level_assigned_vars(&pre_stmts);
+    // Tier 1 (always) + tier 2 (all-branch names referenced downstream). See
+    // the comment above for the rationale behind the downstream-consumption gate.
+    let top_level_names = top_level_assigned_vars(&pre_stmts);
+    let mut downstream_refs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for key in ["odes", "structural_model", "scaling", "derived"] {
+        if let Some(lines) = blocks.get(key) {
+            collect_referenced_identifiers(lines, &mut downstream_refs);
+        }
+    }
+    let indiv_var_names: Vec<String> = unconditionally_assigned_vars(&pre_stmts)
+        .into_iter()
+        .filter(|n| {
+            top_level_names.iter().any(|t| t == n)
+                || downstream_refs.contains(&n.to_ascii_uppercase())
+        })
+        .collect();
     let indiv_ctx =
         ParseCtx::new(&theta_names, &eta_names, &all_assigned).with_nn_specs(&nn_specs_for_ctx);
     let indiv_stmts = parse_block_statements(&indiv_text, indiv_ctx, StatementMode::Plain)?;
@@ -8237,9 +8370,18 @@ fn simplify_expr(expr: &Expression) -> Expression {
 #[allow(dead_code)] // no runtime consumer after #145; see struct doc.
 pub struct IndivParamPartials {
     /// Indiv-param names parallel to `d_d_theta` / `d_d_eta` outer Vec, in
-    /// `[individual_parameters]` source-declaration order. Equals the
-    /// top-level `Assign(name, _)` order, matching
-    /// `CompiledModel.indiv_param_names`.
+    /// `[individual_parameters]` source-declaration order — one row per
+    /// top-level `Assign(name, _)`.
+    ///
+    /// CAUTION (issue #357): this is a *subset* of
+    /// `CompiledModel.indiv_param_names`, not a positional twin. A parameter
+    /// assigned only inside `if`/`else` branches and promoted because a
+    /// downstream block references it (e.g. a conditional `CL`) appears in
+    /// `indiv_param_names` but has NO row here — `build_indiv_param_partials`
+    /// skips `Statement::If`, and a piecewise param has no single symbolic
+    /// partial anyway (the AD inner loop falls back to FD; see the `eta_map`
+    /// note in `parse_full_model`). A future AD consumer MUST look partials up
+    /// by name, never zip them positionally against `indiv_param_names`.
     pub(crate) names: Vec<String>,
     /// `d_d_theta[i][k]` = ∂P_i/∂θ_k. Inner Vec length = `n_theta_base`
     /// (user-declared θ count, NOT including NN-weight or diffusion θ which
@@ -13019,6 +13161,67 @@ if (1 > 0) {
         let all = assigned_vars_in_order(&stmts);
         assert!(all.contains(&"SCALE".to_string()));
         assert!(all.contains(&"V".to_string()));
+    }
+
+    #[test]
+    fn test_unconditionally_assigned_vars_includes_all_branch_assignments() {
+        // V is assigned on BOTH branches → unconditionally defined → promoted.
+        // SCALE is assigned in only one branch → branch-local → excluded.
+        // (Issue #357: a param written on every branch must earn a PK slot.)
+        let block = "
+CL = 1.0
+if (1 > 0) {
+  SCALE = 2.0
+  V = SCALE * 3.0
+} else {
+  V = 4.0
+}
+";
+        let ctx = empty_ctx();
+        let stmts = parse_block_statements(block, ctx, StatementMode::Plain).unwrap();
+        let uncond = unconditionally_assigned_vars(&stmts);
+        assert_eq!(
+            uncond,
+            vec!["CL", "V"],
+            "V is assigned on every branch and must be promoted; SCALE must not"
+        );
+        // top_level still excludes V (its only assignments are inside branches).
+        let top = top_level_assigned_vars(&stmts);
+        assert_eq!(top, vec!["CL"]);
+    }
+
+    #[test]
+    fn test_unconditionally_assigned_vars_branch_only_param() {
+        // The exact issue #357 shape: CL assigned only inside if/else, V at
+        // top level. CL must come first (leading-branch order), then V.
+        let block = "
+if (WT > 70) {
+  CL = TVCL * 1.5
+} else {
+  CL = TVCL
+}
+V = TVV
+";
+        let ctx = empty_ctx();
+        let stmts = parse_block_statements(block, ctx, StatementMode::Plain).unwrap();
+        let uncond = unconditionally_assigned_vars(&stmts);
+        assert_eq!(uncond, vec!["CL", "V"]);
+    }
+
+    #[test]
+    fn test_unconditionally_assigned_vars_if_without_else_excludes() {
+        // No `else` → the name could be undefined on the fall-through path, so
+        // it stays branch-local (not promoted).
+        let block = "
+CL = 1.0
+if (WT > 70) {
+  V = 2.0
+}
+";
+        let ctx = empty_ctx();
+        let stmts = parse_block_statements(block, ctx, StatementMode::Plain).unwrap();
+        let uncond = unconditionally_assigned_vars(&stmts);
+        assert_eq!(uncond, vec!["CL"], "V lacks an else branch — not unconditional");
     }
 
     #[test]

--- a/tests/branch_only_param_ode.rs
+++ b/tests/branch_only_param_ode.rs
@@ -134,7 +134,10 @@ fn assert_branch_matches_top_level(wt: f64) {
             any_positive = true;
         }
     }
-    assert!(any_positive, "all predictions were zero (WT={wt}) — model is degenerate");
+    assert!(
+        any_positive,
+        "all predictions were zero (WT={wt}) — model is degenerate"
+    );
 }
 
 #[test]

--- a/tests/branch_only_param_ode.rs
+++ b/tests/branch_only_param_ode.rs
@@ -1,0 +1,215 @@
+//! Regression test for issue #357: an individual parameter assigned *only*
+//! inside symmetric `if`/`else` branches in `[individual_parameters]` must be
+//! a first-class individual parameter on an ODE model — it has to (a) parse
+//! (the `[odes]` RHS name resolver previously rejected it as undefined), (b)
+//! earn a PK slot, and (c) actually be written back by `pk_param_fn` so the
+//! ODE RHS reads its real value rather than the silent-0 sentinel.
+//!
+//! The check is an equivalence: a model whose `CL` is written on *both*
+//! branches of an `if`/`else` (with the two branches collapsing to the same
+//! value for the covariate we feed it) must `predict()` identically to the
+//! plain top-level-`CL` form. If the fix only silenced the parse error without
+//! wiring the write-back, the branch-only model would predict with `CL = 0`
+//! (a flat, non-eliminating trajectory) and diverge sharply from the twin.
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::predict;
+use ferx_core::types::{DoseEvent, Population, Subject};
+
+mod common;
+
+const ATOL: f64 = 1e-5;
+const RTOL: f64 = 1e-4;
+
+/// Top-level `CL` — the control. `WT` is referenced so both forms parse against
+/// the identical covariate set.
+const TOP_LEVEL: &str = r"
+[parameters]
+  theta TVCL(3.0, 0.01, 100.0)
+  theta TVV(20.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.1
+  sigma PROP_ERR ~ 0.04
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+";
+
+/// `CL` assigned only inside `if`/`else`. Both branches reduce to the same
+/// expression as `TOP_LEVEL` (the `* 1.0` factor keeps the value identical) so
+/// predictions must match the control exactly, proving the branch-only `CL`
+/// is computed into its PK slot and seen by the ODE RHS.
+const BRANCH_ONLY: &str = r"
+[parameters]
+  theta TVCL(3.0, 0.01, 100.0)
+  theta TVV(20.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.1
+  sigma PROP_ERR ~ 0.04
+
+[individual_parameters]
+  if (WT > 70) {
+    CL = TVCL * 1.0 * exp(ETA_CL)
+  } else {
+    CL = TVCL * exp(ETA_CL)
+  }
+  V = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+";
+
+fn population(wt: f64) -> Population {
+    let obs_times = vec![0.5, 1.0, 2.0, 4.0, 8.0, 24.0];
+    let n = obs_times.len();
+    let mut s: Subject = common::subject(
+        "1",
+        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        obs_times,
+        vec![0.0; n],
+        vec![1; n],
+    );
+    s.covariates.insert("WT".to_string(), wt);
+    Population {
+        covariate_names: vec!["WT".to_string()],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![s],
+    }
+}
+
+fn assert_branch_matches_top_level(wt: f64) {
+    let top = parse_full_model(TOP_LEVEL)
+        .unwrap_or_else(|e| panic!("top-level model did not parse: {e}"))
+        .model;
+    // The crux of #357: this used to fail with
+    // `[odes]: RHS references undefined name(s): CL`.
+    let branch = parse_full_model(BRANCH_ONLY)
+        .unwrap_or_else(|e| panic!("branch-only model did not parse (issue #357): {e}"))
+        .model;
+
+    let pop = population(wt);
+    let pt = predict(&top, &pop, &top.default_params);
+    let pb = predict(&branch, &pop, &branch.default_params);
+    assert_eq!(pt.len(), pb.len(), "prediction count mismatch (WT={wt})");
+    assert!(!pt.is_empty(), "no predictions produced (WT={wt})");
+
+    // Every prediction must be a real, eliminating concentration (a silent
+    // CL=0 would leave the central amount constant → a flat, much larger PRED).
+    let mut any_positive = false;
+    for (x, y) in pt.iter().zip(pb.iter()) {
+        let tol = ATOL + RTOL * x.pred.abs();
+        assert!(
+            (x.pred - y.pred).abs() <= tol,
+            "WT={wt} t={:.3}: top-level PRED {:.6} vs branch-only PRED {:.6} (|diff| {:.2e} > tol {:.2e})",
+            wt,
+            x.pred,
+            y.pred,
+            (x.pred - y.pred).abs(),
+            tol
+        );
+        if x.pred.abs() > 0.0 {
+            any_positive = true;
+        }
+    }
+    assert!(any_positive, "all predictions were zero (WT={wt}) — model is degenerate");
+}
+
+#[test]
+fn branch_only_param_predicts_like_top_level_wt_high() {
+    // WT > 70 → the `if` branch fires.
+    assert_branch_matches_top_level(80.0);
+}
+
+#[test]
+fn branch_only_param_predicts_like_top_level_wt_low() {
+    // WT <= 70 → the `else` branch fires. Both must write CL to its slot.
+    assert_branch_matches_top_level(60.0);
+}
+
+/// A branch-only helper named like a reserved PK parameter (`F`) that is NOT
+/// referenced by any downstream block must NOT be promoted into the PK array —
+/// otherwise it silently hijacks the engine's bioavailability slot and corrupts
+/// dosing. Guards the over-promotion regression flagged in review of #357: the
+/// fix promotes an all-branch name only when a downstream block consumes it.
+const UNUSED_BRANCH_F: &str = r"
+[parameters]
+  theta TVCL(3.0, 0.01, 100.0)
+  theta TVV(20.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.1
+  sigma PROP_ERR ~ 0.04
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  if (WT > 70) {
+    F = 0.5
+  } else {
+    F = 0.5
+  }
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+";
+
+#[test]
+fn unused_branch_f_does_not_hijack_bioavailability() {
+    // `F` is assigned on every branch but never referenced in [odes]/[scaling],
+    // so it must stay branch-local and leave the engine's default F = 1.0 in
+    // place. Predictions must equal the model without the F block. If `F` were
+    // promoted it would land in PK_IDX_F = 0.5, halving the delivered dose and
+    // halving every prediction.
+    let top = parse_full_model(TOP_LEVEL)
+        .expect("top-level model did not parse")
+        .model;
+    let with_f = parse_full_model(UNUSED_BRANCH_F)
+        .expect("unused-F model did not parse")
+        .model;
+
+    let pop = population(80.0);
+    let pt = predict(&top, &pop, &top.default_params);
+    let pf = predict(&with_f, &pop, &with_f.default_params);
+    assert_eq!(pt.len(), pf.len());
+    assert!(!pt.is_empty());
+    for (x, y) in pt.iter().zip(pf.iter()) {
+        let tol = ATOL + RTOL * x.pred.abs();
+        assert!(
+            (x.pred - y.pred).abs() <= tol,
+            "t={:.3}: baseline PRED {:.6} vs unused-F PRED {:.6} — F was promoted and hijacked the dosing slot",
+            x.time,
+            x.pred,
+            y.pred
+        );
+    }
+}


### PR DESCRIPTION
## Why

For an ODE model, an individual parameter assigned *only* inside `if`/`else` branches in `[individual_parameters]` was rejected by the `[odes]` RHS validator as an undefined name, even though it is well-defined on every code path (#357):

```
error[E_PARSE]: [odes]: RHS references undefined name(s): CL. ...
```

`indiv_var_names` was built from `top_level_assigned_vars`, which excludes branch-local assignments by design. A NONMEM-style conditional parameter —

```
IF (DISEASE.EQ.2) CL = ...        ; no IOV
IF (DISEASE.NE.2) CL = ... * EXP(IOV)
```

— therefore got no PK slot, was never written back by `pk_param_fn`, and was invisible to the ODE name resolver. The user was forced to bury the conditional inside the expression. Analytical models were unaffected (their PK names come from the structural LHS map).

## What changed

Promote a name assigned on **every** branch of an `if`/`else` to a real individual parameter — but only when a downstream block (`[odes]`, `[structural_model]`, `[scaling]`, `[derived]`) actually references it.

- `unconditionally_assigned_vars` / `unconditional_names_in` — collect top-level assignments plus the intersection of names assigned across all branches (requires an `else`; first-occurrence order).
- `collect_referenced_identifiers` — lexical, case-folded scan of downstream block text; gates promotion on actual consumption.
- The two-tier `indiv_var_names` is assembled at the `parse_full_model` call site: tier 1 = every top-level assignment (always), tier 2 = all-branch names that appear downstream.
- `IndivParamPartials.names` doc updated: it is now a *subset* of `indiv_param_names` (a promoted branch param has no partial row, since `build_indiv_param_partials` skips `If` and a piecewise param has no single symbolic partial); consumers must look up by name, never zip positionally. Latent only — the AD consumer was reverted in #145.

## Alternatives considered

Promoting *every* all-branch name (the naive fix). Rejected: it slots throwaway intermediates into the fixed PK array, which (1) silently hijacks the reserved `F`/`lagtime` slots — corrupting dosing with no error, (2) aliases the CL slot via `pk_indices` `.unwrap_or(0)` for analytical models — reporting a wrong value under the helper's name, and (3) can exhaust the 16-slot layout, turning a previously-valid model into a parse error. The downstream-consumption gate avoids all three while still fixing the reported case.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] None

This relaxes a parse-time rejection; no previously-valid model changes behavior (a branch helper not referenced downstream stays branch-local exactly as before).

## Numerical validation
- [x] Not applicable — the fix is name resolution / slot allocation at parse time. Equivalence is asserted by tests below (branch-only CL predicts identically to top-level CL).

## Performance
- [x] No significant impact expected — one extra lexical scan of a few downstream block lines at parse time.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

`tests/branch_only_param_ode.rs`:
- `branch_only_param_predicts_like_top_level_{wt_high,wt_low}` — a branch-only CL predicts identically to the plain top-level CL form (proves CL reaches its slot, not the silent-0 sentinel).
- `unused_branch_f_does_not_hijack_bioavailability` — an all-branch `F` not referenced in `[odes]` leaves the engine default bioavailability untouched (guards the over-promotion regression).

Unit tests for `unconditionally_assigned_vars` (all-branch promotion, branch-only param ordering, no-else exclusion).

Full `cargo test --lib --no-default-features --features ci` (1073) + `analytical_ode_equivalence` (7) + `warfarin_iov_nonmem` pass.

## Example

`[individual_parameters]` on an ODE model:

```toml
[individual_parameters]
  if (WT > 70) {
    CL = TVCL * 1.5 * exp(ETA_CL)
  } else {
    CL = TVCL * exp(ETA_CL)
  }
  V = TVV

[odes]
  d/dt(central) = -(CL/V) * central
```

`ferx check` before: `error[E_PARSE]: [odes]: RHS references undefined name(s): CL`. After: `ok` (with the existing `W_PARSE` mu-referencing-disabled note for the conditional CL).

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added

## Checklist
- [ ] `cargo clippy` clean — not run locally (clippy unavailable on the enzyme toolchain); CI clippy job will verify
- [x] `cargo check --features autodiff` — N/A locally (requires Enzyme nightly); changed code is on the parse path, not AD-reachable at runtime

## Reviewer hints

Focus on the `parse_full_model` call site (the two-tier `indiv_var_names` assembly) and `collect_referenced_identifiers` — the downstream-consumption gate is what keeps throwaway intermediates out of the PK array. The lexical scan is deliberately crude: a false positive only over-promotes a name that genuinely appears downstream (the safe direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)