### PR TITLE
feat(estimation): optional GPU-accelerated SAEM E-step [closes #368]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,17 @@ section of the SDLC for the versioning policy).
 
 ### Added
 - Optional **GPU-accelerated SAEM E-step** behind the new `gpu` Cargo feature
-  (off by default). A `cubecl` kernel (wgpu → Metal/Vulkan/DX12, or CUDA)
-  evaluates the batched per-subject individual log-likelihood for the
-  1-compartment IV-bolus analytical model with Gaussian error. Selected per fit
-  via the new `saem_backend = auto|cpu|gpu` `[fit_options]` key (default
-  `auto`). The CPU path remains the reference and the default: the GPU path is
-  fully optional and falls back to CPU — with a warning when `gpu` was
-  explicitly requested — whenever the feature is unbuilt, no device is
-  available, or the model is outside the supported subset, so results are
-  unchanged in environments without a GPU. CPU/GPU parity is tested (#368).
+  (off by default). A `cubecl` kernel (wgpu → Metal/Vulkan/DX12, or CUDA) runs
+  the whole per-subject block random-walk Metropolis-Hastings sweep on the GPU
+  (one thread per subject) for the 1-compartment IV-bolus analytical model with
+  Gaussian error, a diagonal Ω, and ≤ 8 random effects; the M-step and
+  step-size adaptation stay on the CPU. Selected per fit via the new
+  `saem_backend = auto|cpu|gpu` `[fit_options]` key (default `auto`). The CPU
+  path remains the reference and the default: the GPU path is fully optional and
+  falls back to CPU — with a warning when `gpu` was explicitly requested —
+  whenever the feature is unbuilt, no device is available, or the model is
+  outside the supported subset, so results are unchanged in environments without
+  a GPU. CPU/GPU NLL parity and full-fit convergence are tested (#368).
   input-rate function in the `[odes]` block (Savic et al. 2007, continuous `n`):
   `R_in(tad) = F·Dose·KTR·(KTR·tad)^n·e^(−KTR·tad)/Γ(n+1)`, `KTR=(n+1)/mtt`. The
   dose is delivered as this appearance rate into the depot (∫R_in dt = F·Dose) —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,16 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
-- Built-in **transit-compartment absorption** for ODE models via a `transit(n, mtt)`
+- Optional **GPU-accelerated SAEM E-step** behind the new `gpu` Cargo feature
+  (off by default). A `cubecl` kernel (wgpu → Metal/Vulkan/DX12, or CUDA)
+  evaluates the batched per-subject individual log-likelihood for the
+  1-compartment IV-bolus analytical model with Gaussian error. Selected per fit
+  via the new `saem_backend = auto|cpu|gpu` `[fit_options]` key (default
+  `auto`). The CPU path remains the reference and the default: the GPU path is
+  fully optional and falls back to CPU — with a warning when `gpu` was
+  explicitly requested — whenever the feature is unbuilt, no device is
+  available, or the model is outside the supported subset, so results are
+  unchanged in environments without a GPU. CPU/GPU parity is tested (#368).
   input-rate function in the `[odes]` block (Savic et al. 2007, continuous `n`):
   `R_in(tad) = F·Dose·KTR·(KTR·tad)^n·e^(−KTR·tad)/Γ(n+1)`, `KTR=(n+1)/mtt`. The
   dose is delivered as this appearance rate into the depot (∫R_in dt = F·Dose) —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -15,6 +36,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -75,16 +111,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -93,6 +221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -106,6 +243,35 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
 
 [[package]]
 name = "cc"
@@ -114,7 +280,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -124,12 +301,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "comrak"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
+dependencies = [
+ "caseless",
+ "entities",
+ "memchr",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "constcat"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -142,6 +432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +448,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -174,6 +479,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -207,6 +518,415 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd203fef6e359472e4cb8f6c0ef3eca062815a1edd560eb6d6c1d5c1397838d9"
+dependencies = [
+ "cubecl-core",
+ "cubecl-cpu",
+ "cubecl-cuda",
+ "cubecl-hip",
+ "cubecl-ir",
+ "cubecl-runtime",
+ "cubecl-std",
+ "cubecl-wgpu",
+ "half",
+]
+
+[[package]]
+name = "cubecl-common"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc956c2dcc993f16f748d03bfdbd900f75cab4d469f4e5d8924f8ee128e861ad"
+dependencies = [
+ "backtrace",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "ciborium",
+ "derive-new",
+ "derive_more",
+ "dirs",
+ "embassy-futures",
+ "embassy-time",
+ "float4",
+ "float8",
+ "futures-lite",
+ "half",
+ "hashbrown 0.16.1",
+ "log",
+ "num-traits",
+ "oneshot",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rand 0.10.1",
+ "sanitize-filename",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "spin",
+ "toml",
+ "tynm",
+ "wasm-bindgen-futures",
+ "web-time",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "cubecl-core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-ir",
+ "cubecl-macros",
+ "cubecl-runtime",
+ "cubecl-zspace",
+ "derive-new",
+ "derive_more",
+ "enumset",
+ "float-ord",
+ "half",
+ "hashbrown 0.16.1",
+ "log",
+ "num-traits",
+ "paste",
+ "serde",
+ "serde_json",
+ "variadics_please",
+]
+
+[[package]]
+name = "cubecl-cpp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411af04828cbf4583ecd388579fb30cd7a644eec19a334bb8f0d9d08522e1458"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "cubecl-cpu"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f572143f54e42a49ee0635a4ec36005f639e62be029e4f49890c808985981b35"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "cubecl-std",
+ "derive-new",
+ "half",
+ "log",
+ "paste",
+ "serde",
+ "sysinfo",
+ "tracel-llvm",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "cubecl-cuda"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b0a69ff45688d322ad8e92c8bf645167b9ca490fa8fa087fc6adac8c5e46be"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-cpp",
+ "cubecl-runtime",
+ "cudarc",
+ "derive-new",
+ "half",
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "cubecl-hip"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b510a9348f06ecd56b32cf10eb6241639e927a87f5c09ec61cc7a7610d5a3"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-cpp",
+ "cubecl-hip-sys",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "log",
+ "paste",
+ "serde",
+]
+
+[[package]]
+name = "cubecl-hip-sys"
+version = "7.2.5321100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58887c6d217859c2261a868a3a6b66aa8f44ea2f4bfa51d0dbe4dcb0d1f5768d"
+dependencies = [
+ "libc",
+ "regex",
+]
+
+[[package]]
+name = "cubecl-ir"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28a897a40c8ee6c57a8b8d76d8823ba2e97f4c2b83db9338f17a0752132d486"
+dependencies = [
+ "cubecl-common",
+ "cubecl-macros-internal",
+ "derive-new",
+ "derive_more",
+ "enumset",
+ "float-ord",
+ "fnv",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.16.1",
+ "num-traits",
+ "portable-atomic",
+ "serde",
+ "variadics_please",
+]
+
+[[package]]
+name = "cubecl-macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77aa6df563e8e6a0926d2e9eeacb968737940a0e1ae9be819f6a65a341006e12"
+dependencies = [
+ "cubecl-common",
+ "darling 0.23.0",
+ "derive-new",
+ "ident_case",
+ "inflections",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cubecl-macros-internal"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a515651a5a91e25d87f71f311f80a088e6cf815798b9922560a97636da6b8740"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cubecl-opt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a599c6c3efefdcee8636994c90e58ef696c7efbed2d18b5b5ad8d5f29923abb"
+dependencies = [
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-ir",
+ "float-ord",
+ "log",
+ "num",
+ "petgraph",
+ "smallvec",
+ "stable-vec",
+ "type-map",
+]
+
+[[package]]
+name = "cubecl-runtime"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68491bf5b3e997ae36bdc4e63b4ccd6d2f0e86b3b596a5d7a48d2b9e92622a0"
+dependencies = [
+ "ahash",
+ "async-channel",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "cubecl-common",
+ "cubecl-ir",
+ "cubecl-zspace",
+ "derive-new",
+ "derive_more",
+ "dirs",
+ "enumset",
+ "hashbrown 0.16.1",
+ "log",
+ "md5",
+ "serde",
+ "serde_json",
+ "spin",
+ "thiserror",
+ "toml",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "cubecl-std"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b391b584a4897683dd9fc0767f96337ac712b733126ce0f68a9ee8a2df073d2d"
+dependencies = [
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-runtime",
+ "half",
+ "num-traits",
+ "paste",
+ "serde",
+ "spin",
+ "variadics_please",
+]
+
+[[package]]
+name = "cubecl-wgpu"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3663c6e1a86187172b2cee495b6b533e7d91a2cb37e26f421649e315fe4c3a"
+dependencies = [
+ "async-channel",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-ir",
+ "cubecl-runtime",
+ "derive-new",
+ "derive_more",
+ "half",
+ "hashbrown 0.16.1",
+ "log",
+ "sanitize-filename",
+ "wasm-bindgen-futures",
+ "wgpu",
+]
+
+[[package]]
+name = "cubecl-zspace"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04054d95698afab785a4dda9f949e297831dd9e4cc6d036a93e6603f88e88b07"
+dependencies = [
+ "derive-new",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+dependencies = [
+ "libloading 0.9.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +938,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +974,37 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -239,10 +1019,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
+
+[[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "enumset"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -257,7 +1139,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -274,6 +1177,7 @@ dependencies = [
  "argmin",
  "argmin-math",
  "csv",
+ "cubecl",
  "nalgebra",
  "nlopt",
  "rand 0.8.5",
@@ -289,10 +1193,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -302,6 +1222,116 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "float4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5404bf31d22893d61cf24d4dda149d8e6b2ff07601c3cb3be651031f61a4ed"
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -321,8 +1351,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -332,9 +1364,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -446,10 +1511,358 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "serde",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -458,7 +1871,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -468,14 +1913,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -484,10 +1992,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -496,10 +2054,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matrixmultiply"
@@ -512,10 +2097,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -525,6 +2122,43 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -573,12 +2207,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nlopt"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6347753a7143118e8477544749322f5f23c8b63e485e9663dde696bdf425bf0"
 dependencies = [
  "cmake",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -610,6 +2310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,16 +2342,214 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -652,12 +2561,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -674,6 +2660,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -694,6 +2686,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -735,6 +2738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +2761,30 @@ checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -778,6 +2811,26 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -810,6 +2863,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,7 +2960,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -844,6 +3020,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +3057,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -887,13 +3103,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -923,6 +3160,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+ "portable-atomic",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "stable-vec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dac7bc0f7d0d44329b200020effbc25a534d89fa142af95e3ddf76113412a5e"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +3261,51 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -943,7 +3318,16 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -967,6 +3351,280 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracel-llvm"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982535db9eb1a30ac0f2c50239a0eec3e5cf50993a88e92b04747bd2f4d365b2"
+dependencies = [
+ "tracel-mlir-rs",
+ "tracel-mlir-sys",
+]
+
+[[package]]
+name = "tracel-llvm-bundler"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c75b8e477cb8d49d907afab029ca74d48459f5b88c27bdb4c6cd6acb5e61977"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "constcat",
+ "dirs",
+ "liblzma",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "walkdir",
+]
+
+[[package]]
+name = "tracel-mlir-rs"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a478a35efd68d0ba73f747adfb7923b121c64e7f5be9cd8364ca1dcb772d5c"
+dependencies = [
+ "tracel-mlir-rs-macros",
+ "tracel-mlir-sys",
+]
+
+[[package]]
+name = "tracel-mlir-rs-macros"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94f36868c3b10b1825945223d99d106c73f4d249f063caa4651deeb9379344"
+dependencies = [
+ "comrak",
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "tracel-llvm-bundler",
+ "tracel-tblgen-rs",
+ "unindent",
+]
+
+[[package]]
+name = "tracel-mlir-sys"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f26d31af0c225a6d2e3d65d012fd6de848c9fc776897b152ee83b7d1bd15c4"
+dependencies = [
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "tracel-tblgen-rs"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d2581070380418ccc33b500f3739e4d4869421fdb477fcea51ff97c6253a52"
+dependencies = [
+ "bindgen",
+ "cc",
+ "paste",
+ "thiserror",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tynm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21cdb0fc8f85c98b1ec812bc4cd69faf6c0fa2fc17d44ea3c2cdd38dc08e999"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,10 +3637,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "variadics_please"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -996,7 +3753,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1010,6 +3776,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1045,6 +3821,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +3884,183 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
 ]
 
 [[package]]
@@ -1065,10 +4074,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1080,10 +4233,293 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1099,6 +4535,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ survival = []
 # Heavy fit-based tests (5–60 min wall each on a 2-core CI runner).
 # Default `cargo test` `#[ignore]`s them; a nightly/manual job opts in.
 slow-tests = []
+# GPU-accelerated SAEM E-step (batched analytical-PK NLL kernel via cubecl,
+# wgpu/Metal + CUDA backends). Off by default: the default build compiles and
+# runs the CPU SAEM path unchanged. With `gpu` enabled the backend is still
+# opt-in per fit (`saem_backend = auto|gpu`) and falls back to CPU at runtime
+# when no device is available or the model is outside the supported subset.
+# See plans / issue #368.
+gpu = ["dep:cubecl"]
 
 [dependencies]
 nalgebra = "0.34"
@@ -44,6 +51,9 @@ argmin = { version = "0.11", features = ["serde1"] }
 argmin-math = { version = "0.5", features = ["nalgebra_latest"] }
 tempfile = "3"
 sha2 = "0.10"
+# Optional GPU compute backend (enabled by the `gpu` feature). The wgpu backend
+# targets Metal (Apple) / Vulkan / DX12; a CUDA backend is available on NVIDIA.
+cubecl = { version = "0.10", features = ["wgpu"], optional = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -103,6 +103,15 @@ step-size adaptation staying on the CPU.
 | `cpu` | Always use the CPU E-step (the reference path). |
 | `gpu` | Prefer the GPU; fall back to CPU (emitting a warning in `FitResult.warnings`) when the feature is absent, no device is available, or the model is unsupported. |
 
+**When it helps.** The GPU runs one MH chain per subject, so the win grows
+with the population size and the per-iteration work. On an Apple M5 Pro the GPU
+E-step overtakes the rayon CPU baseline at roughly ≥ 1500 subjects with the
+default `n_mh_steps = 20`, and wins by a wide margin as `n_mh_steps` (or data
+density) rises — e.g. at 2000 subjects it is ~2.6× faster at `n_mh_steps = 100`
+and ~10× at `500`. Small, light fits stay on a comparable footing, which is why
+`auto` is conservative. (Measured with 50 exploration + 100 convergence
+iterations; numbers are indicative, not a guarantee.)
+
 The GPU path is **opt-in and fully optional**: the default build does not pull
 in `cubecl`, and `saem_backend` defaults to `auto`, so results are unchanged in
 environments without a GPU. The CPU and GPU paths are validated for numerical

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -103,14 +103,25 @@ step-size adaptation staying on the CPU.
 | `cpu` | Always use the CPU E-step (the reference path). |
 | `gpu` | Prefer the GPU; fall back to CPU (emitting a warning in `FitResult.warnings`) when the feature is absent, no device is available, or the model is unsupported. |
 
-**When it helps.** The GPU runs one MH chain per subject, so the win grows
-with the population size and the per-iteration work. On an Apple M5 Pro the GPU
-E-step overtakes the rayon CPU baseline at roughly ≥ 1500 subjects with the
-default `n_mh_steps = 20`, and wins by a wide margin as `n_mh_steps` (or data
-density) rises — e.g. at 2000 subjects it is ~2.6× faster at `n_mh_steps = 100`
-and ~10× at `500`. Small, light fits stay on a comparable footing, which is why
-`auto` is conservative. (Measured with 50 exploration + 100 convergence
-iterations; numbers are indicative, not a guarantee.)
+**When it helps.** The GPU runs one MH chain per subject, so the win grows with
+the population size and the per-iteration work. For the model this kernel
+currently supports — a simple, well-identified 1-compartment IV model — the
+realistic regime is the **default `n_mh_steps`** with a **large, sparsely
+sampled population** (e.g. phase-3-style: thousands of subjects, few samples
+each). There the GPU E-step overtakes the rayon CPU baseline at roughly ≥ 1500
+subjects and reaches ~1.3–1.7× by 4000–8000 subjects on an Apple M5 Pro. Small
+and medium studies sit at parity or below, which is why `auto` is conservative
+and keeps them on the CPU.
+
+Raising `n_mh_steps` makes the GPU win by a wide margin (e.g. ~2.6× at 100,
+~10× at 500 on 2000 subjects), but you would not normally do that for a simple
+1-cpt model — the default mixes fine. That scaling matters because per-iteration
+overhead is fixed while compute is not: it is **latent headroom** for the harder
+models that genuinely need many MH steps (or HMC) to mix — correlated/block Ω,
+ODE/PD, high-dimensional η — which are exactly the cases that currently fall
+back to the CPU. As those kernels are added, the compute-scaling advantage
+becomes the real payoff. (Measured with 50 exploration + 100 convergence
+iterations; indicative, not a guarantee.)
 
 The GPU path is **opt-in and fully optional**: the default build does not pull
 in `cubecl`, and `saem_backend` defaults to `auto`, so results are unchanged in

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -90,11 +90,12 @@ Stochastic Approximation EM. Uses Metropolis-Hastings sampling instead of MAP op
 
 ### GPU backend (`saem_backend`)
 
-The SAEM E-step evaluates the per-subject individual log-likelihood many
-times per iteration — an embarrassingly parallel workload. When ferx-core is
-built with the `gpu` Cargo feature, that batched evaluation can run on a GPU
-via a [`cubecl`](https://github.com/tracel-ai/cubecl) kernel (wgpu → Metal /
-Vulkan / DX12, or CUDA on NVIDIA).
+The SAEM E-step runs an independent Metropolis-Hastings chain per subject —
+an embarrassingly parallel workload. When ferx-core is built with the `gpu`
+Cargo feature, the whole per-subject block random-walk MH sweep runs on a GPU
+(one thread per subject) via a [`cubecl`](https://github.com/tracel-ai/cubecl)
+kernel (wgpu → Metal / Vulkan / DX12, or CUDA on NVIDIA), with the M-step and
+step-size adaptation staying on the CPU.
 
 | Value | Behaviour |
 |-------|-----------|
@@ -108,13 +109,22 @@ environments without a GPU. The CPU and GPU paths are validated for numerical
 parity (within `f32` tolerance — GPUs that lack `f64`, such as Metal, run the
 kernel in `f32`).
 
-**Supported subset.** The current kernel covers the 1-compartment IV-bolus
+Because the per-proposal η changes CL/V every step and the θ,η→PK-parameter
+transform is an arbitrary DSL closure, the kernel reconstructs CL/V from a
+**log-linear** model `CL = CL0·exp(a·η)` whose coefficients are extracted and
+*verified* against the real closure on the host; models that are not log-linear
+in η fall back to CPU. The in-kernel RNG is counter-based, so the GPU and CPU
+chains are not bit-identical — SAEM is stochastic and the Robbins-Monro M-step
+averages over draws, so the two converge to statistically equivalent estimates
+(validated by a full-fit convergence test).
+
+**Supported subset.** The GPU MH E-step covers the 1-compartment IV-bolus
 analytical model with a single Gaussian endpoint (additive / proportional /
-combined error). Anything outside it — other PK models, infusions,
-steady-state doses, system resets, time-varying covariates, M3 BLOQ, SDE, or
-TTE endpoints — transparently falls back to the CPU path. The GPU port of the
-full Metropolis-Hastings / HMC proposal loop is tracked as follow-up work in
-issue #368.
+combined error), a **diagonal Ω**, and **≤ 8** random effects. Anything outside
+it — other PK models, infusions, steady-state doses, system resets,
+time-varying covariates, M3 BLOQ, SDE/TTE, block Ω (which needs the
+componentwise decorrelating sweep), IOV, or HMC (`n_leapfrog > 0`) —
+transparently falls back to the CPU E-step.
 
 ## SIR (Sampling Importance Resampling)
 

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -86,6 +86,35 @@ Stochastic Approximation EM. Uses Metropolis-Hastings sampling instead of MAP op
 | `adapt_interval` | `50` | Iterations between step-size adaptation |
 | `omega_burnin` | `20` | Initial exploration iterations during which Ω (and Ω<sub>IOV</sub>) are held at their starting values while the MH chain warms up. Clamped to `n_exploration`; set `0` to disable. Prevents the Ω collapse described in the SAEM page. |
 | `seed` | `12345` | RNG seed for reproducibility |
+| `saem_backend` | `auto` | Compute backend for the SAEM E-step: `auto`, `cpu`, or `gpu`. See below. |
+
+### GPU backend (`saem_backend`)
+
+The SAEM E-step evaluates the per-subject individual log-likelihood many
+times per iteration — an embarrassingly parallel workload. When ferx-core is
+built with the `gpu` Cargo feature, that batched evaluation can run on a GPU
+via a [`cubecl`](https://github.com/tracel-ai/cubecl) kernel (wgpu → Metal /
+Vulkan / DX12, or CUDA on NVIDIA).
+
+| Value | Behaviour |
+|-------|-----------|
+| `auto` (default) | Use the GPU when the `gpu` feature is built, a device initialises, and the model is in the GPU-supported subset; otherwise use the CPU. Never errors. |
+| `cpu` | Always use the CPU E-step (the reference path). |
+| `gpu` | Prefer the GPU; fall back to CPU (emitting a warning in `FitResult.warnings`) when the feature is absent, no device is available, or the model is unsupported. |
+
+The GPU path is **opt-in and fully optional**: the default build does not pull
+in `cubecl`, and `saem_backend` defaults to `auto`, so results are unchanged in
+environments without a GPU. The CPU and GPU paths are validated for numerical
+parity (within `f32` tolerance — GPUs that lack `f64`, such as Metal, run the
+kernel in `f32`).
+
+**Supported subset.** The current kernel covers the 1-compartment IV-bolus
+analytical model with a single Gaussian endpoint (additive / proportional /
+combined error). Anything outside it — other PK models, infusions,
+steady-state doses, system resets, time-varying covariates, M3 BLOQ, SDE, or
+TTE endpoints — transparently falls back to the CPU path. The GPU port of the
+full Metropolis-Hastings / HMC proposal loop is tracked as follow-up work in
+issue #368.
 
 ## SIR (Sampling Importance Resampling)
 

--- a/src/estimation/gpu_saem.rs
+++ b/src/estimation/gpu_saem.rs
@@ -294,6 +294,7 @@ fn gpu_unavailable_reason(model: &CompiledModel) -> String {
 mod kernel {
     use super::{FlatBatch, MhBatch, GPU_MH_MAX_ETA};
     use cubecl::prelude::*;
+    use cubecl::server::Handle;
     use cubecl::wgpu::WgpuRuntime;
     use std::sync::OnceLock;
 
@@ -629,81 +630,135 @@ mod kernel {
         }
     }
 
-    /// Run one MH sweep on the GPU. Returns `(updated etas flattened, accept
-    /// counts, final nll)` or `None` if no device is available.
-    pub(super) fn run_mh_sweep(
-        batch: &MhBatch,
-        scales: &[f32],
-        n_steps: usize,
-        seed: u64,
-    ) -> Option<(Vec<f32>, Vec<u32>, Vec<f32>)> {
-        let client = client()?;
-        let n = batch.n_subjects;
-        if n == 0 {
-            return Some((Vec::new(), Vec::new(), Vec::new()));
-        }
-        let eta_io = client.create_from_slice(f32::as_bytes(&batch.eta));
-        let cl0 = client.create_from_slice(f32::as_bytes(&batch.cl0));
-        let v0 = client.create_from_slice(f32::as_bytes(&batch.v0));
-        let a_cl = client.create_from_slice(f32::as_bytes(&batch.a_cl));
-        let a_v = client.create_from_slice(f32::as_bytes(&batch.a_v));
-        let omega_diag = client.create_from_slice(f32::as_bytes(&batch.omega_diag));
-        let step_scale = client.create_from_slice(f32::as_bytes(scales));
-        let dose_off = client.create_from_slice(u32::as_bytes(&batch.dose_off));
-        let dose_cnt = client.create_from_slice(u32::as_bytes(&batch.dose_cnt));
-        let dose_amt = client.create_from_slice(u32_pad_f32(&batch.dose_amt));
-        let dose_t = client.create_from_slice(u32_pad_f32(&batch.dose_t));
-        let obs_off = client.create_from_slice(u32::as_bytes(&batch.obs_off));
-        let obs_cnt = client.create_from_slice(u32::as_bytes(&batch.obs_cnt));
-        let obs_y = client.create_from_slice(u32_pad_f32(&batch.obs_y));
-        let obs_t = client.create_from_slice(u32_pad_f32(&batch.obs_t));
-        let fparams = client.create_from_slice(f32::as_bytes(&batch.fparams));
-        let iparams_vec = [batch.n_eta as u32, n_steps as u32, seed as u32];
-        let iparams = client.create_from_slice(u32::as_bytes(&iparams_vec));
-        let accept = client.empty(n * core::mem::size_of::<u32>());
-        let nll = client.empty(n * core::mem::size_of::<f32>());
+    /// A persistent MH-sweep session: the per-subject **static** buffers
+    /// (dose/observation arrays) are uploaded once and live on the device for
+    /// the whole SAEM run; only the per-iteration **dynamic** data (etas,
+    /// intercepts, Ω diagonal, step scales, sigmas, seed) is uploaded each
+    /// sweep. This removes the per-iteration re-upload of the largest arrays.
+    pub(super) struct Session {
+        n: usize,
+        dose_off: Handle,
+        dose_cnt: Handle,
+        dose_amt: Handle,
+        dose_t: Handle,
+        obs_off: Handle,
+        obs_cnt: Handle,
+        obs_y: Handle,
+        obs_t: Handle,
+        l_dose_off: usize,
+        l_dose_cnt: usize,
+        l_dose_amt: usize,
+        l_dose_t: usize,
+        l_obs_off: usize,
+        l_obs_cnt: usize,
+        l_obs_y: usize,
+        l_obs_t: usize,
+    }
 
-        let threads = 64u32;
-        let blocks = ((n as u32) + threads - 1) / threads;
-        unsafe {
-            mh_sweep_kernel::launch_unchecked::<R>(
-                client,
-                CubeCount::Static(blocks, 1, 1),
-                CubeDim::new_1d(threads),
-                ArrayArg::from_raw_parts(eta_io.clone(), batch.eta.len()),
-                ArrayArg::from_raw_parts(cl0, batch.cl0.len()),
-                ArrayArg::from_raw_parts(v0, batch.v0.len()),
-                ArrayArg::from_raw_parts(a_cl, batch.a_cl.len()),
-                ArrayArg::from_raw_parts(a_v, batch.a_v.len()),
-                ArrayArg::from_raw_parts(omega_diag, batch.omega_diag.len()),
-                ArrayArg::from_raw_parts(step_scale, scales.len()),
-                ArrayArg::from_raw_parts(dose_off, batch.dose_off.len()),
-                ArrayArg::from_raw_parts(dose_cnt, batch.dose_cnt.len()),
-                ArrayArg::from_raw_parts(dose_amt, batch.dose_amt.len().max(1)),
-                ArrayArg::from_raw_parts(dose_t, batch.dose_t.len().max(1)),
-                ArrayArg::from_raw_parts(obs_off, batch.obs_off.len()),
-                ArrayArg::from_raw_parts(obs_cnt, batch.obs_cnt.len()),
-                ArrayArg::from_raw_parts(obs_y, batch.obs_y.len().max(1)),
-                ArrayArg::from_raw_parts(obs_t, batch.obs_t.len().max(1)),
-                ArrayArg::from_raw_parts(fparams, batch.fparams.len()),
-                ArrayArg::from_raw_parts(iparams, iparams_vec.len()),
-                ArrayArg::from_raw_parts(accept.clone(), n),
-                ArrayArg::from_raw_parts(nll.clone(), n),
-            );
+    impl Session {
+        /// Upload the static (dose/obs) buffers once. `None` if no device.
+        pub(super) fn new(batch: &MhBatch) -> Option<Session> {
+            let client = client()?;
+            Some(Session {
+                n: batch.n_subjects,
+                dose_off: client.create_from_slice(u32::as_bytes(&batch.dose_off)),
+                dose_cnt: client.create_from_slice(u32::as_bytes(&batch.dose_cnt)),
+                dose_amt: client.create_from_slice(u32_pad_f32(&batch.dose_amt)),
+                dose_t: client.create_from_slice(u32_pad_f32(&batch.dose_t)),
+                obs_off: client.create_from_slice(u32::as_bytes(&batch.obs_off)),
+                obs_cnt: client.create_from_slice(u32::as_bytes(&batch.obs_cnt)),
+                obs_y: client.create_from_slice(u32_pad_f32(&batch.obs_y)),
+                obs_t: client.create_from_slice(u32_pad_f32(&batch.obs_t)),
+                l_dose_off: batch.dose_off.len(),
+                l_dose_cnt: batch.dose_cnt.len(),
+                l_dose_amt: batch.dose_amt.len().max(1),
+                l_dose_t: batch.dose_t.len().max(1),
+                l_obs_off: batch.obs_off.len(),
+                l_obs_cnt: batch.obs_cnt.len(),
+                l_obs_y: batch.obs_y.len().max(1),
+                l_obs_t: batch.obs_t.len().max(1),
+            })
         }
-        let eta_bytes = client.read_one(eta_io).ok()?;
-        let accept_bytes = client.read_one(accept).ok()?;
-        let nll_bytes = client.read_one(nll).ok()?;
-        Some((
-            f32::from_bytes(&eta_bytes).to_vec(),
-            u32::from_bytes(&accept_bytes).to_vec(),
-            f32::from_bytes(&nll_bytes).to_vec(),
-        ))
+
+        /// Run one MH sweep, reusing the resident static buffers and uploading
+        /// only the dynamic arrays. Returns `(etas flat, accepts, final nll)`.
+        #[allow(clippy::too_many_arguments)]
+        pub(super) fn sweep(
+            &self,
+            eta: &[f32],
+            cl0: &[f32],
+            v0: &[f32],
+            a_cl: &[f32],
+            a_v: &[f32],
+            omega_diag: &[f32],
+            scales: &[f32],
+            fparams: &[f32],
+            n_eta: usize,
+            n_steps: usize,
+            seed: u32,
+        ) -> Option<(Vec<f32>, Vec<u32>, Vec<f32>)> {
+            let client = client()?;
+            let n = self.n;
+            if n == 0 {
+                return Some((Vec::new(), Vec::new(), Vec::new()));
+            }
+            let eta_io = client.create_from_slice(f32::as_bytes(eta));
+            let cl0_h = client.create_from_slice(f32::as_bytes(cl0));
+            let v0_h = client.create_from_slice(f32::as_bytes(v0));
+            let a_cl_h = client.create_from_slice(f32::as_bytes(a_cl));
+            let a_v_h = client.create_from_slice(f32::as_bytes(a_v));
+            let omega_h = client.create_from_slice(f32::as_bytes(omega_diag));
+            let scale_h = client.create_from_slice(f32::as_bytes(scales));
+            let fparams_h = client.create_from_slice(f32::as_bytes(fparams));
+            let iparams_vec = [n_eta as u32, n_steps as u32, seed];
+            let iparams = client.create_from_slice(u32::as_bytes(&iparams_vec));
+            let accept = client.empty(n * core::mem::size_of::<u32>());
+            let nll = client.empty(n * core::mem::size_of::<f32>());
+
+            let threads = 64u32;
+            let blocks = ((n as u32) + threads - 1) / threads;
+            unsafe {
+                mh_sweep_kernel::launch_unchecked::<R>(
+                    client,
+                    CubeCount::Static(blocks, 1, 1),
+                    CubeDim::new_1d(threads),
+                    ArrayArg::from_raw_parts(eta_io.clone(), eta.len()),
+                    ArrayArg::from_raw_parts(cl0_h, cl0.len()),
+                    ArrayArg::from_raw_parts(v0_h, v0.len()),
+                    ArrayArg::from_raw_parts(a_cl_h, a_cl.len()),
+                    ArrayArg::from_raw_parts(a_v_h, a_v.len()),
+                    ArrayArg::from_raw_parts(omega_h, omega_diag.len()),
+                    ArrayArg::from_raw_parts(scale_h, scales.len()),
+                    ArrayArg::from_raw_parts(self.dose_off.clone(), self.l_dose_off),
+                    ArrayArg::from_raw_parts(self.dose_cnt.clone(), self.l_dose_cnt),
+                    ArrayArg::from_raw_parts(self.dose_amt.clone(), self.l_dose_amt),
+                    ArrayArg::from_raw_parts(self.dose_t.clone(), self.l_dose_t),
+                    ArrayArg::from_raw_parts(self.obs_off.clone(), self.l_obs_off),
+                    ArrayArg::from_raw_parts(self.obs_cnt.clone(), self.l_obs_cnt),
+                    ArrayArg::from_raw_parts(self.obs_y.clone(), self.l_obs_y),
+                    ArrayArg::from_raw_parts(self.obs_t.clone(), self.l_obs_t),
+                    ArrayArg::from_raw_parts(fparams_h, fparams.len()),
+                    ArrayArg::from_raw_parts(iparams, iparams_vec.len()),
+                    ArrayArg::from_raw_parts(accept.clone(), n),
+                    ArrayArg::from_raw_parts(nll.clone(), n),
+                );
+            }
+            // Single batched read = one device sync per sweep, not three.
+            let mut out = client.read(vec![eta_io, accept, nll]);
+            let nll_bytes = out.pop()?;
+            let accept_bytes = out.pop()?;
+            let eta_bytes = out.pop()?;
+            Some((
+                f32::from_bytes(&eta_bytes).to_vec(),
+                u32::from_bytes(&accept_bytes).to_vec(),
+                f32::from_bytes(&nll_bytes).to_vec(),
+            ))
+        }
     }
 }
 
 #[cfg(feature = "gpu")]
-use kernel::{gpu_data_ll, run_mh_sweep};
+use kernel::gpu_data_ll;
 
 #[cfg(not(feature = "gpu"))]
 fn gpu_data_ll(_batch: &FlatBatch) -> Option<Vec<f32>> {
@@ -757,6 +812,7 @@ fn extract_loglinear(
     theta: &[f64],
     n_eta: usize,
     etas: &[Vec<f64>],
+    verify: bool,
 ) -> Option<LogLinear> {
     let zero = vec![0.0_f64; n_eta];
     let cov0 = &population.subjects[0].covariates;
@@ -796,14 +852,18 @@ fn extract_loglinear(
         // Verify log-linearity for this subject at a non-trivial η and at its
         // current η: the reconstruction must match the real closure. This
         // catches non-log-normal transforms and covariate×η interactions.
-        for probe in [vec![0.3_f64; n_eta], etas[i].clone()] {
-            let actual = (model.pk_param_fn)(theta, &probe, cov);
-            let pred_cl = cl0_i * dot(&a_cl, &probe).exp();
-            let pred_v = v0_i * dot(&a_v, &probe).exp();
-            if rel_err(pred_cl, actual.values[PK_IDX_CL]) > 1e-4
-                || rel_err(pred_v, actual.values[PK_IDX_V]) > 1e-4
-            {
-                return None;
+        // Done once at session setup (`verify = true`); per-iteration sweeps
+        // reuse the verified structure and only recompute the intercepts.
+        if verify {
+            for probe in [vec![0.3_f64; n_eta], etas[i].clone()] {
+                let actual = (model.pk_param_fn)(theta, &probe, cov);
+                let pred_cl = cl0_i * dot(&a_cl, &probe).exp();
+                let pred_v = v0_i * dot(&a_v, &probe).exp();
+                if rel_err(pred_cl, actual.values[PK_IDX_CL]) > 1e-4
+                    || rel_err(pred_v, actual.values[PK_IDX_V]) > 1e-4
+                {
+                    return None;
+                }
             }
         }
         cl0.push(cl0_i as f32);
@@ -818,17 +878,13 @@ fn extract_loglinear(
     })
 }
 
-/// Flattened batch for the MH-sweep kernel.
+/// Static (per-run) layout for the MH-sweep kernel: the dose/observation
+/// arrays that do not change across SAEM iterations. The dynamic per-iteration
+/// data (etas, intercepts, Ω diagonal, sigmas) is supplied to each sweep.
 #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
 struct MhBatch {
     n_subjects: usize,
     n_eta: usize,
-    eta: Vec<f32>,
-    cl0: Vec<f32>,
-    v0: Vec<f32>,
-    a_cl: Vec<f32>,
-    a_v: Vec<f32>,
-    omega_diag: Vec<f32>,
     dose_off: Vec<u32>,
     dose_cnt: Vec<u32>,
     dose_amt: Vec<f32>,
@@ -837,18 +893,18 @@ struct MhBatch {
     obs_cnt: Vec<u32>,
     obs_y: Vec<f32>,
     obs_t: Vec<f32>,
-    fparams: [f32; 3],
 }
 
-/// Build the MH batch, or `None` when the model/population/Ω are outside the
-/// GPU MH-supported subset (diagonal Ω, ≤ `GPU_MH_MAX_ETA` etas, log-linear in
-/// η, plus the same structural gates as [`flatten`]).
+/// Build the static MH batch (and run the gating + log-linear verification), or
+/// `None` when the model/population/Ω are outside the GPU MH-supported subset
+/// (diagonal Ω, ≤ `GPU_MH_MAX_ETA` etas, log-linear in η, plus the same
+/// structural gates as [`flatten`]).
 fn build_mh_batch(
     model: &CompiledModel,
     population: &Population,
     theta: &[f64],
     etas: &[Vec<f64>],
-    sigma: &[f64],
+    _sigma: &[f64],
     omega: &OmegaMatrix,
 ) -> Option<MhBatch> {
     if !gpu_model_supported(model) || !omega.diagonal || population.subjects.is_empty() {
@@ -858,25 +914,19 @@ fn build_mh_batch(
     if n_eta == 0 || n_eta > GPU_MH_MAX_ETA || etas.iter().any(|e| e.len() != n_eta) {
         return None;
     }
-    let mut omega_diag = Vec::with_capacity(n_eta);
     for j in 0..n_eta {
-        let d = omega.matrix[(j, j)];
-        if !(d > 0.0) {
+        if !(omega.matrix[(j, j)] > 0.0) {
             return None;
         }
-        omega_diag.push(d as f32);
     }
-    let em = match &model.error_spec {
-        ErrorSpec::Single(em) => *em,
-        ErrorSpec::PerCmt(_) => return None,
-    };
-    let s0 = *sigma.first().unwrap_or(&0.0) as f32;
-    let s1 = *sigma.get(1).unwrap_or(&0.0) as f32;
+    if !matches!(model.error_spec, ErrorSpec::Single(_)) {
+        return None;
+    }
 
-    let ll = extract_loglinear(model, population, theta, n_eta, etas)?;
+    // Gating: verify the log-linear (CL, V)-in-η reconstruction once here.
+    extract_loglinear(model, population, theta, n_eta, etas, true)?;
 
     let n = population.subjects.len();
-    let mut eta = Vec::with_capacity(n * n_eta);
     let mut dose_off = Vec::with_capacity(n);
     let mut dose_cnt = Vec::with_capacity(n);
     let mut dose_amt = Vec::new();
@@ -886,7 +936,7 @@ fn build_mh_batch(
     let mut obs_y = Vec::new();
     let mut obs_t = Vec::new();
 
-    for (i, subject) in population.subjects.iter().enumerate() {
+    for subject in population.subjects.iter() {
         if subject.has_tv_covariates() || subject.has_resets() || subject.has_ss_doses() {
             return None;
         }
@@ -898,9 +948,6 @@ fn build_mh_batch(
             if d.is_infusion() || d.ss {
                 return None;
             }
-        }
-        for &e in &etas[i] {
-            eta.push(e as f32);
         }
         dose_off.push(dose_amt.len() as u32);
         dose_cnt.push(subject.doses.len() as u32);
@@ -919,12 +966,6 @@ fn build_mh_batch(
     Some(MhBatch {
         n_subjects: n,
         n_eta,
-        eta,
-        cl0: ll.cl0,
-        v0: ll.v0,
-        a_cl: ll.a_cl,
-        a_v: ll.a_v,
-        omega_diag,
         dose_off,
         dose_cnt,
         dose_amt,
@@ -933,7 +974,6 @@ fn build_mh_batch(
         obs_cnt,
         obs_y,
         obs_t,
-        fparams: [error_code(em), s0, s1],
     })
 }
 
@@ -947,10 +987,149 @@ pub struct MhSweepOut {
     pub nll: Vec<f64>,
 }
 
-/// Run one GPU block-RW MH sweep of `n_steps` proposals per subject, or return
-/// `None` when the GPU path is unavailable or the model is unsupported (caller
-/// falls back to the CPU E-step). `step_scales` is per-subject; `seed` should
-/// vary per SAEM iteration.
+/// A persistent GPU MH-sweep session for one SAEM run. Create it once (it
+/// gates the model/population and uploads the static dose/observation buffers
+/// to the device); then call [`GpuMhSession::sweep`] each iteration, which
+/// uploads only the dynamic per-iteration data. `None` from `new` means the
+/// model is unsupported or no GPU is available — the caller uses the CPU E-step.
+#[cfg(feature = "gpu")]
+pub struct GpuMhSession {
+    inner: kernel::Session,
+    n_eta: usize,
+    n_subjects: usize,
+    em: ErrorModel,
+}
+
+/// Stub on non-`gpu` builds: never constructed.
+#[cfg(not(feature = "gpu"))]
+pub struct GpuMhSession {
+    _priv: (),
+}
+
+impl GpuMhSession {
+    /// Gate the model/population and upload the static buffers. `None` when the
+    /// GPU MH path is unavailable or the model is unsupported.
+    #[cfg(feature = "gpu")]
+    pub fn new(
+        model: &CompiledModel,
+        population: &Population,
+        theta: &[f64],
+        etas: &[Vec<f64>],
+        sigma: &[f64],
+        omega: &OmegaMatrix,
+    ) -> Option<Self> {
+        let batch = build_mh_batch(model, population, theta, etas, sigma, omega)?;
+        let em = match &model.error_spec {
+            ErrorSpec::Single(e) => *e,
+            ErrorSpec::PerCmt(_) => return None,
+        };
+        let inner = kernel::Session::new(&batch)?;
+        Some(Self {
+            inner,
+            n_eta: batch.n_eta,
+            n_subjects: batch.n_subjects,
+            em,
+        })
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    pub fn new(
+        _model: &CompiledModel,
+        _population: &Population,
+        _theta: &[f64],
+        _etas: &[Vec<f64>],
+        _sigma: &[f64],
+        _omega: &OmegaMatrix,
+    ) -> Option<Self> {
+        None
+    }
+
+    /// Run one block-RW MH sweep of `n_steps` proposals per subject. Recomputes
+    /// the (cheap) per-subject intercepts for the current `theta`, uploads only
+    /// dynamic data, and reuses the resident static buffers. `seed` should vary
+    /// per SAEM iteration.
+    #[cfg(feature = "gpu")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sweep(
+        &mut self,
+        model: &CompiledModel,
+        population: &Population,
+        theta: &[f64],
+        etas: &[Vec<f64>],
+        sigma: &[f64],
+        omega: &OmegaMatrix,
+        step_scales: &[f64],
+        n_steps: usize,
+        seed: u64,
+    ) -> Option<MhSweepOut> {
+        if etas.len() != self.n_subjects {
+            return None;
+        }
+        let n_eta = self.n_eta;
+        // Reconstruct intercepts/coefficients for the current theta (no verify —
+        // the structure was verified at session creation). Cheap: O(N + n_eta)
+        // closure evals, no per-iteration re-upload of the static buffers.
+        let ll = extract_loglinear(model, population, theta, n_eta, etas, false)?;
+        let mut omega_diag = Vec::with_capacity(n_eta);
+        for j in 0..n_eta {
+            let d = omega.matrix[(j, j)];
+            if !(d > 0.0) {
+                return None;
+            }
+            omega_diag.push(d as f32);
+        }
+        let eta: Vec<f32> = etas
+            .iter()
+            .flat_map(|e| e.iter().map(|&x| x as f32))
+            .collect();
+        let scales: Vec<f32> = step_scales.iter().map(|&s| s as f32).collect();
+        let s0 = *sigma.first().unwrap_or(&0.0) as f32;
+        let s1 = *sigma.get(1).unwrap_or(&0.0) as f32;
+        let fparams = [error_code(self.em), s0, s1];
+
+        let (eta_out, accepts, nll) = self.inner.sweep(
+            &eta,
+            &ll.cl0,
+            &ll.v0,
+            &ll.a_cl,
+            &ll.a_v,
+            &omega_diag,
+            &scales,
+            &fparams,
+            n_eta,
+            n_steps,
+            seed as u32,
+        )?;
+        Some(MhSweepOut {
+            etas: eta_out
+                .chunks(n_eta)
+                .map(|c| c.iter().map(|&x| x as f64).collect())
+                .collect(),
+            accepts: accepts.iter().map(|&a| a as usize).collect(),
+            nll: nll.iter().map(|&x| x as f64).collect(),
+        })
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sweep(
+        &mut self,
+        _model: &CompiledModel,
+        _population: &Population,
+        _theta: &[f64],
+        _etas: &[Vec<f64>],
+        _sigma: &[f64],
+        _omega: &OmegaMatrix,
+        _step_scales: &[f64],
+        _n_steps: usize,
+        _seed: u64,
+    ) -> Option<MhSweepOut> {
+        None
+    }
+}
+
+/// One-shot convenience wrapper (used by tests): create a session and run a
+/// single sweep. Production SAEM uses a persistent [`GpuMhSession`].
 pub fn gpu_mh_sweep(
     model: &CompiledModel,
     population: &Population,
@@ -962,29 +1141,18 @@ pub fn gpu_mh_sweep(
     n_steps: usize,
     seed: u64,
 ) -> Option<MhSweepOut> {
-    let batch = build_mh_batch(model, population, theta, etas, sigma, omega)?;
-    let scales: Vec<f32> = step_scales.iter().map(|&s| s as f32).collect();
-    let (eta_out, accepts, nll) = run_mh_sweep(&batch, &scales, n_steps, seed)?;
-    let n_eta = batch.n_eta;
-    let etas_out: Vec<Vec<f64>> = eta_out
-        .chunks(n_eta)
-        .map(|c| c.iter().map(|&x| x as f64).collect())
-        .collect();
-    Some(MhSweepOut {
-        etas: etas_out,
-        accepts: accepts.iter().map(|&a| a as usize).collect(),
-        nll: nll.iter().map(|&x| x as f64).collect(),
-    })
-}
-
-#[cfg(not(feature = "gpu"))]
-fn run_mh_sweep(
-    _batch: &MhBatch,
-    _scales: &[f32],
-    _n_steps: usize,
-    _seed: u64,
-) -> Option<(Vec<f32>, Vec<u32>, Vec<f32>)> {
-    None
+    let mut session = GpuMhSession::new(model, population, theta, etas, sigma, omega)?;
+    session.sweep(
+        model,
+        population,
+        theta,
+        etas,
+        sigma,
+        omega,
+        step_scales,
+        n_steps,
+        seed,
+    )
 }
 
 #[cfg(test)]
@@ -1209,7 +1377,7 @@ mod tests {
     fn loglinear_extraction_supported_and_rejected() {
         let (model, pop, theta, _sigma, _omega, etas) = fixture();
         // 1-cpt IV with CL=TVCL*exp(ETA_CL), V=TVV*exp(ETA_V) is log-linear.
-        let ll = extract_loglinear(&model, &pop, &theta, 2, &etas);
+        let ll = extract_loglinear(&model, &pop, &theta, 2, &etas, true);
         assert!(
             ll.is_some(),
             "log-normal CL/V must be detected as log-linear"
@@ -1361,6 +1529,69 @@ mod tests {
             let g = gpu.params.omega.matrix[(j, j)];
             let rel = (c - g).abs() / c.abs().max(1e-6);
             assert!(rel < 0.40, "omega[{j}] cpu={c} gpu={g} rel={rel}");
+        }
+    }
+
+    /// Wall-clock CPU vs GPU SAEM across subject counts. Not an assertion —
+    /// run manually:
+    /// `cargo test --release --no-default-features --features ci,gpu
+    ///  gpu_saem_benchmark -- --ignored --nocapture`
+    #[cfg(feature = "gpu")]
+    #[test]
+    #[ignore = "benchmark: run manually with --ignored --nocapture"]
+    fn gpu_saem_benchmark() {
+        use crate::estimation::saem::run_saem;
+        use crate::types::FitOptions;
+        use std::time::Instant;
+
+        let model = iv_combined_model();
+        let mut opts = FitOptions::default();
+        opts.verbose = false;
+        opts.run_covariance_step = false;
+        opts.saem_n_exploration = 50;
+        opts.saem_n_convergence = 100;
+        opts.saem_seed = Some(1);
+
+        let bench = |opts: &mut FitOptions, data: &Population| -> (f64, f64, bool) {
+            opts.saem_backend = SaemBackend::Cpu;
+            let t = Instant::now();
+            let _ = run_saem(&model, data, &model.default_params, opts).expect("cpu");
+            let cpu_ms = t.elapsed().as_secs_f64() * 1e3;
+            opts.saem_backend = SaemBackend::Gpu;
+            let t = Instant::now();
+            let g = run_saem(&model, data, &model.default_params, opts).expect("gpu");
+            let gpu_ms = t.elapsed().as_secs_f64() * 1e3;
+            let used = !g
+                .warnings
+                .iter()
+                .any(|w| w.contains("GPU MH E-step did not run"));
+            (cpu_ms, gpu_ms, used)
+        };
+
+        println!("\n  (A) vary n_subjects, n_mh_steps = 20");
+        println!("  n_subj |   CPU (ms) |   GPU (ms) | speedup | gpu_used");
+        println!("  -------+------------+------------+---------+---------");
+        opts.saem_n_mh_steps = 20;
+        for &n in &[50usize, 200, 1000, 4000, 8000] {
+            let data = synthetic_population(n);
+            let (cpu_ms, gpu_ms, used) = bench(&mut opts, &data);
+            println!(
+                "  {n:>6} | {cpu_ms:>10.1} | {gpu_ms:>10.1} | {:>6.2}x | {used}",
+                cpu_ms / gpu_ms
+            );
+        }
+
+        println!("\n  (B) vary n_mh_steps, n_subjects = 2000");
+        println!("  mh_stp |   CPU (ms) |   GPU (ms) | speedup | gpu_used");
+        println!("  -------+------------+------------+---------+---------");
+        let data = synthetic_population(2000);
+        for &steps in &[20usize, 100, 500, 2000] {
+            opts.saem_n_mh_steps = steps;
+            let (cpu_ms, gpu_ms, used) = bench(&mut opts, &data);
+            println!(
+                "  {steps:>6} | {cpu_ms:>10.1} | {gpu_ms:>10.1} | {:>6.2}x | {used}",
+                cpu_ms / gpu_ms
+            );
         }
     }
 }

--- a/src/estimation/gpu_saem.rs
+++ b/src/estimation/gpu_saem.rs
@@ -1,0 +1,664 @@
+//! GPU-accelerated SAEM E-step support (issue #368).
+//!
+//! This module provides a batched evaluation of the per-subject individual
+//! negative log-likelihood (NLL) for the **analytical 1-compartment IV-bolus**
+//! model on the GPU, via a `cubecl` kernel (wgpu/Metal + CUDA backends). It is
+//! the reusable compute primitive the SAEM E-step calls when running on GPU.
+//!
+//! ## Design: split the work
+//!
+//! The map from `(theta, eta, covariates)` to PK parameters is an arbitrary
+//! DSL-compiled closure (`model.pk_param_fn`) and is **not** GPU-portable. So
+//! the work is split:
+//!
+//! * **CPU** evaluates `pk_param_fn` once per subject to get `(CL_i, V_i)` —
+//!   cheap, and faithful to whatever parameterization / covariate model the
+//!   user wrote.
+//! * **GPU** evaluates the per-observation analytical prediction
+//!   `C(t) = Σ_doses (amt/V)·exp(-(CL/V)·(t−t_dose))` and the Gaussian data
+//!   term `Σ_j [ resid²/v + ln v ]` across all subjects in parallel — the part
+//!   that scales with the number of observations and is pure arithmetic.
+//!
+//! The η-prior term `η'Ω⁻¹η` and `ln|Ω|` are computed on the CPU in `f64`
+//! (cheap, and keeps the prior in full precision), then combined with the GPU
+//! data term: `nll_i = 0.5·(η'Ω⁻¹η + ln|Ω| + data_ll_i)`. This is exactly the
+//! quantity [`crate::stats::likelihood::individual_nll_into`] returns, so the
+//! CPU path is the reference and the GPU path must match it (within `f32`
+//! tolerance — Metal has no `f64`).
+//!
+//! ## Fallback
+//!
+//! Everything outside the supported subset (other PK models, infusions,
+//! steady-state doses, resets, time-varying covariates, M3 BLOQ, SDE, TTE)
+//! routes to the CPU path. The GPU path is also skipped when the `gpu` feature
+//! is not built or no device initialises. See [`batched_individual_nll`].
+
+use crate::pk::EventPkParams;
+use crate::stats::likelihood::individual_nll_into;
+use crate::types::{
+    BloqMethod, CompiledModel, ErrorModel, ErrorSpec, OmegaMatrix, PkModel, Population,
+    SaemBackend, PK_IDX_CL, PK_IDX_V,
+};
+use nalgebra::DVector;
+
+/// Numeric code for the error model, matching the kernel's branch.
+fn error_code(em: ErrorModel) -> f32 {
+    match em {
+        ErrorModel::Additive => 0.0,
+        ErrorModel::Proportional => 1.0,
+        ErrorModel::Combined => 2.0,
+    }
+}
+
+/// True when `model` is in the GPU-supported subset (model-level checks).
+/// Per-subject checks (doses, covariates, resets) happen in [`flatten`].
+pub fn gpu_model_supported(model: &CompiledModel) -> bool {
+    if model.pk_model != PkModel::OneCptIv {
+        return false;
+    }
+    if model.is_sde() {
+        return false;
+    }
+    if model.bloq_method != BloqMethod::Drop {
+        // M3 likelihood (censored rows) is not implemented in the kernel.
+        return false;
+    }
+    // Single-endpoint Gaussian error only.
+    matches!(model.error_spec, ErrorSpec::Single(_))
+}
+
+/// Flattened, `f32`-ready batch for the kernel. All per-subject arrays are
+/// indexed by subject; observations and doses are concatenated with per-subject
+/// `(offset, count)` slices.
+// Fields are read only by the GPU kernel; in a non-`gpu` build the batch is
+// built but never consumed (the dispatcher falls back to CPU before that).
+#[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+struct FlatBatch {
+    n_subjects: usize,
+    cl: Vec<f32>,
+    v: Vec<f32>,
+    dose_off: Vec<u32>,
+    dose_cnt: Vec<u32>,
+    dose_amt: Vec<f32>,
+    dose_t: Vec<f32>,
+    obs_off: Vec<u32>,
+    obs_cnt: Vec<u32>,
+    obs_y: Vec<f32>,
+    obs_t: Vec<f32>,
+    /// `[error_code, sigma0, sigma1]`.
+    params: [f32; 3],
+}
+
+/// Build a [`FlatBatch`] for the population, or `None` when any subject is
+/// outside the GPU-supported subset (caller falls back to CPU).
+fn flatten(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    etas: &[Vec<f64>],
+    sigma: &[f64],
+) -> Option<FlatBatch> {
+    if !gpu_model_supported(model) {
+        return None;
+    }
+    let em = match &model.error_spec {
+        ErrorSpec::Single(em) => *em,
+        ErrorSpec::PerCmt(_) => return None,
+    };
+    let s0 = *sigma.first().unwrap_or(&0.0) as f32;
+    let s1 = *sigma.get(1).unwrap_or(&0.0) as f32;
+
+    let n = population.subjects.len();
+    let mut cl = Vec::with_capacity(n);
+    let mut v = Vec::with_capacity(n);
+    let mut dose_off = Vec::with_capacity(n);
+    let mut dose_cnt = Vec::with_capacity(n);
+    let mut dose_amt = Vec::new();
+    let mut dose_t = Vec::new();
+    let mut obs_off = Vec::with_capacity(n);
+    let mut obs_cnt = Vec::with_capacity(n);
+    let mut obs_y = Vec::new();
+    let mut obs_t = Vec::new();
+
+    for (i, subject) in population.subjects.iter().enumerate() {
+        // Per-subject feature gates: anything the single-CL/V, superposition
+        // kernel cannot express routes the whole batch to the CPU.
+        if subject.has_tv_covariates() || subject.has_resets() || subject.has_ss_doses() {
+            return None;
+        }
+        #[cfg(feature = "survival")]
+        if !subject.obs_records.is_empty() {
+            return None;
+        }
+        for d in &subject.doses {
+            if d.is_infusion() || d.ss {
+                return None;
+            }
+        }
+
+        let eta = &etas[i];
+        let pk = (model.pk_param_fn)(theta, eta, &subject.covariates);
+        let cl_i = pk.values[PK_IDX_CL];
+        let v_i = pk.values[PK_IDX_V];
+        if !(cl_i.is_finite() && v_i.is_finite()) || v_i <= 0.0 {
+            return None;
+        }
+        cl.push(cl_i as f32);
+        v.push(v_i as f32);
+
+        dose_off.push(dose_amt.len() as u32);
+        dose_cnt.push(subject.doses.len() as u32);
+        for d in &subject.doses {
+            dose_amt.push(d.amt as f32);
+            dose_t.push(d.time as f32);
+        }
+
+        obs_off.push(obs_y.len() as u32);
+        obs_cnt.push(subject.observations.len() as u32);
+        for (j, &y) in subject.observations.iter().enumerate() {
+            obs_y.push(y as f32);
+            obs_t.push(subject.obs_times[j] as f32);
+        }
+    }
+
+    Some(FlatBatch {
+        n_subjects: n,
+        cl,
+        v,
+        dose_off,
+        dose_cnt,
+        dose_amt,
+        dose_t,
+        obs_off,
+        obs_cnt,
+        obs_y,
+        obs_t,
+        params: [error_code(em), s0, s1],
+    })
+}
+
+/// CPU reference: per-subject individual NLL via the canonical
+/// [`individual_nll_into`]. This is the behaviour the GPU path must match.
+pub fn batched_individual_nll_cpu(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    etas: &[Vec<f64>],
+    omega: &OmegaMatrix,
+    sigma: &[f64],
+) -> Vec<f64> {
+    use rayon::prelude::*;
+    population
+        .subjects
+        .par_iter()
+        .zip(etas.par_iter())
+        .map_init(EventPkParams::default, |scratch, (subject, eta)| {
+            individual_nll_into(model, subject, theta, eta, omega, sigma, scratch)
+        })
+        .collect()
+}
+
+/// Combine the GPU per-subject data term with the CPU-computed η-prior to form
+/// the full per-subject NLL, matching `individual_nll_into`.
+fn combine_with_prior(data_ll: &[f32], etas: &[Vec<f64>], omega: &OmegaMatrix) -> Vec<f64> {
+    let log_det = omega.log_det;
+    if !log_det.is_finite() {
+        return vec![1e20; data_ll.len()];
+    }
+    let omega_inv = &omega.inv;
+    etas.iter()
+        .zip(data_ll.iter())
+        .map(|(eta, &dll)| {
+            let ev = DVector::from_column_slice(eta);
+            let prior = ev.dot(&(omega_inv * &ev));
+            let nll = 0.5 * (prior + log_det + dll as f64);
+            if nll.is_finite() {
+                nll
+            } else {
+                1e20
+            }
+        })
+        .collect()
+}
+
+/// Outcome of a backend dispatch.
+pub struct Dispatch {
+    /// Per-subject individual NLL (same ordering as `population.subjects`).
+    pub nll: Vec<f64>,
+    /// Whether the GPU path actually ran.
+    pub used_gpu: bool,
+    /// Set when the GPU was requested (`SaemBackend::Gpu`) but the engine fell
+    /// back to CPU. Caller should surface this in `FitResult.warnings`.
+    pub warning: Option<String>,
+}
+
+/// Evaluate the batched per-subject NLL on the requested backend, falling back
+/// to CPU whenever the GPU path is unavailable or the model is unsupported.
+pub fn batched_individual_nll(
+    backend: SaemBackend,
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    etas: &[Vec<f64>],
+    omega: &OmegaMatrix,
+    sigma: &[f64],
+) -> Dispatch {
+    let want_gpu = matches!(backend, SaemBackend::Auto | SaemBackend::Gpu);
+    if want_gpu {
+        if let Some(batch) = flatten(model, population, theta, etas, sigma) {
+            if let Some(data_ll) = gpu_data_ll(&batch) {
+                return Dispatch {
+                    nll: combine_with_prior(&data_ll, etas, omega),
+                    used_gpu: true,
+                    warning: None,
+                };
+            }
+        }
+    }
+    // CPU fallback. Warn only when the GPU was explicitly requested.
+    let warning = if backend == SaemBackend::Gpu {
+        Some(gpu_unavailable_reason(model))
+    } else {
+        None
+    };
+    Dispatch {
+        nll: batched_individual_nll_cpu(model, population, theta, etas, omega, sigma),
+        used_gpu: false,
+        warning,
+    }
+}
+
+fn gpu_unavailable_reason(model: &CompiledModel) -> String {
+    if cfg!(not(feature = "gpu")) {
+        "saem_backend=gpu requested but ferx-core was built without the `gpu` \
+         feature; using the CPU SAEM E-step."
+            .to_string()
+    } else if !gpu_model_supported(model) {
+        "saem_backend=gpu requested but this model is outside the GPU-supported \
+         subset (1-cpt IV bolus, single Gaussian endpoint, no SDE/M3); using \
+         the CPU SAEM E-step."
+            .to_string()
+    } else {
+        "saem_backend=gpu requested but no GPU device was available or the \
+         population is outside the supported subset (infusions, steady-state \
+         doses, resets, or time-varying covariates); using the CPU SAEM E-step."
+            .to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GPU kernel — compiled only with the `gpu` feature.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "gpu")]
+mod kernel {
+    use super::FlatBatch;
+    use cubecl::prelude::*;
+    use cubecl::wgpu::WgpuRuntime;
+    use std::sync::OnceLock;
+
+    type R = WgpuRuntime;
+    type GpuClient = ComputeClient<R>;
+
+    /// Lazily-initialised, process-wide GPU client. `None` when no device is
+    /// available (client creation panics on a headless box with no adapter —
+    /// caught here so the caller falls back to CPU).
+    fn client() -> Option<&'static GpuClient> {
+        static CLIENT: OnceLock<Option<GpuClient>> = OnceLock::new();
+        CLIENT
+            .get_or_init(|| {
+                std::panic::catch_unwind(|| {
+                    let device = Default::default();
+                    R::client(&device)
+                })
+                .ok()
+            })
+            .as_ref()
+    }
+
+    #[cube(launch_unchecked)]
+    fn nll_1cpt_iv_kernel(
+        cl: &Array<f32>,
+        v: &Array<f32>,
+        dose_off: &Array<u32>,
+        dose_cnt: &Array<u32>,
+        dose_amt: &Array<f32>,
+        dose_t: &Array<f32>,
+        obs_off: &Array<u32>,
+        obs_cnt: &Array<u32>,
+        obs_y: &Array<f32>,
+        obs_t: &Array<f32>,
+        params: &Array<f32>,
+        out: &mut Array<f32>,
+    ) {
+        if ABSOLUTE_POS < cl.len() {
+            let i = ABSOLUTE_POS;
+            let vi = v[i];
+            let k = cl[i] / vi;
+            let err = params[0];
+            let s0 = params[1];
+            let s1 = params[2];
+            // Offsets/counts are u32 on the device; cast to usize for indexing
+            // and loop bounds (Array indexing uses usize, matching `len()`).
+            let d_o = usize::cast_from(dose_off[i]);
+            let d_c = usize::cast_from(dose_cnt[i]);
+            let o_o = usize::cast_from(obs_off[i]);
+            let o_c = usize::cast_from(obs_cnt[i]);
+
+            let mut acc = 0.0f32;
+            for j in 0..o_c {
+                let t = obs_t[o_o + j];
+                let y = obs_y[o_o + j];
+                let mut f = 0.0f32;
+                for d in 0..d_c {
+                    let dt = t - dose_t[d_o + d];
+                    if dt >= 0.0 {
+                        f += (dose_amt[d_o + d] / vi) * (-k * dt).exp();
+                    }
+                }
+                let mut vr = s0 * s0;
+                if err >= 0.5 {
+                    let fs = f * s0;
+                    if err >= 1.5 {
+                        vr = fs * fs + s1 * s1;
+                    } else {
+                        vr = fs * fs;
+                    }
+                }
+                if vr < 1e-12 {
+                    vr = 1e-12;
+                }
+                let resid = y - f;
+                acc += resid * resid / vr + vr.ln();
+            }
+            out[i] = acc;
+        }
+    }
+
+    /// Run the kernel; returns the per-subject data term, or `None` if no
+    /// device is available.
+    pub(super) fn gpu_data_ll(batch: &FlatBatch) -> Option<Vec<f32>> {
+        let client = client()?;
+        let n = batch.n_subjects;
+        if n == 0 {
+            return Some(Vec::new());
+        }
+
+        let cl = client.create_from_slice(f32::as_bytes(&batch.cl));
+        let v = client.create_from_slice(f32::as_bytes(&batch.v));
+        let dose_off = client.create_from_slice(u32::as_bytes(&batch.dose_off));
+        let dose_cnt = client.create_from_slice(u32::as_bytes(&batch.dose_cnt));
+        // Empty buffers are not allowed; pad to length 1 when a subject has no
+        // doses/obs (counts still drive the loops, so the pad is never read).
+        let dose_amt = client.create_from_slice(u32_pad_f32(&batch.dose_amt));
+        let dose_t = client.create_from_slice(u32_pad_f32(&batch.dose_t));
+        let obs_off = client.create_from_slice(u32::as_bytes(&batch.obs_off));
+        let obs_cnt = client.create_from_slice(u32::as_bytes(&batch.obs_cnt));
+        let obs_y = client.create_from_slice(u32_pad_f32(&batch.obs_y));
+        let obs_t = client.create_from_slice(u32_pad_f32(&batch.obs_t));
+        let params = client.create_from_slice(f32::as_bytes(&batch.params));
+        let out = client.empty(n * core::mem::size_of::<f32>());
+
+        let threads = 64u32;
+        let blocks = ((n as u32) + threads - 1) / threads;
+        unsafe {
+            nll_1cpt_iv_kernel::launch_unchecked::<R>(
+                client,
+                CubeCount::Static(blocks, 1, 1),
+                CubeDim::new_1d(threads),
+                ArrayArg::from_raw_parts(cl, batch.cl.len()),
+                ArrayArg::from_raw_parts(v, batch.v.len()),
+                ArrayArg::from_raw_parts(dose_off, batch.dose_off.len()),
+                ArrayArg::from_raw_parts(dose_cnt, batch.dose_cnt.len()),
+                ArrayArg::from_raw_parts(dose_amt, batch.dose_amt.len().max(1)),
+                ArrayArg::from_raw_parts(dose_t, batch.dose_t.len().max(1)),
+                ArrayArg::from_raw_parts(obs_off, batch.obs_off.len()),
+                ArrayArg::from_raw_parts(obs_cnt, batch.obs_cnt.len()),
+                ArrayArg::from_raw_parts(obs_y, batch.obs_y.len().max(1)),
+                ArrayArg::from_raw_parts(obs_t, batch.obs_t.len().max(1)),
+                ArrayArg::from_raw_parts(params, batch.params.len()),
+                ArrayArg::from_raw_parts(out.clone(), n),
+            );
+        }
+        let bytes = client.read_one(out).ok()?;
+        Some(f32::from_bytes(&bytes).to_vec())
+    }
+
+    /// `f32::as_bytes` for a possibly-empty slice, padded to one element so the
+    /// GPU buffer is non-empty.
+    fn u32_pad_f32(data: &[f32]) -> &[u8] {
+        static ONE: [f32; 1] = [0.0];
+        if data.is_empty() {
+            f32::as_bytes(&ONE)
+        } else {
+            f32::as_bytes(data)
+        }
+    }
+}
+
+#[cfg(feature = "gpu")]
+use kernel::gpu_data_ll;
+
+#[cfg(not(feature = "gpu"))]
+fn gpu_data_ll(_batch: &FlatBatch) -> Option<Vec<f32>> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::model_parser::parse_model_string;
+    use crate::types::{DoseEvent, Population, Subject};
+    use std::collections::HashMap;
+
+    /// A 1-cpt IV-bolus model with a combined error model and two etas
+    /// (CL, V) — squarely in the GPU-supported subset.
+    fn iv_combined_model() -> CompiledModel {
+        parse_model_string(
+            r"
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV(40.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  sigma PROP ~ 0.1 (sd)
+  sigma ADD  ~ 0.5 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ combined(PROP, ADD)
+",
+        )
+        .expect("1-cpt IV combined model parses")
+    }
+
+    /// A 1-cpt *oral* model — outside the GPU-supported subset (absorption).
+    fn oral_model() -> CompiledModel {
+        parse_model_string(
+            r"
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV(40.0, 1.0, 500.0)
+  theta TVKA(1.0, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.1 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+",
+        )
+        .expect("1-cpt oral model parses")
+    }
+
+    fn subject(id: &str, dose: f64, times: &[f64], obs: &[f64]) -> Subject {
+        Subject {
+            id: id.into(),
+            doses: vec![DoseEvent::new(0.0, dose, 1, 0.0, false, 0.0)],
+            obs_times: times.to_vec(),
+            obs_raw_times: Vec::new(),
+            observations: obs.to_vec(),
+            obs_cmts: vec![1; times.len()],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; times.len()],
+            occasions: vec![],
+            dose_occasions: vec![],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        }
+    }
+
+    fn population() -> Population {
+        Population {
+            subjects: vec![
+                subject(
+                    "1",
+                    100.0,
+                    &[0.5, 1.0, 2.0, 4.0, 8.0],
+                    &[8.0, 6.5, 4.0, 2.0, 0.6],
+                ),
+                subject("2", 120.0, &[0.5, 1.0, 3.0, 6.0], &[9.5, 7.5, 3.5, 1.2]),
+                subject(
+                    "3",
+                    80.0,
+                    &[1.0, 2.0, 4.0, 6.0, 10.0],
+                    &[5.5, 4.0, 2.2, 1.1, 0.3],
+                ),
+            ],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        }
+    }
+
+    fn fixture() -> (
+        CompiledModel,
+        Population,
+        Vec<f64>,
+        Vec<f64>,
+        OmegaMatrix,
+        Vec<Vec<f64>>,
+    ) {
+        let model = iv_combined_model();
+        let pop = population();
+        let theta = vec![4.0_f64, 40.0];
+        let sigma = vec![0.1_f64, 0.5];
+        let omega =
+            OmegaMatrix::from_diagonal(&[0.09, 0.04], vec!["ETA_CL".into(), "ETA_V".into()]);
+        let etas: Vec<Vec<f64>> = vec![vec![0.1, -0.05], vec![-0.2, 0.15], vec![0.0, 0.0]];
+        (model, pop, theta, sigma, omega, etas)
+    }
+
+    #[test]
+    fn supported_subset_detection() {
+        assert!(gpu_model_supported(&iv_combined_model()));
+        assert!(!gpu_model_supported(&oral_model()));
+    }
+
+    #[test]
+    fn cpu_dispatch_matches_individual_nll() {
+        let (model, pop, theta, sigma, omega, etas) = fixture();
+        let reference = batched_individual_nll_cpu(&model, &pop, &theta, &etas, &omega, &sigma);
+        let d = batched_individual_nll(
+            SaemBackend::Cpu,
+            &model,
+            &pop,
+            &theta,
+            &etas,
+            &omega,
+            &sigma,
+        );
+        assert!(!d.used_gpu);
+        assert!(d.warning.is_none());
+        assert_eq!(d.nll.len(), reference.len());
+        for (a, b) in d.nll.iter().zip(reference.iter()) {
+            assert!((a - b).abs() < 1e-9, "cpu dispatch must equal reference");
+        }
+    }
+
+    #[test]
+    fn unsupported_model_falls_back_with_warning() {
+        let model = oral_model();
+        let pop = Population {
+            subjects: vec![subject("1", 100.0, &[1.0, 2.0, 4.0], &[3.0, 2.0, 1.0])],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+        let theta = vec![4.0_f64, 40.0, 1.0];
+        let sigma = vec![0.1_f64];
+        let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
+        let etas = vec![vec![0.0_f64]];
+        let d = batched_individual_nll(
+            SaemBackend::Gpu,
+            &model,
+            &pop,
+            &theta,
+            &etas,
+            &omega,
+            &sigma,
+        );
+        // Oral model is unsupported → CPU fallback, with a warning since GPU
+        // was explicitly requested.
+        assert!(!d.used_gpu);
+        assert!(d.warning.is_some());
+        let reference = batched_individual_nll_cpu(&model, &pop, &theta, &etas, &omega, &sigma);
+        for (a, b) in d.nll.iter().zip(reference.iter()) {
+            assert!((a - b).abs() < 1e-9);
+        }
+    }
+
+    /// GPU/CPU parity. Only meaningful with the `gpu` feature *and* a device;
+    /// when no GPU is present the dispatcher falls back to CPU (`used_gpu ==
+    /// false`) and the test trivially holds.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn gpu_matches_cpu_within_f32_tolerance() {
+        let (model, pop, theta, sigma, omega, etas) = fixture();
+        let reference = batched_individual_nll_cpu(&model, &pop, &theta, &etas, &omega, &sigma);
+        let d = batched_individual_nll(
+            SaemBackend::Gpu,
+            &model,
+            &pop,
+            &theta,
+            &etas,
+            &omega,
+            &sigma,
+        );
+        if !d.used_gpu {
+            eprintln!("no GPU device available; parity check skipped");
+            return;
+        }
+        assert_eq!(d.nll.len(), reference.len());
+        for (i, (g, c)) in d.nll.iter().zip(reference.iter()).enumerate() {
+            // f32 kernel vs f64 reference: relative tolerance.
+            let rel = (g - c).abs() / c.abs().max(1.0);
+            assert!(
+                rel < 1e-3,
+                "subject {i}: gpu={g} cpu={c} rel={rel} exceeds f32 tolerance"
+            );
+        }
+    }
+}

--- a/src/estimation/gpu_saem.rs
+++ b/src/estimation/gpu_saem.rs
@@ -292,7 +292,7 @@ fn gpu_unavailable_reason(model: &CompiledModel) -> String {
 
 #[cfg(feature = "gpu")]
 mod kernel {
-    use super::FlatBatch;
+    use super::{FlatBatch, MhBatch, GPU_MH_MAX_ETA};
     use cubecl::prelude::*;
     use cubecl::wgpu::WgpuRuntime;
     use std::sync::OnceLock;
@@ -434,13 +434,556 @@ mod kernel {
             f32::as_bytes(data)
         }
     }
+
+    // -- MH-sweep kernel ----------------------------------------------------
+
+    /// Integer finalizer hash (lowbias32) for the counter-based RNG.
+    #[cube]
+    fn hash32(x: u32) -> u32 {
+        let mut h = x;
+        h = h ^ (h >> 16u32);
+        h = h * 2146028333u32; // 0x7feb352d
+        h = h ^ (h >> 15u32);
+        h = h * 2221713035u32; // 0x846ca68b
+        h = h ^ (h >> 16u32);
+        h
+    }
+
+    /// Uniform in [0, 1) from a (seed, subject, step, slot) counter.
+    #[cube]
+    fn rand_u(seed: u32, subj: u32, step: u32, slot: u32) -> f32 {
+        let ctr = seed ^ hash32(subj * 2654435761u32 + (step * 64u32 + slot) * 40503u32 + 1u32);
+        let h = hash32(ctr);
+        f32::cast_from(h >> 8u32) * 5.9604645e-8 // 1 / 2^24
+    }
+
+    /// Standard normal via Box-Muller from two uniforms.
+    #[cube]
+    fn rand_n(seed: u32, subj: u32, step: u32, slot: u32) -> f32 {
+        let u1 = rand_u(seed, subj, step, slot * 2u32);
+        let u2 = rand_u(seed, subj, step, slot * 2u32 + 1u32);
+        // Keep `u1c` cube-typed (init from `u1`, then clamp via assignment) so
+        // `.ln()` resolves — a literal `if`-branch would make it ambiguous.
+        let mut u1c = u1;
+        if u1c < 1e-7 {
+            u1c = 1e-7;
+        }
+        let r = (u1c.ln() * -2.0).sqrt();
+        let angle = u2 * 6.2831853;
+        r * angle.cos()
+    }
+
+    /// Individual NLL `0.5·(η'Ω⁻¹η + ln|Ω| + Σ[resid²/v + ln v])` for the
+    /// 1-cpt IV-bolus model with diagonal Ω and log-linear `(CL, V)` in η.
+    #[cube]
+    #[allow(clippy::too_many_arguments)]
+    fn nll_at(
+        eta: &Array<f32>,
+        n_eta: u32,
+        cl0: f32,
+        v0: f32,
+        a_cl: &Array<f32>,
+        a_v: &Array<f32>,
+        omega_diag: &Array<f32>,
+        dose_amt: &Array<f32>,
+        dose_t: &Array<f32>,
+        d_o: u32,
+        d_c: u32,
+        obs_y: &Array<f32>,
+        obs_t: &Array<f32>,
+        o_o: u32,
+        o_c: u32,
+        err: f32,
+        s0: f32,
+        s1: f32,
+    ) -> f32 {
+        let ne = usize::cast_from(n_eta);
+        let mut lin_cl = 0.0f32;
+        let mut lin_v = 0.0f32;
+        let mut prior = 0.0f32;
+        let mut logdet = 0.0f32;
+        for c in 0..ne {
+            let ev = eta[c];
+            lin_cl += a_cl[c] * ev;
+            lin_v += a_v[c] * ev;
+            let od = omega_diag[c];
+            prior += ev * ev / od;
+            logdet += od.ln();
+        }
+        let cl = cl0 * lin_cl.exp();
+        let vv = v0 * lin_v.exp();
+        let k = cl / vv;
+
+        let do_ = usize::cast_from(d_o);
+        let dc = usize::cast_from(d_c);
+        let oo = usize::cast_from(o_o);
+        let oc = usize::cast_from(o_c);
+        let mut data = 0.0f32;
+        for j in 0..oc {
+            let t = obs_t[oo + j];
+            let y = obs_y[oo + j];
+            let mut f = 0.0f32;
+            for d in 0..dc {
+                let dt = t - dose_t[do_ + d];
+                if dt >= 0.0 {
+                    f += (dose_amt[do_ + d] / vv) * (-k * dt).exp();
+                }
+            }
+            let mut vr = s0 * s0;
+            if err >= 0.5 {
+                let fs = f * s0;
+                if err >= 1.5 {
+                    vr = fs * fs + s1 * s1;
+                } else {
+                    vr = fs * fs;
+                }
+            }
+            if vr < 1e-12 {
+                vr = 1e-12;
+            }
+            let resid = y - f;
+            data += resid * resid / vr + vr.ln();
+        }
+        0.5 * (prior + logdet + data)
+    }
+
+    #[cube(launch_unchecked)]
+    #[allow(clippy::too_many_arguments)]
+    fn mh_sweep_kernel(
+        eta_io: &mut Array<f32>,
+        cl0: &Array<f32>,
+        v0: &Array<f32>,
+        a_cl: &Array<f32>,
+        a_v: &Array<f32>,
+        omega_diag: &Array<f32>,
+        step_scale: &Array<f32>,
+        dose_off: &Array<u32>,
+        dose_cnt: &Array<u32>,
+        dose_amt: &Array<f32>,
+        dose_t: &Array<f32>,
+        obs_off: &Array<u32>,
+        obs_cnt: &Array<u32>,
+        obs_y: &Array<f32>,
+        obs_t: &Array<f32>,
+        fparams: &Array<f32>,
+        iparams: &Array<u32>,
+        accept_out: &mut Array<u32>,
+        nll_out: &mut Array<f32>,
+    ) {
+        if ABSOLUTE_POS < cl0.len() {
+            let i = ABSOLUTE_POS;
+            let n_eta = iparams[0];
+            let n_steps = usize::cast_from(iparams[1]);
+            let seed = iparams[2];
+            let ne = usize::cast_from(n_eta);
+            let err = fparams[0];
+            let s0 = fparams[1];
+            let s1 = fparams[2];
+            let ss = step_scale[i];
+            let base = i * ne;
+            let d_o = dose_off[i];
+            let d_c = dose_cnt[i];
+            let o_o = obs_off[i];
+            let o_c = obs_cnt[i];
+            let subj = u32::cast_from(i);
+
+            let mut eta_loc = Array::<f32>::new(GPU_MH_MAX_ETA);
+            let mut prop = Array::<f32>::new(GPU_MH_MAX_ETA);
+            for c in 0..ne {
+                eta_loc[c] = eta_io[base + c];
+            }
+            let mut nll_cur = nll_at(
+                &eta_loc, n_eta, cl0[i], v0[i], a_cl, a_v, omega_diag, dose_amt, dose_t, d_o, d_c,
+                obs_y, obs_t, o_o, o_c, err, s0, s1,
+            );
+
+            let mut accept = 0u32;
+            for step in 0..n_steps {
+                let st = u32::cast_from(step);
+                for c in 0..ne {
+                    let z = rand_n(seed, subj, st, u32::cast_from(c));
+                    prop[c] = eta_loc[c] + ss * omega_diag[c].sqrt() * z;
+                }
+                let nll_prop = nll_at(
+                    &prop, n_eta, cl0[i], v0[i], a_cl, a_v, omega_diag, dose_amt, dose_t, d_o, d_c,
+                    obs_y, obs_t, o_o, o_c, err, s0, s1,
+                );
+                let u = rand_u(seed, subj, st, 63u32);
+                let mut u_c = u;
+                if u_c < 1e-30 {
+                    u_c = 1e-30;
+                }
+                if u_c.ln() < nll_cur - nll_prop {
+                    for c in 0..ne {
+                        eta_loc[c] = prop[c];
+                    }
+                    nll_cur = nll_prop;
+                    accept += 1u32;
+                }
+            }
+            for c in 0..ne {
+                eta_io[base + c] = eta_loc[c];
+            }
+            accept_out[i] = accept;
+            nll_out[i] = nll_cur;
+        }
+    }
+
+    /// Run one MH sweep on the GPU. Returns `(updated etas flattened, accept
+    /// counts, final nll)` or `None` if no device is available.
+    pub(super) fn run_mh_sweep(
+        batch: &MhBatch,
+        scales: &[f32],
+        n_steps: usize,
+        seed: u64,
+    ) -> Option<(Vec<f32>, Vec<u32>, Vec<f32>)> {
+        let client = client()?;
+        let n = batch.n_subjects;
+        if n == 0 {
+            return Some((Vec::new(), Vec::new(), Vec::new()));
+        }
+        let eta_io = client.create_from_slice(f32::as_bytes(&batch.eta));
+        let cl0 = client.create_from_slice(f32::as_bytes(&batch.cl0));
+        let v0 = client.create_from_slice(f32::as_bytes(&batch.v0));
+        let a_cl = client.create_from_slice(f32::as_bytes(&batch.a_cl));
+        let a_v = client.create_from_slice(f32::as_bytes(&batch.a_v));
+        let omega_diag = client.create_from_slice(f32::as_bytes(&batch.omega_diag));
+        let step_scale = client.create_from_slice(f32::as_bytes(scales));
+        let dose_off = client.create_from_slice(u32::as_bytes(&batch.dose_off));
+        let dose_cnt = client.create_from_slice(u32::as_bytes(&batch.dose_cnt));
+        let dose_amt = client.create_from_slice(u32_pad_f32(&batch.dose_amt));
+        let dose_t = client.create_from_slice(u32_pad_f32(&batch.dose_t));
+        let obs_off = client.create_from_slice(u32::as_bytes(&batch.obs_off));
+        let obs_cnt = client.create_from_slice(u32::as_bytes(&batch.obs_cnt));
+        let obs_y = client.create_from_slice(u32_pad_f32(&batch.obs_y));
+        let obs_t = client.create_from_slice(u32_pad_f32(&batch.obs_t));
+        let fparams = client.create_from_slice(f32::as_bytes(&batch.fparams));
+        let iparams_vec = [batch.n_eta as u32, n_steps as u32, seed as u32];
+        let iparams = client.create_from_slice(u32::as_bytes(&iparams_vec));
+        let accept = client.empty(n * core::mem::size_of::<u32>());
+        let nll = client.empty(n * core::mem::size_of::<f32>());
+
+        let threads = 64u32;
+        let blocks = ((n as u32) + threads - 1) / threads;
+        unsafe {
+            mh_sweep_kernel::launch_unchecked::<R>(
+                client,
+                CubeCount::Static(blocks, 1, 1),
+                CubeDim::new_1d(threads),
+                ArrayArg::from_raw_parts(eta_io.clone(), batch.eta.len()),
+                ArrayArg::from_raw_parts(cl0, batch.cl0.len()),
+                ArrayArg::from_raw_parts(v0, batch.v0.len()),
+                ArrayArg::from_raw_parts(a_cl, batch.a_cl.len()),
+                ArrayArg::from_raw_parts(a_v, batch.a_v.len()),
+                ArrayArg::from_raw_parts(omega_diag, batch.omega_diag.len()),
+                ArrayArg::from_raw_parts(step_scale, scales.len()),
+                ArrayArg::from_raw_parts(dose_off, batch.dose_off.len()),
+                ArrayArg::from_raw_parts(dose_cnt, batch.dose_cnt.len()),
+                ArrayArg::from_raw_parts(dose_amt, batch.dose_amt.len().max(1)),
+                ArrayArg::from_raw_parts(dose_t, batch.dose_t.len().max(1)),
+                ArrayArg::from_raw_parts(obs_off, batch.obs_off.len()),
+                ArrayArg::from_raw_parts(obs_cnt, batch.obs_cnt.len()),
+                ArrayArg::from_raw_parts(obs_y, batch.obs_y.len().max(1)),
+                ArrayArg::from_raw_parts(obs_t, batch.obs_t.len().max(1)),
+                ArrayArg::from_raw_parts(fparams, batch.fparams.len()),
+                ArrayArg::from_raw_parts(iparams, iparams_vec.len()),
+                ArrayArg::from_raw_parts(accept.clone(), n),
+                ArrayArg::from_raw_parts(nll.clone(), n),
+            );
+        }
+        let eta_bytes = client.read_one(eta_io).ok()?;
+        let accept_bytes = client.read_one(accept).ok()?;
+        let nll_bytes = client.read_one(nll).ok()?;
+        Some((
+            f32::from_bytes(&eta_bytes).to_vec(),
+            u32::from_bytes(&accept_bytes).to_vec(),
+            f32::from_bytes(&nll_bytes).to_vec(),
+        ))
+    }
 }
 
 #[cfg(feature = "gpu")]
-use kernel::gpu_data_ll;
+use kernel::{gpu_data_ll, run_mh_sweep};
 
 #[cfg(not(feature = "gpu"))]
 fn gpu_data_ll(_batch: &FlatBatch) -> Option<Vec<f32>> {
+    None
+}
+
+// ---------------------------------------------------------------------------
+// GPU Metropolis-Hastings E-step sweep (the proposal-loop port, issue #368).
+//
+// One GPU thread per subject runs the full block random-walk MH chain in
+// kernel: propose η' = η + step·L·z (diagonal Ω ⇒ L = diag(√Ω_jj)), evaluate
+// the individual NLL, accept on ln u < nll − nll'. Because the proposed η
+// changes CL/V every step, and the θ,η→PK-param transform is an opaque DSL
+// closure, the kernel reconstructs CL/V from a *log-linear* model
+// `CL = CL0·exp(a_cl·η)` whose coefficients are extracted and verified on the
+// host (see `extract_loglinear`). Models that are not log-linear in η fall
+// back to CPU.
+//
+// The in-kernel RNG is a counter-based hash, so the GPU chain does not match
+// the CPU chain bit-for-bit; SAEM is stochastic and the M-step averages over
+// draws, so the two converge to statistically equivalent estimates (verified
+// by a full-fit convergence test). The host keeps the M-step, step-size
+// adaptation, and (for unsupported cases) the whole E-step.
+// ---------------------------------------------------------------------------
+
+/// Maximum number of random effects the GPU MH kernel supports (sizes the
+/// per-thread η scratch, which must be a compile-time length).
+pub const GPU_MH_MAX_ETA: usize = 8;
+
+/// Log-linear reconstruction of `(CL, V)` in η: `CL_i = cl0[i]·exp(a_cl·η)`.
+/// Coefficients are population-global; intercepts are per-subject (covariates).
+#[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+struct LogLinear {
+    cl0: Vec<f32>,
+    v0: Vec<f32>,
+    a_cl: Vec<f32>,
+    a_v: Vec<f32>,
+}
+
+fn rel_err(pred: f64, actual: f64) -> f64 {
+    (pred - actual).abs() / actual.abs().max(1e-12)
+}
+
+/// Probe `model.pk_param_fn` to extract a log-linear `(CL, V)`-in-η model and
+/// verify it reproduces the closure (at η = 0.3·1 and at each subject's current
+/// η). Returns `None` when the model is not log-linear in η within tolerance —
+/// the caller then falls back to the CPU E-step.
+fn extract_loglinear(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    n_eta: usize,
+    etas: &[Vec<f64>],
+) -> Option<LogLinear> {
+    let zero = vec![0.0_f64; n_eta];
+    let cov0 = &population.subjects[0].covariates;
+    let base = (model.pk_param_fn)(theta, &zero, cov0);
+    let cl0_ref = base.values[PK_IDX_CL];
+    let v0_ref = base.values[PK_IDX_V];
+    if !(cl0_ref > 0.0 && v0_ref > 0.0) {
+        return None;
+    }
+    // Finite-difference the log-sensitivities a_cl[j] = d ln CL / d eta_j.
+    let h = 1e-3;
+    let mut a_cl = vec![0.0_f64; n_eta];
+    let mut a_v = vec![0.0_f64; n_eta];
+    for j in 0..n_eta {
+        let mut e = zero.clone();
+        e[j] = h;
+        let p = (model.pk_param_fn)(theta, &e, cov0);
+        if !(p.values[PK_IDX_CL] > 0.0 && p.values[PK_IDX_V] > 0.0) {
+            return None;
+        }
+        a_cl[j] = (p.values[PK_IDX_CL] / cl0_ref).ln() / h;
+        a_v[j] = (p.values[PK_IDX_V] / v0_ref).ln() / h;
+    }
+
+    let dot = |a: &[f64], e: &[f64]| a.iter().zip(e).map(|(x, y)| x * y).sum::<f64>();
+
+    let mut cl0 = Vec::with_capacity(population.subjects.len());
+    let mut v0 = Vec::with_capacity(population.subjects.len());
+    for (i, subject) in population.subjects.iter().enumerate() {
+        let cov = &subject.covariates;
+        let b = (model.pk_param_fn)(theta, &zero, cov);
+        let cl0_i = b.values[PK_IDX_CL];
+        let v0_i = b.values[PK_IDX_V];
+        if !(cl0_i > 0.0 && v0_i > 0.0) {
+            return None;
+        }
+        // Verify log-linearity for this subject at a non-trivial η and at its
+        // current η: the reconstruction must match the real closure. This
+        // catches non-log-normal transforms and covariate×η interactions.
+        for probe in [vec![0.3_f64; n_eta], etas[i].clone()] {
+            let actual = (model.pk_param_fn)(theta, &probe, cov);
+            let pred_cl = cl0_i * dot(&a_cl, &probe).exp();
+            let pred_v = v0_i * dot(&a_v, &probe).exp();
+            if rel_err(pred_cl, actual.values[PK_IDX_CL]) > 1e-4
+                || rel_err(pred_v, actual.values[PK_IDX_V]) > 1e-4
+            {
+                return None;
+            }
+        }
+        cl0.push(cl0_i as f32);
+        v0.push(v0_i as f32);
+    }
+
+    Some(LogLinear {
+        cl0,
+        v0,
+        a_cl: a_cl.iter().map(|&x| x as f32).collect(),
+        a_v: a_v.iter().map(|&x| x as f32).collect(),
+    })
+}
+
+/// Flattened batch for the MH-sweep kernel.
+#[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+struct MhBatch {
+    n_subjects: usize,
+    n_eta: usize,
+    eta: Vec<f32>,
+    cl0: Vec<f32>,
+    v0: Vec<f32>,
+    a_cl: Vec<f32>,
+    a_v: Vec<f32>,
+    omega_diag: Vec<f32>,
+    dose_off: Vec<u32>,
+    dose_cnt: Vec<u32>,
+    dose_amt: Vec<f32>,
+    dose_t: Vec<f32>,
+    obs_off: Vec<u32>,
+    obs_cnt: Vec<u32>,
+    obs_y: Vec<f32>,
+    obs_t: Vec<f32>,
+    fparams: [f32; 3],
+}
+
+/// Build the MH batch, or `None` when the model/population/Ω are outside the
+/// GPU MH-supported subset (diagonal Ω, ≤ `GPU_MH_MAX_ETA` etas, log-linear in
+/// η, plus the same structural gates as [`flatten`]).
+fn build_mh_batch(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    etas: &[Vec<f64>],
+    sigma: &[f64],
+    omega: &OmegaMatrix,
+) -> Option<MhBatch> {
+    if !gpu_model_supported(model) || !omega.diagonal || population.subjects.is_empty() {
+        return None;
+    }
+    let n_eta = omega.matrix.nrows();
+    if n_eta == 0 || n_eta > GPU_MH_MAX_ETA || etas.iter().any(|e| e.len() != n_eta) {
+        return None;
+    }
+    let mut omega_diag = Vec::with_capacity(n_eta);
+    for j in 0..n_eta {
+        let d = omega.matrix[(j, j)];
+        if !(d > 0.0) {
+            return None;
+        }
+        omega_diag.push(d as f32);
+    }
+    let em = match &model.error_spec {
+        ErrorSpec::Single(em) => *em,
+        ErrorSpec::PerCmt(_) => return None,
+    };
+    let s0 = *sigma.first().unwrap_or(&0.0) as f32;
+    let s1 = *sigma.get(1).unwrap_or(&0.0) as f32;
+
+    let ll = extract_loglinear(model, population, theta, n_eta, etas)?;
+
+    let n = population.subjects.len();
+    let mut eta = Vec::with_capacity(n * n_eta);
+    let mut dose_off = Vec::with_capacity(n);
+    let mut dose_cnt = Vec::with_capacity(n);
+    let mut dose_amt = Vec::new();
+    let mut dose_t = Vec::new();
+    let mut obs_off = Vec::with_capacity(n);
+    let mut obs_cnt = Vec::with_capacity(n);
+    let mut obs_y = Vec::new();
+    let mut obs_t = Vec::new();
+
+    for (i, subject) in population.subjects.iter().enumerate() {
+        if subject.has_tv_covariates() || subject.has_resets() || subject.has_ss_doses() {
+            return None;
+        }
+        #[cfg(feature = "survival")]
+        if !subject.obs_records.is_empty() {
+            return None;
+        }
+        for d in &subject.doses {
+            if d.is_infusion() || d.ss {
+                return None;
+            }
+        }
+        for &e in &etas[i] {
+            eta.push(e as f32);
+        }
+        dose_off.push(dose_amt.len() as u32);
+        dose_cnt.push(subject.doses.len() as u32);
+        for d in &subject.doses {
+            dose_amt.push(d.amt as f32);
+            dose_t.push(d.time as f32);
+        }
+        obs_off.push(obs_y.len() as u32);
+        obs_cnt.push(subject.observations.len() as u32);
+        for (j, &y) in subject.observations.iter().enumerate() {
+            obs_y.push(y as f32);
+            obs_t.push(subject.obs_times[j] as f32);
+        }
+    }
+
+    Some(MhBatch {
+        n_subjects: n,
+        n_eta,
+        eta,
+        cl0: ll.cl0,
+        v0: ll.v0,
+        a_cl: ll.a_cl,
+        a_v: ll.a_v,
+        omega_diag,
+        dose_off,
+        dose_cnt,
+        dose_amt,
+        dose_t,
+        obs_off,
+        obs_cnt,
+        obs_y,
+        obs_t,
+        fparams: [error_code(em), s0, s1],
+    })
+}
+
+/// Result of one GPU MH sweep.
+pub struct MhSweepOut {
+    /// Updated per-subject etas.
+    pub etas: Vec<Vec<f64>>,
+    /// Acceptances per subject across the sweep.
+    pub accepts: Vec<usize>,
+    /// Final per-subject individual NLL (for the SAEM nll cache).
+    pub nll: Vec<f64>,
+}
+
+/// Run one GPU block-RW MH sweep of `n_steps` proposals per subject, or return
+/// `None` when the GPU path is unavailable or the model is unsupported (caller
+/// falls back to the CPU E-step). `step_scales` is per-subject; `seed` should
+/// vary per SAEM iteration.
+pub fn gpu_mh_sweep(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    etas: &[Vec<f64>],
+    sigma: &[f64],
+    omega: &OmegaMatrix,
+    step_scales: &[f64],
+    n_steps: usize,
+    seed: u64,
+) -> Option<MhSweepOut> {
+    let batch = build_mh_batch(model, population, theta, etas, sigma, omega)?;
+    let scales: Vec<f32> = step_scales.iter().map(|&s| s as f32).collect();
+    let (eta_out, accepts, nll) = run_mh_sweep(&batch, &scales, n_steps, seed)?;
+    let n_eta = batch.n_eta;
+    let etas_out: Vec<Vec<f64>> = eta_out
+        .chunks(n_eta)
+        .map(|c| c.iter().map(|&x| x as f64).collect())
+        .collect();
+    Some(MhSweepOut {
+        etas: etas_out,
+        accepts: accepts.iter().map(|&a| a as usize).collect(),
+        nll: nll.iter().map(|&x| x as f64).collect(),
+    })
+}
+
+#[cfg(not(feature = "gpu"))]
+fn run_mh_sweep(
+    _batch: &MhBatch,
+    _scales: &[f32],
+    _n_steps: usize,
+    _seed: u64,
+) -> Option<(Vec<f32>, Vec<u32>, Vec<f32>)> {
     None
 }
 
@@ -659,6 +1202,165 @@ mod tests {
                 rel < 1e-3,
                 "subject {i}: gpu={g} cpu={c} rel={rel} exceeds f32 tolerance"
             );
+        }
+    }
+
+    #[test]
+    fn loglinear_extraction_supported_and_rejected() {
+        let (model, pop, theta, _sigma, _omega, etas) = fixture();
+        // 1-cpt IV with CL=TVCL*exp(ETA_CL), V=TVV*exp(ETA_V) is log-linear.
+        let ll = extract_loglinear(&model, &pop, &theta, 2, &etas);
+        assert!(
+            ll.is_some(),
+            "log-normal CL/V must be detected as log-linear"
+        );
+        let ll = ll.unwrap();
+        // a_cl ≈ [1, 0], a_v ≈ [0, 1] for this parameterization.
+        assert!((ll.a_cl[0] - 1.0).abs() < 1e-2 && ll.a_cl[1].abs() < 1e-2);
+        assert!(ll.a_v[0].abs() < 1e-2 && (ll.a_v[1] - 1.0).abs() < 1e-2);
+    }
+
+    /// With `n_steps = 0` the GPU MH sweep performs no proposals and must return
+    /// the initial per-subject NLL — a direct check that the in-kernel NLL
+    /// (log-linear CL/V reconstruction + data term) matches the CPU reference.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn gpu_mh_zero_steps_matches_cpu_nll() {
+        let (model, pop, theta, sigma, omega, etas) = fixture();
+        let reference = batched_individual_nll_cpu(&model, &pop, &theta, &etas, &omega, &sigma);
+        let scales = vec![0.3; pop.subjects.len()];
+        let out = gpu_mh_sweep(&model, &pop, &theta, &etas, &sigma, &omega, &scales, 0, 1);
+        let Some(out) = out else {
+            eprintln!("no GPU device; skipped");
+            return;
+        };
+        for (i, (g, c)) in out.nll.iter().zip(reference.iter()).enumerate() {
+            let rel = (g - c).abs() / c.abs().max(1.0);
+            assert!(rel < 1e-3, "subject {i}: gpu_nll={g} cpu_nll={c} rel={rel}");
+            // No proposals → etas unchanged and zero acceptances.
+            assert_eq!(out.accepts[i], 0);
+        }
+        for (eo, ei) in out.etas.iter().zip(etas.iter()) {
+            for (a, b) in eo.iter().zip(ei.iter()) {
+                assert!((a - b).abs() < 1e-5);
+            }
+        }
+    }
+
+    /// A run of MH proposals must move the chain and accept at a sane rate.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn gpu_mh_sweep_accepts_and_moves() {
+        let (model, pop, theta, sigma, omega, etas) = fixture();
+        let scales = vec![0.3; pop.subjects.len()];
+        let out = gpu_mh_sweep(&model, &pop, &theta, &etas, &sigma, &omega, &scales, 200, 7);
+        let Some(out) = out else {
+            eprintln!("no GPU device; skipped");
+            return;
+        };
+        let total: usize = out.accepts.iter().sum();
+        let proposals = 200 * pop.subjects.len();
+        let rate = total as f64 / proposals as f64;
+        assert!(
+            rate > 0.05 && rate < 0.95,
+            "implausible acceptance rate {rate}"
+        );
+        // At least one subject's eta moved.
+        let moved = out
+            .etas
+            .iter()
+            .zip(etas.iter())
+            .any(|(eo, ei)| eo.iter().zip(ei).any(|(a, b)| (a - b).abs() > 1e-4));
+        assert!(moved, "MH chain did not move any eta");
+    }
+
+    /// A deterministic synthetic 1-cpt IV dataset: per-subject CL/V vary
+    /// log-normally; concentrations follow the analytical bolus decay.
+    fn synthetic_population(n: usize) -> Population {
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 12.0];
+        let dose = 100.0;
+        let subjects = (0..n)
+            .map(|i| {
+                let fi = i as f64;
+                let cl = 4.0 * (0.30 * (0.7 * fi).sin()).exp();
+                let v = 40.0 * (0.20 * (0.5 * fi + 1.0).cos()).exp();
+                let k = cl / v;
+                let obs: Vec<f64> = times
+                    .iter()
+                    .enumerate()
+                    .map(|(j, &t)| {
+                        let c = (dose / v) * (-k * t).exp();
+                        // small deterministic multiplicative perturbation
+                        c * (1.0 + 0.05 * ((fi + 1.3 * j as f64).sin()))
+                    })
+                    .collect();
+                subject(&format!("{i}"), dose, &times, &obs)
+            })
+            .collect();
+        Population {
+            subjects,
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        }
+    }
+
+    /// Full SAEM fit, CPU vs GPU backend, on the same data. The two use
+    /// independent RNGs (CPU = ChaCha, GPU = counter-hash) so the chains differ;
+    /// Robbins-Monro averaging should still land both near the same estimates.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn cpu_gpu_saem_converge_similarly() {
+        use crate::estimation::saem::run_saem;
+        use crate::types::FitOptions;
+
+        let model = iv_combined_model();
+        let data = synthetic_population(16);
+
+        let mut opts = FitOptions::default();
+        opts.verbose = false;
+        opts.run_covariance_step = false;
+        opts.saem_n_exploration = 80;
+        opts.saem_n_convergence = 200;
+        opts.saem_seed = Some(2024);
+
+        opts.saem_backend = SaemBackend::Cpu;
+        let cpu = run_saem(&model, &data, &model.default_params, &opts).expect("cpu saem");
+
+        opts.saem_backend = SaemBackend::Gpu;
+        let gpu = run_saem(&model, &data, &model.default_params, &opts).expect("gpu saem");
+
+        // If no device was available the GPU E-step fell back to CPU and warned;
+        // the comparison is then vacuous, so skip.
+        if gpu
+            .warnings
+            .iter()
+            .any(|w| w.contains("GPU MH E-step did not run"))
+        {
+            eprintln!("no GPU device; convergence comparison skipped");
+            return;
+        }
+
+        for (idx, (c, g)) in cpu
+            .params
+            .theta
+            .iter()
+            .zip(gpu.params.theta.iter())
+            .enumerate()
+        {
+            let rel = (c - g).abs() / c.abs().max(1e-6);
+            assert!(
+                rel < 0.10,
+                "theta[{idx}] cpu={c} gpu={g} rel={rel} — backends disagree"
+            );
+        }
+        for j in 0..cpu.params.omega.matrix.nrows() {
+            let c = cpu.params.omega.matrix[(j, j)];
+            let g = gpu.params.omega.matrix[(j, j)];
+            let rel = (c - g).abs() / c.abs().max(1e-6);
+            assert!(rel < 0.40, "omega[{j}] cpu={c} gpu={g} rel={rel}");
         }
     }
 }

--- a/src/estimation/gpu_saem.rs
+++ b/src/estimation/gpu_saem.rs
@@ -460,6 +460,7 @@ mod kernel {
 
     /// Standard normal via Box-Muller from two uniforms.
     #[cube]
+    #[allow(clippy::approx_constant)] // 2π literal in-kernel; const path not usable in cube
     fn rand_n(seed: u32, subj: u32, step: u32, slot: u32) -> f32 {
         let u1 = rand_u(seed, subj, step, slot * 2u32);
         let u2 = rand_u(seed, subj, step, slot * 2u32 + 1u32);

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -1,4 +1,5 @@
 pub mod gauss_newton;
+pub mod gpu_saem;
 pub(crate) mod hmc;
 pub mod impmap;
 pub mod importance_sampling;

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -13,8 +13,7 @@ use crate::estimation::outer_optimizer::{
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::pk::EventPkParams;
 use crate::stats::likelihood::{
-    individual_nll, individual_nll_into, individual_nll_iov, obs_nll_subject_into,
-    split_obs_by_occasion,
+    individual_nll_into, individual_nll_iov, obs_nll_subject_into, split_obs_by_occasion,
 };
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -1188,12 +1187,12 @@ pub fn run_saem(
     } else {
         None
     };
-    let nll_cache: Vec<f64> = population
-        .subjects
-        .iter()
-        .enumerate()
-        .map(|(i, subject)| {
-            if n_kappa > 0 {
+    let nll_cache: Vec<f64> = if n_kappa > 0 {
+        population
+            .subjects
+            .iter()
+            .enumerate()
+            .map(|(i, subject)| {
                 individual_nll_iov(
                     model,
                     subject,
@@ -1204,18 +1203,28 @@ pub fn run_saem(
                     omega_iov_init_om.as_ref(),
                     &sigma_cur,
                 )
-            } else {
-                individual_nll(
-                    model,
-                    subject,
-                    &theta_cur,
-                    &etas[i],
-                    &init_params.omega,
-                    &sigma_cur,
-                )
-            }
-        })
-        .collect();
+            })
+            .collect()
+    } else {
+        // Backend-dispatched batched NLL (issue #368): runs the GPU kernel when
+        // `saem_backend` selects it, the `gpu` feature is built, a device is
+        // available, and the model is in the supported subset; otherwise falls
+        // back to the CPU path. The dispatch reports which path ran so we can
+        // surface a warning when the GPU was explicitly requested but skipped.
+        let dispatch = crate::estimation::gpu_saem::batched_individual_nll(
+            options.saem_backend,
+            model,
+            population,
+            &theta_cur,
+            &etas,
+            &init_params.omega,
+            &sigma_cur,
+        );
+        if let Some(w) = dispatch.warning {
+            warnings.push(w);
+        }
+        dispatch.nll
+    };
 
     // Per-theta packing flag: log for `theta_lower >= 0` (CL/V/KA…),
     // identity when `theta_lower < 0` (covariate exponents like

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1333,6 +1333,15 @@ pub fn run_saem(
     // Only meaningful when `using_hmc = true`; stays all-false otherwise.
     let mut hmc_subjects = vec![false; n_subjects];
 
+    // GPU E-step (issue #368): whether the GPU MH sweep ran on any iteration.
+    // `gpu_estep_eligible` is true when the user asked for the GPU and the
+    // sampler config permits the GPU kernel (no IOV, no HMC).
+    let gpu_estep_eligible = cfg!(feature = "gpu")
+        && matches!(options.saem_backend, SaemBackend::Gpu | SaemBackend::Auto)
+        && n_kappa == 0
+        && !using_hmc;
+    let mut gpu_estep_used = false;
+
     // Main loop
     for k in 1..=n_iter {
         if crate::cancel::is_cancelled(&options.cancel) {
@@ -1396,7 +1405,48 @@ pub fn run_saem(
         // (`mh_steps_componentwise`) that perturbs one η at a time. Kernel (2)
         // is what keeps a block Ω from collapsing to rank-1 — see that fn's
         // docstring.
-        {
+        // GPU E-step fast path (issue #368): run the whole block-RW MH sweep on
+        // the GPU when eligible (diagonal Ω, log-linear PK, supported model —
+        // all checked inside `gpu_mh_sweep`, which returns None to fall back).
+        // Block kernel only; the componentwise decorrelating sweep is for block
+        // Ω, which the GPU path excludes, so it is skipped here.
+        let gpu_estep_done = if gpu_estep_eligible {
+            if let Some(out) = crate::estimation::gpu_saem::gpu_mh_sweep(
+                model,
+                population,
+                &state.theta,
+                &state.etas,
+                &state.sigma_vals,
+                &omega_k,
+                &state.step_scales,
+                n_mh_steps,
+                master_seed.wrapping_add(k as u64 * 100_000),
+            ) {
+                state.etas = out.etas;
+                for i in 0..n_subjects {
+                    state.accept_counts[i] += out.accepts[i];
+                    state.proposal_counts[i] += n_mh_steps;
+                }
+                // Refresh the NLL cache in f64 on the host for objective
+                // fidelity (one eval/subject — negligible vs the sweep).
+                state.nll_cache = crate::estimation::gpu_saem::batched_individual_nll_cpu(
+                    model,
+                    population,
+                    &state.theta,
+                    &state.etas,
+                    &omega_k,
+                    &state.sigma_vals,
+                );
+                gpu_estep_used = true;
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if !gpu_estep_done {
             use rayon::prelude::*;
             let theta_ref = &state.theta;
             let sigma_ref = &state.sigma_vals;
@@ -1942,6 +1992,18 @@ pub fn run_saem(
 
             crate::estimation::trace::write_saem(k, phase, cond_nll, gamma, mh_accept_rate);
         }
+    }
+
+    // GPU E-step diagnostic (issue #368): if the user explicitly asked for the
+    // GPU but the MH sweep never ran (e.g. block Ω, non-log-linear PK, > max
+    // etas, or no device), the E-step ran on the CPU — surface that.
+    if cfg!(feature = "gpu") && options.saem_backend == SaemBackend::Gpu && !gpu_estep_used {
+        warnings.push(
+            "saem_backend=gpu requested but the GPU MH E-step did not run \
+             (requires a diagonal Ω, a log-linear analytical 1-cpt IV model, \
+             ≤ 8 etas, and an available device); the E-step ran on the CPU."
+                .to_string(),
+        );
     }
 
     // If the user cancelled mid-run the loop broke early; skip the final

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1341,6 +1341,22 @@ pub fn run_saem(
         && n_kappa == 0
         && !using_hmc;
     let mut gpu_estep_used = false;
+    // Persistent GPU session: gates the model and uploads the static
+    // dose/observation buffers once; each iteration's sweep uploads only the
+    // dynamic data. `None` ⇒ the GPU MH path is unavailable; the CPU E-step
+    // runs instead.
+    let mut gpu_session = if gpu_estep_eligible {
+        crate::estimation::gpu_saem::GpuMhSession::new(
+            model,
+            population,
+            &state.theta,
+            &state.etas,
+            &state.sigma_vals,
+            &init_params.omega,
+        )
+    } else {
+        None
+    };
 
     // Main loop
     for k in 1..=n_iter {
@@ -1410,8 +1426,8 @@ pub fn run_saem(
         // all checked inside `gpu_mh_sweep`, which returns None to fall back).
         // Block kernel only; the componentwise decorrelating sweep is for block
         // Ω, which the GPU path excludes, so it is skipped here.
-        let gpu_estep_done = if gpu_estep_eligible {
-            if let Some(out) = crate::estimation::gpu_saem::gpu_mh_sweep(
+        let gpu_estep_done = if let Some(sess) = gpu_session.as_mut() {
+            if let Some(out) = sess.sweep(
                 model,
                 population,
                 &state.theta,
@@ -1427,16 +1443,10 @@ pub fn run_saem(
                     state.accept_counts[i] += out.accepts[i];
                     state.proposal_counts[i] += n_mh_steps;
                 }
-                // Refresh the NLL cache in f64 on the host for objective
-                // fidelity (one eval/subject — negligible vs the sweep).
-                state.nll_cache = crate::estimation::gpu_saem::batched_individual_nll_cpu(
-                    model,
-                    population,
-                    &state.theta,
-                    &state.etas,
-                    &omega_k,
-                    &state.sigma_vals,
-                );
+                // Use the kernel's returned per-subject NLL for the cache (f32
+                // precision; the cache feeds diagnostics, not the M-step). This
+                // avoids a full CPU NLL pass per iteration.
+                state.nll_cache = out.nll;
                 gpu_estep_used = true;
                 true
             } else {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3283,6 +3283,19 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "adapt_interval" => opts.saem_adapt_interval = parse_usize("adapt_interval")?,
         "omega_burnin" => opts.saem_omega_burnin = parse_usize("omega_burnin")?,
         "seed" | "saem_seed" => opts.saem_seed = parse_u64_opt("seed")?,
+        "backend" | "saem_backend" => {
+            opts.saem_backend = match value.to_lowercase().as_str() {
+                "auto" => crate::types::SaemBackend::Auto,
+                "cpu" => crate::types::SaemBackend::Cpu,
+                "gpu" => crate::types::SaemBackend::Gpu,
+                other => {
+                    return Err(format!(
+                        "fit option `saem_backend`: unknown value `{other}` — \
+                         expected auto/cpu/gpu"
+                    ));
+                }
+            };
+        }
         "gn_lambda" => opts.gn_lambda = parse_f64("gn_lambda")?,
         "sir" => opts.sir = parse_bool("sir")?,
         "sir_samples" => opts.sir_samples = parse_usize("sir_samples")?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2614,6 +2614,12 @@ pub struct FitOptions {
     /// A positive value (e.g. `3`) enables HMC; requires the `autodiff`
     /// feature and an analytical PK model — falls back to MH otherwise.
     pub saem_n_leapfrog: usize,
+    /// Compute backend for the SAEM E-step. `Auto` (default) uses the GPU when
+    /// the `gpu` feature is built, a device is available, and the model is in
+    /// the GPU-supported subset; otherwise it runs on the CPU. `Cpu` forces the
+    /// existing CPU path. `Gpu` requests the GPU and still falls back to CPU
+    /// (with a warning) when unavailable. See issue #368.
+    pub saem_backend: SaemBackend,
     /// Levenberg-Marquardt damping factor for Gauss-Newton (0 = pure GN).
     pub gn_lambda: f64,
     // SIR options
@@ -2881,6 +2887,7 @@ impl Default for FitOptions {
             saem_omega_burnin: 20,
             saem_seed: None,
             saem_n_leapfrog: 0,
+            saem_backend: SaemBackend::default(),
             gn_lambda: 0.01,
             sir: false,
             sir_samples: 1000,
@@ -3054,6 +3061,36 @@ pub enum EstimationMethod {
     /// importance-sampling proposal, and whose M-step updates θ/Ω/σ from the
     /// importance-weighted posterior moments.
     Impmap,
+}
+
+/// Compute backend for the SAEM E-step (issue #368).
+///
+/// The CPU path is always available and is the reference implementation. The
+/// GPU path (batched analytical-PK NLL kernel via `cubecl`) is compiled only
+/// under the `gpu` feature and is engaged only for models in the supported
+/// subset; in every other case the engine transparently falls back to the CPU
+/// path so results are unchanged in environments without a GPU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SaemBackend {
+    /// Use the GPU when the `gpu` feature is built, a device initialises, and
+    /// the model is GPU-supported; otherwise use the CPU. The safe default.
+    #[default]
+    Auto,
+    /// Always use the CPU E-step (the reference path).
+    Cpu,
+    /// Prefer the GPU E-step; fall back to CPU (with a warning) when the `gpu`
+    /// feature is absent, no device is available, or the model is unsupported.
+    Gpu,
+}
+
+impl SaemBackend {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SaemBackend::Auto => "auto",
+            SaemBackend::Cpu => "cpu",
+            SaemBackend::Gpu => "gpu",
+        }
+    }
 }
 
 impl EstimationMethod {


### PR DESCRIPTION
## Why

Issue #368: the SAEM E-step runs an independent Metropolis-Hastings chain per
subject — embarrassingly parallel and the dominant cost of a SAEM fit. This PR
adds an **optional GPU backend** for it (the strongest GPU candidate in the
engine; far more SIMT-friendly than the FOCEI inner BFGS loop), behind a Cargo
feature that is **off by default** so environments without a GPU are unaffected.

## What changed

A new `estimation/gpu_saem.rs` module + a `gpu` Cargo feature (optional `cubecl`
dep; wgpu → Metal/Vulkan/DX12, or CUDA). Selected per fit via a new
`saem_backend = auto|cpu|gpu` `[fit_options]` key (default `auto`).

- **Batched NLL kernel** — per-subject individual NLL for the analytical 1-cpt
  IV-bolus model, validated for f32 parity against the CPU reference.
- **Full MH proposal loop on GPU** — one thread per subject runs the whole
  block random-walk sweep (propose → recompute NLL → accept) in kernel. Because
  the proposed η changes CL/V every step and the θ,η→PK transform is an opaque
  DSL closure, the kernel reconstructs CL/V from a **log-linear** model
  `CL = CL0·exp(a·η)` whose coefficients are extracted and **verified** against
  the real closure on the host; non-log-linear models fall back to CPU.
- **Performance work** — persistent device session (static dose/obs buffers
  uploaded once), no per-iteration CPU nll-cache refresh, and a single batched
  device read per sweep (was the dominant cost).

The CPU path remains the reference and the default. The engine falls back to CPU
— with a warning when `gpu` was explicitly requested — whenever the feature is
unbuilt, no device is available, or the model is outside the supported subset.
The GPU attempt is compiled out entirely without the `gpu` feature (zero
per-iteration overhead on CPU builds).

**Supported subset:** 1-cpt IV bolus, single Gaussian endpoint (additive /
proportional / combined), diagonal Ω, ≤ 8 etas, log-linear-in-η, no IOV/HMC.
Everything else transparently uses the CPU E-step.

## Alternatives considered

- *Port the PK-parameter transform itself to GPU* — impossible in general: it is
  an arbitrary compiled DSL closure. The host-side log-linear extraction +
  runtime verification is what makes a correct GPU path possible for the common
  log-normal PK class while safely excluding the rest.
- *f64 kernel* — Metal has no f64; the kernel runs in f32 and the prior term is
  kept in f64 on the host. Parity is asserted within f32 tolerance.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

New public API is additive (`SaemBackend`, `FitOptions::saem_backend`, the
`gpu_saem` module). No ferx-r change required; the R wrapper does not build with
the `gpu` feature.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: prior ferx CPU SAEM (same data, CPU vs GPU backend)
- CPU/GPU NLL parity within f32 tolerance (unit test).
- Full CPU-vs-GPU SAEM fit converges to the same estimates within tolerance
  (θ < 10%, ω < 40%; chains differ because the in-kernel RNG is counter-based,
  but the Robbins-Monro M-step averages over draws).

## Performance
- [x] Faster (for the supported subset, on GPU). Measured on an Apple M5 Pro,
  50 exploration + 100 convergence iterations, CPU = rayon over subjects:

```
vary n_subjects, n_mh_steps = 20:
  n=1000  0.85x    n=4000  1.26x    n=8000  1.72x      (crossover ~1500 subjects)
vary n_mh_steps, n_subjects = 2000:
  20 -> 1.07x   100 -> 2.59x   500 -> 10.1x   2000 -> 25.9x
```

**Reading these honestly:** for the model this kernel supports today — a simple,
well-identified 1-cpt IV model — the *realistic* regime is the first table:
default `n_mh_steps` with a large, sparsely sampled population (phase-3-style),
where the win is a modest ~1.3–1.7× past ~1500 subjects. You would **not**
normally raise `n_mh_steps` on a 1-cpt model (the default mixes fine), so the
second table is **not** a typical 1-cpt workload. It is included to show that
per-iteration overhead is fixed while compute is not — i.e. it is *latent
headroom* for the harder models that genuinely need many MH steps (correlated /
block Ω, ODE/PD, high-dim η), which currently fall back to the CPU. That
compute-scaling becomes the real payoff once those kernels are added; for 1-cpt
today the honest claim is "modest win at large N, parity otherwise" — hence the
conservative `auto`. CPU builds are unchanged.

## Tests
- [x] Unit tests added (`gpu_saem` module): NLL parity, in-kernel NLL at zero
  steps, acceptance/chain-movement, log-linear accept/reject, supported-subset
  detection, fallback-with-warning, and a full CPU-vs-GPU convergence test.
  All gated behind the `gpu` feature (so they are skipped in the default CI).
- A vary-N / vary-mh_steps benchmark is included (`#[ignore]`).

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[fit_options]
  method       = saem
  saem_backend = gpu   # auto (default) | cpu | gpu
```

With the crate built `--features gpu` and a GPU present, the SAEM E-step runs on
the device for a supported model; otherwise it falls back to the CPU path
(emitting a warning in `FitResult.warnings` when `gpu` was explicitly requested).

</details>

## Docs
- [x] `docs/src/model-file/fit-options.md` — `saem_backend` key, supported
  subset, and performance characteristics.
- [x] `CHANGELOG.md` `[Unreleased]` entry added.

## Checklist
- [x] `cargo clippy` clean for the new code (no new warnings; one in-kernel
  `approx_constant` lint allowed locally with a comment)
- [x] `cargo check --features autodiff` still compiles (default build unchanged)
- [x] No version bump (additive, non-breaking)

## Reviewer hints

- `estimation/gpu_saem.rs` is the whole feature; the rest is wiring
  (`saem.rs` E-step branch + initial NLL cache, `types.rs` enum/option, parser
  key, Cargo feature).
- Focus points: the **log-linear extraction + verification** (`extract_loglinear`)
  is the correctness keystone for the MH kernel; the **fallback gates**
  (`gpu_model_supported`, `build_mh_batch`, per-subject checks); and the f32
  parity tolerance.
- The in-kernel RNG is counter-based by design (no cross-iteration state);
  parity with CPU is statistical, not bit-exact — see the convergence test.

## Open questions

- Scope of the supported subset for a first merge — happy to keep it to 1-cpt IV
  here and add 2-cpt / oral kernels (and a block-Ω componentwise sweep) as
  follow-ups, or fold one in now if preferred.

Closes #368

