### PR TITLE
fix(estimation): restore GN-TR gradient EBE-response correction after #365 [closes #366]

### DIFF
--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1064,6 +1064,13 @@ pub(crate) struct LaplaceGradCache {
     pub htilde_inv: DMatrix<f64>,
     /// Per-observation `qⱼ = aⱼ'H̃⁻¹aⱼ`.
     pub q: Vec<f64>,
+    /// Per-packed-parameter GN gradient EBE-response correction:
+    /// `t_i[k] = −½ Σⱼ (q̃ⱼ/Rⱼ) · ∂fⱼ/∂θ_k`
+    /// where `q̃ⱼ = (H̃⁻¹ gη)' aⱼ` and `gη[m] = Σⱼ βⱼ qⱼ a_{j,m}`.
+    /// Only the theta block (indices `0..n_theta`) is filled; omega/sigma stay zero (#335).
+    /// Used by `build_gn_system` to correct the fixed-η̂ Laplace gradient for the
+    /// `log|H̃|` EBE-response term the envelope theorem drops.
+    pub gn_theta_correction: Vec<f64>,
 }
 
 /// As [`subject_nll_pop_grad_analytical_laplace`], but also returns the
@@ -1192,6 +1199,36 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
     let log_det_omega = omega.log_det;
     let nll = 0.5 * (data_ll + eta_prior + log_det_omega + log_det_htilde);
 
+    // ── GN gradient EBE-response correction coefficients ─────────────────────
+    // The fixed-η̂ Laplace gradient drops the log|H̃| EBE-response curvature
+    // (envelope theorem zeros the inner NLL but not log|H̃|).  The total gradient
+    // correction for θ_k is t_i[k] = -½ Σⱼ (q̃ⱼ/Rⱼ) · ∂fⱼ/∂θ_k, where:
+    //   gη[m] = Σⱼ βⱼ qⱼ a_{j,m}   (∂log|H̃|/∂η, a-fixed)
+    //   w     = H̃⁻¹ gη              (IFT: dη̂/dθ_k = -H̃⁻¹ · Σⱼ (aⱼ/Rⱼ) ∂fⱼ/∂θ_k)
+    //   q̃ⱼ   = w' · aⱼ             (per-obs scalar)
+    // Accumulated in the theta FD loop below into `gn_theta_correction`.
+    // Identically zero for additive error (βⱼ = 0 when d = 0).
+    let mut g_eta_gn = DVector::zeros(n_eta);
+    for j in 0..n_obs {
+        let aj = h_matrix.row(j);
+        let beta_j = logdet_htilde_beta(d_vec[j], d2_vec[j], 1.0 / r_diag[j]);
+        let coef = beta_j * q[j];
+        for m in 0..n_eta {
+            g_eta_gn[m] += coef * aj[m];
+        }
+    }
+    let w_gn = &htilde_inv * &g_eta_gn;
+    let mut q_tilde = vec![0.0f64; n_obs];
+    for j in 0..n_obs {
+        let aj = h_matrix.row(j);
+        let mut s = 0.0;
+        for m in 0..n_eta {
+            s += w_gn[m] * aj[m];
+        }
+        q_tilde[j] = s;
+    }
+    let mut gn_theta_correction = vec![0.0f64; n];
+
     // ── Theta gradient (forward FD on predictions; closed-form chain rest) ──
     // Per-obs scalar coeff combines data_ll and log|H̃| contributions:
     //   per_j = αⱼ + βⱼ·qⱼ
@@ -1263,10 +1300,15 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
         if denom.abs() < 1e-16 {
             continue;
         }
-        let s: f64 = (0..n_obs)
-            .map(|j| theta_per_j[j] * (num_lhs[j] - num_rhs[j]) / denom)
-            .sum();
+        let mut s = 0.0f64;
+        let mut s_corr = 0.0f64;
+        for j in 0..n_obs {
+            let df = (num_lhs[j] - num_rhs[j]) / denom;
+            s += theta_per_j[j] * df;
+            s_corr += -(q_tilde[j] / r_diag[j]) * df;
+        }
         grad[k] = 0.5 * s;
+        gn_theta_correction[k] = 0.5 * s_corr;
     }
 
     // ── Omega gradient (closed-form chain rule through Ω⁻¹) ─────────────────
@@ -1395,6 +1437,7 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
         hrh,
         htilde_inv,
         q,
+        gn_theta_correction,
     };
     Some((nll, grad, cache))
 }
@@ -1801,20 +1844,7 @@ fn build_gn_system(
             );
             let ti = cache
                 .as_ref()
-                .and_then(|c| {
-                    subject_eta_response_correction(
-                        Some(c),
-                        x,
-                        template,
-                        model,
-                        population,
-                        i,
-                        &eta_hats[i],
-                        &h_matrices[i],
-                        bounds,
-                        options,
-                    )
-                })
+                .map(|c| c.gn_theta_correction.clone())
                 .unwrap_or_else(|| vec![0.0; n]);
             (nll, gi, ti)
         })


### PR DESCRIPTION
## Why

PR #365 removed the vestigial mu-ref H-column gradient shortcut by zeroing `subject_eta_response_correction`. That function is called by **both** the covariance step (correct to zero — #335) **and** `build_gn_system` (wrong to zero — breaks GN-TR convergence).

Without the `log|H̃|` EBE-response correction, the outer-product gradient is wrong under proportional/combined error. Result: `gn_tr_warfarin_ofv_matches_slsqp_baseline` (added in #365 to guard the new behaviour) stalls at OFV **−276.7955** instead of reaching the expected **−279.11**.

## What changed

A general IFT-based EBE-response correction is computed entirely inside the existing theta FD loop of `subject_nll_pop_grad_analytical_laplace_cached`, reusing intermediates already in scope:

```
g_eta[m] = Σⱼ βⱼ qⱼ aⱼₘ        (∂log|H̃|/∂η, a-fixed)
w         = H̃⁻¹ g_eta           (IFT weight vector; no extra linear-algebra)
q̃ⱼ       = w' aⱼ               (per-obs scalar)
t_i[k]   = −½ Σⱼ (q̃ⱼ/Rⱼ) ∂fⱼ/∂θ_k  (accumulated in same FD loop as grad[k])
```

The result is stored in a new `LaplaceGradCache.gn_theta_correction` field (theta block only; omega/sigma stay zero per #335) and consumed only by `build_gn_system`. The covariance path (`subject_eta_response_correction`) remains zeroed, as required by #335/#354.

No mu-ref specificity: `opts.mu_referencing` and `model.mu_refs` are not consulted. The correction is purely structural (βⱼ = 0 for additive error, so it costs nothing there).

## Alternatives considered

Restoring the old mu-ref shortcut directly in `build_gn_system` — rejected because it would re-introduce mu-ref coupling and only fix mu-ref parameters, not arbitrary theta.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation

Warfarin FOCEI (proportional error), GN-TR, 200 outer iterations:

```
# before (main, post-#365)
OFV = −276.7955   (FAIL: expected ≤ −278.8636)

# after (this PR)
OFV converges to ≈ −279.11, matching SLSQP baseline within tolerance
```

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: SLSQP baseline (−279.1136) stored in the test

## Performance
- [x] No significant impact expected (correction reuses FD loop already running per-theta; one extra H̃⁻¹ multiply per subject per outer iteration)

## Tests
- [x] `gn_tr_warfarin_ofv_matches_slsqp_baseline` (slow) now passes — this was the regression introduced by #365
- [x] `part_a_gn_gradient_independent_of_mu_referencing` still passes (correction doesn't consult mu_refs)
- [x] `eta_response_correction_zero_*` still passes (subject_eta_response_correction remains zeroed)
- [x] All 1069 unit tests pass (`cargo test --lib`)

## Example (user-facing features only)
- [x] Not applicable (internal fix, no new API surface)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo check --features autodiff` — not applicable (change is not in AD-reachable code)
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples
- [x] No new `.ferx` DSL syntax or fit options
- [x] No new example files
- [x] No new data files

## Reviewer hints

The key insight: the envelope theorem zeros `∂(inner NLL)/∂η` at η̂ but does NOT zero `∂log|H̃|/∂η`. GN-TR uses a fixed-η̂ Laplace gradient, so it misses the `log|H̃|` EBE-response curvature unless we explicitly add it back. The IFT gives `dη̂/dθ_k = −H̃⁻¹ · (∂²NLL/∂η∂θ_k)|_{η̂}`, and the chain rule through that gives the correction formula above.

Focus review on `subject_nll_pop_grad_analytical_laplace_cached` (~line 1199): the new block computing `g_eta_gn`, `w_gn`, `q_tilde`, and the accumulation into `gn_theta_correction[k]` inside the theta FD loop. The `build_gn_system` change (line ~1844) is a one-liner substitution.

## Open questions

None.
