### PR TITLE
fix(estimation): poll cancel during IMPMAP E-step [closes #273]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,12 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **IMPMAP** now responds to a cooperative cancellation (e.g. an R-session
+  interrupt) during an iteration's E-step, instead of only at iteration
+  boundaries. The importance-sampling pass — the dominant per-iteration cost on
+  large datasets — previously ran to completion before the cancel flag was
+  checked, so a kill request could appear to hang for minutes; the E-step now
+  polls per subject and the run aborts promptly (#273).
 - An individual parameter assigned only inside symmetric `if`/`else` branches in
   `[individual_parameters]` (the NONMEM-style `IF (cond) CL = ...` /
   `IF (!cond) CL = ...` construction) on an **ODE model** is no longer rejected

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -306,6 +306,15 @@ pub fn run_impmap(
             .par_iter()
             .enumerate()
             .map_init(EventPkParams::default, |scratch, (i, subject)| {
+                // Poll per subject: the inner-loop MAP + IS draws below are the
+                // dominant per-iteration cost, so without this a cancel set
+                // mid-iteration is not seen until the next iteration's top-of-loop
+                // check (line ~257) — minutes on a large dataset. Mirrors
+                // `run_importance_sampling`. The driver breaks right after the
+                // collect, so the placeholder draws never reach the M-step.
+                if crate::cancel::is_cancelled(cancel) {
+                    return crate::estimation::importance_sampling::SubjectDraws::cancelled(n_eta);
+                }
                 let h_post = compute_posterior_hessian(
                     model,
                     subject,
@@ -334,6 +343,15 @@ pub fn run_impmap(
                 )
             })
             .collect();
+
+        // If a cancel was observed inside the E-step, the `draws` are placeholders;
+        // break before the M-steps consume them. The post-loop check returns Err.
+        if crate::cancel::is_cancelled(cancel) {
+            if verbose {
+                eprintln!("IMPMAP: cancelled during E-step at iteration {}", k);
+            }
+            break;
+        }
 
         // ESS diagnostics + marginal log-likelihood for the trace.
         let mut ll = 0.0f64;

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -534,6 +534,24 @@ pub(crate) struct SubjectDraws {
     pub second_moment: DMatrix<f64>,
 }
 
+impl SubjectDraws {
+    /// Cheap placeholder returned when a cancellation is observed mid-E-step, so
+    /// the rayon task exits immediately instead of running the inner loop /
+    /// importance sampling. The IMPMAP driver breaks out of the iteration right
+    /// after the `par_iter` collect, so these benign values never feed a real
+    /// M-step.
+    pub(crate) fn cancelled(n_eta: usize) -> Self {
+        SubjectDraws {
+            log_marginal: 0.0,
+            ess_fraction: 1.0,
+            etas: Vec::new(),
+            weights: Vec::new(),
+            mean: vec![0.0; n_eta],
+            second_moment: DMatrix::zeros(n_eta, n_eta),
+        }
+    }
+}
+
 /// Draw `K` importance samples for one subject from a proposal centered at the
 /// conditional mode `η̂` with first-order-variance scale `Σ = (H + λI)⁻¹`, and
 /// return the retained samples, self-normalized weights, and weighted second
@@ -1113,6 +1131,24 @@ pub(crate) fn compute_posterior_hessian(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn subject_draws_cancelled_is_benign_and_correctly_shaped() {
+        // The placeholder returned when the IMPMAP E-step observes a cancel:
+        // zero samples/weights so it can't bias an (already-skipped) M-step, a
+        // zero second moment of the right dimension, and an ESS that does not
+        // count as low-ESS.
+        let n_eta = 3;
+        let d = SubjectDraws::cancelled(n_eta);
+        assert_eq!(d.log_marginal, 0.0);
+        assert_eq!(d.ess_fraction, 1.0);
+        assert!(d.etas.is_empty());
+        assert!(d.weights.is_empty());
+        assert_eq!(d.mean, vec![0.0; n_eta]);
+        assert_eq!(d.second_moment.nrows(), n_eta);
+        assert_eq!(d.second_moment.ncols(), n_eta);
+        assert!(d.second_moment.iter().all(|&x| x == 0.0));
+    }
 
     #[test]
     fn logsumexp_handles_extreme_spread() {


### PR DESCRIPTION
## Why
IMPMAP (`METHOD=IMPMAP`) did not respond to a cooperative cancellation request
(e.g. an R-session interrupt via `CancelFlag`) until the *next* iteration
boundary. Each iteration's E-step — the inner-loop MAP recenter plus the
per-subject importance-sampling `par_iter` — is the dominant per-iteration cost
on large datasets, so a kill request could appear to hang for minutes before
taking effect.

By contrast `run_importance_sampling` and SIR already poll the flag inside their
`par_iter`; IMPMAP was the inconsistent one.

## What changed
- The E-step `par_iter` closure now polls `cancel` per subject and returns a
  benign placeholder via a new `SubjectDraws::cancelled(n_eta)` constructor
  (zero samples/weights, zero second moment, ESS that does not count as
  low-ESS), so the rayon task exits immediately instead of running the inner
  loop / sampling.
- The driver breaks out of the iteration right after the `par_iter` collect,
  before the M-step consumes the placeholder draws. The existing post-loop
  check still returns `Err("cancelled by user")`.

Iteration-top polling is unchanged; this only adds mid-E-step responsiveness.

## Alternatives considered
Polling inside the inner-loop MAP / weighted M-step too. Skipped: the
importance-sampling `par_iter` is the dominant cost, so the per-subject poll
recovers the bulk of responsiveness; the inner loop and M-step are comparatively
short. SAEM's MCMC/HMC E-step has the same iteration-top-only polling but stays
responsive because each iteration is light (one sampler step per subject), so it
is left as-is.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change; `CancelFlag` already `pub`.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (cancellation responsiveness; does not alter converged estimates)

## Performance
- [x] No significant impact expected — one atomic load per subject per iteration.

## Tests
- [x] Unit test added for `SubjectDraws::cancelled` (field shape / benign values).
- [ ] Regression test that fails without the fix: not added — the new break path
  needs a cancel set *mid-`par_iter`*, which is not deterministically reachable
  through the `CancelFlag` (`AtomicBool`) API without a thread race. A pre-set
  flag breaks at the iteration-top check before reaching the E-step.

> Note: could not run `cargo test` / `cargo fmt` locally — the dev `enzyme`
> toolchain ICEs during codegen (pre-existing, reproduces on a clean tree). CI
> runs a standard nightly and will validate. `cargo check --lib --tests` is clean.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → Fixed entry added (#273).
- [x] No other user-visible change (internal responsiveness fix).

## Reviewer hints
Focus on `src/estimation/impmap.rs`: the per-subject poll at the top of the
E-step closure and the break right after the `.collect()`. Confirm the
placeholder draws can never reach the M-step.

## Open questions
None.
