### PR TITLE
feat(api): add nearest and rank pmVPC matching methods [closes #396]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,13 +125,17 @@ section of the SDLC for the versioning policy).
   wall-clock cost (both stencils parallelise over perturbation points). Default
   `true`; set `false` to force the faster analytical-gradient stencil (#335).
 - Propensity-score-matched simulation: `simulate_with_options()` with a new
-  `SimulateOptions { seed, propensity_match }`. When `propensity_match` is set,
-  each replicate's drawn etas are reassigned to subjects by optimal Mahalanobis
-  matching (under the model Ω) against the subjects' fitted (posthoc) etas, so a
-  subject's observed dosing/sampling design is paired with a similar drawn eta.
-  This corrects VPC bias from treatment adaptation in real-world data (longer
-  intervals for high-clearance patients, etc.). Operates on observed data;
-  returns the usual simulation rows for the caller to build the VPC (#288).
+  `SimulateOptions { seed, match_method }`. When `match_method` is `Some(..)`,
+  each replicate's drawn etas are reassigned to subjects by Mahalanobis matching
+  (under the model Ω) against the subjects' fitted (posthoc) etas, so a subject's
+  observed dosing/sampling design is paired with a similar drawn eta. This
+  corrects VPC bias from treatment adaptation in real-world data (longer
+  intervals for high-clearance patients, etc.). Three methods are offered via
+  `MatchMethod`: `Optimal` (global linear-assignment minimum; best on average in
+  simulation, recommended default), `Nearest` (greedy nearest-neighbour,
+  `MatchIt(method="nearest", distance="mahalanobis")`), and `Rank` (pair by the
+  rank of the Mahalanobis norm). Operates on observed data; returns the usual
+  simulation rows for the caller to build the VPC (#288, #396).
 - New `importance_sampling_map` (alias `impmap`) estimation method: a Monte-Carlo
   EM estimator equivalent to NONMEM `METHOD=IMPMAP`. Each iteration re-centers a
   per-subject importance-sampling proposal on the conditional mode (MAP) and

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,6 +9,7 @@ use crate::io::datareader::{
     ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
+use crate::propensity_match::MatchMethod;
 use crate::stats::likelihood::{compute_cwres, foce_subject_nll, foce_subject_nll_iov};
 use crate::stats::residual_error::{compute_iwres, iwres_autocorrelation};
 use crate::types::*;
@@ -4393,26 +4394,28 @@ pub fn simulate_with_seed(
 pub struct SimulateOptions {
     /// Seed for reproducibility. `None` draws from entropy.
     pub seed: Option<u64>,
-    /// When `true`, reassign each replicate's drawn etas to subjects by
+    /// When `Some(method)`, reassign each replicate's drawn etas to subjects by
     /// **propensity-score matching** against the subjects' fitted (posthoc)
-    /// etas — optimal Mahalanobis matching under the model `Ω`. This restores
-    /// the design↔eta association present in adaptively-dosed real-world data
-    /// and corrects the resulting VPC bias (see [`crate::propensity_match`]).
+    /// etas — Mahalanobis matching under the model `Ω` via the chosen
+    /// [`MatchMethod`]. This restores the design↔eta association present in
+    /// adaptively-dosed real-world data and corrects the resulting VPC bias
+    /// (see [`crate::propensity_match`]). `None` disables matching.
     ///
     /// Requires `population` to be observed data: every subject must carry
     /// observations so its posthoc eta can be computed. Has no effect for the
     /// synthetic `[simulation]` block (no observed designs to match against).
-    pub propensity_match: bool,
+    pub match_method: Option<MatchMethod>,
 }
 
 /// Simulate observations, optionally with propensity-score matching.
 ///
-/// With `opts.propensity_match == false` this is identical to
-/// [`simulate_with_seed`] (or [`simulate`] when `opts.seed` is `None`). With it
-/// `true`, the freshly drawn etas of each replicate are reassigned to subjects
-/// so each subject's observed design is paired with a drawn eta close (under the
-/// model `Ω` Mahalanobis metric) to that subject's fitted eta. The fitted
-/// (posthoc) etas are computed once from `params` + the observed `population`.
+/// With `opts.match_method == None` this is identical to
+/// [`simulate_with_seed`] (or [`simulate`] when `opts.seed` is `None`). With a
+/// `Some(method)`, the freshly drawn etas of each replicate are reassigned to
+/// subjects so each subject's observed design is paired with a drawn eta close
+/// (under the model `Ω` Mahalanobis metric) to that subject's fitted eta. The
+/// fitted (posthoc) etas are computed once from `params` + the observed
+/// `population`.
 ///
 /// Returns `Err` if matching is requested but the population is empty or any
 /// subject has no observations.
@@ -4439,11 +4442,14 @@ pub fn simulate_with_options(
     // diagnostic; it is a no-op O(doses) scan on the common all-`Fixed` dataset.
     assert_modeled_doses_supported(model, population);
 
-    if !opts.propensity_match {
-        return Ok(simulate_inner_with_draw(
-            model, population, params, n_sim, 1, None, &mut rng,
-        ));
-    }
+    let method = match opts.match_method {
+        Some(m) => m,
+        None => {
+            return Ok(simulate_inner_with_draw(
+                model, population, params, n_sim, 1, None, &mut rng,
+            ));
+        }
+    };
 
     if population.subjects.is_empty() {
         return Err(
@@ -4495,7 +4501,7 @@ pub fn simulate_with_options(
         params,
         n_sim,
         1,
-        Some((&eta_hats, omega_inv)),
+        Some((&eta_hats, omega_inv, method)),
         &mut rng,
     ))
 }
@@ -4568,11 +4574,12 @@ fn emit_subject_rows<R: rand::Rng>(
     );
 }
 
-/// `matched`, when `Some((fitted_etas, omega_inv))`, reassigns each replicate's
-/// drawn etas to subjects by propensity-score matching against `fitted_etas`
-/// (optimal Mahalanobis matching under `omega_inv`; see `crate::propensity_match`).
-/// `None` is the standard per-subject independent draw and reproduces the
-/// previous behaviour byte-for-byte (same RNG draw order).
+/// `matched`, when `Some((fitted_etas, omega_inv, method))`, reassigns each
+/// replicate's drawn etas to subjects by propensity-score matching against
+/// `fitted_etas` (Mahalanobis matching under `omega_inv` via `method`; see
+/// `crate::propensity_match`). `None` is the standard per-subject independent
+/// draw and reproduces the previous behaviour byte-for-byte (same RNG draw
+/// order).
 #[allow(clippy::too_many_arguments)]
 fn simulate_inner_with_draw<R: rand::Rng>(
     model: &CompiledModel,
@@ -4580,7 +4587,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     params: &ModelParameters,
     n_sim: usize,
     draw: usize,
-    matched: Option<(&[DVector<f64>], &nalgebra::DMatrix<f64>)>,
+    matched: Option<(&[DVector<f64>], &nalgebra::DMatrix<f64>, MatchMethod)>,
     rng: &mut R,
 ) -> Vec<SimulationResult> {
     use rand_distr::Normal;
@@ -4599,7 +4606,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     for sim_idx in 0..n_sim {
         let sim = sim_idx + 1;
         match matched {
-            Some((fitted, omega_inv)) => {
+            Some((fitted, omega_inv, method)) => {
                 // Draw a pool of one eta per subject for this replicate, then
                 // reassign the draws to subjects by matching them to the fitted
                 // (posthoc) etas. Each subject keeps its own observed design.
@@ -4610,8 +4617,9 @@ fn simulate_inner_with_draw<R: rand::Rng>(
                         &params.omega.chol * DVector::from_column_slice(&z)
                     })
                     .collect();
-                let assign =
-                    crate::propensity_match::match_draws_to_fitted(&pool, fitted, omega_inv);
+                let assign = crate::propensity_match::match_draws_to_fitted(
+                    &pool, fitted, omega_inv, method,
+                );
                 for (i, subject) in population.subjects.iter().enumerate() {
                     let mut eta_slice: Vec<f64> = pool[assign[i]].iter().copied().collect();
                     eta_slice.resize(n_eta + model.n_kappa, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use estimation::run_sir::run_sir;
 pub use estimation::uncertainty_samples::UncertaintyMethod;
 pub use io::datareader::{read_nonmem_csv, read_nonmem_csv_with_covariates};
 pub use parser::model_parser::{parse_full_model_file, parse_model_file, parse_model_string};
+pub use propensity_match::MatchMethod;
 pub use suggest_start::{inits_from_nca, NcaInit, SuggestedStart};
 pub use types::*;
 

--- a/src/propensity_match.rs
+++ b/src/propensity_match.rs
@@ -13,9 +13,20 @@
 //! Hughes).
 //!
 //! The metric is the Mahalanobis distance under the model `Ω`,
-//! `d²(a,b) = (a−b)ᵀ Ω⁻¹ (a−b)`, and matching is **optimal** (global minimum of
-//! the total matched distance, i.e. the linear assignment problem) and 1:1
-//! without replacement, mirroring `MatchIt(method = "optimal")`.
+//! `d²(a,b) = (a−b)ᵀ Ω⁻¹ (a−b)`. Three 1:1-without-replacement matching methods
+//! are offered (see [`MatchMethod`]):
+//!
+//! - **optimal** — global minimum of the total matched distance (the linear
+//!   assignment problem), mirroring `MatchIt(method = "optimal")`. Simulation
+//!   studies found this best on average, so it is the recommended default.
+//! - **nearest** — greedy nearest-neighbour in subject order, mirroring
+//!   `MatchIt(method = "nearest", distance = "mahalanobis")`.
+//! - **rank** — pair subjects and draws by the rank of their Mahalanobis norm
+//!   `‖eta‖ = √(etaᵀ Ω⁻¹ eta)` (k-th order statistic to k-th), greedily on rank
+//!   distance.
+//!
+//! "optimal" was best on average in simulation, but other methods can win on
+//! particular datasets, hence all three are exposed (#396).
 
 use nalgebra::{DMatrix, DVector};
 
@@ -129,8 +140,100 @@ pub fn optimal_assignment(cost: &DMatrix<f64>) -> Vec<usize> {
     assign
 }
 
-/// For each subject (indexed by `fitted`), pick the drawn pool index whose eta
-/// optimally matches the subject's fitted eta under the `Ω⁻¹` metric.
+/// Greedy 1:1 assignment without replacement: for each row in index order,
+/// pick the still-available column with least cost (ties → smallest column
+/// index). `cost` must be square `n × n`; the return value `assign` has length
+/// `n` and is a permutation of `0..n`.
+///
+/// Unlike [`optimal_assignment`] this minimises greedily, not globally — the
+/// total matched cost can exceed the optimum. It mirrors the greedy nearest-
+/// neighbour matching of `MatchIt(method = "nearest")`.
+pub fn greedy_assignment(cost: &DMatrix<f64>) -> Vec<usize> {
+    let n = cost.nrows();
+    assert_eq!(
+        cost.ncols(),
+        n,
+        "greedy_assignment requires a square matrix"
+    );
+    let mut used = vec![false; n];
+    let mut assign = vec![0usize; n];
+    for i in 0..n {
+        // n − i ≥ 1 columns remain free when processing row i, so this always
+        // finds a candidate; an all-NaN row would leave best_j unset, hence the
+        // debug_assert below mirrors `optimal_assignment`'s finiteness contract.
+        let mut best_j = usize::MAX;
+        let mut best_c = f64::INFINITY;
+        for j in 0..n {
+            if !used[j] && cost[(i, j)] < best_c {
+                best_c = cost[(i, j)];
+                best_j = j;
+            }
+        }
+        debug_assert!(best_j != usize::MAX, "greedy_assignment: no free column");
+        used[best_j] = true;
+        assign[i] = best_j;
+    }
+    assign
+}
+
+/// Mahalanobis norm of a single eta from the origin: `√(etaᵀ Ω⁻¹ eta)`.
+fn mahalanobis_norm(a: &[f64], omega_inv: &DMatrix<f64>) -> f64 {
+    mahalanobis_sq(a, &vec![0.0; a.len()], omega_inv).sqrt()
+}
+
+/// Dense rank of each eta by its Mahalanobis norm, ascending. Returns a vector
+/// of rank positions `0..n` (ties broken by index, so a stable permutation).
+fn ranks_by_norm(etas: &[DVector<f64>], omega_inv: &DMatrix<f64>) -> Vec<f64> {
+    let scores: Vec<f64> = etas
+        .iter()
+        .map(|e| mahalanobis_norm(e.as_slice(), omega_inv))
+        .collect();
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    order.sort_by(|&a, &b| {
+        scores[a]
+            .partial_cmp(&scores[b])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
+    });
+    let mut rank = vec![0.0f64; scores.len()];
+    for (r, &idx) in order.iter().enumerate() {
+        rank[idx] = r as f64;
+    }
+    rank
+}
+
+/// Squared-Mahalanobis cost matrix: rows = subjects (`fitted`), columns = drawn
+/// `pool`. `cost[(i, j)] = d²(fitted[i], pool[j])` under `Ω⁻¹`.
+fn mahalanobis_cost(
+    pool: &[DVector<f64>],
+    fitted: &[DVector<f64>],
+    omega_inv: &DMatrix<f64>,
+) -> DMatrix<f64> {
+    let n = fitted.len();
+    let mut cost = DMatrix::zeros(n, n);
+    for i in 0..n {
+        for j in 0..n {
+            cost[(i, j)] = mahalanobis_sq(fitted[i].as_slice(), pool[j].as_slice(), omega_inv);
+        }
+    }
+    cost
+}
+
+/// How drawn etas are reassigned to subjects per replicate. See the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMethod {
+    /// Global minimum total Mahalanobis distance (linear assignment).
+    /// `MatchIt(method = "optimal")`. Recommended default.
+    Optimal,
+    /// Greedy nearest-neighbour in subject order, 1:1 without replacement.
+    /// `MatchIt(method = "nearest", distance = "mahalanobis")`.
+    Nearest,
+    /// Pair by Mahalanobis-norm rank (k-th order statistic to k-th).
+    Rank,
+}
+
+/// For each subject (indexed by `fitted`), pick the drawn pool index that
+/// matches the subject's fitted eta under the `Ω⁻¹` metric, using `method`.
 ///
 /// `pool` and `fitted` must have equal length `n`; the return value `assign`
 /// has length `n` with `assign[i]` the `pool` index assigned to subject `i`
@@ -139,17 +242,29 @@ pub fn match_draws_to_fitted(
     pool: &[DVector<f64>],
     fitted: &[DVector<f64>],
     omega_inv: &DMatrix<f64>,
+    method: MatchMethod,
 ) -> Vec<usize> {
     let n = fitted.len();
     assert_eq!(pool.len(), n, "pool and fitted must have equal length");
-    // Rows = subjects (fitted), columns = drawn pool.
-    let mut cost = DMatrix::zeros(n, n);
-    for i in 0..n {
-        for j in 0..n {
-            cost[(i, j)] = mahalanobis_sq(fitted[i].as_slice(), pool[j].as_slice(), omega_inv);
+    match method {
+        MatchMethod::Optimal => optimal_assignment(&mahalanobis_cost(pool, fitted, omega_inv)),
+        MatchMethod::Nearest => greedy_assignment(&mahalanobis_cost(pool, fitted, omega_inv)),
+        MatchMethod::Rank => {
+            // Pair on the rank of each eta's Mahalanobis norm: greedily assign
+            // the pool draw whose rank is closest to the subject's. With a
+            // complete pool (distinct ranks 0..n) this reduces to matching the
+            // k-th order statistic to the k-th, independent of subject order.
+            let rank_fitted = ranks_by_norm(fitted, omega_inv);
+            let rank_pool = ranks_by_norm(pool, omega_inv);
+            let mut cost = DMatrix::zeros(n, n);
+            for i in 0..n {
+                for j in 0..n {
+                    cost[(i, j)] = (rank_fitted[i] - rank_pool[j]).abs();
+                }
+            }
+            greedy_assignment(&cost)
         }
     }
-    optimal_assignment(&cost)
 }
 
 #[cfg(test)]
@@ -253,13 +368,75 @@ mod tests {
             DVector::from_vec(vec![-2.0, 1.0]),
         ];
         let pool = fitted.clone();
-        let assign = match_draws_to_fitted(&pool, &fitted, &omega_inv);
-        assert_eq!(assign, vec![0, 1, 2]);
+        for method in [
+            MatchMethod::Optimal,
+            MatchMethod::Nearest,
+            MatchMethod::Rank,
+        ] {
+            let assign = match_draws_to_fitted(&pool, &fitted, &omega_inv, method);
+            assert_eq!(assign, vec![0, 1, 2], "method {method:?}");
+        }
     }
 
     #[test]
     fn empty_assignment() {
         let cost = DMatrix::<f64>::zeros(0, 0);
         assert!(optimal_assignment(&cost).is_empty());
+        assert!(greedy_assignment(&cost).is_empty());
+    }
+
+    #[test]
+    fn greedy_picks_least_cost_per_row_in_order() {
+        // Row 0's cheapest is col 1; once taken, row 1 must fall back to col 0.
+        let cost = DMatrix::from_row_slice(2, 2, &[5.0, 1.0, 2.0, 3.0]);
+        assert_eq!(greedy_assignment(&cost), vec![1, 0]);
+    }
+
+    #[test]
+    fn greedy_can_be_suboptimal_vs_optimal() {
+        // Greedy in row order takes (0->0, cost 0) then is forced into (1->1,
+        // cost 10): total 10. The optimum is the anti-diagonal: total 2.
+        let cost = DMatrix::from_row_slice(2, 2, &[0.0, 1.0, 1.0, 10.0]);
+        assert_eq!(greedy_assignment(&cost), vec![0, 1]);
+        assert_eq!(total_cost(&cost, &greedy_assignment(&cost)), 10.0);
+        assert_eq!(total_cost(&cost, &optimal_assignment(&cost)), 2.0);
+    }
+
+    #[test]
+    fn greedy_returns_valid_permutation() {
+        let n = 6;
+        let mut cost = DMatrix::zeros(n, n);
+        for i in 0..n {
+            for j in 0..n {
+                cost[(i, j)] = ((i * 5 + j * 2 + (i + j) % 3) % 7) as f64;
+            }
+        }
+        let a = greedy_assignment(&cost);
+        let mut seen = vec![false; n];
+        for &j in &a {
+            assert!(!seen[j], "column {j} used twice");
+            seen[j] = true;
+        }
+    }
+
+    #[test]
+    fn rank_pairs_by_mahalanobis_norm_order_statistics() {
+        // Identity Ω⁻¹ ⇒ norm is Euclidean length. Fitted norms ascending:
+        // idx2 (0) < idx0 (1) < idx1 (2). Pool norms: idx1 (0.5) < idx2 (1.5)
+        // < idx0 (3). Rank-matching pairs the k-th smallest fitted with the
+        // k-th smallest pool: fitted2->pool1, fitted0->pool2, fitted1->pool0.
+        let omega_inv = DMatrix::identity(1, 1);
+        let fitted = vec![
+            DVector::from_vec(vec![1.0]),  // rank 1
+            DVector::from_vec(vec![-2.0]), // rank 2 (norm 2)
+            DVector::from_vec(vec![0.0]),  // rank 0
+        ];
+        let pool = vec![
+            DVector::from_vec(vec![3.0]),  // rank 2
+            DVector::from_vec(vec![0.5]),  // rank 0
+            DVector::from_vec(vec![-1.5]), // rank 1 (norm 1.5)
+        ];
+        let assign = match_draws_to_fitted(&pool, &fitted, &omega_inv, MatchMethod::Rank);
+        assert_eq!(assign, vec![2, 0, 1]);
     }
 }

--- a/tests/modeled_duration.rs
+++ b/tests/modeled_duration.rs
@@ -598,7 +598,7 @@ fn simulate_propensity_on_analytical_model_with_modeled_dose_panics() {
     let pop = pop_of(&coded_csv());
     let opts = SimulateOptions {
         seed: Some(1),
-        propensity_match: true,
+        match_method: Some(ferx_core::MatchMethod::Optimal),
     };
     let _ = simulate_with_options(&model, &pop, &model.default_params, 1, &opts);
 }

--- a/tests/propensity_matched_sim.rs
+++ b/tests/propensity_matched_sim.rs
@@ -1,15 +1,22 @@
 //! Integration tests for propensity-score-matched simulation
-//! (`simulate_with_options` with `propensity_match = true`).
+//! (`simulate_with_options` with `match_method = Some(..)`).
 //!
-//! The matching *math* (Mahalanobis + optimal assignment) is unit-tested in
-//! `src/propensity_match.rs`; these tests exercise the public-API wiring on a
-//! real compiled model: shape, finiteness, the error path, reproducibility of
-//! the unmatched path, and that the matched path is actually distinct.
+//! The matching *math* (Mahalanobis + the assignment algorithms) is unit-tested
+//! in `src/propensity_match.rs`; these tests exercise the public-API wiring on a
+//! real compiled model for every [`MatchMethod`]: shape, finiteness, the error
+//! path, reproducibility of the unmatched path, and that each matched method is
+//! actually distinct from the unmatched draw.
 
 use ferx_core::{
-    parse_model_string, simulate_with_options, simulate_with_seed, DoseEvent, Population,
-    SimulateOptions, Subject,
+    parse_model_string, simulate_with_options, simulate_with_seed, DoseEvent, MatchMethod,
+    Population, SimulateOptions, Subject,
 };
+
+const ALL_METHODS: [MatchMethod; 3] = [
+    MatchMethod::Optimal,
+    MatchMethod::Nearest,
+    MatchMethod::Rank,
+];
 
 mod common;
 
@@ -81,54 +88,68 @@ fn matched_simulation_has_expected_shape_and_finite_dvs() {
     let n_sim = 4;
     let n_obs: usize = pop.subjects.iter().map(|s| s.obs_times.len()).sum();
 
-    let opts = SimulateOptions {
-        seed: Some(2024),
-        propensity_match: true,
-    };
-    let rows = simulate_with_options(&model, &pop, &model.default_params, n_sim, &opts)
-        .expect("matched simulation succeeds");
+    for method in ALL_METHODS {
+        let opts = SimulateOptions {
+            seed: Some(2024),
+            match_method: Some(method),
+        };
+        let rows = simulate_with_options(&model, &pop, &model.default_params, n_sim, &opts)
+            .unwrap_or_else(|e| panic!("matched simulation ({method:?}) succeeds: {e}"));
 
-    assert_eq!(rows.len(), n_obs * n_sim, "one row per obs per replicate");
-    assert!(rows
-        .iter()
-        .all(|r| r.outcome.continuous_value().is_finite()));
-    // Replicate indices span 1..=n_sim.
-    let mut sims: Vec<usize> = rows.iter().map(|r| r.sim).collect();
-    sims.sort_unstable();
-    sims.dedup();
-    assert_eq!(sims, (1..=n_sim).collect::<Vec<_>>());
+        assert_eq!(
+            rows.len(),
+            n_obs * n_sim,
+            "one row per obs per replicate ({method:?})"
+        );
+        assert!(rows
+            .iter()
+            .all(|r| r.outcome.continuous_value().is_finite()));
+        // Replicate indices span 1..=n_sim.
+        let mut sims: Vec<usize> = rows.iter().map(|r| r.sim).collect();
+        sims.sort_unstable();
+        sims.dedup();
+        assert_eq!(sims, (1..=n_sim).collect::<Vec<_>>());
+    }
 }
 
 #[test]
 fn matched_simulation_is_reproducible_and_distinct_from_unmatched() {
     let model = parse_model_string(MODEL).expect("model parses");
     let pop = observed_population(&model, 10);
-
-    let matched = SimulateOptions {
-        seed: Some(7),
-        propensity_match: true,
-    };
-    let a = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
-    let b = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
     let dv = |rs: &[ferx_core::SimulationResult]| {
         rs.iter()
             .map(|r| r.outcome.continuous_value())
             .collect::<Vec<_>>()
     };
-    assert_eq!(
-        dv(&a),
-        dv(&b),
-        "matched path must be reproducible under a seed"
-    );
 
-    // The matched path takes a different branch (pool draw + reassignment), so
-    // its output must differ from the unmatched path on the same seed.
+    // The unmatched path on the same seed, for the distinctness check below.
     let unmatched = SimulateOptions {
         seed: Some(7),
-        propensity_match: false,
+        match_method: None,
     };
     let c = simulate_with_options(&model, &pop, &model.default_params, 3, &unmatched).unwrap();
-    assert_ne!(dv(&a), dv(&c), "matched should differ from unmatched");
+
+    for method in ALL_METHODS {
+        let matched = SimulateOptions {
+            seed: Some(7),
+            match_method: Some(method),
+        };
+        let a = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
+        let b = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
+        assert_eq!(
+            dv(&a),
+            dv(&b),
+            "matched path ({method:?}) must be reproducible under a seed"
+        );
+
+        // The matched path takes a different branch (pool draw + reassignment),
+        // so its output must differ from the unmatched path on the same seed.
+        assert_ne!(
+            dv(&a),
+            dv(&c),
+            "matched ({method:?}) should differ from unmatched"
+        );
+    }
 }
 
 #[test]
@@ -138,7 +159,7 @@ fn unmatched_options_path_equals_simulate_with_seed() {
 
     let opts = SimulateOptions {
         seed: Some(99),
-        propensity_match: false,
+        match_method: None,
     };
     let via_opts = simulate_with_options(&model, &pop, &model.default_params, 2, &opts).unwrap();
     let via_seed = simulate_with_seed(&model, &pop, &model.default_params, 2, 99);
@@ -177,7 +198,7 @@ fn matching_requires_observations() {
 
     let opts = SimulateOptions {
         seed: Some(1),
-        propensity_match: true,
+        match_method: Some(MatchMethod::Optimal),
     };
     let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
         .expect_err("matching without observations must error");


### PR DESCRIPTION
## Why
pmVPC propensity-score matching previously offered only **optimal** (linear-assignment) Mahalanobis matching, exposed as a `propensity_match: bool`. Simulation studies found optimal best *on average*, but for some datasets other matching can do better (#396). Users need to pick the method per dataset.

## What changed
Replace `SimulateOptions.propensity_match: bool` with `match_method: Option<MatchMethod>` (`None` disables matching). New `MatchMethod` enum (re-exported from the crate root), dispatched in `match_draws_to_fitted`:

- **Optimal** — global minimum total Mahalanobis distance, existing Hungarian/JV solver. `MatchIt(method="optimal")`. Recommended default.
- **Nearest** — greedy nearest-neighbour in subject order, 1:1 without replacement, via new `greedy_assignment`. `MatchIt(method="nearest", distance="mahalanobis")`.
- **Rank** — pair on the rank of each eta's Mahalanobis norm `√(ηᵀΩ⁻¹η)`, greedy on rank distance; on a complete pool this reduces to pairing the k-th order statistic to the k-th.

All three use the squared-Mahalanobis metric under the model Ω, as before.

## Alternatives considered
For multivariate **rank**, per-dimension rank distance and a global rank-assignment were considered; the Mahalanobis-norm scalar ranking was chosen (it gives a single principled magnitude ordering and is what the issue's "rank" intent maps to).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet open | after |

The R wrapper still passes a bool `propensity_match` through extendr; it pins ferx-core by git rev, so it is unaffected until the pin is bumped. A follow-up ferx-r PR will switch the user-facing `match` argument to `false | "optimal" | "nearest" | "rank"`.

## Breaking changes
- [x] Public Rust API (`api.rs`)

<details>
<summary>Migration notes (if breaking)</summary>

`SimulateOptions { seed, propensity_match: bool }` → `SimulateOptions { seed, match_method: Option<MatchMethod> }`.
`propensity_match: true` → `match_method: Some(MatchMethod::Optimal)`; `false` → `match_method: None`.
</details>

## Numerical validation
- [x] Not applicable (no estimation/PK change; matching math is deterministic and unit-tested)

## Performance
- [x] No significant impact expected. Nearest/Rank are O(n²) greedy, cheaper than the existing O(n³) optimal solver.

## Tests
- [x] Unit tests in `propensity_match.rs`: greedy least-cost-per-row, greedy-suboptimal-vs-optimal, valid permutation, rank order-statistic pairing, identity-pool across all three methods.
- [x] Integration tests in `tests/propensity_matched_sim.rs` now loop over all three methods (shape/finiteness/reproducibility/distinct-from-unmatched).
- All 15 propensity tests pass (`--no-default-features --features ci`).

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry updated (the propensity entry was still unreleased; amended in place to describe the enum + three methods).

## Checklist
- [x] `cargo clippy` clean for changed files (ran on stable toolchain — the active `enzyme` toolchain has no clippy component)
- [ ] `cargo check --features autodiff` — not run; the `autodiff` default feature requires Enzyme (`-Z autodiff=Enable` + fat LTO), unavailable here. Changes are not AD-reachable.

## Reviewer hints
Focus on `match_draws_to_fitted` dispatch and the rank semantics (`ranks_by_norm` + greedy on rank distance). The `greedy_assignment` finiteness contract mirrors `optimal_assignment`'s (callers screen non-finite etas upstream in `simulate_with_options`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)