### PR TITLE
fix(estimation): poll cancel during Bayes Gibbs sweeps [closes #393]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,11 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **Bayesian estimation** (`method = bayes`) now responds to a cooperative
+  cancellation (e.g. an R-session interrupt): the Gibbs sampler polls the cancel
+  flag at each sweep boundary and aborts within one sweep, returning
+  `cancelled by user` instead of running every chain to completion. Previously a
+  Bayes run could not be stopped once started (#393).
 - **IMPMAP** now responds to a cooperative cancellation (e.g. an R-session
   interrupt) during an iteration's E-step, instead of only at iteration
   boundaries. The importance-sampling pass — the dominant per-iteration cost on

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -456,7 +456,7 @@ pub fn run_bayes(
         })
         .collect();
 
-    for chain in 0..n_chains {
+    'chains: for chain in 0..n_chains {
         let mut rng = StdRng::seed_from_u64(master_seed.wrapping_add(chain as u64 * 0x9E3779B9));
         let mut scratch = EventPkParams::default();
 
@@ -548,6 +548,19 @@ pub fn run_bayes(
 
         let total_sweeps = n_warmup + n_sample;
         for sweep in 0..total_sweeps {
+            // Cooperative cancel: a Gibbs sweep (the η/κ/pop/Ω moves below) is the
+            // dominant per-chain cost, so poll the flag at the sweep boundary so an
+            // interrupt set from the host (e.g. R) takes effect within one sweep
+            // rather than running every chain to completion. `break 'chains` drops
+            // straight to the post-loop check, which returns Err before the
+            // (now-partial) draws reach the summary stage.
+            if crate::cancel::is_cancelled(&options.cancel) {
+                if verbose {
+                    eprintln!("Bayes: cancelled at chain {} sweep {}", chain, sweep);
+                }
+                break 'chains;
+            }
+
             // (re)compute the per-subject NLL at the current (θ, Ω, σ, η, κ).
             let mut nll: Vec<f64> = (0..n_subjects)
                 .map(|i| {
@@ -1081,6 +1094,12 @@ pub fn run_bayes(
         draws_by_chain.push(chain_draws);
     }
 
+    // A cancel observed inside the sweep loop drops here via `break 'chains` with
+    // partial/empty draws; bail before the summary stage indexes into them.
+    if crate::cancel::is_cancelled(&options.cancel) {
+        return Err("cancelled by user".to_string());
+    }
+
     if verbose {
         eprintln!("Bayes sampling complete; computing posterior summaries + EBEs...");
     }
@@ -1570,6 +1589,35 @@ mod tests {
         assert!(res.ofv.is_finite(), "OFV not finite");
         assert!(bayes.max_rhat.is_finite());
         assert_eq!(res.eta_hats.len(), pop.subjects.len());
+    }
+
+    /// A cancel flag set before the run aborts at the first sweep boundary and
+    /// returns Err("cancelled by user") instead of running all chains to
+    /// completion (regression for #393: a Bayes run could not be stopped).
+    #[test]
+    fn run_bayes_cancel_returns_err() {
+        use std::path::Path;
+        let model =
+            crate::parser::model_parser::parse_model_file(Path::new("examples/warfarin.ferx"))
+                .expect("warfarin model parses");
+        let pop = crate::read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+            .expect("warfarin data loads");
+        let params = model.default_params.clone();
+
+        let cancel = crate::cancel::CancelFlag::new();
+        cancel.cancel(); // already requested before the loop starts
+
+        let mut opts = FitOptions::default();
+        opts.bayes_warmup = 1000;
+        opts.bayes_iters = 1000;
+        opts.bayes_chains = 4;
+        opts.bayes_seed = Some(1);
+        opts.cancel = Some(cancel);
+
+        match run_bayes(&model, &pop, &params, &opts) {
+            Err(e) => assert_eq!(e, "cancelled by user"),
+            Ok(_) => panic!("expected cancel to abort the run"),
+        }
     }
 
     /// Regression for the mu-ref θ bound clamp: with a tight `theta_upper` on a


### PR DESCRIPTION
## Why
A Bayesian fit (`method = bayes`) could not be stopped once started (#393), most visibly from R. The Gibbs-within-HMC sampler in `run_bayes` never polled the cooperative cancel flag, so a host interrupt was ignored until **every** chain ran its full warmup + sampling sweeps to completion — minutes-to-hours of apparent hang.

## What changed
- `run_bayes` now polls `options.cancel` at each **sweep boundary** (the natural unit of per-chain cost: each sweep runs the η/κ/pop/Ω Gibbs moves over all subjects). On a set flag it `break 'chains` straight out of the labelled chain loop.
- A post-loop check returns `Err("cancelled by user")` before the now-partial/empty draws reach the summary stage (which indexes `draws_by_chain[c][0]`).
- This mirrors the IMPMAP E-step cancel fix (#390) and propagates through the existing `run_bayes(...)?` call site and `api.rs` cancel check.

## Alternatives considered
Polling per-subject inside a sweep was considered but unnecessary — the per-subject NLL loop here is sequential and a single sweep is short relative to the full run; sweep-boundary granularity stops within one sweep, matching the outer-optimizer convention.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

No public API change — the cancel mechanism (`FitOptions.cancel`) already exists and R already wires it for other methods.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (control-flow fix; convergent-path numerics unchanged — all 15 `estimation::bayes` tests still pass)

## Performance
- [x] No significant impact expected (one atomic load per sweep)

## Tests
- [x] Unit test added: `run_bayes_cancel_returns_err` — a pre-set cancel flag aborts at the first sweep boundary and returns `cancelled by user` (completes in ~0.06s despite 1000+1000 sweeps × 4 chains configured, confirming immediate abort).
- [x] Regression test added that fails without this fix

## Example (user-facing features only)
- [x] Not applicable (internal fix, no new API surface)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added
- No new user-facing surface (existing `method = bayes` behaviour, now interruptible)

## Checklist
- [x] `cargo clippy` clean (no new warnings on touched code)
- [x] `cargo +nightly fmt --check` clean
- [x] Tests pass: `cargo test --lib --no-default-features --features ci estimation::bayes`

## Reviewer hints
Focus: the `'chains:` label + `break 'chains` and the post-loop `Err` guard before the summary stage in `src/estimation/bayes.rs`. The early return matters because partial draws would otherwise panic/garble `summarize_param`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)