### PR TITLE
fix(test): add missing dose_attr_map/fremtype to test struct literals (unbreak main)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -5603,6 +5603,7 @@ mod iov_integration {
             cens: vec![0; 5],
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
             #[cfg(feature = "survival")]
             obs_records: vec![],
         };

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1639,6 +1639,7 @@ mod tests {
             dv_pre_logged: false,
             derived_exprs: vec![],
             output_columns: vec![],
+            dose_attr_map: Default::default(),
             #[cfg(feature = "survival")]
             endpoints: std::collections::HashMap::new(),
             frem_config: Some(crate::types::FremConfig {

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -926,6 +926,7 @@ mod tests {
             eta_map: vec![0, 1, 2],
             pk_idx_f64: vec![0.0, 1.0, 4.0],
             sel_flat: vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            dose_attr_map: Default::default(),
             ode_spec: None,
             diffusion_theta_start: None,
             diffusion_state_indices: Vec::new(),


### PR DESCRIPTION
## Why

`main` HEAD does not compile its test suite. The FREM PR (#226) added the
`dose_attr_map` field to `CompiledModel` and `fremtype` to `Subject`, but three
test-module struct literals were never updated to set them. As a result the
`Test`, `Check`, `Survival (TTE)`, and `Slow regression tests` checks are all red
on `main` (verified on commit 71c969e8), and every branch cut from `main` inherits
the failure.

## What changed

Added the missing fields (empty / `Default::default()`, matching the sibling
literals in the same files) to the three offending test literals:

- `src/api.rs` — the oral-depot-infusion sdtab test's `Subject` (missing `fremtype`)
- `src/estimation/inner_optimizer.rs` — `test_frem_jacobian_overrides_fd_with_exact_values`'s `CompiledModel` (missing `dose_attr_map`)
- `src/frem/mod.rs` — a `CompiledModel` literal (missing `dose_attr_map`)

No behavioural change — test scaffolding only.

## Alternatives considered

None — these are required fields with no default on the struct; the literals must
set them.

## Cross-repo dependency
| Repo | PR | Status | Must merge first |
|------|----|--------|-----------------|
| ferx-core (engine) | — | n/a | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (test scaffolding / compile fix)

## Tests
- [x] `cargo test --no-default-features --features ci` compiles and passes
      (`test_frem_jacobian_overrides_fd_with_exact_values` passes).
- [x] `cargo check --tests --no-default-features --features ci,survival` compiles
      (fixes the Survival check too — the literals are not feature-gated).

## Docs
- [x] No user-visible change.

## Checklist
- [x] `cargo fmt` clean.

## Reviewer hints

Mechanical field additions; diff is three single-line inserts. The fields match
how the other `CompiledModel`/`Subject` literals in each file already set them.
