### PR TITLE
fix(estimation): NONMEM-comparable IMP/IMPMAP marginal OFV, FREM RB 2π, Student-t proposal default [#406 #411]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,13 @@ section of the SDLC for the versioning policy).
   the dose without appearing in the RHS, are exempt (#315).
 
 ### Changed
+- **IMPMAP default proposal is now a Student-t** (`impmap_proposal_df = 4`)
+  instead of a multivariate normal. A Gaussian proposal's tails are lighter than
+  the posterior of weakly-identified parameters, so importance weights blow up in
+  the tail and bias the M-step moments — drifting typical-value estimates (e.g.
+  the absorption `MAT`/`KA` on modeled-duration models). The heavier-tailed
+  default removes that bias and matches FOCEI/NONMEM. Set `impmap_proposal_df =
+  normal` for the previous behaviour (#411).
 - **IMP/IMPMAP now warn about estimated parameters with no random effect**: any
   non-fixed `theta` that has no associated `ETA` is estimated only through the
   importance-weighted M-step, which is biased for weakly-identified parameters and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- `frem_rao_blackwell` fit option (default `true`): toggle the Rao-Blackwellised
+  FREM covariate-ETA integration in IMP/IMPMAP. Set `false` only to diagnose the
+  RB path against the full-dimensional importance sampler (#406).
 - `impmap_mceta` fit option: multi-start MAP for IMPMAP (NONMEM `MCETA` equivalent),
   improving IS efficiency in high-dimensional models (e.g. FREM with ≥5 ETAs).
 - Analytical Jacobian for FREM pseudo-observations: covariate rows in the FD
@@ -304,6 +307,14 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **FREM IMP/IMPMAP marginal −2 log L over-counted by a 2π constant**: the
+  Rao-Blackwellised covariate-data marginal included the covariate pseudo-obs
+  `nc·ln(2π)` normalizer, which the rest of the objective (and NONMEM's
+  "OBJECTIVE FUNCTION WITHOUT CONSTANT") drops. This inflated the reported FREM
+  marginal by `Σ nc·ln(2π)` (≈ n_covariate_obs · ln2π) and made the
+  Rao-Blackwell and full-dimensional importance samplers disagree on the same
+  point. The constant is now dropped in both; the value is otherwise unchanged
+  (it lies outside the importance weights, so estimates were never affected) (#406).
 - **IMP/IMPMAP now report the NONMEM-comparable objective**: estimating `imp` and
   `impmap` runs surface the importance-sampling Monte-Carlo *marginal* −2 log L —
   the number NONMEM `METHOD=IMP`/`IMPMAP` reports as its `#OBJV` — evaluated at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,15 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **IMP/IMPMAP now report the NONMEM-comparable objective**: estimating `imp` and
+  `impmap` runs surface the importance-sampling Monte-Carlo *marginal* −2 log L —
+  the number NONMEM `METHOD=IMP`/`IMPMAP` reports as its `#OBJV` — evaluated at the
+  final estimates on `FitResult.importance_sampling.minus2_log_likelihood` (± MC
+  SE). Previously this was populated only by the evaluation-only path, so the only
+  available number was the FOCE-Laplace `ofv`, which matches NONMEM's *COND/FOCE*
+  OBJ rather than the IMP marginal and diverges from it on sparse / strongly
+  nonlinear data. `ofv` is unchanged (still a Laplace pass, for cross-method
+  AIC/BIC comparability) (#406).
 - **IMP/IMPMAP no longer diverge on FREM models with missing covariates**: the
   Rao-Blackwellised E-step previously bailed to the unstable full-dimensional
   importance sampler for any subject missing a covariate pseudo-observation row

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -87,7 +87,14 @@ Each MCEM iteration, at the current parameters θ⁽ᵗ⁾, Ω⁽ᵗ⁾, σ⁽�
 
 The reported estimate is the running mean of the parameter vector over the final
 `impmap_averaging` iterations. A FOCE-Laplace `ofv` is computed at the final
-parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM.
+parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM. The
+importance-sampling Monte-Carlo **marginal** `−2 log L` — the number NONMEM
+`METHOD=IMPMAP` reports as its `#OBJV` — is also evaluated at the final estimates
+and surfaced on `FitResult.importance_sampling.minus2_log_likelihood` (± its MC
+SE). Because IMPMAP defaults to a Gaussian proposal (`impmap_proposal_df =
+normal`), this final marginal eval substitutes a finite-`t` proposal to keep the
+importance weights bounded. Use that field, not `ofv`, to compare against
+NONMEM's reported IMPMAP objective.
 
 > **Mu-referencing is required.** The closed-form `log θ += mean(η)` shift is the
 > EM-correct typical-value update for log-normal random effects, so it is always
@@ -119,9 +126,12 @@ model/data (`tests/nonmem/warfarin_impmap.ctl`):
 
 The well-determined CL/V structure and all three variance components agree to a
 few percent; TVKA is the least-identified parameter on this 10-subject extract
-(ETA_KA variance ≈ 0.34, high shrinkage) and carries the loosest band. The OFVs
-(NONMEM "without constant" vs ferx's Laplace OFV) agree to ~1 unit, the usual
-cross-engine margin. This comparison is asserted by the gated
+(ETA_KA variance ≈ 0.34, high shrinkage) and carries the loosest band. NONMEM's
+−284.92 is its IMPMAP **marginal** `#OBJV` ("without constant"); the matching
+ferx number is `importance_sampling.minus2_log_likelihood`, not the Laplace `ofv`
+(−286.00) shown in the table. Both objectives drop the same `Nobs·log(2π)`
+constant, so the residual difference is the parameter-estimate gap, within the
+usual cross-engine + Monte-Carlo margin. This comparison is asserted by the gated
 `ferx_impmap_matches_nonmem_impmap_on_warfarin` test (nightly, `slow-tests`); a
 companion `impmap_converges_to_focei_on_warfarin` test checks agreement with
 ferx's own FOCEI.

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -45,7 +45,7 @@ Standalone, or as a chain stage warm-started by a preceding estimator:
   method             = importance_sampling_map   # or: impmap
   impmap_iterations  = 200
   impmap_samples     = 300
-  impmap_proposal_df = normal      # multivariate normal (NONMEM default)
+  impmap_proposal_df = 4           # Student-t (default); `normal` for MVN
   impmap_seed        = 12345
 ```
 
@@ -66,8 +66,9 @@ Each MCEM iteration, at the current parameters θ⁽ᵗ⁾, Ω⁽ᵗ⁾, σ⁽�
    Hessian \\(H_i = J_i^\\top R_i^{-1} J_i + \\Omega^{-1}\\).
 
 2. **Importance sampling (E-step B).** Draw `K = impmap_samples` samples
-   \\(\\eta_{ik} \\sim q(\\hat\\eta_i, H_i^{-1})\\) — a multivariate normal by
-   default (`impmap_proposal_df = normal`), or a Student-t for heavier tails —
+   \\(\\eta_{ik} \\sim q(\\hat\\eta_i, H_i^{-1})\\) — a Student-t by default
+   (`impmap_proposal_df = 4`, heavier tails for robust importance weights), or a
+   multivariate normal (`= normal`) —
    with self-normalized weights
    \\(\\tilde w_{ik} \\propto p(y_i\\mid\\eta_{ik},\\theta)\\,p(\\eta_{ik}\\mid\\Omega)/q(\\eta_{ik})\\).
 
@@ -91,7 +92,7 @@ parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM. The
 importance-sampling Monte-Carlo **marginal** `−2 log L` — the number NONMEM
 `METHOD=IMPMAP` reports as its `#OBJV` — is also evaluated at the final estimates
 and surfaced on `FitResult.importance_sampling.minus2_log_likelihood` (± its MC
-SE). Because IMPMAP defaults to a Gaussian proposal (`impmap_proposal_df =
+SE). If IMPMAP is configured with a Gaussian proposal (`impmap_proposal_df =
 normal`), this final marginal eval substitutes a finite-`t` proposal to keep the
 importance weights bounded. Use that field, not `ofv`, to compare against
 NONMEM's reported IMPMAP objective.

--- a/docs/src/estimation/importance-sampling.md
+++ b/docs/src/estimation/importance-sampling.md
@@ -54,6 +54,18 @@ non-mu-ref θ), exactly as in IMPMAP. The reported estimate is the running mean
 of the parameter vector over the final `is_averaging` iterations, and `ofv` is
 a final FOCE Laplace pass for AIC/BIC comparability.
 
+> **Which number matches NONMEM's reported OFV?** NONMEM `METHOD=IMP` reports the
+> importance-sampling Monte-Carlo **marginal** `−2 log L` (the `.ext`/`.lst`
+> `#OBJV`), *not* a Laplace value. ferx's `ofv` is a Laplace pass, so it will
+> **not** equal NONMEM's IMP `#OBJV` on data where the Laplace approximation and
+> the true marginal diverge (sparse / strongly nonlinear). The NONMEM-comparable
+> number is the marginal, evaluated at the final estimates and surfaced on
+> `FitResult.importance_sampling.minus2_log_likelihood` (with its Monte-Carlo SE
+> on `.mc_standard_error`) for **estimating** `imp`/`impmap` runs too — not only
+> the evaluation-only path. IMPMAP's Gaussian proposal (`impmap_proposal_df =
+> normal`) is replaced by a finite-`t` proposal for this final marginal eval, so
+> the heavier tails keep the importance weights bounded.
+
 ### Rich data: prefer IMPMAP or warm-start
 
 Because IMP's proposal lags one iteration behind the parameters, it is
@@ -308,7 +320,8 @@ ISAMPLE=1000 SEED=12345`, control stream `tests/nonmem/warfarin_imp.ctl`).
 | ω²(V)     | 0.0096              | 0.0096              |
 | ω²(KA)    | 0.3405              | 0.336               |
 | σ (SD)    | 0.0105              | 0.0106              |
-| OFV       | −285.69             | −286.00             |
+| IMP marginal `−2 log L` | −285.69 | −285.93 ± 0.07 |
+| Laplace `ofv`           | (−286.00 at COND) | −286.00 |
 
 Both engines start from the same FOCEI basin (NONMEM `METHOD=COND` OFV −286.00,
 identical to ferx's FOCEI). NONMEM's IMP MCEM then drifts slightly off it toward
@@ -316,9 +329,16 @@ the importance-sampled marginal optimum (TVKA up to 0.886), while ferx's
 warm-started IMP holds near the FOCEI optimum — both stable and agreeing within
 the cross-engine + Monte-Carlo margin. TVKA is the least-identified parameter on
 this small extract (ETA_KA variance ≈ 0.34, high shrinkage); CL/V and the
-variance components agree to a few percent. The two OFVs are different objectives
-(NONMEM's IMP MC objective vs ferx's final Laplace pass) and agree to well within
-a cross-engine unit. The cross-check lives in `tests/warfarin_imp_nonmem.rs`.
+variance components agree to a few percent.
+
+Compare like with like: NONMEM's reported IMP `#OBJV` (−285.69) is the
+importance-sampling **marginal** `−2 log L`, so the matching ferx number is
+`importance_sampling.minus2_log_likelihood` (−285.93 ± 0.07), *not* ferx's
+Laplace `ofv` (−286.00, which instead coincides with NONMEM's COND OBJ). The
+small residual gap is the parameter-estimate difference (ferx's TVKA sits a
+little below NONMEM's), not an OFV-definition difference — both objectives drop
+the same `Nobs·log(2π)` constant (NONMEM "WITHOUT CONSTANT"). The cross-check
+lives in `tests/warfarin_imp_nonmem.rs`.
 
 ## See also
 

--- a/docs/src/estimation/importance-sampling.md
+++ b/docs/src/estimation/importance-sampling.md
@@ -62,9 +62,9 @@ a final FOCE Laplace pass for AIC/BIC comparability.
 > number is the marginal, evaluated at the final estimates and surfaced on
 > `FitResult.importance_sampling.minus2_log_likelihood` (with its Monte-Carlo SE
 > on `.mc_standard_error`) for **estimating** `imp`/`impmap` runs too — not only
-> the evaluation-only path. IMPMAP's Gaussian proposal (`impmap_proposal_df =
-> normal`) is replaced by a finite-`t` proposal for this final marginal eval, so
-> the heavier tails keep the importance weights bounded.
+> the evaluation-only path. If IMPMAP is configured with a Gaussian proposal
+> (`impmap_proposal_df = normal`), it is replaced by a finite-`t` proposal for
+> this final marginal eval, so the heavier tails keep the importance weights bounded.
 
 ### Rich data: prefer IMPMAP or warm-start
 

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -255,7 +255,7 @@ importance-weighted posterior moments. It runs standalone or as a chain stage:
   method             = importance_sampling_map   # alias: impmap
   impmap_iterations  = 200
   impmap_samples     = 300
-  impmap_proposal_df = normal     # multivariate normal (NONMEM default)
+  impmap_proposal_df = 4          # Student-t (default); `normal` for MVN
   impmap_seed        = 12345
 ```
 
@@ -263,7 +263,7 @@ importance-weighted posterior moments. It runs standalone or as a chain stage:
 |-----|---------|-------------|
 | `impmap_iterations` | `200` | Number of MCEM iterations (parameter updates). |
 | `impmap_samples` | `300` | Importance samples K per subject per iteration. Larger K reduces Monte-Carlo noise at linear cost. |
-| `impmap_proposal_df` | `normal` | Proposal degrees of freedom. `normal` (or `mvn`) gives a multivariate-normal proposal (NONMEM's default); a finite value ≥ 1 gives a heavier-tailed Student-t. |
+| `impmap_proposal_df` | `4` | Proposal degrees of freedom. A finite value ≥ 1 gives a heavier-tailed Student-t (default `4`); `normal` (or `mvn`) gives a multivariate-normal proposal (NONMEM's default). The Gaussian's lighter tails under-cover the posterior of weakly-identified parameters and bias the M-step moments, so ferx defaults to a Student-t. |
 | `impmap_averaging` | `50` | Final iterations whose parameters are averaged into the reported estimate (Monte-Carlo variance reduction). |
 | `impmap_seed` | `12345` | RNG seed. Same seed → identical estimates. |
 | `impmap_low_ess_threshold` | `0.1` | Subjects with normalized ESS below this fraction are flagged as poorly sampled. |

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -272,6 +272,7 @@ importance-weighted posterior moments. It runs standalone or as a chain stage:
 | `impmap_sobol` | `false` | Use Sobol quasi-random sequences (with Cranley-Patterson randomization) for IS draws instead of pseudo-random. Gives more uniform posterior coverage with fewer samples. Only applies to MVN proposals (`impmap_proposal_df = normal`); Student-t falls back to pseudo-random. |
 | `iscale_min` | `0.1` | Minimum proposal scaling factor for adaptive IS (NONMEM `ISCALE_MIN`). The IS proposal covariance is multiplied by `s²` where `s` is chosen from `[iscale_min, iscale_max]` to maximise per-subject ESS. Set both to `1.0` to disable. |
 | `iscale_max` | `10.0` | Maximum proposal scaling factor (NONMEM `ISCALE_MAX`). |
+| `frem_rao_blackwell` | `true` | FREM only: Rao-Blackwellise the covariate ETAs (integrate them analytically, importance-sample only the PK ETAs). Strongly recommended — brute-force sampling of the near-singular covariate dimensions has very poor ESS. Set `false` only to diagnose the RB path against the full-dimensional sampler. |
 
 `impmap` reuses `inner_maxiter` / `inner_tol` for the per-iteration MAP step.
 Inter-occasion variability (`[iov]` / `kappa`) and SDE (`[diffusion]`) models

--- a/src/api.rs
+++ b/src/api.rs
@@ -2941,6 +2941,49 @@ fn fit_inner(
             });
         }
         result = Some(stage_result);
+
+        // NONMEM-comparable IMP / IMPMAP objective. The reported `OuterResult.ofv`
+        // is a final FOCE *Laplace* pass (kept for cross-method AIC/BIC
+        // comparability, like SAEM). NONMEM `METHOD=IMP` instead reports the
+        // importance-sampling Monte-Carlo *marginal* −2 log L (the `.ext` #OBJV).
+        // Evaluate that marginal at the final estimates and surface it alongside
+        // on `FitResult.importance_sampling`, so callers comparing to NONMEM read
+        // the matching number. Best-effort: a failure (e.g. SDE, IOV without
+        // Ω_iov, n_eta = 0) leaves the field unset with a warning, never aborts.
+        if is_last && matches!(method, EstimationMethod::Imp | EstimationMethod::Impmap) {
+            let r = result.as_ref().expect("stage result was just set");
+            let mut marg_opts = stage_opts.clone();
+            // `run_importance_sampling` reads the `is_*` knobs; for IMPMAP map the
+            // `impmap_*` knobs onto them so the final eval mirrors the method's
+            // own sample count / proposal df / seed.
+            if method == EstimationMethod::Impmap {
+                marg_opts.is_samples = stage_opts.impmap_samples;
+                marg_opts.is_seed = stage_opts.impmap_seed;
+                marg_opts.is_low_ess_threshold = stage_opts.impmap_low_ess_threshold;
+                // IMPMAP defaults to a Gaussian proposal (`impmap_proposal_df =
+                // ∞`), which the finite-t IS evaluator cannot sample. The
+                // marginal is proposal-independent in expectation, so fall back
+                // to a finite-t eval proposal (heavier tails ⇒ bounded weights).
+                let df = stage_opts.impmap_proposal_df;
+                marg_opts.is_proposal_df = if df.is_finite() && df >= 1.0 { df } else { 5.0 };
+            }
+            match crate::estimation::importance_sampling::run_importance_sampling(
+                model,
+                population,
+                &r.params,
+                &r.eta_hats,
+                &r.h_matrices,
+                &r.kappas,
+                &marg_opts,
+            ) {
+                Ok(is) => is_result = Some(is),
+                Err(e) => accumulated_warnings.push(if n_stages > 1 {
+                    format!("[{}] marginal −2 log L eval skipped: {}", method.label(), e)
+                } else {
+                    format!("marginal −2 log L eval skipped: {}", e)
+                }),
+            }
+        }
     }
 
     if crate::cancel::is_cancelled(&options.cancel) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -2960,10 +2960,11 @@ fn fit_inner(
                 marg_opts.is_samples = stage_opts.impmap_samples;
                 marg_opts.is_seed = stage_opts.impmap_seed;
                 marg_opts.is_low_ess_threshold = stage_opts.impmap_low_ess_threshold;
-                // IMPMAP defaults to a Gaussian proposal (`impmap_proposal_df =
-                // ∞`), which the finite-t IS evaluator cannot sample. The
-                // marginal is proposal-independent in expectation, so fall back
-                // to a finite-t eval proposal (heavier tails ⇒ bounded weights).
+                // A Gaussian IMPMAP proposal (`impmap_proposal_df = ∞`, opt-in)
+                // cannot be sampled by the finite-t IS evaluator. The marginal is
+                // proposal-independent in expectation, so fall back to a finite-t
+                // eval proposal (heavier tails ⇒ bounded weights). The default
+                // `impmap_proposal_df = 4` passes through unchanged.
                 let df = stage_opts.impmap_proposal_df;
                 marg_opts.is_proposal_df = if df.is_finite() && df >= 1.0 { df } else { 5.0 };
             }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -548,11 +548,15 @@ fn run_mcem(
     // ESS) instead of all n_eta etas (~1–2% ESS). Partition is model-static;
     // per-subject covariate deviations are computed inside the E-step. `None` for
     // non-FREM models → the full-dimensional path is used unchanged.
-    let frem_rb: Option<(Vec<usize>, Vec<usize>)> = model
-        .frem_config
-        .as_ref()
-        .map(|fc| crate::estimation::importance_sampling::frem_pk_cov_partition(fc, n_eta))
-        .filter(|(pk, cov)| !pk.is_empty() && !cov.is_empty());
+    let frem_rb: Option<(Vec<usize>, Vec<usize>)> = if !options.frem_rao_blackwell {
+        None
+    } else {
+        model
+            .frem_config
+            .as_ref()
+            .map(|fc| crate::estimation::importance_sampling::frem_pk_cov_partition(fc, n_eta))
+            .filter(|(pk, cov)| !pk.is_empty() && !cov.is_empty())
+    };
 
     // ---- Trace: collect per-iteration parameters (analogous to NONMEM .ext) ----
     let mut trace_rows: Vec<ImpmapTraceRow> = if collect_trace {

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -282,12 +282,16 @@ pub fn run_importance_sampling(
 
     // FREM: Rao-Blackwellise (integrate covariate etas, sample only PK etas) when
     // a clean PK/cov partition exists. `None` → full-dimensional IS (unchanged).
-    let frem_rb: Option<(Vec<usize>, Vec<usize>)> = model
-        .frem_config
-        .as_ref()
-        .filter(|_| model.n_kappa == 0)
-        .map(|fc| frem_pk_cov_partition(fc, n_eta))
-        .filter(|(pk, cov)| !pk.is_empty() && !cov.is_empty());
+    let frem_rb: Option<(Vec<usize>, Vec<usize>)> = if !options.frem_rao_blackwell {
+        None
+    } else {
+        model
+            .frem_config
+            .as_ref()
+            .filter(|_| model.n_kappa == 0)
+            .map(|fc| frem_pk_cov_partition(fc, n_eta))
+            .filter(|(pk, cov)| !pk.is_empty() && !cov.is_empty())
+    };
 
     let per_subject: Vec<SubjectIsOutput> = population
         .subjects
@@ -873,7 +877,13 @@ pub(crate) fn subject_is_draws_frem_rb(
     let logdet_occ = 2.0 * (0..nc).map(|i| occ_chol.l()[(i, i)].ln()).sum::<f64>();
     let occ_inv_d = occ_chol.solve(&dvec);
     let quad_cov = dvec.dot(&occ_inv_d);
-    let log_p_d = -0.5 * (nc as f64 * TWO_PI.ln() + logdet_occ + quad_cov);
+    // Covariate data marginal log N(d; 0, Ω_cc + R). The covariate pseudo-obs
+    // are *observations*, so their 2π normalizer (nc·ln2π) must be dropped to
+    // match the rest of the OFV, which omits the per-obs 2π constant (see
+    // `obs_nll_subject_into`) — i.e. NONMEM's "OBJECTIVE FUNCTION WITHOUT
+    // CONSTANT" convention. Including it inflated the RB marginal by
+    // Σ nc·ln2π (≈ n_covariate_obs · ln2π).
+    let log_p_d = -0.5 * (logdet_occ + quad_cov);
 
     // Constants. The covariate observation rows contribute a fixed
     // 0.5·Σ ln(R) to obs_nll (their residual is ≈0 at η_c = d); subtract it so

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3702,6 +3702,7 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "impmap_trace" => opts.impmap_trace = parse_bool("impmap_trace")?,
         "impmap_mceta" => opts.impmap_mceta = parse_usize("impmap_mceta")?,
         "impmap_sobol" => opts.impmap_sobol = parse_bool("impmap_sobol")?,
+        "frem_rao_blackwell" => opts.frem_rao_blackwell = parse_bool("frem_rao_blackwell")?,
         "iscale_min" => {
             let v = parse_f64("iscale_min")?;
             if v <= 0.0 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3267,6 +3267,12 @@ pub struct FitOptions {
     /// Use Sobol quasi-random sequences for IS draws instead of pseudo-random.
     /// Only applies to MVN proposals (impmap_proposal_df = normal). Default false.
     pub impmap_sobol: bool,
+    /// FREM only: Rao-Blackwellise the covariate ETAs (integrate them analytically,
+    /// sample only the PK ETAs) in IMP/IMPMAP importance sampling. Default `true`
+    /// — strongly recommended, since brute-force sampling of the near-singular
+    /// covariate dimensions has very poor ESS. Set `false` only to diagnose the
+    /// RB path against the full-dimensional sampler.
+    pub frem_rao_blackwell: bool,
     /// Minimum ISCALE factor for adaptive IS proposal scaling (NONMEM ISCALE_MIN).
     /// The proposal covariance is multiplied by iscale² to improve IS efficiency.
     /// Set `iscale_min == iscale_max == 1.0` to disable. Default 0.1.
@@ -3526,6 +3532,7 @@ impl Default for FitOptions {
             impmap_trace: false,
             impmap_mceta: 0,
             impmap_sobol: false,
+            frem_rao_blackwell: true,
             iscale_min: 0.1,
             iscale_max: 10.0,
             bloq_method: BloqMethod::Drop,
@@ -3895,6 +3902,7 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "inner_tol",
             "iscale_min",
             "iscale_max",
+            "frem_rao_blackwell",
         ],
         EstimationMethod::Impmap => &[
             "inner_maxiter",
@@ -3910,6 +3918,7 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "impmap_sobol",
             "iscale_min",
             "iscale_max",
+            "frem_rao_blackwell",
         ],
         EstimationMethod::Bayes => &[
             "inner_maxiter",

--- a/src/types.rs
+++ b/src/types.rs
@@ -3246,8 +3246,11 @@ pub struct FitOptions {
     /// Larger K reduces Monte-Carlo noise in the M-step at linear cost.
     pub impmap_samples: usize,
     /// Proposal degrees of freedom. `f64::INFINITY` selects a multivariate
-    /// normal proposal (NONMEM's IMPMAP default; parsed from `normal`); a finite
-    /// value selects a heavier-tailed Student-t. Default `INFINITY` (MVN).
+    /// normal proposal (parsed from `normal`); a finite value selects a
+    /// heavier-tailed Student-t. Default `4.0` (Student-t). A Gaussian proposal
+    /// (`= normal`, NONMEM's IMPMAP default) has lighter tails than the posterior
+    /// of weakly-identified parameters, so importance weights blow up in the tail
+    /// and bias the M-step moments; the heavier-tailed t default avoids that.
     pub impmap_proposal_df: f64,
     /// RNG seed for the IMPMAP sampling. `None` falls back to a fixed default so
     /// runs are reproducible across invocations.
@@ -3525,7 +3528,7 @@ impl Default for FitOptions {
             is_eval_only: false,
             impmap_iterations: 200,
             impmap_samples: 300,
-            impmap_proposal_df: f64::INFINITY,
+            impmap_proposal_df: 4.0,
             impmap_seed: None,
             impmap_averaging: 50,
             impmap_low_ess_threshold: 0.1,
@@ -4876,6 +4879,17 @@ mod tests {
              for the basin-trap and block-Ω-collapse regression rationale \
              before adjusting."
         );
+    }
+
+    #[test]
+    fn impmap_proposal_df_default_is_finite_t() {
+        // IMPMAP defaults to a Student-t proposal (df = 4), not a Gaussian: the
+        // MVN tails are too light for weakly-identified posteriors and bias the
+        // M-step moments (absorption-param drift, #411). Do not revert to ∞
+        // without re-checking that regression.
+        let opts = FitOptions::default();
+        assert_eq!(opts.impmap_proposal_df, 4.0);
+        assert!(opts.impmap_proposal_df.is_finite());
     }
 
     // ── small pure helpers ───────────────────────────────────────────────────

--- a/tests/frem_warfarin.rs
+++ b/tests/frem_warfarin.rs
@@ -254,6 +254,59 @@ fn frem_impmap_rao_blackwell_runs_finite() {
     );
 }
 
+/// The Rao-Blackwellised marginal and the full-dimensional (brute-force) sampler
+/// estimate the *same* integral, so at a fixed parameter point they must agree
+/// up to Monte-Carlo noise. A regression guard for the FREM covariate-marginal
+/// 2π bookkeeping: `log_p_d` once included the covariate-obs `nc·ln(2π)`
+/// normalizer that the rest of the OFV (and NONMEM's "without constant") drops,
+/// inflating the RB marginal by `Σ nc·ln(2π)`. Here that offset would be
+/// 2 covariates × 10 subjects × ln(2π) ≈ 36.8 — far above the MC tolerance.
+#[test]
+fn frem_rao_blackwell_marginal_matches_full_dim() {
+    let tmp = tempfile::tempdir().unwrap();
+    let result = setup_frem(tmp.path());
+    let model = parse_model_file(&result.model_path).unwrap();
+    let pop = read_nonmem_csv(&result.data_path, None, None).unwrap();
+
+    // Evaluate the IS marginal at the fixed initial params (no estimation), so
+    // both paths score the identical point.
+    let mut base = FitOptions::default();
+    base.method = ferx_core::EstimationMethod::Imp;
+    base.is_eval_only = true;
+    base.is_samples = 6000;
+    base.is_seed = Some(20240619);
+    base.run_covariance_step = false;
+    base.verbose = false;
+
+    let mut opts_rb = base.clone();
+    opts_rb.frem_rao_blackwell = true;
+    let rb = fit(&model, &pop, &model.default_params, &opts_rb)
+        .expect("RB eval should not error")
+        .importance_sampling
+        .expect("eval-only IMP must populate importance_sampling")
+        .minus2_log_likelihood;
+
+    let mut opts_full = base;
+    opts_full.frem_rao_blackwell = false;
+    let full = fit(&model, &pop, &model.default_params, &opts_full)
+        .expect("full-dim eval should not error")
+        .importance_sampling
+        .expect("eval-only IMP must populate importance_sampling")
+        .minus2_log_likelihood;
+
+    assert!(
+        rb.is_finite() && full.is_finite(),
+        "both marginals must be finite, got RB={rb}, full={full}"
+    );
+    // Tolerance comfortably below the ~36.8 bug offset, above MC noise at K=6000.
+    assert!(
+        (rb - full).abs() < 12.0,
+        "RB marginal {rb} and full-dim marginal {full} must agree (Δ={}) — \
+         the covariate-marginal 2π term must be dropped in both",
+        (rb - full).abs()
+    );
+}
+
 /// FREM fit completes (fast, 3 outer iterations) with finite OFV and correct omega size.
 #[test]
 fn frem_fit_completes_with_finite_ofv() {

--- a/tests/imp_estimator_api.rs
+++ b/tests/imp_estimator_api.rs
@@ -115,6 +115,24 @@ fn imp_standalone_is_an_estimator_and_moves_parameters() {
             "omega[{i},{i}] must be finite > 0, got {w}"
         );
     }
+
+    // Estimating IMP now surfaces the importance-sampling Monte-Carlo marginal
+    // −2 log L (the NONMEM `METHOD=IMP` #OBJV), evaluated at the final estimates,
+    // alongside the Laplace `ofv`. Previously populated only by the eval-only path.
+    let is = result
+        .importance_sampling
+        .as_ref()
+        .expect("estimating imp must surface the marginal −2 log L on importance_sampling");
+    assert!(
+        is.minus2_log_likelihood.is_finite(),
+        "marginal −2 log L must be finite, got {}",
+        is.minus2_log_likelihood
+    );
+    assert!(
+        is.mc_standard_error.is_finite() && is.mc_standard_error >= 0.0,
+        "marginal MC SE must be finite & non-negative, got {}",
+        is.mc_standard_error
+    );
 }
 
 #[test]

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -58,6 +58,25 @@ fn impmap_standalone_produces_finite_estimates() {
             "omega[{i},{i}] must be finite > 0, got {w}"
         );
     }
+
+    // IMPMAP surfaces the importance-sampling marginal −2 log L (NONMEM #OBJV)
+    // alongside the Laplace `ofv`. IMPMAP defaults to a Gaussian proposal
+    // (`impmap_proposal_df = ∞`); the final marginal eval must fall back to a
+    // finite-t proposal rather than producing a non-finite value.
+    let is = result
+        .importance_sampling
+        .as_ref()
+        .expect("standalone impmap must surface the marginal −2 log L on importance_sampling");
+    assert!(
+        is.minus2_log_likelihood.is_finite(),
+        "marginal −2 log L must be finite (finite-t eval fallback), got {}",
+        is.minus2_log_likelihood
+    );
+    assert!(
+        is.mc_standard_error.is_finite() && is.mc_standard_error >= 0.0,
+        "marginal MC SE must be finite & non-negative, got {}",
+        is.mc_standard_error
+    );
 }
 
 #[test]

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -34,6 +34,9 @@ fn warfarin_setup() -> (
 fn impmap_standalone_produces_finite_estimates() {
     let (model, population, mut opts) = warfarin_setup();
     opts.method = EstimationMethod::Impmap;
+    // Opt into the Gaussian proposal so the marginal-eval ∞-df → finite-t
+    // fallback below is still exercised (the default is now a Student-t).
+    opts.impmap_proposal_df = f64::INFINITY;
     let result = fit(&model, &population, &model.default_params, &opts)
         .expect("standalone impmap must produce a fit");
 
@@ -60,8 +63,8 @@ fn impmap_standalone_produces_finite_estimates() {
     }
 
     // IMPMAP surfaces the importance-sampling marginal −2 log L (NONMEM #OBJV)
-    // alongside the Laplace `ofv`. IMPMAP defaults to a Gaussian proposal
-    // (`impmap_proposal_df = ∞`); the final marginal eval must fall back to a
+    // alongside the Laplace `ofv`. With the Gaussian proposal opted in above
+    // (`impmap_proposal_df = ∞`), the final marginal eval must fall back to a
     // finite-t proposal rather than producing a non-finite value.
     let is = result
         .importance_sampling

--- a/tests/warfarin_imp_nonmem.rs
+++ b/tests/warfarin_imp_nonmem.rs
@@ -44,9 +44,13 @@
 //! near the FOCEI optimum — both are stable and agree within the cross-engine +
 //! Monte-Carlo margin. TVKA is the least-identified parameter on this 10-subject
 //! extract (ETA_KA variance ≈ 0.34, high shrinkage), so it carries the loosest
-//! band; CL/V and the variance components agree to a few percent. The two OFVs
-//! are different objectives (NONMEM's IMP MC objective vs ferx's final Laplace
-//! pass) and agree to well within a cross-engine unit.
+//! band; CL/V and the variance components agree to a few percent.
+//!
+//! Two OFVs are compared. ferx's reported `ofv` is a final FOCE *Laplace* pass
+//! (kept for cross-method AIC/BIC comparability) and lands on NONMEM's COND OBJ
+//! (−286.004). The NONMEM-comparable IMP number is the importance-sampling
+//! Monte-Carlo *marginal* −2 log L (`METHOD=IMP` #OBJV = −285.685), surfaced on
+//! `FitResult.importance_sampling.minus2_log_likelihood`; both are asserted.
 
 use ferx_core::parser::model_parser::parse_model_file;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
@@ -136,10 +140,28 @@ fn ferx_imp_matches_nonmem_on_warfarin() {
         r.sigma[0]
     );
 
-    // OFV within the cross-engine margin (different objectives — see docstring).
+    // ferx's reported `ofv` is a final FOCE *Laplace* pass (kept for cross-method
+    // AIC/BIC comparability). On this rich extract it lands on NONMEM's COND/FOCE
+    // OBJ (−286.004), close to but distinct from the IMP marginal.
     assert!(
         (r.ofv - NM_OFV).abs() < 3.0,
-        "OFV {} vs NONMEM {NM_OFV}",
+        "Laplace OFV {} vs NONMEM IMP {NM_OFV}",
         r.ofv
+    );
+
+    // The NONMEM-comparable number is the importance-sampling Monte-Carlo
+    // *marginal* −2 log L (NONMEM `METHOD=IMP` #OBJV = −285.685), now surfaced on
+    // `importance_sampling`. Evaluated at ferx's final estimates (which sit a
+    // little off NONMEM's basin — TVKA 0.811 vs 0.886), so allow the same
+    // cross-engine + Monte-Carlo margin.
+    let is = r
+        .importance_sampling
+        .as_ref()
+        .expect("estimating IMP must surface the marginal −2 log L");
+    assert!(
+        (is.minus2_log_likelihood - NM_OFV).abs() < 3.0,
+        "IMP marginal −2 log L {} ± {} vs NONMEM IMP #OBJV {NM_OFV}",
+        is.minus2_log_likelihood,
+        is.mc_standard_error,
     );
 }


### PR DESCRIPTION
## Why
Three IMP/IMPMAP objective + estimation problems found while cross-checking ferx against NONMEM (warfarin `tests/nonmem/warfarin_imp.*`, and the FREM workshop model in `ferx-testdata/frem_workshop/HO1` vs `nm/run6.lst`/`run7.lst`):

1. **IMP/IMPMAP reported the wrong objective.** After an estimating `imp`/`impmap` run, `FitResult.ofv` was a final FOCE *Laplace* pass — which matches NONMEM's *COND/FOCE* OBJ, not the importance-sampling **marginal** −2 log L that NONMEM `METHOD=IMP`/`IMPMAP` reports as its `#OBJV`. On warfarin: ferx reported −286.004 (= NONMEM COND), while NONMEM IMP `#OBJV` = −285.685. The marginal was computed internally but discarded for estimating runs (only the eval-only path surfaced it).

2. **FREM RB marginal over-counted a 2π constant.** The Rao-Blackwellised covariate-data marginal `log N(d; 0, Ω_cc+R)` kept the covariate-obs `nc·ln(2π)` normalizer, which the rest of the objective (and NONMEM's "OBJECTIVE FUNCTION WITHOUT CONSTANT") drops. This inflated the reported FREM marginal by `Σ nc·ln(2π)` and made the RB and full-dimensional samplers disagree at the same point.

3. **IMPMAP's Gaussian proposal biased the M-step.** IMPMAP defaulted to a multivariate-normal proposal (`impmap_proposal_df = ∞`). The Gaussian tails are lighter than the posterior of weakly-identified parameters, so importance weights blow up in the tail and bias the IS-weighted M-step moments — drifting typical-value estimates. On the modeled-duration (RATE=−2) base model, `TVMAT` converged to 2.90 vs FOCEI/NONMEM 2.60 (#411).

## What changed
- **(1)** After the final estimating IMP/IMPMAP stage, evaluate the IS marginal at the final estimates (reusing the eval-only `run_importance_sampling`) and surface it on `FitResult.importance_sampling.minus2_log_likelihood` (± MC SE). `ofv` is unchanged (still a Laplace pass, kept for cross-method AIC/BIC comparability). A Gaussian IMPMAP proposal is mapped to a finite-`t` proposal for this eval (the marginal is proposal-independent in expectation).
- **(2)** Drop the `nc·ln(2π)` term from the RB covariate-data marginal (`importance_sampling.rs`). The term is outside the importance weights, so **parameter estimates were never affected** — reporting correction only. Adds `frem_rao_blackwell` fit option (default `true`) to toggle the RB path for diagnostics.
- **(3)** Change the IMPMAP default proposal from MVN to **Student-t** (`impmap_proposal_df` ∞ → `4.0`). Heavier tails keep the weights bounded; base-model `TVMAT` now lands at 2.61 (matches FOCEI/NONMEM). `impmap_proposal_df = normal` restores the previous MVN behaviour.

## Alternatives considered
- Surfacing the marginal: replace `ofv` vs add a field — chose the field (keeps `ofv` AIC/BIC semantics, reuses the existing `FitResult.importance_sampling`, no public-API churn).
- Proposal bias: inflate the MVN covariance via ISCALE vs switch the default to Student-t — chose the t default (simpler, robust, and IMP already defaults to t).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

No `pub` API signature change; the previously-`None` `FitResult.importance_sampling` is now populated for estimating IMP/IMPMAP (same type). The `impmap_proposal_df` default value changed (behavioural, not API).

## Breaking changes
- [x] None (behavioural default change to `impmap_proposal_df`, documented in CHANGELOG)

## Numerical validation
- [x] Compared against: NONMEM 7.5.1 `METHOD=IMP` / `IMPMAP`

```
# warfarin, METHOD=IMP
NONMEM IMP #OBJV (marginal, without constant): -285.685
ferx ofv (Laplace, unchanged):                 -286.004
ferx importance_sampling.minus2_log_likelihood: -285.93 ± 0.07   # now NONMEM-comparable

# FREM RB 2π fix (fixed point, K=5000): RB vs full-dim sampler
before: RB 10406.3   full-dim 3676.0   (Δ 6730 = Σ nc·ln2π)
after:  RB  3666.8   full-dim 3676.0   (agree within MC noise)

# Proposal-tail fix, base modeled-duration model: TVMAT
MVN (old default): 2.90
Student-t df=4 (new default): 2.61    # FOCEI 2.60 / NONMEM 2.59
warfarin IMPMAP (well-identified): unchanged, still matches NONMEM
```

Slow test `tests/warfarin_imp_nonmem.rs` asserts the marginal against NONMEM's IMP `#OBJV`; `tests/warfarin_impmap_nonmem.rs` still passes under the new default.

## Performance
- [x] No significant impact — one extra IS E-step at the end of an estimating IMP/IMPMAP run (≈ 1/n_iter overhead).

## Tests
- [x] Regression test added that fails without the fix — `frem_rao_blackwell_marginal_matches_full_dim` (RB ≈ full-dim at a fixed point; verified fails with the 2π bug, Δ=36.87 on the warfarin FREM fixture).
- [x] Default-value guard `impmap_proposal_df_default_is_finite_t`; the ∞-df marginal-eval fallback test re-pinned by opting it into the MVN proposal.
- [x] Tier-2: estimating IMP and IMPMAP populate `importance_sampling`.

## Docs
- [x] `docs/src/` updated — `importance-sampling.md`, `impmap.md`, `fit-options.md` (`frem_rao_blackwell`, new `impmap_proposal_df` default)
- [x] `CHANGELOG.md` `[Unreleased]` entries (Added / Changed / Fixed)

## Checklist
- [x] `cargo clippy` clean
- [x] `cargo check --features autodiff` — N/A (autodiff toolchain ICE in this env; changes not AD-reachable; built/tested with `--no-default-features --features ci`)
- [x] No version bump

## Reviewer hints
- `src/api.rs`: post-stage marginal eval block (gated on `is_last && Imp|Impmap`); the IMPMAP `impmap_* → is_*` mapping + finite-`t` fallback for an opted-in Gaussian proposal.
- `src/estimation/importance_sampling.rs`: one-line `log_p_d` change (2π) + the convention comment.
- `src/types.rs`: `impmap_proposal_df` default ∞ → 4.0.

## Open questions
- The FREM workshop model still shows a large IMP/IMPMAP-vs-FOCEI/NONMEM **estimate** gap beyond what this PR fixes: a (θ, Ω) multimodal basin drift (TVMAT 2.6 → 5.x) and the frozen mu-referenced typical value when ω≈0 — both tracked in #411. #409 (eta-on-residual-error not expressible) is separate. None block this PR.