### PR TITLE
fix(impmap): close the FREM IS estimation bias — adaptive sampling + mu-ref M-step [#411]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- `is_auto` / `impmap_auto` fit options (NONMEM `AUTO`), **on by default**:
+  adaptive importance-sample count. `is_samples` / `impmap_samples` is the
+  *starting* count and is ramped up (×2 per iteration, capped at 10000) whenever
+  the objective's Monte-Carlo standard deviation exceeds 1.0 (NONMEM `STDOBJ`),
+  so high-dimensional / FREM fits reach a low-noise objective automatically
+  instead of carrying a sample-count-dependent M-step bias. On the FREM workshop
+  model (13 ETAs) this ramps 300→10000 and brings the absorption typical value
+  from ~4.6 (fixed K=300) to ~3.0, matching NONMEM. Low-dimensional, well-sampled
+  fits never trip the threshold, so there is no cost there; set `false` to pin
+  the sample count (#411).
 - IMP/IMPMAP now warn when the importance-sample count is low for the model
   dimension (`K < 100·n_eta`) or when a subject's proposal fully collapses
   (ESS ≈ 0). The self-normalized M-step moments carry a finite-sample bias that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,14 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **IMP/IMPMAP no longer freeze the typical value of a mu-referenced parameter
+  with negligible IIV**: a log-mu-referenced θ (e.g. `KA = TVKA*exp(ETA_KA)`)
+  whose random effect has a tiny, often `FIX`ed ω was updated only through the
+  closed-form `log θ += mean(η)` shift — which is ≈ 0 when the η carries no
+  variance, leaving the typical value stuck at its initial value. Such
+  parameters are now routed to the weighted-likelihood M-step (the channel that
+  estimates σ and non-mu-ref θ), so the data can move them; a warning names any
+  parameter routed this way. Makes the estimate init-independent (#411).
 - **FREM IMP/IMPMAP marginal −2 log L over-counted by a 2π constant**: the
   Rao-Blackwellised covariate-data marginal included the covariate pseudo-obs
   `nc·ln(2π)` normalizer, which the rest of the objective (and NONMEM's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- IMP/IMPMAP now warn when the importance-sample count is low for the model
+  dimension (`K < 100·n_eta`) or when a subject's proposal fully collapses
+  (ESS ≈ 0). The self-normalized M-step moments carry a finite-sample bias that
+  grows with dimension, so high-dimensional / FREM fits at the default sample
+  count can converge to biased typical-value and Ω estimates; the warning
+  recommends raising `impmap_samples` / `is_samples` (#411).
 - `frem_rao_blackwell` fit option (default `true`): toggle the Rao-Blackwellised
   FREM covariate-ETA integration in IMP/IMPMAP. Set `false` only to diagnose the
   RB path against the full-dimensional importance sampler (#406).

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -86,6 +86,16 @@ Each MCEM iteration, at the current parameters θ⁽ᵗ⁾, Ω⁽ᵗ⁾, σ⁽�
      likelihood \\(\\sum_i \\sum_k \\tilde w_{ik}\\log p(y_i\\mid\\eta_{ik},\\theta,\\sigma)\\)
      with a derivative-free NLopt BOBYQA step.
 
+> **High-dimensional models need more samples.** The self-normalized importance
+> weights make the M-step moments carry a finite-sample bias that grows with the
+> number of ETAs, so the default `impmap_samples = 300` — ample for a 3–4 ETA PK
+> model — is badly under-sampled for a high-dimensional FREM model (often 10+
+> ETAs) and can bias the typical-value and Ω estimates (e.g. the absorption
+> parameter on a 13-ETA FREM model drifts at `K = 300` and recovers as `K` grows
+> into the thousands). IMPMAP warns when `K < 100·n_eta`; raise `impmap_samples`
+> accordingly (FREM models typically want several thousand). FOCEI is unaffected
+> and is a good cross-check for the typical values.
+
 The reported estimate is the running mean of the parameter vector over the final
 `impmap_averaging` iterations. A FOCE-Laplace `ofv` is computed at the final
 parameters for AIC/BIC comparability with FOCE/FOCEI/SAEM. The

--- a/docs/src/estimation/impmap.md
+++ b/docs/src/estimation/impmap.md
@@ -92,9 +92,13 @@ Each MCEM iteration, at the current parameters θ⁽ᵗ⁾, Ω⁽ᵗ⁾, σ⁽�
 > model — is badly under-sampled for a high-dimensional FREM model (often 10+
 > ETAs) and can bias the typical-value and Ω estimates (e.g. the absorption
 > parameter on a 13-ETA FREM model drifts at `K = 300` and recovers as `K` grows
-> into the thousands). IMPMAP warns when `K < 100·n_eta`; raise `impmap_samples`
-> accordingly (FREM models typically want several thousand). FOCEI is unaffected
-> and is a good cross-check for the typical values.
+> into the thousands). Two options address this: set **`impmap_auto = true`**
+> (NONMEM `AUTO`) to ramp the sample count automatically until the objective's
+> Monte-Carlo SE drops below 1.0 — on the 13-ETA FREM model this ramps
+> `300 → 10000` and brings the absorption typical value from ~4.6 to ~3.0
+> (matching NONMEM); or raise `impmap_samples` manually (several thousand for
+> FREM). IMPMAP also warns when the objective is left under-sampled. FOCEI is
+> unaffected and is a good cross-check for the typical values.
 
 The reported estimate is the running mean of the parameter vector over the final
 `impmap_averaging` iterations. A FOCE-Laplace `ofv` is computed at the final

--- a/docs/src/model-file/fit-options.md
+++ b/docs/src/model-file/fit-options.md
@@ -235,6 +235,7 @@ sparsely-sampled PK).
 | `is_averaging` | `50` | Terminal iterations averaged into the reported estimate (estimator only). |
 | `is_samples` | `1000` | Importance samples K per subject. 2000–5000 recommended for publication-quality MC SE. |
 | `is_proposal_df` | `5.0` | Student-t proposal degrees of freedom (≥ 1), or `normal`/`mvn` for a multivariate-normal proposal. Lower = heavier tails. |
+| `is_auto` | `true` | Adaptive sample count (NONMEM `AUTO`). When `true`, `is_samples` is the *starting* count and is ramped up (×2/iteration, cap 10000) while the objective's Monte-Carlo SE exceeds 1.0. Recommended for high-dimensional / FREM models, where a fixed count biases the M-step. |
 | `is_seed` | `12345` | RNG seed. Same seed → identical result. |
 | `is_low_ess_threshold` | `0.1` | Subjects with normalized ESS below this fraction get flagged in the result. Set `0` to silence. |
 
@@ -264,6 +265,7 @@ importance-weighted posterior moments. It runs standalone or as a chain stage:
 | `impmap_iterations` | `200` | Number of MCEM iterations (parameter updates). |
 | `impmap_samples` | `300` | Importance samples K per subject per iteration. Larger K reduces Monte-Carlo noise at linear cost. |
 | `impmap_proposal_df` | `4` | Proposal degrees of freedom. A finite value ≥ 1 gives a heavier-tailed Student-t (default `4`); `normal` (or `mvn`) gives a multivariate-normal proposal (NONMEM's default). The Gaussian's lighter tails under-cover the posterior of weakly-identified parameters and bias the M-step moments, so ferx defaults to a Student-t. |
+| `impmap_auto` | `true` | Adaptive sample count (NONMEM `AUTO`). When `true`, `impmap_samples` is the *starting* count and is ramped up (×2/iteration, cap 10000) while the objective's Monte-Carlo SE exceeds 1.0 (NONMEM `STDOBJ`). Strongly recommended for FREM / high-dimensional models — a fixed count leaves a sample-count-dependent bias in the typical-value and Ω estimates. |
 | `impmap_averaging` | `50` | Final iterations whose parameters are averaged into the reported estimate (Monte-Carlo variance reduction). |
 | `impmap_seed` | `12345` | RNG seed. Same seed → identical estimates. |
 | `impmap_low_ess_threshold` | `0.1` | Subjects with normalized ESS below this fraction are flagged as poorly sampled. |

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -595,6 +595,11 @@ fn run_mcem(
         Vec::new()
     };
 
+    // ESS state from the final completed E-step, used to flag importance-sampling
+    // moment bias (which scales as 1/(K·ESS) and is severe in high dimensions).
+    let mut final_ess_median = 1.0_f64;
+    let mut final_n_collapsed = 0usize;
+
     for k in 1..=n_iter {
         if crate::cancel::is_cancelled(cancel) {
             if verbose {
@@ -792,13 +797,19 @@ fn run_mcem(
         // ESS diagnostics + marginal log-likelihood for the trace.
         let mut ll = 0.0f64;
         let mut n_low_ess = 0usize;
+        let mut ess_fracs: Vec<f64> = Vec::with_capacity(draws.len());
         for d in &draws {
             ll += d.log_marginal;
             if d.ess_fraction < threshold {
                 n_low_ess += 1;
             }
+            ess_fracs.push(d.ess_fraction);
         }
         let minus2ll = -2.0 * ll;
+        // Track the final E-step's ESS health for the post-fit bias warning.
+        final_n_collapsed = ess_fracs.iter().filter(|&&f| f <= 1e-6).count();
+        ess_fracs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        final_ess_median = ess_fracs.get(ess_fracs.len() / 2).copied().unwrap_or(1.0);
 
         // Record this iteration's parameters for the trace (opt-in).
         if collect_trace {
@@ -938,6 +949,51 @@ fn run_mcem(
 
     if crate::cancel::is_cancelled(cancel) {
         return Err("cancelled by user".to_string());
+    }
+
+    // ---- Importance-sampling bias warning ----
+    // Self-normalized IS moment estimates carry a finite-sample bias that drives
+    // the M-step. For a fixed proposal quality it scales as ≈ 1/K, but the
+    // constant grows with the sampling dimension, so a sample count that is ample
+    // in low dimensions becomes badly under-sampled for a high-dimensional (e.g.
+    // FREM) model. Empirically the absorption typical value on the FREM workshop
+    // model (13 ETAs) drifts from ~2.6 (FOCEI/NONMEM) to ~4.6 at K=300 and
+    // recovers toward ~2.8 at K=6000 — while the *median* ESS stays ~0.8 the
+    // whole time, so ESS alone does not flag it. Use the per-dimension sample
+    // density K / n_eta as the trigger (≥ ~100 keeps the bias small here), plus
+    // any fully-collapsed subjects. Skip for eval-only IS (no M-step to bias).
+    const MIN_SAMPLES_PER_ETA: usize = 100;
+    let under_sampled = n_eta > 0 && k_opt < MIN_SAMPLES_PER_ETA * n_eta;
+    if !options.is_eval_only && (under_sampled || final_n_collapsed > 0) {
+        let sample_opt = if recenter == ProposalRecenter::Map {
+            "impmap_samples"
+        } else {
+            "is_samples"
+        };
+        let collapse = if final_n_collapsed > 0 {
+            format!(
+                " {} subject(s) had a fully collapsed proposal (ESS ≈ 0), whose moments \
+                 are unreliable regardless of sample count — check their EBE/Hessian quality.",
+                final_n_collapsed
+            )
+        } else {
+            String::new()
+        };
+        let suggestion = (MIN_SAMPLES_PER_ETA * n_eta).max(k_opt);
+        warnings.push(format!(
+            "{label}: only {} importance samples for a {}-ETA model (≈ {} per ETA, median \
+             ESS/K = {:.2}). The weighted M-step moments carry a finite-sample bias that grows \
+             with dimension, so typical-value and Ω estimates may be off — and it shrinks only \
+             as the sample count grows, not as iterations proceed. Raise `{}` to ≳ {} (high-\
+             dimensional / FREM models typically need several thousand) and re-fit.{}",
+            k_opt,
+            n_eta,
+            k_opt / n_eta.max(1),
+            final_ess_median,
+            sample_opt,
+            suggestion,
+            collapse
+        ));
     }
 
     // ---- Final (averaged) parameters ----

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -512,7 +512,37 @@ fn run_mcem(
     }
 
     let mu_ref_pairs = mu_ref_log_pairs(model);
-    let use_closed_form = !mu_ref_pairs.is_empty();
+    // A log-mu-referenced typical value is updated only through the closed-form
+    // `log θ += mean(η)` shift. When its paired η carries negligible IIV (a tiny,
+    // often `FIX`ed ω — e.g. a structural parameter given a dummy random effect
+    // so it can be mu-referenced), that population mean is ≈ 0 and the typical
+    // value would be frozen at its initial value (#411). Route those pairs to the
+    // weighted-likelihood M-step instead (the same channel that estimates σ and
+    // non-mu-ref θ), where the data can actually move them. Decided once from the
+    // initial Ω so a parameter never toggles channels between iterations.
+    const WEAK_IIV_VAR: f64 = 1e-3;
+    let weak_mu_ref: std::collections::HashSet<usize> = mu_ref_pairs
+        .iter()
+        .filter(|&&(_t, e)| init_params.omega.matrix[(e, e)] < WEAK_IIV_VAR)
+        .map(|&(t, _e)| t)
+        .collect();
+    if !weak_mu_ref.is_empty() {
+        let mut names: Vec<&str> = weak_mu_ref
+            .iter()
+            .map(|&t| model.theta_names.get(t).map(String::as_str).unwrap_or("?"))
+            .collect();
+        names.sort_unstable();
+        warnings.push(format!(
+            "{label}: typical value(s) {} are log-mu-referenced but their random effect has \
+             negligible variance (ω < {WEAK_IIV_VAR:.0e}); the mu-ref mean-shift carries no \
+             information, so they are estimated through the weighted M-step instead.",
+            names.join(", ")
+        ));
+    }
+    // Closed-form mu-ref shift is used as long as at least one pair has real IIV.
+    let use_closed_form = mu_ref_pairs
+        .iter()
+        .any(|&(t, _e)| !weak_mu_ref.contains(&t));
     if !use_closed_form {
         // No log-mu-ref parameter: every typical value goes through the weighted
         // M-step, which cannot resolve the θ/η-mean confounding on its own. Flag
@@ -809,6 +839,11 @@ fn run_mcem(
         let mut mstep_theta_upper = log_theta_upper.clone();
         if use_closed_form {
             for &(t, _e) in &mu_ref_pairs {
+                // Weak-IIV mu-ref θ are estimated by this M-step, not the shift,
+                // so leave their bounds free here.
+                if weak_mu_ref.contains(&t) {
+                    continue;
+                }
                 mstep_theta_lower[t] = log_theta[t];
                 mstep_theta_upper[t] = log_theta[t];
             }
@@ -844,6 +879,11 @@ fn run_mcem(
                 *acc /= n_subjects as f64;
             }
             for &(t, e) in &mu_ref_pairs {
+                // Weak-IIV mu-ref θ were already updated by the weighted M-step;
+                // their η-mean shift is ≈ 0 and uninformative — skip it.
+                if weak_mu_ref.contains(&t) {
+                    continue;
+                }
                 log_theta[t] =
                     (log_theta[t] + eta_bar[e]).clamp(log_theta_lower[t], log_theta_upper[t]);
             }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -64,6 +64,15 @@ fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floo
 /// Positive-definite floor for free Ω diagonals (matches the SAEM constant).
 const OMEGA_DIAG_FLOOR: f64 = 1e-6;
 
+/// Adaptive-sampling (`auto`) target for the objective's Monte-Carlo standard
+/// deviation, in −2 log L units. Mirrors NONMEM's `AUTO` default `STDOBJ = 1.0`:
+/// the per-subject sample count is ramped until the objective MC SE drops to
+/// this level, so the M-step is driven by signal, not sampling noise.
+const AUTO_STDOBJ_TARGET: f64 = 1.0;
+
+/// Hard cap on the adaptive per-subject sample count (NONMEM `ISAMPEND` default).
+const AUTO_SAMPLES_MAX: usize = 10_000;
+
 /// Absolute lower bound on the IMP proposal-covariance diagonal — a numerical
 /// guard against a literally-zero (degenerate-ESS) variance, NOT a statistical
 /// floor. It must stay well below any real conditional variance: with rich data
@@ -296,6 +305,7 @@ pub fn run_impmap(
         options.impmap_mceta,
         options.impmap_sobol && nu.is_infinite(),
         options.impmap_trace,
+        options.impmap_auto,
     )
 }
 
@@ -328,6 +338,7 @@ pub fn run_imp(
         0,     // mceta: no multi-start MAP for IMP
         false, // use_sobol: IMP has no Sobol option
         false, // collect_trace: IMP has no trace option
+        options.is_auto,
     )
 }
 
@@ -352,6 +363,7 @@ fn run_mcem(
     mceta: usize,
     use_sobol: bool,
     collect_trace: bool,
+    auto: bool,
 ) -> Result<OuterResult, String> {
     let n_subjects = population.subjects.len();
     let n_eta = model.n_eta;
@@ -386,7 +398,9 @@ fn run_mcem(
     }
 
     let n_iter = n_iter_opt.max(1);
-    let k_samples = k_opt.max(2);
+    // `k_samples` is mutable so the adaptive (`auto`) path can ramp it up between
+    // iterations when the objective is too Monte-Carlo-noisy (NONMEM `AUTO`).
+    let mut k_samples = k_opt.max(2);
     // `INFINITY` selects the multivariate-normal proposal; any finite value must
     // be a valid Student-t DoF (>= 1). Guard here so a programmatic caller that
     // bypasses the parser's range check can't reach the `ChiSquared::new(nu)`
@@ -599,6 +613,10 @@ fn run_mcem(
     // moment bias (which scales as 1/(K·ESS) and is severe in high dimensions).
     let mut final_ess_median = 1.0_f64;
     let mut final_n_collapsed = 0usize;
+    // Effective (possibly ramped) sample count and the final objective MC SE,
+    // for the post-fit under-sampling warning.
+    let mut final_k_samples = k_samples;
+    let mut final_mc_se = 0.0_f64;
 
     for k in 1..=n_iter {
         if crate::cancel::is_cancelled(cancel) {
@@ -806,6 +824,34 @@ fn run_mcem(
             ess_fracs.push(d.ess_fraction);
         }
         let minus2ll = -2.0 * ll;
+        // Objective Monte-Carlo standard error from the self-normalized ESS
+        // (Geweke: Var(log p̂ᵢ) ≈ (1/ESS_frac − 1)/K; degenerate subjects get a
+        // finite fallback). −2 log L scales this by 2.
+        let var_ll: f64 = ess_fracs
+            .iter()
+            .map(|&f| {
+                if f > 1e-6 {
+                    ((1.0 / f) - 1.0).max(0.0) / k_samples as f64
+                } else {
+                    1.0
+                }
+            })
+            .sum();
+        let mc_se = 2.0 * var_ll.sqrt();
+        final_mc_se = mc_se;
+        final_k_samples = k_samples;
+        // Adaptive sampling (NONMEM `AUTO`): ramp K up (×2, capped) while the
+        // objective is too MC-noisy, so the M-step is driven by signal not noise.
+        if auto && mc_se > AUTO_STDOBJ_TARGET && k_samples < AUTO_SAMPLES_MAX {
+            let new_k = (k_samples.saturating_mul(2)).min(AUTO_SAMPLES_MAX);
+            if verbose {
+                eprintln!(
+                    "{label}: auto-sampling — objective MC SE {mc_se:.2} > {AUTO_STDOBJ_TARGET:.1}, \
+                     raising K {k_samples} → {new_k}"
+                );
+            }
+            k_samples = new_k;
+        }
         // Track the final E-step's ESS health for the post-fit bias warning.
         final_n_collapsed = ess_fracs.iter().filter(|&&f| f <= 1e-6).count();
         ess_fracs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
@@ -962,13 +1008,23 @@ fn run_mcem(
     // whole time, so ESS alone does not flag it. Use the per-dimension sample
     // density K / n_eta as the trigger (≥ ~100 keeps the bias small here), plus
     // any fully-collapsed subjects. Skip for eval-only IS (no M-step to bias).
+    // Triggers, using the *effective* (possibly auto-ramped) sample count:
+    //  - too few samples for the dimension (a fast proxy that catches the common
+    //    case before the MC SE is even trustworthy), or
+    //  - the objective is still MC-noisy at the end (the direct measure — also
+    //    fires when `auto` ramped to the cap and could not reach the target), or
+    //  - a subject's proposal fully collapsed.
     const MIN_SAMPLES_PER_ETA: usize = 100;
-    let under_sampled = n_eta > 0 && k_opt < MIN_SAMPLES_PER_ETA * n_eta;
-    if !options.is_eval_only && (under_sampled || final_n_collapsed > 0) {
-        let sample_opt = if recenter == ProposalRecenter::Map {
-            "impmap_samples"
+    // The dimension heuristic only applies when `auto` is off — with `auto` on,
+    // a low starting count is fine because it ramps when (and only when) the
+    // objective is actually noisy, so the direct MC-SE check is the only trigger.
+    let under_sampled = !auto && n_eta > 0 && final_k_samples < MIN_SAMPLES_PER_ETA * n_eta;
+    let noisy = final_mc_se > 2.0 * AUTO_STDOBJ_TARGET;
+    if !options.is_eval_only && (under_sampled || noisy || final_n_collapsed > 0) {
+        let (sample_opt, auto_opt) = if recenter == ProposalRecenter::Map {
+            ("impmap_samples", "impmap_auto")
         } else {
-            "is_samples"
+            ("is_samples", "is_auto")
         };
         let collapse = if final_n_collapsed > 0 {
             format!(
@@ -979,19 +1035,29 @@ fn run_mcem(
         } else {
             String::new()
         };
-        let suggestion = (MIN_SAMPLES_PER_ETA * n_eta).max(k_opt);
+        let advice = if auto {
+            format!(
+                "`{auto_opt}` is enabled but the sample count {} (cap {AUTO_SAMPLES_MAX}) \
+                 was not enough to reach the MC-SE target.",
+                final_k_samples
+            )
+        } else {
+            format!(
+                "Raise `{sample_opt}` (high-dimensional / FREM models typically need several \
+                 thousand) or set `{auto_opt} = true` to ramp it automatically."
+            )
+        };
         warnings.push(format!(
-            "{label}: only {} importance samples for a {}-ETA model (≈ {} per ETA, median \
-             ESS/K = {:.2}). The weighted M-step moments carry a finite-sample bias that grows \
-             with dimension, so typical-value and Ω estimates may be off — and it shrinks only \
-             as the sample count grows, not as iterations proceed. Raise `{}` to ≳ {} (high-\
-             dimensional / FREM models typically need several thousand) and re-fit.{}",
-            k_opt,
+            "{label}: {} importance samples for a {}-ETA model give a noisy objective \
+             (MC SE = {:.2}, target {:.1}; median ESS/K = {:.2}). The weighted M-step moments \
+             then carry a finite-sample bias — typical-value and Ω estimates may be off, and it \
+             shrinks only as the sample count grows. {}{}",
+            final_k_samples,
             n_eta,
-            k_opt / n_eta.max(1),
+            final_mc_se,
+            AUTO_STDOBJ_TARGET,
             final_ess_median,
-            sample_opt,
-            suggestion,
+            advice,
             collapse
         ));
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3703,6 +3703,8 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "impmap_mceta" => opts.impmap_mceta = parse_usize("impmap_mceta")?,
         "impmap_sobol" => opts.impmap_sobol = parse_bool("impmap_sobol")?,
         "frem_rao_blackwell" => opts.frem_rao_blackwell = parse_bool("frem_rao_blackwell")?,
+        "is_auto" => opts.is_auto = parse_bool("is_auto")?,
+        "impmap_auto" => opts.impmap_auto = parse_bool("impmap_auto")?,
         "iscale_min" => {
             let v = parse_f64("iscale_min")?;
             if v <= 0.0 {
@@ -11620,6 +11622,16 @@ mod tests {
             assert_eq!(apply_fit_option(&mut opts, "sir", v), Ok(true));
             assert!(!opts.sir, "value `{v}` should parse as false");
         }
+    }
+
+    #[test]
+    fn test_apply_fit_option_adaptive_sampling_flags() {
+        let mut opts = FitOptions::default();
+        assert!(opts.is_auto && opts.impmap_auto, "default on");
+        assert_eq!(apply_fit_option(&mut opts, "is_auto", "false"), Ok(true));
+        assert!(!opts.is_auto);
+        assert_eq!(apply_fit_option(&mut opts, "impmap_auto", "no"), Ok(true));
+        assert!(!opts.impmap_auto);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3276,6 +3276,17 @@ pub struct FitOptions {
     /// covariate dimensions has very poor ESS. Set `false` only to diagnose the
     /// RB path against the full-dimensional sampler.
     pub frem_rao_blackwell: bool,
+    /// Adaptive importance-sample count for IMP (NONMEM `AUTO`/`STDOBJ`). When
+    /// `true` (the default), `is_samples` is the *starting* count and is ramped
+    /// up (×2 per iteration, capped at 10000) whenever the objective's Monte-Carlo
+    /// standard deviation exceeds 1.0, so high-dimensional / FREM fits reach a
+    /// low-noise objective automatically instead of carrying a sample-count-
+    /// dependent M-step bias. Low-dimensional, well-sampled fits never trip the
+    /// threshold, so there is no cost there. Set `false` to pin the sample count.
+    pub is_auto: bool,
+    /// Adaptive importance-sample count for IMPMAP (NONMEM `AUTO`/`STDOBJ`). As
+    /// [`FitOptions::is_auto`] but ramps `impmap_samples`. Default `true`.
+    pub impmap_auto: bool,
     /// Minimum ISCALE factor for adaptive IS proposal scaling (NONMEM ISCALE_MIN).
     /// The proposal covariance is multiplied by iscale² to improve IS efficiency.
     /// Set `iscale_min == iscale_max == 1.0` to disable. Default 0.1.
@@ -3536,6 +3547,8 @@ impl Default for FitOptions {
             impmap_mceta: 0,
             impmap_sobol: false,
             frem_rao_blackwell: true,
+            is_auto: true,
+            impmap_auto: true,
             iscale_min: 0.1,
             iscale_max: 10.0,
             bloq_method: BloqMethod::Drop,
@@ -3906,6 +3919,7 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "iscale_min",
             "iscale_max",
             "frem_rao_blackwell",
+            "is_auto",
         ],
         EstimationMethod::Impmap => &[
             "inner_maxiter",
@@ -3922,6 +3936,7 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "iscale_min",
             "iscale_max",
             "frem_rao_blackwell",
+            "impmap_auto",
         ],
         EstimationMethod::Bayes => &[
             "inner_maxiter",

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -7,6 +7,7 @@
 
 use ferx_core::parser::model_parser::parse_model_file;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::io::Write;
 use std::path::Path;
 
 fn warfarin_setup() -> (
@@ -80,6 +81,77 @@ fn impmap_standalone_produces_finite_estimates() {
         "marginal MC SE must be finite & non-negative, got {}",
         is.mc_standard_error
     );
+}
+
+/// A log-mu-referenced typical value whose paired η has negligible IIV (tiny
+/// `FIX`ed ω) must still be estimated: IMPMAP routes it to the weighted M-step
+/// instead of the closed-form `log θ += mean(η)` shift, which would freeze it at
+/// its initial value (#411). Guards both that the routing warning fires and that
+/// the typical value actually moves off a deliberately-wrong init.
+#[test]
+fn impmap_estimates_mu_ref_param_with_negligible_iiv() {
+    // KA carries a near-zero FIXed ω, so without routing its typical value would
+    // be frozen at the (deliberately low) init of 0.5.
+    const KA_INIT: f64 = 0.5;
+    let model_src = format!(
+        r#"
+[parameters]
+  theta TVCL(0.13, 0.001, 10)
+  theta TVV(8.0, 0.1, 100)
+  theta TVKA({KA_INIT}, 0.01, 50)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 1e-8 FIX
+  sigma PROP ~ 0.05
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP)
+[fit_options]
+  method = importance_sampling_map
+"#
+    );
+    let tmp = tempfile::tempdir().unwrap();
+    let mpath = tmp.path().join("ka_weak.ferx");
+    std::fs::File::create(&mpath)
+        .unwrap()
+        .write_all(model_src.as_bytes())
+        .unwrap();
+    let model = parse_model_file(&mpath).expect("model must parse");
+    let pop = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).unwrap();
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Impmap;
+    opts.run_covariance_step = false;
+    opts.impmap_iterations = 25;
+    opts.impmap_samples = 200;
+    opts.impmap_seed = Some(7);
+
+    let r = fit(&model, &pop, &model.default_params, &opts).expect("IMPMAP fit must succeed");
+
+    // The routing warning must fire and name TVKA.
+    assert!(
+        r.warnings
+            .iter()
+            .any(|w| w.contains("TVKA") && w.contains("negligible variance")),
+        "expected a negligible-IIV routing warning for TVKA, got {:?}",
+        r.warnings
+    );
+    // TVKA must have moved off its frozen init (warfarin's true KA ≈ 1+).
+    let tvka = r.theta[r
+        .theta_names
+        .iter()
+        .position(|n| n == "TVKA")
+        .expect("TVKA present")];
+    assert!(
+        (tvka - KA_INIT).abs() > 0.1,
+        "TVKA must be estimated off its init {KA_INIT} (was frozen?), got {tvka}"
+    );
+    assert!(tvka.is_finite() && tvka > 0.0);
 }
 
 #[test]

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -93,6 +93,7 @@ fn impmap_warns_when_under_sampled_for_dimension() {
     let fires = |k: usize| -> bool {
         let mut opts = base.clone();
         opts.method = EstimationMethod::Impmap;
+        opts.impmap_auto = false; // test the fixed-count dimension heuristic
         opts.impmap_samples = k;
         opts.impmap_iterations = 3;
         fit(&model, &population, &model.default_params, &opts)
@@ -109,6 +110,34 @@ fn impmap_warns_when_under_sampled_for_dimension() {
         !fires(400),
         "no under-sampling warning expected at K=400 (> 100·3)"
     );
+}
+
+/// `impmap_auto` (NONMEM `AUTO`) ramps the per-subject sample count when the
+/// objective is Monte-Carlo-noisy. Here it must plumb through, run, and return
+/// finite estimates — and on a low-start-K noisy fit it must not produce a
+/// *worse* (less converged) objective than the same fixed-K run. (The full
+/// 300→10000 ramp is validated manually on the FREM workshop model; a fast
+/// fixture is not noisy enough to exercise the cap.)
+#[test]
+fn impmap_auto_runs_and_does_not_regress() {
+    let (model, population, base) = warfarin_setup();
+    let run = |auto: bool, k: usize| {
+        let mut opts = base.clone();
+        opts.method = EstimationMethod::Impmap;
+        opts.impmap_auto = auto;
+        opts.impmap_samples = k;
+        opts.impmap_iterations = 6;
+        fit(&model, &population, &model.default_params, &opts).expect("fit must succeed")
+    };
+    let r = run(true, 8);
+    assert_eq!(r.method, EstimationMethod::Impmap);
+    assert!(r.ofv.is_finite(), "auto OFV must be finite, got {}", r.ofv);
+    for (n, v) in r.theta_names.iter().zip(r.theta.iter()) {
+        assert!(v.is_finite() && *v > 0.0, "theta {n} finite > 0, got {v}");
+    }
+    for i in 0..model.n_eta {
+        assert!(r.omega[(i, i)].is_finite() && r.omega[(i, i)] > 0.0);
+    }
 }
 
 /// A log-mu-referenced typical value whose paired η has negligible IIV (tiny

--- a/tests/impmap_api.rs
+++ b/tests/impmap_api.rs
@@ -83,6 +83,34 @@ fn impmap_standalone_produces_finite_estimates() {
     );
 }
 
+/// IMPMAP warns when the importance-sample count is low relative to the model
+/// dimension (`K < 100·n_eta`), since the self-normalized M-step moments then
+/// carry a dimension-amplified finite-sample bias (#411). The warning must fire
+/// when under-sampled and stay silent when the count is adequate.
+#[test]
+fn impmap_warns_when_under_sampled_for_dimension() {
+    let (model, population, base) = warfarin_setup(); // 3 ETAs → threshold K = 300
+    let fires = |k: usize| -> bool {
+        let mut opts = base.clone();
+        opts.method = EstimationMethod::Impmap;
+        opts.impmap_samples = k;
+        opts.impmap_iterations = 3;
+        fit(&model, &population, &model.default_params, &opts)
+            .expect("fit must succeed")
+            .warnings
+            .iter()
+            .any(|w| w.contains("importance samples for"))
+    };
+    assert!(
+        fires(50),
+        "expected an under-sampling warning at K=50 (< 100·3)"
+    );
+    assert!(
+        !fires(400),
+        "no under-sampling warning expected at K=400 (> 100·3)"
+    );
+}
+
 /// A log-mu-referenced typical value whose paired η has negligible IIV (tiny
 /// `FIX`ed ω) must still be estimated: IMPMAP routes it to the weighted M-step
 /// instead of the closed-form `log θ += mean(η)` shift, which would freeze it at


### PR DESCRIPTION
## Why
`imp`/`impmap` converged to a wrong absorption optimum on the FREM workshop model (`ferx-testdata/frem_workshop/HO1`): `TVMAT ≈ 4.6–5.1` vs FOCEI/NONMEM `2.6`. ferx FOCEI reaches `2.67` on the same model, and warm-starting IMPMAP from it still drifts — so the FREM likelihood is fine; the **IMP/IMPMAP estimator** was biased. Root-caused to three independent effects (#411):

1. **Frozen mu-referenced typical values.** A log-mu-referenced θ whose paired η has negligible IIV (tiny, often `FIX`ed ω — e.g. the absorption fraction `FRD1`, ω = 1e-4) is updated only by the closed-form `log θ += mean(η)` shift, which is ≈ 0 — so the typical value stayed frozen at its initial value.
2. **Under-sampling for the dimension.** The self-normalized M-step moments carry a finite-sample bias whose constant grows with the number of ETAs, so a fixed count ample for a 3–4 ETA PK model is badly under-sampled for a 13-ETA FREM model. ferx used a fixed count; NONMEM's IMPMAP/IMP default to **`AUTO=1`**, which ramps `ISAMPLE` up to 10000 by the objective's MC standard deviation (`STDOBJ`). (The premise "NONMEM also uses 300" was the misread — 300 is `AUTO`'s *starting* value.)
3. (Surfaced, follow-up) a couple of steady-state subjects whose IS proposal collapses (ESS ≈ 0) even at the sample cap.

## What changed
- **Adaptive sampling `is_auto` / `impmap_auto` (NONMEM `AUTO`), default `true`.** `is_samples`/`impmap_samples` is the *starting* count; ramped ×2 per iteration (cap 10000) whenever the objective MC SE exceeds 1.0 (the `STDOBJ` default observed in run6/run7). Low-dimensional, well-sampled fits never trip the threshold, so there's no cost there.
- **Weak-IIV mu-ref routing.** A mu-ref θ whose η has ω below a small threshold (decided once from the initial Ω) is estimated through the weighted-likelihood M-step instead of the frozen mean-shift. Init-independent; a warning names any parameter routed this way.
- **Under-sampling warning** keyed off the effective (ramped) sample count and the final objective MC SE; the dimension heuristic applies only when `auto` is off.

## Alternatives considered
For #2: scale a fixed default with dimension, vs. ramp adaptively. Chose adaptive (NONMEM-equivalent) — the right count depends on the achieved MC noise, not dimension alone, and it self-limits on easy problems. Ruled out (all tested, not assumed): basin/local-optimum, the Rao-Blackwell path, proposal width/ISCALE, the collapsed tail subjects, modeled-duration subjects, and covariate conditioning/standardization — see issue #411 for the matrix.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

New `pub` `FitOptions` fields (`is_auto`, `impmap_auto`) — additive, defaulted, no signature break.

## Breaking changes
- [x] None (behavioural: adaptive sampling now on by default; documented in CHANGELOG)

## Numerical validation
- [x] Compared against NONMEM 7.5.1 `METHOD=IMPMAP AUTO=1`

```
# FREM workshop model (13 ETAs), method = impmap
                         TVCL     TVV     TVMAT
NONMEM (AUTO 300→10000)  7.07     136     2.59
ferx fixed K=300         ~6.8     ~113    4.63     <- biased
ferx impmap_auto=true    7.04     132.7   2.96     <- ramps 300→10000

# warfarin (3 ETAs): not noisy → never ramps → NONMEM anchors unchanged
```

Live ramp on FREM: `K 300→600→1200→2400→4800→9600→10000` as MC SE fell 2.50→1.07.

## Performance
- [x] No impact on low-dim fits (MC SE below target → no ramp). High-dim/FREM fits do more work — that is the fix (was silently biased). Capped at 10000.

## Tests
- [x] Parser test for `is_auto`/`impmap_auto`; functional test that `impmap_auto` runs finite and does not regress.
- [x] Regression test: weak-IIV mu-ref typical value is estimated off a wrong init (fails when routing disabled).
- [x] Under-sampling warning test (auto off): fires when under-sampled, silent when adequate.

## Example
```toml
[fit_options]
  method      = impmap
  impmap_auto = true      # default; ramps the sample count to control MC noise (NONMEM AUTO)
```

## Docs
- [x] `docs/src/estimation/impmap.md`, `docs/src/model-file/fit-options.md` (`is_auto`/`impmap_auto`)
- [x] `CHANGELOG.md` `[Unreleased]`

## Checklist
- [x] `cargo clippy` clean
- [x] `cargo check --features autodiff` — N/A (enzyme toolchain ICE in this env; changes not AD-reachable; built/tested with `--no-default-features --features ci`)
- [x] No version bump

## Reviewer hints
- `src/estimation/impmap.rs`: the ramp lives in the ESS block of `run_mcem` (objective MC SE from Geweke ESS → ×2 ramp to `AUTO_SAMPLES_MAX`), the weak-IIV `mu_ref` routing near `mu_ref_log_pairs`, and the rewritten under-sampling warning.

## Open questions
- Residual `TVMAT 2.96` vs `2.59` is the ~2 steady-state subjects whose proposal collapses even at the sample cap (ESS ≈ 0). Tracked as a follow-up in #411 — a per-subject proposal-quality issue, not blocking; the dominant drift (4.6→3.0) is resolved here.