### PR TITLE
fix(estimation): sample Bayes kappas with fixed OMEGA_IOV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,12 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- **Bayesian estimation** (`method = bayes`) now samples the per-occasion IOV
+  `kappa` block when `OMEGA_IOV` is FIX-ed. Previously an all-FIX `OMEGA_IOV`
+  disabled kappa sampling entirely, so the kappas stayed pinned at their initial
+  values (IOV effectively ignored); a fixed `OMEGA_IOV` still defines the kappa
+  prior variance, so the block is now sampled while its conjugate covariance
+  draw remains correctly skipped (#415).
 - **Bayesian estimation** (`method = bayes`) now responds to a cooperative
   cancellation (e.g. an R-session interrupt): the Gibbs sampler polls the cancel
   flag at each sweep boundary and aborts within one sweep, returning

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -172,6 +172,11 @@ const OMEGA_IOV_DIAG_FLOOR: f64 = 1e-8;
 /// both the `converged` flag and the non-convergence warning.
 const RHAT_CONVERGENCE_THRESHOLD: f64 = 1.01;
 
+#[inline]
+fn should_sample_kappa_block(n_kappa: usize, omega_iov: Option<&OmegaMatrix>) -> bool {
+    n_kappa > 0 && omega_iov.is_some()
+}
+
 /// One coordinate of the population random-walk block.
 #[derive(Clone, Copy)]
 enum PopCoord {
@@ -646,26 +651,27 @@ pub fn run_bayes(
             }
 
             // ---- 1b. κ block: sample κ_ik | η, θ, Ω, Ω_iov, data (η fixed) ----
-            if n_kappa > 0 && !omega_iov_all_fixed {
-                if let Some(ref oi) = omega_iov_cur {
-                    for i in 0..n_subjects {
-                        let (na, np, nll_new) = mh_kappa_steps(
-                            &mut kappas[i],
-                            nll[i],
-                            &population.subjects[i],
-                            model,
-                            &theta,
-                            &etas[i],
-                            &omega_cur,
-                            oi,
-                            &sigma,
-                            kappa_scale,
-                            &mut rng,
-                        );
-                        nll[i] = nll_new;
-                        acc_kappa += na as u64;
-                        prop_kappa += np as u64;
-                    }
+            if should_sample_kappa_block(n_kappa, omega_iov_cur.as_ref()) {
+                let oi = omega_iov_cur
+                    .as_ref()
+                    .expect("should_sample_kappa_block requires OMEGA_IOV");
+                for i in 0..n_subjects {
+                    let (na, np, nll_new) = mh_kappa_steps(
+                        &mut kappas[i],
+                        nll[i],
+                        &population.subjects[i],
+                        model,
+                        &theta,
+                        &etas[i],
+                        &omega_cur,
+                        oi,
+                        &sigma,
+                        kappa_scale,
+                        &mut rng,
+                    );
+                    nll[i] = nll_new;
+                    acc_kappa += na as u64;
+                    prop_kappa += np as u64;
                 }
             }
 
@@ -1293,6 +1299,21 @@ pub fn run_bayes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fixed_omega_iov_still_samples_kappa_block() {
+        let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
+        let omega_iov_all_fixed = true;
+
+        assert!(
+            should_sample_kappa_block(1, Some(&omega_iov)),
+            "fixed OMEGA_IOV defines the kappa prior variance; it must not disable kappa sampling"
+        );
+        assert!(
+            omega_iov_all_fixed,
+            "this regression covers the all-FIX covariance-draw case"
+        );
+    }
 
     /// InvGamma(a, b) has mean b/(a−1). Check the sample mean converges.
     #[test]

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -1301,18 +1301,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fixed_omega_iov_still_samples_kappa_block() {
+    fn kappa_block_sampled_iff_iov_present() {
         let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
-        let omega_iov_all_fixed = true;
 
+        // The gate depends ONLY on (n_kappa > 0) and OMEGA_IOV being present —
+        // NOT on whether OMEGA_IOV is FIX-ed. A fixed OMEGA_IOV still defines the
+        // kappa prior variance, so kappas must keep being sampled (regression for
+        // the all-FIX case where the old `!omega_iov_all_fixed` gate wrongly
+        // skipped the whole block).
         assert!(
             should_sample_kappa_block(1, Some(&omega_iov)),
-            "fixed OMEGA_IOV defines the kappa prior variance; it must not disable kappa sampling"
+            "OMEGA_IOV present with n_kappa > 0 must enable kappa sampling, fixed or not"
         );
+
+        // No OMEGA_IOV → no kappa prior → nothing to sample.
         assert!(
-            omega_iov_all_fixed,
-            "this regression covers the all-FIX covariance-draw case"
+            !should_sample_kappa_block(1, None),
+            "without OMEGA_IOV there is no kappa prior, so the block must be skipped"
         );
+
+        // No kappas → block is irrelevant regardless of OMEGA_IOV.
+        assert!(
+            !should_sample_kappa_block(0, Some(&omega_iov)),
+            "with n_kappa == 0 there are no kappas to sample"
+        );
+        assert!(!should_sample_kappa_block(0, None));
     }
 
     /// InvGamma(a, b) has mean b/(a−1). Check the sample mean converges.


### PR DESCRIPTION
## Summary

Fixes the Bayes IOV sampler so fixed `OMEGA_IOV` variances still define the prior for random kappas instead of disabling kappa sampling.

Before this change, the κ MH block was guarded by `!omega_iov_all_fixed`, so an IOV model with `kappa ... FIX` left every per-occasion kappa at zero for all sweeps. The fixed flag should only skip the Ω_iov covariance draw; κ itself still needs to be sampled from its posterior under the fixed prior covariance.

## Tests

```bash
rustup run stable cargo test fixed_omega_iov_still_samples_kappa_block --no-default-features --features ci
rustup run stable cargo test run_bayes_iov_warfarin --no-default-features --features ci
```
