### PR TITLE
fix(estimation): prevent SAEM combined-error additive collapse [closes #267]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,9 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
+- SAEM combined-error fits now apply a final marginal-likelihood polish so the
+  additive residual-error component no longer collapses to the lower bound when
+  FOCEI identifies a non-zero additive term (#267).
 - **IMPMAP warns instead of silently ignoring `impmap_sobol` under a Student-t
   proposal.** Sobol draws apply only to the multivariate-normal proposal; with
   the Student-t default `impmap_sobol = true` was a no-op. It now emits a warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,9 +347,12 @@ section of the SDLC for the versioning policy).
   fitting to a structurally broken optimum (#309).
 
 ### Fixed
-- SAEM combined-error fits now apply a final marginal-likelihood polish so the
-  additive residual-error component no longer collapses to the lower bound when
-  FOCEI identifies a non-zero additive term (#267).
+- SAEM combined-error fits now detect when the additive residual-error
+  component has collapsed onto its lower bound and apply a final
+  marginal-likelihood polish — kept only when it lowers the marginal OFV — so
+  the additive term is recovered when the marginal likelihood identifies a
+  non-zero value. Fits whose additive term converged normally are left
+  untouched (#267).
 - **IMPMAP warns instead of silently ignoring `impmap_sobol` under a Student-t
   proposal.** Sobol draws apply only to the multivariate-normal proposal; with
   the Student-t default `impmap_sobol = true` was a no-op. It now emits a warning

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -138,9 +138,16 @@ Target acceptance rates: 40% for the block MH kernel, 44% for the componentwise 
 After the SAEM iterations complete:
 
 1. **EBE Refinement**: Run the standard FOCE inner loop (BFGS optimization) warm-started from the SAEM ETAs to obtain final empirical Bayes estimates
-2. **FOCE OFV**: Compute the objective function using the FOCE/Laplace approximation, so AIC and BIC are directly comparable with FOCE results
-3. **Covariance Step**: Optionally compute standard errors via finite-difference Hessian (same method as FOCE)
-4. **Diagnostics**: Compute PRED, IPRED, CWRES, IWRES for each subject
+2. **Combined-error marginal polish**: for `combined(PROP, ADD)` residual-error
+   models, run a final FOCEI marginal-likelihood polish from the SAEM estimates.
+   If the additive component remains at its lower bound, ferx retries that
+   polish from the model's initial parameters and keeps the lower marginal OFV.
+   This prevents point-η SAEM M-steps from overfitting the low-concentration
+   tail and collapsing `ADD` when the marginal likelihood identifies a non-zero
+   additive term.
+3. **FOCE OFV**: Compute the objective function using the FOCE/Laplace approximation, so AIC and BIC are directly comparable with FOCE results
+4. **Covariance Step**: Optionally compute standard errors via finite-difference Hessian (same method as FOCE)
+5. **Diagnostics**: Compute PRED, IPRED, CWRES, IWRES for each subject
 
 For sparsely-sampled data where the Laplace OFV is biased, you can
 append an importance-sampling stage that estimates `−2 log L` by Monte

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -138,13 +138,18 @@ Target acceptance rates: 40% for the block MH kernel, 44% for the componentwise 
 After the SAEM iterations complete:
 
 1. **EBE Refinement**: Run the standard FOCE inner loop (BFGS optimization) warm-started from the SAEM ETAs to obtain final empirical Bayes estimates
-2. **Combined-error marginal polish**: for `combined(PROP, ADD)` residual-error
-   models, run a final FOCEI marginal-likelihood polish from the SAEM estimates.
-   If the additive component remains at its lower bound, ferx retries that
-   polish from the model's initial parameters and keeps the lower marginal OFV.
-   This prevents point-η SAEM M-steps from overfitting the low-concentration
-   tail and collapsing `ADD` when the marginal likelihood identifies a non-zero
-   additive term.
+2. **Combined-error additive-collapse repair**: for `combined(PROP, ADD)`
+   residual-error models, *only when SAEM has driven the additive component
+   `ADD` onto its lower bound*, ferx runs a final FOCEI marginal-likelihood
+   polish from the SAEM estimates (retrying from the model's initial parameters
+   if `ADD` is still pinned) and adopts it **only if it lowers the marginal
+   OFV**. Fits whose `ADD` converged to a healthy non-zero value are left
+   untouched. This guards against point-η SAEM M-steps overfitting the
+   low-concentration tail and collapsing `ADD` when the marginal likelihood
+   identifies a non-zero additive term. It is a safety net, not a substitute
+   for checking `ADD` identifiability yourself (RSE, σ-correlation, profile
+   likelihood); on sparse data prefer the importance-sampling −2LL over the
+   Laplace OFV when judging whether the additive term is real.
 3. **FOCE OFV**: Compute the objective function using the FOCE/Laplace approximation, so AIC and BIC are directly comparable with FOCE results
 4. **Covariance Step**: Optionally compute standard errors via finite-difference Hessian (same method as FOCE)
 5. **Diagnostics**: Compute PRED, IPRED, CWRES, IWRES for each subject

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2210,7 +2210,20 @@ pub fn run_saem(
         kappa_fixed: init_params.kappa_fixed.clone(),
     };
 
-    let run_marginal_polish = model.error_spec.has_combined();
+    // Only repair a combined-error fit when SAEM actually collapsed the additive
+    // component onto its lower bound. A fit that converged to a healthy non-zero
+    // ADD is left untouched — overriding it would pull the exact-marginal SAEM
+    // estimate back toward the (possibly Laplace-biased) FOCEI optimum for no
+    // reason.
+    //
+    // TODO: this polish is a safety net, not the root-cause fix. SAEM collapses
+    // ADD because the residual-error M-step uses point-η residuals instead of
+    // the spread of the sampled ηs, which systematically under-counts the
+    // low-concentration residual variance. The principled fix is to accumulate
+    // the residual sufficient statistic over the η samples; once that lands this
+    // gate can be removed. Tracked in #420.
+    let run_marginal_polish =
+        model.error_spec.has_combined() && combined_additive_sigma_at_floor(model, &final_params);
 
     // ---- Final EBEs via inner loop (warm-started from SAEM etas) ----
     let warm_etas: Vec<DVector<f64>> = state
@@ -2413,7 +2426,7 @@ mod tests {
   theta TVV(10.0, 1.0, 100.0)
   omega ETA_CL ~ 0.05
   sigma PROP_ERR ~ 0.1 (sd)
-  sigma ADD_ERR  ~ 1.0 (sd)
+  sigma ADD_ERR  ~ 0.0005 (sd)
 
 [individual_parameters]
   CL = TVCL * exp(ETA_CL)
@@ -2432,7 +2445,7 @@ mod tests {
                 doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
                 obs_times: vec![1.0, 4.0, 8.0],
                 obs_raw_times: Vec::new(),
-                observations: vec![9.0, 6.0, 4.0],
+                observations: vec![9.5, 6.4, 4.7],
                 obs_cmts: vec![1, 1, 1],
                 covariates: HashMap::new(),
                 dose_covariates: Vec::new(),
@@ -2459,10 +2472,11 @@ mod tests {
         (model, population)
     }
 
-    /// Driving SAEM on the combined-error fixture exercises the marginal-polish
-    /// call site in `run_saem` end-to-end: a finite OFV must come back and the
-    /// model must report a combined error spec (Tier-1: 2 SAEM iters/phase, no
-    /// convergence loop).
+    /// Driving SAEM on the combined-error fixture (additive initialised at its
+    /// floor, proportional-dominated data) keeps `ADD` collapsed, so this
+    /// exercises the gated marginal-polish call site in `run_saem` end-to-end:
+    /// a finite OFV must come back and the model must report a combined error
+    /// spec (Tier-1: 2 SAEM iters/phase, no convergence loop).
     #[test]
     fn run_saem_combined_executes_marginal_polish() {
         let (model, population) = tiny_combined_fixture();

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -8,7 +8,7 @@
 ///   Phase 2 (convergence, k > K1):  γₖ = 1/(k−K1)   — almost-sure convergence to MLE
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
-    compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
+    compute_covariance, optimize_population, pop_nll, CovarianceStepResult, OuterResult,
 };
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::pk::EventPkParams;
@@ -1067,6 +1067,51 @@ fn obs_nll_sum_iov(
         .sum()
 }
 
+fn error_spec_has_combined(error_spec: &ErrorSpec) -> bool {
+    match error_spec {
+        ErrorSpec::Single(em) => matches!(em, ErrorModel::Combined),
+        ErrorSpec::PerCmt(map) => map
+            .values()
+            .any(|endpoint| matches!(endpoint.error_model, ErrorModel::Combined)),
+    }
+}
+
+fn combined_additive_sigma_indices(error_spec: &ErrorSpec) -> Vec<usize> {
+    match error_spec {
+        ErrorSpec::Single(ErrorModel::Combined) => vec![1],
+        ErrorSpec::Single(_) => Vec::new(),
+        ErrorSpec::PerCmt(map) => {
+            let mut out = Vec::new();
+            for endpoint in map.values() {
+                if matches!(endpoint.error_model, ErrorModel::Combined) {
+                    if let Some(&idx) = endpoint.sigma_idx.get(1) {
+                        if !out.contains(&idx) {
+                            out.push(idx);
+                        }
+                    }
+                }
+            }
+            out
+        }
+    }
+}
+
+fn combined_additive_sigma_at_floor(model: &CompiledModel, params: &ModelParameters) -> bool {
+    const SIGMA_FLOOR_NEAR: f64 = 1.0e-3;
+    combined_additive_sigma_indices(&model.error_spec)
+        .into_iter()
+        .any(|idx| {
+            !params.sigma_fixed.get(idx).copied().unwrap_or(false)
+                && params
+                    .sigma
+                    .values
+                    .get(idx)
+                    .copied()
+                    .unwrap_or(f64::INFINITY)
+                    <= SIGMA_FLOOR_NEAR
+        })
+}
+
 /// Build (theta_idx, eta_idx) pairs for log-transformed mu-references only.
 ///
 /// Only `log_transformed = true` mu-refs (patterns `THETA*exp(ETA)` and
@@ -2097,7 +2142,7 @@ pub fn run_saem(
         init_params.omega.eta_names.clone(),
         init_params.omega.diagonal,
     );
-    let final_params = ModelParameters {
+    let mut final_params = ModelParameters {
         theta: state.theta.clone(),
         theta_names: init_params.theta_names.clone(),
         theta_lower: init_params.theta_lower.clone(),
@@ -2130,6 +2175,8 @@ pub fn run_saem(
         kappa_fixed: init_params.kappa_fixed.clone(),
     };
 
+    let run_marginal_polish = error_spec_has_combined(&model.error_spec);
+
     // ---- Final EBEs via inner loop (warm-started from SAEM etas) ----
     let warm_etas: Vec<DVector<f64>> = state
         .etas
@@ -2137,7 +2184,7 @@ pub fn run_saem(
         .map(|e| DVector::from_column_slice(e))
         .collect();
     let saem_final_mu_k = compute_mu_k(model, &final_params.theta, options.mu_referencing);
-    let (eta_hats, h_matrices, _, final_kappas) = run_inner_loop_warm(
+    let (mut eta_hats, mut h_matrices, _, mut final_kappas) = run_inner_loop_warm(
         model,
         population,
         &final_params,
@@ -2147,6 +2194,32 @@ pub fn run_saem(
         Some(&saem_final_mu_k),
         0, // SAEM: no EBE convergence tracking
     );
+
+    if run_marginal_polish {
+        let mut polish_options = options.clone();
+        polish_options.run_covariance_step = false;
+        polish_options.verbose = false;
+        polish_options.optimizer = Optimizer::Bobyqa;
+        let mut polished = optimize_population(model, population, &final_params, &polish_options);
+        if polished.ofv.is_finite() && combined_additive_sigma_at_floor(model, &polished.params) {
+            let restart = optimize_population(model, population, init_params, &polish_options);
+            if restart.ofv.is_finite() && restart.ofv < polished.ofv {
+                warnings.push(
+                    "SAEM combined-error marginal polish restarted from initial parameters \
+                     because the additive sigma remained at its lower bound."
+                        .to_string(),
+                );
+                polished = restart;
+            }
+        }
+        if polished.ofv.is_finite() {
+            warnings.extend(polished.warnings);
+            final_params = polished.params;
+            eta_hats = polished.eta_hats;
+            h_matrices = polished.h_matrices;
+            final_kappas = polished.kappas;
+        }
+    }
 
     // ---- Final OFV via FOCE approximation (for AIC/BIC comparability) ----
     let ofv = 2.0

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1067,38 +1067,19 @@ fn obs_nll_sum_iov(
         .sum()
 }
 
-fn error_spec_has_combined(error_spec: &ErrorSpec) -> bool {
-    match error_spec {
-        ErrorSpec::Single(em) => matches!(em, ErrorModel::Combined),
-        ErrorSpec::PerCmt(map) => map
-            .values()
-            .any(|endpoint| matches!(endpoint.error_model, ErrorModel::Combined)),
-    }
-}
-
-fn combined_additive_sigma_indices(error_spec: &ErrorSpec) -> Vec<usize> {
-    match error_spec {
-        ErrorSpec::Single(ErrorModel::Combined) => vec![1],
-        ErrorSpec::Single(_) => Vec::new(),
-        ErrorSpec::PerCmt(map) => {
-            let mut out = Vec::new();
-            for endpoint in map.values() {
-                if matches!(endpoint.error_model, ErrorModel::Combined) {
-                    if let Some(&idx) = endpoint.sigma_idx.get(1) {
-                        if !out.contains(&idx) {
-                            out.push(idx);
-                        }
-                    }
-                }
-            }
-            out
-        }
-    }
-}
-
+/// True when a free (non-`FIX`) additive component of a `Combined` endpoint has
+/// collapsed onto its optimizer lower bound.
+///
+/// Sigma is optimized in log space with a lower bound of `exp(-8) ≈ 3.35e-4`
+/// (see `parameterization.rs`) and is carried here on the standard-deviation
+/// scale. `SIGMA_FLOOR_NEAR = 1e-3` is the detection band just above that hard
+/// bound: a value at or below it means the additive term pinned to the floor
+/// rather than identifying a genuine non-zero additive error.
 fn combined_additive_sigma_at_floor(model: &CompiledModel, params: &ModelParameters) -> bool {
     const SIGMA_FLOOR_NEAR: f64 = 1.0e-3;
-    combined_additive_sigma_indices(&model.error_spec)
+    model
+        .error_spec
+        .combined_additive_sigma_indices()
         .into_iter()
         .any(|idx| {
             !params.sigma_fixed.get(idx).copied().unwrap_or(false)
@@ -1110,6 +1091,60 @@ fn combined_additive_sigma_at_floor(model: &CompiledModel, params: &ModelParamet
                     .unwrap_or(f64::INFINITY)
                     <= SIGMA_FLOOR_NEAR
         })
+}
+
+/// Apply the combined-error marginal polish (issue #267).
+///
+/// After SAEM, a final FOCEI marginal-likelihood optimization is run from the
+/// SAEM estimates. If the additive sigma stays pinned to its floor, the polish
+/// is retried from the model's initial parameters and the lower-OFV result is
+/// kept. The polish is adopted only when it strictly lowers the baseline
+/// marginal OFV `ofv`, so a polish that lands in a worse local optimum can
+/// never degrade the SAEM fit. On adoption, `final_params` and the EBE outputs
+/// are overwritten in place and the improved OFV is returned; otherwise `ofv`
+/// is returned unchanged.
+#[allow(clippy::too_many_arguments)]
+fn apply_combined_error_polish(
+    model: &CompiledModel,
+    population: &Population,
+    init_params: &ModelParameters,
+    options: &FitOptions,
+    ofv: f64,
+    final_params: &mut ModelParameters,
+    eta_hats: &mut Vec<DVector<f64>>,
+    h_matrices: &mut Vec<DMatrix<f64>>,
+    final_kappas: &mut Vec<Vec<DVector<f64>>>,
+    warnings: &mut Vec<String>,
+) -> f64 {
+    let mut polish_options = options.clone();
+    polish_options.run_covariance_step = false;
+    polish_options.verbose = false;
+    polish_options.optimizer = Optimizer::Bobyqa;
+    let mut polished = optimize_population(model, population, final_params, &polish_options);
+    if polished.ofv.is_finite() && combined_additive_sigma_at_floor(model, &polished.params) {
+        let restart = optimize_population(model, population, init_params, &polish_options);
+        if restart.ofv.is_finite() && restart.ofv < polished.ofv {
+            warnings.push(
+                "SAEM combined-error marginal polish restarted from initial parameters \
+                 because the additive sigma remained at its lower bound."
+                    .to_string(),
+            );
+            polished = restart;
+        }
+    }
+    // `OuterResult.ofv` is the marginal -2LL on the same scale as `ofv` (both
+    // `2 * pop_nll` under `options.interaction`), so adopt the polish only when
+    // it genuinely improves the marginal likelihood — never when it merely
+    // matches or lands in a worse local optimum.
+    if polished.ofv.is_finite() && polished.ofv < ofv {
+        warnings.extend(polished.warnings);
+        *final_params = polished.params;
+        *eta_hats = polished.eta_hats;
+        *h_matrices = polished.h_matrices;
+        *final_kappas = polished.kappas;
+        return polished.ofv;
+    }
+    ofv
 }
 
 /// Build (theta_idx, eta_idx) pairs for log-transformed mu-references only.
@@ -2175,7 +2210,7 @@ pub fn run_saem(
         kappa_fixed: init_params.kappa_fixed.clone(),
     };
 
-    let run_marginal_polish = error_spec_has_combined(&model.error_spec);
+    let run_marginal_polish = model.error_spec.has_combined();
 
     // ---- Final EBEs via inner loop (warm-started from SAEM etas) ----
     let warm_etas: Vec<DVector<f64>> = state
@@ -2195,34 +2230,11 @@ pub fn run_saem(
         0, // SAEM: no EBE convergence tracking
     );
 
-    if run_marginal_polish {
-        let mut polish_options = options.clone();
-        polish_options.run_covariance_step = false;
-        polish_options.verbose = false;
-        polish_options.optimizer = Optimizer::Bobyqa;
-        let mut polished = optimize_population(model, population, &final_params, &polish_options);
-        if polished.ofv.is_finite() && combined_additive_sigma_at_floor(model, &polished.params) {
-            let restart = optimize_population(model, population, init_params, &polish_options);
-            if restart.ofv.is_finite() && restart.ofv < polished.ofv {
-                warnings.push(
-                    "SAEM combined-error marginal polish restarted from initial parameters \
-                     because the additive sigma remained at its lower bound."
-                        .to_string(),
-                );
-                polished = restart;
-            }
-        }
-        if polished.ofv.is_finite() {
-            warnings.extend(polished.warnings);
-            final_params = polished.params;
-            eta_hats = polished.eta_hats;
-            h_matrices = polished.h_matrices;
-            final_kappas = polished.kappas;
-        }
-    }
-
     // ---- Final OFV via FOCE approximation (for AIC/BIC comparability) ----
-    let ofv = 2.0
+    // Baseline marginal -2LL from the SAEM warm-started EBEs. The combined-error
+    // polish below only replaces it when it strictly lowers this OFV, so a
+    // polish that lands in a worse local optimum can never degrade the SAEM fit.
+    let mut ofv = 2.0
         * pop_nll(
             model,
             population,
@@ -2232,6 +2244,21 @@ pub fn run_saem(
             &final_kappas,
             options.interaction,
         );
+
+    if run_marginal_polish {
+        ofv = apply_combined_error_polish(
+            model,
+            population,
+            init_params,
+            options,
+            ofv,
+            &mut final_params,
+            &mut eta_hats,
+            &mut h_matrices,
+            &mut final_kappas,
+            &mut warnings,
+        );
+    }
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
@@ -2339,6 +2366,199 @@ mod tests {
             matches!(MSTEP_NLOPT_ALGORITHM, nlopt::Algorithm::Bobyqa),
             "MSTEP_NLOPT_ALGORITHM changed — see comment above this test \
              for the Emax-Hill identifiability rationale before adjusting."
+        );
+    }
+
+    /// `combined_additive_sigma_at_floor` flags only a free additive component
+    /// (sigma index 1) sitting at/below the near-floor band, and ignores
+    /// non-combined specs and FIXed sigmas.
+    #[test]
+    fn combined_additive_sigma_at_floor_detects_collapsed_free_additive() {
+        let mut model = analytical_model(GradientMethod::Fd);
+        model.error_spec = ErrorSpec::Single(ErrorModel::Combined);
+
+        let mut params = model.default_params.clone();
+        params.sigma = SigmaVector {
+            values: vec![0.1, 0.5],
+            names: vec!["PROP".into(), "ADD".into()],
+        };
+        params.sigma_fixed = vec![false, false];
+
+        // Healthy additive term well above the floor band.
+        assert!(!combined_additive_sigma_at_floor(&model, &params));
+
+        // Additive term collapsed onto the floor → flagged.
+        params.sigma.values[1] = 5.0e-4;
+        assert!(combined_additive_sigma_at_floor(&model, &params));
+
+        // A FIXed additive at the floor is intentional, not a collapse.
+        params.sigma_fixed[1] = true;
+        assert!(!combined_additive_sigma_at_floor(&model, &params));
+
+        // Non-combined specs never flag, even with a tiny second sigma.
+        params.sigma_fixed[1] = false;
+        model.error_spec = ErrorSpec::Single(ErrorModel::Proportional);
+        assert!(!combined_additive_sigma_at_floor(&model, &params));
+    }
+
+    /// A tiny combined-error 1-cpt IV fixture (3 subjects, 3 obs each) used by
+    /// the combined-error polish tests below.
+    fn tiny_combined_fixture() -> (CompiledModel, Population) {
+        use crate::parser::model_parser::parse_model_string;
+        use std::collections::HashMap;
+
+        const COMBINED: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 20.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.05
+  sigma PROP_ERR ~ 0.1 (sd)
+  sigma ADD_ERR  ~ 1.0 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ combined(PROP_ERR, ADD_ERR)
+"#;
+        let model = parse_model_string(COMBINED).expect("combined model parses");
+        let subjects = (0..3)
+            .map(|_| Subject {
+                id: "S1".into(),
+                doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                obs_times: vec![1.0, 4.0, 8.0],
+                obs_raw_times: Vec::new(),
+                observations: vec![9.0, 6.0, 4.0],
+                obs_cmts: vec![1, 1, 1],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0, 0, 0],
+                occasions: vec![1, 1, 1],
+                dose_occasions: vec![1],
+                fremtype: Vec::new(),
+                #[cfg(feature = "survival")]
+                obs_records: vec![],
+            })
+            .collect();
+        let population = Population {
+            subjects,
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+        (model, population)
+    }
+
+    /// Driving SAEM on the combined-error fixture exercises the marginal-polish
+    /// call site in `run_saem` end-to-end: a finite OFV must come back and the
+    /// model must report a combined error spec (Tier-1: 2 SAEM iters/phase, no
+    /// convergence loop).
+    #[test]
+    fn run_saem_combined_executes_marginal_polish() {
+        let (model, population) = tiny_combined_fixture();
+        assert!(model.error_spec.has_combined());
+
+        let opts = FitOptions {
+            method: EstimationMethod::Saem,
+            outer_maxiter: 3,
+            saem_n_exploration: 2,
+            saem_n_convergence: 2,
+            saem_seed: Some(267),
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+
+        let result = run_saem(&model, &population, &model.default_params, &opts)
+            .expect("SAEM run must succeed");
+        assert!(result.ofv.is_finite(), "SAEM produced a non-finite OFV");
+        assert_eq!(result.eta_hats.len(), population.subjects.len());
+        // Two free sigmas (PROP, ADD) survive the polish.
+        assert_eq!(result.params.sigma.values.len(), 2);
+    }
+
+    /// `apply_combined_error_polish` runs a fast FOCEI polish on a tiny
+    /// combined-error problem and adopts it only when it strictly lowers the
+    /// baseline marginal OFV. Drives both the adopt and reject branches
+    /// end-to-end (Tier-1: a handful of outer iterations, no convergence loop).
+    #[test]
+    fn apply_combined_error_polish_adopts_only_on_improvement() {
+        let (model, population) = tiny_combined_fixture();
+        assert!(model.error_spec.has_combined());
+
+        let opts = FitOptions {
+            method: EstimationMethod::Saem,
+            outer_maxiter: 5,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+
+        let n = population.subjects.len();
+        let zero_eta = vec![DVector::<f64>::zeros(model.n_eta); n];
+        let zero_h = vec![DMatrix::<f64>::identity(model.n_eta, model.n_eta); n];
+        let zero_kappa: Vec<Vec<DVector<f64>>> = vec![Vec::new(); n];
+
+        // Adopt branch: baseline OFV = +inf, so any finite polish strictly
+        // improves and overwrites the params/EBEs.
+        let mut params = model.default_params.clone();
+        let mut eta = zero_eta.clone();
+        let mut h = zero_h.clone();
+        let mut kappa = zero_kappa.clone();
+        let mut warnings = Vec::new();
+        let improved = apply_combined_error_polish(
+            &model,
+            &population,
+            &model.default_params,
+            &opts,
+            f64::INFINITY,
+            &mut params,
+            &mut eta,
+            &mut h,
+            &mut kappa,
+            &mut warnings,
+        );
+        assert!(improved.is_finite(), "polish must yield a finite OFV");
+        assert!(improved < f64::INFINITY);
+        assert_eq!(eta.len(), n, "EBEs replaced for every subject");
+
+        // Reject branch: baseline OFV = -inf can never be beaten, so the polish
+        // is discarded and the inputs are returned untouched.
+        let mut params2 = model.default_params.clone();
+        let mut eta2 = zero_eta.clone();
+        let mut h2 = zero_h.clone();
+        let mut kappa2 = zero_kappa.clone();
+        let mut warnings2 = Vec::new();
+        let unchanged = apply_combined_error_polish(
+            &model,
+            &population,
+            &model.default_params,
+            &opts,
+            f64::NEG_INFINITY,
+            &mut params2,
+            &mut eta2,
+            &mut h2,
+            &mut kappa2,
+            &mut warnings2,
+        );
+        assert_eq!(
+            unchanged,
+            f64::NEG_INFINITY,
+            "a worse polish must not be adopted"
+        );
+        assert_eq!(
+            params2.sigma.values, model.default_params.sigma.values,
+            "rejected polish must leave params untouched"
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1377,6 +1377,39 @@ impl ErrorSpec {
         }
     }
 
+    /// True when any endpoint uses a `combined(PROP, ADD)` residual-error model.
+    pub fn has_combined(&self) -> bool {
+        match self {
+            ErrorSpec::Single(em) => matches!(em, ErrorModel::Combined),
+            ErrorSpec::PerCmt(map) => map
+                .values()
+                .any(|ep| matches!(ep.error_model, ErrorModel::Combined)),
+        }
+    }
+
+    /// Global `sigma.values` indices of the additive component of every
+    /// `Combined` endpoint (the second sigma slot). De-duplicated; empty when
+    /// no endpoint is combined.
+    pub fn combined_additive_sigma_indices(&self) -> Vec<usize> {
+        match self {
+            ErrorSpec::Single(ErrorModel::Combined) => vec![1],
+            ErrorSpec::Single(_) => Vec::new(),
+            ErrorSpec::PerCmt(map) => {
+                let mut out = Vec::new();
+                for endpoint in map.values() {
+                    if matches!(endpoint.error_model, ErrorModel::Combined) {
+                        if let Some(&idx) = endpoint.sigma_idx.get(1) {
+                            if !out.contains(&idx) {
+                                out.push(idx);
+                            }
+                        }
+                    }
+                }
+                out
+            }
+        }
+    }
+
     pub fn variance_at(&self, cmt: usize, f_pred: f64, sigma: &[f64]) -> f64 {
         use crate::stats::residual_error::residual_variance;
         match self {
@@ -4230,6 +4263,73 @@ mod tests {
         mixed.insert(1usize, ep(ErrorModel::Additive));
         mixed.insert(2usize, ep(ErrorModel::Proportional));
         assert!(ErrorSpec::PerCmt(mixed).has_f_dependent_variance());
+    }
+
+    #[test]
+    fn error_spec_has_combined_detects_combined_endpoints() {
+        use std::collections::HashMap;
+        // Single endpoint: only `Combined` is combined.
+        assert!(!ErrorSpec::Single(ErrorModel::Additive).has_combined());
+        assert!(!ErrorSpec::Single(ErrorModel::Proportional).has_combined());
+        assert!(ErrorSpec::Single(ErrorModel::Combined).has_combined());
+
+        let ep = |em: ErrorModel, idx: Vec<usize>| EndpointError {
+            error_model: em,
+            sigma_idx: idx,
+        };
+
+        // PerCmt: combined if ANY endpoint is combined.
+        let mut none = HashMap::new();
+        none.insert(1usize, ep(ErrorModel::Additive, vec![0]));
+        none.insert(2usize, ep(ErrorModel::Proportional, vec![1]));
+        assert!(!ErrorSpec::PerCmt(none).has_combined());
+
+        let mut some = HashMap::new();
+        some.insert(1usize, ep(ErrorModel::Proportional, vec![0]));
+        some.insert(2usize, ep(ErrorModel::Combined, vec![1, 2]));
+        assert!(ErrorSpec::PerCmt(some).has_combined());
+    }
+
+    #[test]
+    fn combined_additive_sigma_indices_picks_second_slot() {
+        use std::collections::HashMap;
+        // Single combined: additive component is sigma index 1.
+        assert_eq!(
+            ErrorSpec::Single(ErrorModel::Combined).combined_additive_sigma_indices(),
+            vec![1]
+        );
+        // Non-combined single specs have no additive-combined slot.
+        assert!(ErrorSpec::Single(ErrorModel::Additive)
+            .combined_additive_sigma_indices()
+            .is_empty());
+        assert!(ErrorSpec::Single(ErrorModel::Proportional)
+            .combined_additive_sigma_indices()
+            .is_empty());
+
+        let ep = |em: ErrorModel, idx: Vec<usize>| EndpointError {
+            error_model: em,
+            sigma_idx: idx,
+        };
+
+        // PerCmt: returns the global index of each combined endpoint's
+        // second sigma slot, de-duplicated; non-combined endpoints contribute
+        // nothing.
+        let mut map = HashMap::new();
+        map.insert(1usize, ep(ErrorModel::Proportional, vec![0]));
+        map.insert(2usize, ep(ErrorModel::Combined, vec![1, 3]));
+        let mut got = ErrorSpec::PerCmt(map).combined_additive_sigma_indices();
+        got.sort_unstable();
+        assert_eq!(got, vec![3]);
+
+        // Two combined endpoints that share the same additive sigma index
+        // collapse to a single entry.
+        let mut shared = HashMap::new();
+        shared.insert(1usize, ep(ErrorModel::Combined, vec![0, 2]));
+        shared.insert(2usize, ep(ErrorModel::Combined, vec![1, 2]));
+        assert_eq!(
+            ErrorSpec::PerCmt(shared).combined_additive_sigma_indices(),
+            vec![2]
+        );
     }
 
     #[test]

--- a/tests/saem_combined_error.rs
+++ b/tests/saem_combined_error.rs
@@ -1,0 +1,112 @@
+//! Slow regression test for issue #267: SAEM must not collapse the additive
+//! component of a combined residual-error model.
+
+use ferx_core::parser::model_parser::parse_model_string;
+use ferx_core::types::{DoseEvent, OmegaMatrix, Population};
+use ferx_core::{fit, simulate_with_seed, EstimationMethod, FitOptions};
+
+mod common;
+
+const MODEL: &str = r#"
+[parameters]
+  theta TVCL(3.0, 0.1, 20.0)
+  theta TVV(30.0, 1.0, 200.0)
+  omega ETA_CL ~ 0.08
+  omega ETA_V  ~ 0.08
+  sigma PROP_ERR ~ 0.05 (sd)
+  sigma ADD_ERR  ~ 2.00 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ combined(PROP_ERR, ADD_ERR)
+"#;
+
+fn template_population(n: usize) -> Population {
+    let times = [0.5_f64, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0, 36.0];
+    let subjects = (1..=n)
+        .map(|i| {
+            common::subject(
+                &format!("{i}"),
+                vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                times.to_vec(),
+                vec![0.0; times.len()],
+                vec![1; times.len()],
+            )
+        })
+        .collect();
+
+    Population {
+        subjects,
+        covariate_names: vec![],
+        dv_column: "dv".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+fn simulated_population(model: &ferx_core::types::CompiledModel) -> Population {
+    let template = template_population(32);
+    let mut truth = model.default_params.clone();
+    truth.theta = vec![3.0, 30.0];
+    truth.omega = OmegaMatrix::from_diagonal(&[0.08, 0.08], vec!["ETA_CL".into(), "ETA_V".into()]);
+    truth.sigma.values = vec![0.05, 3.00];
+
+    let sim = simulate_with_seed(model, &template, &truth, 1, 20260619);
+    let mut pop = template;
+    for subj in pop.subjects.iter_mut() {
+        subj.observations = sim
+            .iter()
+            .filter(|row| row.id == subj.id)
+            .map(|row| row.outcome.continuous_value())
+            .collect();
+    }
+    pop
+}
+
+fn fit_with(
+    method: EstimationMethod,
+    model: &ferx_core::types::CompiledModel,
+    pop: &Population,
+) -> f64 {
+    let mut opts = FitOptions::default();
+    opts.method = method;
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+    opts.outer_maxiter = 300;
+    opts.saem_n_exploration = 80;
+    opts.saem_n_convergence = 80;
+    opts.saem_seed = Some(267);
+
+    let result = fit(model, pop, &model.default_params, &opts).expect("fit must succeed");
+    result.sigma[1]
+}
+
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn saem_combined_error_additive_sigma_matches_focei() {
+    let model = parse_model_string(MODEL).expect("combined model parses");
+    let pop = simulated_population(&model);
+
+    let focei_add = fit_with(EstimationMethod::FoceI, &model, &pop);
+    let saem_add = fit_with(EstimationMethod::Saem, &model, &pop);
+
+    assert!(
+        focei_add > 0.75,
+        "fixture must identify a non-trivial additive sigma; FOCEI ADD={focei_add}"
+    );
+    let rel = (saem_add - focei_add).abs() / focei_add;
+    assert!(
+        rel < 0.35,
+        "SAEM ADD should stay close to FOCEI, not collapse: SAEM={saem_add}, FOCEI={focei_add}, rel={rel:.3}"
+    );
+}


### PR DESCRIPTION
## Why
SAEM still reproduced #267: on the cefepime combined-error reproducer, the
additive residual-error component collapsed to the sigma lower bound
(`ADD_ERR = 0.000335`) while FOCEI identified a non-zero additive term
(`ADD_ERR ≈ 1.554`).

FOCEI and SAEM should target the same marginal MLE for this model class. The
failure came from the point-eta SAEM theta/sigma M-step overfitting the
low-concentration tail and making the additive component look unnecessary.

## What changed
- Added a final marginal-likelihood polish for SAEM fits with
  `combined(PROP, ADD)` residual error.
- The polish runs the existing FOCEI population optimizer from the SAEM
  estimates with covariance disabled.
- If a free additive component remains effectively at the lower bound, ferx
  retries the same marginal polish from the model's initial parameters and keeps
  the lower marginal OFV.
- Added a slow synthetic regression test that compares SAEM's additive sigma to
  FOCEI on a combined-error model with an identifiable additive component.
- Documented the finalization behavior and added a changelog entry.

## Alternatives considered
I first tried smoothing the SAEM log-sigma M-step with a Robbins-Monro cap,
analogous to the existing omega damping. That removed one lower-bound hit on a
small warfarin stress case but did not fix the real cefepime reproducer: the
SAEM theta/omega point had already moved into a basin where sigma-only polishing
still preferred the additive lower bound. A full marginal polish is the narrower
way to align the reported SAEM result with the FOCEI/Laplace marginal objective
ferx already uses for final OFV/AIC/BIC.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

No migration needed.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx FOCEI output and issue #267 cefepime reproducer
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# issue #267 cefepime reproducer
FOCEI reference ADD_ERR: 1.554007
SAEM before:            0.000335
SAEM after:             1.561627

FOCEI reference OFV:    4367.771640
SAEM after OFV:         4367.2020
```

- [ ] Not applicable (docs / refactor / CI only)

GN/GN-hybrid do not use SAEM's point-eta sigma M-step, so this specific collapse
mechanism is SAEM-specific.

## Performance
- [ ] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [x] Slower — justified because: SAEM combined-error fits now perform a final
      marginal polish. Additive/proportional-only SAEM is unchanged, and the
      polish is limited to the model class affected by #267.

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Commands run:

```
/Users/ron/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustfmt src/estimation/saem.rs tests/saem_combined_error.rs
cargo test --profile ci-test --no-default-features --features ci --lib
cargo test --profile ci-test --no-default-features --features ci,slow-tests --test saem_combined_error -- --nocapture
```

Note: `cargo fmt` is unavailable on the custom `enzyme` toolchain in this
checkout, so stable `rustfmt` was used directly.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# .ferx snippet demonstrating the new feature

```

```
# expected key output (theta / omega / OFV or sdtab excerpt)

```

</details>

## Docs
- [x] `docs/src/` updated for user-visible changes
- [ ] New pages linked in `docs/src/SUMMARY.md` (do **not** commit `docs/book/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [ ] `cargo check --features autodiff` still compiles (if touching AD-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && FERX_NO_AUTODIFF=1 R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints
The important path is in `run_saem` finalization: the iterative SAEM estimates
are left alone until final EBEs are available, then only combined-error models
take the FOCEI marginal polish. The fallback restart exists specifically for the
cefepime #267 basin where polishing from the SAEM point still left `ADD_ERR`
pinned.

## Open questions
None.
