### PR TITLE
chore(deps): bump nalgebra to 0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,11 @@ section of the SDLC for the versioning policy).
   the dose without appearing in the RHS, are exempt (#315).
 
 ### Changed
+- Bumped `nalgebra` to 0.35 (from 0.34). The `argmin-math` dependency now uses
+  its `vec` feature instead of `nalgebra_latest`, since the argmin trust-region
+  path operates on `Vec` params and never on `nalgebra` types — this avoids
+  pulling a second, conflicting `nalgebra` version into the graph. Downstream
+  Rust consumers (e.g. `ferx-r`) must move to `nalgebra` 0.35 in lockstep.
 - IMP fit options now use the `imp_*` prefix (`imp_samples`,
   `imp_eval_only`, `imp_auto`, etc.) instead of the older `is_*` names. The
   old names are not retained as aliases because IMP support is still new.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,6 @@ checksum = "ba6958a87117ff5e1d0d7716856a4303752518012ec4a67a68446b6631a1a54d"
 dependencies = [
  "anyhow",
  "cfg-if",
- "nalgebra",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -346,96 +345,6 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
-
-[[package]]
-name = "glam"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
-
-[[package]]
-name = "glam"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
-
-[[package]]
-name = "glam"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
-
-[[package]]
-name = "glam"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
-
-[[package]]
-name = "glam"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
-
-[[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-
-[[package]]
-name = "glam"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
-
-[[package]]
-name = "glam"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
-
-[[package]]
-name = "glam"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
-
-[[package]]
-name = "glam"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
-
-[[package]]
-name = "glam"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-
-[[package]]
-name = "glam"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
-
-[[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-
-[[package]]
-name = "glam"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
-
-[[package]]
-name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
@@ -451,6 +360,12 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
 
 [[package]]
 name = "hashbrown"
@@ -556,29 +471,15 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.34.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
- "glam 0.14.0",
- "glam 0.15.2",
- "glam 0.16.0",
- "glam 0.17.3",
- "glam 0.18.0",
- "glam 0.19.0",
- "glam 0.20.5",
- "glam 0.21.3",
- "glam 0.22.0",
- "glam 0.23.0",
- "glam 0.24.2",
- "glam 0.25.0",
- "glam 0.27.0",
- "glam 0.28.0",
- "glam 0.29.3",
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
+ "glam 0.33.1",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -869,9 +770,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -938,14 +839,13 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simba"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
  "wide",
 ]
 
@@ -1099,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ survival = []
 slow-tests = []
 
 [dependencies]
-nalgebra = "0.34"
+nalgebra = "0.35"
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -41,7 +41,7 @@ regex = "1.11"
 thiserror = "2"
 nlopt = "0.8"
 argmin = { version = "0.11", features = ["serde1"] }
-argmin-math = { version = "0.5", features = ["nalgebra_latest"] }
+argmin-math = { version = "0.5", features = ["vec"] }
 tempfile = "3"
 sha2 = "0.10"
 sobol = "1.0"


### PR DESCRIPTION
## Why
The dependabot bump of `nalgebra` 0.34 → 0.35 in **ferx-r** (FeRx-NLME/ferx-r#177)
fails CI with `error[E0308]: mismatched types ... multiple different versions of
crate nalgebra in the dependency graph`. `nalgebra` is a shared public dependency:
ferx-r's Rust glue constructs `nalgebra::DMatrix` values (e.g. `omega_init`) and
passes them to ferx-core APIs typed with nalgebra **0.34**. Bumping ferx-r alone
puts two incompatible nalgebra versions in one graph. ferx-core has to move to 0.35
first.

## What changed
- `nalgebra` 0.34 → 0.35 (pulls simba 0.10, wide 1.5, glam 0.33).
- `argmin-math` feature `nalgebra_latest` → `vec`. The argmin trust-region path
  (`estimation/trust_region.rs`) uses `Vec<f64>` params and never touches nalgebra
  types (see the comment at `trust_region.rs:141`), so the `nalgebra_latest` feature
  was vestigial — and it was the *only* thing pinning a second nalgebra 0.34 into the
  graph (the latest argmin-math, 0.5.1, still resolves `nalgebra_latest` to 0.34).
  With it dropped, the graph resolves to a single nalgebra 0.35.

## Alternatives considered
Keeping `nalgebra_latest` and waiting for an argmin-math release that supports
nalgebra 0.35 — none exists (0.5.1 is latest). Closing #177 and pinning nalgebra
0.34 via a dependabot ignore — defers the bump indefinitely. The `vec`-feature swap
unblocks now with no behavioural change.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#177 | open | after (needs the ferx-core lock bumped to this commit) |

## Breaking changes
- [x] None

(Public Rust API surface is unchanged; only the nalgebra *version* exposed through
it moves. Downstream Rust consumers must adopt nalgebra 0.35 in lockstep — noted in
the CHANGELOG.)

## Numerical validation
- [x] Not applicable (dependency bump; no estimator/PK/stats logic changed)

`cargo check` passes clean. (`cargo test --lib` ICEs locally on the enzyme toolchain
over the autodiff feature — pre-existing, identical on `main`, unrelated to this
change.)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (dependency version bump; existing suite exercises the code)

## Example (user-facing features only)
- [x] Not applicable (internal / dependency bump)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (under Changed)
- [x] No other user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] `Cargo.toml` version not bumped (non-breaking)

## Reviewer hints
The load-bearing claim is that `argmin-math`'s `nalgebra_latest` feature is unused by
our argmin usage — confirmed by `trust_region.rs:141` ("use Vec ... avoiding nalgebra
version conflicts") and `cargo tree`, which shows nalgebra 0.34 vanishing from the
graph once the feature is dropped.

## Open questions
None.
