### PR TITLE
docs(pk): refresh absorption.rs header for sens/Dual2 (Enzyme retired)

### DIFF
--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -6,11 +6,16 @@
 //! dose); per-dose contributions are superposed by the caller.
 //!
 //! These are the inherently-numerical absorption models that feed an explicit
-//! ODE disposition (see `plans/absorption-models.md`). They are AD/Enzyme-safe
-//! (only `+ − * /`, `.ln()`, `.exp()`; no `f64::max`/`min` intrinsics — see
-//! CLAUDE.md). Written for `f64` for now; a shared numeric trait for the
-//! `Dual`/Enzyme paths follows when these are wired into the autodiff ODE
-//! gradient (the roadmap's escape hatch — duplicate-free generics later).
+//! ODE disposition (see `plans/absorption-models.md`). They use only
+//! `+ − * /`, `.ln()`, `.exp()`, `.sqrt()`, and `ln_gamma`. Written for `f64`:
+//! a `transit()`/`igd()` model currently differentiates by finite differences,
+//! because the built-in input-rate forcing is on `sens/ode_provider.rs`'s
+//! not-yet-supported list and falls back to FD (rather than being evaluated
+//! over `Dual2`). Making `PreparedInputRate::rate` (and the `ln_gamma` it calls)
+//! generic over the `PkNum` trait — the `sens/` `*_g<T>` convention — would let
+//! the ODE forcing inherit exact analytic sensitivities. (The Enzyme `autodiff`
+//! path these once targeted was retired in #367/#381; `Dual2` handles `max`/`min`
+//! by comparison, so the old `f64::max`/`min` restriction no longer applies.)
 
 use crate::stats::special::ln_gamma;
 


### PR DESCRIPTION
## Why

The `src/pk/absorption.rs` module header still described the input-rate functions as
"AD/Enzyme-safe" and promised a "`Dual`/Enzyme" numeric trait "when these are wired into the
autodiff ODE gradient (the roadmap's escape hatch)." Both are obsolete: the Enzyme autodiff
path (`src/ad/`, the `autodiff` feature) was **retired** in #367/#381 in favour of the `sens/`
`Dual2` engine. The stale header misdescribes how `transit()` / `igd()` are differentiated
today and points at machinery that no longer exists.

## What changed

Comment-only edit to the module header. It now states the current reality:

- the input functions are `f64`-only, so a `transit()` / `igd()` model differentiates by
  **finite differences** — because the built-in input-rate forcing is on
  `sens/ode_provider.rs`'s *not-yet-supported* list (FD fallback), not because no autodiff ODE
  path exists (one does, over `Dual2`);
- making `PreparedInputRate::rate` (and the `ln_gamma` it calls) generic over the `PkNum`
  trait — the `sens/` `*_g<T>` convention — would let the ODE forcing inherit exact analytic
  sensitivities;
- the old `f64::max`/`min` Enzyme-intrinsic restriction no longer applies (`Dual2` handles
  `max`/`min` by comparison).

No behavioural change.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / comment only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (comment-only documentation change; no code path altered)

## Docs
- [x] No user-visible change
- [x] `CHANGELOG.md` N/A (internal module comment)

## Checklist
- [x] `cargo clippy` clean (comment-only; no code change)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (no gradient-reachable code touched)
- [x] No version bump needed

## Example execution
- [x] No example execution step needed (docs-only / no user-visible change)

## Reviewer hints

One-paragraph module doc comment; the substance is that it now matches the post-#367
`sens/`/`Dual2` reality and names the concrete `PkNum`-generic follow-up for giving the
absorption forcing exact sensitivities. A companion update to `plans/absorption-models.md`
(same Enzyme-retirement cleanup, plus refreshed phase status and the inverted Phase 0a finding)
lives on the `docs/absorption-plan-analytical-tilting` branch.
