### PR TITLE
feat(sens): analytic Dual2 sensitivities for igd() absorption forcing [#430]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ rustc-ice-*.txt
 .archive/
 
 # Built documentation output — generated and deployed by CI (.github/workflows/docs.yml)
-docs/book/
 docs/_site/
 bench_*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ section of the SDLC for the versioning policy).
   gradient differentiates the scaled prediction `f / scale` exactly (quotient
   rule) instead of falling back to finite differences. Validated against finite
   differences of the production predictor and against a NONMEM reference (#367).
+- **Analytic sensitivities for inverse-Gaussian (`igd()`) absorption** on ODE
+  models: the built-in input-rate forcing is now evaluated over `Dual2` by the
+  analytic ODE sensitivity provider, so an `igd()` model drives exact FOCE/FOCEI/
+  Bayes gradients instead of falling back to finite differences (estimates
+  unchanged; gradients exact and cheaper). The forcing was lifted to a
+  `PkNum`-generic form; transit (`transit()`) still uses FD pending its own
+  `ln_gamma` `Dual2` rule. Validated by an analytic≡central-FD gradient parity
+  test in the default build (#430).
 
 ### Changed
 - **Documentation now builds as a Quarto website** using the shared ferx site

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -17,6 +17,7 @@
 //! path these once targeted was retired in #367/#381; `Dual2` handles `max`/`min`
 //! by comparison, so the old `f64::max`/`min` restriction no longer applies.)
 
+use crate::sens::num::PkNum;
 use crate::stats::special::ln_gamma;
 
 /// `ln(2π)` — the inverse-Gaussian log-density normalisation constant. A literal
@@ -116,6 +117,17 @@ pub enum InputRateKind {
     InverseGaussian,
 }
 
+impl InputRateKind {
+    /// Whether this kind's input-rate forcing has been lifted to `PkNum`/`Dual2`
+    /// so the analytic ODE sensitivity provider (`sens/ode_provider.rs`) can
+    /// evaluate it over dual numbers; otherwise a model using it stays on the FD
+    /// fallback. #430 lifts inverse-Gaussian first (no new special function);
+    /// transit follows once `ln_gamma` has a `Dual2` rule, Weibull with Phase 2.
+    pub fn supported_over_dual(self) -> bool {
+        matches!(self, InputRateKind::InverseGaussian)
+    }
+}
+
 /// A built-in absorption input-rate term attached to one ODE compartment.
 ///
 /// Design A (see `plans/absorption-models.md`): the input-rate function is split
@@ -135,14 +147,17 @@ pub struct InputRateForcing {
 
 impl InputRateForcing {
     /// Read this forcing's argument `i` from the flat individual-parameter
-    /// vector `params`, falling back to `dflt` if the slot is absent.
+    /// vector `params`, falling back to `dflt` if the slot is absent. Generic
+    /// over `T: PkNum` so the same reader serves the `f64` prediction path and
+    /// the `Dual2<N>` sensitivity provider (`params` is then the dual
+    /// individual-parameter vector).
     #[inline]
-    fn arg(&self, params: &[f64], i: usize, dflt: f64) -> f64 {
+    fn arg<T: PkNum>(&self, params: &[T], i: usize, dflt: f64) -> T {
         self.arg_slots
             .get(i)
             .and_then(|&s| params.get(s))
             .copied()
-            .unwrap_or(dflt)
+            .unwrap_or(T::from_f64(dflt))
     }
 
     /// Precompute the dose-invariant constants for this forcing's parameters
@@ -177,90 +192,88 @@ impl InputRateForcing {
             }
         }
     }
+
+    /// Build the prepared input-rate constants over `T: PkNum` (e.g.
+    /// `T = Dual2<N>` for the analytic ODE sensitivity provider, #430) from the
+    /// individual-parameter vector `params` — laid out identically to the `f64`
+    /// [`Self::prepare`] input, so `arg_slots` index the same way. Returns `None`
+    /// for kinds not yet lifted to `PkNum` (transit, until its `ln_gamma`
+    /// `Dual2` rule lands), so the provider keeps those on the FD fallback;
+    /// [`InputRateKind::supported_over_dual`] gates which kinds reach here.
+    pub fn prepare_dual<T: PkNum>(&self, params: &[T]) -> Option<PreparedInputRate<T>> {
+        match self.kind {
+            InputRateKind::InverseGaussian => Some(PreparedInputRate::inverse_gaussian(
+                self.arg(params, 0, 1.0),
+                self.arg(params, 1, 1.0),
+            )),
+            InputRateKind::Transit => None,
+        }
+    }
 }
 
 /// An input-rate forcing with its dose-invariant constants precomputed for the
 /// ODE hot path. Built once per RHS evaluation by [`InputRateForcing::prepare`];
 /// [`Self::rate`] then costs only the `tad`/`dose`-dependent arithmetic per dose.
+/// Generic over the numeric type `T`: `T = f64` for predictions, `T = Dual2<N>`
+/// for the analytic ODE sensitivity provider (#430). The default `T = f64` keeps
+/// every existing scalar call site (`PreparedInputRate`) unchanged.
 #[derive(Debug, Clone, Copy)]
-pub enum PreparedInputRate {
+pub enum PreparedInputRate<T = f64> {
     /// Savic transit constants: `KTR`, `ln KTR`, `n`, and `ln Γ(n + 1)`.
     Transit {
-        ktr: f64,
-        ln_ktr: f64,
-        n: f64,
-        ln_gamma_np1: f64,
+        ktr: T,
+        ln_ktr: T,
+        n: T,
+        ln_gamma_np1: T,
     },
     /// Inverse-Gaussian constants: the mean `mat`, the dose-invariant log
     /// prefactor `c0 = ½·(ln mat − ln 2π − ln cv2)`, and `inv_2cv2mat
     /// = 1/(2·cv2·mat)`. (`cv2` is folded into `c0`/`inv_2cv2mat`, so it is not
     /// stored separately.)
-    InverseGaussian { mat: f64, c0: f64, inv_2cv2mat: f64 },
+    InverseGaussian { mat: T, c0: T, inv_2cv2mat: T },
 }
 
-impl PreparedInputRate {
+impl<T: PkNum> PreparedInputRate<T> {
     /// Domain floor for the strictly-positive input-rate parameters (transit
     /// `mtt`; inverse-Gaussian `mat`, `cv2`) when clamping a transient mid-fit
-    /// excursion (see [`Self::transit`], [`Self::inverse_gaussian`]). Far below
+    /// excursion (see the `transit` / `inverse_gaussian` constructors). Far below
     /// any realistic value, so it never perturbs a converged fit — it only keeps
     /// a transient `≤ 0` from turning a `.ln()` / `1/x` into a `NaN`/`∞`. The
-    /// clamp itself is [`crate::types::clamp_above_floor`], shared with the
-    /// modeled-duration floor ([`crate::types::DoseEvent::DURATION_FLOOR`]) so the
-    /// domain-wall clamps can't drift apart.
+    /// generic clamp is [`PkNum::guard_floor`], which for `T = f64` is identical
+    /// to [`crate::types::clamp_above_floor`] (the modeled-duration floor) for
+    /// all inputs incl. `NaN`, so the domain-wall clamps can't drift apart.
     const MIN_PARAM: f64 = 1e-8;
-
-    /// Precompute the transit constants for `(n, mtt)`.
-    ///
-    /// The arguments are **clamped to the valid domain** (`mtt > 0`, `n ≥ 0`).
-    /// The fit-time guard ([`validate_transit`], wired into
-    /// `check_absorption_dosing`) already rejects an out-of-domain *typical*
-    /// value loudly; but during estimation the inner BFGS perturbs `eta` and the
-    /// outer FD step perturbs `theta`, so an additive parameterisation
-    /// (`MTT = TVMTT + ETA_MTT`) or a wide FD step can drive a transient
-    /// `mtt ≤ 0` / `n < 0` *mid-search*. Left unclamped that yields
-    /// `ktr.ln()` / `ln Γ(n+1) = NaN`, which propagates through the ODE RHS into
-    /// an opaque `NaN` OFV instead of a recoverable step. Clamping keeps `R_in`
-    /// finite at the domain wall so the optimiser can climb back to the interior;
-    /// the converged optimum is interior, so reported estimates are unaffected.
-    /// `NaN` inputs also fall to the floor (every `>`/`>=` is false for `NaN`).
-    #[inline]
-    fn transit(n: f64, mtt: f64) -> Self {
-        let mtt = crate::types::clamp_above_floor(mtt, Self::MIN_PARAM);
-        let n = if n >= 0.0 { n } else { 0.0 };
-        let ktr = (n + 1.0) / mtt;
-        PreparedInputRate::Transit {
-            ktr,
-            ln_ktr: ktr.ln(),
-            n,
-            ln_gamma_np1: ln_gamma(n + 1.0),
-        }
-    }
 
     /// Precompute the inverse-Gaussian constants for `(mat, cv2)`.
     ///
-    /// As with [`Self::transit`], the arguments are **clamped to the valid
-    /// domain** (`mat > 0`, `cv2 > 0`, floor [`Self::MIN_PARAM`]) so a transient
-    /// mid-search excursion (additive `eta`, wide FD step) yields a finite
-    /// `R_in` at the domain wall instead of a `NaN` (`ln`/`1/0`) that would
-    /// poison the ODE RHS; the converged optimum is interior, so reported
-    /// estimates are unaffected. `NaN` inputs also fall to the floor.
+    /// The arguments are **clamped to the valid domain** (`mat > 0`, `cv2 > 0`,
+    /// floor [`Self::MIN_PARAM`]) so a transient mid-search excursion (additive
+    /// `eta`, wide FD step) yields a finite `R_in` at the domain wall instead of
+    /// a `NaN` (`ln`/`1/0`) that would poison the ODE RHS; the converged optimum
+    /// is interior, so reported estimates are unaffected. `NaN` inputs also fall
+    /// to the floor. Generic over `T` (the `sens/` `*_g<T>` convention) so the
+    /// `Dual2` provider gets exact analytic sensitivities for `mat`/`cv2` — the
+    /// constants here use only `ln` / `+ − * /`, all on [`PkNum`].
     #[inline]
-    fn inverse_gaussian(mat: f64, cv2: f64) -> Self {
-        let mat = crate::types::clamp_above_floor(mat, Self::MIN_PARAM);
-        let cv2 = crate::types::clamp_above_floor(cv2, Self::MIN_PARAM);
+    fn inverse_gaussian(mat: T, cv2: T) -> Self {
+        let mat = mat.guard_floor(Self::MIN_PARAM);
+        let cv2 = cv2.guard_floor(Self::MIN_PARAM);
         PreparedInputRate::InverseGaussian {
             mat,
-            c0: 0.5 * (mat.ln() - LN_2PI - cv2.ln()),
-            inv_2cv2mat: 1.0 / (2.0 * cv2 * mat),
+            c0: T::from_f64(0.5) * (mat.ln() - T::from_f64(LN_2PI) - cv2.ln()),
+            inv_2cv2mat: T::from_f64(1.0) / (T::from_f64(2.0) * cv2 * mat),
         }
     }
 
     /// Appearance rate `R_in(tad)` for one dose (`dose = F · amt`). Per-dose
-    /// contributions are summed by the caller; `tad ≤ 0` or `dose ≤ 0 ⇒ 0`.
+    /// contributions are summed by the caller; `tad ≤ 0` or `dose ≤ 0 ⇒ 0` (the
+    /// guard branches on `.val()`, so for a `Dual2` it returns a flat zero). The
+    /// body uses only `ln`/`exp`/`+ − * /`, so it carries exact `Dual2`
+    /// sensitivities for `T = Dual2<N>` with no new special function (#430).
     #[inline]
-    pub fn rate(&self, tad: f64, dose: f64) -> f64 {
-        if tad <= 0.0 || dose <= 0.0 {
-            return 0.0;
+    pub fn rate(&self, tad: T, dose: T) -> T {
+        if tad.val() <= 0.0 || dose.val() <= 0.0 {
+            return T::from_f64(0.0);
         }
         match *self {
             // ln R_in = ln dose + ln KTR + n·ln(KTR·tad) − KTR·tad − ln Γ(n + 1).
@@ -286,8 +299,42 @@ impl PreparedInputRate {
                 inv_2cv2mat,
             } => {
                 let d = tad - mat;
-                (dose.ln() + c0 - 1.5 * tad.ln() - d * d * inv_2cv2mat / tad).exp()
+                (dose.ln() + c0 - T::from_f64(1.5) * tad.ln() - d * d * inv_2cv2mat / tad).exp()
             }
+        }
+    }
+}
+
+impl PreparedInputRate<f64> {
+    /// Precompute the transit constants for `(n, mtt)`.
+    ///
+    /// The arguments are **clamped to the valid domain** (`mtt > 0`, `n ≥ 0`).
+    /// The fit-time guard ([`validate_transit`], wired into
+    /// `check_absorption_dosing`) already rejects an out-of-domain *typical*
+    /// value loudly; but during estimation the inner BFGS perturbs `eta` and the
+    /// outer FD step perturbs `theta`, so an additive parameterisation
+    /// (`MTT = TVMTT + ETA_MTT`) or a wide FD step can drive a transient
+    /// `mtt ≤ 0` / `n < 0` *mid-search*. Left unclamped that yields
+    /// `ktr.ln()` / `ln Γ(n+1) = NaN`, which propagates through the ODE RHS into
+    /// an opaque `NaN` OFV instead of a recoverable step. Clamping keeps `R_in`
+    /// finite at the domain wall so the optimiser can climb back to the interior;
+    /// the converged optimum is interior, so reported estimates are unaffected.
+    /// `NaN` inputs also fall to the floor (every `>`/`>=` is false for `NaN`).
+    ///
+    /// `f64`-only for now: the `ln_gamma(n+1)` constant needs a `Dual2` rule
+    /// (digamma/trigamma) before transit can join the analytic provider path —
+    /// the slice-2 follow-up of #430. Until then a transit model differentiates
+    /// by FD (see [`InputRateKind::supported_over_dual`]).
+    #[inline]
+    fn transit(n: f64, mtt: f64) -> Self {
+        let mtt = crate::types::clamp_above_floor(mtt, Self::MIN_PARAM);
+        let n = if n >= 0.0 { n } else { 0.0 };
+        let ktr = (n + 1.0) / mtt;
+        PreparedInputRate::Transit {
+            ktr,
+            ln_ktr: ktr.ln(),
+            n,
+            ln_gamma_np1: ln_gamma(n + 1.0),
         }
     }
 }
@@ -618,5 +665,34 @@ mod tests {
         let mut bad_cv2 = ok.clone();
         bad_cv2[5] = 0.0;
         assert!(forcing.validate(&bad_cv2).unwrap_err().contains("cv2"));
+    }
+
+    /// `prepare_dual` lifts the IG forcing to a `PkNum` type (here `T = f64`),
+    /// reproducing the scalar `prepare` exactly, and returns `None` for transit —
+    /// not yet lifted, so the provider keeps it on the FD fallback (#430 slice 1).
+    #[test]
+    fn prepare_dual_lifts_ig_and_declines_transit() {
+        let ig = InputRateForcing {
+            cmt: 1,
+            kind: InputRateKind::InverseGaussian,
+            arg_slots: vec![4, 5], // mat @ 4, cv2 @ 5
+        };
+        let mut params = vec![0.0; crate::types::MAX_PK_PARAMS];
+        params[4] = 2.0; // mat
+        params[5] = 0.3; // cv2
+                         // T = f64: the lifted constants reproduce the scalar `prepare` exactly.
+        let lifted = ig.prepare_dual::<f64>(&params).expect("IG is lifted");
+        let scalar = ig.prepare(&params);
+        for &tad in &[0.0, 0.1, 1.0, 4.0, 12.0] {
+            assert_eq!(lifted.rate(tad, 100.0), scalar.rate(tad, 100.0));
+        }
+
+        // Transit is not lifted in slice 1 → None (provider falls back to FD).
+        let transit = InputRateForcing {
+            cmt: 0,
+            kind: InputRateKind::Transit,
+            arg_slots: vec![6, 7],
+        };
+        assert!(transit.prepare_dual::<f64>(&params).is_none());
     }
 }

--- a/src/sens/num.rs
+++ b/src/sens/num.rs
@@ -152,7 +152,11 @@ impl<const N: usize> PkNum for Dual1<N> {
     }
     #[inline]
     fn guard_floor(self, lo: f64) -> Self {
-        if self.value < lo {
+        // `!(value >= lo)` (not `value < lo`) so a `NaN` value floors too, matching
+        // `f64::max(lo)` on the scalar path (`NaN.max(lo) == lo`) — otherwise a
+        // transient `NaN` would give a finite f64 prediction but a `NaN` dual
+        // gradient (the clamped region is flat, so the floored jet is zero) (#430).
+        if !(self.value >= lo) {
             Dual1::constant(lo)
         } else {
             self
@@ -211,7 +215,9 @@ impl<const NA: usize, const N: usize> PkNum for DualMixed<NA, N> {
     }
     #[inline]
     fn guard_floor(self, lo: f64) -> Self {
-        if self.value < lo {
+        // `!(value >= lo)` floors `NaN` too, matching `f64::max(lo)` — see the
+        // `Dual1` impl above (#430).
+        if !(self.value >= lo) {
             DualMixed::constant(lo)
         } else {
             self
@@ -253,5 +259,27 @@ mod tests {
         exercise::<Dual1<1>>(Dual1::var(0.7, 0));
         exercise::<Dual2<1>>(Dual2::var(0.7, 0));
         exercise::<DualMixed<1, 2>>(DualMixed::var(0.7, 0));
+    }
+
+    /// `guard_floor(NaN)` must floor (return `lo`) on the duals exactly as it does on
+    /// `f64` (`NaN.max(lo) == lo`) — a sub-floor / `NaN` value lands in the flat
+    /// clamped region, so the dual's value is `lo` and its jet is zero. Without this,
+    /// a transient `NaN` would give a finite f64 prediction but a `NaN` dual gradient
+    /// (#430 review #2).
+    #[test]
+    fn guard_floor_floors_nan_consistently_across_impls() {
+        let lo = 1e-6;
+        assert_eq!(f64::NAN.guard_floor(lo), lo);
+        assert_eq!(Dual1::<1>::var(f64::NAN, 0).guard_floor(lo).value, lo);
+        assert_eq!(Dual2::<1>::var(f64::NAN, 0).guard_floor(lo).value, lo);
+        assert_eq!(
+            DualMixed::<1, 2>::var(f64::NAN, 0).guard_floor(lo).value,
+            lo
+        );
+        // The floored dual carries a zero jet (flat clamped region).
+        let g = Dual1::<1>::var(f64::NAN, 0).guard_floor(lo);
+        assert_eq!(g.grad[0], 0.0);
+        // A value already above the floor is untouched.
+        assert_eq!(Dual1::<1>::var(5.0, 0).guard_floor(lo).value, 5.0);
     }
 }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -115,22 +115,26 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     // (ODE models have no `tv_fn` — typical values come from `pk_param_fn` at
     // η = 0 instead; see `run_subject`.)
     // Lagtime shifts the dosing timeline; supporting an estimated lagtime needs
-    // ∂(timeline)/∂θ, which is not yet wired — exclude models that estimate it. This
-    // catches the bare `PK_IDX_LAGTIME` slot; the compartment-indexed `ALAG{n}` form
-    // lands in the dose-attr map instead (never at `PK_IDX_LAGTIME`) and is declined
-    // alongside `F` just below.
-    if model.pk_indices.iter().any(|&s| s == PK_IDX_LAGTIME) {
+    // ∂(timeline)/∂θ, which is not yet wired — exclude models that estimate it.
+    // Use `has_lagtime()`, not a raw `pk_indices`/`PK_IDX_LAGTIME` scan: an ODE
+    // model wires lagtime by name (bare `LAGTIME`/`ALAG`, or a compartment-indexed
+    // `ALAG{n}` routed through the `DoseAttrMap`), and neither a named bare lag nor
+    // an `ALAG{n}` lands in `pk_indices` (see `CompiledModel::has_lagtime`). The
+    // dual loop never applies the dose-attr lag, so a missed `ALAG{n}` would yield a
+    // no-lag gradient that diverges from the f64 predictor (#430 / #449 review #1).
+    // Bioavailability F *is* supported (it scales the dose amount/rate as a dual).
+    if model.has_lagtime() {
         return false;
     }
-    // Per-compartment bioavailability / lag time (`F1`/`F2`, `ALAG{n}`, #369):
-    // production resolves `f_bio(d.cmt)` per dose compartment and shifts the dose to
-    // `d.time + lagtime(d.cmt)`, but both the static `integrate_g` and the TV-cov
-    // walk apply the single bare `PK_IDX_F` slot and dose at the bare `d.time`. A
-    // compartment-indexed `F` or lag would give the wrong analytic gradient, so
-    // decline to FD (the bare / no-`F` case is unaffected) (#449 review #7, #1).
-    let attrs = model.active_dose_attr_map();
-    if attrs.has_indexed_attr(crate::types::DoseAttr::F)
-        || attrs.has_indexed_attr(crate::types::DoseAttr::Lag)
+    // Per-compartment bioavailability (`F1`/`F2`, #369): production resolves
+    // `f_bio(d.cmt)` per dose compartment, but both the static `integrate_g` and the
+    // TV-cov walk apply the single bare `PK_IDX_F` slot, so a compartment-indexed `F`
+    // would give the wrong analytic gradient — decline to FD (the bare / no-`F` case
+    // is unaffected). (Per-compartment lag is already covered by `has_lagtime()`
+    // above.) (#449 review #7, #1)
+    if model
+        .active_dose_attr_map()
+        .has_indexed_attr(crate::types::DoseAttr::F)
     {
         return false;
     }
@@ -2893,6 +2897,71 @@ mod tests {
   ode_abstol = 1e-11
 "#;
 
+    // Same as IGD_ODE but with an estimated bioavailability F. The dose into the
+    // igd() compartment is suppressed as a bolus and fed to `R_in` as `F·amt`, so
+    // F appears *only* inside the forcing — `∂f/∂THETA_F` exercises the F
+    // derivative carried by the Dual2 forcing's `f_bio` (uncovered by IGD_ODE,
+    // which has no F; #430 review finding 2).
+    const IGD_ODE_F: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVMAT(2.0, 0.05, 24.0)
+  theta TVCV2(0.3, 0.001, 10.0)
+  theta THETA_F(0.7, 0.001, 0.999)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV  * exp(ETA_V)
+  MAT = TVMAT
+  CV2 = TVCV2
+  F   = THETA_F
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = igd(mat=MAT, cv2=CV2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+    // Same as IGD_ODE but with a compartment-indexed absorption lag `ALAG1` on
+    // the igd() compartment. The lag is wired through the `DoseAttrMap`, *not*
+    // `pk_indices` (and not the bare `PK_IDX_LAGTIME` slot), so the provider gate
+    // must consult `has_lagtime()` to exclude it (#430 review finding 1).
+    const IGD_ALAG_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVMAT(2.0, 0.05, 24.0)
+  theta TVCV2(0.3, 0.001, 10.0)
+  theta TVLAG(0.3, 0.01, 5.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL    = TVCL * exp(ETA_CL)
+  V     = TVV  * exp(ETA_V)
+  MAT   = TVMAT
+  CV2   = TVCV2
+  ALAG1 = TVLAG
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = igd(mat=MAT, cv2=CV2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
     // Same disposition shape but with a `transit()` forcing — *not* lifted to
     // Dual2 in slice 1, so it must stay on the FD fallback.
     const TRANSIT_ODE: &str = r#"
@@ -2973,6 +3042,43 @@ mod tests {
             ode_subject_sensitivities(&model, &subject, &[5.0, 50.0, 2.0, 0.3], &[0.1, -0.05])
                 .is_none(),
             "IG + reset must fall back to FD in slice 1 of #430"
+        );
+    }
+
+    /// Bioavailability F on an igd() model flows *only* through the input-rate
+    /// forcing (the dose into the absorption compartment is suppressed as a bolus
+    /// and fed to `R_in` as `F·amt`), so the analytic `∂f/∂THETA_F` here exercises
+    /// the F derivative carried by the Dual2 forcing — the path IGD_ODE (no F)
+    /// leaves untested (#430 review finding 2).
+    #[test]
+    fn ode_provider_igd_absorption_with_f_matches_production() {
+        let model = parse_model_string(IGD_ODE_F).expect("parse");
+        assert!(
+            ode_analytical_supported(&model),
+            "igd()+F should be supported (F scales the dose as a dual)"
+        );
+        let subject = bolus_subject(&[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        let theta = vec![5.0, 50.0, 2.0, 0.3, 0.7];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+    }
+
+    /// Regression for #430 review finding 1: an igd() model that also declares a
+    /// compartment-indexed `ALAG{n}` lag must stay on the FD fallback. The lag is
+    /// wired through the `DoseAttrMap`, so it lands in neither `pk_indices` nor the
+    /// bare `PK_IDX_LAGTIME` slot — the gate must consult `has_lagtime()`, or it
+    /// would serve the model and the dual loop would compute a no-lag gradient
+    /// that diverges from the f64 predictor (which shifts the forcing by the lag).
+    #[test]
+    fn ode_provider_igd_with_alag_stays_on_fd_fallback() {
+        let model = parse_model_string(IGD_ALAG_ODE).expect("parse");
+        assert!(
+            model.has_lagtime(),
+            "ALAG1 must enable has_lagtime() (precondition for the gate)"
+        );
+        assert!(
+            !ode_analytical_supported(&model),
+            "igd()+ALAG1 must stay on the FD fallback (#430 finding 1)"
         );
     }
 }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -31,8 +31,9 @@ use super::dual1::Dual1;
 use super::dual2::Dual2;
 use super::dual_mixed::DualMixed;
 use super::provider::{ObsGrad, ObsSens, SubjectSens};
-use crate::ode::predictions::OdeReadout;
+use crate::ode::predictions::{input_rate_consumes_cmt, OdeReadout, OdeSpec};
 use crate::ode::solver::solve_ode_g;
+use crate::pk::absorption::PreparedInputRate;
 use crate::types::{CompiledModel, ScalingSpec, Subject, PK_IDX_F, PK_IDX_LAGTIME};
 use std::cell::RefCell;
 
@@ -86,7 +87,14 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     if !readout_ok {
         return false;
     }
-    if !ode.input_rate.is_empty() || !ode.diffusion_var.is_empty() {
+    if !ode.diffusion_var.is_empty() {
+        return false;
+    }
+    // Built-in absorption input-rate forcing is evaluated over Dual2 only for
+    // kinds lifted to PkNum (#430: inverse-Gaussian). Other kinds — transit
+    // until its `ln_gamma` dual rule, Weibull until Phase 2 — keep the FD
+    // fallback, so a model using one is not "supported" here.
+    if ode.input_rate.iter().any(|f| !f.kind.supported_over_dual()) {
         return false;
     }
     if model.n_kappa != 0 {
@@ -204,6 +212,12 @@ pub(crate) fn ode_tvcov_supported(model: &CompiledModel, subject: &Subject) -> b
     let Some(ode) = model.ode_spec.as_ref() else {
         return false;
     };
+    // Built-in absorption input-rate forcing (igd, #430): the TV-cov event-driven
+    // walk (`integrate_tvcov_g`) does not carry the `R_in` forcing, so a TV-cov igd
+    // model must route to the static / FD path instead of silently dropping it.
+    if !ode.input_rate.is_empty() {
+        return false;
+    }
     // The bolus walk seeds compartments at zero; `init(...)` needs the seeded
     // initial-state machinery the static path uses, so route those to FD.
     if ode.init_fn.is_some() {
@@ -262,6 +276,14 @@ pub fn ode_subject_sensitivities(
     // evaluated once and threaded into the drivers, so neither recomputes them.
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates);
     if pk.values[PK_IDX_LAGTIME].abs() > 1e-12 {
+        return None;
+    }
+    // Built-in absorption forcing + EVID 3/4 resets: the f64 path turns off pre-reset
+    // dose tails via a `reset_floor`; rather than replicate that subtle bookkeeping in
+    // the dual loop (slice 1 of #430), keep reset+absorption subjects on the FD
+    // fallback. Non-absorption reset subjects are unaffected and still served here.
+    let ode = model.ode_spec.as_ref()?;
+    if !ode.input_rate.is_empty() && !subject.reset_times.is_empty() {
         return None;
     }
     // Individual-parameter η/θ derivatives (cheap: one dual eval, no integration).
@@ -768,12 +790,24 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
         .map(|d| d.time)
         .fold(f64::INFINITY, f64::min);
 
-    // Integrate the dual state through bolus + infusion events, capturing the full
-    // state at each observation time.
+    // Built-in absorption input-rate forcings (#430), parallel to `ode.input_rate`,
+    // built over the dual type `T` (so they thread through `Dual2`/`Dual1`/`DualMixed`
+    // alike). The gate (`ode_analytical_supported`) admits only kinds lifted to
+    // `PkNum`, so `prepare_dual` returns `Some` for each; `?` bails to FD otherwise.
+    let mut prepared_forcings: Vec<PreparedInputRate<T>> =
+        Vec::with_capacity(ode.input_rate.len());
+    for f in &ode.input_rate {
+        prepared_forcings.push(f.prepare_dual::<T>(&params_dual)?);
+    }
+
+    // Integrate the dual state through bolus + infusion + absorption-forcing events,
+    // capturing the full state at each observation time.
     let states = integrate_g::<T>(
         program,
         ode.n_states,
         subject,
+        ode,
+        &prepared_forcings,
         &params_dual,
         f_bio,
         init_state,
@@ -1500,10 +1534,13 @@ fn obs_time_matches(ot: f64, t: f64) -> bool {
 /// the full outer gradient (value + grad + Hessian), `Dual1<N>` for the light inner
 /// η-gradient (value + grad only) — issue #410.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn integrate_g<T: crate::sens::num::PkNum>(
     program: &crate::parser::model_parser::OdeRhsProgram,
     n_states: usize,
     subject: &Subject,
+    ode: &OdeSpec,
+    prepared_forcings: &[PreparedInputRate<T>],
     params_dual: &[T],
     f_bio: T,
     init_state: &[T],
@@ -1583,8 +1620,15 @@ fn integrate_g<T: crate::sens::num::PkNum>(
 
         // Apply bolus doses (non-infusions) at t_start: u[cmt] += F·amt. CMT is
         // 1-based; a malformed `CMT=0` must not silently dose compartment 0 (#449 #8).
+        // A compartment fed by a built-in absorption input rate is skipped here — the
+        // dose feeds R_in (the forcing in the RHS below), not a bolus (#430, mirroring
+        // production's `input_rate_consumes_cmt` routing).
         for dose in &subject.doses {
-            if !dose.is_infusion() && (dose.time - t_start).abs() < 1e-12 && dose.cmt >= 1 {
+            if !dose.is_infusion()
+                && (dose.time - t_start).abs() < 1e-12
+                && dose.cmt >= 1
+                && !input_rate_consumes_cmt(ode, dose.cmt)
+            {
                 let cmt_idx = dose.cmt - 1;
                 if cmt_idx < n_states {
                     u[cmt_idx] = u[cmt_idx] + f_bio * T::from_f64(dose.amt);
@@ -1652,6 +1696,30 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                 if cmt < du.len() {
                     du[cmt] = du[cmt] + f_bio * T::from_f64(rate);
                 }
+            }
+            // Built-in absorption input-rate forcing R_in(tad), summed over the
+            // doses feeding each forcing's compartment — the Dual2 analogue of
+            // `add_prepared_input_rate_forcing` (#430). Lagtime is excluded from
+            // this provider, so tad = t − dose.time is parameter-independent (a
+            // constant dual); only the prepared constants and F·amt carry
+            // derivatives. Reset subjects are excluded (FD fallback), so there is
+            // no `reset_floor` to apply here.
+            for (forcing, prep) in ode.input_rate.iter().zip(prepared_forcings) {
+                if forcing.cmt >= du.len() {
+                    continue;
+                }
+                let mut acc = T::from_f64(0.0);
+                for d in &subject.doses {
+                    if d.cmt.saturating_sub(1) != forcing.cmt {
+                        continue;
+                    }
+                    let tad_f = t - d.time;
+                    if tad_f <= 0.0 {
+                        continue;
+                    }
+                    acc = acc + prep.rate(T::from_f64(tad_f), f_bio * T::from_f64(d.amt));
+                }
+                du[forcing.cmt] = du[forcing.cmt] + acc;
             }
         };
 
@@ -2788,5 +2856,123 @@ mod tests {
         inf.doses[0].rate = inf.doses[0].amt;
         assert!(crate::ode::predictions::is_real_infusion(&inf.doses[0]));
         assert!(!ode_tvcov_supported(&model, &inf));
+    }
+
+    // ---- #430 slice 1: built-in inverse-Gaussian absorption forcing over Dual2 ----
+
+    // 1-cpt oral disposition with Freijer & Post inverse-Gaussian absorption via
+    // the built-in `igd()` input rate (mirrors examples/igd_inverse_gaussian.ferx).
+    // MAT/CV2 are θ-only and appear *only* inside `igd()`, so `∂f/∂(TVMAT,TVCV2)`
+    // flows entirely through the forcing — the parity check fails if the Dual2
+    // forcing is wrong. Tight ODE tolerances so analytic ≡ FD is clean.
+    const IGD_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0,  0.1, 100.0)
+  theta TVV(50.0,  5.0, 500.0)
+  theta TVMAT(2.0, 0.05, 24.0)
+  theta TVCV2(0.3, 0.001, 10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV  * exp(ETA_V)
+  MAT = TVMAT
+  CV2 = TVCV2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = igd(mat=MAT, cv2=CV2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+    // Same disposition shape but with a `transit()` forcing — *not* lifted to
+    // Dual2 in slice 1, so it must stay on the FD fallback.
+    const TRANSIT_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVMTT(1.0, 0.05, 24.0)
+  theta TVN(3.0, 0.1, 20.0)
+  theta TVKA(1.0, 0.05, 20.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+  MTT = TVMTT
+  N   = TVN
+  KA  = TVKA
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+[odes]
+  d/dt(depot)   = transit(n=N, mtt=MTT) - KA*depot
+  d/dt(central) = KA*depot - CL/V*central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    /// The kind gate: only inverse-Gaussian is lifted to Dual2 in slice 1 of
+    /// #430; transit (and, later, Weibull) stay on the FD fallback.
+    #[test]
+    fn input_rate_kind_supported_over_dual_gates_kinds() {
+        use crate::pk::absorption::InputRateKind;
+        assert!(InputRateKind::InverseGaussian.supported_over_dual());
+        assert!(!InputRateKind::Transit.supported_over_dual());
+    }
+
+    /// With the IG forcing lifted to Dual2, an `igd()` model is served by the
+    /// analytic provider, and its `f`/`∂f/∂η`/`∂f/∂θ` match the production
+    /// predictor + central FD — including `∂f/∂(TVMAT,TVCV2)`, which flow only
+    /// through the forcing.
+    #[test]
+    fn ode_provider_igd_absorption_matches_production() {
+        let model = parse_model_string(IGD_ODE).expect("parse");
+        assert!(
+            ode_analytical_supported(&model),
+            "igd() model should be supported once the IG forcing is lifted to Dual2"
+        );
+        let subject = bolus_subject(&[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        let theta = vec![5.0, 50.0, 2.0, 0.3];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+    }
+
+    /// Slice 1 lifts only IG: a `transit()` model is still *not* served by the
+    /// analytic provider (it differentiates by FD until transit's `ln_gamma`
+    /// Dual2 rule lands in slice 2).
+    #[test]
+    fn ode_provider_transit_absorption_stays_on_fd_fallback() {
+        let model = parse_model_string(TRANSIT_ODE).expect("parse");
+        assert!(
+            !ode_analytical_supported(&model),
+            "transit() must stay on the FD fallback in slice 1 of #430"
+        );
+    }
+
+    /// Built-in absorption + an EVID 3/4 reset is kept on the FD fallback in
+    /// slice 1: the dual loop doesn't yet apply the `reset_floor` that turns off
+    /// pre-reset dose tails, so `ode_subject_sensitivities` declines the subject.
+    #[test]
+    fn ode_provider_igd_with_reset_falls_back_to_fd() {
+        let model = parse_model_string(IGD_ODE).expect("parse");
+        let mut subject = bolus_subject(&[1.0, 3.0, 6.0, 11.0, 13.0, 16.0]);
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(10.0, 100.0, 1, 0.0, false, 0.0),
+        ];
+        subject.reset_times = vec![10.0];
+        assert!(
+            ode_subject_sensitivities(&model, &subject, &[5.0, 50.0, 2.0, 0.3], &[0.1, -0.05])
+                .is_none(),
+            "IG + reset must fall back to FD in slice 1 of #430"
+        );
     }
 }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -798,8 +798,7 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
     // built over the dual type `T` (so they thread through `Dual2`/`Dual1`/`DualMixed`
     // alike). The gate (`ode_analytical_supported`) admits only kinds lifted to
     // `PkNum`, so `prepare_dual` returns `Some` for each; `?` bails to FD otherwise.
-    let mut prepared_forcings: Vec<PreparedInputRate<T>> =
-        Vec::with_capacity(ode.input_rate.len());
+    let mut prepared_forcings: Vec<PreparedInputRate<T>> = Vec::with_capacity(ode.input_rate.len());
     for f in &ode.input_rate {
         prepared_forcings.push(f.prepare_dual::<T>(&params_dual)?);
     }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -3063,6 +3063,84 @@ mod tests {
         check_vs_production(&model, &subject, &theta, &eta);
     }
 
+    /// Multi-dose superposition through the IG dual forcing: with two doses the
+    /// forcing loop sums `R_in(tad)` over both, and the analytic ∂f/∂(η,θ) must
+    /// still match the production predictor + FD. The single-dose IGD_ODE parity
+    /// test never exercises the superposition sum.
+    #[test]
+    fn ode_provider_igd_multidose_matches_production() {
+        let model = parse_model_string(IGD_ODE).expect("parse");
+        let mut subject = bolus_subject(&[0.5, 1.5, 4.0, 8.0, 13.0, 16.0, 25.0]);
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(12.0, 80.0, 1, 0.0, false, 0.0),
+        ];
+        let theta = vec![5.0, 50.0, 2.0, 0.3];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+    }
+
+    /// Second-order blocks of the IG forcing: `check_vs_production` only checks
+    /// first order, but FOCEI consumes `d2f_deta2` and `d2f_deta_dtheta`. Validate
+    /// both against central FD of the analytic (already FD-checked) `df_deta` — if
+    /// the forcing's Dual2 second-order content were wrong, this fails while the
+    /// first-order parity still passes. TVMAT/TVCV2 are θ-only and live solely in
+    /// the forcing, so the θ-cross block exercises the forcing's curvature.
+    #[test]
+    fn ode_provider_igd_second_order_matches_fd_of_gradient() {
+        let model = parse_model_string(IGD_ODE).expect("parse");
+        let subject = bolus_subject(&[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        let theta = vec![5.0, 50.0, 2.0, 0.3];
+        let eta = vec![0.1, -0.05];
+        let n_eta = model.n_eta;
+        let n_theta = model.n_theta;
+        let base = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
+
+        // η-η block: FD of df_deta over η.
+        let he = 1e-5;
+        for l in 0..n_eta {
+            let mut ep = eta.clone();
+            ep[l] += he;
+            let mut em = eta.clone();
+            em[l] -= he;
+            let sp = ode_subject_sensitivities(&model, &subject, &theta, &ep).expect("supported");
+            let sm = ode_subject_sensitivities(&model, &subject, &theta, &em).expect("supported");
+            for (j, obs) in base.obs.iter().enumerate() {
+                for k in 0..n_eta {
+                    let fd = (sp.obs[j].df_deta[k] - sm.obs[j].df_deta[k]) / (2.0 * he);
+                    approx::assert_relative_eq!(
+                        obs.d2f_deta2[k * n_eta + l],
+                        fd,
+                        max_relative = 2e-3,
+                        epsilon = 1e-6
+                    );
+                }
+            }
+        }
+
+        // η-θ cross block: FD of df_deta over θ.
+        for m in 0..n_theta {
+            let s = 1e-5 * (1.0 + theta[m].abs());
+            let mut tp = theta.clone();
+            tp[m] += s;
+            let mut tm = theta.clone();
+            tm[m] -= s;
+            let sp = ode_subject_sensitivities(&model, &subject, &tp, &eta).expect("supported");
+            let sm = ode_subject_sensitivities(&model, &subject, &tm, &eta).expect("supported");
+            for (j, obs) in base.obs.iter().enumerate() {
+                for k in 0..n_eta {
+                    let fd = (sp.obs[j].df_deta[k] - sm.obs[j].df_deta[k]) / (2.0 * s);
+                    approx::assert_relative_eq!(
+                        obs.d2f_deta_dtheta[k * n_theta + m],
+                        fd,
+                        max_relative = 2e-3,
+                        epsilon = 1e-6
+                    );
+                }
+            }
+        }
+    }
+
     /// Regression for #430 review finding 1: an igd() model that also declares a
     /// compartment-indexed `ALAG{n}` lag must stay on the FD fallback. The lag is
     /// wired through the `DoseAttrMap`, so it lands in neither `pk_indices` nor the

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -190,6 +190,18 @@ pub(crate) fn ode_subject_supported(model: &CompiledModel, subject: &Subject) ->
     if model.has_bioavailability() && subject.has_rate_defined_infusion() {
         return false;
     }
+    // Built-in absorption forcing (igd, #430) + EVID 3/4 resets: the f64 path turns
+    // off pre-reset dose tails via a `reset_floor`, which the dual forcing loop in
+    // `integrate_g` doesn't yet replicate (it sums `R_in` over every dose with
+    // `tad > 0`). Keep reset+absorption subjects on the FD fallback. This is the
+    // SHARED scope gate for both the outer θ-sensitivities and the inner η-gradient,
+    // so the inner EBE loop can't silently run an analytic no-`reset_floor` gradient
+    // while the outer correctly falls back to FD (#430 review #1).
+    if let Some(ode) = model.ode_spec.as_ref() {
+        if !ode.input_rate.is_empty() && !subject.reset_times.is_empty() {
+            return false;
+        }
+    }
     true
 }
 
@@ -282,14 +294,8 @@ pub fn ode_subject_sensitivities(
     if pk.values[PK_IDX_LAGTIME].abs() > 1e-12 {
         return None;
     }
-    // Built-in absorption forcing + EVID 3/4 resets: the f64 path turns off pre-reset
-    // dose tails via a `reset_floor`; rather than replicate that subtle bookkeeping in
-    // the dual loop (slice 1 of #430), keep reset+absorption subjects on the FD
-    // fallback. Non-absorption reset subjects are unaffected and still served here.
-    let ode = model.ode_spec.as_ref()?;
-    if !ode.input_rate.is_empty() && !subject.reset_times.is_empty() {
-        return None;
-    }
+    // (reset+absorption FD fallback is enforced by the shared `ode_subject_supported`
+    // gate above, so both the outer and inner paths decline it together — #430 review #1.)
     // Individual-parameter η/θ derivatives (cheap: one dual eval, no integration).
     // Besides feeding the chain, the `∂p/∂η` rows tell us which individual parameters
     // carry IIV, which decides the dual's Hessian width.
@@ -1537,7 +1543,6 @@ fn obs_time_matches(ot: f64, t: f64) -> bool {
 /// the full outer gradient (value + grad + Hessian), `Dual1<N>` for the light inner
 /// η-gradient (value + grad only) — issue #410.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn integrate_g<T: crate::sens::num::PkNum>(
     program: &crate::parser::model_parser::OdeRhsProgram,
     n_states: usize,
@@ -1717,6 +1722,9 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                         continue;
                     }
                     let tad_f = t - d.time;
+                    // Pre-dose skip: `tad ≤ 0` contributes nothing. `rate` re-checks
+                    // this same wall (`tad.val() <= 0`), so this is an optimization
+                    // (skip the dual `rate` call), not the source of truth (#430 review).
                     if tad_f <= 0.0 {
                         continue;
                     }
@@ -3037,10 +3045,22 @@ mod tests {
             DoseEvent::new(10.0, 100.0, 1, 0.0, false, 0.0),
         ];
         subject.reset_times = vec![10.0];
+        let theta = [5.0, 50.0, 2.0, 0.3];
+        let eta = [0.1, -0.05];
         assert!(
-            ode_subject_sensitivities(&model, &subject, &[5.0, 50.0, 2.0, 0.3], &[0.1, -0.05])
-                .is_none(),
-            "IG + reset must fall back to FD in slice 1 of #430"
+            ode_subject_sensitivities(&model, &subject, &theta, &eta).is_none(),
+            "IG + reset must fall back to FD on the outer θ-sensitivity path (#430)"
+        );
+        // The inner η-gradient shares the scope gate, so it must decline too — else
+        // the EBE loop would run an analytic no-`reset_floor` gradient while the outer
+        // falls back to FD (#430 review #1). Guarded by `ode_subject_supported`.
+        assert!(
+            !ode_subject_supported(&model, &subject),
+            "IG + reset must be out of shared scope (covers the inner η-gradient)"
+        );
+        assert!(
+            ode_subject_eta_grad(&model, &subject, &theta, &eta).is_none(),
+            "IG + reset must fall back to FD on the inner η-gradient path too (#430 review #1)"
         );
     }
 


### PR DESCRIPTION

## Why

After the Enzyme retirement (#367/#381), ODE models get analytic first/second-order `Dual2` sensitivities through `sens/ode_provider.rs` — but the **built-in absorption input-rate forcing** was on the provider's not-yet-supported list, so `igd()`/`transit()` models were the **lone ODE models still differentiating by finite differences**. This PR lifts the inverse-Gaussian forcing onto the analytic path, so `igd()` fits (shipped in #389) drive exact, cheaper FOCE/FOCEI/Bayes gradients. **Slice 1 of #430.**

Extra leverage: the generic plumbing here is also the *only* analytic-gradient route for Weibull (which has no closed form), so Phase 2's Weibull rides it for free.

## What changed

- **`src/pk/absorption.rs`** — `PreparedInputRate`, `rate`, `inverse_gaussian`, and `arg` are now generic over `T: PkNum` (default `T = f64`, so every scalar call site is byte-identical). The IG forcing needs **no new special function** — its hot path uses only `ln`/`exp`/arithmetic, all already on `PkNum`. Added `InputRateForcing::prepare_dual` + `InputRateKind::supported_over_dual`. `transit` stays `impl PreparedInputRate<f64>` (its `ln_gamma` needs a `Dual2` rule — slice 2).
- **`src/sens/ode_provider.rs`** — the gate now admits dual-supported forcings per-kind; the `Dual2` forcing is summed into the generic `integrate_g<T>` RHS, the analogue of the f64 `add_prepared_input_rate_forcing`.
- **Dose routing** — the dual bolus loop skips doses consumed by an input rate (`input_rate_consumes_cmt`), so the `igd()` dose feeds `R_in`, not a double-counted bolus.
- **Resets** — reset+absorption subjects fall back to FD (the dual loop doesn't yet apply the f64 path's `reset_floor`); correct fallback, lifted later.

## Alternatives considered

- *Duplicating the IG formula inline in the provider* — rejected; it reintroduces the two-copies-to-sync anti-pattern `PkNum` exists to remove, and the generic lift is the approach #430 specifies.
- *Handling reset+absorption in the dual loop now* — deferred to keep slice 1 minimal and not re-derive the `reset_floor` bookkeeping; the FD fallback is correct.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Internal exactness change — no `pub` API consumed by ferx-r, no DSL/behaviour change. `igd()` already parses (syntax shipped in #389); this only changes how its gradient is computed.

## Breaking changes
- [x] None

The `pub` signature change (`PreparedInputRate<T = f64>`, `rate(&self, tad: T, dose: T) -> T`) is **source-compatible**: existing `PreparedInputRate` uses resolve to `<f64>` via the default type parameter, and `rate(f64, f64) -> f64` is unchanged. ferx-r doesn't call these (DSL-only).

## Numerical validation
- [x] Estimates are **unchanged** (same objective; FD and analytic are both valid gradients). The new path is validated by an **analytic ≡ central-FD gradient parity** test against the production predictor, including `∂f/∂MAT` and `∂f/∂CV2` (which flow *only* through the forcing): `ode_provider_igd_absorption_matches_production`. This is the analytic-path gradient-agreement check CLAUDE.md mandates for absorption params, in the default `--features ci` build. (igd's NONMEM anchor `tests/igd_nonmem_anchor.rs`, #389, is unchanged.)

## Performance
- [x] Faster — `igd()` fits drop the per-parameter finite-difference re-solves for the absorption parameters (exact `Dual2` instead of FD). No hard benchmark in this PR; the mechanism is removing the FD-gradient multiplier on IG models.

  > **Status caveat:** not realized in production *yet*. The ODE analytic provider is gated off (`ODE_SENS_ENABLED = false`), and arming it is more than a flag flip — the inner EBE gradient stays FD for ODE models and the default outer optimizer is derivative-free (see #410). This PR is correct, tested, **dormant** infrastructure; the speed/exactness lands when #410 wires ODE sensitivities on. Verified there that the analytic outer gradient ≡ FD (bit-identical converged igd fit) and matches NONMEM.

## Tests
- [x] Unit tests added (`cargo test --lib` passes): IG analytic≡FD parity, the kind gate, transit-stays-FD, reset→FD fallback, and `prepare_dual`. Full lib suite green (1404 passed).
- Existing f64 absorption tests + `igd_absorption` integration test pass unchanged (the generic lift is byte-identical at `f64`).

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (### Added).
- [x] No user-visible behaviour change (no `docs/src/` change needed).

## Checklist
- [x] `cargo clippy` — no new warnings from this change (the pre-existing project warnings in these files — the by-design `!(x > 0.0)` NaN guards, etc. — are unchanged; CI's clippy job is not `-D warnings`).
- [x] Functions on the `Dual2` sensitivity path stay differentiable — that is the point of this PR; the IG forcing is now `PkNum`-generic and the parity test guards it.
- [x] No `Cargo.toml` version bump (non-breaking).

### Example execution
- [x] No example execution step needed (internal change, no user-visible behaviour; `igd()` DSL already exists).

## Reviewer hints

- The crux is `integrate_dual`'s RHS closure in `ode_provider.rs`: the new forcing loop mirrors the f64 `add_prepared_input_rate_forcing`, but in the provider's supported scope **lagtime is excluded**, so `tad = t − dose.time` is parameter-independent (a constant dual) — only the prepared constants and `F·amt` carry derivatives.
- Slicing seam: `InputRateKind::supported_over_dual()` (IG=true, transit=false). Slice 2 adds `ln_gamma`'s `Dual2` rule and flips transit; Weibull (Phase 2) needs no new special function and rides this.
- `PreparedInputRate<T = f64>`'s default type parameter is what keeps the f64 prediction path untouched.

## Open questions

None — transit (slice 2) and Phase 2/3 sequencing are tracked on #430 / #322.




