### PR TITLE
test(estimation): re-enable Schnider NONMEM match via NLopt L-BFGS [closes #333]

### DIFF
--- a/tests/schnider_propofol_nonmem.rs
+++ b/tests/schnider_propofol_nonmem.rs
@@ -47,15 +47,23 @@
 //! | TVQ2  | 1.34   | Σ     | 0.0540 |
 //! | TVQ3  | 0.868  |       |        |
 //!
-//! ferx (FOCEI, BOBYQA) reaches: TVV1 5.49, TVV2 24.4, TVV3 289, TVCL 1.93,
-//! TVQ2 1.35, TVQ3 0.864; Ω(V1,V2,CL,Q2) = (0.075, 0.094, 0.017, 0.135);
-//! Σ(var) = 0.054. The structural thetas match to <7%; the BSV variances trade
-//! off between V1 and V2 (their total is within ~2% of NONMEM) — typical of
-//! weakly-identified variance components across FOCEI implementations. The
-//! decisive regression guard is TVCL ≈ 1.9 (the bug pushed it past 3.4).
+//! ## Optimizer (#333)
+//!
+//! The 3-cpt V1/V2/V3 volume split is weakly identified, and the default
+//! derivative-free BOBYQA false-converges ~36 OFV units above the true minimum
+//! (TVV3 ≈ 243, 21% off). A gradient-based variable-metric optimizer — the same
+//! family NONMEM uses for the outer problem — reaches the true minimum and
+//! reproduces NONMEM exactly. This test therefore pins the optimizer to NLopt
+//! L-BFGS (`Optimizer::NloptLbfgs`) with a tight inner tolerance (`inner_tol =
+//! 1e-8`); the marginal OFV is too noisy at the default 1e-5 to resolve the
+//! split. With that configuration ferx reaches TVV1 5.76, TVV2 26.0, TVV3 309,
+//! TVCL 1.92, TVQ2 1.34, TVQ3 0.868; Ω(V1,V2,CL,Q2) = (0.095, 0.076, 0.019,
+//! 0.127); Σ(var) = 0.054 — every parameter within ~1% of NONMEM (OFV −3039.3).
+//! The decisive regression guard is still TVCL ≈ 1.9 (the #195 bug pushed it
+//! past 3.4).
 
 use ferx_core::parser::model_parser::parse_full_model;
-use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions, Optimizer};
 use std::path::Path;
 
 const SCHNIDER_MODEL: &str = r#"
@@ -97,11 +105,10 @@ const NM_OMEGA: [f64; 4] = [0.0948, 0.0757, 0.0193, 0.127];
 const NM_SIGMA_VAR: f64 = 0.0540;
 
 #[test]
-// TEMP-DISABLED (#333): the 3-cpt V1/V2/V3 split is weakly identified — at the
-// default inner_tol the TVV3 estimate drifts outside the NONMEM 15% band (the
-// thetas come into band only at inner_tol=1e-8 and the ω components remain
-// inflated). Not fixed by the #330 inner_tol/θ-block work; tracked in #333.
-#[ignore = "weakly-identified 3-cpt volume split — tracked in #333"]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
 fn schnider_propofol_matches_nonmem() {
     let parsed = parse_full_model(SCHNIDER_MODEL).expect("model parses");
     let model = parsed.model;
@@ -117,6 +124,11 @@ fn schnider_propofol_matches_nonmem() {
 
     let mut opts = FitOptions::default();
     opts.method = EstimationMethod::FoceI;
+    // The weakly-identified V1/V2/V3 split needs a gradient-based variable-metric
+    // optimizer (BOBYQA false-converges here) and a tight inner tolerance to
+    // resolve the split — see the module docs and #333.
+    opts.optimizer = Optimizer::NloptLbfgs;
+    opts.inner_tol = 1e-8;
     opts.run_covariance_step = false;
     opts.outer_maxiter = 800;
     opts.verbose = false;


### PR DESCRIPTION
## Why

`schnider_propofol_matches_nonmem` (the #195 acceptance test for multi-occasion `EVID=4` resets) has been `#[ignore]`d under #333 because the 3-cpt V1/V2/V3 volume split is weakly identified and the default derivative-free **BOBYQA false-converges** ~36 OFV units above the true minimum — TVV3 lands at ~243 (21% off the NONMEM 309), outside the test's 15% band.

A focused optimizer sweep (posted on #333/#338) showed this is **not** a fundamental identifiability wall: it's an optimizer + inner-precision problem. A gradient-based **variable-metric quasi-Newton** optimizer — the same family NONMEM uses for the outer problem — reaches the true minimum (OFV −3039.3) and reproduces NONMEM on every parameter.

## What changed

Test-only. `tests/schnider_propofol_nonmem.rs` now pins the fit to:

```rust
opts.optimizer = Optimizer::NloptLbfgs;
opts.inner_tol = 1e-8;
```

and replaces the #333 `#[ignore]` with the standard `slow-tests` gate. The module docs are updated to record why (BOBYQA's false-convergence; the marginal OFV is too noisy at the default `inner_tol = 1e-5` to resolve the split). No production code or defaults change.

## Alternatives considered

From the optimizer sweep (full table on #338):
- **`mma`** also reaches the Schnider minimum but is a fragile generalist (stalls at the initial point on warfarin/two_cpt, explodes on emax) — rejected.
- **built-in `lbfgs`** (`Optimizer::Lbfgs`) reaches the same minimum but is ~6.5× slower and never formally converges (Armijo-only line search + gradient-norm-only stop vs NLopt's Wolfe line search + tolf/tolx convergence) — rejected in favour of `nlopt_lbfgs`.
- **`gn_hybrid`** is comparably accurate (−3038.9, all params in band) but Gauss-Newton is a different family from NONMEM's variable-metric update; `nlopt_lbfgs` is the algorithmically faithful choice.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: **NONMEM 7.6.0** (Eleveld reference, #195)

`Optimizer::NloptLbfgs`, `inner_tol = 1e-8`, FOCEI:

```
                TVV1   TVV2   TVV3   TVCL   TVQ2   TVQ3 | OFV
NONMEM          5.76   26.1   309    1.92   1.34   0.868
ferx (this PR)  5.76   26.0   309    1.92   1.34   0.868  -3039.3
                Ω V1     Ω V2     Ω CL     Ω Q2    Σ(var)
NONMEM          0.0948   0.0757   0.0193   0.127   0.0540
ferx (this PR)  0.0949   0.0758   0.0193   0.127   0.0540
```

Every theta and omega within ~1% of NONMEM; the fit converges cleanly.

## Performance
- [x] No significant impact expected — slow test only; runs in ~13s under `--features slow-tests`.

## Tests
- [x] Regression test re-enabled (was `#[ignore]` under #333); passes with `cargo test --release --features ci,slow-tests --test schnider_propofol_nonmem`.

## Docs
- [x] N/A (test-only; no user-facing change). The optimizer/inner_tol choice is a test configuration, not a default change.

## Reviewer hints

The decisive regression guard remains TVCL ≈ 1.9 (the #195 double-dosing bug pushed it past 3.4). The new `optimizer`/`inner_tol` lines are the substantive change; everything else is the doc comment and the gate swap. This deliberately does **not** touch the global default optimizer — that decision is tracked separately (#338).

## Open questions

None. Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
