### PR TITLE
feat(sens): analytic gradients for per-CMT (multi-endpoint) ODE readouts [#439]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Analytic gradients for per-CMT (multi-endpoint) ODE readouts** (#439). The
+  `[scaling] y[CMT=N] = <expr>` Form-C readout is now differentiated by the ODE
+  sensitivity provider — each endpoint's compiled output program is evaluated over
+  `Dual2` (outer) and `Dual1` (inner), dispatched per observation by its CMT — so
+  multi-analyte / PK-PD models (e.g. parent + metabolite, or PK + effect) get the
+  exact analytic FOCE/FOCEI gradient instead of falling back to finite differences;
+  `gradient = fd` is no longer required for these models. Validated against finite
+  differences of the production predictor.
 - **Analytic FOCE/FOCEI gradients for user-`[odes]` models** (#410). The ODE
   sensitivity engine — an augmented `Dual2` RK45 that propagates `∂state/∂(θ,η)`
   alongside the state — is now armed, so in-scope ODE models drive the exact

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -109,7 +109,7 @@ All `[scaling]` variants on the **analytical PK path** support the default
 | Scalar `obs_scale = K` | exact analytic | exact FD | The constant threads as one entry per observation. |
 | Expression `obs_scale = <expr>` | subject-static analytic | exact FD | See subject-static caveat below. |
 | Per-CMT `obs_scale[CMT=N]` | subject-static analytic | exact FD | One per-observation scale entry per observation, dispatched by `subject.obs_cmts[i]`. |
-| Form C `y[…] = <expr>` (ODE only) | finite differences | exact FD | Form C only exists on ODE models, where the analytic gradient is not available regardless of scaling. |
+| Form C `y[…] = <expr>` (ODE only) | exact analytic (in-scope ODE) | exact FD | Since #410/#439 the ODE sensitivity provider differentiates the Form C readout — uniform `y = <expr>` and per-CMT `y[CMT=N] = <expr>` — over `Dual2`/`Dual1` (outer and inner). Out-of-scope ODE features (steady state, IOV, …) fall back to FD. |
 
 **Analytic outer gradient handles expression scaling exactly.** The analytic
 sensitivity provider that drives the gradient-based outer optimizers (`bfgs`,
@@ -186,6 +186,10 @@ subject-static `pk_param_fn` evaluation. See
 [Interaction with gradients](#interaction-with-gradients) for the subject-static
 caveat that applies to all expression-form scales.
 
-Form C per-CMT (`y[CMT=N] = <expr>`) still requires `gradient = fd` —
-not because of the per-CMT dispatch but because Form C only exists on
-ODE models, where the analytic route is not available.
+Since #439, Form C per-CMT (`y[CMT=N] = <expr>`) is differentiated
+analytically by the ODE sensitivity provider — each endpoint's compiled
+output program is evaluated over `Dual2` (outer gradient) and `Dual1`
+(inner EBE η-gradient), dispatched per observation by `subject.obs_cmts[i]`.
+So `gradient = auto` serves it; `gradient = fd` is no longer required (the
+fit falls back to FD only for out-of-scope ODE features such as steady
+state, IOV, or time-varying covariates).

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -193,3 +193,16 @@ output program is evaluated over `Dual2` (outer gradient) and `Dual1`
 So `gradient = auto` serves it; `gradient = fd` is no longer required (the
 fit falls back to FD only for out-of-scope ODE features such as steady
 state, IOV, or time-varying covariates).
+
+**Numerical validation.** The per-CMT analytic gradient inherits the NONMEM
+validation of the user-ODE sensitivity engine (#410): the gradient machinery —
+the augmented `Dual2`/`Dual1` RK45 and the η/θ chain — is unchanged, and per-CMT
+only selects, per observation, which CMT's compiled Form-C output program to
+evaluate. Each such program is the same readout already validated for the uniform
+`y = <expr>` case. The per-observation routing itself is verified by the
+`ode_provider_percmt_matches_production` test (analytic `f`, `∂f/∂η`, `∂f/∂θ` vs
+the production predictor + finite differences on a two-endpoint model) and the
+`ode_provider_percmt_light_matches_full` test (the `Dual1` inner η-gradient
+equals the `Dual2` outer to 1e-9). A dedicated NONMEM cross-check on a
+multi-endpoint model is therefore not re-run here; it is covered transitively by
+#410's validation plus these routing tests.

--- a/examples/scaling_multi_analyte.ferx
+++ b/examples/scaling_multi_analyte.ferx
@@ -8,11 +8,12 @@
 # but fit() validates coverage at startup and errors with a clear
 # message naming any missing CMTs.
 #
-# `gradient = fd` is required because this example uses Form C (the
-# `y[CMT=N] = ...` readout — ODE-only, no AD path). Per-CMT
-# `obs_scale[CMT=N] = K` (Forms A/B post-multiply) DOES support AD via
+# Since #439 the `y[CMT=N] = ...` per-CMT Form C readout is differentiated
+# analytically over `Dual2`/`Dual1` (each endpoint's program), so the default
+# `gradient = auto` route serves it — `gradient = fd` is no longer required.
+# Per-CMT `obs_scale[CMT=N] = K` (Forms A/B post-multiply) also supports AD via
 # the per-observation scale array — see `scaling_expression.ferx` and
-# `docs/src/model-file/scaling.md` for the gradient-method matrix.
+# `docs/model-file/scaling.qmd` for the gradient-method matrix.
 
 [parameters]
   theta TVCL(5.0,  0.1,  50.0)
@@ -51,4 +52,4 @@
   method     = focei
   maxiter    = 500
   covariance = true
-  gradient   = fd                     # required for per-CMT scaling
+  gradient   = auto                   # per-CMT Form C is analytic since #439

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -555,7 +555,17 @@ pub enum OdeReadout {
     /// `subject.obs_cmts[i]`, which is `usize`). Fit-time validation
     /// enforces that every observed CMT has an entry; missing entries
     /// fall through to NaN at runtime as a defensive guard.
-    PerCmt(HashMap<usize, OdeOutputFn>),
+    PerCmt(HashMap<usize, PerCmtReadout>),
+}
+
+/// One per-CMT Form-C readout (`y[CMT=N] = <expr>`): the f64 closure the production
+/// predictor calls, plus the optional `PkNum`-differentiable program the analytic
+/// sensitivity provider evaluates over `Dual2`/`Dual1` (issue #439). `program` is
+/// `None` for hand-constructed readouts that bypass the parser — those keep the f64
+/// FD path (the dual provider declines them).
+pub struct PerCmtReadout {
+    pub out_fn: OdeOutputFn,
+    pub program: Option<crate::parser::model_parser::OdeOutputProgram>,
 }
 
 /// Read the observable value at observation `obs_idx`.
@@ -576,7 +586,7 @@ fn read_observable(
         OdeReadout::ObsCmt(idx) => u[*idx],
         OdeReadout::Single(out_fn) => out_fn(u, pk_params_flat, theta, eta, covariates),
         OdeReadout::PerCmt(map) => match map.get(&obs_cmt) {
-            Some(out_fn) => out_fn(u, pk_params_flat, theta, eta, covariates),
+            Some(r) => (r.out_fn)(u, pk_params_flat, theta, eta, covariates),
             // Parser + fit-time validation guarantee every observed CMT
             // has an entry. NaN here is a defensive guard against
             // hand-constructed CompiledModels that bypassed validation —
@@ -3351,9 +3361,21 @@ mod tests {
         // distinct, finite readouts of the same single-state system, so we can
         // confirm each observation got its own value (not one overwriting the
         // other).
-        let mut map: HashMap<usize, OdeOutputFn> = HashMap::new();
-        map.insert(1, Box::new(|s: &[f64], _pk: &[f64], _t, _e, _c| s[0]));
-        map.insert(2, Box::new(|s: &[f64], _pk: &[f64], _t, _e, _c| 2.0 * s[0]));
+        let mut map: HashMap<usize, PerCmtReadout> = HashMap::new();
+        map.insert(
+            1,
+            PerCmtReadout {
+                out_fn: Box::new(|s: &[f64], _pk: &[f64], _t, _e, _c| s[0]),
+                program: None,
+            },
+        );
+        map.insert(
+            2,
+            PerCmtReadout {
+                out_fn: Box::new(|s: &[f64], _pk: &[f64], _t, _e, _c| 2.0 * s[0]),
+                program: None,
+            },
+        );
         let mut ode = one_cpt_ode_spec();
         ode.readout = OdeReadout::PerCmt(map);
 
@@ -3385,10 +3407,13 @@ mod tests {
         // Build an OdeReadout::PerCmt that DELIBERATELY returns NaN for
         // CMT=1 — emulating a missing-CMT lookup that bypassed pre-fit
         // validation. The resulting prediction must be NaN, not 0.
-        let mut map: HashMap<usize, OdeOutputFn> = HashMap::new();
+        let mut map: HashMap<usize, PerCmtReadout> = HashMap::new();
         map.insert(
             1,
-            Box::new(|_state: &[f64], _pk: &[f64], _theta, _eta, _cov| f64::NAN),
+            PerCmtReadout {
+                out_fn: Box::new(|_state: &[f64], _pk: &[f64], _theta, _eta, _cov| f64::NAN),
+                program: None,
+            },
         );
         let mut ode = one_cpt_ode_spec();
         ode.readout = OdeReadout::PerCmt(map);

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4318,9 +4318,10 @@ fn parse_scaling_block(
     let mut obs_scale_uniform: Option<ScalingSpec> = None;
     let mut obs_scale_per_cmt: HashMap<usize, ScalingSpec> = HashMap::new();
     let mut y_uniform: Option<crate::ode::OdeOutputFn> = None;
-    let mut y_per_cmt: HashMap<usize, crate::ode::OdeOutputFn> = HashMap::new();
-    // Sensitivity program for the uniform `y = <expr>` readout (issue #367); the
-    // per-CMT form is out of the analytic-sensitivity scope, so it carries none.
+    let mut y_per_cmt: HashMap<usize, crate::ode::PerCmtReadout> = HashMap::new();
+    // Sensitivity program for the uniform `y = <expr>` readout (issue #367). The
+    // per-CMT readouts carry their own program inside each `PerCmtReadout` (#439),
+    // so the analytic-sensitivity provider can differentiate each endpoint.
     let mut y_uniform_program: Option<OdeOutputProgram> = None;
 
     for line in lines {
@@ -4432,7 +4433,13 @@ fn parse_scaling_block(
                         if y_per_cmt.contains_key(&cmt) {
                             return Err(format!("[scaling]: duplicate `y[CMT={}]` key", cmt));
                         }
-                        y_per_cmt.insert(cmt, out_fn);
+                        y_per_cmt.insert(
+                            cmt,
+                            crate::ode::PerCmtReadout {
+                                out_fn,
+                                program: Some(out_program),
+                            },
+                        );
                     }
                 }
             }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -12,10 +12,11 @@
 //! via the **general** individual-parameter derivatives `∂p/∂η, ∂p/∂θ` (FD of
 //! `pk_param_fn` — see [`param_derivatives`]; no log-normal assumption).
 //!
-//! **Supported:** single-endpoint `ObsCmt` or simple Form C (`y = central/V1`)
-//! readout; **bolus and infusion** doses; **bioavailability F** (incl. estimated,
-//! any parameterization — log-normal, logit-normal, additive); **EVID 3/4 resets
-//! / multi-occasion**; **non-zero `init(...)` initial conditions**; static
+//! **Supported:** single-endpoint `ObsCmt`, uniform Form C (`y = central/V1`), or
+//! per-CMT Form C (`y[CMT=N] = <expr>` — each endpoint differentiated over the dual,
+//! #439) readout; **bolus and infusion** doses; **bioavailability F** (incl.
+//! estimated, any parameterization — log-normal, logit-normal, additive); **EVID 3/4
+//! resets / multi-occasion**; **non-zero `init(...)` initial conditions**; static
 //! covariates; a constant `obs_scale` divisor and **LTBS** (`log(DV) ~ …`) output
 //! transforms; up to [`MAX_ODE_SENS_DIM`] individual parameters. Both the full
 //! `Dual2` **outer** gradient and a light `Dual1` **inner** η-gradient
@@ -23,7 +24,7 @@
 //!
 //! **Not yet supported** (falls back to the gradient-free / FD path): steady-state
 //! dosing, lagtime, built-in input-rate absorption, IOV, SDE/diffusion, expression
-//! `obs_scale`, time-varying covariates, per-CMT Form C.
+//! `obs_scale`, time-varying covariates.
 #![allow(clippy::needless_range_loop)]
 
 use super::dual1::Dual1;
@@ -67,12 +68,19 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     if ode.rhs_program.is_none() {
         return false;
     }
-    // Readout: either the state directly (`ObsCmt`) or a simple Form C output
-    // program (`y = <expr>` over states/indiv params, e.g. `central / V1`).
+    // Readout: the state directly (`ObsCmt`), a simple Form C output program
+    // (`y = <expr>` over states/indiv params, e.g. `central / V1`), or a per-CMT
+    // Form C (`y[CMT=N] = <expr>`) where every endpoint carries a simple program
+    // (#439 — each observation reads its CMT's program over the dual state).
     let readout_ok = match &ode.readout {
         OdeReadout::ObsCmt(_) => true,
         OdeReadout::Single(_) => ode.readout_program.as_ref().is_some_and(|p| p.is_simple()),
-        OdeReadout::PerCmt(_) => false,
+        OdeReadout::PerCmt(map) => {
+            !map.is_empty()
+                && map
+                    .values()
+                    .all(|r| r.program.as_ref().is_some_and(|p| p.is_simple()))
+        }
     };
     if !readout_ok {
         return false;
@@ -519,7 +527,8 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
     let mut ro_stack: Vec<T> = Vec::new();
     let preds: Vec<T> = states
         .iter()
-        .map(|st| {
+        .enumerate()
+        .map(|(j, st)| {
             let raw = match &ode.readout {
                 OdeReadout::ObsCmt(idx) => st.get(*idx).copied().unwrap_or(T::from_f64(0.0)),
                 OdeReadout::Single(_) => ode
@@ -527,7 +536,14 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
                     .as_ref()
                     .map(|p| p.eval_output_g::<T>(st, &params_dual, &mut ro_vars, &mut ro_stack))
                     .unwrap_or(T::from_f64(0.0)),
-                OdeReadout::PerCmt(_) => T::from_f64(0.0),
+                // Per-CMT (#439): observation j reads its own CMT's output program.
+                OdeReadout::PerCmt(cmt_map) => subject
+                    .obs_cmts
+                    .get(j)
+                    .and_then(|cmt| cmt_map.get(cmt))
+                    .and_then(|r| r.program.as_ref())
+                    .map(|p| p.eval_output_g::<T>(st, &params_dual, &mut ro_vars, &mut ro_stack))
+                    .unwrap_or(T::from_f64(f64::NAN)),
             };
             apply_output_transform::<T>(model, raw)
         })
@@ -1421,6 +1437,83 @@ mod tests {
                     g,
                     max_relative = 1e-3,
                     epsilon = 1e-6
+                );
+            }
+        }
+    }
+
+    // Per-CMT Form-C readout (#439): a 2-cpt model observed at two endpoints —
+    // central concentration at CMT 1 (`central/V1`) and peripheral concentration
+    // at CMT 2 (`peripheral/V2`). Each observation reads its own CMT's output
+    // program over the dual state, selected by `subject.obs_cmts`.
+    const TWOCPT_ODE_PERCMT: &str = r#"
+[parameters]
+  theta TVCL(4.0,  0.1, 100.0)
+  theta TVV1(12.0, 1.0, 500.0)
+  theta TVQ(2.0,   0.01, 100.0)
+  theta TVV2(25.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.15
+  omega ETA_V1 ~ 0.15
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q  = TVQ
+  V2 = TVV2
+[structural_model]
+  ode(states=[central, peripheral])
+[odes]
+  d/dt(central)    = -(CL/V1) * central - (Q/V1) * central + (Q/V2) * peripheral
+  d/dt(peripheral) =  (Q/V1) * central  - (Q/V2) * peripheral
+[scaling]
+  y[CMT=1] = central / V1
+  y[CMT=2] = peripheral / V2
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+    fn percmt_subject(times: &[f64], cmts: &[usize]) -> Subject {
+        let mut s = bolus_subject(times);
+        s.obs_cmts = cmts.to_vec();
+        s
+    }
+
+    /// The per-CMT provider's `f`/`∂f/∂η`/`∂f/∂θ` must match the production predictor
+    /// + FD, with each observation routed through its CMT's output program.
+    #[test]
+    fn ode_provider_percmt_matches_production() {
+        let model = parse_model_string(TWOCPT_ODE_PERCMT).expect("parse");
+        assert!(
+            ode_analytical_supported(&model),
+            "per-CMT Form-C ODE readout should be supported (#439)"
+        );
+        // Observations alternate between the two endpoints.
+        let subject = percmt_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0], &[1, 2, 1, 2, 1, 2]);
+        check_vs_production(&model, &subject, &[4.0, 12.0, 2.0, 25.0], &[0.12, -0.08]);
+    }
+
+    /// The light `Dual1` inner η-gradient must equal the full `Dual2` outer
+    /// `df_deta` for a per-CMT model too (each endpoint's program over both duals).
+    #[test]
+    fn ode_provider_percmt_light_matches_full() {
+        let model = parse_model_string(TWOCPT_ODE_PERCMT).expect("parse");
+        let subject = percmt_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0], &[1, 2, 1, 2, 1, 2]);
+        let theta = vec![4.0, 12.0, 2.0, 25.0];
+        let eta = vec![0.12, -0.08];
+        let full = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("full");
+        let light = ode_subject_eta_grad(&model, &subject, &theta, &eta).expect("light");
+        assert_eq!(full.obs.len(), light.len());
+        for (a, b) in full.obs.iter().zip(light.iter()) {
+            approx::assert_relative_eq!(a.f, b.f, max_relative = 1e-12, epsilon = 1e-12);
+            for k in 0..model.n_eta {
+                approx::assert_relative_eq!(
+                    a.df_deta[k],
+                    b.df_deta[k],
+                    max_relative = 1e-9,
+                    epsilon = 1e-10
                 );
             }
         }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1495,6 +1495,62 @@ mod tests {
         check_vs_production(&model, &subject, &[4.0, 12.0, 2.0, 25.0], &[0.12, -0.08]);
     }
 
+    /// The `PerCmt` gate's negative branches must drop the model out of analytic
+    /// scope (→ FD), not silently admit it: an empty endpoint map, or an endpoint
+    /// whose `program` is `None` (hand-constructed / non-`is_simple`, which the dual
+    /// provider can't evaluate) (#446 review — patch coverage on the reject path).
+    #[test]
+    fn ode_provider_percmt_gate_rejects_incomplete_map() {
+        // Empty per-CMT map → declined.
+        let mut empty = parse_model_string(TWOCPT_ODE_PERCMT).expect("parse");
+        empty.ode_spec.as_mut().expect("ode").readout =
+            OdeReadout::PerCmt(std::collections::HashMap::new());
+        assert!(
+            !ode_analytical_supported(&empty),
+            "empty per-CMT map must decline to FD"
+        );
+
+        // One endpoint with `program: None` (keeps its f64 `out_fn`) → declined,
+        // since the dual provider has no differentiable program to evaluate.
+        let mut no_prog = parse_model_string(TWOCPT_ODE_PERCMT).expect("parse");
+        match &mut no_prog.ode_spec.as_mut().expect("ode").readout {
+            OdeReadout::PerCmt(map) => {
+                let any_cmt = *map.keys().next().expect("at least one endpoint");
+                map.get_mut(&any_cmt).expect("entry").program = None;
+            }
+            _ => panic!("expected PerCmt readout"),
+        }
+        assert!(
+            !ode_analytical_supported(&no_prog),
+            "per-CMT endpoint with no differentiable program must decline to FD"
+        );
+    }
+
+    /// An observation whose CMT is absent from the per-CMT map hits the defensive
+    /// NaN fallback in the readout (fit-time `validate_per_cmt_scaling` rejects this
+    /// upstream, so it is unreachable in a real fit — but the provider must produce
+    /// NaN, not panic or silently zero it) (#446 review — patch coverage on the
+    /// fallback arm, shared by the Dual2 and Dual1 walks via `integrate_subject_duals`).
+    #[test]
+    fn ode_provider_percmt_missing_cmt_yields_nan() {
+        let model = parse_model_string(TWOCPT_ODE_PERCMT).expect("parse");
+        // CMT 3 has no readout entry (the map covers 1 and 2); the gate still passes
+        // (map non-empty, every present program simple).
+        let subject = percmt_subject(&[0.5, 1.0, 2.0], &[1, 3, 2]);
+        let theta = [4.0, 12.0, 2.0, 25.0];
+        let eta = [0.12, -0.08];
+        let sens = ode_subject_sensitivities(&model, &subject, &theta, &eta)
+            .expect("gate passes: map non-empty, programs simple");
+        assert!(
+            sens.obs[1].f.is_nan(),
+            "obs on uncovered CMT 3 → NaN readout"
+        );
+        assert!(
+            sens.obs[0].f.is_finite() && sens.obs[2].f.is_finite(),
+            "covered CMTs stay finite"
+        );
+    }
+
     /// The light `Dual1` inner η-gradient must equal the full `Dual2` outer
     /// `df_deta` for a per-CMT model too (each endpoint's program over both duals).
     #[test]


### PR DESCRIPTION
## Why

Closes the **per-CMT readout** Tier-1 item of #439. The `[scaling] y[CMT=N] = <expr>`
multi-endpoint Form-C readout (parent + metabolite, PK + effect, …) was the last ODE
readout shape still differentiating by **finite differences** — `gradient = fd` was
*required* for it. This arms the analytic gradient for it, and is the remaining piece
that puts the **#134 Emax PK/PD** per-CMT benchmark on the analytic inner loop.

> **Stacked on #438** (base `feat/arm-ode-sens-410`): it builds on the
> `integrate_g<T>` / `run_subject_eta` (light `Dual1` inner) machinery armed there.
> Review the per-CMT diff here; rebases onto `main` trivially once #438 lands.

## What changed

The parser already compiled each `y[CMT=N]` expression to **both** an f64 closure and
a `Dual2`/`Dual1`-differentiable `OdeOutputProgram` (via `build_y_output_fn`) — it just
*discarded* the program for the per-CMT branch. Now:

- **`OdeReadout::PerCmt`** holds a `HashMap<usize, PerCmtReadout>`, where
  `PerCmtReadout { out_fn, program: Option<OdeOutputProgram> }` keeps the closure
  (production f64 path) *and* the per-endpoint program (`None` for hand-constructed
  readouts, which keep the FD path). Single-field variant → no destructure-arity churn.
- **Parser** stores the per-CMT program in each `PerCmtReadout`.
- **Provider** (`run_subject` `Dual2` + `run_subject_eta` `Dual1`) evaluates, per
  observation `j`, the program for `subject.obs_cmts[j]` over the dual state.
- **Gate** (`ode_analytical_supported`) admits a `PerCmt` readout when every endpoint
  carries a simple program; otherwise the model falls back to FD as before.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`PerCmtReadout` is a new `pub` type in `crate::ode`, but it is an internal model-build
detail (not part of the R surface).

## Breaking changes
- [x] None (additive; the f64 production path is unchanged — `read_observable` reads
  `r.out_fn`).

## Numerical validation
- [x] `ode_provider_percmt_matches_production`: a 2-cpt model observed at two endpoints
  (`y[CMT=1]=central/V1`, `y[CMT=2]=peripheral/V2`) — provider `f`/`∂f/∂η`/`∂f/∂θ` match
  the production predictor + central FD, with observations alternating between CMTs.
- [x] `ode_provider_percmt_light_matches_full`: the light `Dual1` inner `∂f/∂η` equals
  the full `Dual2` outer `df_deta` (1e-9) for the per-CMT model.

## Performance
- [x] No new cost beyond the existing dual walk; per-CMT just selects a different
  compiled program per observation.

## Tests
- [x] Two unit tests added (above). Existing per-CMT *production* tests
  (`test_ode_predictions_*`, parser per-CMT tests) still pass under the new type.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry.
- [x] `docs/model-file/scaling.qmd` gradient-method matrix + per-CMT note updated
  (Form C is analytic since #410/#439, not FD-only).
- [x] `examples/scaling_multi_analyte.ferx` switched to `gradient = auto` with an
  updated comment (the `fd`-required note is no longer true).
- [x] `sens/ode_provider.rs` module scope list refreshed (per-CMT moved to Supported).

## Checklist
- [x] `cargo clippy` clean
- [x] `Dual2`/`Dual1` sensitivity path stays differentiable (the per-CMT program uses
  the same `eval_output_dual`/`eval_output_g` as the uniform Form-C readout).

## Reviewer hints
The substantive design choice is storing the per-endpoint program inside
`PerCmtReadout` (in `OdeReadout::PerCmt`) rather than a new `OdeSpec` field — it
localizes the change and keeps the f64 production path a one-line `.out_fn` access.
The provider arms select the program by `subject.obs_cmts[j]`, mirroring production's
`read_observable` dispatch.