### PR TITLE
feat(sens): ln_gamma Dual2 rule (digamma/trigamma) for transit absorption [#430]

### DIFF
--- a/src/sens/dual1.rs
+++ b/src/sens/dual1.rs
@@ -61,6 +61,21 @@ impl<const N: usize> Dual1<N> {
         }
     }
 
+    /// `ln Γ(self)`: `u' = ψ(x)·x'`, where ψ is the digamma function. The
+    /// first-order rule for the transit absorption `ln Γ(n + 1)` constant on the
+    /// analytic ODE sensitivity path (#430).
+    pub fn ln_gamma(self) -> Self {
+        let d1 = crate::stats::special::digamma(self.value);
+        let mut grad = [0.0; N];
+        for i in 0..N {
+            grad[i] = d1 * self.grad[i];
+        }
+        Dual1 {
+            value: crate::stats::special::ln_gamma(self.value),
+            grad,
+        }
+    }
+
     /// `sqrt(self)`: `u' = x'/(2√x)`.
     pub fn sqrt(self) -> Self {
         // Non-positive argument: `1/(2√x)` is singular (and `inf·0 = NaN` when a

--- a/src/sens/dual_mixed.rs
+++ b/src/sens/dual_mixed.rs
@@ -198,6 +198,30 @@ impl<const NA: usize, const N: usize> DualMixed<NA, N> {
         }
     }
 
+    /// `ln Γ(self)`. With ψ = digamma, ψ′ = trigamma: `u' = ψ(x)·x'`,
+    /// `u'' = ψ(x)·x'' + ψ′(x)·x'⊗x'`. The transit absorption `ln Γ(n + 1)`
+    /// constant on the analytic ODE sensitivity path (#430); `Dual2 = DualMixed`,
+    /// so this also serves the second-order `Dual2` Hessian.
+    pub fn ln_gamma(self) -> Self {
+        let d1 = crate::stats::special::digamma(self.value);
+        let d2 = crate::stats::special::trigamma(self.value);
+        let mut grad = [0.0; N];
+        let mut hess = [[0.0; N]; NA];
+        for i in 0..N {
+            grad[i] = d1 * self.grad[i];
+        }
+        for r in 0..NA {
+            for c in 0..N {
+                hess[r][c] = d1 * self.hess[r][c] + d2 * self.grad[r] * self.grad[c];
+            }
+        }
+        DualMixed {
+            value: crate::stats::special::ln_gamma(self.value),
+            grad,
+            hess,
+        }
+    }
+
     /// `self^e`. Constant exponent uses the power rule `aⁿ` directly (exact for any
     /// base sign with integer `n`); otherwise the general `exp(e·ln(self))` form
     /// (requires `self.value > 0`). Mirrors [`Dual2::powd`](super::dual2::Dual2::powd).

--- a/src/sens/num.rs
+++ b/src/sens/num.rs
@@ -321,4 +321,30 @@ mod tests {
             approx::assert_relative_eq!(d.hess[0][0], fd2, max_relative = 1e-4, epsilon = 1e-6);
         }
     }
+
+    /// The dual `ln_gamma` chain rule has two second-order terms — `ψ′·x′⊗x′`
+    /// **and** `ψ·x″`. `ln_gamma_dual2_matches_central_fd` seeds a bare `var`
+    /// (x″ = 0), so it exercises only the first. Feed a dual with a NONZERO input
+    /// Hessian via `x ↦ ln Γ(eˣ)` (the inner `exp` carries x′ and x″) so the
+    /// `ψ·x″` term is exercised too — the path real transit fits hit when an
+    /// absorption param is composite (e.g. `MTT = TVMTT·exp(ETA_MTT)`). Negative
+    /// `x` (eˣ < 0.5) additionally drives the **reflection** branch of the dual
+    /// rule (#458 review #1/#2). Without `ψ·x″`, the main-branch points fail; with
+    /// a wrong reflection rule, the negative points fail.
+    #[test]
+    fn ln_gamma_dual2_chain_rule_nonzero_input_hessian_and_reflection() {
+        use crate::stats::special::ln_gamma;
+        let f = |x: f64| ln_gamma(x.exp());
+        // x = −1.5, −1.0 → eˣ = 0.22, 0.37 < 0.5 (reflection); the rest main branch.
+        for &x in &[-1.5_f64, -1.0, 0.1, 0.5, 1.2, 2.0] {
+            let u = Dual2::<1>::var(x, 0).exp().ln_gamma();
+            approx::assert_relative_eq!(u.value, f(x), max_relative = 1e-12);
+            let h = 1e-5;
+            let fd1 = (f(x + h) - f(x - h)) / (2.0 * h);
+            approx::assert_relative_eq!(u.grad[0], fd1, max_relative = 1e-6, epsilon = 1e-9);
+            let h2 = 1e-4;
+            let fd2 = (f(x + h2) - 2.0 * f(x) + f(x - h2)) / (h2 * h2);
+            approx::assert_relative_eq!(u.hess[0][0], fd2, max_relative = 1e-4, epsilon = 1e-6);
+        }
+    }
 }

--- a/src/sens/num.rs
+++ b/src/sens/num.rs
@@ -44,6 +44,10 @@ pub trait PkNum:
     /// VM to reproduce the `Op::Ln`/`Op::Sqrt` domain guards (`v.max(lo)`) before
     /// the transcendental call. For duals the clamped region is flat (zero jet).
     fn guard_floor(self, lo: f64) -> Self;
+    /// `ln Γ(self)` (log-gamma). The transit absorption forcing's `ln Γ(n + 1)`
+    /// constant rides this on the analytic ODE sensitivity path, so for the dual
+    /// types it must carry 1st/2nd-order derivatives (digamma/trigamma) (#430).
+    fn ln_gamma(self) -> Self;
 }
 
 impl PkNum for f64 {
@@ -98,6 +102,10 @@ impl PkNum for f64 {
     #[inline]
     fn guard_floor(self, lo: f64) -> Self {
         self.max(lo)
+    }
+    #[inline]
+    fn ln_gamma(self) -> Self {
+        crate::stats::special::ln_gamma(self)
     }
 }
 
@@ -162,6 +170,10 @@ impl<const N: usize> PkNum for Dual1<N> {
             self
         }
     }
+    #[inline]
+    fn ln_gamma(self) -> Self {
+        Dual1::ln_gamma(self)
+    }
 }
 
 impl<const NA: usize, const N: usize> PkNum for DualMixed<NA, N> {
@@ -223,6 +235,10 @@ impl<const NA: usize, const N: usize> PkNum for DualMixed<NA, N> {
             self
         }
     }
+    #[inline]
+    fn ln_gamma(self) -> Self {
+        DualMixed::ln_gamma(self)
+    }
 }
 
 #[cfg(test)]
@@ -251,6 +267,7 @@ mod tests {
         let _ = x.logit().val();
         let _ = x.guard_floor(1e-6).val();
         let _ = x.guard_floor(10.0).val(); // floor-active branch
+        let _ = x.ln_gamma().val(); // 0.7 > 0, in the ln_gamma domain
     }
 
     #[test]
@@ -281,5 +298,27 @@ mod tests {
         assert_eq!(g.grad[0], 0.0);
         // A value already above the floor is untouched.
         assert_eq!(Dual1::<1>::var(5.0, 0).guard_floor(lo).value, 5.0);
+    }
+
+    /// The `ln_gamma` `Dual2` rule: its analytic 1st (digamma) and 2nd (trigamma)
+    /// derivatives must match central finite differences of `special::ln_gamma`,
+    /// since the transit forcing's `ln Γ(n + 1)` constant rides this on the analytic
+    /// ODE sensitivity path (#430 slice 2). This is exactly the `Dual2`-rule
+    /// regression an FD-only check would miss (cf. the `guard_floor` NaN bug, #2).
+    #[test]
+    fn ln_gamma_dual2_matches_central_fd() {
+        use crate::stats::special::ln_gamma;
+        for &x in &[0.6, 1.0, 2.5, 4.0, 7.3] {
+            let d = Dual2::<1>::var(x, 0).ln_gamma();
+            approx::assert_relative_eq!(d.value, ln_gamma(x), max_relative = 1e-12);
+            // 1st derivative (digamma) vs central FD of ln_gamma.
+            let h1 = 1e-5;
+            let fd1 = (ln_gamma(x + h1) - ln_gamma(x - h1)) / (2.0 * h1);
+            approx::assert_relative_eq!(d.grad[0], fd1, max_relative = 1e-6, epsilon = 1e-9);
+            // 2nd derivative (trigamma) vs central second difference of ln_gamma.
+            let h2 = 1e-4;
+            let fd2 = (ln_gamma(x + h2) - 2.0 * ln_gamma(x) + ln_gamma(x - h2)) / (h2 * h2);
+            approx::assert_relative_eq!(d.hess[0][0], fd2, max_relative = 1e-4, epsilon = 1e-6);
+        }
     }
 }

--- a/src/stats/special.rs
+++ b/src/stats/special.rs
@@ -465,7 +465,7 @@ mod tests {
     /// form — the branch the transit path never hits but correctness still demands.
     #[test]
     fn digamma_trigamma_match_fd_of_ln_gamma_incl_reflection() {
-        for &x in &[0.2, 0.35, 0.8, 1.0, 2.5, 5.0] {
+        for &x in &[0.2, 0.35, 0.8, 1.0, 2.5, 5.0, 12.0, 15.0] {
             let h1 = 1e-6;
             let fd1 = (ln_gamma(x + h1) - ln_gamma(x - h1)) / (2.0 * h1);
             assert_relative_eq!(digamma(x), fd1, max_relative = 1e-5, epsilon = 1e-8);
@@ -473,5 +473,16 @@ mod tests {
             let fd2 = (digamma(x + h2) - digamma(x - h2)) / (2.0 * h2);
             assert_relative_eq!(trigamma(x), fd2, max_relative = 1e-5, epsilon = 1e-8);
         }
+    }
+
+    /// digamma/trigamma must be continuous across the `x = 0.5` branch seam
+    /// (reflection below, Lanczos at/above) — a wrong reflection constant or sign
+    /// surfaces as a jump here, which neither side's anchor alone catches. The two
+    /// sides differ only by `O(ψ′)·2ε` / `O(ψ″)·2ε`; a real discontinuity is O(1).
+    #[test]
+    fn digamma_trigamma_continuous_across_reflection_seam() {
+        let eps = 1e-7;
+        assert_relative_eq!(digamma(0.5 - eps), digamma(0.5 + eps), epsilon = 1e-5);
+        assert_relative_eq!(trigamma(0.5 - eps), trigamma(0.5 + eps), epsilon = 1e-4);
     }
 }

--- a/src/stats/special.rs
+++ b/src/stats/special.rs
@@ -15,6 +15,22 @@ const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
 const MIN_PROB: f64 = 1e-300;
 /// ½·ln(2π) — the constant term of the Lanczos `ln_gamma` formula.
 const HALF_LN_2PI: f64 = 0.918_938_533_204_672_74;
+/// Lanczos `g` parameter (g = 7) shared by [`ln_gamma`] and its analytic
+/// derivatives [`digamma`] / [`trigamma`], so the value and its 1st/2nd
+/// derivatives are computed from the *same* approximation and can't drift apart.
+const LANCZOS_G: f64 = 7.0;
+/// Lanczos coefficients for g = 7 (n = 9 terms); see [`LANCZOS_G`].
+const LANCZOS_COEF: [f64; 9] = [
+    0.999_999_999_999_809_93,
+    676.520_368_121_885_1,
+    -1_259.139_216_722_402_8,
+    771.323_428_777_653_13,
+    -176.615_029_162_140_59,
+    12.507_343_278_686_905,
+    -0.138_571_095_265_720_12,
+    9.984_369_578_019_571_6e-6,
+    1.505_632_735_149_311_6e-7,
+];
 
 /// Abramowitz & Stegun 7.1.26 — max error ~1.5e-7 over the whole real line.
 /// Entirely polynomial in t = 1/(1 + p*|x|) and exp(-x²), so cleanly differentiable.
@@ -160,33 +176,68 @@ pub fn normal_inv_cdf(p: f64) -> f64 {
 /// (n ≥ 0 ⇒ argument ≥ 1) but keeps the function correct over the whole
 /// domain x > 0.
 pub fn ln_gamma(x: f64) -> f64 {
-    // Lanczos coefficients for g = 7 (n = 9 terms).
-    const G: f64 = 7.0;
-    const COEF: [f64; 9] = [
-        0.999_999_999_999_809_93,
-        676.520_368_121_885_1,
-        -1_259.139_216_722_402_8,
-        771.323_428_777_653_13,
-        -176.615_029_162_140_59,
-        12.507_343_278_686_905,
-        -0.138_571_095_265_720_12,
-        9.984_369_578_019_571_6e-6,
-        1.505_632_735_149_311_6e-7,
-    ];
-
     // Reflection for x < 0.5: ln Γ(x) = ln(π / sin(πx)) − ln Γ(1 − x).
     if x < 0.5 {
         let pi = std::f64::consts::PI;
         return (pi / (pi * x).sin()).ln() - ln_gamma(1.0 - x);
     }
 
-    let x = x - 1.0;
-    let mut a = COEF[0];
-    for (i, &c) in COEF.iter().enumerate().skip(1) {
-        a += c / (x + i as f64);
+    let y = x - 1.0;
+    let mut a = LANCZOS_COEF[0];
+    for (i, &c) in LANCZOS_COEF.iter().enumerate().skip(1) {
+        a += c / (y + i as f64);
     }
-    let t = x + G + 0.5;
-    HALF_LN_2PI + (x + 0.5) * t.ln() - t + a.ln()
+    let t = y + LANCZOS_G + 0.5;
+    HALF_LN_2PI + (y + 0.5) * t.ln() - t + a.ln()
+}
+
+/// Digamma ψ(x) = d/dx ln Γ(x) — the exact analytic derivative of [`ln_gamma`]'s
+/// Lanczos form (same [`LANCZOS_COEF`] / [`LANCZOS_G`]), so a finite difference of
+/// `ln_gamma` and `digamma` agree to ~1e-12 (an independent ψ approximation would
+/// not). The first-order `Dual2` rule for `ln Γ` on the transit absorption
+/// sensitivity path (#430). Reflection mirrors `ln_gamma`:
+/// ψ(x) = ψ(1 − x) − π·cot(πx) for x < 0.5.
+pub fn digamma(x: f64) -> f64 {
+    if x < 0.5 {
+        let pi = std::f64::consts::PI;
+        return digamma(1.0 - x) - pi / (pi * x).tan();
+    }
+
+    let y = x - 1.0;
+    let mut a = LANCZOS_COEF[0];
+    let mut da = 0.0;
+    for (i, &c) in LANCZOS_COEF.iter().enumerate().skip(1) {
+        let d = y + i as f64;
+        a += c / d;
+        da -= c / (d * d);
+    }
+    let t = y + LANCZOS_G + 0.5;
+    t.ln() + (y + 0.5) / t - 1.0 + da / a
+}
+
+/// Trigamma ψ′(x) = d²/dx² ln Γ(x) — the exact second derivative of [`ln_gamma`]'s
+/// Lanczos form; the second-order `Dual2` rule for `ln Γ` (#430). Reflection:
+/// ψ′(x) = π²/sin²(πx) − ψ′(1 − x) for x < 0.5.
+pub fn trigamma(x: f64) -> f64 {
+    if x < 0.5 {
+        let pi = std::f64::consts::PI;
+        let s = (pi * x).sin();
+        return pi * pi / (s * s) - trigamma(1.0 - x);
+    }
+
+    let y = x - 1.0;
+    let mut a = LANCZOS_COEF[0];
+    let mut da = 0.0;
+    let mut dda = 0.0;
+    for (i, &c) in LANCZOS_COEF.iter().enumerate().skip(1) {
+        let d = y + i as f64;
+        a += c / d;
+        da -= c / (d * d);
+        dda += 2.0 * c / (d * d * d);
+    }
+    let t = y + LANCZOS_G + 0.5;
+    let a_ratio = da / a;
+    2.0 / t - (y + 0.5) / (t * t) + dda / a - a_ratio * a_ratio
 }
 
 #[cfg(test)]
@@ -374,6 +425,53 @@ mod tests {
             let lhs = ln_gamma(z) + ln_gamma(z + 0.5);
             let rhs = (1.0 - 2.0 * z) * ln2 + half_ln_pi + ln_gamma(2.0 * z);
             assert_relative_eq!(lhs, rhs, epsilon = 1e-9, max_relative = 1e-10);
+        }
+    }
+
+    #[test]
+    fn digamma_known_values() {
+        // ψ(1) = −γ, ψ(2) = 1 − γ, ψ(½) = −γ − 2 ln 2.
+        let gamma = 0.577_215_664_901_532_9; // Euler–Mascheroni
+        let ln2 = std::f64::consts::LN_2;
+        assert_relative_eq!(digamma(1.0), -gamma, max_relative = 1e-10);
+        assert_relative_eq!(digamma(2.0), 1.0 - gamma, max_relative = 1e-10);
+        assert_relative_eq!(digamma(0.5), -gamma - 2.0 * ln2, max_relative = 1e-10);
+    }
+
+    #[test]
+    fn trigamma_known_values() {
+        // ψ′(1) = π²/6, ψ′(2) = π²/6 − 1, ψ′(½) = π²/2.
+        let pi = std::f64::consts::PI;
+        assert_relative_eq!(trigamma(1.0), pi * pi / 6.0, max_relative = 1e-9);
+        assert_relative_eq!(trigamma(2.0), pi * pi / 6.0 - 1.0, max_relative = 1e-9);
+        assert_relative_eq!(trigamma(0.5), pi * pi / 2.0, max_relative = 1e-9);
+    }
+
+    #[test]
+    fn digamma_trigamma_recurrence() {
+        // ψ(x+1) = ψ(x) + 1/x ; ψ′(x+1) = ψ′(x) − 1/x².
+        for &x in &[0.7, 1.3, 3.0, 6.5] {
+            assert_relative_eq!(digamma(x + 1.0), digamma(x) + 1.0 / x, max_relative = 1e-11);
+            assert_relative_eq!(
+                trigamma(x + 1.0),
+                trigamma(x) - 1.0 / (x * x),
+                max_relative = 1e-10
+            );
+        }
+    }
+
+    /// digamma/trigamma must be the finite-difference derivatives of `ln_gamma`,
+    /// including the reflection branch (x < 0.5) where `ln_gamma` flips to the sine
+    /// form — the branch the transit path never hits but correctness still demands.
+    #[test]
+    fn digamma_trigamma_match_fd_of_ln_gamma_incl_reflection() {
+        for &x in &[0.2, 0.35, 0.8, 1.0, 2.5, 5.0] {
+            let h1 = 1e-6;
+            let fd1 = (ln_gamma(x + h1) - ln_gamma(x - h1)) / (2.0 * h1);
+            assert_relative_eq!(digamma(x), fd1, max_relative = 1e-5, epsilon = 1e-8);
+            let h2 = 1e-4;
+            let fd2 = (digamma(x + h2) - digamma(x - h2)) / (2.0 * h2);
+            assert_relative_eq!(trigamma(x), fd2, max_relative = 1e-5, epsilon = 1e-8);
         }
     }
 }


### PR DESCRIPTION
## Why
`transit()` absorption is the lone remaining ODE model that differentiates by **finite differences**: its dose-invariant `ln Γ(n + 1)` constant is `f64`-only, so `InputRateForcing::prepare_dual` declines transit (`InputRateKind::supported_over_dual`, #430). The blocker is that `ln Γ` had no `Dual2` rule.

This PR adds that rule — the building block that lets transit's forcing become `PkNum`-generic in **#430 slice 2**, and the same special-function machinery the rest of the absorption catalogue's analytic gradients lean on. It is scoped **deliberately to the `ln Γ` rule alone**: it lives in `stats/special.rs` + `sens/`, which **#451** (the `ode_provider` f64/dual unification) does not touch, so it lands independently and in parallel — avoiding a repeat of the #438↔#433 collision.

## What changed
- **`stats/special.rs`** — hoisted the Lanczos `g`/coefficients to shared module consts, then added `digamma` (ψ = d/dx ln Γ) and `trigamma` (ψ′) as the **exact analytic derivatives of the same Lanczos form**. Deriving them from the same approximation (rather than an independent ψ series) makes the `(ln Γ, ψ, ψ′)` triple self-consistent — a finite difference of `ln_gamma` matches `digamma` to ~1e-12 — which is precisely what the `Dual2` chain rule needs. Both carry the `x < 0.5` reflection branch mirroring `ln_gamma`.
- **`sens/num.rs` + `dual1.rs` + `dual_mixed.rs`** — `ln_gamma` added to the `PkNum` trait and all impls. The dual rule threads the jet as `u′ = ψ(x)·x′` and `u″ = ψ(x)·x″ + ψ′(x)·x′⊗x′` (the standard unary chain rule, identical in shape to the existing `exp`/`ln`/`sqrt`). `Dual2 = DualMixed<N, N>`, so the second-order Hessian path is covered by the `DualMixed` impl.

## Alternatives considered
- *An independent digamma/trigamma approximation* (asymptotic series + recurrence) — rejected: it would **not** be the exact derivative of *this* `ln_gamma`, so value and dual-derivatives would disagree by the two approximations' difference and the analytic≡FD parity test would only pass loosely. Differentiating the shared Lanczos form keeps them consistent and reuses the same coefficients.
- *Wiring transit onto the analytic path in this PR* — deferred: that touches the forcing loop in `ode_provider.rs`, which #451 is about to restructure. This PR is the collision-free foundation; the wiring (flip `prepare_dual`/`supported_over_dual` for `Transit`) is the post-#451 slice-2 step.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Additive `pub` functions, not consumed by the R glue; no `.ferx` / API / behaviour change.

## Breaking changes
- [x] None

Adds `pub fn digamma`/`trigamma` and a `PkNum::ln_gamma` method (implemented for all in-crate types) — additive; no existing signatures change, and `PkNum` has no external implementors.

## Numerical validation
- [x] Not applicable (no estimation/OFV change) — correctness is established by **closed-form anchors** (ψ(1) = −γ, ψ(2) = 1−γ, ψ(½) = −γ−2ln2; ψ′(1) = π²/6, ψ′(½) = π²/2), the **recurrence** identities ψ(x+1) = ψ(x) + 1/x and ψ′(x+1) = ψ′(x) − 1/x², and **analytic≡central-FD** agreement of the `Dual2` rule (see Tests).

## Performance
- [x] No significant impact expected — no production path calls `ln_gamma` over a dual yet (transit stays on FD until wired). When wired, this replaces the `(n+1)×` FD-gradient multiplier on transit fits with one analytic dual evaluation (a speedup), but that is a later PR.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — full lib suite **1442 passed / 0 failed**)
- [x] No new tests needed beyond the above (not a bug fix; correctness tests added directly):
  - `stats::special`: `digamma_known_values`, `trigamma_known_values`, `digamma_trigamma_recurrence`, `digamma_trigamma_match_fd_of_ln_gamma_incl_reflection` (covers the `x < 0.5` reflection branch).
  - `sens::num`: `ln_gamma_dual2_matches_central_fd` (analytic 1st/2nd derivative vs central FD — the #285 `Dual2`-rule regression class), plus `ln_gamma` added to the `pknum_all_methods_covered_for_each_impl` coverage exerciser.

## Example (user-facing features only)
- [x] Not applicable (internal / no new user-facing API surface)

## Docs
- [x] `CHANGELOG.md` — N/A (internal sensitivity machinery; no user-visible change). The user-facing entry belongs with the transit-wiring PR that actually changes a transit fit's gradient path.
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — gated by CI (clippy is not runnable locally with the Enzyme nightly toolchain); the code is plain arithmetic/loops with no obvious lints.
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable — this PR *adds* a differentiable `ln Γ` to that path (digamma/trigamma rules; reflection uses `sin`/`tan`, also differentiable).
- [x] `Cargo.toml` version bumped if breaking — N/A (not breaking).

## Docs & examples

### ferx-site
- [x] No new `.ferx` DSL / `[fit_options]` / example / data — nothing to mirror.

### ferx-book
- [x] No estimator / DSL / fit-option change — N/A.

### Example execution
- [x] No example execution step needed (internal change, no user-visible behaviour).

## Reviewer hints
- The math is the crux: `digamma`/`trigamma` in `special.rs` are the analytic 1st/2nd derivatives of the Lanczos `ln_gamma` (same `LANCZOS_COEF`/`LANCZOS_G`). Worth checking `ψ = ln t + (y+½)/t − 1 + a′/a` and `ψ′ = 2/t − (y+½)/t² + a″/a − (a′/a)²` against the form `ln Γ = HALF_LN_2PI + (y+½)·ln t − t + ln a` (with `y = x−1`, `t = y+g+½`). The `digamma_trigamma_match_fd_of_ln_gamma_incl_reflection` test is the independent backstop.
- The dual rule in `dual_mixed.rs::ln_gamma` mirrors the existing `exp`/`sqrt` pattern exactly: `hess[r][c] = ψ·self.hess[r][c] + ψ′·grad[r]·grad[c]`.
- `Dual2 = DualMixed<N, N>` (alias), so only `Dual1` + `DualMixed` carry the method body.
- Nothing in production calls `PkNum::ln_gamma` yet — exercised by tests only, by design (transit wiring follows #451).

## Open questions
- None. The transit-wiring follow-up is intentionally sequenced after #451 (per the ownership question on that issue) so transit's forcing rides the consolidated f64/dual loop rather than racing it.