### PR TITLE
ODE sensitivity: unify f64/dual forcing + LTBS transform, TV-cov inner-gradient perf [#451]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Performance
+- **Faster analytic time-varying-covariate inner η-gradient + ODE-sensitivity path
+  consolidation** (#451). The per-subject event schedule is now reused across inner
+  BFGS steps instead of rebuilt each step, identical per-event covariate snapshots are
+  seeded once, and the time-after-dose anchor advances incrementally — cutting
+  redundant work in the inner EBE loop for TV-covariate analytical fits. Internally,
+  the production `f64` and dual ODE-sensitivity paths now share single generic helpers
+  for the built-in absorption input-rate forcing and the LTBS log transform, so the
+  predictor and the analytic gradient can't silently drift; no change to results.
 - **Analytic inner η-gradient for time-varying covariates / oral infusion on
   analytical PK models** (#447). The light `Dual1` inner EBE gradient previously
   declined these subjects and reverted to finite differences even though the

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -435,13 +435,14 @@ pub fn find_ebe(
             let profile = inner_profile_enabled();
             let agrad = |e: &[f64]| -> Vec<f64> {
                 let t0 = std::time::Instant::now();
-                match analytic_eta_nll_gradient(
+                match analytic_eta_nll_gradient_with_schedule(
                     model,
                     subject,
                     &params.theta,
                     e,
                     &params.omega,
                     &params.sigma.values,
+                    schedule.as_ref(),
                 ) {
                     Some(g) => {
                         GRADIENT_TIMINGS.record_analytic(t0.elapsed().as_nanos() as u64);
@@ -992,9 +993,31 @@ pub(crate) fn analytic_eta_nll_gradient(
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
 ) -> Option<Vec<f64>> {
+    analytic_eta_nll_gradient_with_schedule(model, subject, theta, eta, omega, sigma, None)
+}
+
+/// As [`analytic_eta_nll_gradient`], but reusing the per-subject `EventSchedule` the
+/// inner optimizer cached once, so the TV-cov provider doesn't rebuild it every inner
+/// BFGS step (#449 re-review #6). `None` rebuilds locally.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn analytic_eta_nll_gradient_with_schedule(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    omega: &crate::types::OmegaMatrix,
+    sigma: &[f64],
+    cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
+) -> Option<Vec<f64>> {
     // Light first-order provider (value + ∂f/∂η only); the inner gradient never
     // needs the second-order / θ blocks the full `subject_sensitivities` carries.
-    let sens = crate::sens::provider::subject_eta_grad(model, subject, theta, eta)?;
+    let sens = crate::sens::provider::subject_eta_grad_with_schedule(
+        model,
+        subject,
+        theta,
+        eta,
+        cached_schedule,
+    )?;
     let n_eta = model.n_eta;
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
     let mut grad = vec![0.0_f64; n_eta];

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -425,23 +425,30 @@ fn prepare_input_rates(ode: &OdeSpec, params: &[f64]) -> Vec<PreparedInputRate> 
 /// tail uses the *current* occasion's `n`/`mtt`. This is exact for IIV and when
 /// `II` exceeds the absorption window; only overlapping-occasion tails are
 /// approximated.
+///
+/// Generic over the numeric type `T: PkNum` so the **single** superposition loop
+/// serves both the production `f64` predictor (`T = f64`, byte-identical to the
+/// original) and the analytic ODE sensitivity provider's dual walk (`T = Dual*`),
+/// instead of `sens/ode_provider.rs` hand-maintaining a second copy (#430 review
+/// #4 / #451). The dual caller passes `dose_lagtimes = &[]` (lagtime gated off) and
+/// `reset_floor = NEG_INFINITY` (reset gated off), so those branches are inert there.
 #[inline]
 #[allow(clippy::too_many_arguments)] // mirrors the dose context threaded into the RHS wrappers
-fn add_prepared_input_rate_forcing(
+pub(crate) fn add_prepared_input_rate_forcing<T: crate::sens::num::PkNum>(
     ode: &OdeSpec,
-    prepared: &[PreparedInputRate],
+    prepared: &[PreparedInputRate<T>],
     doses: &[DoseEvent],
     dose_lagtimes: &[f64],
-    dose_f_bio: &[f64],
+    dose_f_bio: &[T],
     reset_floor: f64,
     t: f64,
-    dy: &mut [f64],
+    dy: &mut [T],
 ) {
     for (forcing, prep) in ode.input_rate.iter().zip(prepared) {
         if forcing.cmt >= dy.len() {
             continue;
         }
-        let mut acc = 0.0;
+        let mut acc = T::from_f64(0.0);
         for (k, d) in doses.iter().enumerate() {
             if d.cmt.saturating_sub(1) != forcing.cmt {
                 continue;
@@ -457,10 +464,11 @@ fn add_prepared_input_rate_forcing(
             if tad <= 0.0 {
                 continue;
             }
-            let dose_mass = dose_f_bio.get(k).copied().unwrap_or(1.0) * d.amt;
-            acc += prep.rate(tad, dose_mass);
+            let dose_mass =
+                dose_f_bio.get(k).copied().unwrap_or(T::from_f64(1.0)) * T::from_f64(d.amt);
+            acc = acc + prep.rate(T::from_f64(tad), dose_mass);
         }
-        dy[forcing.cmt] += acc;
+        dy[forcing.cmt] = dy[forcing.cmt] + acc;
     }
 }
 

--- a/src/pk/absorption.rs
+++ b/src/pk/absorption.rs
@@ -124,7 +124,16 @@ impl InputRateKind {
     /// fallback. #430 lifts inverse-Gaussian first (no new special function);
     /// transit follows once `ln_gamma` has a `Dual2` rule, Weibull with Phase 2.
     pub fn supported_over_dual(self) -> bool {
-        matches!(self, InputRateKind::InverseGaussian)
+        // Exhaustive (no `_` arm) so adding a kind forces a decision here, and must
+        // stay consistent with [`InputRateForcing::prepare_dual`] — a kind marked
+        // supported here but returning `None` there would let the ODE provider admit
+        // the model and then silently bail the whole subject to FD. The
+        // `supported_over_dual_agrees_with_prepare_dual` test pins that consistency
+        // (#430 review #5 / #451).
+        match self {
+            InputRateKind::InverseGaussian => true,
+            InputRateKind::Transit => false,
+        }
     }
 }
 
@@ -694,5 +703,30 @@ mod tests {
             arg_slots: vec![6, 7],
         };
         assert!(transit.prepare_dual::<f64>(&params).is_none());
+    }
+
+    /// Drift tripwire: `InputRateKind::supported_over_dual` (the gate the ODE
+    /// provider reads) must agree with whether `prepare_dual` actually lifts the
+    /// kind. A kind marked supported but returning `None` would let
+    /// `ode_analytical_supported` admit the model, then the `?` in
+    /// `integrate_subject_duals` silently bails the whole subject to FD with no
+    /// error. Adding a kind: extend `ALL_KINDS` here too (#430 review #5 / #451).
+    #[test]
+    fn supported_over_dual_agrees_with_prepare_dual() {
+        const ALL_KINDS: &[InputRateKind] =
+            &[InputRateKind::InverseGaussian, InputRateKind::Transit];
+        let params = vec![1.0; crate::types::MAX_PK_PARAMS];
+        for &kind in ALL_KINDS {
+            let forcing = InputRateForcing {
+                cmt: 1,
+                kind,
+                arg_slots: vec![4, 5],
+            };
+            assert_eq!(
+                kind.supported_over_dual(),
+                forcing.prepare_dual::<f64>(&params).is_some(),
+                "supported_over_dual must match prepare_dual liftability for {kind:?}"
+            );
+        }
     }
 }

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -292,9 +292,22 @@ pub(crate) const LTBS_FLOOR: f64 = 1e-12;
 pub(crate) fn apply_log_transform(model: &CompiledModel, preds: &mut [f64]) {
     if model.log_transform {
         for p in preds.iter_mut() {
-            *p = p.max(LTBS_FLOOR).ln();
+            *p = ltbs_log_g(*p);
         }
     }
+}
+
+/// The LTBS log transform, generic over `T: PkNum`, so the production `f64`
+/// predictor and the analytic ODE/analytical sensitivity dual walks apply the
+/// *same* floor-then-log (`p.max(LTBS_FLOOR).ln()` for `T = f64`, byte-identical to
+/// the original) instead of each re-deriving it — the consistency the
+/// `apply_log_transform` doc demands (#438 review #4 / #451). `guard_floor` also
+/// floors `NaN` to the floor (matching `f64::max`), so a transient `NaN` maps to
+/// `ln(LTBS_FLOOR)` on every path; the dual callers keep their own pre-check when a
+/// `NaN` readout must instead stay visible (e.g. a per-CMT miss).
+#[inline]
+pub(crate) fn ltbs_log_g<T: crate::sens::num::PkNum>(p: T) -> T {
+    p.guard_floor(LTBS_FLOOR).ln()
 }
 
 pub fn predict_iov(

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1187,11 +1187,11 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
     let ode = model
         .ode_spec
         .as_ref()
-        .expect("ode_tvcov_supported guarantees ode_spec");
+        .expect("ode_analytical_supported (via ode_tvcov_supported) guarantees ode_spec");
     let program = ode
         .rhs_program
         .as_ref()
-        .expect("ode_analytical_supported guarantees rhs_program");
+        .expect("ode_analytical_supported (via ode_tvcov_supported) guarantees rhs_program");
     let opts = ode.solver_opts;
 
     // Raw slot, mirroring production's `DoseAttrMap::f_bio` (1.0 default baked in at
@@ -1239,6 +1239,43 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
     preds
 }
 
+/// Seed the per-event PK duals for a TV-cov subject's doses and observations,
+/// deduplicating identical covariate snapshots. With TV covariates that change at
+/// only a few breakpoints, most dose/obs events share a snapshot, so a full dual
+/// eval per event re-does identical work; memoising by snapshot collapses that. The
+/// seed is deterministic in the snapshot, so a cache hit is bit-identical to
+/// re-seeding. The dose and obs vectors share one cache, so a snapshot common to
+/// both is evaluated once. `seed` is fallible (`None` aborts the whole subject →
+/// FD fallback); an infallible seeder wraps its result in `Some`.
+///
+/// One generic home for both the outer (`Dual2`) and inner (`Dual1`) TV-cov walks,
+/// so the memoisation policy isn't maintained as two near-identical closures
+/// (#451 re-review #8 / #451 review #3). The cache is a linear-scanned `Vec` keyed on
+/// `HashMap<String, f64>` value-equality — fine for the few-snapshot common case;
+/// note a snapshot with a missing (`NaN`) covariate value never compares equal to
+/// itself, so it isn't deduplicated (a re-seed, identical result, never a wrong one).
+fn seed_tvcov_snapshots<T: Clone>(
+    subject: &Subject,
+    mut seed: impl FnMut(&std::collections::HashMap<String, f64>) -> Option<Vec<T>>,
+) -> Option<(Vec<Vec<T>>, Vec<Vec<T>>)> {
+    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<T>)> = Vec::new();
+    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Option<Vec<T>> {
+        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
+            return Some(v.clone());
+        }
+        let v = seed(cov)?;
+        snap_cache.push((cov.clone(), v.clone()));
+        Some(v)
+    };
+    let pk_at_dose: Vec<Vec<T>> = (0..subject.doses.len())
+        .map(|k| seed_for(subject.dose_cov(k)))
+        .collect::<Option<_>>()?;
+    let pk_at_obs: Vec<Vec<T>> = (0..subject.obs_times.len())
+        .map(|j| seed_for(subject.obs_cov(j)))
+        .collect::<Option<_>>()?;
+    Some((pk_at_dose, pk_at_obs))
+}
+
 /// Time-varying-covariate outer (`Dual2<M>`, `M = n_theta + n_eta`) sensitivities
 /// for an ODE model — the ODE counterpart of `run_obs_tvcov`. Seeds the per-event
 /// PK params on `(θ,η)`, runs the shared TV-cov walk + readout, and reads
@@ -1254,26 +1291,11 @@ fn run_subject_tvcov<const M: usize>(
     let n_eta = model.n_eta;
     let n_theta = model.n_theta;
 
-    // Seed each event's per-snapshot PK duals, deduplicating identical covariate
-    // snapshots: with TV covariates that change at only a few breakpoints, most
-    // dose/obs events share a snapshot, so a full dual eval per event re-does
-    // identical work. Memoise by snapshot (the result is deterministic in the
-    // snapshot, so a cache hit is bit-identical to re-seeding) (#451 re-review #8).
-    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<Dual2<M>>)> = Vec::new();
-    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Vec<Dual2<M>> {
-        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
-            return v.clone();
-        }
-        let v = seed_pk_dual2::<M>(model, prog, theta, eta, cov);
-        snap_cache.push((cov.clone(), v.clone()));
-        v
-    };
-    let pk_at_dose: Vec<Vec<Dual2<M>>> = (0..subject.doses.len())
-        .map(|k| seed_for(subject.dose_cov(k)))
-        .collect();
-    let pk_at_obs: Vec<Vec<Dual2<M>>> = (0..subject.obs_times.len())
-        .map(|j| seed_for(subject.obs_cov(j)))
-        .collect();
+    // Seed each event's per-snapshot PK duals via the shared dedup helper.
+    // `seed_pk_dual2` is infallible, so wrap it in `Some`; the `?` never fires here.
+    let (pk_at_dose, pk_at_obs) = seed_tvcov_snapshots::<Dual2<M>>(subject, |cov| {
+        Some(seed_pk_dual2::<M>(model, prog, theta, eta, cov))
+    })?;
 
     let preds = integrate_tvcov_readout::<Dual2<M>>(model, subject, &pk_at_dose, &pk_at_obs);
 
@@ -1377,22 +1399,10 @@ fn run_subject_tvcov_eta<const N: usize>(
     let prog = ode.indiv_param_program.as_ref()?;
     let n_eta = model.n_eta;
 
-    // Dedup identical covariate snapshots — see `run_subject_tvcov` (#451 re-review #8).
-    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<Dual1<N>>)> = Vec::new();
-    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Option<Vec<Dual1<N>>> {
-        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
-            return Some(v.clone());
-        }
-        let v = seed_pk_dual1::<N>(model, prog, theta, eta, cov)?;
-        snap_cache.push((cov.clone(), v.clone()));
-        Some(v)
-    };
-    let pk_at_dose: Vec<Vec<Dual1<N>>> = (0..subject.doses.len())
-        .map(|k| seed_for(subject.dose_cov(k)))
-        .collect::<Option<_>>()?;
-    let pk_at_obs: Vec<Vec<Dual1<N>>> = (0..subject.obs_times.len())
-        .map(|j| seed_for(subject.obs_cov(j)))
-        .collect::<Option<_>>()?;
+    // Dedup identical covariate snapshots via the shared helper (#451 re-review #8).
+    let (pk_at_dose, pk_at_obs) = seed_tvcov_snapshots::<Dual1<N>>(subject, |cov| {
+        seed_pk_dual1::<N>(model, prog, theta, eta, cov)
+    })?;
 
     let preds = integrate_tvcov_readout::<Dual1<N>>(model, subject, &pk_at_dose, &pk_at_obs);
 

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1245,11 +1245,25 @@ fn run_subject_tvcov<const M: usize>(
     let n_eta = model.n_eta;
     let n_theta = model.n_theta;
 
+    // Seed each event's per-snapshot PK duals, deduplicating identical covariate
+    // snapshots: with TV covariates that change at only a few breakpoints, most
+    // dose/obs events share a snapshot, so a full dual eval per event re-does
+    // identical work. Memoise by snapshot (the result is deterministic in the
+    // snapshot, so a cache hit is bit-identical to re-seeding) (#451 re-review #8).
+    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<Dual2<M>>)> = Vec::new();
+    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Vec<Dual2<M>> {
+        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
+            return v.clone();
+        }
+        let v = seed_pk_dual2::<M>(model, prog, theta, eta, cov);
+        snap_cache.push((cov.clone(), v.clone()));
+        v
+    };
     let pk_at_dose: Vec<Vec<Dual2<M>>> = (0..subject.doses.len())
-        .map(|k| seed_pk_dual2::<M>(model, prog, theta, eta, subject.dose_cov(k)))
+        .map(|k| seed_for(subject.dose_cov(k)))
         .collect();
     let pk_at_obs: Vec<Vec<Dual2<M>>> = (0..subject.obs_times.len())
-        .map(|j| seed_pk_dual2::<M>(model, prog, theta, eta, subject.obs_cov(j)))
+        .map(|j| seed_for(subject.obs_cov(j)))
         .collect();
 
     let preds = integrate_tvcov_readout::<Dual2<M>>(model, subject, &pk_at_dose, &pk_at_obs);
@@ -1354,11 +1368,21 @@ fn run_subject_tvcov_eta<const N: usize>(
     let prog = ode.indiv_param_program.as_ref()?;
     let n_eta = model.n_eta;
 
+    // Dedup identical covariate snapshots — see `run_subject_tvcov` (#451 re-review #8).
+    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<Dual1<N>>)> = Vec::new();
+    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Option<Vec<Dual1<N>>> {
+        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
+            return Some(v.clone());
+        }
+        let v = seed_pk_dual1::<N>(model, prog, theta, eta, cov)?;
+        snap_cache.push((cov.clone(), v.clone()));
+        Some(v)
+    };
     let pk_at_dose: Vec<Vec<Dual1<N>>> = (0..subject.doses.len())
-        .map(|k| seed_pk_dual1::<N>(model, prog, theta, eta, subject.dose_cov(k)))
+        .map(|k| seed_for(subject.dose_cov(k)))
         .collect::<Option<_>>()?;
     let pk_at_obs: Vec<Vec<Dual1<N>>> = (0..subject.obs_times.len())
-        .map(|j| seed_pk_dual1::<N>(model, prog, theta, eta, subject.obs_cov(j)))
+        .map(|j| seed_for(subject.obs_cov(j)))
         .collect::<Option<_>>()?;
 
     let preds = integrate_tvcov_readout::<Dual1<N>>(model, subject, &pk_at_dose, &pk_at_obs);

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -785,13 +785,13 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
         return None;
     }
     // Bioavailability F scales the dosed amount/rate (NONMEM F·AMT / F·RATE). F
-    // lives at PK_IDX_F (pk_param_fn defaults it to 1 when undeclared); when F is
-    // an estimated individual parameter, its derivative flows via `params_dual`.
-    let f_bio = if pk_values[PK_IDX_F] > 0.0 {
-        params_dual[PK_IDX_F]
-    } else {
-        T::from_f64(1.0)
-    };
+    // lives at PK_IDX_F (pk_param_fn defaults it to 1 when undeclared); when F is an
+    // estimated individual parameter, its derivative flows via `params_dual`. Use the
+    // raw slot — mirroring production's `DoseAttrMap::f_bio` (raw `params[PK_IDX_F]`,
+    // with the 1.0 default baked into the slot at construction) — so a transient
+    // F ≤ 0 mid-fit scales the dose by F exactly as the f64 predictor does, rather
+    // than substituting 1.0 and dropping ∂/∂F (#451 / #433 review #3).
+    let f_bio = params_dual[PK_IDX_F];
 
     // Dose-time anchors for TAFD/TAD (constants w.r.t. the parameters).
     let first_dose_time = subject
@@ -1167,21 +1167,25 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
     subject: &Subject,
     pk_at_dose: &[Vec<T>],
     pk_at_obs: &[Vec<T>],
-) -> Option<Vec<T>> {
-    let ode = model.ode_spec.as_ref()?;
-    let program = ode.rhs_program.as_ref()?;
+) -> Vec<T> {
+    // `ode_tvcov_supported` (checked by both TV-cov entry points before reaching
+    // here) calls `ode_analytical_supported`, which declines a model whose `ode_spec`
+    // or `rhs_program` is `None` — so both are guaranteed present and this readout is
+    // infallible (the former `Option` return was dead) (#451 re-review #12).
+    let ode = model
+        .ode_spec
+        .as_ref()
+        .expect("ode_tvcov_supported guarantees ode_spec");
+    let program = ode
+        .rhs_program
+        .as_ref()
+        .expect("ode_analytical_supported guarantees rhs_program");
     let opts = ode.solver_opts;
 
-    let f_bio_at_dose: Vec<T> = pk_at_dose
-        .iter()
-        .map(|p| {
-            if p[PK_IDX_F].val() > 0.0 {
-                p[PK_IDX_F]
-            } else {
-                T::from_f64(1.0)
-            }
-        })
-        .collect();
+    // Raw slot, mirroring production's `DoseAttrMap::f_bio` (1.0 default baked in at
+    // construction) — a transient F ≤ 0 scales the dose by F like the f64 predictor,
+    // not 1.0 (#451 / #433 review #3).
+    let f_bio_at_dose: Vec<T> = pk_at_dose.iter().map(|p| p[PK_IDX_F]).collect();
     let first_dose_time = subject
         .doses
         .iter()
@@ -1220,7 +1224,7 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
             )
         })
         .collect();
-    Some(preds)
+    preds
 }
 
 /// Time-varying-covariate outer (`Dual2<M>`, `M = n_theta + n_eta`) sensitivities
@@ -1245,7 +1249,7 @@ fn run_subject_tvcov<const M: usize>(
         .map(|j| seed_pk_dual2::<M>(model, prog, theta, eta, subject.obs_cov(j)))
         .collect();
 
-    let preds = integrate_tvcov_readout::<Dual2<M>>(model, subject, &pk_at_dose, &pk_at_obs)?;
+    let preds = integrate_tvcov_readout::<Dual2<M>>(model, subject, &pk_at_dose, &pk_at_obs);
 
     let mut out = Vec::with_capacity(preds.len());
     for fd in &preds {
@@ -1354,7 +1358,7 @@ fn run_subject_tvcov_eta<const N: usize>(
         .map(|j| seed_pk_dual1::<N>(model, prog, theta, eta, subject.obs_cov(j)))
         .collect::<Option<_>>()?;
 
-    let preds = integrate_tvcov_readout::<Dual1<N>>(model, subject, &pk_at_dose, &pk_at_obs)?;
+    let preds = integrate_tvcov_readout::<Dual1<N>>(model, subject, &pk_at_dose, &pk_at_obs);
 
     let mut out = Vec::with_capacity(preds.len());
     for fd in &preds {

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1421,6 +1421,19 @@ fn eval_rhs_anchored<T: crate::sens::num::PkNum>(
 /// are the per-event flat PK-slot duals pre-seeded by the caller on `(θ,η)` (outer)
 /// or `η` (inner); `f_bio_at_dose[k]` is dose `k`'s bioavailability dual. Returns
 /// one state vector per observation (parallel to `subject.obs_times`).
+///
+/// **Deliberately kept separate from [`integrate_g`]** (the #451 fold was assessed
+/// and declined): the two have divergent control flow that can't merge without
+/// either a regression or a net complexity *increase*. Production's static walk
+/// (`ode_predictions`) — which the static dual `integrate_g` must match to 1e-9 —
+/// integrates each break-time segment under **constant** params and records
+/// observations as **in-segment solver save points**. This TV-cov walk instead
+/// switches params at **every event** (NONMEM end-of-interval), so observations
+/// must be **segment boundaries**, not interior save points. Forcing one
+/// obs-handling form onto both would make the static dual diverge from production
+/// (the 1e-9 risk); keeping both behind a mode branch is just two control flows
+/// glued together. The genuinely shareable pieces — `eval_rhs_anchored`,
+/// `resolve_obs_readout`, `solve_ode_g` — are already factored out and used by both.
 #[allow(clippy::too_many_arguments)]
 fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     program: &crate::parser::model_parser::OdeRhsProgram,
@@ -1476,6 +1489,14 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     let vars_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
     let stack_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
 
+    // TAD anchor: the most recent dose at or before the current segment start. The
+    // timeline is sorted and doses sort before a co-timed obs, so this only advances
+    // as dose events pass — track it incrementally instead of re-scanning all doses
+    // per segment (#451 re-review #6). A dose at the segment start is applied *after*
+    // that segment integrates, so it anchors the *next* segment — matching the prior
+    // `dt <= cur_t` scan.
+    let mut last_dose_eff = f64::NEG_INFINITY;
+
     for &(t_event, _order, is_dose, idx) in &tl {
         // Segment `[cur_t, t_event]` uses the params evaluated at `t_event`.
         let params: &[T] = if is_dose {
@@ -1484,12 +1505,6 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
             &pk_at_obs[idx]
         };
         if t_event > cur_t {
-            let last_dose_eff = subject
-                .doses
-                .iter()
-                .map(|d| d.time)
-                .filter(|&dt| dt <= cur_t + 1e-12)
-                .fold(f64::NEG_INFINITY, f64::max);
             let rhs = |us: &[T], ps: &[T], t: f64, du: &mut [T]| {
                 eval_rhs_anchored::<T>(
                     program,
@@ -1522,6 +1537,9 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
                     u[cmt_idx] = u[cmt_idx] + f_bio_at_dose[idx] * T::from_f64(d.amt);
                 }
             }
+            // This dose now anchors TAD for every later segment (all dose times count,
+            // matching the prior all-doses scan, regardless of compartment validity).
+            last_dose_eff = last_dose_eff.max(d.time);
         } else {
             states[idx].copy_from_slice(&u);
         }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2911,6 +2911,49 @@ mod tests {
         assert!(!ode_tvcov_supported(&model, &inf));
     }
 
+    /// A model whose individual-parameter program carries more than `MAX_ODE_AXES`
+    /// (16) axes must make `param_derivatives_at_cov` return `None` gracefully (its
+    /// dispatch only specializes `1..=16`, hitting the `_ => None` arm) rather than
+    /// panic — the seeders propagate that `None` via `?`, so the caller falls back to
+    /// FD. (The gate caps `n_theta + n_eta ≤ 16`, so this `_ => None` is otherwise
+    /// reachable only through intermediate-axis inflation — see #455.) (#451 re-review #10)
+    #[test]
+    fn param_derivatives_at_cov_declines_over_max_axes_gracefully() {
+        // 16 thetas + 1 eta = 17 axes (> MAX_ODE_AXES). All thetas feed CL so the
+        // program carries every θ-axis.
+        let n_th = MAX_ODE_AXES;
+        let mut src = String::from("[parameters]\n");
+        for i in 1..=n_th {
+            src += &format!("  theta T{i}(1.0, 0.1, 10.0)\n");
+        }
+        src += "  omega ETA_CL ~ 0.09\n  sigma PROP_ERR ~ 0.04 (sd)\n\
+                [individual_parameters]\n  CL = exp(ETA_CL) * (";
+        src += &(1..=n_th)
+            .map(|i| format!("T{i}"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        src += ")\n  V = T2\n[structural_model]\n  ode(obs_cmt=central, states=[central])\n\
+                [odes]\n  d/dt(central) = -CL/V * central\n[error_model]\n  \
+                DV ~ proportional(PROP_ERR)\n";
+        let model = parse_model_string(&src).expect("parse");
+        assert_eq!(model.n_theta, n_th);
+        assert_eq!(model.n_eta, 1);
+        let prog = model
+            .ode_spec
+            .as_ref()
+            .expect("ode")
+            .indiv_param_program
+            .as_ref()
+            .expect("prog");
+        assert!(prog.n_axes() > MAX_ODE_AXES, "fixture must exceed the cap");
+        let theta = vec![1.0; n_th];
+        let pd = param_derivatives_at_cov(prog, &model, &HashMap::new(), &theta, &[0.1]);
+        assert!(
+            pd.is_none(),
+            "> MAX_ODE_AXES axes must decline to FD, not panic"
+        );
+    }
+
     // ---- #430 slice 1: built-in inverse-Gaussian absorption forcing over Dual2 ----
 
     // 1-cpt oral disposition with Freijer & Post inverse-Gaussian absorption via

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -697,11 +697,20 @@ fn apply_output_transform<T: crate::sens::num::PkNum>(model: &CompiledModel, p: 
         ScalingSpec::ScalarScale(k) if k != 1.0 => p / T::from_f64(k),
         _ => p,
     };
-    // LTBS log via the shared generic transform — same floor-then-log production runs
-    // on f64 (#451). The `NaN` pre-check above keeps a `NaN` readout visible rather
-    // than letting the floor convert it to `ln(LTBS_FLOOR)`.
+    // LTBS log. The value goes through the shared generic transform — the same
+    // floor-then-log production runs on f64 (#451); the `NaN` pre-check above keeps a
+    // `NaN` readout visible rather than letting the floor convert it to `ln(LTBS_FLOOR)`.
+    // The gradient keys on the strict `> LTBS_FLOOR` boundary, matching the analytical
+    // path (`provider.rs`) and `apply_log_transform`'s clamp semantics: at or below the
+    // floor the readout is clamped to a constant so its derivatives vanish, rather than
+    // `guard_floor` retaining the jet exactly at the floor (#460 review). Above the
+    // floor the dual `ln` carries the jet (and `ltbs_log_g` is then just `p.ln()`).
     if model.log_transform {
-        crate::pk::ltbs_log_g(p)
+        if p.val() > crate::pk::LTBS_FLOOR {
+            crate::pk::ltbs_log_g(p)
+        } else {
+            T::from_f64(crate::pk::ltbs_log_g(p.val()))
+        }
     } else {
         p
     }
@@ -1250,21 +1259,35 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
 ///
 /// One generic home for both the outer (`Dual2`) and inner (`Dual1`) TV-cov walks,
 /// so the memoisation policy isn't maintained as two near-identical closures
-/// (#451 re-review #8 / #451 review #3). The cache is a linear-scanned `Vec` keyed on
-/// `HashMap<String, f64>` value-equality — fine for the few-snapshot common case;
-/// note a snapshot with a missing (`NaN`) covariate value never compares equal to
-/// itself, so it isn't deduplicated (a re-seed, identical result, never a wrong one).
+/// (#451 re-review #8 / #451 review #3). The cache is a `HashMap` keyed on the
+/// snapshot's canonical bit form — names sorted, values as `f64::to_bits` — giving
+/// O(1) amortised lookup (not a linear scan) and, because `to_bits` is total, making a
+/// snapshot with a missing (`NaN`) covariate deduplicate correctly: the seed is
+/// deterministic in the snapshot, so sharing one bit-identical result is exactly a
+/// re-seed (#460 review).
 fn seed_tvcov_snapshots<T: Clone>(
     subject: &Subject,
     mut seed: impl FnMut(&std::collections::HashMap<String, f64>) -> Option<Vec<T>>,
 ) -> Option<(Vec<Vec<T>>, Vec<Vec<T>>)> {
-    let mut snap_cache: Vec<(std::collections::HashMap<String, f64>, Vec<T>)> = Vec::new();
-    let mut seed_for = |cov: &std::collections::HashMap<String, f64>| -> Option<Vec<T>> {
-        if let Some((_, v)) = snap_cache.iter().find(|(c, _)| c == cov) {
+    use std::collections::HashMap;
+    // Canonical, hashable key for a covariate snapshot. `f64` is neither `Hash` nor
+    // `Eq`, so key on `to_bits` (name-sorted); `to_bits` is total, so `NaN` keys are
+    // well-defined and equal NaNs collapse — unlike `f64` `==`, which never matches a
+    // `NaN` to itself (which left the old `Vec` cache scanning dead, unmatchable entries).
+    fn snapshot_key(cov: &HashMap<String, f64>) -> Vec<(String, u64)> {
+        let mut kv: Vec<(String, u64)> =
+            cov.iter().map(|(k, v)| (k.clone(), v.to_bits())).collect();
+        kv.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        kv
+    }
+    let mut cache: HashMap<Vec<(String, u64)>, Vec<T>> = HashMap::new();
+    let mut seed_for = |cov: &HashMap<String, f64>| -> Option<Vec<T>> {
+        let key = snapshot_key(cov);
+        if let Some(v) = cache.get(&key) {
             return Some(v.clone());
         }
         let v = seed(cov)?;
-        snap_cache.push((cov.clone(), v.clone()));
+        cache.insert(key, v.clone());
         Some(v)
     };
     let pk_at_dose: Vec<Vec<T>> = (0..subject.doses.len())

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1614,6 +1614,11 @@ fn integrate_g<T: crate::sens::num::PkNum>(
     let vars_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
     let stack_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
 
+    // Per-dose bioavailability for the shared absorption-forcing helper. The static
+    // walk applies one `f_bio` to every dose (per-compartment F is gated off), built
+    // once per subject rather than per RK45 stage (#451 / #433 review #6).
+    let dose_f_bio_all: Vec<T> = vec![f_bio; subject.doses.len()];
+
     for w in 0..(break_times.len() - 1) {
         let t_start = break_times[w];
         let t_end = break_times[w + 1];
@@ -1709,32 +1714,22 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                     du[cmt] = du[cmt] + f_bio * T::from_f64(rate);
                 }
             }
-            // Built-in absorption input-rate forcing R_in(tad), summed over the
-            // doses feeding each forcing's compartment — the Dual2 analogue of
-            // `add_prepared_input_rate_forcing` (#430). Lagtime is excluded from
-            // this provider, so tad = t − dose.time is parameter-independent (a
-            // constant dual); only the prepared constants and F·amt carry
-            // derivatives. Reset subjects are excluded (FD fallback), so there is
-            // no `reset_floor` to apply here.
-            for (forcing, prep) in ode.input_rate.iter().zip(prepared_forcings) {
-                if forcing.cmt >= du.len() {
-                    continue;
-                }
-                let mut acc = T::from_f64(0.0);
-                for d in &subject.doses {
-                    if d.cmt.saturating_sub(1) != forcing.cmt {
-                        continue;
-                    }
-                    let tad_f = t - d.time;
-                    // Pre-dose skip: `tad ≤ 0` contributes nothing. `rate` re-checks
-                    // this same wall (`tad.val() <= 0`), so this is an optimization
-                    // (skip the dual `rate` call), not the source of truth (#430 review).
-                    if tad_f <= 0.0 {
-                        continue;
-                    }
-                    acc = acc + prep.rate(T::from_f64(tad_f), f_bio * T::from_f64(d.amt));
-                }
-                du[forcing.cmt] = du[forcing.cmt] + acc;
+            // Built-in absorption input-rate forcing R_in(tad), via the shared
+            // generic helper — the same superposition loop production runs on `f64`,
+            // now monomorphised on the dual type `T`. Lagtime is excluded from this
+            // provider (`&[]` → tad = t − dose.time), and reset+absorption is gated to
+            // FD (`NEG_INFINITY` floor → no pre-reset skip) (#430 review #4 / #451).
+            if !prepared_forcings.is_empty() {
+                crate::ode::predictions::add_prepared_input_rate_forcing::<T>(
+                    ode,
+                    prepared_forcings,
+                    &subject.doses,
+                    &[],
+                    &dose_f_bio_all,
+                    f64::NEG_INFINITY,
+                    t,
+                    du,
+                );
             }
         };
 

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2810,6 +2810,44 @@ mod tests {
         subject
     }
 
+    /// A TV-cov model whose RHS references the `TAD` (time-after-dose) builtin, so
+    /// the event-driven TV-cov walk's `last_dose_eff` / time-anchoring is exercised
+    /// — the other TV-cov parity tests use a `t`-independent RHS, leaving the
+    /// anchoring covered only through a constant (#451 / #449 review #10). Same
+    /// parameter shape as `ONECPT_ODE_TVCOV`, so `tvcov_subject` + the same θ/η apply.
+    #[test]
+    fn ode_provider_tvcov_tad_dependent_rhs_matches_production() {
+        const TVCOV_TAD_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta THETA_WT(0.75, 0.01, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL = TVCL * (WT / 70)^THETA_WT * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central * (1.0 + 0.02 * TAD)
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+        let model = parse_model_string(TVCOV_TAD_ODE).expect("parse");
+        assert!(model.ode_spec.as_ref().unwrap().input_rate.is_empty());
+        let subject = tvcov_subject();
+        assert!(ode_tvcov_supported(&model, &subject));
+        // Analytic TV-cov walk (f / ∂η / ∂θ) must match the production predictor + FD
+        // with the TAD-dependent RHS.
+        check_vs_production(&model, &subject, &[1.0, 20.0, 0.75], &[0.1]);
+    }
+
     /// The light `Dual1` inner η-gradient must equal the full `Dual2` outer
     /// `df_deta` for a TV-cov subject too — exercised through the dispatch, so this
     /// also covers `ode_tvcov_supported` routing both entry points (#439).

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1127,6 +1127,15 @@ fn seed_pk_dual2<const M: usize>(
     // `n_theta..M`), so the index guards are always satisfied — flat loops, no `< M`
     // / `.min(M)` (#449 review #15). The assert pins the invariant.
     debug_assert_eq!(M, n_theta + n_eta);
+    // `pd` (the dual program eval) carries the individual-parameter *values* too, so
+    // the separate `pk_param_fn` call below looks redundant (#451 re-review #9). It is
+    // retained deliberately: `pk_param_fn` returns the **full** slot vector including
+    // the non-individual-parameter slots (reserved `F`/lag defaults, etc.) that the
+    // indiv-param program — hence `pd` — never produces. Reconstructing those from a
+    // defaults base would re-encode `pk_param_fn`'s slot semantics here and risk silent
+    // gradient divergence for any model that fills a non-indiv slot non-trivially,
+    // while saving only the cheap f64 eval (the M²-Hessian dual eval dominates, and the
+    // covariate-snapshot dedup already elides repeats). Not worth that trade.
     let pd = pd_from_program::<M>(prog, model, cov, theta, eta);
     let pk = (model.pk_param_fn)(theta, eta, cov);
     let mut out: Vec<Dual2<M>> = pk.values.iter().map(|&v| Dual2::constant(v)).collect();

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -689,16 +689,19 @@ fn apply_output_transform<T: crate::sens::num::PkNum>(model: &CompiledModel, p: 
     if p.val().is_nan() {
         return p;
     }
+    // `ScalarScale` is the only scaling the gate (`ode_analytical_supported`) admits
+    // over duals — `ExpressionScale`/`PerCmt` scaling route to the Form-C `y = state/V`
+    // readout instead, so production's full `build_obs_scale_array` need not be lifted
+    // here. Divide (not multiply by `1/k`) to match production's `pred /= s` exactly.
     let p = match model.scaling {
-        ScalingSpec::ScalarScale(k) if k != 1.0 => p * T::from_f64(1.0 / k),
+        ScalingSpec::ScalarScale(k) if k != 1.0 => p / T::from_f64(k),
         _ => p,
     };
+    // LTBS log via the shared generic transform — same floor-then-log production runs
+    // on f64 (#451). The `NaN` pre-check above keeps a `NaN` readout visible rather
+    // than letting the floor convert it to `ln(LTBS_FLOOR)`.
     if model.log_transform {
-        if p.val() > crate::pk::LTBS_FLOOR {
-            p.ln()
-        } else {
-            T::from_f64(crate::pk::LTBS_FLOOR.ln())
-        }
+        crate::pk::ltbs_log_g(p)
     } else {
         p
     }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -1267,7 +1267,6 @@ pub(crate) fn subject_eta_grad_tvcov_with_schedule(
 /// PK-param `Dual1` seeded on η (`∂p/∂η_k` on axis `k`), the event-driven walk over
 /// `Dual1<N>`, and `∂conc/∂η` read straight into `ObsGrad`.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn run_obs_grad_tvcov<const N: usize>(
     model: &CompiledModel,
     subject: &Subject,

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -1584,9 +1584,12 @@ fn subject_eta_grad_impl(
             }
         }
     }
-    // LTBS: `g = ln(f)`, so `∂g/∂η = ∂f/∂η / f`. Applied after scaling, mirroring
-    // `pk::apply_log_transform` (`p = p.max(LTBS_FLOOR).ln()`). Below the floor the
-    // production transform clamps to a constant, so the gradient vanishes.
+    // LTBS: `g = ln(f)`, so `∂g/∂η = ∂f/∂η / f`. Applied after scaling. The value
+    // half goes through the shared `pk::ltbs_log_g` — the same floor-then-log the f64
+    // predictor and the ODE dual walk use — so the analytical gradient can't silently
+    // drift from production either (#451 review #5). The gradient still keys on the
+    // strict `> LTBS_FLOOR` boundary: below the floor the transform clamps to a
+    // constant, so the gradient vanishes.
     if model.log_transform {
         for o in out.iter_mut() {
             if o.f > crate::pk::LTBS_FLOOR {
@@ -1594,13 +1597,12 @@ fn subject_eta_grad_impl(
                 for g in o.df_deta.iter_mut() {
                     *g *= inv;
                 }
-                o.f = o.f.ln();
             } else {
                 for g in o.df_deta.iter_mut() {
                     *g = 0.0;
                 }
-                o.f = crate::pk::LTBS_FLOOR.ln();
             }
+            o.f = crate::pk::ltbs_log_g(o.f);
         }
     }
     Some(out)
@@ -2072,8 +2074,11 @@ fn subject_sensitivities_impl(
     //   ∂g/∂x      = inv · ∂f/∂x
     //   ∂²g/∂x∂y   = inv · ∂²f/∂x∂y − inv² · ∂f/∂x · ∂f/∂y     (x,y ∈ {η,θ})
     // Second derivatives are computed from the *original* first derivatives, so
-    // those are read before `df_deta`/`df_dtheta` are overwritten. Below the floor
-    // the production transform clamps to a constant ⇒ all derivatives vanish.
+    // those are read before `df_deta`/`df_dtheta` are overwritten. The value half
+    // goes through the shared `pk::ltbs_log_g` (same floor-then-log as the f64
+    // predictor and the ODE dual walk), applied after the jet is transformed
+    // (#451 review #5). Below the floor the transform clamps to a constant ⇒ all
+    // derivatives vanish.
     if model.log_transform {
         let n_eta = sens.obs.first().map_or(0, |o| o.df_deta.len());
         let n_theta = sens.obs.first().map_or(0, |o| o.df_dtheta.len());
@@ -2100,7 +2105,6 @@ fn subject_sensitivities_impl(
                 for g in o.df_deta.iter_mut().chain(o.df_dtheta.iter_mut()) {
                     *g *= inv;
                 }
-                o.f = o.f.ln();
             } else {
                 for v in o
                     .df_deta
@@ -2111,8 +2115,8 @@ fn subject_sensitivities_impl(
                 {
                     *v = 0.0;
                 }
-                o.f = crate::pk::LTBS_FLOOR.ln();
             }
+            o.f = crate::pk::ltbs_log_g(o.f);
         }
     }
     Some(sens)

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -1189,6 +1189,19 @@ pub fn subject_eta_grad_tvcov(
     theta: &[f64],
     eta: &[f64],
 ) -> Option<Vec<ObsGrad>> {
+    subject_eta_grad_tvcov_with_schedule(model, subject, theta, eta, None)
+}
+
+/// As [`subject_eta_grad_tvcov`], but reusing a per-subject `EventSchedule` the inner
+/// optimizer cached once (η-invariant) instead of rebuilding it every inner BFGS step
+/// (#449 re-review #6). `None` rebuilds locally (identical result).
+pub(crate) fn subject_eta_grad_tvcov_with_schedule(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
+) -> Option<Vec<ObsGrad>> {
     if !tvcov_analytical_supported(model)
         || !(subject.has_tv_covariates() || subject_has_oral_infusion(model, subject))
     {
@@ -1221,7 +1234,7 @@ pub fn subject_eta_grad_tvcov(
     macro_rules! disp {
         ($($n:literal),+) => {
             match n_eta {
-                $($n => run_obs_grad_tvcov::<$n>(model, subject, theta, eta, prog, &slot_row, n_eta),)+
+                $($n => run_obs_grad_tvcov::<$n>(model, subject, theta, eta, prog, &slot_row, n_eta, cached_schedule),)+
                 _ => None,
             }
         };
@@ -1254,6 +1267,7 @@ pub fn subject_eta_grad_tvcov(
 /// PK-param `Dual1` seeded on η (`∂p/∂η_k` on axis `k`), the event-driven walk over
 /// `Dual1<N>`, and `∂conc/∂η` read straight into `ObsGrad`.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn run_obs_grad_tvcov<const N: usize>(
     model: &CompiledModel,
     subject: &Subject,
@@ -1262,6 +1276,7 @@ fn run_obs_grad_tvcov<const N: usize>(
     prog: &crate::parser::model_parser::IndivParamProgram,
     slot_row: &[Option<usize>; N_PK],
     n_eta: usize,
+    cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
 ) -> Option<Vec<ObsGrad>> {
     use crate::pk::event_driven::EventSchedule;
     use crate::sens::ode_provider::param_derivatives_at_cov;
@@ -1311,13 +1326,24 @@ fn run_obs_grad_tvcov<const N: usize>(
         .map(|m| mk(subject.pk_only_cov(m)))
         .collect::<Option<Vec<_>>>()?;
 
-    let dose_lagtimes = vec![0.0; subject.doses.len()];
-    let schedule =
-        EventSchedule::for_subject(subject, model.pk_model, &subject.doses, &dose_lagtimes);
+    // The event schedule is invariant across inner BFGS steps (it depends only on the
+    // subject + doses + zero lagtimes, not on η). Reuse the schedule the inner
+    // optimizer cached once per subject when available, instead of rebuilding it every
+    // gradient step; fall back to building it locally otherwise (#449 re-review #6).
+    let owned_schedule;
+    let schedule: &EventSchedule = match cached_schedule {
+        Some(s) => s,
+        None => {
+            let dose_lagtimes = vec![0.0; subject.doses.len()];
+            owned_schedule =
+                EventSchedule::for_subject(subject, model.pk_model, &subject.doses, &dose_lagtimes);
+            &owned_schedule
+        }
+    };
     let conc = event_driven_sens_g::<Dual1<N>>(
         model.pk_model,
         subject,
-        &schedule,
+        schedule,
         &pk_at_dose,
         &pk_at_obs,
         &pk_at_pk_only,
@@ -1411,11 +1437,25 @@ pub fn subject_eta_grad(
     theta: &[f64],
     eta: &[f64],
 ) -> Option<Vec<ObsGrad>> {
+    subject_eta_grad_with_schedule(model, subject, theta, eta, None)
+}
+
+/// As [`subject_eta_grad`], but threading a per-subject cached `EventSchedule` (built
+/// once by the inner optimizer) into the TV-cov walk so it isn't rebuilt every inner
+/// BFGS step (#449 re-review #6). `None` (and every non-TV-cov / ODE route) rebuilds
+/// locally — identical result.
+pub(crate) fn subject_eta_grad_with_schedule(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
+) -> Option<Vec<ObsGrad>> {
     if !sens_profile_enabled() {
-        return subject_eta_grad_impl(model, subject, theta, eta);
+        return subject_eta_grad_impl(model, subject, theta, eta, cached_schedule);
     }
     let t0 = std::time::Instant::now();
-    let r = subject_eta_grad_impl(model, subject, theta, eta);
+    let r = subject_eta_grad_impl(model, subject, theta, eta, cached_schedule);
     PROFILE_ETA_NANOS.fetch_add(
         t0.elapsed().as_nanos() as u64,
         std::sync::atomic::Ordering::Relaxed,
@@ -1429,6 +1469,7 @@ fn subject_eta_grad_impl(
     subject: &Subject,
     theta: &[f64],
     eta: &[f64],
+    cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
 ) -> Option<Vec<ObsGrad>> {
     // ODE models: the light `Dual1` inner η-gradient (#410), gated by the master
     // switch. Out-of-scope ODE subjects decline (→ FD inner), the same per-subject
@@ -1443,7 +1484,7 @@ fn subject_eta_grad_impl(
     // already serves these via `subject_sensitivities_tvcov`; route the inner to the
     // matching `Dual1` walk (out-of-scope cases return `None` → FD per point).
     if subject.has_tv_covariates() || subject_has_oral_infusion(model, subject) {
-        return subject_eta_grad_tvcov(model, subject, theta, eta);
+        return subject_eta_grad_tvcov_with_schedule(model, subject, theta, eta, cached_schedule);
     }
     // Same model/subject scope as the full provider …
     if !analytical_supported(model) {

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -4133,6 +4133,24 @@ mod tests {
                 );
                 (m, s, vec![0.2, 10.0, 0.75], vec![0.12, -0.09])
             },
+            {
+                // Constant `ScalarScale` (`obs_scale = 1000`) on the TV-cov **inner**:
+                // exercises `run_obs_grad_tvcov`'s `∂(f/k)/∂η = (∂f/∂η)/k` division,
+                // which the other inner cases (no output scaling) leave uncovered
+                // (#451 / #449 review #10).
+                let m = parse_model_string(ONECPT_ORAL_TVCOV_SCALED)
+                    .expect("parse 1cpt oral tvcov scaled");
+                let s = tvcov_subject(
+                    vec![bolus(0.0)],
+                    &[70.0],
+                    &[1.0, 2.0, 4.0, 8.0, 24.0],
+                    &[70.0, 72.0, 80.0, 85.0, 90.0],
+                    Vec::new(),
+                    Vec::new(),
+                    &[],
+                );
+                (m, s, vec![0.2, 10.0, 1.5, 0.75], vec![0.15, -0.10, 0.25])
+            },
         ];
         for (model, subject, theta, eta) in &cases {
             let full =


### PR DESCRIPTION
Closes the dedup / perf / coverage follow-ups tracked in #451 (deferred from the #438 / #449 review rounds), taken on a clean `main` after the ODE analytic-sensitivity stack (#438 → #446 → #449 → #448 → #433) landed. Full lib suite green (1440 passed, 0 failed). All numeric results are unchanged — the f64 production paths are byte-identical and the dual paths are bit-identical to before.

## Refactor / altitude — collapse the parallel paths
- **Single generic absorption-forcing helper.** `add_prepared_input_rate_forcing` is now generic over `T: PkNum` (`pub(crate)`); the hand-maintained second copy of the superposition loop in `integrate_g` is removed. For `T = f64` every operation is identical, so the production predictor is byte-identical; the analytic dual walk calls the same helper (`&[]` lagtimes, `NEG_INFINITY` reset floor — both gated off there).
- **Shared LTBS log transform.** Production `apply_log_transform` and the ODE dual `apply_output_transform` now both call `pk::ltbs_log_g<T> = guard_floor(LTBS_FLOOR).ln()` — for `f64` this is `p.max(LTBS_FLOOR).ln()`, byte-identical. The `ScalarScale` divisor in the dual path now divides (matching production's `pred /= s`) rather than multiplying by `1/k`. The dual keeps its `NaN` pre-check (a per-CMT miss must stay visible).

## Performance
- **EventSchedule reuse in the TV-cov inner gradient.** The inner optimizer already caches an η-invariant `EventSchedule` per subject for the NLL objective; the analytic inner η-gradient (`run_obs_grad_tvcov`) rebuilt its own every BFGS step. It is now threaded the cached schedule (`_with_schedule` variants; public APIs preserved). `for_subject` treats empty == zero lagtimes and the cache is built under exactly the TV-cov gate's conditions, so the reused schedule is bit-identical; `None` rebuilds locally.
- **Covariate-snapshot dedup** in the TV-cov seeders — identical per-event snapshots are seeded once (common single-breakpoint case drops from O(events) dual evals to O(distinct snapshots)).
- **Incremental TAD anchor** in `integrate_tvcov_g` — `last_dose_eff` advances along the sorted timeline instead of an O(n_doses) rescan per segment.

## Cleanup / coverage
- Kind-drift tripwire tying `InputRateKind::supported_over_dual` to `prepare_dual` liftability; `F ≤ 0` `f_bio` now uses the raw `PK_IDX_F` slot (matching production's `DoseAttrMap::f_bio`); `integrate_tvcov_readout` returns `Vec<T>` instead of a dead `Option`.
- Coverage arms: TAD/TAFD-dependent RHS, `ScalarScale`-inner division, and a `>MAX_ODE_AXES` graceful decline.

## Assessed and deliberately not taken (rationale documented in-code)
- **Fold `integrate_tvcov_g` into `integrate_g`** (#449 review #11). Production's static walk — which the static dual must match to 1e-9 — records observations as in-segment save points under **constant** params; the TV-cov walk switches params at **every event**, so observations must be segment boundaries. Forcing one form onto both regresses the static path; keeping both behind a mode branch is no simplification. The genuinely shared pieces (`eval_rhs_anchored`, `resolve_obs_readout`, `solve_ode_g`) were already factored in prior rounds.
- **Seeder / dispatch-table dedup.** The static path differentiates w.r.t. PK slots (axis-seeded) and chains `pd` externally, while the TV-cov seeders bake `pd` into `(θ,η)` axes directly — different AD strategies that cannot share a packing helper; `Dual1` (η-only) and `Dual2` (θ+η+Hessian) differ in scope.
- **Seed double-eval** (#449 re-review #9). `pk_param_fn` supplies the full slot vector including non-individual-parameter defaults the indiv-param program never produces; reconstructing those re-encodes its slot semantics and risks silent gradient divergence, for a gain dominated by the M²-Hessian dual eval (and already mitigated by the snapshot dedup).

## Out of scope
The broader event-schedule caching architecture is its own concern; this PR reuses the inner optimizer's existing per-subject cache rather than introducing a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
