### PR TITLE
feat(api): add adaptive-dosing controller types [#391]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod parser;
 pub mod pk;
 pub mod propensity_match;
 pub mod sens;
+pub mod sim;
 pub mod stats;
 pub mod suggest_start;
 #[cfg(feature = "survival")]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -40,6 +40,10 @@ impl DoseAction {
     /// `None` for [`DoseAction::Hold`] / [`DoseAction::Stop`] (which inject
     /// nothing). Bioavailability and lag are applied downstream by the
     /// integrator, exactly as for any `subject.doses` entry — never here.
+    ///
+    /// Assumes a well-formed action — call [`DoseAction::validate`] first; a
+    /// malformed `Infuse`/`Bolus` (e.g. `cmt = 0`, `rate ≤ 0`) is not the
+    /// concern of this pure mapping.
     pub fn to_dose_event(&self, time: f64) -> Option<DoseEvent> {
         match *self {
             DoseAction::Bolus { amt, cmt } => Some(DoseEvent::new(time, amt, cmt, 0.0, false, 0.0)),
@@ -54,6 +58,38 @@ impl DoseAction {
     /// driver should issue no further decisions for this subject.
     pub fn is_stop(&self) -> bool {
         matches!(self, DoseAction::Stop)
+    }
+
+    /// Reject the malformed actions a controller can produce, with a typed error,
+    /// before any are applied. Guards the cases that would otherwise corrupt the
+    /// integrator: compartment `0` (CMT is 1-based — `cmt - 1` would underflow a
+    /// `usize`), a non-positive or non-finite infusion `rate` (which
+    /// [`DoseEvent::new`] would silently turn into a zero-duration "infusion",
+    /// i.e. a degenerate bolus), and a non-finite / negative `amt`. `Hold`/`Stop`
+    /// are always valid. The driver (S1.3a) calls this and surfaces the error
+    /// rather than letting a bad action reach the integrator.
+    pub fn validate(&self) -> Result<(), String> {
+        let (amt, cmt, rate) = match *self {
+            DoseAction::Bolus { amt, cmt } => (amt, cmt, None),
+            DoseAction::Infuse { amt, cmt, rate } => (amt, cmt, Some(rate)),
+            DoseAction::Hold | DoseAction::Stop => return Ok(()),
+        };
+        if cmt == 0 {
+            return Err("dose target compartment is 0, but CMT is 1-based".to_string());
+        }
+        if !amt.is_finite() || amt < 0.0 {
+            return Err(format!(
+                "dose amount must be finite and non-negative; got {amt}"
+            ));
+        }
+        if let Some(rate) = rate {
+            if !(rate.is_finite() && rate > 0.0) {
+                return Err(format!(
+                    "Infuse requires a positive, finite rate; got {rate}"
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -156,9 +192,11 @@ impl ControllerCtx<'_> {
 pub struct DoseLedgerEntry {
     /// Subject id.
     pub subject: String,
-    /// Replicate tag (param-draw × subject × residual replicate); aligns with the
-    /// simulation output's row tags (filled in by S1.4).
-    pub replicate: usize,
+    /// Parameter-uncertainty draw index — matches [`crate::SimulationResult::draw`]
+    /// so a ledger row joins to the trajectory rows it produced.
+    pub draw: usize,
+    /// Replicate index within the draw — matches [`crate::SimulationResult::sim`].
+    pub sim: usize,
     /// 0-based index of this dose among the subject's realized doses.
     pub dose_idx: usize,
     /// Time the dose was applied.
@@ -177,10 +215,12 @@ pub struct DoseLedgerEntry {
     /// What the controller observed at this decision (per-analyte value + mode).
     pub observed_signals: Vec<ObservedSignal>,
     /// State immediately before / after the dose discontinuity — the inputs to
-    /// the double-entry / mass-balance checks (S6).
-    pub pre_state: Vec<f64>,
+    /// the double-entry / mass-balance checks (S6). `None` when state snapshots
+    /// are not retained (verification disabled), so a large run isn't charged two
+    /// heap allocations per dose for data nothing consumes.
+    pub pre_state: Option<Vec<f64>>,
     /// See [`DoseLedgerEntry::pre_state`].
-    pub post_state: Vec<f64>,
+    pub post_state: Option<Vec<f64>>,
     /// Bioavailable fraction applied to this dose.
     pub f_applied: f64,
 }
@@ -275,7 +315,8 @@ mod tests {
         };
         let entry = DoseLedgerEntry {
             subject: "1".to_string(),
-            replicate: 0,
+            draw: 0,
+            sim: 0,
             dose_idx: 2,
             time: 48.0,
             amt: 75.0,
@@ -284,12 +325,67 @@ mod tests {
             decision_idx: 2,
             rule_fired: "bolus".to_string(),
             observed_signals: vec![obs.clone()],
-            pre_state: vec![0.5, 0.1],
-            post_state: vec![75.5, 0.1],
+            pre_state: Some(vec![0.5, 0.1]),
+            post_state: Some(vec![75.5, 0.1]),
             f_applied: 1.0,
         };
         assert_eq!(entry.clone(), entry);
         assert_eq!(entry.observed_signals[0], obs);
-        assert_eq!(entry.post_state[0] - entry.pre_state[0], 75.0);
+        let pre = entry.pre_state.as_ref().unwrap();
+        let post = entry.post_state.as_ref().unwrap();
+        assert_eq!(post[0] - pre[0], 75.0);
+    }
+
+    #[test]
+    fn validate_rejects_zero_compartment() {
+        assert!(DoseAction::Bolus { amt: 100.0, cmt: 0 }.validate().is_err());
+        assert!(DoseAction::Infuse {
+            amt: 100.0,
+            cmt: 0,
+            rate: 10.0,
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn validate_rejects_nonpositive_or_nonfinite_infusion_rate() {
+        for rate in [0.0, -5.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                DoseAction::Infuse {
+                    amt: 100.0,
+                    cmt: 1,
+                    rate,
+                }
+                .validate()
+                .is_err(),
+                "rate {rate} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_negative_or_nonfinite_amount() {
+        assert!(DoseAction::Bolus { amt: -1.0, cmt: 1 }.validate().is_err());
+        assert!(DoseAction::Bolus {
+            amt: f64::NAN,
+            cmt: 1,
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_actions_and_holds() {
+        assert!(DoseAction::Bolus { amt: 100.0, cmt: 1 }.validate().is_ok());
+        assert!(DoseAction::Infuse {
+            amt: 100.0,
+            cmt: 2,
+            rate: 25.0,
+        }
+        .validate()
+        .is_ok());
+        assert!(DoseAction::Hold.validate().is_ok());
+        assert!(DoseAction::Stop.validate().is_ok());
     }
 }

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -1,0 +1,295 @@
+//! Vocabulary for state-reactive ("adaptive" / feedback) dosing simulation (#391).
+//!
+//! This is step **S1.1**: the *types* the reactive driver (S1.3+) and the public
+//! `simulate_adaptive()` entry point (S1.4) are built on — no integration logic
+//! yet. The shapes here are deliberately the public API surface:
+//!
+//! - a controller is `FnMut(&ControllerCtx) -> Vec<DoseAction>`;
+//! - it reads a set of declared [`MonitorSpec`] signals, **each on its own**
+//!   [`ObserveMode`] (so PK can be observed latent while a safety marker is
+//!   observed with assay noise — see [`ObserveMode`]);
+//! - every realized dose is recorded as a [`DoseLedgerEntry`] for the Part-D
+//!   output and the Part-E frozen-replay verifier.
+//!
+//! The engine — not the controller — resolves each monitored signal and draws any
+//! assay noise, so draw order stays reproducible for the verifier (#391 S1.5).
+
+use crate::types::DoseEvent;
+use std::collections::HashMap;
+
+/// A dosing action a controller can take at a decision time.
+///
+/// `Hold` and `Stop` carry no payload: `Hold` skips *this* decision (the regimen
+/// continues), while `Stop` discontinues all future dosing for the subject. Only
+/// `Bolus`/`Infuse` map to a [`DoseEvent`] — see [`DoseAction::to_dose_event`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum DoseAction {
+    /// Instantaneous dose of `amt` into 1-based compartment `cmt`.
+    Bolus { amt: f64, cmt: usize },
+    /// Zero-order infusion of `amt` into `cmt` at `rate` (amount per time); the
+    /// duration is `amt / rate`.
+    Infuse { amt: f64, cmt: usize, rate: f64 },
+    /// Skip this decision — no dose now, the regimen continues.
+    Hold,
+    /// Discontinue — no further doses for this subject.
+    Stop,
+}
+
+impl DoseAction {
+    /// Convert an action issued at `time` into a concrete [`DoseEvent`], or
+    /// `None` for [`DoseAction::Hold`] / [`DoseAction::Stop`] (which inject
+    /// nothing). Bioavailability and lag are applied downstream by the
+    /// integrator, exactly as for any `subject.doses` entry — never here.
+    pub fn to_dose_event(&self, time: f64) -> Option<DoseEvent> {
+        match *self {
+            DoseAction::Bolus { amt, cmt } => Some(DoseEvent::new(time, amt, cmt, 0.0, false, 0.0)),
+            DoseAction::Infuse { amt, cmt, rate } => {
+                Some(DoseEvent::new(time, amt, cmt, rate, false, 0.0))
+            }
+            DoseAction::Hold | DoseAction::Stop => None,
+        }
+    }
+
+    /// `true` for [`DoseAction::Stop`] — the controller has discontinued and the
+    /// driver should issue no further decisions for this subject.
+    pub fn is_stop(&self) -> bool {
+        matches!(self, DoseAction::Stop)
+    }
+}
+
+/// How a monitored signal is observed at a decision time.
+///
+/// Generalizes "clean prediction vs noisy measurement" to **latent vs realized**,
+/// so it extends to non-Gaussian endpoints later (#391 Part F): for a continuous
+/// endpoint `Dv` adds the endpoint's residual draw; for an ordinal/TTE endpoint it
+/// becomes a *sampled* outcome rather than a Gaussian perturbation. The mode is
+/// chosen **per analyte** (see [`MonitorSpec`]), e.g. PK on `Ipred`, a neutrophil
+/// count driving CTCAE grading on `Dv` (the grade is defined on the measured lab).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ObserveMode {
+    /// Latent individual prediction — the model's value, no measurement noise.
+    #[default]
+    Ipred,
+    /// Realized measurement — `Ipred` plus the endpoint's residual draw (the
+    /// "assay noise" path; the realistic TDM / grading signal).
+    Dv,
+}
+
+/// One declared monitored signal the controller can read by `name`.
+///
+/// `cmt` is the 1-based endpoint/compartment whose error model supplies the
+/// residual when `mode == ObserveMode::Dv`; under `Ipred` it selects the latent
+/// readout. Each monitor carries its **own** [`ObserveMode`], so a PK signal can
+/// run on `Ipred` while a safety marker runs on `Dv` in the same simulation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MonitorSpec {
+    /// Label the controller reads this signal by ([`ControllerCtx::signal`]).
+    pub name: String,
+    /// 1-based compartment / endpoint this signal observes.
+    pub cmt: usize,
+    /// Latent (`Ipred`) or realized / assay-noised (`Dv`) — chosen per analyte.
+    pub mode: ObserveMode,
+}
+
+impl MonitorSpec {
+    /// Declare a monitored signal `name` reading endpoint `cmt` under `mode`.
+    pub fn new(name: impl Into<String>, cmt: usize, mode: ObserveMode) -> Self {
+        Self {
+            name: name.into(),
+            cmt,
+            mode,
+        }
+    }
+}
+
+/// The value a monitored signal actually presented to the controller at a
+/// decision, plus the mode it was resolved under — recorded on each
+/// [`DoseLedgerEntry`] so decision-audit replay (#391 Part E) can reproduce the
+/// exact inputs the controller saw.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedSignal {
+    /// Matches the [`MonitorSpec::name`] that produced it.
+    pub name: String,
+    /// The resolved value (latent or assay-noised per the monitor's mode).
+    pub value: f64,
+    /// The mode it was resolved under.
+    pub mode: ObserveMode,
+}
+
+/// Read-only context handed to a controller at each decision time.
+///
+/// The controller inspects this and returns the [`DoseAction`]s to apply. It
+/// borrows the live integration state, so it is valid only for the duration of
+/// the call — the driver (S1.3+) owns the timeline. `signals` holds the
+/// engine-resolved value of every declared [`MonitorSpec`], each already on its
+/// own [`ObserveMode`], so the controller never draws assay noise itself
+/// (reproducibility is the engine's responsibility, #391 S1.5).
+pub struct ControllerCtx<'a> {
+    /// Decision time on the subject's clock.
+    pub t: f64,
+    /// Current ODE state vector (0-based compartments). The controller may
+    /// compute any expression over this directly.
+    pub state: &'a [f64],
+    /// Subject covariates (LOCF), as the model sees them.
+    pub covariates: &'a HashMap<String, f64>,
+    /// Doses issued so far this simulation (the realized history).
+    pub history: &'a [DoseEvent],
+    /// 0-based index of this decision in the schedule.
+    pub decision_index: usize,
+    /// Resolved monitored signals keyed by [`MonitorSpec::name`] (latent or
+    /// assay-noised per each monitor's mode).
+    pub signals: &'a HashMap<String, f64>,
+}
+
+impl ControllerCtx<'_> {
+    /// Value of the monitored signal `name`, or `None` if no such monitor was
+    /// declared — `None` rather than a silent `0.0`, so a typo surfaces instead
+    /// of quietly driving a wrong decision.
+    pub fn signal(&self, name: &str) -> Option<f64> {
+        self.signals.get(name).copied()
+    }
+}
+
+/// One realized dose, with the provenance the Part-D ledger output and the
+/// Part-E verifier need. Emitted for every dose a controller actually issues.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DoseLedgerEntry {
+    /// Subject id.
+    pub subject: String,
+    /// Replicate tag (param-draw × subject × residual replicate); aligns with the
+    /// simulation output's row tags (filled in by S1.4).
+    pub replicate: usize,
+    /// 0-based index of this dose among the subject's realized doses.
+    pub dose_idx: usize,
+    /// Time the dose was applied.
+    pub time: f64,
+    /// Nominal amount (pre-bioavailability).
+    pub amt: f64,
+    /// 1-based target compartment.
+    pub cmt: usize,
+    /// Infusion rate (`0.0` for a bolus).
+    pub rate: f64,
+    /// 0-based decision that produced this dose.
+    pub decision_idx: usize,
+    /// Human-readable tag for the action/rule that fired (e.g. `"bolus"`, or a
+    /// named ladder rule once S2 lands).
+    pub rule_fired: String,
+    /// What the controller observed at this decision (per-analyte value + mode).
+    pub observed_signals: Vec<ObservedSignal>,
+    /// State immediately before / after the dose discontinuity — the inputs to
+    /// the double-entry / mass-balance checks (S6).
+    pub pre_state: Vec<f64>,
+    /// See [`DoseLedgerEntry::pre_state`].
+    pub post_state: Vec<f64>,
+    /// Bioavailable fraction applied to this dose.
+    pub f_applied: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bolus_action_maps_to_instantaneous_dose_event() {
+        let de = DoseAction::Bolus { amt: 100.0, cmt: 1 }
+            .to_dose_event(5.0)
+            .expect("bolus yields a dose event");
+        assert_eq!(de.time, 5.0);
+        assert_eq!(de.amt, 100.0);
+        assert_eq!(de.cmt, 1);
+        assert_eq!(de.rate, 0.0);
+        assert_eq!(de.duration, 0.0);
+        assert!(!de.ss);
+        assert_eq!(de.ii, 0.0);
+    }
+
+    #[test]
+    fn infuse_action_sets_rate_and_derived_duration() {
+        let de = DoseAction::Infuse {
+            amt: 100.0,
+            cmt: 2,
+            rate: 25.0,
+        }
+        .to_dose_event(0.0)
+        .expect("infusion yields a dose event");
+        assert_eq!(de.cmt, 2);
+        assert_eq!(de.rate, 25.0);
+        // DoseEvent::new derives duration = amt / rate.
+        assert_eq!(de.duration, 4.0);
+    }
+
+    #[test]
+    fn hold_and_stop_inject_no_dose() {
+        assert!(DoseAction::Hold.to_dose_event(1.0).is_none());
+        assert!(DoseAction::Stop.to_dose_event(1.0).is_none());
+    }
+
+    #[test]
+    fn is_stop_only_for_stop() {
+        assert!(DoseAction::Stop.is_stop());
+        assert!(!DoseAction::Hold.is_stop());
+        assert!(!DoseAction::Bolus { amt: 1.0, cmt: 1 }.is_stop());
+    }
+
+    #[test]
+    fn observe_mode_defaults_to_ipred() {
+        assert_eq!(ObserveMode::default(), ObserveMode::Ipred);
+    }
+
+    #[test]
+    fn monitor_spec_new_sets_fields() {
+        let m = MonitorSpec::new("ANC", 3, ObserveMode::Dv);
+        assert_eq!(m.name, "ANC");
+        assert_eq!(m.cmt, 3);
+        assert_eq!(m.mode, ObserveMode::Dv);
+    }
+
+    #[test]
+    fn controller_ctx_signal_lookup_is_some_only_for_declared() {
+        let state = [1.0, 2.0];
+        let covariates = HashMap::new();
+        let history: Vec<DoseEvent> = Vec::new();
+        let mut signals = HashMap::new();
+        signals.insert("CONC".to_string(), 1.5);
+
+        let ctx = ControllerCtx {
+            t: 24.0,
+            state: &state,
+            covariates: &covariates,
+            history: &history,
+            decision_index: 0,
+            signals: &signals,
+        };
+
+        assert_eq!(ctx.t, 24.0);
+        assert_eq!(ctx.signal("CONC"), Some(1.5));
+        assert_eq!(ctx.signal("missing"), None);
+    }
+
+    #[test]
+    fn ledger_entry_and_observed_signal_round_trip() {
+        let obs = ObservedSignal {
+            name: "CONC".to_string(),
+            value: 12.5,
+            mode: ObserveMode::Dv,
+        };
+        let entry = DoseLedgerEntry {
+            subject: "1".to_string(),
+            replicate: 0,
+            dose_idx: 2,
+            time: 48.0,
+            amt: 75.0,
+            cmt: 1,
+            rate: 0.0,
+            decision_idx: 2,
+            rule_fired: "bolus".to_string(),
+            observed_signals: vec![obs.clone()],
+            pre_state: vec![0.5, 0.1],
+            post_state: vec![75.5, 0.1],
+            f_applied: 1.0,
+        };
+        assert_eq!(entry.clone(), entry);
+        assert_eq!(entry.observed_signals[0], obs);
+        assert_eq!(entry.post_state[0] - entry.pre_state[0], 75.0);
+    }
+}

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1,0 +1,7 @@
+//! Simulation back-ends beyond the basic forward pass.
+//!
+//! Houses the state-reactive ("adaptive" / feedback) dosing machinery for issue
+//! #391. Step S1.1 lands the [`adaptive`] vocabulary; the reactive driver and the
+//! public `simulate_adaptive()` entry point follow in later steps.
+
+pub mod adaptive;


### PR DESCRIPTION
## Why
Foundation for the adaptive/feedback-dosing epic (#391). Before any reactive
driver can exist, the controller needs a vocabulary: what a controller *returns*
(dose actions), what it *reads* (monitored signals, each on its own observation
mode), and what every realized dose is *recorded* as (the ledger row the Part-D
output and the Part-E frozen-replay verifier consume).

This is step **S1.1** of the [#391 plan](https://github.com/FeRx-NLME/ferx-core/issues/391#issuecomment-4770226047). Types only — no integration logic.

## What changed
New module `src/sim/adaptive.rs` (+ `src/sim/mod.rs`, wired `pub mod sim;`):

- **`DoseAction`** `{Bolus, Infuse, Hold, Stop}` with pure
  `to_dose_event(time) -> Option<DoseEvent>` (the action→payload mapping; `None`
  for Hold/Stop) and `is_stop()`.
- **`ObserveMode`** `{Ipred, Dv}` — documented as **latent-vs-realized** so it
  generalizes to ordinal/TTE endpoints later (Part F), default `Ipred`.
- **`MonitorSpec`** `{name, cmt, mode}` — the **per-analyte** monitoring seam:
  one monitor per analyte, each with its own mode (PK on `Ipred`, e.g. a
  neutrophil count driving CTCAE grading on `Dv`).
- **`ControllerCtx`** `{t, state, covariates, history, decision_index, signals}`
  with `signal(name) -> Option<f64>` (returns `None` on an unknown name — never a
  silent `0.0`).
- **`ObservedSignal`** + **`DoseLedgerEntry`** — the Part-D realized-dose row with
  provenance (decision index, rule fired, per-analyte observed signals, pre/post
  state, F).

The engine (not the controller) will resolve each monitored signal and draw any
assay noise, so RNG order stays reproducible for the verifier (S1.5) — these types
encode that contract but contain no draw logic.

## Alternatives considered
- **Single global `observe_mode`** vs **per-`MonitorSpec` mode** — chose
  per-analyte: a PK exposure target and a safety-marker grade legitimately need
  different modes in the same run, and CTCAE grading is defined on the *measured*
  lab.
- **`ControllerCtx::signal` returns `Option`** rather than a silent `0.0`, so a
  mistyped monitor name surfaces instead of quietly driving a wrong decision.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Additive public types; no `pub fn` consumes them yet, so nothing in ferx-r
references them.

## Breaking changes
- [x] None (additive new module)

## Numerical validation
- [x] Not applicable — vocabulary types, no numerics.

## Performance
- [x] No significant impact expected — type definitions only.

## Tests
- [x] Unit test(s) added in the same module — 8 Tier-1 tests (`cargo test --lib`):
  action→`DoseEvent` mapping (incl. derived infusion duration), Hold/Stop inject
  nothing, `is_stop`, `ObserveMode` default, `MonitorSpec::new`, `ControllerCtx`
  signal lookup (`Some`/`None`), ledger/observed-signal round-trip.

## Docs
- [x] No user-visible change yet — `CHANGELOG` entry lands with `simulate_adaptive()`
  (S1.4), when the surface becomes user-facing.

## Checklist
- [x] `cargo clippy` clean (no findings on the new module)
- [x] `Dual2` sensitivity path untouched — simulation-only vocabulary, not
  gradient-reachable (`sens/` and `*_g<T: PkNum>` unaffected)
- [x] No version bump (additive, non-breaking)

## Reviewer hints
The only executable logic is `to_dose_event` / `is_stop` / `MonitorSpec::new` /
`ControllerCtx::signal` (all unit-tested); the rest is data shapes. The design
point to sanity-check is **per-analyte `ObserveMode`** (mode lives on each
`MonitorSpec`, not globally) and the latent-vs-realized framing of `Dv`.

## Open questions
`DoseLedgerEntry`'s field set may grow as S1.3/S1.4 fill it (e.g. tighter
replicate tagging to match `SimulationResult`) — landing the schema now, refining
as the driver consumes it.
