### PR TITLE
perf(sens): light Dual1 inner η-gradient for analytical PK models [closes #491]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,17 @@ section of the SDLC for the versioning policy).
   so the inner EBE loop is exact and replaces FD's `~2·n_eta+1` predictions per step
   with one. Validated against the FD-validated outer `df_deta` (1-/2-/3-cpt, IV/oral,
   steady state).
+- **Light `Dual1` inner η-gradient for analytical PK models** (#491). The inner
+  EBE loop's `∂p/∂η` for analytical 1-/2-/3-cpt models was computed over the full
+  `Dual2<n_theta + n_eta>` (carrying the θ-axes gradient and the second-order
+  Hessian) and then all but the η-block discarded. It now uses the light
+  `Dual1<n_eta>` walk the ODE inner loop already used (#410), seeding η only — so
+  e.g. a 10-θ / 4-η fit drops a `Dual2<14>` (14-vector grad + 14×14 Hessian per
+  op) to a `Dual1<4>`. Converged EBEs and OFV are unchanged (the inner gradient
+  method only affects the path to the mode); validated by the existing
+  analytic-vs-FD inner-gradient tests. Also serves models whose combined
+  `n_theta + n_eta` exceeds the dual dispatch ceiling but whose `n_eta` does not
+  (previously an FD fall-back).
 
 ### Added
 - **`ebe_warm_start` fit option** (default `false`, opt-in). When a per-subject

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -475,6 +475,26 @@ fn param_eta_derivatives(
     eta: &[f64],
 ) -> Option<Vec<Vec<f64>>> {
     let prog = model.ode_spec.as_ref()?.indiv_param_program.as_ref()?;
+    param_eta_derivatives_from_prog(prog, model, subject, theta, eta)
+}
+
+/// First-order `∂p/∂η` (the η-block of [`ParamDerivs::dp_deta`]) from an explicit
+/// individual-parameter program, over a `Dual1<M>` seeded on η (`M = n_eta`). The
+/// light inner counterpart of [`param_derivatives_from_prog`], shared by the ODE
+/// provider (program on `ode_spec`) and the analytical PK provider (program on
+/// `indiv_param_partials`): it skips the θ-axes and second-order Hessian the full
+/// `Dual2` path computes, since the inner EBE η-gradient consumes only `dp_deta`
+/// (#410). Dispatches on `n_eta` alone — so unlike the `Dual2`
+/// [`param_derivatives_from_prog`] it still serves models whose combined
+/// `n_theta + n_eta` exceeds the dual dispatch ceiling, as long as `n_eta` does
+/// not. Returns `None` on the same axis-count mismatch as the full path.
+pub(crate) fn param_eta_derivatives_from_prog(
+    prog: &crate::parser::model_parser::IndivParamProgram,
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<Vec<Vec<f64>>> {
     if prog.n_theta_axis() != model.n_theta || prog.n_eta_axis() != model.n_eta {
         return None;
     }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -1537,8 +1537,14 @@ fn subject_eta_grad_impl(
         .as_ref()
         .filter(|prog| prog_covers_required_pk_slots(model, prog))
         .and_then(|prog| {
-            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
-                .map(|pd| (pd.dp_deta, prog.pk_slots()))
+            // Light `Dual1<n_eta>` η-gradient: the inner EBE loop consumes only
+            // `∂p/∂η`, so seeding η alone avoids the θ-axes and second-order
+            // Hessian the full `Dual2` `param_derivatives_from_prog` carries (#485
+            // follow-up).
+            crate::sens::ode_provider::param_eta_derivatives_from_prog(
+                prog, model, subject, theta, eta,
+            )
+            .map(|dp_deta| (dp_deta, prog.pk_slots()))
         }) {
         Some(v) => v,
         None => {


### PR DESCRIPTION
## Why
For analytical PK models the **inner** EBE η-gradient (`subject_eta_grad_impl`, `src/sens/provider.rs`) computed `∂p/∂η` over the full `Dual2<n_theta + n_eta>` — carrying the θ-axes gradient *and* the second-order Hessian — then discarded everything except the η-block (`pd.dp_deta`). The inner loop only needs `∂p/∂η`.

The light `Dual1<n_eta>` walk the ODE inner loop has used since #410 computes exactly that and skips the θ-axes + Hessian; the analytical inner path was never migrated to it. For jasmine (10 θ, 4 η) the inner loop carried a `Dual2<14>` (14-vector gradient + 14×14 Hessian per op) where a `Dual1<4>` suffices.

Follow-up to #485, found during the same jasmine FOCEI profiling.

## What changed
- Extracted `param_eta_derivatives_from_prog` in `src/sens/ode_provider.rs` — the prog-taking, `Dual1<n_eta>` light η-gradient, shared by the ODE provider (program on `ode_spec`) and the analytical PK provider (program on `indiv_param_partials`). The existing ODE-only `param_eta_derivatives` now delegates to it.
- Routed the analytical inner path (`subject_eta_grad_impl`) through it instead of the full `Dual2` `param_derivatives_from_prog`.
- Dispatching on `n_eta` alone also serves models whose combined `n_theta + n_eta` exceeds the dual dispatch ceiling (16) but whose `n_eta` does not — previously an FD fall-back in the inner loop.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change.

## Breaking changes
- [x] None

## Numerical validation
Converged EBEs and OFV are **unchanged** — the inner gradient *method* only affects the search path to the EBE mode, not the fixed point.
- [x] Compared against: full `Dual2` provider + central FD. The existing parity tests assert the light inner η-gradient (now `Dual1`) matches the full `Dual2` `subject_sensitivities` `df_deta` to `1e-9`:
  - `static_cov_intermediate_params_uses_program_path_and_matches_fd` (analytical program path, static covariates)
  - `tvcov_eta_grad_matches_full`, `provider_matches_fd_of_production_predictor`
- Full `cargo test --lib`: green.

## Performance
- [x] Faster — analytical inner EBE η-gradient drops from `Dual2<n_theta+n_eta>` (gradient + full Hessian) to `Dual1<n_eta>` (gradient only). For jasmine: `Dual2<14>` → `Dual1<4>` per inner-loop param evaluation.

## Tests
- [x] Covered by existing analytic-vs-FD inner-gradient parity tests (now exercising the `Dual1` path via `subject_eta_grad`).
- [x] No new test needed: the swapped path is the one those tests already pin to `1e-9` against the full provider and FD; a divergence would fail them.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → Performance entry added.
- [x] No user-visible behavioural change (results identical), so no `docs/` page change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)