### PR TITLE
fix(survival): right-censor TTE simulation at the observation window [#440]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ section of the SDLC for the versioning policy).
   (#367).
 
 ### Fixed
+- **TTE simulation now applies administrative right-censoring** (#440). `simulate()`
+  for a `[event_model]` (TTE) endpoint previously emitted *every* drawn event time as
+  an uncensored event, so simulated data could not reproduce a study's censoring
+  pattern (which broke simulation-estimation validation). Each subject's observation
+  window — the `ObsRecord::Event` time — is now honoured: a draw that reaches the
+  window is recorded as right-censored at the window (`observed = false`), and
+  left-truncated (delayed-entry) subjects draw conditional on survival past entry.
+  Behind the `survival` feature.
 - **Analytic sensitivities and predictions for time-varying covariates with
   intermediate `[individual_parameters]` assignments** (#455, #456). A model whose
   individual-parameter block computes intermediate quantities (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,11 +136,15 @@ section of the SDLC for the versioning policy).
 - **TTE simulation now applies administrative right-censoring** (#440). `simulate()`
   for a `[event_model]` (TTE) endpoint previously emitted *every* drawn event time as
   an uncensored event, so simulated data could not reproduce a study's censoring
-  pattern (which broke simulation-estimation validation). Each subject's observation
-  window — the `ObsRecord::Event` time — is now honoured: a draw that reaches the
-  window is recorded as right-censored at the window (`observed = false`), and
-  left-truncated (delayed-entry) subjects draw conditional on survival past entry.
-  Behind the `survival` feature.
+  pattern (which broke simulation-estimation validation). A subject's administrative
+  observation horizon is now honoured: a draw that reaches it is recorded as
+  right-censored at the horizon (`observed = false`). The horizon is the
+  `ObsRecord::Event` time of a *right-censored* record; an exact-event (or
+  interval-censored) record carries no horizon — its `time` is the event time, not a
+  censoring window — so it draws uncensored rather than being truncated at the
+  realized event time (which would bias re-simulation / VPC). Left-truncated
+  (delayed-entry) subjects draw conditional on survival past entry. Behind the
+  `survival` feature.
 - **Analytic sensitivities and predictions for time-varying covariates with
   intermediate `[individual_parameters]` assignments** (#455, #456). A model whose
   individual-parameter block computes intermediate quantities (e.g.

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -196,9 +196,12 @@ pub fn shi_step_sizes(eval: impl Fn(&[f64]) -> f64, eta_hat: &[f64]) -> Vec<f64>
 /// `entry_time > 0` draws conditionally on survival past entry (left
 /// truncation, §3.6). The samplers return `f64::MAX` for degenerate / improper
 /// cases (`λ = 0`; a Gompertz with `γ < 0` whose survival never reaches the
-/// drawn quantile). Testing `t_event < window` (rather than `t_event >= window`)
-/// makes those censor at the window instead of reporting a spurious event at
-/// `f64::MAX`.
+/// drawn quantile). An event is recorded only for a draw that is strictly below
+/// the window **and** below that `f64::MAX` sentinel, so a degenerate draw is
+/// censored rather than reported as a spurious event — even when `window` is
+/// unbounded (`+∞`, an event record carrying no administrative horizon; see
+/// [`observation_window`]), where a bare `t_event < window` test would let the
+/// `f64::MAX` sentinel through.
 fn draw_tte_outcome<R: rand::Rng>(
     family: HazardFamily,
     params: &[f64],
@@ -214,21 +217,48 @@ fn draw_tte_outcome<R: rand::Rng>(
     } else {
         sample_event_time(family, params, u)
     };
-    if t_event < window {
+    // `t_event < f64::MAX` rejects the samplers' degenerate / improper sentinel
+    // (`f64::MAX`); without it an unbounded window would mis-report that sentinel
+    // as an observed event at `f64::MAX`.
+    if t_event < window && t_event < f64::MAX {
         (t_event, true)
     } else {
         (window, false)
     }
 }
 
+/// The administrative right-censoring horizon for a TTE record, or `+∞` when the
+/// record carries none.
+///
+/// Only a `RightCensored` record marks an administrative horizon: the subject
+/// was event-free through `time`, at which point observation ended, so a
+/// simulated draw reaching `time` is genuinely censored there. An `Exact` or
+/// `IntervalCensored` record instead marks an *event* — its `time` field is the
+/// realized event time (or interval upper bound), **not** a horizon. Censoring a
+/// re-simulated draw at a realized event time would truncate the simulated
+/// event-time distribution at the data's own event times (a re-simulation / VPC
+/// bias), so those records draw uncensored (`+∞`). Administrative censoring for
+/// such a design is supplied either by the design itself (right-censored
+/// template rows, as the SSE tests do) or by the forthcoming
+/// `[simulation] horizon` (Phase 2).
+fn observation_window(event_type: &EventType, time: f64) -> f64 {
+    match event_type {
+        EventType::RightCensored => time,
+        EventType::Exact | EventType::IntervalCensored { .. } => f64::INFINITY,
+    }
+}
+
 /// Draw TTE event/censoring outcomes for every TTE record on a subject and
 /// append them to `results`.
 ///
-/// Called from `api::simulate_inner_with_draw` after the Gaussian path. Each
-/// `ObsRecord::Event` carries the subject's observation window in its `time`
-/// field; the simulated event is administratively right-censored at that window
-/// when it would occur later, so simulated data reproduce the censoring pattern
-/// of the design rather than every draw being an uncensored event.
+/// Called from `api::simulate_inner_with_draw` after the Gaussian path. A
+/// simulated draw is administratively right-censored at the subject's
+/// observation horizon when it would occur later, so simulated data reproduce
+/// the censoring pattern of the design rather than every draw being an
+/// uncensored event. The horizon is derived per record by
+/// [`observation_window`]: a right-censored record censors at its `time`; an
+/// event record (`Exact` / `IntervalCensored`) carries no horizon and draws
+/// uncensored.
 pub fn simulate_tte<R: rand::Rng>(
     model: &crate::types::CompiledModel,
     subject: &crate::types::Subject,
@@ -243,8 +273,8 @@ pub fn simulate_tte<R: rand::Rng>(
         let ObsRecord::Event {
             cmt,
             entry_time,
-            time: window,
-            ..
+            time,
+            event_type,
         } = record;
 
         let Some(EndpointLikelihood::Tte { hazard }) = model.endpoints.get(cmt) else {
@@ -253,7 +283,8 @@ pub fn simulate_tte<R: rand::Rng>(
         let HazardSpec::Analytic { family, param_fn } = hazard;
         let params = param_fn(theta, eta, &subject.covariates);
 
-        let (t, observed) = draw_tte_outcome(*family, &params, *entry_time, *window, rng);
+        let window = observation_window(event_type, *time);
+        let (t, observed) = draw_tte_outcome(*family, &params, *entry_time, window, rng);
 
         results.push(crate::api::SimulationResult {
             draw,
@@ -485,8 +516,8 @@ mod tests {
     #[test]
     fn draw_tte_degenerate_zero_hazard_censors_at_window() {
         use rand::SeedableRng;
-        // λ=0 ⇒ sampler returns f64::MAX; the `t_event < window` test must censor
-        // at the window rather than emit a spurious event at f64::MAX.
+        // λ=0 ⇒ sampler returns f64::MAX; with a finite window the draw must
+        // censor at the window rather than emit a spurious event at f64::MAX.
         let mut rng = rand::rngs::StdRng::seed_from_u64(99);
         let window = 12.5_f64;
         for _ in 0..100 {
@@ -522,6 +553,51 @@ mod tests {
         assert!(
             saw_event && saw_censor,
             "expected a mix of events and censored draws"
+        );
+    }
+
+    #[test]
+    fn draw_tte_unbounded_window_degenerate_does_not_emit_spurious_event() {
+        use rand::SeedableRng;
+        // λ=0 ⇒ sampler returns f64::MAX. With an unbounded window (an event
+        // record carries no administrative horizon, so `observation_window`
+        // returns +∞) a bare `t_event < window` test would mis-report that
+        // sentinel as an observed event at f64::MAX. The `t_event < f64::MAX`
+        // guard must classify it as censored (no event) instead.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(123);
+        for _ in 0..100 {
+            let (t, observed) = draw_tte_outcome(
+                HazardFamily::Exponential,
+                &[0.0],
+                0.0,
+                f64::INFINITY,
+                &mut rng,
+            );
+            assert!(
+                !observed,
+                "a degenerate (no-event) draw must never be reported as an observed event"
+            );
+            assert_eq!(t, f64::INFINITY, "censored at the (unbounded) window");
+        }
+    }
+
+    #[test]
+    fn observation_window_only_right_censored_has_a_horizon() {
+        // A right-censored record's `time` IS the administrative horizon.
+        assert_eq!(observation_window(&EventType::RightCensored, 12.0), 12.0);
+        // Event records carry no administrative horizon: their `time` is an
+        // event time / interval bound, so they must draw uncensored (+∞) rather
+        // than truncate at a realized event time.
+        assert_eq!(observation_window(&EventType::Exact, 12.0), f64::INFINITY);
+        assert_eq!(
+            observation_window(
+                &EventType::IntervalCensored {
+                    left: 1.0,
+                    right: 5.0
+                },
+                5.0
+            ),
+            f64::INFINITY
         );
     }
 }

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -4,7 +4,8 @@
 //   tte_data_term         — negative log-likelihood for a TTE subject's records
 //   data_term_hessian_fd  — 4-point FD Hessian of any scalar eta-function
 //   shi_step_sizes        — adaptive Shi (2021) step-size vector for FD Hessian
-//   simulate_tte          — draw TTE event times and append to SimulationResult vec
+//   simulate_tte          — draw TTE event times (administratively right-censored at
+//                           each subject's observation window) into a SimulationResult vec
 //
 // See plans/tte-survival-markov.md §3.1, §2.3, §9.3, §8.8.2.
 
@@ -18,7 +19,9 @@ pub use parametric::{
 use nalgebra::DMatrix;
 use std::collections::HashMap;
 
-use crate::types::{EndpointLikelihood, EventType, HazardSpec, ObsRecord, SimOutcome};
+use crate::types::{
+    EndpointLikelihood, EventType, HazardFamily, HazardSpec, ObsRecord, SimOutcome,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  TTE data term
@@ -182,12 +185,50 @@ pub fn shi_step_sizes(eval: impl Fn(&[f64]) -> f64, eta_hat: &[f64]) -> Vec<f64>
 //  Simulation
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Draw TTE event times for all TTE records on a subject and append to `results`.
+/// Draw one TTE outcome within the observation window `window`.
 ///
-/// Called from `api::simulate_inner_with_draw` after the Gaussian path.
-/// Administrative censoring is not applied here — the event time is drawn from
-/// the unconditional distribution. Users can filter by time in post-processing.
-/// (Phase 2 will add `[simulation] horizon` support.)
+/// Returns `(time, observed)`:
+/// - an **event** at the drawn time when it falls before `window`
+///   (`observed = true`, `time = t_event`);
+/// - **administrative right-censoring** at `window` when the drawn event time
+///   reaches the window (`observed = false`, `time = window`).
+///
+/// `entry_time > 0` draws conditionally on survival past entry (left
+/// truncation, §3.6). The samplers return `f64::MAX` for degenerate / improper
+/// cases (`λ = 0`; a Gompertz with `γ < 0` whose survival never reaches the
+/// drawn quantile). Testing `t_event < window` (rather than `t_event >= window`)
+/// makes those censor at the window instead of reporting a spurious event at
+/// `f64::MAX`.
+fn draw_tte_outcome<R: rand::Rng>(
+    family: HazardFamily,
+    params: &[f64],
+    entry_time: f64,
+    window: f64,
+    rng: &mut R,
+) -> (f64, bool) {
+    // Open01 samples from (0, 1) exclusive, avoiding the u=0 edge case that
+    // would send -ln(u) to +∞.
+    let u: f64 = rng.sample(rand::distributions::Open01);
+    let t_event = if entry_time > 0.0 {
+        sample_conditional_event_time(family, params, entry_time, u)
+    } else {
+        sample_event_time(family, params, u)
+    };
+    if t_event < window {
+        (t_event, true)
+    } else {
+        (window, false)
+    }
+}
+
+/// Draw TTE event/censoring outcomes for every TTE record on a subject and
+/// append them to `results`.
+///
+/// Called from `api::simulate_inner_with_draw` after the Gaussian path. Each
+/// `ObsRecord::Event` carries the subject's observation window in its `time`
+/// field; the simulated event is administratively right-censored at that window
+/// when it would occur later, so simulated data reproduce the censoring pattern
+/// of the design rather than every draw being an uncensored event.
 pub fn simulate_tte<R: rand::Rng>(
     model: &crate::types::CompiledModel,
     subject: &crate::types::Subject,
@@ -200,7 +241,10 @@ pub fn simulate_tte<R: rand::Rng>(
 ) {
     for record in &subject.obs_records {
         let ObsRecord::Event {
-            cmt, entry_time, ..
+            cmt,
+            entry_time,
+            time: window,
+            ..
         } = record;
 
         let Some(EndpointLikelihood::Tte { hazard }) = model.endpoints.get(cmt) else {
@@ -209,30 +253,16 @@ pub fn simulate_tte<R: rand::Rng>(
         let HazardSpec::Analytic { family, param_fn } = hazard;
         let params = param_fn(theta, eta, &subject.covariates);
 
-        // Open01 samples from (0, 1) exclusive, avoiding the u=0 edge case that
-        // would send -ln(u) to +∞ and clamp the event time to f64::MAX.
-        let u: f64 = rng.sample(rand::distributions::Open01);
-        let t_event = if *entry_time > 0.0 {
-            sample_conditional_event_time(*family, &params, *entry_time, u)
-        } else {
-            sample_event_time(*family, &params, u)
-        };
+        let (t, observed) = draw_tte_outcome(*family, &params, *entry_time, *window, rng);
 
         results.push(crate::api::SimulationResult {
             draw,
             sim,
             id: subject.id.clone(),
-            time: t_event,
+            time: t,
             cmt: *cmt,
             ipred: f64::NAN,
-            outcome: SimOutcome::Event {
-                time: t_event,
-                // TODO(phase-2): apply horizon censoring from [simulation] block;
-                // set observed=false and time=horizon when t_event >= horizon.
-                // Until then, every draw is an uncensored event — simulated data
-                // will not match the censoring pattern of the reference scripts.
-                observed: true,
-            },
+            outcome: SimOutcome::Event { time: t, observed },
         });
     }
 }
@@ -397,5 +427,101 @@ mod tests {
         let a = 0.1_f64 * 10.0; // H(left) - H(entry)
         let expected = a - ((-delta).exp_m1().abs().ln());
         assert_abs_diff_eq!(nll, expected, epsilon = 1e-8);
+    }
+
+    // ── draw_tte_outcome: administrative censoring at the observation window ──
+
+    #[test]
+    fn draw_tte_censoring_fraction_matches_survival() {
+        use rand::SeedableRng;
+        // Exponential λ=0.1 over a window τ=10 ⇒ P(censored) = S(τ) = exp(−λτ) ≈ 0.3679.
+        // 20 000 draws; proportion SE ≈ 0.0034 ⇒ a 0.02 tolerance is ~6σ.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+        let lambda = 0.1_f64;
+        let window = 10.0_f64;
+        let n = 20_000;
+        let mut censored = 0usize;
+        for _ in 0..n {
+            let (t, observed) =
+                draw_tte_outcome(HazardFamily::Exponential, &[lambda], 0.0, window, &mut rng);
+            if observed {
+                assert!(
+                    t > 0.0 && t < window,
+                    "event time must lie in (0, window): {t}"
+                );
+            } else {
+                assert_eq!(t, window, "censored time must equal the window");
+                censored += 1;
+            }
+        }
+        let frac = censored as f64 / n as f64;
+        let expected = (-lambda * window).exp();
+        assert!(
+            (frac - expected).abs() < 0.02,
+            "censoring fraction {frac} should track S(τ) = {expected}"
+        );
+    }
+
+    #[test]
+    fn draw_tte_infinite_window_never_censors() {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+        for _ in 0..1000 {
+            let (t, observed) = draw_tte_outcome(
+                HazardFamily::Exponential,
+                &[1.0],
+                0.0,
+                f64::INFINITY,
+                &mut rng,
+            );
+            assert!(observed, "no censoring is possible with an infinite window");
+            assert!(
+                t.is_finite() && t > 0.0,
+                "event time must be finite positive: {t}"
+            );
+        }
+    }
+
+    #[test]
+    fn draw_tte_degenerate_zero_hazard_censors_at_window() {
+        use rand::SeedableRng;
+        // λ=0 ⇒ sampler returns f64::MAX; the `t_event < window` test must censor
+        // at the window rather than emit a spurious event at f64::MAX.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(99);
+        let window = 12.5_f64;
+        for _ in 0..100 {
+            let (t, observed) =
+                draw_tte_outcome(HazardFamily::Exponential, &[0.0], 0.0, window, &mut rng);
+            assert!(!observed, "zero hazard can never produce an event");
+            assert_eq!(t, window);
+        }
+    }
+
+    #[test]
+    fn draw_tte_left_truncation_respects_entry_and_window() {
+        use rand::SeedableRng;
+        // entry=5, window=8, λ=0.2 (memoryless): P(event before window)
+        // = 1 − exp(−0.2·3) ≈ 0.45 ⇒ both outcomes appear in 5 000 draws.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2024);
+        let (entry, window) = (5.0_f64, 8.0_f64);
+        let (mut saw_event, mut saw_censor) = (false, false);
+        for _ in 0..5000 {
+            let (t, observed) =
+                draw_tte_outcome(HazardFamily::Exponential, &[0.2], entry, window, &mut rng);
+            if observed {
+                assert!(
+                    t > entry && t < window,
+                    "conditional event in (entry, window): {t}"
+                );
+                saw_event = true;
+            } else {
+                assert_eq!(t, window);
+                saw_censor = true;
+            }
+        }
+        assert!(
+            saw_event && saw_censor,
+            "expected a mix of events and censored draws"
+        );
     }
 }

--- a/tests/tte_convergence.rs
+++ b/tests/tte_convergence.rs
@@ -86,27 +86,25 @@ fn fit_opts() -> FitOptions {
 }
 
 /// `n` bare TTE subjects (one placeholder Event each on CMT 2) used only as a
-/// `simulate()` template — the drawn event time replaces the placeholder. This is
-/// exactly [`common::tte_pop_from_pairs`] over `n` exact-event rows at `t = 0`.
-fn tte_sim_template(n: usize) -> Population {
-    common::tte_pop_from_pairs(&vec![(0.0, 1); n])
+/// `simulate()` template. Each placeholder carries the administrative censoring
+/// window `censor` in its record `time`; `simulate_tte` right-censors any draw
+/// that reaches it (the drawn event time otherwise replaces the placeholder).
+/// This is exactly [`common::tte_pop_from_pairs`] over `n` right-censored rows at
+/// `t = censor`.
+fn tte_sim_template(n: usize, censor: f64) -> Population {
+    common::tte_pop_from_pairs(&vec![(censor, 0); n])
 }
 
-/// Map ferx `simulate()` outcomes to `(time, dv)` pairs, applying administrative
-/// right-censoring at `t_censor` exactly as `simulate.R` does: `simulate_tte`
-/// draws *uncensored* event times (every draw is observed), so a draw past
-/// `t_censor` becomes a right-censored row at `t_censor`. Panics on any non-`Event`
-/// outcome — that would mean a Gaussian model/template was simulated by mistake.
-fn sims_to_pairs(sims: &[SimulationResult], t_censor: f64) -> Vec<(f64, u8)> {
+/// Map ferx `simulate()` outcomes to `(time, dv)` pairs. `simulate_tte` already
+/// applies administrative right-censoring at each subject's observation window
+/// (set by [`tte_sim_template`]), so this just reads the `observed` flag: an
+/// observed draw is an event row `(time, 1)`, a censored draw a `(window, 0)` row.
+/// Panics on any non-`Event` outcome — that would mean a Gaussian model/template
+/// was simulated by mistake.
+fn sims_to_pairs(sims: &[SimulationResult]) -> Vec<(f64, u8)> {
     sims.iter()
         .map(|r| match r.outcome {
-            SimOutcome::Event { time, .. } => {
-                if time <= t_censor {
-                    (time, 1)
-                } else {
-                    (t_censor, 0)
-                }
-            }
+            SimOutcome::Event { time, observed } => (time, observed as u8),
             _ => panic!("expected an Event outcome for a TTE simulation"),
         })
         .collect()
@@ -142,12 +140,12 @@ fn tte_sse_exponential_recovers_truth() {
     const SEED: u64 = 20260621;
 
     let truth = parse_model_string(EXP_TRUTH).expect("truth model must parse");
-    let template = tte_sim_template(N);
+    let template = tte_sim_template(N, T_CENSOR);
 
     let sims = simulate_with_seed(&truth, &template, &truth.default_params, 1, SEED);
     assert_eq!(sims.len(), N, "one simulated event per template subject");
 
-    let pairs = sims_to_pairs(&sims, T_CENSOR);
+    let pairs = sims_to_pairs(&sims);
 
     let event_frac = pairs.iter().filter(|(_, dv)| *dv == 1).count() as f64 / N as f64;
     eprintln!("[SSE] event fraction = {event_frac:.4} (expected ~0.88 at lambda_pop=0.1, omega^2=0.25, censor t=24)");
@@ -319,9 +317,15 @@ fn tte_sse_weibull_recovers_truth() {
     const SEED: u64 = 20260622;
 
     let truth = parse_model_string(WEIBULL_TRUTH).expect("truth model must parse");
-    let sims = simulate_with_seed(&truth, &tte_sim_template(N), &truth.default_params, 1, SEED);
+    let sims = simulate_with_seed(
+        &truth,
+        &tte_sim_template(N, T_CENSOR),
+        &truth.default_params,
+        1,
+        SEED,
+    );
 
-    let pairs = sims_to_pairs(&sims, T_CENSOR);
+    let pairs = sims_to_pairs(&sims);
 
     let model = parse_model_string(WEIBULL_FIT).expect("fit model must parse");
     let r = fit(
@@ -551,9 +555,15 @@ fn tte_sse_gompertz_recovers_truth() {
     const SEED: u64 = 20260623;
 
     let truth = parse_model_string(GOMPERTZ_TRUTH_FRAILTY).expect("truth model must parse");
-    let sims = simulate_with_seed(&truth, &tte_sim_template(N), &truth.default_params, 1, SEED);
+    let sims = simulate_with_seed(
+        &truth,
+        &tte_sim_template(N, T_CENSOR),
+        &truth.default_params,
+        1,
+        SEED,
+    );
 
-    let pairs = sims_to_pairs(&sims, T_CENSOR);
+    let pairs = sims_to_pairs(&sims);
 
     let model = parse_model_string(GOMPERTZ_FIT_FRAILTY).expect("fit model must parse");
     let r = fit(

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -302,6 +302,50 @@ mod survival_smoke {
         );
     }
 
+    /// An **exact-event** template (`dv = 1`) carries no administrative horizon —
+    /// its record `time` is the realized event time, not a censoring window — so
+    /// `simulate()` must draw every outcome uncensored from the model's full
+    /// predictive distribution rather than truncate at that event time. Guards
+    /// against re-introducing the re-simulation / VPC truncation bias.
+    #[test]
+    fn simulate_tte_exact_event_template_draws_uncensored() {
+        use ferx_core::{simulate_with_seed, SimOutcome};
+        // 300 exact-event rows at t=5. The (old, buggy) behaviour would have
+        // censored every draw past t=5 at the event time; the correct behaviour
+        // ignores it as a horizon and draws fresh, finite event times.
+        let model = parse_model_string(EXP_TTE_MODEL).expect("model must parse");
+        let template = common::tte_pop_from_pairs(&vec![(5.0, 1); 300]);
+
+        let sims = simulate_with_seed(&model, &template, &model.default_params, 1, 1234);
+        assert_eq!(sims.len(), 300, "one TTE outcome per template subject");
+
+        let mut beyond_event_time = 0usize;
+        for r in &sims {
+            match r.outcome {
+                SimOutcome::Event { time, observed } => {
+                    assert!(
+                        observed,
+                        "an exact-event template carries no horizon → every draw is observed"
+                    );
+                    assert!(
+                        time.is_finite() && time > 0.0,
+                        "event time must be finite positive: {time}"
+                    );
+                    if time > 5.0 {
+                        beyond_event_time += 1;
+                    }
+                }
+                ref other => panic!("expected an Event outcome, got {other:?}"),
+            }
+        }
+        // With λ≈0.05 the median event time is ~14, so the bulk of draws land
+        // past t=5 — impossible under the old truncate-at-event-time behaviour.
+        assert!(
+            beyond_event_time > 0,
+            "expected draws beyond the record's event time (got {beyond_event_time})"
+        );
+    }
+
     /// `fit()` on a fixed-effects TTE model (n_eta=0, no inner loop) must
     /// return Ok immediately (single outer-loop evaluation per iteration).
     #[test]

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -260,6 +260,48 @@ mod survival_smoke {
         }
     }
 
+    /// `simulate()` must administratively right-censor TTE draws at each subject's
+    /// observation window (the `ObsRecord::Event.time`) rather than emit every draw
+    /// as an uncensored event. Drives the full `simulate_tte` wiring; the draw/censor
+    /// logic itself is unit-tested in `survival/mod.rs` (`draw_tte_*`).
+    #[test]
+    fn simulate_tte_censors_at_observation_window() {
+        use ferx_core::{simulate_with_seed, SimOutcome};
+        // 300 subjects sharing a τ=20 window. λ≈0.05 ⇒ S(20)=exp(−1)≈0.37 censored,
+        // so the run must contain both observed events and administrative censors.
+        const TAU: f64 = 20.0;
+        let model = parse_model_string(EXP_TTE_MODEL).expect("model must parse");
+        let template = common::tte_pop_from_pairs(&vec![(TAU, 0); 300]);
+
+        let sims = simulate_with_seed(&model, &template, &model.default_params, 1, 4242);
+        assert_eq!(sims.len(), 300, "one TTE outcome per template subject");
+
+        let (mut events, mut censored) = (0usize, 0usize);
+        for r in &sims {
+            match r.outcome {
+                SimOutcome::Event { time, observed } => {
+                    assert!(time <= TAU, "no outcome may exceed the window: {time}");
+                    if observed {
+                        assert!(
+                            time < TAU,
+                            "an observed event must precede the window: {time}"
+                        );
+                        events += 1;
+                    } else {
+                        assert_eq!(time, TAU, "a censored outcome sits exactly at the window");
+                        censored += 1;
+                    }
+                }
+                ref other => panic!("expected an Event outcome, got {other:?}"),
+            }
+        }
+        assert!(events > 0, "expected some observed events (got {events})");
+        assert!(
+            censored > 0,
+            "expected some administratively censored subjects (got {censored})"
+        );
+    }
+
     /// `fit()` on a fixed-effects TTE model (n_eta=0, no inner loop) must
     /// return Ok immediately (single outer-loop evaluation per iteration).
     #[test]


### PR DESCRIPTION
## Why
`simulate_tte` drew **every** TTE event time as observed and never censored (the `observed` flag was hard-coded `true`, with a `TODO(phase-2)`). So simulated TTE data could not reproduce a study's censoring pattern, and **simulation-estimation (SSE) validation was dishonest** — the Tier-3 SSE tests had to re-apply administrative censoring in test glue to compensate. This is the correctness prerequisite for the rest of the TTE roadmap (Phase 1b competing risks, Phase 3 RTTE), which both need honest simulated censoring to validate against.

Tracked under #440.

## What changed
- Extracted the draw+censor logic into a small, isolated `draw_tte_outcome(family, params, entry_time, window, rng) -> (time, observed)` in `src/survival/mod.rs`. It censors at the subject's observation window (= `ObsRecord::Event.time`):
  - draw before the window → event `(t_event, true)`;
  - draw reaching the window → administrative right-censoring `(window, false)`.
  - `entry_time > 0` draws conditionally on survival past entry (left truncation, §3.6).
  - Uses `t_event < window` (not `>=`) so the samplers' `f64::MAX` degenerate sentinel (`λ=0`, improper Gompertz `γ<0`) censors at the window instead of emitting a spurious event at `f64::MAX`.
- `simulate_tte` is now a thin wrapper over the helper; no signature change.
- **Consumer update (necessary):** the Tier-3 SSE tests in `tests/tte_convergence.rs` relied on the old "never censors" contract (`tte_sim_template(n)` used a placeholder window of `0.0` and re-censored in `sims_to_pairs(sims, t_censor)`). They now push the window into the template (`tte_sim_template(n, censor)`) and read the `observed` flag (`sims_to_pairs(sims)`). The censoring rule and RNG draw order are unchanged, so the numbers are bit-identical.

## Alternatives considered
A global `[simulation] horizon` field on `SimulationSpec`, plumbed through `simulate()`. Rejected for this PR: `simulate()` takes a `Population` (not a `SimulationSpec`), each subject already carries its own observation window in `ObsRecord::Event.time` (a single source of truth that also supports differing per-subject follow-up), and no public-API change is needed. Separately noted: the `[simulation]`-block CLI path (`run_model_simulate`) builds synthetic subjects with **empty** `obs_records`, so it emits no TTE rows at all today — a distinct, larger gap left as a follow-up.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API/`FitResult`/sdtab change. The `observed` flag (which already existed on `SimOutcome::Event`) now actually varies for TTE — a behaviour heads-up for the in-flight ferx-r `predict_survival` draft (FeRx-NLME/ferx-r#194), but nothing to merge here.

## Breaking changes
- [x] None

(`simulate_tte` is `pub` behind the `survival` feature; its signature and the `SimulationResult`/`SimOutcome` shapes are unchanged. The behaviour change is a bug fix.)

## Numerical validation
- [x] Compared against: prior ferx baseline (the documented SSE numbers)
- [x] Reference values:

```
# Tier-3 exponential SSE (tte_sse_exponential_recovers_truth), seed-fixed
# before (documented baseline) / after this PR — bit-identical:
event fraction = 0.8830
lambda_pop     = 0.09904   (truth 0.1)
omega^2        = 0.23187   (truth 0.25)
```

All 8 `tte_convergence` Tier-3 tests pass (`RAYON_NUM_THREADS=1`, `--features ci,survival,slow-tests --profile ci-test`, ~10s).

## Performance
- [x] No significant impact expected (one comparison per drawn event).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes): 4 Tier-1 `draw_tte_*` tests (censoring fraction ≈ S(τ); infinite-window-never-censors; `λ=0`-degenerate-censors-at-window; left-truncation events in (entry, window)).
- [x] Regression test added that fails without this fix: Tier-2 `simulate_tte_censors_at_observation_window` (asserts both observed events **and** administrative censors appear, and times ≤ window) — fails on the old always-`observed=true` behaviour.

## Example (user-facing features only)
- [x] Not applicable (fix to simulation behaviour; no new API surface).

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `### Fixed` entry added (#440).
- [x] No docs page covers TTE-simulation censoring specifically; behaviour fix only.

## Checklist
- [x] `cargo clippy` clean **for the changed code** (CI's clippy job runs `--features ci`, which does not compile the `survival` module; verified locally with `--features ci,survival --tests` — my new code adds no warnings. Pre-existing, unrelated: `manual_clamp` in `shi_step_sizes`, `too_many_arguments` on `simulate_tte` (both on main), and 4 `approx_constant` errors in `src/sens/two_cpt_explicit.rs`).
- [x] `Dual2` sensitivity path untouched (simulation path, not gradient-reachable).
- [x] No version bump (non-breaking).

## Reviewer hints
- The substance is `draw_tte_outcome` and the `simulate_tte` wrapper in `src/survival/mod.rs`. The `tte_convergence.rs` changes are a mechanical consumer update; the key evidence they're behaviour-preserving is the bit-identical SSE numbers above.
- The `<` vs `>=` boundary at `t_event == window` differs from the old `sims_to_pairs`' `<=` convention only on a measure-zero set; the bit-identical results confirm no realised draw hit it.

## Open questions
- None blocking. Follow-ups (separate PRs): Phase 1b competing-risks simulation + CIF; and TTE-row generation for the `[simulation]`-block CLI path (currently emits none).