### PR TITLE
feat(ode): analytic Dual2 gradients for compartment-indexed F on ODE models [#486]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ section of the SDLC for the versioning policy).
   steady state).
 
 ### Added
+- **Analytic FOCE/FOCEI gradients for compartment-indexed bioavailability
+  (`F1`/`F2`, …) on ODE models** (#486). An ODE model that sets a per-compartment
+  bioavailability now drives the exact analytic outer gradient and light `Dual1`
+  inner η-gradient instead of finite differences: both the static and
+  time-varying-covariate dual walks resolve `F` per dose compartment (the indexed
+  `F{cmt}` slot, else the bare `F`), matching production's `DoseAttrMap::f_bio` and
+  carrying `∂/∂F{cmt}` exactly. Estimates are unchanged; the gradient is exact and
+  cheaper. Validated by an analytic≡production+central-FD parity test (single
+  indexed `F1` with IIV, and distinct `F1`≠`F2` dosed into two compartments).
+  Per-compartment *lag* (`ALAG{cmt}`) stays on FD for now (→ #472).
 - **`ebe_warm_start` fit option** (default `false`, opt-in). When a per-subject
   inner BFGS solve fails and falls back to Nelder–Mead, seed the simplex from the
   BFGS partial η̂ instead of cold-starting from the prior mode η=0. On

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2470,6 +2470,52 @@ mod tests {
         );
     }
 
+    /// Indexed `F` is now in model-level scope (parity test above), but the
+    /// *per-subject* gate must still route a **rate-defined infusion under `F ≠ 1`**
+    /// to FD. NONMEM reshapes such an infusion's window (holds the rate, scales the
+    /// duration to `F·amt/rate`, #419), whereas the dual walk scales the rate
+    /// magnitude over the *original* window — so the analytic gradient would diverge
+    /// from the f64 predictor. The model-level gate admits the indexed-`F` model; the
+    /// subject gate (`has_bioavailability() && has_rate_defined_infusion()`) declines
+    /// it. Crucially `has_bioavailability()` detects the indexed `F{cmt}` form too, so
+    /// dropping the `ode_analytical_supported` indexed-`F` decline (#486) does *not*
+    /// open this infusion path. A bolus of the same model stays in scope, so the
+    /// decline is attributable to the infusion, not the `F`.
+    #[test]
+    fn ode_subject_declines_indexed_f_rate_defined_infusion() {
+        let model = parse_model_string(F1F2_IV_ODE).expect("parse F1F2");
+        // Model-level scope admits indexed F (the indexed-F decline gate is gone, #486).
+        assert!(
+            ode_analytical_supported(&model),
+            "indexed F1/F2 model is in model-level scope"
+        );
+
+        // A bolus subject of this model IS served analytically.
+        let bolus = bolus_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        assert!(
+            !bolus.doses[0].is_infusion(),
+            "control dose must be a bolus"
+        );
+        assert!(
+            ode_subject_supported(&model, &bolus),
+            "indexed-F bolus subject should be served analytically"
+        );
+
+        // The same model with a *rate-defined* infusion (RATE>0) into the dosed
+        // compartment must decline to FD: `F` reshapes the window, which the dual rate
+        // scale does not reproduce (#419).
+        let mut infusion = bolus.clone();
+        infusion.doses = vec![DoseEvent::new(0.0, 1000.0, 1, 200.0, false, 0.0)];
+        assert!(
+            infusion.doses[0].is_infusion(),
+            "rate=200 must be a rate-defined infusion"
+        );
+        assert!(
+            !ode_subject_supported(&model, &infusion),
+            "rate-defined infusion under indexed F must decline to FD (#419)"
+        );
+    }
+
     /// Infusion doses (RATE>0): the dual loop must add the rate forcing over the
     /// infusion window and match the production predictor through during- and
     /// post-infusion observations.

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -15,15 +15,17 @@
 //! **Supported:** single-endpoint `ObsCmt`, uniform Form C (`y = central/V1`), or
 //! per-CMT Form C (`y[CMT=N] = <expr>` — each endpoint differentiated over the dual,
 //! #439) readout; **bolus and infusion** doses; **bioavailability F** (incl.
-//! estimated, any parameterization — log-normal, logit-normal, additive); **EVID 3/4
-//! resets / multi-occasion**; **non-zero `init(...)` initial conditions**; static
-//! covariates; a constant `obs_scale` divisor and **LTBS** (`log(DV) ~ …`) output
-//! transforms; up to [`MAX_ODE_SENS_DIM`] individual parameters. Both the full
-//! `Dual2` **outer** gradient and a light `Dual1` **inner** η-gradient
-//! ([`ode_subject_eta_grad`]) are served (#410).
+//! estimated, any parameterization — log-normal, logit-normal, additive — and the
+//! compartment-indexed `F{cmt}` form, #486); **EVID 3/4 resets / multi-occasion**;
+//! **non-zero `init(...)` initial conditions**; static covariates; a constant
+//! `obs_scale` divisor and **LTBS** (`log(DV) ~ …`) output transforms; the built-in
+//! igd/transit input-rate forcings (#430/#468); up to [`MAX_ODE_SENS_DIM`] individual
+//! parameters. Both the full `Dual2` **outer** gradient and a light `Dual1` **inner**
+//! η-gradient ([`ode_subject_eta_grad`]) are served (#410).
 //!
 //! **Not yet supported** (falls back to the gradient-free / FD path): steady-state
-//! dosing, lagtime, built-in input-rate absorption, IOV, SDE/diffusion, expression
+//! dosing, lagtime (incl. compartment-indexed `ALAG{cmt}`), `weibull()` and other
+//! input-rate forcings beyond igd/transit, IOV, SDE/diffusion, expression
 //! `obs_scale`, time-varying covariates.
 #![allow(clippy::needless_range_loop)]
 
@@ -91,9 +93,9 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
         return false;
     }
     // Built-in absorption input-rate forcing is evaluated over Dual2 only for
-    // kinds lifted to PkNum (#430: inverse-Gaussian). Other kinds — transit
-    // until its `ln_gamma` dual rule, Weibull until Phase 2 — keep the FD
-    // fallback, so a model using one is not "supported" here.
+    // kinds lifted to PkNum: inverse-Gaussian (#430) and transit (#468, riding the
+    // `ln_gamma` Dual2 rule #458). Other kinds — Weibull until Phase 2, and any later
+    // kind — keep the FD fallback, so a model using one is not "supported" here.
     if ode.input_rate.iter().any(|f| !f.kind.supported_over_dual()) {
         return false;
     }
@@ -126,18 +128,14 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     if model.has_lagtime() {
         return false;
     }
-    // Per-compartment bioavailability (`F1`/`F2`, #369): production resolves
-    // `f_bio(d.cmt)` per dose compartment, but both the static `integrate_g` and the
-    // TV-cov walk apply the single bare `PK_IDX_F` slot, so a compartment-indexed `F`
-    // would give the wrong analytic gradient — decline to FD (the bare / no-`F` case
-    // is unaffected). (Per-compartment lag is already covered by `has_lagtime()`
-    // above.) (#449 review #7, #1)
-    if model
-        .active_dose_attr_map()
-        .has_indexed_attr(crate::types::DoseAttr::F)
-    {
-        return false;
-    }
+    // Per-compartment bioavailability (`F1`/`F2`, #369) IS supported: both the static
+    // `integrate_g` and the TV-cov walk resolve `F` per dose compartment via
+    // `f_bio_slot` (the indexed `F{cmt}` slot, else the bare `PK_IDX_F`), mirroring
+    // production's `DoseAttrMap::f_bio` — so the analytic gradient carries `∂/∂F{cmt}`
+    // exactly (#486). The indexed `F{cmt}` is an ordinary individual parameter, so its
+    // slot is seeded in `params_dual` like any other. Per-compartment *lag*
+    // (`ALAG{cmt}`) is still gated to FD by the `has_lagtime()` check above — the dual
+    // loop applies no dose-time shift, so it stays out of scope (→ #472).
     // The η/θ chain evaluates the individual-parameter program over `Dual2`
     // seeded on (θ, η); require it present, with matching axis counts (no NN-θ /
     // IOV), and within the analytic-chain dual-width cap.
@@ -761,6 +759,19 @@ fn resolve_obs_readout<T: crate::sens::num::PkNum>(
     apply_output_transform::<T>(model, raw)
 }
 
+/// PK-parameter slot holding bioavailability `F` for a dose into 1-based `cmt`:
+/// the compartment-indexed `F{cmt}` slot when the model declared one (#369), else
+/// the bare [`PK_IDX_F`] (default 1.0). Mirrors production's
+/// [`DoseAttrMap::f_bio`](crate::types::DoseAttrMap::f_bio) slot resolution so the
+/// dual walk applies the same per-compartment `F` the f64 predictor does —
+/// `params_dual[slot]` then carries `∂/∂F{cmt}`, since an indexed `F{cmt}` is an
+/// ordinary seeded individual parameter (#486).
+fn f_bio_slot(ode: &OdeSpec, cmt: usize) -> usize {
+    ode.dose_attr_map
+        .indexed_slot(crate::types::DoseAttr::F, cmt)
+        .unwrap_or(PK_IDX_F)
+}
+
 /// Shared setup for both ODE drivers, generic over the dual type `T` (`Dual2<N>`
 /// for the full outer walk, `Dual1<N>` for the light inner η-gradient): seed the
 /// flat PK-parameter vector (individual parameter `i` → dual dimension `i`),
@@ -796,14 +807,20 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
     if pk_values[PK_IDX_LAGTIME].abs() > 1e-12 {
         return None;
     }
-    // Bioavailability F scales the dosed amount/rate (NONMEM F·AMT / F·RATE). F
-    // lives at PK_IDX_F (pk_param_fn defaults it to 1 when undeclared); when F is an
-    // estimated individual parameter, its derivative flows via `params_dual`. Use the
-    // raw slot — mirroring production's `DoseAttrMap::f_bio` (raw `params[PK_IDX_F]`,
-    // with the 1.0 default baked into the slot at construction) — so a transient
-    // F ≤ 0 mid-fit scales the dose by F exactly as the f64 predictor does, rather
-    // than substituting 1.0 and dropping ∂/∂F (#451 / #433 review #3).
-    let f_bio = params_dual[PK_IDX_F];
+    // Bioavailability F scales the dosed amount/rate (NONMEM F·AMT / F·RATE),
+    // resolved *per dose compartment*: `F{cmt}` if the model declared a
+    // compartment-indexed bioavailability for that dose's compartment, else the bare
+    // `PK_IDX_F` (#369 / #486). When F is an estimated individual parameter its
+    // derivative flows via `params_dual[slot]`. Use the raw slot — mirroring
+    // production's `DoseAttrMap::f_bio` (the 1.0 default baked into the bare slot at
+    // construction) — so a transient F ≤ 0 mid-fit scales the dose by F exactly as the
+    // f64 predictor does, rather than substituting 1.0 and dropping ∂/∂F (#451 / #433
+    // review #3).
+    let dose_f_bio: Vec<T> = subject
+        .doses
+        .iter()
+        .map(|d| params_dual[f_bio_slot(ode, d.cmt)])
+        .collect();
 
     // Dose-time anchors for TAFD/TAD (constants w.r.t. the parameters).
     let first_dose_time = subject
@@ -830,7 +847,7 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
         ode,
         &prepared_forcings,
         &params_dual,
-        f_bio,
+        &dose_f_bio,
         init_state,
         first_dose_time,
         &opts,
@@ -1203,10 +1220,17 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
         .expect("ode_analytical_supported (via ode_tvcov_supported) guarantees rhs_program");
     let opts = ode.solver_opts;
 
-    // Raw slot, mirroring production's `DoseAttrMap::f_bio` (1.0 default baked in at
+    // Per dose compartment, mirroring production's `DoseAttrMap::f_bio`: `F{cmt}` if
+    // declared else the bare `PK_IDX_F` slot (#369 / #486), read from that dose's own
+    // covariate snapshot `pk_at_dose[k]`. Raw slot (1.0 default baked in at
     // construction) — a transient F ≤ 0 scales the dose by F like the f64 predictor,
     // not 1.0 (#451 / #433 review #3).
-    let f_bio_at_dose: Vec<T> = pk_at_dose.iter().map(|p| p[PK_IDX_F]).collect();
+    let f_bio_at_dose: Vec<T> = subject
+        .doses
+        .iter()
+        .zip(pk_at_dose.iter())
+        .map(|(d, p)| p[f_bio_slot(ode, d.cmt)])
+        .collect();
     let first_dose_time = subject
         .doses
         .iter()
@@ -1641,7 +1665,7 @@ fn integrate_g<T: crate::sens::num::PkNum>(
     ode: &OdeSpec,
     prepared_forcings: &[PreparedInputRate<T>],
     params_dual: &[T],
-    f_bio: T,
+    dose_f_bio: &[T],
     init_state: &[T],
     first_dose_time: f64,
     opts: &crate::ode::solver::OdeSolverOptions,
@@ -1701,10 +1725,12 @@ fn integrate_g<T: crate::sens::num::PkNum>(
     let vars_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
     let stack_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
 
-    // Per-dose bioavailability for the shared absorption-forcing helper. The static
-    // walk applies one `f_bio` to every dose (per-compartment F is gated off), built
-    // once per subject rather than per RK45 stage (#451 / #433 review #6).
-    let dose_f_bio_all: Vec<T> = vec![f_bio; subject.doses.len()];
+    // `dose_f_bio` (one bioavailability per dose, resolved per compartment by the
+    // caller — `F{cmt}` else bare `PK_IDX_F`, #486) is built once per subject and
+    // indexed by dose position throughout: the bolus load, the infusion rate forcing,
+    // and the shared absorption-forcing helper all read `dose_f_bio[k]` (#451 / #433
+    // review #6).
+    debug_assert_eq!(dose_f_bio.len(), subject.doses.len());
 
     for w in 0..(break_times.len() - 1) {
         let t_start = break_times[w];
@@ -1727,7 +1753,7 @@ fn integrate_g<T: crate::sens::num::PkNum>(
         // A compartment fed by a built-in absorption input rate is skipped here — the
         // dose feeds R_in (the forcing in the RHS below), not a bolus (#430, mirroring
         // production's `input_rate_consumes_cmt` routing).
-        for dose in &subject.doses {
+        for (k, dose) in subject.doses.iter().enumerate() {
             if !dose.is_infusion()
                 && (dose.time - t_start).abs() < 1e-12
                 && dose.cmt >= 1
@@ -1735,7 +1761,7 @@ fn integrate_g<T: crate::sens::num::PkNum>(
             {
                 let cmt_idx = dose.cmt - 1;
                 if cmt_idx < n_states {
-                    u[cmt_idx] = u[cmt_idx] + f_bio * T::from_f64(dose.amt);
+                    u[cmt_idx] = u[cmt_idx] + dose_f_bio[k] * T::from_f64(dose.amt);
                 }
             }
         }
@@ -1765,14 +1791,17 @@ fn integrate_g<T: crate::sens::num::PkNum>(
         saveat.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
 
         // Infusions spanning this whole segment add a constant rate forcing
-        // F·rate to their compartment (the break times guarantee a segment is
-        // fully inside or outside each infusion window).
-        let active_inf: Vec<(usize, f64)> = subject
+        // `F·rate` to their compartment (the break times guarantee a segment is
+        // fully inside or outside each infusion window). `F` is resolved per dose
+        // compartment (`dose_f_bio[k]`, #486); pre-scale `F·rate` as a dual once per
+        // segment so the RHS closure (called every RK45 stage) just adds it.
+        let active_inf: Vec<(usize, T)> = subject
             .doses
             .iter()
-            .filter(|d| d.is_infusion())
-            .filter(|d| d.time <= t_start + 1e-9 && d.time + d.duration >= t_end - 1e-9)
-            .map(|d| (d.cmt.saturating_sub(1), d.rate))
+            .enumerate()
+            .filter(|(_, d)| d.is_infusion())
+            .filter(|(_, d)| d.time <= t_start + 1e-9 && d.time + d.duration >= t_end - 1e-9)
+            .map(|(k, d)| (d.cmt.saturating_sub(1), dose_f_bio[k] * T::from_f64(d.rate)))
             .collect();
 
         // Last effective dose at or before the segment start, for TAD.
@@ -1796,9 +1825,10 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                 &mut stack_cell.borrow_mut(),
             );
             // Infusion rate forcing (static walk only; the TV-cov subset is bolus-only).
-            for &(cmt, rate) in &active_inf {
+            // `scaled_rate` already carries `F·rate` for this dose's compartment (#486).
+            for &(cmt, scaled_rate) in &active_inf {
                 if cmt < du.len() {
-                    du[cmt] = du[cmt] + f_bio * T::from_f64(rate);
+                    du[cmt] = du[cmt] + scaled_rate;
                 }
             }
             // Built-in absorption input-rate forcing R_in(tad), via the shared
@@ -1812,7 +1842,7 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                     prepared_forcings,
                     &subject.doses,
                     &[],
-                    &dose_f_bio_all,
+                    dose_f_bio,
                     f64::NEG_INFINITY,
                     t,
                     du,
@@ -2196,6 +2226,12 @@ mod tests {
         s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
         check(&m, &s, &[5.0, 50.0, 1.5, 0.70], &[0.15, 0.2]);
 
+        // Compartment-indexed F1 (with IIV) → per-compartment `f_bio_slot` path (#486).
+        let m = parse_model_string(F1_ODE).expect("parse");
+        let mut s = bolus_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        check(&m, &s, &[5.0, 50.0, 1.5, 0.70], &[0.15, 0.2]);
+
         // LTBS output transform over the Dual1 readout.
         let m = parse_model_string(TWOCPT_ODE_LTBS).expect("parse");
         check(
@@ -2278,26 +2314,25 @@ mod tests {
         check_vs_production(&model, &subject, &[5.0, 50.0, 1.5, 0.70], &[0.15, 0.2]);
     }
 
-    /// Compartment-indexed bioavailability (`F1`) and lag time (`ALAG1`) land in the
-    /// dose-attr map, not the bare `PK_IDX_F` / `PK_IDX_LAGTIME` slots — the dual
-    /// walks apply only the bare `F` and dose at the bare `d.time`, so the analytic
-    /// gradient would diverge from production's per-compartment `f_bio(cmt)` /
-    /// `d.time + lagtime(cmt)`. The gate must decline both to FD (#449 re-review #1, #3).
-    #[test]
-    fn ode_analytical_declines_per_compartment_f_and_lag() {
-        const F1_ODE: &str = r#"
+    // 1-cpt oral ODE with a *compartment-indexed* bioavailability `F1` (dose into the
+    // depot, cmt 1) carrying IIV (logit-normal). `F1` lands in the dose-attr map at its
+    // own slot, NOT the bare `PK_IDX_F` (which stays 1.0): so a walk that read the bare
+    // slot would apply F = 1.0 and diverge from production's `f_bio(cmt=1)` — both in
+    // value and in ∂/∂F. The IIV (`ETA_F`) routes F1 into the inner η-gradient too (#486).
+    const F1_ODE: &str = r#"
 [parameters]
   theta TVCL(5.0, 0.1, 50.0)
   theta TVV(50.0, 5.0, 500.0)
   theta TVKA(1.5, 0.05, 20.0)
   theta THETA_F1(0.70, 0.001, 0.999)
   omega ETA_CL ~ 0.09
+  omega ETA_F  ~ 0.10
   sigma PROP_ERR ~ 0.15 (sd)
 [individual_parameters]
   CL = TVCL * exp(ETA_CL)
   V  = TVV
   KA = TVKA
-  F1 = THETA_F1
+  F1 = inv_logit(logit(THETA_F1) + ETA_F)
 [structural_model]
   ode(obs_cmt=central, states=[depot, central])
 [odes]
@@ -2305,13 +2340,108 @@ mod tests {
   d/dt(central) = KA * depot / V - CL/V * central
 [error_model]
   DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
 "#;
-        let m = parse_model_string(F1_ODE).expect("parse F1");
-        assert!(
-            !ode_analytical_supported(&m),
-            "compartment-indexed F1 must decline to FD"
-        );
 
+    // 2-cpt IV ODE with *distinct* per-compartment bioavailabilities `F1` (central,
+    // cmt 1) and `F2` (peripheral, cmt 2). With one dose into each compartment, a walk
+    // that did not key F by the dose's own compartment (e.g. applied dose 0's F to
+    // both) would diverge from production. `obs_cmt = central`, so both F1 (direct) and
+    // F2 (via peripheral→central redistribution) move the observed concentration, hence
+    // both ∂/∂F1 and ∂/∂F2 are observable (#486).
+    const F1F2_IV_ODE: &str = r#"
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV1(12.0, 1.0, 500.0)
+  theta TVQ(2.0, 0.01, 100.0)
+  theta TVV2(25.0, 1.0, 500.0)
+  theta THETA_F1(0.80, 0.001, 0.999)
+  theta THETA_F2(0.50, 0.001, 0.999)
+  omega ETA_CL ~ 0.10
+  sigma PROP_ERR ~ 0.05 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q  = TVQ
+  V2 = TVV2
+  F1 = THETA_F1
+  F2 = THETA_F2
+[structural_model]
+  ode(obs_cmt=central, states=[central, peripheral])
+[odes]
+  d/dt(central)    = -(CL/V1) * central - (Q/V1) * central + (Q/V2) * peripheral
+  d/dt(peripheral) =  (Q/V1) * central  - (Q/V2) * peripheral
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+    /// `f_bio_slot` resolves a dose's bioavailability slot per compartment: the
+    /// indexed `F{cmt}` slot when declared, else the bare `PK_IDX_F` (#486).
+    #[test]
+    fn f_bio_slot_resolves_indexed_then_bare() {
+        let m = parse_model_string(F1F2_IV_ODE).expect("parse F1F2");
+        let ode = m.ode_spec.as_ref().expect("ode_spec");
+        let bare = crate::types::PK_IDX_F;
+        let s1 = f_bio_slot(ode, 1);
+        let s2 = f_bio_slot(ode, 2);
+        assert_ne!(s1, bare, "F1 must resolve to its own indexed slot");
+        assert_ne!(s2, bare, "F2 must resolve to its own indexed slot");
+        assert_ne!(s1, s2, "F1 and F2 occupy distinct slots");
+        assert_eq!(
+            s1,
+            ode.dose_attr_map
+                .indexed_slot(crate::types::DoseAttr::F, 1)
+                .unwrap()
+        );
+        // A compartment with no indexed `F` falls back to the bare slot.
+        assert_eq!(f_bio_slot(ode, 3), bare);
+    }
+
+    /// Compartment-indexed bioavailability (`F1`/`F2`, #369) is now served analytically
+    /// (#486): the dual walks resolve `F` per dose compartment, so analytic f / ∂f/∂η /
+    /// ∂f/∂θ match the production predictor and its FD. Covers the single-indexed depot
+    /// case (with IIV on F1) and distinct F1≠F2 into two compartments.
+    #[test]
+    fn ode_provider_compartment_indexed_f_matches_production() {
+        // Single indexed F1 into the depot, with IIV.
+        let model = parse_model_string(F1_ODE).expect("parse F1");
+        assert!(
+            ode_analytical_supported(&model),
+            "compartment-indexed F1 should now be in scope"
+        );
+        let mut subject = bolus_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        check_vs_production(&model, &subject, &[5.0, 50.0, 1.5, 0.70], &[0.15, 0.2]);
+
+        // Distinct F1 (central) and F2 (peripheral) with a dose into each compartment.
+        let model = parse_model_string(F1F2_IV_ODE).expect("parse F1F2");
+        assert!(
+            ode_analytical_supported(&model),
+            "distinct per-compartment F1/F2 should be in scope"
+        );
+        let mut subject = bolus_subject(&[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(0.0, 50.0, 2, 0.0, false, 0.0),
+        ];
+        check_vs_production(
+            &model,
+            &subject,
+            &[4.0, 12.0, 2.0, 25.0, 0.80, 0.50],
+            &[0.1],
+        );
+    }
+
+    /// Compartment-indexed lag (`ALAG1`) is still declined to FD: the dual loop applies
+    /// no dose-time shift, so an estimated per-compartment lag stays out of scope (→
+    /// #472). (Indexed `F` is now supported — see the parity test above.)
+    #[test]
+    fn ode_analytical_declines_per_compartment_lag() {
         const ALAG1_ODE: &str = r#"
 [parameters]
   theta TVCL(5.0, 0.1, 50.0)


### PR DESCRIPTION
## Why
Issue #486 (the analytic-sensitivity status snapshot) lists **compartment-indexed `F` / lagtime** as falling back to finite differences on the ODE path. The ODE feature itself works — `F1`/`F2` are resolved by production's `DoseAttrMap::f_bio` per dose compartment — but the analytic `Dual2`/`Dual1` sensitivity walks applied only the **bare** `PK_IDX_F` slot, so a compartment-indexed-`F` model was declined to FD (`ode_provider.rs:135-140`). This is one of the gaps left by the Enzyme-AD retirement (#381): under AD these models were differentiated generically; the hand-rolled dual engine needs each feature wired explicitly.

This PR closes the **`F` half** of that gap (compartment-indexed *lagtime* stays on FD — it needs the dose-time-shift / saltation machinery tracked by #472).

## What changed
- New private helper `f_bio_slot(ode, cmt)` → the indexed `F{cmt}` slot if declared, else bare `PK_IDX_F` (mirrors `DoseAttrMap::f_bio`).
- The **static** walk (`integrate_subject_duals` → `integrate_g`) now carries a per-dose `dose_f_bio: &[T]` instead of a single scalar `f_bio`, applied at the bolus load, the infusion rate forcing (pre-scaled `F·rate` per segment), and the absorption-forcing helper.
- The **TV-cov** walk (`integrate_tvcov_readout`) resolves `f_bio_at_dose[k]` from each dose's own covariate snapshot via `f_bio_slot`.
- Removed the `ode_analytical_supported` gate that declined indexed-`F` models. An indexed `F{cmt}` is an ordinary seeded individual parameter, so `params_dual[slot]` already carries `∂/∂F{cmt}`.
- Drive-by: fixed two stale doc comments (`ode_provider.rs` module doc + the `supported_over_dual` gate) that still called `transit()` / built-in input-rate absorption FD-only after #468 lifted transit.

## Alternatives considered
Resolving `F` inside the per-stage RHS closure (rejected — re-resolves the slot every RK45 stage; pre-building the per-dose vector once per subject mirrors the existing `dose_f_bio_all` pattern). Keeping `integrate_g`'s scalar `f_bio` and special-casing indexed `F` (rejected — two code paths to keep in sync; the per-dose vector subsumes the scalar case).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change (`f_bio_slot` and `integrate_g` are private; `ode_analytical_supported`'s signature is unchanged), so no ferx-r pin bump.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: the production f64 predictor (`compute_predictions_with_tv`) + central finite differences, in the default (FD-capable) build.
- [x] Reference values: analytic `f` / `∂f/∂η` / `∂f/∂θ` match production+FD to the harness tolerances (`max_relative = 2e-3` on the FD gradients) for (a) a 1-cpt oral model with a single indexed `F1` carrying IIV, and (b) a 2-cpt IV model with **distinct** `F1`≠`F2` dosed into two different compartments. The production per-compartment `F` path is itself NONMEM-anchored via #369 (`two_cmt_dose_nonmem` F1/F2), so this validation is transitively NONMEM-anchored.

The parity test is discriminating, not a happy path: before this change the walk read the bare slot (`F = 1.0`), so the analytic **value** alone diverges from production (`F1 ≈ 0.7`) and the test fails — it passes only because the per-compartment slot is now read.

## Performance
- [x] Faster — affected models move off the FD sensitivity fallback onto the exact analytic `Dual2`/`Dual1` gradient (fewer prediction walks per gradient); estimates unchanged.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 1490 pass / 0 fail)
- [x] Regression test added that fails without this fix (`ode_provider_compartment_indexed_f_matches_production`)

New/updated: `ode_provider_compartment_indexed_f_matches_production`, `f_bio_slot_resolves_indexed_then_bare`, `ode_analytical_declines_per_compartment_lag` (was the F+lag decline test — F portion flipped to the parity test, ALAG1 kept), and an `F1`-with-IIV case added to `ode_light_inner_eta_grad_matches_full_provider`.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (`### Added`)
- [x] No docs page needed (makes an existing feature's gradient analytic; no new DSL/fit-option surface — same as #430/#468)

## Checklist
- [x] `cargo clippy` clean (no new warnings introduced; pre-existing warnings unchanged)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — the per-dose `F` is threaded as `T`, not collapsed to `f64`
- [x] `Cargo.toml` version bump not needed (non-breaking)

## Reviewer hints
The seeding linchpin: `pk_indices = ode_slot_map` for ODE models (`model_parser.rs:1667`) and an indexed `F{cmt}` lands at `indiv_param_slots[i]` (`model_parser.rs:6041`), so its slot is in `pk_indices` and gets seeded at `ode_provider.rs:790` — that's why `params_dual[f_bio_slot(...)]` carries `∂/∂F{cmt}` with no special seeding. The infusion path pre-scales `F·rate` as a dual once per segment (not per RK45 stage). Compartment-indexed *lag* is deliberately still gated to FD via `has_lagtime()`.

## Open questions
None — scope is intentionally `F` only; indexed `ALAG{cmt}` is left for the lagtime/saltation work (#472).
