### PR TITLE
feat(ode): adaptive driver emits a per-decision log (S1.4a) [#391]

### DIFF
--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -10,8 +10,8 @@
 use crate::ode::solver::{solve_ode, OdeSolverOptions};
 use crate::pk::absorption::PreparedInputRate;
 use crate::sim::adaptive::{
-    AdaptiveRun, ControllerCtx, DoseAction, DoseLedgerEntry, MonitorSpec, ObserveMode,
-    ObservedSignal,
+    AdaptiveRun, ControllerCtx, DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry,
+    MonitorSpec, ObserveMode, ObservedSignal,
 };
 use crate::types::{DoseEvent, PkParams, Subject};
 use std::borrow::Cow;
@@ -1225,6 +1225,7 @@ pub(crate) fn ode_predictions_adaptive(
     let mut u = ode.initial_state(pk_params_flat);
     let mut predictions = vec![f64::NAN; n_obs];
     let mut ledger: Vec<DoseLedgerEntry> = Vec::new();
+    let mut decisions: Vec<DecisionLogEntry> = Vec::new();
 
     // Shadow subject accumulates the controller's realized doses (the #324
     // pattern); `integrate_segment` reads `shadow.doses` for the TAD anchor.
@@ -1314,6 +1315,9 @@ pub(crate) fn ode_predictions_adaptive(
                     controller(&ctx)
                 };
 
+                // Count realized doses this decision so the log can categorize the
+                // outcome (a held / zero-amount decision leaves no ledger row).
+                let mut n_dosed = 0usize;
                 for action in actions {
                     action
                         .validate()
@@ -1356,6 +1360,7 @@ pub(crate) fn ode_predictions_adaptive(
                                 post_state: None,
                                 f_applied: f,
                             });
+                            n_dosed += 1;
                         }
                         DoseAction::Infuse { amt, cmt, rate } => {
                             // A zero-amount infusion is a no-op; don't record an empty dose.
@@ -1404,6 +1409,7 @@ pub(crate) fn ode_predictions_adaptive(
                                 post_state: None,
                                 f_applied: f,
                             });
+                            n_dosed += 1;
                         }
                         DoseAction::Hold => {}
                         DoseAction::Stop => {
@@ -1412,6 +1418,27 @@ pub(crate) fn ode_predictions_adaptive(
                         }
                     }
                 }
+
+                // Log every decision — including holds and no-change, which leave
+                // no ledger row. `stopped` was false on entry to this hook (it gates
+                // the hook), so its truth here means the `Stop` fired this decision.
+                // `observed` is moved in (the ledger rows above already cloned it).
+                let outcome = if stopped {
+                    DecisionOutcome::Stop { dosed: n_dosed }
+                } else if n_dosed > 0 {
+                    DecisionOutcome::Dosed { n: n_dosed }
+                } else {
+                    DecisionOutcome::Hold
+                };
+                decisions.push(DecisionLogEntry {
+                    subject: shadow.id.clone(),
+                    draw: 0,
+                    sim: 0,
+                    decision_idx: decision_index,
+                    time: t_start,
+                    observed_signals: observed,
+                    outcome,
+                });
             }
         }
 
@@ -1481,6 +1508,7 @@ pub(crate) fn ode_predictions_adaptive(
     Ok(AdaptiveRun {
         predictions,
         ledger,
+        decisions,
     })
 }
 
@@ -3555,6 +3583,142 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("lag time"), "got: {err}");
+    }
+
+    // ----- S1.4a decision log (#391) ------------------------------------
+
+    #[test]
+    fn adaptive_decision_log_records_dose_hold_and_stop() {
+        // Every decision is logged — including the hold, which leaves no ledger
+        // row — with the signal the controller observed and the outcome it chose.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let monitors = [MonitorSpec::new("A", 1, ObserveMode::Ipred)];
+        let decisions = [0.0, 24.0, 48.0];
+        let mut controller = |ctx: &ControllerCtx| match ctx.decision_index {
+            0 => vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+            1 => vec![DoseAction::Hold],
+            _ => vec![DoseAction::Stop],
+        };
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &monitors,
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+
+        assert_eq!(run.decisions.len(), 3, "one log entry per decision");
+        for (i, d) in run.decisions.iter().enumerate() {
+            assert_eq!(d.decision_idx, i);
+            assert_eq!(d.time, decisions[i]);
+            assert_eq!(d.observed_signals.len(), 1);
+            assert_eq!(d.observed_signals[0].name, "A");
+        }
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Dosed { n: 1 });
+        assert_eq!(run.decisions[1].outcome, DecisionOutcome::Hold);
+        assert_eq!(run.decisions[2].outcome, DecisionOutcome::Stop { dosed: 0 });
+        // The pre-dose signal at the first decision is the empty initial state.
+        assert_eq!(run.decisions[0].observed_signals[0].value, 0.0);
+    }
+
+    #[test]
+    fn adaptive_decision_log_omits_decisions_after_stop() {
+        // Once the controller stops, the driver issues no further decisions, so
+        // the Stop entry is the last record (no phantom post-stop log rows).
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |ctx: &ControllerCtx| {
+            if ctx.decision_index == 0 {
+                vec![DoseAction::Stop]
+            } else {
+                vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }]
+            }
+        };
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0, 10.0, 20.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1, "only the stop decision is logged");
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Stop { dosed: 0 });
+        assert!(run.ledger.is_empty());
+    }
+
+    #[test]
+    fn adaptive_decision_log_dose_then_stop_in_one_action_list() {
+        // `[Bolus, Stop]` — a final dose, then discontinue — is logged as
+        // `Stop { dosed: 1 }`, not a bare stop, and the dose reaches the ledger.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller =
+            |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }, DoseAction::Stop];
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0, 24.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1, "stop ends the schedule after one");
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Stop { dosed: 1 });
+        assert_eq!(run.ledger.len(), 1);
+    }
+
+    #[test]
+    fn adaptive_decision_log_counts_multiple_doses_in_one_decision() {
+        // A decision can issue more than one dose (e.g. a loading split); the log
+        // records `Dosed { n }` with the realized count, and a zero-amount action
+        // in the same list is excluded (it leaves no ledger row).
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |_ctx: &ControllerCtx| {
+            vec![
+                DoseAction::Bolus { amt: 50.0, cmt: 1 },
+                DoseAction::Bolus { amt: 0.0, cmt: 1 }, // normalized to Hold, not counted
+                DoseAction::Bolus { amt: 50.0, cmt: 1 },
+            ]
+        };
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1);
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Dosed { n: 2 });
+        assert_eq!(
+            run.ledger.len(),
+            2,
+            "two realized doses, the zero-amt excluded"
+        );
     }
 
     #[test]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1315,13 +1315,29 @@ pub(crate) fn ode_predictions_adaptive(
                     controller(&ctx)
                 };
 
+                // Validate the whole action list up front — before any action is
+                // applied — and require `Stop` to be the final action. A malformed
+                // action anywhere (not only one before the first `Stop`) is a typed
+                // error, and a controller that issues actions *after* discontinuing
+                // (`[Stop, …]`) is rejected rather than silently truncated, so the
+                // decision log can never disagree with the ledger about what ran.
+                for (j, action) in actions.iter().enumerate() {
+                    action
+                        .validate()
+                        .map_err(|e| format!("decision {decision_index} at t={t_start}: {e}"))?;
+                    if action.is_stop() && j + 1 < actions.len() {
+                        return Err(format!(
+                            "decision {decision_index} at t={t_start}: Stop must be the final \
+                             action, but {} action(s) follow it",
+                            actions.len() - j - 1
+                        ));
+                    }
+                }
+
                 // Count realized doses this decision so the log can categorize the
                 // outcome (a held / zero-amount decision leaves no ledger row).
                 let mut n_dosed = 0usize;
                 for action in actions {
-                    action
-                        .validate()
-                        .map_err(|e| format!("decision {decision_index} at t={t_start}: {e}"))?;
                     match action {
                         DoseAction::Bolus { amt, cmt } => {
                             // A zero-amount bolus is a no-op; don't record an empty dose.
@@ -3638,7 +3654,12 @@ mod tests {
             if ctx.decision_index == 0 {
                 vec![DoseAction::Stop]
             } else {
-                vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }]
+                // The driver must never call the controller again after a Stop;
+                // reaching here would be the bug this test guards against.
+                unreachable!(
+                    "driver issued a decision after Stop (idx {})",
+                    ctx.decision_index
+                )
             }
         };
         let base = make_subject(vec![], vec![1.0]);
@@ -3719,6 +3740,150 @@ mod tests {
             2,
             "two realized doses, the zero-amt excluded"
         );
+    }
+
+    #[test]
+    fn adaptive_decision_log_records_infusion_as_dosed() {
+        // An infusion is a realized dose: its decision categorizes to `Dosed { n }`
+        // exactly as a bolus does (the outcome doesn't distinguish route), and it
+        // reaches the ledger.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |_ctx: &ControllerCtx| {
+            vec![DoseAction::Infuse {
+                amt: 100.0,
+                cmt: 1,
+                rate: 50.0,
+            }]
+        };
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1);
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Dosed { n: 1 });
+        assert_eq!(run.ledger.len(), 1);
+    }
+
+    #[test]
+    fn adaptive_decision_log_infusion_then_stop() {
+        // `[Infuse, Stop]` mirrors the bolus dose-then-stop: a final infusion, then
+        // discontinue, logged as `Stop { dosed: 1 }` with the infusion in the ledger.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |_ctx: &ControllerCtx| {
+            vec![
+                DoseAction::Infuse {
+                    amt: 100.0,
+                    cmt: 1,
+                    rate: 50.0,
+                },
+                DoseAction::Stop,
+            ]
+        };
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0, 24.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1, "stop ends the schedule after one");
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Stop { dosed: 1 });
+        assert_eq!(run.ledger.len(), 1);
+    }
+
+    #[test]
+    fn adaptive_decision_log_empty_action_list_is_hold() {
+        // An empty action list is a no-change decision: it categorizes to `Hold`
+        // (no dose, not stopped) and leaves no ledger row — same as `[Hold]`.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |_ctx: &ControllerCtx| Vec::<DoseAction>::new();
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &[],
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+        assert_eq!(run.decisions.len(), 1);
+        assert_eq!(run.decisions[0].outcome, DecisionOutcome::Hold);
+        assert!(run.ledger.is_empty());
+    }
+
+    #[test]
+    fn adaptive_driver_rejects_malformed_or_post_stop_actions() {
+        // The whole action list is validated up front, before anything is applied:
+        // a malformed action is a typed error wherever it sits, and `Stop` must be
+        // the final action — a controller that issues actions after discontinuing is
+        // rejected, not silently truncated, so the log can't disagree with the
+        // ledger. Nothing is applied when the list is rejected (the ledger would be
+        // discarded with the `Err` regardless).
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let base = make_subject(vec![], vec![1.0]);
+
+        let cases: [(Vec<DoseAction>, &str); 3] = [
+            // Malformed action (compartment 0) -> the up-front validate() error.
+            (
+                vec![DoseAction::Bolus { amt: 100.0, cmt: 0 }],
+                "compartment is 0",
+            ),
+            // A well-formed action after a Stop -> Stop-must-be-final error.
+            (
+                vec![DoseAction::Stop, DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+                "Stop must be the final action",
+            ),
+            // A Stop in the middle of the list -> same rejection (not a silent drop
+            // of the trailing dose).
+            (
+                vec![
+                    DoseAction::Bolus { amt: 50.0, cmt: 1 },
+                    DoseAction::Stop,
+                    DoseAction::Bolus { amt: 50.0, cmt: 1 },
+                ],
+                "Stop must be the final action",
+            ),
+        ];
+
+        for (actions, needle) in cases {
+            let mut controller = |_ctx: &ControllerCtx| actions.clone();
+            let err = ode_predictions_adaptive(
+                &ode,
+                &pk.values,
+                &[],
+                &[],
+                &base,
+                &[0.0],
+                &[],
+                &mut controller,
+                100,
+            )
+            .expect_err("malformed / post-stop action list is rejected");
+            assert!(err.contains(needle), "expected {needle:?}, got: {err}");
+        }
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -225,9 +225,55 @@ pub struct DoseLedgerEntry {
     pub f_applied: f64,
 }
 
+/// What a controller did at one decision — the audit summary the decision log
+/// records alongside the signals it observed.
+///
+/// The realized doses themselves live in the [`DoseLedgerEntry`] rows tagged with
+/// the same `decision_idx`; this only categorizes the decision so a held / no-dose
+/// decision (invisible in the dose ledger) is still on the record. `Stop` carries
+/// `dosed` so a "give a final dose, then discontinue" action list (`[Bolus, Stop]`)
+/// is logged faithfully rather than as a bare stop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecisionOutcome {
+    /// The controller issued `n` realized dose(s) (bolus/infusion with `amt > 0`).
+    Dosed { n: usize },
+    /// No dose this decision — every action was `Hold` or a zero-amount dose.
+    Hold,
+    /// The controller discontinued; `dosed` counts any dose(s) issued *before* the
+    /// `Stop` in the same action list (`0` for a bare stop).
+    Stop { dosed: usize },
+}
+
+/// One decision the controller made, recorded for **every** decision time —
+/// including holds and no-change, which leave no [`DoseLedgerEntry`]. This is the
+/// Part-D decision log and the input to the Part-E decision-audit replay (S1.6):
+/// it pins exactly what the controller saw (`observed_signals`) and what it did
+/// (`outcome`) at each decision, so the run can be reproduced and audited.
+///
+/// A decision reached *after* a `Stop` is not logged — once discontinued the
+/// driver issues no further decisions, so the `Stop` entry is the last record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecisionLogEntry {
+    /// Subject id.
+    pub subject: String,
+    /// Parameter-uncertainty draw index — matches [`crate::SimulationResult::draw`].
+    pub draw: usize,
+    /// Replicate index within the draw — matches [`crate::SimulationResult::sim`].
+    pub sim: usize,
+    /// 0-based index of this decision in the schedule.
+    pub decision_idx: usize,
+    /// Decision time on the subject's clock.
+    pub time: f64,
+    /// What the controller observed at this decision (per-analyte value + mode) —
+    /// the exact inputs to reproduce the decision.
+    pub observed_signals: Vec<ObservedSignal>,
+    /// What the controller did (dose / hold / stop).
+    pub outcome: DecisionOutcome,
+}
+
 /// Result of one reactive-dosing run over a single subject: the observation-time
-/// predictions (same layout as [`crate::ode::predictions::ode_predictions`]) and
-/// the realized-dose ledger the controller produced. S1.4 wraps this with the
+/// predictions (same layout as [`crate::ode::predictions::ode_predictions`]), the
+/// realized-dose ledger, and the per-decision log. S1.4 wraps this with the
 /// per-subject/replicate orchestration and the public output schema.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AdaptiveRun {
@@ -236,6 +282,9 @@ pub struct AdaptiveRun {
     pub predictions: Vec<f64>,
     /// Every dose the controller actually issued, in time order.
     pub ledger: Vec<DoseLedgerEntry>,
+    /// One entry per decision (incl. holds), in schedule order, up to and
+    /// including any `Stop`.
+    pub decisions: Vec<DecisionLogEntry>,
 }
 
 #[cfg(test)]
@@ -347,6 +396,34 @@ mod tests {
         let pre = entry.pre_state.as_ref().unwrap();
         let post = entry.post_state.as_ref().unwrap();
         assert_eq!(post[0] - pre[0], 75.0);
+    }
+
+    #[test]
+    fn decision_log_entry_round_trips_and_outcomes_are_distinct() {
+        let obs = ObservedSignal {
+            name: "A".to_string(),
+            value: 0.0,
+            mode: ObserveMode::Ipred,
+        };
+        let entry = DecisionLogEntry {
+            subject: "1".to_string(),
+            draw: 0,
+            sim: 0,
+            decision_idx: 3,
+            time: 72.0,
+            observed_signals: vec![obs.clone()],
+            outcome: DecisionOutcome::Dosed { n: 2 },
+        };
+        assert_eq!(entry.clone(), entry);
+        assert_eq!(entry.observed_signals[0], obs);
+        // The three outcome categories are distinct, and `Stop` carries the count
+        // of any dose(s) issued before discontinuation.
+        assert_ne!(DecisionOutcome::Hold, DecisionOutcome::Dosed { n: 0 });
+        assert_ne!(
+            DecisionOutcome::Stop { dosed: 0 },
+            DecisionOutcome::Stop { dosed: 1 }
+        );
+        assert_ne!(DecisionOutcome::Hold, DecisionOutcome::Stop { dosed: 0 });
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -258,9 +258,11 @@ pub enum DecisionOutcome {
 /// Reproducibility assumes the controller decides from its declared
 /// `observed_signals`. [`ControllerCtx`] also exposes the raw `state`,
 /// `covariates`, and dose `history`, but those are deterministically re-derivable
-/// from the frozen inputs + ledger + schedule, so they are not re-stored here —
-/// the signals are recorded precisely because they are the one input that is *not*
-/// otherwise recoverable once S1.5 adds the per-subject assay-noise draw.
+/// from the frozen inputs + ledger + schedule, so they are not re-stored here. The
+/// signals *are* stored: under S1.3a (`Ipred` only) they are likewise re-derivable
+/// and serve as a self-contained, directly-auditable record, and under S1.5's `Dv`
+/// mode they pin the realized assay-noise draw, so the audit can verify what the
+/// controller saw without re-running the stochastic observation.
 ///
 /// A decision reached *after* a `Stop` is not logged — once discontinued the
 /// driver issues no further decisions, so the `Stop` entry is the last record.

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -236,11 +236,16 @@ pub struct DoseLedgerEntry {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecisionOutcome {
     /// The controller issued `n` realized dose(s) (bolus/infusion with `amt > 0`).
+    /// Always `n >= 1`: a decision whose actions are all `Hold` or zero-amount is
+    /// [`DecisionOutcome::Hold`], not `Dosed { n: 0 }`.
     Dosed { n: usize },
-    /// No dose this decision — every action was `Hold` or a zero-amount dose.
+    /// No dose this decision — every action was `Hold`, an empty action list, or a
+    /// zero-amount dose.
     Hold,
     /// The controller discontinued; `dosed` counts any dose(s) issued *before* the
-    /// `Stop` in the same action list (`0` for a bare stop).
+    /// `Stop` in the same action list (`0` for a bare stop). `Stop` must be the
+    /// final action — the driver rejects any action after it — so `dosed` is a
+    /// faithful count, never an undercount from a silently-dropped trailing dose.
     Stop { dosed: usize },
 }
 
@@ -249,6 +254,13 @@ pub enum DecisionOutcome {
 /// Part-D decision log and the input to the Part-E decision-audit replay (S1.6):
 /// it pins exactly what the controller saw (`observed_signals`) and what it did
 /// (`outcome`) at each decision, so the run can be reproduced and audited.
+///
+/// Reproducibility assumes the controller decides from its declared
+/// `observed_signals`. [`ControllerCtx`] also exposes the raw `state`,
+/// `covariates`, and dose `history`, but those are deterministically re-derivable
+/// from the frozen inputs + ledger + schedule, so they are not re-stored here —
+/// the signals are recorded precisely because they are the one input that is *not*
+/// otherwise recoverable once S1.5 adds the per-subject assay-noise draw.
 ///
 /// A decision reached *after* a `Stop` is not logged — once discontinued the
 /// driver issues no further decisions, so the `Stop` entry is the last record.


### PR DESCRIPTION
## Why
Adaptive-dosing slice **S1.4a** of epic #391 ([S1.4 breakdown](https://github.com/FeRx-NLME/ferx-core/issues/391#issuecomment-4790294559)). The reactive driver (#467/#493) recorded only *realized doses* (`DoseLedgerEntry`), so a **held / no-change decision left no trace**. S1.4 needs a complete decision record: what the controller observed and what it decided at *every* decision. That's the Part-D **decision log** and the input to the S1.6 frozen-replay **decision-audit**.

## What changed
New in `sim/adaptive.rs`:
- `DecisionOutcome` = `Dosed { n }` | `Hold` | `Stop { dosed }`. `Stop` carries `dosed` so a *"give a final dose, then discontinue"* action list (`[Bolus, Stop]`) is logged faithfully, not as a bare stop.
- `DecisionLogEntry { subject, draw, sim, decision_idx, time, observed_signals, outcome }`.
- `AdaptiveRun` gains `decisions: Vec<DecisionLogEntry>`.

`ode_predictions_adaptive` emits **one entry per decision — including holds** (invisible in the dose ledger). A decision reached *after* a `Stop` is not logged: once discontinued the driver issues no further decisions, so the `Stop` entry is the last record. **Predictions and the dose ledger are unchanged** — the S1.3a/S1.3b oracles are the regression check.

The driver now also **validates the whole action list up front** and requires `Stop` to be the final action: a controller that issues actions after discontinuing (`[Stop, …]`, `[Bolus, Stop, Bolus]`) is a typed error rather than a silent truncation, so the decision log can never disagree with the ledger about what ran. The audit-completeness contract — controllers decide from their declared `observed_signals`; raw `state`/`covariates`/`history` are re-derivable from frozen inputs + ledger + schedule — is documented on `DecisionLogEntry`.

## Alternatives considered
A flat `{ n_doses, stopped }` struct was simpler but loses the "dosed-then-stopped" case as a first-class outcome; the enum with `Stop { dosed }` records it without a separate boolean, and reads cleanly at the call site.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`ode_predictions_adaptive` stays `pub(crate)`; the public `simulate_adaptive()` that surfaces the log lands in **S1.4b**.

## Breaking changes
- [x] None. The new `DecisionOutcome` / `DecisionLogEntry` types and the `AdaptiveRun.decisions` field are `pub` within `pub mod adaptive`, but **no public function surfaces them yet** (`ode_predictions_adaptive` is `pub(crate)`), so there is no user-reachable API change — the same treatment the existing `sim::adaptive` types got in S1.1/S1.3.

## Numerical validation
- [x] Not applicable — no numerical output changes. Predictions and the dose ledger are byte-for-byte unchanged; this only adds an audit artifact. The S1.3a/S1.3b oracles (bit-exact-vs-static + closed-form) still pass in the full suite.

## Performance
- [x] No significant impact expected (one `DecisionLogEntry` push per decision; decisions are O(schedule), not O(integration steps)).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 49/49 adaptive; full lib suite 1509 green)
- [x] Regression test added that fails without this fix (the decision-log assertions; predictions/ledger oracles unchanged)

New tests: dose / hold / stop all logged with their observed signals; **post-stop omission**; **dose-then-stop** → `Stop { dosed: 1 }`; **multi-dose decision** → `Dosed { n: 2 }` with a zero-amount action correctly excluded; **infusion** → `Dosed` and **infusion-then-stop** → `Stop { dosed: 1 }`; **empty action list** → `Hold`; **malformed / post-`Stop` action lists rejected**; type round-trip + outcome distinctness.

## Docs
- [x] No user-visible change — the new types are `pub` but unreachable through any public function until `simulate_adaptive()` lands; docs + `CHANGELOG.md` land with that public API in S1.4b.

## Checklist
- [x] `cargo clippy` clean (no warnings in touched code)
- [x] Not on the `Dual2` sensitivity path — simulation-only, never differentiated
- [x] `Cargo.toml` version bump not needed (non-breaking)

## Reviewer hints
- The change is the new types + the `AdaptiveRun` field, plus two blocks in the decision hook of `ode_predictions_adaptive`: an up-front validation pass (validate each action; reject any action after a `Stop`) and the emission block at the end. `stopped` is false on entry to the hook (it gates the hook), so its truth after the action loop means the `Stop` fired *this* decision — that's how the outcome is categorized.
- `draw`/`sim` are stamped `0` (deterministic single pass); S1.5 threads real replicate indices post-hoc, so this needs no signature change later.

## Open questions
- None. S1.4b (public `simulate_adaptive()`) consumes this next.
