### PR TITLE
chore(deps): combine Dependabot updates

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal
 
@@ -48,7 +48,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal
 
@@ -90,7 +90,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install stable toolchain
         run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 
@@ -129,7 +129,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal -c clippy
 
@@ -143,7 +143,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal -c rustfmt
 
@@ -159,7 +159,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install stable toolchain
         run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 
@@ -207,7 +207,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install stable toolchain
         run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,15 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "argmin"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,11 +84,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -129,6 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,10 +140,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -182,12 +190,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -212,35 +219,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -281,7 +267,7 @@ dependencies = [
  "csv",
  "nalgebra",
  "nlopt",
- "rand 0.8.5",
+ "rand 0.10.1",
  "rand_distr",
  "rayon",
  "regex",
@@ -306,29 +292,8 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -339,8 +304,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -372,6 +349,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -604,15 +590,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -620,18 +601,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -646,15 +628,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -663,13 +636,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -690,9 +669,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -710,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -733,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rle-decode-fast"
@@ -809,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -822,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -910,28 +889,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "typed-path"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1050,20 +1023,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "typed-path",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,17 +35,17 @@ nalgebra = "0.35"
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "8", default-features = false, features = ["deflate"] }
 rayon = "1.10"
-rand = { version = "0.8", features = ["small_rng"] }
-rand_distr = "0.4"
+rand = "0.10"
+rand_distr = "0.6"
 regex = "1.11"
 thiserror = "2"
 nlopt = "0.8"
 argmin = { version = "0.11", features = ["serde1"] }
 argmin-math = { version = "0.5", features = ["vec"] }
 tempfile = "3"
-sha2 = "0.10"
+sha2 = "0.11"
 sobol = "1.0"
 
 [dev-dependencies]

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,7 +37,7 @@ fn build_neural_network_infos(model: &CompiledModel) -> Vec<NeuralNetworkInfo> {
         })
         .collect()
 }
-use rand::SeedableRng;
+use rand::{RngExt, SeedableRng};
 use rand_distr::{Distribution, Normal};
 use rayon::prelude::*;
 use std::path::Path;
@@ -4664,8 +4664,8 @@ pub fn simulate(
     params: &ModelParameters,
     n_sim: usize,
 ) -> Vec<SimulationResult> {
-    use rand::prelude::*;
-    simulate_inner(model, population, params, n_sim, &mut thread_rng())
+    let mut rng = rand::rng();
+    simulate_inner(model, population, params, n_sim, &mut rng)
 }
 
 /// Simulate with a fixed seed for reproducibility.
@@ -4721,7 +4721,7 @@ pub fn simulate_with_options(
     use rand::SeedableRng;
     let mut rng: rand::rngs::StdRng = match opts.seed {
         Some(s) => rand::rngs::StdRng::seed_from_u64(s),
-        None => rand::rngs::StdRng::from_entropy(),
+        None => rand::make_rng(),
     };
 
     // Guard the modeled-`RATE` dose precondition up front (#324). The
@@ -4968,7 +4968,7 @@ pub struct SimulateUncertaintyOptions {
     pub n_sim_per_draw: usize,
     /// How to draw the parameter sets — asymptotic MVN or SIR resamples.
     pub method: crate::estimation::uncertainty_samples::UncertaintyMethod,
-    /// Optional seed for reproducibility. `None` uses `thread_rng`.
+    /// Optional seed for reproducibility. `None` draws from entropy.
     pub seed: Option<u64>,
 }
 
@@ -4994,7 +4994,7 @@ pub fn simulate_with_uncertainty(
         Some(seed) => rand::rngs::StdRng::seed_from_u64(seed),
         // Re-seed StdRng from entropy so simulate-without-seed is still
         // independent across calls but uses a uniform RNG type internally.
-        None => rand::rngs::StdRng::from_entropy(),
+        None => rand::make_rng(),
     };
 
     let template =

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -31,7 +31,7 @@ use crate::types::{
 };
 use nalgebra::{Cholesky, DMatrix, DVector};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_distr::{ChiSquared, Distribution, Gamma, StandardNormal};
 
 /// Draw from an inverse-gamma distribution `InvGamma(shape, scale)` with the
@@ -906,7 +906,7 @@ pub fn run_bayes(
                     let sum_prop: f64 = nll_prop.iter().sum();
                     let d_nlp = 0.5 * ((u_new - u0[c]).powi(2) - (u_old - u0[c]).powi(2)) * inv_var;
                     prop_pop[c] += 1;
-                    if rng.gen::<f64>().ln() < (sum_cur - sum_prop) - d_nlp {
+                    if rng.random::<f64>().ln() < (sum_cur - sum_prop) - d_nlp {
                         nll = nll_prop;
                         acc_pop[c] += 1;
                     } else if is_theta {
@@ -964,7 +964,7 @@ pub fn run_bayes(
                             * inv_var;
                     }
                     joint_prop += 1;
-                    if rng.gen::<f64>().ln() < (sum_cur - sum_prop) - d_nlp {
+                    if rng.random::<f64>().ln() < (sum_cur - sum_prop) - d_nlp {
                         theta = theta_prop;
                         sigma = sigma_prop;
                         nll = nll_prop;

--- a/src/estimation/hmc.rs
+++ b/src/estimation/hmc.rs
@@ -11,7 +11,7 @@
 //! ([`crate::estimation::inner_optimizer::analytic_eta_nll_gradient`]) — the same
 //! exact gradient the FOCEI inner loop uses — so HMC needs no autodiff.
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand_distr::StandardNormal;
 
 /// Leapfrog energy-error magnitude above which an HMC transition is flagged
@@ -179,7 +179,7 @@ pub fn hmc_step(
     // diagnostic. Threshold matches Stan's Δ_max.
     let divergent = !delta_h.is_finite() || delta_h.abs() > HMC_DIVERGENCE_THRESHOLD;
 
-    let log_u: f64 = rng.gen::<f64>().ln();
+    let log_u: f64 = rng.random::<f64>().ln();
     if log_u < delta_h {
         Some((eta_prop, nll_prop, true, divergent)) // accepted: advance to proposal
     } else {

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -30,6 +30,7 @@ use crate::stats::special::ln_gamma;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rand::rngs::StdRng;
+use rand::RngExt;
 use rand::SeedableRng;
 use rand_distr::{ChiSquared, Distribution, StandardNormal};
 use rayon::prelude::*;
@@ -112,7 +113,7 @@ fn sobol_normal_draws(d: usize, k_samples: usize, seed: u64) -> Vec<Vec<f64>> {
 
     // Cranley-Patterson rotation: shift Sobol points by a uniform random vector
     let mut rng = StdRng::seed_from_u64(seed.wrapping_add(0x534F_424F_4C00_0000u64));
-    let shift: Vec<f64> = (0..d).map(|_| rand::Rng::gen::<f64>(&mut rng)).collect();
+    let shift: Vec<f64> = (0..d).map(|_| rng.random::<f64>()).collect();
 
     let params = JoeKuoD6::minimal(); // supports up to 100 dims
     let sobol_seq = Sobol::<f64>::new(d, &params);

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -202,7 +202,7 @@ pub(crate) fn mh_steps(
         // Symmetric proposal q(η_prop|η) = q(η|η_prop) cancels in the ratio,
         // so the prior+likelihood difference encoded in `individual_nll` is
         // the full acceptance criterion.
-        let log_u: f64 = rng.gen::<f64>().ln();
+        let log_u: f64 = rng.random::<f64>().ln();
         if log_u < nll - nll_prop {
             eta.copy_from_slice(&eta_prop);
             nll = nll_prop;
@@ -282,7 +282,7 @@ pub(crate) fn mh_steps_componentwise(
             };
 
             // Symmetric scalar proposal cancels, same as the block kernel.
-            let log_u: f64 = rng.gen::<f64>().ln();
+            let log_u: f64 = rng.random::<f64>().ln();
             if log_u < nll - nll_prop {
                 nll = nll_prop;
                 per_eta_accepted[j] += 1;
@@ -352,7 +352,7 @@ pub(crate) fn mh_kappa_steps(
             sigma_values,
         );
 
-        let log_u: f64 = rng.gen::<f64>().ln();
+        let log_u: f64 = rng.random::<f64>().ln();
         if log_u < nll - nll_prop {
             // Accept
             nll = nll_prop;

--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -15,8 +15,8 @@ use crate::estimation::parameterization::{
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-use rand_distr::{ChiSquared, Distribution, StandardNormal, WeightedIndex};
+use rand::{RngExt, SeedableRng};
+use rand_distr::{weighted::WeightedIndex, ChiSquared, Distribution, StandardNormal};
 use rayon::prelude::*;
 
 /// Results from the SIR procedure.

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -19,7 +19,7 @@ use crate::estimation::parameterization::{
 };
 use crate::types::{FitResult, ModelParameters, OmegaMatrix, SigmaVector};
 use nalgebra::{DMatrix, DVector};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand_distr::StandardNormal;
 
 /// How parameter-uncertainty draws are produced.
@@ -278,7 +278,7 @@ fn draw_sir(
             ));
         }
         tries += 1;
-        let idx = rng.gen_range(0..pool.len());
+        let idx = rng.random_range(0..pool.len());
         let mut x_k = pool[idx].clone();
         // Re-pin fixed indices defensively: SIR samples should already
         // respect the pin (SIR's own bounds use `compute_bounds`), but

--- a/src/io/hash.rs
+++ b/src/io/hash.rs
@@ -9,11 +9,21 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
 /// Compute the SHA-256 of `bytes`, returning the lowercase hex digest (64 chars).
 pub fn sha256_bytes(bytes: &[u8]) -> String {
     let mut h = Sha256::new();
     h.update(bytes);
-    format!("{:x}", h.finalize())
+    hex_lower(h.finalize().as_ref())
 }
 
 /// Read `path` and return its SHA-256 hex digest. Streams the file in 64 KiB
@@ -31,7 +41,7 @@ pub fn sha256_file(path: &Path) -> Result<String, String> {
         }
         h.update(&buf[..n]);
     }
-    Ok(format!("{:x}", h.finalize()))
+    Ok(hex_lower(h.finalize().as_ref()))
 }
 
 #[cfg(test)]

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -17,6 +17,7 @@ pub use parametric::{
 };
 
 use nalgebra::DMatrix;
+use rand::RngExt;
 use std::collections::HashMap;
 
 use crate::types::{
@@ -211,7 +212,7 @@ fn draw_tte_outcome<R: rand::Rng>(
 ) -> (f64, bool) {
     // Open01 samples from (0, 1) exclusive, avoiding the u=0 edge case that
     // would send -ln(u) to +∞.
-    let u: f64 = rng.sample(rand::distributions::Open01);
+    let u: f64 = rng.sample(rand::distr::Open01);
     let t_event = if entry_time > 0.0 {
         sample_conditional_event_time(family, params, entry_time, u)
     } else {


### PR DESCRIPTION
## Why
Combine Dependabot PRs #475, #476, #477, #478, #479, and #480 into one reviewable dependency PR and one CI run.

## What changed
- Bumped `actions/checkout` from 6 to 7 across workflows.
- Bumped Cargo dependencies from the Dependabot PR set: `serde_json`, `rayon`, `regex`, `sha2`, `rand`, `rand_distr`, and `zip`.
- Updated source compatibility for the combined Rust dependency graph:
  - `rand_distr 0.6.0` currently depends on `rand 0.10.1`, so direct `rand` was aligned to `0.10` instead of leaving this crate on `0.9.4` from #478.
  - Migrated `rand` call sites to `RngExt`, `random`, `random_range`, and `rand::rng` / `rand::make_rng`.
  - Updated `sha2` digest formatting for `sha2 0.11`.

## Alternatives considered
Merging the Dependabot PRs individually would keep the bot-authored commits intact, but it would leave six PRs and CI runs. Cherry-picking all Cargo lockfile commits directly did not fit current `main` cleanly enough because the dependency graph needs `rand`/`rand_distr` compatibility fixes.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

No migration required.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):

```
# before / reference
N/A

# after
N/A
```

- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [ ] Regression test added that fails without this fix
- [x] No new tests needed (why: dependency-only update plus compatibility fixes covered by existing compile/test suite)

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# N/A
```

```
# N/A
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints
Focus on the `rand`/`rand_distr` compatibility choice: `rand_distr 0.6.0` brings `rand 0.10.1`, so the direct `rand` dependency is also on `0.10` to avoid mixed distribution traits in this crate's sampling code.

Verification run locally:
- `cargo check`
- `cargo test --lib`
- `cargo check --features survival`

## Open questions
None.
