### PR TITLE
fix(ci): silence install-time Rust warnings [closes #511]

### DIFF
--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -899,7 +899,7 @@ fn parse_subject(
     // runs inside `#[cfg(feature = "survival")]` blocks.
     tte_cmts: &HashSet<usize>,
     // Column index of the TENTRY (left-truncation time) column, if present.
-    tentry_col: Option<usize>,
+    _tentry_col: Option<usize>,
 ) -> Result<(Subject, usize, usize, SubjectExclusion, Vec<String>, usize), String> {
     let mut doses = Vec::new();
     let mut obs_times = Vec::new();
@@ -1308,7 +1308,7 @@ fn parse_subject(
                 #[cfg(feature = "survival")]
                 {
                     use crate::types::{EventType, ObsRecord};
-                    let raw_entry = tentry_col
+                    let raw_entry = _tentry_col
                         .and_then(|c| row.get(c))
                         .map(|s| parse_f64(s))
                         .unwrap_or(0.0)

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2120,8 +2120,10 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // Theta/eta indices used in event_model expressions are collected here so
     // that check_unused_parameters (below) can suppress false "not referenced"
     // warnings for parameters that only appear in [event_model].
+    #[cfg_attr(not(feature = "survival"), allow(unused_mut))]
     let mut event_model_used_thetas: std::collections::HashSet<usize> =
         std::collections::HashSet::new();
+    #[cfg_attr(not(feature = "survival"), allow(unused_mut))]
     let mut event_model_used_etas: std::collections::HashSet<usize> =
         std::collections::HashSet::new();
     #[cfg(feature = "survival")]

--- a/src/sens/jet.rs
+++ b/src/sens/jet.rs
@@ -172,7 +172,7 @@ impl<const N: usize> Jet<N> {
 /// volume `V1` (PK axis 1): `f = num/V1`, `∂f/∂V1 = −num/V1²`,
 /// `∂²f/∂V1² = 2·num/V1³`. Shared by the 2-/3-cpt explicit kernels, which seed
 /// `V1` on axis 1 (`CL=0, V1=1, …`).
-pub fn over_v1<const N: usize>(num: f64, v1: f64) -> Jet<N> {
+pub(crate) fn over_v1<const N: usize>(num: f64, v1: f64) -> Jet<N> {
     let mut j = Jet::<N>::cst(num / v1);
     j.g[1] = -num / (v1 * v1);
     j.h[1][1] = 2.0 * num / (v1 * v1 * v1);

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -900,8 +900,8 @@ fn integrate_subject_duals<T: crate::sens::num::PkNum>(
 fn run_subject<const N: usize>(
     model: &CompiledModel,
     subject: &Subject,
-    theta: &[f64],
-    eta: &[f64],
+    _theta: &[f64],
+    _eta: &[f64],
     pk_values: &[f64],
     pd: &ParamDerivs,
 ) -> Option<SubjectSens> {
@@ -998,8 +998,8 @@ fn run_subject<const N: usize>(
 fn run_subject_mixed<const NA: usize, const N: usize>(
     model: &CompiledModel,
     subject: &Subject,
-    theta: &[f64],
-    eta: &[f64],
+    _theta: &[f64],
+    _eta: &[f64],
     pk_values: &[f64],
     pd: &ParamDerivs,
     axis_of: &[usize],


### PR DESCRIPTION
## Why
R package installs against the local ferx-core checkout emit harmless Rust warnings from default `cargo check`/build paths. The noise makes package installation look less clean and can hide real warnings.

Closes #511.

## What changed
- Marked the TENTRY column parameter as intentionally optional for non-survival builds while preserving survival-feature use.
- Kept `[event_model]` parameter-usage sets mutable for the survival feature and silenced the non-survival `unused_mut` warning.
- Prefixed intentionally unused ODE sensitivity helper parameters with `_`.
- Narrowed `sens::jet::over_v1` to `pub(crate)` so it no longer exposes a crate-private return type at wider visibility.

## Alternatives considered
Leaving the warnings alone would keep behavior unchanged, but it keeps noisy R package installs. Removing the feature-gated parameters/sets was not appropriate because they are used when `survival` is enabled.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

No migration required.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):

```
# before / reference
N/A

# after
N/A
```

- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [ ] Regression test added that fails without this fix
- [x] No new tests needed (why: warning-only cleanup; existing compile/test coverage exercises these modules)

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# N/A
```

```
# N/A
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints
This is intentionally scoped to the warnings seen during R package install/default builds. `cargo test --lib` still emits a few test-only warnings from unrelated `#[cfg(test)]` code; those are outside this install-time cleanup.

Verification run locally:
- `cargo check` — clean, no warnings
- `cargo check --features survival` — clean, no warnings
- `cargo test --lib` — 1509 passed, 16 ignored; test build has three unrelated test-only warnings

## Open questions
None.
