### PR TITLE
fix(parser): stop spurious "ignored" warning for ode_reltol/abstol/max_steps [closes #516]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,7 +230,7 @@ section of the SDLC for the versioning policy).
 ### Fixed
 - The ODE-solver fit options `ode_reltol`, `ode_abstol`, and `ode_max_steps` no
   longer emit a spurious "is not used by method … and will be ignored" warning
-  (#503). They configure the RK45 integrator and *are* applied to any ODE model
+  (#516). They configure the RK45 integrator and *are* applied to any ODE model
   under every estimation method; they were simply missing from the warning's
   framework-key allowlist. Behaviour is unchanged — only the misleading warning
   is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,12 @@ section of the SDLC for the versioning policy).
   (#367).
 
 ### Fixed
+- The ODE-solver fit options `ode_reltol`, `ode_abstol`, and `ode_max_steps` no
+  longer emit a spurious "is not used by method … and will be ignored" warning
+  (#503). They configure the RK45 integrator and *are* applied to any ODE model
+  under every estimation method; they were simply missing from the warning's
+  framework-key allowlist. Behaviour is unchanged — only the misleading warning
+  is removed.
 - Simulation, NPDE/NPD diagnostics, and the NCA-init grid sweep now honour
   time-varying covariate snapshots on dose, observation, and EVID=2 rows instead
   of using only each subject's baseline covariates (#506). FREM covariate

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13257,6 +13257,29 @@ mod tests {
     }
 
     #[test]
+    fn test_ode_solver_keys_do_not_warn() {
+        // ode_reltol/ode_abstol/ode_max_steps configure the RK45 integrator (any
+        // ODE model, any estimation method) — they are framework-level, not
+        // method-specific. Regression for the spurious "is not used by method
+        // FOCEI and will be ignored" warning these once produced even though
+        // `sync_ode_solver_opts` does apply them.
+        for method in ["focei", "foce", "saem", "imp", "bayes"] {
+            let opts = parse_fit_options(&[
+                format!("method = {method}"),
+                "ode_reltol = 1e-9".to_string(),
+                "ode_abstol = 1e-11".to_string(),
+                "ode_max_steps = 1000000".to_string(),
+            ])
+            .unwrap();
+            assert!(
+                opts.unsupported_keys_warnings().is_empty(),
+                "method={method} spuriously warned on ODE-solver keys: {:?}",
+                opts.unsupported_keys_warnings()
+            );
+        }
+    }
+
+    #[test]
     fn test_inner_optimizer_under_focei_does_not_warn() {
         // `inner_optimizer` drives the per-subject EBE loop, which FOCEI uses —
         // it must be in the method's recognized keys and not flagged "ignored".

--- a/src/types.rs
+++ b/src/types.rs
@@ -4232,6 +4232,14 @@ pub fn framework_keys() -> &'static [&'static str] {
         "inits_from_nca",
         "frem_predictions",
         "frem_sigma",
+        // RK45 ODE-solver knobs: applied to the integrator at parse time via
+        // `sync_ode_solver_opts` (gated on the model being an ODE model, not on
+        // the estimation method), so they are framework-level — every method
+        // that integrates an ODE model honours them. Listing them here keeps
+        // `unsupported_keys_warnings` from falsely flagging them as "ignored".
+        "ode_reltol",
+        "ode_abstol",
+        "ode_max_steps",
     ]
 }
 


### PR DESCRIPTION
## Why

The ODE-solver fit options `ode_reltol`, `ode_abstol`, and `ode_max_steps` emit a false *"is not used by method `<M>` and will be ignored"* warning, even though they **are** applied to the RK45 integrator for any ODE model via `CompiledModel::sync_ode_solver_opts` (`src/types.rs:2286`) at parse time. Most visible on ODE absorption models that set tight tolerances to match NONMEM's `TOL=9` — surfaced by the Weibull anchor (#503). Closes #516. Not method- or Weibull-specific.

## What changed

`FitOptions::unsupported_keys_warnings()` checks each user-set key against `framework_keys() ∪ method_specific_keys(method)`. The three integrator keys were in neither list. They are framework-level — method-agnostic, gated on the model being an ODE model, not on the estimator — so they are added to `framework_keys()` (alongside `threads` / `covariance`). The false positive disappears with no behaviour change.

## Alternatives considered

Adding them to each method's `method_specific_keys()` instead — rejected: they are not method-specific (every estimator that integrates an ODE model honours them), and that would duplicate the keys across all eight methods.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No API change; warning text only.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only) — warning text only; no numerical path touched.

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix — `test_ode_solver_keys_do_not_warn` (asserts no warning under focei/foce/saem/imp/bayes); the warning suite is green (53 passed).

## Example (user-facing features only)
- [x] Not applicable (internal / fix with no new API surface)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (under `Fixed`)
- [x] No user-visible change beyond removing the misleading warning (the keys were already documented in `docs/model-file/fit-options.qmd` as "ODE models only").

## Checklist
- [x] `cargo clippy` clean — change is string literals + a straightforward test loop; CI confirms
- [x] Functions on the `Dual2` sensitivity path stay differentiable — N/A (not touched)
- [x] `Cargo.toml` version bumped if breaking — N/A (additive)

## Docs & examples

### Example execution
- [x] No example execution step needed (warning-text fix / no user-visible behaviour change)

## Reviewer hints

The whole change is `src/types.rs` `framework_keys()` (+3 entries with a comment) and the regression test in `src/parser/model_parser.rs`. The key fact to verify: `CompiledModel::sync_ode_solver_opts` (`types.rs:2286`) really does apply these to the integrator at parse time for the CLI / `predict` / `fit_from_files` paths, so listing them as framework keys is correct (they are applied, not ignored).

## Open questions

None.
