### PR TITLE
docs(absorption): add beta maturity label to built-in absorption models

### DIFF
--- a/docs/maturity.qmd
+++ b/docs/maturity.qmd
@@ -59,6 +59,7 @@ visible at the point of use:
 | Individual parameters DSL | **beta** | [Individual Parameters](model-file/individual-parameters.qmd) |
 | BLOQ / censored observations (M3) | **beta** | [BLOQ](model-file/bloq.qmd) |
 | ODE models (Dormand-Prince RK45) | **beta** | [ODE Models](model-file/ode-models.qmd) |
+| Built-in absorption models (transit / inverse-Gaussian / Weibull) | **beta** | [Absorption](model-file/absorption.qmd) |
 | Scaling | **beta** | [Scaling](model-file/scaling.qmd) |
 | Data selection | **beta** | [Data Selection](model-file/data-selection.qmd) |
 | Derived columns | **beta** | [Derived Columns](model-file/derived.qmd) |

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -1,5 +1,7 @@
 # Built-in Absorption Models
 
+> **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.
+
 ferx provides built-in **absorption input-rate functions** for ODE models — a
 dose-driven appearance rate `R_in(tad)` that is added into the dosing
 compartment instead of treating the dose as an instantaneous bolus. They let you


### PR DESCRIPTION
## Why
The built-in absorption page — covering `transit()` (#343), `igd()` (#389), and `weibull()` (#498) — was the **only** model-file reference page in the sidebar with no maturity banner, and it had no row in `docs/maturity.qmd`, which describes itself as "the authoritative list." A reader had no way to tell how battle-tested built-in absorption is.

## What changed
- `docs/model-file/absorption.qmd`: added the standard `> **Maturity: beta** …` banner under the H1, matching every other model-file page.
- `docs/maturity.qmd`: added a "Built-in absorption models (transit / inverse-Gaussian / Weibull)" row to the model-file feature table, placed right after ODE models (which absorption rides on).

## Alternatives considered
Labeling Weibull **experimental** (it is the newest, merged this week). Rejected for consistency: the maturity page states experimental features emit a fit-time warning, and absorption emits none — only `W_EXPERIMENTAL_NN` and `W_EXPERIMENTAL_SDE` exist. All three models also carry NONMEM cross-checks (transit/igd full anchors; Weibull an approximate anchor plus a mass-balance invariant and an analytic-gradient convergence test), which is beyond the "single toy example" bar for experimental. The page prose already conveys that Weibull is the newest of the three.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: docs-only — adds a maturity label, no behavioral change)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (no new page — absorption.qmd already in sidebar)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI) — N/A, docs-only maturity label
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no Rust changes)

## Docs & examples
### ferx-book
- [ ] No estimator/DSL/fit-option change — maturity label only

### Example execution
- [x] No example execution step needed (docs-only / no user-visible change)

## Reviewer hints
Two-file, 3-line diff. The only judgment call is beta-vs-experimental for Weibull — rationale in *Alternatives considered*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)