### PR TITLE
feat(survival): [simulation] horizon + TTE-row generation for competing-risks VPC [closes #522]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ section of the SDLC for the versioning policy).
   plus the all-cause survival `survival_all` (with `Σ_k cif_k(t) + survival_all(t) = 1`),
   the correct competing-risks quantities. Example `examples/tte_competing_risks.ferx`.
   Behind the `survival` feature.
+- **`[simulation] horizon` for TTE / competing-risks VPC** (#522). A new
+  `horizon = <t>` key sets an administrative censoring time that is *decoupled
+  from the observed event times*: when present it overrides each TTE record's
+  per-record observation window, so re-simulating event-bearing data (a VPC)
+  censors every cause at the planned study end `t` instead of drawing unbounded.
+  It is also honoured by the `[simulation]`-block `--simulate` path, which now
+  generates one right-censored TTE row per cause compartment per synthetic subject
+  (a TTE model under `[simulation]` therefore requires `horizon`); previously that
+  path emitted zero TTE rows. Exposed on the library `SimulateOptions { horizon }`.
+  Behind the `survival` feature.
 - **`[event_model]` hazard expressions can reference `[individual_parameters]`** names —
   e.g. a hazard driven by an individual `CL` — resolved per subject at evaluation time, in
   addition to the existing theta/eta/covariate namespace. Intermediate variables and names

--- a/docs/api/simulation.qmd
+++ b/docs/api/simulation.qmd
@@ -66,6 +66,7 @@ pub fn simulate_with_options(
 pub struct SimulateOptions {
     pub seed: Option<u64>,                  // None draws from entropy
     pub match_method: Option<MatchMethod>,  // None disables matching
+    pub horizon: Option<f64>,               // TTE administrative censoring time; None = per-record window
 }
 
 pub enum MatchMethod {
@@ -75,8 +76,15 @@ pub enum MatchMethod {
 }
 ```
 
-With `match_method = None` this is identical to `simulate_with_seed()` (or
-`simulate()` when `seed` is `None`).
+With `match_method = None` and `horizon = None` this is identical to
+`simulate_with_seed()` (or `simulate()` when `seed` is `None`).
+
+`horizon = Some(t)` sets an administrative censoring time for **time-to-event**
+endpoints, decoupled from the observed event times: it overrides each TTE
+record's per-record observation window so a re-simulated event-bearing subject
+(a competing-risks VPC) censors at the planned study end `t` rather than drawing
+unbounded. It has no effect on Gaussian endpoints. See
+[TTE simulation](../model-file/simulation.qmd#tte-simulation).
 
 ### Why match?
 

--- a/docs/estimation/tte.qmd
+++ b/docs/estimation/tte.qmd
@@ -279,6 +279,29 @@ cause-specific hazard covers the standard pharmacometric use case.
    # ferx analytic: F_k(t) = (lam_k/(lamA+lamB)) * (1 - exp(-(lamA+lamB)*t))
    ```
 
+**Simulation and VPC.** `simulate()` draws the competing causes with the same
+earliest-cause-wins rule: a latent time is drawn per cause, the earliest is the
+observed event, and every other cause is right-censored at that time. For a
+**visual predictive check** the simulation needs an administrative censoring
+horizon that is *decoupled from the observed event times* — otherwise a
+re-simulated subject that already carries an event re-draws unbounded, biasing the
+simulated event-time distribution. Supply it with the
+[`[simulation] horizon`](../model-file/simulation.qmd#tte-simulation) key (or
+`SimulateOptions { horizon, .. }` on the library API); when set, it overrides each
+record's per-record window so every cause censors at the planned study end:
+
+``` {.ferx}
+[simulation]
+  n_subjects = 200
+  horizon    = 14     # follow each subject to t = 14, censoring survivors there
+  seed       = 12345
+```
+
+Running `ferx examples/tte_competing_risks.ferx --simulate` then generates one
+right-censored TTE row per cause compartment (CMT 2 and CMT 3) per synthetic
+subject and overwrites each with the drawn outcome. A TTE `[simulation]` block
+**requires `horizon`** (there are no continuous `times` to schedule).
+
 ## Comparison with reference software
 
 The exponential validation dataset is `tests/reference/tte_exponential/tte_exp.csv`

--- a/docs/model-file/simulation.qmd
+++ b/docs/model-file/simulation.qmd
@@ -25,10 +25,17 @@ The optional `[simulation]` block defines a virtual clinical trial design for ge
 | `times` | | Continuous observation time points (Gaussian endpoints) |
 | `horizon` | | Administrative censoring time for TTE endpoints (finite, `> 0`) |
 
-A block must define **at least one of `times` or `horizon`** — `times` for a
-Gaussian (continuous) model, `horizon` for a time-to-event model. A model with a
-[time-to-event endpoint](../estimation/tte.qmd) **requires `horizon`** (see
-[TTE simulation](#tte-simulation) below).
+A block must define **at least one of `times` or `horizon`**, matched to the
+model's endpoints:
+
+- a model with a **continuous** (residual-error) endpoint **requires `times`**;
+- a model with a [**time-to-event** endpoint](../estimation/tte.qmd) **requires
+  `horizon`** (see [TTE simulation](#tte-simulation) below);
+- a **joint PK + TTE** model requires **both**.
+
+Supplying only `horizon` for a model that has a continuous endpoint is an error
+(it would otherwise simulate zero continuous observations), as is supplying only
+`times` for a TTE model.
 
 An **unknown or malformed key in `[simulation]` is a parse error** (not silently
 ignored), so a typo such as `n_subject`, or a line missing its `=` such as

--- a/docs/model-file/simulation.qmd
+++ b/docs/model-file/simulation.qmd
@@ -13,6 +13,7 @@ The optional `[simulation]` block defines a virtual clinical trial design for ge
   dose_cmt   = COMPARTMENT
   seed       = SEED
   times      = [t1, t2, t3, ...]
+  horizon    = T          # TTE only — administrative censoring time
 ```
 
 | Key | Aliases | Description |
@@ -21,11 +22,18 @@ The optional `[simulation]` block defines a virtual clinical trial design for ge
 | `dose_amt` | `dose` | Dose amount administered to each subject |
 | `dose_cmt` | `cmt` | Dosing compartment (1-indexed) |
 | `seed` | | Random seed for reproducible simulations |
-| `times` | | Observation time points (required) |
+| `times` | | Continuous observation time points (Gaussian endpoints) |
+| `horizon` | | Administrative censoring time for TTE endpoints (finite, `> 0`) |
+
+A block must define **at least one of `times` or `horizon`** — `times` for a
+Gaussian (continuous) model, `horizon` for a time-to-event model. A model with a
+[time-to-event endpoint](../estimation/tte.qmd) **requires `horizon`** (see
+[TTE simulation](#tte-simulation) below).
 
 An **unknown or malformed key in `[simulation]` is a parse error** (not silently
 ignored), so a typo such as `n_subject`, or a line missing its `=` such as
-`n_subjects 6`, is reported rather than falling back to the default.
+`n_subjects 6`, is reported rather than falling back to the default. A `horizon`
+that is not finite and strictly positive is likewise rejected.
 
 ## Example
 
@@ -61,6 +69,45 @@ This will:
 3. Predictions are generated using the structural model
 4. Residual error is added: $DV = IPRED + \epsilon$, where $\epsilon \sim N(0, V)$
 5. Observations below 0.001 are clipped to 0.001
+
+## TTE simulation {#tte-simulation}
+
+For a [time-to-event model](../estimation/tte.qmd) there are no continuous
+observations to schedule; instead each synthetic subject is followed until an
+event occurs or until the **administrative `horizon`**, at which point an
+event-free subject is right-censored. `--simulate` therefore generates, for each
+subject, **one right-censored TTE row per event (cause) compartment**, then draws
+the outcome:
+
+- a single `[event_model]` yields one row per subject — an event before the
+  horizon, or right-censoring at the horizon;
+- [competing risks](../estimation/tte.qmd#competing-risks-cause-specific-hazards)
+  (several `[event_model]` blocks on distinct compartments) yield one row per
+  cause: the earliest latent event is observed and the remaining causes are
+  right-censored at that same time, or — if no cause fires before the horizon —
+  every cause is right-censored at the horizon.
+
+```
+[simulation]
+  n_subjects = 200
+  horizon    = 14     # follow each subject to t = 14, censoring survivors there
+  seed       = 12345
+```
+
+Because a TTE design has no continuous `times`, the `horizon` key is **required**
+when the model has a TTE endpoint; omitting it is a parse error. See
+`examples/tte_competing_risks.ferx`.
+
+### Decoupled horizon and VPC
+
+The `horizon` is an administrative censoring time **decoupled from the observed
+event times**. This matters when re-simulating an *existing* event-bearing
+dataset for a visual predictive check (VPC): without an explicit horizon a record
+that already carries an event imposes no censoring window (it would re-draw
+unbounded), which biases the simulated event-time distribution. Supplying
+`horizon` overrides each record's per-record window so every simulated cause
+censors at the planned study end. The same control is available on the library
+API as `SimulateOptions { horizon, .. }`.
 
 ## Covariates in Simulation
 

--- a/examples/tte_competing_risks.ferx
+++ b/examples/tte_competing_risks.ferx
@@ -46,3 +46,14 @@
 [fit_options]
   method  = focei
   maxiter = 300
+
+# Simulation design (used by `--simulate`, not by `--data`). `horizon` is the
+# administrative censoring time: each synthetic subject gets one right-censored
+# TTE row per cause compartment (CMT 2 and CMT 3), and the draw either records the
+# earliest cause as the event or right-censors the subject at the horizon. It is
+# also the decoupled censoring window a competing-risks VPC needs when
+# re-simulating event-bearing data (#522). A TTE `[simulation]` requires it.
+[simulation]
+  n_subjects = 200
+  horizon    = 14
+  seed       = 12345

--- a/src/api.rs
+++ b/src/api.rs
@@ -217,6 +217,24 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
             .to_string());
     }
 
+    // A synthetic design must have *something* to observe: continuous `times` for
+    // a Gaussian model, or TTE rows for a TTE model. The parser's `times`-or-
+    // `horizon` rule lets a Gaussian model through with `horizon` alone, which
+    // would otherwise build zero-observation subjects and fit on empty data with
+    // no diagnostic — restore the early, clear error the old `times`-required rule
+    // gave for that case (#522 review).
+    #[cfg(feature = "survival")]
+    let model_has_tte = !tte_cmts.is_empty();
+    #[cfg(not(feature = "survival"))]
+    let model_has_tte = false;
+    if sim_spec.obs_times.is_empty() && !model_has_tte {
+        return Err(
+            "[simulation] has no `times` and the model has no TTE endpoint \
+             to observe — a Gaussian model requires `times = [...]`"
+                .to_string(),
+        );
+    }
+
     // Build template population
     let subjects: Vec<Subject> = (1..=sim_spec.n_subjects)
         .map(|i| Subject {
@@ -4821,6 +4839,20 @@ pub fn simulate_with_options(
     opts: &SimulateOptions,
 ) -> Result<Vec<SimulationResult>, String> {
     use rand::SeedableRng;
+
+    // Validate the TTE horizon on the library path too — the `.ferx` parser
+    // already rejects a non-finite / non-positive horizon, but a direct caller of
+    // this API must get the same guard: a NaN window makes every `t_event < window`
+    // test false (silent NaN event times), and a `<= 0` horizon censors every
+    // subject at or before entry (#522 review).
+    if let Some(h) = opts.horizon {
+        if !h.is_finite() || h <= 0.0 {
+            return Err(format!(
+                "SimulateOptions.horizon must be finite and > 0 (got {h})"
+            ));
+        }
+    }
+
     let mut rng: rand::rngs::StdRng = match opts.seed {
         Some(s) => rand::rngs::StdRng::seed_from_u64(s),
         None => rand::make_rng(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -217,22 +217,42 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
             .to_string());
     }
 
-    // A synthetic design must have *something* to observe: continuous `times` for
-    // a Gaussian model, or TTE rows for a TTE model. The parser's `times`-or-
-    // `horizon` rule lets a Gaussian model through with `horizon` alone, which
-    // would otherwise build zero-observation subjects and fit on empty data with
-    // no diagnostic — restore the early, clear error the old `times`-required rule
-    // gave for that case (#522 review).
+    // A synthetic design must have something to observe. The parser's
+    // `times`-or-`horizon` rule is deliberately permissive (a pure-TTE model has
+    // no continuous `times`), so enforce the model-specific requirement here, once
+    // the endpoints are known (#522 review):
+    //   - a model with a residual-error (continuous) endpoint needs `times` — this
+    //     keeps the pre-#522 contract and closes the gap where a Gaussian, or a
+    //     joint PK+TTE, model given only `horizon` would silently build
+    //     zero-`observation` subjects and fit on empty continuous data;
+    //   - a pure-TTE model (no error model, hence no sigma) instead needs a
+    //     `horizon`, already enforced above.
+    // A declared `[error_model]` is the signal for "produces continuous
+    // observations": it is the only thing that allocates sigma, and every model
+    // otherwise carries a default `pk_model`, so the structural model alone can't
+    // distinguish intent.
+    let model_has_continuous = !parsed.model.default_params.sigma.values.is_empty();
     #[cfg(feature = "survival")]
     let model_has_tte = !tte_cmts.is_empty();
     #[cfg(not(feature = "survival"))]
     let model_has_tte = false;
-    if sim_spec.obs_times.is_empty() && !model_has_tte {
-        return Err(
-            "[simulation] has no `times` and the model has no TTE endpoint \
-             to observe — a Gaussian model requires `times = [...]`"
-                .to_string(),
-        );
+    if sim_spec.obs_times.is_empty() {
+        if model_has_continuous {
+            return Err(
+                "[simulation] has no `times`, but the model has a continuous \
+                 (residual-error) endpoint that needs observation times — add \
+                 `times = [...]` (a joint PK + TTE design needs both `times` and a \
+                 `horizon`)"
+                    .to_string(),
+            );
+        }
+        if !model_has_tte {
+            return Err(
+                "[simulation] has no `times` and the model has no TTE endpoint \
+                 to observe at a `horizon` — nothing to simulate"
+                    .to_string(),
+            );
+        }
     }
 
     // Build template population

--- a/src/api.rs
+++ b/src/api.rs
@@ -190,6 +190,33 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
 
     eprintln!("Model: {}", parsed.model.name);
 
+    // TTE endpoints (survival only): a synthetic subject must carry one
+    // right-censored template row per cause CMT — otherwise `--simulate` emits
+    // zero TTE rows (the synthetic `obs_records` are empty). The administrative
+    // `[simulation] horizon` is the censoring time for those rows; the per-subject
+    // draw then overwrites each template with its realised outcome (#522). Compute
+    // the cause-CMT list once, outside the per-subject loop.
+    #[cfg(feature = "survival")]
+    let tte_cmts: Vec<usize> = {
+        let mut c: Vec<usize> = parsed
+            .model
+            .endpoints
+            .iter()
+            .filter_map(|(cmt, ep)| {
+                matches!(ep, crate::types::EndpointLikelihood::Tte { .. }).then_some(*cmt)
+            })
+            .collect();
+        c.sort_unstable();
+        c
+    };
+    #[cfg(feature = "survival")]
+    if !tte_cmts.is_empty() && sim_spec.horizon.is_none() {
+        return Err("[simulation] with a TTE endpoint requires `horizon = <t>` \
+             (the administrative censoring time at which event-free subjects are \
+             right-censored)"
+            .to_string());
+    }
+
     // Build template population
     let subjects: Vec<Subject> = (1..=sim_spec.n_subjects)
         .map(|i| Subject {
@@ -216,8 +243,19 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
+            // One right-censored template row per cause CMT, at the administrative
+            // horizon (overwritten by the draw). Empty when the model has no TTE
+            // endpoint, reproducing the previous all-Gaussian behaviour. (#522)
             #[cfg(feature = "survival")]
-            obs_records: vec![],
+            obs_records: tte_cmts
+                .iter()
+                .map(|&cmt| crate::types::ObsRecord::Event {
+                    time: sim_spec.horizon.unwrap_or(f64::INFINITY),
+                    event_type: crate::types::EventType::RightCensored,
+                    entry_time: 0.0,
+                    cmt,
+                })
+                .collect(),
         })
         .collect();
     let template = Population {
@@ -234,17 +272,35 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         "Simulating {} subjects (seed={})...",
         sim_spec.n_subjects, sim_spec.seed
     );
-    let sim_results = simulate_with_seed(
+    // Pass the administrative `horizon` through so TTE causes censor at the
+    // planned study end (#522). `match_method = None` makes this identical to
+    // `simulate_with_seed` for the Gaussian path (same seeded RNG, no matching),
+    // and the `None`-matching branch cannot error.
+    let sim_results = simulate_with_options(
         &parsed.model,
         &template,
         &parsed.model.default_params,
         1,
-        sim_spec.seed,
-    );
+        &SimulateOptions {
+            seed: Some(sim_spec.seed),
+            match_method: None,
+            horizon: sim_spec.horizon,
+        },
+    )
+    .map_err(|e| format!("simulation failed: {e}"))?;
 
     let mut population = template;
     for subject in &mut population.subjects {
-        let sims: Vec<_> = sim_results.iter().filter(|s| s.id == subject.id).collect();
+        // Gaussian write-back: only continuous outcomes map onto `observations`.
+        // A TTE `Event` row would trip `continuous_value()`'s debug-assert, so
+        // filter it out here; the TTE outcomes are written into `obs_records` below.
+        let sims: Vec<_> = sim_results
+            .iter()
+            .filter(|s| {
+                s.id == subject.id
+                    && matches!(s.outcome, crate::types::SimOutcome::Continuous { .. })
+            })
+            .collect();
         for (j, s) in sims.iter().enumerate() {
             if j < subject.observations.len() {
                 // Under LTBS the simulated DV is on the log scale and may be
@@ -257,6 +313,36 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
                     v.max(0.001)
                 };
             }
+        }
+    }
+
+    // TTE write-back (#522): replace each subject's template rows with the
+    // realised simulated outcomes — `Exact` at the drawn event time, or
+    // `RightCensored` at the horizon when no cause fired — so the fitted dataset
+    // (and any output) carries the simulated events rather than the placeholders.
+    #[cfg(feature = "survival")]
+    for subject in &mut population.subjects {
+        let events: Vec<crate::types::ObsRecord> = sim_results
+            .iter()
+            .filter(|s| s.id == subject.id)
+            .filter_map(|s| match s.outcome {
+                crate::types::SimOutcome::Event { time, observed } => {
+                    Some(crate::types::ObsRecord::Event {
+                        time,
+                        event_type: if observed {
+                            crate::types::EventType::Exact
+                        } else {
+                            crate::types::EventType::RightCensored
+                        },
+                        entry_time: 0.0,
+                        cmt: s.cmt,
+                    })
+                }
+                _ => None,
+            })
+            .collect();
+        if !events.is_empty() {
+            subject.obs_records = events;
         }
     }
 
@@ -4707,6 +4793,12 @@ pub struct SimulateOptions {
     /// observations so its posthoc eta can be computed. Has no effect for the
     /// synthetic `[simulation]` block (no observed designs to match against).
     pub match_method: Option<MatchMethod>,
+    /// Administrative censoring horizon for TTE endpoints (#522). When `Some(t)`,
+    /// `t` overrides every TTE record's per-record `observation_window` so a
+    /// re-simulated event-bearing subject censors at the planned study end `t`
+    /// rather than drawing unbounded — the decoupled horizon a competing-risks VPC
+    /// needs. `None` keeps the per-record window. No effect on Gaussian endpoints.
+    pub horizon: Option<f64>,
 }
 
 /// Simulate observations, optionally with propensity-score matching.
@@ -4748,7 +4840,14 @@ pub fn simulate_with_options(
         Some(m) => m,
         None => {
             return Ok(simulate_inner_with_draw(
-                model, population, params, n_sim, 1, None, &mut rng,
+                model,
+                population,
+                params,
+                n_sim,
+                1,
+                None,
+                opts.horizon,
+                &mut rng,
             ));
         }
     };
@@ -4804,6 +4903,7 @@ pub fn simulate_with_options(
         n_sim,
         1,
         Some((&eta_hats, omega_inv, method)),
+        opts.horizon,
         &mut rng,
     ))
 }
@@ -4815,7 +4915,9 @@ fn simulate_inner<R: rand::Rng>(
     n_sim: usize,
     rng: &mut R,
 ) -> Vec<SimulationResult> {
-    simulate_inner_with_draw(model, population, params, n_sim, 1, None, rng)
+    // `simulate` / `simulate_with_seed` carry no horizon; the per-record window
+    // applies. An explicit `[simulation] horizon` enters via `simulate_with_options`.
+    simulate_inner_with_draw(model, population, params, n_sim, 1, None, None, rng)
 }
 
 /// Emit all observation rows for one subject given a fully-formed `eta_slice`
@@ -4830,9 +4932,15 @@ fn emit_subject_rows<R: rand::Rng>(
     draw: usize,
     sim: usize,
     normal: rand_distr::Normal<f64>,
+    horizon: Option<f64>,
     rng: &mut R,
     results: &mut Vec<SimulationResult>,
 ) {
+    // `horizon` is consumed only by the TTE path below; without the `survival`
+    // feature there are no TTE endpoints, so discard it to avoid an unused-arg warn.
+    #[cfg(not(feature = "survival"))]
+    let _ = horizon;
+
     // Use the same TV-covariate-aware dispatcher as estimation and post-fit
     // diagnostics. For no-TV subjects this stays on the one-pk-param fast path.
     let ipreds = pk::compute_predictions_with_tv(model, subject, &params.theta, eta_slice);
@@ -4875,6 +4983,7 @@ fn emit_subject_rows<R: rand::Rng>(
         eta_slice,
         draw,
         sim,
+        horizon,
         rng,
         results,
     );
@@ -4894,6 +5003,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     n_sim: usize,
     draw: usize,
     matched: Option<(&[DVector<f64>], &nalgebra::DMatrix<f64>, MatchMethod)>,
+    horizon: Option<f64>,
     rng: &mut R,
 ) -> Vec<SimulationResult> {
     use rand_distr::Normal;
@@ -4937,6 +5047,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
                         draw,
                         sim,
                         normal,
+                        horizon,
                         rng,
                         &mut results,
                     );
@@ -4958,6 +5069,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
                         draw,
                         sim,
                         normal,
+                        horizon,
                         rng,
                         &mut results,
                     );
@@ -5029,6 +5141,7 @@ pub fn simulate_with_uncertainty(
             params,
             opts.n_sim_per_draw,
             k + 1,
+            None,
             None,
             &mut rng,
         );

--- a/src/api.rs
+++ b/src/api.rs
@@ -376,6 +376,9 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
                         } else {
                             crate::types::EventType::RightCensored
                         },
+                        // Synthetic `[simulation]` subjects always enter at 0 (no
+                        // left truncation), matching the template row above; keep
+                        // the two in sync if this path ever gains delayed entry.
                         entry_time: 0.0,
                         cmt: s.cmt,
                     })

--- a/src/api.rs
+++ b/src/api.rs
@@ -263,12 +263,16 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
             fremtype: Vec::new(),
             // One right-censored template row per cause CMT, at the administrative
             // horizon (overwritten by the draw). Empty when the model has no TTE
-            // endpoint, reproducing the previous all-Gaussian behaviour. (#522)
+            // endpoint, reproducing the previous all-Gaussian behaviour. The
+            // `expect` cannot fire: a non-empty `tte_cmts` guarantees `horizon` is
+            // `Some` (the TTE-requires-horizon check above returns early). (#522)
             #[cfg(feature = "survival")]
             obs_records: tte_cmts
                 .iter()
                 .map(|&cmt| crate::types::ObsRecord::Event {
-                    time: sim_spec.horizon.unwrap_or(f64::INFINITY),
+                    time: sim_spec
+                        .horizon
+                        .expect("TTE endpoints require a horizon (checked above)"),
                     event_type: crate::types::EventType::RightCensored,
                     entry_time: 0.0,
                     cmt,
@@ -364,10 +368,22 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         }
     }
 
+    // `n_obs()` counts only Gaussian observations; add the simulated TTE event
+    // rows so a TTE-only `--simulate` run doesn't misleadingly report "0
+    // observations" (#522 review).
+    #[cfg(feature = "survival")]
+    let n_records = population.n_obs()
+        + population
+            .subjects
+            .iter()
+            .map(|s| s.obs_records.len())
+            .sum::<usize>();
+    #[cfg(not(feature = "survival"))]
+    let n_records = population.n_obs();
     eprintln!(
         "Loaded {} subjects, {} observations",
         population.subjects.len(),
-        population.n_obs()
+        n_records
     );
 
     let init_params = build_init_params(&parsed);
@@ -4850,6 +4866,24 @@ pub fn simulate_with_options(
             return Err(format!(
                 "SimulateOptions.horizon must be finite and > 0 (got {h})"
             ));
+        }
+        // A horizon below a subject's TTE entry_time would censor it before it
+        // entered observation (a row with time = h < entry_time). The
+        // `[simulation]`-block path always enters at 0, but a left-truncated
+        // population passed to this API must be rejected (#522 review).
+        #[cfg(feature = "survival")]
+        for subject in &population.subjects {
+            for record in &subject.obs_records {
+                let crate::types::ObsRecord::Event { entry_time, .. } = record;
+                if *entry_time > h {
+                    return Err(format!(
+                        "SimulateOptions.horizon ({h}) is below subject '{}' entry_time \
+                         ({entry_time}); the administrative horizon must be ≥ every \
+                         subject's entry time",
+                        subject.id
+                    ));
+                }
+            }
         }
     }
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3519,6 +3519,7 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
     let mut dose_cmt = 1;
     let mut obs_times = Vec::new();
     let mut seed = 42u64;
+    let mut horizon: Option<f64> = None;
 
     for line in lines {
         let parts: Vec<&str> = line.splitn(2, '=').map(|s| s.trim()).collect();
@@ -3562,11 +3563,34 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
                 obs_times = parse_float_array(parts[1])
                     .map_err(|e| format!("[simulation]: bad times: {e}"))?
             }
+            // Administrative censoring horizon for TTE endpoints (#522). Must be a
+            // finite, strictly-positive time: it is the right-censoring window for
+            // every simulated TTE cause and a non-positive / non-finite horizon
+            // would censor every subject at or before entry (no events possible).
+            "horizon" => {
+                let t: f64 = parts[1]
+                    .parse()
+                    .map_err(|_| format!("[simulation]: bad horizon: {}", line))?;
+                if !t.is_finite() || t <= 0.0 {
+                    return Err(format!(
+                        "[simulation]: horizon must be finite and > 0: {}",
+                        line
+                    ));
+                }
+                horizon = Some(t);
+            }
             other => return Err(format!("[simulation]: unknown key `{}`", other)),
         }
     }
-    if obs_times.is_empty() {
-        return Err("[simulation] block requires 'times = [...]'".to_string());
+    // A synthetic design needs *something* to observe: continuous `times` for a
+    // Gaussian model, or a `horizon` for a TTE model (#522). Require at least one;
+    // the model-vs-spec check (e.g. "TTE endpoint needs a horizon") happens once
+    // the endpoints are known, in `api::run_model_simulate`.
+    if obs_times.is_empty() && horizon.is_none() {
+        return Err(
+            "[simulation] block requires 'times = [...]' (Gaussian) or 'horizon = <t>' (TTE)"
+                .to_string(),
+        );
     }
 
     Ok(SimulationSpec {
@@ -3575,6 +3599,7 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
         dose_cmt,
         obs_times,
         seed,
+        horizon,
         covariates: vec![],
     })
 }
@@ -21925,5 +21950,52 @@ CL V KA WT
     fn simulation_requires_times() {
         let err = parse_simulation_block(&sim_lines(&["n_subjects = 5"])).unwrap_err();
         assert!(err.contains("times"), "got: {err}");
+    }
+
+    #[test]
+    fn simulation_horizon_parses() {
+        // `horizon = <t>` is captured as the administrative censoring window (#522).
+        let spec = parse_simulation_block(&sim_lines(&["horizon = 14", "times = [1.0]"]))
+            .expect("horizon parses");
+        assert_eq!(spec.horizon, Some(14.0));
+        // Absent ⇒ None (the per-record window path).
+        let spec = parse_simulation_block(&sim_lines(&["times = [1.0]"])).expect("no horizon");
+        assert_eq!(spec.horizon, None);
+    }
+
+    #[test]
+    fn simulation_horizon_satisfies_observe_requirement() {
+        // A TTE-only design has no continuous `times`; a `horizon` alone is enough
+        // to make the block valid (the relaxed times-OR-horizon rule).
+        let spec = parse_simulation_block(&sim_lines(&["n_subjects = 5", "horizon = 14"]))
+            .expect("horizon alone is a valid design");
+        assert_eq!(spec.horizon, Some(14.0));
+        assert!(spec.obs_times.is_empty());
+    }
+
+    #[test]
+    fn simulation_horizon_rejects_nonpositive_and_nonfinite() {
+        for bad in [
+            "horizon = 0",
+            "horizon = -3",
+            "horizon = inf",
+            "horizon = nan",
+        ] {
+            let err = parse_simulation_block(&sim_lines(&[bad, "times = [1.0]"])).unwrap_err();
+            assert!(
+                err.starts_with("[simulation]:") && err.contains("horizon"),
+                "`{bad}` gave: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn simulation_horizon_bad_value_errors() {
+        let err =
+            parse_simulation_block(&sim_lines(&["horizon = abc", "times = [1.0]"])).unwrap_err();
+        assert!(
+            err.starts_with("[simulation]:") && err.contains("horizon"),
+            "got: {err}"
+        );
     }
 }

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -296,6 +296,16 @@ fn resolve_competing_risks(latents: &[f64], window: f64) -> (usize, f64, bool) {
 ///   (+∞), so only an all-`RightCensored` subject is censored, at its common
 ///   window (the `max` of the per-cause windows — see the match arm). One row per
 ///   cause CMT is emitted, giving the cause-specific layout the data reader expects.
+///
+/// `horizon` (`[simulation] horizon`, #522), when `Some(h)`, **overrides** the
+/// per-record [`observation_window`] for every cause: `h` becomes the shared
+/// administrative censoring window regardless of each record's `event_type`. This
+/// is what a competing-risks VPC needs — re-simulating event-bearing data
+/// (`Exact` records, which on their own draw unbounded) then censors at the
+/// *planned* study end `h` rather than at the data's own observed event times.
+/// `None` keeps the per-record window. The override changes only the censoring
+/// comparison, never the number of uniforms drawn, so the RNG sequence (and the
+/// SSE characterization tests) are unaffected.
 pub fn simulate_tte<R: rand::Rng>(
     model: &crate::types::CompiledModel,
     subject: &crate::types::Subject,
@@ -303,6 +313,7 @@ pub fn simulate_tte<R: rand::Rng>(
     eta: &[f64],
     draw: usize,
     sim: usize,
+    horizon: Option<f64>,
     rng: &mut R,
     results: &mut Vec<crate::api::SimulationResult>,
 ) {
@@ -322,9 +333,10 @@ pub fn simulate_tte<R: rand::Rng>(
         };
         let HazardSpec::Analytic { family, param_fn } = hazard;
         let params = param_fn(theta, eta, &subject.covariates);
-        // Only a right-censored record marks an administrative horizon; an event
-        // record draws uncensored (+∞) — see `observation_window`.
-        let window = observation_window(event_type, *time);
+        // With an explicit `horizon`, every cause shares it as the administrative
+        // window (#522); otherwise only a right-censored record marks a horizon and
+        // an event record draws uncensored (+∞) — see `observation_window`.
+        let window = horizon.unwrap_or_else(|| observation_window(event_type, *time));
         causes.push((*cmt, *family, params, *entry_time, window));
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4368,6 +4368,14 @@ pub struct SimulationSpec {
     pub dose_cmt: usize,
     pub obs_times: Vec<f64>,
     pub seed: u64,
+    /// Administrative censoring horizon for TTE endpoints (`[simulation] horizon`).
+    /// `Some(t)` makes `t` the right-censoring window for **every** simulated TTE
+    /// cause, overriding the per-record `observation_window` so a re-simulated
+    /// event-bearing subject censors at the planned study end rather than drawing
+    /// unbounded (the competing-risks VPC fix — see `survival::simulate_tte`).
+    /// `None` falls back to the per-record window. Required when the model has a
+    /// TTE endpoint and synthetic subjects are generated.
+    pub horizon: Option<f64>,
     /// Optional per-subject covariates: (name, values) — length must equal n_subjects
     pub covariates: Vec<(String, Vec<f64>)>,
 }

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -208,6 +208,52 @@ fn simulate_writes_outputs() {
     assert!(tmp.path().join("sim_model-fit.yaml").exists());
 }
 
+/// A Gaussian `[simulation]` block given only `horizon` (no `times`) must fail
+/// loudly. The relaxed `times`-or-`horizon` parser rule (added for TTE models)
+/// accepts it, but a Gaussian model has nothing to observe at a TTE horizon, so
+/// `--simulate` must error rather than silently build zero-observation subjects
+/// and fit on empty data (#522 review). Fast — errors before any fitting.
+#[test]
+fn simulate_gaussian_horizon_only_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let model_src = "\
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[simulation]
+  n_subjects = 5
+  horizon    = 14
+";
+    let model = tmp.path().join("gauss_horizon_only.ferx");
+    std::fs::write(&model, model_src).expect("write model");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_ferx"))
+        .current_dir(tmp.path())
+        .arg(&model)
+        .arg("--simulate")
+        .output()
+        .expect("run ferx --simulate");
+    assert!(
+        !out.status.success(),
+        "a Gaussian horizon-only [simulation] must fail, not fit on empty data"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("times"),
+        "error must point at the missing `times`: {stderr}"
+    );
+}
+
 /// Covers the arg-parsing error exits in `main` (each calls `process::exit(1)`
 /// before any fitting, so these are fast). One subprocess per bad flag.
 #[test]

--- a/tests/modeled_duration.rs
+++ b/tests/modeled_duration.rs
@@ -927,6 +927,7 @@ fn simulate_propensity_on_analytical_model_with_modeled_dose_panics() {
     let opts = SimulateOptions {
         seed: Some(1),
         match_method: Some(ferx_core::MatchMethod::Optimal),
+        horizon: None,
     };
     let _ = simulate_with_options(&model, &pop, &model.default_params, 1, &opts);
 }

--- a/tests/propensity_matched_sim.rs
+++ b/tests/propensity_matched_sim.rs
@@ -92,6 +92,7 @@ fn matched_simulation_has_expected_shape_and_finite_dvs() {
         let opts = SimulateOptions {
             seed: Some(2024),
             match_method: Some(method),
+            horizon: None,
         };
         let rows = simulate_with_options(&model, &pop, &model.default_params, n_sim, &opts)
             .unwrap_or_else(|e| panic!("matched simulation ({method:?}) succeeds: {e}"));
@@ -126,6 +127,7 @@ fn matched_simulation_is_reproducible_and_distinct_from_unmatched() {
     let unmatched = SimulateOptions {
         seed: Some(7),
         match_method: None,
+        horizon: None,
     };
     let c = simulate_with_options(&model, &pop, &model.default_params, 3, &unmatched).unwrap();
 
@@ -133,6 +135,7 @@ fn matched_simulation_is_reproducible_and_distinct_from_unmatched() {
         let matched = SimulateOptions {
             seed: Some(7),
             match_method: Some(method),
+            horizon: None,
         };
         let a = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
         let b = simulate_with_options(&model, &pop, &model.default_params, 3, &matched).unwrap();
@@ -160,6 +163,7 @@ fn unmatched_options_path_equals_simulate_with_seed() {
     let opts = SimulateOptions {
         seed: Some(99),
         match_method: None,
+        horizon: None,
     };
     let via_opts = simulate_with_options(&model, &pop, &model.default_params, 2, &opts).unwrap();
     let via_seed = simulate_with_seed(&model, &pop, &model.default_params, 2, 99);
@@ -199,6 +203,7 @@ fn matching_requires_observations() {
     let opts = SimulateOptions {
         seed: Some(1),
         match_method: Some(MatchMethod::Optimal),
+        horizon: None,
     };
     let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
         .expect_err("matching without observations must error");

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -511,6 +511,222 @@ mod survival_smoke {
         );
     }
 
+    /// Competing-risks VPC (#522): re-simulating event-bearing data **with** an
+    /// explicit `[simulation] horizon` must (a) decouple the draw from the data's
+    /// own event times — simulated events may land *after* the original event
+    /// time, not truncated at it — and (b) administratively censor at the planned
+    /// horizon, so no outcome exceeds it and a subject surviving every cause past
+    /// the horizon lands exactly on it. The complement of
+    /// `simulate_competing_risks_event_record_draws_uncensored` (no horizon ⇒
+    /// unbounded redraw): the horizon overrides the per-record `observation_window`.
+    #[test]
+    fn simulate_competing_risks_horizon_censors_at_planned_end() {
+        use ferx_core::{simulate_with_options, SimOutcome, SimulateOptions};
+        use std::collections::HashMap;
+        const H: f64 = 14.0; // planned study end (≈ above the ~8.7 median total event time)
+        let model = parse_model_string(COMPETING_RISKS_MODEL).expect("model must parse");
+        // 300 subjects with cause A (CMT 2) observed at t=0.5 — the data's event
+        // time, which must NOT bound the re-simulation under an explicit horizon.
+        let template = common::tte_competing_pop(&vec![(0.5_f64, 2u8); 300]);
+        let opts = SimulateOptions {
+            seed: Some(99),
+            match_method: None,
+            horizon: Some(H),
+        };
+        let sims = simulate_with_options(&model, &template, &model.default_params, 1, &opts)
+            .expect("simulate with horizon must succeed");
+
+        // Group the two cause rows per subject (they share one outcome time, with
+        // at most one cause observed — the earliest-cause-wins layout).
+        let mut by_id: HashMap<String, Vec<&ferx_core::SimulationResult>> = HashMap::new();
+        for s in &sims {
+            by_id.entry(s.id.clone()).or_default().push(s);
+        }
+        assert_eq!(by_id.len(), 300, "one group per subject");
+
+        let (mut events_after_original, mut censored_at_h) = (0usize, 0usize);
+        for rowset in by_id.values() {
+            assert_eq!(rowset.len(), 2, "one row per cause CMT");
+            let mut t0 = None;
+            let mut observed_any = false;
+            for s in rowset {
+                let (time, observed) = match s.outcome {
+                    SimOutcome::Event { time, observed } => (time, observed),
+                    _ => panic!("expected an Event outcome"),
+                };
+                // (b) the horizon is a hard cap: no outcome can exceed the planned end.
+                assert!(time <= H + 1e-9, "outcome {time} exceeds horizon {H}");
+                let prev = *t0.get_or_insert(time);
+                assert!(
+                    (time - prev).abs() < 1e-12,
+                    "both rows share the outcome time"
+                );
+                observed_any |= observed;
+            }
+            let t0 = t0.unwrap();
+            if observed_any {
+                // (a) decoupled from the data: events may fall after the original 0.5.
+                if t0 > 0.5 + 1e-6 {
+                    events_after_original += 1;
+                }
+            } else {
+                // A subject with no cause firing is censored administratively at the
+                // horizon — exactly, not at the data's 0.5 event time.
+                assert!(
+                    (t0 - H).abs() < 1e-9,
+                    "a fully-censored subject must land on the horizon, got {t0}"
+                );
+                censored_at_h += 1;
+            }
+        }
+        // A proper VPC mix: events past the original event time, plus survivors
+        // censored at the planned horizon.
+        assert!(
+            events_after_original > 0,
+            "horizon must not truncate the redraw at the original 0.5 event time"
+        );
+        assert!(
+            censored_at_h > 0,
+            "expected subjects surviving every cause past the horizon (censored at H)"
+        );
+    }
+
+    /// `[simulation]`-block path (#522): `run_model_simulate` (the `--simulate`
+    /// CLI entry) must generate one TTE row per cause CMT per synthetic subject,
+    /// censored at the `[simulation] horizon`. Without it the synthetic
+    /// `obs_records` are empty and `--simulate` emits zero TTE rows. A
+    /// fixed-effects (n_eta=0) competing model keeps the bundled fit fast.
+    #[test]
+    fn simulate_block_generates_competing_tte_rows() {
+        const H: f64 = 8.0;
+        let model_src = r"
+[parameters]
+  theta TVLAMBDA_A(0.10, 0.001, 10.0)
+  theta TVLAMBDA_B(0.06, 0.001, 10.0)
+
+[event_model cause_a]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA_A
+
+[event_model cause_b]
+  cmt    = 3
+  family = exponential
+  scale  = TVLAMBDA_B
+
+[fit_options]
+  method  = focei
+  maxiter = 1
+
+[simulation]
+  n_subjects = 40
+  horizon    = 8
+  seed       = 7
+";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("competing_sim.ferx");
+        std::fs::write(&path, model_src).expect("write model");
+
+        let (_fit, pop) =
+            ferx_core::run_model_simulate(path.to_str().unwrap()).expect("simulate+fit succeeds");
+        assert_eq!(
+            pop.subjects.len(),
+            40,
+            "one synthetic subject per n_subjects"
+        );
+
+        let (mut events, mut censored_at_h) = (0usize, 0usize);
+        for subj in &pop.subjects {
+            // One row per cause CMT (2 and 3), each at entry 0 and within horizon.
+            assert_eq!(subj.obs_records.len(), 2, "one TTE row per cause CMT");
+            let mut cmts: Vec<usize> = subj
+                .obs_records
+                .iter()
+                .map(|r| {
+                    let ObsRecord::Event {
+                        cmt,
+                        entry_time,
+                        time,
+                        ..
+                    } = r;
+                    assert_eq!(
+                        *entry_time, 0.0,
+                        "synthetic subjects have no left truncation"
+                    );
+                    assert!(*time <= H + 1e-9, "row time {time} exceeds horizon {H}");
+                    *cmt
+                })
+                .collect();
+            cmts.sort_unstable();
+            assert_eq!(cmts, vec![2, 3], "rows on both cause CMTs");
+
+            let n_observed = subj
+                .obs_records
+                .iter()
+                .filter(|r| {
+                    let ObsRecord::Event { event_type, .. } = r;
+                    matches!(event_type, EventType::Exact)
+                })
+                .count();
+            assert!(n_observed <= 1, "at most one cause is the observed event");
+            if n_observed == 1 {
+                events += 1;
+            } else {
+                // No cause fired ⇒ both rows right-censored at the horizon.
+                for r in &subj.obs_records {
+                    let ObsRecord::Event {
+                        time, event_type, ..
+                    } = r;
+                    assert!(matches!(event_type, EventType::RightCensored));
+                    assert!(
+                        (time - H).abs() < 1e-9,
+                        "censored row must land on the horizon, got {time}"
+                    );
+                }
+                censored_at_h += 1;
+            }
+        }
+        assert!(
+            events > 0,
+            "synthetic competing data must contain observed events"
+        );
+        assert!(
+            censored_at_h > 0,
+            "with horizon {H} some subjects survive every cause and censor at it"
+        );
+    }
+
+    /// A TTE model simulated via `[simulation]` *requires* a `horizon` (there are
+    /// no continuous `times` to censor against). `times` alone satisfies the
+    /// parser, but `run_model_simulate` must then reject the TTE design with a
+    /// clear, actionable error (#522).
+    #[test]
+    fn simulate_block_tte_requires_horizon() {
+        let model_src = r"
+[parameters]
+  theta TVLAMBDA(0.10, 0.001, 10.0)
+
+[event_model only_cause]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA
+
+[simulation]
+  n_subjects = 3
+  times      = [1.0]
+";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("tte_no_horizon.ferx");
+        std::fs::write(&path, model_src).expect("write model");
+
+        let err = ferx_core::run_model_simulate(path.to_str().unwrap())
+            .expect_err("a TTE [simulation] without a horizon must error");
+        assert!(
+            err.contains("horizon") && err.contains("TTE"),
+            "error must name the missing horizon: {err}"
+        );
+    }
+
     /// `predict_survival` must keep the partition invariant `Σ_k CIF_k + S_all = 1`
     /// even when the caller supplies an out-of-order time grid: the CIF telescopes
     /// the all-cause survival drop, so the grid is sorted internally. Guards the

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -696,6 +696,82 @@ mod survival_smoke {
         );
     }
 
+    /// `[simulation]`-block path with a **single** `[event_model]` (#522): the
+    /// docs promise "a single `[event_model]` yields one row per subject — an event
+    /// before the horizon, or right-censoring at the horizon". The competing test
+    /// above covers ≥2 causes; this pins the single-cause `run_model_simulate` path
+    /// end-to-end: exactly one TTE row per synthetic subject, at entry 0 and within
+    /// the horizon, with a mix of observed events and horizon-censored survivors.
+    #[test]
+    fn simulate_block_generates_single_cause_tte_rows() {
+        const H: f64 = 8.0;
+        let model_src = r"
+[parameters]
+  theta TVLAMBDA(0.10, 0.001, 10.0)
+
+[event_model only_cause]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA
+
+[fit_options]
+  method  = focei
+  maxiter = 1
+
+[simulation]
+  n_subjects = 60
+  horizon    = 8
+  seed       = 11
+";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("single_cause_sim.ferx");
+        std::fs::write(&path, model_src).expect("write model");
+
+        let (_fit, pop) =
+            ferx_core::run_model_simulate(path.to_str().unwrap()).expect("simulate+fit succeeds");
+        assert_eq!(
+            pop.subjects.len(),
+            60,
+            "one synthetic subject per n_subjects"
+        );
+
+        let (mut events, mut censored_at_h) = (0usize, 0usize);
+        for subj in &pop.subjects {
+            assert_eq!(subj.obs_records.len(), 1, "single cause ⇒ one TTE row");
+            let ObsRecord::Event {
+                time,
+                event_type,
+                entry_time,
+                cmt,
+            } = &subj.obs_records[0];
+            assert_eq!(*cmt, 2, "row on the cause CMT");
+            assert_eq!(
+                *entry_time, 0.0,
+                "synthetic subjects have no left truncation"
+            );
+            assert!(*time <= H + 1e-9, "row time {time} exceeds horizon {H}");
+            match event_type {
+                EventType::Exact => events += 1,
+                EventType::RightCensored => {
+                    assert!(
+                        (time - H).abs() < 1e-9,
+                        "a censored row must land on the horizon, got {time}"
+                    );
+                    censored_at_h += 1;
+                }
+                other => panic!("unexpected event_type {other:?}"),
+            }
+        }
+        assert!(
+            events > 0,
+            "synthetic single-cause data must contain observed events"
+        );
+        assert!(
+            censored_at_h > 0,
+            "with horizon {H} some subjects survive past it and censor there"
+        );
+    }
+
     /// A TTE model simulated via `[simulation]` *requires* a `horizon` (there are
     /// no continuous `times` to censor against). `times` alone satisfies the
     /// parser, but `run_model_simulate` must then reject the TTE design with a

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -790,6 +790,54 @@ mod survival_smoke {
         }
     }
 
+    /// A **joint** PK+TTE model given only `horizon` (no `times`) must error, not
+    /// silently simulate zero PK observations. The model has a residual-error
+    /// (continuous) endpoint, so `times` is required even though it also has a TTE
+    /// endpoint — the mixed-model half of the silent-data gap the pure-Gaussian
+    /// guard left open (#522 review).
+    #[test]
+    fn simulate_block_mixed_horizon_only_errors() {
+        let model_src = r"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 1.0, 500.0)
+  theta TVLAMBDA(0.10, 0.001, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[event_model only_cause]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA
+
+[simulation]
+  n_subjects = 4
+  dose_amt   = 100
+  dose_cmt   = 1
+  horizon    = 14
+";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("mixed_horizon_only.ferx");
+        std::fs::write(&path, model_src).expect("write model");
+
+        let err = ferx_core::run_model_simulate(path.to_str().unwrap())
+            .expect_err("a joint PK+TTE model with horizon but no times must error");
+        assert!(
+            err.contains("times") && err.contains("continuous"),
+            "error must point at the missing continuous `times`: {err}"
+        );
+    }
+
     /// The library `simulate_with_options` validates `horizon` the same way the
     /// `.ferx` parser does: a non-finite or non-positive horizon is rejected, so a
     /// NaN window (every `t_event < NaN` is false → silent NaN event times) or a

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -727,6 +727,69 @@ mod survival_smoke {
         );
     }
 
+    /// A joint **PK + TTE** `[simulation]` (both `times` and `horizon` set):
+    /// continuous PK observations and TTE event rows are generated for the same
+    /// subjects, the Gaussian write-back routes the continuous rows into
+    /// `observations`, and the TTE write-back routes the event rows into
+    /// `obs_records` (its non-`Event` `filter_map` arm sees the continuous rows).
+    /// Exercises the mixed path end-to-end (#522 review).
+    #[test]
+    fn simulate_block_mixed_pk_and_tte() {
+        let model_src = r"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 1.0, 500.0)
+  theta TVLAMBDA(0.10, 0.001, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[event_model only_cause]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA
+
+[fit_options]
+  method  = focei
+  maxiter = 1
+
+[simulation]
+  n_subjects = 6
+  dose_amt   = 100
+  dose_cmt   = 1
+  times      = [0.5, 2.0, 8.0]
+  horizon    = 14
+  seed       = 3
+";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("mixed_pk_tte.ferx");
+        std::fs::write(&path, model_src).expect("write model");
+
+        let (_fit, pop) =
+            ferx_core::run_model_simulate(path.to_str().unwrap()).expect("mixed simulate+fit");
+        assert_eq!(pop.subjects.len(), 6);
+        for subj in &pop.subjects {
+            // Continuous PK observations: one per `times` entry, written by the
+            // Gaussian write-back.
+            assert_eq!(subj.observations.len(), 3, "3 continuous PK observations");
+            // One TTE row on the cause CMT, written by the TTE write-back. Reaching
+            // this also drives the non-`Event` `filter_map` arm (the continuous rows).
+            assert_eq!(subj.obs_records.len(), 1, "one TTE event row");
+            let ObsRecord::Event { time, cmt, .. } = &subj.obs_records[0];
+            assert_eq!(*cmt, 2, "TTE row on the cause CMT");
+            assert!(*time <= 14.0 + 1e-9, "TTE outcome within the horizon");
+        }
+    }
+
     /// The library `simulate_with_options` validates `horizon` the same way the
     /// `.ferx` parser does: a non-finite or non-positive horizon is rejected, so a
     /// NaN window (every `t_event < NaN` is false → silent NaN event times) or a

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -756,6 +756,48 @@ mod survival_smoke {
         assert!(simulate_with_options(&model, &pop, &model.default_params, 1, &ok).is_ok());
     }
 
+    /// A horizon below a left-truncated subject's `entry_time` would censor it
+    /// before it entered observation (a row with `time < entry_time`); the library
+    /// path rejects it. The `[simulation]`-block path always enters at 0, so this
+    /// only guards `SimulateOptions { horizon }` on real left-truncated data (#522
+    /// review).
+    #[test]
+    fn simulate_with_options_rejects_horizon_below_entry_time() {
+        use ferx_core::{simulate_with_options, SimulateOptions};
+        let model = parse_model_string(COMPETING_RISKS_MODEL).expect("model parses");
+        // One left-truncated subject: enters at t = 5 on both causes.
+        let mut pop = common::tte_competing_pop(&[(10.0_f64, 0u8)]);
+        pop.subjects[0].obs_records = vec![
+            ObsRecord::Event {
+                time: 10.0,
+                event_type: EventType::RightCensored,
+                entry_time: 5.0,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 10.0,
+                event_type: EventType::RightCensored,
+                entry_time: 5.0,
+                cmt: 3,
+            },
+        ];
+        let below = SimulateOptions {
+            seed: Some(1),
+            match_method: None,
+            horizon: Some(3.0), // < entry_time 5.0
+        };
+        let err = simulate_with_options(&model, &pop, &model.default_params, 1, &below)
+            .expect_err("horizon below entry_time must error");
+        assert!(err.contains("entry_time"), "got: {err}");
+        // A horizon at/above entry is fine.
+        let above = SimulateOptions {
+            seed: Some(1),
+            match_method: None,
+            horizon: Some(8.0),
+        };
+        assert!(simulate_with_options(&model, &pop, &model.default_params, 1, &above).is_ok());
+    }
+
     /// `predict_survival` must keep the partition invariant `Σ_k CIF_k + S_all = 1`
     /// even when the caller supplies an out-of-order time grid: the CIF telescopes
     /// the all-cause survival drop, so the grid is sorted internally. Guards the

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -727,6 +727,35 @@ mod survival_smoke {
         );
     }
 
+    /// The library `simulate_with_options` validates `horizon` the same way the
+    /// `.ferx` parser does: a non-finite or non-positive horizon is rejected, so a
+    /// NaN window (every `t_event < NaN` is false → silent NaN event times) or a
+    /// `<= 0` horizon (censors every subject at/before entry) cannot slip in via
+    /// the API (#522 review).
+    #[test]
+    fn simulate_with_options_rejects_bad_horizon() {
+        use ferx_core::{simulate_with_options, SimulateOptions};
+        let model = parse_model_string(COMPETING_RISKS_MODEL).expect("model parses");
+        let pop = common::tte_competing_pop(&vec![(0.5_f64, 2u8); 4]);
+        for bad in [f64::NAN, f64::INFINITY, 0.0, -3.0] {
+            let opts = SimulateOptions {
+                seed: Some(1),
+                match_method: None,
+                horizon: Some(bad),
+            };
+            let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
+                .expect_err("non-finite / non-positive horizon must error");
+            assert!(err.contains("horizon"), "got: {err}");
+        }
+        // A valid horizon still succeeds.
+        let ok = SimulateOptions {
+            seed: Some(1),
+            match_method: None,
+            horizon: Some(10.0),
+        };
+        assert!(simulate_with_options(&model, &pop, &model.default_params, 1, &ok).is_ok());
+    }
+
     /// `predict_survival` must keep the partition invariant `Σ_k CIF_k + S_all = 1`
     /// even when the caller supplies an out-of-order time grid: the CIF telescopes
     /// the all-cause survival drop, so the grid is sorted internally. Guards the


### PR DESCRIPTION
## Why

Competing-risks TTE simulation (#501) is correct for the template-driven workflow, but a proper competing-risks **VPC** needs an administrative censoring horizon that is *decoupled from the observed event times*. Under #494's anti-truncation rule an event-bearing record (`Exact`) imposes no window (`+∞`), so re-simulating it draws unbounded — right for SSE, wrong for a VPC. In the cause-specific data layout the subject's planned follow-up isn't recoverable from the data alone, so it must be supplied explicitly. Separately, the `[simulation]`-block `--simulate` path emitted **zero** TTE rows (synthetic subjects had empty `obs_records`).

## What changed

1. **`[simulation] horizon` key** — parsed and validated (finite, `> 0`); a block now requires `times` *or* `horizon`, and a TTE model requires `horizon`. New `SimulationSpec.horizon`.
2. **Horizon override** — `Option<f64>` threaded through `simulate_tte` → `emit_subject_rows` → `simulate_inner_with_draw`, and exposed on `SimulateOptions.horizon`. When set it overrides each TTE record's per-record `observation_window` for every cause, so a re-simulated event-bearing subject censors at the planned study end. It changes only the censor comparison, never the number of uniforms drawn — RNG order (and the #501 SSE tests) are unaffected. The library API also validates the horizon (finite, `> 0`, and `≥` every subject's `entry_time`).
3. **Synthetic TTE rows** — `run_model_simulate` precomputes the cause-CMT list once, emits one right-censored template row per cause compartment per synthetic subject, and writes drawn outcomes back into `obs_records`. A Gaussian model with no `times` (only `horizon`) is rejected up front rather than fitting on empty data.

## Alternatives considered

Per-subject horizon column (vs the global scalar) — deferred; the global scalar covers every acceptance test. The threading is designed so a per-subject column (resolved from a covariate, falling back to the global) is a thin follow-up.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | [FeRx-NLME/ferx-r#200](https://github.com/FeRx-NLME/ferx-r/pull/200) | open | together |

ferx-r's two `SimulateOptions { seed, match_method }` literals are exhaustive, so the new `horizon` field would break them (`E0063`) once the pin reaches this commit — and immediately for a local build via the `[patch]` sibling swap. ferx-r#200 switches them to `..Default::default()`, which compiles against **both** the current and the new ferx-core (no pin bump needed). R-side exposure of `horizon` is a later follow-up.

## Breaking changes
- [x] Public Rust API (`api.rs` / `types.rs`) — **additive**: new fields on `SimulateOptions` / `SimulationSpec` (both derive `Default`); `survival::simulate_tte` gains a `horizon` arg (behind the `survival` feature). No `.ferx` or `FitResult`/sdtab changes. (Exhaustive `SimulateOptions` constructors must add the field or use `..Default::default()` — see ferx-r#200.)

## Numerical validation
- [x] No separate NONMEM run needed — the `horizon` adds **no new numerical machinery**; it only sets the administrative `window` fed to the existing draw/censor and CIF code, which are already anchored against external references:
  - **Censoring distribution → closed form.** `draw_tte_censoring_fraction_matches_survival` (`src/survival/mod.rs`) simulates 20 000 draws of an exponential hazard over a window `τ` and asserts the censored fraction matches `S(τ) = exp(−λτ)` to ~6σ. A `horizon` is exactly that window set uniformly across causes.
  - **Cumulative incidence → R `cmprsk::cuminc`.** #501 cross-checks the per-cause CIF against `cmprsk::cuminc` over 200 000 simulated subjects (table in `docs/estimation/tte.qmd`), plus two closed-form / independent-quadrature anchors.
  - This PR's own tests then assert the horizon's structural invariants: every draw caps at the horizon, a fully-censored subject lands exactly on it, and events are decoupled from the data's own event times.

## Performance
- [x] No significant impact expected — cause-CMT list and per-subject templates built once outside the per-subject/draw loops; horizon is a zero-cost `Option<f64>`; RNG draw order preserved.

## Tests
- [x] Tier-1 parser: horizon parse, observe-rule, non-positive / non-finite + bad-value rejection.
- [x] Tier-2: VPC horizon censoring, synthetic per-cause row generation, TTE-requires-horizon, library horizon validation (non-finite / `≤0` / below `entry_time`), Gaussian-`horizon`-only rejection, **joint PK+TTE simulation** (both `times` and `horizon`) and its **mixed-`horizon`-only rejection** (a continuous endpoint requires `times`). Full lib suite green; patch coverage 100% (the one TTE-write-back arm is now exercised by the mixed-model test).

## Example
- [x] `[simulation]` block added to `examples/tte_competing_risks.ferx`.

## Docs
- [x] `docs/model-file/simulation.qmd` (TTE / VPC section), `docs/estimation/tte.qmd` (competing-risks VPC), `docs/api/simulation.qmd`.
- [x] `CHANGELOG.md` `[Unreleased]` entry added.

## Checklist
- [x] `cargo clippy` clean (no new warnings on the diff; CI runs `--features ci`)
- [x] `simulate_tte` is not on the `Dual2` sensitivity path (simulation-only)

## Reviewer hints
The override is one line in `simulate_tte` (`horizon.unwrap_or_else(observation_window)`); the bulk is `run_model_simulate` row generation + the TTE write-back. Note the Gaussian write-back filters to `Continuous` outcomes (a TTE `Event` row would trip `continuous_value()`'s debug-assert).

Hardened via `/code-review xhigh` self-review (commits after the initial push): library-API horizon validation, the Gaussian-`horizon`-only guard, a horizon-`<`-`entry_time` guard, the TTE-aware "observations" log, a dead-branch tidy, and — closing a mixed-model gap — requiring `times` whenever the model has a residual-error (continuous) endpoint (so a joint PK+TTE model given only `horizon` errors instead of silently dropping its PK observations). Each with a test.

Follow-up tech-debt (tracked in #531, not in this PR): two `O(n²)` write-back passes on the small-N synthetic path, a shared `gather_tte_causes` helper between `simulate_tte` and `predict_survival`, and reusing `has_tte()`.

## Open questions
Per-subject horizon column was deferred (global scalar covers all acceptance tests) — flag if you want it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
