### PR TITLE
perf(ad): exact Dual2/Dual1 gradients for analytical initial conditions [closes #524]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ section of the SDLC for the versioning policy).
   equivalent of NONMEM's `A_0(cmt)` and of the ODE-path `init(...)` in `[odes]`.
   A pre-dose baseline (e.g. `init(central) = CONC0 * V`) no longer forces the
   numerical ODE solver: on the 6-thioguanine `run14` model this cuts FOCEI wall
-  time ~13× (27 s → ~2 s) at matching estimates. Models with an initial
-  condition use `gradient = fd` for now (exact-analytic gradients are a
-  follow-up). Edge cases are handled explicitly: the baseline is wiped by a
+  time ~13× (27 s → ~2 s) at matching estimates. Non-IOV init models use exact
+  analytic FOCE/FOCEI gradients under `gradient = auto` (#524); IOV init models
+  use `gradient = fd` for now. Edge cases are handled explicitly: the baseline is wiped by a
   system reset (`EVID = 3/4`), its decay uses each occasion's PK parameters under
   IOV, a `KAPPA_*` reference in the init expression is rejected, and the
   combination with a steady-state dose (`W_STEADY_STATE_INIT`) or a compartment
@@ -58,6 +58,15 @@ section of the SDLC for the versioning policy).
   (#474)
 
 ### Performance
+- **Exact analytic gradients for `[initial_conditions]` models** (#524). A non-IOV
+  closed-form model with an `[initial_conditions]` baseline now runs FOCE/FOCEI
+  on exact analytic `Dual2`/`Dual1` sensitivities under `gradient = auto` instead
+  of falling back to finite differences: the init impulse `A₀ · kernel(t, pk)`
+  and its θ/η dependence thread through the analytic provider (outer θ/η jet and
+  inner η-gradient). Faster (no per-parameter FD probe) and exact, and it
+  re-enables the HMC SAEM E-step (`n_leapfrog > 0`) for baseline models. The
+  analytic gradient matches Richardson finite differences of the (NONMEM-validated)
+  FOCEI marginal to ~1e-3. IOV init models keep the FD fallback (follow-up).
 - **Ω-preconditioned inner EBE loop for all FOCE/FOCEI fits.** The inner BFGS
   now initialises its inverse-Hessian (the search `H0`) to the prior conditional
   scale `diag(1/Ω⁻¹ᵢᵢ)` for every model, not just FREM. A correlated or

--- a/docs/model-file/initial-conditions.qmd
+++ b/docs/model-file/initial-conditions.qmd
@@ -96,11 +96,14 @@ above — numerically equivalent, and still allocation-free.
   reconstruction does not seed it, so `[derived]` expressions referencing
   `compartments[i]` evaluate to `NaN` for baseline models (`W_DERIVED_INIT_ANALYTICAL`).
   Use an ODE model if compartment amounts are required.
-- **Gradient falls back to finite differences.** A model with
-  `[initial_conditions]` uses `gradient = fd` automatically (the analytic
-  `Dual2` sensitivity kernels do not yet carry the init impulse's θ/η
-  dependence). Results are correct; the exact-analytic outer/inner gradient is a
-  planned follow-up. The startup banner reports `gradient: FD [requested: auto]`.
+- **IOV models fall back to finite differences.** A non-IOV
+  `[initial_conditions]` model uses exact analytic FOCE/FOCEI gradients under
+  `gradient = auto` (issue #524): the `Dual2`/`Dual1` sensitivity kernels carry
+  the init impulse and its θ/η dependence, so the baseline no longer forces FD.
+  An **IOV** model (kappa) with an init baseline still uses `gradient = fd`
+  automatically — the per-occasion analytic init gradient is a planned follow-up.
+  Results are correct in both cases; for an IOV init model the startup banner
+  reports `gradient: FD [requested: auto]`.
 
 ## NONMEM comparison
 

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -3397,6 +3397,136 @@ mod tests {
         }
     }
 
+    // 1-cpt oral with a parameter-dependent central baseline (#524). The analytic
+    // init impulse and its θ/η jet must flow through the packed FOCEI/FOCE
+    // population gradient — i.e. the gradient that `gradient = auto` uses must
+    // match Richardson FD of the marginal objective (`gradient = fd`), the
+    // population-level analogue of the per-subject provider-vs-FD init test.
+    const ONECPT_ORAL_INIT_OUTER: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta TVC0(5.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[initial_conditions]
+  init(central) = TVC0 * V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    #[test]
+    fn population_packed_gradient_init_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        use crate::types::Population;
+
+        let model = parse_model_string(ONECPT_ORAL_INIT_OUTER).expect("parse init outer");
+        assert_eq!(model.analytical_init.len(), 1);
+        assert!(
+            crate::sens::provider::analytical_supported(&model),
+            "init model must use the analytic outer gradient, not FD"
+        );
+        let theta = [0.22, 11.0, 1.4, 6.0];
+        let eta_ref = [0.12, -0.08, 0.2];
+
+        // Two plain (non-TV) subjects with a baseline-bearing oral dose; obs are
+        // the init-aware prediction at eta_ref scaled down so EBEs are non-trivial.
+        let make = |id: &str, times: &[f64]| -> Subject {
+            let n = times.len();
+            let mut s = Subject {
+                id: id.to_string(),
+                doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                obs_times: times.to_vec(),
+                obs_raw_times: Vec::new(),
+                observations: vec![0.0; n],
+                obs_cmts: vec![1; n],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0; n],
+                occasions: vec![1; n],
+                dose_occasions: Vec::new(),
+                fremtype: Vec::new(),
+                #[cfg(feature = "survival")]
+                obs_records: vec![],
+            };
+            let preds = crate::pk::compute_predictions_with_tv(&model, &s, &theta, &eta_ref);
+            s.observations = preds.iter().map(|p| p * 0.85).collect();
+            s
+        };
+        let pop = Population {
+            subjects: vec![
+                make("init_a", &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]),
+                make("init_b", &[1.0, 3.0, 6.0, 12.0]),
+            ],
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ehs: Vec<DVector<f64>> = pop
+            .subjects
+            .iter()
+            .map(|s| DVector::from_vec(precise_ebe(&model, s, &params)))
+            .collect();
+
+        for interaction in [true, false] {
+            let analytic = if interaction {
+                population_gradient_sens(&model, &pop, &template, &x, &ehs)
+            } else {
+                population_gradient_sens_foce(&model, &pop, &template, &x, &ehs)
+            }
+            .expect("init subject supported by analytic gradient");
+
+            let ofv = |xv: &[f64]| -> f64 {
+                let p = unpack_params(xv, &template);
+                2.0 * pop
+                    .subjects
+                    .iter()
+                    .map(|s| {
+                        if interaction {
+                            marginal_nll(&model, s, &p)
+                        } else {
+                            marginal_nll_foce(&model, s, &p)
+                        }
+                    })
+                    .sum::<f64>()
+            };
+            let fd_at = |k: usize, h: f64| -> f64 {
+                let mut xp = x.clone();
+                xp[k] += h;
+                let mut xm = x.clone();
+                xm[k] -= h;
+                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+            };
+            for k in 0..x.len() {
+                let h = 1e-4 * (1.0 + x[k].abs());
+                let f1 = fd_at(k, h);
+                let f2 = fd_at(k, h / 2.0);
+                let fd = (4.0 * f2 - f1) / 3.0;
+                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
+            }
+        }
+    }
+
     // 1-cpt oral with a log-normal dose lagtime (`LAGTIME = TVLAG·exp(ETA_LAG)`):
     // the lagtime θ (`TVLAG`) and ω (`ETA_LAG`) enter the packed gradient through
     // the provider's `∂f/∂θ` / `∂²f/∂η∂θ` for the lag slot, with no special-casing.

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4223,6 +4223,51 @@ fn parse_scaling_key(key: &str) -> Result<(&str, Option<usize>), String> {
     }
 }
 
+/// Lower a parsed scalar expression to a `Dual2`-differentiable
+/// [`ScaleDerivProgram`] over `(θ, η, individual-parameter vars, covariates)`.
+///
+/// Single source of truth for the `obs_scale` (issue #367) and `init` amount
+/// (issue #524) programs — they share the same axis layout, so they must lower
+/// identically or the analytic provider would differentiate the two on
+/// inconsistent ABIs. A `Variable(name)` (an individual parameter) → var slot `i`
+/// (flat PK slot `pk_indices[i]`); covariates → sorted cov slots; θ/η are read
+/// directly from the seed duals. The input `expr` is cloned, so the caller keeps
+/// its AST for the runtime closure.
+fn compile_scale_deriv_program(
+    expr: &Expression,
+    theta_names: &[String],
+    eta_names: &[String],
+    indiv_var_names: &[String],
+    pk_indices: &[usize],
+) -> ScaleDerivProgram {
+    let mut e = expr.clone();
+    let var_idx: HashMap<String, usize> = indiv_var_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.clone(), i))
+        .collect();
+    let var_to_pk_slot: Vec<usize> = (0..indiv_var_names.len())
+        .map(|i| pk_indices.get(i).copied().unwrap_or(i))
+        .collect();
+    let mut cov_set = std::collections::HashSet::new();
+    collect_covariates(&e, &mut cov_set);
+    let mut cov_names: Vec<String> = cov_set.into_iter().collect();
+    cov_names.sort();
+    let cov_idx: HashMap<String, usize> = cov_names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.clone(), i))
+        .collect();
+    resolve_expr_indices(&mut e, &var_idx, &cov_idx);
+    ScaleDerivProgram {
+        bc: compile_bytecode(&e),
+        n_theta: theta_names.len(),
+        n_eta: eta_names.len(),
+        var_to_pk_slot,
+        cov_names,
+    }
+}
+
 /// Build a `ScalingSpec` (None / ScalarScale / ExpressionScale) from one
 /// `obs_scale[…] = value` line. Shared between the uniform and per-CMT paths.
 fn build_obs_scale_spec(
@@ -4256,39 +4301,16 @@ fn build_obs_scale_spec(
         .map(|(i, name)| (name.clone(), pk_indices.get(i).copied().unwrap_or(i)))
         .collect();
     // Differentiable scale program (issue #367): compile the same expression to
-    // bytecode over (θ, η, individual-parameter vars, covariates) so the analytic
-    // sensitivity provider can differentiate `f / scale` exactly instead of
-    // finite-differencing the opaque closure. `Variable(name)` (an individual
-    // parameter) → var slot `i` (flat PK slot `pk_indices[i]`); covariates → cov
-    // slots; θ/η are read directly from the seed duals.
-    let deriv = {
-        let mut e = expr.clone();
-        let var_idx: HashMap<String, usize> = indiv_var_names
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.clone(), i))
-            .collect();
-        let var_to_pk_slot: Vec<usize> = (0..indiv_var_names.len())
-            .map(|i| pk_indices.get(i).copied().unwrap_or(i))
-            .collect();
-        let mut cov_set = std::collections::HashSet::new();
-        collect_covariates(&e, &mut cov_set);
-        let mut cov_names: Vec<String> = cov_set.into_iter().collect();
-        cov_names.sort();
-        let cov_idx: HashMap<String, usize> = cov_names
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n.clone(), i))
-            .collect();
-        resolve_expr_indices(&mut e, &var_idx, &cov_idx);
-        Some(ScaleDerivProgram {
-            bc: compile_bytecode(&e),
-            n_theta: theta_names.len(),
-            n_eta: eta_names.len(),
-            var_to_pk_slot,
-            cov_names,
-        })
-    };
+    // bytecode so the analytic sensitivity provider can differentiate `f / scale`
+    // exactly instead of finite-differencing the opaque closure. Shared lowering
+    // with the `init` amount program (issue #524) — see `compile_scale_deriv_program`.
+    let deriv = Some(compile_scale_deriv_program(
+        &expr,
+        theta_names,
+        eta_names,
+        indiv_var_names,
+        pk_indices,
+    ));
     let scale_fn: ScaleFn = Box::new(
         move |theta: &[f64],
               eta: &[f64],
@@ -4374,38 +4396,12 @@ fn build_init_amount_fn(
     kappa_names: &[String],
 ) -> Result<(ScaleFn, Option<ScaleDerivProgram>), String> {
     // Build the differentiable `A₀` program from a (possibly resolved) expression
-    // AST, mirroring the `obs_scale` deriv block in `build_obs_scale_spec`: a
-    // `Variable(name)` (an individual parameter) → var slot `i` (flat PK slot
-    // `pk_indices[i]`); covariates → cov slots; θ/η are read from the seed duals.
-    // This lets the analytic sensitivity provider differentiate the init impulse
-    // exactly (issue #524) instead of finite-differencing `amount_fn`.
+    // AST. Shares the `obs_scale` lowering (`compile_scale_deriv_program`) so the
+    // init impulse and the scale divisor differentiate on the same ABI; this lets
+    // the analytic sensitivity provider differentiate the init impulse exactly
+    // (issue #524) instead of finite-differencing `amount_fn`.
     let build_deriv = |expr: &Expression| -> ScaleDerivProgram {
-        let mut e = expr.clone();
-        let var_idx: HashMap<String, usize> = indiv_var_names
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.clone(), i))
-            .collect();
-        let var_to_pk_slot: Vec<usize> = (0..indiv_var_names.len())
-            .map(|i| pk_indices.get(i).copied().unwrap_or(i))
-            .collect();
-        let mut cov_set = std::collections::HashSet::new();
-        collect_covariates(&e, &mut cov_set);
-        let mut cov_names: Vec<String> = cov_set.into_iter().collect();
-        cov_names.sort();
-        let cov_idx: HashMap<String, usize> = cov_names
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n.clone(), i))
-            .collect();
-        resolve_expr_indices(&mut e, &var_idx, &cov_idx);
-        ScaleDerivProgram {
-            bc: compile_bytecode(&e),
-            n_theta: theta_names.len(),
-            n_eta: eta_names.len(),
-            var_to_pk_slot,
-            cov_names,
-        }
+        compile_scale_deriv_program(expr, theta_names, eta_names, indiv_var_names, pk_indices)
     };
 
     // Constant fast path (e.g. `init(central) = 0.0`). Still build a (constant)
@@ -9915,6 +9911,45 @@ impl ScaleDerivProgram {
         let empty_nn: Vec<Vec<f64>> = Vec::new();
         let mut stack: Vec<Dual2<M>> = Vec::new();
         eval_bytecode_g::<Dual2<M>>(
+            &self.bc, &theta_d, &eta_d, &cov_vec, var_duals, &empty_nn, &mut stack,
+        )
+    }
+
+    /// First-order η-only evaluation: returns `value` and `∂/∂η_k` on axis `k` over
+    /// `Dual1<N>` (`N = n_eta`). θ and individual-param vars enter as constants
+    /// except the seeded η axes, so this drops the θ axes and the `Dual2` Hessian
+    /// that [`eval_scale_dual`](Self::eval_scale_dual) carries. Used by the inner
+    /// init-amount gradient, whose EBE loop consumes only `∂A₀/∂η` (#524 follow-up).
+    pub(crate) fn eval_scale_dual1<const N: usize>(
+        &self,
+        theta: &[f64],
+        eta: &[f64],
+        cov: &HashMap<String, f64>,
+        var_duals: &[crate::sens::dual1::Dual1<N>],
+    ) -> crate::sens::dual1::Dual1<N> {
+        use crate::sens::dual1::Dual1;
+        // θ and individual-param vars are constants on the inner path (no θ axes);
+        // η_k seeds axis k directly (no `n_theta` offset).
+        let theta_d: Vec<Dual1<N>> = theta.iter().map(|&v| Dual1::constant(v)).collect();
+        let eta_d: Vec<Dual1<N>> = eta
+            .iter()
+            .enumerate()
+            .map(|(k, &v)| {
+                if k < N {
+                    Dual1::var(v, k)
+                } else {
+                    Dual1::constant(v)
+                }
+            })
+            .collect();
+        let cov_vec: Vec<f64> = self
+            .cov_names
+            .iter()
+            .map(|n| cov.get(n).copied().unwrap_or(0.0))
+            .collect();
+        let empty_nn: Vec<Vec<f64>> = Vec::new();
+        let mut stack: Vec<Dual1<N>> = Vec::new();
+        eval_bytecode_g::<Dual1<N>>(
             &self.bc, &theta_d, &eta_d, &cov_vec, var_duals, &empty_nn, &mut stack,
         )
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4364,6 +4364,7 @@ fn analytical_init_cmt(pk_model: PkModel, name: &str) -> Result<usize, String> {
 /// Mirrors the Form-B `obs_scale` expression closure in [`build_obs_scale_spec`]:
 /// individual-parameter names resolve from the subject-static `pk_params`, so
 /// `init(central) = CONC0 * V` reads `V` from its PK slot.
+#[allow(clippy::type_complexity)]
 fn build_init_amount_fn(
     value: &str,
     theta_names: &[String],
@@ -4371,12 +4372,49 @@ fn build_init_amount_fn(
     indiv_var_names: &[String],
     pk_indices: &[usize],
     kappa_names: &[String],
-) -> Result<ScaleFn, String> {
-    // Constant fast path (e.g. `init(central) = 0.0`).
+) -> Result<(ScaleFn, Option<ScaleDerivProgram>), String> {
+    // Build the differentiable `A₀` program from a (possibly resolved) expression
+    // AST, mirroring the `obs_scale` deriv block in `build_obs_scale_spec`: a
+    // `Variable(name)` (an individual parameter) → var slot `i` (flat PK slot
+    // `pk_indices[i]`); covariates → cov slots; θ/η are read from the seed duals.
+    // This lets the analytic sensitivity provider differentiate the init impulse
+    // exactly (issue #524) instead of finite-differencing `amount_fn`.
+    let build_deriv = |expr: &Expression| -> ScaleDerivProgram {
+        let mut e = expr.clone();
+        let var_idx: HashMap<String, usize> = indiv_var_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        let var_to_pk_slot: Vec<usize> = (0..indiv_var_names.len())
+            .map(|i| pk_indices.get(i).copied().unwrap_or(i))
+            .collect();
+        let mut cov_set = std::collections::HashSet::new();
+        collect_covariates(&e, &mut cov_set);
+        let mut cov_names: Vec<String> = cov_set.into_iter().collect();
+        cov_names.sort();
+        let cov_idx: HashMap<String, usize> = cov_names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.clone(), i))
+            .collect();
+        resolve_expr_indices(&mut e, &var_idx, &cov_idx);
+        ScaleDerivProgram {
+            bc: compile_bytecode(&e),
+            n_theta: theta_names.len(),
+            n_eta: eta_names.len(),
+            var_to_pk_slot,
+            cov_names,
+        }
+    };
+
+    // Constant fast path (e.g. `init(central) = 0.0`). Still build a (constant)
+    // deriv program so a constant baseline keeps `gradient = auto` support.
     if let Ok(k) = value.parse::<f64>() {
-        return Ok(Box::new(
-            move |_: &[f64], _: &[f64], _: &HashMap<String, f64>, _: &PkParams| k,
-        ));
+        let deriv = build_deriv(&Expression::Literal(k));
+        let scale_fn: ScaleFn =
+            Box::new(move |_: &[f64], _: &[f64], _: &HashMap<String, f64>, _: &PkParams| k);
+        return Ok((scale_fn, Some(deriv)));
     }
     let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
     let expr = parse_scalar_expression(value, ctx)
@@ -4397,12 +4435,13 @@ fn build_init_amount_fn(
              structural parameter (e.g. CL) instead."
         ));
     }
+    let deriv = build_deriv(&expr);
     let indiv_to_pk_slot: HashMap<String, usize> = indiv_var_names
         .iter()
         .enumerate()
         .map(|(i, name)| (name.clone(), pk_indices.get(i).copied().unwrap_or(i)))
         .collect();
-    Ok(Box::new(
+    let scale_fn: ScaleFn = Box::new(
         move |theta: &[f64],
               eta: &[f64],
               covariates: &HashMap<String, f64>,
@@ -4417,7 +4456,8 @@ fn build_init_amount_fn(
             let empty_nn: Vec<Vec<f64>> = Vec::new();
             eval_expression(&expr, theta, eta, covariates, &vars, &empty_nn)
         },
-    ))
+    );
+    Ok((scale_fn, Some(deriv)))
 }
 
 /// Parse the `[initial_conditions]` block (issue #521) into the analytical
@@ -4457,7 +4497,7 @@ fn parse_initial_conditions_block(
                 name
             ));
         }
-        let amount_fn = build_init_amount_fn(
+        let (amount_fn, amount_deriv) = build_init_amount_fn(
             &expr,
             theta_names,
             eta_names,
@@ -4465,7 +4505,11 @@ fn parse_initial_conditions_block(
             pk_indices,
             kappa_names,
         )?;
-        out.push(crate::types::AnalyticalInit { cmt, amount_fn });
+        out.push(crate::types::AnalyticalInit {
+            cmt,
+            amount_fn,
+            amount_deriv,
+        });
     }
     Ok(out)
 }

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -182,37 +182,72 @@ fn analytical_init_concentration(
     t: f64,
     p: &PkParams,
 ) -> f64 {
-    use crate::sens::one_cpt::{one_cpt_iv_bolus_g, one_cpt_oral_g};
-    use crate::sens::three_cpt::{three_cpt_iv_bolus_g, three_cpt_oral_g};
-    use crate::sens::two_cpt::{two_cpt_iv_bolus_g, two_cpt_oral_g};
+    // Delegate to the generic form at `T = f64`; the single formula dispatch
+    // lives there so the Dual2/Dual1 sensitivity path (#524) cannot drift from
+    // the f64 prediction.
+    analytical_init_concentration_g::<f64>(
+        pk_model,
+        cmt,
+        a0,
+        t,
+        p.cl(),
+        p.v(),
+        p.q(),
+        p.v2(),
+        p.ka(),
+        p.q3(),
+        p.v3(),
+    )
+}
 
-    let (cl, v) = (p.cl(), p.v());
+/// Generic form of [`analytical_init_concentration`] over [`PkNum`]: evaluating
+/// in `f64` gives the prediction; evaluating in `Dual2<N>`/`Dual1<N>` (with the
+/// amount `a0` and the PK params seeded as duals) gives the exact `∂C/∂A₀`,
+/// `∂C/∂(CL,V,…)` the analytic FOCE/FOCEI provider needs (#524). The amount is a
+/// pre-loaded compartment quantity, so `F = 1` everywhere — an initial condition
+/// is not an absorbed dose. Returns 0 for unsupported compartments defensively
+/// (peripheral inits are rejected at parse time).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn analytical_init_concentration_g<T: crate::sens::num::PkNum>(
+    pk_model: PkModel,
+    cmt: usize,
+    a0: T,
+    t: T,
+    cl: T,
+    v: T,
+    q: T,
+    v2: T,
+    ka: T,
+    q3: T,
+    v3: T,
+) -> T {
+    use crate::sens::one_cpt::{one_cpt_iv_bolus_amt_g, one_cpt_oral_amt_g};
+    use crate::sens::three_cpt::{three_cpt_iv_bolus_amt_g, three_cpt_oral_amt_g};
+    use crate::sens::two_cpt::{two_cpt_iv_bolus_amt_g, two_cpt_oral_amt_g};
+
+    let one = T::from_f64(1.0);
     // Central is cmt 2 for oral models (depot is cmt 1), cmt 1 for IV models.
     let central = if pk_model.is_oral() { 2 } else { 1 };
 
     if cmt == central {
         // IV-bolus impulse directly into the central compartment.
         match pk_model {
-            PkModel::OneCptIv | PkModel::OneCptOral => one_cpt_iv_bolus_g::<f64>(a0, t, cl, v),
-            PkModel::TwoCptIv | PkModel::TwoCptOral => {
-                two_cpt_iv_bolus_g::<f64>(a0, t, cl, v, p.q(), p.v2())
-            }
+            PkModel::OneCptIv | PkModel::OneCptOral => one_cpt_iv_bolus_amt_g(a0, t, cl, v),
+            PkModel::TwoCptIv | PkModel::TwoCptOral => two_cpt_iv_bolus_amt_g(a0, t, cl, v, q, v2),
             PkModel::ThreeCptIv | PkModel::ThreeCptOral => {
-                three_cpt_iv_bolus_g::<f64>(a0, t, cl, v, p.q(), p.v2(), p.q3(), p.v3())
+                three_cpt_iv_bolus_amt_g(a0, t, cl, v, q, v2, q3, v3)
             }
         }
     } else if pk_model.is_oral() && cmt == 1 {
         // Pre-loaded depot amount: first-order absorption into central, F=1.
         match pk_model {
-            PkModel::OneCptOral => one_cpt_oral_g::<f64>(a0, t, cl, v, p.ka(), 1.0),
-            PkModel::TwoCptOral => two_cpt_oral_g::<f64>(a0, t, cl, v, p.q(), p.v2(), p.ka(), 1.0),
-            PkModel::ThreeCptOral => {
-                three_cpt_oral_g::<f64>(a0, t, cl, v, p.q(), p.v2(), p.q3(), p.v3(), p.ka(), 1.0)
-            }
-            _ => 0.0,
+            PkModel::OneCptOral => one_cpt_oral_amt_g(a0, t, cl, v, ka, one),
+            PkModel::TwoCptOral => two_cpt_oral_amt_g(a0, t, cl, v, q, v2, ka, one),
+            PkModel::ThreeCptOral => three_cpt_oral_amt_g(a0, t, cl, v, q, v2, q3, v3, ka, one),
+            _ => T::from_f64(0.0),
         }
     } else {
-        0.0
+        T::from_f64(0.0)
     }
 }
 

--- a/src/sens/one_cpt.rs
+++ b/src/sens/one_cpt.rs
@@ -15,20 +15,34 @@ use crate::types::DoseEvent;
 /// generic so the caller can seed it as a dual carrying the lagtime sensitivity
 /// (`∂t/∂lagtime = −1`); pass an `f64` for the plain prediction.
 pub fn one_cpt_iv_bolus_g<T: PkNum>(amt: f64, t: T, cl: T, v: T) -> T {
+    one_cpt_iv_bolus_amt_g(T::from_f64(amt), t, cl, v)
+}
+
+/// As [`one_cpt_iv_bolus_g`] but the amount `amt` is itself generic over
+/// [`PkNum`], so an analytical initial condition `A₀(θ,η)` (issue #524) threads
+/// its parameter sensitivity through the impulse. The single-dose path passes a
+/// constant `amt` via [`one_cpt_iv_bolus_g`]; the only formula lives here.
+pub fn one_cpt_iv_bolus_amt_g<T: PkNum>(amt: T, t: T, cl: T, v: T) -> T {
     if t.val() < 0.0 || v.val() <= 0.0 || cl.val() <= 0.0 {
         return T::from_f64(0.0);
     }
     let k = cl / v;
-    (T::from_f64(amt) / v) * (-(k * t)).exp()
+    (amt / v) * (-(k * t)).exp()
 }
 
 /// 1-cpt oral (first-order absorption), with the `KA ≈ k` L'Hôpital limit.
 pub fn one_cpt_oral_g<T: PkNum>(amt: f64, t: T, cl: T, v: T, ka: T, f_bio: T) -> T {
+    one_cpt_oral_amt_g(T::from_f64(amt), t, cl, v, ka, f_bio)
+}
+
+/// As [`one_cpt_oral_g`] but with a generic amount `amt` (issue #524). The
+/// initial-condition path passes `A₀` as a dual with `F = 1`.
+pub fn one_cpt_oral_amt_g<T: PkNum>(amt: T, t: T, cl: T, v: T, ka: T, f_bio: T) -> T {
     if t.val() < 0.0 || v.val() <= 0.0 || cl.val() <= 0.0 || ka.val() <= 0.0 {
         return T::from_f64(0.0);
     }
     let k = cl / v;
-    let d = f_bio * T::from_f64(amt);
+    let d = f_bio * amt;
     if (ka.val() - k.val()).abs() < 1e-6 {
         (d * ka / v) * t * (-(k * t)).exp()
     } else {

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -236,6 +236,45 @@ fn init_supported(model: &CompiledModel) -> bool {
 /// (the `Dual2<M>` dispatch table). Beyond this the scale falls back to FD.
 const MAX_SCALE_AXES: usize = 16;
 
+/// Monomorphize the analytic `[initial_conditions]` impulse on a runtime axis
+/// count, dispatching `$apply::<K>(args…)` over the `1..=MAX_SCALE_AXES` table.
+/// Written **once** so the inner ([`apply_analytical_init_inner`], dispatched on
+/// `n_eta`) and outer ([`apply_analytical_init_outer`], dispatched on
+/// `n_theta + n_eta`) paths can never drift to different axis tables. The `_` arm is
+/// unreachable for a supported init model: `init_supported` bounds `n_theta + n_eta`
+/// to `1..=MAX_SCALE_AXES`, and each path's axis count is `≤ n_theta + n_eta`.
+macro_rules! dispatch_init_impulse {
+    ($axes:expr, $apply:ident, $($arg:expr),+ $(,)?) => {
+        match $axes {
+            1 => $apply::<1>($($arg),+),
+            2 => $apply::<2>($($arg),+),
+            3 => $apply::<3>($($arg),+),
+            4 => $apply::<4>($($arg),+),
+            5 => $apply::<5>($($arg),+),
+            6 => $apply::<6>($($arg),+),
+            7 => $apply::<7>($($arg),+),
+            8 => $apply::<8>($($arg),+),
+            9 => $apply::<9>($($arg),+),
+            10 => $apply::<10>($($arg),+),
+            11 => $apply::<11>($($arg),+),
+            12 => $apply::<12>($($arg),+),
+            13 => $apply::<13>($($arg),+),
+            14 => $apply::<14>($($arg),+),
+            15 => $apply::<15>($($arg),+),
+            16 => $apply::<16>($($arg),+),
+            _ => {}
+        }
+    };
+}
+
+// The `dispatch_init_impulse!` table is hand-written for `1..=16`. If the axis cap
+// changes, the table (and the scale-program dispatch tables) must change with it —
+// fail to compile rather than silently drop the init impulse on the `_` arm.
+const _: () = assert!(
+    MAX_SCALE_AXES == 16,
+    "dispatch_init_impulse! enumerates 1..=16; update it when MAX_SCALE_AXES changes",
+);
+
 /// Maximum `(θ, η)` axis count (`n_theta + n_eta`) for the TV-cov event-driven dual
 /// walk. The outer `run_obs_tvcov` (`m_dim`) and inner `run_obs_grad_tvcov` (`n_eta
 /// ≤ m_dim`) dispatch tables both enumerate `1..=MAX_TVCOV_AXES`, and
@@ -533,8 +572,12 @@ pub fn iov_analytical_supported(model: &CompiledModel) -> bool {
     if !matches!(model.scaling, ScalingSpec::None) || model.log_transform || model.has_lagtime() {
         return false;
     }
-    // Initial-compartment amounts (#521) are not yet differentiated by the
-    // analytic kernels — fall back to FD (see `analytical_supported`).
+    // Initial-compartment amounts (#521) ARE differentiable by the analytic kernels
+    // now (#524), but only on the dose-superposition path: the init impulse is
+    // layered per-subject in `subject_sensitivities` / `subject_eta_grad`, not in the
+    // IOV event-driven walk, which would have to re-seed the `A₀·kernel` baseline into
+    // each occasion block. Until that occasion-block seeding lands, an IOV + init
+    // model falls back to FD (see `analytical_supported` for the non-IOV exact path).
     if !model.analytical_init.is_empty() {
         return false;
     }
@@ -975,6 +1018,19 @@ fn run_obs_iov<const M: usize>(
 /// [`pd_from_program`](crate::sens::ode_provider::pd_from_program).
 pub fn tvcov_analytical_supported(model: &CompiledModel) -> bool {
     if !analytical_supported(model) || model.has_lagtime() || model.log_transform {
+        return false;
+    }
+    // The TV-cov event-driven walk does not yet layer the analytic
+    // `[initial_conditions]` impulse — #524 added exact init gradients only to the
+    // dose-superposition path (`subject_sensitivities` / `subject_eta_grad`), not to
+    // `run_obs_tvcov`. Production's `compute_predictions_with_tv`, however, always
+    // adds the `A₀·kernel` baseline. Admitting an init model here would walk a
+    // gradient that omits the init while the objective keeps it — a silent mismatch
+    // that biases the FOCE/FOCEI gradient (outer and inner). Decline init models so
+    // their TV-cov / oral-infusion subjects fall back to FD (which differentiates the
+    // true objective); their non-TV-cov subjects still take the exact init path. Lift
+    // this once the walk carries the init impulse (#524 follow-up).
+    if !model.analytical_init.is_empty() {
         return false;
     }
     // Bound total axes to the dual-walk dispatch cap so the outer (`m_dim`) and inner
@@ -1634,23 +1690,24 @@ fn subject_eta_grad_impl(
     let mut out = disp!(1, 2, 3, 4, 5, 6, 7, 8, 9)?;
     // Analytic `[initial_conditions]` impulse (#524): η-gradient only, layered on
     // BEFORE scaling — same insertion order as the f64 `pk::add_analytical_init`.
-    // `analytical_supported` (`init_supported`) bounds `n_theta + n_eta` to the
-    // dispatch table, and the inner path declines `ExpressionScale` above, so the
-    // `_ => {}` arm is unreachable for an init model that gets here.
+    // The inner path runs on `Dual1<n_eta>`, so it dispatches on `n_eta` (≤ the
+    // `n_theta + n_eta` that `init_supported` bounds to the table). The inner path
+    // declines `ExpressionScale` above, so the `_` arm is unreachable here.
     if !model.analytical_init.is_empty() {
-        let n_theta = model.n_theta;
-        macro_rules! disp_init {
-            ($($mm:literal),+) => {
-                match n_theta + n_eta {
-                    $($mm => apply_analytical_init_inner::<$mm>(
-                        &mut out, model, subject, &pk, &dp_deta, &slots, theta, eta,
-                        &subject.covariates, n_theta, n_eta,
-                    ),)+
-                    _ => {}
-                }
-            };
-        }
-        disp_init!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+        dispatch_init_impulse!(
+            n_eta,
+            apply_analytical_init_inner,
+            &mut out,
+            model,
+            subject,
+            &pk,
+            &dp_deta,
+            &slots,
+            theta,
+            eta,
+            &subject.covariates,
+            n_eta
+        );
     }
     // Constant `ScalarScale` output divisor: `f_scaled = f/k`, and `∂f/∂η` is
     // linear in `f` so it divides by the same `k` (η-independent). Matches
@@ -1945,46 +2002,43 @@ fn pk_slot_dual_outer<const M: usize>(
 }
 
 /// First-order counterpart of [`pk_slot_dual_outer`] for the inner η-gradient:
-/// only the η axes carry derivatives (from `dp_deta`); θ axes and the Hessian
-/// stay zero (the inner path consumes neither). Still a `Dual2<M>` so the same
-/// `eval_scale_dual` / init-impulse code differentiates it; the unused blocks are
-/// just zero.
-fn pk_slot_dual_inner<const M: usize>(
+/// a `Dual1<N>` (`N = n_eta`) seeded with `∂p/∂η_k` on axis `k` (from `dp_deta`).
+/// The inner EBE loop consumes only `∂f/∂η`, so this drops the θ axes and the
+/// `Dual2` Hessian the outer path carries — the η axes alone (no `n_theta` offset).
+/// A slot the program references but the provider does not differentiate
+/// (`slots` miss) enters as a constant.
+fn pk_slot_dual_inner<const N: usize>(
     slot: usize,
     value: f64,
     dp_deta: &[Vec<f64>],
     slots: &[usize],
-    n_theta: usize,
     n_eta: usize,
-) -> Dual2<M> {
+) -> Dual1<N> {
     match slots.iter().position(|&x| x == slot) {
         Some(j) => {
-            let mut grad = [0.0; M];
-            for k in 0..n_eta {
-                if n_theta + k < M {
-                    grad[n_theta + k] = dp_deta[j][k];
-                }
+            let mut grad = [0.0; N];
+            for k in 0..n_eta.min(N) {
+                grad[k] = dp_deta[j][k];
             }
-            Dual2 {
-                value,
-                grad,
-                hess: [[0.0; M]; M],
-            }
+            Dual1 { value, grad }
         }
-        None => Dual2::constant(value),
+        None => Dual1::constant(value),
     }
 }
 
 /// The seven PK-param duals the init impulse reads, built from a per-slot dual
 /// constructor. Order matches [`crate::pk::analytical_init_concentration_g`].
-struct InitPkDuals<const M: usize> {
-    cl: Dual2<M>,
-    v: Dual2<M>,
-    q: Dual2<M>,
-    v2: Dual2<M>,
-    ka: Dual2<M>,
-    q3: Dual2<M>,
-    v3: Dual2<M>,
+/// Generic over the seeded number type `T` so the outer path runs it as
+/// `Dual2<M>` (full `(θ,η)` jet + Hessian) and the inner path as `Dual1<n_eta>`
+/// (η-gradient only, no θ axes, no Hessian).
+struct InitPkDuals<T: crate::sens::num::PkNum> {
+    cl: T,
+    v: T,
+    q: T,
+    v2: T,
+    ka: T,
+    q3: T,
+    v3: T,
 }
 
 /// Add the analytic `[initial_conditions]` impulse to an already-computed jet
@@ -1992,22 +2046,23 @@ struct InitPkDuals<const M: usize> {
 /// scaling — the same insertion point as the f64 `pk::add_analytical_init` — so
 /// this runs after `run_obs`/`run_obs_grad` and before the scale/LTBS transforms.
 ///
-/// `a0_dual(prog)` evaluates the baseline amount `A₀` and its `(θ, η)` jet from
-/// the init program; `pk` supplies the seven PK-param duals. The impulse jet
-/// comes from [`crate::pk::analytical_init_concentration_g`] over `Dual2<M>`, so
+/// `a0_dual(prog)` evaluates the baseline amount `A₀` and its jet from the init
+/// program; `pk` supplies the seven PK-param duals. The impulse jet comes from
+/// [`crate::pk::analytical_init_concentration_g`] over the seeded type `T`, so
 /// `∂C/∂A₀` and `∂C/∂(CL,V,…)` are exact. `add(j, &c)` folds observation `j`'s
-/// impulse into the caller's jet (full Hessian for the outer path, value+grad for
-/// the inner). A reset (EVID=3/4) wipes the baseline, so observations at/after the
-/// first reset get none — matching `add_analytical_init_with`.
-fn add_init_impulse<const M: usize, FA, FAdd>(
+/// impulse into the caller's jet (full `Dual2` Hessian for the outer path, the
+/// `Dual1` η-gradient for the inner). A reset (EVID=3/4) wipes the baseline, so
+/// observations at/after the first reset get none — matching `add_analytical_init_with`.
+fn add_init_impulse<T, FA, FAdd>(
     model: &CompiledModel,
     subject: &Subject,
-    pk: &InitPkDuals<M>,
+    pk: &InitPkDuals<T>,
     mut a0_dual: FA,
     mut add: FAdd,
 ) where
-    FA: FnMut(&crate::parser::model_parser::ScaleDerivProgram) -> Dual2<M>,
-    FAdd: FnMut(usize, &Dual2<M>),
+    T: crate::sens::num::PkNum,
+    FA: FnMut(&crate::parser::model_parser::ScaleDerivProgram) -> T,
+    FAdd: FnMut(usize, &T),
 {
     let first_reset = subject
         .reset_times
@@ -2019,18 +2074,26 @@ fn add_init_impulse<const M: usize, FA, FAdd>(
             continue;
         };
         let a0 = a0_dual(prog);
-        if a0.value == 0.0 || !a0.value.is_finite() {
+        // Skip only a non-finite amount. Unlike the f64 value path
+        // (`add_analytical_init_with`), which drops `A₀ == 0` because it adds zero
+        // concentration, the gradient must NOT be dropped at `A₀ == 0`: the impulse
+        // is `C = A₀·kernel(t, pk)`, so `∂C/∂(θ,η) = kernel·∂A₀/∂(θ,η)` is nonzero
+        // wherever the amount has nonzero parameter sensitivity (e.g. an additive
+        // form passing through zero). Skipping there would zero a gradient component
+        // an FD of the objective still sees. With `A₀.val() == 0` the kernel jet
+        // folds value 0 and the correct `kernel·∂A₀/∂(θ,η)` gradient.
+        if !a0.val().is_finite() {
             continue;
         }
         for (j, &t) in subject.obs_times.iter().enumerate() {
             if t < 0.0 || t >= first_reset {
                 continue;
             }
-            let c = crate::pk::analytical_init_concentration_g::<Dual2<M>>(
+            let c = crate::pk::analytical_init_concentration_g::<T>(
                 model.pk_model,
                 init.cmt,
                 a0,
-                Dual2::constant(t),
+                T::from_f64(t),
                 pk.cl,
                 pk.v,
                 pk.q,
@@ -2071,7 +2134,7 @@ fn apply_analytical_init_outer<const M: usize>(
         q3: dual(PK_IDX_Q3, pk.q3()),
         v3: dual(PK_IDX_V3, pk.v3()),
     };
-    add_init_impulse::<M, _, _>(
+    add_init_impulse::<Dual2<M>, _, _>(
         model,
         subject,
         &pkd,
@@ -2107,10 +2170,13 @@ fn apply_analytical_init_outer<const M: usize>(
     );
 }
 
-/// Inner (Dual1-equivalent) analytic init impulse: η-gradient only, folded into
-/// `out`. Uses [`pk_slot_dual_inner`] (η axes carry derivatives, θ/Hessian zero).
+/// Inner analytic init impulse: η-gradient only, folded into `out`. Runs on
+/// `Dual1<N>` (`N = n_eta`) via [`pk_slot_dual_inner`] and
+/// [`ScaleDerivProgram::eval_scale_dual1`] — no θ axes, no Hessian, so the dual
+/// width is `n_eta` rather than the outer path's `n_theta + n_eta`, and `c.grad[k]`
+/// is `∂C/∂η_k` directly (no `n_theta` offset).
 #[allow(clippy::too_many_arguments)]
-fn apply_analytical_init_inner<const M: usize>(
+fn apply_analytical_init_inner<const N: usize>(
     out: &mut [ObsGrad],
     model: &CompiledModel,
     subject: &Subject,
@@ -2120,11 +2186,9 @@ fn apply_analytical_init_inner<const M: usize>(
     theta: &[f64],
     eta: &[f64],
     cov: &std::collections::HashMap<String, f64>,
-    n_theta: usize,
     n_eta: usize,
 ) {
-    let dual =
-        |slot: usize, val: f64| pk_slot_dual_inner::<M>(slot, val, dp_deta, slots, n_theta, n_eta);
+    let dual = |slot: usize, val: f64| pk_slot_dual_inner::<N>(slot, val, dp_deta, slots, n_eta);
     let pkd = InitPkDuals {
         cl: dual(PK_IDX_CL, pk.cl()),
         v: dual(PK_IDX_V, pk.v()),
@@ -2134,23 +2198,23 @@ fn apply_analytical_init_inner<const M: usize>(
         q3: dual(PK_IDX_Q3, pk.q3()),
         v3: dual(PK_IDX_V3, pk.v3()),
     };
-    add_init_impulse::<M, _, _>(
+    add_init_impulse::<Dual1<N>, _, _>(
         model,
         subject,
         &pkd,
         |prog| {
-            let var_duals: Vec<Dual2<M>> = prog
+            let var_duals: Vec<Dual1<N>> = prog
                 .var_to_pk_slot()
                 .iter()
                 .map(|&s| dual(s, pk.values.get(s).copied().unwrap_or(0.0)))
                 .collect();
-            prog.eval_scale_dual::<M>(theta, eta, cov, &var_duals)
+            prog.eval_scale_dual1::<N>(theta, eta, cov, &var_duals)
         },
         |j, c| {
             if let Some(o) = out.get_mut(j) {
                 o.f += c.value;
-                for k in 0..n_eta {
-                    o.df_deta[k] += c.grad[n_theta + k];
+                for k in 0..n_eta.min(N) {
+                    o.df_deta[k] += c.grad[k];
                 }
             }
         },
@@ -2348,18 +2412,21 @@ fn subject_sensitivities_impl(
     // `(θ, η)` axis count `n_theta + n_eta` (init programs use the same layout as
     // the scale program); `init_supported` bounds it to the table.
     if !model.analytical_init.is_empty() {
-        macro_rules! disp_init {
-            ($($mm:literal),+) => {
-                match n_theta + n_eta {
-                    $($mm => apply_analytical_init_outer::<$mm>(
-                        &mut sens, model, subject, &pk, &pd, &slots, theta, eta,
-                        &subject.covariates, n_theta, n_eta,
-                    ),)+
-                    _ => {}
-                }
-            };
-        }
-        disp_init!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+        dispatch_init_impulse!(
+            n_theta + n_eta,
+            apply_analytical_init_outer,
+            &mut sens,
+            model,
+            subject,
+            &pk,
+            &pd,
+            &slots,
+            theta,
+            eta,
+            &subject.covariates,
+            n_theta,
+            n_eta
+        );
     }
     // Constant `ScalarScale` output divisor: `f_scaled = f/k`. Every derivative is
     // linear in `f` and `k` is constant (`∂k/∂η = ∂k/∂θ = 0`), so the whole jet
@@ -3215,6 +3282,127 @@ mod tests {
                 }
             }
         }
+    }
+
+    // 1-cpt IV with WT-on-CL *and* an `[initial_conditions]` baseline. Regression
+    // for the #527/#524 review: the TV-cov event-driven walk does not layer the init
+    // impulse, so an init model must decline TV-cov analytic support and route its
+    // TV-cov subjects to FD — otherwise the analytic gradient omits the init baseline
+    // while the objective keeps it.
+    const ONECPT_IV_TVCOV_INIT: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta THETA_WT(0.75, 0.01, 2.0)
+  theta TVC0(4.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  sigma PROP_ERR ~ 0.2 (sd)
+[individual_parameters]
+  CL = TVCL * (WT/70)^THETA_WT * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[initial_conditions]
+  init(central) = TVC0 * V
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    /// #527/#524 review (finding #1): an `[initial_conditions]` model whose subject
+    /// has time-varying covariates must fall back to FD, because the TV-cov walk
+    /// never layers the init impulse. Before the fix `tvcov_analytical_supported`
+    /// returned `true` for the model and the walk silently dropped the `A₀·kernel`
+    /// baseline from the FOCE/FOCEI gradient (outer and inner) while the objective —
+    /// which uses the init-aware f64 predictor — kept it, biasing the estimates. The
+    /// non-TV-cov subjects of the same model must still take the exact init path.
+    #[test]
+    fn analytical_init_tvcov_subject_falls_back_to_fd() {
+        let m = parse_model_string(ONECPT_IV_TVCOV_INIT).expect("parse");
+        assert_eq!(m.analytical_init.len(), 1, "init parsed");
+        assert!(
+            !tvcov_analytical_supported(&m),
+            "init model must decline TV-cov analytic support (walk omits the init)"
+        );
+
+        let theta = vec![0.2, 10.0, 0.75, 4.0];
+        let eta = vec![0.15, -0.10];
+
+        // TV-cov subject (WT changes across records): outer full provider AND inner
+        // η-gradient must decline so the caller falls back to FD.
+        let tv = tvcov_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            &[70.0],
+            &[1.0, 2.0, 4.0, 8.0],
+            &[70.0, 80.0, 90.0, 100.0],
+            Vec::new(),
+            Vec::new(),
+            &[],
+        );
+        assert!(tv.has_tv_covariates(), "fixture must carry TV covariates");
+        assert!(
+            subject_sensitivities(&m, &tv, &theta, &eta).is_none(),
+            "TV-cov init subject must fall back to FD, not the init-less walk"
+        );
+        assert!(
+            subject_eta_grad(&m, &tv, &theta, &eta).is_none(),
+            "inner η-gradient must fall back to FD too"
+        );
+
+        // A static-covariate subject of the SAME model still takes the exact analytic
+        // init path (dose superposition + layered impulse).
+        let mut stat = oral_subject(&[1.0, 2.0, 4.0, 8.0]);
+        stat.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        stat.covariates = wt_map(70.0);
+        assert!(!stat.has_tv_covariates(), "static-covariate subject");
+        assert!(
+            subject_sensitivities(&m, &stat, &theta, &eta).is_some(),
+            "static-covariate init subject keeps the exact analytic init path"
+        );
+    }
+
+    // 1-cpt IV with `init(central) = TVC0 * V` and a `TVC0` bound that admits zero.
+    // At `TVC0 = 0` the baseline amount `A₀` is exactly 0 but `∂A₀/∂TVC0 = V ≠ 0`.
+    const ONECPT_IV_INIT_ZERO: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVC0(0.0, -50.0, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  sigma PROP_ERR ~ 0.2 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[initial_conditions]
+  init(central) = TVC0 * V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    /// #527/#524 review (finding #2): when the init amount evaluates to exactly 0 but
+    /// has nonzero parameter sensitivity, the gradient must NOT be dropped. Evaluated
+    /// at `TVC0 = 0`, `A₀ = 0` yet `∂A₀/∂TVC0 = V`, so the init contributes 0 to the
+    /// value but `V·kernel` to `∂f/∂TVC0` (and the mixed `∂²f/∂η∂TVC0`). Before the
+    /// fix `add_init_impulse` skipped the whole impulse on `A₀ == 0`, zeroing those
+    /// derivatives; the FD of the objective sees the nonzero slope, so the full
+    /// provider jet (checked here) diverged from FD on the `TVC0` axis.
+    #[test]
+    fn analytical_init_zero_amount_keeps_gradient() {
+        let m = parse_model_string(ONECPT_IV_INIT_ZERO).expect("parse");
+        assert_eq!(m.analytical_init.len(), 1, "init parsed");
+        assert!(
+            analytical_supported(&m),
+            "model must use the analytic provider"
+        );
+        let mut s = oral_subject(&[1.0, 2.0, 4.0, 8.0, 24.0]);
+        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        // TVC0 = 0 → A₀ = 0 exactly, the boundary the dropped-gradient bug lived on.
+        check_full_provider_vs_fd(&m, &s, &[0.2, 10.0, 0.0], &[0.1, -0.1]);
     }
 
     // 2-cpt IV with an *additive* η on V1 (`V1 = TVV1 + ETA_V1`): a non-log-normal

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -211,15 +211,25 @@ pub fn analytical_supported(model: &CompiledModel) -> bool {
         && model.tv_fn.is_some()
         && model.n_kappa == 0
         && scaling_supported(model)
-        // Initial-compartment amounts (`[initial_conditions]`, #521) are added to
-        // the prediction by `pk::add_analytical_init` but the Dual2 sensitivity
-        // kernels here do not yet carry the init impulse or its θ/η dependence, so
-        // a model with one falls back to FD (correct, just slower). Phase 2 lifts
-        // this once the `*_init_g` differentiable forms land.
-        && model.analytical_init.is_empty()
+        && init_supported(model)
         // Every individual-parameter slot must be one we differentiate. A
         // LAGTIME (slot 8) routes to fall back.
         && model.pk_indices.iter().all(|&s| slot_to_dim(s).is_some())
+}
+
+/// Whether the model's `[initial_conditions]` baseline (#521) is one the Dual2
+/// provider differentiates exactly (#524): every init carries a compiled
+/// `amount_deriv` program and the `(θ, η)` axis count fits the init dispatch
+/// table (`1..=MAX_SCALE_AXES`, shared with the scale program). An init-free
+/// model is trivially supported; a hand-built init with no program, or a model
+/// with more axes than the table covers, routes to FD (correct, just slower).
+fn init_supported(model: &CompiledModel) -> bool {
+    model.analytical_init.is_empty()
+        || (model
+            .analytical_init
+            .iter()
+            .all(|i| i.amount_deriv.is_some())
+            && (1..=MAX_SCALE_AXES).contains(&(model.n_theta + model.n_eta)))
 }
 
 /// Maximum `(θ, η)` axis count for the differentiable `ExpressionScale` program
@@ -1622,6 +1632,26 @@ fn subject_eta_grad_impl(
         };
     }
     let mut out = disp!(1, 2, 3, 4, 5, 6, 7, 8, 9)?;
+    // Analytic `[initial_conditions]` impulse (#524): η-gradient only, layered on
+    // BEFORE scaling — same insertion order as the f64 `pk::add_analytical_init`.
+    // `analytical_supported` (`init_supported`) bounds `n_theta + n_eta` to the
+    // dispatch table, and the inner path declines `ExpressionScale` above, so the
+    // `_ => {}` arm is unreachable for an init model that gets here.
+    if !model.analytical_init.is_empty() {
+        let n_theta = model.n_theta;
+        macro_rules! disp_init {
+            ($($mm:literal),+) => {
+                match n_theta + n_eta {
+                    $($mm => apply_analytical_init_inner::<$mm>(
+                        &mut out, model, subject, &pk, &dp_deta, &slots, theta, eta,
+                        &subject.covariates, n_theta, n_eta,
+                    ),)+
+                    _ => {}
+                }
+            };
+        }
+        disp_init!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    }
     // Constant `ScalarScale` output divisor: `f_scaled = f/k`, and `∂f/∂η` is
     // linear in `f` so it divides by the same `k` (η-independent). Matches
     // `pk::apply_scaling` (`pred /= s`). Other scaling variants are gated out.
@@ -1801,46 +1831,21 @@ fn apply_expression_scale<const M: usize>(
     n_theta: usize,
     n_eta: usize,
 ) {
-    // Build the dual for each PK slot the scale references: value + ∂p/∂(θ,η),
-    // with the unused θ-θ Hessian block left zero (the quotient rule only reads
-    // η-η and η-θ). PK params not in `slots` (literal constants / undifferentiated)
-    // enter as constants.
+    // Build the dual for each PK slot the scale references: value + ∂p/∂(θ,η) +
+    // η-η / η-θ Hessian (the quotient rule only reads those). PK params not in
+    // `slots` enter as constants. Shared with the analytic init impulse (#524).
     let var_duals: Vec<Dual2<M>> = prog
         .var_to_pk_slot()
         .iter()
-        .map(|&s| match slots.iter().position(|&x| x == s) {
-            Some(j) => {
-                let mut grad = [0.0; M];
-                let mut hess = [[0.0; M]; M];
-                for m in 0..n_theta.min(M) {
-                    grad[m] = pd.dp_dtheta[j][m];
-                }
-                for k in 0..n_eta {
-                    if n_theta + k < M {
-                        grad[n_theta + k] = pd.dp_deta[j][k];
-                    }
-                }
-                for k in 0..n_eta {
-                    for l in 0..n_eta {
-                        if n_theta + k < M && n_theta + l < M {
-                            hess[n_theta + k][n_theta + l] = pd.d2p_deta2[j][k][l];
-                        }
-                    }
-                    for m in 0..n_theta {
-                        if n_theta + k < M && m < M {
-                            let v = pd.d2p_detadtheta[j][k][m];
-                            hess[n_theta + k][m] = v;
-                            hess[m][n_theta + k] = v;
-                        }
-                    }
-                }
-                Dual2 {
-                    value: pk.values.get(s).copied().unwrap_or(0.0),
-                    grad,
-                    hess,
-                }
-            }
-            None => Dual2::constant(pk.values.get(s).copied().unwrap_or(0.0)),
+        .map(|&s| {
+            pk_slot_dual_outer::<M>(
+                s,
+                pk.values.get(s).copied().unwrap_or(0.0),
+                pd,
+                slots,
+                n_theta,
+                n_eta,
+            )
         })
         .collect();
 
@@ -1891,6 +1896,265 @@ fn apply_expression_scale<const M: usize>(
         }
         o.f = f * inv;
     }
+}
+
+/// Build the `Dual2<M>` for PK slot `slot` in `(θ, η)`-axis layout (axes
+/// `0..n_theta` are θ, `n_theta + k` is `η_k`), carrying value + `∂p/∂(θ,η)` +
+/// the η-η / η-θ Hessian blocks from the outer `ParamDerivs`. A slot the program
+/// references but the provider does not differentiate (`slots` miss) enters as a
+/// constant. Shared by the `ExpressionScale` quotient path and the analytic init
+/// impulse (#524) so both seed PK params identically.
+fn pk_slot_dual_outer<const M: usize>(
+    slot: usize,
+    value: f64,
+    pd: &crate::sens::ode_provider::ParamDerivs,
+    slots: &[usize],
+    n_theta: usize,
+    n_eta: usize,
+) -> Dual2<M> {
+    match slots.iter().position(|&x| x == slot) {
+        Some(j) => {
+            let mut grad = [0.0; M];
+            let mut hess = [[0.0; M]; M];
+            for m in 0..n_theta.min(M) {
+                grad[m] = pd.dp_dtheta[j][m];
+            }
+            for k in 0..n_eta {
+                if n_theta + k < M {
+                    grad[n_theta + k] = pd.dp_deta[j][k];
+                }
+            }
+            for k in 0..n_eta {
+                for l in 0..n_eta {
+                    if n_theta + k < M && n_theta + l < M {
+                        hess[n_theta + k][n_theta + l] = pd.d2p_deta2[j][k][l];
+                    }
+                }
+                for m in 0..n_theta {
+                    if n_theta + k < M && m < M {
+                        let v = pd.d2p_detadtheta[j][k][m];
+                        hess[n_theta + k][m] = v;
+                        hess[m][n_theta + k] = v;
+                    }
+                }
+            }
+            Dual2 { value, grad, hess }
+        }
+        None => Dual2::constant(value),
+    }
+}
+
+/// First-order counterpart of [`pk_slot_dual_outer`] for the inner η-gradient:
+/// only the η axes carry derivatives (from `dp_deta`); θ axes and the Hessian
+/// stay zero (the inner path consumes neither). Still a `Dual2<M>` so the same
+/// `eval_scale_dual` / init-impulse code differentiates it; the unused blocks are
+/// just zero.
+fn pk_slot_dual_inner<const M: usize>(
+    slot: usize,
+    value: f64,
+    dp_deta: &[Vec<f64>],
+    slots: &[usize],
+    n_theta: usize,
+    n_eta: usize,
+) -> Dual2<M> {
+    match slots.iter().position(|&x| x == slot) {
+        Some(j) => {
+            let mut grad = [0.0; M];
+            for k in 0..n_eta {
+                if n_theta + k < M {
+                    grad[n_theta + k] = dp_deta[j][k];
+                }
+            }
+            Dual2 {
+                value,
+                grad,
+                hess: [[0.0; M]; M],
+            }
+        }
+        None => Dual2::constant(value),
+    }
+}
+
+/// The seven PK-param duals the init impulse reads, built from a per-slot dual
+/// constructor. Order matches [`crate::pk::analytical_init_concentration_g`].
+struct InitPkDuals<const M: usize> {
+    cl: Dual2<M>,
+    v: Dual2<M>,
+    q: Dual2<M>,
+    v2: Dual2<M>,
+    ka: Dual2<M>,
+    q3: Dual2<M>,
+    v3: Dual2<M>,
+}
+
+/// Add the analytic `[initial_conditions]` impulse to an already-computed jet
+/// (#524). The init contributes `A₀ · kernel(t, pk)` to the prediction *before*
+/// scaling — the same insertion point as the f64 `pk::add_analytical_init` — so
+/// this runs after `run_obs`/`run_obs_grad` and before the scale/LTBS transforms.
+///
+/// `a0_dual(prog)` evaluates the baseline amount `A₀` and its `(θ, η)` jet from
+/// the init program; `pk` supplies the seven PK-param duals. The impulse jet
+/// comes from [`crate::pk::analytical_init_concentration_g`] over `Dual2<M>`, so
+/// `∂C/∂A₀` and `∂C/∂(CL,V,…)` are exact. `add(j, &c)` folds observation `j`'s
+/// impulse into the caller's jet (full Hessian for the outer path, value+grad for
+/// the inner). A reset (EVID=3/4) wipes the baseline, so observations at/after the
+/// first reset get none — matching `add_analytical_init_with`.
+fn add_init_impulse<const M: usize, FA, FAdd>(
+    model: &CompiledModel,
+    subject: &Subject,
+    pk: &InitPkDuals<M>,
+    mut a0_dual: FA,
+    mut add: FAdd,
+) where
+    FA: FnMut(&crate::parser::model_parser::ScaleDerivProgram) -> Dual2<M>,
+    FAdd: FnMut(usize, &Dual2<M>),
+{
+    let first_reset = subject
+        .reset_times
+        .iter()
+        .copied()
+        .fold(f64::INFINITY, f64::min);
+    for init in &model.analytical_init {
+        let Some(prog) = &init.amount_deriv else {
+            continue;
+        };
+        let a0 = a0_dual(prog);
+        if a0.value == 0.0 || !a0.value.is_finite() {
+            continue;
+        }
+        for (j, &t) in subject.obs_times.iter().enumerate() {
+            if t < 0.0 || t >= first_reset {
+                continue;
+            }
+            let c = crate::pk::analytical_init_concentration_g::<Dual2<M>>(
+                model.pk_model,
+                init.cmt,
+                a0,
+                Dual2::constant(t),
+                pk.cl,
+                pk.v,
+                pk.q,
+                pk.v2,
+                pk.ka,
+                pk.q3,
+                pk.v3,
+            );
+            add(j, &c);
+        }
+    }
+}
+
+/// Outer (Dual2) analytic init impulse: builds PK-param + amount duals from the
+/// full `ParamDerivs` and folds value + `∂/∂(θ,η)` + η-η / η-θ Hessian into `sens`.
+#[allow(clippy::too_many_arguments)]
+fn apply_analytical_init_outer<const M: usize>(
+    sens: &mut SubjectSens,
+    model: &CompiledModel,
+    subject: &Subject,
+    pk: &crate::types::PkParams,
+    pd: &crate::sens::ode_provider::ParamDerivs,
+    slots: &[usize],
+    theta: &[f64],
+    eta: &[f64],
+    cov: &std::collections::HashMap<String, f64>,
+    n_theta: usize,
+    n_eta: usize,
+) {
+    let dual =
+        |slot: usize, val: f64| pk_slot_dual_outer::<M>(slot, val, pd, slots, n_theta, n_eta);
+    let pkd = InitPkDuals {
+        cl: dual(PK_IDX_CL, pk.cl()),
+        v: dual(PK_IDX_V, pk.v()),
+        q: dual(PK_IDX_Q, pk.q()),
+        v2: dual(PK_IDX_V2, pk.v2()),
+        ka: dual(PK_IDX_KA, pk.ka()),
+        q3: dual(PK_IDX_Q3, pk.q3()),
+        v3: dual(PK_IDX_V3, pk.v3()),
+    };
+    add_init_impulse::<M, _, _>(
+        model,
+        subject,
+        &pkd,
+        |prog| {
+            let var_duals: Vec<Dual2<M>> = prog
+                .var_to_pk_slot()
+                .iter()
+                .map(|&s| dual(s, pk.values.get(s).copied().unwrap_or(0.0)))
+                .collect();
+            prog.eval_scale_dual::<M>(theta, eta, cov, &var_duals)
+        },
+        |j, c| {
+            if let Some(o) = sens.obs.get_mut(j) {
+                o.f += c.value;
+                for k in 0..n_eta {
+                    o.df_deta[k] += c.grad[n_theta + k];
+                }
+                for m in 0..n_theta {
+                    o.df_dtheta[m] += c.grad[m];
+                }
+                for k in 0..n_eta {
+                    for l in 0..n_eta {
+                        o.d2f_deta2[k * n_eta + l] += c.hess[n_theta + k][n_theta + l];
+                    }
+                }
+                for k in 0..n_eta {
+                    for m in 0..n_theta {
+                        o.d2f_deta_dtheta[k * n_theta + m] += c.hess[n_theta + k][m];
+                    }
+                }
+            }
+        },
+    );
+}
+
+/// Inner (Dual1-equivalent) analytic init impulse: η-gradient only, folded into
+/// `out`. Uses [`pk_slot_dual_inner`] (η axes carry derivatives, θ/Hessian zero).
+#[allow(clippy::too_many_arguments)]
+fn apply_analytical_init_inner<const M: usize>(
+    out: &mut [ObsGrad],
+    model: &CompiledModel,
+    subject: &Subject,
+    pk: &crate::types::PkParams,
+    dp_deta: &[Vec<f64>],
+    slots: &[usize],
+    theta: &[f64],
+    eta: &[f64],
+    cov: &std::collections::HashMap<String, f64>,
+    n_theta: usize,
+    n_eta: usize,
+) {
+    let dual =
+        |slot: usize, val: f64| pk_slot_dual_inner::<M>(slot, val, dp_deta, slots, n_theta, n_eta);
+    let pkd = InitPkDuals {
+        cl: dual(PK_IDX_CL, pk.cl()),
+        v: dual(PK_IDX_V, pk.v()),
+        q: dual(PK_IDX_Q, pk.q()),
+        v2: dual(PK_IDX_V2, pk.v2()),
+        ka: dual(PK_IDX_KA, pk.ka()),
+        q3: dual(PK_IDX_Q3, pk.q3()),
+        v3: dual(PK_IDX_V3, pk.v3()),
+    };
+    add_init_impulse::<M, _, _>(
+        model,
+        subject,
+        &pkd,
+        |prog| {
+            let var_duals: Vec<Dual2<M>> = prog
+                .var_to_pk_slot()
+                .iter()
+                .map(|&s| dual(s, pk.values.get(s).copied().unwrap_or(0.0)))
+                .collect();
+            prog.eval_scale_dual::<M>(theta, eta, cov, &var_duals)
+        },
+        |j, c| {
+            if let Some(o) = out.get_mut(j) {
+                o.f += c.value;
+                for k in 0..n_eta {
+                    o.df_deta[k] += c.grad[n_theta + k];
+                }
+            }
+        },
+    );
 }
 
 /// True when an **oral** model carries an **infusion** dose (RATE>0 into the
@@ -2078,6 +2342,25 @@ fn subject_sensitivities_impl(
         };
     }
     let mut sens = disp!(1, 2, 3, 4, 5, 6, 7, 8, 9)?;
+    // Analytic `[initial_conditions]` impulse (#524): layer `A₀ · kernel(t, pk)`
+    // and its exact `(θ, η)` jet onto every observation BEFORE scaling — the same
+    // insertion order as the f64 `pk::add_analytical_init`. Dispatched on the
+    // `(θ, η)` axis count `n_theta + n_eta` (init programs use the same layout as
+    // the scale program); `init_supported` bounds it to the table.
+    if !model.analytical_init.is_empty() {
+        macro_rules! disp_init {
+            ($($mm:literal),+) => {
+                match n_theta + n_eta {
+                    $($mm => apply_analytical_init_outer::<$mm>(
+                        &mut sens, model, subject, &pk, &pd, &slots, theta, eta,
+                        &subject.covariates, n_theta, n_eta,
+                    ),)+
+                    _ => {}
+                }
+            };
+        }
+        disp_init!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    }
     // Constant `ScalarScale` output divisor: `f_scaled = f/k`. Every derivative is
     // linear in `f` and `k` is constant (`∂k/∂η = ∂k/∂θ = 0`), so the whole jet
     // divides by `k`. Matches `pk::apply_scaling` (`pred /= s`).
@@ -2771,6 +3054,168 @@ mod tests {
 [error_model]
   DV ~ proportional(PROP_ERR)
 "#;
+
+    // ── [initial_conditions] analytic gradient fixtures (#524) ──────────────
+    // 1-cpt oral with a parameter-dependent CENTRAL baseline `A₀ = TVC0 · V`
+    // (IV-bolus impulse kernel). A₀ depends on θ_TVC0, θ_TVV, and η_V, so the
+    // analytic ∂C/∂A₀ · ∂A₀/∂(θ,η) chain is exercised.
+    const ONECPT_ORAL_INIT_CENTRAL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta TVC0(5.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[initial_conditions]
+  init(central) = TVC0 * V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    // 1-cpt oral with a pre-loaded DEPOT baseline (oral first-order kernel, F=1).
+    const ONECPT_ORAL_INIT_DEPOT: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta TVD0(80.0, 0.01, 500.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[initial_conditions]
+  init(depot) = TVD0
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    // 2-cpt IV with a central baseline (2-cpt IV-bolus impulse kernel).
+    const TWOCPT_IV_INIT_CENTRAL: &str = r#"
+[parameters]
+  theta TVCL(10.0, 1.0, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(15.0, 1.0, 100.0)
+  theta TVV2(100.0, 10.0, 1000.0)
+  theta TVC0(3.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q  = TVQ
+  V2 = TVV2
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)
+[initial_conditions]
+  init(central) = TVC0 * V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    // 3-cpt IV with a central baseline (3-cpt IV-bolus impulse kernel).
+    const THREECPT_IV_INIT_CENTRAL: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.5, 50.0)
+  theta TVV1(10.0, 1.0, 100.0)
+  theta TVQ2(2.0, 0.1, 20.0)
+  theta TVV2(20.0, 2.0, 200.0)
+  theta TVQ3(1.5, 0.1, 20.0)
+  theta TVV3(30.0, 3.0, 300.0)
+  theta TVC0(4.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q2 = TVQ2
+  V2 = TVV2
+  Q3 = TVQ3
+  V3 = TVV3
+[structural_model]
+  pk three_cpt_iv(cl=CL, v1=V1, q2=Q2, v2=V2, q3=Q3, v3=V3)
+[initial_conditions]
+  init(central) = TVC0 * V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    /// The analytic `[initial_conditions]` impulse (#524) and its `(θ, η)` jet
+    /// must match central finite differences of the production predictor
+    /// `compute_predictions_with_tv` (which layers the f64 init), across the
+    /// 1-/2-/3-cpt central kernels and the oral-depot kernel. The light inner
+    /// η-gradient provider must agree with the full outer one too.
+    #[test]
+    fn analytical_init_provider_matches_fd() {
+        let cases: &[(&str, &str, Vec<f64>, Vec<f64>)] = &[
+            (
+                "1cpt oral central",
+                ONECPT_ORAL_INIT_CENTRAL,
+                vec![0.2, 10.0, 1.5, 5.0],
+                vec![0.15, -0.10, 0.25],
+            ),
+            (
+                "1cpt oral depot",
+                ONECPT_ORAL_INIT_DEPOT,
+                vec![0.2, 10.0, 1.5, 80.0],
+                vec![0.15, -0.10, 0.25],
+            ),
+            (
+                "2cpt iv central",
+                TWOCPT_IV_INIT_CENTRAL,
+                vec![10.0, 50.0, 15.0, 100.0, 3.0],
+                vec![0.12, -0.08],
+            ),
+            (
+                "3cpt iv central",
+                THREECPT_IV_INIT_CENTRAL,
+                vec![5.0, 10.0, 2.0, 20.0, 1.5, 30.0, 4.0],
+                vec![0.12, -0.08],
+            ),
+        ];
+        for (label, src, theta, eta) in cases {
+            let m = parse_model_string(src).unwrap_or_else(|e| panic!("{label}: parse: {e}"));
+            assert_eq!(m.analytical_init.len(), 1, "{label}: init parsed");
+            assert!(
+                analytical_supported(&m),
+                "{label}: init model must use the analytic provider, not FD"
+            );
+            let s = oral_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+            // Full outer jet (value, ∂η, ∂²η², ∂θ, ∂²η∂θ) vs central FD of the
+            // init-aware production predictor.
+            check_full_provider_vs_fd(&m, &s, theta, eta);
+            // Light inner η-gradient must agree with the full provider.
+            let full = subject_sensitivities(&m, &s, theta, eta).expect("full supported");
+            let light = subject_eta_grad(&m, &s, theta, eta).expect("light supported");
+            assert_eq!(light.len(), full.obs.len());
+            for (lo, fo) in light.iter().zip(full.obs.iter()) {
+                for k in 0..m.n_eta {
+                    approx::assert_relative_eq!(
+                        lo.df_deta[k],
+                        fo.df_deta[k],
+                        max_relative = 1e-9,
+                        epsilon = 1e-12
+                    );
+                }
+            }
+        }
+    }
 
     // 2-cpt IV with an *additive* η on V1 (`V1 = TVV1 + ETA_V1`): a non-log-normal
     // parameterization, so `∂V1/∂η = 1` (not `V1·sel`). Forces both providers down

--- a/src/sens/three_cpt.rs
+++ b/src/sens/three_cpt.rs
@@ -99,6 +99,23 @@ pub fn three_cpt_iv_bolus_g<T: PkNum>(
     q3: T,
     v3: T,
 ) -> T {
+    three_cpt_iv_bolus_amt_g(T::from_f64(amt), t, cl, v1, q2, v2, q3, v3)
+}
+
+/// As [`three_cpt_iv_bolus_g`] but with a generic amount `amt` (issue #524), so
+/// an analytical initial condition `A₀(θ,η)` threads its sensitivity through the
+/// central impulse. The single-dose path delegates here with a constant `amt`.
+#[allow(clippy::too_many_arguments)]
+pub fn three_cpt_iv_bolus_amt_g<T: PkNum>(
+    amt: T,
+    t: T,
+    cl: T,
+    v1: T,
+    q2: T,
+    v2: T,
+    q3: T,
+    v3: T,
+) -> T {
     if t.val() < 0.0 || v1.val() <= 0.0 || v2.val() <= 0.0 || v3.val() <= 0.0 || cl.val() <= 0.0 {
         return T::from_f64(0.0);
     }
@@ -113,7 +130,7 @@ pub fn three_cpt_iv_bolus_g<T: PkNum>(
     if ab.val().abs() < 1e-12 || ag.val().abs() < 1e-12 || bg.val().abs() < 1e-12 {
         return T::from_f64(0.0);
     }
-    let d = T::from_f64(amt) / v1;
+    let d = amt / v1;
     let a = d * (alpha - k21) * (alpha - k31) / (ab * ag);
     let b = d * (beta - k21) * (beta - k31) / (-(ab) * bg);
     let g = d * (gamma - k21) * (gamma - k31) / (ag * bg);
@@ -188,6 +205,24 @@ pub fn three_cpt_oral_g<T: PkNum>(
     ka: T,
     f_bio: T,
 ) -> T {
+    three_cpt_oral_amt_g(T::from_f64(amt), t, cl, v1, q2, v2, q3, v3, ka, f_bio)
+}
+
+/// As [`three_cpt_oral_g`] but with a generic amount `amt` (issue #524); the
+/// initial-condition path passes a pre-loaded depot `A₀` as a dual with `F = 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn three_cpt_oral_amt_g<T: PkNum>(
+    amt: T,
+    t: T,
+    cl: T,
+    v1: T,
+    q2: T,
+    v2: T,
+    q3: T,
+    v3: T,
+    ka: T,
+    f_bio: T,
+) -> T {
     if t.val() < 0.0
         || v1.val() <= 0.0
         || v2.val() <= 0.0
@@ -208,7 +243,7 @@ pub fn three_cpt_oral_g<T: PkNum>(
     if ab.val().abs() < 1e-12 || ag.val().abs() < 1e-12 || bg.val().abs() < 1e-12 {
         return T::from_f64(0.0);
     }
-    let coeff = f_bio * T::from_f64(amt) * ka / v1;
+    let coeff = f_bio * amt * ka / v1;
     let a = (alpha - k21) * (alpha - k31) / (ab * ag);
     let b = (beta - k21) * (beta - k31) / (-(ab) * bg);
     let c = (gamma - k21) * (gamma - k31) / (ag * bg);

--- a/src/sens/two_cpt.rs
+++ b/src/sens/two_cpt.rs
@@ -38,6 +38,13 @@ pub(crate) fn macro_rates_g<T: PkNum>(cl: T, v1: T, q: T, v2: T) -> (T, T, T) {
 /// 2-cpt IV bolus: `C = A·e^{−αt} + B·e^{−βt}`. `t` is generic so the caller can
 /// seed it as a dual carrying the lagtime sensitivity (`∂t/∂lagtime = −1`).
 pub fn two_cpt_iv_bolus_g<T: PkNum>(amt: f64, t: T, cl: T, v1: T, q: T, v2: T) -> T {
+    two_cpt_iv_bolus_amt_g(T::from_f64(amt), t, cl, v1, q, v2)
+}
+
+/// As [`two_cpt_iv_bolus_g`] but with a generic amount `amt` (issue #524), so an
+/// analytical initial condition `A₀(θ,η)` threads its sensitivity through the
+/// central impulse. The single-dose path delegates here with a constant `amt`.
+pub fn two_cpt_iv_bolus_amt_g<T: PkNum>(amt: T, t: T, cl: T, v1: T, q: T, v2: T) -> T {
     if t.val() < 0.0 || v1.val() <= 0.0 || cl.val() <= 0.0 {
         return T::from_f64(0.0);
     }
@@ -50,7 +57,7 @@ pub fn two_cpt_iv_bolus_g<T: PkNum>(amt: f64, t: T, cl: T, v1: T, q: T, v2: T) -
     if diff.val().abs() < 1e-12 {
         return T::from_f64(0.0);
     }
-    let amt_v1 = T::from_f64(amt) / v1;
+    let amt_v1 = amt / v1;
     let a = amt_v1 * (alpha - k21) / diff;
     let b = amt_v1 * (k21 - beta) / diff;
     a * (-(alpha * t)).exp() + b * (-(beta * t)).exp()
@@ -94,6 +101,13 @@ pub fn two_cpt_infusion_g<T: PkNum>(
 
 /// 2-cpt oral (first-order absorption), with `ka ≈ α`/`ka ≈ β` L'Hôpital limits.
 pub fn two_cpt_oral_g<T: PkNum>(amt: f64, t: T, cl: T, v1: T, q: T, v2: T, ka: T, f_bio: T) -> T {
+    two_cpt_oral_amt_g(T::from_f64(amt), t, cl, v1, q, v2, ka, f_bio)
+}
+
+/// As [`two_cpt_oral_g`] but with a generic amount `amt` (issue #524); the
+/// initial-condition path passes a pre-loaded depot `A₀` as a dual with `F = 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn two_cpt_oral_amt_g<T: PkNum>(amt: T, t: T, cl: T, v1: T, q: T, v2: T, ka: T, f_bio: T) -> T {
     if t.val() < 0.0 || v1.val() <= 0.0 || cl.val() <= 0.0 || ka.val() <= 0.0 {
         return T::from_f64(0.0);
     }
@@ -106,7 +120,7 @@ pub fn two_cpt_oral_g<T: PkNum>(amt: f64, t: T, cl: T, v1: T, q: T, v2: T, ka: T
     if diff.val().abs() < 1e-12 {
         return T::from_f64(0.0);
     }
-    let d = f_bio * T::from_f64(amt) * ka / v1;
+    let d = f_bio * amt * ka / v1;
     let tt = t;
 
     // Combined ka→α (or ka→β) L'Hôpital limit: the e^{-ka·t} term shares the

--- a/src/types.rs
+++ b/src/types.rs
@@ -1632,6 +1632,11 @@ pub type ScaleFn =
 /// `(theta, eta, covariates, pk_params)` and returns `A₀`, so the expression
 /// may reference thetas, etas, covariates, and individual parameters (e.g.
 /// `init(central) = CONC0 * V`).
+///
+/// `#[non_exhaustive]`: constructed only inside the crate (the parser), and the
+/// field set grew once already (`amount_deriv`, #524). The marker keeps adding
+/// further compiled-program fields a non-breaking change for external callers.
+#[non_exhaustive]
 pub struct AnalyticalInit {
     /// 1-based compartment index the initial amount is deposited into.
     pub cmt: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1637,6 +1637,14 @@ pub struct AnalyticalInit {
     pub cmt: usize,
     /// Evaluates the initial amount `A₀` for a subject. See type docs.
     pub amount_fn: ScaleFn,
+    /// The same `A₀` expression compiled to a `Dual2`-differentiable program
+    /// (issue #524), so the analytic FOCE/FOCEI provider can differentiate the
+    /// init impulse `A₀ · kernel(t, pk)` exactly instead of falling back to
+    /// finite differences. Reuses [`ScaleDerivProgram`] — the init amount has the
+    /// same `(θ, η, individual-param, covariate)` shape as an `obs_scale`
+    /// expression. `None` only for hand-constructed inits with no parsed
+    /// expression (those keep the FD fallback).
+    pub amount_deriv: Option<crate::parser::model_parser::ScaleDerivProgram>,
 }
 
 /// How the structural model's raw output is mapped to the observed `DV`.


### PR DESCRIPTION
## Why
Phase 2 of analytical `[initial_conditions]` (#521, landed in #523). Phase 1 added the f64 init impulse to every likelihood path, so FOCEI `gradient = fd` already worked — but the analytic `Dual2`/`Dual1` kernels did not carry the init contribution, so any baseline model was forced onto finite differences by guards in `analytical_supported` / `iov_analytical_supported`. This lands the differentiable init impulse so **non-IOV** baseline models use exact analytic FOCE/FOCEI gradients under `gradient = auto`: faster (no per-parameter FD probe), exact, and it re-enables the HMC SAEM E-step (`n_leapfrog > 0`) for baseline models.

## What changed
The init amount `A₀` is parameter-dependent (e.g. `CONC0 * V`), so it threads as `T: PkNum`, not the f64 it is in Phase 1.

1. **Differentiable impulse forms** (`src/sens/{one,two,three}_cpt.rs`). Extracted `*_amt_g<T>` cores that take a generic `amt: T`; the existing `*_g(amt: f64)` forms delegate via `T::from_f64`. No closed-form formula is duplicated — the single copy now lives in the `_amt_g` core (honors the "edit the generic version" rule in CLAUDE.md).
2. **Generic dispatch** (`src/pk/mod.rs`). `analytical_init_concentration_g<T: PkNum>` is the one central/depot dispatch the f64 prediction and the dual gradients share (the f64 `analytical_init_concentration` now delegates to it), so the sensitivity path can't drift from the prediction.
3. **Differentiable `A₀` program** (`src/parser/model_parser.rs`, `src/types.rs`). The `init(...)` RHS is compiled to a `ScaleDerivProgram` (the same machinery `obs_scale` uses — the init amount has the identical `(θ, η, individual-param, covariate)` shape) and stored on `AnalyticalInit.amount_deriv`. Built for the constant fast path too, so a constant baseline keeps `auto` support.
4. **Provider wiring** (`src/sens/provider.rs`). New `apply_analytical_init_{outer,inner}` layer `A₀ · kernel(t, pk)` and its `(θ, η)` jet onto the outer (Dual2: value + ∂η + ∂²η² + ∂θ + ∂²η∂θ) and inner (Dual1: value + ∂η) gradients **before scaling** — the same insertion point as the f64 `pk::add_analytical_init` — honoring the first-reset gate. The `analytical_init.is_empty()` guard in `analytical_supported` is replaced by `init_supported` (every init has a compiled program and `n_theta + n_eta` fits the dispatch table). The PK-slot dual builder is now shared with the `ExpressionScale` quotient path.

**IOV is out of scope**: `iov_analytical_supported` keeps its guard, so an IOV init model stays on FD (per-occasion analytic init gradient is a follow-up). Peripheral and ODE init are unchanged.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`AnalyticalInit` gains a public field but is constructed only by ferx-core's parser; ferx-r consumes `FitResult`/sdtab (unchanged), so no lock bump is required.

## Breaking changes
- [x] Public Rust API (`api.rs` / `types.rs`) — new public field `AnalyticalInit.amount_deriv` and new public `*_amt_g` sens forms. Additive; constructed only inside ferx-core.
- [ ] None

## Numerical validation
- [x] Per-subject analytic value / `∂η` / `∂²η²` / `∂θ` / `∂²η∂θ` and the light inner `∂η` match central FD of the init-aware production predictor (`compute_predictions_with_tv`) across **1-/2-/3-cpt central** and **oral-depot** kernels — `analytical_init_provider_matches_fd`.
- [x] Packed **FOCEI and FOCE** population gradient (the `gradient = auto` path) matches Richardson FD of the marginal objective to ~1e-3 — `population_packed_gradient_init_matches_fd`.
- [x] Init predictions still match the ODE twin (existing `tests/analytical_init_equivalence.rs` unchanged and passing).

The per-subject gradient equality means the `auto` and `fd` optimizer trajectories coincide up to FD noise, i.e. same OFV/estimates on the 6-thioguanine `run14` baseline model (the #523 NONMEM comparison still holds; `auto` is just faster and exact).

## Performance
- [x] Faster — non-IOV init models drop the per-parameter FD probe for exact analytic FOCE/FOCEI gradients; also re-enables HMC SAEM for baseline models.

## Tests
- [x] Unit tests added (`cargo test --lib` passes, 1584 tests)
- `analytical_init_provider_matches_fd` (provider) — 4 model/kernel variants, outer + inner.
- `population_packed_gradient_init_matches_fd` (outer gradient assembly) — FOCEI + FOCE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)