### PR TITLE
perf(estimation): convergence-based early stop for SS equilibration [#519]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,15 @@ section of the SDLC for the versioning policy).
   (#474)
 
 ### Performance
+- **Convergence-based early stop for steady-state equilibration** (#519). The SS=1
+  pre-equilibration (both the f64 predictor and the `Dual1`/`Dual2` gradient path,
+  and the closed-form/event-driven SS loops) previously always expanded a fixed
+  50-cycle `(apply dose; integrate II)` train. It now stops once the trough stops
+  moving — a shared per-compartment relative-`L∞` criterion (`SS_EQUILIBRATION_TOL
+  = 1e-12`) applied identically across all paths, driven by the value parts so the
+  dual truncation matches the f64 one. Fast disposition converges in ~14 cycles
+  (~3.5× fewer); slow PK still runs the full budget, so SS predictions, gradients,
+  and covariance SEs are unchanged. The dominant cost of analytic-gradient SS fits.
 - **Exact analytic gradients for `[initial_conditions]` models** (#524). A non-IOV
   closed-form model with an `[initial_conditions]` baseline now runs FOCE/FOCEI
   on exact analytic `Dual2`/`Dual1` sensitivities under `gradient = auto` instead

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -115,19 +115,49 @@ pub(crate) const SS_EQUILIBRATION_CYCLES: usize = 50;
 /// trips it and runs the full [`SS_EQUILIBRATION_CYCLES`] — identical to the old behaviour.
 pub(crate) const SS_EQUILIBRATION_TOL: f64 = 1e-12;
 
-/// Whether the SS-equilibration trough has converged between two successive cycles, by
-/// **relative `L∞`** change (scale-invariant across dose magnitudes / compartment scales).
-/// Shared by the f64 predictor and the dual gradient path so both truncate on the *same*
-/// criterion — the dual feeds the value parts (`PkNum::val`) of its state (#519).
+/// Whether the SS-equilibration trough has converged between two successive cycles. Shared
+/// by the f64 predictor and the dual gradient path so both truncate on the *same* criterion
+/// — the dual feeds the value parts (`PkNum::val`) of its state (#519).
+///
+/// **Per-compartment** relative test (#532 review #1): each compartment must stop moving
+/// relative to *itself* (`|Δ| ≤ tol·|cur|`), so in a scale-separated model a small
+/// compartment (effect-site / metabolite many orders below central) is not held only to the
+/// dominant compartment's scale. Compartments negligible versus the overall state
+/// (`|cur| ≤ tol·max_mag`) can't affect any prediction, so they don't block the stop.
+///
+/// A **non-finite** (`NaN`/`Inf`) compartment means the integration blew up: never report
+/// convergence — don't early-exit and silently return a poisoned state; run the full cycle
+/// budget exactly as the pre-#519 code did so the failure surfaces identically (#532 review
+/// #4). Required because `f64::max` would otherwise *drop* a `NaN` and mask it.
 pub(crate) fn ss_cycle_converged(cur: &[f64], prev: &[f64], tol: f64) -> bool {
-    let mut max_delta = 0.0_f64;
-    let mut max_mag = 0.0_f64;
-    for (&a, &b) in cur.iter().zip(prev) {
-        max_delta = max_delta.max((a - b).abs());
-        max_mag = max_mag.max(a.abs());
+    if cur.iter().any(|x| !x.is_finite()) {
+        return false;
     }
-    max_delta <= tol * max_mag
+    let max_mag = cur.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
+    let floor = tol * max_mag;
+    cur.iter()
+        .zip(prev)
+        .all(|(&a, &b)| (a - b).abs() <= tol * a.abs() || a.abs() <= floor)
 }
+
+#[cfg(test)]
+thread_local! {
+    /// Cycles the most recent [`equilibrate_ss_state`] call ran — a **test-only** observation
+    /// of the #519 early stop, so a test can assert it fired for fast PK and ran the full
+    /// budget for slow PK (#532 review #6 — otherwise the stop logic ships unverified, since
+    /// the loose end-value tolerances absorb a too-early exit).
+    static LAST_SS_EQUILIBRATION_CYCLES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_ss_equilibration_cycles(n: usize) {
+    LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.set(n));
+}
+
+/// No-op in non-test builds (zero cost on the hot path).
+#[cfg(not(test))]
+#[inline(always)]
+fn record_ss_equilibration_cycles(_n: usize) {}
 
 /// Pre-equilibrate the ODE state to its steady-state value for an SS=1
 /// dose with interval `dose.ii`. NONMEM SS=1 semantics: at the time of
@@ -184,6 +214,7 @@ fn equilibrate_ss_state(
     // Early stop once the trough stops moving (#519): `prev` holds the previous cycle's
     // state; from cycle 1 on, break when the relative change is below `SS_EQUILIBRATION_TOL`.
     let mut prev = vec![0.0; n];
+    let mut cycles_run = 0usize;
     for cycle in 0..SS_EQUILIBRATION_CYCLES {
         if is_inf {
             // Active-infusion window: wrapped RHS injects rate into the
@@ -238,11 +269,13 @@ fn equilibrate_ss_state(
                 u.copy_from_slice(&last.u);
             }
         }
+        cycles_run = cycle + 1;
         if cycle > 0 && ss_cycle_converged(&u, &prev, SS_EQUILIBRATION_TOL) {
             break;
         }
         prev.copy_from_slice(&u);
     }
+    record_ss_equilibration_cycles(cycles_run);
 
     u
 }
@@ -5046,6 +5079,56 @@ mod tests {
             &[0.0, 0.0],
             SS_EQUILIBRATION_TOL
         ));
+        // Non-finite compartment (blown-up integration) is never "converged" → no early exit.
+        assert!(!ss_cycle_converged(
+            &[f64::NAN, 1.0],
+            &[f64::NAN, 1.0],
+            SS_EQUILIBRATION_TOL
+        ));
+        assert!(!ss_cycle_converged(
+            &[f64::INFINITY],
+            &[1.0],
+            SS_EQUILIBRATION_TOL
+        ));
+        // Per-compartment: a small compartment moving 1% (relative to itself) blocks the stop
+        // even though the dominant compartment is steady — global-max normalization would miss it.
+        assert!(!ss_cycle_converged(
+            &[100.0, 1e-3],
+            &[100.0, 1e-3 * 1.01],
+            SS_EQUILIBRATION_TOL
+        ));
+    }
+
+    #[test]
+    fn ss_equilibration_early_stop_fires_for_fast_pk() {
+        // #532 review #6: pin that the #519 early stop actually fires (the loose end-value
+        // tolerances would otherwise hide a broken stop). Use a tight integrator tol — the
+        // gradient context where the speedup matters.
+        let mut ode = one_cpt_ode_spec();
+        ode.solver_opts.reltol = 1e-10;
+        ode.solver_opts.abstol = 1e-12;
+        let dose = DoseEvent::new(0.0, 1000.0, 1, 0.0, true, 12.0);
+
+        // Fast disposition (ke = CL/V = 2.0, λ·II = 24): the trough converges in a few cycles,
+        // so the early stop fires well inside SS_EQUILIBRATION_CYCLES.
+        let fast = pk_one(20.0, 10.0);
+        let _ = equilibrate_ss_state(&ode, &fast.values, &dose, &ode.solver_opts);
+        let fast_cycles = LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get());
+        assert!(
+            (2..SS_EQUILIBRATION_CYCLES).contains(&fast_cycles),
+            "fast PK should early-stop inside the budget, ran {fast_cycles}"
+        );
+
+        // Near-non-eliminating (ke ≈ 5e-4, λ·II ≈ 6e-3): never reaches the 1e-12 relative
+        // threshold in the budget → runs the full SS_EQUILIBRATION_CYCLES (this is the
+        // pre-existing slow-PK truncation, tracked separately — #532 review #12).
+        let slow = pk_one(0.05, 100.0);
+        let _ = equilibrate_ss_state(&ode, &slow.values, &dose, &ode.solver_opts);
+        let slow_cycles = LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get());
+        assert_eq!(
+            slow_cycles, SS_EQUILIBRATION_CYCLES,
+            "slow PK should run the full budget, ran {slow_cycles}"
+        );
     }
 
     #[test]
@@ -5070,9 +5153,10 @@ mod tests {
 
         for (j, &t) in obs_times.iter().enumerate() {
             let expected = one_cpt_iv_bolus_ss(&dose, t, cl, v);
-            // RK45 default tolerance is ~1e-6 relative; SS equilibration
-            // truncation at N=50 leaves a ~1e-9 tail. 1e-4 is the safe
-            // headroom across the population.
+            // The RK45 reltol/abstol set in `[fit_options]` dominate the error here; the SS
+            // equilibration now stops on the `SS_EQUILIBRATION_TOL` (1e-12) early-stop
+            // (#519) rather than a fixed N=50 truncation, so its own tail is negligible.
+            // 1e-4 is the safe headroom across the population.
             assert_relative_eq!(preds[j] / v, expected, epsilon = 1e-6, max_relative = 1e-4);
         }
     }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -105,6 +105,30 @@ pub(crate) fn resolve_subject_doses<'a>(
 /// same constant so its trough can't drift from this f64 predictor (#473 review #11).
 pub(crate) const SS_EQUILIBRATION_CYCLES: usize = 50;
 
+/// Relative-`L∞` tolerance for the steady-state equilibration **early stop** (#519). The
+/// `(apply dose; integrate II)` cycle is a geometric contraction with ratio `≈ exp(−λ·II)`;
+/// once the cycle-to-cycle state change falls below this *relative* threshold, every
+/// remaining cycle would move the trough by less still, so the truncation is already at f64
+/// precision and we stop. Conservative (`1e-12`): the dropped tail is far below the
+/// `provider`-vs-production parity tolerance, so the value is unchanged for any realistic
+/// PK. Fast disposition (`λ·II ≈ 2`) converges in ~14 cycles; slow PK (`λ·II ≈ 0.1`) never
+/// trips it and runs the full [`SS_EQUILIBRATION_CYCLES`] — identical to the old behaviour.
+pub(crate) const SS_EQUILIBRATION_TOL: f64 = 1e-12;
+
+/// Whether the SS-equilibration trough has converged between two successive cycles, by
+/// **relative `L∞`** change (scale-invariant across dose magnitudes / compartment scales).
+/// Shared by the f64 predictor and the dual gradient path so both truncate on the *same*
+/// criterion — the dual feeds the value parts (`PkNum::val`) of its state (#519).
+pub(crate) fn ss_cycle_converged(cur: &[f64], prev: &[f64], tol: f64) -> bool {
+    let mut max_delta = 0.0_f64;
+    let mut max_mag = 0.0_f64;
+    for (&a, &b) in cur.iter().zip(prev) {
+        max_delta = max_delta.max((a - b).abs());
+        max_mag = max_mag.max(a.abs());
+    }
+    max_delta <= tol * max_mag
+}
+
 /// Pre-equilibrate the ODE state to its steady-state value for an SS=1
 /// dose with interval `dose.ii`. NONMEM SS=1 semantics: at the time of
 /// the SS dose, the compartments are loaded with the steady-state
@@ -157,7 +181,10 @@ fn equilibrate_ss_state(
         return u;
     }
 
-    for _ in 0..SS_EQUILIBRATION_CYCLES {
+    // Early stop once the trough stops moving (#519): `prev` holds the previous cycle's
+    // state; from cycle 1 on, break when the relative change is below `SS_EQUILIBRATION_TOL`.
+    let mut prev = vec![0.0; n];
+    for cycle in 0..SS_EQUILIBRATION_CYCLES {
         if is_inf {
             // Active-infusion window: wrapped RHS injects rate into the
             // dosing compartment.
@@ -211,6 +238,10 @@ fn equilibrate_ss_state(
                 u.copy_from_slice(&last.u);
             }
         }
+        if cycle > 0 && ss_cycle_converged(&u, &prev, SS_EQUILIBRATION_TOL) {
+            break;
+        }
+        prev.copy_from_slice(&u);
     }
 
     u
@@ -4982,6 +5013,40 @@ mod tests {
     // must match `one_cpt_iv_bolus_ss` to RK45 tolerance, and similarly
     // for infusion. This cross-checks the per-cycle pulse-expansion
     // equilibration loop in `equilibrate_ss_state`.
+
+    #[test]
+    fn ss_cycle_converged_is_relative_linf() {
+        // Below tol (relative L∞): a 1e-13 absolute change on a magnitude-100 state is
+        // 1e-15 relative ≪ 1e-12 → converged.
+        assert!(ss_cycle_converged(
+            &[100.0, 50.0],
+            &[100.0 + 1e-13, 50.0],
+            SS_EQUILIBRATION_TOL
+        ));
+        // Above tol: a 1e-4 absolute change is 1e-6 relative ≫ 1e-12 → not converged.
+        assert!(!ss_cycle_converged(
+            &[100.0, 50.0],
+            &[100.0001, 50.0],
+            SS_EQUILIBRATION_TOL
+        ));
+        // Scale-invariant: the same *relative* change at a tiny magnitude → same verdict.
+        assert!(ss_cycle_converged(
+            &[1e-6],
+            &[1e-6 + 1e-19],
+            SS_EQUILIBRATION_TOL
+        ));
+        assert!(!ss_cycle_converged(
+            &[1e-6],
+            &[1e-6 + 1e-15],
+            SS_EQUILIBRATION_TOL
+        ));
+        // A genuinely zero state (no dose effect) is trivially converged.
+        assert!(ss_cycle_converged(
+            &[0.0, 0.0],
+            &[0.0, 0.0],
+            SS_EQUILIBRATION_TOL
+        ));
+    }
 
     #[test]
     fn ode_ss_iv_bolus_matches_analytical_ss() {

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -375,7 +375,9 @@ fn equilibrate_ss_state_event_driven(
 
     // Constant params across all SS-equilibration cycles → one eigendata solve.
     let mut eigen = crate::sens::propagate::EigenCacheG::default();
-    for _ in 0..EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES {
+    // Shared early stop (#519, #532 review #11): same relative-L∞ criterion as the ODE path.
+    let mut prev = vec![0.0_f64; state.len()];
+    for cycle in 0..EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES {
         if !is_inf {
             // Bolus pulse: instantaneous amount jump (with F).
             state[cmt_idx] += pk.bioavailable_amount(dose.amt);
@@ -390,6 +392,16 @@ fn equilibrate_ss_state_event_driven(
             f64::NEG_INFINITY,
             &mut eigen,
         );
+        if cycle > 0
+            && crate::ode::predictions::ss_cycle_converged(
+                &state,
+                &prev,
+                crate::ode::predictions::SS_EQUILIBRATION_TOL,
+            )
+        {
+            break;
+        }
+        prev.copy_from_slice(&state);
     }
 
     state

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2321,7 +2321,11 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
         let quiet = dose.ii - t_inf;
         let saveat_inf = [t_inf];
         let saveat_q = [quiet];
-        for _ in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
+        // Shared early stop (#519): break on the value parts once the trough converges, on
+        // the *same* relative-L∞ criterion the f64 predictor uses, so both truncate alike.
+        let mut prev = vec![0.0_f64; n_states];
+        let mut cur = vec![0.0_f64; n_states];
+        for cycle in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
             let rhs_active = |us: &[T], ps: &[T], t: f64, du: &mut [T]| {
                 bare_rhs(us, ps, t, du);
                 if cmt_idx < du.len() {
@@ -2338,18 +2342,46 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
                     u.copy_from_slice(&last.u);
                 }
             }
+            for (c, x) in cur.iter_mut().zip(u.iter()) {
+                *c = x.val();
+            }
+            if cycle > 0
+                && crate::ode::predictions::ss_cycle_converged(
+                    &cur,
+                    &prev,
+                    crate::ode::predictions::SS_EQUILIBRATION_TOL,
+                )
+            {
+                break;
+            }
+            prev.copy_from_slice(&cur);
         }
         return u;
     }
     // Bolus SS: each cycle applies the pulse `F·amt`, then decays over one interval.
     let amt = T::from_f64(dose.amt);
     let saveat = [dose.ii];
-    for _ in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
+    let mut prev = vec![0.0_f64; n_states];
+    let mut cur = vec![0.0_f64; n_states];
+    for cycle in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
         u[cmt_idx] = u[cmt_idx] + f_bio * amt;
         let sol = solve_ode_g(&bare_rhs, &u, (0.0, dose.ii), params, &saveat, opts);
         if let Some(last) = sol.last() {
             u.copy_from_slice(&last.u);
         }
+        for (c, x) in cur.iter_mut().zip(u.iter()) {
+            *c = x.val();
+        }
+        if cycle > 0
+            && crate::ode::predictions::ss_cycle_converged(
+                &cur,
+                &prev,
+                crate::ode::predictions::SS_EQUILIBRATION_TOL,
+            )
+        {
+            break;
+        }
+        prev.copy_from_slice(&cur);
     }
     u
 }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2321,8 +2321,8 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
         let quiet = dose.ii - t_inf;
         let saveat_inf = [t_inf];
         let saveat_q = [quiet];
-        // Shared early stop (#519): break on the value parts once the trough converges, on
-        // the *same* relative-L∞ criterion the f64 predictor uses, so both truncate alike.
+        // Shared early stop (#519): break once the trough converges, on the same relative-L∞
+        // criterion the f64 predictor uses (driver shared with `equilibrate_ss_g`, #532 #9/#10).
         let mut prev = vec![0.0_f64; n_states];
         let mut cur = vec![0.0_f64; n_states];
         for cycle in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
@@ -2342,19 +2342,9 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
                     u.copy_from_slice(&last.u);
                 }
             }
-            for (c, x) in cur.iter_mut().zip(u.iter()) {
-                *c = x.val();
-            }
-            if cycle > 0
-                && crate::ode::predictions::ss_cycle_converged(
-                    &cur,
-                    &prev,
-                    crate::ode::predictions::SS_EQUILIBRATION_TOL,
-                )
-            {
+            if crate::sens::propagate::ss_dual_cycle_should_stop(cycle, &u, &mut cur, &mut prev) {
                 break;
             }
-            prev.copy_from_slice(&cur);
         }
         return u;
     }
@@ -2369,19 +2359,9 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
         if let Some(last) = sol.last() {
             u.copy_from_slice(&last.u);
         }
-        for (c, x) in cur.iter_mut().zip(u.iter()) {
-            *c = x.val();
-        }
-        if cycle > 0
-            && crate::ode::predictions::ss_cycle_converged(
-                &cur,
-                &prev,
-                crate::ode::predictions::SS_EQUILIBRATION_TOL,
-            )
-        {
+        if crate::sens::propagate::ss_dual_cycle_should_stop(cycle, &u, &mut cur, &mut prev) {
             break;
         }
-        prev.copy_from_slice(&cur);
     }
     u
 }

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -862,6 +862,34 @@ fn propagate_bounds_g<T: PkNum>(
     }
 }
 
+/// Shared early-stop driver for the **dual** SS-equilibration loops (#519; #532 review #9/#10):
+/// refresh `cur` from the value parts (`PkNum::val`) of the dual state `u`, decide the stop on
+/// the *same* relative-`L∞` criterion the f64 predictor uses (from cycle 1 on), and roll
+/// `cur`→`prev` by swap — no per-cycle `O(n_states)` copy. Returns `true` to break. Used by
+/// both `equilibrate_ss_g` (here) and `equilibrate_ss_state_g` (the ODE provider) so the dual
+/// convergence logic lives in **one** place.
+pub(crate) fn ss_dual_cycle_should_stop<T: PkNum>(
+    cycle: usize,
+    u: &[T],
+    cur: &mut Vec<f64>,
+    prev: &mut Vec<f64>,
+) -> bool {
+    for (c, x) in cur.iter_mut().zip(u) {
+        *c = x.val();
+    }
+    if cycle > 0
+        && crate::ode::predictions::ss_cycle_converged(
+            cur,
+            prev,
+            crate::ode::predictions::SS_EQUILIBRATION_TOL,
+        )
+    {
+        return true;
+    }
+    std::mem::swap(cur, prev);
+    false
+}
+
 /// Equilibrate the dual state to its SS value for an SS=1 dose, per-event (uses
 /// `pk`, the dose-event's params). Generic mirror of
 /// `event_driven::equilibrate_ss_state_event_driven` for the 1-/2-cpt models;
@@ -894,7 +922,11 @@ fn equilibrate_ss_g<T: PkNum>(pk_model: PkModel, pk: &PkDual<T>, dose: &DoseEven
     } else {
         vec![0.0, dose.ii]
     };
-    for _ in 0..SS_EQUILIBRATION_CYCLES {
+    // Shared early stop (#519, #532 review #11): the closed-form propagator equilibrates the
+    // same geometric train, so the same relative-L∞ stop applies here too.
+    let mut prev = vec![0.0_f64; n_states];
+    let mut cur = vec![0.0_f64; n_states];
+    for cycle in 0..SS_EQUILIBRATION_CYCLES {
         if !is_inf {
             state[cmt_idx] = state[cmt_idx] + pk.f * T::from_f64(dose.amt);
         }
@@ -907,6 +939,9 @@ fn equilibrate_ss_g<T: PkNum>(pk_model: PkModel, pk: &PkDual<T>, dose: &DoseEven
             &synthetic_lag,
             f64::NEG_INFINITY,
         );
+        if ss_dual_cycle_should_stop(cycle, &state, &mut cur, &mut prev) {
+            break;
+        }
     }
     state
 }


### PR DESCRIPTION
Closes #519 — the perf tail of #473 (analytic SS-bolus+infusion gradient).

## Problem
Both the f64 predictor (`equilibrate_ss_state`) and the dual gradient path (`equilibrate_ss_state_g`) expand a **fixed `SS_EQUILIBRATION_CYCLES = 50`** cycles of `(apply dose; integrate II)` from a zero state, once per SS subject per objective eval and once per gradient eval (over `Dual2`/`Dual1`). On run14 the equilibration — not the `Dual2` — is the dominant remaining cost.

The cycle is a geometric contraction (ratio `≈ exp(−λ·II)`), so for typical disposition the trough reaches f64 precision long before 50 cycles. The 50 were sized for the *slowest* realistic PK.

## Change
A shared **relative-`L∞` early stop** applied to **both** paths on the **same criterion**:
- `SS_EQUILIBRATION_TOL = 1e-12`, `ss_cycle_converged(cur, prev, tol)` in `src/ode/predictions.rs` (scale-invariant: `max|Δ| ≤ tol·max|state|`).
- The dual path feeds the **value parts** (`PkNum::val`) of its state into the same predicate, so f64 and dual truncate identically.
- Fast disposition (`λ·II ≈ 2`) converges in **~14 cycles (~3.5× fewer)**; slow PK (`λ·II ≈ 0.1`) never trips it and runs the full 50 — **bit-for-bit the old behaviour**.

## Value-preservation (the gradient stays the gradient of the objective)
The dropped tail is below the `provider`-vs-production parity tolerance, so values are unchanged:
- `ode_ss_iv_bolus_matches_analytical_ss` (f64 vs the closed-form SS) — green.
- All `ode_provider_ss_*` provider-vs-production **and** `check_hessian_vs_fd_of_grad` SS tests — green.
- New unit test `ss_cycle_converged_is_relative_linf` guards the criterion.
- Full lib suite (1623) + the full `--features ci` lib+integration suite — green.

(Option 3 in #519, closed-form SS for linear subsystems, is left as a follow-up — it would change values and needs its own NONMEM re-validation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)