### PR TITLE
fix(ode): use observation covariates for Form C readouts [closes #535]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,20 @@ section of the SDLC for the versioning policy).
   `[derived]` reference (`W_DERIVED_INIT_ANALYTICAL`) warns rather than silently
   mispredicting. See [Initial Conditions](model-file/initial-conditions.qmd).
 ### Fixed
+- **Form C (`[scaling] y = <expr>`) ODE readouts now use per-observation covariate
+  snapshots** (#535, #538). The explicit-output readout is evaluated against the
+  covariate values on each observation's own data row rather than the subject's
+  first-row values, so time-varying covariates referenced in a Form C expression
+  now drive predictions, diagnostics, and the adaptive-trial decision monitors at
+  the correct time. As a consequence, covariates referenced **only** from a Form C
+  expression are now treated as required data columns: a model whose readout
+  references a covariate absent from the dataset now fails loudly with
+  `E_MISSING_COVARIATE` (and undeclared-but-present covariates raise the usual
+  warning), where previously the missing value silently read as `0.0`. **NONMEM
+  comparison:** for time-constant covariates the readout is byte-identical to the
+  prior behaviour; the paired total/free-assay regression
+  (`ode_event_driven_form_c_uses_observation_covariates`) pins the time-varying
+  case.
 - **Exact analytic FOCE/FOCEI gradient for `iiv_on_ruv` (IIV on residual error).**
   Models with a residual-error eta (`Y = IPRED + EPS·EXP(η_ruv)`) now use the
   exact closed-form gradient on both the inner EBE and outer θ/Ω/σ loops, where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,10 +120,17 @@ section of the SDLC for the versioning policy).
   references a covariate absent from the dataset now fails loudly with
   `E_MISSING_COVARIATE` (and undeclared-but-present covariates raise the usual
   warning), where previously the missing value silently read as `0.0`. **NONMEM
-  comparison:** for time-constant covariates the readout is byte-identical to the
-  prior behaviour; the paired total/free-assay regression
-  (`ode_event_driven_form_c_uses_observation_covariates`) pins the time-varying
-  case.
+  comparison:** validated against the `fluconazole_radboudumc` model (ADVAN3 TRANS4
+  with a free/total protein-binding `$ERROR` that selects `CTOT` when `FREE==0` and
+  `CU` when `FREE==1` — paired assay rows at the same time). Evaluated at identical
+  parameters, ferx's per-record population predictions match NONMEM's `PRED` to
+  ~1e-4 relative on **both** the total-assay and free-assay rows (e.g. subject 1 at
+  t=1: ferx 21.5105 / 2.9070 vs NONMEM 21.511 / 2.907), confirming the readout reads
+  each observation's own `FREE` value rather than the subject's first row. (The two
+  rows at a given time differ only by that per-record covariate.) For time-constant
+  covariates the readout is byte-identical to the prior behaviour; the
+  `ode_event_driven_form_c_uses_observation_covariates` unit test pins the
+  per-observation path.
 - **Gradient-based outer optimizers now precondition with magnitude scaling
   (`Abs`) instead of bound-half-width (`Rescale2`).** Under the default
   `optimizer = auto` (which resolves to NLopt L-BFGS when an analytic gradient is

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -84,6 +84,15 @@ references a covariate that is absent from the dataset the fit fails with
 `E_MISSING_COVARIATE` rather than silently reading the missing value as
 `0.0`. For time-constant covariates the readout is unchanged.
 
+This matches NONMEM's per-record `$ERROR` semantics. Validated against a
+free/total protein-binding model (NONMEM ADVAN3 TRANS4 whose `$ERROR`
+selects the total concentration when `FREE==0` and the unbound
+concentration when `FREE==1`, with paired assay rows at the same time):
+evaluated at identical parameters, ferx's per-record population
+predictions reproduce NONMEM's `PRED` to ~1e-4 relative on both the
+total-assay and free-assay rows — the two rows at a given time differing
+only by that per-record covariate.
+
 Form C is only valid for ODE models. The parser rejects `y = ...` on
 analytical models with a clear error.
 

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -75,6 +75,15 @@ at evaluation time — states from the ODE solver, individual parameters
 from the subject-static `pk_param_fn`, and thetas/etas/covariates from
 the values supplied by the caller.
 
+Covariates in a Form C expression are read from the **per-observation
+covariate snapshot** — the values on each observation's own data row — so
+a time-varying covariate drives the readout at the time it is observed
+(since #535/#538). Because a Form C covariate is therefore an input the
+prediction depends on, it is a **required data column**: if the readout
+references a covariate that is absent from the dataset the fit fails with
+`E_MISSING_COVARIATE` rather than silently reading the missing value as
+`0.0`. For time-constant covariates the readout is unchanged.
+
 Form C is only valid for ODE models. The parser rejects `y = ...` on
 analytical models with a clear error.
 

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -613,6 +613,14 @@ fn read_observable(
     }
 }
 
+#[inline]
+fn observation_covariates<'a>(subject: &'a Subject, obs_idx: usize) -> &'a HashMap<String, f64> {
+    subject
+        .obs_covariates
+        .get(obs_idx)
+        .unwrap_or(&subject.covariates)
+}
+
 /// ODE specification for a model
 pub struct OdeSpec {
     /// RHS function: (u, pk_params_flat, t, du) — writes derivatives into du
@@ -852,7 +860,7 @@ fn integrate_segment(
                     pk_params_flat,
                     theta,
                     eta,
-                    &subject.covariates,
+                    observation_covariates(subject, obs_idx),
                     cmt,
                 );
             }
@@ -1014,7 +1022,7 @@ pub fn ode_predictions(
                     pk_params_flat,
                     theta,
                     eta,
-                    &subject.covariates,
+                    observation_covariates(subject, obs_idx),
                     cmt,
                 );
             }
@@ -1467,8 +1475,15 @@ pub(crate) fn ode_predictions_adaptive(
         if let Some(obs_idxs) = obs_map.get(&t_start.to_bits()) {
             for &obs_idx in obs_idxs {
                 let cmt = shadow.obs_cmts.get(obs_idx).copied().unwrap_or(0);
-                predictions[obs_idx] =
-                    read_observable(ode, &u, pk_params_flat, theta, eta, &shadow.covariates, cmt);
+                predictions[obs_idx] = read_observable(
+                    ode,
+                    &u,
+                    pk_params_flat,
+                    theta,
+                    eta,
+                    observation_covariates(&shadow, obs_idx),
+                    cmt,
+                );
             }
         }
 
@@ -1827,7 +1842,7 @@ pub fn ode_predictions_event_driven(
                     &pk_now.values,
                     theta,
                     eta,
-                    &subject.covariates,
+                    observation_covariates(subject, idx),
                     cmt,
                 );
                 // Clamp negative readouts (ODE solver overshoot guard);
@@ -2152,7 +2167,7 @@ pub fn ode_predictions_with_states(
                     pk_params_flat,
                     theta,
                     eta,
-                    &subject.covariates,
+                    observation_covariates(subject, obs_idx),
                     cmt,
                 );
                 states[obs_idx] = u.clone();
@@ -2239,7 +2254,7 @@ pub fn ode_predictions_with_states(
                         pk_params_flat,
                         theta,
                         eta,
-                        &subject.covariates,
+                        observation_covariates(subject, obs_idx),
                         cmt,
                     );
                     states[obs_idx] = pt.u.clone();
@@ -4748,6 +4763,47 @@ mod tests {
         for (b, e) in baseline.iter().zip(event_driven.iter()) {
             assert_relative_eq!(*b, *e, epsilon = 1e-3, max_relative = 1e-4);
         }
+    }
+
+    #[test]
+    fn ode_event_driven_form_c_uses_observation_covariates() {
+        // Regression for a NONMEM translation with paired total/free assays:
+        // the dose row carried FREE=3, while same-time observation rows carried
+        // FREE=0 and FREE=1. Form C must see the observation snapshot, not the
+        // subject-level first-row covariate.
+        let ode = OdeSpec {
+            rhs: Box::new(|_y: &[f64], _p: &[f64], _t: f64, dy: &mut [f64]| {
+                dy[0] = 0.0;
+            }),
+            n_states: 1,
+            state_names: vec!["central".into()],
+            readout: OdeReadout::Single(Box::new(|state, _pk, _theta, _eta, covariates| {
+                state[0] * covariates.get("FREE").copied().unwrap_or(0.0)
+            })),
+            diffusion_var: Vec::new(),
+            solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
+            rhs_program: None,
+            readout_program: None,
+            indiv_param_program: None,
+            dose_attr_map: Default::default(),
+            init_fn: None,
+        };
+        let mut subj = make_subject(
+            vec![DoseEvent::new(0.0, 10.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 1.0],
+        );
+        subj.covariates.insert("FREE".into(), 3.0);
+        subj.dose_covariates = vec![HashMap::from([("FREE".to_string(), 3.0)])];
+        subj.obs_covariates = vec![
+            HashMap::from([("FREE".to_string(), 0.0)]),
+            HashMap::from([("FREE".to_string(), 1.0)]),
+        ];
+        let pk = pk_one(0.0, 1.0);
+        let preds = ode_predictions_event_driven(&ode, &subj, &[], &[], &[pk], &[pk, pk], &[]);
+
+        assert_relative_eq!(preds[0], 0.0, epsilon = 1e-12);
+        assert_relative_eq!(preds[1], 10.0, epsilon = 1e-12);
     }
 
     #[test]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -613,14 +613,6 @@ fn read_observable(
     }
 }
 
-#[inline]
-fn observation_covariates<'a>(subject: &'a Subject, obs_idx: usize) -> &'a HashMap<String, f64> {
-    subject
-        .obs_covariates
-        .get(obs_idx)
-        .unwrap_or(&subject.covariates)
-}
-
 /// ODE specification for a model
 pub struct OdeSpec {
     /// RHS function: (u, pk_params_flat, t, du) — writes derivatives into du
@@ -860,7 +852,7 @@ fn integrate_segment(
                     pk_params_flat,
                     theta,
                     eta,
-                    observation_covariates(subject, obs_idx),
+                    subject.obs_cov(obs_idx),
                     cmt,
                 );
             }
@@ -1022,7 +1014,7 @@ pub fn ode_predictions(
                     pk_params_flat,
                     theta,
                     eta,
-                    observation_covariates(subject, obs_idx),
+                    subject.obs_cov(obs_idx),
                     cmt,
                 );
             }
@@ -1294,19 +1286,22 @@ pub(crate) fn ode_predictions_adaptive(
         // --- Decision hook: observe (pre-dose trough) -> decide -> dose. ---
         if !stopped {
             if let Some(&decision_index) = decision_index_of.get(&t_start.to_bits()) {
+                // Covariate snapshot in effect at the decision time. When the
+                // decision coincides with an observation row, use that row's
+                // per-observation snapshot (so time-varying covariates drive the
+                // monitored readouts and the controller's view); otherwise fall
+                // back to the subject-static map.
+                let decision_cov = obs_map
+                    .get(&t_start.to_bits())
+                    .and_then(|idxs| idxs.first())
+                    .map(|&i| shadow.obs_cov(i))
+                    .unwrap_or(&shadow.covariates);
                 // Resolve each monitored signal at the current (pre-dose) state.
                 let mut signals: HashMap<String, f64> = HashMap::new();
                 let mut observed: Vec<ObservedSignal> = Vec::with_capacity(monitors.len());
                 for m in monitors {
-                    let value = read_observable(
-                        ode,
-                        &u,
-                        pk_params_flat,
-                        theta,
-                        eta,
-                        &shadow.covariates,
-                        m.cmt,
-                    );
+                    let value =
+                        read_observable(ode, &u, pk_params_flat, theta, eta, decision_cov, m.cmt);
                     signals.insert(m.name.clone(), value);
                     observed.push(ObservedSignal {
                         name: m.name.clone(),
@@ -1319,7 +1314,7 @@ pub(crate) fn ode_predictions_adaptive(
                     let ctx = ControllerCtx {
                         t: t_start,
                         state: &u,
-                        covariates: &shadow.covariates,
+                        covariates: decision_cov,
                         history: &shadow.doses,
                         decision_index,
                         signals: &signals,
@@ -1481,7 +1476,7 @@ pub(crate) fn ode_predictions_adaptive(
                     pk_params_flat,
                     theta,
                     eta,
-                    observation_covariates(&shadow, obs_idx),
+                    shadow.obs_cov(obs_idx),
                     cmt,
                 );
             }
@@ -1842,7 +1837,7 @@ pub fn ode_predictions_event_driven(
                     &pk_now.values,
                     theta,
                     eta,
-                    observation_covariates(subject, idx),
+                    subject.obs_cov(idx),
                     cmt,
                 );
                 // Clamp negative readouts (ODE solver overshoot guard);
@@ -2167,7 +2162,7 @@ pub fn ode_predictions_with_states(
                     pk_params_flat,
                     theta,
                     eta,
-                    observation_covariates(subject, obs_idx),
+                    subject.obs_cov(obs_idx),
                     cmt,
                 );
                 states[obs_idx] = u.clone();
@@ -2254,7 +2249,7 @@ pub fn ode_predictions_with_states(
                         pk_params_flat,
                         theta,
                         eta,
-                        observation_covariates(subject, obs_idx),
+                        subject.obs_cov(obs_idx),
                         cmt,
                     );
                     states[obs_idx] = pt.u.clone();
@@ -2829,6 +2824,81 @@ mod tests {
             let exact = 100.0 * (-ke * t).exp();
             assert_relative_eq!(run.predictions[i], exact, max_relative = 1e-5);
         }
+    }
+
+    #[test]
+    fn adaptive_decision_monitor_uses_observation_covariates() {
+        // Regression (#538): at a decision time the monitored Form-C readout
+        // must see the covariate snapshot in effect at that time (the coincident
+        // observation row), not the subject-level first-row covariate. The
+        // readout is `state * FREE`; with no decay the state stays at the dose
+        // amount, so the monitored signal is driven purely by FREE.
+        let ode = OdeSpec {
+            rhs: Box::new(|_y: &[f64], _p: &[f64], _t: f64, dy: &mut [f64]| {
+                dy[0] = 0.0;
+            }),
+            n_states: 1,
+            state_names: vec!["central".into()],
+            readout: OdeReadout::Single(Box::new(|state, _pk, _theta, _eta, covariates| {
+                state[0] * covariates.get("FREE").copied().unwrap_or(0.0)
+            })),
+            diffusion_var: Vec::new(),
+            solver_opts: OdeSolverOptions::default(),
+            input_rate: Vec::new(),
+            rhs_program: None,
+            readout_program: None,
+            indiv_param_program: None,
+            dose_attr_map: Default::default(),
+            init_fn: None,
+        };
+        let pk = pk_one(0.0, 1.0); // ke = 0 -> state holds at the dose amount
+        let monitors = [MonitorSpec::new("A", 1, ObserveMode::Ipred)];
+        let decisions = [0.0, 10.0];
+
+        // Single observation at the second decision time, carrying FREE=2.0;
+        // the subject-static map carries the stale FREE=1.0.
+        let mut base = make_subject(vec![], vec![10.0]);
+        base.covariates.insert("FREE".into(), 1.0);
+        base.obs_covariates = vec![HashMap::from([("FREE".to_string(), 2.0)])];
+
+        // Dose 100 at t=0 (signal 0 < 150). At t=10 the pre-dose state is 100,
+        // so the monitored signal is 100*FREE. With the observation snapshot
+        // (FREE=2) the signal is 200 >= 150 -> hold; with the stale static
+        // value (FREE=1) it would be 100 < 150 -> a second (wrong) dose.
+        let mut controller = |ctx: &ControllerCtx| {
+            if ctx.signal("A").expect("monitor A is declared") < 150.0 {
+                vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }]
+            } else {
+                vec![DoseAction::Hold]
+            }
+        };
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &monitors,
+            &mut controller,
+            100,
+        )
+        .expect("driver runs");
+
+        assert_eq!(
+            run.ledger.len(),
+            1,
+            "dose only at t=0; the t=10 monitor must read FREE=2 (signal 200) and hold"
+        );
+        assert_eq!(run.ledger[0].time, 0.0);
+        // The decision at t=10 logged the monitored signal computed with the
+        // observation-row covariate: 100 * 2.0 = 200.
+        let d10 = run
+            .decisions
+            .iter()
+            .find(|d| d.time == 10.0)
+            .expect("decision logged at t=10");
+        assert_relative_eq!(d10.observed_signals[0].value, 200.0, epsilon = 1e-9);
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1910,7 +1910,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             .unwrap_or_default();
         let is_ode_model = model.ode_spec.is_some();
 
-        let (scaling, output_fn, output_program) = parse_scaling_block(
+        let (scaling, output_fn, output_program, scaling_covariates) = parse_scaling_block(
             scaling_lines,
             &theta_names_for_scaling,
             &eta_names_for_scaling,
@@ -1936,6 +1936,12 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             ode_spec.readout_program = output_program;
         }
 
+        for cov in scaling_covariates {
+            if !model.referenced_covariates.contains(&cov) {
+                model.referenced_covariates.push(cov);
+            }
+        }
+        model.referenced_covariates.sort();
         model.scaling = scaling;
     }
 
@@ -4520,7 +4526,7 @@ fn build_y_output_fn(
     pk_indices: &[usize],
     state_names: &[String],
     kappa_names: &[String],
-) -> Result<(crate::ode::OdeOutputFn, OdeOutputProgram), String> {
+) -> Result<(crate::ode::OdeOutputFn, OdeOutputProgram, Vec<String>), String> {
     // Form C: expression may reference state names, individual params,
     // thetas, etas, and covariates. ParseCtx::new + theta/eta in scope.
     let mut defined: Vec<String> = state_names.to_vec();
@@ -4632,6 +4638,7 @@ fn build_y_output_fn(
     // and ODE RHS never interleave on a single thread (readout runs
     // post-integration).
     let n_cov = cov_names.len();
+    let cov_names_for_fn = cov_names.clone();
 
     let out_fn: crate::ode::OdeOutputFn = Box::new(
         move |state: &[f64],
@@ -4666,7 +4673,7 @@ fn build_y_output_fn(
                 scratch.y_cov.clear();
                 if n_cov > 0 {
                     scratch.y_cov.resize(n_cov, 0.0);
-                    for (i, name) in cov_names.iter().enumerate() {
+                    for (i, name) in cov_names_for_fn.iter().enumerate() {
                         if let Some(&v) = covariates.get(name) {
                             scratch.y_cov[i] = v;
                         }
@@ -4686,7 +4693,7 @@ fn build_y_output_fn(
             })
         },
     );
-    Ok((out_fn, output_program))
+    Ok((out_fn, output_program, cov_names))
 }
 
 /// Parsed contents of a `[scaling]` block.
@@ -4729,6 +4736,7 @@ fn parse_scaling_block(
         ScalingSpec,
         Option<crate::ode::OdeReadout>,
         Option<OdeOutputProgram>,
+        Vec<String>,
     ),
     String,
 > {
@@ -4744,6 +4752,7 @@ fn parse_scaling_block(
     // per-CMT readouts carry their own program inside each `PerCmtReadout` (#439),
     // so the analytic-sensitivity provider can differentiate each endpoint.
     let mut y_uniform_program: Option<OdeOutputProgram> = None;
+    let mut y_covariates: Vec<String> = Vec::new();
 
     for line in lines {
         let trimmed = line.trim();
@@ -4823,7 +4832,7 @@ fn parse_scaling_block(
                          use `obs_scale = <expr>` for analytical PK"
                         .into());
                 }
-                let (out_fn, out_program) = build_y_output_fn(
+                let (out_fn, out_program, cov_names) = build_y_output_fn(
                     value,
                     theta_names,
                     eta_names,
@@ -4832,6 +4841,11 @@ fn parse_scaling_block(
                     state_names,
                     kappa_names,
                 )?;
+                for cov in cov_names {
+                    if !y_covariates.contains(&cov) {
+                        y_covariates.push(cov);
+                    }
+                }
                 match cmt_opt {
                     None => {
                         if y_uniform.is_some() {
@@ -4890,7 +4904,8 @@ fn parse_scaling_block(
     } else {
         None
     };
-    Ok((scaling, readout, readout_program))
+    y_covariates.sort();
+    Ok((scaling, readout, readout_program, y_covariates))
 }
 
 // ── ode_template desugaring + the analytical+ODE-only-absorption error rule ──
@@ -18861,6 +18876,10 @@ if (WT > 70) {
             Some("  y = central / V * WT\n"),
         );
         let model = parse_model_string(&src).expect("Form C with covariate parses");
+        assert!(
+            model.referenced_covariates.contains(&"WT".to_string()),
+            "Form C covariates must be retained for data loading and TV pruning"
+        );
         let ode = model.ode_spec.as_ref().unwrap();
         let out_fn = match &ode.readout {
             crate::ode::OdeReadout::Single(f) => f,


### PR DESCRIPTION
## Why
Fixes #535.

ODE Form C readouts (`[scaling] y = ...`) were evaluated with `subject.covariates`.
For time-varying or row-specific covariates this can be wrong. The fluconazole
NONMEM translation exposed it: dose rows carry `FREE=3`, while paired observation
rows carry `FREE=0` or `FREE=1`. The readout saw `FREE=3`, produced negative
values, and the ODE prediction clamp turned the sdtab predictions into zero,
driving FOCEI OFV to ~1e17.

Follow-up translation gaps from the same investigation are tracked separately:
#536 and #537.

## What changed
Form C ODE readouts now use the per-observation covariate snapshot when present,
falling back to subject-level covariates for non-TV subjects.

The parser also records covariates referenced only by Form C readouts in
`model.referenced_covariates`, so data loading and TV-covariate pruning retain
those observation snapshots.

## Alternatives considered
Only special-casing the fluconazole `FREE` flag would have fixed the local model
but left the same bug for any Form C readout that references row-level
covariates. Threading the observation snapshot through the existing ODE readout
sites fixes the general case.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

None.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# before
Fluconazole Form C readout used dose-row FREE=3 for observation rows; subject 1
initial predictions were all zero and FOCEI started around 3e17 OFV.

# after
Direct prediction probe on the same model/data produced nonzero subject 1 initial
predictions: 21.51, 2.91, 18.24, 2.45.
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# Existing Form C syntax; no new syntax.
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [ ] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [x] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints
Focus on the ODE readout call sites and the parser bookkeeping for Form C
covariates. The code intentionally falls back to subject-level covariates when
observation snapshots are absent.

## Open questions
None.
