### PR TITLE
fix(estimation): precondition gradient optimizers with Abs scaling, not Rescale2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,20 @@ section of the SDLC for the versioning policy).
   `[derived]` reference (`W_DERIVED_INIT_ANALYTICAL`) warns rather than silently
   mispredicting. See [Initial Conditions](model-file/initial-conditions.qmd).
 ### Fixed
+- **Gradient-based outer optimizers now precondition with magnitude scaling
+  (`Abs`) instead of bound-half-width (`Rescale2`).** Under the default
+  `optimizer = auto` (which resolves to NLopt L-BFGS when an analytic gradient is
+  available), `Rescale2` was the wrong preconditioner and made FOCE/FOCEI
+  converge to a parameter bound or a local minimum on several models — warfarin
+  FOCEI stalled at OFV −243 (TVV 6.08) instead of −286 (TVV 7.74); a
+  time-varying-covariate fit landed at a +166 local minimum with TVV pinned at
+  its lower bound; SLSQP froze at its start on a 2-cpt covariate model. Switching
+  the gradient-based optimizers (`bfgs`/`lbfgs`/`nlopt_lbfgs`/`slsqp`) to `Abs`
+  scaling recovers the correct optimum in every case while preserving the SLSQP
+  cold-start fix (#335). This fixes the downstream IMP/IMPMAP warm-start collapse
+  and the simulation-based NPDE/NPD diagnostic, which inherited the bad fit.
+  (Scaling is disabled automatically when an identity-packed covariate θ is
+  present, as before.)
 - **Exact analytic FOCE/FOCEI gradient for `iiv_on_ruv` (IIV on residual error).**
   Models with a residual-error eta (`Y = IPRED + EPS·EXP(η_ruv)`) now use the
   exact closed-form gradient on both the inner EBE and outer θ/Ω/σ loops, where

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -565,20 +565,38 @@ fn compute_rescale2_scale(bounds: &PackedBounds) -> Vec<f64> {
 }
 
 /// Resolve [`ParameterScaling::Auto`] to a concrete strategy. `Auto` applies
-/// `Rescale2` to the gradient-based optimizers that benefit (`Bfgs`, `Lbfgs`,
-/// `NloptLbfgs`, `Slsqp`) and `None` otherwise — critically, the derivative-free
-/// default `Bobyqa` is left unscaled because `Rescale2` distorts its trust-region
-/// quadratic model and regresses multi-cpt / PD fits (e.g. emax_pkpd −36.8→−13.5,
-/// three_cpt_iv −730.6→−715.9). `Slsqp` is included because the bound-half-width
-/// rescaling fixes its cold-start convergence — e.g. pure FOCEI/SLSQP on
-/// warfarin_iov reaches OFV 307.84 from the cold default start instead of
-/// stalling at 343.5 (#335). `Mma`/`TrustRegion` are left to the unscaled (legacy
-/// `scale_params` / IOV-auto) branch. Non-`Auto` values pass through unchanged.
+/// `Abs` (per-coordinate magnitude scaling, normalise by |packed value|) to the
+/// gradient-based optimizers (`Bfgs`, `Lbfgs`, `NloptLbfgs`, `Slsqp`) and `None`
+/// otherwise. `Abs` is the correct preconditioner for a quasi-Newton / SQP step:
+/// it presents O(1) coordinates so the optimizer's first move is well-scaled.
+///
+/// This replaces the earlier `Rescale2` (bound-half-width) scaling, which is the
+/// *wrong* preconditioner for gradient optimizers — bound width is unrelated to
+/// curvature, so it drove L-BFGS into a parameter bound on ill-conditioned fits
+/// (warfarin FOCEI −286→−243; tvcov to a +166 local min with TVV pinned at its
+/// lower bound) and froze SLSQP's first step on two_cpt_oral_cov (−1026, no move
+/// from init). `Abs` recovers the correct optimum in every one of those cases
+/// (warfarin −286, tvcov −188.6 at truth, two_cpt_oral_cov −1165) and preserves
+/// SLSQP's warfarin_iov cold-start win (OFV 307.8, the #335 case).
+///
+/// The derivative-free default `Bobyqa` is left unscaled — any per-coordinate
+/// scaling distorts its trust-region quadratic model and regresses multi-cpt / PD
+/// fits (e.g. emax_pkpd −36.8→−13.5, three_cpt_iv −730.6→−715.9). `Mma` /
+/// `TrustRegion` are left to the unscaled (legacy `scale_params` / IOV-auto)
+/// branch. Non-`Auto` values pass through unchanged.
 fn resolve_scaling(ps: ParameterScaling, opt: Optimizer) -> ParameterScaling {
     match ps {
         ParameterScaling::Auto => match opt {
+            // Gradient-based optimizers condition best with magnitude scaling
+            // (`Abs` = normalise by |packed value|). `Rescale2` (bound-half-width)
+            // is the wrong preconditioner: it drives L-BFGS into a bound on
+            // ill-conditioned fits (warfarin −286→−243, tvcov to a local min) and
+            // freezes SLSQP's first step on two_cpt_oral_cov (−1026, no move).
+            // `Abs` recovers the correct optimum for both (warfarin −286, tvcov
+            // −188.6 at truth, two_cpt_oral_cov −1165) while preserving SLSQP's
+            // warfarin_iov cold-start win (OFV 307.8, the #335 case).
             Optimizer::Bfgs | Optimizer::Lbfgs | Optimizer::NloptLbfgs | Optimizer::Slsqp => {
-                ParameterScaling::Rescale2
+                ParameterScaling::Abs
             }
             _ => ParameterScaling::None,
         },
@@ -636,7 +654,19 @@ fn optimize_nlopt(
     let auto_scale_iov = model.n_kappa > 0 && matches!(options.optimizer, Optimizer::Slsqp);
     let scale: Vec<f64> = match resolve_scaling(options.parameter_scaling, options.optimizer) {
         ParameterScaling::Rescale2 => compute_rescale2_scale(&bounds),
-        ParameterScaling::Abs => compute_scale(&x0),
+        // Magnitude scaling, but disabled when an identity-packed theta is present
+        // (covariate effects with `theta_lower < 0`): `compute_scale` leaves those
+        // small coordinates near their raw value while log-packed θ become O(1), and
+        // the resulting wildly-mixed scaled magnitudes hurt the quasi-Newton/SQP
+        // Hessian estimate (observed: SAD_SCEN1 FOCEI 510+ evals vs ~90 unscaled).
+        // Falling back to the natural mixed space keeps that protection.
+        ParameterScaling::Abs => {
+            if has_identity_theta {
+                vec![1.0; n]
+            } else {
+                compute_scale(&x0)
+            }
+        }
         // `Auto` is resolved away by `resolve_scaling`; group with `None`.
         ParameterScaling::None | ParameterScaling::Auto => {
             if (options.scale_params || auto_scale_iov) && !has_identity_theta {
@@ -3876,11 +3906,12 @@ mod tests {
         assert_eq!(cov_progress_eta(40, 40, 8.0), 0.0); // done → 0 remaining
     }
 
-    /// `resolve_scaling` maps `Auto` to `Rescale2` for the gradient-based
-    /// optimizers that benefit (incl. `Slsqp` — the #335 cold-start fix) and to
-    /// `None` for the derivative-free `Bobyqa` default (and `Mma`/`TrustRegion`);
-    /// explicit non-`Auto` values pass through unchanged. Guards the #341/#335
-    /// default-scaling routing.
+    /// `resolve_scaling` maps `Auto` to `Abs` (magnitude scaling) for the
+    /// gradient-based optimizers (incl. `Slsqp`) and to `None` for the
+    /// derivative-free `Bobyqa` default (and `Mma`/`TrustRegion`); explicit
+    /// non-`Auto` values pass through unchanged. Guards the gradient-optimizer
+    /// preconditioner routing (Rescale2 → Abs, the fix that recovers warfarin /
+    /// tvcov / two_cpt_oral_cov convergence while preserving #335).
     #[test]
     fn resolve_scaling_routes_auto_by_optimizer() {
         use crate::types::ParameterScaling::{Abs, Auto, None as PsNone, Rescale2};
@@ -3892,8 +3923,8 @@ mod tests {
         ] {
             assert_eq!(
                 resolve_scaling(Auto, opt),
-                Rescale2,
-                "{opt:?} should be Rescale2 under Auto"
+                Abs,
+                "{opt:?} should be Abs under Auto"
             );
         }
         for opt in [Optimizer::Bobyqa, Optimizer::Mma, Optimizer::TrustRegion] {


### PR DESCRIPTION
## Why

Nightly `slow-tests` have been red on `main` since 2026-06-18 — five tests failing on every run:

| Test | Symptom |
|------|---------|
| `npde_validation` | NPD variance 0.22 (should be ≈1) |
| `impmap_api::impmap_converges_to_focei` | in-test FOCEI reference lands at TVV 6.08 vs IMPMAP 7.74 |
| `warfarin_imp_nonmem` | TVCL collapses to its 0.001 lower bound |
| `tvcov_convergence` | TVCL 0.283 vs truth 0.15 (TVV pinned at its bound) |
| `outer_optimizer::test_slsqp_moves…` | SLSQP byte-identical to init (issue #55 symptom) |

Root cause: `resolve_scaling` preconditioned the **gradient-based** outer optimizers with `Rescale2` (bound-half-width). Bound width is unrelated to curvature, so it is the wrong preconditioner for a quasi-Newton / SQP step — it drove NLopt L-BFGS into a parameter bound or a local minimum on ill-conditioned FOCE/FOCEI fits, and froze SLSQP's first step. `#490` made `optimizer = auto` → NLopt L-BFGS the default, which turned the whole FOCEI default path red; `npde`/`impmap`/`warfarin_imp` are all downstream of that bad default fit.

The gradient itself and the outer stopping tolerance were ruled out as causes by controlled experiments (analytic gradient == finite-difference == reconverged-FD; outer `xtol`/`ftol` sweep 1e-12→1e-4 was flat).

## What changed

`resolve_scaling`: `Auto` → **`Abs`** (normalise by |packed value|, a magnitude preconditioner) for `bfgs`/`lbfgs`/`nlopt_lbfgs`/`slsqp`, instead of `Rescale2`. `Abs` presents O(1) coordinates so the optimizer's first step is well-scaled. NLopt L-BFGS remains the default. Scaling is still auto-disabled when an identity-packed covariate θ is present (preserves the prior SAD_SCEN1 protection).

## Alternatives considered

- Reverting the `#490` default to BOBYQA — fixes 3/5 but abandons the gradient-optimizer default and leaves the explicit-optimizer tests red. Rejected.
- Fixing the analytic gradient / EBE-response, tightening `inner_tol`, the stagnation guard, a bounded initial step, the in-house L-BFGS, and looser outer tolerances — all empirically ruled out (both NLopt and the custom L-BFGS fail identically on tvcov under `Rescale2`/`None`; only the preconditioner matters).

## Breaking changes
- [x] None (internal default; estimates are unchanged or strictly closer to the optimum)

## Numerical validation

Under NLopt L-BFGS:

```
model                Rescale2 (old)        Abs (fix)            truth
warfarin FOCEI       -243 (TVV 6.08)       -286 (TVV 7.74)      -286 (NONMEM)
tvcov (TV-cov)       +166 (TVV at bound)   -188.6 (TVCL .15)    -188
two_cpt_oral_cov     -1026 (slsqp frozen)  -1165 (slsqp moves)  <-1140
warfarin_iov slsqp   307.8                 307.8                307.8 (#335 preserved)
```

- [x] Warfarin converges and estimates are within tolerance (TVV 7.74, OFV −286.0, matches NONMEM)
- [x] Compared against: NONMEM (warfarin/tvcov truth) and the gradient-free BOBYQA path

## Performance
- [x] Faster on the affected path — `warfarin_imp_nonmem` 75s → 7.5s (L-BFGS now converges instead of grinding to the bound)

## Tests
- [x] Unit test updated (`resolve_scaling_routes_auto_by_optimizer` now asserts `Abs`)
- [x] All five previously-red slow-tests pass
- [x] Full unit suite: 1678 passed, 0 failed
- [x] Regression subset (scaling_convergence, scaling_block, structural_param_nonmem, iov_convergence, ltbs_convergence, iiv_on_ruv, warfarin_covariance_nonmem): all pass, no regressions

## Checklist
- [x] `cargo clippy` / build clean (warning-free)
- [x] No `Dual2`-path code touched

## Docs & examples
- [x] No user-visible DSL/API change (internal optimizer default)

## Reviewer hints

The whole change is `resolve_scaling` (Rescale2 → Abs for gradient optimizers) plus a `has_identity_theta` guard on the `Abs` branch in `optimize_nlopt`. The docstring carries the per-model before/after evidence.
