### PR TITLE
feat(ode): analytic gradients for Form C readouts referencing covariates [closes #540]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Analytic FOCE/FOCEI gradients for Form C readouts that reference covariates** (#540).
+  An ODE Form C readout (`[scaling] y = <expr>`) that branches on or scales by a covariate
+  — e.g. a free→total protein-binding readout gated on a `FREE` assay flag — now gets the
+  exact analytic `Dual2`/`Dual1` gradient instead of falling back to finite differences.
+  Covariates carry no parameter derivative in the individual-parameter dual basis the ODE
+  sensitivity provider seeds, so they thread into the dual readout as constants from the
+  per-observation covariate snapshot (consistent with #535/#538), for both the static and
+  time-varying-covariate walks. θ or η referenced *directly* in a Form C readout (rather
+  than via an `[individual_parameters]` entry) still falls back to FD. Validated on the
+  `fluconazole_radboudumc` readout shape (free/total fluconazole with saturable
+  albumin-dependent protein binding): the analytic `∂f/∂η`/`∂f/∂θ` match the production
+  predictor and its central finite differences to ~1e-6 for both subject-static and
+  per-observation `FREE` snapshots (`ode_provider_form_c_*` tests).
 - **Exact analytic FOCE/FOCEI gradients for steady-state (SS=1) ODE dosing** (#439). User-
   `[odes]` models with a steady-state dose now get exact analytic gradients instead of
   finite differences. NONMEM SS=1 loads the compartments with an infinite-past pulse

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -118,7 +118,7 @@ All `[scaling]` variants on the **analytical PK path** support the default
 | Scalar `obs_scale = K` | exact analytic | exact FD | The constant threads as one entry per observation. |
 | Expression `obs_scale = <expr>` | subject-static analytic | exact FD | See subject-static caveat below. |
 | Per-CMT `obs_scale[CMT=N]` | subject-static analytic | exact FD | One per-observation scale entry per observation, dispatched by `subject.obs_cmts[i]`. |
-| Form C `y[…] = <expr>` (ODE only) | exact analytic (in-scope ODE) | exact FD | Since #410/#439 the ODE sensitivity provider differentiates the Form C readout — uniform `y = <expr>` and per-CMT `y[CMT=N] = <expr>` — over `Dual2`/`Dual1` (outer and inner). Out-of-scope ODE features (steady state, IOV, …) fall back to FD. |
+| Form C `y[…] = <expr>` (ODE only) | exact analytic (in-scope ODE) | exact FD | Since #410/#439 the ODE sensitivity provider differentiates the Form C readout — uniform `y = <expr>` and per-CMT `y[CMT=N] = <expr>` — over `Dual2`/`Dual1` (outer and inner), including **covariate references** in the readout (#540): a covariate threads in as a constant from the per-observation snapshot, so a free→total protein-binding readout gated on a `FREE` flag stays analytic. A θ or η referenced *directly* in the readout (rather than via an `[individual_parameters]` entry) falls back to FD, as do out-of-scope ODE features (steady state, IOV, …). |
 
 **Analytic outer gradient handles expression scaling exactly.** The analytic
 sensitivity provider that drives the gradient-based outer optimizers (`bfgs`,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4615,12 +4615,14 @@ fn build_y_output_fn(
 
     // Snapshot the readout as an `OdeOutputProgram` for the analytic-sensitivity
     // path (issue #367): same bytecode + layout, evaluated over `Dual2<N>`. It is
-    // `simple` (dual-evaluable with empty θ/η/cov) when the expression references
-    // only states / individual parameters / constants.
-    let output_simple = !bc.ops.iter().any(|op| {
+    // dual-evaluable when the expression references only states / individual
+    // parameters / covariates / constants — covariates thread in as constants
+    // from the per-observation snapshot (#540), so only a direct θ/η/NN reference
+    // (which would need extra chain terms) disqualifies the analytic readout.
+    let output_dual_evaluable = !bc.ops.iter().any(|op| {
         matches!(
             op,
-            Op::PushTheta(_) | Op::PushEta(_) | Op::PushCov(_) | Op::PushNnOutput(_, _)
+            Op::PushTheta(_) | Op::PushEta(_) | Op::PushNnOutput(_, _)
         )
     });
     let output_program = OdeOutputProgram {
@@ -4628,7 +4630,8 @@ fn build_y_output_fn(
         n_states,
         n_indiv,
         indiv_to_pk: indiv_to_pk.clone(),
-        simple: output_simple,
+        cov_names: cov_names.clone(),
+        dual_evaluable: output_dual_evaluable,
     };
 
     // Per-thread scratch for the y readout vars + covariate slice + bytecode
@@ -9874,28 +9877,38 @@ pub struct OdeOutputProgram {
     n_indiv: usize,
     /// Per individual parameter `i`, its slot in the flat PK-parameter vector.
     indiv_to_pk: Vec<usize>,
+    /// Covariate names the bytecode's `PushCov(i)` reads, in index order. The
+    /// dual readout resolves these from the per-observation covariate snapshot
+    /// and feeds them as constants — a covariate carries no parameter derivative
+    /// in the individual-parameter dual basis the ODE provider seeds (#540).
+    cov_names: Vec<String>,
     /// True when the expression references only states / individual parameters /
-    /// constants (no θ/η/covariate/NN terms) — the case the dual readout can
-    /// evaluate with empty θ/η/cov inputs.
-    simple: bool,
+    /// covariates / constants (no θ/η/NN terms) — the case the dual readout can
+    /// evaluate, threading the covariate snapshot in while leaving θ/η empty.
+    /// θ/η referenced *directly* in the readout would need extra chain terms the
+    /// ODE provider does not yet assemble, so those stay on the FD fallback.
+    dual_evaluable: bool,
 }
 
 impl OdeOutputProgram {
-    /// See [`OdeOutputProgram::simple`].
-    pub(crate) fn is_simple(&self) -> bool {
-        self.simple
+    /// See [`OdeOutputProgram::dual_evaluable`].
+    pub(crate) fn is_dual_evaluable(&self) -> bool {
+        self.dual_evaluable
     }
 
     /// Evaluate the output expression over a dual type, generic over [`PkNum`]
     /// (`Dual1` light inner / `Dual2` full outer; #410) — the Form-C readout.
     /// `state` is the integrated dual state; `params` is the flat PK-parameter
     /// vector with the differentiated slots seeded as dual variables (so `V1`'s
-    /// derivative flows into `central / V1`). `vars`/`stack` are caller-owned
-    /// scratch. Only valid when [`is_simple`](Self::is_simple) holds.
+    /// derivative flows into `central / V1`); `cov` is the per-observation
+    /// covariate snapshot, whose values thread in as constants (#540). `vars`/
+    /// `stack` are caller-owned scratch. Only valid when
+    /// [`is_dual_evaluable`](Self::is_dual_evaluable) holds.
     pub(crate) fn eval_output_g<T: crate::sens::num::PkNum>(
         &self,
         state: &[T],
         params: &[T],
+        cov: &HashMap<String, f64>,
         vars: &mut Vec<T>,
         stack: &mut Vec<T>,
     ) -> T {
@@ -9908,8 +9921,15 @@ impl OdeOutputProgram {
                 *dst = v;
             }
         }
+        // Covariate values in `PushCov` index order (== `cov_names` order); a
+        // missing covariate reads 0.0, mirroring the f64 readout `out_fn`.
+        let cov_vec: Vec<f64> = self
+            .cov_names
+            .iter()
+            .map(|n| cov.get(n).copied().unwrap_or(0.0))
+            .collect();
         let empty_nn: Vec<Vec<f64>> = Vec::new();
-        eval_bytecode_g::<T>(&self.bc, &[], &[], &[], vars, &empty_nn, stack)
+        eval_bytecode_g::<T>(&self.bc, &[], &[], &cov_vec, vars, &empty_nn, stack)
     }
 }
 

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -14,7 +14,10 @@
 //!
 //! **Supported:** single-endpoint `ObsCmt`, uniform Form C (`y = central/V1`), or
 //! per-CMT Form C (`y[CMT=N] = <expr>` — each endpoint differentiated over the dual,
-//! #439) readout; **bolus and infusion** doses; **bioavailability F** (incl.
+//! #439) readout, including **covariate references** in the Form C expression
+//! (e.g. a free→total protein-binding readout that branches on a `FREE` flag, #540)
+//! — covariates thread in as constants from the per-observation snapshot; **bolus
+//! and infusion** doses; **bioavailability F** (incl.
 //! estimated, any parameterization — log-normal, logit-normal, additive — and the
 //! compartment-indexed `F{cmt}` form, #486); **EVID 3/4 resets / multi-occasion**;
 //! **non-zero `init(...)` initial conditions**; static covariates; a constant
@@ -26,7 +29,9 @@
 //! **Not yet supported** (falls back to the gradient-free / FD path): steady-state
 //! dosing, lagtime (incl. compartment-indexed `ALAG{cmt}`), `weibull()` and other
 //! input-rate forcings beyond igd/transit, IOV, SDE/diffusion, expression
-//! `obs_scale`, time-varying covariates.
+//! `obs_scale`, time-varying covariates, and **θ/η referenced *directly* in a Form C
+//! readout** (these need extra direct readout-gradient terms beyond the
+//! individual-parameter chain; reference them via `[individual_parameters]` instead).
 #![allow(clippy::needless_range_loop)]
 
 use super::dual1::Dual1;
@@ -99,12 +104,15 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     // (#439 — each observation reads its CMT's program over the dual state).
     let readout_ok = match &ode.readout {
         OdeReadout::ObsCmt(_) => true,
-        OdeReadout::Single(_) => ode.readout_program.as_ref().is_some_and(|p| p.is_simple()),
+        OdeReadout::Single(_) => ode
+            .readout_program
+            .as_ref()
+            .is_some_and(|p| p.is_dual_evaluable()),
         OdeReadout::PerCmt(map) => {
             !map.is_empty()
                 && map
                     .values()
-                    .all(|r| r.program.as_ref().is_some_and(|p| p.is_simple()))
+                    .all(|r| r.program.as_ref().is_some_and(|p| p.is_dual_evaluable()))
         }
     };
     if !readout_ok {
@@ -401,12 +409,15 @@ pub fn ode_iov_supported(model: &CompiledModel) -> bool {
     // Readout: state directly, simple Form-C, or per-CMT — same set as the non-IOV gate.
     let readout_ok = match &ode.readout {
         OdeReadout::ObsCmt(_) => true,
-        OdeReadout::Single(_) => ode.readout_program.as_ref().is_some_and(|p| p.is_simple()),
+        OdeReadout::Single(_) => ode
+            .readout_program
+            .as_ref()
+            .is_some_and(|p| p.is_dual_evaluable()),
         OdeReadout::PerCmt(map) => {
             !map.is_empty()
                 && map
                     .values()
-                    .all(|r| r.program.as_ref().is_some_and(|p| p.is_simple()))
+                    .all(|r| r.program.as_ref().is_some_and(|p| p.is_dual_evaluable()))
         }
     };
     if !readout_ok {
@@ -955,12 +966,16 @@ fn resolve_obs_readout<T: crate::sens::num::PkNum>(
     ro_vars: &mut Vec<T>,
     ro_stack: &mut Vec<T>,
 ) -> T {
+    // Per-observation covariate snapshot the readout's covariate references read
+    // (#540); for static covariates this is the subject map. Threaded as constants
+    // — a covariate carries no derivative in the individual-parameter dual basis.
+    let obs_cov = subject.obs_cov(j);
     let raw = match &ode.readout {
         OdeReadout::ObsCmt(idx) => st.get(*idx).copied().unwrap_or(T::from_f64(0.0)),
         OdeReadout::Single(_) => ode
             .readout_program
             .as_ref()
-            .map(|p| p.eval_output_g::<T>(st, params, ro_vars, ro_stack))
+            .map(|p| p.eval_output_g::<T>(st, params, obs_cov, ro_vars, ro_stack))
             .unwrap_or(T::from_f64(0.0)),
         // Per-CMT (#439): observation j reads its own CMT's output program.
         OdeReadout::PerCmt(cmt_map) => subject
@@ -968,7 +983,7 @@ fn resolve_obs_readout<T: crate::sens::num::PkNum>(
             .get(j)
             .and_then(|cmt| cmt_map.get(cmt))
             .and_then(|r| r.program.as_ref())
-            .map(|p| p.eval_output_g::<T>(st, params, ro_vars, ro_stack))
+            .map(|p| p.eval_output_g::<T>(st, params, obs_cov, ro_vars, ro_stack))
             .unwrap_or(T::from_f64(f64::NAN)),
     };
     // Negative-readout clamp (ODE overshoot guard), parity with production's
@@ -3292,6 +3307,95 @@ mod tests {
         }
     }
 
+    // 2-cpt ODE whose Form C readout references a **covariate** (`FREE`) — a
+    // free/total protein-binding readout (#540, the fluconazole_radboudumc shape).
+    // The saturable bound term is gated off for free assays (FREE==1) and on for
+    // total assays (FREE==0). `BMAX`/`KD` are individual parameters; the covariate
+    // threads into the dual readout as a constant from the per-observation snapshot,
+    // so the analytic gradient must still match production + FD.
+    const TWOCPT_ODE_READOUT_COV: &str = r#"
+[parameters]
+  theta TVCL(4.0,   0.1, 100.0)
+  theta TVV1(12.0,  1.0, 500.0)
+  theta TVQ(2.0,    0.01, 100.0)
+  theta TVV2(25.0,  1.0, 500.0)
+  theta TVBMAX(3.0, 0.0, 100.0)
+  theta TVKD(5.0,   0.01, 100.0)
+  omega ETA_CL ~ 0.15
+  omega ETA_V1 ~ 0.15
+  sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V1   = TVV1 * exp(ETA_V1)
+  Q    = TVQ
+  V2   = TVV2
+  BMAX = TVBMAX
+  KD   = TVKD
+[structural_model]
+  ode(states=[central, peripheral])
+[odes]
+  d/dt(central)    = -(CL/V1) * central - (Q/V1) * central + (Q/V2) * peripheral
+  d/dt(peripheral) =  (Q/V1) * central  - (Q/V2) * peripheral
+[scaling]
+  y = central / V1 + (1.0 - FREE) * BMAX * (central / V1) / (KD + central / V1)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+    /// #540: a Form C readout referencing a covariate is now analytic. With the
+    /// covariate held constant per subject (`obs_covariates` empty → the static
+    /// walk), the provider gradient must match production + FD for both the total
+    /// assay (bound term active) and the free assay (bound term zeroed).
+    #[test]
+    fn ode_provider_form_c_static_covariate_matches_production() {
+        let model = parse_model_string(TWOCPT_ODE_READOUT_COV).expect("parse");
+        assert!(
+            ode_analytical_supported(&model),
+            "Form C readout referencing a covariate should be analytic (#540)"
+        );
+        let theta = vec![4.0, 12.0, 2.0, 25.0, 3.0, 5.0];
+        let eta = vec![0.12, -0.08];
+        let times = [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 24.0];
+
+        let mut total = bolus_subject(&times);
+        total.covariates.insert("FREE".to_string(), 0.0);
+        check_vs_production(&model, &total, &theta, &eta);
+
+        let mut free = bolus_subject(&times);
+        free.covariates.insert("FREE".to_string(), 1.0);
+        check_vs_production(&model, &free, &theta, &eta);
+    }
+
+    /// #540: the readout covariate read per observation. `FREE` alternates row to
+    /// row (paired free/total assays on one subject), so the bound term switches on
+    /// and off per observation — the TV-cov walk's `obs_cov(j)` snapshot path. The
+    /// analytic gradient must still match the production predictor + FD.
+    #[test]
+    fn ode_provider_form_c_per_obs_covariate_matches_production() {
+        let model = parse_model_string(TWOCPT_ODE_READOUT_COV).expect("parse");
+        let theta = vec![4.0, 12.0, 2.0, 25.0, 3.0, 5.0];
+        let eta = vec![0.12, -0.08];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0];
+
+        let mut subj = bolus_subject(&times);
+        subj.obs_covariates = (0..times.len())
+            .map(|i| HashMap::from([("FREE".to_string(), (i % 2) as f64)]))
+            .collect();
+        assert!(
+            subj.has_tv_covariates(),
+            "alternating FREE must register as time-varying"
+        );
+        assert!(
+            ode_tvcov_supported(&model, &subj),
+            "TV-cov Form C readout referencing a covariate should be analytic (#540)"
+        );
+        check_vs_production(&model, &subj, &theta, &eta);
+    }
+
     /// Shared check: provider `f`/`∂f/∂η`/`∂f/∂θ` vs production predictor + FD.
     fn check_vs_production(model: &CompiledModel, subject: &Subject, theta: &[f64], eta: &[f64]) {
         let sens = ode_subject_sensitivities(model, subject, theta, eta).expect("supported");
@@ -4826,7 +4930,7 @@ mod tests {
 
     /// The `PerCmt` gate's negative branches must drop the model out of analytic
     /// scope (→ FD), not silently admit it: an empty endpoint map, or an endpoint
-    /// whose `program` is `None` (hand-constructed / non-`is_simple`, which the dual
+    /// whose `program` is `None` (hand-constructed / non-`is_dual_evaluable`, which the dual
     /// provider can't evaluate) (#446 review — patch coverage on the reject path).
     #[test]
     fn ode_provider_percmt_gate_rejects_incomplete_map() {


### PR DESCRIPTION
## Why

A Form C ODE readout (`[scaling] y = <expr>`) that references a **covariate** — e.g. a free→total protein-binding readout gated on a `FREE` assay flag (the `fluconazole_radboudumc` shape) — was forced onto the finite-difference gradient even under `gradient = auto`. The analytic readout (`OdeOutputProgram`) was only admitted when it referenced states / individual parameters / constants alone, so any covariate (or θ/η/NN) reference dropped the whole subject to FD. Closes #540.

## What changed

A covariate carries **no parameter derivative** in the individual-parameter dual basis the ODE sensitivity provider seeds, so it can thread into the dual readout as a constant — no change to the η/θ chain or the FOCEI Hessian (a covariate adds no axis).

- `OdeOutputProgram`: gate widened from "no θ/η/cov" → "no θ/η/NN" (`simple` → `dual_evaluable`); now carries the readout's `cov_names`; `eval_output_g` builds the covariate slice and passes it to the bytecode VM (`PushCov` lifts an f64 to `T::from_f64`).
- `resolve_obs_readout` resolves the **per-observation** covariate snapshot `subject.obs_cov(j)` (the single readout site shared by the static and TV-cov walks), consistent with the per-obs snapshot semantics in the base branch (#535/#538).
- θ or η referenced **directly** in a Form C readout still falls back to FD — those need direct readout-gradient terms beyond the individual-parameter chain; filed as a follow-up.

## Alternatives considered

Seeding θ/η axes onto the state dual to support direct θ/η in the readout — heavier (wider duals, Hessian cross-terms) and not needed for the motivating models, where parameter-like refs go through `[individual_parameters]`. Deferred.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change (the gate flag/method are `pub(crate)`; `Subject::obs_cov` already public).

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: production predictor + central finite differences
- Analytic `∂f/∂η`, `∂f/∂θ` match the production predictor and its central FD to ~1e-6 on the fluconazole readout shape, for both subject-static `FREE` and alternating per-observation `FREE`:
  - `ode_provider_form_c_static_covariate_matches_production`
  - `ode_provider_form_c_per_obs_covariate_matches_production`
- End-to-end: `fluconazole_radboudumc` now reports `gradient: analytic (Dual2) [requested: auto]` instead of falling back to FD.

## Performance
- [x] No significant impact expected (covariate threads in as a constant lookup; the dual readout cost is unchanged). Note: routing an **SS-infusion** model like fluconazole onto the analytic path surfaces the separate, pre-existing SS-equilibration cost — tracked in #543, not introduced here.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 1630 lib tests)
- [x] Regression test added that fails without this fix (the two parity tests above mismatch production when the readout covariate is dropped)

## Example (user-facing features only)
- [x] Not applicable (no new DSL surface — existing Form C syntax, now analytic where it previously used FD)

A model that benefits:
```ferx
[scaling]
  y = central / V1 + (1.0 - FREE) * BMAX * ALBBMAX * (central / V1) / (KD + central / V1)
```
`FREE` is a covariate; with `gradient = auto` this now gets the exact `Dual2`/`Dual1` gradient.

## Docs
- [x] `docs/model-file/scaling.qmd` gradient-interaction table updated
- [x] `CHANGELOG.md` `[Unreleased]` → Added entry

## Checklist
- [x] `cargo clippy` clean (no new warnings on the diff)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (`eval_output_g` is generic over `PkNum`; covariate enters as a constant)
- [x] No `Cargo.toml` version bump needed

## Reviewer hints
- Core change: `OdeOutputProgram` (`src/parser/model_parser.rs`) + `resolve_obs_readout` (`src/sens/ode_provider.rs`).
- The key correctness argument is that a covariate is a constant in the individual-parameter dual basis, so the existing η/θ chain and FOCEI Hessian are untouched — only the readout's *value* (and the indiv-param derivatives that flow through it) change.

## Open questions
- This PR is **stacked on #538** (`fix/form-c-observation-covariates`): the analytic readout uses `obs_cov(j)`, which only matches the production predictor once #538 switches production to per-observation snapshots. Base is set to the #538 branch — retarget to `main` after #538 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)