### PR TITLE
test(ode): pin analytic M3 BLOQ gradients on the ODE path [#486]

### DIFF
--- a/examples/warfarin_ode_bloq.ferx
+++ b/examples/warfarin_ode_bloq.ferx
@@ -1,0 +1,41 @@
+# One-compartment oral PK model (ODE) with M3 BLOQ likelihood.
+#
+# ODE counterpart of warfarin_bloq.ferx — same data (data/warfarin_bloq.csv),
+# same true parameters, observations below LLOQ=2.0 flagged via CENS. Exercises
+# the M3 censored likelihood gradient on the event-driven ODE sensitivity walk.
+# States:
+#   CMT=1  depot   — oral dose (mg)
+#   CMT=2  central — concentration (mg/L)
+
+[parameters]
+  theta TVCL(0.2,  0.001, 10.0)
+  theta TVV(10.0,  0.1,  500.0)
+  theta TVKA(1.5,  0.01,  50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) =  KA * depot / V - (CL/V) * central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method       = focei
+  maxiter      = 300
+  bloq_method  = m3
+  ode_reltol   = 1e-10
+  ode_abstol   = 1e-12

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2135,6 +2135,62 @@ mod tests {
         }
     }
 
+    /// ODE counterpart of [`analytic_inner_gradient_m3_matches_fd_on_warfarin_bloq`]:
+    /// the analytic M3 inner η-gradient produced via the **event-driven ODE
+    /// sensitivity walk** (not the closed-form provider) must match a central FD of
+    /// the inner objective on the warfarin BLOQ data — confirming non-IOV ODE+M3 is
+    /// served analytically on the inner loop (the censored `−logΦ` coefficient rides
+    /// the same provider-agnostic `apply_*_inner` path as the closed-form engine).
+    #[test]
+    fn analytic_inner_gradient_m3_matches_fd_on_warfarin_ode_bloq() {
+        use std::cell::RefCell;
+        use std::path::Path;
+        let model = crate::parser::model_parser::parse_model_file(Path::new(
+            "examples/warfarin_ode_bloq.ferx",
+        ))
+        .expect("warfarin ODE BLOQ model parses");
+        assert!(
+            matches!(model.bloq_method, crate::types::BloqMethod::M3),
+            "model must be M3"
+        );
+        assert!(
+            model.is_ode_based(),
+            "model must be on the ODE path for this probe"
+        );
+        let pop =
+            crate::io::datareader::read_nonmem_csv(Path::new("data/warfarin_bloq.csv"), None, None)
+                .expect("warfarin BLOQ data loads");
+        let subject = pop
+            .subjects
+            .iter()
+            .find(|s| s.cens.iter().any(|&c| c != 0))
+            .expect("at least one subject with a censored row");
+
+        let theta = &model.default_params.theta;
+        let omega = &model.default_params.omega;
+        let sigma = &model.default_params.sigma.values;
+        let eta = vec![0.12, -0.05, 0.2];
+
+        let analytic = analytic_eta_nll_gradient(&model, subject, theta, &eta, omega, sigma)
+            .expect("analytic M3 inner gradient must be supported on ODE path");
+
+        let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
+        let obj = |e: &[f64]| -> f64 {
+            let mut s = scratch.borrow_mut();
+            individual_nll_into_with_schedule(&model, subject, theta, e, omega, sigma, &mut s, None)
+        };
+        let fd = gradient_fd(&obj, &eta, model.n_eta);
+
+        for k in 0..model.n_eta {
+            assert!(
+                (analytic[k] - fd[k]).abs() < 1e-4 * (1.0 + fd[k].abs()),
+                "η[{k}]: analytic {} vs FD {}",
+                analytic[k],
+                fd[k]
+            );
+        }
+    }
+
     /// Dense BFGS vs L-BFGS scaling with inner dimension `n`, on an
     /// ill-conditioned 1-D-Laplacian quadratic `½xᵀLx − 1ᵀx` (cond ≈ (n/π)², so
     /// the solve needs ~O(n) curvature updates — representative of a curved inner

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -3673,6 +3673,114 @@ mod tests {
         }
     }
 
+    // 1-cpt oral **user-ODE** model with M3 BLOQ, tight tolerances. ODE counterpart
+    // of the closed-form `population_packed_gradient_m3_matches_fd`: the censored
+    // `−logΦ` term enters `prepare`'s M3 branch on top of the ODE walk's `ObsSens`
+    // (the same provider-agnostic assembly), proving non-IOV ODE+M3 is analytic on
+    // the outer loop.
+    const ONECPT_ODE_M3_OUTER: &str = r#"
+[parameters]
+  theta TVCL(0.2,  0.001, 10.0)
+  theta TVV(10.0,  0.1,  500.0)
+  theta TVKA(1.5,  0.01,  50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) =  KA * depot / V - (CL/V) * central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method      = focei
+  bloq_method = m3
+  ode_reltol  = 1e-9
+  ode_abstol  = 1e-11
+"#;
+
+    /// ODE counterpart of [`population_packed_gradient_m3_matches_fd`]: the analytic
+    /// FOCEI M3 packed gradient assembled from the **event-driven ODE sensitivity
+    /// walk** (censored rows enter `prepare`'s M3 branch) must match reconverged FD
+    /// of the M3 FOCEI objective. Proves non-IOV ODE+M3 is analytic on the outer
+    /// loop (the inner counterpart lives in `inner_optimizer.rs`).
+    #[test]
+    fn population_packed_gradient_ode_m3_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        use crate::types::{BloqMethod, Population};
+
+        let model = parse_model_string(ONECPT_ODE_M3_OUTER).expect("parse ODE M3");
+        assert!(matches!(model.bloq_method, BloqMethod::M3), "must be M3");
+        assert!(model.is_ode_based(), "must be on the ODE path");
+        let theta = [0.22, 11.0, 1.4];
+
+        let mut s1 = subject_with_obs(&model, &theta, &[0.5, 1.0, 2.0, 8.0]);
+        let mut s2 = subject_with_obs(&model, &theta, &[0.25, 1.5, 6.0, 12.0, 36.0]);
+        for s in [&mut s1, &mut s2] {
+            let n = s.observations.len();
+            s.cens[n - 1] = 1;
+            s.cens[n - 2] = 1;
+        }
+        assert!(s1.cens.iter().any(|&c| c != 0) && s2.cens.iter().any(|&c| c != 0));
+
+        let pop = Population {
+            subjects: vec![s1, s2],
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ehs: Vec<DVector<f64>> = pop
+            .subjects
+            .iter()
+            .map(|s| DVector::from_vec(precise_ebe(&model, s, &params)))
+            .collect();
+
+        let analytic =
+            population_gradient_sens(&model, &pop, &template, &x, &ehs).expect("ODE M3 supported");
+
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            2.0 * pop
+                .subjects
+                .iter()
+                .map(|s| marginal_nll(&model, s, &p))
+                .sum::<f64>()
+        };
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.clone();
+            xp[k] += h;
+            let mut xm = x.clone();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0;
+            eprintln!(
+                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic[k],
+                fd,
+                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(analytic[k], fd, max_relative = 5e-3, epsilon = 1e-5);
+        }
+    }
+
     /// The analytic **FOCE** (Sheiner–Beal, non-interaction) M3 packed gradient
     /// (censored rows excluded from R̃, added as `−logΦ((LLOQ−f̂)/√R⁰)` with the
     /// population variance) must match the reconverged-FD of ferx's FOCE-M3


### PR DESCRIPTION
## Why

The [#486](https://github.com/FeRx-NLME/ferx-core/issues/486) analytic-gradient status matrix records **non-IOV M3 BLOQ** as `analytical ✅ · ✅ · ODE FD · FD` — i.e. analytic on the closed-form path but finite-difference on the ODE path. That cell is **stale**: non-IOV ODE + M3 already produces analytic gradients on *both* loops, it just had no test pinning it and was mis-recorded.

The M3 censored data term (`−logΦ(z)`, `z = (LLOQ−f)/√V`) enters through **provider-agnostic** code:

- **inner** — `m3_censored_dterm_df` is applied to whatever `df_deta` the inner provider emits (`inner_optimizer.rs`), closed-form *or* ODE walk;
- **outer** — `m3_censored_scalars` is applied in `prepare_stacked` (`sens_outer_gradient.rs`) to whatever `ObsSens` the walk produced.

No non-IOV M3 gate exists in either provider — only **IOV + M3** is routed to FD (added in `3d7aca0e`, whose own comment notes *"Non-IOV M3 is fully analytic"*). So the ODE path has served M3 analytically since that commit; this PR locks the behaviour in and corrects the record.

## What changed

Test-only. Two regression tests + one fixture, no production code touched:

- `examples/warfarin_ode_bloq.ferx` — ODE counterpart of `warfarin_bloq.ferx` (1-cpt oral as `[odes]`, `bloq_method = m3`, tight solver tolerances), reusing `data/warfarin_bloq.csv`.
- `analytic_inner_gradient_m3_matches_fd_on_warfarin_ode_bloq` (`inner_optimizer.rs`) — the analytic M3 inner η-gradient from the event-driven ODE walk matches a central FD of the inner objective on the real warfarin BLOQ data.
- `population_packed_gradient_ode_m3_matches_fd` (`sens_outer_gradient.rs`) — the analytic FOCEI M3 packed θ/Ω/σ gradient matches reconverged Richardson FD of the M3 marginal objective.

## Alternatives considered

Initially scoped as "implement M3 on the ODE path" (the matrix said FD). An adversarial scope check found the gradient was already analytic and correct, so the work collapsed from *implement* to *verify + cover + correct the tracker* — confirmed by writing the FD-comparison tests before assuming any gap.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change (no new `pub` surface), so no ferx-r lock bump.

## Breaking changes
- [x] None

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit (analytic ≡ central/Richardson finite differences of the production M3 objective)
- [x] Reference values:

```
# Outer packed gradient (population_packed_gradient_ode_m3_matches_fd), analytic vs Richardson FD:
#   max relative error <= 3e-6 across all 7 packed parameters (theta, Omega, sigma)
# Inner eta-gradient (analytic_inner_gradient_m3_matches_fd_on_warfarin_ode_bloq):
#   analytic ≡ central FD within 1e-4 relative on the warfarin BLOQ subject
```

## Performance
- [x] No significant impact expected (test-only; the analytic path it exercises was already live)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added (pins ODE+M3 analytic; would fail if the path regressed to FD or a wrong gradient)

## Example (user-facing features only)
- [x] Example added to `examples/` (`warfarin_ode_bloq.ferx`)
- [ ] Not applicable

The new fixture is a test asset (ODE twin of the existing BLOQ example); it does not introduce user-visible behaviour, so it is not added to the docs nav.

## Docs
- [x] No user-visible change — the model already fit correctly via FD or analytic; this only pins/labels the gradient method. Repo docs are already correct (`docs/examples/bloq.qmd` already states "Both have exact analytic gradients"). The only stale claim lives in the **#486 issue tracker**, which will be corrected post-merge (matrix row → `✅ · ✅ · ✅ · ✅`).
- [x] `CHANGELOG.md` N/A — internal/test-only, no behaviour change.

## Checklist
- [x] `cargo clippy` clean (no production code changed)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (none touched)
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### Example execution
- [x] No example execution step needed (test-only; no user-visible change). The fixture is exercised by `cargo test --lib`.

## Reviewer hints

Focus on whether the two tests genuinely exercise the **ODE** provider (not the closed-form one): both assert `model.is_ode_based()`, and the fixture/model strings use `[odes]` blocks. The outer test marks the last two observations of each synthetic subject as censored (`CENS=1`) so each subject mixes quantified and BLOQ rows. Everything else is a mirror of the existing closed-form M3 tests (`analytic_inner_gradient_m3_matches_fd_on_warfarin_bloq`, `population_packed_gradient_m3_matches_fd`).

## Open questions

None. IOV + M3 remains correctly FD (out of scope, separate gate).
