### PR TITLE
feat(estimation): support cross-endpoint residual covariance [closes #546]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Support NONMEM-style `block_sigma` residual covariance across paired same-time
+  multi-endpoint observations under FOCE (#546).
 - Support fixed residual-error correlations via `block_sigma` for FOCE combined-error
   models, with a NONMEM `$SIGMA BLOCK(2) FIX` validation example (#537).
 - **Analytic FOCE/FOCEI gradients for Form C readouts that reference covariates** (#540).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,10 @@ section of the SDLC for the versioning policy).
   `[derived]` reference (`W_DERIVED_INIT_ANALYTICAL`) warns rather than silently
   mispredicting. See [Initial Conditions](model-file/initial-conditions.qmd).
 ### Fixed
+- Reject `block_sigma` with IOV until the IOV inner objective supports the full
+  residual covariance matrix, use shifted times when pairing reset-segment
+  residual blocks, and keep FREM CWRES variances unscaled by `iiv_on_ruv`
+  (#549).
 - **Form C (`[scaling] y = <expr>`) ODE readouts now use per-observation covariate
   snapshots** (#535, #538). The explicit-output readout is evaluated against the
   covariate values on each observation's own data row rather than the subject's

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -232,12 +232,17 @@ $$
 
 The diagonal sigma SDs are estimated unless marked `FIX`; the off-diagonal
 covariance is always converted to a fixed correlation. A nonzero `block_sigma`
-covariance must connect sigmas that co-load on the same `combined(...)`
-endpoint; cross-endpoint residual covariances are rejected.
+covariance can connect sigmas that co-load on the same `combined(...)` endpoint,
+or sigmas used by different CMT endpoints measured at the same subject time and
+occasion. In the cross-endpoint case ferx builds a subject-level residual
+covariance matrix, so paired rows such as total/unbound assays receive the
+NONMEM-style covariance term `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
 
-Current scope: `block_sigma` is supported for `method = foce`. FOCEI/GN,
-SAEM, and importance-sampling paths reject correlated residual sigma blocks
-until their residual-error derivative code is extended beyond diagonal RUV.
+Current scope: `block_sigma` is supported for ordinary Gaussian `method = foce`
+fits. FOCEI/GN, SAEM, importance-sampling paths, M3 censored-observation
+likelihoods, FREM covariate pseudo-observations, and `iiv_on_ruv` reject
+correlated residual sigma blocks until their residual-error derivative code is
+extended beyond diagonal RUV.
 
 Validation: `examples/correlated_residual_combined.ferx` and
 `nonmem_anchor/correlated_residual_combined.ctl` run the same fixed-parameter

--- a/src/api.rs
+++ b/src/api.rs
@@ -927,6 +927,36 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 break;
             }
         }
+        if matches!(model.bloq_method, BloqMethod::M3) {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_M3_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     M3 censored-observation likelihoods.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        if model.frem_config.is_some() {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_FREM_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     FREM covariate pseudo-observations.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        if model.residual_error_eta.is_some() {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_IIV_ON_RUV_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     iiv_on_ruv residual-error scaling.",
+                )
+                .with_block("fit_options"),
+            );
+        }
     }
 
     // `imp` may appear at most once in a chain. By default it is an MCEM

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,9 @@ use crate::io::datareader::{
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;
-use crate::stats::likelihood::{compute_cwres, foce_subject_nll, foce_subject_nll_iov};
+use crate::stats::likelihood::{
+    build_frem_r_override, compute_cwres, foce_subject_nll, foce_subject_nll_iov,
+};
 use crate::stats::residual_error::{compute_iwres_with_correlations, iwres_autocorrelation};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -953,6 +955,17 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                     "E_BLOCK_SIGMA_IIV_ON_RUV_UNSUPPORTED",
                     "block_sigma correlated residual errors are not yet supported with \
                      iiv_on_ruv residual-error scaling.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        if model.n_kappa > 0 {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_IOV_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     inter-occasion variability (κ / [iov]) because the IOV inner \
+                     objective does not yet use the full residual covariance matrix.",
                 )
                 .with_block("fit_options"),
             );
@@ -4108,6 +4121,11 @@ fn compute_subject_results(
             }
 
             // CWRES
+            let frem_r_override = build_frem_r_override(
+                model.frem_config.as_ref(),
+                &subject.fremtype,
+                &params.sigma.values,
+            );
             let cwres = compute_cwres(
                 subject,
                 &ipred,
@@ -4117,6 +4135,7 @@ fn compute_subject_results(
                 &params.sigma.values,
                 &model.error_spec,
                 &model.residual_correlations,
+                frem_r_override.as_deref(),
                 model.residual_error_eta,
             );
 
@@ -5953,6 +5972,27 @@ mod iov_integration {
         assert!(!super::check_model_options(&model, &foce)
             .iter()
             .any(|d| d.code == "E_BLOCK_SIGMA_METHOD_UNSUPPORTED"));
+    }
+
+    #[test]
+    fn test_check_model_options_block_sigma_rejects_iov() {
+        let mut model = make_iov_model();
+        model.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+
+        let opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+        let diags = super::check_model_options(&model, &opts);
+        let d = diags
+            .iter()
+            .find(|d| d.code == "E_BLOCK_SIGMA_IOV_UNSUPPORTED")
+            .expect("expected E_BLOCK_SIGMA_IOV_UNSUPPORTED for block_sigma + IOV");
+
+        assert!(d.is_error());
+        assert!(d.message.contains("inter-occasion"));
+        assert_eq!(d.block.as_deref(), Some("fit_options"));
     }
 
     // IMPMAP does not yet support IOV; `ferx check` must flag it up front rather

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -534,9 +534,13 @@ pub fn find_ebe(
     // and then overridden, which keeps the diff minimal and trivially
     // revertible while the values come from the exact sensitivities.
     let t_jac = std::time::Instant::now();
-    let analytic_jac: Option<DMatrix<f64>> =
+    let analytic_jac: Option<DMatrix<f64>> = if analytic_inner_grad_supported(model, subject) {
         crate::sens::provider::subject_eta_jacobian(model, subject, &params.theta, &eta_true)
-            .map(|j| DMatrix::from_row_slice(subject.obs_times.len(), n_eta, &j));
+            .map(|j| DMatrix::from_row_slice(subject.obs_times.len(), n_eta, &j))
+            .filter(|j| j.iter().all(|v| v.is_finite()))
+    } else {
+        None
+    };
     if analytic_jac.is_some() {
         GRADIENT_TIMINGS.record_jac_analytic(t_jac.elapsed().as_nanos() as u64);
     }
@@ -2045,6 +2049,7 @@ pub fn run_inner_loop_warm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     /// The M3 censored coefficient `∂/∂f[−logΦ((y−f)/√v)]` must equal a central
     /// finite difference of that data term — across additive (`dv_df = 0`) and
@@ -2084,6 +2089,86 @@ mod tests {
                 "f={f}, sig_add={sig_add}, sig_prop={sig_prop}: analytic {analytic} vs FD {fd}"
             );
         }
+    }
+
+    #[test]
+    fn find_ebe_uses_fd_h_matrix_when_inner_gradient_forced_fd() {
+        use crate::parser::model_parser::parse_model_string;
+
+        let mut model = parse_model_string(
+            r#"
+[parameters]
+  theta TVCL(0.15, 0.01, 10.0)
+  theta TVV(5.0, 0.1, 100.0)
+  theta TVIMAX(-0.3, -10.0, 10.0)
+  theta TVTI50(100.0, 1.0, 700.0)
+  theta TVHILL(3.0, 0.1, 10.0)
+  omega ETA_CL ~ 0.1
+  omega ETA_V  ~ 0.01
+  sigma PROP_ERR ~ 0.04
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  IMAX = TVIMAX
+  TI50 = TVTI50
+  HILL = TVHILL
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL * exp(IMAX * TIME^HILL / (TI50^HILL + TIME^HILL)) / V) * central
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  gradient = fd
+"#,
+        )
+        .expect("parse");
+        model.gradient_method = GradientMethod::Fd;
+
+        let subject = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 200.0, 1, 9600.0, false, 0.0)],
+            obs_times: vec![20.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![12.0],
+            obs_cmts: vec![1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+
+        let result = find_ebe(
+            &model,
+            &subject,
+            &model.default_params,
+            50,
+            1e-5,
+            None,
+            None,
+        );
+
+        assert!(
+            result.h_matrix.iter().all(|v| v.is_finite()),
+            "forced-FD inner route must not consume a non-finite analytic h_matrix: {:?}",
+            result.h_matrix
+        );
     }
 
     /// End-to-end: the analytic M3 inner η-gradient must match a central finite

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1108,6 +1108,7 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
         if no_analytic_inner_forced()
             || matches!(model.gradient_method, GradientMethod::Fd)
             || model.is_sde()
+            || !model.residual_correlations.is_empty()
             || model.iiv_on_ruv_forces_fd()
         {
             return false;

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -7222,10 +7222,13 @@ fn validate_residual_correlations(
     };
 
     for corr in correlations {
-        let co_loaded = endpoint_loadings
+        let left_used = endpoint_loadings
             .iter()
-            .any(|loadings| loadings.contains(&corr.sigma_i) && loadings.contains(&corr.sigma_j));
-        if !co_loaded {
+            .any(|loadings| loadings.contains(&corr.sigma_i));
+        let right_used = endpoint_loadings
+            .iter()
+            .any(|loadings| loadings.contains(&corr.sigma_j));
+        if !(left_used && right_used) {
             let left = sigma_names
                 .get(corr.sigma_i)
                 .map(String::as_str)
@@ -7235,9 +7238,8 @@ fn validate_residual_correlations(
                 .map(String::as_str)
                 .unwrap_or("<unknown>");
             return Err(format!(
-                "block_sigma covariance between '{}' and '{}' is not used by any \
-                 single observation in [error_model]; correlated residual sigmas \
-                 must belong to the same combined endpoint",
+                "block_sigma covariance between '{}' and '{}' references a sigma \
+                 that is not used by [error_model]",
                 left, right
             ));
         }
@@ -15292,11 +15294,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_full_model_block_sigma_cross_endpoint_covariance_errs() {
-        // A covariance between sigmas that never co-load on the same
-        // observation would be skipped by the variance helper. Reject it at
-        // parse time so users do not think a cross-endpoint covariance is in
-        // the likelihood.
+    fn test_parse_full_model_block_sigma_cross_endpoint_covariance_builds_correlation() {
+        // Cross-endpoint covariances are carried by the subject-level residual
+        // covariance matrix for paired observations.
         let content = r#"
 [parameters]
   theta TVCL(5.0, 0.1, 50.0)
@@ -15324,11 +15324,8 @@ mod tests {
   CMT=1: DV ~ combined(S_PROP, S_ADD)
   CMT=2: DV ~ additive(S_PD)
 "#;
-        let err = expect_parse_err(content);
-        assert!(
-            err.contains("block_sigma") && err.contains("same combined endpoint"),
-            "got: {err}"
-        );
+        let parsed = parse_full_model(content).expect("cross-endpoint block_sigma should parse");
+        assert_eq!(parsed.model.residual_correlations.len(), 1);
     }
 
     #[test]

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -626,6 +626,18 @@ pub fn build_frem_r_override(
     )
 }
 
+fn apply_frem_r_matrix_overrides(r_matrix: &mut DMatrix<f64>, overrides: &[Option<f64>]) {
+    for (j, ov) in overrides.iter().enumerate() {
+        if let (Some(v), true) = (ov, j < r_matrix.nrows()) {
+            for k in 0..r_matrix.ncols() {
+                r_matrix[(j, k)] = 0.0;
+                r_matrix[(k, j)] = 0.0;
+            }
+            r_matrix[(j, j)] = *v;
+        }
+    }
+}
+
 /// path — so inside this function the only case we need to handle is
 /// `bloq_method == Drop` (treat CENS rows as ordinary obs) or no CENS at all.
 pub fn foce_subject_nll_standard(
@@ -677,15 +689,7 @@ pub fn foce_subject_nll_standard(
         }
     }
     if let Some(overrides) = frem_r_override {
-        for (j, ov) in overrides.iter().enumerate() {
-            if let (Some(v), true) = (ov, j < r_matrix.nrows()) {
-                for k in 0..r_matrix.ncols() {
-                    r_matrix[(j, k)] = 0.0;
-                    r_matrix[(k, j)] = 0.0;
-                }
-                r_matrix[(j, j)] = *v;
-            }
-        }
+        apply_frem_r_matrix_overrides(&mut r_matrix, overrides);
     }
     let r_diag: Vec<f64> = (0..r_matrix.nrows()).map(|j| r_matrix[(j, j)]).collect();
 
@@ -1349,6 +1353,7 @@ pub fn compute_cwres(
     sigma_values: &[f64],
     error_spec: &ErrorSpec,
     residual_correlations: &[ResidualCorrelation],
+    frem_r_override: Option<&[Option<f64>]>,
     // IIV-on-RUV eta index (or None). Scales the residual diagonal `R` by
     // exp(2·η̂_ruv) so CWRES uses the subject's actual residual SD (#409).
     residual_error_eta: Option<usize>,
@@ -1374,9 +1379,24 @@ pub fn compute_cwres(
         sigma_values,
         residual_correlations,
     );
+    if let Some(overrides) = frem_r_override {
+        apply_frem_r_matrix_overrides(&mut r_matrix, overrides);
+    }
     let ruv_scale = ruv_scale_from(eta_hat.as_slice(), residual_error_eta);
     if ruv_scale != 1.0 {
-        r_matrix *= ruv_scale;
+        if let Some(overrides) = frem_r_override {
+            for j in 0..r_matrix.nrows() {
+                let j_is_frem = overrides.get(j).and_then(|x| *x).is_some();
+                for k in 0..r_matrix.ncols() {
+                    let k_is_frem = overrides.get(k).and_then(|x| *x).is_some();
+                    if !j_is_frem && !k_is_frem {
+                        r_matrix[(j, k)] *= ruv_scale;
+                    }
+                }
+            }
+        } else {
+            r_matrix *= ruv_scale;
+        }
     }
     let r_tilde = compute_r_tilde_with_r(h_matrix, &omega.matrix, &r_matrix);
 
@@ -1591,6 +1611,7 @@ mod tests {
     use crate::types::{
         BloqMethod, DoseEvent, ErrorModel, ErrorSpec, GradientMethod, PkModel, PkParams,
     };
+    use approx::assert_relative_eq;
     use std::collections::HashMap;
 
     fn make_simple_subject() -> Subject {
@@ -2219,6 +2240,54 @@ mod tests {
             (focei - focei_none).abs() > 1e-6,
             "residual-eta marginal must differ from the no-RUV-eta marginal"
         );
+    }
+
+    #[test]
+    fn compute_cwres_does_not_scale_frem_rows_by_iiv_on_ruv() {
+        let subject = Subject {
+            id: "1".to_string(),
+            doses: Vec::new(),
+            obs_times: vec![1.0, 2.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![11.0, 21.0],
+            obs_cmts: vec![1, 1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: vec![0, 100],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let ipreds = vec![10.0, 20.0];
+        let eta_hat = DVector::from_vec(vec![0.5]);
+        let h = DMatrix::<f64>::zeros(2, 1);
+        let omega = OmegaMatrix::from_diagonal(&[0.1], vec!["ETA_RUV".into()]);
+        let sigma = vec![2.0, 0.5];
+        let overrides = vec![None, Some(0.25)];
+
+        let cwres = compute_cwres(
+            &subject,
+            &ipreds,
+            &eta_hat,
+            &h,
+            &omega,
+            &sigma,
+            &ErrorSpec::Single(ErrorModel::Additive),
+            &[],
+            Some(&overrides),
+            Some(0),
+        );
+
+        let pk_expected = 1.0 / (sigma[0] * eta_hat[0].exp());
+        let frem_expected = 1.0 / sigma[1];
+        assert_relative_eq!(cwres[0], pk_expected, epsilon = 1e-12);
+        assert_relative_eq!(cwres[1], frem_expected, epsilon = 1e-12);
     }
 
     /// IIV on residual error (#409): `individual_nll` must multiply the residual

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -1,5 +1,5 @@
 use crate::pk;
-use crate::stats::residual_error::compute_r_diag_with_correlations;
+use crate::stats::residual_error::compute_r_matrix_with_correlations;
 use crate::stats::special::log_normal_cdf;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -160,31 +160,69 @@ pub fn individual_nll_into_with_schedule(
     // this factor is applied) or the EKF process noise `p_obs`.
     let ruv_scale = model.residual_var_scale(eta);
     let mut data_ll = 0.0;
-    for (j, (&y, &f_pred)) in subject.observations.iter().zip(preds.iter()).enumerate() {
-        // FREM dispatch: covariate pseudo-observations use theta+eta as
-        // prediction and a near-zero additive sigma.
-        let fremtype_val = subject.fremtype.get(j).copied().unwrap_or(0);
-        if fremtype_val > 0 {
-            if let Some(ref fc) = model.frem_config {
-                if let Some(&(theta_idx, eta_idx)) = fc.fremtype_to_indices.get(&fremtype_val) {
-                    let frem_pred = theta[theta_idx] + eta[eta_idx];
-                    let frem_sigma = sigma_values[fc.covariate_sigma_index];
-                    let frem_v = (frem_sigma * frem_sigma).max(1e-12);
-                    let resid = y - frem_pred;
-                    data_ll += resid * resid / frem_v + frem_v.ln();
-                    continue;
-                }
+    let has_censored_m3 =
+        matches!(model.bloq_method, BloqMethod::M3) && subject.has_censored_observation();
+    let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
+    if !model.residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
+        let mut r = compute_r_matrix_with_correlations(
+            &model.error_spec,
+            &preds,
+            &subject.obs_cmts,
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            sigma_values,
+            &model.residual_correlations,
+        );
+        if ruv_scale != 1.0 {
+            r *= ruv_scale;
+        }
+        for (j, v) in p_obs.iter().enumerate() {
+            if j < r.nrows() {
+                r[(j, j)] += *v;
             }
         }
-        let v_resid =
-            model.residual_variance_at(subject.obs_cmts[j], f_pred, sigma_values) * ruv_scale;
-        let v = v_resid + p_obs.get(j).copied().unwrap_or(0.0);
-        let cens = subject.cens.get(j).copied().unwrap_or(0);
-        if matches!(model.bloq_method, BloqMethod::M3) && cens != 0 {
-            data_ll += -2.0 * m3_logcdf(y, f_pred, v.sqrt(), cens);
-        } else {
-            let resid = y - f_pred;
-            data_ll += resid * resid / v + v.ln();
+        let chol = match r.cholesky() {
+            Some(c) => c,
+            None => return 1e20,
+        };
+        let residuals = DVector::from_iterator(
+            subject.observations.len(),
+            subject
+                .observations
+                .iter()
+                .zip(preds.iter())
+                .map(|(&y, &f)| y - f),
+        );
+        let solved = chol.solve(&residuals);
+        data_ll += residuals.dot(&solved) + chol_log_det(&chol.l());
+    } else {
+        for (j, (&y, &f_pred)) in subject.observations.iter().zip(preds.iter()).enumerate() {
+            // FREM dispatch: covariate pseudo-observations use theta+eta as
+            // prediction and a near-zero additive sigma.
+            let fremtype_val = subject.fremtype.get(j).copied().unwrap_or(0);
+            if fremtype_val > 0 {
+                if let Some(ref fc) = model.frem_config {
+                    if let Some(&(theta_idx, eta_idx)) = fc.fremtype_to_indices.get(&fremtype_val) {
+                        let frem_pred = theta[theta_idx] + eta[eta_idx];
+                        let frem_sigma = sigma_values[fc.covariate_sigma_index];
+                        let frem_v = (frem_sigma * frem_sigma).max(1e-12);
+                        let resid = y - frem_pred;
+                        data_ll += resid * resid / frem_v + frem_v.ln();
+                        continue;
+                    }
+                }
+            }
+            let v_resid =
+                model.residual_variance_at(subject.obs_cmts[j], f_pred, sigma_values) * ruv_scale;
+            let v = v_resid + p_obs.get(j).copied().unwrap_or(0.0);
+            let cens = subject.cens.get(j).copied().unwrap_or(0);
+            if matches!(model.bloq_method, BloqMethod::M3) && cens != 0 {
+                data_ll += -2.0 * m3_logcdf(y, f_pred, v.sqrt(), cens);
+            } else {
+                let resid = y - f_pred;
+                data_ll += resid * resid / v + v.ln();
+            }
         }
     }
 
@@ -618,23 +656,38 @@ pub fn foce_subject_nll_standard(
         .map(|(j, &ip)| ip - h_eta[j])
         .collect();
 
-    // R diagonal; inflate with EKF process-noise variance for SDE models, then
-    // overwrite FREM covariate rows with their EPSCOV² overrides. The override
-    // must come last so it survives the r_pred_override re-evaluation of R.
+    // R; inflate the diagonal with EKF process-noise variance for SDE models,
+    // then overwrite FREM covariate rows with their EPSCOV² overrides. The
+    // override must come last so it survives the r_pred_override re-evaluation
+    // of R.
     let r_eval: &[f64] = r_pred_override.unwrap_or(&f0);
-    let mut r_diag = compute_r_diag_with_correlations(
+    let mut r_matrix = compute_r_matrix_with_correlations(
         error_spec,
         r_eval,
         &subject.obs_cmts,
+        &subject.obs_times,
+        &subject.obs_raw_times,
+        &subject.occasions,
         sigma_values,
         residual_correlations,
     );
-    for (j, r) in r_diag.iter_mut().enumerate() {
-        *r += p_obs.get(j).copied().unwrap_or(0.0);
+    for (j, v) in p_obs.iter().enumerate() {
+        if j < r_matrix.nrows() {
+            r_matrix[(j, j)] += *v;
+        }
     }
     if let Some(overrides) = frem_r_override {
-        apply_frem_r_overrides(&mut r_diag, overrides);
+        for (j, ov) in overrides.iter().enumerate() {
+            if let (Some(v), true) = (ov, j < r_matrix.nrows()) {
+                for k in 0..r_matrix.ncols() {
+                    r_matrix[(j, k)] = 0.0;
+                    r_matrix[(k, j)] = 0.0;
+                }
+                r_matrix[(j, j)] = *v;
+            }
+        }
     }
+    let r_diag: Vec<f64> = (0..r_matrix.nrows()).map(|j| r_matrix[(j, j)]).collect();
 
     // M3 BLOQ under FOCE: the censored rows leave the Sheiner–Beal marginal (R̃ and
     // the quadratic form are built over the quantified rows only) and re-enter as
@@ -660,7 +713,7 @@ pub fn foce_subject_nll_standard(
         }
     }
 
-    // R_tilde = H_q * Omega * H_q' + diag(R_q) over the quantified rows; quad form
+    // R_tilde = H_q * Omega * H_q' + R_q over the quantified rows; quad form
     // and log|R̃| over the same submatrix. (Non-M3: quant = all rows, unchanged.)
     let nq = quant.len();
     let h_q = if m3 {
@@ -668,8 +721,12 @@ pub fn foce_subject_nll_standard(
     } else {
         h_matrix.clone()
     };
-    let r_diag_q: Vec<f64> = quant.iter().map(|&j| r_diag[j]).collect();
-    let r_tilde = compute_r_tilde(&h_q, &omega.matrix, &r_diag_q);
+    let r_q = if m3 {
+        select_symmetric_submatrix(&r_matrix, &quant)
+    } else {
+        r_matrix
+    };
+    let r_tilde = compute_r_tilde_with_r(&h_q, &omega.matrix, &r_q);
 
     let chol = match r_tilde.clone().cholesky() {
         Some(c) => c,
@@ -984,6 +1041,23 @@ pub(crate) fn compute_r_tilde(
     r_tilde
 }
 
+/// R_tilde = H * Omega * H' + R for models with a non-diagonal residual
+/// covariance matrix.
+pub(crate) fn compute_r_tilde_with_r(
+    h: &DMatrix<f64>,
+    omega: &DMatrix<f64>,
+    r: &DMatrix<f64>,
+) -> DMatrix<f64> {
+    let h_omega = h * omega;
+    &h_omega * h.transpose() + r
+}
+
+fn select_symmetric_submatrix(matrix: &DMatrix<f64>, indices: &[usize]) -> DMatrix<f64> {
+    DMatrix::from_fn(indices.len(), indices.len(), |row, col| {
+        matrix[(indices[row], indices[col])]
+    })
+}
+
 /// log-determinant from Cholesky factor L: 2 * sum(log(L_ii))
 pub(crate) fn chol_log_det(l: &DMatrix<f64>) -> f64 {
     let n = l.nrows();
@@ -1290,23 +1364,21 @@ pub fn compute_cwres(
         .collect();
 
     // R_tilde
-    let mut r_diag = compute_r_diag_with_correlations(
+    let mut r_matrix = compute_r_matrix_with_correlations(
         error_spec,
         &f0,
         &subject.obs_cmts,
+        &subject.obs_times,
+        &subject.obs_raw_times,
+        &subject.occasions,
         sigma_values,
         residual_correlations,
     );
     let ruv_scale = ruv_scale_from(eta_hat.as_slice(), residual_error_eta);
     if ruv_scale != 1.0 {
-        for (j, v) in r_diag.iter_mut().enumerate() {
-            // FREM covariate pseudo-obs carry no PK residual error; leave them.
-            if subject.fremtype.get(j).copied().unwrap_or(0) == 0 {
-                *v *= ruv_scale;
-            }
-        }
+        r_matrix *= ruv_scale;
     }
-    let r_tilde = compute_r_tilde(h_matrix, &omega.matrix, &r_diag);
+    let r_tilde = compute_r_tilde_with_r(h_matrix, &omega.matrix, &r_matrix);
 
     // CWRES_j = (y_j - f0_j) / sqrt(R_tilde_jj), or NaN if censored.
     (0..n_obs)

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -63,13 +63,8 @@ pub fn compute_r_diag_with_correlations(
         .collect()
 }
 
-fn observation_time_key(obs_times: &[f64], obs_raw_times: &[f64], j: usize) -> u64 {
-    obs_raw_times
-        .get(j)
-        .or_else(|| obs_times.get(j))
-        .copied()
-        .unwrap_or(0.0)
-        .to_bits()
+fn observation_time_key(obs_times: &[f64], j: usize) -> u64 {
+    obs_times.get(j).copied().unwrap_or(0.0).to_bits()
 }
 
 fn observation_occasion_key(occasions: &[u32], j: usize) -> u32 {
@@ -78,13 +73,12 @@ fn observation_occasion_key(occasions: &[u32], j: usize) -> u32 {
 
 fn same_residual_block(
     obs_times: &[f64],
-    obs_raw_times: &[f64],
+    _obs_raw_times: &[f64],
     occasions: &[u32],
     j: usize,
     k: usize,
 ) -> bool {
-    observation_time_key(obs_times, obs_raw_times, j)
-        == observation_time_key(obs_times, obs_raw_times, k)
+    observation_time_key(obs_times, j) == observation_time_key(obs_times, k)
         && observation_occasion_key(occasions, j) == observation_occasion_key(occasions, k)
 }
 
@@ -442,6 +436,52 @@ mod tests {
         assert_relative_eq!(r[(0, 1)], 50.0 * 5.0 * 0.5 * 0.3 * 0.2, epsilon = 1e-12);
         assert_relative_eq!(r[(1, 0)], r[(0, 1)], epsilon = 1e-12);
         assert_eq!(r[(0, 2)], 0.0);
+    }
+
+    #[test]
+    fn test_compute_r_matrix_with_correlations_uses_shifted_time_after_reset() {
+        let spec = ErrorSpec::PerCmt(HashMap::from([
+            (
+                1,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![1],
+                },
+            ),
+            (
+                2,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![0],
+                },
+            ),
+        ]));
+        let ipreds = [50.0, 5.0, 40.0, 4.0];
+        let cmts = [1usize, 2, 1, 2];
+        let shifted_times = [1.0, 1.0, 101.0, 101.0];
+        let raw_times = [1.0, 1.0, 1.0, 1.0];
+        let sigma = [0.2, 0.3];
+        let corr = crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        };
+
+        let r = compute_r_matrix_with_correlations(
+            &spec,
+            &ipreds,
+            &cmts,
+            &shifted_times,
+            &raw_times,
+            &[],
+            &sigma,
+            &[corr],
+        );
+
+        assert_relative_eq!(r[(0, 1)], 50.0 * 5.0 * 0.5 * 0.3 * 0.2, epsilon = 1e-12);
+        assert_relative_eq!(r[(2, 3)], 40.0 * 4.0 * 0.5 * 0.3 * 0.2, epsilon = 1e-12);
+        assert_eq!(r[(0, 3)], 0.0);
+        assert_eq!(r[(1, 2)], 0.0);
     }
 
     #[test]

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -1,4 +1,5 @@
 use crate::types::{ErrorModel, ErrorSpec, ResidualCorrelation, SubjectResult};
+use nalgebra::DMatrix;
 
 const MIN_VARIANCE: f64 = 1e-12;
 
@@ -60,6 +61,140 @@ pub fn compute_r_diag_with_correlations(
             error_spec.variance_at_with_correlations(cmt, f, sigma_values, correlations)
         })
         .collect()
+}
+
+fn observation_time_key(obs_times: &[f64], obs_raw_times: &[f64], j: usize) -> u64 {
+    obs_raw_times
+        .get(j)
+        .or_else(|| obs_times.get(j))
+        .copied()
+        .unwrap_or(0.0)
+        .to_bits()
+}
+
+fn observation_occasion_key(occasions: &[u32], j: usize) -> u32 {
+    occasions.get(j).copied().unwrap_or(0)
+}
+
+fn same_residual_block(
+    obs_times: &[f64],
+    obs_raw_times: &[f64],
+    occasions: &[u32],
+    j: usize,
+    k: usize,
+) -> bool {
+    observation_time_key(obs_times, obs_raw_times, j)
+        == observation_time_key(obs_times, obs_raw_times, k)
+        && observation_occasion_key(occasions, j) == observation_occasion_key(occasions, k)
+}
+
+fn cross_observation_covariance(
+    load_j: &[(usize, f64)],
+    load_k: &[(usize, f64)],
+    sigma_values: &[f64],
+    correlations: &[ResidualCorrelation],
+) -> f64 {
+    let mut cov = 0.0;
+    for corr in correlations {
+        let j_has_i = load_j.iter().any(|(idx, _)| *idx == corr.sigma_i);
+        let j_has_j = load_j.iter().any(|(idx, _)| *idx == corr.sigma_j);
+        let k_has_i = load_k.iter().any(|(idx, _)| *idx == corr.sigma_i);
+        let k_has_j = load_k.iter().any(|(idx, _)| *idx == corr.sigma_j);
+        if (j_has_i && j_has_j) || (k_has_i && k_has_j) {
+            continue;
+        }
+        let Some(&si) = sigma_values.get(corr.sigma_i) else {
+            return f64::NAN;
+        };
+        let Some(&sj) = sigma_values.get(corr.sigma_j) else {
+            return f64::NAN;
+        };
+        let cov_ij = corr.rho * si * sj;
+        let ci_j = load_j
+            .iter()
+            .find(|(idx, _)| *idx == corr.sigma_i)
+            .map(|(_, coeff)| *coeff);
+        let cj_k = load_k
+            .iter()
+            .find(|(idx, _)| *idx == corr.sigma_j)
+            .map(|(_, coeff)| *coeff);
+        if let (Some(ci), Some(cj)) = (ci_j, cj_k) {
+            cov += ci * cj * cov_ij;
+        }
+
+        let cj_j = load_j
+            .iter()
+            .find(|(idx, _)| *idx == corr.sigma_j)
+            .map(|(_, coeff)| *coeff);
+        let ci_k = load_k
+            .iter()
+            .find(|(idx, _)| *idx == corr.sigma_i)
+            .map(|(_, coeff)| *coeff);
+        if let (Some(cj), Some(ci)) = (cj_j, ci_k) {
+            cov += cj * ci * cov_ij;
+        }
+    }
+    cov
+}
+
+/// Build the subject-level residual covariance matrix `R`.
+///
+/// The diagonal is the existing per-observation residual variance, including
+/// within-observation `block_sigma` terms for `combined(...)` endpoints. When a
+/// `block_sigma` off-diagonal connects sigmas used by different endpoint rows,
+/// rows at the same subject time and occasion receive the corresponding
+/// cross-observation covariance. This mirrors NONMEM-style paired endpoint
+/// records such as total/unbound assays written as separate rows.
+#[allow(clippy::too_many_arguments)]
+pub fn compute_r_matrix_with_correlations(
+    error_spec: &ErrorSpec,
+    ipreds: &[f64],
+    obs_cmts: &[usize],
+    obs_times: &[f64],
+    obs_raw_times: &[f64],
+    occasions: &[u32],
+    sigma_values: &[f64],
+    correlations: &[ResidualCorrelation],
+) -> DMatrix<f64> {
+    let n = ipreds.len();
+    let mut r = DMatrix::<f64>::zeros(n, n);
+    let r_diag =
+        compute_r_diag_with_correlations(error_spec, ipreds, obs_cmts, sigma_values, correlations);
+    for (j, &v) in r_diag.iter().enumerate() {
+        r[(j, j)] = v;
+    }
+    if correlations.is_empty() {
+        return r;
+    }
+
+    let loadings: Vec<Vec<(usize, f64)>> = ipreds
+        .iter()
+        .zip(obs_cmts.iter())
+        .map(|(&f, &cmt)| error_spec.sigma_loadings(cmt, f, sigma_values.len()))
+        .collect();
+    for j in 0..n {
+        if loadings[j].is_empty() {
+            continue;
+        }
+        for k in (j + 1)..n {
+            if loadings[k].is_empty()
+                || !same_residual_block(obs_times, obs_raw_times, occasions, j, k)
+            {
+                continue;
+            }
+            let cov = cross_observation_covariance(
+                &loadings[j],
+                &loadings[k],
+                sigma_values,
+                correlations,
+            );
+            if cov != 0.0 {
+                r[(j, k)] = cov;
+                r[(k, j)] = cov;
+            }
+        }
+    }
+    r
 }
 
 /// Individual weighted residual: IWRES_j = (y_j - f_j) / sqrt(V_j)
@@ -186,8 +321,9 @@ pub fn iwres_autocorrelation(subjects: &[SubjectResult]) -> (f64, f64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::GradientMethod;
+    use crate::types::{EndpointError, GradientMethod};
     use approx::assert_relative_eq;
+    use std::collections::HashMap;
 
     #[test]
     fn test_additive_variance() {
@@ -262,6 +398,50 @@ mod tests {
         };
         let with = compute_r_diag_with_correlations(&spec, &ipreds, &cmts, &sigma, &[corr]);
         assert_relative_eq!(with[0], 7.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_compute_r_matrix_with_correlations_links_paired_endpoints() {
+        let spec = ErrorSpec::PerCmt(HashMap::from([
+            (
+                1,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![1],
+                },
+            ),
+            (
+                2,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![0],
+                },
+            ),
+        ]));
+        let ipreds = [50.0, 5.0, 40.0];
+        let cmts = [1usize, 2, 2];
+        let times = [1.0, 1.0, 2.0];
+        let sigma = [0.2, 0.3];
+        let corr = crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        };
+        let r = compute_r_matrix_with_correlations(
+            &spec,
+            &ipreds,
+            &cmts,
+            &times,
+            &[],
+            &[],
+            &sigma,
+            &[corr],
+        );
+        assert_relative_eq!(r[(0, 0)], (50.0_f64 * 0.3).powi(2), epsilon = 1e-12);
+        assert_relative_eq!(r[(1, 1)], (5.0_f64 * 0.2).powi(2), epsilon = 1e-12);
+        assert_relative_eq!(r[(0, 1)], 50.0 * 5.0 * 0.5 * 0.3 * 0.2, epsilon = 1e-12);
+        assert_relative_eq!(r[(1, 0)], r[(0, 1)], epsilon = 1e-12);
+        assert_eq!(r[(0, 2)], 0.0);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2140,11 +2140,12 @@ pub struct CompiledModel {
     pub error_spec: ErrorSpec,
     /// Fixed residual-error correlations declared by `block_sigma`.
     ///
-    /// Empty for ordinary diagonal `$SIGMA` models. When non-empty, each
-    /// observation's residual variance gains the within-observation covariance
-    /// cross term `2·cᵢ·cⱼ·ρ·σᵢ·σⱼ` (from the observation's sigma loadings) on
-    /// the R diagonal; distinct observations stay independent, so R remains
-    /// diagonal. This covers NONMEM `$SIGMA BLOCK(2)` combined-error models.
+    /// Empty for ordinary diagonal `$SIGMA` models. When non-empty, the
+    /// residual-error helpers use each observation's sigma loadings to add both
+    /// within-observation covariance terms (for `combined(...)` endpoints) and
+    /// cross-observation covariance terms for paired same-time/same-occasion
+    /// endpoint rows. This covers NONMEM `$SIGMA BLOCK` combined-error models
+    /// and paired multi-endpoint records such as total/unbound assays.
     pub residual_correlations: Vec<ResidualCorrelation>,
     pub pk_param_fn: PkParamFn,
     pub n_theta: usize,


### PR DESCRIPTION
## Why

Closes #546.

A fluconazole model translated from NONMEM uses `$SIGMA BLOCK(2)` to correlate total and unbound proportional residual errors. In ferx DSL that is represented as two per-CMT proportional endpoints with a shared `block_sigma` off-diagonal. Before this PR, the parser rejected that model because `block_sigma` covariance was only supported when both sigmas co-loaded into a single `combined(...)` observation.

Relaxing only the parser would be wrong: the old likelihood still used `R_tilde = HΩH' + diag(R)`, so the cross-endpoint covariance would be silently ignored.

## What changed

- Added subject-level residual covariance matrix construction for correlated residual sigmas.
- Cross-endpoint covariance is applied to paired rows with the same subject time and occasion.
- FOCE now evaluates `R_tilde = HΩH' + R` when residual correlations are active.
- The individual EBE objective uses the matching multivariate Gaussian residual likelihood for ordinary Gaussian correlated-residual models.
- Parser validation now accepts cross-endpoint `block_sigma` when both sigmas are used by `[error_model]`.
- Correlated-residual ODE models route inner gradients to FD; dense residual covariance is not represented in the analytic inner kernels yet.
- Unsupported combinations remain explicitly gated: non-FOCE estimators, M3, FREM, and `iiv_on_ruv`.
- Opened #548 to track extending the same feature to SAEM.

## Alternatives considered

A parser-only change was rejected because it would parse NONMEM-style models while leaving the off-diagonal covariance out of the likelihood. The implementation uses a dense per-subject `DMatrix` for the correlated-residual case and keeps the existing scalar/diagonal path for ordinary models.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

No migration needed. Previously rejected cross-endpoint `block_sigma` models now parse for the supported FOCE subset.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: NONMEM / nlmixr2 / prior ferx commit `origin/main @ 3fe16241`
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# NONMEM reference: ferx-testdata/fluconazole_radboudumc/nm/fluconfinal014.mod
# Objective function value: 734.6440
# Final SIGMA covariance in fluconfinal014.lst:
#   EPS1 variance     2.03E-01
#   EPS2 covariance   1.74E-01
#   EPS2 variance     1.72E-01
#   EPS correlation   9.34E-01

# ferx smoke check after this PR
cargo run --quiet --bin ferx -- \
  /Users/ron/git/ferx/ferx-testdata/fluconazole_radboudumc/ferx/fluconfinal.ferx \
  --data /Users/ron/git/ferx/ferx-testdata/fluconazole_radboudumc/fluconfinal_ferx_endpoints.csv \
  --maxiter 0

# Result: model parses and starts FOCE with the nonzero cross-endpoint block_sigma.
# Startup banner confirms the safe FD route for dense residual covariance:
#   gradient: FD  [requested: auto]
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

The dense residual covariance matrix is only built when `block_sigma` residual correlations are active. Ordinary diagonal-RUV models keep the existing path.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Validation run after rebasing onto latest `origin/main`:

```
cargo fmt --check && cargo check --lib
cargo test --lib
# test result: ok. 1683 passed; 0 failed; 17 ignored; 0 measured; 0 filtered out
```

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
[parameters]
  block_sigma (PROP_ERR_UNBOUND, PROP_ERR_TOTAL) = [
    0.05,
    0.01, 0.05
  ]

[error_model]
  CMT=1: DV ~ proportional(PROP_ERR_TOTAL)
  CMT=2: DV ~ proportional(PROP_ERR_UNBOUND)

[fit_options]
  method = foce
```

```
# Paired CMT=1/CMT=2 rows at the same subject TIME/OCC receive:
# Cov(y_total, y_unbound) = f_total * f_unbound * Cov(EPS_total, EPS_unbound)
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

Focus on `stats/residual_error.rs` and `stats/likelihood.rs`. The subtle behavior is that cross-row covariance is only created for same-time/same-occasion paired endpoint rows, while within-row `combined(...)` covariance remains on the diagonal via the existing loading logic.

The implementation deliberately leaves SAEM unsupported; #548 tracks that work.

## Open questions

- Should cross-endpoint residual grouping remain automatic by subject TIME/OCC, or should we add an explicit grouping key in the DSL/data for more complex NONMEM translations?
- Should IWRES eventually expose a whitened residual for correlated endpoint blocks, in addition to the current marginal rowwise standardization?
