### PR TITLE
fix(estimation): fall back on non-finite FOCEI h-matrices [closes #551]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@ section of the SDLC for the versioning policy).
   `[derived]` reference (`W_DERIVED_INIT_ANALYTICAL`) warns rather than silently
   mispredicting. See [Initial Conditions](model-file/initial-conditions.qmd).
 ### Fixed
+- FOCEI now falls back to finite-difference h-matrices when an ODE analytic
+  Jacobian is unavailable or non-finite, avoiding sentinel-inflated OFVs on sparse
+  subjects such as the pembrolizumab RadboudUMC model (#551).
 - **Form C (`[scaling] y = <expr>`) ODE readouts now use per-observation covariate
   snapshots** (#535, #538). The explicit-output readout is evaluated against the
   covariate values on each observation's own data row rather than the subject's

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -534,9 +534,13 @@ pub fn find_ebe(
     // and then overridden, which keeps the diff minimal and trivially
     // revertible while the values come from the exact sensitivities.
     let t_jac = std::time::Instant::now();
-    let analytic_jac: Option<DMatrix<f64>> =
+    let analytic_jac: Option<DMatrix<f64>> = if analytic_inner_grad_supported(model, subject) {
         crate::sens::provider::subject_eta_jacobian(model, subject, &params.theta, &eta_true)
-            .map(|j| DMatrix::from_row_slice(subject.obs_times.len(), n_eta, &j));
+            .map(|j| DMatrix::from_row_slice(subject.obs_times.len(), n_eta, &j))
+            .filter(|j| j.iter().all(|v| v.is_finite()))
+    } else {
+        None
+    };
     if analytic_jac.is_some() {
         GRADIENT_TIMINGS.record_jac_analytic(t_jac.elapsed().as_nanos() as u64);
     }
@@ -2044,6 +2048,7 @@ pub fn run_inner_loop_warm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     /// The M3 censored coefficient `∂/∂f[−logΦ((y−f)/√v)]` must equal a central
     /// finite difference of that data term — across additive (`dv_df = 0`) and
@@ -2083,6 +2088,86 @@ mod tests {
                 "f={f}, sig_add={sig_add}, sig_prop={sig_prop}: analytic {analytic} vs FD {fd}"
             );
         }
+    }
+
+    #[test]
+    fn find_ebe_uses_fd_h_matrix_when_inner_gradient_forced_fd() {
+        use crate::parser::model_parser::parse_model_string;
+
+        let mut model = parse_model_string(
+            r#"
+[parameters]
+  theta TVCL(0.15, 0.01, 10.0)
+  theta TVV(5.0, 0.1, 100.0)
+  theta TVIMAX(-0.3, -10.0, 10.0)
+  theta TVTI50(100.0, 1.0, 700.0)
+  theta TVHILL(3.0, 0.1, 10.0)
+  omega ETA_CL ~ 0.1
+  omega ETA_V  ~ 0.01
+  sigma PROP_ERR ~ 0.04
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  IMAX = TVIMAX
+  TI50 = TVTI50
+  HILL = TVHILL
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL * exp(IMAX * TIME^HILL / (TI50^HILL + TIME^HILL)) / V) * central
+
+[scaling]
+  obs_scale = V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  gradient = fd
+"#,
+        )
+        .expect("parse");
+        model.gradient_method = GradientMethod::Fd;
+
+        let subject = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 200.0, 1, 9600.0, false, 0.0)],
+            obs_times: vec![20.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![12.0],
+            obs_cmts: vec![1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+
+        let result = find_ebe(
+            &model,
+            &subject,
+            &model.default_params,
+            50,
+            1e-5,
+            None,
+            None,
+        );
+
+        assert!(
+            result.h_matrix.iter().all(|v| v.is_finite()),
+            "forced-FD inner route must not consume a non-finite analytic h_matrix: {:?}",
+            result.h_matrix
+        );
     }
 
     /// End-to-end: the analytic M3 inner η-gradient must match a central finite


### PR DESCRIPTION
## Why
The pembrolizumab ODE model reported a huge FOCEI objective at the initial parameter values:

```text
Eval    1: OFV = 8200000000000000000000.000000
```

NONMEM `model066.ext` reports the same initial parameters at OFV `6807.5824409736588`, so this was not an optimizer-convergence issue. Diagnosis showed 41 subjects had non-finite FOCEI `h_matrix` entries; each contributed the `1e20` sentinel to `foce_subject_nll`, giving `41 * 2e20 = 8.2e21`. Closes #551.

## What changed
`find_ebe` now only accepts the analytic post-EBE Jacobian when the subject is actually on the analytic inner-gradient route, and it rejects non-finite analytic Jacobians. Otherwise it uses the existing finite-difference h-matrix fallback.

This keeps the FOCEI marginal from consuming a non-finite ODE sensitivity matrix when the resolved inner path is FD or when the analytic provider returns non-finite values for a subject.

## Alternatives considered
Forcing `gradient = fd` in the model was tested, but it did not avoid the bad OFV because the h-matrix path still asked the analytic provider. Fixing the h-matrix route directly is narrower than disabling the ODE provider more broadly.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

None.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: NONMEM
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```text
# before / reference
NONMEM model066.ext initial OFV: 6807.5824409736588
ferx before fix first eval:      8200000000000000000000.000000

# after
ferx after fix first eval:       6787.950583
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [ ] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [x] Slower — justified because: affected subjects now fall back to finite-difference h-matrices instead of consuming non-finite analytic Jacobians. This only applies when the analytic h-matrix is not usable; the previous behavior produced sentinel-inflated OFVs.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# N/A
```

```text
# N/A
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints
Focus on `find_ebe` h-matrix routing. The subtle point is that `gradient = fd` and subject-level FD routing must also govern the post-EBE h-matrix, not only the EBE optimizer gradient.

## Open questions
None.
