### PR TITLE
feat(estimation): support block_sigma covariance in SAEM [closes #548]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Support NONMEM-style `block_sigma` residual covariance under SAEM for ordinary
+  Gaussian paired-endpoint models (#548).
 - Support NONMEM-style `block_sigma` residual covariance across paired same-time
   multi-endpoint observations under FOCE (#546).
 - Support fixed residual-error correlations via `block_sigma` for FOCE combined-error

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -239,16 +239,18 @@ covariance matrix, so paired rows such as total/unbound assays receive the
 NONMEM-style covariance term `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
 
 Current scope: `block_sigma` is supported for ordinary Gaussian `method = foce`
-fits. FOCEI/GN, SAEM, importance-sampling paths, M3 censored-observation
-likelihoods, FREM covariate pseudo-observations, and `iiv_on_ruv` reject
-correlated residual sigma blocks until their residual-error derivative code is
-extended beyond diagonal RUV.
+and `method = saem` fits. FOCEI/GN, importance-sampling paths, M3
+censored-observation likelihoods, FREM covariate pseudo-observations,
+`iiv_on_ruv`, SDE/EKF, TTE, and IOV reject correlated residual sigma blocks
+until their residual-error derivative code is extended beyond diagonal RUV.
 
 Validation: `examples/correlated_residual_combined.ferx` and
 `nonmem_anchor/correlated_residual_combined.ctl` run the same fixed-parameter
 one-compartment IV model with `$SIGMA BLOCK(2) FIX`. On
 `data/correlated_residual_combined.csv`, NONMEM 7.5.1 (`METHOD=1 MAXEVAL=0`)
 reports OFV 18.715849 and ferx FOCE reports OFV 18.727365 (difference 0.0115).
+The SAEM path uses the same dense residual covariance likelihood for its E-step
+acceptance checks and theta/sigma M-step objective.
 
 ## IIV on residual error (`iiv_on_ruv`)
 

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -241,16 +241,28 @@ NONMEM-style covariance term `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`
 Current scope: `block_sigma` is supported for ordinary Gaussian `method = foce`
 and `method = saem` fits. FOCEI/GN, importance-sampling paths, M3
 censored-observation likelihoods, FREM covariate pseudo-observations,
-`iiv_on_ruv`, SDE/EKF, TTE, and IOV reject correlated residual sigma blocks
+`iiv_on_ruv`, TTE endpoints, and IOV reject correlated residual sigma blocks
 until their residual-error derivative code is extended beyond diagonal RUV.
+SDE/EKF process-noise models carry the correlation under `method = foce` (the
+EKF variance is added to the dense `R`) but are rejected under `method = saem`,
+whose M-step data term does not yet include the process-noise inflation.
 
 Validation: `examples/correlated_residual_combined.ferx` and
 `nonmem_anchor/correlated_residual_combined.ctl` run the same fixed-parameter
 one-compartment IV model with `$SIGMA BLOCK(2) FIX`. On
 `data/correlated_residual_combined.csv`, NONMEM 7.5.1 (`METHOD=1 MAXEVAL=0`)
 reports OFV 18.715849 and ferx FOCE reports OFV 18.727365 (difference 0.0115).
-The SAEM path uses the same dense residual covariance likelihood for its E-step
-acceptance checks and theta/sigma M-step objective.
+
+The SAEM path reuses the same dense residual-covariance likelihood
+(`dense_residual_data_term`) for its E-step Metropolis acceptance and its
+theta/sigma M-step objective, and its reported OFV (the FOCE-approximation
+`2·pop_nll` used for AIC/BIC comparability) is routed through the
+correlation-aware non-interaction objective. On the same fixed-parameter model
+ferx SAEM reports OFV 18.7274 — matching ferx FOCE to 4 decimals — against
+NONMEM's importance-sampling marginal −2LL at the reference parameters
+(`METHOD=IMP EONLY=1`, 30 000 samples) of 18.68. Dropping the off-diagonal
+covariance (a diagonal `$SIGMA`) lowers all three engines to ≈14.62, so the
+≈4-OFV gap is the cross-endpoint correlation being correctly accounted for.
 
 ## IIV on residual error (`iiv_on_ruv`)
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1113,16 +1113,27 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 .with_block("fit_options"),
             );
         }
-        if model.is_sde() {
+        // SDE is unsupported for SAEM only: the FOCE non-interaction path adds the
+        // EKF process-noise `p_obs` into the dense R (foce_subject_nll_standard),
+        // so FOCE + block_sigma + SDE works, but SAEM's M-step data term
+        // (`obs_nll_subject_into`) carries no `p_obs`, so its E-step sampler and
+        // M-step objective would optimize different likelihoods. FOCE keeps the
+        // combination it supported before this PR added SAEM support.
+        let chain_has_saem = chain.iter().any(|&m| m == EstimationMethod::Saem);
+        if chain_has_saem && model.is_sde() {
             diags.push(
                 Diagnostic::error(
                     "E_BLOCK_SIGMA_SDE_UNSUPPORTED",
                     "block_sigma correlated residual errors are not yet supported with \
-                     SDE / EKF process-noise likelihoods.",
+                     method = saem and SDE / EKF process-noise likelihoods.",
                 )
                 .with_block("fit_options"),
             );
         }
+        // TTE is unsupported for every method: the TTE Laplace path
+        // (foce_subject_nll_interaction_with_tte) accumulates R diagonally and
+        // cannot represent the cross-endpoint covariance, so it would silently
+        // drop the correlation for FOCE as well as SAEM.
         if model.has_tte() {
             diags.push(
                 Diagnostic::error(
@@ -6201,6 +6212,68 @@ mod iov_integration {
             .any(|d| d.code == "E_BLOCK_SIGMA_IOV_UNSUPPORTED"));
     }
 
+    // The block_sigma + SDE rejection is scoped to SAEM: the FOCE dense path adds
+    // the EKF process-noise `p_obs` into R and worked before SAEM support was
+    // added, so a FOCE-only chain must stay accepted. Regression guard against
+    // the over-broad method-agnostic rejection (PR #557 review).
+    #[test]
+    fn test_check_model_options_block_sigma_sde_rejected_for_saem_not_foce() {
+        let mut model =
+            crate::types::test_helpers::analytical_model(crate::types::GradientMethod::Fd);
+        model.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+        // is_sde() reads diffusion_theta_start; flag the model as an SDE/EKF model.
+        model.diffusion_theta_start = Some(0);
+
+        let saem = fast_opts(EstimationMethod::Saem, Optimizer::Bobyqa, false);
+        assert!(super::check_model_options(&model, &saem)
+            .iter()
+            .any(|d| d.code == "E_BLOCK_SIGMA_SDE_UNSUPPORTED"));
+
+        let foce = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+        assert!(!super::check_model_options(&model, &foce)
+            .iter()
+            .any(|d| d.code == "E_BLOCK_SIGMA_SDE_UNSUPPORTED"));
+    }
+
+    // The block_sigma + TTE rejection is blanket (every method): the TTE Laplace
+    // path accumulates R diagonally and cannot carry the cross-endpoint
+    // covariance, so it must be rejected for FOCE as well as SAEM (PR #557).
+    #[cfg(feature = "survival")]
+    #[test]
+    fn test_check_model_options_block_sigma_tte_rejected_all_methods() {
+        let mut model =
+            crate::types::test_helpers::analytical_model(crate::types::GradientMethod::Fd);
+        model.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+        // has_tte() scans endpoints for a Tte variant; attach a trivial one.
+        model.endpoints.insert(
+            2,
+            crate::types::EndpointLikelihood::Tte {
+                hazard: crate::types::HazardSpec::Analytic {
+                    family: crate::types::HazardFamily::Exponential,
+                    param_fn: Box::new(|_theta, _eta, _cov| vec![0.1]),
+                },
+            },
+        );
+
+        for method in [EstimationMethod::Saem, EstimationMethod::Foce] {
+            let opts = fast_opts(method, Optimizer::Bobyqa, false);
+            assert!(
+                super::check_model_options(&model, &opts)
+                    .iter()
+                    .any(|d| d.code == "E_BLOCK_SIGMA_TTE_UNSUPPORTED"),
+                "TTE + block_sigma must be rejected for {method:?}"
+            );
+        }
+    }
+
     #[test]
     fn test_saem_accepts_block_sigma_cross_endpoint_fit() {
         use crate::parser::model_parser::parse_model_string;
@@ -6284,6 +6357,104 @@ mod iov_integration {
         let result = fit(&model, &population, &model.default_params, &opts)
             .expect("SAEM fit with cross-endpoint block_sigma should succeed");
         assert!(result.ofv.is_finite(), "SAEM OFV must be finite");
+    }
+
+    // Regression: the SAEM final OFV (computed via `2·pop_nll` with
+    // `interaction = true`) must include the block_sigma cross-endpoint
+    // covariance. The interaction Laplace accumulator builds R diagonally, so
+    // before #557 SAEM silently dropped the correlation and reported the
+    // diagonal OFV (~4 units low here) instead of the FOCE/NONMEM value. At
+    // fully-fixed parameters both estimators evaluate the same conditional
+    // likelihood, so their OFVs must agree.
+    #[test]
+    fn test_saem_block_sigma_ofv_matches_foce() {
+        use crate::parser::model_parser::parse_model_string;
+        use std::collections::HashMap;
+
+        // Single-endpoint combined error with a fixed correlated $SIGMA block —
+        // the docs validation model (NONMEM FOCE OFV 18.7158, ferx FOCE 18.7274).
+        let model = parse_model_string(
+            r"
+[parameters]
+  theta TVCL(1.0, 0.01, 10.0) FIX
+  theta TVV(10.0, 0.1, 100.0) FIX
+  omega ETA_CL ~ 0.04 FIX
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ combined(PROP_ERR, ADD_ERR)
+",
+        )
+        .expect("fixed-param block_sigma combined model parses");
+
+        let mut subjects = Vec::new();
+        for (id, obs) in [
+            ("1", vec![9.5, 8.0, 6.2]),
+            ("2", vec![10.5, 7.4, 5.6]),
+            ("3", vec![8.8, 7.9, 6.7]),
+        ] {
+            subjects.push(Subject {
+                id: id.into(),
+                doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                obs_times: vec![1.0, 2.0, 4.0],
+                obs_raw_times: Vec::new(),
+                observations: obs,
+                obs_cmts: vec![1, 1, 1],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0; 3],
+                occasions: Vec::new(),
+                dose_occasions: Vec::new(),
+                fremtype: Vec::new(),
+                #[cfg(feature = "survival")]
+                obs_records: vec![],
+            });
+        }
+        let population = Population {
+            subjects,
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        // FOCE evaluation (all params fixed → maxiter 0 just evaluates the OFV).
+        let mut foce_opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+        foce_opts.outer_maxiter = 0;
+        let foce_ofv = fit(&model, &population, &model.default_params, &foce_opts)
+            .expect("FOCE block_sigma evaluation succeeds")
+            .ofv;
+
+        // SAEM evaluation at the same fixed params.
+        let mut saem_opts = fast_opts(EstimationMethod::Saem, Optimizer::Bobyqa, false);
+        saem_opts.saem_n_exploration = 2;
+        saem_opts.saem_n_convergence = 0;
+        saem_opts.saem_n_mh_steps = 1;
+        saem_opts.saem_adapt_interval = 10;
+        saem_opts.saem_omega_burnin = 0;
+        saem_opts.saem_seed = Some(12345);
+        let saem_ofv = fit(&model, &population, &model.default_params, &saem_opts)
+            .expect("SAEM block_sigma evaluation succeeds")
+            .ofv;
+
+        // Params are fixed, so the EBEs (hence the conditional OFV) are identical
+        // regardless of estimator; the dense covariance must be carried by both.
+        assert!(
+            (saem_ofv - foce_ofv).abs() < 1e-3,
+            "SAEM OFV {saem_ofv} must match FOCE OFV {foce_ofv} (block_sigma correlation dropped?)"
+        );
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1059,13 +1059,13 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
 
     if !model.residual_correlations.is_empty() {
         for &m in &chain {
-            if m != EstimationMethod::Foce {
+            if !matches!(m, EstimationMethod::Foce | EstimationMethod::Saem) {
                 diags.push(
                     Diagnostic::error(
                         "E_BLOCK_SIGMA_METHOD_UNSUPPORTED",
                         "block_sigma correlated residual errors are currently supported for \
-                         method = foce only. FOCEI, GN, SAEM, and importance-sampling paths \
-                         still use diagonal residual-error derivatives.",
+                         method = foce and method = saem only. FOCEI, GN, and \
+                         importance-sampling paths still use diagonal residual-error derivatives.",
                     )
                     .with_block("fit_options"),
                 );
@@ -1109,6 +1109,26 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                     "block_sigma correlated residual errors are not yet supported with \
                      inter-occasion variability (κ / [iov]) because the IOV inner \
                      objective does not yet use the full residual covariance matrix.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        if model.is_sde() {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_SDE_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     SDE / EKF process-noise likelihoods.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        if model.has_tte() {
+            diags.push(
+                Diagnostic::error(
+                    "E_BLOCK_SIGMA_TTE_UNSUPPORTED",
+                    "block_sigma correlated residual errors are not yet supported with \
+                     time-to-event endpoints.",
                 )
                 .with_block("fit_options"),
             );
@@ -6142,10 +6162,10 @@ mod iov_integration {
         assert!(super::check_model_options(&model, &ok_opts).is_empty());
     }
 
-    // block_sigma correlated residual errors are only wired into FOCE; every
-    // other method in the chain must be rejected up front (PR #545).
+    // block_sigma correlated residual errors are wired into ordinary Gaussian
+    // FOCE and SAEM; every other method in the chain must be rejected up front.
     #[test]
-    fn test_check_model_options_block_sigma_rejects_non_foce() {
+    fn test_check_model_options_block_sigma_rejects_unsupported_methods() {
         let mut model =
             crate::types::test_helpers::analytical_model(crate::types::GradientMethod::Fd);
         model.residual_correlations = vec![crate::types::ResidualCorrelation {
@@ -6161,11 +6181,11 @@ mod iov_integration {
             .iter()
             .find(|d| d.code == "E_BLOCK_SIGMA_METHOD_UNSUPPORTED")
             .expect("expected E_BLOCK_SIGMA_METHOD_UNSUPPORTED for FOCEI");
-        assert!(d.is_error() && d.message.contains("method = foce"));
+        assert!(d.is_error() && d.message.contains("method = foce") && d.message.contains("saem"));
 
-        // SAEM is rejected too.
+        // SAEM is accepted for the ordinary Gaussian subset.
         let saem = fast_opts(EstimationMethod::Saem, Optimizer::Bobyqa, false);
-        assert!(super::check_model_options(&model, &saem)
+        assert!(!super::check_model_options(&model, &saem)
             .iter()
             .any(|d| d.code == "E_BLOCK_SIGMA_METHOD_UNSUPPORTED"));
 
@@ -6174,6 +6194,96 @@ mod iov_integration {
         assert!(!super::check_model_options(&model, &foce)
             .iter()
             .any(|d| d.code == "E_BLOCK_SIGMA_METHOD_UNSUPPORTED"));
+
+        model.n_kappa = 1;
+        assert!(super::check_model_options(&model, &saem)
+            .iter()
+            .any(|d| d.code == "E_BLOCK_SIGMA_IOV_UNSUPPORTED"));
+    }
+
+    #[test]
+    fn test_saem_accepts_block_sigma_cross_endpoint_fit() {
+        use crate::parser::model_parser::parse_model_string;
+        use std::collections::HashMap;
+
+        let model = parse_model_string(
+            r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  block_sigma (PROP_ERR_UNBOUND, PROP_ERR_TOTAL) = [
+    0.04,
+    0.01, 0.09
+  ]
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+
+[structural_model]
+  ode(states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[scaling]
+  y[CMT=1] = 2.0 * central / V
+  y[CMT=2] = central / V
+
+[error_model]
+  CMT=1: DV ~ proportional(PROP_ERR_TOTAL)
+  CMT=2: DV ~ proportional(PROP_ERR_UNBOUND)
+",
+        )
+        .expect("cross-endpoint block_sigma ODE model parses");
+
+        let mut subjects = Vec::new();
+        for (id, dose_amt, obs) in [
+            ("1", 100.0, vec![17.0, 8.0, 15.0, 7.0]),
+            ("2", 80.0, vec![14.0, 6.8, 12.0, 6.0]),
+        ] {
+            subjects.push(Subject {
+                id: id.into(),
+                doses: vec![DoseEvent::new(0.0, dose_amt, 1, 0.0, false, 0.0)],
+                obs_times: vec![1.0, 1.0, 2.0, 2.0],
+                obs_raw_times: Vec::new(),
+                observations: obs,
+                obs_cmts: vec![1, 2, 1, 2],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0; 4],
+                occasions: Vec::new(),
+                dose_occasions: Vec::new(),
+                fremtype: Vec::new(),
+                #[cfg(feature = "survival")]
+                obs_records: vec![],
+            });
+        }
+        let population = Population {
+            subjects,
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let mut opts = fast_opts(EstimationMethod::Saem, Optimizer::Bobyqa, false);
+        opts.saem_n_exploration = 1;
+        opts.saem_n_convergence = 0;
+        opts.saem_n_mh_steps = 1;
+        opts.saem_adapt_interval = 10;
+        opts.saem_omega_burnin = 0;
+        opts.saem_seed = Some(548);
+
+        let result = fit(&model, &population, &model.default_params, &opts)
+            .expect("SAEM fit with cross-endpoint block_sigma should succeed");
+        assert!(result.ofv.is_finite(), "SAEM OFV must be finite");
     }
 
     #[test]

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -473,14 +473,16 @@ fn obs_nll_subject_grad_iov(
     pk_scratch: &mut crate::pk::EventPkParams,
 ) -> (f64, Vec<f64>) {
     let n = n_theta + n_sigma;
-    let m3 = matches!(model.bloq_method, BloqMethod::M3);
+    let fd_all =
+        matches!(model.bloq_method, BloqMethod::M3) || !model.residual_correlations.is_empty();
     // Fall back to full FD when TTE endpoints are present: the analytic non-M3
     // path is Gaussian-only and would silently zero hazard-parameter gradients.
     #[cfg(feature = "survival")]
-    let m3 = m3 || !model.endpoints.is_empty();
+    let fd_all = fd_all || !model.endpoints.is_empty();
 
-    if m3 {
-        // M3 / TTE path: forward-FD of obs_nll_subject_into_iov.
+    if fd_all {
+        // M3 / TTE / dense residual-covariance path: forward-FD of
+        // obs_nll_subject_into_iov.
         let nll_base =
             obs_nll_subject_into_iov(model, subject, theta, sigma_values, eta, kappas, pk_scratch);
         let mut grad = vec![0.0f64; n];
@@ -861,14 +863,16 @@ fn obs_nll_subject_grad(
     pk_scratch: &mut EventPkParams,
 ) -> (f64, Vec<f64>) {
     let n = n_theta + n_sigma;
-    let m3 = matches!(model.bloq_method, BloqMethod::M3);
+    let fd_all =
+        matches!(model.bloq_method, BloqMethod::M3) || !model.residual_correlations.is_empty();
     // Fall back to the full-FD path when TTE endpoints are present: the analytic
     // non-M3 path is Gaussian-only and would silently zero hazard-parameter gradients.
     #[cfg(feature = "survival")]
-    let m3 = m3 || !model.endpoints.is_empty();
+    let fd_all = fd_all || !model.endpoints.is_empty();
 
-    if m3 {
-        // M3 / TTE path: forward-FD of obs_nll_subject_into for all parameters.
+    if fd_all {
+        // M3 / TTE / dense residual-covariance path: forward-FD of
+        // obs_nll_subject_into for all parameters.
         let nll_base = obs_nll_subject_into(model, subject, theta, sigma_values, eta, pk_scratch);
         let mut grad = vec![0.0f64; n];
         let h = 1e-5;
@@ -3199,6 +3203,135 @@ mod tests {
                 rel < 1e-3,
                 "per-CMT grad[{j}]: analytical={:.6e}, fd={:.6e}, rel={:.2e}",
                 total_grad[j],
+                ref_grad[j],
+                rel
+            );
+        }
+    }
+
+    /// Dense residual-covariance M-step gradient must match FD of the same
+    /// dense observation NLL. This exercises the `block_sigma` SAEM path, which
+    /// deliberately routes through full FD because the analytic scalar-RUV score
+    /// terms do not apply to off-diagonal R blocks.
+    #[test]
+    fn obs_nll_subject_grad_block_sigma_cross_endpoint_matches_fd() {
+        use crate::parser::model_parser::parse_model_string;
+        use crate::types::{DoseEvent, Population};
+        use std::collections::HashMap;
+
+        let model = parse_model_string(
+            r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  block_sigma (PROP_ERR_UNBOUND, PROP_ERR_TOTAL) = [
+    0.04,
+    0.01, 0.09
+  ]
+
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+
+[structural_model]
+  ode(states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[scaling]
+  y[CMT=1] = 2.0 * central / V
+  y[CMT=2] = central / V
+
+[error_model]
+  CMT=1: DV ~ proportional(PROP_ERR_TOTAL)
+  CMT=2: DV ~ proportional(PROP_ERR_UNBOUND)
+",
+        )
+        .expect("cross-endpoint block_sigma ODE model parses");
+
+        let subject = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 1.0, 2.0, 2.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![17.0, 8.0, 15.0, 7.0],
+            obs_cmts: vec![1, 2, 1, 2],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; 4],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subject.clone()],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let theta = vec![1.0f64, 10.0];
+        let sigma_values = vec![0.20f64, 0.30];
+        let etas: Vec<Vec<f64>> = vec![vec![0.05]];
+        let n_theta = 2;
+        let n_sigma = 2;
+        let n = n_theta + n_sigma;
+
+        let f0 = obs_nll_sum(&model, &population, &theta, &sigma_values, &etas);
+        let h = 1e-6;
+        let mut ref_grad = vec![0.0f64; n];
+        for i in 0..n_theta {
+            let mut tp = theta.clone();
+            tp[i] += h;
+            let fp = obs_nll_sum(&model, &population, &tp, &sigma_values, &etas);
+            ref_grad[i] = theta[i] * (fp - f0) / h;
+        }
+        for k in 0..n_sigma {
+            let mut sp = sigma_values.clone();
+            sp[k] += h;
+            let fp = obs_nll_sum(&model, &population, &theta, &sp, &etas);
+            ref_grad[n_theta + k] = sigma_values[k] * (fp - f0) / h;
+        }
+
+        let mask = vec![true; n_theta];
+        let lo = vec![-1e30f64; n];
+        let hi = vec![1e30f64; n];
+        let mut scratch = EventPkParams::default();
+        let (nll, grad) = obs_nll_subject_grad(
+            &model,
+            &subject,
+            &theta,
+            &sigma_values,
+            &etas[0],
+            &mask,
+            &lo,
+            &hi,
+            n_theta,
+            n_sigma,
+            &mut scratch,
+        );
+
+        assert!((nll - f0).abs() < 1e-8, "nll mismatch: {nll} vs {f0}");
+        for j in 0..n {
+            let rel = if ref_grad[j].abs() > 1e-8 {
+                (grad[j] - ref_grad[j]).abs() / ref_grad[j].abs()
+            } else {
+                (grad[j] - ref_grad[j]).abs()
+            };
+            assert!(
+                rel < 1e-4,
+                "block_sigma grad[{j}]: fd-path={:.6e}, ref={:.6e}, rel={:.2e}",
+                grad[j],
                 ref_grad[j],
                 rel
             );

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -13,8 +13,8 @@ use crate::estimation::outer_optimizer::{
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::pk::EventPkParams;
 use crate::stats::likelihood::{
-    individual_nll, individual_nll_into, individual_nll_iov, obs_nll_subject_into,
-    split_obs_by_occasion,
+    individual_nll, individual_nll_into, individual_nll_iov, obs_nll_subject_from_preds,
+    obs_nll_subject_into, split_obs_by_occasion,
 };
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -473,16 +473,17 @@ fn obs_nll_subject_grad_iov(
     pk_scratch: &mut crate::pk::EventPkParams,
 ) -> (f64, Vec<f64>) {
     let n = n_theta + n_sigma;
-    let fd_all =
-        matches!(model.bloq_method, BloqMethod::M3) || !model.residual_correlations.is_empty();
+    // IOV + block_sigma is rejected up front (E_BLOCK_SIGMA_IOV_UNSUPPORTED), so
+    // `residual_correlations` is never set on this IOV path — only M3 (and TTE,
+    // under the `survival` feature) need the full-FD fallback here.
+    let fd_all = matches!(model.bloq_method, BloqMethod::M3);
     // Fall back to full FD when TTE endpoints are present: the analytic non-M3
     // path is Gaussian-only and would silently zero hazard-parameter gradients.
     #[cfg(feature = "survival")]
     let fd_all = fd_all || !model.endpoints.is_empty();
 
     if fd_all {
-        // M3 / TTE / dense residual-covariance path: forward-FD of
-        // obs_nll_subject_into_iov.
+        // M3 / TTE path: forward-FD of obs_nll_subject_into_iov.
         let nll_base =
             obs_nll_subject_into_iov(model, subject, theta, sigma_values, eta, kappas, pk_scratch);
         let mut grad = vec![0.0f64; n];
@@ -872,8 +873,13 @@ fn obs_nll_subject_grad(
 
     if fd_all {
         // M3 / TTE / dense residual-covariance path: forward-FD of
-        // obs_nll_subject_into for all parameters.
-        let nll_base = obs_nll_subject_into(model, subject, theta, sigma_values, eta, pk_scratch);
+        // obs_nll_subject_into for all parameters. Predictions are σ-independent,
+        // so solve the model once and reuse the base predictions across every σ
+        // perturbation — only θ perturbations need a fresh solve (#557).
+        let preds_base =
+            crate::pk::compute_predictions_with_tv_into(model, subject, theta, eta, pk_scratch);
+        let nll_base =
+            obs_nll_subject_from_preds(model, subject, &preds_base, theta, sigma_values, eta);
         let mut grad = vec![0.0f64; n];
         let h = 1e-5;
         for i in 0..n {
@@ -897,7 +903,8 @@ fn obs_nll_subject_grad(
                 let mut sigma_p = sigma_values.to_vec();
                 let delta = h * (1.0 + sigma_values[k].abs());
                 sigma_p[k] += delta;
-                let nll_p = obs_nll_subject_into(model, subject, theta, &sigma_p, eta, pk_scratch);
+                let nll_p =
+                    obs_nll_subject_from_preds(model, subject, &preds_base, theta, &sigma_p, eta);
                 // log-packing for sigma: d/d(log_sigma_k) = sigma_k * d/d(sigma_k)
                 grad[i] = sigma_values[k] * (nll_p - nll_base) / delta;
             }

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -294,25 +294,58 @@ pub(crate) fn obs_nll_subject_into(
     // FREM covariate rows keep their own (unscaled) EPSCOV variance.
     let ruv_scale = model.residual_var_scale(eta);
     let mut nll = 0.0;
-    for (j, (&y, &f)) in subject.observations.iter().zip(preds.iter()).enumerate() {
-        let frem_var = frem_ov.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
-        // FREM covariate pseudo-observations predict a covariate *value* (any
-        // real: centered/standardized/log-scale covariates are routinely ≤ 0),
-        // not a concentration — do NOT clamp them to 1e-12. Clamping a negative
-        // covariate prediction up to 1e-12 fabricates a huge residual and, on the
-        // Rao-Blackwellised path, breaks the `obs_nll(η_c=d) ≈ const` assumption
-        // (#406). Ordinary PK rows keep the positivity clamp.
-        let f = if frem_var.is_some() { f } else { f.max(1e-12) };
-        let v = match frem_var {
-            Some(vv) => vv.max(1e-12),
-            None => (model.residual_variance_at(subject.obs_cmts[j], f, sigma_values) * ruv_scale)
-                .max(1e-12),
+    let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
+    if !model.residual_correlations.is_empty() && !m3 && !has_frem_rows {
+        let preds_eval: Vec<f64> = preds.iter().map(|&f| f.max(1e-12)).collect();
+        let mut r = compute_r_matrix_with_correlations(
+            &model.error_spec,
+            &preds_eval,
+            &subject.obs_cmts,
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            sigma_values,
+            &model.residual_correlations,
+        );
+        if ruv_scale != 1.0 {
+            r *= ruv_scale;
+        }
+        let chol = match r.cholesky() {
+            Some(c) => c,
+            None => return 1e20,
         };
-        let cens = subject.cens.get(j).copied().unwrap_or(0);
-        if m3 && cens != 0 {
-            nll += -m3_logcdf(y, f, v.sqrt(), cens);
-        } else {
-            nll += 0.5 * (v.ln() + (y - f).powi(2) / v);
+        let residuals = DVector::from_iterator(
+            subject.observations.len(),
+            subject
+                .observations
+                .iter()
+                .zip(preds_eval.iter())
+                .map(|(&y, &f)| y - f),
+        );
+        let solved = chol.solve(&residuals);
+        nll += 0.5 * (residuals.dot(&solved) + chol_log_det(&chol.l()));
+    } else {
+        for (j, (&y, &f)) in subject.observations.iter().zip(preds.iter()).enumerate() {
+            let frem_var = frem_ov.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
+            // FREM covariate pseudo-observations predict a covariate *value* (any
+            // real: centered/standardized/log-scale covariates are routinely ≤ 0),
+            // not a concentration — do NOT clamp them to 1e-12. Clamping a negative
+            // covariate prediction up to 1e-12 fabricates a huge residual and, on the
+            // Rao-Blackwellised path, breaks the `obs_nll(η_c=d) ≈ const` assumption
+            // (#406). Ordinary PK rows keep the positivity clamp.
+            let f = if frem_var.is_some() { f } else { f.max(1e-12) };
+            let v = match frem_var {
+                Some(vv) => vv.max(1e-12),
+                None => (model.residual_variance_at(subject.obs_cmts[j], f, sigma_values)
+                    * ruv_scale)
+                    .max(1e-12),
+            };
+            let cens = subject.cens.get(j).copied().unwrap_or(0);
+            if m3 && cens != 0 {
+                nll += -m3_logcdf(y, f, v.sqrt(), cens);
+            } else {
+                nll += 0.5 * (v.ln() + (y - f).powi(2) / v);
+            }
         }
     }
 
@@ -1609,7 +1642,8 @@ pub fn individual_nll_iov(
 mod tests {
     use super::*;
     use crate::types::{
-        BloqMethod, DoseEvent, ErrorModel, ErrorSpec, GradientMethod, PkModel, PkParams,
+        BloqMethod, DoseEvent, EndpointError, ErrorModel, ErrorSpec, GradientMethod, PkModel,
+        PkParams, ResidualCorrelation,
     };
     use approx::assert_relative_eq;
     use std::collections::HashMap;
@@ -1713,6 +1747,56 @@ mod tests {
             residual_error_eta: None,
             analytical_init: Vec::new(),
         }
+    }
+
+    #[test]
+    fn obs_nll_subject_into_uses_cross_endpoint_residual_covariance() {
+        let mut model = make_model();
+        model.error_spec = ErrorSpec::PerCmt(HashMap::from([
+            (
+                1,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![1],
+                },
+            ),
+            (
+                2,
+                EndpointError {
+                    error_model: ErrorModel::Proportional,
+                    sigma_idx: vec![0],
+                },
+            ),
+        ]));
+        model.residual_correlations = vec![ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+
+        let mut subj = make_simple_subject();
+        subj.obs_times = vec![1.0, 1.0];
+        subj.obs_raw_times = Vec::new();
+        subj.observations = vec![1.8, 2.4];
+        subj.obs_cmts = vec![1, 2];
+        subj.cens = vec![0, 0];
+        subj.occasions = vec![1, 1];
+        subj.fremtype = Vec::new();
+        let theta = vec![5.0, 50.0];
+        let eta = vec![0.0];
+        let sigma = vec![0.2, 0.3];
+        let mut scratch = pk::EventPkParams::default();
+
+        let dense = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+        model.residual_correlations.clear();
+        let diagonal = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+
+        assert!(dense.is_finite());
+        assert!(diagonal.is_finite());
+        assert!(
+            (dense - diagonal).abs() > 1e-6,
+            "cross-endpoint residual covariance must contribute to SAEM obs NLL"
+        );
     }
 
     #[test]

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -164,38 +164,10 @@ pub fn individual_nll_into_with_schedule(
         matches!(model.bloq_method, BloqMethod::M3) && subject.has_censored_observation();
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
     if !model.residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
-        let mut r = compute_r_matrix_with_correlations(
-            &model.error_spec,
-            &preds,
-            &subject.obs_cmts,
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            sigma_values,
-            &model.residual_correlations,
-        );
-        if ruv_scale != 1.0 {
-            r *= ruv_scale;
-        }
-        for (j, v) in p_obs.iter().enumerate() {
-            if j < r.nrows() {
-                r[(j, j)] += *v;
-            }
-        }
-        let chol = match r.cholesky() {
-            Some(c) => c,
+        match dense_residual_data_term(model, subject, &preds, sigma_values, ruv_scale, &p_obs) {
+            Some(term) => data_ll += term,
             None => return 1e20,
-        };
-        let residuals = DVector::from_iterator(
-            subject.observations.len(),
-            subject
-                .observations
-                .iter()
-                .zip(preds.iter())
-                .map(|(&y, &f)| y - f),
-        );
-        let solved = chol.solve(&residuals);
-        data_ll += residuals.dot(&solved) + chol_log_det(&chol.l());
+        }
     } else {
         for (j, (&y, &f_pred)) in subject.observations.iter().zip(preds.iter()).enumerate() {
             // FREM dispatch: covariate pseudo-observations use theta+eta as
@@ -269,6 +241,59 @@ pub fn individual_nll_into_with_schedule(
     }
 }
 
+/// Dense correlated-residual (block_sigma) Gaussian data term for one subject.
+///
+/// Builds the residual covariance `R` from [`compute_r_matrix_with_correlations`],
+/// scales it by `ruv_scale`, adds the per-observation EKF process-noise `p_obs`
+/// to the diagonal (`&[]` on the SAEM / non-SDE paths), then returns the
+/// un-halved quadratic form plus log-determinant `rᵀ R⁻¹ r + log|R|`. Returns
+/// `None` when `R` is not positive-definite so the caller can emit its `1e20`
+/// sentinel.
+///
+/// Shared by the FOCE/E-step ([`individual_nll_into_with_schedule`]) and the
+/// SAEM M-step ([`obs_nll_subject_into`]) so both evaluate an identical
+/// conditional likelihood — the two previously carried divergent copies, one of
+/// which floored predictions while the other did not, biasing SAEM σ/θ when a
+/// prediction reached ≤ 0 (#557).
+fn dense_residual_data_term(
+    model: &CompiledModel,
+    subject: &Subject,
+    preds: &[f64],
+    sigma_values: &[f64],
+    ruv_scale: f64,
+    p_obs: &[f64],
+) -> Option<f64> {
+    let mut r = compute_r_matrix_with_correlations(
+        &model.error_spec,
+        preds,
+        &subject.obs_cmts,
+        &subject.obs_times,
+        &subject.obs_raw_times,
+        &subject.occasions,
+        sigma_values,
+        &model.residual_correlations,
+    );
+    if ruv_scale != 1.0 {
+        r *= ruv_scale;
+    }
+    for (j, v) in p_obs.iter().enumerate() {
+        if j < r.nrows() {
+            r[(j, j)] += *v;
+        }
+    }
+    let chol = r.cholesky()?;
+    let residuals = DVector::from_iterator(
+        subject.observations.len(),
+        subject
+            .observations
+            .iter()
+            .zip(preds.iter())
+            .map(|(&y, &f)| y - f),
+    );
+    let solved = chol.solve(&residuals);
+    Some(residuals.dot(&solved) + chol_log_det(&chol.l()))
+}
+
 /// Observation-only NLL for a single subject with ETAs held fixed.
 ///
 /// Returns the data term `−log p(y_i | η, θ, σ)` (no prior, no |Ω| term) — the
@@ -284,8 +309,26 @@ pub(crate) fn obs_nll_subject_into(
     eta: &[f64],
     pk_scratch: &mut pk::EventPkParams,
 ) -> f64 {
-    let m3 = matches!(model.bloq_method, BloqMethod::M3);
     let preds = pk::compute_predictions_with_tv_into(model, subject, theta, eta, pk_scratch);
+    obs_nll_subject_from_preds(model, subject, &preds, theta, sigma_values, eta)
+}
+
+/// Observation-only NLL from *precomputed* predictions.
+///
+/// Identical to [`obs_nll_subject_into`] except the caller supplies `preds`
+/// (predictions are independent of `σ`), letting the SAEM M-step σ-gradient FD
+/// loop reuse one ODE solve across all σ perturbations instead of re-solving per
+/// element (#557). `theta` is only consumed by the TTE hazard term.
+#[cfg_attr(not(feature = "survival"), allow(unused_variables))]
+pub(crate) fn obs_nll_subject_from_preds(
+    model: &CompiledModel,
+    subject: &Subject,
+    preds: &[f64],
+    theta: &[f64],
+    sigma_values: &[f64],
+    eta: &[f64],
+) -> f64 {
+    let m3 = matches!(model.bloq_method, BloqMethod::M3);
     // FREM covariate rows use EPSCOV, not the PK residual error (see
     // build_frem_r_override); FREM covariate rows are never BLOQ.
     let frem_ov =
@@ -296,34 +339,12 @@ pub(crate) fn obs_nll_subject_into(
     let mut nll = 0.0;
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
     if !model.residual_correlations.is_empty() && !m3 && !has_frem_rows {
-        let preds_eval: Vec<f64> = preds.iter().map(|&f| f.max(1e-12)).collect();
-        let mut r = compute_r_matrix_with_correlations(
-            &model.error_spec,
-            &preds_eval,
-            &subject.obs_cmts,
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            sigma_values,
-            &model.residual_correlations,
-        );
-        if ruv_scale != 1.0 {
-            r *= ruv_scale;
-        }
-        let chol = match r.cholesky() {
-            Some(c) => c,
+        // block_sigma + SDE is rejected up front (E_BLOCK_SIGMA_SDE_UNSUPPORTED)
+        // for the SAEM M-step, so no EKF process noise enters here.
+        match dense_residual_data_term(model, subject, preds, sigma_values, ruv_scale, &[]) {
+            Some(term) => nll += 0.5 * term,
             None => return 1e20,
-        };
-        let residuals = DVector::from_iterator(
-            subject.observations.len(),
-            subject
-                .observations
-                .iter()
-                .zip(preds_eval.iter())
-                .map(|(&y, &f)| y - f),
-        );
-        let solved = chol.solve(&residuals);
-        nll += 0.5 * (residuals.dot(&solved) + chol_log_det(&chol.l()));
+        }
     } else {
         for (j, (&y, &f)) in subject.observations.iter().zip(preds.iter()).enumerate() {
             let frem_var = frem_ov.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
@@ -573,7 +594,15 @@ pub fn foce_subject_nll(
     // takes the interaction path. This matches NONMEM `METHOD=1 LAPLACE` with vs
     // without INTER (FOCE-M3 and FOCEI-M3 are genuinely different optima).
     let _ = m3_active;
-    if interaction {
+    // block_sigma cross-endpoint residual covariance is only carried by the
+    // non-interaction (Sheiner–Beal) path via `compute_r_matrix_with_correlations`;
+    // the interaction accumulator builds R diagonally and would silently drop the
+    // off-diagonal covariance. FOCEI + block_sigma is rejected up front
+    // (E_BLOCK_SIGMA_METHOD_UNSUPPORTED), and SAEM — which evaluates this OFV with
+    // `interaction = true` for AIC/BIC comparability — has no interaction-aware
+    // correlated objective to match, so route any correlated model through the
+    // FOCE objective instead of returning a correlation-free OFV (#557).
+    if interaction && model.residual_correlations.is_empty() {
         foce_subject_nll_interaction(
             subject,
             &ipreds,


### PR DESCRIPTION
## Why
#548 tracks extending the NONMEM-style `block_sigma` residual covariance support from FOCE to SAEM. Before this change, SAEM remained gated off because its observation likelihood and theta/sigma M-step gradient logic assumed diagonal residual error, so paired endpoints such as total/unbound assays could silently miss the off-diagonal covariance if accepted.

## What changed
- SAEM observation likelihood now uses the dense subject-level residual covariance matrix when `block_sigma` residual correlations are present for ordinary Gaussian paired-endpoint rows.
- SAEM theta/sigma M-step gradients route through full finite differences for dense residual covariance models, avoiding scalar residual-error score assumptions.
- `check_model_options()` now accepts `method = saem` for the supported ordinary Gaussian subset and keeps clear diagnostics for unsupported combinations: FOCEI/GN/importance sampling, M3, FREM, `iiv_on_ruv`, SDE/EKF, TTE, and IOV.
- Added regression coverage for the dense SAEM likelihood, M-step gradient parity, public `fit()` acceptance, and unsupported-method gating.
- Updated `docs/model-file/error-model.qmd` and `CHANGELOG.md`.

## Alternatives considered
A closed-form dense-R sigma gradient would be faster, but it is more error-prone and not needed to unlock the scoped SAEM support. The conservative finite-difference M-step path matches the objective actually used by SAEM and keeps the implementation aligned with the existing M3/TTE fallback pattern.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

No migration required.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: NONMEM fixed-parameter residual covariance anchor from #549
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
NONMEM anchor:
nonmem_anchor/correlated_residual_combined.ctl
METHOD=1 MAXEVAL=0 with $SIGMA BLOCK(2) FIX
OFV: 18.715849

ferx anchor documented in docs/model-file/error-model.qmd:
examples/correlated_residual_combined.ferx
FOCE OFV: 18.727365
Delta: 0.0115

This PR reuses the same dense residual covariance likelihood for SAEM E-step acceptance checks and theta/sigma M-step objective. Unit tests verify that SAEM NLL changes under nonzero cross-endpoint covariance and that the SAEM M-step gradient matches finite differences of the dense objective.
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [ ] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [x] Slower — justified because: SAEM models with dense residual covariance use full finite differences for theta/sigma M-step gradients. This only applies when `block_sigma` residual correlations are active and avoids diagonal-RUV analytic score assumptions.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

## Example (user-facing features only)
- [x] Example added to `examples/` or inline below
- [ ] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
[parameters]
  theta TVCL(1.0, 0.1, 10.0)
  theta TVV(10.0, 1.0, 100.0)
  omega ETA_CL ~ 0.04
  block_sigma (PROP_ERR_UNBOUND, PROP_ERR_TOTAL) = [
    0.04,
    0.01, 0.09
  ]

[individual_parameters]
  CL = TVCL * exp(ETA_CL)
  V  = TVV

[structural_model]
  ode(states=[central])

[odes]
  d/dt(central) = -CL/V * central

[scaling]
  y[CMT=1] = 2.0 * central / V
  y[CMT=2] = central / V

[error_model]
  CMT=1: DV ~ proportional(PROP_ERR_TOTAL)
  CMT=2: DV ~ proportional(PROP_ERR_UNBOUND)

[fit_options]
  method = saem
```

```
Expected behavior: SAEM accepts the model for ordinary Gaussian paired endpoint rows and includes the off-diagonal residual covariance in the observation likelihood and theta/sigma M-step objective.
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (no new standalone example/data file; behavior covered by unit/API regressions and docs)

## Reviewer hints
Focus on `obs_nll_subject_into()` in `src/stats/likelihood.rs` and the SAEM M-step gradient fallbacks in `src/estimation/saem.rs`. The intended invariant is that once dense residual covariance is active, SAEM scores the same dense observation objective everywhere instead of mixing dense likelihood with diagonal residual-error gradients.

## Open questions
None.

Tests run locally:
- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib block_sigma`
- `cargo test --lib test_saem_accepts_block_sigma_cross_endpoint_fit`
- `cargo test --lib` (`1695 passed; 0 failed; 17 ignored`)

