### PR TITLE
feat(estimation): warn when no estimation method is specified (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- Warn when no estimation method is set in the model file's `[fit_options]` or by
+  the caller, making the implicit fallback to FOCEI visible instead of silent (#558).
 - Support NONMEM-style `block_sigma` residual covariance under SAEM for ordinary
   Gaussian paired-endpoint models (#548).
 - Support NONMEM-style `block_sigma` residual covariance across paired same-time

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -13,7 +13,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
-| `method` | `foce`, `focei`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). |
+| `method` | `foce`, `focei`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). When neither this key nor a wrapper's `method` argument is set, the engine falls back to `focei` and emits a warning so the implicit choice is visible — set `method` here to silence it. |
 | `maxiter` | integer | `500` | Maximum outer loop iterations |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
 | `covariance_method` | `r`, `s`, `rsr` | `r` | Which covariance estimator to assemble, mirroring NONMEM `$COVARIANCE MATRIX=`. `r` = inverse Hessian `R⁻¹` (model-based; the default). `s` = inverse score cross-product `S⁻¹` (empirical information). `rsr` = the Huber–White sandwich `R⁻¹SR⁻¹` (robust to model mis-specification; NONMEM's default). **ferx defaults to `r`, but NONMEM's `$COVARIANCE` default is `rsr`** — set `covariance_method = rsr` when reconciling SEs against a NONMEM run that used the default `$COV`. `s`/`rsr` are supported for FOCEI, FOCE, and IOV fits; all three anchored against NONMEM `$COV MATRIX=S`/`RSR` within ~10%. All methods require a positive-definite FD Hessian (a non-PD Hessian is not yet routed to the `s` cross-product). Requires `covariance = true`. |

--- a/src/api.rs
+++ b/src/api.rs
@@ -2862,7 +2862,12 @@ fn fit_inner(
     // Compute up-front so we can both surface the warnings before the fit
     // starts (a long-running fit shouldn't bury a "this option is unused"
     // notice at the end) and carry them through into FitResult.warnings.
-    let unsupported_warnings = options.unsupported_keys_warnings();
+    let mut unsupported_warnings = options.unsupported_keys_warnings();
+    // Surface a "no method specified, defaulting to FOCEI" notice through the
+    // same channel so it reaches both stderr and FitResult.warnings.
+    if let Some(w) = options.method_default_warning() {
+        unsupported_warnings.push(w);
+    }
 
     // Capture thread count before chain runs (current_num_threads() reports
     // whichever Rayon pool is active — scoped pool when threads=Some, else global).

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13377,6 +13377,21 @@ mod tests {
     }
 
     #[test]
+    fn test_method_default_warning() {
+        // A model file with no `method` key leaves `user_set_keys` without
+        // "method", so the engine warns it defaulted to FOCEI.
+        let opts = parse_fit_options(&["covariance = false".to_string()]).unwrap();
+        let w = opts.method_default_warning();
+        assert!(w.is_some());
+        assert!(w.unwrap().contains("FOCEI"));
+        // An explicit `method` key suppresses the warning.
+        let opts = parse_fit_options(&["method = saem".to_string()]).unwrap();
+        assert!(opts.method_default_warning().is_none());
+        // Bare default (constructed directly) also warns.
+        assert!(FitOptions::default().method_default_warning().is_some());
+    }
+
+    #[test]
     fn test_parse_method_chain_empty_rejected() {
         assert!(parse_fit_options(&["method = []".to_string()]).is_err());
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4387,6 +4387,26 @@ impl FitOptions {
         }
         warnings
     }
+
+    /// Warn when no estimation method was set anywhere — neither in the model
+    /// file's `[fit_options]` nor by the caller (CLI / R / Python wrapper).
+    /// In that case `method` carries its `FOCEI` default, and the user may not
+    /// realise the engine picked it for them. Wrappers mark an explicit method
+    /// by pushing `"method"` onto `user_set_keys` (the parser does the same for
+    /// a model-file `method = ...` line), so the absence of that key is the
+    /// reliable signal that the value defaulted. Returns `None` once a method
+    /// has been specified anywhere.
+    pub fn method_default_warning(&self) -> Option<String> {
+        if self.user_set_keys.iter().any(|k| k == "method") {
+            return None;
+        }
+        Some(format!(
+            "No estimation method was specified in the model file or the call; \
+             defaulting to `{}`. Set `method` in [fit_options] or pass it \
+             explicitly to silence this warning.",
+            self.method.label()
+        ))
+    }
 }
 
 /// Framework-level fit-option keys: consumed by every method and typically


### PR DESCRIPTION
## Why
Closes the engine half of #558. When a model file's `[fit_options]` set
`method = saem` but the user called `ferx_fit(model, data)` without a `method`
argument, the R wrapper's `method = "focei"` default silently overrode the
model file. Part of the fix is making the *implicit* fallback to FOCEI visible
instead of silent, so a user who never sets a method anywhere is told the engine
chose one for them.

(The actual override bug lives in the R wrapper — see the ferx-r PR below. This
PR adds the engine-level warning so every wrapper, CLI included, benefits.)

## What changed
- New `FitOptions::method_default_warning()` returns a warning when no method was
  set in the model file or by the caller. The signal is the absence of `"method"`
  in `user_set_keys` — the parser pushes that key on a model-file `method = ...`
  line, and wrappers push it when they pass an explicit method.
- `fit()` surfaces it through the same path as the unused-key warnings, so it
  reaches both stderr and `FitResult.warnings`.

## Alternatives considered
Detecting "defaulted" by comparing `opts.method` to FOCEI — rejected: a caller
could legitimately *choose* FOCEI, and that should not warn. `user_set_keys`
distinguishes "chose FOCEI" from "never chose".

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#202 | open | together |

The ferx-r PR is the behavioural fix (stop defaulting `method`); this PR is the
visibility warning. They are independent code-wise (the warning keys off
`user_set_keys`, a field already `pub`), but conceptually land together.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (warning only; no numerical change)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test added (`test_method_default_warning` in `model_parser.rs`):
  no method → warns; explicit `method = saem` → no warning; bare `FitOptions::default()` → warns.

## Example (user-facing features only)
- [x] Not applicable (internal / warning surface)

## Docs
- [x] `docs/model-file/fit-options.qmd` `method` row notes the fallback + warning
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo test --lib` passes (1698 + new test)

## Reviewer hints
Focus on the `user_set_keys` contract: does every path that sets a method push
the key? Parser does (`model_parser.rs:3687`). The ferx-r glue PR adds the push
on the R override path.
