### PR TITLE
refactor(survival): consolidate TTE simulation helpers [closes #531]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -199,18 +199,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
     // draw then overwrites each template with its realised outcome (#522). Compute
     // the cause-CMT list once, outside the per-subject loop.
     #[cfg(feature = "survival")]
-    let tte_cmts: Vec<usize> = {
-        let mut c: Vec<usize> = parsed
-            .model
-            .endpoints
-            .iter()
-            .filter_map(|(cmt, ep)| {
-                matches!(ep, crate::types::EndpointLikelihood::Tte { .. }).then_some(*cmt)
-            })
-            .collect();
-        c.sort_unstable();
-        c
-    };
+    let tte_cmts: Vec<usize> = parsed.model.tte_cmts();
     #[cfg(feature = "survival")]
     if !tte_cmts.is_empty() && sim_spec.horizon.is_none() {
         return Err("[simulation] with a TTE endpoint requires `horizon = <t>` \
@@ -234,10 +223,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
     // otherwise carries a default `pk_model`, so the structural model alone can't
     // distinguish intent.
     let model_has_continuous = !parsed.model.default_params.sigma.values.is_empty();
-    #[cfg(feature = "survival")]
-    let model_has_tte = !tte_cmts.is_empty();
-    #[cfg(not(feature = "survival"))]
-    let model_has_tte = false;
+    let model_has_tte = parsed.model.has_tte();
     if sim_spec.obs_times.is_empty() {
         if model_has_continuous {
             return Err(
@@ -333,19 +319,31 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
     )
     .map_err(|e| format!("simulation failed: {e}"))?;
 
+    // Group the simulation results by subject id once (they are emitted in
+    // subject order, but a map keeps the write-back independent of that), then
+    // write each subject's outcomes back in a single pass instead of re-scanning
+    // all of `sim_results` per subject twice (Gaussian, then TTE).
+    let mut sims_by_id: HashMap<&str, Vec<&SimulationResult>> = HashMap::new();
+    for s in &sim_results {
+        sims_by_id.entry(s.id.as_str()).or_default().push(s);
+    }
+
     let mut population = template;
     for subject in &mut population.subjects {
+        let Some(sims) = sims_by_id.get(subject.id.as_str()) else {
+            continue;
+        };
+
         // Gaussian write-back: only continuous outcomes map onto `observations`.
         // A TTE `Event` row would trip `continuous_value()`'s debug-assert, so
-        // filter it out here; the TTE outcomes are written into `obs_records` below.
-        let sims: Vec<_> = sim_results
+        // skip it here (the TTE outcomes go into `obs_records` below). Enumerating
+        // *after* the filter makes `j` index the continuous subsequence, matching
+        // the per-subject observation grid.
+        for (j, s) in sims
             .iter()
-            .filter(|s| {
-                s.id == subject.id
-                    && matches!(s.outcome, crate::types::SimOutcome::Continuous { .. })
-            })
-            .collect();
-        for (j, s) in sims.iter().enumerate() {
+            .filter(|s| matches!(s.outcome, crate::types::SimOutcome::Continuous { .. }))
+            .enumerate()
+        {
             if j < subject.observations.len() {
                 // Under LTBS the simulated DV is on the log scale and may be
                 // negative, so the positivity floor only applies to natural-scale
@@ -358,38 +356,39 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
                 };
             }
         }
-    }
 
-    // TTE write-back (#522): replace each subject's template rows with the
-    // realised simulated outcomes — `Exact` at the drawn event time, or
-    // `RightCensored` at the horizon when no cause fired — so the fitted dataset
-    // (and any output) carries the simulated events rather than the placeholders.
-    #[cfg(feature = "survival")]
-    for subject in &mut population.subjects {
-        let events: Vec<crate::types::ObsRecord> = sim_results
-            .iter()
-            .filter(|s| s.id == subject.id)
-            .filter_map(|s| match s.outcome {
-                crate::types::SimOutcome::Event { time, observed } => {
-                    Some(crate::types::ObsRecord::Event {
-                        time,
-                        event_type: if observed {
-                            crate::types::EventType::Exact
-                        } else {
-                            crate::types::EventType::RightCensored
-                        },
-                        // Synthetic `[simulation]` subjects always enter at 0 (no
-                        // left truncation), matching the template row above; keep
-                        // the two in sync if this path ever gains delayed entry.
-                        entry_time: 0.0,
-                        cmt: s.cmt,
-                    })
-                }
-                _ => None,
-            })
-            .collect();
-        if !events.is_empty() {
-            subject.obs_records = events;
+        // TTE write-back (#522): replace the subject's template rows with the
+        // realised simulated outcomes — `Exact` at the drawn event time, or
+        // `RightCensored` at the horizon when no cause fired — so the fitted
+        // dataset (and any output) carries the simulated events rather than the
+        // placeholders.
+        #[cfg(feature = "survival")]
+        {
+            let events: Vec<crate::types::ObsRecord> = sims
+                .iter()
+                .filter_map(|s| match s.outcome {
+                    crate::types::SimOutcome::Event { time, observed } => {
+                        Some(crate::types::ObsRecord::Event {
+                            time,
+                            event_type: if observed {
+                                crate::types::EventType::Exact
+                            } else {
+                                crate::types::EventType::RightCensored
+                            },
+                            // Synthetic `[simulation]` subjects always enter at 0
+                            // (no left truncation), matching the template row
+                            // above; keep the two in sync if this path ever gains
+                            // delayed entry.
+                            entry_time: 0.0,
+                            cmt: s.cmt,
+                        })
+                    }
+                    _ => None,
+                })
+                .collect();
+            if !events.is_empty() {
+                subject.obs_records = events;
+            }
         }
     }
 
@@ -5522,8 +5521,9 @@ pub fn predict_survival(
     params: &ModelParameters,
     time_grid: &[f64],
 ) -> Vec<SurvivalPredictionResult> {
-    use crate::survival::{cif_curves, hazard_and_cum_hazard, mean_survival, median_survival};
-    use crate::types::EndpointLikelihood;
+    use crate::survival::{
+        cif_curves, hazard_and_cum_hazard, mean_survival, median_survival, tte_cause_params,
+    };
 
     // The competing-risks CIF telescopes the all-cause survival drop, which
     // requires the grid in ascending time order; sort a local copy so the
@@ -5542,15 +5542,15 @@ pub fn predict_survival(
         // each grid point, so collect the per-cause parameters up front.
         let mut causes: Vec<(usize, crate::types::HazardFamily, Vec<f64>, f64, f64)> = Vec::new();
         for (&cmt, endpoint) in &model.endpoints {
-            let EndpointLikelihood::Tte { hazard } = endpoint else {
+            let Some((family, params_vec)) =
+                tte_cause_params(endpoint, &params.theta, &zero_eta, &subject.covariates)
+            else {
                 continue;
             };
-            let crate::types::HazardSpec::Analytic { family, param_fn } = hazard;
-            let params_vec = param_fn(&params.theta, &zero_eta, &subject.covariates);
             // Distributional summaries are parameter-dependent, not time-dependent.
-            let t_median = median_survival(*family, &params_vec);
-            let t_mean = mean_survival(*family, &params_vec);
-            causes.push((cmt, *family, params_vec, t_median, t_mean));
+            let t_median = median_survival(family, &params_vec);
+            let t_mean = mean_survival(family, &params_vec);
+            causes.push((cmt, family, params_vec, t_median, t_mean));
         }
         if causes.is_empty() {
             continue;

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -540,6 +540,36 @@ mod tests {
     }
 
     #[test]
+    fn tte_cause_params_evaluates_tte_and_skips_non_tte() {
+        use crate::types::{EndpointError, ErrorModel, HazardFamily, HazardParamFn};
+        let theta = [0.1_f64];
+        let eta = [0.0_f64];
+        let cov = HashMap::new();
+
+        // A `Tte` endpoint yields `Some((family, evaluated params))`.
+        let param_fn: HazardParamFn =
+            Box::new(|theta: &[f64], _eta: &[f64], _cov: &HashMap<String, f64>| vec![theta[0]]);
+        let tte = EndpointLikelihood::Tte {
+            hazard: HazardSpec::Analytic {
+                family: HazardFamily::Exponential,
+                param_fn,
+            },
+        };
+        let (family, params) =
+            tte_cause_params(&tte, &theta, &eta, &cov).expect("Tte endpoint must yield Some");
+        assert_eq!(family, HazardFamily::Exponential);
+        assert_eq!(params, vec![0.1]);
+
+        // A non-`Tte` (Gaussian) endpoint takes the `None` branch, letting callers
+        // `filter_map`/`continue` over a mixed endpoint map.
+        let gaussian = EndpointLikelihood::Gaussian(EndpointError {
+            error_model: ErrorModel::Additive,
+            sigma_idx: vec![],
+        });
+        assert!(tte_cause_params(&gaussian, &theta, &eta, &cov).is_none());
+    }
+
+    #[test]
     fn tte_data_term_exact_event_exponential() {
         use crate::types::HazardFamily;
         // lambda=0.1, T=10, exact event → -log L = H(T) - log h(T) = 1.0 - log(0.1) = 1.0 + 2.303

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -306,6 +306,34 @@ fn resolve_competing_risks(latents: &[f64], window: f64) -> (usize, f64, bool) {
 /// `None` keeps the per-record window. The override changes only the censoring
 /// comparison, never the number of uniforms drawn, so the RNG sequence (and the
 /// SSE characterization tests) are unaffected.
+/// Destructure a TTE endpoint and evaluate its hazard parameters at the given
+/// `(theta, eta, covariates)`. Returns `None` for any non-`Tte` endpoint so
+/// callers can `filter_map`/`?` over `model.endpoints` or a looked-up CMT.
+///
+/// This centralises the `EndpointLikelihood::Tte { HazardSpec::Analytic {
+/// family, param_fn } }` destructure and `param_fn` evaluation shared by
+/// `simulate_tte` (per `obs_record`) and `predict_survival` (per endpoint), so a
+/// new `HazardSpec`/`HazardFamily` variant only has to be handled here. Callers
+/// supply their own trailing per-cause fields (window/entry time vs. summary
+/// statistics).
+pub(crate) fn tte_cause_params(
+    endpoint: &EndpointLikelihood,
+    theta: &[f64],
+    eta: &[f64],
+    covariates: &HashMap<String, f64>,
+) -> Option<(HazardFamily, Vec<f64>)> {
+    let EndpointLikelihood::Tte { hazard } = endpoint else {
+        return None;
+    };
+    let HazardSpec::Analytic { family, param_fn } = hazard;
+    Some((*family, param_fn(theta, eta, covariates)))
+}
+
+// Same flat (model, subject, params, replicate indices, RNG, output sink) shape
+// as the sole caller `emit_subject_rows`, which carries this same allow: the args
+// are heterogeneous with no cohesive struct to bundle, and splitting them would
+// only diverge from that sibling.
+#[allow(clippy::too_many_arguments)]
 pub fn simulate_tte<R: rand::Rng>(
     model: &crate::types::CompiledModel,
     subject: &crate::types::Subject,
@@ -328,16 +356,18 @@ pub fn simulate_tte<R: rand::Rng>(
             time,
             event_type,
         } = record;
-        let Some(EndpointLikelihood::Tte { hazard }) = model.endpoints.get(cmt) else {
+        let Some(endpoint) = model.endpoints.get(cmt) else {
             continue;
         };
-        let HazardSpec::Analytic { family, param_fn } = hazard;
-        let params = param_fn(theta, eta, &subject.covariates);
+        let Some((family, params)) = tte_cause_params(endpoint, theta, eta, &subject.covariates)
+        else {
+            continue;
+        };
         // With an explicit `horizon`, every cause shares it as the administrative
         // window (#522); otherwise only a right-censored record marks a horizon and
         // an event record draws uncensored (+∞) — see `observation_window`.
         let window = horizon.unwrap_or_else(|| observation_window(event_type, *time));
-        causes.push((*cmt, *family, params, *entry_time, window));
+        causes.push((*cmt, family, params, *entry_time, window));
     }
 
     let push = |cmt: usize, time: f64, observed: bool, results: &mut Vec<_>| {

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -279,6 +279,29 @@ fn resolve_competing_risks(latents: &[f64], window: f64) -> (usize, f64, bool) {
     (win_idx, if event { t_star } else { window }, event)
 }
 
+/// Destructure a TTE endpoint and evaluate its hazard parameters at the given
+/// `(theta, eta, covariates)`. Returns `None` for any non-`Tte` endpoint so
+/// callers can `filter_map`/`?` over `model.endpoints` or a looked-up CMT.
+///
+/// This centralises the `EndpointLikelihood::Tte { HazardSpec::Analytic {
+/// family, param_fn } }` destructure and `param_fn` evaluation shared by
+/// `simulate_tte` (per `obs_record`) and `predict_survival` (per endpoint), so a
+/// new `HazardSpec`/`HazardFamily` variant only has to be handled here. Callers
+/// supply their own trailing per-cause fields (window/entry time vs. summary
+/// statistics).
+pub(crate) fn tte_cause_params(
+    endpoint: &EndpointLikelihood,
+    theta: &[f64],
+    eta: &[f64],
+    covariates: &HashMap<String, f64>,
+) -> Option<(HazardFamily, Vec<f64>)> {
+    let EndpointLikelihood::Tte { hazard } = endpoint else {
+        return None;
+    };
+    let HazardSpec::Analytic { family, param_fn } = hazard;
+    Some((*family, param_fn(theta, eta, covariates)))
+}
+
 /// Draw TTE event/censoring outcomes for a subject and append them to `results`.
 ///
 /// Called from `api::simulate_inner_with_draw` after the Gaussian path. Each
@@ -306,29 +329,6 @@ fn resolve_competing_risks(latents: &[f64], window: f64) -> (usize, f64, bool) {
 /// `None` keeps the per-record window. The override changes only the censoring
 /// comparison, never the number of uniforms drawn, so the RNG sequence (and the
 /// SSE characterization tests) are unaffected.
-/// Destructure a TTE endpoint and evaluate its hazard parameters at the given
-/// `(theta, eta, covariates)`. Returns `None` for any non-`Tte` endpoint so
-/// callers can `filter_map`/`?` over `model.endpoints` or a looked-up CMT.
-///
-/// This centralises the `EndpointLikelihood::Tte { HazardSpec::Analytic {
-/// family, param_fn } }` destructure and `param_fn` evaluation shared by
-/// `simulate_tte` (per `obs_record`) and `predict_survival` (per endpoint), so a
-/// new `HazardSpec`/`HazardFamily` variant only has to be handled here. Callers
-/// supply their own trailing per-cause fields (window/entry time vs. summary
-/// statistics).
-pub(crate) fn tte_cause_params(
-    endpoint: &EndpointLikelihood,
-    theta: &[f64],
-    eta: &[f64],
-    covariates: &HashMap<String, f64>,
-) -> Option<(HazardFamily, Vec<f64>)> {
-    let EndpointLikelihood::Tte { hazard } = endpoint else {
-        return None;
-    };
-    let HazardSpec::Analytic { family, param_fn } = hazard;
-    Some((*family, param_fn(theta, eta, covariates)))
-}
-
 // Same flat (model, subject, params, replicate indices, RNG, output sink) shape
 // as the sole caller `emit_subject_rows`, which carries this same allow: the args
 // are heterogeneous with no cohesive struct to bundle, and splitting them would

--- a/src/types.rs
+++ b/src/types.rs
@@ -2486,6 +2486,22 @@ impl CompiledModel {
             .any(|e| matches!(e, EndpointLikelihood::Tte { .. }))
     }
 
+    /// CMTs routed to a `Tte` endpoint, sorted ascending. Keeps the
+    /// "is this a TTE endpoint" predicate in one place (shared with
+    /// [`has_tte`](Self::has_tte)); callers that need the cause list — e.g.
+    /// building one censoring template row per cause in `run_model_simulate` —
+    /// use this instead of inlining the `matches!` filter.
+    #[cfg(feature = "survival")]
+    pub fn tte_cmts(&self) -> Vec<usize> {
+        let mut c: Vec<usize> = self
+            .endpoints
+            .iter()
+            .filter_map(|(cmt, ep)| matches!(ep, EndpointLikelihood::Tte { .. }).then_some(*cmt))
+            .collect();
+        c.sort_unstable();
+        c
+    }
+
     /// Always false without the `survival` feature - TTE endpoints can't be
     /// parsed, so no model can carry one.
     #[cfg(not(feature = "survival"))]


### PR DESCRIPTION
## Why

Closes #531 — the low-priority cleanups surfaced during the `/code-review` of #526 (TTE `[simulation] horizon`). None are correctness bugs; this is pure tidy-up of the TTE simulation paths.

## What changed

- **Fold the two write-back passes in `run_model_simulate`.** The function ran two separate `for subject in &mut population.subjects` passes — the Gaussian write-back (`Continuous` → `observations`) then the TTE write-back (`Event` → `obs_records`) — each re-scanning all of `sim_results` with `.filter(|s| s.id == subject.id)`, i.e. `O(n_subjects × n_results)` twice. Now `sim_results` is grouped by id once and each subject's outcomes are written in a single pass. The Gaussian loop uses `.filter(..).enumerate()` so the observation index still tracks the continuous subsequence.
- **Share `tte_cause_params`.** New `pub(crate)` helper in `survival/mod.rs` centralises the `EndpointLikelihood::Tte { HazardSpec::Analytic { family, param_fn } }` destructure + `param_fn` evaluation that `simulate_tte` (per `obs_record`) and `predict_survival` (per endpoint) both did inline. Each caller keeps its own trailing per-cause fields (window/entry-time vs. summary stats); only the shared destructure moved.
- **Reuse the TTE-endpoint predicate.** New `CompiledModel::tte_cmts()` (sorted) next to `has_tte()`. `run_model_simulate` uses `tte_cmts()` for the cause list and `has_tte()` for `model_has_tte` (which also drops a `#[cfg]` pair, since `has_tte()` already has a non-survival stub).
- **`simulate_tte` `too_many_arguments` lint.** Quieted with `#[allow(clippy::too_many_arguments)]`, matching the same allow its sole caller `emit_subject_rows` already carries for the identical (model, subject, params, replicate-indices, RNG, sink) shape.

## Alternatives considered

For the args lint, bundling into a `struct` was rejected: the args are heterogeneous (inputs, replicate indices, RNG, output sink) with no cohesive grouping, and `simulate_tte`'s only caller `emit_subject_rows` keeps the same flat shape under the same allow — a struct on one but not the other would diverge the two sibling emit functions.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`tte_cmts()` is an additive public method; `tte_cause_params` is `pub(crate)`. No existing signature changed, and ferx-r does not call any of these.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (refactor) — behaviour-preserving. Tier-3 TTE SSE recovery numbers (`tte_sse_exponential/weibull/gompertz/competing_risks_recovers_truth`) stay **bit-identical**, which is the guard that the simulate path is unchanged.

## Performance
- [x] No significant impact expected — removes two `O(n_subjects × n_results)` re-scans on the `--simulate` path, but `n_subjects` there is small (default ≤ ~200), so this is a tidiness win, not a hot-path optimisation.

## Tests
- [x] No new tests needed — the refactored paths are already covered: `simulate_block_mixed_pk_and_tte` exercises the folded write-back (asserts both the continuous observations **and** the TTE row per subject), `competing_risks_fits_and_predicts_cif` covers the `predict_survival` helper, and the `simulate_block_*` / Tier-3 SSE tests cover `simulate_tte` and `tte_cmts()`.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor)

## Docs
- [x] No user-visible change (no CHANGELOG entry — internal refactor)

## Checklist
- [x] `cargo clippy` clean (ci,survival) — no new warnings; the `simulate_tte` args lint is now resolved
- [x] `Dual2` path unaffected — `simulate_tte` is an `f64` simulation path, not on the `sens/` gradient-reachable code
- [x] No version bump (non-breaking)

## Docs & examples
### Example execution
- [x] No example execution step needed (internal refactor, no user-visible change)

## Reviewer hints

The one behaviourally-sensitive change is the write-back fold in `run_model_simulate`. Key equivalence points: (1) grouping preserves per-subject order — `sims_by_id[id]` is pushed in `sim_results` iteration order, so the Gaussian `.filter().enumerate()` index matches the old pre-filtered-then-enumerated index; (2) the two write-backs are independent per subject (no cross-subject dependency), so interleaving them in one loop is equivalent to the old two sequential passes; (3) a subject absent from `sim_results` is skipped (`else { continue }`) — same no-op as the old empty-filter. Confirmed in both build configs: `ci,survival` and default `ci` (the Gaussian-only path, with the TTE `cfg` block compiled out, is green via `cli_binaries`).

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
