### PR TITLE
feat(sim): assay-noised (Dv) monitors + per-purpose RNG substreams (S1.5) [closes #566]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,14 @@ section of the SDLC for the versioning policy).
   oncology dose reduction, biomarker titration). ODE models only; the controller is supplied
   as a per-subject factory; every realized dose and every decision (including holds) is
   returned alongside the trajectories, and a frozen-schedule replay verifier checks the dose
-  bookkeeping by default. Ipred monitors only for now (assay-noised `Dv` monitoring follows).
-  See [Adaptive dosing](model-file/adaptive-dosing.qmd).
+  bookkeeping by default. See [Adaptive dosing](model-file/adaptive-dosing.qmd).
+- **Assay-noised (`Dv`) monitors for `simulate_adaptive()`** (#566, epic #391). A controller can
+  titrate on the realized, assay-noised measurement — `IPRED + ε·√(residual variance)`, clamped
+  at 0, drawn from the endpoint's `[error_model]` — instead of (or, per-monitor, alongside) the
+  latent `Ipred`. This is the realistic TDM / titration signal. The assay draws come from a
+  per-purpose RNG substream keyed by `(subject, replicate, decision, analyte)`, so they are
+  deterministic under a fixed seed, invariant to subject ordering, and never perturb another
+  monitor's (or η's) draws.
 - Warn when no estimation method is set in the model file's `[fit_options]` or by
   the caller, making the implicit fallback to FOCEI visible instead of silent (#558).
 - Support NONMEM-style `block_sigma` residual covariance under SAEM for ordinary

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -46,14 +46,26 @@ A controller reads named signals declared as [`MonitorSpec`]s. Each monitor
 observes a 1-based compartment/endpoint under an [`ObserveMode`]:
 
 - `Ipred` — the latent individual prediction (no measurement noise).
-- `Dv` — the realized, assay-noised measurement (the realistic TDM signal).
+- `Dv` — the realized, assay-noised measurement: `IPRED + ε·√(residual variance)`,
+  clamped at 0, with the residual variance taken from the endpoint's own
+  `[error_model]`. This is the realistic TDM / titration signal — a clinician
+  titrates on a *measured* value, not the latent truth.
 
-> **This slice supports `Ipred` monitors only.** A `Dv` monitor is rejected with
-> a typed error; assay-noised monitoring (and its per-subject reproducible RNG
-> substreams) lands in a follow-up.
+Mode is chosen **per monitor**, so a PK exposure target can run on `Ipred` while a
+safety marker (e.g. ANC → CTCAE grade) runs on `Dv` in the same simulation.
 
-The engine — not the controller — resolves every monitor, so draw order stays
-reproducible.
+The engine — not the controller — resolves every monitor and draws any assay
+noise, on a dedicated **controller-assay RNG substream** keyed by
+`(subject, replicate, decision, analyte)`. That identity keying makes the assay
+draws (under a fixed `seed`):
+
+- **deterministic** — re-running reproduces them exactly;
+- **permutation-invariant** — a subject's draws do not depend on iteration order;
+- **non-perturbing** — adding a monitor never shifts another monitor's (or η's)
+  draws, so the frozen-replay verifier stays exact.
+
+A `Dv` monitor on a compartment with no `[error_model]` is a typed error (never a
+fabricated σ), and a noised reading below zero is clamped to 0.
 
 ## Example
 
@@ -65,7 +77,9 @@ use ferx_core::{
 let opts = AdaptiveSimulateOptions {
     seed: Some(42),
     decision_times: vec![0.0, 24.0, 48.0, 72.0, 96.0],
-    monitors: vec![MonitorSpec::new("CONC", 1, ObserveMode::Ipred)],
+    // Titrate on the noisy assay (DV), as in real TDM. Use `ObserveMode::Ipred`
+    // to titrate on the latent prediction instead.
+    monitors: vec![MonitorSpec::new("CONC", 1, ObserveMode::Dv)],
     ..Default::default() // verify = true, max_decisions = 10_000
 };
 
@@ -133,7 +147,8 @@ family. It is validated instead by:
   dose-free simulation.
 - **Dose-free base subjects** — the regimen is fully controller-driven; a subject
   that already carries doses is rejected.
-- **`Ipred` monitors only** (assay-noised `Dv` follows).
+- **Diagonal assay noise** — each `Dv` monitor draws independently; correlated
+  cross-endpoint (`block_sigma`) assay noise is a follow-up.
 - **Between-subject variability only** — η is drawn per subject/replicate;
   parameter-uncertainty propagation is a later layer.
 - **Programmatic API only** — the declarative `[adaptive_dosing]` block,

--- a/src/api.rs
+++ b/src/api.rs
@@ -5490,6 +5490,19 @@ where
     let normal = Normal::new(0.0, 1.0).unwrap();
     let n_eta = model.n_eta;
 
+    // Root seed for the controller-assay substreams (DV-mode monitors, S1.5).
+    // Resolved independently of the η `rng` above so that enabling a `Dv` monitor
+    // never shifts the η draws (the all-`Ipred` path stays byte-identical). With no
+    // run seed it is drawn from a fresh entropy source, matching the η stream's own
+    // nondeterminism.
+    let assay_root: u64 = match opts.seed {
+        Some(s) => s,
+        None => {
+            let mut entropy: rand::rngs::StdRng = rand::make_rng();
+            entropy.random::<u64>()
+        }
+    };
+
     let mut trajectories: Vec<SimulationResult> = Vec::new();
     let mut ledger: Vec<DoseLedgerEntry> = Vec::new();
     let mut decisions: Vec<DecisionLogEntry> = Vec::new();
@@ -5506,6 +5519,28 @@ where
 
             let pk = (model.pk_param_fn)(&params.theta, &eta_slice, &subject.covariates);
 
+            // Controller-assay capability for any `Dv` monitor: resolve the
+            // endpoint's residual variance by CMT (scaled by this subject's
+            // `ruv_scale` for IIV-on-RUV), or `None` when no [error_model] covers
+            // that compartment (S1.5 edge a). The base seed keys this
+            // (subject, replicate)'s controller-assay substream.
+            let ruv_scale = model.residual_var_scale(&eta_slice);
+            let sigma = &params.sigma.values;
+            let resid_var = |cmt: usize, ipred: f64| -> Option<f64> {
+                if !model.has_residual_error_for_cmt(cmt, sigma) {
+                    return None;
+                }
+                Some(model.residual_variance_at(cmt, ipred, sigma) * ruv_scale)
+            };
+            let assay = crate::sim::adaptive::AssayNoise {
+                resid_var: &resid_var,
+                base_seed: crate::sim::adaptive::subject_assay_base_seed(
+                    assay_root,
+                    &subject.id,
+                    sim,
+                ),
+            };
+
             // A fresh controller per (subject, replicate) — see the factory note.
             let mut controller = make_controller();
             let run: AdaptiveRun = crate::ode::ode_predictions_adaptive(
@@ -5518,6 +5553,7 @@ where
                 &opts.monitors,
                 &mut controller,
                 opts.max_decisions,
+                Some(&assay),
             )
             .map_err(|e| format!("subject '{}' (sim {sim}): {e}", subject.id))?;
 
@@ -10322,19 +10358,21 @@ mod adaptive_sim_tests {
     }
 
     #[test]
-    fn rejects_dv_monitor() {
-        // The Dv (assay-noised) path needs the per-subject RNG substreams of
-        // S1.5; until then a Dv monitor is a typed error.
+    fn dv_monitor_without_error_model_is_rejected() {
+        // Edge (a): a DV monitor on a model with no residual error (here sigma is
+        // stripped) is a typed error, never a fabricated σ.
         let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let mut params = model.default_params.clone();
+        params.sigma.values = vec![]; // no [error_model] coverage for the monitor
         let pop = population(vec![subj("1", vec![6.0], vec![])]);
         let opts = AdaptiveSimulateOptions {
             decision_times: vec![0.0],
             monitors: vec![MonitorSpec::new("A", 1, ObserveMode::Dv)],
             ..Default::default()
         };
-        let err = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
-            .expect_err("Dv monitor must be rejected");
-        assert!(err.contains("DV") || err.contains("S1.5"), "got: {err}");
+        let err = simulate_adaptive(&model, &pop, &params, 1, fixed_bolus, &opts)
+            .expect_err("DV monitor with no error model must be rejected");
+        assert!(err.contains("error_model"), "got: {err}");
     }
 
     #[test]
@@ -10373,5 +10411,172 @@ mod adaptive_sim_tests {
             r.trajectories.iter().map(|t| t.ipred).collect::<Vec<_>>()
         };
         assert_eq!(ip(&checked), ip(&unchecked));
+    }
+
+    // ----- S1.5: DV-mode (assay-noised) monitors --------------------------
+
+    /// Factory (mirrors `fixed_bolus`): titrate on the *measured* (DV) central
+    /// amount "A" — dose 100 mg when it falls below 50, else hold.
+    fn dv_threshold() -> impl FnMut(&ControllerCtx) -> Vec<DoseAction> {
+        |ctx: &ControllerCtx| {
+            if ctx.signal("A").expect("monitor A declared") < 50.0 {
+                vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }]
+            } else {
+                vec![DoseAction::Hold]
+            }
+        }
+    }
+
+    #[test]
+    fn dv_monitor_run_passes_default_verifier() {
+        // End-to-end: a controller titrating on the DV signal, verify = true. Covers
+        // the assay-noise wiring (resid_var closure + per-subject base seed) and the
+        // driver's DV branch, and confirms the frozen-replay verifier stays green on
+        // a DV run (it replays realized doses, not decisions).
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let pop = population(vec![subj("1", vec![2.0, 6.0, 10.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(7),
+            decision_times: vec![0.0, 4.0, 8.0],
+            monitors: vec![MonitorSpec::new("A", 1, ObserveMode::Dv)],
+            ..Default::default()
+        };
+        let res = simulate_adaptive(&model, &pop, &model.default_params, 1, dv_threshold, &opts)
+            .expect("DV run passes the verifier");
+        assert_eq!(res.decisions.len(), 3);
+        // The DV value the controller saw is recorded, tagged as the Dv mode.
+        assert!(res
+            .decisions
+            .iter()
+            .all(|d| d.observed_signals[0].mode == ObserveMode::Dv));
+    }
+
+    #[test]
+    fn dv_monitor_collapses_to_ipred_as_sigma_to_zero() {
+        // sigma -> 0: titrating on the DV reproduces titrating on the latent IPRED,
+        // realized-ledger for realized-ledger.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let pop = population(vec![subj("1", vec![2.0, 6.0, 10.0], vec![])]);
+        let mut params = model.default_params.clone();
+        params.sigma.values = vec![1e-12];
+        let decision_times = vec![0.0, 4.0, 8.0];
+
+        let dv_opts = AdaptiveSimulateOptions {
+            seed: Some(7),
+            decision_times: decision_times.clone(),
+            monitors: vec![MonitorSpec::new("A", 1, ObserveMode::Dv)],
+            ..Default::default()
+        };
+        let ipred_opts = AdaptiveSimulateOptions {
+            seed: Some(7),
+            decision_times,
+            monitors: vec![MonitorSpec::new("A", 1, ObserveMode::Ipred)],
+            ..Default::default()
+        };
+        let dv = simulate_adaptive(&model, &pop, &params, 1, dv_threshold, &dv_opts).expect("dv");
+        let ip =
+            simulate_adaptive(&model, &pop, &params, 1, dv_threshold, &ipred_opts).expect("ipred");
+        // Compare the *dosing decisions* (time/amt/cmt/rate), not the recorded
+        // observed signals: the residual variance floors at MIN_VARIANCE, so the DV
+        // readout never collapses to IPRED bit-for-bit — but the decisions it drives
+        // do. (The exact bit-for-bit collapse is pinned at the driver level with a
+        // literal zero-variance resolver.)
+        let schedule = |r: &AdaptiveSimulationResult| {
+            r.ledger
+                .iter()
+                .map(|e| (e.time, e.amt, e.cmt, e.rate))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            schedule(&dv),
+            schedule(&ip),
+            "DV with sigma→0 must make the same dosing decisions as IPRED"
+        );
+    }
+
+    #[test]
+    fn adding_dv_monitor_does_not_perturb_eta_trajectory() {
+        // Isolation: the controller-assay substream is disjoint from the η stream,
+        // so enabling a DV monitor leaves the η draws (hence the IPRED trajectory)
+        // bit-identical. Uses ODE_IIV (η on CL) and a signal-independent controller,
+        // so any trajectory difference could only come from a shifted η draw.
+        let model = parse_model_string(ODE_IIV).expect("parse");
+        let pop = population(vec![
+            subj("1", vec![6.0, 30.0], vec![]),
+            subj("2", vec![6.0, 30.0], vec![]),
+        ]);
+        let opts = |monitors: Vec<MonitorSpec>| AdaptiveSimulateOptions {
+            seed: Some(3),
+            decision_times: vec![0.0, 24.0],
+            monitors,
+            ..Default::default()
+        };
+        let no_mon = simulate_adaptive(
+            &model,
+            &pop,
+            &model.default_params,
+            3,
+            fixed_bolus,
+            &opts(vec![]),
+        )
+        .expect("no monitor");
+        let with_dv = simulate_adaptive(
+            &model,
+            &pop,
+            &model.default_params,
+            3,
+            fixed_bolus,
+            &opts(vec![MonitorSpec::new("A", 1, ObserveMode::Dv)]),
+        )
+        .expect("dv monitor");
+        let ip = |r: &AdaptiveSimulationResult| {
+            r.trajectories.iter().map(|t| t.ipred).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ip(&no_mon),
+            ip(&with_dv),
+            "a DV monitor must not shift the η draws / IPRED trajectory"
+        );
+    }
+
+    #[test]
+    fn dv_assay_draws_are_permutation_invariant() {
+        // The controller-assay substream is keyed by subject id, so a subject's DV
+        // draws — and thus its decisions — do not depend on iteration order. A large
+        // residual CV makes the noise flip decisions (so a position-keyed stream
+        // *would* change the ledger), and ODE_NO_IIV keeps η out of the picture.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let mut params = model.default_params.clone();
+        params.sigma.values = vec![0.3]; // 30% proportional CV: noise is consequential
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(11),
+            decision_times: vec![0.0, 4.0, 8.0],
+            monitors: vec![MonitorSpec::new("A", 1, ObserveMode::Dv)],
+            ..Default::default()
+        };
+        let a = subj("A", vec![2.0, 6.0, 10.0], vec![]);
+        let b = subj("B", vec![2.0, 6.0, 10.0], vec![]);
+        let pop_ab = population(vec![a.clone(), b.clone()]);
+        let pop_ba = population(vec![b, a]);
+        let r_ab = simulate_adaptive(&model, &pop_ab, &params, 1, dv_threshold, &opts).expect("ab");
+        let r_ba = simulate_adaptive(&model, &pop_ba, &params, 1, dv_threshold, &opts).expect("ba");
+
+        let ledger_for = |r: &AdaptiveSimulationResult, id: &str| {
+            r.ledger
+                .iter()
+                .filter(|e| e.subject == id)
+                .map(|e| (e.time, e.amt))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ledger_for(&r_ab, "A"),
+            ledger_for(&r_ba, "A"),
+            "A's DV-driven doses must be order-independent"
+        );
+        assert_eq!(
+            ledger_for(&r_ab, "B"),
+            ledger_for(&r_ba, "B"),
+            "B's DV-driven doses must be order-independent"
+        );
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -10578,5 +10578,22 @@ mod adaptive_sim_tests {
             ledger_for(&r_ba, "B"),
             "B's DV-driven doses must be order-independent"
         );
+
+        // Non-vacuity: the assay noise must actually be id-keyed (not a no-op), or
+        // the invariance above could hold even under a position-keyed stream. At
+        // t=4 the trough is ~67 (non-zero, so proportional noise is live), and A and
+        // B observe *different* measured values — confirming the noise is consequential.
+        let dv_at = |r: &AdaptiveSimulationResult, id: &str, didx: usize| {
+            r.decisions
+                .iter()
+                .find(|d| d.subject == id && d.decision_idx == didx)
+                .map(|d| d.observed_signals[0].value)
+                .expect("decision logged")
+        };
+        assert_ne!(
+            dv_at(&r_ab, "A", 1),
+            dv_at(&r_ab, "B", 1),
+            "id-keyed assay noise must differ between subjects (test would be vacuous otherwise)"
+        );
     }
 }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1649,6 +1649,11 @@ pub(crate) fn ode_predictions_adaptive(
                                     m.name, m.cmt
                                 )
                             })?;
+                            // `has_residual_error_for_cmt` (the gate behind `resid_var`)
+                            // requires `sigma` to cover the model's σ indices, so a `Some`
+                            // here is panic-free and structurally finite — no downstream
+                            // finiteness guard. Value-pathology (a NaN/∞ in `sigma`, a
+                            // diverged IPRED) is whole-sim garbage-in, out of scope here.
                             let eps = assay_standard_normal(a.base_seed, decision_index, &m.name);
                             // Edge (b): an assay cannot read below zero; clamp the
                             // noised value at 0 (BLQ-blinding is deferred to Part F).

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -10,8 +10,8 @@
 use crate::ode::solver::{solve_ode, OdeSolverOptions};
 use crate::pk::absorption::PreparedInputRate;
 use crate::sim::adaptive::{
-    AdaptiveRun, ControllerCtx, DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry,
-    MonitorSpec, ObserveMode, ObservedSignal,
+    assay_standard_normal, AdaptiveRun, AssayNoise, ControllerCtx, DecisionLogEntry,
+    DecisionOutcome, DoseAction, DoseLedgerEntry, MonitorSpec, ObserveMode, ObservedSignal,
 };
 use crate::types::{DoseEvent, PkParams, Subject};
 use std::borrow::Cow;
@@ -1470,8 +1470,13 @@ fn reject_unsupported_dose_compartment(
 ///   discontinues *future* decisions only; an infusion already in flight
 ///   completes its delivery (a committed dose is not retracted — a true safety
 ///   halt is a separate, explicit action, tracked as a follow-up).
-/// - **`ObserveMode::Ipred` only.** A `Dv` (assay-noised) monitor errors until
-///   S1.5 adds the per-subject RNG substreams that keep assay draws verifier-safe.
+/// - **Monitors resolve per-mode (S1.5).** `ObserveMode::Ipred` reads the latent
+///   state; `ObserveMode::Dv` adds the endpoint's residual draw — `IPRED +
+///   ε·√(residual variance)`, clamped at 0 — on the controller-assay substream
+///   carried in `assay` (keyed `(subject, replicate, decision, analyte)`). A `Dv`
+///   monitor with `assay = None`, or on a compartment with no `[error_model]`, is
+///   a typed error (never a fabricated σ). The all-`Ipred` path draws nothing, so
+///   it is byte-identical regardless of `assay`.
 /// - **Dose-free base subject** — the regimen is entirely controller-driven
 ///   (augmenting pre-scheduled doses is a later step).
 /// - **No lagged or input-rate (absorption) dosing.** Controller dosing into a
@@ -1512,6 +1517,9 @@ pub(crate) fn ode_predictions_adaptive(
     monitors: &[MonitorSpec],
     controller: &mut dyn FnMut(&ControllerCtx) -> Vec<DoseAction>,
     max_decisions: usize,
+    // Assay-noise capability for `Dv` monitors (#391 S1.5). `None` ⇒ Ipred-only;
+    // a `Dv` monitor then errors at its first decision.
+    assay: Option<&AssayNoise>,
 ) -> Result<AdaptiveRun, String> {
     let n = ode.n_states;
 
@@ -1531,13 +1539,6 @@ pub(crate) fn ode_predictions_adaptive(
         ));
     }
     for m in monitors {
-        if m.mode == ObserveMode::Dv {
-            return Err(format!(
-                "monitor '{}' requests DV (assay-noised) observation, which needs the per-subject \
-                 RNG substreams added in S1.5; the S1.3a driver serves Ipred monitors only",
-                m.name
-            ));
-        }
         if m.cmt == 0 || m.cmt > n {
             return Err(format!(
                 "monitor '{}' observes compartment {} but the model has {} state(s)",
@@ -1622,8 +1623,38 @@ pub(crate) fn ode_predictions_adaptive(
                 let mut signals: HashMap<String, f64> = HashMap::new();
                 let mut observed: Vec<ObservedSignal> = Vec::with_capacity(monitors.len());
                 for m in monitors {
-                    let value =
+                    let latent =
                         read_observable(ode, &u, pk_params_flat, theta, eta, decision_cov, m.cmt);
+                    // Resolve the monitored signal on its own mode: Ipred is the
+                    // latent readout; Dv adds the endpoint's assay residual draw on
+                    // the controller-assay substream (#391 S1.5).
+                    let value = match m.mode {
+                        ObserveMode::Ipred => latent,
+                        ObserveMode::Dv => {
+                            let a = assay.ok_or_else(|| {
+                                format!(
+                                    "decision {decision_index} at t={t_start}: monitor '{}' \
+                                     requests DV (assay-noised) observation but no assay-noise \
+                                     capability was supplied (Ipred-only run)",
+                                    m.name
+                                )
+                            })?;
+                            // Edge (a): a DV monitor on a compartment with no
+                            // residual error model is a typed error, not a guessed σ.
+                            let var = (a.resid_var)(m.cmt, latent).ok_or_else(|| {
+                                format!(
+                                    "decision {decision_index} at t={t_start}: monitor '{}' \
+                                     requests DV observation on compartment {} but no [error_model] \
+                                     defines residual error there",
+                                    m.name, m.cmt
+                                )
+                            })?;
+                            let eps = assay_standard_normal(a.base_seed, decision_index, &m.name);
+                            // Edge (b): an assay cannot read below zero; clamp the
+                            // noised value at 0 (BLQ-blinding is deferred to Part F).
+                            (latent + var.sqrt() * eps).max(0.0)
+                        }
+                    };
                     signals.insert(m.name.clone(), value);
                     observed.push(ObservedSignal {
                         name: m.name.clone(),
@@ -3224,6 +3255,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3270,6 +3302,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3332,6 +3365,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         // Exactly one realized dose (t=0); the t=2 / t=4 decisions held.
@@ -3384,6 +3418,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert!(
@@ -3472,6 +3507,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3548,6 +3584,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3583,6 +3620,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert!(
@@ -3611,6 +3649,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert!(run.ledger.is_empty(), "zero-amount bolus records no dose");
@@ -3652,6 +3691,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3674,11 +3714,18 @@ mod tests {
         }
     }
 
+    // ----- S1.5: DV-mode (assay-noised) monitors (#391) -----------------
+
+    fn dv_monitor() -> [MonitorSpec; 1] {
+        [MonitorSpec::new("A", 1, ObserveMode::Dv)]
+    }
+
     #[test]
-    fn adaptive_rejects_dv_monitor() {
+    fn adaptive_dv_without_assay_capability_errors() {
+        // A DV monitor on an Ipred-only run (assay = None) is a typed error, not a
+        // silent fallback to the latent value.
         let ode = one_cpt_ode_spec();
         let pk = pk_one(1.0, 10.0);
-        let monitors = [MonitorSpec::new("A", 1, ObserveMode::Dv)];
         let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
         let base = make_subject(vec![], vec![1.0]);
         let err = ode_predictions_adaptive(
@@ -3688,12 +3735,228 @@ mod tests {
             &[],
             &base,
             &[0.0],
-            &monitors,
+            &dv_monitor(),
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
-        assert!(err.contains("DV") || err.contains("S1.5"), "got: {err}");
+        assert!(
+            err.contains("DV") && err.contains("capability"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_dv_no_error_model_errors() {
+        // Edge (a): a DV monitor on a compartment with no residual error model is a
+        // typed error (resid_var returns None), never a fabricated sigma.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
+        let base = make_subject(vec![], vec![1.0]);
+        let no_model = |_cmt: usize, _ipred: f64| None;
+        let assay = AssayNoise {
+            resid_var: &no_model,
+            base_seed: 7,
+        };
+        let err = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &dv_monitor(),
+            &mut controller,
+            100,
+            Some(&assay),
+        )
+        .unwrap_err();
+        assert!(err.contains("error_model"), "got: {err}");
+    }
+
+    #[test]
+    fn adaptive_dv_zero_variance_equals_ipred() {
+        // sigma -> 0: the DV signal collapses to the latent IPRED. Compare the value
+        // the controller saw under a zero-variance assay against an Ipred monitor on
+        // the same realized run.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0); // ke = 0.1
+        let decisions = [0.0, 24.0]; // dose at t=0, observe pre-dose trough at t=24
+        let base = make_subject(vec![], vec![24.0]);
+        let dose = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+
+        let mut ctrl_ref = dose;
+        let ref_run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &[MonitorSpec::new("A", 1, ObserveMode::Ipred)],
+            &mut ctrl_ref,
+            100,
+            None,
+        )
+        .expect("ipred run");
+        let ipred = ref_run.decisions[1].observed_signals[0].value;
+
+        let zero_var = |_cmt: usize, _ipred: f64| Some(0.0);
+        let assay = AssayNoise {
+            resid_var: &zero_var,
+            base_seed: 12345,
+        };
+        let mut ctrl_dv = dose;
+        let dv_run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &dv_monitor(),
+            &mut ctrl_dv,
+            100,
+            Some(&assay),
+        )
+        .expect("dv run");
+        let dv = dv_run.decisions[1].observed_signals[0].value;
+
+        assert!(ipred > 0.0, "expected a non-zero trough at t=24");
+        assert_relative_eq!(dv, ipred, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn adaptive_dv_noised_and_deterministic() {
+        // Non-zero variance perturbs the latent IPRED, and the draw is reproducible:
+        // the same base seed yields the same value, a different seed a different one.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let decisions = [0.0, 24.0];
+        let base = make_subject(vec![], vec![24.0]);
+        let var4 = |_cmt: usize, _ipred: f64| Some(4.0); // sd = 2
+
+        let observe = |seed: u64| {
+            let assay = AssayNoise {
+                resid_var: &var4,
+                base_seed: seed,
+            };
+            let mut ctrl = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+            ode_predictions_adaptive(
+                &ode,
+                &pk.values,
+                &[],
+                &[],
+                &base,
+                &decisions,
+                &dv_monitor(),
+                &mut ctrl,
+                100,
+                Some(&assay),
+            )
+            .expect("dv run")
+            .decisions[1]
+                .observed_signals[0]
+                .value
+        };
+
+        let a = observe(999);
+        let b = observe(999);
+        let c = observe(1000);
+        assert_eq!(a, b, "same base seed must reproduce the assay draw");
+        assert_ne!(a, c, "a different base seed must change the assay draw");
+        let latent = 100.0 * (-2.4f64).exp(); // trough at t=24
+        assert!(
+            (a - latent).abs() > 1e-9,
+            "expected the assay to perturb the latent value"
+        );
+    }
+
+    #[test]
+    fn adaptive_dv_clamps_negative_at_zero() {
+        // Edge (b): the noised value cannot read below zero. At t=0 the pre-dose
+        // trough is 0, so a negative assay draw with a large sigma would push it
+        // negative; assert it clamps to exactly 0.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let neg_seed = (0u64..)
+            .find(|&s| assay_standard_normal(s, 0, "A") < 0.0)
+            .expect("some seed gives a negative draw");
+        let big_var = |_cmt: usize, _ipred: f64| Some(1.0e6);
+        let assay = AssayNoise {
+            resid_var: &big_var,
+            base_seed: neg_seed,
+        };
+        let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
+        let base = make_subject(vec![], vec![1.0]);
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &dv_monitor(),
+            &mut controller,
+            100,
+            Some(&assay),
+        )
+        .expect("dv run");
+        assert_eq!(
+            run.decisions[0].observed_signals[0].value, 0.0,
+            "a negative assay reading must clamp at 0"
+        );
+    }
+
+    #[test]
+    fn adaptive_dv_added_monitor_does_not_perturb_other_draw() {
+        // Non-perturbing: adding a second DV monitor (a new analyte) must not change
+        // the first analyte's draw — each is keyed by its own analyte name.
+        let ode = one_cpt_ode_spec();
+        let pk = pk_one(1.0, 10.0);
+        let decisions = [0.0, 24.0];
+        let base = make_subject(vec![], vec![24.0]);
+        let var4 = |_cmt: usize, _ipred: f64| Some(4.0);
+
+        let signal_a = |monitors: &[MonitorSpec]| {
+            let assay = AssayNoise {
+                resid_var: &var4,
+                base_seed: 555,
+            };
+            let mut ctrl = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+            let run = ode_predictions_adaptive(
+                &ode,
+                &pk.values,
+                &[],
+                &[],
+                &base,
+                &decisions,
+                monitors,
+                &mut ctrl,
+                100,
+                Some(&assay),
+            )
+            .expect("dv run");
+            run.decisions[1]
+                .observed_signals
+                .iter()
+                .find(|s| s.name == "A")
+                .expect("analyte A present")
+                .value
+        };
+
+        let one = [MonitorSpec::new("A", 1, ObserveMode::Dv)];
+        let two = [
+            MonitorSpec::new("A", 1, ObserveMode::Dv),
+            MonitorSpec::new("B", 1, ObserveMode::Dv),
+        ];
+        assert_eq!(
+            signal_a(&one),
+            signal_a(&two),
+            "adding analyte B must not perturb A's draw"
+        );
     }
 
     #[test]
@@ -3715,6 +3978,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("dose-free"), "got: {err}");
@@ -3736,6 +4000,7 @@ mod tests {
             &[],
             &mut controller,
             2,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("max_decisions"), "got: {err}");
@@ -3757,6 +4022,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("compartment"), "got: {err}");
@@ -3789,6 +4055,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3827,6 +4094,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("state"), "got: {err}");
@@ -3850,6 +4118,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("state"), "got: {err}");
@@ -3879,6 +4148,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("input-rate"), "got: {err}");
@@ -3903,6 +4173,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("lag time"), "got: {err}");
@@ -3947,6 +4218,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -3994,6 +4266,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -4042,6 +4315,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.ledger.len(), 1, "only the first decision infuses");
@@ -4090,6 +4364,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -4145,6 +4420,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -4197,6 +4473,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -4233,6 +4510,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert!(
@@ -4264,6 +4542,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("rate"), "got: {err}");
@@ -4291,6 +4570,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("state"), "got: {err}");
@@ -4323,6 +4603,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("input-rate"), "got: {err}");
@@ -4351,6 +4632,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("lag time"), "got: {err}");
@@ -4382,6 +4664,7 @@ mod tests {
             &monitors,
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
 
@@ -4428,6 +4711,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1, "only the stop decision is logged");
@@ -4454,6 +4738,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1, "stop ends the schedule after one");
@@ -4486,6 +4771,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1);
@@ -4522,6 +4808,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1);
@@ -4556,6 +4843,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1, "stop ends the schedule after one");
@@ -4581,6 +4869,7 @@ mod tests {
             &[],
             &mut controller,
             100,
+            None,
         )
         .expect("driver runs");
         assert_eq!(run.decisions.len(), 1);
@@ -4635,6 +4924,7 @@ mod tests {
                 &[],
                 &mut controller,
                 100,
+                None,
             )
             .expect_err("malformed / post-stop action list is rejected");
             assert!(err.contains(needle), "expected {needle:?}, got: {err}");

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -311,6 +311,92 @@ pub struct AdaptiveRun {
     pub decisions: Vec<DecisionLogEntry>,
 }
 
+// ── Controller-assay RNG substream (#391 S1.5) ──────────────────────────────
+//
+// A DV-mode monitor observes a *realized* measurement = IPRED + ε·√(residual
+// variance). Those ε draws live on their **own** per-purpose substream, separate
+// from the η draws and the (currently latent) output trajectory, and each draw is
+// independently keyed by `(subject, replicate, decision_index, analyte)`. Keying
+// by identity rather than draw order makes the assay noise:
+//   * **deterministic** — a pure function of the run seed and the key;
+//   * **permutation-invariant** — subject iteration order cannot change a
+//     subject's draws (Part E);
+//   * **non-perturbing** — adding a monitor (a new analyte) or a decision never
+//     shifts any other monitor's draws, because no draw consumes a shared stream
+//     position.
+// The controller-less frozen-replay verifier therefore reproduces the trajectory
+// regardless of these draws (it replays realized doses, not decisions).
+
+/// Purpose tag folded into the assay seed so the controller-assay stream is
+/// disjoint from any other stream derived from the same run seed (η, output).
+const ASSAY_PURPOSE_SALT: u64 = 0xA55A_E155_0DE0_0001;
+
+/// 64-bit golden-ratio odd constant for seed mixing (same family as the
+/// per-chain seeding in `estimation/bayes.rs`).
+const GOLDEN64: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// FNV-1a 64-bit hash of a string — a *stable* (cross-platform, cross-run) hash
+/// for keying substreams by subject id / analyte name. `DefaultHasher` is
+/// deliberately avoided because its output is not guaranteed stable across builds.
+pub(crate) fn stable_hash_str(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Fold one more key component into a running seed (a splitmix64 finalizer over a
+/// golden-ratio-scrambled component). Order-sensitive, so distinct key tuples map
+/// to distinct seeds.
+pub(crate) fn combine_seed(seed: u64, component: u64) -> u64 {
+    let mut z = seed ^ component.wrapping_mul(GOLDEN64);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+/// Per-(subject, replicate) base seed for the controller-assay substream, rooted
+/// at the run-level `root` seed. Keyed by the subject *id* (not its loop
+/// position), so the stream is permutation-invariant.
+pub(crate) fn subject_assay_base_seed(root: u64, subject_id: &str, replicate: usize) -> u64 {
+    let s = combine_seed(root ^ ASSAY_PURPOSE_SALT, stable_hash_str(subject_id));
+    combine_seed(s, replicate as u64)
+}
+
+/// One standard-normal assay draw for monitor `analyte` at decision
+/// `decision_index`, on the substream rooted at `base_seed`. A fresh RNG is seeded
+/// per draw from the full key, so the draw depends on nothing else in the run
+/// (the non-perturbing property).
+pub(crate) fn assay_standard_normal(base_seed: u64, decision_index: usize, analyte: &str) -> f64 {
+    use rand::SeedableRng;
+    use rand_distr::{Distribution, Normal};
+    let key = combine_seed(
+        combine_seed(base_seed, decision_index as u64),
+        stable_hash_str(analyte),
+    );
+    let mut rng = rand::rngs::StdRng::seed_from_u64(key);
+    Normal::new(0.0, 1.0).unwrap().sample(&mut rng)
+}
+
+/// Assay-noise capability threaded into
+/// [`crate::ode::predictions::ode_predictions_adaptive`] so it can resolve
+/// DV-mode monitors (#391 S1.5). Bundles the residual-variance resolver (already
+/// folded with the subject's `ruv_scale`) and the per-(subject, replicate) base
+/// seed that keys the controller-assay substream.
+///
+/// `resid_var(cmt, ipred)` returns `Some(variance)` for a compartment that has a
+/// residual error model and `None` when none is defined — the driver turns the
+/// `None` into a typed error rather than fabricating a σ (S1.5 edge a).
+pub(crate) struct AssayNoise<'a> {
+    /// `(cmt, ipred) -> Some(residual variance incl. ruv_scale)`, or `None` when
+    /// no residual error model covers `cmt`.
+    pub resid_var: &'a dyn Fn(usize, f64) -> Option<f64>,
+    /// Per-(subject, replicate) base seed; see [`subject_assay_base_seed`].
+    pub base_seed: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -501,5 +587,88 @@ mod tests {
         .is_ok());
         assert!(DoseAction::Hold.validate().is_ok());
         assert!(DoseAction::Stop.validate().is_ok());
+    }
+
+    // ----- S1.5: controller-assay substream seed helpers ----------------
+
+    #[test]
+    fn stable_hash_str_is_deterministic_and_distinguishes() {
+        assert_eq!(stable_hash_str("CONC"), stable_hash_str("CONC"));
+        assert_ne!(stable_hash_str("CONC"), stable_hash_str("ANC"));
+        // Empty string is well-defined (the FNV-1a offset basis).
+        assert_eq!(stable_hash_str(""), 0xcbf2_9ce4_8422_2325);
+    }
+
+    #[test]
+    fn combine_seed_is_order_sensitive() {
+        // Folding components in a different order yields a different seed, so key
+        // tuples map injectively enough for substream separation.
+        assert_ne!(
+            combine_seed(combine_seed(0, 1), 2),
+            combine_seed(combine_seed(0, 2), 1)
+        );
+    }
+
+    #[test]
+    fn subject_assay_base_seed_separates_subjects_and_replicates() {
+        let a = subject_assay_base_seed(42, "subj-1", 1);
+        assert_eq!(a, subject_assay_base_seed(42, "subj-1", 1), "deterministic");
+        assert_ne!(
+            a,
+            subject_assay_base_seed(42, "subj-2", 1),
+            "subject id keys the stream"
+        );
+        assert_ne!(
+            a,
+            subject_assay_base_seed(42, "subj-1", 2),
+            "replicate keys the stream"
+        );
+        assert_ne!(
+            a,
+            subject_assay_base_seed(7, "subj-1", 1),
+            "root seed keys the stream"
+        );
+    }
+
+    #[test]
+    fn assay_standard_normal_is_deterministic_and_key_separated() {
+        let x = assay_standard_normal(100, 0, "A");
+        assert_eq!(x, assay_standard_normal(100, 0, "A"), "deterministic");
+        assert_ne!(
+            x,
+            assay_standard_normal(100, 1, "A"),
+            "decision index keys the draw"
+        );
+        assert_ne!(
+            x,
+            assay_standard_normal(100, 0, "B"),
+            "analyte keys the draw"
+        );
+        assert_ne!(
+            x,
+            assay_standard_normal(101, 0, "A"),
+            "base seed keys the draw"
+        );
+    }
+
+    #[test]
+    fn assay_standard_normal_spans_both_signs() {
+        // The clamp (edge b) is only reachable if draws can be negative; confirm the
+        // generator produces both signs across keys, with a mean near 0.
+        let n = 2000;
+        let draws: Vec<f64> = (0..n).map(|i| assay_standard_normal(1, i, "A")).collect();
+        assert!(
+            draws.iter().any(|&d| d < 0.0),
+            "some draws must be negative"
+        );
+        assert!(
+            draws.iter().any(|&d| d > 0.0),
+            "some draws must be positive"
+        );
+        let mean = draws.iter().sum::<f64>() / n as f64;
+        assert!(
+            mean.abs() < 0.1,
+            "standard-normal draws should center near 0, got {mean}"
+        );
     }
 }

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -670,5 +670,12 @@ mod tests {
             mean.abs() < 0.1,
             "standard-normal draws should center near 0, got {mean}"
         );
+        // Unit variance too, so the noise scale is right (a mis-scaled generator
+        // would still pass the sign/mean checks).
+        let var = draws.iter().map(|&d| (d - mean).powi(2)).sum::<f64>() / n as f64;
+        assert!(
+            (var - 1.0).abs() < 0.2,
+            "standard-normal draws should have ~unit variance, got {var}"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2569,6 +2569,21 @@ impl CompiledModel {
         )
     }
 
+    /// True when a residual error model is defined for `cmt`, so a DV
+    /// (assay-noised) observation can be drawn there. False for a
+    /// [`ErrorSpec::PerCmt`] spec that omits `cmt`, or a model with no
+    /// `[error_model]` at all (empty `sigma`). `simulate_adaptive` consults this
+    /// before drawing a DV monitor so an un-modeled compartment is a typed error
+    /// rather than a fabricated σ (#391 S1.5 edge a) — and so
+    /// [`residual_variance_at`](Self::residual_variance_at), which indexes
+    /// `sigma[0]` for a `Single` model, is never reached with an empty `sigma`.
+    pub fn has_residual_error_for_cmt(&self, cmt: usize, sigma: &[f64]) -> bool {
+        match &self.error_spec {
+            ErrorSpec::Single(_) => !sigma.is_empty(),
+            ErrorSpec::PerCmt(map) => map.contains_key(&cmt),
+        }
+    }
+
     /// Multiplicative factor applied to the residual *variance* for a subject
     /// whose random-effect vector is `eta`, from the IIV-on-RUV term
     /// (`Y = IPRED + EPS*EXP(ETA)`). Returns `exp(2*eta[k])` when
@@ -6245,5 +6260,38 @@ mod tests {
         }];
         let v = model.residual_variance_at(0, 10.0, &[0.2, 1.0]);
         assert_relative_eq!(v, 7.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn has_residual_error_for_cmt_covers_single_and_per_cmt() {
+        let mut model = test_helpers::analytical_model(GradientMethod::Fd);
+
+        // Single error model: defined for every cmt iff sigma is non-empty.
+        model.error_spec = ErrorSpec::Single(ErrorModel::Proportional);
+        assert!(model.has_residual_error_for_cmt(1, &[0.1]));
+        assert!(model.has_residual_error_for_cmt(99, &[0.1]));
+        assert!(
+            !model.has_residual_error_for_cmt(1, &[]),
+            "no sigma ⇒ no error model"
+        );
+
+        // PerCmt: defined only for compartments present in the map.
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            2usize,
+            EndpointError {
+                error_model: ErrorModel::Proportional,
+                sigma_idx: vec![0],
+            },
+        );
+        model.error_spec = ErrorSpec::PerCmt(map);
+        assert!(
+            model.has_residual_error_for_cmt(2, &[0.1]),
+            "cmt 2 has an endpoint"
+        );
+        assert!(
+            !model.has_residual_error_for_cmt(1, &[0.1]),
+            "cmt 1 is not in the map"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2572,19 +2572,27 @@ impl CompiledModel {
     /// True when a residual error model is defined for `cmt` *and* its sigmas
     /// resolve in `sigma`, so a DV (assay-noised) observation can be drawn there.
     /// False for a [`ErrorSpec::PerCmt`] spec that omits `cmt` (or whose endpoint
-    /// `sigma_idx` falls outside `sigma`), or a model with no `[error_model]` at
-    /// all (empty `sigma`). `simulate_adaptive` consults this before drawing a DV
-    /// monitor so an un-modeled compartment is a typed error rather than a
-    /// fabricated σ (#391 S1.5 edge a) — and so
+    /// `sigma_idx` falls outside `sigma`), or a `Single` model whose `sigma` is
+    /// shorter than its error model needs (`< n_sigma` — e.g. a `Combined` model
+    /// carrying one σ, down to no `[error_model]` at all). `simulate_adaptive`
+    /// consults this before drawing a DV monitor so an un-modeled compartment is a
+    /// typed error rather than a fabricated σ (#391 S1.5 edge a) — and so
     /// [`residual_variance_at`](Self::residual_variance_at), which indexes
-    /// `sigma[0]` for a `Single` model (and the endpoint's `sigma_idx` for a
-    /// `PerCmt` one), is never reached with a `sigma` too short to cover it.
+    /// `sigma[0..n_sigma]` for a `Single` model (and the endpoint's `sigma_idx` for
+    /// a `PerCmt` one), is never reached with a `sigma` too short to cover it
+    /// (which would otherwise **panic** for `Single` or return **NaN** for
+    /// `PerCmt`). The two branches are symmetric: each requires `sigma` to cover
+    /// every index the variance computation will read.
     pub fn has_residual_error_for_cmt(&self, cmt: usize, sigma: &[f64]) -> bool {
         match &self.error_spec {
-            ErrorSpec::Single(_) => !sigma.is_empty(),
-            ErrorSpec::PerCmt(map) => map
-                .get(&cmt)
-                .is_some_and(|ep| ep.sigma_idx.iter().all(|&i| i < sigma.len())),
+            ErrorSpec::Single(em) => sigma.len() >= em.n_sigma(),
+            ErrorSpec::PerCmt(map) => map.get(&cmt).is_some_and(|ep| {
+                // The endpoint must carry enough sigma indices for its model *and*
+                // every one must resolve in `sigma`; `variance_at` reads
+                // `sigma_idx[0..n_sigma]`, so either shortfall yields a NaN variance.
+                ep.sigma_idx.len() >= ep.error_model.n_sigma()
+                    && ep.sigma_idx.iter().all(|&i| i < sigma.len())
+            }),
         }
     }
 
@@ -6270,13 +6278,22 @@ mod tests {
     fn has_residual_error_for_cmt_covers_single_and_per_cmt() {
         let mut model = test_helpers::analytical_model(GradientMethod::Fd);
 
-        // Single error model: defined for every cmt iff sigma is non-empty.
+        // Single error model: defined for every cmt iff sigma covers its n_sigma.
         model.error_spec = ErrorSpec::Single(ErrorModel::Proportional);
         assert!(model.has_residual_error_for_cmt(1, &[0.1]));
         assert!(model.has_residual_error_for_cmt(99, &[0.1]));
         assert!(
             !model.has_residual_error_for_cmt(1, &[]),
             "no sigma ⇒ no error model"
+        );
+        // A Combined model needs two sigmas; one is too short — `residual_variance`
+        // would otherwise index `sigma[1]` and PANIC (symmetric to the PerCmt
+        // out-of-range guard below, never a fabricated σ).
+        model.error_spec = ErrorSpec::Single(ErrorModel::Combined);
+        assert!(model.has_residual_error_for_cmt(1, &[0.1, 0.2]));
+        assert!(
+            !model.has_residual_error_for_cmt(1, &[0.1]),
+            "Combined needs 2 sigmas; 1 is too short to draw a DV"
         );
 
         // PerCmt: defined only for compartments present in the map.
@@ -6303,6 +6320,21 @@ mod tests {
         assert!(
             !model.has_residual_error_for_cmt(2, &[]),
             "cmt 2's sigma_idx is out of range for an empty sigma"
+        );
+        // A Combined endpoint needs two sigma indices; one is too few — `variance_at`
+        // would read `sigma_idx[1]` (absent) and return NaN even though sigma is long.
+        let mut combined_map = std::collections::HashMap::new();
+        combined_map.insert(
+            2usize,
+            EndpointError {
+                error_model: ErrorModel::Combined,
+                sigma_idx: vec![0], // only one index for a two-sigma model
+            },
+        );
+        model.error_spec = ErrorSpec::PerCmt(combined_map);
+        assert!(
+            !model.has_residual_error_for_cmt(2, &[0.1, 0.2]),
+            "a Combined endpoint with too few sigma indices is not drawable"
         );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2569,18 +2569,22 @@ impl CompiledModel {
         )
     }
 
-    /// True when a residual error model is defined for `cmt`, so a DV
-    /// (assay-noised) observation can be drawn there. False for a
-    /// [`ErrorSpec::PerCmt`] spec that omits `cmt`, or a model with no
-    /// `[error_model]` at all (empty `sigma`). `simulate_adaptive` consults this
-    /// before drawing a DV monitor so an un-modeled compartment is a typed error
-    /// rather than a fabricated σ (#391 S1.5 edge a) — and so
+    /// True when a residual error model is defined for `cmt` *and* its sigmas
+    /// resolve in `sigma`, so a DV (assay-noised) observation can be drawn there.
+    /// False for a [`ErrorSpec::PerCmt`] spec that omits `cmt` (or whose endpoint
+    /// `sigma_idx` falls outside `sigma`), or a model with no `[error_model]` at
+    /// all (empty `sigma`). `simulate_adaptive` consults this before drawing a DV
+    /// monitor so an un-modeled compartment is a typed error rather than a
+    /// fabricated σ (#391 S1.5 edge a) — and so
     /// [`residual_variance_at`](Self::residual_variance_at), which indexes
-    /// `sigma[0]` for a `Single` model, is never reached with an empty `sigma`.
+    /// `sigma[0]` for a `Single` model (and the endpoint's `sigma_idx` for a
+    /// `PerCmt` one), is never reached with a `sigma` too short to cover it.
     pub fn has_residual_error_for_cmt(&self, cmt: usize, sigma: &[f64]) -> bool {
         match &self.error_spec {
             ErrorSpec::Single(_) => !sigma.is_empty(),
-            ErrorSpec::PerCmt(map) => map.contains_key(&cmt),
+            ErrorSpec::PerCmt(map) => map
+                .get(&cmt)
+                .is_some_and(|ep| ep.sigma_idx.iter().all(|&i| i < sigma.len())),
         }
     }
 
@@ -6292,6 +6296,13 @@ mod tests {
         assert!(
             !model.has_residual_error_for_cmt(1, &[0.1]),
             "cmt 1 is not in the map"
+        );
+        // An endpoint whose sigma_idx falls outside `sigma` is not drawable —
+        // `residual_variance_at` would otherwise return NaN (symmetric to the
+        // Single empty-sigma guard, never a fabricated σ).
+        assert!(
+            !model.has_residual_error_for_cmt(2, &[]),
+            "cmt 2's sigma_idx is out of range for an empty sigma"
         );
     }
 }


### PR DESCRIPTION
## Why

Epic #391 (state-reactive / feedback dosing) builds its foundation in fine slices. S1.4b (#554) shipped the public `simulate_adaptive()` with **Ipred-only** monitors. This PR is **S1.5** (issue #566): assay-noised `Dv` monitors — the controller titrates on the *measured* value, not the latent truth, which is the headline TDM / oncology realism of the epic (a clinician titrates on a reported lab, not the true concentration). It is the **last remaining slice of the S1 foundation** — the frozen-replay verifier originally planned as S1.6 was pulled forward into S1.4b, so merging this completes S1 and unblocks S2 (the declarative `[adaptive_dosing]` block).

## What changed

The reactive driver now resolves each monitor on its own `ObserveMode`:

- **`Dv` resolution** (`ode/predictions.rs`): `Dv = (latent + √(residual_variance_at(cmt, latent, σ)·ruv_scale)·ε).max(0)`, reusing the same residual model `simulate()` draws from. The driver gained one internal param, `assay: Option<&AssayNoise>` (a residual-variance resolver + a base seed); the all-`Ipred` path draws nothing and stays byte-identical.
- **Per-purpose RNG substream** (`sim/adaptive.rs`): assay draws come from a controller-assay substream **keyed `(subject, replicate, decision, analyte)`** — each draw independently seeded (FNV-1a string hash + golden-ratio / splitmix64 mixing). That makes the draws deterministic under a fixed seed, permutation-invariant, and **non-perturbing**: adding a monitor never shifts another monitor's (or η's) draws. The root seed is resolved independently of the η stream, so enabling a `Dv` monitor cannot move the η realizations.
- **`simulate_adaptive()`** (`api.rs`) builds the capability per subject: `resid_var` by CMT × `ruv_scale` (IIV-on-RUV), and `subject_assay_base_seed(root, id, replicate)`.
- **Three edges** (from #391): (a) a `Dv` monitor on a compartment with no `[error_model]` is a typed error (new `CompiledModel::has_residual_error_for_cmt`, never a fabricated σ — also guards `residual_variance`'s `sigma[0]` panic on empty σ); (b) a sub-zero reading clamps at 0 (BLQ-blinding deferred to Part F); (c) the assay stream is structurally separate from η / output.

The frozen-replay verifier is unchanged — it replays the realized doses through the static engine and the trajectory stays `Ipred`, so `Dv` noise can't perturb it.

## Alternatives considered

- **Per-draw identity keying vs. a sequential per-subject stream.** A sequential stream would mean adding a monitor (or a decision) shifts every later draw — breaking the "adding an analyte never perturbs another's draws" and permutation-invariance properties #391 requires. Independent per-`(subject, replicate, decision, analyte)` seeding makes those properties structural.
- **Threading `&CompiledModel` into the driver vs. a closure.** The driver takes `&OdeSpec` (not the full model) and its ~15 unit tests construct an `OdeSpec` directly. A `resid_var` closure (+ base seed), bundled as `AssayNoise`, keeps the residual-model knowledge in `api.rs` and the driver tests model-free.
- **Floor-aware σ→0 collapse.** `residual_variance` floors at `MIN_VARIANCE`, so the *recorded* `Dv` value never collapses to `Ipred` bit-for-bit; the exact collapse is pinned at the driver level with a literal zero-variance resolver, and the api-level test asserts the σ→0 *decisions* match.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

The public API is unchanged — `ObserveMode::Dv` was already a public enum variant (it previously errored at runtime); this PR only makes it functional. No ferx-r change.

## Breaking changes
- [x] None

`DoseAction` / `ObserveMode` / `simulate_adaptive` signatures are unchanged; the new driver parameter is `pub(crate)`.

## Numerical validation
- [x] Not applicable in the NONMEM sense — per epic #391 and the CLAUDE.md exception, feedback dosing has no equivalent NONMEM run. S1.5 adds **no new PK/ODE math** (it reuses the already-anchored residual model). Validated by:
  - **σ→0 collapse** — the `Dv` readout → `Ipred` (driver, bit-exact with a zero-variance resolver) and drives identical decisions (api).
  - **η-isolation** — adding a `Dv` monitor leaves the IPRED trajectory bit-identical (ODE_IIV + signal-independent controller).
  - **Determinism + permutation-invariance** — same seed reproduces draws; subject order doesn't change a subject's result.
  - **Frozen-replay verifier stays green** on a `Dv` run (default-on).
  - The external **mrgsolve** comparator lands with S2.

## Performance
- [x] No significant impact expected — new opt-in path; one extra cheap RNG seed + normal draw per `Dv` monitor per decision.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — full lib **1743 passed, 0 failed**)
- [x] Regression test added that fails without this fix (the `adaptive_rejects_dv_monitor` contract is flipped; `adding_dv_monitor_does_not_perturb_eta_trajectory` would fail if the assay stream weren't isolated)

12 new tests: 6 driver-level (no-assay error, no-error-model error, σ→0≡Ipred, noised+deterministic, negative-clamp, added-monitor-no-perturb), seed-helper / `has_residual_error_for_cmt` units, and 4 api-level (verifier-green on a Dv run, σ→0 collapse, η-isolation, permutation-invariance) + the no-error-model rejection.

## Example (user-facing features only)
- [x] Inline below (programmatic API — no `.ferx` syntax in this slice)

<details>
<summary>Example</summary>

```rust
use ferx_core::{simulate_adaptive, AdaptiveSimulateOptions};
use ferx_core::sim::adaptive::{ControllerCtx, DoseAction, MonitorSpec, ObserveMode};

let opts = AdaptiveSimulateOptions {
    seed: Some(42),
    decision_times: vec![0.0, 24.0, 48.0, 72.0, 96.0],
    // Titrate on the noisy assay (DV), as in real TDM.
    monitors: vec![MonitorSpec::new("CONC", 1, ObserveMode::Dv)],
    ..Default::default()
};
let make_controller = || {
    move |ctx: &ControllerCtx| match ctx.signal("CONC") {
        Some(c) if c < 10.0 => vec![DoseAction::Bolus { amt: 150.0, cmt: 1 }],
        Some(c) if c > 20.0 => vec![DoseAction::Hold],
        _ => vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
    }
};
let result = simulate_adaptive(&model, &population, &params, 100, make_controller, &opts)?;
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes (`docs/model-file/adaptive-dosing.qmd` — Dv monitor behavior, the per-purpose substream and its properties, the edges; the example now titrates on `Dv`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path stay differentiable — N/A (simulation-only; no gradient-reachable code touched)
- [x] `Cargo.toml` version bumped if breaking — N/A (not breaking)

## Docs & examples

### ferx-site
- [x] N/A — no new `.ferx` DSL syntax or `[fit_options]` key (programmatic API); no new example `.ferx` or data file.

### Example execution
- [x] No example execution step needed (programmatic API; no `.ferx` / data change).

## Reviewer hints

- The load-bearing piece is the **substream keying** (`sim/adaptive.rs`): `assay_standard_normal(base, decision, analyte)` seeds a fresh RNG per draw from the full key. The three properties — deterministic, permutation-invariant, non-perturbing — are pinned by the seed-helper unit tests and the `permutation_invariance` / `added_monitor_does_not_perturb` tests.
- The `assay_root` resolution in `simulate_adaptive` is deliberately independent of the η `rng` (so the all-`Ipred` path is byte-identical) — `adding_dv_monitor_does_not_perturb_eta_trajectory` guards this.
- Edge (a) flows through `has_residual_error_for_cmt` → `resid_var` returns `None` → driver typed error, which also prevents `residual_variance`'s `sigma[0]` panic on empty σ.

## Open questions

None — this completes the S1 foundation; S2 (declarative `[adaptive_dosing]` + mrgsolve anchor) is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
