### PR TITLE
feat(sim): declarative [adaptive_dosing] block — parse, compile, run (S2.1–S2.3) [#391]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ section of the SDLC for the versioning policy).
   per-purpose RNG substream keyed by `(subject, replicate, decision, analyte)`, so they are
   deterministic under a fixed seed, invariant to subject ordering, and never perturb another
   monitor's (or η's) draws.
+- **Declarative `[adaptive_dosing]` model-file block — `simulate_adaptive_from_spec()`**
+  (#584, epic #391). A reactive dosing *policy* can now be written in the model file — an
+  `observe` signal expression, a decision schedule (`at`), `start_dose` / `route` /
+  `dose_bounds`, an optional `confirm` debounce and discrete `levels` ladder, and a
+  first-match-wins ladder of `when signal <op> value : increase/decrease/hold/stop` rules —
+  and run with `simulate_adaptive_from_spec()`, no controller code required. It compiles to
+  the same reactive engine, dose ledger, decision log, RNG substreams, and frozen-replay
+  verifier as the programmatic `simulate_adaptive()`; titrating on the assay-noised
+  measurement (`with_assay_error`) reuses the `Dv` substream. Example
+  `examples/adaptive_tdm_titration.ferx`. See [Adaptive dosing](model-file/adaptive-dosing.qmd).
 - Warn when no estimation method is set in the model file's `[fit_options]` or by
   the caller, making the implicit fallback to FOCEI visible instead of silent (#558).
 - Support NONMEM-style `block_sigma` residual covariance under SAEM for ordinary

--- a/docs/maturity.qmd
+++ b/docs/maturity.qmd
@@ -67,7 +67,7 @@ visible at the point of use:
 | Time-to-event endpoints (TTE) | **beta** | [Time-to-Event Endpoints](model-file/event-model.qmd) |
 | Stochastic differential equations (SDE) | **experimental** | [SDE](model-file/diffusion.qmd) |
 | Neural networks (DCM / NODE) | **experimental** | [Neural Networks](model-file/neural-networks.qmd) |
-| Adaptive (feedback) dosing — `simulate_adaptive()` | **experimental** | [Adaptive Dosing](model-file/adaptive-dosing.qmd) |
+| Adaptive (feedback) dosing — `[adaptive_dosing]` block / `simulate_adaptive()` | **experimental** | [Adaptive Dosing](model-file/adaptive-dosing.qmd) |
 
 ### Estimation features
 

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -45,15 +45,17 @@ with the run, never with a fitted model's parameters.
 
 | Key | Required | Meaning |
 |-----|:--------:|---------|
-| `observe` | ✓ | The monitored signal: an expression over states + individual parameters (e.g. `central / V` for concentration). Compiled against the model, so it titrates on the *derived* quantity, not the raw amount. The `when` rules compare the keyword `signal` to this value. |
+| `observe` | signal¹ | The **latent** monitored signal — a free-form expression over states + individual parameters (e.g. `central / V` for concentration), titrated on with **no** measurement noise. Provide this *or* `with_assay_error`, never both. The `when` rules compare the keyword `signal` to its value. |
 | `at` | ✓ | Decision schedule on the subject clock: an explicit list `[0, 24, 48]` or an arithmetic sequence `every <Δ> from <t0> to <t1>` (inclusive). |
 | `start_dose` | ✓ | The dose issued at the first decision; seeds the running dose. |
 | `route` | ✓ | `bolus(cmt=N)` or `infuse(cmt=N, over=T)` (zero-order over duration `T`). |
 | `dose_bounds` | ✓ | Inclusive `[low, high]` clamp applied to every emitted dose. |
 | `confirm` | | Debounce: act only after this many *consecutive* matches of the same rule (default `1` = act on the first breach). |
 | `levels` | | Discrete titration ladder `[d1, d2, …]` (oncology). With `levels`, bare `increase`/`decrease` step one rung; without it, use `increase N%` / `decrease N%`. |
-| `with_assay_error` | | Titrate on the assay-noised `Dv` instead of the latent `Ipred` (default `false`). See [Monitors](#monitors). |
-| `assay_cmt` | | Which endpoint's `[error_model]` σ supplies the assay noise — **required** when `with_assay_error` is on and `observe` is a multi-term expression (otherwise the σ is ambiguous, a parse error). The noise σ is computed from the `observe` value, so `observe` must be on the **same scale** as that endpoint's error model (e.g. `observe = central / V` with a proportional error fit on the concentration). Designating `assay_cmt` is your assertion that the two agree. |
+| `with_assay_error` | signal¹ | Titrate on the **noised measurement** of a model output (named by `assay_cmt`) instead of a latent expression (default `false`). The signal's value comes from that output's `[scaling]` readout and its σ from that output's `[error_model]`, so the two are always on the same scale — there is no re-typed `observe` expression to mis-scale. Mutually exclusive with `observe`. |
+| `assay_cmt` | | The 1-based compartment of the model output measured under `with_assay_error` — its `[scaling]` readout is the signal value and its `[error_model]` σ the noise. **Required** with `with_assay_error`. |
+
+¹ **The signal source is exactly one of `observe` (a latent expression, un-noised) or `with_assay_error = true` + `assay_cmt` (a noised model output).** Setting both, or neither, is a parse error. Titrating on a *measured* quantity uses the model's own output (so its value and σ can never disagree on scale); titrating on a *derived latent* quantity (effect-site, a ratio — anything with no error model) uses `observe`.
 
 ### Rules — `when signal <op> <value> : <action>`
 

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -53,7 +53,7 @@ with the run, never with a fitted model's parameters.
 | `confirm` | | Debounce: act only after this many *consecutive* matches of the same rule (default `1` = act on the first breach). |
 | `levels` | | Discrete titration ladder `[d1, d2, …]` (oncology). With `levels`, bare `increase`/`decrease` step one rung; without it, use `increase N%` / `decrease N%`. |
 | `with_assay_error` | | Titrate on the assay-noised `Dv` instead of the latent `Ipred` (default `false`). See [Monitors](#monitors). |
-| `assay_cmt` | | Which endpoint's `[error_model]` σ supplies the assay noise — **required** when `with_assay_error` is on and `observe` is a multi-term expression (otherwise the σ is ambiguous, a parse error). |
+| `assay_cmt` | | Which endpoint's `[error_model]` σ supplies the assay noise — **required** when `with_assay_error` is on and `observe` is a multi-term expression (otherwise the σ is ambiguous, a parse error). The noise σ is computed from the `observe` value, so `observe` must be on the **same scale** as that endpoint's error model (e.g. `observe = central / V` with a proportional error fit on the concentration). Designating `assay_cmt` is your assertion that the two agree. |
 
 ### Rules — `when signal <op> <value> : <action>`
 

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -9,9 +9,96 @@ A plain [simulation](simulation.qmd) is a pure forward pass: every dose is fixed
 before integration. Here a *controller* is consulted at a schedule of decision
 times, reads the current state, and chooses what to do next.
 
-This page documents the first slice (epic #391): a **programmatic** entry point,
-`simulate_adaptive()`. The declarative `[adaptive_dosing]` model-file block and
-multi-model composition are on the roadmap and not yet available.
+There are two ways to drive a controller, and they compile to the **same**
+reactive engine — the same dose ledger, decision log, RNG substreams, and
+frozen-replay verifier (epic #391):
+
+- the declarative **`[adaptive_dosing]` model-file block**, run with
+  [`simulate_adaptive_from_spec()`] — the file-driven path, documented next;
+- the **programmatic** [`simulate_adaptive()`], which takes a hand-written
+  controller closure — the lower-level path, documented under
+  [The controller](#the-controller).
+
+Multi-model composition (PK + PD + safety) and an imperative `[dose_control]`
+block remain on the roadmap.
+
+## The declarative `[adaptive_dosing]` block
+
+Put the policy in the model file and run it with
+[`simulate_adaptive_from_spec()`]. The block is **declarative** — a fixed dosing
+*policy* (trough < target → increase, grade 4 → stop), not a script — that rides
+with the run, never with a fitted model's parameters.
+
+```
+[adaptive_dosing]
+  observe     = central / V              # monitored signal: a derived expression
+  at          = every 24 from 0 to 168   # decision schedule (or an explicit list)
+  start_dose  = 100                      # dose issued at the first decision
+  route       = bolus(cmt=1)             # or: infuse(cmt=1, over=2)
+  dose_bounds = [0, 400]                 # every emitted dose is clamped here
+  confirm     = 2                        # act only after 2 consecutive breaches
+  when signal < 10 : increase 25%        # first matching rule wins
+  when signal > 20 : decrease 25%
+```
+
+### Keys
+
+| Key | Required | Meaning |
+|-----|:--------:|---------|
+| `observe` | ✓ | The monitored signal: an expression over states + individual parameters (e.g. `central / V` for concentration). Compiled against the model, so it titrates on the *derived* quantity, not the raw amount. The `when` rules compare the keyword `signal` to this value. |
+| `at` | ✓ | Decision schedule on the subject clock: an explicit list `[0, 24, 48]` or an arithmetic sequence `every <Δ> from <t0> to <t1>` (inclusive). |
+| `start_dose` | ✓ | The dose issued at the first decision; seeds the running dose. |
+| `route` | ✓ | `bolus(cmt=N)` or `infuse(cmt=N, over=T)` (zero-order over duration `T`). |
+| `dose_bounds` | ✓ | Inclusive `[low, high]` clamp applied to every emitted dose. |
+| `confirm` | | Debounce: act only after this many *consecutive* matches of the same rule (default `1` = act on the first breach). |
+| `levels` | | Discrete titration ladder `[d1, d2, …]` (oncology). With `levels`, bare `increase`/`decrease` step one rung; without it, use `increase N%` / `decrease N%`. |
+| `with_assay_error` | | Titrate on the assay-noised `Dv` instead of the latent `Ipred` (default `false`). See [Monitors](#monitors). |
+| `assay_cmt` | | Which endpoint's `[error_model]` σ supplies the assay noise — **required** when `with_assay_error` is on and `observe` is a multi-term expression (otherwise the σ is ambiguous, a parse error). |
+
+### Rules — `when signal <op> <value> : <action>`
+
+Rules are evaluated top to bottom and the **first match wins**, so order the
+most specific / most severe condition first. `<op>` is one of `< <= > >= ==`.
+
+| Action | Meaning |
+|--------|---------|
+| `increase N%` / `decrease N%` | Scale the running dose by ±N % (continuous titration). |
+| `increase` / `decrease` | Step one rung up / down a `levels` ladder. |
+| `hold` | Skip this decision's dose. |
+| `stop` | Discontinue all future dosing. |
+
+A dose change is clamped to `dose_bounds`; a level step saturates at the ends of
+the ladder. When no rule matches (or a matched rule has not yet `confirm`-ed),
+the running dose is **re-issued** unchanged — the regimen continues, an explicit
+no-op rather than a silent skip.
+
+### Running it
+
+```rust
+use ferx_core::{parse_full_model_file, simulate_adaptive_from_spec, AdaptiveSimulateOptions};
+use std::path::Path;
+
+let parsed = parse_full_model_file(Path::new("titration.ferx"))?;
+let spec = parsed
+    .adaptive_dosing
+    .as_ref()
+    .ok_or("model has no [adaptive_dosing] block")?;
+
+// The block owns the schedule and the monitor, so leave `decision_times` and
+// `monitors` empty here (setting either is a typed error); `seed` / `verify` /
+// `max_decisions` still apply.
+let opts = AdaptiveSimulateOptions { seed: Some(42), ..Default::default() };
+
+let result = simulate_adaptive_from_spec(
+    &parsed.model, &population, &parsed.model.default_params, 100, spec, &opts,
+)?;
+```
+
+The block compiles to exactly the controller, monitor, and engine described
+below, so every guarantee in [Monitors](#monitors) and
+[Verification](#verification-on-by-default) applies unchanged, and `result` is
+the same bundled `trajectories` / `ledger` / `decisions`. The lower-level
+programmatic API follows.
 
 ## The controller
 
@@ -135,9 +222,16 @@ family. It is validated instead by:
   a plain simulation of that regimen, bit-for-bit;
 - the **frozen-schedule replay** verifier above (an exact internal bookkeeping
   anchor);
+- the **three-witnesses** check — a declarative `[adaptive_dosing]` block and a
+  hand-written controller closure with the identical ladder realize the identical
+  ledger, decision log, and trajectory, byte-for-byte (so the block compiles to
+  exactly the engine the programmatic API exercises);
+- a **closed-loop** check — a titration that starts below its target band drives
+  the trough into the band and holds it there;
 - for genuinely reactive behaviour, reproduction of a published **mrgsolve**
   dynamic-dosing example (the apples-to-apples external comparator, since mrgsolve
-  does do feedback dosing) — landing with the declarative block.
+  does do feedback dosing) — the external anchor lands in a later slice of epic
+  #391.
 
 ## Current scope and limits
 
@@ -151,10 +245,15 @@ family. It is validated instead by:
   cross-endpoint (`block_sigma`) assay noise is a follow-up.
 - **Between-subject variability only** — η is drawn per subject/replicate;
   parameter-uncertainty propagation is a later layer.
-- **Programmatic API only** — the declarative `[adaptive_dosing]` block,
-  imperative `[dose_control]`, and PK+PD+safety model composition are roadmap.
+- **One monitored signal per block** — the declarative block titrates on a single
+  `observe`; multiple named per-analyte monitors (already supported by the
+  programmatic engine) are a declarative-surface follow-up.
+- **Roadmap** — per-subject outcome metrics on the result, the imperative
+  `[dose_control]` block, and PK + PD + safety model composition.
 
 [`ControllerCtx`]: https://docs.rs/ferx-core
 [`DoseAction`]: https://docs.rs/ferx-core
 [`MonitorSpec`]: https://docs.rs/ferx-core
 [`ObserveMode`]: https://docs.rs/ferx-core
+[`simulate_adaptive()`]: https://docs.rs/ferx-core
+[`simulate_adaptive_from_spec()`]: https://docs.rs/ferx-core

--- a/examples/adaptive_tdm_titration.ferx
+++ b/examples/adaptive_tdm_titration.ferx
@@ -39,9 +39,8 @@
   DV ~ proportional(PROP)
 
 [adaptive_dosing]
-  observe          = central / V          # titrate on concentration (mg/L)
-  with_assay_error = true                 # ... as measured (proportional assay noise)
-  assay_cmt        = 1                     # endpoint whose residual error noises the reading
+  with_assay_error = true                 # titrate on the *measured* trough (assay-noised)
+  assay_cmt        = 1                     # output #1 — the concentration (y = central/V) + its proportional error
   at               = every 12 from 0 to 96 # a TDM decision before each q12h dose
   start_dose       = 1000                  # initial dose (mg)
   route            = infuse(cmt=1, over=1) # 1-hour IV infusion

--- a/examples/adaptive_tdm_titration.ferx
+++ b/examples/adaptive_tdm_titration.ferx
@@ -1,0 +1,51 @@
+# Adaptive (feedback) dosing — TDM trough titration (epic #391)
+#
+# A vancomycin-style therapeutic-drug-monitoring (TDM) example: the dose is
+# titrated every 12 h to drive the measured pre-dose trough concentration into a
+# 10–20 mg/L window. This is a *declarative dosing policy* — the next dose
+# depends on the simulated, assay-noised state — so it is run with
+# `simulate_adaptive_from_spec()`, not the plain forward `simulate()`.
+#
+# 1-compartment IV model; the observed/predicted endpoint is the concentration
+# C = central / V (mg/L). The controller titrates on the *measured* trough
+# (`with_assay_error = true`), as a clinician would, so the proportional assay
+# error feeds each decision.
+#
+# See docs/model-file/adaptive-dosing.qmd for the block reference.
+
+[parameters]
+  theta TVCL(4.0,  0.5,  20.0)    # clearance (L/h)
+  theta TVV(50.0,  5.0, 200.0)    # volume of distribution (L)
+
+  omega ETA_CL ~ 0.09             # between-subject variability on CL (log-normal)
+
+  sigma PROP ~ 0.10 (sd)          # proportional assay error (10% CV)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(states=[central])
+
+[odes]
+  # central: drug amount (mg); concentration C = central / V (mg/L)
+  d/dt(central) = -(CL / V) * central
+
+[scaling]
+  y = central / V                 # observed/predicted endpoint is concentration
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[adaptive_dosing]
+  observe          = central / V          # titrate on concentration (mg/L)
+  with_assay_error = true                 # ... as measured (proportional assay noise)
+  assay_cmt        = 1                     # endpoint whose residual error noises the reading
+  at               = every 12 from 0 to 96 # a TDM decision before each q12h dose
+  start_dose       = 1000                  # initial dose (mg)
+  route            = infuse(cmt=1, over=1) # 1-hour IV infusion
+  dose_bounds      = [250, 2000]           # never below 250 or above 2000 mg
+  confirm          = 1                     # act on the first breach
+  when signal < 10 : increase 25%          # sub-therapeutic trough → escalate
+  when signal > 20 : decrease 25%          # supra-therapeutic trough → de-escalate

--- a/src/api.rs
+++ b/src/api.rs
@@ -5659,9 +5659,26 @@ where
             .to_string());
     }
 
-    // Programmatic path: cmt-based monitors only, no compiled `observe`
-    // expressions, so the empty `observe_exprs` keeps the reactive driver
-    // byte-for-byte identical to the pre-S2 behaviour.
+    // Programmatic path: cmt-based monitors (no compiled `observe` expression) and
+    // a `Vec<DoseAction>` controller with no rule provenance. Adapt both into the
+    // engine's paired-monitor / `ControllerDecision` contract; the all-`None`
+    // `observe`/`rule` keeps the reactive driver byte-for-byte identical to the
+    // pre-S2 behaviour.
+    let monitors: Vec<crate::sim::adaptive::AdaptiveMonitor> = opts
+        .monitors
+        .iter()
+        .map(|spec| crate::sim::adaptive::AdaptiveMonitor {
+            spec,
+            observe: None,
+        })
+        .collect();
+    let make = move || {
+        let mut c = make_controller();
+        move |ctx: &ControllerCtx| crate::sim::adaptive::ControllerDecision {
+            actions: c(ctx),
+            rule: None,
+        }
+    };
     run_adaptive_population(
         model,
         ode,
@@ -5669,9 +5686,8 @@ where
         params,
         n_sim,
         &opts.decision_times,
-        &opts.monitors,
-        &[],
-        make_controller,
+        &monitors,
+        make,
         opts,
     )
 }
@@ -5683,9 +5699,11 @@ where
 ///
 /// The decision schedule and monitors are passed explicitly: the programmatic
 /// entry takes them from `opts`, the declarative entry derives them from the
-/// `[adaptive_dosing]` spec. `observe_exprs`, aligned to `monitors`, lets a
-/// monitor take its latent value from a compiled `observe` expression — it is
-/// empty for the programmatic path (cmt readout only), so that path is unchanged.
+/// `[adaptive_dosing]` spec. Each [`AdaptiveMonitor`](crate::sim::adaptive) carries
+/// its own optional compiled `observe` expression (the declarative signal) or
+/// `None` (the programmatic cmt readout, byte-for-byte unchanged), and the
+/// controller returns a `ControllerDecision` so the ledger can record which rule
+/// fired.
 ///
 /// Both entries resolve `ode` and validate the schedule before calling, so this
 /// helper assumes them well-formed and focuses on the run loop.
@@ -5697,14 +5715,13 @@ fn run_adaptive_population<F, C>(
     params: &ModelParameters,
     n_sim: usize,
     decision_times: &[f64],
-    monitors: &[MonitorSpec],
-    observe_exprs: &[Option<&crate::ode::OdeOutputFn>],
+    monitors: &[crate::sim::adaptive::AdaptiveMonitor],
     make_controller: F,
     opts: &AdaptiveSimulateOptions,
 ) -> Result<AdaptiveSimulationResult, String>
 where
     F: Fn() -> C,
-    C: FnMut(&ControllerCtx) -> Vec<DoseAction>,
+    C: FnMut(&ControllerCtx) -> crate::sim::adaptive::ControllerDecision,
 {
     use rand::SeedableRng;
 
@@ -5779,7 +5796,6 @@ where
                 &mut controller,
                 opts.max_decisions,
                 Some(&assay),
-                observe_exprs,
             )
             .map_err(|e| format!("subject '{}' (sim {sim}): {e}", subject.id))?;
 
@@ -5926,7 +5942,12 @@ pub fn simulate_adaptive_from_spec(
         .ode_spec
         .as_ref()
         .expect("compile_adaptive accepted the model, so it carries an ODE spec");
-    let observe_exprs: Vec<Option<&crate::ode::OdeOutputFn>> = vec![Some(&compiled.observe)];
+    // Pair the single `signal` monitor with its compiled `observe` expression so
+    // the driver reads the engine-resolved signal rather than the bare cmt readout.
+    let monitors = vec![crate::sim::adaptive::AdaptiveMonitor {
+        spec: &compiled.monitors[0],
+        observe: Some(&compiled.observe),
+    }];
 
     run_adaptive_population(
         model,
@@ -5935,8 +5956,7 @@ pub fn simulate_adaptive_from_spec(
         params,
         n_sim,
         &spec.at,
-        &compiled.monitors,
-        &observe_exprs,
+        &monitors,
         compiled.make_controller.as_ref(),
         opts,
     )
@@ -11176,6 +11196,12 @@ mod adaptive_sim_tests {
             res.ledger.iter().all(|e| e.amt == 100.0),
             "fixed start_dose, never titrated"
         );
+        // No `when` rule ever fires here, so every dose is a re-issue: `rule_fired`
+        // records the route, never a fabricated rule (#391 S2 traceability).
+        assert!(
+            res.ledger.iter().all(|e| e.rule_fired == "bolus"),
+            "a re-issue records the dose by its route, not a rule"
+        );
 
         // Static reference: the same fixed schedule pre-scheduled through predict().
         let static_doses: Vec<DoseEvent> = [0.0, 24.0, 48.0]
@@ -11257,9 +11283,60 @@ mod adaptive_sim_tests {
             !from_spec.ledger.is_empty(),
             "the ladder must fire and dose"
         );
-        assert_eq!(
-            from_spec.ledger, programmatic.ledger,
-            "declarative block and hand-written closure must realize the identical ledger"
+        // Identical *dosing* — every realized-dose field matches bit-for-bit. The
+        // one field that legitimately differs is the audit-only `rule_fired`: the
+        // declarative path now names the rung that fired, while a hand-written
+        // closure has no rule to name (asserted separately below).
+        assert_eq!(from_spec.ledger.len(), programmatic.ledger.len());
+        for (d, p) in from_spec.ledger.iter().zip(&programmatic.ledger) {
+            assert_eq!(
+                (
+                    &d.subject,
+                    d.draw,
+                    d.sim,
+                    d.dose_idx,
+                    d.time,
+                    d.amt,
+                    d.cmt,
+                    d.rate,
+                    d.decision_idx,
+                    &d.observed_signals,
+                    d.f_applied,
+                ),
+                (
+                    &p.subject,
+                    p.draw,
+                    p.sim,
+                    p.dose_idx,
+                    p.time,
+                    p.amt,
+                    p.cmt,
+                    p.rate,
+                    p.decision_idx,
+                    &p.observed_signals,
+                    p.f_applied,
+                ),
+                "declarative block and hand-written closure must realize the identical dosing"
+            );
+        }
+        // Traceability (#391 S2): the declarative ledger names the rung that fired;
+        // the programmatic ledger (arbitrary controller, no rules) records the
+        // dose by its route.
+        assert!(
+            from_spec
+                .ledger
+                .iter()
+                .all(|e| e.rule_fired == "signal < 50 : increase 25%"),
+            "declarative rule_fired names the rung that fired: {:?}",
+            from_spec
+                .ledger
+                .iter()
+                .map(|e| e.rule_fired.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            programmatic.ledger.iter().all(|e| e.rule_fired == "bolus"),
+            "programmatic rule_fired records the route, not a rule"
         );
         assert_eq!(
             from_spec.decisions, programmatic.decisions,

--- a/src/api.rs
+++ b/src/api.rs
@@ -5942,11 +5942,12 @@ pub fn simulate_adaptive_from_spec(
         .ode_spec
         .as_ref()
         .expect("compile_adaptive accepted the model, so it carries an ODE spec");
-    // Pair the single `signal` monitor with its compiled `observe` expression so
-    // the driver reads the engine-resolved signal rather than the bare cmt readout.
+    // Pair the single `signal` monitor with its compiled `observe` expression (the
+    // latent/`Ipred` case); under `Dv` `compiled.observe` is `None`, so the driver
+    // reads the model's own output for that cmt — value and σ from one source.
     let monitors = vec![crate::sim::adaptive::AdaptiveMonitor {
         spec: &compiled.monitors[0],
-        observe: Some(&compiled.observe),
+        observe: compiled.observe.as_ref(),
     }];
 
     run_adaptive_population(
@@ -11146,7 +11147,7 @@ mod adaptive_sim_tests {
     /// tests, which never reach the run loop.
     fn simple_titration_spec() -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
-            observe: "central".to_string(),
+            observe: Some("central".to_string()),
             with_assay_error: false,
             assay_cmt: None,
             at: vec![0.0, 24.0],
@@ -11235,7 +11236,7 @@ mod adaptive_sim_tests {
         let pop = population(vec![subj("S", obs.clone(), vec![])]);
 
         let spec = AdaptiveDosingSpec {
-            observe: "central".to_string(),
+            observe: Some("central".to_string()),
             with_assay_error: false,
             assay_cmt: None,
             at: at.clone(),
@@ -11457,7 +11458,7 @@ mod adaptive_sim_tests {
         // Reject it loudly, exactly as a fit does for model covariates.
         let model = parse_model_string(ODE_NO_IIV).expect("parse");
         let spec = AdaptiveDosingSpec {
-            observe: "central / BADCOV".to_string(),
+            observe: Some("central / BADCOV".to_string()),
             ..simple_titration_spec()
         };
         let pop = population(vec![subj("1", vec![6.0], vec![])]); // no covariate columns
@@ -11484,7 +11485,7 @@ mod adaptive_sim_tests {
         let pop = population(vec![subj("1", vec![6.0, 30.0, 54.0], vec![])]);
 
         let ipred_spec = AdaptiveDosingSpec {
-            observe: "central".to_string(),
+            observe: Some("central".to_string()),
             with_assay_error: false,
             assay_cmt: None,
             at: at.clone(),
@@ -11499,8 +11500,13 @@ mod adaptive_sim_tests {
                 action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
             }],
         };
+        // Choice-2 Dv: no observe expression — measure model output #1 (whose
+        // readout `y = central` for ODE_NO_IIV is the same quantity the Ipred spec
+        // observes) with assay noise.
         let dv_spec = AdaptiveDosingSpec {
+            observe: None,
             with_assay_error: true,
+            assay_cmt: Some(1),
             ..ipred_spec.clone()
         };
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5900,6 +5900,28 @@ pub fn simulate_adaptive_from_spec(
     // here rather than allowed to silently produce nothing.
     let compiled = crate::sim::adaptive_control::compile_adaptive(model, spec)
         .map_err(|e| format!("simulate_adaptive_from_spec: {e}"))?;
+    // An `observe` covariate absent from the data would silently read 0.0 and
+    // drive the controller off a wrong signal (`central / WT` → central / 0 = inf).
+    // Apply the same loud check fits use for model covariates (`check_covariates`).
+    let missing: Vec<&str> = compiled
+        .observe_covariates
+        .iter()
+        .filter(|name| !population.covariate_names.iter().any(|n| n == *name))
+        .map(|s| s.as_str())
+        .collect();
+    if !missing.is_empty() {
+        let available = if population.covariate_names.is_empty() {
+            "(none)".to_string()
+        } else {
+            population.covariate_names.join(", ")
+        };
+        return Err(format!(
+            "simulate_adaptive_from_spec: [adaptive_dosing] `observe` references covariate(s) \
+             not found in data (case-sensitive): {}. Available covariate columns: {}.",
+            missing.join(", "),
+            available
+        ));
+    }
     let ode = model
         .ode_spec
         .as_ref()
@@ -11349,6 +11371,26 @@ mod adaptive_sim_tests {
         let err = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &opts)
             .unwrap_err();
         assert!(err.contains("ODE model"), "got: {err}");
+    }
+
+    #[test]
+    fn from_spec_rejects_observe_covariate_absent_from_data() {
+        // An `observe` covariate not present in the data would silently read 0.0 and
+        // drive the controller off a wrong signal (`central / BADCOV` → central/0).
+        // Reject it loudly, exactly as a fit does for model covariates.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let spec = AdaptiveDosingSpec {
+            observe: "central / BADCOV".to_string(),
+            ..simple_titration_spec()
+        };
+        let pop = population(vec![subj("1", vec![6.0], vec![])]); // no covariate columns
+        let opts = AdaptiveSimulateOptions::default();
+        let err = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &opts)
+            .unwrap_err();
+        assert!(
+            err.contains("BADCOV") && err.contains("not found in data"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -5513,11 +5513,14 @@ fn simulate_inner_with_draw<R: rand::Rng>(
 // ======================================================================
 // Adaptive (state-reactive / feedback) dosing — epic #391, experimental.
 //
-// Public entry point that wraps the `pub(crate)` reactive driver
-// (`ode_predictions_adaptive`) with per-(subject, replicate) orchestration, the
-// tagged-row output schema (Part D), and the frozen-schedule replay verifier
-// (Part E backbone, default-on). Ipred monitors only; the `Dv` (assay-noised)
-// path and per-subject RNG substreams land in S1.5.
+// Two public entry points wrap the `pub(crate)` reactive driver
+// (`ode_predictions_adaptive_impl`) with shared per-(subject, replicate)
+// orchestration (`run_adaptive_population`), the tagged-row output schema
+// (Part D), and the frozen-schedule replay verifier (Part E backbone,
+// default-on): `simulate_adaptive` takes a hand-written controller closure, and
+// `simulate_adaptive_from_spec` compiles a declarative `[adaptive_dosing]` block
+// into the same engine. Both support Ipred and `Dv` (assay-noised) monitors on
+// the S1.5 controller-assay substreams.
 // ======================================================================
 
 use crate::sim::adaptive::{
@@ -5638,8 +5641,6 @@ where
     F: Fn() -> C,
     C: FnMut(&ControllerCtx) -> Vec<DoseAction>,
 {
-    use rand::SeedableRng;
-
     let ode = model.ode_spec.as_ref().ok_or_else(|| {
         "simulate_adaptive requires an ODE model (the reactive driver runs on the ODE \
          engine); this model has no [odes] block"
@@ -5657,6 +5658,55 @@ where
              is never consulted and no dose is ever issued"
             .to_string());
     }
+
+    // Programmatic path: cmt-based monitors only, no compiled `observe`
+    // expressions, so the empty `observe_exprs` keeps the reactive driver
+    // byte-for-byte identical to the pre-S2 behaviour.
+    run_adaptive_population(
+        model,
+        ode,
+        population,
+        params,
+        n_sim,
+        &opts.decision_times,
+        &opts.monitors,
+        &[],
+        make_controller,
+        opts,
+    )
+}
+
+/// Shared per-(subject, replicate) orchestration behind [`simulate_adaptive`] and
+/// [`simulate_adaptive_from_spec`]: draw η ~ N(0, Ω), mint a **fresh** controller,
+/// run the reactive ODE driver, (optionally) verify the frozen-schedule replay,
+/// and stamp the replicate tags onto the trajectory / ledger / decision rows.
+///
+/// The decision schedule and monitors are passed explicitly: the programmatic
+/// entry takes them from `opts`, the declarative entry derives them from the
+/// `[adaptive_dosing]` spec. `observe_exprs`, aligned to `monitors`, lets a
+/// monitor take its latent value from a compiled `observe` expression — it is
+/// empty for the programmatic path (cmt readout only), so that path is unchanged.
+///
+/// Both entries resolve `ode` and validate the schedule before calling, so this
+/// helper assumes them well-formed and focuses on the run loop.
+#[allow(clippy::too_many_arguments)]
+fn run_adaptive_population<F, C>(
+    model: &CompiledModel,
+    ode: &crate::ode::OdeSpec,
+    population: &Population,
+    params: &ModelParameters,
+    n_sim: usize,
+    decision_times: &[f64],
+    monitors: &[MonitorSpec],
+    observe_exprs: &[Option<&crate::ode::OdeOutputFn>],
+    make_controller: F,
+    opts: &AdaptiveSimulateOptions,
+) -> Result<AdaptiveSimulationResult, String>
+where
+    F: Fn() -> C,
+    C: FnMut(&ControllerCtx) -> Vec<DoseAction>,
+{
+    use rand::SeedableRng;
 
     let mut rng: rand::rngs::StdRng = match opts.seed {
         Some(s) => rand::rngs::StdRng::seed_from_u64(s),
@@ -5718,17 +5768,18 @@ where
 
             // A fresh controller per (subject, replicate) — see the factory note.
             let mut controller = make_controller();
-            let run: AdaptiveRun = crate::ode::ode_predictions_adaptive(
+            let run: AdaptiveRun = crate::ode::ode_predictions_adaptive_impl(
                 ode,
                 &pk.values,
                 &params.theta,
                 &eta_slice,
                 subject,
-                &opts.decision_times,
-                &opts.monitors,
+                decision_times,
+                monitors,
                 &mut controller,
                 opts.max_decisions,
                 Some(&assay),
+                observe_exprs,
             )
             .map_err(|e| format!("subject '{}' (sim {sim}): {e}", subject.id))?;
 
@@ -5739,7 +5790,7 @@ where
                     &params.theta,
                     &eta_slice,
                     subject,
-                    &opts.decision_times,
+                    decision_times,
                     &run,
                 )
                 .map_err(|e| {
@@ -5784,6 +5835,89 @@ where
         ledger,
         decisions,
     })
+}
+
+/// Simulate a declarative `[adaptive_dosing]` block over a population — the
+/// file-driven counterpart to [`simulate_adaptive`] (epic #391, **experimental**).
+///
+/// Where [`simulate_adaptive`] takes a hand-written controller closure, this entry
+/// point takes the parsed `[adaptive_dosing]` `spec` and compiles it into the
+/// *same* reactive engine: the `observe` expression becomes the monitored signal,
+/// the `when … : …` ladder becomes the controller, and the block's `at` becomes
+/// the decision schedule. Everything downstream — the dose ledger, the decision
+/// log (including holds), and the frozen-schedule replay verifier — is identical
+/// to the programmatic path, so the declarative block inherits every S1 guarantee
+/// (a re-emitted fixed regimen reproduces [`simulate`] bit-for-bit via the
+/// verifier; a genuinely reactive schedule is replay-checked each run).
+///
+/// Obtain `spec` from [`crate::parse_full_model_file`]
+/// (`ParsedModel::adaptive_dosing`, `None` when the model declares no block).
+///
+/// ## The spec owns the schedule and the monitor
+///
+/// The decision schedule (`spec.at`) and the monitored signal (`spec.observe`)
+/// come from the block, so `opts.decision_times` and `opts.monitors` **must be
+/// left empty**: setting either is a typed error rather than a silently-ignored
+/// field (the spec would otherwise have two sources of truth). `opts.seed`,
+/// `opts.verify`, and `opts.max_decisions` apply exactly as for
+/// [`simulate_adaptive`].
+///
+/// The `observe` expression is compiled against the model, so it titrates on the
+/// derived signal it names — `observe = central / V` drives on the concentration,
+/// not the raw compartment amount. With `with_assay_error`, the designated
+/// endpoint's residual error noises the reading on the S1.5 controller-assay
+/// substream; an `observe` whose endpoint is ambiguous is rejected at parse time.
+pub fn simulate_adaptive_from_spec(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    n_sim: usize,
+    spec: &crate::sim::adaptive::AdaptiveDosingSpec,
+    opts: &AdaptiveSimulateOptions,
+) -> Result<AdaptiveSimulationResult, String> {
+    // The spec is the single source of truth for the decision schedule and the
+    // monitored signal; an `opts` that *also* sets them is ambiguous (two
+    // schedules, two monitors) — reject it rather than silently pick one.
+    if !opts.decision_times.is_empty() {
+        return Err(
+            "simulate_adaptive_from_spec takes its decision schedule from the \
+             [adaptive_dosing] block's `at`; leave `opts.decision_times` empty"
+                .to_string(),
+        );
+    }
+    if !opts.monitors.is_empty() {
+        return Err(
+            "simulate_adaptive_from_spec takes its monitor from the [adaptive_dosing] \
+             block's `observe`; leave `opts.monitors` empty"
+                .to_string(),
+        );
+    }
+
+    // Compile the block against the model: the `observe` expression, the single
+    // `signal` monitor (carrying the assay endpoint under `with_assay_error`), and
+    // the per-(subject, replicate) controller factory. This is also the ODE gate —
+    // the reactive driver runs on the ODE engine, so an analytical model is rejected
+    // here rather than allowed to silently produce nothing.
+    let compiled = crate::sim::adaptive_control::compile_adaptive(model, spec)
+        .map_err(|e| format!("simulate_adaptive_from_spec: {e}"))?;
+    let ode = model
+        .ode_spec
+        .as_ref()
+        .expect("compile_adaptive accepted the model, so it carries an ODE spec");
+    let observe_exprs: Vec<Option<&crate::ode::OdeOutputFn>> = vec![Some(&compiled.observe)];
+
+    run_adaptive_population(
+        model,
+        ode,
+        population,
+        params,
+        n_sim,
+        &spec.at,
+        &compiled.monitors,
+        &observe_exprs,
+        compiled.make_controller.as_ref(),
+        opts,
+    )
 }
 
 /// Options controlling `simulate_with_uncertainty()`.
@@ -10333,8 +10467,11 @@ mod tests_derived_iov_kappa {
 #[cfg(test)]
 mod adaptive_sim_tests {
     use super::*;
-    use crate::parser::model_parser::parse_model_string;
-    use crate::sim::adaptive::{ControllerCtx, DoseAction, MonitorSpec, ObserveMode};
+    use crate::parser::model_parser::{parse_full_model, parse_model_string};
+    use crate::sim::adaptive::{
+        AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
+        DoseAction, DoseStep, MonitorSpec, ObserveMode,
+    };
     use std::collections::HashMap;
 
     // 1-cpt IV ODE, state = central amount, readout y = central (amount units).
@@ -10900,6 +11037,447 @@ mod adaptive_sim_tests {
             dv_at(&r_ab, "A", 1),
             dv_at(&r_ab, "B", 1),
             "id-keyed assay noise must differ between subjects (test would be vacuous otherwise)"
+        );
+    }
+
+    // ── S2.3: declarative [adaptive_dosing] entry — simulate_adaptive_from_spec ──
+
+    // The ODE_NO_IIV structural core plus a declarative block whose lone rule can
+    // never fire (`signal < 0` on a non-negative amount): the controller re-issues
+    // `start_dose` at every decision, i.e. a fixed 100 mg q24 regimen.
+    const SPEC_DEGENERATE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central
+  at = [0, 24, 48]
+  start_dose = 100
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 0 : increase 25%
+"#;
+
+    // Same structural core; a two-sided band titration that walks the maintenance
+    // dose up until the pre-dose trough settles inside [8, 13].
+    const SPEC_TITRATE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central
+  at = every 24 from 0 to 336
+  start_dose = 20
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 8 : increase 25%
+  when signal > 13 : decrease 25%
+"#;
+
+    /// A minimal valid titration spec (built directly, no file) for the rejection
+    /// tests, which never reach the run loop.
+    fn simple_titration_spec() -> AdaptiveDosingSpec {
+        AdaptiveDosingSpec {
+            observe: "central".to_string(),
+            with_assay_error: false,
+            assay_cmt: None,
+            at: vec![0.0, 24.0],
+            start_dose: 100.0,
+            route: AdaptiveRoute::Bolus { cmt: 1 },
+            dose_bounds: (0.0, 400.0),
+            confirm: 1,
+            levels: None,
+            rules: vec![AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 50.0,
+                action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            }],
+        }
+    }
+
+    #[test]
+    fn from_spec_degenerate_oracle_matches_static_predict_bit_for_bit() {
+        // The declarative path's degenerate oracle: a block that never titrates
+        // re-issues a fixed 100 mg bolus at every decision, so it must reproduce the
+        // static engine on that same realized schedule. A dose lands at every
+        // decision and the last obs (54) is the global max ⇒ bit-exact agreement,
+        // and the frozen-replay verifier (on by default) also passes.
+        let parsed = parse_full_model(SPEC_DEGENERATE).expect("parse model + block");
+        let spec = parsed
+            .adaptive_dosing
+            .as_ref()
+            .expect("[adaptive_dosing] present");
+        let obs = vec![6.0, 30.0, 54.0];
+        let pop = population(vec![subj("1", obs.clone(), vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect("declarative adaptive sim runs");
+
+        assert_eq!(res.ledger.len(), 3, "100 mg re-issued at every decision");
+        assert!(
+            res.ledger.iter().all(|e| e.amt == 100.0),
+            "fixed start_dose, never titrated"
+        );
+
+        // Static reference: the same fixed schedule pre-scheduled through predict().
+        let static_doses: Vec<DoseEvent> = [0.0, 24.0, 48.0]
+            .iter()
+            .map(|&t| DoseEvent::new(t, 100.0, 1, 0.0, false, 0.0))
+            .collect();
+        let static_pop = population(vec![subj("1", obs.clone(), static_doses)]);
+        let preds = predict(&parsed.model, &static_pop, &parsed.model.default_params);
+        assert_eq!(res.trajectories.len(), preds.len());
+        for (traj, pred) in res.trajectories.iter().zip(preds.iter()) {
+            assert!(
+                (traj.ipred - pred.pred).abs() <= 1e-9 + 1e-9 * pred.pred.abs(),
+                "declarative IPRED {} != static predict {} at t={}",
+                traj.ipred,
+                pred.pred,
+                traj.time
+            );
+        }
+    }
+
+    #[test]
+    fn from_spec_three_witnesses_equals_handwritten_closure() {
+        // Witness 1: the declarative block. Witness 2: a hand-written controller
+        // closure with the identical ladder. Witness 3: the realized ledger they
+        // must share, byte-for-byte. `observe = central` reads the same state the
+        // programmatic monitor's cmt readout returns (model readout y = central), so
+        // both controllers see the same signal and decide identically.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let at = vec![0.0, 24.0, 48.0, 72.0];
+        let obs = vec![12.0, 36.0, 78.0];
+        let pop = population(vec![subj("S", obs.clone(), vec![])]);
+
+        let spec = AdaptiveDosingSpec {
+            observe: "central".to_string(),
+            with_assay_error: false,
+            assay_cmt: None,
+            at: at.clone(),
+            start_dose: 100.0,
+            route: AdaptiveRoute::Bolus { cmt: 1 },
+            dose_bounds: (0.0, 1000.0),
+            confirm: 1,
+            levels: None,
+            rules: vec![AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 50.0,
+                action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            }],
+        };
+        let spec_opts = AdaptiveSimulateOptions {
+            seed: Some(7),
+            ..Default::default()
+        };
+        let from_spec =
+            simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &spec_opts)
+                .expect("declarative run");
+
+        // The same ladder, hand-written: bump the running dose 25% (clamped) when
+        // the signal is below 50, else re-issue it.
+        let make = || {
+            let mut dose = 100.0_f64;
+            move |ctx: &ControllerCtx| {
+                if ctx.signal("signal").expect("signal monitor") < 50.0 {
+                    dose = (dose * 1.25).clamp(0.0, 1000.0);
+                }
+                vec![DoseAction::Bolus { amt: dose, cmt: 1 }]
+            }
+        };
+        let prog_opts = AdaptiveSimulateOptions {
+            seed: Some(7),
+            decision_times: at.clone(),
+            monitors: vec![MonitorSpec::new("signal", 1, ObserveMode::Ipred)],
+            ..Default::default()
+        };
+        let programmatic =
+            simulate_adaptive(&model, &pop, &model.default_params, 1, make, &prog_opts)
+                .expect("programmatic run");
+
+        assert!(
+            !from_spec.ledger.is_empty(),
+            "the ladder must fire and dose"
+        );
+        assert_eq!(
+            from_spec.ledger, programmatic.ledger,
+            "declarative block and hand-written closure must realize the identical ledger"
+        );
+        assert_eq!(
+            from_spec.decisions, programmatic.decisions,
+            "and the identical decision log"
+        );
+        let ip = |r: &AdaptiveSimulationResult| {
+            r.trajectories.iter().map(|t| t.ipred).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ip(&from_spec),
+            ip(&programmatic),
+            "and identical trajectories"
+        );
+    }
+
+    #[test]
+    fn from_spec_closed_loop_converges_into_target_band() {
+        // Closed-loop convergence: the trough (pre-dose central amount) starts far
+        // below the [8, 13] band; the `increase 25%` rule walks the maintenance dose
+        // up until the trough settles inside the band, after which no rule fires and
+        // the dose is re-issued unchanged. k = 0.1/h with τ = 24 h washes out ~91%
+        // each interval, so the trough tracks ~0.1·dose and the loop is stable.
+        let parsed = parse_full_model(SPEC_TITRATE).expect("parse titrating block");
+        let spec = parsed.adaptive_dosing.as_ref().expect("block present");
+        // One observation after the last decision (336) so the schedule's last time
+        // is the global max; the convergence assertions read the decision log.
+        let pop = population(vec![subj("P", vec![342.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(3),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect("titration runs and the verifier passes");
+
+        let signal_at = |d: usize| res.decisions[d].observed_signals[0].value;
+        let n = res.decisions.len();
+        assert_eq!(n, 15, "every-24h-from-0-to-336 ⇒ 15 decisions");
+
+        // Started below the band ...
+        assert!(
+            signal_at(1) < 8.0,
+            "decision 1 trough {} should start below the band",
+            signal_at(1)
+        );
+        // ... and converged into it: the last three troughs sit inside [8, 13].
+        for d in (n - 3)..n {
+            let s = signal_at(d);
+            assert!(
+                (8.0..=13.0).contains(&s),
+                "decision {d} trough {s} should be inside the target band [8, 13]"
+            );
+        }
+        // Converged ⇒ the maintenance dose has settled (the loop holds it steady).
+        let last = res.ledger.last().expect("doses issued");
+        let prev = &res.ledger[res.ledger.len() - 2];
+        assert_eq!(
+            last.amt, prev.amt,
+            "the maintenance dose should be steady once the trough is in band"
+        );
+    }
+
+    #[test]
+    fn from_spec_rejects_decision_times_in_opts() {
+        // The block's `at` is the schedule; an `opts.decision_times` is a second,
+        // conflicting source of truth — rejected, not silently ignored.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let spec = simple_titration_spec();
+        let pop = population(vec![subj("1", vec![6.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            decision_times: vec![0.0, 24.0],
+            ..Default::default()
+        };
+        let err = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &opts)
+            .unwrap_err();
+        assert!(err.contains("opts.decision_times"), "got: {err}");
+    }
+
+    #[test]
+    fn from_spec_rejects_monitors_in_opts() {
+        // The block's `observe` is the monitor; an `opts.monitors` is a second,
+        // conflicting source of truth — rejected, not silently ignored.
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let spec = simple_titration_spec();
+        let pop = population(vec![subj("1", vec![6.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            monitors: vec![MonitorSpec::new("signal", 1, ObserveMode::Ipred)],
+            ..Default::default()
+        };
+        let err = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &opts)
+            .unwrap_err();
+        assert!(err.contains("opts.monitors"), "got: {err}");
+    }
+
+    #[test]
+    fn from_spec_rejects_analytical_model() {
+        // The reactive driver runs on the ODE engine; an analytical model has no ODE
+        // spec and is rejected at compile (the ODE gate), never silently no-op.
+        let model = parse_model_string(ANALYTICAL).expect("parse analytical");
+        let spec = simple_titration_spec();
+        let pop = population(vec![subj("1", vec![6.0], vec![])]);
+        let opts = AdaptiveSimulateOptions::default();
+        let err = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 1, &spec, &opts)
+            .unwrap_err();
+        assert!(err.contains("ODE model"), "got: {err}");
+    }
+
+    #[test]
+    fn from_spec_dv_collapses_to_ipred_as_sigma_to_zero() {
+        // The `with_assay_error` path adds the endpoint's residual draw to the signal
+        // on the S1.5 controller-assay substream; as σ → 0 that draw vanishes, so the
+        // assay-noised block must realize the same dose schedule as the latent (Ipred)
+        // block. `observe = central` is a bare endpoint, so `assay_cmt` resolves to
+        // compartment 1 with no ambiguity. (The full ledger does not bit-collapse —
+        // residual variance floors at a minimum — so the *dose schedule* is the
+        // collapse-invariant, exactly as for the programmatic Dv test.)
+        let model = parse_model_string(ODE_NO_IIV).expect("parse");
+        let at = vec![0.0, 24.0, 48.0];
+        let pop = population(vec![subj("1", vec![6.0, 30.0, 54.0], vec![])]);
+
+        let ipred_spec = AdaptiveDosingSpec {
+            observe: "central".to_string(),
+            with_assay_error: false,
+            assay_cmt: None,
+            at: at.clone(),
+            start_dose: 100.0,
+            route: AdaptiveRoute::Bolus { cmt: 1 },
+            dose_bounds: (0.0, 1000.0),
+            confirm: 1,
+            levels: None,
+            rules: vec![AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 50.0,
+                action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            }],
+        };
+        let dv_spec = AdaptiveDosingSpec {
+            with_assay_error: true,
+            ..ipred_spec.clone()
+        };
+
+        // Drive σ → 0 so the assay draw collapses onto the latent value.
+        let mut params = model.default_params.clone();
+        for s in params.sigma.values.iter_mut() {
+            *s = 1e-12;
+        }
+
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(5),
+            ..Default::default()
+        };
+        let ipred = simulate_adaptive_from_spec(&model, &pop, &params, 1, &ipred_spec, &opts)
+            .expect("ipred run");
+        let dv =
+            simulate_adaptive_from_spec(&model, &pop, &params, 1, &dv_spec, &opts).expect("dv run");
+
+        let schedule = |r: &AdaptiveSimulationResult| {
+            r.ledger
+                .iter()
+                .map(|e| (e.time, e.amt, e.cmt))
+                .collect::<Vec<_>>()
+        };
+        assert!(!dv.ledger.is_empty(), "the ladder fired");
+        assert_eq!(
+            schedule(&ipred),
+            schedule(&dv),
+            "with σ→0 the assay-noised block must realize the same doses as the latent block"
+        );
+    }
+
+    #[test]
+    fn from_spec_is_deterministic_under_a_fixed_seed() {
+        // Reproducibility through the declarative entry: a fixed seed gives identical
+        // η draws (ODE_IIV puts variability on CL), so two runs agree exactly across
+        // subjects and replicates.
+        let model = parse_model_string(ODE_IIV).expect("parse");
+        let spec = simple_titration_spec();
+        let pop = population(vec![
+            subj("A", vec![6.0, 30.0], vec![]),
+            subj("B", vec![6.0, 30.0], vec![]),
+        ]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(42),
+            ..Default::default()
+        };
+        let r1 = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 2, &spec, &opts)
+            .expect("run 1");
+        let r2 = simulate_adaptive_from_spec(&model, &pop, &model.default_params, 2, &spec, &opts)
+            .expect("run 2");
+        assert_eq!(r1.ledger, r2.ledger, "same seed ⇒ identical ledger");
+        assert_eq!(
+            r1.decisions, r2.decisions,
+            "same seed ⇒ identical decisions"
+        );
+    }
+
+    #[test]
+    fn from_spec_runs_the_shipped_tdm_example() {
+        // The shipped example parses from disk, carries an [adaptive_dosing] block,
+        // and runs end-to-end through the file-driven entry — exercising the
+        // expression `observe`, the `with_assay_error` assay path, and the infusion
+        // route together, with the frozen-replay verifier on by default.
+        use crate::parser::model_parser::parse_full_model_file;
+        use std::path::Path;
+        let parsed = parse_full_model_file(Path::new("examples/adaptive_tdm_titration.ferx"))
+            .expect("the shipped TDM example must parse");
+        let spec = parsed
+            .adaptive_dosing
+            .as_ref()
+            .expect("example declares an [adaptive_dosing] block");
+        // Dose-free subjects; a trough is sampled just before each q12h decision,
+        // with a final observation past the last infusion's end.
+        let obs = vec![11.9, 23.9, 35.9, 47.9, 59.9, 71.9, 83.9, 95.9, 108.0];
+        let pop = population(vec![
+            subj("p1", obs.clone(), vec![]),
+            subj("p2", obs.clone(), vec![]),
+        ]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(2024),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect("the example titration runs and the verifier passes");
+        assert!(!res.ledger.is_empty(), "the titration issues doses");
+        assert!(
+            res.ledger.iter().all(|e| e.amt >= 250.0 && e.amt <= 2000.0),
+            "every realized dose must respect dose_bounds [250, 2000]"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ pub use propensity_match::MatchMethod;
 // of `AdaptiveSimulationResult` (`ledger` / `decisions`) — is usable without
 // reaching into the `sim::adaptive` module path.
 pub use sim::adaptive::{
-    ControllerCtx, DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry, MonitorSpec,
+    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
+    DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry, DoseStep, MonitorSpec,
     ObserveMode, ObservedSignal,
 };
 pub use suggest_start::{inits_from_nca, NcaInit, SuggestedStart};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,10 @@ pub mod types;
 pub use api::{
     check_model_data, check_model_data_warnings, check_model_options, fit, fit_from_files, predict,
     run_from_file, run_model_simulate, run_model_with_data, run_model_with_data_inits, simulate,
-    simulate_adaptive, simulate_with_options, simulate_with_seed, simulate_with_uncertainty,
-    validate_model_file, AdaptiveSimulateOptions, AdaptiveSimulationResult, PredictionResult,
-    SimulateOptions, SimulateUncertaintyOptions, SimulationResult,
+    simulate_adaptive, simulate_adaptive_from_spec, simulate_with_options, simulate_with_seed,
+    simulate_with_uncertainty, validate_model_file, AdaptiveSimulateOptions,
+    AdaptiveSimulationResult, PredictionResult, SimulateOptions, SimulateUncertaintyOptions,
+    SimulationResult,
 };
 pub use cancel::CancelFlag;
 pub use diagnostics::{CheckReport, Diagnostic, Severity};

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1588,7 +1588,8 @@ pub(crate) fn ode_predictions_adaptive_impl(
     }
     if decision_times.len() > max_decisions {
         return Err(format!(
-            "decision schedule has {} points, exceeding max_decisions = {} (runaway guard)",
+            "decision schedule has {} points, exceeding max_decisions = {} (runaway guard); \
+             raise `max_decisions` in the simulate options if the schedule is intentional",
             decision_times.len(),
             max_decisions
         ));

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1725,17 +1725,13 @@ pub(crate) fn ode_predictions_adaptive_impl(
                                     m.name
                                 )
                             })?;
-                            // σ is `residual_variance_at(cmt, latent)`, so `latent`
-                            // (the `observe` value) must be on the *same scale* as
-                            // `cmt`'s error model — e.g. `observe = central / V` with
-                            // a proportional error fit on that concentration. The
-                            // parser already forces the user to designate `assay_cmt`
-                            // for an expression `observe` (the σ would otherwise be
-                            // ambiguous); designating it is the user's assertion that
-                            // the two scales agree. Verifying that agreement at compile
-                            // time would need the endpoint's readout source, which the
-                            // model does not retain (`OdeReadout::Single` is an opaque
-                            // closure) — tracked as a follow-up, see #391.
+                            // Scale-correct by construction: under `Dv` the
+                            // declarative path compiles no `observe` expression, so
+                            // `latent` here is the model's own readout for this
+                            // monitor's `cmt` (`am.observe == None` ⇒ `read_observable`
+                            // above) and σ is `residual_variance_at(cmt, latent)` — both
+                            // come from the same model output, so the noised signal is
+                            // always on the error model's scale (#391 S2).
                             //
                             // Edge (a): a DV monitor on a compartment with no
                             // residual error model is a typed error, not a guessed σ.
@@ -7130,7 +7126,7 @@ mod tests {
         let mut controller = (compiled.make_controller)();
         let monitors = vec![crate::sim::adaptive::AdaptiveMonitor {
             spec: &compiled.monitors[0],
-            observe: Some(&compiled.observe),
+            observe: compiled.observe.as_ref(),
         }];
         let run = ode_predictions_adaptive_impl(
             model.ode_spec.as_ref().unwrap(),

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1515,9 +1515,14 @@ fn reject_unsupported_dose_compartment(
 /// break only restarts the integrator on a no-event segment, so predictions are
 /// unaffected on the smooth models tested; genuinely reactive/hold regimens are
 /// therefore pinned against the closed form instead.
-// Consumed by the public `crate::api::simulate_adaptive()` entry point (S1.4b,
-// #391), which wraps it with per-(subject, replicate) orchestration.
-#[allow(clippy::too_many_arguments)]
+// The cmt-only adaptive driver entry: forwards to `ode_predictions_adaptive_impl`
+// with no compiled `observe` expressions. The driver's own unit tests exercise the
+// reactive engine through this focused path, so it is retained as a named cmt-only
+// entry (`dead_code`: production no longer calls it directly). Both public entry
+// points — the programmatic `crate::api::simulate_adaptive` and the declarative
+// `crate::api::simulate_adaptive_from_spec` — go through `_impl`, so the
+// declarative path can supply expression-backed `observe` monitors (S2.3, #391).
+#[allow(dead_code, clippy::too_many_arguments)]
 pub(crate) fn ode_predictions_adaptive(
     ode: &OdeSpec,
     pk_params_flat: &[f64],

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1532,6 +1532,45 @@ pub(crate) fn ode_predictions_adaptive(
     // a `Dv` monitor then errors at its first decision.
     assay: Option<&AssayNoise>,
 ) -> Result<AdaptiveRun, String> {
+    // Cmt-based monitors only (the programmatic path): no expression-backed
+    // `observe`, so every monitor resolves via its `cmt`.
+    ode_predictions_adaptive_impl(
+        ode,
+        pk_params_flat,
+        theta,
+        eta,
+        subject,
+        decision_times,
+        monitors,
+        controller,
+        max_decisions,
+        assay,
+        &[],
+    )
+}
+
+/// As [`ode_predictions_adaptive`], but monitor `i` whose `observe_exprs[i]` is
+/// `Some(f)` takes its **latent** value from the compiled expression `f` rather
+/// than from `read_observable(cmt)` — the engine-resolved signal for a
+/// declarative `[adaptive_dosing]` block (#391 S2.2). `Dv` still draws its σ from
+/// the monitor's `cmt`. An empty `observe_exprs` (or a `None` entry) means
+/// cmt-based resolution, so the programmatic path is byte-for-byte unchanged.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn ode_predictions_adaptive_impl(
+    ode: &OdeSpec,
+    pk_params_flat: &[f64],
+    theta: &[f64],
+    eta: &[f64],
+    subject: &Subject,
+    decision_times: &[f64],
+    monitors: &[MonitorSpec],
+    controller: &mut dyn FnMut(&ControllerCtx) -> Vec<DoseAction>,
+    max_decisions: usize,
+    assay: Option<&AssayNoise>,
+    // Per-monitor compiled `observe` expressions, aligned to `monitors`. A
+    // `Some(f)` overrides the cmt readout for that monitor's latent value.
+    observe_exprs: &[Option<&OdeOutputFn>],
+) -> Result<AdaptiveRun, String> {
     let n = ode.n_states;
 
     // --- Preconditions (typed errors, never silent) ----------------------
@@ -1633,9 +1672,22 @@ pub(crate) fn ode_predictions_adaptive(
                 // Resolve each monitored signal at the current (pre-dose) state.
                 let mut signals: HashMap<String, f64> = HashMap::new();
                 let mut observed: Vec<ObservedSignal> = Vec::with_capacity(monitors.len());
-                for m in monitors {
-                    let latent =
-                        read_observable(ode, &u, pk_params_flat, theta, eta, decision_cov, m.cmt);
+                for (mi, m) in monitors.iter().enumerate() {
+                    // A declarative `[adaptive_dosing]` block (S2.2) supplies a
+                    // compiled `observe` expression for the latent value; absent
+                    // one (the programmatic path), read the model's cmt readout.
+                    let latent = match observe_exprs.get(mi).copied().flatten() {
+                        Some(f) => f(&u, pk_params_flat, theta, eta, decision_cov),
+                        None => read_observable(
+                            ode,
+                            &u,
+                            pk_params_flat,
+                            theta,
+                            eta,
+                            decision_cov,
+                            m.cmt,
+                        ),
+                    };
                     // Resolve the monitored signal on its own mode: Ipred is the
                     // latent readout; Dv adds the endpoint's assay residual draw on
                     // the controller-assay substream (#391 S1.5).
@@ -6989,5 +7041,78 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn adaptive_observe_expression_flows_through_driver() {
+        // The model readout is the raw `central` amount (`[scaling] y = central`),
+        // but the declarative controller observes `central / V` (concentration).
+        // The driver must feed the controller the compiled expression's value, not
+        // the cmt readout — this exercises the S2.2 `observe_exprs` path.
+        const M: &str = r#"
+[parameters]
+  theta TVCL(1.0)
+  theta TVV(50.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central / V
+  at = [24, 48]
+  start_dose = 100
+  route = bolus(cmt = 1)
+  dose_bounds = [0, 400]
+  when signal > 1000 : decrease 25%
+"#;
+        let parsed = crate::parser::model_parser::parse_full_model(M).expect("parses");
+        let model = parsed.model;
+        let spec = parsed.adaptive_dosing.expect("has adaptive block");
+        let compiled =
+            crate::sim::adaptive_control::compile_adaptive(&model, &spec).expect("compiles");
+        let theta = model.default_params.theta.clone();
+        let eta = vec![0.0; model.n_eta + model.n_kappa];
+        let pk = (model.pk_param_fn)(&theta, &eta, &HashMap::new());
+        let subject = make_subject(vec![], spec.at.clone());
+        let mut controller = (compiled.make_controller)();
+        let observe_refs: Vec<Option<&OdeOutputFn>> = vec![Some(&compiled.observe)];
+        let run = ode_predictions_adaptive_impl(
+            model.ode_spec.as_ref().unwrap(),
+            &pk.values,
+            &theta,
+            &eta,
+            &subject,
+            &spec.at,
+            &compiled.monitors,
+            &mut controller,
+            spec.at.len() + 1,
+            None,
+            &observe_refs,
+        )
+        .expect("driver runs");
+
+        // Decision 0 is the pre-dose trough (central = 0 ⇒ concentration 0).
+        assert_eq!(run.decisions[0].observed_signals[0].value, 0.0);
+        // Decision 1: one bolus of start_dose decayed over Δt, divided by V — the
+        // CONCENTRATION. Reading the cmt amount instead would be ~50× larger (the
+        // raw `central`), so this pins the expression path.
+        let ke = theta[0] / theta[1]; // CL/V at eta = 0
+        let dt = spec.at[1] - spec.at[0];
+        let expected_conc = spec.start_dose * (-ke * dt).exp() / theta[1];
+        let got = run.decisions[1].observed_signals[0].value;
+        assert!(
+            (got - expected_conc).abs() < 1e-3,
+            "observed {got}, expected concentration {expected_conc} (raw amount would be ~{})",
+            expected_conc * theta[1]
+        );
     }
 }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -10,9 +10,14 @@
 use crate::ode::solver::{solve_ode, OdeSolverOptions};
 use crate::pk::absorption::PreparedInputRate;
 use crate::sim::adaptive::{
-    assay_standard_normal, AdaptiveRun, AssayNoise, ControllerCtx, DecisionLogEntry,
-    DecisionOutcome, DoseAction, DoseLedgerEntry, MonitorSpec, ObserveMode, ObservedSignal,
+    assay_standard_normal, AdaptiveMonitor, AdaptiveRun, AssayNoise, ControllerCtx,
+    ControllerDecision, DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry,
+    ObserveMode, ObservedSignal,
 };
+// `MonitorSpec` is named only by the `#[cfg(test)]` cmt-only wrapper and the
+// driver's unit tests (production pairs it inside `AdaptiveMonitor`).
+#[cfg(test)]
+use crate::sim::adaptive::MonitorSpec;
 use crate::types::{DoseEvent, PkParams, Subject};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -1515,14 +1520,16 @@ fn reject_unsupported_dose_compartment(
 /// break only restarts the integrator on a no-event segment, so predictions are
 /// unaffected on the smooth models tested; genuinely reactive/hold regimens are
 /// therefore pinned against the closed form instead.
-// The cmt-only adaptive driver entry: forwards to `ode_predictions_adaptive_impl`
-// with no compiled `observe` expressions. The driver's own unit tests exercise the
-// reactive engine through this focused path, so it is retained as a named cmt-only
-// entry (`dead_code`: production no longer calls it directly). Both public entry
-// points — the programmatic `crate::api::simulate_adaptive` and the declarative
-// `crate::api::simulate_adaptive_from_spec` — go through `_impl`, so the
-// declarative path can supply expression-backed `observe` monitors (S2.3, #391).
-#[allow(dead_code, clippy::too_many_arguments)]
+// The cmt-only adaptive driver entry used by the driver's own unit tests: wraps
+// each [`MonitorSpec`] into an [`AdaptiveMonitor`] with no compiled `observe`
+// expression (every signal resolves via its `cmt`) and adapts a plain
+// `Vec<DoseAction>` controller to the engine's [`ControllerDecision`] contract
+// (rule provenance is the declarative path's, so `None` here). `#[cfg(test)]`:
+// production goes through `_impl` directly — both public entry points supply
+// expression-backed monitors and rule-aware controllers — so this is test-only
+// scaffolding, not dead production code (#391).
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn ode_predictions_adaptive(
     ode: &OdeSpec,
     pk_params_flat: &[f64],
@@ -1537,8 +1544,17 @@ pub(crate) fn ode_predictions_adaptive(
     // a `Dv` monitor then errors at its first decision.
     assay: Option<&AssayNoise>,
 ) -> Result<AdaptiveRun, String> {
-    // Cmt-based monitors only (the programmatic path): no expression-backed
-    // `observe`, so every monitor resolves via its `cmt`.
+    let mons: Vec<AdaptiveMonitor> = monitors
+        .iter()
+        .map(|spec| AdaptiveMonitor {
+            spec,
+            observe: None,
+        })
+        .collect();
+    let mut decide = |ctx: &ControllerCtx| ControllerDecision {
+        actions: controller(ctx),
+        rule: None,
+    };
     ode_predictions_adaptive_impl(
         ode,
         pk_params_flat,
@@ -1546,20 +1562,22 @@ pub(crate) fn ode_predictions_adaptive(
         eta,
         subject,
         decision_times,
-        monitors,
-        controller,
+        &mons,
+        &mut decide,
         max_decisions,
         assay,
-        &[],
     )
 }
 
-/// As [`ode_predictions_adaptive`], but monitor `i` whose `observe_exprs[i]` is
-/// `Some(f)` takes its **latent** value from the compiled expression `f` rather
-/// than from `read_observable(cmt)` — the engine-resolved signal for a
-/// declarative `[adaptive_dosing]` block (#391 S2.2). `Dv` still draws its σ from
-/// the monitor's `cmt`. An empty `observe_exprs` (or a `None` entry) means
-/// cmt-based resolution, so the programmatic path is byte-for-byte unchanged.
+/// The core reactive driver. Each [`AdaptiveMonitor`] carries its own optional
+/// compiled `observe` expression: `Some(f)` takes the monitor's **latent** value
+/// from `f` (the engine-resolved signal for a declarative `[adaptive_dosing]`
+/// block, #391 S2), `None` reads `read_observable(cmt)` (the programmatic path,
+/// byte-for-byte unchanged). `Dv` still draws its σ from the monitor's `cmt`.
+///
+/// The controller returns a [`ControllerDecision`] — the dose actions plus the
+/// optional label of the `when` rule that fired, recorded as each dose row's
+/// `rule_fired`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn ode_predictions_adaptive_impl(
     ode: &OdeSpec,
@@ -1568,13 +1586,10 @@ pub(crate) fn ode_predictions_adaptive_impl(
     eta: &[f64],
     subject: &Subject,
     decision_times: &[f64],
-    monitors: &[MonitorSpec],
-    controller: &mut dyn FnMut(&ControllerCtx) -> Vec<DoseAction>,
+    monitors: &[AdaptiveMonitor],
+    controller: &mut dyn FnMut(&ControllerCtx) -> ControllerDecision,
     max_decisions: usize,
     assay: Option<&AssayNoise>,
-    // Per-monitor compiled `observe` expressions, aligned to `monitors`. A
-    // `Some(f)` overrides the cmt readout for that monitor's latent value.
-    observe_exprs: &[Option<&OdeOutputFn>],
 ) -> Result<AdaptiveRun, String> {
     let n = ode.n_states;
 
@@ -1594,7 +1609,8 @@ pub(crate) fn ode_predictions_adaptive_impl(
             max_decisions
         ));
     }
-    for m in monitors {
+    for am in monitors {
+        let m = am.spec;
         if m.cmt == 0 || m.cmt > n {
             return Err(format!(
                 "monitor '{}' observes compartment {} but the model has {} state(s)",
@@ -1678,11 +1694,12 @@ pub(crate) fn ode_predictions_adaptive_impl(
                 // Resolve each monitored signal at the current (pre-dose) state.
                 let mut signals: HashMap<String, f64> = HashMap::new();
                 let mut observed: Vec<ObservedSignal> = Vec::with_capacity(monitors.len());
-                for (mi, m) in monitors.iter().enumerate() {
-                    // A declarative `[adaptive_dosing]` block (S2.2) supplies a
+                for am in monitors.iter() {
+                    let m = am.spec;
+                    // A declarative `[adaptive_dosing]` block (S2) supplies a
                     // compiled `observe` expression for the latent value; absent
                     // one (the programmatic path), read the model's cmt readout.
-                    let latent = match observe_exprs.get(mi).copied().flatten() {
+                    let latent = match am.observe {
                         Some(f) => f(&u, pk_params_flat, theta, eta, decision_cov),
                         None => read_observable(
                             ode,
@@ -1708,6 +1725,18 @@ pub(crate) fn ode_predictions_adaptive_impl(
                                     m.name
                                 )
                             })?;
+                            // σ is `residual_variance_at(cmt, latent)`, so `latent`
+                            // (the `observe` value) must be on the *same scale* as
+                            // `cmt`'s error model — e.g. `observe = central / V` with
+                            // a proportional error fit on that concentration. The
+                            // parser already forces the user to designate `assay_cmt`
+                            // for an expression `observe` (the σ would otherwise be
+                            // ambiguous); designating it is the user's assertion that
+                            // the two scales agree. Verifying that agreement at compile
+                            // time would need the endpoint's readout source, which the
+                            // model does not retain (`OdeReadout::Single` is an opaque
+                            // closure) — tracked as a follow-up, see #391.
+                            //
                             // Edge (a): a DV monitor on a compartment with no
                             // residual error model is a typed error, not a guessed σ.
                             let var = (a.resid_var)(m.cmt, latent).ok_or_else(|| {
@@ -1737,7 +1766,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
                     });
                 }
 
-                let actions = {
+                let decision = {
                     let ctx = ControllerCtx {
                         t: t_start,
                         state: &u,
@@ -1748,6 +1777,11 @@ pub(crate) fn ode_predictions_adaptive_impl(
                     };
                     controller(&ctx)
                 };
+                // The `when` rule that produced these actions (declarative path);
+                // `None` for a re-issue or a programmatic controller, in which case
+                // the ledger records the dose by its route below.
+                let rule_fired = decision.rule;
+                let actions = decision.actions;
 
                 // Validate the whole action list up front — before any action is
                 // applied — and require `Stop` to be the final action. A malformed
@@ -1804,7 +1838,9 @@ pub(crate) fn ode_predictions_adaptive_impl(
                                 cmt,
                                 rate: 0.0,
                                 decision_idx: decision_index,
-                                rule_fired: "bolus".to_string(),
+                                rule_fired: rule_fired
+                                    .clone()
+                                    .unwrap_or_else(|| "bolus".to_string()),
                                 observed_signals: observed.clone(),
                                 pre_state: None,
                                 post_state: None,
@@ -1853,7 +1889,9 @@ pub(crate) fn ode_predictions_adaptive_impl(
                                 cmt,
                                 rate,
                                 decision_idx: decision_index,
-                                rule_fired: "infuse".to_string(),
+                                rule_fired: rule_fired
+                                    .clone()
+                                    .unwrap_or_else(|| "infuse".to_string()),
                                 observed_signals: observed.clone(),
                                 pre_state: None,
                                 post_state: None,
@@ -7090,7 +7128,10 @@ mod tests {
         let pk = (model.pk_param_fn)(&theta, &eta, &HashMap::new());
         let subject = make_subject(vec![], spec.at.clone());
         let mut controller = (compiled.make_controller)();
-        let observe_refs: Vec<Option<&OdeOutputFn>> = vec![Some(&compiled.observe)];
+        let monitors = vec![crate::sim::adaptive::AdaptiveMonitor {
+            spec: &compiled.monitors[0],
+            observe: Some(&compiled.observe),
+        }];
         let run = ode_predictions_adaptive_impl(
             model.ode_spec.as_ref().unwrap(),
             &pk.values,
@@ -7098,11 +7139,10 @@ mod tests {
             &eta,
             &subject,
             &spec.at,
-            &compiled.monitors,
+            &monitors,
             &mut controller,
             spec.at.len() + 1,
             None,
-            &observe_refs,
         )
         .expect("driver runs");
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1,5 +1,6 @@
 use crate::sim::adaptive::{
-    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, DoseStep,
+    validate_increasing_finite, AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule,
+    Comparison, DoseStep,
 };
 use crate::types::*;
 use regex::Regex;
@@ -3971,27 +3972,6 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     };
     spec.validate()?;
     Ok(spec)
-}
-
-/// Validate a `[adaptive_dosing]` float list is non-empty, all-finite, and
-/// strictly increasing — the shared contract of the `levels` ladder and an
-/// explicit `at` decision list, so the two can't drift apart. `what` names the
-/// list in the error (e.g. `"levels"`, `` "`at` times" ``).
-fn validate_increasing_finite(xs: &[f64], what: &str) -> Result<(), String> {
-    if xs.is_empty() {
-        return Err(format!(
-            "[adaptive_dosing]: {what} must be a non-empty list"
-        ));
-    }
-    if !xs.iter().all(|x| x.is_finite()) {
-        return Err(format!("[adaptive_dosing]: {what} must all be finite"));
-    }
-    if xs.windows(2).any(|w| w[1] <= w[0]) {
-        return Err(format!(
-            "[adaptive_dosing]: {what} must be strictly increasing"
-        ));
-    }
-    Ok(())
 }
 
 /// Parse an `at =` decision schedule: either an explicit list `[t1, t2, …]` or an

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1,3 +1,6 @@
+use crate::sim::adaptive::{
+    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, DoseStep,
+};
 use crate::types::*;
 use regex::Regex;
 use std::collections::HashMap;
@@ -1834,6 +1837,12 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .get("simulation")
         .map(|lines| parse_simulation_block(lines))
         .transpose()?;
+    // Declarative reactive-dosing controller (#391 S2). Parsed and validated here;
+    // compiled to a controller and run by the adaptive simulate path in a later slice.
+    let adaptive_dosing = blocks
+        .get("adaptive_dosing")
+        .map(|lines| parse_adaptive_dosing_block(lines))
+        .transpose()?;
     let mut fit_options = if let Some(lines) = blocks.get("fit_options") {
         parse_fit_options(lines)?
     } else {
@@ -2457,6 +2466,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     Ok(ParsedModel {
         model,
         simulation,
+        adaptive_dosing,
         fit_options,
         covariate_decls,
         block_lines: extracted.block_lines.clone(),
@@ -3815,6 +3825,450 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
         horizon,
         covariates: vec![],
     })
+}
+
+// ── [adaptive_dosing] block parser (#391 S2.1) ──────────────────────────────
+
+/// Parse a declarative `[adaptive_dosing]` block into an [`AdaptiveDosingSpec`]
+/// (#391 S2).
+///
+/// Pure syntax: every malformed, unknown, or ambiguous construct is a typed error
+/// with no silent default (mirroring the strict `[simulation]` / `[fit_options]`
+/// parsers). No controller is built and the `observe` expression is **not**
+/// compiled here — that, and resolving which endpoint a bare `observe` maps to,
+/// is the S2.2 step. The one ambiguity this parser *can* settle without the model
+/// — `with_assay_error` on an expression `observe` with no designated endpoint —
+/// is rejected here rather than left to guess a σ downstream.
+fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, String> {
+    let mut observe: Option<String> = None;
+    let mut with_assay_error = false;
+    let mut assay_cmt: Option<usize> = None;
+    let mut at: Option<Vec<f64>> = None;
+    let mut start_dose: Option<f64> = None;
+    let mut route: Option<AdaptiveRoute> = None;
+    let mut dose_bounds: Option<(f64, f64)> = None;
+    let mut confirm: u32 = 1;
+    let mut levels: Option<Vec<f64>> = None;
+    let mut rules: Vec<AdaptiveRule> = Vec::new();
+
+    for line in lines {
+        let line = line.trim();
+        // Rule lines (`when …`) carry no top-level `=`; everything else is `key = value`.
+        if let Some(rest) = line.strip_prefix("when ") {
+            rules.push(parse_adaptive_rule(rest)?);
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '=').map(|s| s.trim()).collect();
+        if parts.len() != 2 {
+            return Err(format!(
+                "[adaptive_dosing]: malformed line (expected `key = value` or `when …`): {line}"
+            ));
+        }
+        let (key, val) = (parts[0], parts[1]);
+        match key {
+            "observe" => {
+                if val.is_empty() {
+                    return Err("[adaptive_dosing]: `observe` requires an expression".to_string());
+                }
+                observe = Some(val.to_string());
+            }
+            "with_assay_error" => {
+                with_assay_error = match val {
+                    "true" => true,
+                    "false" => false,
+                    other => {
+                        return Err(format!(
+                            "[adaptive_dosing]: with_assay_error must be `true` or `false`, got `{other}`"
+                        ))
+                    }
+                };
+            }
+            "assay_cmt" => {
+                let c: usize = val.parse().map_err(|_| {
+                    format!("[adaptive_dosing]: bad assay_cmt (expected a positive integer): {val}")
+                })?;
+                if c == 0 {
+                    return Err(
+                        "[adaptive_dosing]: assay_cmt is 1-based and must be >= 1".to_string()
+                    );
+                }
+                assay_cmt = Some(c);
+            }
+            "at" => at = Some(parse_decision_schedule(val)?),
+            "start_dose" => {
+                let d: f64 = val
+                    .parse()
+                    .map_err(|_| format!("[adaptive_dosing]: bad start_dose: {val}"))?;
+                if !d.is_finite() || d < 0.0 {
+                    return Err(format!(
+                        "[adaptive_dosing]: start_dose must be finite and >= 0: {val}"
+                    ));
+                }
+                start_dose = Some(d);
+            }
+            "route" => route = Some(parse_adaptive_route(val)?),
+            "dose_bounds" => {
+                let b = parse_float_array(val)
+                    .map_err(|e| format!("[adaptive_dosing]: bad dose_bounds: {e}"))?;
+                if b.len() != 2 {
+                    return Err(format!(
+                        "[adaptive_dosing]: dose_bounds must be `[low, high]`: {val}"
+                    ));
+                }
+                let (lo, hi) = (b[0], b[1]);
+                if !lo.is_finite() || !hi.is_finite() || lo < 0.0 || hi < lo {
+                    return Err(format!(
+                        "[adaptive_dosing]: dose_bounds must be finite with 0 <= low <= high: {val}"
+                    ));
+                }
+                dose_bounds = Some((lo, hi));
+            }
+            "confirm" => {
+                let n: u32 = val.parse().map_err(|_| {
+                    format!("[adaptive_dosing]: bad confirm (expected a positive integer): {val}")
+                })?;
+                if n == 0 {
+                    return Err(
+                        "[adaptive_dosing]: confirm must be >= 1 (1 acts on the first breach)"
+                            .to_string(),
+                    );
+                }
+                confirm = n;
+            }
+            "levels" => {
+                let l = parse_float_array(val)
+                    .map_err(|e| format!("[adaptive_dosing]: bad levels: {e}"))?;
+                if l.is_empty() {
+                    return Err("[adaptive_dosing]: levels must be a non-empty list".to_string());
+                }
+                if !l.iter().all(|x| x.is_finite()) {
+                    return Err(format!(
+                        "[adaptive_dosing]: levels must all be finite: {val}"
+                    ));
+                }
+                if l.windows(2).any(|w| w[1] <= w[0]) {
+                    return Err(format!(
+                        "[adaptive_dosing]: levels must be strictly increasing: {val}"
+                    ));
+                }
+                levels = Some(l);
+            }
+            other => return Err(format!("[adaptive_dosing]: unknown key `{other}`")),
+        }
+    }
+
+    // ── Required keys ──
+    let observe = observe.ok_or("[adaptive_dosing]: missing required `observe`")?;
+    let at = at.ok_or("[adaptive_dosing]: missing required `at` (decision schedule)")?;
+    let start_dose = start_dose.ok_or("[adaptive_dosing]: missing required `start_dose`")?;
+    let route = route.ok_or("[adaptive_dosing]: missing required `route`")?;
+    let dose_bounds = dose_bounds.ok_or("[adaptive_dosing]: missing required `dose_bounds`")?;
+    if rules.is_empty() {
+        return Err("[adaptive_dosing]: at least one `when … : …` rule is required".to_string());
+    }
+
+    // ── Cross-field invariants (no happy paths) ──
+    if start_dose < dose_bounds.0 || start_dose > dose_bounds.1 {
+        return Err(format!(
+            "[adaptive_dosing]: start_dose {start_dose} is outside dose_bounds [{}, {}]",
+            dose_bounds.0, dose_bounds.1
+        ));
+    }
+    if assay_cmt.is_some() && !with_assay_error {
+        return Err("[adaptive_dosing]: assay_cmt is set but with_assay_error = false".to_string());
+    }
+    // The load-bearing S2 fork: assay noise on an *expression* observe is
+    // ambiguous (which endpoint's σ?). A bare endpoint can be resolved against the
+    // model in S2.2; an expression cannot, so it must designate `assay_cmt` — else
+    // a typed error, never a guessed σ.
+    if with_assay_error && assay_cmt.is_none() && observe.chars().any(|c| "+-*/() ".contains(c)) {
+        return Err(format!(
+            "[adaptive_dosing]: with_assay_error on an expression observe (`{observe}`) is \
+             ambiguous — which endpoint's residual error applies? Designate it with `assay_cmt = N`."
+        ));
+    }
+
+    // Percentage vs one-level dose steps are mutually exclusive and tied to `levels`.
+    let has_percent = rules.iter().any(|r| {
+        matches!(
+            r.action,
+            AdaptiveAction::Increase(DoseStep::Percent(_))
+                | AdaptiveAction::Decrease(DoseStep::Percent(_))
+        )
+    });
+    let has_level = rules.iter().any(|r| {
+        matches!(
+            r.action,
+            AdaptiveAction::Increase(DoseStep::Level) | AdaptiveAction::Decrease(DoseStep::Level)
+        )
+    });
+    match &levels {
+        Some(l) => {
+            if has_percent {
+                return Err("[adaptive_dosing]: percentage actions (`increase N%`) are not \
+                            allowed with `levels`; use bare `increase`/`decrease` to step one level"
+                    .to_string());
+            }
+            if !l.contains(&start_dose) {
+                return Err(format!(
+                    "[adaptive_dosing]: start_dose {start_dose} must be one of the declared levels {l:?}"
+                ));
+            }
+        }
+        None => {
+            if has_level {
+                return Err(
+                    "[adaptive_dosing]: bare `increase`/`decrease` (a level step) requires \
+                            a `levels = [...]` ladder; use `increase N%` for continuous titration"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    Ok(AdaptiveDosingSpec {
+        observe,
+        with_assay_error,
+        assay_cmt,
+        at,
+        start_dose,
+        route,
+        dose_bounds,
+        confirm,
+        levels,
+        rules,
+    })
+}
+
+/// Parse an `at =` decision schedule: either an explicit list `[t1, t2, …]` or an
+/// arithmetic sequence `every <Δ> from <t0> to <t1>` (inclusive), expanded to
+/// explicit times. The `to` bound is required (an open-ended schedule has no
+/// finite decision list); times must be finite and strictly increasing.
+fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
+    let v = val.trim();
+    if v.starts_with('[') {
+        let times = parse_float_array(v).map_err(|e| format!("[adaptive_dosing]: bad at: {e}"))?;
+        if times.is_empty() {
+            return Err("[adaptive_dosing]: `at` schedule is empty".to_string());
+        }
+        if !times.iter().all(|t| t.is_finite()) {
+            return Err(format!(
+                "[adaptive_dosing]: `at` times must be finite: {val}"
+            ));
+        }
+        if times.windows(2).any(|w| w[1] <= w[0]) {
+            return Err(format!(
+                "[adaptive_dosing]: `at` times must be strictly increasing: {val}"
+            ));
+        }
+        return Ok(times);
+    }
+    let toks: Vec<&str> = v.split_whitespace().collect();
+    if toks.len() != 6 || toks[0] != "every" || toks[2] != "from" || toks[4] != "to" {
+        return Err(format!(
+            "[adaptive_dosing]: `at` must be a list `[t1, t2, …]` or \
+             `every <Δ> from <t0> to <t1>`: {val}"
+        ));
+    }
+    let step: f64 = toks[1]
+        .parse()
+        .map_err(|_| format!("[adaptive_dosing]: bad `at` interval: {}", toks[1]))?;
+    let t0: f64 = toks[3]
+        .parse()
+        .map_err(|_| format!("[adaptive_dosing]: bad `at` start: {}", toks[3]))?;
+    let t1: f64 = toks[5]
+        .parse()
+        .map_err(|_| format!("[adaptive_dosing]: bad `at` end: {}", toks[5]))?;
+    if !step.is_finite() || step <= 0.0 {
+        return Err(format!(
+            "[adaptive_dosing]: `at` interval must be finite and > 0: {}",
+            toks[1]
+        ));
+    }
+    if !t0.is_finite() || !t1.is_finite() || t1 < t0 {
+        return Err(format!(
+            "[adaptive_dosing]: `at` range must be finite with start <= end: {val}"
+        ));
+    }
+    let n_f = ((t1 - t0) / step).floor();
+    if n_f > 100_000.0 {
+        return Err(
+            "[adaptive_dosing]: `at` schedule expands to too many decision times (> 100000)"
+                .to_string(),
+        );
+    }
+    let n = n_f as usize;
+    // Index-based expansion (t0 + i·Δ) avoids accumulating floating-point drift.
+    let times: Vec<f64> = (0..=n).map(|i| t0 + i as f64 * step).collect();
+    Ok(times)
+}
+
+/// Parse a `route =` value: `bolus(cmt = N)` or `infuse(cmt = N, over = T)`.
+fn parse_adaptive_route(val: &str) -> Result<AdaptiveRoute, String> {
+    let v = val.trim();
+    let (kind, args) = v
+        .strip_suffix(')')
+        .and_then(|s| s.split_once('('))
+        .ok_or_else(|| {
+            format!(
+                "[adaptive_dosing]: route must be `bolus(cmt=N)` or `infuse(cmt=N, over=T)`: {val}"
+            )
+        })?;
+    let mut cmt: Option<usize> = None;
+    let mut over: Option<f64> = None;
+    for arg in args.split(',') {
+        let arg = arg.trim();
+        if arg.is_empty() {
+            continue;
+        }
+        let (k, x) = arg.split_once('=').ok_or_else(|| {
+            format!("[adaptive_dosing]: bad route argument `{arg}` (expected key = value)")
+        })?;
+        match (k.trim(), x.trim()) {
+            ("cmt", x) => {
+                let c: usize = x
+                    .parse()
+                    .map_err(|_| format!("[adaptive_dosing]: bad route cmt: {x}"))?;
+                if c == 0 {
+                    return Err(
+                        "[adaptive_dosing]: route cmt is 1-based and must be >= 1".to_string()
+                    );
+                }
+                cmt = Some(c);
+            }
+            ("over", x) => {
+                let t: f64 = x
+                    .parse()
+                    .map_err(|_| format!("[adaptive_dosing]: bad route over: {x}"))?;
+                if !t.is_finite() || t <= 0.0 {
+                    return Err(format!(
+                        "[adaptive_dosing]: route over (infusion duration) must be finite and > 0: {x}"
+                    ));
+                }
+                over = Some(t);
+            }
+            (other, _) => {
+                return Err(format!(
+                    "[adaptive_dosing]: unknown route argument `{other}`"
+                ))
+            }
+        }
+    }
+    let cmt = cmt.ok_or_else(|| {
+        format!(
+            "[adaptive_dosing]: route `{}` requires cmt = N",
+            kind.trim()
+        )
+    })?;
+    match kind.trim() {
+        "bolus" => {
+            if over.is_some() {
+                return Err(
+                    "[adaptive_dosing]: bolus route does not take `over` (use infuse)".to_string(),
+                );
+            }
+            Ok(AdaptiveRoute::Bolus { cmt })
+        }
+        "infuse" => {
+            let over = over
+                .ok_or("[adaptive_dosing]: infuse route requires over = T (infusion duration)")?;
+            Ok(AdaptiveRoute::Infuse { cmt, over })
+        }
+        other => Err(format!(
+            "[adaptive_dosing]: unknown route `{other}` (expected bolus or infuse)"
+        )),
+    }
+}
+
+/// Parse the body of a `when …` rule line (everything after `when `):
+/// `<signal-condition> : <action>`.
+fn parse_adaptive_rule(rest: &str) -> Result<AdaptiveRule, String> {
+    let (cond, action) = rest.split_once(':').ok_or_else(|| {
+        format!(
+            "[adaptive_dosing]: rule must be `when <signal> <op> <value> : <action>`: when {rest}"
+        )
+    })?;
+    let (op, threshold) = parse_signal_condition(cond.trim())?;
+    let action = parse_rule_action(action.trim())?;
+    Ok(AdaptiveRule {
+        op,
+        threshold,
+        action,
+    })
+}
+
+/// Parse `signal <op> <value>` where `<op>` is one of `< <= > >= ==`.
+fn parse_signal_condition(cond: &str) -> Result<(Comparison, f64), String> {
+    let rest = cond.trim().strip_prefix("signal").ok_or_else(|| {
+        format!("[adaptive_dosing]: rule condition must compare `signal`: {cond}")
+    })?;
+    let rest = rest.trim_start();
+    // Two-character operators first so `<=`/`>=` aren't read as `<`/`>`.
+    let (op, num) = if let Some(r) = rest.strip_prefix("<=") {
+        (Comparison::Le, r)
+    } else if let Some(r) = rest.strip_prefix(">=") {
+        (Comparison::Ge, r)
+    } else if let Some(r) = rest.strip_prefix("==") {
+        (Comparison::Eq, r)
+    } else if let Some(r) = rest.strip_prefix('<') {
+        (Comparison::Lt, r)
+    } else if let Some(r) = rest.strip_prefix('>') {
+        (Comparison::Gt, r)
+    } else {
+        return Err(format!(
+            "[adaptive_dosing]: rule needs a comparison operator (< <= > >= ==): {cond}"
+        ));
+    };
+    let threshold: f64 = num
+        .trim()
+        .parse()
+        .map_err(|_| format!("[adaptive_dosing]: bad rule threshold: {}", num.trim()))?;
+    if !threshold.is_finite() {
+        return Err(format!(
+            "[adaptive_dosing]: rule threshold must be finite: {cond}"
+        ));
+    }
+    Ok((op, threshold))
+}
+
+/// Parse a rule action: `increase N%` / `decrease N%` (continuous), bare
+/// `increase` / `decrease` (one discrete level), `hold`, or `stop`.
+fn parse_rule_action(action: &str) -> Result<AdaptiveAction, String> {
+    let a = action.trim();
+    match a {
+        "hold" => return Ok(AdaptiveAction::Hold),
+        "stop" => return Ok(AdaptiveAction::Stop),
+        "" => return Err("[adaptive_dosing]: rule has no action after `:`".to_string()),
+        _ => {}
+    }
+    let (verb, operand) = match a.split_once(char::is_whitespace) {
+        Some((v, o)) => (v, o.trim()),
+        None => (a, ""),
+    };
+    let step = if operand.is_empty() {
+        DoseStep::Level
+    } else {
+        let pct = operand.strip_suffix('%').ok_or_else(|| {
+            format!("[adaptive_dosing]: dose change must be a percentage like `25%` (or bare for a level step): {action}")
+        })?;
+        let p: f64 = pct
+            .trim()
+            .parse()
+            .map_err(|_| format!("[adaptive_dosing]: bad percentage in action: {action}"))?;
+        if !p.is_finite() || p < 0.0 {
+            return Err(format!(
+                "[adaptive_dosing]: percentage must be finite and >= 0: {action}"
+            ));
+        }
+        DoseStep::Percent(p)
+    };
+    match verb {
+        "increase" => Ok(AdaptiveAction::Increase(step)),
+        "decrease" => Ok(AdaptiveAction::Decrease(step)),
+        other => Err(format!(
+            "[adaptive_dosing]: unknown action `{other}` (expected increase/decrease/hold/stop): {action}"
+        )),
+    }
 }
 
 // ── [fit_options] block parser ──────────────────────────────────────────────
@@ -24052,5 +24506,462 @@ CL V KA WT
             err.starts_with("[simulation]:") && err.contains("horizon"),
             "got: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod adaptive_dosing_tests {
+    use super::*;
+
+    fn lines(body: &[&str]) -> Vec<String> {
+        body.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A minimal block that parses — the base every "one thing wrong" error test
+    /// mutates. Continuous (percentage) titration, bare-endpoint observe.
+    fn valid_min() -> Vec<&'static str> {
+        vec![
+            "observe = central",
+            "at = [24, 48]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "when signal < 10 : increase 25%",
+        ]
+    }
+
+    /// `valid_min` with every line starting with `prefix` removed.
+    fn without(prefix: &str) -> Vec<String> {
+        valid_min()
+            .into_iter()
+            .filter(|l| !l.starts_with(prefix))
+            .map(String::from)
+            .collect()
+    }
+
+    fn perr(body: &[&str]) -> String {
+        parse_adaptive_dosing_block(&lines(body)).expect_err("expected a typed parse error")
+    }
+
+    // ── Happy paths ──
+
+    #[test]
+    fn full_continuous_block_parses() {
+        let spec = parse_adaptive_dosing_block(&lines(&[
+            "observe = central / V",
+            "at = every 24 from 24 to 96",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "confirm = 2",
+            "when signal < 10 : increase 25%",
+            "when signal > 20 : decrease 25%",
+            "when signal > 30 : hold",
+            "when signal > 40 : stop",
+        ]))
+        .expect("canonical block parses");
+        assert_eq!(spec.observe, "central / V");
+        assert!(!spec.with_assay_error);
+        assert_eq!(spec.assay_cmt, None);
+        assert_eq!(spec.at, vec![24.0, 48.0, 72.0, 96.0]);
+        assert_eq!(spec.start_dose, 100.0);
+        assert_eq!(spec.route, AdaptiveRoute::Bolus { cmt: 1 });
+        assert_eq!(spec.dose_bounds, (0.0, 400.0));
+        assert_eq!(spec.confirm, 2);
+        assert_eq!(spec.levels, None);
+        assert_eq!(spec.rules.len(), 4);
+        assert_eq!(
+            spec.rules[0],
+            AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 10.0,
+                action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            }
+        );
+        assert_eq!(
+            spec.rules[1].action,
+            AdaptiveAction::Decrease(DoseStep::Percent(25.0))
+        );
+        assert_eq!(spec.rules[1].op, Comparison::Gt);
+        assert_eq!(spec.rules[2].action, AdaptiveAction::Hold);
+        assert_eq!(spec.rules[3].action, AdaptiveAction::Stop);
+    }
+
+    #[test]
+    fn minimal_block_parses_with_defaults() {
+        let spec = parse_adaptive_dosing_block(&without("nothing")).expect("valid_min parses");
+        // Optional keys take their documented defaults.
+        assert_eq!(spec.confirm, 1);
+        assert!(!spec.with_assay_error);
+        assert_eq!(spec.assay_cmt, None);
+        assert_eq!(spec.levels, None);
+    }
+
+    #[test]
+    fn at_explicit_list_is_honored() {
+        let spec = parse_adaptive_dosing_block(&{
+            let mut b = without("at");
+            b.push("at = [24, 48, 72]".into());
+            b
+        })
+        .expect("explicit at list parses");
+        assert_eq!(spec.at, vec![24.0, 48.0, 72.0]);
+    }
+
+    #[test]
+    fn at_every_from_to_expands_inclusive() {
+        let spec = parse_adaptive_dosing_block(&{
+            let mut b = without("at");
+            b.push("at = every 12 from 12 to 48".into());
+            b
+        })
+        .expect("every-from-to parses");
+        assert_eq!(spec.at, vec![12.0, 24.0, 36.0, 48.0]);
+    }
+
+    #[test]
+    fn all_comparison_operators_parse() {
+        let spec = parse_adaptive_dosing_block(&lines(&[
+            "observe = central",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "when signal < 1 : hold",
+            "when signal <= 2 : hold",
+            "when signal > 3 : hold",
+            "when signal >= 4 : hold",
+            "when signal == 5 : hold",
+        ]))
+        .expect("all operators parse");
+        let ops: Vec<Comparison> = spec.rules.iter().map(|r| r.op).collect();
+        assert_eq!(
+            ops,
+            vec![
+                Comparison::Lt,
+                Comparison::Le,
+                Comparison::Gt,
+                Comparison::Ge,
+                Comparison::Eq,
+            ]
+        );
+    }
+
+    #[test]
+    fn discrete_levels_block_parses() {
+        let spec = parse_adaptive_dosing_block(&lines(&[
+            "observe = neutrophils",
+            "at = [24, 48]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 200]",
+            "levels = [50, 100, 150, 200]",
+            "when signal < 1 : increase",
+            "when signal > 3 : decrease",
+        ]))
+        .expect("discrete levels block parses");
+        assert_eq!(spec.levels, Some(vec![50.0, 100.0, 150.0, 200.0]));
+        assert_eq!(
+            spec.rules[0].action,
+            AdaptiveAction::Increase(DoseStep::Level)
+        );
+        assert_eq!(
+            spec.rules[1].action,
+            AdaptiveAction::Decrease(DoseStep::Level)
+        );
+    }
+
+    #[test]
+    fn infuse_route_parses() {
+        let spec = parse_adaptive_dosing_block(&{
+            let mut b = without("route");
+            b.push("route = infuse(cmt = 2, over = 1.5)".into());
+            b
+        })
+        .expect("infuse route parses");
+        assert_eq!(spec.route, AdaptiveRoute::Infuse { cmt: 2, over: 1.5 });
+    }
+
+    #[test]
+    fn assay_error_on_bare_endpoint_with_cmt_parses() {
+        let spec = parse_adaptive_dosing_block(&lines(&[
+            "observe = central",
+            "with_assay_error = true",
+            "assay_cmt = 2",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "when signal < 10 : increase 25%",
+        ]))
+        .expect("assay error with designated endpoint parses");
+        assert!(spec.with_assay_error);
+        assert_eq!(spec.assay_cmt, Some(2));
+    }
+
+    // ── Typed-error matrix (no happy paths) ──
+
+    fn assert_adaptive_err(err: &str, needle: &str) {
+        assert!(
+            err.starts_with("[adaptive_dosing]:") && err.contains(needle),
+            "expected an [adaptive_dosing] error containing {needle:?}, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_key_errors() {
+        assert_adaptive_err(&perr(&["foo = 1"]), "unknown key");
+    }
+
+    #[test]
+    fn malformed_line_errors() {
+        assert_adaptive_err(&perr(&["this is not a key value pair"]), "malformed line");
+    }
+
+    #[test]
+    fn missing_required_keys_error() {
+        for (prefix, needle) in [
+            ("observe", "missing required `observe`"),
+            ("at", "missing required `at`"),
+            ("start_dose", "missing required `start_dose`"),
+            ("route", "missing required `route`"),
+            ("dose_bounds", "missing required `dose_bounds`"),
+        ] {
+            let err = parse_adaptive_dosing_block(&without(prefix)).unwrap_err();
+            assert_adaptive_err(&err, needle);
+        }
+    }
+
+    #[test]
+    fn no_rules_errors() {
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&without("when")).unwrap_err(),
+            "rule",
+        );
+    }
+
+    #[test]
+    fn dose_bounds_problems_error() {
+        let mk = |bounds: &str| {
+            let mut b = without("dose_bounds");
+            b.push(format!("dose_bounds = {bounds}"));
+            parse_adaptive_dosing_block(&b).unwrap_err()
+        };
+        assert_adaptive_err(&mk("[400, 0]"), "0 <= low <= high"); // inverted
+        assert_adaptive_err(&mk("[-1, 400]"), "0 <= low <= high"); // negative low
+        assert_adaptive_err(&mk("[0, 100, 200]"), "[low, high]"); // wrong length
+    }
+
+    #[test]
+    fn start_dose_outside_bounds_errors() {
+        let mut b = without("start_dose");
+        b.push("start_dose = 500".into()); // bounds are [0, 400]
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "outside dose_bounds",
+        );
+    }
+
+    #[test]
+    fn confirm_zero_errors() {
+        let mut b = without("nothing");
+        b.push("confirm = 0".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "confirm must be >= 1",
+        );
+    }
+
+    #[test]
+    fn assay_error_on_expression_without_cmt_is_ambiguous() {
+        let err = perr(&[
+            "observe = central / V",
+            "with_assay_error = true",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "when signal < 10 : increase 25%",
+        ]);
+        assert_adaptive_err(&err, "ambiguous");
+    }
+
+    #[test]
+    fn assay_cmt_without_assay_error_errors() {
+        let mut b = without("nothing");
+        b.push("assay_cmt = 2".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "with_assay_error = false",
+        );
+    }
+
+    #[test]
+    fn mixed_percent_and_levels_errors() {
+        let err = perr(&[
+            "observe = central",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 200]",
+            "levels = [50, 100, 150]",
+            "when signal < 10 : increase 25%", // percentage with levels declared
+        ]);
+        assert_adaptive_err(&err, "not");
+    }
+
+    #[test]
+    fn bare_level_step_without_levels_errors() {
+        let err = perr(&[
+            "observe = central",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 400]",
+            "when signal < 10 : increase", // level step, no levels ladder
+        ]);
+        assert_adaptive_err(&err, "requires a `levels");
+    }
+
+    #[test]
+    fn start_dose_not_a_level_errors() {
+        let err = perr(&[
+            "observe = central",
+            "at = [24]",
+            "start_dose = 120",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 200]",
+            "levels = [50, 100, 150, 200]",
+            "when signal < 10 : increase",
+        ]);
+        assert_adaptive_err(&err, "one of the declared levels");
+    }
+
+    #[test]
+    fn levels_not_strictly_increasing_errors() {
+        let mut b = without("nothing");
+        b.push("levels = [50, 50, 100]".into());
+        b.push("when signal < 10 : increase".into()); // make it a level block
+                                                      // valid_min already has a percentage rule; drop it so only level steps remain.
+        let b: Vec<String> = b.into_iter().filter(|l| !l.contains("25%")).collect();
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "strictly increasing",
+        );
+    }
+
+    #[test]
+    fn rule_condition_must_compare_signal() {
+        let mut b = without("when");
+        b.push("when conc < 10 : hold".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "compare `signal`",
+        );
+    }
+
+    #[test]
+    fn rule_missing_operator_errors() {
+        let mut b = without("when");
+        b.push("when signal 10 : hold".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "comparison operator",
+        );
+    }
+
+    #[test]
+    fn rule_missing_action_colon_errors() {
+        let mut b = without("when");
+        b.push("when signal < 10".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "when <signal>",
+        );
+    }
+
+    #[test]
+    fn unknown_action_errors() {
+        let mut b = without("when");
+        b.push("when signal < 10 : obliterate".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&b).unwrap_err(),
+            "unknown action",
+        );
+    }
+
+    #[test]
+    fn percentage_missing_percent_sign_errors() {
+        let mut b = without("when");
+        b.push("when signal < 10 : increase 25".into()); // no % and not bare → not a level
+                                                         // `increase 25` has an operand `25` that is not a percentage.
+        assert_adaptive_err(&parse_adaptive_dosing_block(&b).unwrap_err(), "percentage");
+    }
+
+    #[test]
+    fn route_problems_error() {
+        let mk = |route: &str| {
+            let mut b = without("route");
+            b.push(format!("route = {route}"));
+            parse_adaptive_dosing_block(&b).unwrap_err()
+        };
+        assert_adaptive_err(&mk("squirt(cmt = 1)"), "unknown route");
+        assert_adaptive_err(&mk("bolus(cmt = 1, over = 2)"), "bolus route does not take");
+        assert_adaptive_err(&mk("infuse(cmt = 1)"), "infuse route requires over");
+        assert_adaptive_err(&mk("bolus()"), "requires cmt");
+        assert_adaptive_err(&mk("bolus(cmt = 0)"), "1-based");
+        assert_adaptive_err(&mk("bolus(cmt = 1, dose = 5)"), "unknown route argument");
+        assert_adaptive_err(&mk("bolus cmt 1"), "bolus(cmt=N)");
+    }
+
+    #[test]
+    fn at_problems_error() {
+        let mk = |at: &str| {
+            let mut b = without("at");
+            b.push(format!("at = {at}"));
+            parse_adaptive_dosing_block(&b).unwrap_err()
+        };
+        assert_adaptive_err(&mk("every 24 from 24"), "every <"); // missing `to`
+        assert_adaptive_err(&mk("[48, 24]"), "strictly increasing"); // out of order
+        assert_adaptive_err(
+            &mk("every 0 from 24 to 96"),
+            "interval must be finite and > 0",
+        );
+    }
+
+    // ── End-to-end wiring: the block reaches ParsedModel ──
+
+    const MODEL_HEAD: &str = r#"
+[parameters]
+  theta TVCL(0.2)
+  theta TVV(10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    #[test]
+    fn parsed_model_carries_adaptive_dosing_block() {
+        let with_block = format!(
+            "{MODEL_HEAD}\n[adaptive_dosing]\n  observe = central / V\n  at = every 24 from 24 to 96\n  start_dose = 100\n  route = bolus(cmt = 1)\n  dose_bounds = [0, 400]\n  when signal < 10 : increase 25%\n"
+        );
+        let parsed = parse_full_model(&with_block).expect("model with [adaptive_dosing] parses");
+        let spec = parsed
+            .adaptive_dosing
+            .expect("the block must attach to ParsedModel");
+        assert_eq!(spec.start_dose, 100.0);
+        assert_eq!(spec.at.len(), 4);
+    }
+
+    #[test]
+    fn parsed_model_without_block_is_none() {
+        let parsed = parse_full_model(MODEL_HEAD).expect("plain model parses");
+        assert!(parsed.adaptive_dosing.is_none());
     }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3946,7 +3946,9 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     }
 
     // ── Required keys ──
-    let observe = observe.ok_or("[adaptive_dosing]: missing required `observe`")?;
+    // `observe` is *conditionally* required (a latent signal needs it; an
+    // assay-noised signal uses the model output instead) — `validate()` enforces
+    // the `observe` xor `with_assay_error` rule, so it stays an `Option` here.
     let at = at.ok_or("[adaptive_dosing]: missing required `at` (decision schedule)")?;
     let start_dose = start_dose.ok_or("[adaptive_dosing]: missing required `start_dose`")?;
     let route = route.ok_or("[adaptive_dosing]: missing required `route`")?;
@@ -24520,7 +24522,7 @@ mod adaptive_dosing_tests {
             "when signal > 40 : stop",
         ]))
         .expect("canonical block parses");
-        assert_eq!(spec.observe, "central / V");
+        assert_eq!(spec.observe.as_deref(), Some("central / V"));
         assert!(!spec.with_assay_error);
         assert_eq!(spec.assay_cmt, None);
         assert_eq!(spec.at, vec![24.0, 48.0, 72.0, 96.0]);
@@ -24643,9 +24645,10 @@ mod adaptive_dosing_tests {
     }
 
     #[test]
-    fn assay_error_on_bare_endpoint_with_cmt_parses() {
+    fn assay_error_names_output_parses() {
+        // With assay error the signal is the noised model output named by
+        // `assay_cmt` — there is no `observe` expression to re-type.
         let spec = parse_adaptive_dosing_block(&lines(&[
-            "observe = central",
             "with_assay_error = true",
             "assay_cmt = 2",
             "at = [24]",
@@ -24654,9 +24657,10 @@ mod adaptive_dosing_tests {
             "dose_bounds = [0, 400]",
             "when signal < 10 : increase 25%",
         ]))
-        .expect("assay error with designated endpoint parses");
+        .expect("assay error naming the output parses");
         assert!(spec.with_assay_error);
         assert_eq!(spec.assay_cmt, Some(2));
+        assert_eq!(spec.observe, None);
     }
 
     // ── Typed-error matrix (no happy paths) ──
@@ -24680,8 +24684,9 @@ mod adaptive_dosing_tests {
 
     #[test]
     fn missing_required_keys_error() {
+        // `observe` is conditionally required (it is the latent signal), so it is
+        // covered by the signal-source matrix below, not here.
         for (prefix, needle) in [
-            ("observe", "missing required `observe`"),
             ("at", "missing required `at`"),
             ("start_dose", "missing required `start_dose`"),
             ("route", "missing required `route`"),
@@ -24690,6 +24695,30 @@ mod adaptive_dosing_tests {
             let err = parse_adaptive_dosing_block(&without(prefix)).unwrap_err();
             assert_adaptive_err(&err, needle);
         }
+    }
+
+    #[test]
+    fn signal_source_matrix_errors() {
+        // No signal (drop `observe`, no assay error).
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&without("observe")).unwrap_err(),
+            "a signal is required",
+        );
+        // Both an observe expression and assay error.
+        let mut both = without("nothing"); // full valid block (observe present)…
+        both.push("with_assay_error = true".into());
+        both.push("assay_cmt = 1".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&both).unwrap_err(),
+            "remove `observe`",
+        );
+        // Assay error without naming the measured output.
+        let mut no_cmt = without("observe");
+        no_cmt.push("with_assay_error = true".into());
+        assert_adaptive_err(
+            &parse_adaptive_dosing_block(&no_cmt).unwrap_err(),
+            "requires `assay_cmt",
+        );
     }
 
     #[test]
@@ -24790,20 +24819,6 @@ mod adaptive_dosing_tests {
             &parse_adaptive_dosing_block(&b).unwrap_err(),
             "confirm must be >= 1",
         );
-    }
-
-    #[test]
-    fn assay_error_on_expression_without_cmt_is_ambiguous() {
-        let err = perr(&[
-            "observe = central / V",
-            "with_assay_error = true",
-            "at = [24]",
-            "start_dose = 100",
-            "route = bolus(cmt = 1)",
-            "dose_bounds = [0, 400]",
-            "when signal < 10 : increase 25%",
-        ]);
-        assert_adaptive_err(&err, "ambiguous");
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -5213,8 +5213,10 @@ fn parse_initial_conditions_block(
 
 /// Build an `OdeOutputFn` from one `y[…] = value` line. Shared between
 /// the uniform and per-CMT paths.
-fn build_y_output_fn(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_y_output_fn(
     value: &str,
+    context: &str,
     theta_names: &[String],
     eta_names: &[String],
     indiv_var_names: &[String],
@@ -5231,7 +5233,7 @@ fn build_y_output_fn(
         }
     }
     let ctx = ParseCtx::new(theta_names, eta_names, &defined);
-    let expr = parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] y: {}", e))?;
+    let expr = parse_scalar_expression(value, ctx).map_err(|e| format!("{context}: {e}"))?;
 
     // Reject KAPPA_* (IOV) references in a Form C ODE output expression: the
     // readout is evaluated once per observation with a single eta, so under IOV
@@ -5243,7 +5245,7 @@ fn build_y_output_fn(
     // occasion-dependent structural parameter (e.g. CL) instead.
     if let Some(name) = expr_references_kappa(&expr, kappa_names) {
         return Err(format!(
-            "[scaling] y: Form C output expressions cannot reference the IOV \
+            "{context}: Form C output expressions cannot reference the IOV \
              parameter `{name}` — the ODE readout is evaluated per observation and \
              would see kappa = 0. Reference the occasion-dependent structural \
              parameter (e.g. CL) instead. See issue #107."
@@ -5532,6 +5534,7 @@ fn parse_scaling_block(
                 }
                 let (out_fn, out_program, cov_names) = build_y_output_fn(
                     value,
+                    "[scaling] y",
                     theta_names,
                     eta_names,
                     indiv_var_names,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3963,70 +3963,11 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     let start_dose = start_dose.ok_or("[adaptive_dosing]: missing required `start_dose`")?;
     let route = route.ok_or("[adaptive_dosing]: missing required `route`")?;
     let dose_bounds = dose_bounds.ok_or("[adaptive_dosing]: missing required `dose_bounds`")?;
-    if rules.is_empty() {
-        return Err("[adaptive_dosing]: at least one `when … : …` rule is required".to_string());
-    }
-
-    // ── Cross-field invariants (no happy paths) ──
-    if start_dose < dose_bounds.0 || start_dose > dose_bounds.1 {
-        return Err(format!(
-            "[adaptive_dosing]: start_dose {start_dose} is outside dose_bounds [{}, {}]",
-            dose_bounds.0, dose_bounds.1
-        ));
-    }
-    if assay_cmt.is_some() && !with_assay_error {
-        return Err("[adaptive_dosing]: assay_cmt is set but with_assay_error = false".to_string());
-    }
-    // The load-bearing S2 fork: assay noise on an *expression* observe is
-    // ambiguous (which endpoint's σ?). A bare endpoint can be resolved against the
-    // model in S2.2; an expression cannot, so it must designate `assay_cmt` — else
-    // a typed error, never a guessed σ.
-    if with_assay_error && assay_cmt.is_none() && observe.chars().any(|c| "+-*/() ".contains(c)) {
-        return Err(format!(
-            "[adaptive_dosing]: with_assay_error on an expression observe (`{observe}`) is \
-             ambiguous — which endpoint's residual error applies? Designate it with `assay_cmt = N`."
-        ));
-    }
-
-    // Percentage vs one-level dose steps are mutually exclusive and tied to `levels`.
-    let has_percent = rules.iter().any(|r| {
-        matches!(
-            r.action,
-            AdaptiveAction::Increase(DoseStep::Percent(_))
-                | AdaptiveAction::Decrease(DoseStep::Percent(_))
-        )
-    });
-    let has_level = rules.iter().any(|r| {
-        matches!(
-            r.action,
-            AdaptiveAction::Increase(DoseStep::Level) | AdaptiveAction::Decrease(DoseStep::Level)
-        )
-    });
-    match &levels {
-        Some(l) => {
-            if has_percent {
-                return Err("[adaptive_dosing]: percentage actions (`increase N%`) are not \
-                            allowed with `levels`; use bare `increase`/`decrease` to step one level"
-                    .to_string());
-            }
-            if !l.contains(&start_dose) {
-                return Err(format!(
-                    "[adaptive_dosing]: start_dose {start_dose} must be one of the declared levels {l:?}"
-                ));
-            }
-        }
-        None => {
-            if has_level {
-                return Err(
-                    "[adaptive_dosing]: bare `increase`/`decrease` (a level step) requires \
-                            a `levels = [...]` ladder; use `increase N%` for continuous titration"
-                        .to_string(),
-                );
-            }
-        }
-    }
-
-    Ok(AdaptiveDosingSpec {
+    // Assemble the spec, then enforce every cross-field invariant in one place
+    // (`AdaptiveDosingSpec::validate`). The same validator runs again in
+    // `compile_adaptive`, so a programmatically-built spec can never reach the
+    // controller with a contradiction the parser would have rejected here.
+    let spec = AdaptiveDosingSpec {
         observe,
         with_assay_error,
         assay_cmt,
@@ -4037,7 +3978,9 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
         confirm,
         levels,
         rules,
-    })
+    };
+    spec.validate()?;
+    Ok(spec)
 }
 
 /// Parse an `at =` decision schedule: either an explicit list `[t1, t2, …]` or an
@@ -4047,6 +3990,11 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
 fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
     let v = val.trim();
     if v.starts_with('[') {
+        if !v.ends_with(']') {
+            return Err(format!(
+                "[adaptive_dosing]: `at` list is missing its closing `]`: {val}"
+            ));
+        }
         let times = parse_float_array(v).map_err(|e| format!("[adaptive_dosing]: bad at: {e}"))?;
         if times.is_empty() {
             return Err("[adaptive_dosing]: `at` schedule is empty".to_string());
@@ -4060,6 +4008,11 @@ fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
             return Err(format!(
                 "[adaptive_dosing]: `at` times must be strictly increasing: {val}"
             ));
+        }
+        // Strictly increasing ⇒ the first element is the minimum; reject a
+        // negative decision time (start_dose / dose_bounds reject < 0 too).
+        if times[0] < 0.0 {
+            return Err(format!("[adaptive_dosing]: `at` times must be >= 0: {val}"));
         }
         return Ok(times);
     }
@@ -4085,12 +4038,15 @@ fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
             toks[1]
         ));
     }
-    if !t0.is_finite() || !t1.is_finite() || t1 < t0 {
+    if !t0.is_finite() || !t1.is_finite() || t1 < t0 || t0 < 0.0 {
         return Err(format!(
-            "[adaptive_dosing]: `at` range must be finite with start <= end: {val}"
+            "[adaptive_dosing]: `at` range must be finite with 0 <= start <= end: {val}"
         ));
     }
-    let n_f = ((t1 - t0) / step).floor();
+    // Relative tolerance so float division error (e.g. 1.0 / 0.1 = 9.999…8) does
+    // not drop the inclusive final time when `t1` is an exact multiple of `step`.
+    let ratio = (t1 - t0) / step;
+    let n_f = (ratio + 1e-9 * ratio.max(1.0)).floor();
     if n_f > 100_000.0 {
         return Err(
             "[adaptive_dosing]: `at` schedule expands to too many decision times (> 100000)"
@@ -24762,6 +24718,66 @@ mod adaptive_dosing_tests {
         assert_adaptive_err(
             &parse_adaptive_dosing_block(&b).unwrap_err(),
             "outside dose_bounds",
+        );
+    }
+
+    #[test]
+    fn levels_outside_dose_bounds_error() {
+        // start_dose is in both `levels` and `dose_bounds`, but a rung exceeds the
+        // high bound — `step_dose` would clamp the dose while the rung index keeps
+        // advancing, decoupling the decision log from the realized dose.
+        let err = parse_adaptive_dosing_block(&lines(&[
+            "observe = central",
+            "at = [24]",
+            "start_dose = 100",
+            "route = bolus(cmt = 1)",
+            "dose_bounds = [0, 120]",
+            "levels = [100, 150, 200]",
+            "when signal < 10 : increase",
+        ]))
+        .unwrap_err();
+        assert_adaptive_err(&err, "outside dose_bounds");
+    }
+
+    #[test]
+    fn schedule_negative_times_error() {
+        // `start_dose` / `dose_bounds` reject < 0; `at` must too, on both forms.
+        let mk = |at: &str| {
+            let mut b = without("at");
+            b.push(format!("at = {at}"));
+            parse_adaptive_dosing_block(&b).unwrap_err()
+        };
+        assert_adaptive_err(&mk("[-24, 0, 24]"), ">= 0");
+        assert_adaptive_err(&mk("every 24 from -24 to 24"), "0 <= start <= end");
+    }
+
+    #[test]
+    fn schedule_unclosed_bracket_errors() {
+        // `[24, 48` (no closing `]`) was silently accepted as [24, 48].
+        let mut b = without("at");
+        b.push("at = [24, 48".into());
+        assert_adaptive_err(&parse_adaptive_dosing_block(&b).unwrap_err(), "closing `]`");
+    }
+
+    #[test]
+    fn schedule_every_keeps_inclusive_endpoint_for_decimal_step() {
+        // 0.3 / 0.1 = 2.999…6 in f64; a bare floor() drops the inclusive endpoint.
+        let mk = |at: &str| {
+            let mut b = without("at");
+            b.push(format!("at = {at}"));
+            parse_adaptive_dosing_block(&b).expect("schedule parses").at
+        };
+        let decimal = mk("every 0.1 from 0 to 0.3");
+        assert_eq!(
+            decimal.len(),
+            4,
+            "expected the inclusive 0.3, got {decimal:?}"
+        );
+        assert!((decimal.last().unwrap() - 0.3).abs() < 1e-12);
+        // A non-multiple endpoint stays excluded (last point < t1, no spurious add).
+        assert_eq!(
+            mk("every 24 from 0 to 100"),
+            vec![0.0, 24.0, 48.0, 72.0, 96.0]
         );
     }
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3938,19 +3938,7 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
             "levels" => {
                 let l = parse_float_array(val)
                     .map_err(|e| format!("[adaptive_dosing]: bad levels: {e}"))?;
-                if l.is_empty() {
-                    return Err("[adaptive_dosing]: levels must be a non-empty list".to_string());
-                }
-                if !l.iter().all(|x| x.is_finite()) {
-                    return Err(format!(
-                        "[adaptive_dosing]: levels must all be finite: {val}"
-                    ));
-                }
-                if l.windows(2).any(|w| w[1] <= w[0]) {
-                    return Err(format!(
-                        "[adaptive_dosing]: levels must be strictly increasing: {val}"
-                    ));
-                }
+                validate_increasing_finite(&l, "levels")?;
                 levels = Some(l);
             }
             other => return Err(format!("[adaptive_dosing]: unknown key `{other}`")),
@@ -3983,6 +3971,27 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     Ok(spec)
 }
 
+/// Validate a `[adaptive_dosing]` float list is non-empty, all-finite, and
+/// strictly increasing — the shared contract of the `levels` ladder and an
+/// explicit `at` decision list, so the two can't drift apart. `what` names the
+/// list in the error (e.g. `"levels"`, `` "`at` times" ``).
+fn validate_increasing_finite(xs: &[f64], what: &str) -> Result<(), String> {
+    if xs.is_empty() {
+        return Err(format!(
+            "[adaptive_dosing]: {what} must be a non-empty list"
+        ));
+    }
+    if !xs.iter().all(|x| x.is_finite()) {
+        return Err(format!("[adaptive_dosing]: {what} must all be finite"));
+    }
+    if xs.windows(2).any(|w| w[1] <= w[0]) {
+        return Err(format!(
+            "[adaptive_dosing]: {what} must be strictly increasing"
+        ));
+    }
+    Ok(())
+}
+
 /// Parse an `at =` decision schedule: either an explicit list `[t1, t2, …]` or an
 /// arithmetic sequence `every <Δ> from <t0> to <t1>` (inclusive), expanded to
 /// explicit times. The `to` bound is required (an open-ended schedule has no
@@ -3996,19 +4005,7 @@ fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
             ));
         }
         let times = parse_float_array(v).map_err(|e| format!("[adaptive_dosing]: bad at: {e}"))?;
-        if times.is_empty() {
-            return Err("[adaptive_dosing]: `at` schedule is empty".to_string());
-        }
-        if !times.iter().all(|t| t.is_finite()) {
-            return Err(format!(
-                "[adaptive_dosing]: `at` times must be finite: {val}"
-            ));
-        }
-        if times.windows(2).any(|w| w[1] <= w[0]) {
-            return Err(format!(
-                "[adaptive_dosing]: `at` times must be strictly increasing: {val}"
-            ));
-        }
+        validate_increasing_finite(&times, "`at` times")?;
         // Strictly increasing ⇒ the first element is the minimum; reject a
         // negative decision time (start_dose / dose_bounds reject < 0 too).
         if times[0] < 0.0 {
@@ -4048,8 +4045,12 @@ fn parse_decision_schedule(val: &str) -> Result<Vec<f64>, String> {
     let ratio = (t1 - t0) / step;
     let n_f = (ratio + 1e-9 * ratio.max(1.0)).floor();
     if n_f > 100_000.0 {
+        // Hard parse-time expansion bound (avoids allocating a runaway `Vec` here);
+        // distinct from, and far above, the runtime `max_decisions` cap. Tighten the
+        // range or step rather than relying on either as a policy knob.
         return Err(
-            "[adaptive_dosing]: `at` schedule expands to too many decision times (> 100000)"
+            "[adaptive_dosing]: `at` schedule expands to too many decision times (> 100000); \
+             tighten the range or step"
                 .to_string(),
         );
     }

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -450,6 +450,112 @@ pub struct AdaptiveDosingSpec {
     pub rules: Vec<AdaptiveRule>,
 }
 
+impl AdaptiveDosingSpec {
+    /// Enforce every cross-field invariant the block parser checks, in one place.
+    ///
+    /// The struct is `pub` with `pub` fields, so a programmatically-built spec can
+    /// reach the controller without going through the parser. The parser calls
+    /// this on the spec it assembles, and
+    /// [`compile_adaptive`](crate::sim::adaptive_control::compile_adaptive) calls
+    /// it again as the safety net for hand-built specs — so neither path can drive
+    /// the controller with a contradiction (a `Level` step without a `levels`
+    /// ladder, a `start_dose` outside `dose_bounds`, a rung outside `dose_bounds`,
+    /// …) the other would have rejected.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.rules.is_empty() {
+            return Err(
+                "[adaptive_dosing]: at least one `when … : …` rule is required".to_string(),
+            );
+        }
+        let (lo, hi) = self.dose_bounds;
+        if !lo.is_finite() || !hi.is_finite() || lo < 0.0 || hi < lo {
+            return Err(format!(
+                "[adaptive_dosing]: dose_bounds must be finite with 0 <= low <= high: [{lo}, {hi}]"
+            ));
+        }
+        if !self.start_dose.is_finite() || self.start_dose < 0.0 {
+            return Err(format!(
+                "[adaptive_dosing]: start_dose must be finite and >= 0: {}",
+                self.start_dose
+            ));
+        }
+        if self.start_dose < lo || self.start_dose > hi {
+            return Err(format!(
+                "[adaptive_dosing]: start_dose {} is outside dose_bounds [{lo}, {hi}]",
+                self.start_dose
+            ));
+        }
+        if self.assay_cmt.is_some() && !self.with_assay_error {
+            return Err(
+                "[adaptive_dosing]: assay_cmt is set but with_assay_error = false".to_string(),
+            );
+        }
+        // The load-bearing S2 fork: assay noise on an *expression* observe is
+        // ambiguous (which endpoint's σ?). A bare endpoint can be resolved against
+        // the model in S2.2; an expression cannot, so it must designate `assay_cmt`
+        // — else a typed error, never a guessed σ.
+        if self.with_assay_error
+            && self.assay_cmt.is_none()
+            && self.observe.chars().any(|c| "+-*/() ".contains(c))
+        {
+            return Err(format!(
+                "[adaptive_dosing]: with_assay_error on an expression observe (`{}`) is \
+                 ambiguous — which endpoint's residual error applies? Designate it with `assay_cmt = N`.",
+                self.observe
+            ));
+        }
+
+        // Percentage vs one-level dose steps are mutually exclusive and tied to `levels`.
+        let has_percent = self.rules.iter().any(|r| {
+            matches!(
+                r.action,
+                AdaptiveAction::Increase(DoseStep::Percent(_))
+                    | AdaptiveAction::Decrease(DoseStep::Percent(_))
+            )
+        });
+        let has_level = self.rules.iter().any(|r| {
+            matches!(
+                r.action,
+                AdaptiveAction::Increase(DoseStep::Level)
+                    | AdaptiveAction::Decrease(DoseStep::Level)
+            )
+        });
+        match &self.levels {
+            Some(l) => {
+                if has_percent {
+                    return Err("[adaptive_dosing]: percentage actions (`increase N%`) are not \
+                                allowed with `levels`; use bare `increase`/`decrease` to step one level"
+                        .to_string());
+                }
+                if !l.contains(&self.start_dose) {
+                    return Err(format!(
+                        "[adaptive_dosing]: start_dose {} must be one of the declared levels {l:?}",
+                        self.start_dose
+                    ));
+                }
+                // Every rung must lie within `dose_bounds`; otherwise `step_dose`
+                // clamps the emitted dose while the rung index keeps advancing,
+                // decoupling the decision log from the realized dose.
+                if let Some(bad) = l.iter().find(|&&x| x < lo || x > hi) {
+                    return Err(format!(
+                        "[adaptive_dosing]: level {bad} is outside dose_bounds [{lo}, {hi}]"
+                    ));
+                }
+            }
+            None => {
+                if has_level {
+                    return Err(
+                        "[adaptive_dosing]: bare `increase`/`decrease` (a level step) requires \
+                                a `levels = [...]` ladder; use `increase N%` for continuous titration"
+                            .to_string(),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 /// How an adaptive dose is delivered.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AdaptiveRoute {
@@ -565,6 +671,65 @@ mod tests {
         assert_eq!(m.name, "ANC");
         assert_eq!(m.cmt, 3);
         assert_eq!(m.mode, ObserveMode::Dv);
+    }
+
+    fn base_spec() -> AdaptiveDosingSpec {
+        AdaptiveDosingSpec {
+            observe: "central".to_string(),
+            with_assay_error: false,
+            assay_cmt: None,
+            at: vec![24.0],
+            start_dose: 100.0,
+            route: AdaptiveRoute::Bolus { cmt: 1 },
+            dose_bounds: (0.0, 400.0),
+            confirm: 1,
+            levels: None,
+            rules: vec![AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 10.0,
+                action: AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            }],
+        }
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_spec() {
+        assert!(base_spec().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_programmatic_spec_violations() {
+        // The struct is `pub` with `pub` fields, so these never pass through the
+        // block parser — `validate` (called by `compile_adaptive`) is the guard.
+        let level_rule = || {
+            vec![AdaptiveRule {
+                op: Comparison::Lt,
+                threshold: 10.0,
+                action: AdaptiveAction::Increase(DoseStep::Level),
+            }]
+        };
+
+        // start_dose outside dose_bounds.
+        let mut s = base_spec();
+        s.start_dose = 500.0;
+        assert!(s.validate().unwrap_err().contains("outside dose_bounds"));
+
+        // no rules.
+        let mut s = base_spec();
+        s.rules.clear();
+        assert!(s.validate().unwrap_err().contains("rule"));
+
+        // a Level step with no `levels` ladder (a silent no-op in `step_dose`).
+        let mut s = base_spec();
+        s.rules = level_rule();
+        assert!(s.validate().unwrap_err().contains("levels"));
+
+        // a level rung outside dose_bounds.
+        let mut s = base_spec();
+        s.dose_bounds = (0.0, 120.0);
+        s.levels = Some(vec![100.0, 150.0]);
+        s.rules = level_rule();
+        assert!(s.validate().unwrap_err().contains("outside dose_bounds"));
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -148,6 +148,29 @@ impl MonitorSpec {
     }
 }
 
+/// A monitor paired with its optional compiled `observe` expression — the
+/// driver's per-signal input.
+///
+/// Pairing the expression *with* its [`MonitorSpec`] (rather than carrying a
+/// parallel `observe_exprs` slice the driver indexes by position) makes a
+/// monitor/expression desync unrepresentable. `observe == None` ⇒ read the
+/// model's `cmt` readout (the programmatic path); `Some(f)` ⇒ the declarative
+/// `[adaptive_dosing]` block's compiled signal expression (#391 S2).
+pub(crate) struct AdaptiveMonitor<'a> {
+    pub spec: &'a MonitorSpec,
+    pub observe: Option<&'a crate::ode::OdeOutputFn>,
+}
+
+/// What a controller returns at one decision: the dose [`DoseAction`]s to apply,
+/// plus optional provenance — the label of the declarative `when` rule that
+/// fired, so the dose ledger can record *why* a dose changed. `rule == None` for
+/// a programmatic controller or a no-rule re-issue (the driver then records the
+/// dose by its route), so the field never fabricates a rule that did not fire.
+pub(crate) struct ControllerDecision {
+    pub actions: Vec<DoseAction>,
+    pub rule: Option<String>,
+}
+
 /// The value a monitored signal actually presented to the controller at a
 /// decision, plus the mode it was resolved under — recorded on each
 /// [`DoseLedgerEntry`] so decision-audit replay (#391 Part E) can reproduce the
@@ -620,6 +643,47 @@ pub enum DoseStep {
     Percent(f64),
     /// Step one discrete level. Valid only when the block declares `levels`.
     Level,
+}
+
+impl Comparison {
+    /// The operator's source symbol, for rule labels / diagnostics.
+    fn symbol(self) -> &'static str {
+        match self {
+            Comparison::Lt => "<",
+            Comparison::Le => "<=",
+            Comparison::Gt => ">",
+            Comparison::Ge => ">=",
+            Comparison::Eq => "==",
+        }
+    }
+}
+
+impl AdaptiveAction {
+    /// The action's source-like label (`"increase 25%"`, `"hold"`, …).
+    fn label(&self) -> String {
+        match self {
+            AdaptiveAction::Increase(DoseStep::Percent(p)) => format!("increase {p}%"),
+            AdaptiveAction::Increase(DoseStep::Level) => "increase".to_string(),
+            AdaptiveAction::Decrease(DoseStep::Percent(p)) => format!("decrease {p}%"),
+            AdaptiveAction::Decrease(DoseStep::Level) => "decrease".to_string(),
+            AdaptiveAction::Hold => "hold".to_string(),
+            AdaptiveAction::Stop => "stop".to_string(),
+        }
+    }
+}
+
+impl AdaptiveRule {
+    /// A human-readable label reconstructing the rule as written
+    /// (`"signal < 10 : increase 25%"`) — recorded as the dose ledger's
+    /// `rule_fired` so an audit can name which rung produced each dose.
+    pub(crate) fn label(&self) -> String {
+        format!(
+            "signal {} {} : {}",
+            self.op.symbol(),
+            self.threshold,
+            self.action.label()
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -451,6 +451,17 @@ pub struct AdaptiveDosingSpec {
 }
 
 impl AdaptiveDosingSpec {
+    /// Whether `observe` is a multi-token *expression* (so its measured endpoint is
+    /// not self-evident) rather than a bare endpoint (a state name or compartment
+    /// number). The single classifier behind both the parse-time
+    /// `with_assay_error` ambiguity check ([`AdaptiveDosingSpec::validate`]) and the
+    /// compile-time endpoint resolver
+    /// ([`resolve_observe_cmt`](crate::sim::adaptive_control)), so the two can't
+    /// disagree about what counts as an expression.
+    pub(crate) fn observe_is_expression(&self) -> bool {
+        self.observe.chars().any(|c| "+-*/() ".contains(c))
+    }
+
     /// Enforce every cross-field invariant the block parser checks, in one place.
     ///
     /// The struct is `pub` with `pub` fields, so a programmatically-built spec can
@@ -494,10 +505,7 @@ impl AdaptiveDosingSpec {
         // ambiguous (which endpoint's σ?). A bare endpoint can be resolved against
         // the model in S2.2; an expression cannot, so it must designate `assay_cmt`
         // — else a typed error, never a guessed σ.
-        if self.with_assay_error
-            && self.assay_cmt.is_none()
-            && self.observe.chars().any(|c| "+-*/() ".contains(c))
-        {
+        if self.with_assay_error && self.assay_cmt.is_none() && self.observe_is_expression() {
             return Err(format!(
                 "[adaptive_dosing]: with_assay_error on an expression observe (`{}`) is \
                  ambiguous — which endpoint's residual error applies? Designate it with `assay_cmt = N`.",

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -397,6 +397,117 @@ pub(crate) struct AssayNoise<'a> {
     pub base_seed: u64,
 }
 
+// ── Declarative `[adaptive_dosing]` block (#391 S2) ─────────────────────────
+//
+// The *parsed* form of the file-driven reactive controller. This is pure syntax
+// (an AST): it carries no binding to the model's parameters and no runtime. The
+// `observe` expression is kept as source text and compiled against the model's
+// parameter context when the controller is built (S2.2) — holding the spec as
+// data keeps the parser independent of the integration engine. The parser
+// (`parse_adaptive_dosing_block` in `parser::model_parser`) is the single place
+// that establishes the field invariants documented below.
+
+/// A parsed `[adaptive_dosing]` block: a declarative, file-driven reactive
+/// controller (#391 S2).
+///
+/// **Invariants** (guaranteed by the block parser, assumed downstream): `at` is
+/// non-empty and strictly increasing; `dose_bounds.0 <= dose_bounds.1` with
+/// `0 <= dose_bounds.0`; `start_dose` lies within `dose_bounds`; `confirm >= 1`;
+/// `rules` is non-empty; `levels`, when present, is non-empty and strictly
+/// increasing and contains `start_dose`; and the rule ladder uses percentage
+/// dose steps iff `levels` is `None` and one-level steps iff `levels` is `Some`
+/// (never mixed). When `with_assay_error` is set on an *expression* `observe`,
+/// `assay_cmt` designates the endpoint whose residual error supplies the noise.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdaptiveDosingSpec {
+    /// The monitored signal — an expression over states + individual parameters
+    /// (e.g. `central / V`). Stored as validated source text; compiled against the
+    /// model in S2.2. The `when` rules compare the keyword `signal` to this value.
+    pub observe: String,
+    /// Titrate on the assay-noised DV (`true`) rather than the latent IPRED
+    /// (`false`, the default).
+    pub with_assay_error: bool,
+    /// 1-based compartment whose `[error_model]` σ supplies the assay noise. Used
+    /// when `with_assay_error` is on and `observe` is an expression (so the
+    /// endpoint is not itself obvious). `None` otherwise.
+    pub assay_cmt: Option<usize>,
+    /// Decision schedule (subject clock), expanded to explicit times at parse
+    /// time — the times the controller is consulted.
+    pub at: Vec<f64>,
+    /// Dose issued at the first decision; seeds the controller's running dose.
+    pub start_dose: f64,
+    /// How an emitted dose is delivered.
+    pub route: AdaptiveRoute,
+    /// Inclusive `(low, high)` clamp applied to every emitted dose.
+    pub dose_bounds: (f64, f64),
+    /// Debounce: act only after this many *consecutive* matches of the same rule.
+    /// `1` acts on the first breach.
+    pub confirm: u32,
+    /// Discrete titration levels (oncology). When set, `increase`/`decrease` step
+    /// one level; mutually exclusive with percentage steps.
+    pub levels: Option<Vec<f64>>,
+    /// The first-matching-rule ladder, in file order.
+    pub rules: Vec<AdaptiveRule>,
+}
+
+/// How an adaptive dose is delivered.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdaptiveRoute {
+    /// Instantaneous dose into 1-based compartment `cmt`.
+    Bolus { cmt: usize },
+    /// Zero-order infusion of duration `over` into 1-based compartment `cmt`.
+    Infuse { cmt: usize, over: f64 },
+}
+
+/// One rung of the ladder: `when signal <op> <threshold> : <action>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdaptiveRule {
+    /// The comparison applied to the observed `signal`.
+    pub op: Comparison,
+    /// The right-hand side of the comparison.
+    pub threshold: f64,
+    /// What to do when this rule is the first to match.
+    pub action: AdaptiveAction,
+}
+
+/// A signal comparison operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Comparison {
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+    /// `==`
+    Eq,
+}
+
+/// What a matched rule does to the running dose.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdaptiveAction {
+    /// Raise the dose (by a percentage, or one level if the block declares `levels`).
+    Increase(DoseStep),
+    /// Lower the dose (by a percentage, or one level if the block declares `levels`).
+    Decrease(DoseStep),
+    /// Skip this decision — no dose now, the regimen continues.
+    Hold,
+    /// Discontinue all future dosing.
+    Stop,
+}
+
+/// The magnitude of an [`AdaptiveAction::Increase`] / [`AdaptiveAction::Decrease`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum DoseStep {
+    /// Scale by this percent, e.g. `Percent(25.0)` for `increase 25%`. Valid only
+    /// when the block has no `levels` ladder.
+    Percent(f64),
+    /// Step one discrete level. Valid only when the block declares `levels`.
+    Level,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -478,8 +478,31 @@ pub struct AdaptiveDosingSpec {
     pub rules: Vec<AdaptiveRule>,
 }
 
+/// Validate a `[adaptive_dosing]` float list is non-empty, all-finite, and
+/// strictly increasing — the shared contract of the `levels` ladder and an
+/// explicit `at` decision list. Called from BOTH the block parser and
+/// [`AdaptiveDosingSpec::validate`] so the file-driven and programmatic paths
+/// enforce it identically (a single source of truth, not two that can drift).
+/// `what` names the list in the error (e.g. `"levels"`, `` "`at` times" ``).
+pub(crate) fn validate_increasing_finite(xs: &[f64], what: &str) -> Result<(), String> {
+    if xs.is_empty() {
+        return Err(format!(
+            "[adaptive_dosing]: {what} must be a non-empty list"
+        ));
+    }
+    if !xs.iter().all(|x| x.is_finite()) {
+        return Err(format!("[adaptive_dosing]: {what} must all be finite"));
+    }
+    if xs.windows(2).any(|w| w[1] <= w[0]) {
+        return Err(format!(
+            "[adaptive_dosing]: {what} must be strictly increasing"
+        ));
+    }
+    Ok(())
+}
+
 impl AdaptiveDosingSpec {
-    /// Enforce every cross-field invariant the block parser checks, in one place.
+    /// Enforce every invariant the block parser checks, in one place.
     ///
     /// The struct is `pub` with `pub` fields, so a programmatically-built spec can
     /// reach the controller without going through the parser. The parser calls
@@ -488,7 +511,8 @@ impl AdaptiveDosingSpec {
     /// it again as the safety net for hand-built specs — so neither path can drive
     /// the controller with a contradiction (a `Level` step without a `levels`
     /// ladder, a `start_dose` outside `dose_bounds`, a rung outside `dose_bounds`,
-    /// …) the other would have rejected.
+    /// an empty or unsorted `at`/`levels`, a `confirm` of 0, …) the other would
+    /// have rejected.
     pub fn validate(&self) -> Result<(), String> {
         if self.rules.is_empty() {
             return Err(
@@ -512,6 +536,23 @@ impl AdaptiveDosingSpec {
                 "[adaptive_dosing]: start_dose {} is outside dose_bounds [{lo}, {hi}]",
                 self.start_dose
             ));
+        }
+        // The decision schedule must be a non-empty, finite, strictly-increasing
+        // list of non-negative times. The parser enforces this on the way in;
+        // re-check here so a hand-built spec can't silently run with no doses
+        // (empty `at`) or a permuted decision log (unsorted `at`).
+        validate_increasing_finite(&self.at, "`at` times")?;
+        if self.at[0] < 0.0 {
+            // Strictly increasing ⇒ `at[0]` is the minimum.
+            return Err(format!(
+                "[adaptive_dosing]: `at` times must be >= 0: {}",
+                self.at[0]
+            ));
+        }
+        if self.confirm < 1 {
+            return Err(
+                "[adaptive_dosing]: confirm must be >= 1 (1 acts on the first breach)".to_string(),
+            );
         }
         // Exactly one signal source. `observe` is the latent (Ipred) signal — a
         // free-form expression with no measurement noise. `with_assay_error = true`
@@ -570,6 +611,11 @@ impl AdaptiveDosingSpec {
         });
         match &self.levels {
             Some(l) => {
+                // Non-empty, finite, strictly increasing: a `Level` step indexes
+                // this ladder and assumes ascending order — on a descending list
+                // `increase` would *lower* the dose. The parser checks this on the
+                // way in; re-check for hand-built specs.
+                validate_increasing_finite(l, "levels")?;
                 if has_percent {
                     return Err("[adaptive_dosing]: percentage actions (`increase N%`) are not \
                                 allowed with `levels`; use bare `increase`/`decrease` to step one level"
@@ -819,6 +865,47 @@ mod tests {
         s.levels = Some(vec![100.0, 150.0]);
         s.rules = level_rule();
         assert!(s.validate().unwrap_err().contains("outside dose_bounds"));
+    }
+
+    #[test]
+    fn validate_rejects_schedule_and_levels_ordering() {
+        // These single-field invariants are enforced by the block parser; `validate`
+        // is the safety net for a hand-built `pub` spec that never saw the parser.
+        // Without them a programmatic spec drives a silent wrong result through the
+        // public `simulate_adaptive_from_spec`.
+
+        // empty `at` — would otherwise run a silent no-dose simulation.
+        let mut s = base_spec();
+        s.at = vec![];
+        assert!(s.validate().unwrap_err().contains("non-empty"));
+
+        // unsorted `at` — would permute the decision log.
+        let mut s = base_spec();
+        s.at = vec![48.0, 24.0];
+        assert!(s.validate().unwrap_err().contains("strictly increasing"));
+
+        // negative decision time.
+        let mut s = base_spec();
+        s.at = vec![-1.0, 24.0];
+        assert!(s.validate().unwrap_err().contains(">= 0"));
+
+        // confirm = 0 (the parser requires >= 1).
+        let mut s = base_spec();
+        s.confirm = 0;
+        assert!(s.validate().unwrap_err().contains("confirm"));
+
+        // Descending `levels` — the regression that motivated this: a `Level` step
+        // on a non-ascending ladder makes `increase` *lower* the dose. `validate`
+        // must reject it rather than let the controller silently invert.
+        let mut s = base_spec();
+        s.start_dose = 200.0;
+        s.levels = Some(vec![200.0, 100.0, 50.0]);
+        s.rules = vec![AdaptiveRule {
+            op: Comparison::Lt,
+            threshold: 10.0,
+            action: AdaptiveAction::Increase(DoseStep::Level),
+        }];
+        assert!(s.validate().unwrap_err().contains("strictly increasing"));
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -439,20 +439,25 @@ pub(crate) struct AssayNoise<'a> {
 /// `rules` is non-empty; `levels`, when present, is non-empty and strictly
 /// increasing and contains `start_dose`; and the rule ladder uses percentage
 /// dose steps iff `levels` is `None` and one-level steps iff `levels` is `Some`
-/// (never mixed). When `with_assay_error` is set on an *expression* `observe`,
-/// `assay_cmt` designates the endpoint whose residual error supplies the noise.
+/// (never mixed). Exactly one signal source: `observe` (a latent expression, with
+/// `with_assay_error = false`) **or** `with_assay_error = true` naming a model
+/// output via `assay_cmt` — never both.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AdaptiveDosingSpec {
-    /// The monitored signal — an expression over states + individual parameters
-    /// (e.g. `central / V`). Stored as validated source text; compiled against the
-    /// model in S2.2. The `when` rules compare the keyword `signal` to this value.
-    pub observe: String,
-    /// Titrate on the assay-noised DV (`true`) rather than the latent IPRED
-    /// (`false`, the default).
+    /// The latent (Ipred) monitored signal — a free-form expression over states +
+    /// individual parameters (e.g. `central / V`), compiled against the model in
+    /// S2.2. `Some` for an un-noised signal; `None` when `with_assay_error` is set
+    /// (the signal is then the noised model output named by `assay_cmt`, not a
+    /// re-typed expression). The `when` rules compare the keyword `signal` to it.
+    pub observe: Option<String>,
+    /// Titrate on the assay-noised measurement of a model output (`true`) rather
+    /// than a latent expression (`false`, the default). When set, the signal's
+    /// value *and* its σ both come from the output named by `assay_cmt`, so they
+    /// can never be on different scales.
     pub with_assay_error: bool,
-    /// 1-based compartment whose `[error_model]` σ supplies the assay noise. Used
-    /// when `with_assay_error` is on and `observe` is an expression (so the
-    /// endpoint is not itself obvious). `None` otherwise.
+    /// 1-based compartment of the model output to measure under `with_assay_error`
+    /// — its `[scaling]` readout is the signal value and its `[error_model]` σ the
+    /// noise. Required iff `with_assay_error`; `None` otherwise.
     pub assay_cmt: Option<usize>,
     /// Decision schedule (subject clock), expanded to explicit times at parse
     /// time — the times the controller is consulted.
@@ -474,17 +479,6 @@ pub struct AdaptiveDosingSpec {
 }
 
 impl AdaptiveDosingSpec {
-    /// Whether `observe` is a multi-token *expression* (so its measured endpoint is
-    /// not self-evident) rather than a bare endpoint (a state name or compartment
-    /// number). The single classifier behind both the parse-time
-    /// `with_assay_error` ambiguity check ([`AdaptiveDosingSpec::validate`]) and the
-    /// compile-time endpoint resolver
-    /// ([`resolve_observe_cmt`](crate::sim::adaptive_control)), so the two can't
-    /// disagree about what counts as an expression.
-    pub(crate) fn observe_is_expression(&self) -> bool {
-        self.observe.chars().any(|c| "+-*/() ".contains(c))
-    }
-
     /// Enforce every cross-field invariant the block parser checks, in one place.
     ///
     /// The struct is `pub` with `pub` fields, so a programmatically-built spec can
@@ -519,21 +513,44 @@ impl AdaptiveDosingSpec {
                 self.start_dose
             ));
         }
-        if self.assay_cmt.is_some() && !self.with_assay_error {
-            return Err(
-                "[adaptive_dosing]: assay_cmt is set but with_assay_error = false".to_string(),
-            );
-        }
-        // The load-bearing S2 fork: assay noise on an *expression* observe is
-        // ambiguous (which endpoint's σ?). A bare endpoint can be resolved against
-        // the model in S2.2; an expression cannot, so it must designate `assay_cmt`
-        // — else a typed error, never a guessed σ.
-        if self.with_assay_error && self.assay_cmt.is_none() && self.observe_is_expression() {
-            return Err(format!(
-                "[adaptive_dosing]: with_assay_error on an expression observe (`{}`) is \
-                 ambiguous — which endpoint's residual error applies? Designate it with `assay_cmt = N`.",
-                self.observe
-            ));
+        // Exactly one signal source. `observe` is the latent (Ipred) signal — a
+        // free-form expression with no measurement noise. `with_assay_error = true`
+        // makes the signal the *noised measurement* of the model output named by
+        // `assay_cmt`: its value and σ both come from that one output, so they can
+        // never be on different scales. The two forms are mutually exclusive.
+        match (
+            self.with_assay_error,
+            self.observe.is_some(),
+            self.assay_cmt.is_some(),
+        ) {
+            (false, true, false) => {} // Ipred: titrate on the `observe` expression.
+            (true, false, true) => {}  // Dv: titrate on the noised output at `assay_cmt`.
+            (false, false, _) => {
+                return Err(
+                    "[adaptive_dosing]: a signal is required — set `observe = <expr>` to titrate \
+                     on a latent quantity, or `with_assay_error = true` with `assay_cmt = N` to \
+                     titrate on a noised measurement"
+                        .to_string(),
+                )
+            }
+            (false, true, true) => {
+                return Err(
+                    "[adaptive_dosing]: assay_cmt is set but with_assay_error = false".to_string(),
+                )
+            }
+            (true, true, _) => {
+                return Err(
+                    "[adaptive_dosing]: with `with_assay_error = true` the signal is the noised \
+                     measurement of the model output named by `assay_cmt`; remove `observe` (it \
+                     applies only to un-noised Ipred titration)"
+                        .to_string(),
+                )
+            }
+            (true, false, false) => return Err(
+                "[adaptive_dosing]: `with_assay_error = true` requires `assay_cmt = N` to name \
+                     which model output is measured"
+                    .to_string(),
+            ),
         }
 
         // Percentage vs one-level dose steps are mutually exclusive and tied to `levels`.
@@ -747,7 +764,7 @@ mod tests {
 
     fn base_spec() -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
-            observe: "central".to_string(),
+            observe: Some("central".to_string()),
             with_assay_error: false,
             assay_cmt: None,
             at: vec![24.0],
@@ -802,6 +819,46 @@ mod tests {
         s.levels = Some(vec![100.0, 150.0]);
         s.rules = level_rule();
         assert!(s.validate().unwrap_err().contains("outside dose_bounds"));
+    }
+
+    #[test]
+    fn validate_enforces_one_signal_source() {
+        // `observe` (latent) and `with_assay_error` (noised model output) are
+        // mutually exclusive; exactly one is required.
+        // valid Ipred: observe set, no assay error.
+        assert!(base_spec().validate().is_ok());
+
+        // valid Dv: no observe, with_assay_error naming the output.
+        let mut s = base_spec();
+        s.observe = None;
+        s.with_assay_error = true;
+        s.assay_cmt = Some(1);
+        assert!(s.validate().is_ok());
+
+        // no signal at all.
+        let mut s = base_spec();
+        s.observe = None;
+        assert!(s.validate().unwrap_err().contains("a signal is required"));
+
+        // both an observe expression and assay error.
+        let mut s = base_spec();
+        s.with_assay_error = true;
+        s.assay_cmt = Some(1);
+        assert!(s.validate().unwrap_err().contains("remove `observe`"));
+
+        // assay error without naming the measured output.
+        let mut s = base_spec();
+        s.observe = None;
+        s.with_assay_error = true;
+        assert!(s.validate().unwrap_err().contains("requires `assay_cmt"));
+
+        // assay_cmt set but no assay error.
+        let mut s = base_spec();
+        s.assay_cmt = Some(1);
+        assert!(s
+            .validate()
+            .unwrap_err()
+            .contains("assay_cmt is set but with_assay_error = false"));
     }
 
     #[test]

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -14,10 +14,9 @@
 //! from the model (compiling the `observe` expression and feeding it through the
 //! engine's monitor mechanism, so `Dv` keeps the S1.5 assay substream) is the
 //! separate engine-side half of S2.2.
-// Wired to the public file-driven entry point in S2.3 (#391); until then the
-// compile / controller items below are constructed only by tests (mirrors the
-// `#[allow(dead_code)]` the S1.3a driver carried before S1.4 made it public).
-#![allow(dead_code)]
+//!
+//! Wired to the public file-driven entry point [`crate::simulate_adaptive_from_spec`]
+//! in S2.3 (#391).
 
 use crate::ode::OdeOutputFn;
 use crate::sim::adaptive::{

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -230,9 +230,12 @@ pub(crate) fn build_adaptive_controller(
     }
 }
 
-/// Compile the spec's `observe` expression into the engine's readout-closure
-/// shape ([`OdeOutputFn`]) by reusing the model's own output-expression compiler
-/// ([`crate::parser::model_parser::build_y_output_fn`]).
+/// Compile a latent (`Ipred`) `observe` expression into the engine's
+/// readout-closure shape ([`OdeOutputFn`]) by reusing the model's own
+/// output-expression compiler
+/// ([`crate::parser::model_parser::build_y_output_fn`]). Used only for the latent
+/// signal; the assay-noised (`Dv`) path reads the model's own output instead, so
+/// no expression is compiled there.
 ///
 /// The closure resolves states + individual parameters + covariates exactly as a
 /// model readout does, so the controller observes the same quantity the model
@@ -241,7 +244,7 @@ pub(crate) fn build_adaptive_controller(
 /// or an IOV reference in `observe` is rejected by the shared compiler.
 pub(crate) fn compile_observe(
     model: &CompiledModel,
-    spec: &AdaptiveDosingSpec,
+    observe: &str,
 ) -> Result<(OdeOutputFn, Vec<String>), String> {
     let ode = model.ode_spec.as_ref().ok_or_else(|| {
         "[adaptive_dosing] requires an ODE model (the analytical engine is a follow-up)".to_string()
@@ -251,7 +254,7 @@ pub(crate) fn compile_observe(
     // instead of silently reading 0.0 (the readout leaves an absent covariate at
     // 0.0, which would drive the controller off a wrong signal).
     let (out_fn, _program, cov_names) = crate::parser::model_parser::build_y_output_fn(
-        &spec.observe,
+        observe,
         "[adaptive_dosing] observe",
         &model.theta_names,
         &model.eta_names,
@@ -263,58 +266,22 @@ pub(crate) fn compile_observe(
     Ok((out_fn, cov_names))
 }
 
-/// The 1-based compartment whose `[error_model]` σ supplies assay noise for a
-/// `Dv` observe. Uses the explicit `assay_cmt` when given; otherwise resolves a
-/// bare `observe` (a state name or a compartment number) to its compartment. A
-/// `Dv` observe that is neither — e.g. a multi-term expression — is rejected at
-/// parse time, so reaching here without a resolvable endpoint is a typed error,
-/// never a guessed σ.
-fn resolve_observe_cmt(model: &CompiledModel, spec: &AdaptiveDosingSpec) -> Result<usize, String> {
-    if let Some(c) = spec.assay_cmt {
-        return Ok(c);
-    }
-    let obs = spec.observe.trim();
-    if let Ok(n) = obs.parse::<usize>() {
-        if n >= 1 {
-            return Ok(n);
-        }
-    }
-    if let Some(ode) = model.ode_spec.as_ref() {
-        if let Some(idx) = ode.state_names.iter().position(|s| s == obs) {
-            return Ok(idx + 1);
-        }
-    }
-    // Use the same classifier the parser's ambiguity check uses, so an expression
-    // (normally rejected at parse) and a bare-but-unresolvable name give coherent
-    // guidance instead of two unrelated messages.
-    if spec.observe_is_expression() {
-        Err(format!(
-            "[adaptive_dosing] with_assay_error on an expression observe (`{}`) is ambiguous — \
-             which endpoint's residual error applies? Designate it with `assay_cmt = N`",
-            spec.observe
-        ))
-    } else {
-        Err(format!(
-            "[adaptive_dosing] with_assay_error: cannot resolve observe `{}` to a model endpoint \
-             (neither a compartment number nor a declared state) — set `assay_cmt = N`",
-            spec.observe
-        ))
-    }
-}
-
 /// Everything needed to drive a declarative `[adaptive_dosing]` block through the
 /// S1 reactive engine: the monitor(s) the engine resolves into `ControllerCtx`,
 /// the compiled `observe` readout the engine evaluates for the signal's latent
 /// value, and the per-subject controller factory.
 pub(crate) struct CompiledAdaptive {
-    /// Single monitor named [`ADAPTIVE_SIGNAL`]; its `cmt` supplies the σ under
-    /// `Dv` and is unused under `Ipred`.
+    /// Single monitor named [`ADAPTIVE_SIGNAL`]. Under `Dv` its `cmt` is the
+    /// measured model output (value *and* σ); under `Ipred` the value comes from
+    /// `observe` and the `cmt` is unused.
     pub monitors: Vec<MonitorSpec>,
-    /// Compiled `observe` expression — the latent signal value at each decision.
-    pub observe: OdeOutputFn,
-    /// Covariate names the `observe` expression references — the file-driven entry
-    /// validates these against the data's covariate columns so a misspelt covariate
-    /// fails loudly instead of silently reading 0.0.
+    /// Compiled latent (`Ipred`) `observe` expression, or `None` under
+    /// `with_assay_error` (`Dv`) — where the signal is the model's own readout for
+    /// the monitor's `cmt` plus its assay noise, not a re-typed expression.
+    pub observe: Option<OdeOutputFn>,
+    /// Covariate names the `observe` expression references (empty under `Dv`) — the
+    /// file-driven entry validates these against the data's covariate columns so a
+    /// misspelt covariate fails loudly instead of silently reading 0.0.
     pub observe_covariates: Vec<String>,
     /// Mints a fresh controller per `(subject, replicate)` (state isolation).
     #[allow(clippy::type_complexity)]
@@ -331,32 +298,36 @@ pub(crate) fn compile_adaptive(
     // with `pub` fields, so a programmatically-built spec may not have passed
     // through the block parser (which validates on its way out).
     spec.validate()?;
-    let (observe, observe_covariates) = compile_observe(model, spec)?;
-    let mode = if spec.with_assay_error {
-        ObserveMode::Dv
-    } else {
-        ObserveMode::Ipred
-    };
-    // Under `Dv` the cmt selects the residual σ; under `Ipred` the latent value
-    // comes from the compiled `observe`, so the cmt is unused (placeholder 1).
-    let cmt = match mode {
-        ObserveMode::Dv => resolve_observe_cmt(model, spec)?,
-        ObserveMode::Ipred => spec.assay_cmt.unwrap_or(1),
-    };
-    // Bound the σ compartment against the model so an out-of-range `assay_cmt` /
-    // bare-number `observe` is a compile error here, not a deferred driver failure
-    // (`cmt > n_states`) at the first decision. Only `Dv` reads σ from `cmt`.
-    if mode == ObserveMode::Dv {
-        if let Some(ode) = model.ode_spec.as_ref() {
-            if cmt > ode.n_states {
-                return Err(format!(
-                    "[adaptive_dosing]: assay compartment {cmt} is out of range \
-                     (model has {} compartment(s))",
-                    ode.n_states
-                ));
-            }
+    // The reactive engine is ODE-only; reject an analytical model on both paths.
+    let ode = model.ode_spec.as_ref().ok_or_else(|| {
+        "[adaptive_dosing] requires an ODE model (the analytical engine is a follow-up)".to_string()
+    })?;
+    let (mode, observe, observe_covariates, cmt) = if spec.with_assay_error {
+        // Dv: the signal is the *noised measurement* of the model output named by
+        // `assay_cmt` (validate() requires it). Its value comes from the model's
+        // own readout — `observe = None` makes the driver read `read_observable(cmt)`
+        // — and its σ from that cmt's `[error_model]`, so the two share one source
+        // and can never be on different scales.
+        let cmt = spec
+            .assay_cmt
+            .expect("validate() requires assay_cmt under with_assay_error");
+        if cmt == 0 || cmt > ode.n_states {
+            return Err(format!(
+                "[adaptive_dosing]: assay_cmt = {cmt} is out of range (model has {} compartment(s))",
+                ode.n_states
+            ));
         }
-    }
+        (ObserveMode::Dv, None, Vec::new(), cmt)
+    } else {
+        // Ipred: titrate on the compiled `observe` expression (no measurement
+        // noise); the monitor `cmt` is unused (placeholder 1).
+        let observe_src = spec
+            .observe
+            .as_deref()
+            .expect("validate() requires observe without with_assay_error");
+        let (out_fn, cov) = compile_observe(model, observe_src)?;
+        (ObserveMode::Ipred, Some(out_fn), cov, 1)
+    };
     let monitors = vec![MonitorSpec::new(ADAPTIVE_SIGNAL, cmt, mode)];
     let factory = build_adaptive_controller(spec);
     Ok(CompiledAdaptive {
@@ -382,7 +353,7 @@ mod tests {
         rules: Vec<AdaptiveRule>,
     ) -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
-            observe: "central".to_string(),
+            observe: Some("central".to_string()),
             with_assay_error: false,
             assay_cmt: None,
             at: vec![24.0, 48.0],
@@ -730,7 +701,9 @@ mod tests {
         assay_cmt: Option<usize>,
     ) -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
-            observe: observe.to_string(),
+            // `observe` is the latent (Ipred) signal; under assay error there is no
+            // expression — the signal is the named model output (`assay_cmt`).
+            observe: (!with_assay_error).then(|| observe.to_string()),
             with_assay_error,
             assay_cmt,
             at: vec![24.0, 48.0],
@@ -746,8 +719,7 @@ mod tests {
     #[test]
     fn compile_observe_yields_concentration_not_amount() {
         let model = parse_full_model(ODE_MODEL).expect("ODE model parses").model;
-        let (observe, _cov) = compile_observe(&model, &mk_spec("central / V", false, None))
-            .expect("observe compiles");
+        let (observe, _cov) = compile_observe(&model, "central / V").expect("observe compiles");
         let theta = model.default_params.theta.clone();
         let eta = vec![0.0; model.n_eta + model.n_kappa];
         let cov = HashMap::new();
@@ -763,7 +735,7 @@ mod tests {
     #[test]
     fn compile_observe_requires_ode_model() {
         let model = parse_full_model(ANALYTICAL_MODEL).unwrap().model;
-        let err = compile_observe(&model, &mk_spec("central / V", false, None))
+        let err = compile_observe(&model, "central / V")
             .err()
             .expect("analytical model must error");
         assert!(err.contains("requires an ODE model"), "got: {err}");
@@ -776,51 +748,37 @@ mod tests {
         assert_eq!(ipred.monitors.len(), 1);
         assert_eq!(ipred.monitors[0].name, ADAPTIVE_SIGNAL);
         assert_eq!(ipred.monitors[0].mode, ObserveMode::Ipred);
+        assert!(
+            ipred.observe.is_some(),
+            "Ipred compiles the observe expression"
+        );
 
-        let dv = compile_adaptive(&model, &mk_spec("central / V", true, Some(1))).unwrap();
+        // Dv: the signal is the noised model output named by `assay_cmt`; its value
+        // comes from the model's own readout, so no `observe` expression is compiled.
+        let dv = compile_adaptive(&model, &mk_spec("", true, Some(1))).unwrap();
         assert_eq!(dv.monitors[0].mode, ObserveMode::Dv);
         assert_eq!(dv.monitors[0].cmt, 1);
+        assert!(
+            dv.observe.is_none(),
+            "Dv reads the model output, not a re-typed expression"
+        );
     }
 
     #[test]
-    fn resolve_observe_cmt_bare_name_number_explicit_and_error() {
-        let model = parse_full_model(ODE_MODEL).unwrap().model;
-        // bare state name → its 1-based compartment
-        assert_eq!(
-            resolve_observe_cmt(&model, &mk_spec("central", true, None)).unwrap(),
-            1
-        );
-        // bare compartment number
-        assert_eq!(
-            resolve_observe_cmt(&model, &mk_spec("2", true, None)).unwrap(),
-            2
-        );
-        // explicit assay_cmt wins
-        assert_eq!(
-            resolve_observe_cmt(&model, &mk_spec("central / V", true, Some(3))).unwrap(),
-            3
-        );
-        // an expression with no assay_cmt cannot designate an endpoint → typed error
-        // (the same "ambiguous" classifier the parser's check uses)
-        let err = resolve_observe_cmt(&model, &mk_spec("central / V", true, None)).unwrap_err();
-        assert!(err.contains("ambiguous"), "got: {err}");
-        // a bare name that is neither a number nor a declared state
-        let err = resolve_observe_cmt(&model, &mk_spec("conc", true, None)).unwrap_err();
-        assert!(err.contains("cannot resolve observe"), "got: {err}");
-    }
-
-    #[test]
-    fn compile_adaptive_rejects_out_of_range_assay_compartment() {
-        // ODE_MODEL has a single compartment; a σ endpoint above it would only
-        // surface as a deferred driver failure, so reject it at compile time.
-        let model = parse_full_model(ODE_MODEL).unwrap().model;
-        let err = compile_adaptive(&model, &mk_spec("2", true, None))
+    fn compile_adaptive_rejects_signal_misconfiguration() {
+        let model = parse_full_model(ODE_MODEL).unwrap().model; // single compartment
+                                                                // assay error without naming which output is measured
+        let err = compile_adaptive(&model, &mk_spec("", true, None))
             .err()
-            .expect("out-of-range bare number must error");
-        assert!(err.contains("out of range"), "bare number: {err}");
-        let err = compile_adaptive(&model, &mk_spec("central / V", true, Some(3)))
+            .expect("with_assay_error needs assay_cmt");
+        assert!(
+            err.contains("requires `assay_cmt"),
+            "needs assay_cmt: {err}"
+        );
+        // a measured output beyond the model's compartments
+        let err = compile_adaptive(&model, &mk_spec("", true, Some(3)))
             .err()
             .expect("out-of-range assay_cmt must error");
-        assert!(err.contains("out of range"), "explicit assay_cmt: {err}");
+        assert!(err.contains("out of range"), "out of range: {err}");
     }
 }

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -21,7 +21,7 @@
 use crate::ode::OdeOutputFn;
 use crate::sim::adaptive::{
     AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
-    DoseAction, DoseStep, MonitorSpec, ObserveMode,
+    ControllerDecision, DoseAction, DoseStep, MonitorSpec, ObserveMode,
 };
 use crate::types::CompiledModel;
 
@@ -97,9 +97,12 @@ impl AdaptiveController {
 
     /// One decision: read the signal, find the first matching rule, apply the
     /// `confirm` debounce, and return the dose action(s).
-    fn decide(&mut self, ctx: &ControllerCtx) -> Vec<DoseAction> {
+    fn decide(&mut self, ctx: &ControllerCtx) -> ControllerDecision {
         if self.stopped {
-            return vec![];
+            return ControllerDecision {
+                actions: vec![],
+                rule: None,
+            };
         }
         // The engine-side half always declares the `signal` monitor this
         // controller reads, so `None` is an internal wiring bug, not user input;
@@ -107,7 +110,12 @@ impl AdaptiveController {
         // signal.
         let signal = match ctx.signal(ADAPTIVE_SIGNAL) {
             Some(v) => v,
-            None => return self.emit_dose(self.dose),
+            None => {
+                return ControllerDecision {
+                    actions: self.emit_dose(self.dose),
+                    rule: None,
+                }
+            }
         };
 
         let matched = self.rules.iter().position(|r| r.matches(signal));
@@ -129,11 +137,20 @@ impl AdaptiveController {
         if let Some(idx) = matched {
             if self.streak >= self.confirm {
                 self.streak = 0; // a fresh streak must build before acting again
+                                 // Name the rule that fired (for the ledger's `rule_fired`); compute
+                                 // the label before `apply` takes `&mut self`.
+                let rule = self.rules[idx].label();
                 let action = self.rules[idx].action.clone();
-                return self.apply(action);
+                return ControllerDecision {
+                    actions: self.apply(action),
+                    rule: Some(rule),
+                };
             }
         }
-        self.emit_dose(self.dose)
+        ControllerDecision {
+            actions: self.emit_dose(self.dose),
+            rule: None,
+        }
     }
 
     fn apply(&mut self, action: AdaptiveAction) -> Vec<DoseAction> {
@@ -205,7 +222,7 @@ impl AdaptiveController {
 #[allow(clippy::type_complexity)] // a controller factory is inherently nested Fn/FnMut
 pub(crate) fn build_adaptive_controller(
     spec: &AdaptiveDosingSpec,
-) -> impl Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>> {
+) -> impl Fn() -> Box<dyn FnMut(&ControllerCtx) -> ControllerDecision> {
     let template = AdaptiveController::new(spec);
     move || {
         let mut controller = template.clone();
@@ -301,7 +318,7 @@ pub(crate) struct CompiledAdaptive {
     pub observe_covariates: Vec<String>,
     /// Mints a fresh controller per `(subject, replicate)` (state isolation).
     #[allow(clippy::type_complexity)]
-    pub make_controller: Box<dyn Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>>>,
+    pub make_controller: Box<dyn Fn() -> Box<dyn FnMut(&ControllerCtx) -> ControllerDecision>>,
 }
 
 /// Compile a declarative spec against its model into the engine-ready
@@ -406,7 +423,7 @@ mod tests {
                     decision_index: i,
                     signals: &sig,
                 };
-                controller(&ctx)
+                controller(&ctx).actions
             })
             .collect()
     }
@@ -662,10 +679,10 @@ mod tests {
         // start from 100 again, proving no shared state.
         let mut a = factory();
         let _ = a(&ctx);
-        let a2 = a(&ctx);
+        let a2 = a(&ctx).actions;
         assert_eq!(a2, bolus(225.0, 1));
         let mut b = factory();
-        let b1 = b(&ctx);
+        let b1 = b(&ctx).actions;
         assert_eq!(b1, bolus(150.0, 1));
     }
 

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -1,0 +1,503 @@
+//! Compile a declarative [`AdaptiveDosingSpec`] into a runnable controller
+//! (#391 S2.2).
+//!
+//! This module turns the parsed `[adaptive_dosing]` AST into a **controller
+//! factory** of the exact shape [`crate::api::simulate_adaptive`] consumes —
+//! `Fn() -> impl FnMut(&ControllerCtx) -> Vec<DoseAction>` — so the declarative
+//! block reuses the S1 reactive engine, ledger, decision log, verifier, and DV
+//! substreams unchanged.
+//!
+//! The control *logic* here (the first-matching-rule ladder, the `confirm`
+//! debounce, continuous vs. discrete-level titration, `dose_bounds` clamping, the
+//! running dose) is **model-independent**: it reads its signal by name from
+//! [`ControllerCtx::signal`] and returns [`DoseAction`]s. Resolving that signal
+//! from the model (compiling the `observe` expression and feeding it through the
+//! engine's monitor mechanism, so `Dv` keeps the S1.5 assay substream) is the
+//! separate engine-side half of S2.2.
+
+use crate::sim::adaptive::{
+    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
+    DoseAction, DoseStep,
+};
+
+/// The monitor name the declarative controller reads — the `signal` keyword the
+/// `when signal <op> <value>` rules compare. The engine-side half declares its
+/// `observe` monitor under this same name so the two always agree.
+pub(crate) const ADAPTIVE_SIGNAL: &str = "signal";
+
+impl AdaptiveRule {
+    /// Does the observed `signal` satisfy this rule's comparison?
+    ///
+    /// `Eq` uses exact `f64` equality deliberately — it is the user-written
+    /// `signal == <value>` semantics; titrating on an exact equality is unusual
+    /// but it is what the rule says, not a tolerance we get to invent.
+    #[allow(clippy::float_cmp)]
+    fn matches(&self, signal: f64) -> bool {
+        match self.op {
+            Comparison::Lt => signal < self.threshold,
+            Comparison::Le => signal <= self.threshold,
+            Comparison::Gt => signal > self.threshold,
+            Comparison::Ge => signal >= self.threshold,
+            Comparison::Eq => signal == self.threshold,
+        }
+    }
+}
+
+/// A compiled, stateful controller for one `(subject, replicate)`.
+///
+/// Cloned fresh by the factory for every run so per-subject state (the running
+/// dose, the `confirm` streak, the titration rung) never leaks across subjects —
+/// the structural isolation [`crate::api::simulate_adaptive`] requires.
+#[derive(Clone)]
+struct AdaptiveController {
+    // ── plan (immutable) ──
+    route: AdaptiveRoute,
+    dose_bounds: (f64, f64),
+    confirm: u32,
+    rules: Vec<AdaptiveRule>,
+    levels: Option<Vec<f64>>,
+    // ── running state ──
+    /// The dose carried forward between decisions (re-issued when no rule fires).
+    dose: f64,
+    /// Index into `levels` (discrete titration only).
+    level: usize,
+    /// The rule index matched at the previous decision (for the `confirm` streak).
+    last_rule: Option<usize>,
+    /// Consecutive matches of `last_rule` so far.
+    streak: u32,
+    /// Set once a `stop` rule fires; the controller emits nothing thereafter.
+    stopped: bool,
+}
+
+impl AdaptiveController {
+    #[allow(clippy::float_cmp)] // start_dose ∈ levels is guaranteed by the parser
+    fn new(spec: &AdaptiveDosingSpec) -> Self {
+        let level = match &spec.levels {
+            Some(l) => l.iter().position(|&x| x == spec.start_dose).unwrap_or(0),
+            None => 0,
+        };
+        Self {
+            route: spec.route.clone(),
+            dose_bounds: spec.dose_bounds,
+            confirm: spec.confirm,
+            rules: spec.rules.clone(),
+            levels: spec.levels.clone(),
+            dose: spec.start_dose,
+            level,
+            last_rule: None,
+            streak: 0,
+            stopped: false,
+        }
+    }
+
+    /// One decision: read the signal, find the first matching rule, apply the
+    /// `confirm` debounce, and return the dose action(s).
+    fn decide(&mut self, ctx: &ControllerCtx) -> Vec<DoseAction> {
+        if self.stopped {
+            return vec![];
+        }
+        // The engine-side half always declares the `signal` monitor this
+        // controller reads, so `None` is an internal wiring bug, not user input;
+        // re-issue the current dose rather than fabricate a decision on a missing
+        // signal.
+        let signal = match ctx.signal(ADAPTIVE_SIGNAL) {
+            Some(v) => v,
+            None => return self.emit_dose(self.dose),
+        };
+
+        let matched = self.rules.iter().position(|r| r.matches(signal));
+        match matched {
+            Some(idx) if self.last_rule == Some(idx) => self.streak += 1,
+            Some(idx) => {
+                self.last_rule = Some(idx);
+                self.streak = 1;
+            }
+            None => {
+                self.last_rule = None;
+                self.streak = 0;
+            }
+        }
+
+        // Act only once a rule has matched `confirm` times in a row; until then
+        // (and when nothing matches) re-issue the current dose — the regimen
+        // continues unchanged, an explicit no-op rather than a silent skip.
+        if let Some(idx) = matched {
+            if self.streak >= self.confirm {
+                self.streak = 0; // a fresh streak must build before acting again
+                let action = self.rules[idx].action.clone();
+                return self.apply(action);
+            }
+        }
+        self.emit_dose(self.dose)
+    }
+
+    fn apply(&mut self, action: AdaptiveAction) -> Vec<DoseAction> {
+        match action {
+            AdaptiveAction::Hold => vec![], // skip this decision's dose
+            AdaptiveAction::Stop => {
+                self.stopped = true;
+                vec![DoseAction::Stop]
+            }
+            AdaptiveAction::Increase(step) => {
+                self.step_dose(step, true);
+                self.emit_dose(self.dose)
+            }
+            AdaptiveAction::Decrease(step) => {
+                self.step_dose(step, false);
+                self.emit_dose(self.dose)
+            }
+        }
+    }
+
+    /// Move the running dose one step up/down, clamped to `dose_bounds`.
+    fn step_dose(&mut self, step: DoseStep, up: bool) {
+        let (lo, hi) = self.dose_bounds;
+        match (step, &self.levels) {
+            (DoseStep::Percent(p), _) => {
+                let factor = if up { 1.0 + p / 100.0 } else { 1.0 - p / 100.0 };
+                self.dose = (self.dose * factor).clamp(lo, hi);
+            }
+            (DoseStep::Level, Some(levels)) => {
+                self.level = if up {
+                    (self.level + 1).min(levels.len() - 1)
+                } else {
+                    self.level.saturating_sub(1)
+                };
+                self.dose = levels[self.level].clamp(lo, hi);
+            }
+            // Parser guarantees a Level step only appears with a `levels` ladder.
+            (DoseStep::Level, None) => {}
+        }
+    }
+
+    fn emit_dose(&self, dose: f64) -> Vec<DoseAction> {
+        match self.route {
+            AdaptiveRoute::Bolus { cmt } => vec![DoseAction::Bolus { amt: dose, cmt }],
+            AdaptiveRoute::Infuse { cmt, over } => vec![DoseAction::Infuse {
+                amt: dose,
+                cmt,
+                rate: dose / over,
+            }],
+        }
+    }
+}
+
+/// Compile a declarative spec into a per-subject controller **factory**.
+///
+/// Each call to the returned factory mints a *fresh* controller with its own
+/// running state (dose / `confirm` streak / titration rung), so a controller's
+/// state never leaks across `(subject, replicate)` runs — the isolation
+/// [`crate::api::simulate_adaptive`] makes structural via a factory rather than a
+/// shared closure. The controller reads its signal under [`ADAPTIVE_SIGNAL`].
+pub(crate) fn build_adaptive_controller(
+    spec: &AdaptiveDosingSpec,
+) -> impl Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>> {
+    let template = AdaptiveController::new(spec);
+    move || {
+        let mut controller = template.clone();
+        Box::new(move |ctx: &ControllerCtx| controller.decide(ctx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::adaptive::DoseStep;
+    use std::collections::HashMap;
+
+    fn spec(
+        start_dose: f64,
+        route: AdaptiveRoute,
+        dose_bounds: (f64, f64),
+        confirm: u32,
+        levels: Option<Vec<f64>>,
+        rules: Vec<AdaptiveRule>,
+    ) -> AdaptiveDosingSpec {
+        AdaptiveDosingSpec {
+            observe: "central".to_string(),
+            with_assay_error: false,
+            assay_cmt: None,
+            at: vec![24.0, 48.0],
+            start_dose,
+            route,
+            dose_bounds,
+            confirm,
+            levels,
+            rules,
+        }
+    }
+
+    fn rule(op: Comparison, threshold: f64, action: AdaptiveAction) -> AdaptiveRule {
+        AdaptiveRule {
+            op,
+            threshold,
+            action,
+        }
+    }
+
+    /// Drive a fresh controller through a sequence of signal values, returning the
+    /// action list each decision produced.
+    fn run(spec: &AdaptiveDosingSpec, signals: &[f64]) -> Vec<Vec<DoseAction>> {
+        let factory = build_adaptive_controller(spec);
+        let mut controller = factory();
+        let empty_cov: HashMap<String, f64> = HashMap::new();
+        signals
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| {
+                let mut sig = HashMap::new();
+                sig.insert(ADAPTIVE_SIGNAL.to_string(), s);
+                let ctx = ControllerCtx {
+                    t: i as f64,
+                    state: &[],
+                    covariates: &empty_cov,
+                    history: &[],
+                    decision_index: i,
+                    signals: &sig,
+                };
+                controller(&ctx)
+            })
+            .collect()
+    }
+
+    fn bolus(amt: f64, cmt: usize) -> Vec<DoseAction> {
+        vec![DoseAction::Bolus { amt, cmt }]
+    }
+
+    #[test]
+    fn reissues_start_dose_when_no_rule_matches() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(
+                Comparison::Lt,
+                10.0,
+                AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            )],
+        );
+        let out = run(&s, &[50.0, 50.0]); // signal never < 10
+        assert_eq!(out[0], bolus(100.0, 1));
+        assert_eq!(out[1], bolus(100.0, 1));
+    }
+
+    #[test]
+    fn confirm_one_acts_immediately() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(
+                Comparison::Lt,
+                10.0,
+                AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            )],
+        );
+        let out = run(&s, &[5.0]);
+        assert_eq!(out[0], bolus(125.0, 1));
+    }
+
+    #[test]
+    fn confirm_debounces_then_acts_then_rebuilds_streak() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 1000.0),
+            2,
+            None,
+            vec![rule(
+                Comparison::Lt,
+                10.0,
+                AdaptiveAction::Increase(DoseStep::Percent(25.0)),
+            )],
+        );
+        // signal < 10 at every decision; confirm = 2 ⇒ act on every 2nd consecutive match.
+        let out = run(&s, &[5.0, 5.0, 5.0, 5.0]);
+        assert_eq!(out[0], bolus(100.0, 1)); // streak 1 → re-issue
+        assert_eq!(out[1], bolus(125.0, 1)); // streak 2 → +25%, reset
+        assert_eq!(out[2], bolus(125.0, 1)); // streak 1 → re-issue
+        assert_eq!(out[3], bolus(156.25, 1)); // streak 2 → +25% again
+    }
+
+    #[test]
+    fn decrease_clamps_at_lower_bound() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (10.0, 400.0),
+            1,
+            None,
+            vec![rule(
+                Comparison::Gt,
+                20.0,
+                AdaptiveAction::Decrease(DoseStep::Percent(50.0)),
+            )],
+        );
+        let out = run(&s, &[30.0, 30.0, 30.0]); // 100 → 50 → 25 → 12.5? clamp at 10
+        assert_eq!(out[0], bolus(50.0, 1));
+        assert_eq!(out[1], bolus(25.0, 1));
+        assert_eq!(out[2], bolus(12.5, 1)); // 12.5 still ≥ 10
+    }
+
+    #[test]
+    fn decrease_to_zero_emits_zero_bolus() {
+        // low bound 0 ⇒ a 100% decrease floors at 0; the driver later normalises
+        // amt==0 to Hold, but the controller's job is just to emit the clamped dose.
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(
+                Comparison::Gt,
+                1.0,
+                AdaptiveAction::Decrease(DoseStep::Percent(100.0)),
+            )],
+        );
+        let out = run(&s, &[50.0]);
+        assert_eq!(out[0], bolus(0.0, 1));
+    }
+
+    #[test]
+    fn discrete_levels_step_up_and_saturate_then_down() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 200.0),
+            1,
+            Some(vec![50.0, 100.0, 150.0, 200.0]),
+            vec![
+                rule(
+                    Comparison::Lt,
+                    1.0,
+                    AdaptiveAction::Increase(DoseStep::Level),
+                ),
+                rule(
+                    Comparison::Gt,
+                    3.0,
+                    AdaptiveAction::Decrease(DoseStep::Level),
+                ),
+            ],
+        );
+        // start at level idx 1 (=100). up, up (saturate at 200), then down.
+        let out = run(&s, &[0.0, 0.0, 0.0, 5.0]);
+        assert_eq!(out[0], bolus(150.0, 1));
+        assert_eq!(out[1], bolus(200.0, 1));
+        assert_eq!(out[2], bolus(200.0, 1)); // saturates at top level
+        assert_eq!(out[3], bolus(150.0, 1)); // signal > 3 → step down
+    }
+
+    #[test]
+    fn hold_skips_then_regimen_continues() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(Comparison::Gt, 20.0, AdaptiveAction::Hold)],
+        );
+        let out = run(&s, &[30.0, 5.0]);
+        assert!(out[0].is_empty()); // hold → no dose this cycle
+        assert_eq!(out[1], bolus(100.0, 1)); // no rule matches → re-issue
+    }
+
+    #[test]
+    fn stop_emits_stop_then_silence() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(Comparison::Gt, 40.0, AdaptiveAction::Stop)],
+        );
+        let out = run(&s, &[50.0, 50.0]);
+        assert_eq!(out[0], vec![DoseAction::Stop]);
+        assert!(out[1].is_empty()); // nothing after Stop
+    }
+
+    #[test]
+    fn infuse_route_sets_rate_from_duration() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Infuse { cmt: 1, over: 2.0 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![rule(Comparison::Lt, 1.0, AdaptiveAction::Hold)],
+        );
+        let out = run(&s, &[50.0]); // no match → re-issue start_dose as an infusion
+        assert_eq!(
+            out[0],
+            vec![DoseAction::Infuse {
+                amt: 100.0,
+                cmt: 1,
+                rate: 50.0, // 100 / over(2)
+            }]
+        );
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 400.0),
+            1,
+            None,
+            vec![
+                rule(Comparison::Gt, 10.0, AdaptiveAction::Hold), // matches first for signal 50
+                rule(
+                    Comparison::Gt,
+                    20.0,
+                    AdaptiveAction::Decrease(DoseStep::Percent(50.0)),
+                ),
+            ],
+        );
+        let out = run(&s, &[50.0]);
+        assert!(out[0].is_empty()); // first rule (Hold) wins over the later Decrease
+    }
+
+    #[test]
+    fn factory_mints_independent_controllers() {
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Bolus { cmt: 1 },
+            (0.0, 1000.0),
+            1,
+            None,
+            vec![rule(
+                Comparison::Lt,
+                10.0,
+                AdaptiveAction::Increase(DoseStep::Percent(50.0)),
+            )],
+        );
+        let factory = build_adaptive_controller(&s);
+        let empty_cov: HashMap<String, f64> = HashMap::new();
+        let mut sig = HashMap::new();
+        sig.insert(ADAPTIVE_SIGNAL.to_string(), 5.0);
+        let ctx = ControllerCtx {
+            t: 0.0,
+            state: &[],
+            covariates: &empty_cov,
+            history: &[],
+            decision_index: 0,
+            signals: &sig,
+        };
+        // Drive controller A twice (100 → 150 → 225); a fresh controller B must
+        // start from 100 again, proving no shared state.
+        let mut a = factory();
+        let _ = a(&ctx);
+        let a2 = a(&ctx);
+        assert_eq!(a2, bolus(225.0, 1));
+        let mut b = factory();
+        let b1 = b(&ctx);
+        assert_eq!(b1, bolus(150.0, 1));
+    }
+}

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -267,11 +267,22 @@ fn resolve_observe_cmt(model: &CompiledModel, spec: &AdaptiveDosingSpec) -> Resu
             return Ok(idx + 1);
         }
     }
-    Err(format!(
-        "[adaptive_dosing] with_assay_error: cannot determine which endpoint's residual error \
-         applies to observe `{}` — set `assay_cmt = N`",
-        spec.observe
-    ))
+    // Use the same classifier the parser's ambiguity check uses, so an expression
+    // (normally rejected at parse) and a bare-but-unresolvable name give coherent
+    // guidance instead of two unrelated messages.
+    if spec.observe_is_expression() {
+        Err(format!(
+            "[adaptive_dosing] with_assay_error on an expression observe (`{}`) is ambiguous — \
+             which endpoint's residual error applies? Designate it with `assay_cmt = N`",
+            spec.observe
+        ))
+    } else {
+        Err(format!(
+            "[adaptive_dosing] with_assay_error: cannot resolve observe `{}` to a model endpoint \
+             (neither a compartment number nor a declared state) — set `assay_cmt = N`",
+            spec.observe
+        ))
+    }
 }
 
 /// Everything needed to drive a declarative `[adaptive_dosing]` block through the
@@ -773,8 +784,12 @@ mod tests {
             3
         );
         // an expression with no assay_cmt cannot designate an endpoint → typed error
+        // (the same "ambiguous" classifier the parser's check uses)
         let err = resolve_observe_cmt(&model, &mk_spec("central / V", true, None)).unwrap_err();
-        assert!(err.contains("cannot determine"), "got: {err}");
+        assert!(err.contains("ambiguous"), "got: {err}");
+        // a bare name that is neither a number nor a declared state
+        let err = resolve_observe_cmt(&model, &mk_spec("conc", true, None)).unwrap_err();
+        assert!(err.contains("cannot resolve observe"), "got: {err}");
     }
 
     #[test]

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -176,6 +176,14 @@ impl AdaptiveController {
     }
 
     fn emit_dose(&self, dose: f64) -> Vec<DoseAction> {
+        // A dose titrated to exactly 0 is a hold, not a degenerate zero-amount
+        // dose. An `Infuse { amt: 0 }` would carry `rate = 0 / over = 0`, which the
+        // driver's up-front action validation rejects (`rate > 0`), erroring the
+        // whole run instead of holding — whereas a zero bolus is silently skipped.
+        // Emitting `Hold` keeps the bolus and infusion routes symmetric.
+        if dose == 0.0 {
+            return vec![DoseAction::Hold];
+        }
         match self.route {
             AdaptiveRoute::Bolus { cmt } => vec![DoseAction::Bolus { amt: dose, cmt }],
             AdaptiveRoute::Infuse { cmt, over } => vec![DoseAction::Infuse {
@@ -217,11 +225,15 @@ pub(crate) fn build_adaptive_controller(
 pub(crate) fn compile_observe(
     model: &CompiledModel,
     spec: &AdaptiveDosingSpec,
-) -> Result<OdeOutputFn, String> {
+) -> Result<(OdeOutputFn, Vec<String>), String> {
     let ode = model.ode_spec.as_ref().ok_or_else(|| {
         "[adaptive_dosing] requires an ODE model (the analytical engine is a follow-up)".to_string()
     })?;
-    let (out_fn, _program, _cov_names) = crate::parser::model_parser::build_y_output_fn(
+    // `cov_names` are the covariates the `observe` expression references; the
+    // caller validates them against the data so a misspelt name fails loudly
+    // instead of silently reading 0.0 (the readout leaves an absent covariate at
+    // 0.0, which would drive the controller off a wrong signal).
+    let (out_fn, _program, cov_names) = crate::parser::model_parser::build_y_output_fn(
         &spec.observe,
         "[adaptive_dosing] observe",
         &model.theta_names,
@@ -231,7 +243,7 @@ pub(crate) fn compile_observe(
         &ode.state_names,
         &model.kappa_names,
     )?;
-    Ok(out_fn)
+    Ok((out_fn, cov_names))
 }
 
 /// The 1-based compartment whose `[error_model]` σ supplies assay noise for a
@@ -272,6 +284,10 @@ pub(crate) struct CompiledAdaptive {
     pub monitors: Vec<MonitorSpec>,
     /// Compiled `observe` expression — the latent signal value at each decision.
     pub observe: OdeOutputFn,
+    /// Covariate names the `observe` expression references — the file-driven entry
+    /// validates these against the data's covariate columns so a misspelt covariate
+    /// fails loudly instead of silently reading 0.0.
+    pub observe_covariates: Vec<String>,
     /// Mints a fresh controller per `(subject, replicate)` (state isolation).
     #[allow(clippy::type_complexity)]
     pub make_controller: Box<dyn Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>>>,
@@ -283,7 +299,11 @@ pub(crate) fn compile_adaptive(
     model: &CompiledModel,
     spec: &AdaptiveDosingSpec,
 ) -> Result<CompiledAdaptive, String> {
-    let observe = compile_observe(model, spec)?;
+    // Re-check the spec's cross-field invariants here too: the struct is `pub`
+    // with `pub` fields, so a programmatically-built spec may not have passed
+    // through the block parser (which validates on its way out).
+    spec.validate()?;
+    let (observe, observe_covariates) = compile_observe(model, spec)?;
     let mode = if spec.with_assay_error {
         ObserveMode::Dv
     } else {
@@ -295,11 +315,26 @@ pub(crate) fn compile_adaptive(
         ObserveMode::Dv => resolve_observe_cmt(model, spec)?,
         ObserveMode::Ipred => spec.assay_cmt.unwrap_or(1),
     };
+    // Bound the σ compartment against the model so an out-of-range `assay_cmt` /
+    // bare-number `observe` is a compile error here, not a deferred driver failure
+    // (`cmt > n_states`) at the first decision. Only `Dv` reads σ from `cmt`.
+    if mode == ObserveMode::Dv {
+        if let Some(ode) = model.ode_spec.as_ref() {
+            if cmt > ode.n_states {
+                return Err(format!(
+                    "[adaptive_dosing]: assay compartment {cmt} is out of range \
+                     (model has {} compartment(s))",
+                    ode.n_states
+                ));
+            }
+        }
+    }
     let monitors = vec![MonitorSpec::new(ADAPTIVE_SIGNAL, cmt, mode)];
     let factory = build_adaptive_controller(spec);
     Ok(CompiledAdaptive {
         monitors,
         observe,
+        observe_covariates,
         make_controller: Box::new(factory),
     })
 }
@@ -449,23 +484,40 @@ mod tests {
     }
 
     #[test]
-    fn decrease_to_zero_emits_zero_bolus() {
-        // low bound 0 ⇒ a 100% decrease floors at 0; the driver later normalises
-        // amt==0 to Hold, but the controller's job is just to emit the clamped dose.
+    fn decrease_to_zero_holds_for_both_routes() {
+        // low bound 0 ⇒ a 100% decrease floors the dose at 0. A 0 dose is a *hold*,
+        // not a zero-amount dose: an `Infuse { amt: 0 }` would carry `rate = 0`,
+        // which the driver's up-front action validation rejects (`rate > 0`),
+        // erroring the whole run. Both routes must emit `Hold` instead.
+        let decrease_100 = || {
+            vec![rule(
+                Comparison::Gt,
+                1.0,
+                AdaptiveAction::Decrease(DoseStep::Percent(100.0)),
+            )]
+        };
+        // Bolus route (previously a zero bolus the driver silently skipped).
         let s = spec(
             100.0,
             AdaptiveRoute::Bolus { cmt: 1 },
             (0.0, 400.0),
             1,
             None,
-            vec![rule(
-                Comparison::Gt,
-                1.0,
-                AdaptiveAction::Decrease(DoseStep::Percent(100.0)),
-            )],
+            decrease_100(),
         );
-        let out = run(&s, &[50.0]);
-        assert_eq!(out[0], bolus(0.0, 1));
+        assert_eq!(run(&s, &[50.0])[0], vec![DoseAction::Hold]);
+
+        // Infuse route: previously emitted `Infuse { amt: 0, rate: 0 }`, the
+        // route-asymmetric crash this guards against.
+        let s = spec(
+            100.0,
+            AdaptiveRoute::Infuse { cmt: 1, over: 2.0 },
+            (0.0, 400.0),
+            1,
+            None,
+            decrease_100(),
+        );
+        assert_eq!(run(&s, &[50.0])[0], vec![DoseAction::Hold]);
     }
 
     #[test]
@@ -666,7 +718,7 @@ mod tests {
     #[test]
     fn compile_observe_yields_concentration_not_amount() {
         let model = parse_full_model(ODE_MODEL).expect("ODE model parses").model;
-        let observe = compile_observe(&model, &mk_spec("central / V", false, None))
+        let (observe, _cov) = compile_observe(&model, &mk_spec("central / V", false, None))
             .expect("observe compiles");
         let theta = model.default_params.theta.clone();
         let eta = vec![0.0; model.n_eta + model.n_kappa];
@@ -723,5 +775,20 @@ mod tests {
         // an expression with no assay_cmt cannot designate an endpoint → typed error
         let err = resolve_observe_cmt(&model, &mk_spec("central / V", true, None)).unwrap_err();
         assert!(err.contains("cannot determine"), "got: {err}");
+    }
+
+    #[test]
+    fn compile_adaptive_rejects_out_of_range_assay_compartment() {
+        // ODE_MODEL has a single compartment; a σ endpoint above it would only
+        // surface as a deferred driver failure, so reject it at compile time.
+        let model = parse_full_model(ODE_MODEL).unwrap().model;
+        let err = compile_adaptive(&model, &mk_spec("2", true, None))
+            .err()
+            .expect("out-of-range bare number must error");
+        assert!(err.contains("out of range"), "bare number: {err}");
+        let err = compile_adaptive(&model, &mk_spec("central / V", true, Some(3)))
+            .err()
+            .expect("out-of-range assay_cmt must error");
+        assert!(err.contains("out of range"), "explicit assay_cmt: {err}");
     }
 }

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -14,11 +14,17 @@
 //! from the model (compiling the `observe` expression and feeding it through the
 //! engine's monitor mechanism, so `Dv` keeps the S1.5 assay substream) is the
 //! separate engine-side half of S2.2.
+// Wired to the public file-driven entry point in S2.3 (#391); until then the
+// compile / controller items below are constructed only by tests (mirrors the
+// `#[allow(dead_code)]` the S1.3a driver carried before S1.4 made it public).
+#![allow(dead_code)]
 
+use crate::ode::OdeOutputFn;
 use crate::sim::adaptive::{
     AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
-    DoseAction, DoseStep,
+    DoseAction, DoseStep, MonitorSpec, ObserveMode,
 };
+use crate::types::CompiledModel;
 
 /// The monitor name the declarative controller reads — the `signal` keyword the
 /// `when signal <op> <value>` rules compare. The engine-side half declares its
@@ -189,6 +195,7 @@ impl AdaptiveController {
 /// state never leaks across `(subject, replicate)` runs — the isolation
 /// [`crate::api::simulate_adaptive`] makes structural via a factory rather than a
 /// shared closure. The controller reads its signal under [`ADAPTIVE_SIGNAL`].
+#[allow(clippy::type_complexity)] // a controller factory is inherently nested Fn/FnMut
 pub(crate) fn build_adaptive_controller(
     spec: &AdaptiveDosingSpec,
 ) -> impl Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>> {
@@ -197,6 +204,105 @@ pub(crate) fn build_adaptive_controller(
         let mut controller = template.clone();
         Box::new(move |ctx: &ControllerCtx| controller.decide(ctx))
     }
+}
+
+/// Compile the spec's `observe` expression into the engine's readout-closure
+/// shape ([`OdeOutputFn`]) by reusing the model's own output-expression compiler
+/// ([`crate::parser::model_parser::build_y_output_fn`]).
+///
+/// The closure resolves states + individual parameters + covariates exactly as a
+/// model readout does, so the controller observes the same quantity the model
+/// would predict — `observe = central / V` yields the concentration, not the raw
+/// amount. ODE-only (the adaptive engine runs on the ODE path); an unknown name
+/// or an IOV reference in `observe` is rejected by the shared compiler.
+pub(crate) fn compile_observe(
+    model: &CompiledModel,
+    spec: &AdaptiveDosingSpec,
+) -> Result<OdeOutputFn, String> {
+    let ode = model.ode_spec.as_ref().ok_or_else(|| {
+        "[adaptive_dosing] requires an ODE model (the analytical engine is a follow-up)".to_string()
+    })?;
+    let (out_fn, _program, _cov_names) = crate::parser::model_parser::build_y_output_fn(
+        &spec.observe,
+        "[adaptive_dosing] observe",
+        &model.theta_names,
+        &model.eta_names,
+        &model.indiv_param_names,
+        &model.pk_indices,
+        &ode.state_names,
+        &model.kappa_names,
+    )?;
+    Ok(out_fn)
+}
+
+/// The 1-based compartment whose `[error_model]` σ supplies assay noise for a
+/// `Dv` observe. Uses the explicit `assay_cmt` when given; otherwise resolves a
+/// bare `observe` (a state name or a compartment number) to its compartment. A
+/// `Dv` observe that is neither — e.g. a multi-term expression — is rejected at
+/// parse time, so reaching here without a resolvable endpoint is a typed error,
+/// never a guessed σ.
+fn resolve_observe_cmt(model: &CompiledModel, spec: &AdaptiveDosingSpec) -> Result<usize, String> {
+    if let Some(c) = spec.assay_cmt {
+        return Ok(c);
+    }
+    let obs = spec.observe.trim();
+    if let Ok(n) = obs.parse::<usize>() {
+        if n >= 1 {
+            return Ok(n);
+        }
+    }
+    if let Some(ode) = model.ode_spec.as_ref() {
+        if let Some(idx) = ode.state_names.iter().position(|s| s == obs) {
+            return Ok(idx + 1);
+        }
+    }
+    Err(format!(
+        "[adaptive_dosing] with_assay_error: cannot determine which endpoint's residual error \
+         applies to observe `{}` — set `assay_cmt = N`",
+        spec.observe
+    ))
+}
+
+/// Everything needed to drive a declarative `[adaptive_dosing]` block through the
+/// S1 reactive engine: the monitor(s) the engine resolves into `ControllerCtx`,
+/// the compiled `observe` readout the engine evaluates for the signal's latent
+/// value, and the per-subject controller factory.
+pub(crate) struct CompiledAdaptive {
+    /// Single monitor named [`ADAPTIVE_SIGNAL`]; its `cmt` supplies the σ under
+    /// `Dv` and is unused under `Ipred`.
+    pub monitors: Vec<MonitorSpec>,
+    /// Compiled `observe` expression — the latent signal value at each decision.
+    pub observe: OdeOutputFn,
+    /// Mints a fresh controller per `(subject, replicate)` (state isolation).
+    #[allow(clippy::type_complexity)]
+    pub make_controller: Box<dyn Fn() -> Box<dyn FnMut(&ControllerCtx) -> Vec<DoseAction>>>,
+}
+
+/// Compile a declarative spec against its model into the engine-ready
+/// [`CompiledAdaptive`] bundle (#391 S2.2).
+pub(crate) fn compile_adaptive(
+    model: &CompiledModel,
+    spec: &AdaptiveDosingSpec,
+) -> Result<CompiledAdaptive, String> {
+    let observe = compile_observe(model, spec)?;
+    let mode = if spec.with_assay_error {
+        ObserveMode::Dv
+    } else {
+        ObserveMode::Ipred
+    };
+    // Under `Dv` the cmt selects the residual σ; under `Ipred` the latent value
+    // comes from the compiled `observe`, so the cmt is unused (placeholder 1).
+    let cmt = match mode {
+        ObserveMode::Dv => resolve_observe_cmt(model, spec)?,
+        ObserveMode::Ipred => spec.assay_cmt.unwrap_or(1),
+    };
+    let monitors = vec![MonitorSpec::new(ADAPTIVE_SIGNAL, cmt, mode)];
+    let factory = build_adaptive_controller(spec);
+    Ok(CompiledAdaptive {
+        monitors,
+        observe,
+        make_controller: Box::new(factory),
+    })
 }
 
 #[cfg(test)]
@@ -499,5 +605,124 @@ mod tests {
         let mut b = factory();
         let b1 = b(&ctx);
         assert_eq!(b1, bolus(150.0, 1));
+    }
+
+    // ── Engine-side compile (observe expression → readout closure) ──
+
+    use crate::parser::model_parser::parse_full_model;
+
+    const ODE_MODEL: &str = r#"
+[parameters]
+  theta TVCL(1.0)
+  theta TVV(50.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+    const ANALYTICAL_MODEL: &str = r#"
+[parameters]
+  theta TVCL(1.0)
+  theta TVV(50.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+    fn mk_spec(
+        observe: &str,
+        with_assay_error: bool,
+        assay_cmt: Option<usize>,
+    ) -> AdaptiveDosingSpec {
+        AdaptiveDosingSpec {
+            observe: observe.to_string(),
+            with_assay_error,
+            assay_cmt,
+            at: vec![24.0, 48.0],
+            start_dose: 100.0,
+            route: AdaptiveRoute::Bolus { cmt: 1 },
+            dose_bounds: (0.0, 400.0),
+            confirm: 1,
+            levels: None,
+            rules: vec![rule(Comparison::Gt, 1000.0, AdaptiveAction::Hold)],
+        }
+    }
+
+    #[test]
+    fn compile_observe_yields_concentration_not_amount() {
+        let model = parse_full_model(ODE_MODEL).expect("ODE model parses").model;
+        let observe = compile_observe(&model, &mk_spec("central / V", false, None))
+            .expect("observe compiles");
+        let theta = model.default_params.theta.clone();
+        let eta = vec![0.0; model.n_eta + model.n_kappa];
+        let cov = HashMap::new();
+        let pk = (model.pk_param_fn)(&theta, &eta, &cov);
+        // central amount = 200, V = 50 ⇒ concentration 4.0 — NOT the raw amount 200.
+        let v = observe(&[200.0], &pk.values, &theta, &eta, &cov);
+        assert!(
+            (v - 4.0).abs() < 1e-9,
+            "expected concentration 4.0, got {v}"
+        );
+    }
+
+    #[test]
+    fn compile_observe_requires_ode_model() {
+        let model = parse_full_model(ANALYTICAL_MODEL).unwrap().model;
+        let err = compile_observe(&model, &mk_spec("central / V", false, None))
+            .err()
+            .expect("analytical model must error");
+        assert!(err.contains("requires an ODE model"), "got: {err}");
+    }
+
+    #[test]
+    fn compile_adaptive_sets_monitor_mode_and_cmt() {
+        let model = parse_full_model(ODE_MODEL).unwrap().model;
+        let ipred = compile_adaptive(&model, &mk_spec("central / V", false, None)).unwrap();
+        assert_eq!(ipred.monitors.len(), 1);
+        assert_eq!(ipred.monitors[0].name, ADAPTIVE_SIGNAL);
+        assert_eq!(ipred.monitors[0].mode, ObserveMode::Ipred);
+
+        let dv = compile_adaptive(&model, &mk_spec("central / V", true, Some(1))).unwrap();
+        assert_eq!(dv.monitors[0].mode, ObserveMode::Dv);
+        assert_eq!(dv.monitors[0].cmt, 1);
+    }
+
+    #[test]
+    fn resolve_observe_cmt_bare_name_number_explicit_and_error() {
+        let model = parse_full_model(ODE_MODEL).unwrap().model;
+        // bare state name → its 1-based compartment
+        assert_eq!(
+            resolve_observe_cmt(&model, &mk_spec("central", true, None)).unwrap(),
+            1
+        );
+        // bare compartment number
+        assert_eq!(
+            resolve_observe_cmt(&model, &mk_spec("2", true, None)).unwrap(),
+            2
+        );
+        // explicit assay_cmt wins
+        assert_eq!(
+            resolve_observe_cmt(&model, &mk_spec("central / V", true, Some(3))).unwrap(),
+            3
+        );
+        // an expression with no assay_cmt cannot designate an endpoint → typed error
+        let err = resolve_observe_cmt(&model, &mk_spec("central / V", true, None)).unwrap_err();
+        assert!(err.contains("cannot determine"), "got: {err}");
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1,8 +1,10 @@
 //! Simulation back-ends beyond the basic forward pass.
 //!
 //! Houses the state-reactive ("adaptive" / feedback) dosing machinery for issue
-//! #391. The [`adaptive`] module holds the controller vocabulary; the reactive
+//! #391. The [`adaptive`] module holds the controller vocabulary; [`adaptive_control`]
+//! compiles a declarative `[adaptive_dosing]` block into a controller; the reactive
 //! driver lives in [`crate::ode::predictions`] and the public
 //! [`crate::api::simulate_adaptive`] entry point wraps it.
 
 pub mod adaptive;
+pub mod adaptive_control;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4884,6 +4884,11 @@ pub struct SimulationSpec {
 pub struct ParsedModel {
     pub model: CompiledModel,
     pub simulation: Option<SimulationSpec>,
+    /// Parsed `[adaptive_dosing]` block (#391 S2): a declarative, file-driven
+    /// reactive controller. `None` when the block is absent. This slice (S2.1)
+    /// only parses and validates the spec; compiling it to a controller and
+    /// running it against `model` is a later step (S2.2+).
+    pub adaptive_dosing: Option<crate::sim::adaptive::AdaptiveDosingSpec>,
     pub fit_options: FitOptions,
     /// Declarations from the optional `[covariates]` block. `None` when the
     /// block is absent (legacy auto-detect: every non-standard CSV column is a


### PR DESCRIPTION
## Why

S1 (#391) shipped a programmatic reactive-dosing engine (`simulate_adaptive()`), but the controller is a Rust closure — a poor surface for modelers and for R. S2 (#584) adds the declarative **`[adaptive_dosing]` block**: a file-driven first-matching-rule controller. This PR lands the first three slices, **end-to-end and user-runnable**:

- **S2.1** — parse + validate the block into an `AdaptiveDosingSpec` AST.
- **S2.2** — compile that spec into a controller + an engine-resolved `observe`, driven through the S1 reactive engine.
- **S2.3** — the public file-driven entry point `simulate_adaptive_from_spec()`, the reactive-behaviour oracles, docs, CHANGELOG, and an example.

## What changed

**S2.1 — parser.** `parse_adaptive_dosing_block` → `AdaptiveDosingSpec` (+ `AdaptiveRoute` / `AdaptiveRule` / `Comparison` / `AdaptiveAction` / `DoseStep`) on `ParsedModel`; strict typed errors for every malformed / unknown / inverted / mixed / ambiguous construct (mirrors the `[simulation]` parser).

**S2.2 — compile + drive.**
- `build_adaptive_controller(spec)` — a per-subject controller **factory** implementing the first-matching-rule ladder, the `confirm` consecutive-breach debounce, continuous (%) and discrete (`levels`) titration, `dose_bounds` clamping, the running dose, and the bolus/infuse route. Model-independent: reads `ctx.signal`, returns `DoseAction`s.
- `compile_observe` — compiles the `observe` expression into the engine's readout-closure shape (`OdeOutputFn`) by **reusing the model's own output compiler** (`build_y_output_fn`, now context-labelled + `pub(crate)`), so `observe = central / V` yields the concentration, not the raw amount. `compile_adaptive` bundles controller + observe + monitor(s).
- Driver: `ode_predictions_adaptive_impl` takes a monitor's **latent** value from its compiled `observe` when present, else the cmt readout. `Dv` still draws its σ from the designated `assay_cmt` (the S1.5 substream).

**S2.3 — public entry + oracles + docs.**
- `pub fn simulate_adaptive_from_spec(model, pop, params, n_sim, spec, opts)` — the file-driven counterpart to `simulate_adaptive()`. A shared `run_adaptive_population` orchestrator is factored out of `simulate_adaptive` so **both** entries share the η draw, the controller-assay substream, the driver call, the frozen-replay verifier, and the tagged-row output. The programmatic path passes an empty `observe_exprs` ⇒ byte-identical to before (`ode_predictions_adaptive`, the cmt-only wrapper, now backs only the driver's unit tests; production routes through `_impl`).
- **The spec owns the schedule and the monitor.** `spec.at` is the decision schedule and `spec.observe` the monitor, so a non-empty `opts.decision_times` / `opts.monitors` is a **typed error**, not a silently-ignored field (the spec would otherwise have two sources of truth). `seed` / `verify` / `max_decisions` still apply.

Two load-bearing design calls (from #584) are honored: `observe` is a first-class expression (no syntax churn); `with_assay_error` on an expression requires a designated `assay_cmt` (no guessed σ).

## Alternatives considered

- Bare-compartment-only `observe` — rejected: a parser-accepts-but-runtime-rejects gap is itself a happy-path trap, and derived-signal titration (TCI effect-site, biomarker) is a core use case. The expression path reuses the existing compiler and leaves the bit-exact dose/segment path untouched (monitors are read-only at decision times).
- A dedicated options struct for the declarative entry — rejected in favour of reusing `AdaptiveSimulateOptions` and rejecting the schedule/monitor fields, so the two entries share one options type and one orchestrator.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | follow-up **after** this merges to main | — |

`simulate_adaptive_from_spec` is the callback-free R surface, but ferx-r's pin only advances to a **main** commit (`tools/update-ferx-core-lock.sh`), so R exposure is a separate PR once this lands.

## Breaking changes
- [x] None — additive (new `pub` fn + re-export; `simulate_adaptive` / `ode_predictions_adaptive` signatures unchanged; the orchestrator extraction is behaviour-preserving, asserted by the unchanged 44 driver tests + the existing `simulate_adaptive` suite).

## Numerical validation
- [x] In-house oracles (per CLAUDE.md this feature family validates against in-house oracles + mrgsolve, never NONMEM — there is no native NONMEM feedback dosing):
  - **degenerate** — a never-firing block re-issues a fixed regimen and reproduces `predict()` bit-for-bit (the frozen-replay verifier, on by default, also passes);
  - **three-witnesses** — the declarative block and a hand-written controller closure with the identical ladder realize the identical ledger, decision log, and trajectory, byte-for-byte;
  - **closed-loop** — a titration that starts below its target band drives the trough into the band and holds it there;
  - **σ→0** — the `with_assay_error` block collapses onto the latent (`Ipred`) dose schedule as residual error vanishes.
  - The mrgsolve external anchor (genuinely-reactive comparison) lands in a later slice (S2.5).

## Tests
- [x] Unit tests added; **full lib suite 1824/0; clippy + fmt clean**; `cargo check --tests` clean under `survival` and `ci`.

S2.3 adds 9 tests (degenerate, three-witnesses, closed-loop convergence, two opts-rejections, analytical-model rejection, σ→0 Dv collapse, determinism, and the shipped example run end-to-end from disk). On top of S2.1's 30 parser tests and S2.2's 16 controller/compile/driver tests.

## Docs
- [x] **User-visible now.** `docs/model-file/adaptive-dosing.qmd` graduated: two-entry intro, a full `[adaptive_dosing]` key + rule reference, a `simulate_adaptive_from_spec()` run example, and the new oracles in the Validation section; the maturity row names the block. CHANGELOG `[Unreleased]` Added. New `examples/adaptive_tdm_titration.ferx` (vancomycin-style trough TDM: expression `observe` + `with_assay_error` + infusion route).

## Deferred (tracked on #584)
1. **Open-ended `at`** (`every <Δ> from <t0>` with no `to`) — still deferred; it needs a simulation horizon the public entry does not thread yet. The literal-`to` form is the only schedule for now.
2. **Multiple named monitors** (per-analyte modes) — a later S2 refinement; the engine already supports it, only the declarative surface is single-`observe` today.

## Checklist
- [x] `cargo clippy` clean (no new warnings on the changed lines, under CI's `--no-default-features --features ci`)
- [x] Not on the `Dual2` sensitivity path (sim-only)
- [x] No `Cargo.toml` version bump (additive)

## Reviewer hints
S2.3: `simulate_adaptive_from_spec` (the opts-ownership guards + `compile_adaptive` as the ODE gate) and `run_adaptive_population` (the extracted orchestrator — the diff against the old `simulate_adaptive` body is the load-bearing part; the empty-`observe_exprs` programmatic path must stay byte-identical). The three-witnesses test is the strongest oracle: it asserts the full ledger + decisions + trajectory of the block equal a hand-written closure's.
