### PR TITLE
test(ode): report transit RK45 step regime

### DIFF
--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -7,7 +7,7 @@
 //! infusion's end time and adding `+rate` to the corresponding compartment's
 //! derivative for the duration of the infusion via an RHS wrapper.
 
-use crate::ode::solver::{solve_ode, OdeSolverOptions};
+use crate::ode::solver::{solve_ode, solve_ode_with_stats, OdeSolverOptions, OdeSolverStats};
 use crate::pk::absorption::PreparedInputRate;
 use crate::sim::adaptive::{
     assay_standard_normal, AdaptiveRun, AssayNoise, ControllerCtx, DecisionLogEntry,
@@ -1069,6 +1069,7 @@ fn integrate_segment(
     eta: &[f64],
     obs_map: &HashMap<u64, Vec<usize>>,
     predictions: &mut [f64],
+    stats: Option<&mut OdeSolverStats>,
 ) {
     let opts = ode.solver_opts;
 
@@ -1152,13 +1153,14 @@ fn integrate_segment(
         InfusionInput::Spanning(active),
         &zero_order,
     );
-    let sol = solve_ode(
+    let sol = solve_ode_with_stats(
         &wrapped_rhs,
         u,
         (t_start, t_end),
         ext_params,
         &saveat,
         &opts,
+        stats,
     );
 
     // Extract predictions and update state
@@ -1193,7 +1195,35 @@ pub fn ode_predictions(
     eta: &[f64],
     subject: &Subject,
 ) -> Vec<f64> {
-    ode_predictions_with_extra_breaks(ode, pk_params_flat, theta, eta, subject, &[])
+    ode_predictions_with_extra_breaks_and_stats(ode, pk_params_flat, theta, eta, subject, &[], None)
+}
+
+/// [`ode_predictions`] plus aggregate RK45 step counters across all integration
+/// segments in this subject.
+///
+/// This is an opt-in diagnostic path: production predictions call
+/// [`ode_predictions`] and pay no stats plumbing. The integration segmentation,
+/// dose handling, forcing wrapper, and readout logic are otherwise identical,
+/// so the returned counters classify the same RK45 work the production
+/// predictor performs.
+pub fn ode_predictions_with_solver_stats(
+    ode: &OdeSpec,
+    pk_params_flat: &[f64],
+    theta: &[f64],
+    eta: &[f64],
+    subject: &Subject,
+) -> (Vec<f64>, OdeSolverStats) {
+    let mut stats = OdeSolverStats::default();
+    let predictions = ode_predictions_with_extra_breaks_and_stats(
+        ode,
+        pk_params_flat,
+        theta,
+        eta,
+        subject,
+        &[],
+        Some(&mut stats),
+    );
+    (predictions, stats)
 }
 
 /// [`ode_predictions`] with additional, dose-free segment break points seeded
@@ -1218,6 +1248,26 @@ pub(crate) fn ode_predictions_with_extra_breaks(
     eta: &[f64],
     subject: &Subject,
     extra_breaks: &[f64],
+) -> Vec<f64> {
+    ode_predictions_with_extra_breaks_and_stats(
+        ode,
+        pk_params_flat,
+        theta,
+        eta,
+        subject,
+        extra_breaks,
+        None,
+    )
+}
+
+fn ode_predictions_with_extra_breaks_and_stats(
+    ode: &OdeSpec,
+    pk_params_flat: &[f64],
+    theta: &[f64],
+    eta: &[f64],
+    subject: &Subject,
+    extra_breaks: &[f64],
+    mut stats: Option<&mut OdeSolverStats>,
 ) -> Vec<f64> {
     let n = ode.n_states;
     let n_obs = subject.obs_times.len();
@@ -1402,6 +1452,7 @@ pub(crate) fn ode_predictions_with_extra_breaks(
             eta,
             &obs_map,
             &mut predictions,
+            stats.as_deref_mut(),
         );
     }
 
@@ -1921,6 +1972,7 @@ pub(crate) fn ode_predictions_adaptive(
                 eta,
                 &obs_map,
                 &mut predictions,
+                None,
             );
         }
 
@@ -3232,6 +3284,7 @@ mod tests {
             &[],
             &obs_map,
             &mut predictions,
+            None,
         );
 
         assert_eq!(u, vec![10.0], "zero-length segment must not change state");
@@ -3269,6 +3322,7 @@ mod tests {
             &[],
             &obs_map,
             &mut predictions,
+            None,
         );
 
         let expected = 10.0 * (-1.0f64).exp(); // 10·e^{-ke·10}, ke = 0.1
@@ -5008,6 +5062,7 @@ mod tests {
             &[],
             &obs_map,
             &mut predictions,
+            None,
         );
 
         // TAD anchor must be the dose time (0.0), not NaN.

--- a/tests/transit_nonmem_anchor.rs
+++ b/tests/transit_nonmem_anchor.rs
@@ -30,6 +30,7 @@
 //! `docs/model-file/absorption.qmd` "Verification against NONMEM"). This
 //! test therefore sets the tight tolerances explicitly.
 
+use ferx_core::ode::{ode_predictions_with_solver_stats, OdeSolverStats};
 use ferx_core::parser::model_parser::parse_full_model;
 use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
 use std::path::Path;
@@ -115,5 +116,64 @@ fn savic_transit_matches_nonmem_ofv() {
         result.ofv,
         EXPECTED_OFV,
         TOLERANCE,
+    );
+}
+
+/// The #387 solver-decision gate: at NONMEM-equivalent tolerances the Savic
+/// transit anchor should be accepted-step dominated, not rejection/min-step
+/// dominated. That means a stabilized low-order method such as ROCK2 should not
+/// be treated as the expected #385 fix without a separate loose-tolerance stiff
+/// benchmark.
+#[test]
+fn savic_transit_1e9_rk45_stats_are_accepted_step_dominated() {
+    let mut model = parse_full_model(MODEL_SRC)
+        .expect("Savic transit model must parse")
+        .model;
+    let pop = read_nonmem_csv(Path::new("data/transit_oral.csv"), None, None)
+        .expect("transit_oral data must load");
+    {
+        let ode = model
+            .ode_spec
+            .as_mut()
+            .expect("Savic transit model must be ODE-based");
+        ode.solver_opts.reltol = 1e-9;
+        ode.solver_opts.abstol = 1e-9;
+    }
+
+    // Tight-tolerance ferx estimates from the NONMEM anchor documentation:
+    // docs/model-file/absorption.qmd, "Savic transit (`transit`)".
+    let theta = [5.453, 55.759, 0.950, 0.966, 3.128];
+    let eta = vec![0.0; model.n_eta];
+    let mut stats = OdeSolverStats::default();
+    let mut n_pred = 0usize;
+
+    for subject in &pop.subjects {
+        let pk = (model.pk_param_fn)(&theta, &eta, &subject.covariates);
+        let (pred, subject_stats) = ode_predictions_with_solver_stats(
+            model.ode_spec.as_ref().unwrap(),
+            &pk.values,
+            &theta,
+            &eta,
+            subject,
+        );
+        n_pred += pred.len();
+        stats.attempted_steps += subject_stats.attempted_steps;
+        stats.accepted_steps += subject_stats.accepted_steps;
+        stats.rejected_steps += subject_stats.rejected_steps;
+        stats.min_step_clamped_steps += subject_stats.min_step_clamped_steps;
+    }
+
+    assert_eq!(n_pred, 240);
+    assert_eq!(
+        stats.attempted_steps,
+        stats.accepted_steps + stats.rejected_steps
+    );
+    assert!(
+        stats.accepted_steps > 10 * stats.rejected_steps.max(1),
+        "Savic transit at 1e-9 should be accepted-step dominated; stats = {stats:?}"
+    );
+    assert_eq!(
+        stats.min_step_clamped_steps, 0,
+        "Savic transit at 1e-9 should not be min-step clamped; stats = {stats:?}"
     );
 }


### PR DESCRIPTION
## Summary
- add an opt-in `ode_predictions_with_solver_stats` wrapper that aggregates RK45 counters across production no-TV ODE prediction segments
- add a Savic transit anchor test at `ode_reltol = ode_abstol = 1e-9`
- measured the anchor as accepted-step dominated: attempted 4060, accepted 3940, rejected 120, min-step clamped 0

Updates #387.

## Tests
- cargo fmt --all --check
- cargo test savic_transit_1e9_rk45_stats_are_accepted_step_dominated -- --nocapture
- cargo test ode::solver::tests::solve_ode