### PR TITLE
fix(estimation): gate #555 inner argmin fallback to ODE objectives (FREM IMP regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,17 +308,19 @@ section of the SDLC for the versioning policy).
   then discarded the correct estimate and restarted Nelder–Mead from η=0, which on a
   multimodal inner objective (e.g. `obs_scale = V1` with `V1 = … · exp(ETA_V1)`) settled
   in a worse local minimum and inflated the FOCEI objective (≈370 OFV on the
-  `two_cpt_oral_cov` example; its analytical twin was unaffected). Two changes fix it:
-  the inner fallback (both the BSV and the IOV paths) now keeps the **lower-objective** of
-  the BFGS partial and the Nelder–Mead restart instead of blindly overwriting with NM; and
-  the inner BFGS gained an objective-stall stop (active only for ODE models, so analytical
-  and finite-difference fits are bit-identical to before) so it converges at the mode
-  rather than spinning. The ODE form's OFV-at-init now matches its analytical twin
-  (`−1193.59`, previously `−823.05`), at the default ODE tolerance, and affected subjects
-  converge in far fewer inner iterations. *Note:* with `ebe_warm_start` off (the default), a
-  fit that hits the inner fallback with a BFGS partial that beats the η=0 restart now
-  returns that partial rather than the NM-from-0 result, so a previously fallback-stalled
-  EBE/OFV may shift toward the better optimum.
+  `two_cpt_oral_cov` example; its analytical twin was unaffected). Two changes fix it, both
+  scoped to ODE objectives so analytical, event-driven, FREM and finite-difference fits stay
+  bit-identical to before: for ODE models the inner fallback (both the BSV and the IOV paths)
+  now keeps the **lower-objective** of the BFGS partial and the Nelder–Mead restart instead
+  of blindly overwriting with NM, and the inner BFGS gained an objective-stall stop so it
+  converges at the mode rather than spinning. Exact objectives have no gradient-noise floor,
+  so a BFGS failure there is genuine non-convergence and the historical NM-from-η=0 recovery
+  is retained. The ODE form's OFV-at-init now matches its analytical twin (`−1193.59`,
+  previously `−823.05`), at the default ODE tolerance, and affected subjects converge in far
+  fewer inner iterations. *Note:* with `ebe_warm_start` off (the default), an **ODE** fit that
+  hits the inner fallback with a BFGS partial that beats the η=0 restart now returns that
+  partial rather than the NM-from-0 result, so a previously fallback-stalled EBE/OFV may shift
+  toward the better optimum.
 - **Form C (`[scaling] y = <expr>`) ODE readouts now use per-observation covariate
   snapshots** (#535, #538). The explicit-output readout is evaluated against the
   covariate values on each observation's own data row rather than the subject's

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -686,16 +686,32 @@ pub fn find_ebe(
         enable_stall,
     );
 
-    // If BFGS failed, fall back to Nelder-Mead — keeping the lower-objective of the BFGS
-    // partial and the NM restart rather than blindly overwriting with NM (#555). See
-    // [`argmin_inner_fallback`] for the rationale; the cold seed is η=0.
+    // If BFGS failed, fall back to Nelder-Mead. The recovery policy depends on whether the
+    // objective carries a gradient-noise floor (ODE) or is exact (analytical / event-driven /
+    // FREM):
+    //   * ODE (#555): the "failure" is usually a *certification* failure — the adaptive RK45
+    //     gradient-noise floor blocks `gnorm < tol` at a genuine mode. Keep the lower-objective
+    //     of {BFGS partial, NM-from-0} so a correct, lower-objective partial is never discarded
+    //     for a worse NM basin (the #555 bug). See [`argmin_inner_fallback`].
+    //   * Exact objectives: there is no noise floor, so a BFGS failure is genuine
+    //     non-convergence and the partial may be a non-stationary, merely-low-objective point
+    //     (e.g. run out along a FREM covariate pseudo-obs flat direction). Keeping it would
+    //     mis-center the FREM/IMP proposal, so recover with NM from η=0 (or the warm partial)
+    //     exactly as prior releases — bit-identical for analytical/FREM fits.
     let bfgs_converged = result;
     let (nm_converged, used_fallback) = if !bfgs_converged {
         let partial = eta.clone();
         let cold = vec![0.0; n_eta];
-        let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol);
-        eta = best;
-        (ok, true)
+        if enable_stall {
+            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol);
+            eta = best;
+            (ok, true)
+        } else {
+            let warm = ebe_warm_start_enabled() && partial.iter().all(|v| v.is_finite());
+            eta = if warm { partial } else { cold };
+            let nm_ok = nelder_mead_minimize(&obj, &mut eta, n_eta, max_iter * 5, tol);
+            (nm_ok, true)
+        }
     } else {
         (false, false)
     };
@@ -894,17 +910,25 @@ fn find_ebe_iov(
         None,
         enable_stall,
     );
-    // On BFGS failure, keep the lower-objective of the BFGS partial and a Nelder–Mead
-    // restart (cold seed = prior mode `bsv_psi = μ`, κ = 0) rather than blindly overwriting
-    // with NM — the same #555 argmin policy as the non-IOV `find_ebe`, so the IOV inner
-    // loop no longer discards a correct η̂ when its gradient floors above `tol`.
+    // On BFGS failure, recover with the same ODE-gated policy as the non-IOV `find_ebe`
+    // (cold seed = prior mode `bsv_psi = μ`, κ = 0): for ODE objectives keep the
+    // lower-objective of {BFGS partial, NM restart} so a correct η̂ floored above `tol` by
+    // solver noise is never discarded (#555); for exact objectives recover with NM from the
+    // cold seed, as prior releases, so a non-stationary low-objective partial can't be kept.
     let (nm_converged, used_fallback) = if !bfgs_converged {
         let partial = x.clone();
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
-        let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
-        x = best;
-        (ok, true)
+        if enable_stall {
+            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
+            x = best;
+            (ok, true)
+        } else {
+            let warm = ebe_warm_start_enabled() && partial.iter().all(|v| v.is_finite());
+            x = if warm { partial } else { cold };
+            let nm_ok = nelder_mead_minimize(&obj, &mut x, n_flat, max_iter * 5, tol);
+            (nm_ok, true)
+        }
     } else {
         (false, false)
     };


### PR DESCRIPTION
## Why

PR #587 (#555) made the inner-EBE Nelder–Mead fallback keep the **lower-objective** of the BFGS partial and the NM restart for **all** models. That regressed the FREM IMP Rao–Blackwell marginal on the merged `main`: `frem_warfarin::frem_rao_blackwell_marginal_drops_covariate_2pi_constant` returns **530** instead of the seeded reference **19781** (Δ≈19250). The `Survival (TTE)` and `Coverage (fast, patch)` CI jobs went red on `main` after #587 merged.

Root cause:

- **FREM** inner searches use a *preconditioned* convergence test (#406). A BFGS "failure" there is **genuine non-convergence** along the flat covariate-pseudo-observation directions — the partial has low `individual_nll` but is **non-stationary**. Keeping it (instead of the NM-from-η=0 restart that prior releases used) mis-centers the IMP importance-sampling proposal, collapsing the marginal estimate.
- **#555 (ODE)** is the opposite: the BFGS partial sits at a *true* mode whose gradient norm is merely floored above `tol` by adaptive-RK45 solver noise, so keeping the lower-objective partial is correct.

So "keep the lower-objective partial" is right for ODE objectives and wrong for exact (analytical / event-driven / FREM) ones. #587's own CHANGELOG claimed analytical fits were bit-identical — the un-gated argmin made that false.

## What changed

Gate both inner fallbacks (BSV `find_ebe` and IOV `find_ebe_iov`) on `model.ode_spec.is_some()` — the same flag that already gates the #555 objective-stall stop:

- **ODE:** keep the argmin of {BFGS partial, NM restart} (the #555 fix, unchanged).
- **Exact objectives:** restore the historical NM-from-η=0 (or warm-partial) recovery — bit-identical to releases before #587.

CHANGELOG #555 entry corrected to state the ODE-only scope.

## Alternatives considered

A strict stationarity check on the partial (keep it only if the gradient is near-zero) was tried during #587 review and regressed legitimately-converged weakly-identified fits (analytic vs FD gradient disagree at ~1e-5 on flat κ directions). Gating on the objective type is the precise, principled discriminator: only ODE objectives carry the gradient-noise floor that makes a stationary partial look "failed."

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: prior ferx commit (pre-#587) and the analytical FREM reference.
- [x] Reference values:

```
frem_warfarin::frem_rao_blackwell_marginal_drops_covariate_2pi_constant (RB IMP marginal, seeded K=6000):
  reference (pre-#587) : 19781.13
  after #587 (bug)     :   530.21   (Δ≈19250, CI red)
  this PR              : 19781.13   (restored)

two_cpt_oral_cov FOCEI OFV-at-init (the #555 ODE fix, preserved):
  ODE obs_scale = V1   : -1193.59   (matches analytical twin)
```

## Performance
- [x] No significant impact expected (changes only the fallback path on BFGS failure; ODE path unchanged, exact-objective path reverts to the prior recovery).

## Tests
- [x] Regression covered by the existing `frem_rao_blackwell_marginal_drops_covariate_2pi_constant` (fails on `main`, passes here) and the #555 ODE regressions (`repro555_ode_exprscale_ebe_finds_global_min`, still green).
- [x] `cargo test --lib` passes (1802 + main's additions); FREM survival set 7/7.

## Example (user-facing features only)
- [x] Not applicable (internal fix; restores correct behaviour for exact-objective fits).

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` #555 entry scope corrected
- [x] No new user-visible behaviour/DSL

## Checklist
- [x] `cargo clippy` clean on changed code (no new warnings at changed lines)
- [x] `Dual2` sensitivity path untouched (change is in the inner optimizer fallback only)
- [x] `Cargo.toml` version bump — N/A (non-breaking)

### Example execution
- [x] No example execution step needed (internal fix; restores a previously-correct OFV/marginal)

## Reviewer hints

Focus on the two fallback call sites in `src/estimation/inner_optimizer.rs` (`find_ebe`, `find_ebe_iov`): each now branches on `enable_stall` (= `model.ode_spec.is_some()`) between the argmin helper and the historical NM-from-cold-seed recovery. `argmin_inner_fallback` itself is unchanged and still exercised by `argmin_inner_fallback_keeps_better_basin`.

## Open questions

None — the discriminator (ODE objective ⇒ gradient-noise floor ⇒ keep stationary partial) is well-defined and matches the #555 stall gate.