### PR TITLE
fix(estimation): avoid ODE IOV worker stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,9 @@ section of the SDLC for the versioning policy).
 - ODE+IOV models with many occasion blocks or dose-only occasions now keep analytic
   inner/outer gradients when otherwise in scope, covering per-subject stacks up to 96
   axes (#590).
+- Wide ODE+IOV analytic gradients now run on larger Rayon worker stacks, avoiding
+  native stack-overflow crashes in R/CLI release builds for PNA-scale occasion counts
+  (#590).
 - Standard errors for `theta` parameters with a **negative lower bound** (estimated on
   the natural scale — e.g. exposure–hazard slopes, covariate exponents) are no longer
   mis-scaled (#564). The delta-method back-transform `SE(θ) = θ·SE(log θ)` was applied to

--- a/src/api.rs
+++ b/src/api.rs
@@ -58,6 +58,40 @@ pub(crate) fn fit_thread_pool_builder() -> rayon::ThreadPoolBuilder {
     rayon::ThreadPoolBuilder::new().stack_size(FIT_RAYON_STACK_SIZE)
 }
 
+/// Build a fit-scoped Rayon pool with the ferx worker stack and an explicit thread
+/// count. Used only when the caller pins `options.threads` to a positive value; the
+/// common (unpinned) path reuses the shared [`default_fit_pool`] instead.
+pub(crate) fn build_fit_pool(n_threads: usize) -> Result<rayon::ThreadPool, String> {
+    fit_thread_pool_builder()
+        .num_threads(n_threads)
+        .build()
+        .map_err(|e| format!("failed to build rayon pool with {n_threads} threads: {e}"))
+}
+
+/// The process-wide fit pool, built once with the ferx worker stack (32 MiB) so wide
+/// ODE+IOV analytic gradients do not overflow the platform-default worker stack. Shared
+/// across every default-threads `fit()` call so batch / concurrent callers do not each
+/// spawn-and-tear-down a fresh `N × 32 MiB` pool (which oversubscribes CPUs and can
+/// exhaust address space). Sized to `rayon::current_num_threads()` at first use, so a
+/// CLI `--threads N` (which sets the global pool count before the first fit) is honored.
+///
+/// Returns `None` only if the one-time build fails (e.g. resource limits); callers then
+/// run on the ambient pool rather than aborting the fit.
+pub(crate) fn default_fit_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: std::sync::OnceLock<Option<rayon::ThreadPool>> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        // Pin to the ambient worker count (the global pool size, which a CLI `--threads N`
+        // sets via `build_global` before the first fit). A bare `build()` would instead
+        // default to *all* logical CPUs and ignore `--threads`. Evaluated outside any fit
+        // pool, so it reads the global pool's configured size.
+        fit_thread_pool_builder()
+            .num_threads(rayon::current_num_threads())
+            .build()
+            .ok()
+    })
+    .as_ref()
+}
+
 /// Route predictions through analytical PK or ODE solver, then apply
 /// `model.scaling` so simulate / predict / post-fit IPRED see the same
 /// scaled output as the estimation dispatcher in `pk::compute_predictions_with_tv_into_with_schedule`.
@@ -2017,19 +2051,18 @@ pub fn fit(
 
     // Single-start fast path (default)
     if options.n_starts <= 1 {
-        let mut pool_builder = fit_thread_pool_builder();
-        let n_threads = options
-            .threads
-            .filter(|&n| n > 0)
-            .unwrap_or_else(rayon::current_num_threads);
-        pool_builder = pool_builder.num_threads(n_threads);
-        let pool = pool_builder.build().map_err(|e| match options.threads {
-            Some(n) if n > 0 => {
-                format!("failed to build rayon pool with {} threads: {}", n, e)
-            }
-            _ => format!("failed to build rayon pool: {e}"),
-        })?;
-        let res = { pool.install(|| fit_inner(model, pop_ref, init_params, options)) };
+        let run = || fit_inner(model, pop_ref, init_params, options);
+        // A pinned positive `threads` builds a fit-scoped pool sized to it (and surfaces a
+        // build failure as `Err`, as before). The unpinned default reuses the shared
+        // big-stack pool; if that one-time build ever failed we run on the ambient pool
+        // rather than turning a previously-successful default fit into an `Err`.
+        let res = match options.threads.filter(|&n| n > 0) {
+            Some(n) => build_fit_pool(n)?.install(run),
+            None => match default_fit_pool() {
+                Some(pool) => pool.install(run),
+                None => run(),
+            },
+        };
         return res.map(|mut result| {
             result.warnings.splice(0..0, ltbs_warnings);
             rebuild_warnings_structured(&mut result);
@@ -2038,9 +2071,12 @@ pub fn fit(
     }
 
     // Multi-start: run n_starts fits in parallel, return the lowest-OFV converged result.
-    // Use one fit-scoped pool for both the outer start loop and inner per-subject work.
-    // Creating a new ThreadPool per start inside an outer into_par_iter() spawns n_starts
-    // independent pools that all compete on the same CPUs, causing oversubscription.
+    // `threads` controls per-subject parallelism inside a single-start fit; in multi-start
+    // mode the shared fit pool handles both levels (outer start × inner per-subject), so we
+    // do not narrow it to `threads` here — that would cap the combined fan-out below the
+    // available cores. Running one shared pool (rather than a fresh ThreadPool per start
+    // inside the outer into_par_iter()) also avoids spawning n_starts independent pools that
+    // all compete on the same CPUs, causing oversubscription.
     let base_seed: u64 = options.multi_start_seed.unwrap_or(42);
     let base_saem_seed: u64 = options.saem_seed.unwrap_or(12345);
     let base_bayes_seed: u64 = options.bayes_seed.unwrap_or(12345);
@@ -2057,18 +2093,7 @@ pub fn fit(
         ));
     }
 
-    let mut pool_builder = fit_thread_pool_builder();
-    let n_threads = options
-        .threads
-        .filter(|&n| n > 0)
-        .unwrap_or_else(rayon::current_num_threads);
-    pool_builder = pool_builder.num_threads(n_threads);
-    let pool = pool_builder.build().map_err(|e| match options.threads {
-        Some(n) if n > 0 => format!("failed to build rayon pool with {} threads: {}", n, e),
-        _ => format!("failed to build rayon pool: {e}"),
-    })?;
-
-    let results: Vec<(usize, Result<FitResult, String>)> = pool.install(|| {
+    let par_starts = || -> Vec<(usize, Result<FitResult, String>)> {
         (0..n)
             .into_par_iter()
             .map(|k| {
@@ -2097,7 +2122,14 @@ pub fn fit(
                 (k, fit_inner(model, pop_ref, &init_k, opts_ref))
             })
             .collect()
-    });
+    };
+
+    // Run the start fan-out on the shared big-stack pool; fall back to the ambient pool
+    // only if its one-time build failed.
+    let results: Vec<(usize, Result<FitResult, String>)> = match default_fit_pool() {
+        Some(pool) => pool.install(par_starts),
+        None => par_starts(),
+    };
 
     // Pick best converged result; fall back to best unconverged if none converged.
     let mut best: Option<(usize, FitResult)> = None;

--- a/src/api.rs
+++ b/src/api.rs
@@ -45,6 +45,19 @@ use rayon::prelude::*;
 use std::path::Path;
 use std::time::Instant;
 
+/// Worker-stack size for ferx-managed Rayon pools.
+///
+/// Wide ODE+IOV analytic sensitivities instantiate `Dual2<M>` with `M` close to 100.
+/// Each dual carries an `M x M` Hessian, and the ODE/event-walk frames hold several
+/// of them at once. Rayon/default pthread stacks can be as small as 2 MiB on macOS,
+/// which overflows before Rust can unwind. Use a larger fit-scoped stack for Rayon
+/// workers that may evaluate these gradients.
+pub(crate) const FIT_RAYON_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+pub(crate) fn fit_thread_pool_builder() -> rayon::ThreadPoolBuilder {
+    rayon::ThreadPoolBuilder::new().stack_size(FIT_RAYON_STACK_SIZE)
+}
+
 /// Route predictions through analytical PK or ODE solver, then apply
 /// `model.scaling` so simulate / predict / post-fit IPRED see the same
 /// scaled output as the estimation dispatcher in `pk::compute_predictions_with_tv_into_with_schedule`.
@@ -2004,16 +2017,19 @@ pub fn fit(
 
     // Single-start fast path (default)
     if options.n_starts <= 1 {
-        let res = match options.threads {
+        let mut pool_builder = fit_thread_pool_builder();
+        let n_threads = options
+            .threads
+            .filter(|&n| n > 0)
+            .unwrap_or_else(rayon::current_num_threads);
+        pool_builder = pool_builder.num_threads(n_threads);
+        let pool = pool_builder.build().map_err(|e| match options.threads {
             Some(n) if n > 0 => {
-                let pool = rayon::ThreadPoolBuilder::new()
-                    .num_threads(n)
-                    .build()
-                    .map_err(|e| format!("failed to build rayon pool with {} threads: {}", n, e))?;
-                pool.install(|| fit_inner(model, pop_ref, init_params, options))
+                format!("failed to build rayon pool with {} threads: {}", n, e)
             }
-            _ => fit_inner(model, pop_ref, init_params, options),
-        };
+            _ => format!("failed to build rayon pool: {e}"),
+        })?;
+        let res = { pool.install(|| fit_inner(model, pop_ref, init_params, options)) };
         return res.map(|mut result| {
             result.warnings.splice(0..0, ltbs_warnings);
             rebuild_warnings_structured(&mut result);
@@ -2022,12 +2038,9 @@ pub fn fit(
     }
 
     // Multi-start: run n_starts fits in parallel, return the lowest-OFV converged result.
-    // `threads` controls per-subject parallelism inside each start; in multi-start mode
-    // we let the global rayon pool handle both levels (outer start × inner per-subject).
+    // Use one fit-scoped pool for both the outer start loop and inner per-subject work.
     // Creating a new ThreadPool per start inside an outer into_par_iter() spawns n_starts
-    // independent pools that all compete on the same CPUs, causing oversubscription —
-    // so we only honour `threads` when the global pool hasn't been entered yet (single-start
-    // path above). Here we always use the global pool for the outer par_iter.
+    // independent pools that all compete on the same CPUs, causing oversubscription.
     let base_seed: u64 = options.multi_start_seed.unwrap_or(42);
     let base_saem_seed: u64 = options.saem_seed.unwrap_or(12345);
     let base_bayes_seed: u64 = options.bayes_seed.unwrap_or(12345);
@@ -2044,34 +2057,47 @@ pub fn fit(
         ));
     }
 
-    let results: Vec<(usize, Result<FitResult, String>)> = (0..n)
-        .into_par_iter()
-        .map(|k| {
-            let init_k = perturb_init(init_params, k, sigma, base_seed);
-            // Per-start option overrides for k > 0:
-            // - saem_seed / bayes_seed: derive from base so each start gets a different
-            //   MH/MCMC trajectory. The Bayes sampler keys off bayes_seed, so without
-            //   perturbing it every start runs an identical RNG trajectory (differing
-            //   only by the perturbed init) — wasted compute and false multi-start
-            //   robustness. Start 0 keeps the user's seeds for reproducibility.
-            // - global_search: CRS2-LM ignores the starting point and samples freely in
-            //   [lower, upper], so running it on starts 1..n overrides the perturbation
-            //   and makes multi-start a no-op for those starts. Only run it on start 0.
-            let opts_k_storage;
-            let opts_ref: &FitOptions = if k == 0 {
-                options
-            } else {
-                opts_k_storage = FitOptions {
-                    saem_seed: Some(base_saem_seed.wrapping_add(k as u64)),
-                    bayes_seed: Some(base_bayes_seed.wrapping_add(k as u64)),
-                    global_search: false,
-                    ..options.clone()
+    let mut pool_builder = fit_thread_pool_builder();
+    let n_threads = options
+        .threads
+        .filter(|&n| n > 0)
+        .unwrap_or_else(rayon::current_num_threads);
+    pool_builder = pool_builder.num_threads(n_threads);
+    let pool = pool_builder.build().map_err(|e| match options.threads {
+        Some(n) if n > 0 => format!("failed to build rayon pool with {} threads: {}", n, e),
+        _ => format!("failed to build rayon pool: {e}"),
+    })?;
+
+    let results: Vec<(usize, Result<FitResult, String>)> = pool.install(|| {
+        (0..n)
+            .into_par_iter()
+            .map(|k| {
+                let init_k = perturb_init(init_params, k, sigma, base_seed);
+                // Per-start option overrides for k > 0:
+                // - saem_seed / bayes_seed: derive from base so each start gets a different
+                //   MH/MCMC trajectory. The Bayes sampler keys off bayes_seed, so without
+                //   perturbing it every start runs an identical RNG trajectory (differing
+                //   only by the perturbed init) — wasted compute and false multi-start
+                //   robustness. Start 0 keeps the user's seeds for reproducibility.
+                // - global_search: CRS2-LM ignores the starting point and samples freely in
+                //   [lower, upper], so running it on starts 1..n overrides the perturbation
+                //   and makes multi-start a no-op for those starts. Only run it on start 0.
+                let opts_k_storage;
+                let opts_ref: &FitOptions = if k == 0 {
+                    options
+                } else {
+                    opts_k_storage = FitOptions {
+                        saem_seed: Some(base_saem_seed.wrapping_add(k as u64)),
+                        bayes_seed: Some(base_bayes_seed.wrapping_add(k as u64)),
+                        global_search: false,
+                        ..options.clone()
+                    };
+                    &opts_k_storage
                 };
-                &opts_k_storage
-            };
-            (k, fit_inner(model, pop_ref, &init_k, opts_ref))
-        })
-        .collect();
+                (k, fit_inner(model, pop_ref, &init_k, opts_ref))
+            })
+            .collect()
+    });
 
     // Pick best converged result; fall back to best unconverged if none converged.
     let mut best: Option<(usize, FitResult)> = None;

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -2,8 +2,6 @@ use ferx_core::NcaInit;
 use std::env;
 use std::time::Instant;
 
-const FIT_RAYON_STACK_SIZE: usize = 32 * 1024 * 1024;
-
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -58,20 +56,18 @@ fn main() {
         eprintln!("Warning: --include-data ignored (no --data file to embed)");
     }
 
-    // Configure rayon's global pool before any parallel work starts. build_global()
-    // is once-per-process — correct for a CLI binary. Even without a --threads flag,
-    // use ferx's larger worker stack so wide ODE+IOV analytic gradients do not overflow
-    // the platform default worker stack.
-    let mut pool_builder = rayon::ThreadPoolBuilder::new().stack_size(FIT_RAYON_STACK_SIZE);
+    // Honor --threads by sizing rayon's global pool (build_global() is once-per-process,
+    // correct for a CLI binary) so fit()'s default pool — sized to current_num_threads()
+    // — inherits the count. The 32 MiB worker stack that wide ODE+IOV analytic gradients
+    // need is applied by fit()'s own fit-scoped pool (api::default_fit_pool), so the
+    // global pool keeps the platform-default stack here rather than reserving a second
+    // 32 MiB × N. Without --threads, fit() sizes its pool to all cores.
     if let Some(n) = threads {
-        pool_builder = pool_builder.num_threads(n);
-    }
-    if let Err(e) = pool_builder.build_global() {
-        if let Some(n) = threads {
-            eprintln!(
-                "Warning: failed to configure thread pool with {} threads: {}",
-                n, e
-            );
+        if let Err(e) = rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global()
+        {
+            eprintln!("Warning: failed to configure thread pool with {n} threads: {e}");
         }
     }
 

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -2,6 +2,8 @@ use ferx_core::NcaInit;
 use std::env;
 use std::time::Instant;
 
+const FIT_RAYON_STACK_SIZE: usize = 32 * 1024 * 1024;
+
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -57,13 +59,15 @@ fn main() {
     }
 
     // Configure rayon's global pool before any parallel work starts. build_global()
-    // is once-per-process — correct for a CLI binary. Without a --threads flag we
-    // leave rayon's default (one worker per logical CPU) in place.
+    // is once-per-process — correct for a CLI binary. Even without a --threads flag,
+    // use ferx's larger worker stack so wide ODE+IOV analytic gradients do not overflow
+    // the platform default worker stack.
+    let mut pool_builder = rayon::ThreadPoolBuilder::new().stack_size(FIT_RAYON_STACK_SIZE);
     if let Some(n) = threads {
-        if let Err(e) = rayon::ThreadPoolBuilder::new()
-            .num_threads(n)
-            .build_global()
-        {
+        pool_builder = pool_builder.num_threads(n);
+    }
+    if let Err(e) = pool_builder.build_global() {
+        if let Some(n) = threads {
             eprintln!(
                 "Warning: failed to configure thread pool with {} threads: {}",
                 n, e

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -6000,7 +6000,18 @@ mod tests {
         }
     }
 
+    /// Regression guard for the ODE IOV worker-stack overflow (#601): a PNA-scale,
+    /// 86-occasion subject yields a `Dual2<90>` (90×90 Hessian per dual) whose
+    /// event-walk frames overflow the platform-default (~2 MiB) Rayon worker stack. The
+    /// gradient is run on [`crate::api::default_fit_pool`] — the *same* pool `fit()` uses
+    /// by default — so dropping the 32 MiB stack from that pool re-introduces the crash
+    /// here. Heavy (full wide-`M` sensitivity through RK45), so it is gated to the
+    /// nightly slow-tests tier rather than the fast per-PR job.
     #[test]
+    #[cfg_attr(
+        not(feature = "slow-tests"),
+        ignore = "slow: opt in with --features slow-tests"
+    )]
     fn fit_rayon_stack_handles_pna_scale_ode_iov_gradient() {
         let model = parse_model_string(WARFARIN_IOV_ODE).expect("parse ODE IOV");
         let n_occ = 86;
@@ -6035,10 +6046,9 @@ mod tests {
         let m_dim = model.n_theta + stacked.len();
         assert_eq!(m_dim, 90, "fixture mirrors the PNA-scale occasion width");
 
-        let pool = crate::api::fit_thread_pool_builder()
-            .num_threads(1)
-            .build()
-            .expect("fit-scoped rayon pool");
+        // Run on the actual default fit pool, so a regression that drops the big stack
+        // from `default_fit_pool` (or `fit_thread_pool_builder`) overflows here.
+        let pool = crate::api::default_fit_pool().expect("ferx default fit pool");
         pool.install(|| {
             crate::sens::ode_provider::ode_subject_sensitivities_iov(
                 &model, &subject, &theta, &stacked,

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -6000,6 +6000,53 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fit_rayon_stack_handles_pna_scale_ode_iov_gradient() {
+        let model = parse_model_string(WARFARIN_IOV_ODE).expect("parse ODE IOV");
+        let n_occ = 86;
+        let obs_times: Vec<f64> = (0..n_occ).map(|i| i as f64 * 24.0 + 1.0).collect();
+        let occasions: Vec<u32> = (1..=n_occ as u32).collect();
+        let doses: Vec<DoseEvent> = (0..n_occ)
+            .map(|i| DoseEvent::new(i as f64 * 24.0, 100.0, 1, 0.0, false, 0.0))
+            .collect();
+        let n = obs_times.len();
+        let subject = Subject {
+            id: "pna-scale-iov".to_string(),
+            doses,
+            obs_times,
+            obs_raw_times: Vec::new(),
+            observations: vec![1.0; n],
+            obs_cmts: vec![1; n],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n],
+            occasions,
+            dose_occasions: (1..=n_occ as u32).collect(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let theta = vec![0.2, 10.0];
+        let stacked = vec![0.0; model.n_eta + n_occ * model.n_kappa];
+        let m_dim = model.n_theta + stacked.len();
+        assert_eq!(m_dim, 90, "fixture mirrors the PNA-scale occasion width");
+
+        let pool = crate::api::fit_thread_pool_builder()
+            .num_threads(1)
+            .build()
+            .expect("fit-scoped rayon pool");
+        pool.install(|| {
+            crate::sens::ode_provider::ode_subject_sensitivities_iov(
+                &model, &subject, &theta, &stacked,
+            )
+            .expect("PNA-scale ODE IOV gradient should fit on ferx worker stack");
+        });
+    }
+
     /// A dose in an occasion that carries no sampled observations still gets its own κ
     /// axis. That kappa can affect later observations through carryover, so the ODE IOV
     /// provider must keep the subject on the analytic path rather than falling back to FD.


### PR DESCRIPTION
## Why

The pna_ahus ODE+IOV model still selected analytic gradients after #600, but R could abort shortly after NLopt started. The macOS crash report pointed at the Rayon worker stack guard with frames in `seed_pk_dual2_iov` / `run_subject_iov` / `subject_packed_gradient_iov`.

The root cause is that wide ODE+IOV analytic sensitivities instantiate `Dual2<M>` with `M` close to 100. Each dual carries an `M x M` Hessian, and the ODE/event-walk frames hold enough of them to overflow the default worker stack on R/macOS before Rust can unwind.

## What changed

- Added a fit-scoped Rayon pool builder with a 32 MiB worker stack for library fits.
- Run both single-start and multi-start fits inside one larger-stack pool, preserving explicit `options.threads` and otherwise inheriting the active Rayon pool size.
- Configure the CLI global Rayon pool with the same larger stack so CLI examples and nested fit work use the safer stack.
- Added a focused regression that evaluates a PNA-scale ODE+IOV analytic sensitivity width on a ferx-managed worker stack.
- Added a changelog entry.

## Alternatives considered

- Falling back to finite differences for wide ODE+IOV would avoid the stack pressure but regress the behavior fixed in #600.
- Boxing/reworking the wide `Dual2` frames would be a deeper AD-layout change. The stack-size fix is smaller and directly addresses the native crash on the current analytic path.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

None.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit `227eeec6` / this branch smoke run
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# before / reference
pna_ahus R/release analytic-gradient path aborted before Eval 1 with a native stack overflow in ODE IOV sensitivity frames.

# after
cargo run --release --bin ferx -- /Users/ron/git/ferx/ferx-testdata/pna_ahus_radboudumc/ferx/lineair_model20.ferx --data /Users/ron/git/ferx/ferx-testdata/pna_ahus_radboudumc/data/PNHAHUS_prepared.csv --threads 8
Starting estimation (chain: FOCEI) on 8 threads...
gradient: analytic (Dual2)  [requested: auto]
Eval    1: OFV = 9259.852438
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

The change reserves a larger worker stack for ferx-managed Rayon pools; it does not change the number of workers or the gradient calculations.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Local verification:

```
cargo test --lib fit_rayon_stack_handles_pna_scale_ode_iov_gradient
cargo check
cargo check --tests
cargo clippy
```

`cargo clippy` exits 0; the repository still reports existing clippy warnings unrelated to this PR.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# N/A
```

```
# N/A
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

`cargo clippy` exits 0 but reports existing warnings unrelated to this PR.

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

I did run the affected pna_ahus release CLI smoke command shown above through Eval 1, then interrupted it intentionally.

## Reviewer hints

Focus on `fit()` pool scope/thread-count preservation and the PNA-scale regression in `src/sens/provider.rs`. The sensitivity equations themselves are unchanged.

## Open questions

None.
