### PR TITLE
fix(estimation): avoid ODE IOV stalls on bad trials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,9 @@ section of the SDLC for the versioning policy).
 - Wide ODE+IOV analytic gradients now run on larger Rayon worker stacks, avoiding
   native stack-overflow crashes in R/CLI release builds for PNA-scale occasion counts
   (#590).
+- ODE+IOV fits no longer launch Nelder-Mead EBE fallback searches for bad outer
+  trial points, and RK45 now exits repeated minimum-step clamps early, avoiding
+  apparent stalls after rejected LBFGS steps in PNA-scale models (#590).
 - Standard errors for `theta` parameters with a **negative lower bound** (estimated on
   the natural scale — e.g. exposure–hazard slopes, covariate exponents) are no longer
   mis-scaled (#564). The delta-method back-transform `SE(θ) = θ·SE(log θ)` was applied to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,8 +273,11 @@ section of the SDLC for the versioning policy).
   native stack-overflow crashes in R/CLI release builds for PNA-scale occasion counts
   (#590).
 - ODE+IOV fits no longer launch Nelder-Mead EBE fallback searches for bad outer
-  trial points, and RK45 now exits repeated minimum-step clamps early, avoiding
-  apparent stalls after rejected LBFGS steps in PNA-scale models (#590).
+  trial points, and RK45 now exits repeated **non-finite** minimum-step clamps early,
+  avoiding apparent stalls after rejected LBFGS steps in PNA-scale models while leaving
+  finite-but-stiff segments to integrate normally (#590, #603). Subjects rejected at a
+  pathological inner start now force the outer trial to be rejected outright — including
+  in the SLSQP fallback — so a degenerate EBE can no longer bias an accepted OFV (#603).
 - Standard errors for `theta` parameters with a **negative lower bound** (estimated on
   the natural scale — e.g. exposure–hazard slopes, covariate exponents) are no longer
   mis-scaled (#564). The delta-method back-transform `SE(θ) = θ·SE(log θ)` was applied to

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -292,6 +292,7 @@ fn run_map_multistart(
     let stats = InnerLoopStats {
         n_unconverged: results.iter().filter(|r| !r.converged).count(),
         n_fallback: results.iter().filter(|r| r.used_fallback).count(),
+        n_start_rejected: results.iter().filter(|r| r.hard_reject).count(),
     };
     let eta_hats: Vec<DVector<f64>> = results.iter().map(|r| r.eta.clone()).collect();
     let h_matrices: Vec<DMatrix<f64>> = results.iter().map(|r| r.h_matrix.clone()).collect();

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -393,6 +393,13 @@ pub struct EbeResult {
     /// `kappas[k]` corresponds to the k-th unique occasion (same order as
     /// `iov_occasion_groups`).
     pub kappas: Vec<DVector<f64>>,
+    /// True when the subject was hard-rejected at its inner start (a pathological
+    /// ODE+IOV warm-start NLL — see [`reject_ode_iov_inner_start`]). The returned
+    /// `eta`/`h_matrix` are then a degenerate placeholder (off-mode η, zero H), so the
+    /// outer loop must reject the whole trial rather than fold them into an accepted
+    /// OFV. Unlike plain non-convergence this forces rejection regardless of
+    /// `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
+    pub hard_reject: bool,
 }
 
 /// Aggregate statistics from running the inner loop over all subjects.
@@ -402,6 +409,10 @@ pub struct InnerLoopStats {
     pub n_unconverged: usize,
     /// Subjects for which the BFGS→Nelder-Mead fallback was triggered.
     pub n_fallback: usize,
+    /// Subjects hard-rejected at their inner start (pathological ODE+IOV warm-start
+    /// NLL). Any non-zero count forces the outer EBE guard to reject the trial,
+    /// regardless of `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
+    pub n_start_rejected: usize,
 }
 
 /// Inner-EBE fallback shared by [`find_ebe`] and [`find_ebe_iov`], invoked when the inner
@@ -453,20 +464,28 @@ fn argmin_inner_fallback(
     (best, nm_ok)
 }
 
+/// An ODE-based model that also carries IOV (`κ`) random effects. The inner EBE path for
+/// these models is the expensive one this module special-cases (per-vertex ODE +
+/// steady-state work), so both the Nelder-Mead skip and the start-rejection gate key off
+/// this single classifier (#603 review #8).
+fn is_ode_iov(model: &CompiledModel) -> bool {
+    model.ode_spec.is_some() && model.n_kappa > 0
+}
+
 /// Nelder-Mead is a useful last-resort recovery for low-dimensional closed-form EBEs, but
 /// it is not a practical recovery strategy for ODE+IOV. A single bad outer line-search
 /// point can otherwise launch simplex searches where each vertex is a full ODE and
 /// steady-state prediction. Keep the BFGS partial and report the subject unconverged
 /// instead; the outer EBE guard can then reject the trial.
 fn skip_ode_iov_nm_fallback(model: &CompiledModel) -> bool {
-    model.ode_spec.is_some() && model.n_kappa > 0
+    is_ode_iov(model)
 }
 
 const ODE_IOV_START_REJECT_NLL_PER_OBS: f64 = 250.0;
 const ODE_IOV_START_REJECT_NLL_MIN: f64 = 1_000.0;
 
 fn reject_ode_iov_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
-    if !(model.ode_spec.is_some() && model.n_kappa > 0) {
+    if !is_ode_iov(model) {
         return false;
     }
     if !nll.is_finite() {
@@ -785,6 +804,7 @@ pub fn find_ebe(
         grad_norm: 0.0, // not computed to avoid extra FD calls; available via nll.is_finite()
         nll,
         kappas: Vec::new(),
+        hard_reject: false,
     }
 }
 
@@ -924,6 +944,10 @@ fn find_ebe_iov(
         let kappas_vec: Vec<DVector<f64>> = (0..k_occasions)
             .map(|k| DVector::from_column_slice(&x[n_eta + k * n_kappa..n_eta + (k + 1) * n_kappa]))
             .collect();
+        // Degenerate placeholder: the η/κ here are the (un-optimized) warm start and the
+        // H-matrix is zero — folding them into an OFV would corrupt the FOCEI curvature
+        // term. `hard_reject` makes the outer guard reject the whole trial rather than
+        // average this in, so the placeholder is never compared as a real OFV (#603 #1/#2).
         return EbeResult {
             eta: DVector::from_column_slice(&bsv_eta),
             h_matrix: DMatrix::zeros(subject.obs_times.len(), n_eta),
@@ -932,6 +956,7 @@ fn find_ebe_iov(
             grad_norm: 0.0,
             nll: start_nll,
             kappas: kappas_vec,
+            hard_reject: true,
         };
     }
 
@@ -1031,6 +1056,7 @@ fn find_ebe_iov(
         grad_norm: 0.0,
         nll,
         kappas: kappas_vec,
+        hard_reject: false,
     }
 }
 
@@ -2475,6 +2501,9 @@ pub fn run_inner_loop_warm(
             .filter(|(r, s)| !r.converged && s.observations.len() >= min_obs.max(1))
             .count(),
         n_fallback: results.iter().filter(|r| r.used_fallback).count(),
+        // No `min_obs` filter: a hard reject forces trial rejection even for a single
+        // short-record subject, which the `n_unconverged` filter would otherwise drop.
+        n_start_rejected: results.iter().filter(|r| r.hard_reject).count(),
     };
     let eta_hats: Vec<DVector<f64>> = results.iter().map(|r| r.eta.clone()).collect();
     let h_matrices: Vec<DMatrix<f64>> = results.iter().map(|r| r.h_matrix.clone()).collect();
@@ -2984,6 +3013,7 @@ mod tests {
             grad_norm: 0.0,
             nll: 1.5,
             kappas: Vec::new(),
+            hard_reject: false,
         };
         assert!(r.converged);
         assert!(!r.used_fallback);
@@ -3004,6 +3034,7 @@ mod tests {
                 grad_norm: 0.0,
                 nll: 1.0,
                 kappas: Vec::new(),
+                hard_reject: false,
             },
             EbeResult {
                 eta: nalgebra::DVector::zeros(1),
@@ -3013,6 +3044,7 @@ mod tests {
                 grad_norm: 0.0,
                 nll: 2.0,
                 kappas: Vec::new(),
+                hard_reject: false,
             },
         ];
         // Simulate filter: first subject has 1 obs (below min_obs=2), second has 3 obs.
@@ -3028,6 +3060,39 @@ mod tests {
         assert_eq!(n_unconverged, 1);
         // Both fallback counts regardless of min_obs.
         assert_eq!(n_fallback, 1);
+    }
+
+    /// #603 review #1/#2: a hard-rejected subject must be counted even with a short record,
+    /// so a single one forces the outer guard to reject the trial. Mirrors the `n_start_rejected`
+    /// derivation in `run_inner_loop_warm` (no `min_obs` filter, unlike `n_unconverged`).
+    #[test]
+    fn test_inner_loop_stats_counts_hard_reject_regardless_of_obs() {
+        let make = |hard_reject: bool| EbeResult {
+            eta: nalgebra::DVector::zeros(1),
+            h_matrix: nalgebra::DMatrix::zeros(1, 1),
+            converged: false,
+            used_fallback: false,
+            grad_norm: 0.0,
+            nll: 1.0,
+            kappas: Vec::new(),
+            hard_reject,
+        };
+        // One hard-rejected subject with a single observation, one normal subject.
+        let results = [make(true), make(false)];
+        let obs_counts = [1_usize, 5_usize];
+        let min_obs = 3_usize;
+
+        // The `min_obs` filter would drop the 1-obs subject from `n_unconverged` …
+        let n_unconverged = results
+            .iter()
+            .zip(obs_counts.iter())
+            .filter(|(r, &n_obs)| !r.converged && n_obs >= min_obs.max(1))
+            .count();
+        assert_eq!(n_unconverged, 1); // only the 5-obs subject
+
+        // … but `n_start_rejected` counts the hard reject regardless of obs count.
+        let n_start_rejected = results.iter().filter(|r| r.hard_reject).count();
+        assert_eq!(n_start_rejected, 1);
     }
 
     #[test]

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -453,6 +453,30 @@ fn argmin_inner_fallback(
     (best, nm_ok)
 }
 
+/// Nelder-Mead is a useful last-resort recovery for low-dimensional closed-form EBEs, but
+/// it is not a practical recovery strategy for ODE+IOV. A single bad outer line-search
+/// point can otherwise launch simplex searches where each vertex is a full ODE and
+/// steady-state prediction. Keep the BFGS partial and report the subject unconverged
+/// instead; the outer EBE guard can then reject the trial.
+fn skip_ode_iov_nm_fallback(model: &CompiledModel) -> bool {
+    model.ode_spec.is_some() && model.n_kappa > 0
+}
+
+const ODE_IOV_START_REJECT_NLL_PER_OBS: f64 = 250.0;
+const ODE_IOV_START_REJECT_NLL_MIN: f64 = 1_000.0;
+
+fn reject_ode_iov_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
+    if !(model.ode_spec.is_some() && model.n_kappa > 0) {
+        return false;
+    }
+    if !nll.is_finite() {
+        return true;
+    }
+    let threshold =
+        ODE_IOV_START_REJECT_NLL_MIN.max(ODE_IOV_START_REJECT_NLL_PER_OBS * n_obs.max(1) as f64);
+    nll > threshold
+}
+
 /// Find Empirical Bayes Estimates (EBEs) for a single subject via BFGS.
 ///
 /// When `mu_k` is provided (mu-referencing active), the inner optimizer works
@@ -884,6 +908,33 @@ fn find_ebe_iov(
             None => gradient_fd(&obj, p, n_flat),
         }
     };
+
+    let start_nll = obj(&x);
+    let has_informative_warm_start = eta_init
+        .map(|warm| warm.iter().any(|v| v.abs() > 1e-8))
+        .unwrap_or(false);
+    if has_informative_warm_start
+        && reject_ode_iov_inner_start(model, subject.obs_times.len(), start_nll)
+    {
+        let bsv_eta: Vec<f64> = x[..n_eta]
+            .iter()
+            .zip(mu.iter())
+            .map(|(p, m)| p - m)
+            .collect();
+        let kappas_vec: Vec<DVector<f64>> = (0..k_occasions)
+            .map(|k| DVector::from_column_slice(&x[n_eta + k * n_kappa..n_eta + (k + 1) * n_kappa]))
+            .collect();
+        return EbeResult {
+            eta: DVector::from_column_slice(&bsv_eta),
+            h_matrix: DMatrix::zeros(subject.obs_times.len(), n_eta),
+            converged: false,
+            used_fallback: false,
+            grad_norm: 0.0,
+            nll: start_nll,
+            kappas: kappas_vec,
+        };
+    }
+
     let bfgs_converged = inner_minimize_with_grad(
         &obj,
         &agrad,
@@ -904,7 +955,9 @@ fn find_ebe_iov(
         let partial = x.clone();
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
-        if enable_stall {
+        if skip_ode_iov_nm_fallback(model) {
+            (false, false)
+        } else if enable_stall {
             let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
             x = best;
             (ok, true)
@@ -3864,6 +3917,40 @@ mod iov_tests {
             "warm seed held the deep well, got {eta4:?}"
         );
         set_ebe_warm_start(false);
+    }
+
+    #[test]
+    fn ode_iov_skips_nelder_mead_inner_fallback() {
+        use crate::parser::model_parser::parse_model_string;
+        let ode_iov = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  kappa KAPPA_CL ~ 0.01\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n  iov_column = OCC\n",
+        )
+        .expect("parse ODE IOV");
+        assert!(skip_ode_iov_nm_fallback(&ode_iov));
+
+        let closed_form_iov = make_iov_model();
+        assert!(!skip_ode_iov_nm_fallback(&closed_form_iov));
+    }
+
+    #[test]
+    fn ode_iov_start_rejects_only_pathological_ode_iov_nll() {
+        use crate::parser::model_parser::parse_model_string;
+        let ode_iov = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  kappa KAPPA_CL ~ 0.01\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n  iov_column = OCC\n",
+        )
+        .expect("parse ODE IOV");
+        let closed_form_iov = make_iov_model();
+
+        assert!(!reject_ode_iov_inner_start(&ode_iov, 4, 999.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 4, 1_001.0));
+        assert!(!reject_ode_iov_inner_start(&ode_iov, 20, 4_999.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 20, 5_001.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 20, f64::NAN));
+        assert!(!reject_ode_iov_inner_start(
+            &closed_form_iov,
+            4,
+            1_000_000.0
+        ));
     }
 
     /// Closed-form IOV + `iiv_on_ruv` (#4b): the analytic stacked-η inner gradient

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1,4 +1,4 @@
-use crate::estimation::inner_optimizer::{find_ebe, run_inner_loop_warm};
+use crate::estimation::inner_optimizer::{find_ebe, run_inner_loop_warm, InnerLoopStats};
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::stats::likelihood::{foce_population_nll, foce_population_nll_iov};
 use crate::types::*;
@@ -361,6 +361,31 @@ struct NloptState {
 /// `enabled = false` disables the guard entirely: never latches and never
 /// reports stagnation, so the optimizer runs to its own termination
 /// criterion (or to `outer_maxiter`).
+/// Whether the EBE convergence guard rejects this outer trial. Two independent triggers:
+///
+/// 1. **Hard reject** — any subject was rejected at its inner start (a pathological ODE+IOV
+///    warm-start NLL). Its returned `(η, H)` is a degenerate placeholder, so the trial must
+///    be rejected regardless of `max_unconverged_frac` or the `min_obs` filter, otherwise a
+///    zero H-matrix would corrupt an *accepted* OFV (#603 review #1/#2).
+/// 2. **Too many unconverged** — the fraction of (long-enough-record) subjects whose inner
+///    optimizer failed exceeds `max_unconverged_frac` and the OFV is finite.
+///
+/// A negative `max_unconverged_frac` disables the fraction trigger (but never the hard
+/// reject). Centralising the predicate keeps the five evaluation sites in this module from
+/// drifting (#603 review #8).
+fn ebe_guard_rejects(
+    stats: &InnerLoopStats,
+    n_subj: usize,
+    raw_ofv: f64,
+    max_unconverged_frac: f64,
+) -> bool {
+    if stats.n_start_rejected > 0 {
+        return true;
+    }
+    let frac = stats.n_unconverged as f64 / (n_subj as f64).max(1.0);
+    raw_ofv.is_finite() && frac > max_unconverged_frac && max_unconverged_frac >= 0.0
+}
+
 fn detect_stagnation(state: &mut NloptState, n: usize, enabled: bool) -> bool {
     if !enabled {
         return false;
@@ -507,10 +532,7 @@ fn run_global_presearch(
             options.interaction,
         );
         let raw = 2.0 * nll;
-        let frac = ebe_stats.n_unconverged as f64 / (n_subj as f64).max(1.0);
-        let guarded = raw.is_finite()
-            && frac > options.max_unconverged_frac
-            && options.max_unconverged_frac >= 0.0;
+        let guarded = ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac);
         if !raw.is_finite() || guarded {
             1e20
         } else {
@@ -559,10 +581,8 @@ fn run_global_presearch(
         );
         let raw_ofv = 2.0 * nll;
 
-        let unconverged_frac = ebe_stats.n_unconverged as f64 / (n_subj as f64).max(1.0);
-        let ebe_guard = raw_ofv.is_finite()
-            && unconverged_frac > options.max_unconverged_frac
-            && options.max_unconverged_frac >= 0.0;
+        let ebe_guard =
+            ebe_guard_rejects(&ebe_stats, n_subj, raw_ofv, options.max_unconverged_frac);
         let ofv = if ebe_guard {
             1e20
         } else if raw_ofv.is_finite() {
@@ -953,11 +973,10 @@ fn optimize_nlopt(
         );
         let raw_ofv = 2.0 * nll;
 
-        // EBE convergence guard: reject step when too many subjects unconverged.
-        let unconverged_frac = ebe_stats.n_unconverged as f64 / (n_subj as f64).max(1.0);
-        let ebe_guard_triggered = raw_ofv.is_finite()
-            && unconverged_frac > options.max_unconverged_frac
-            && options.max_unconverged_frac >= 0.0;
+        // EBE convergence guard: reject step when too many subjects unconverged or any
+        // subject was hard-rejected at its inner start.
+        let ebe_guard_triggered =
+            ebe_guard_rejects(&ebe_stats, n_subj, raw_ofv, options.max_unconverged_frac);
         {
             let mut acc = ebe_accum_cl.lock().unwrap();
             if acc.max_unconverged < ebe_stats.n_unconverged {
@@ -980,59 +999,58 @@ fn optimize_nlopt(
         // Compute gradient if requested (central FD with fixed EBEs)
         let mut grad_norm_for_trace: Option<f64> = None;
         if let Some(g) = grad {
-            // If OFV is non-finite or the EBE guard rejected this trial, the gradient is
-            // meaningless — use steepest ascent toward center of bounds to nudge optimizer
-            // back without spending time on a population gradient at a point we will reject.
+            // A rejected or non-finite point has no useful population gradient: steepest
+            // ascent toward bounds center nudges the optimizer back. Fall through (no early
+            // return) so the eval is still traced and prev_x / stagnation stay correct,
+            // just skipping the expensive population gradient (#603 review #5).
             if ebe_guard_triggered || !raw_ofv.is_finite() {
                 for i in 0..g.len() {
                     let center_s = (lower_s[i] + upper_s[i]) / 2.0;
                     g[i] = 100.0 * (xs[i] - center_s);
                 }
-                state.n_evals += 1;
-                n_evals_cl.fetch_add(1, Ordering::Relaxed);
-                return ofv;
-            }
-            // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
-            let grad_raw = population_gradient(
-                &x,
-                n_subj,
-                init_params,
-                model,
-                population,
-                &ehs,
-                &hms,
-                &kappas,
-                &bounds,
-                options,
-                &mut state.n_grad_evals,
-            );
-            let mut sq = 0.0_f64;
-            for k in 0..g.len() {
-                let gi = if grad_raw[k].is_finite() {
-                    grad_raw[k] * scale[k]
-                } else {
-                    0.0
-                };
-                g[k] = gi;
-                sq += gi * gi;
-            }
-            grad_norm_for_trace = Some(sq.sqrt());
-            if matches!(algo, nlopt::Algorithm::Slsqp) {
-                cap_slsqp_gradient(g, &lower_s, &upper_s);
-            }
-            // Gate on the global best (same reason as the `best_seen` update
-            // below): `state.best_ofv` resets to INFINITY when the SLSQP
-            // fallback starts, so using it here would let the fallback's first
-            // eval overwrite a better gradient found by the primary run.
-            {
-                let global_best = best_seen_cl
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .map(|(_, o)| *o)
-                    .unwrap_or(f64::INFINITY);
-                if ofv < global_best {
-                    *last_gradient_cl.lock().unwrap() = Some(grad_raw.clone());
+            } else {
+                // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
+                let grad_raw = population_gradient(
+                    &x,
+                    n_subj,
+                    init_params,
+                    model,
+                    population,
+                    &ehs,
+                    &hms,
+                    &kappas,
+                    &bounds,
+                    options,
+                    &mut state.n_grad_evals,
+                );
+                let mut sq = 0.0_f64;
+                for k in 0..g.len() {
+                    let gi = if grad_raw[k].is_finite() {
+                        grad_raw[k] * scale[k]
+                    } else {
+                        0.0
+                    };
+                    g[k] = gi;
+                    sq += gi * gi;
+                }
+                grad_norm_for_trace = Some(sq.sqrt());
+                if matches!(algo, nlopt::Algorithm::Slsqp) {
+                    cap_slsqp_gradient(g, &lower_s, &upper_s);
+                }
+                // Gate on the global best (same reason as the `best_seen` update
+                // below): `state.best_ofv` resets to INFINITY when the SLSQP
+                // fallback starts, so using it here would let the fallback's first
+                // eval overwrite a better gradient found by the primary run.
+                {
+                    let global_best = best_seen_cl
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .map(|(_, o)| *o)
+                        .unwrap_or(f64::INFINITY);
+                    if ofv < global_best {
+                        *last_gradient_cl.lock().unwrap() = Some(grad_raw.clone());
+                    }
                 }
             }
         }
@@ -1278,10 +1296,8 @@ fn optimize_nlopt(
             );
             let raw_ofv = 2.0 * nll;
 
-            let unconverged_frac2 = ebe_stats2.n_unconverged as f64 / (n_subj as f64).max(1.0);
-            let ebe_guard2 = raw_ofv.is_finite()
-                && unconverged_frac2 > options.max_unconverged_frac
-                && options.max_unconverged_frac >= 0.0;
+            let ebe_guard2 =
+                ebe_guard_rejects(&ebe_stats2, n_subj, raw_ofv, options.max_unconverged_frac);
             {
                 let mut acc = ebe_accum_cl2.lock().unwrap();
                 if acc.max_unconverged < ebe_stats2.n_unconverged {
@@ -1302,54 +1318,57 @@ fn optimize_nlopt(
 
             let mut grad_norm_for_trace: Option<f64> = None;
             if let Some(g) = grad {
-                if !raw_ofv.is_finite() {
+                // Mirror the primary closure: a guard-rejected or non-finite point gets a
+                // steepest-ascent nudge instead of a population gradient (the iteration-6
+                // stall this PR targets also reaches the SLSQP fallback — #603 review #3),
+                // and falls through to the shared bookkeeping so the eval stays traced
+                // (#603 review #5).
+                if ebe_guard2 || !raw_ofv.is_finite() {
                     for i in 0..g.len() {
                         let center_s = (lower_s[i] + upper_s[i]) / 2.0;
                         g[i] = 100.0 * (xs[i] - center_s);
                     }
-                    state.n_evals += 1;
-                    n_evals_cl2.fetch_add(1, Ordering::Relaxed);
-                    return ofv;
-                }
-                // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
-                let grad_raw = population_gradient(
-                    &x,
-                    n_subj,
-                    init_params,
-                    model,
-                    population,
-                    &ehs,
-                    &hms,
-                    &kappas,
-                    &bounds,
-                    options,
-                    &mut state.n_grad_evals,
-                );
-                let mut sq = 0.0_f64;
-                for k in 0..g.len() {
-                    let gi = if grad_raw[k].is_finite() {
-                        grad_raw[k] * scale[k]
-                    } else {
-                        0.0
-                    };
-                    g[k] = gi;
-                    sq += gi * gi;
-                }
-                grad_norm_for_trace = Some(sq.sqrt());
-                // SLSQP overshoot guard (issue #55) — this fallback
-                // closure is unconditionally SLSQP.
-                cap_slsqp_gradient(g, &lower_s, &upper_s);
-                // See `best_seen` comment in the primary closure — gate on the
-                // global accumulator, not `state.best_ofv` which is fresh here.
-                {
-                    let global_best = best_seen_cl2
-                        .lock()
-                        .unwrap()
-                        .as_ref()
-                        .map(|(_, o)| *o)
-                        .unwrap_or(f64::INFINITY);
-                    if ofv < global_best {
-                        *last_gradient_cl2.lock().unwrap() = Some(grad_raw.clone());
+                } else {
+                    // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x); then scale for optimizer space.
+                    let grad_raw = population_gradient(
+                        &x,
+                        n_subj,
+                        init_params,
+                        model,
+                        population,
+                        &ehs,
+                        &hms,
+                        &kappas,
+                        &bounds,
+                        options,
+                        &mut state.n_grad_evals,
+                    );
+                    let mut sq = 0.0_f64;
+                    for k in 0..g.len() {
+                        let gi = if grad_raw[k].is_finite() {
+                            grad_raw[k] * scale[k]
+                        } else {
+                            0.0
+                        };
+                        g[k] = gi;
+                        sq += gi * gi;
+                    }
+                    grad_norm_for_trace = Some(sq.sqrt());
+                    // SLSQP overshoot guard (issue #55) — this fallback
+                    // closure is unconditionally SLSQP.
+                    cap_slsqp_gradient(g, &lower_s, &upper_s);
+                    // See `best_seen` comment in the primary closure — gate on the
+                    // global accumulator, not `state.best_ofv` which is fresh here.
+                    {
+                        let global_best = best_seen_cl2
+                            .lock()
+                            .unwrap()
+                            .as_ref()
+                            .map(|(_, o)| *o)
+                            .unwrap_or(f64::INFINITY);
+                        if ofv < global_best {
+                            *last_gradient_cl2.lock().unwrap() = Some(grad_raw.clone());
+                        }
                     }
                 }
             }
@@ -2060,9 +2079,8 @@ fn reconverged_fd_gradient(
                 &kappas,
                 options.interaction,
             );
-        let frac = ebe_stats.n_unconverged as f64 / (n_subj as f64).max(1.0);
         if !raw.is_finite()
-            || (options.max_unconverged_frac >= 0.0 && frac > options.max_unconverged_frac)
+            || ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac)
         {
             1e20
         } else {
@@ -4005,6 +4023,32 @@ pub(crate) fn invert_psd_with_floor(sym: &DMatrix<f64>) -> Option<RegularizedInv
 mod tests {
     use super::*;
     use crate::estimation::parameterization::{compute_bounds, pack_params};
+
+    /// #603 review #1/#2/#8: the centralised EBE guard. A hard reject forces rejection
+    /// unconditionally; otherwise the fraction trigger behaves as before.
+    #[test]
+    fn ebe_guard_rejects_on_hard_reject_and_fraction() {
+        let stats = |n_unconverged, n_start_rejected| InnerLoopStats {
+            n_unconverged,
+            n_fallback: 0,
+            n_start_rejected,
+        };
+
+        // A single hard reject forces rejection even with a finite OFV, zero unconverged
+        // fraction, and the fraction trigger disabled (negative threshold).
+        assert!(ebe_guard_rejects(&stats(0, 1), 100, 1234.5, -1.0));
+
+        // No hard reject, fraction below threshold → not rejected.
+        assert!(!ebe_guard_rejects(&stats(5, 0), 100, 1234.5, 0.1)); // 0.05 <= 0.10
+
+        // No hard reject, fraction above threshold with finite OFV → rejected.
+        assert!(ebe_guard_rejects(&stats(20, 0), 100, 1234.5, 0.1)); // 0.20 > 0.10
+
+        // Fraction trigger needs a finite OFV (non-finite is handled by the caller's
+        // `!raw.is_finite()` branch), and a negative threshold disables it.
+        assert!(!ebe_guard_rejects(&stats(20, 0), 100, f64::NAN, 0.1));
+        assert!(!ebe_guard_rejects(&stats(99, 0), 100, 1234.5, -1.0));
+    }
 
     /// `outer_ftol` auto-selection (#469): pure-TTE tightens to 1e-8; ODE/PK/LTBS
     /// and TTE-on-ODE keep 1e-6; an explicit override always wins.

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -980,9 +980,10 @@ fn optimize_nlopt(
         // Compute gradient if requested (central FD with fixed EBEs)
         let mut grad_norm_for_trace: Option<f64> = None;
         if let Some(g) = grad {
-            // If OFV is non-finite, gradient is meaningless — use steepest ascent
-            // toward center of bounds to nudge optimizer back
-            if !raw_ofv.is_finite() {
+            // If OFV is non-finite or the EBE guard rejected this trial, the gradient is
+            // meaningless — use steepest ascent toward center of bounds to nudge optimizer
+            // back without spending time on a population gradient at a point we will reject.
+            if ebe_guard_triggered || !raw_ofv.is_finite() {
                 for i in 0..g.len() {
                     let center_s = (lower_s[i] + upper_s[i]) / 2.0;
                     g[i] = 100.0 * (xs[i] - center_s);

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -40,6 +40,15 @@ const E5: f64 = -17253.0 / 339200.0;
 const E6: f64 = 22.0 / 525.0;
 const E7: f64 = -1.0 / 40.0;
 
+/// Consecutive force-accepted minimum-step attempts before an integration
+/// segment is treated as unrecoverably pathological.
+///
+/// A few min-step clamps are the intended escape hatch for roundoff at a hard
+/// event boundary. Long runs of them mean RK45 has reached a singular or
+/// rejection-dominated region; continuing to `max_steps` just spends time on a
+/// trajectory the likelihood will reject anyway.
+const MAX_CONSECUTIVE_MIN_STEP_CLAMPS: usize = 64;
+
 /// ODE right-hand side function type.
 /// `rhs(u, params, t) -> du/dt`  where u and du are `&[f64]` of length n_states.
 pub type OdeRhsFn = Box<dyn Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync>;
@@ -188,6 +197,7 @@ pub fn solve_ode_with_stats(
     // Any future revisit should condition PI on a non-FD gradient route
     // (analytical / analytic-sensitivity).
     const I_EXP: f64 = 1.0 / 5.0; // 0.20 — I-controller exponent for order p=5
+    let mut consecutive_min_step_clamps = 0usize;
 
     for _step in 0..opts.max_steps {
         if t >= tf - 1e-15 {
@@ -251,6 +261,7 @@ pub fn solve_ode_with_stats(
         err_norm = (err_norm / n as f64).sqrt();
 
         let accepted = err_norm <= 1.0 || dt_eff <= opts.min_dt;
+        let min_step_clamped = accepted && !(err_norm <= 1.0) && dt_eff <= opts.min_dt;
         if let Some(s) = stats.as_deref_mut() {
             s.record(accepted, err_norm, dt_eff, opts.min_dt);
         }
@@ -271,13 +282,24 @@ pub fn solve_ode_with_stats(
                 });
                 save_idx += 1;
             }
+
+            if min_step_clamped {
+                consecutive_min_step_clamps += 1;
+                if consecutive_min_step_clamps >= MAX_CONSECUTIVE_MIN_STEP_CLAMPS {
+                    break;
+                }
+            } else {
+                consecutive_min_step_clamps = 0;
+            }
         }
         // On reject: (u, t) is unchanged, so the existing k1 is still rhs(u, t)
         // for the next attempt; nothing to do.
 
         // Adapt step size (memoryless I-controller — see note above).
         let safety = 0.9;
-        let factor = if err_norm > 1e-15 {
+        let factor = if !err_norm.is_finite() {
+            0.2
+        } else if err_norm > 1e-15 {
             safety * err_norm.powf(-I_EXP)
         } else {
             5.0
@@ -370,6 +392,7 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
     let mut save_idx = 0;
     let mut have_k1 = false;
     const I_EXP: f64 = 1.0 / 5.0;
+    let mut consecutive_min_step_clamps = 0usize;
 
     // Scalar-weighted combination `u[i] + dt·Σ wⱼ·kⱼ[i]` lifted to `T`.
     let comb = |base: T, dt_eff: f64, terms: &[(f64, T)]| -> T {
@@ -466,6 +489,7 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
         err_norm = (err_norm / n as f64).sqrt();
 
         let accepted = err_norm <= 1.0 || dt_eff <= opts.min_dt;
+        let min_step_clamped = accepted && !(err_norm <= 1.0) && dt_eff <= opts.min_dt;
         if let Some(s) = stats.as_deref_mut() {
             s.record(accepted, err_norm, dt_eff, opts.min_dt);
         }
@@ -480,10 +504,21 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
                 });
                 save_idx += 1;
             }
+
+            if min_step_clamped {
+                consecutive_min_step_clamps += 1;
+                if consecutive_min_step_clamps >= MAX_CONSECUTIVE_MIN_STEP_CLAMPS {
+                    break;
+                }
+            } else {
+                consecutive_min_step_clamps = 0;
+            }
         }
 
         let safety = 0.9;
-        let factor = if err_norm > 1e-15 {
+        let factor = if !err_norm.is_finite() {
+            0.2
+        } else if err_norm > 1e-15 {
             safety * err_norm.powf(-I_EXP)
         } else {
             5.0
@@ -716,6 +751,69 @@ mod tests {
         assert_eq!(stats.accepted_steps, 1);
         assert_eq!(stats.rejected_steps, 0);
         assert_eq!(stats.min_step_clamped_steps, 1);
+    }
+
+    #[test]
+    fn solve_ode_breaks_repeated_min_step_clamps_before_max_steps() {
+        let rhs = |_u: &[f64], _p: &[f64], _t: f64, du: &mut [f64]| {
+            du[0] = f64::NAN;
+        };
+        let opts = OdeSolverOptions {
+            initial_dt: 1e-6,
+            min_dt: 1e-6,
+            max_steps: 10_000,
+            abstol: 1e-12,
+            reltol: 1e-12,
+        };
+        let mut stats = OdeSolverStats::default();
+        let result = solve_ode_with_stats(
+            &rhs,
+            &[1.0],
+            (0.0, 1.0),
+            &[],
+            &[1.0],
+            &opts,
+            Some(&mut stats),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(stats.attempted_steps, MAX_CONSECUTIVE_MIN_STEP_CLAMPS);
+        assert_eq!(
+            stats.min_step_clamped_steps,
+            MAX_CONSECUTIVE_MIN_STEP_CLAMPS
+        );
+    }
+
+    #[test]
+    fn solve_ode_g_breaks_repeated_min_step_clamps_like_scalar() {
+        use crate::sens::dual2::Dual2;
+        let rhs = |_u: &[Dual2<1>], _p: &[Dual2<1>], _t: f64, du: &mut [Dual2<1>]| {
+            du[0] = Dual2::constant(f64::NAN);
+        };
+        let opts = OdeSolverOptions {
+            initial_dt: 1e-6,
+            min_dt: 1e-6,
+            max_steps: 10_000,
+            abstol: 1e-12,
+            reltol: 1e-12,
+        };
+        let mut stats = OdeSolverStats::default();
+        let result = solve_ode_g_with_stats(
+            &rhs,
+            &[Dual2::<1>::constant(1.0)],
+            (0.0, 1.0),
+            &[],
+            &[1.0],
+            &opts,
+            Some(&mut stats),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(stats.attempted_steps, MAX_CONSECUTIVE_MIN_STEP_CLAMPS);
+        assert_eq!(
+            stats.min_step_clamped_steps,
+            MAX_CONSECUTIVE_MIN_STEP_CLAMPS
+        );
     }
 
     #[test]

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -40,14 +40,21 @@ const E5: f64 = -17253.0 / 339200.0;
 const E6: f64 = 22.0 / 525.0;
 const E7: f64 = -1.0 / 40.0;
 
-/// Consecutive force-accepted minimum-step attempts before an integration
-/// segment is treated as unrecoverably pathological.
+/// Consecutive force-accepted minimum-step attempts with a **non-finite** local error
+/// before an integration segment is treated as unrecoverably pathological.
 ///
-/// A few min-step clamps are the intended escape hatch for roundoff at a hard
-/// event boundary. Long runs of them mean RK45 has reached a singular or
-/// rejection-dominated region; continuing to `max_steps` just spends time on a
-/// trajectory the likelihood will reject anyway.
+/// The break is gated on a non-finite error norm (NaN/∞) on purpose: that is the signature
+/// of a diverging trajectory whose padded-out predictions the likelihood will reject anyway.
+/// A *finite* error above tolerance at `min_dt` is merely a stiff or under-resolved segment —
+/// truncating it would freeze-pad the remaining save points with finite (but wrong) values
+/// that the likelihood would silently accept, so those are left to run to `max_steps` as
+/// before (#603 review #4).
 const MAX_CONSECUTIVE_MIN_STEP_CLAMPS: usize = 64;
+
+/// Step-shrink factor applied when the local error estimate is non-finite (NaN/∞). The
+/// trajectory is diverging, so shrink toward `min_dt` instead of falling into the
+/// I-controller's growth branch, which would otherwise enlarge the step on a NaN error.
+const NONFINITE_ERR_SHRINK_FACTOR: f64 = 0.2;
 
 /// ODE right-hand side function type.
 /// `rhs(u, params, t) -> du/dt`  where u and du are `&[f64]` of length n_states.
@@ -261,7 +268,10 @@ pub fn solve_ode_with_stats(
         err_norm = (err_norm / n as f64).sqrt();
 
         let accepted = err_norm <= 1.0 || dt_eff <= opts.min_dt;
-        let min_step_clamped = accepted && !(err_norm <= 1.0) && dt_eff <= opts.min_dt;
+        // Only a force-accept at `min_dt` with a *non-finite* error counts toward the
+        // pathological-divergence break (#603 review #4); a finite-but-stiff clamp is left
+        // to run rather than freeze-padded into a silently-accepted wrong trajectory.
+        let nonfinite_min_step = accepted && dt_eff <= opts.min_dt && !err_norm.is_finite();
         if let Some(s) = stats.as_deref_mut() {
             s.record(accepted, err_norm, dt_eff, opts.min_dt);
         }
@@ -283,7 +293,7 @@ pub fn solve_ode_with_stats(
                 save_idx += 1;
             }
 
-            if min_step_clamped {
+            if nonfinite_min_step {
                 consecutive_min_step_clamps += 1;
                 if consecutive_min_step_clamps >= MAX_CONSECUTIVE_MIN_STEP_CLAMPS {
                     break;
@@ -298,7 +308,7 @@ pub fn solve_ode_with_stats(
         // Adapt step size (memoryless I-controller — see note above).
         let safety = 0.9;
         let factor = if !err_norm.is_finite() {
-            0.2
+            NONFINITE_ERR_SHRINK_FACTOR
         } else if err_norm > 1e-15 {
             safety * err_norm.powf(-I_EXP)
         } else {
@@ -489,7 +499,9 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
         err_norm = (err_norm / n as f64).sqrt();
 
         let accepted = err_norm <= 1.0 || dt_eff <= opts.min_dt;
-        let min_step_clamped = accepted && !(err_norm <= 1.0) && dt_eff <= opts.min_dt;
+        // Mirror the scalar path: only a non-finite force-accept at `min_dt` counts toward
+        // the pathological-divergence break (#603 review #4).
+        let nonfinite_min_step = accepted && dt_eff <= opts.min_dt && !err_norm.is_finite();
         if let Some(s) = stats.as_deref_mut() {
             s.record(accepted, err_norm, dt_eff, opts.min_dt);
         }
@@ -505,7 +517,7 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
                 save_idx += 1;
             }
 
-            if min_step_clamped {
+            if nonfinite_min_step {
                 consecutive_min_step_clamps += 1;
                 if consecutive_min_step_clamps >= MAX_CONSECUTIVE_MIN_STEP_CLAMPS {
                     break;
@@ -517,7 +529,7 @@ pub fn solve_ode_g_with_stats<T: crate::sens::num::PkNum>(
 
         let safety = 0.9;
         let factor = if !err_norm.is_finite() {
-            0.2
+            NONFINITE_ERR_SHRINK_FACTOR
         } else if err_norm > 1e-15 {
             safety * err_norm.powf(-I_EXP)
         } else {
@@ -782,6 +794,76 @@ mod tests {
             stats.min_step_clamped_steps,
             MAX_CONSECUTIVE_MIN_STEP_CLAMPS
         );
+    }
+
+    /// Regression for #603 review #4: a *finite-but-stiff* min-step clamp (large finite local
+    /// error pinned at `min_dt`) must NOT trip the divergence break — only non-finite errors
+    /// do. Otherwise the remaining save points get frozen-padded with finite-but-wrong values
+    /// the likelihood would silently accept. High-frequency finite forcing keeps every step
+    /// clamped with a finite error, so the solve runs its full `max_steps` budget (>> the
+    /// clamp limit) and returns finite predictions rather than breaking at the limit.
+    #[test]
+    fn solve_ode_does_not_break_on_finite_stiff_min_step_clamps() {
+        let rhs = |_u: &[f64], _p: &[f64], t: f64, du: &mut [f64]| {
+            du[0] = 1e6 * (t * 1e7).sin();
+        };
+        let opts = OdeSolverOptions {
+            initial_dt: 1e-3,
+            min_dt: 1e-3,
+            max_steps: 200,
+            abstol: 1e-12,
+            reltol: 1e-12,
+        };
+        let mut stats = OdeSolverStats::default();
+        let result = solve_ode_with_stats(
+            &rhs,
+            &[1.0],
+            (0.0, 1.0),
+            &[],
+            &[1.0],
+            &opts,
+            Some(&mut stats),
+        );
+
+        // Ran the full budget — no early break at MAX_CONSECUTIVE_MIN_STEP_CLAMPS …
+        assert_eq!(stats.attempted_steps, opts.max_steps);
+        assert!(stats.attempted_steps > MAX_CONSECUTIVE_MIN_STEP_CLAMPS);
+        // … the segment really was in the stiff min-step-clamp regime …
+        assert!(stats.min_step_clamped_steps > MAX_CONSECUTIVE_MIN_STEP_CLAMPS);
+        // … and the predictions stayed finite (not NaN-padded).
+        assert_eq!(result.len(), 1);
+        assert!(result[0].u[0].is_finite());
+    }
+
+    /// Dual path mirrors [`solve_ode_does_not_break_on_finite_stiff_min_step_clamps`].
+    #[test]
+    fn solve_ode_g_does_not_break_on_finite_stiff_min_step_clamps() {
+        use crate::sens::dual2::Dual2;
+        let rhs = |_u: &[Dual2<1>], _p: &[Dual2<1>], t: f64, du: &mut [Dual2<1>]| {
+            du[0] = Dual2::constant(1e6 * (t * 1e7).sin());
+        };
+        let opts = OdeSolverOptions {
+            initial_dt: 1e-3,
+            min_dt: 1e-3,
+            max_steps: 200,
+            abstol: 1e-12,
+            reltol: 1e-12,
+        };
+        let mut stats = OdeSolverStats::default();
+        let result = solve_ode_g_with_stats(
+            &rhs,
+            &[Dual2::<1>::constant(1.0)],
+            (0.0, 1.0),
+            &[],
+            &[1.0],
+            &opts,
+            Some(&mut stats),
+        );
+
+        assert_eq!(stats.attempted_steps, opts.max_steps);
+        assert!(stats.min_step_clamped_steps > MAX_CONSECUTIVE_MIN_STEP_CLAMPS);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].u[0].value.is_finite());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The PNA/AHUS ODE+IOV model appeared to hang after Eval 6 after the analytic-gradient work. Sampling showed this was not a deadlock: NLopt probed a bad outer trial point, and the inner ODE+IOV EBE path spent a long time in expensive RK45/steady-state work. In the worst case it also launched Nelder-Mead fallback searches where each simplex vertex required full ODE prediction work.

Refs #590.

## What changed

- Skip Nelder-Mead inner fallback for ODE+IOV EBE failures; keep the BFGS partial and mark the subject unconverged so the outer EBE guard can reject the trial.
- Add a warm-start-only ODE+IOV inner-start rejection for clearly pathological NLLs, avoiding BFGS line-search work on bad outer trial points while leaving the initial EBE solve untouched.
- Skip population-gradient work when the EBE guard has already rejected an NLopt trial.
- Teach RK45 to treat non-finite error norms as large errors and to break out after repeated force-accepted minimum-step clamps, in both scalar and dual solver paths.

## Alternatives considered

I first tried only removing the Nelder-Mead fallback. That removed the old simplex hot path but still left the run spending time in ODE+IOV BFGS line-search steady-state solves. I also tried a start-NLL rejection that applied to the first all-zero inner solve, but that changed the initial OFV path, so the final guard is limited to informative warm starts.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

None.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit `eef94439` / current main behavior on the PNA/AHUS smoke
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# before / reference
PNA/AHUS release smoke reached:
Eval    5: OFV = 9248.260822
Eval    6: OFV = 9225.215395

Sampling after Eval 6 showed the run was active in expensive ODE+IOV inner work:
- first in Nelder-Mead fallback before this patch series
- then in BFGS line-search steady-state ODE solves after removing the fallback only

# after
PNA/AHUS release smoke keeps the initial OFV path unchanged and progresses past Eval 6:
Eval    1: OFV = 9259.852438
Eval    5: OFV = 9248.260410
Eval    6: OFV = 9225.215418
Eval    9: OFV = 9128.807926
Eval   10: OFV = 9112.920157
Eval   11: OFV = 8844.259160
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [ ] No significant impact expected
- [x] Faster — benchmark: PNA/AHUS bad post-Eval-6 trial previously appeared stalled in ODE+IOV inner work; after this patch the same smoke progressed through Eval 11 before manual interrupt.
- [ ] Slower — justified because: `______`

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Focused tests run:

```
cargo test --lib ode_iov_skips_nelder_mead_inner_fallback
cargo test --lib ode_iov_start_rejects_only_pathological_ode_iov_nll
cargo test --lib solve_ode_breaks_repeated_min_step_clamps_before_max_steps
cargo test --lib solve_ode_g_breaks_repeated_min_step_clamps_like_scalar
cargo check
cargo check --tests
cargo clippy
```

`cargo clippy` exits 0; the repo still emits existing warnings unrelated to this change.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
# Not applicable.
```

```
# Not applicable.
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

Focus on the ODE+IOV scoping:

- `skip_ode_iov_nm_fallback` should not affect closed-form IOV or non-IOV ODE models.
- The start-NLL rejection is warm-start-only so the first all-zero inner solve keeps the same OFV path.
- RK45 clamp handling is mirrored between scalar and dual solvers.

## Open questions

None.
