### PR TITLE
feat(sim): per-subject adaptive-dosing metrics + target_window (S2.4) [#391]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Per-subject outcome metrics for adaptive dosing** (#391, S2.4). `simulate_adaptive()` and
+  `simulate_adaptive_from_spec()` now return a `metrics` field on `AdaptiveSimulationResult` —
+  one `AdaptiveSubjectMetrics` row per realized `(subject, draw, sim)` run: cumulative dose,
+  dose-increase / -decrease / hold / discontinuation counts, time-to-discontinuation, and the
+  observed-signal summary (min / max / mean). A new optional `[adaptive_dosing] target_window =
+  [low, high]` key adds `pct_time_in_window` (the fraction of decisions whose observed signal fell
+  in the band; `high` may be `inf` for a one-sided target) — it reports a metric only and never
+  influences dosing. Every metric is derived from the realized dose ledger and decision log alone.
+  See [Adaptive dosing](model-file/adaptive-dosing.qmd).
 - **Parallel / mixed dual-pathway absorption — `first_order(ka)` composition** (#505). A new
   built-in `first_order(ka)` input-rate function exposes the classic first-order (Bateman)
   absorption for composition in `[odes]`, so two absorption pathways can be split by a dose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ section of the SDLC for the versioning policy).
   one `AdaptiveSubjectMetrics` row per realized `(subject, draw, sim)` run: cumulative dose,
   dose-increase / -decrease / hold / discontinuation counts, time-to-discontinuation, and the
   observed-signal summary (min / max / mean). A new optional `[adaptive_dosing] target_window =
-  [low, high]` key adds `pct_time_in_window` (the fraction of decisions whose observed signal fell
-  in the band; `high` may be `inf` for a one-sided target) — it reports a metric only and never
+  [low, high]` key adds `pct_time_in_window` (the fraction of the signal-bearing decisions whose
+  observed signal fell in the band; `high` may be `inf` for a one-sided target) — it reports a metric only and never
   influences dosing. Every metric is derived from the realized dose ledger and decision log alone.
   See [Adaptive dosing](model-file/adaptive-dosing.qmd).
 - **Parallel / mixed dual-pathway absorption — `first_order(ka)` composition** (#505). A new

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -52,6 +52,7 @@ with the run, never with a fitted model's parameters.
 | `dose_bounds` | ✓ | Inclusive `[low, high]` clamp applied to every emitted dose. |
 | `confirm` | | Debounce: act only after this many *consecutive* matches of the same rule (default `1` = act on the first breach). |
 | `levels` | | Discrete titration ladder `[d1, d2, …]` (oncology). With `levels`, bare `increase`/`decrease` step one rung; without it, use `increase N%` / `decrease N%`. |
+| `target_window` | | Therapeutic band `[low, high]` for the monitored signal, used **only** to report the `pct_time_in_window` outcome metric — it does **not** influence dosing (the `when` rules do). `high` may be `inf` for a one-sided "at or above `low`" target. Omit it to leave `pct_time_in_window` unreported, rather than guessing a band from the rule thresholds. |
 | `with_assay_error` | signal¹ | Titrate on the **noised measurement** of a model output (named by `assay_cmt`) instead of a latent expression (default `false`). The signal's value comes from that output's `[scaling]` readout and its σ from that output's `[error_model]`, so the two are always on the same scale — there is no re-typed `observe` expression to mis-scale. Mutually exclusive with `observe`. |
 | `assay_cmt` | | The 1-based compartment of the model output measured under `with_assay_error` — its `[scaling]` readout is the signal value and its `[error_model]` σ the noise. **Required** with `with_assay_error`. |
 
@@ -184,7 +185,7 @@ let make_controller = || {
 let result = simulate_adaptive(&model, &population, &params, 100, make_controller, &opts)?;
 ```
 
-The result bundles the three tidy, long-form artifacts — each tagged by
+The result bundles four tidy, long-form artifacts — each tagged by
 `(draw, sim, id)` so they join cleanly:
 
 - `trajectories` — per-observation predictions (`Vec<SimulationResult>`).
@@ -192,6 +193,17 @@ The result bundles the three tidy, long-form artifacts — each tagged by
   observed signals, applied bioavailability).
 - `decisions` — one row per decision **including holds**, so non-events are on the
   record rather than inferred from gaps in the ledger.
+- `metrics` — one per-subject `AdaptiveSubjectMetrics` row per realized run:
+  cumulative dose, dose-increase / -decrease / hold / discontinuation counts,
+  time-to-discontinuation, the observed-signal summary (min / max / mean), and
+  `pct_time_in_window` when the block declares a `target_window`. Every field is
+  derived from `ledger` + `decisions` alone, so it is auditable against those rows
+  (no re-integration). Increases / decreases are counted by realized dose change,
+  not by which rule fired — a `decrease` clamped at the lower bound re-issues the
+  same dose and is not counted. The signal summary is over the troughs/peaks the
+  controller saw at the decision times (a decision-grid summary, not a
+  dense-trajectory extremum). Population summaries **with uncertainty bands** ride
+  with the uncertainty slice, where bands carry meaning.
 
 ## Verification (on by default)
 
@@ -250,7 +262,7 @@ family. It is validated instead by:
 - **One monitored signal per block** — the declarative block titrates on a single
   `observe`; multiple named per-analyte monitors (already supported by the
   programmatic engine) are a declarative-surface follow-up.
-- **Roadmap** — per-subject outcome metrics on the result, the imperative
+- **Roadmap** — population outcome summaries with uncertainty bands, the imperative
   `[dose_control]` block, and PK + PD + safety model composition.
 
 [`ControllerCtx`]: https://docs.rs/ferx-core

--- a/src/api.rs
+++ b/src/api.rs
@@ -5588,7 +5588,8 @@ fn simulate_inner_with_draw<R: rand::Rng>(
 // ======================================================================
 
 use crate::sim::adaptive::{
-    AdaptiveRun, ControllerCtx, DecisionLogEntry, DoseAction, DoseLedgerEntry, MonitorSpec,
+    AdaptiveRun, AdaptiveSubjectMetrics, ControllerCtx, DecisionLogEntry, DoseAction,
+    DoseLedgerEntry, MonitorSpec,
 };
 
 /// Options for [`simulate_adaptive`].
@@ -5635,9 +5636,8 @@ impl Default for AdaptiveSimulateOptions {
 /// returned as one verified unit so a caller can never pair a trajectory with
 /// the wrong ledger. All three are long-form rows tagged by `(draw, sim, id)`.
 ///
-/// `#[non_exhaustive]`: the remaining Part-D artifacts (per-subject metrics,
-/// population summary, run manifest) land as added fields without breaking
-/// callers who receive this struct.
+/// `#[non_exhaustive]`: the remaining Part-D artifacts (population summary, run
+/// manifest) land as added fields without breaking callers who receive this struct.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct AdaptiveSimulationResult {
@@ -5651,6 +5651,13 @@ pub struct AdaptiveSimulationResult {
     /// One row per decision (including holds), in schedule order, up to and
     /// including any `Stop`.
     pub decisions: Vec<DecisionLogEntry>,
+    /// Per-subject outcome metrics (#391 S2.4): one row per realized `(subject,
+    /// draw, sim)` run — cumulative dose, dose-change / hold / discontinuation
+    /// counts, the observed-signal summary, and `pct_time_in_window` when the block
+    /// declares a `target_window`. Derived from `ledger` + `decisions` alone (no
+    /// re-integration). The population summary *with bands* rides with the
+    /// uncertainty slice (S5), where bands carry meaning.
+    pub metrics: Vec<AdaptiveSubjectMetrics>,
 }
 
 /// Simulate state-reactive ("adaptive" / feedback) dosing over a population
@@ -5752,6 +5759,9 @@ where
         &opts.decision_times,
         &monitors,
         make,
+        // Programmatic path: no declarative block, so no target band — the
+        // window-dependent metric (`pct_time_in_window`) is left unreported.
+        None,
         opts,
     )
 }
@@ -5781,6 +5791,7 @@ fn run_adaptive_population<F, C>(
     decision_times: &[f64],
     monitors: &[crate::sim::adaptive::AdaptiveMonitor],
     make_controller: F,
+    target_window: Option<(f64, f64)>,
     opts: &AdaptiveSimulateOptions,
 ) -> Result<AdaptiveSimulationResult, String>
 where
@@ -5812,6 +5823,7 @@ where
     let mut trajectories: Vec<SimulationResult> = Vec::new();
     let mut ledger: Vec<DoseLedgerEntry> = Vec::new();
     let mut decisions: Vec<DecisionLogEntry> = Vec::new();
+    let mut metrics: Vec<AdaptiveSubjectMetrics> = Vec::new();
 
     for sim_idx in 0..n_sim {
         let sim = sim_idx + 1;
@@ -5895,6 +5907,20 @@ where
                 });
             }
 
+            // Per-subject outcome metrics for this run, computed from its realized
+            // ledger + decision log (S2.4). Taken before the rows are moved into the
+            // population vectors below; the `(subject, draw, sim)` key is stamped here
+            // rather than read from the rows (whose tags the single-subject driver
+            // still leaves at 0).
+            metrics.push(crate::sim::adaptive::compute_subject_metrics(
+                &subject.id,
+                1,
+                sim,
+                &run.ledger,
+                &run.decisions,
+                target_window,
+            ));
+
             // Stamp the replicate tags onto the ledger + decision rows — the
             // single-subject driver emits draw/sim = 0.
             for mut e in run.ledger {
@@ -5914,6 +5940,7 @@ where
         trajectories,
         ledger,
         decisions,
+        metrics,
     })
 }
 
@@ -6023,6 +6050,9 @@ pub fn simulate_adaptive_from_spec(
         &spec.at,
         &monitors,
         compiled.make_controller.as_ref(),
+        // The declarative block's optional therapeutic band feeds the
+        // `pct_time_in_window` metric (it never influences dosing).
+        spec.target_window,
         opts,
     )
 }
@@ -11220,6 +11250,7 @@ mod adaptive_sim_tests {
             dose_bounds: (0.0, 400.0),
             confirm: 1,
             levels: None,
+            target_window: None,
             rules: vec![AdaptiveRule {
                 op: Comparison::Lt,
                 threshold: 50.0,
@@ -11309,6 +11340,7 @@ mod adaptive_sim_tests {
             dose_bounds: (0.0, 1000.0),
             confirm: 1,
             levels: None,
+            target_window: None,
             rules: vec![AdaptiveRule {
                 op: Comparison::Lt,
                 threshold: 50.0,
@@ -11471,6 +11503,92 @@ mod adaptive_sim_tests {
     }
 
     #[test]
+    fn from_spec_metrics_track_titration_and_window() {
+        // End-to-end: the per-subject metrics row is populated from the same run's
+        // ledger + decision log, keyed by (subject, draw, sim), and the
+        // `pct_time_in_window` metric reads the spec's `target_window`. Uses the
+        // converging titration with the band [8, 13] declared as the target.
+        let parsed = parse_full_model(SPEC_TITRATE).expect("parse titrating block");
+        let mut spec = parsed.adaptive_dosing.clone().expect("block present");
+        spec.target_window = Some((8.0, 13.0));
+        let pop = population(vec![subj("P", vec![342.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(3),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            &spec,
+            &opts,
+        )
+        .expect("titration runs");
+
+        assert_eq!(res.metrics.len(), 1, "one (subject, draw, sim) run");
+        let m = &res.metrics[0];
+        assert_eq!(m.subject, "P");
+        assert_eq!((m.draw, m.sim), (1, 1));
+
+        // The dose walks up from 20 and never holds/stops (a non-matching decision
+        // re-issues the current dose), so every decision yields a ledger row.
+        assert_eq!(m.n_doses, res.ledger.len());
+        assert!(m.n_increases >= 1, "the dose climbs from start_dose = 20");
+        assert_eq!(m.n_holds, 0);
+        assert!(!m.discontinued);
+        assert_eq!(m.time_to_discontinuation, None);
+
+        // cumulative_dose mirrors the ledger sum, signal summary is populated.
+        let ledger_sum: f64 = res.ledger.iter().map(|e| e.amt).sum();
+        assert_eq!(m.cumulative_dose, ledger_sum);
+        assert!(m.signal_min.is_some() && m.signal_max.is_some() && m.signal_mean.is_some());
+
+        // pct_time_in_window re-derives from the decision log's observed troughs.
+        let n = res.decisions.len();
+        let in_band = res
+            .decisions
+            .iter()
+            .filter(|d| (8.0..=13.0).contains(&d.observed_signals[0].value))
+            .count();
+        assert_eq!(m.pct_time_in_window, Some(in_band as f64 / n as f64));
+    }
+
+    #[test]
+    fn from_spec_metrics_degenerate_run_has_no_changes() {
+        // The metrics half of the degenerate oracle: a block that never titrates
+        // re-issues a fixed 100 mg at each of the 3 decisions, so the metrics show no
+        // dose changes, no holds, no discontinuation, and — with no `target_window`
+        // declared — `pct_time_in_window` is unreported.
+        let parsed = parse_full_model(SPEC_DEGENERATE).expect("parse model + block");
+        let spec = parsed.adaptive_dosing.as_ref().expect("block present");
+        let pop = population(vec![subj("1", vec![6.0, 30.0, 54.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect("degenerate run");
+
+        assert_eq!(res.metrics.len(), 1);
+        let m = &res.metrics[0];
+        assert_eq!(m.n_doses, 3, "100 mg re-issued at every decision");
+        assert_eq!(m.n_increases, 0);
+        assert_eq!(m.n_decreases, 0);
+        assert_eq!(m.n_holds, 0);
+        assert!(!m.discontinued);
+        assert_eq!(m.cumulative_dose, 300.0);
+        assert_eq!(m.pct_time_in_window, None, "no target_window in the block");
+    }
+
+    #[test]
     fn from_spec_rejects_decision_times_in_opts() {
         // The block's `at` is the schedule; an `opts.decision_times` is a second,
         // conflicting source of truth — rejected, not silently ignored.
@@ -11558,6 +11676,7 @@ mod adaptive_sim_tests {
             dose_bounds: (0.0, 1000.0),
             confirm: 1,
             levels: None,
+            target_window: None,
             rules: vec![AdaptiveRule {
                 op: Comparison::Lt,
                 threshold: 50.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ pub use propensity_match::MatchMethod;
 // of `AdaptiveSimulationResult` (`ledger` / `decisions`) — is usable without
 // reaching into the `sim::adaptive` module path.
 pub use sim::adaptive::{
-    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, Comparison, ControllerCtx,
-    DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry, DoseStep, MonitorSpec,
-    ObserveMode, ObservedSignal,
+    AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule, AdaptiveSubjectMetrics,
+    Comparison, ControllerCtx, DecisionLogEntry, DecisionOutcome, DoseAction, DoseLedgerEntry,
+    DoseStep, MonitorSpec, ObserveMode, ObservedSignal,
 };
 pub use suggest_start::{inits_from_nca, NcaInit, SuggestedStart};
 pub use types::*;

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3850,6 +3850,7 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     let mut dose_bounds: Option<(f64, f64)> = None;
     let mut confirm: u32 = 1;
     let mut levels: Option<Vec<f64>> = None;
+    let mut target_window: Option<(f64, f64)> = None;
     let mut rules: Vec<AdaptiveRule> = Vec::new();
 
     for line in lines {
@@ -3942,6 +3943,27 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
                 validate_increasing_finite(&l, "levels")?;
                 levels = Some(l);
             }
+            "target_window" => {
+                // Therapeutic band `[low, high]` for the `pct_time_in_window` metric
+                // only — it does not affect dosing. `low` must be finite; `high` may
+                // be `inf` for a one-sided "at or above low" target. The same check
+                // runs in `AdaptiveDosingSpec::validate`.
+                let b = parse_float_array(val)
+                    .map_err(|e| format!("[adaptive_dosing]: bad target_window: {e}"))?;
+                if b.len() != 2 {
+                    return Err(format!(
+                        "[adaptive_dosing]: target_window must be `[low, high]`: {val}"
+                    ));
+                }
+                let (lo, hi) = (b[0], b[1]);
+                if !lo.is_finite() || hi.is_nan() || hi < lo {
+                    return Err(format!(
+                        "[adaptive_dosing]: target_window must be `[low, high]` with low finite \
+                         and low <= high (high may be `inf`): {val}"
+                    ));
+                }
+                target_window = Some((lo, hi));
+            }
             other => return Err(format!("[adaptive_dosing]: unknown key `{other}`")),
         }
     }
@@ -3968,6 +3990,7 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
         dose_bounds,
         confirm,
         levels,
+        target_window,
         rules,
     };
     spec.validate()?;
@@ -24673,6 +24696,50 @@ mod adaptive_dosing_tests {
         assert!(!spec.with_assay_error);
         assert_eq!(spec.assay_cmt, None);
         assert_eq!(spec.levels, None);
+        // No `target_window` declared ⇒ `None` (metrics leave `pct_time_in_window`
+        // unreported rather than guessing a band).
+        assert_eq!(spec.target_window, None);
+    }
+
+    #[test]
+    fn target_window_parses_band_and_one_sided() {
+        let band = parse_adaptive_dosing_block(&{
+            let mut b = without("nothing");
+            b.push("target_window = [10, 20]".into());
+            b
+        })
+        .expect("two-sided target_window parses");
+        assert_eq!(band.target_window, Some((10.0, 20.0)));
+
+        // A one-sided "at or above 10" target: `high = inf` is allowed.
+        let one_sided = parse_adaptive_dosing_block(&{
+            let mut b = without("nothing");
+            b.push("target_window = [10, inf]".into());
+            b
+        })
+        .expect("one-sided target_window parses");
+        let (lo, hi) = one_sided.target_window.expect("Some");
+        assert_eq!(lo, 10.0);
+        assert!(hi.is_infinite() && hi > 0.0);
+    }
+
+    #[test]
+    fn target_window_bad_band_errors() {
+        // Inverted, non-finite low, and wrong arity each reject loudly, naming the key.
+        for bad in [
+            "target_window = [20, 10]", // high < low
+            "target_window = [nan, 20]",
+            "target_window = [inf, 20]", // low must be finite
+            "target_window = [10]",      // not [low, high]
+        ] {
+            let mut b = without("nothing");
+            b.push(bad.into());
+            let err = parse_adaptive_dosing_block(&b).expect_err("expected a typed parse error");
+            assert!(
+                err.starts_with("[adaptive_dosing]:") && err.contains("target_window"),
+                "`{bad}` gave: {err}"
+            );
+        }
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -1084,6 +1084,41 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_inverted_or_nan_target_window() {
+        // `target_window` only feeds the `pct_time_in_window` metric, but a bad band
+        // must still be rejected: the parser checks it on the way in, and `validate`
+        // is the safety net for a hand-built `pub` spec reaching
+        // `simulate_adaptive_from_spec` without ever seeing the parser. Mirrors the
+        // parser's check (low finite, low <= high, high may be +inf).
+
+        // high < low (inverted).
+        let mut s = base_spec();
+        s.target_window = Some((20.0, 10.0));
+        assert!(s.validate().unwrap_err().contains("target_window"));
+
+        // non-finite low (NaN and +inf both rejected — low must be finite).
+        let mut s = base_spec();
+        s.target_window = Some((f64::NAN, 20.0));
+        assert!(s.validate().unwrap_err().contains("target_window"));
+        let mut s = base_spec();
+        s.target_window = Some((f64::INFINITY, 20.0));
+        assert!(s.validate().unwrap_err().contains("target_window"));
+
+        // NaN high.
+        let mut s = base_spec();
+        s.target_window = Some((10.0, f64::NAN));
+        assert!(s.validate().unwrap_err().contains("target_window"));
+
+        // Valid bands pass: a closed band and a one-sided "at or above low".
+        let mut s = base_spec();
+        s.target_window = Some((10.0, 20.0));
+        assert!(s.validate().is_ok());
+        let mut s = base_spec();
+        s.target_window = Some((10.0, f64::INFINITY));
+        assert!(s.validate().is_ok());
+    }
+
+    #[test]
     fn validate_enforces_one_signal_source() {
         // `observe` (latent) and `with_assay_error` (noised model output) are
         // mutually exclusive; exactly one is required.

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -379,17 +379,21 @@ pub struct AdaptiveSubjectMetrics {
     pub discontinued: bool,
     /// Time of the `Stop` decision, or `None` if the run never discontinued.
     pub time_to_discontinuation: Option<f64>,
-    /// Lowest observed signal across the run's decisions (the deepest trough the
-    /// monitor saw), or `None` if no decision recorded a signal.
+    /// Lowest observed signal across the decisions that recorded one (the deepest
+    /// trough the monitor saw), or `None` if no decision recorded a signal.
     pub signal_min: Option<f64>,
-    /// Highest observed signal across the run's decisions.
+    /// Highest observed signal across the decisions that recorded one.
     pub signal_max: Option<f64>,
-    /// Mean observed signal across the run's decisions.
+    /// Mean observed signal across the decisions that recorded one.
     pub signal_mean: Option<f64>,
-    /// Fraction of decisions whose observed signal fell within the spec's
-    /// `target_window` `[lo, hi]` (inclusive), in `[0, 1]`. `None` when no
-    /// `target_window` is declared (or no signal was recorded) — never a band
-    /// guessed from the rule thresholds (#584).
+    /// Fraction of the **signal-bearing** decisions whose observed value fell
+    /// within the spec's `target_window` `[lo, hi]` (inclusive), in `[0, 1]`. The
+    /// denominator is the count of decisions that recorded a signal — the same
+    /// basis as the signal summary above — not the raw decision count: a decision
+    /// with no recorded signal is neither in nor out of band, so it is excluded
+    /// rather than counted as a miss. `None` when no `target_window` is declared
+    /// (or no signal was recorded) — never a band guessed from the rule
+    /// thresholds (#584).
     pub pct_time_in_window: Option<f64>,
 }
 
@@ -1475,5 +1479,36 @@ mod tests {
         assert_eq!(m.signal_max, None);
         assert_eq!(m.signal_mean, None);
         assert_eq!(m.pct_time_in_window, None);
+    }
+
+    #[test]
+    fn metrics_signalless_decisions_are_excluded_not_counted_as_misses() {
+        // A *mixed* decision log — some decisions recorded a signal, some did not.
+        // `compute_subject_metrics` is a pure function whose contract admits this
+        // (a decision can carry an empty `observed_signals`), even though the
+        // current single-monitor engine records one at every decision. The signal
+        // summary and `pct_time_in_window` are over the **signal-bearing** decisions
+        // only: a measurement-less decision is neither in nor out of band, so it is
+        // excluded from the denominator rather than counted as a miss.
+        let ledger = vec![ledger_entry(100.0), ledger_entry(100.0)];
+        let decisions = vec![
+            decision(0.0, Some(12.0), DecisionOutcome::Dosed { n: 1 }), // in [10, 20]
+            decision(24.0, None, DecisionOutcome::Dosed { n: 1 }),      // no signal
+            decision(48.0, Some(8.0), DecisionOutcome::Dosed { n: 1 }), // below band
+            decision(72.0, None, DecisionOutcome::Hold),                // no signal
+        ];
+        let m = compute_subject_metrics("S", 1, 1, &ledger, &decisions, Some((10.0, 20.0)));
+
+        // Summary spans only the two decisions that recorded a signal (12 and 8),
+        // not the two signal-less ones.
+        assert_eq!(m.signal_min, Some(8.0));
+        assert_eq!(m.signal_max, Some(12.0));
+        assert_eq!(m.signal_mean, Some(10.0));
+        // Denominator = 2 signal-bearing decisions, of which one (12) is in band:
+        // 1/2 = 0.5 — not 1/4 (raw decision count) and not 1/3.
+        assert_eq!(m.pct_time_in_window, Some(0.5));
+        // Holds are counted over all decisions, independent of whether a signal
+        // was recorded, so the signal-less Hold still registers.
+        assert_eq!(m.n_holds, 1);
     }
 }

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -334,6 +334,156 @@ pub struct AdaptiveRun {
     pub decisions: Vec<DecisionLogEntry>,
 }
 
+/// Per-subject outcome metrics for one realized adaptive-dosing run (#391 S2.4).
+///
+/// One row per `(subject, draw, sim)` — the same key as the trajectory, ledger,
+/// and decision-log rows in [`crate::AdaptiveSimulationResult`], so a metrics row
+/// joins to exactly the run it summarizes. Every field is computed by
+/// [`compute_subject_metrics`] from that run's realized dose ledger and decision
+/// log **alone** — no re-integration — so each number is a direct, auditable
+/// function of the recorded artifacts (the same "reproduce it from the artifacts"
+/// contract as the decision log).
+///
+/// The signal summary (`signal_min`/`max`/`mean`, `pct_time_in_window`) is over the
+/// values the controller actually observed at the decision times — the troughs/peaks
+/// the monitor saw, which for TDM is the clinically reported quantity. It is a
+/// **decision-grid** summary, not a dense-trajectory extremum, and (when several
+/// monitors are declared) summarizes the first one. When the run recorded no signal
+/// at any decision, the summary fields are `None`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdaptiveSubjectMetrics {
+    /// Subject id (matches [`DoseLedgerEntry::subject`]).
+    pub subject: String,
+    /// Parameter-uncertainty draw index (matches [`crate::SimulationResult::draw`]).
+    pub draw: usize,
+    /// Replicate index within the draw (matches [`crate::SimulationResult::sim`]).
+    pub sim: usize,
+    /// Total nominal dose delivered — Σ `amt` over the run's ledger rows
+    /// (pre-bioavailability: the prescribed amount, matching the ledger).
+    pub cumulative_dose: f64,
+    /// Number of realized doses (ledger rows). Holds and a bare `Stop` leave no
+    /// ledger row, so this counts doses actually given, not decisions.
+    pub n_doses: usize,
+    /// Times the realized dose stepped **up** relative to the previous realized
+    /// dose. By dose-delta (not which rule fired), so it counts dose changes that
+    /// actually happened — a `decrease` rule clamped at the lower bound re-issues
+    /// the same dose and is not counted. `rule_fired` on the ledger remains for
+    /// finer audit.
+    pub n_increases: usize,
+    /// Times the realized dose stepped **down** relative to the previous realized
+    /// dose (see [`AdaptiveSubjectMetrics::n_increases`]).
+    pub n_decreases: usize,
+    /// Decisions that issued no dose ([`DecisionOutcome::Hold`]).
+    pub n_holds: usize,
+    /// Whether the controller discontinued (a [`DecisionOutcome::Stop`] decision).
+    pub discontinued: bool,
+    /// Time of the `Stop` decision, or `None` if the run never discontinued.
+    pub time_to_discontinuation: Option<f64>,
+    /// Lowest observed signal across the run's decisions (the deepest trough the
+    /// monitor saw), or `None` if no decision recorded a signal.
+    pub signal_min: Option<f64>,
+    /// Highest observed signal across the run's decisions.
+    pub signal_max: Option<f64>,
+    /// Mean observed signal across the run's decisions.
+    pub signal_mean: Option<f64>,
+    /// Fraction of decisions whose observed signal fell within the spec's
+    /// `target_window` `[lo, hi]` (inclusive), in `[0, 1]`. `None` when no
+    /// `target_window` is declared (or no signal was recorded) — never a band
+    /// guessed from the rule thresholds (#584).
+    pub pct_time_in_window: Option<f64>,
+}
+
+/// Compute the [`AdaptiveSubjectMetrics`] for one realized run from its dose
+/// `ledger` and decision log alone (#391 S2.4).
+///
+/// `ledger` and `decisions` are the artifacts of a **single** `(subject, draw,
+/// sim)` run (the rows the per-subject driver emits), in emission order: `ledger`
+/// in dose order and `decisions` in schedule order. The function is pure — it
+/// re-integrates nothing — so it is unit-testable on hand-built rows. `target_window`
+/// comes from the [`AdaptiveDosingSpec`] (the file-driven path); the programmatic
+/// path passes `None`, leaving `pct_time_in_window` unreported.
+pub(crate) fn compute_subject_metrics(
+    subject: &str,
+    draw: usize,
+    sim: usize,
+    ledger: &[DoseLedgerEntry],
+    decisions: &[DecisionLogEntry],
+    target_window: Option<(f64, f64)>,
+) -> AdaptiveSubjectMetrics {
+    let cumulative_dose: f64 = ledger.iter().map(|e| e.amt).sum();
+    let n_doses = ledger.len();
+
+    // Dose changes between consecutive *realized* doses. A re-issued dose
+    // (unchanged, or clamped to the same bound) is bit-identical; a genuine step
+    // differs by the titration increment, so a small relative tolerance separates
+    // "no change" from a real step without miscounting float noise in compounded
+    // percentage steps.
+    let mut n_increases = 0usize;
+    let mut n_decreases = 0usize;
+    for w in ledger.windows(2) {
+        let (prev, cur) = (w[0].amt, w[1].amt);
+        let tol = 1e-9 * prev.abs().max(cur.abs()).max(1.0);
+        if cur > prev + tol {
+            n_increases += 1;
+        } else if cur < prev - tol {
+            n_decreases += 1;
+        }
+    }
+
+    let n_holds = decisions
+        .iter()
+        .filter(|d| matches!(d.outcome, DecisionOutcome::Hold))
+        .count();
+    let stop = decisions
+        .iter()
+        .find(|d| matches!(d.outcome, DecisionOutcome::Stop { .. }));
+    let discontinued = stop.is_some();
+    let time_to_discontinuation = stop.map(|d| d.time);
+
+    // Signal summary over the value the controller observed at each decision (the
+    // first monitor when several are declared). Decisions with no recorded signal
+    // are skipped, so an empty list yields `None` rather than a NaN.
+    let signal_vals: Vec<f64> = decisions
+        .iter()
+        .filter_map(|d| d.observed_signals.first().map(|s| s.value))
+        .collect();
+    let (signal_min, signal_max, signal_mean) = if signal_vals.is_empty() {
+        (None, None, None)
+    } else {
+        let min = signal_vals.iter().copied().fold(f64::INFINITY, f64::min);
+        let max = signal_vals
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max);
+        let mean = signal_vals.iter().sum::<f64>() / signal_vals.len() as f64;
+        (Some(min), Some(max), Some(mean))
+    };
+    let pct_time_in_window = match target_window {
+        Some((lo, hi)) if !signal_vals.is_empty() => {
+            let n_in = signal_vals.iter().filter(|&&v| v >= lo && v <= hi).count();
+            Some(n_in as f64 / signal_vals.len() as f64)
+        }
+        _ => None,
+    };
+
+    AdaptiveSubjectMetrics {
+        subject: subject.to_string(),
+        draw,
+        sim,
+        cumulative_dose,
+        n_doses,
+        n_increases,
+        n_decreases,
+        n_holds,
+        discontinued,
+        time_to_discontinuation,
+        signal_min,
+        signal_max,
+        signal_mean,
+        pct_time_in_window,
+    }
+}
+
 // ── Controller-assay RNG substream (#391 S1.5) ──────────────────────────────
 //
 // A DV-mode monitor observes a *realized* measurement = IPRED + ε·√(residual
@@ -474,6 +624,14 @@ pub struct AdaptiveDosingSpec {
     /// Discrete titration levels (oncology). When set, `increase`/`decrease` step
     /// one level; mutually exclusive with percentage steps.
     pub levels: Option<Vec<f64>>,
+    /// Optional therapeutic target band `[low, high]` (inclusive) for the
+    /// monitored signal. It feeds **only** the `pct_time_in_window` outcome metric
+    /// (#391 S2.4) — it never influences dosing (the `when` rules do). `high` may
+    /// be `+∞` for a one-sided "at or above `low`" target. `None` leaves
+    /// `pct_time_in_window` unreported rather than guessing a band from the rule
+    /// thresholds (which conflates the control law with the clinical target). See
+    /// [`crate::AdaptiveSubjectMetrics`].
+    pub target_window: Option<(f64, f64)>,
     /// The first-matching-rule ladder, in file order.
     pub rules: Vec<AdaptiveRule>,
 }
@@ -536,6 +694,18 @@ impl AdaptiveDosingSpec {
                 "[adaptive_dosing]: start_dose {} is outside dose_bounds [{lo}, {hi}]",
                 self.start_dose
             ));
+        }
+        // `target_window` (metrics only): low must be finite and low <= high; high
+        // may be +∞ (a one-sided "at or above low" target). Checked here too, not
+        // just in the parser, so a hand-built spec can't reach metrics with an
+        // inverted/NaN band.
+        if let Some((wlo, whi)) = self.target_window {
+            if !wlo.is_finite() || whi.is_nan() || whi < wlo {
+                return Err(format!(
+                    "[adaptive_dosing]: target_window must be [low, high] with low finite and \
+                     low <= high (high may be inf): [{wlo}, {whi}]"
+                ));
+            }
         }
         // The decision schedule must be a non-empty, finite, strictly-increasing
         // list of non-negative times. The parser enforces this on the way in;
@@ -819,6 +989,7 @@ mod tests {
             dose_bounds: (0.0, 400.0),
             confirm: 1,
             levels: None,
+            target_window: None,
             rules: vec![AdaptiveRule {
                 op: Comparison::Lt,
                 threshold: 10.0,
@@ -1169,5 +1340,140 @@ mod tests {
             (var - 1.0).abs() < 0.2,
             "standard-normal draws should have ~unit variance, got {var}"
         );
+    }
+
+    // ── Per-subject metrics (#391 S2.4) ──────────────────────────────────────
+
+    fn ledger_entry(amt: f64) -> DoseLedgerEntry {
+        DoseLedgerEntry {
+            subject: "S".to_string(),
+            draw: 0,
+            sim: 0,
+            dose_idx: 0,
+            time: 0.0,
+            amt,
+            cmt: 1,
+            rate: 0.0,
+            decision_idx: 0,
+            rule_fired: "bolus".to_string(),
+            observed_signals: Vec::new(),
+            pre_state: None,
+            post_state: None,
+            f_applied: 1.0,
+        }
+    }
+
+    fn decision(time: f64, signal: Option<f64>, outcome: DecisionOutcome) -> DecisionLogEntry {
+        DecisionLogEntry {
+            subject: "S".to_string(),
+            draw: 0,
+            sim: 0,
+            decision_idx: 0,
+            time,
+            observed_signals: signal
+                .map(|v| {
+                    vec![ObservedSignal {
+                        name: "signal".to_string(),
+                        value: v,
+                        mode: ObserveMode::Ipred,
+                    }]
+                })
+                .unwrap_or_default(),
+            outcome,
+        }
+    }
+
+    #[test]
+    fn metrics_summarize_doses_holds_and_discontinuation() {
+        // A titration that steps up once (100→125), back down once (125→100),
+        // re-issues unchanged (100→100), holds once, then discontinues.
+        let ledger = vec![
+            ledger_entry(100.0),
+            ledger_entry(125.0),
+            ledger_entry(100.0),
+            ledger_entry(100.0),
+        ];
+        let decisions = vec![
+            decision(24.0, Some(8.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(48.0, Some(5.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(72.0, Some(22.0), DecisionOutcome::Hold),
+            decision(96.0, Some(15.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(120.0, Some(45.0), DecisionOutcome::Stop { dosed: 0 }),
+        ];
+
+        let m = compute_subject_metrics("S", 1, 2, &ledger, &decisions, None);
+
+        assert_eq!(m.subject, "S");
+        assert_eq!((m.draw, m.sim), (1, 2));
+        assert_eq!(m.cumulative_dose, 425.0);
+        assert_eq!(m.n_doses, 4);
+        assert_eq!(m.n_increases, 1, "100→125 is the only step up");
+        assert_eq!(
+            m.n_decreases, 1,
+            "125→100 is the only step down; 100→100 is no change"
+        );
+        assert_eq!(m.n_holds, 1);
+        assert!(m.discontinued);
+        assert_eq!(m.time_to_discontinuation, Some(120.0));
+        assert_eq!(m.signal_min, Some(5.0));
+        assert_eq!(m.signal_max, Some(45.0));
+        assert_eq!(m.signal_mean, Some(19.0)); // (8+5+22+15+45)/5
+        assert_eq!(m.pct_time_in_window, None, "no target_window declared");
+    }
+
+    #[test]
+    fn metrics_pct_time_in_window_counts_signals_in_band() {
+        let ledger = vec![ledger_entry(100.0)];
+        let decisions = vec![
+            decision(0.0, Some(8.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(24.0, Some(5.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(48.0, Some(22.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(72.0, Some(15.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(96.0, Some(45.0), DecisionOutcome::Dosed { n: 1 }),
+        ];
+        // Two-sided band [10, 20]: only 15 is in band ⇒ 1/5.
+        let band = compute_subject_metrics("S", 1, 1, &ledger, &decisions, Some((10.0, 20.0)));
+        assert_eq!(band.pct_time_in_window, Some(0.2));
+        // One-sided "at or above 10" ([10, +∞]): 22, 15, 45 ⇒ 3/5.
+        let one_sided =
+            compute_subject_metrics("S", 1, 1, &ledger, &decisions, Some((10.0, f64::INFINITY)));
+        assert_eq!(one_sided.pct_time_in_window, Some(0.6));
+    }
+
+    #[test]
+    fn metrics_reissued_doses_are_not_changes() {
+        // A fixed regimen (the degenerate controller): every dose identical ⇒ no
+        // increases, no decreases — the metrics half of the degenerate oracle.
+        let ledger = vec![ledger_entry(50.0), ledger_entry(50.0), ledger_entry(50.0)];
+        let decisions = vec![
+            decision(0.0, Some(3.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(24.0, Some(3.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(48.0, Some(3.0), DecisionOutcome::Dosed { n: 1 }),
+        ];
+        let m = compute_subject_metrics("S", 1, 1, &ledger, &decisions, None);
+        assert_eq!(m.n_increases, 0);
+        assert_eq!(m.n_decreases, 0);
+        assert_eq!(m.n_holds, 0);
+        assert!(!m.discontinued);
+        assert_eq!(m.time_to_discontinuation, None);
+        assert_eq!(m.cumulative_dose, 150.0);
+    }
+
+    #[test]
+    fn metrics_empty_run_has_no_signal_summary() {
+        // No doses, no decisions: counts are zero and the signal summary is `None`
+        // (not a NaN), even when a target_window is set (no signal to score).
+        let m = compute_subject_metrics("S", 1, 1, &[], &[], Some((10.0, 20.0)));
+        assert_eq!(m.cumulative_dose, 0.0);
+        assert_eq!(m.n_doses, 0);
+        assert_eq!(m.n_increases, 0);
+        assert_eq!(m.n_decreases, 0);
+        assert_eq!(m.n_holds, 0);
+        assert!(!m.discontinued);
+        assert_eq!(m.time_to_discontinuation, None);
+        assert_eq!(m.signal_min, None);
+        assert_eq!(m.signal_max, None);
+        assert_eq!(m.signal_mean, None);
+        assert_eq!(m.pct_time_in_window, None);
     }
 }

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -362,6 +362,7 @@ mod tests {
             dose_bounds,
             confirm,
             levels,
+            target_window: None,
             rules,
         }
     }
@@ -712,6 +713,7 @@ mod tests {
             dose_bounds: (0.0, 400.0),
             confirm: 1,
             levels: None,
+            target_window: None,
             rules: vec![rule(Comparison::Gt, 1000.0, AdaptiveAction::Hold)],
         }
     }


### PR DESCRIPTION
## Why

Sub-issue **S2.4** of the declarative adaptive-dosing slice (#584, epic #391). The
reactive engine already returns `trajectories` / `ledger` / `decisions`, but not the
**per-subject outcome numbers a modeler actually reports** — cumulative dose, how many
times the dose was modified, time-to-discontinuation, and time-in-therapeutic-window.
S2.4 turns the recorded artifacts into those metrics.

## What changed

- New `metrics: Vec<AdaptiveSubjectMetrics>` field on `AdaptiveSimulationResult` (the
  struct is already `#[non_exhaustive]`, so this is additive). Populated by **both**
  `simulate_adaptive()` and `simulate_adaptive_from_spec()`.
- New pure `compute_subject_metrics(subject, draw, sim, ledger, decisions, target_window)`
  in `sim/adaptive.rs` — one row per realized `(subject, draw, sim)` run, derived from
  that run's dose ledger and decision log **alone** (no re-integration). Fields:
  `cumulative_dose`, `n_doses`, `n_increases` / `n_decreases`, `n_holds`,
  `discontinued` + `time_to_discontinuation`, `signal_min` / `signal_max` /
  `signal_mean`, and `pct_time_in_window`.
- New optional `[adaptive_dosing] target_window = [low, high]` key (parser + `validate()`
  + spec field). It feeds `pct_time_in_window` **only** and never influences dosing;
  `high` may be `inf` for a one-sided "at or above `low`" target. Absent the key,
  `pct_time_in_window` is `None`.
- `n_increases` / `n_decreases` are counted by **realized dose change**, not by which
  rule fired: a `decrease` clamped at the lower bound re-issues the same dose and is not
  counted (the `rule_fired` provenance on the ledger remains for finer audit).

## Alternatives considered

For the `pct_time_in_window` band I considered **deriving the window from the rule
thresholds** (the `increase`-below / `decrease`-above cutoffs) instead of an explicit
key. Rejected: it is undefined for de-escalation-only ladders (the oncology platelet
ladder often has no `increase` rung → no lower edge) and multi-threshold ladders, it
conflates the *control law* (when you act) with the *clinical target* (what you report
attainment against), and it would silently move a headline efficacy number when a safety
threshold is edited — the exact "silent wrong answer" #584 forbids. The explicit
`target_window` is final syntax, `None` when undeclared (never guessed), and also the
through-line to the AUC target the vancomycin anchor (S2.5b) will need.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet open | after |

Exposing the 4th (metrics) data frame from `ferx_simulate_adaptive()` is a follow-up
ferx-r PR (per ferx-r/CLAUDE.md), landing **after** this. Rust callers are unaffected
(the result struct is `#[non_exhaustive]`), so ferx-r CI is not blocked by this merge.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed
- [x] Public Rust API (`api.rs` / `types.rs`)
- [ ] None

<details>
<summary>Migration notes</summary>

Additive and non-breaking for the supported paths: `AdaptiveSimulationResult` is
`#[non_exhaustive]` (the new `metrics` field cannot break field-exhaustive matches), and
the new `.ferx` `target_window` key is optional. `AdaptiveDosingSpec` gains an optional
`target_window` field — code that builds the spec via a **struct literal** (rather than
the parser, the supported path) must add `target_window: None`.

</details>

## Numerical validation
- [ ] Warfarin example converges …
- [ ] Compared against: NONMEM / nlmixr2 / …
- [x] Not applicable (no estimation; and per CLAUDE.md adaptive-dosing exception, **no
  NONMEM** comparator exists for feedback dosing)

Metrics are *exact* functions of the realized ledger + decision-log artifacts, so they
are verified rather than estimated:
- **Degenerate oracle** — a fixed (never-titrating) regimen yields `n_increases =
  n_decreases = n_holds = 0` and `n_doses = #decisions` (`from_spec_metrics_degenerate_run_has_no_changes`).
- **End-to-end re-derivation** — on the converging titration, `pct_time_in_window` equals
  the fraction of decision-log troughs in `[8, 13]` and `cumulative_dose` equals the
  ledger sum (`from_spec_metrics_track_titration_and_window`).
- **Pure-function units** — counts, discontinuation, signal summary, one-sided/empty
  window edge cases.

## Performance
- [x] No significant impact expected — `O(#decisions)` per run over already-materialized rows.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression/behaviour tests added (8: 4 pure-function units, 2 parser happy/typed-error, 2 end-to-end)
- [ ] No new tests needed

All 146 adaptive tests pass under the CI feature set (`cargo test --no-default-features
--features ci --lib adaptive`).

## Example (user-facing features only)
- [x] Example inline below
- [ ] Not applicable

<details>
<summary>Example — `target_window` + reading metrics</summary>

```toml
[adaptive_dosing]
  observe      = central
  at           = every 24 from 0 to 336
  start_dose   = 20
  route        = bolus(cmt=1)
  dose_bounds  = [0, 1000]
  target_window = [8, 13]          # NEW: feeds pct_time_in_window (metric only)
  when signal < 8  : increase 25%
  when signal > 13 : decrease 25%
```

```
# AdaptiveSimulationResult.metrics[0] (one per subject × replicate)
AdaptiveSubjectMetrics {
    subject: "P", draw: 1, sim: 1,
    cumulative_dose: …, n_doses: 15, n_increases: 3, n_decreases: 0, n_holds: 0,
    discontinued: false, time_to_discontinuation: None,
    signal_min: Some(…), signal_max: Some(…), signal_mean: Some(…),
    pct_time_in_window: Some(0.4),   // fraction of decision troughs in [8, 13]
}
```

</details>

## Docs
- [x] `docs/` updated (`docs/model-file/adaptive-dosing.qmd`: `target_window` key, the
  `metrics` artifact, roadmap)
- [ ] New pages linked in `docs/_quarto.yml` (no new page)
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new lints; `run_adaptive_population` already carries the too-many-args allow)
- [x] `Dual2` sensitivity path untouched (sim-only, no gradient-reachable code)
- [ ] `Cargo.toml` version bumped — not needed (additive, pre-1.0)

## Docs & examples

### ferx-site / ferx-book
- [ ] New DSL key (`target_window`) → ferx-site `model-dsl/` update is a follow-up (separate repo; not blocking).

### Example execution
- [x] No example execution step needed — engine-only; no new `examples/*.ferx` or `data/`
  in this PR (the adaptive example model shipped in S2.3), and the feature is a
  `simulate_*` API, not a CLI fit path.

## Reviewer hints

- The heart is `compute_subject_metrics` in `src/sim/adaptive.rs` — a pure function;
  read it against the 4 unit tests.
- The one design call worth scrutiny: `target_window` as explicit syntax vs deriving the
  band from rule thresholds (see *Alternatives considered*).
- `n_increases`/`n_decreases` count realized dose-deltas, not rule firings — intentional;
  see the doc comment on `AdaptiveSubjectMetrics::n_increases`.

## Open questions

None blocking. Deliberately deferred: **AUC-target attainment** (and the dense-grid
AUC-of-signal plumbing it needs) lands with the vancomycin anchor in S2.5b; the signal
summary here is a **decision-grid** (trough/peak) summary, not a dense-trajectory
extremum.
