### PR TITLE
Warn on non-mu-referenced SAEM parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,12 @@ section of the SDLC for the versioning policy).
   report the value in the data file; no per-subject time shift is applied.
 
 ### Changed
+- **SAEM now warns on non-mu-referenced individual parameters instead of listing detected
+  mu-referencing** (#621). The broad `mu-ref: ...` info notice is replaced by a SAEM-only
+  warning that names any individual parameter whose random effect is not mu-referenced
+  (e.g. `CL = TVCL + ETA_CL` rather than `CL = TVCL * exp(ETA_CL)`), since such forms can
+  strongly slow SAEM convergence. The warning fires whenever the estimation chain runs SAEM,
+  independent of the `mu_referencing` fit option.
 - **IOV occasions with doses but no observations now contribute their own κ random-effect
   axis** (#590). Occasion grouping (`iov_occasion_groups`) now includes every occasion in
   the dose record, not only those carrying sampled observations, so a dose-only occasion

--- a/docs/estimation/saem.qmd
+++ b/docs/estimation/saem.qmd
@@ -119,6 +119,19 @@ The NLopt M-step uses **BOBYQA** (derivative-free trust-region with quadratic in
 
 When `mu_referencing = false`, the full NLopt M-step runs for all thetas as before.
 
+::: {.callout-warning}
+## Non-mu-referenced parameters slow SAEM convergence
+
+Whenever the estimation chain runs SAEM, ferx warns if any individual parameter's
+random effect is **not** mu-referenced — for example `CL = TVCL + ETA_CL` (or any
+non-loglinear form) instead of `CL = TVCL * exp(ETA_CL)`. Such parameters cannot use
+the closed-form EM update above and fall back to the slower NLopt M-step, which can
+strongly slow convergence. The warning fires independently of the `mu_referencing`
+fit option: turning the option off does not remove the risk — it removes the
+mu-centering that mitigates it — so the diagnostic is most warranted in exactly that
+case. Prefer log-mu-referenced forms (`P = TV * exp(ETA)`) where the model allows.
+:::
+
 The number of NLopt evaluations saved is stored in `FitResult::saem_mu_ref_m_step_evals_saved`, accumulated across SAEM iterations as `2 × mstep_maxiter × n_mu_ref_pairs` per outer step (one finite-difference probe pair per pinned mu-ref dimension, capped at `mstep_maxiter` NLopt gradient requests). The field is `None` when mu-referencing is off or method ≠ SAEM.
 
 When `n_leapfrog > 0`, `FitResult::saem_n_subjects_hmc` records how many subjects used HMC at least once during the E-step (the remainder used MH fallback). The field is `None` for MH-only runs. The fit YAML also emits `saem_n_subjects_hmc` and `saem_n_subjects_mh` when the field is `Some`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -3076,6 +3076,31 @@ pub(crate) fn compute_extra_output_columns(
     }
 }
 
+fn saem_non_mu_referenced_individual_params_warning(model: &CompiledModel) -> Option<String> {
+    let mut names = Vec::new();
+    for (param_name, &eta_idx) in model.indiv_param_names.iter().zip(model.eta_map.iter()) {
+        if eta_idx < 0 {
+            continue;
+        }
+        let Some(eta_name) = model.eta_names.get(eta_idx as usize) else {
+            continue;
+        };
+        if !model.mu_refs.contains_key(eta_name) {
+            names.push(param_name.as_str());
+        }
+    }
+
+    if names.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "SAEM: individual parameter(s) not mu-referenced: {}. This can strongly \
+             affect convergence; prefer forms such as `CL = TVCL * exp(ETA_CL)` when possible.",
+            names.join(", ")
+        ))
+    }
+}
+
 fn fit_inner(
     model: &CompiledModel,
     population: &Population,
@@ -3800,18 +3825,14 @@ fn fit_inner(
         }
     }
 
-    // Report detected mu-referencing relationships (only when feature is enabled)
-    if options.mu_referencing && !model.mu_refs.is_empty() {
-        let mut names: Vec<&String> = model.mu_refs.keys().collect();
-        names.sort();
-        warnings.push(format!(
-            "mu-ref: {}",
-            names
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
+    if options.mu_referencing && chain.iter().any(|&m| m == EstimationMethod::Saem) {
+        if let Some(w) = saem_non_mu_referenced_individual_params_warning(model) {
+            warnings.push(if n_stages > 1 {
+                format!("[SAEM] {w}")
+            } else {
+                w
+            });
+        }
     }
 
     // M3 censoring under non-interaction FOCE is a consistent Sheiner–Beal fit (the
@@ -4929,6 +4950,51 @@ mod tests {
         assert!(eps_shrinkage_warning(-0.05).is_none());
         // NaN — no warning.
         assert!(eps_shrinkage_warning(f64::NAN).is_none());
+    }
+
+    #[test]
+    fn saem_non_mu_referenced_warning_lists_individual_params_with_unmapped_eta() {
+        let mut model = crate::types::test_helpers::analytical_model(GradientMethod::Auto);
+        model.indiv_param_names = vec!["CL".into(), "V".into(), "KA".into()];
+        model.eta_names = vec!["ETA_CL".into(), "ETA_V".into()];
+        model.eta_map = vec![0, 1, -1];
+        model.mu_refs.insert(
+            "ETA_CL".into(),
+            MuRef {
+                theta_name: "TVCL".into(),
+                log_transformed: true,
+            },
+        );
+
+        let warning =
+            saem_non_mu_referenced_individual_params_warning(&model).expect("expected warning");
+        assert!(warning.contains("not mu-referenced: V."));
+        assert!(!warning.contains("not mu-referenced: CL"));
+        assert!(!warning.contains("KA"));
+    }
+
+    #[test]
+    fn saem_non_mu_referenced_warning_is_none_when_all_eta_params_are_muref() {
+        let mut model = crate::types::test_helpers::analytical_model(GradientMethod::Auto);
+        model.indiv_param_names = vec!["CL".into(), "V".into(), "KA".into()];
+        model.eta_names = vec!["ETA_CL".into(), "ETA_V".into()];
+        model.eta_map = vec![0, 1, -1];
+        model.mu_refs.insert(
+            "ETA_CL".into(),
+            MuRef {
+                theta_name: "TVCL".into(),
+                log_transformed: true,
+            },
+        );
+        model.mu_refs.insert(
+            "ETA_V".into(),
+            MuRef {
+                theta_name: "TVV".into(),
+                log_transformed: true,
+            },
+        );
+
+        assert!(saem_non_mu_referenced_individual_params_warning(&model).is_none());
     }
 
     // ── kappa shrinkage ──────────────────────────────────────────────────────

--- a/src/api.rs
+++ b/src/api.rs
@@ -3094,7 +3094,7 @@ fn saem_non_mu_referenced_individual_params_warning(model: &CompiledModel) -> Op
         None
     } else {
         Some(format!(
-            "SAEM: individual parameter(s) not mu-referenced: {}. This can strongly \
+            "individual parameter(s) not mu-referenced: {}. This can strongly \
              affect convergence; prefer forms such as `CL = TVCL * exp(ETA_CL)` when possible.",
             names.join(", ")
         ))
@@ -3825,12 +3825,16 @@ fn fit_inner(
         }
     }
 
-    if options.mu_referencing && chain.iter().any(|&m| m == EstimationMethod::Saem) {
+    // Emitted whenever the chain runs SAEM, independent of `options.mu_referencing`:
+    // the non-mu-referenced case is *most* at risk under SAEM when mu-centering is
+    // off, so gating on the opt-in flag would silence the warning exactly when it
+    // matters most (#621).
+    if chain.iter().any(|&m| m == EstimationMethod::Saem) {
         if let Some(w) = saem_non_mu_referenced_individual_params_warning(model) {
             warnings.push(if n_stages > 1 {
                 format!("[SAEM] {w}")
             } else {
-                w
+                format!("SAEM: {w}")
             });
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3395,7 +3395,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // "falls back to" intentionally removed: no emitted message uses that exact
         // phrase. The SAEM HMC message is fully covered by "hmc is unavailable".
         (WarningSeverity::Info, "gradient_fallback")
-    } else if lower.contains("saem:") && lower.contains("not mu-referenced") {
+    } else if lower.contains("not mu-referenced") {
         (WarningSeverity::Warning, "mu_referencing")
     } else if lower.contains("mu-ref") || lower.contains("mu-referencing") {
         (WarningSeverity::Info, "mu_referencing")
@@ -5762,7 +5762,7 @@ mod tests {
                 "covariance_step",
             ),
             (
-                "[SAEM] SAEM: individual parameter(s) not mu-referenced: V",
+                "[SAEM] individual parameter(s) not mu-referenced: V",
                 Warning,
                 "mu_referencing",
             ),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3395,6 +3395,8 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // "falls back to" intentionally removed: no emitted message uses that exact
         // phrase. The SAEM HMC message is fully covered by "hmc is unavailable".
         (WarningSeverity::Info, "gradient_fallback")
+    } else if lower.contains("saem:") && lower.contains("not mu-referenced") {
+        (WarningSeverity::Warning, "mu_referencing")
     } else if lower.contains("mu-ref") || lower.contains("mu-referencing") {
         (WarningSeverity::Info, "mu_referencing")
     } else if lower.contains("global_search disabled") {
@@ -5492,6 +5494,16 @@ mod tests {
     }
 
     #[test]
+    fn classify_warning_saem_non_mu_ref_is_warning() {
+        let w = classify_warning(
+            "SAEM: individual parameter(s) not mu-referenced: V. This can strongly \
+             affect convergence; prefer forms such as `CL = TVCL * exp(ETA_CL)` when possible.",
+        );
+        assert_eq!(w.severity, WarningSeverity::Warning);
+        assert_eq!(w.category, "mu_referencing");
+    }
+
+    #[test]
     fn classify_warning_strips_chain_prefix() {
         let w = classify_warning("[FOCEI] Covariance step failed");
         assert_eq!(w.source_method.as_deref(), Some("FOCEI"));
@@ -5634,6 +5646,12 @@ mod tests {
             ),
             ("mu-ref: CL, V, KA", Info, "mu_referencing"),
             (
+                "SAEM: individual parameter(s) not mu-referenced: V. This can strongly \
+                 affect convergence; prefer forms such as `CL = TVCL * exp(ETA_CL)` when possible.",
+                Warning,
+                "mu_referencing",
+            ),
+            (
                 "Multi-start: best result from start 3/8",
                 Info,
                 "multi_start",
@@ -5743,7 +5761,11 @@ mod tests {
                 Critical,
                 "covariance_step",
             ),
-            ("[SAEM] mu-ref: CL", Info, "mu_referencing"),
+            (
+                "[SAEM] SAEM: individual parameter(s) not mu-referenced: V",
+                Warning,
+                "mu_referencing",
+            ),
             (
                 "[FOCEI] Outer optimization did not converge",
                 Critical,


### PR DESCRIPTION
## Summary
- replace the broad mu-ref info notice with a SAEM-only warning for individual parameters whose ETA is not mu-referenced
- classify the new SAEM message as warning-level mu_referencing metadata
- add unit coverage for the warning helper and classifier

Closes #621
