### PR TITLE
fix(sim): score auc_target_attainment over realized decisions under discontinuation [#391]

### DIFF
--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -208,8 +208,12 @@ The result bundles four tidy, long-form artifacts — each tagged by
   integrated-exposure field: the fraction of inter-decision windows whose area
   under the monitored signal falls in the `auc_target` band, computed by a separate
   signal-AUC pass that re-integrates the realized doses on a dense grid (it never
-  perturbs the reactive run). Population summaries **with uncertainty bands** ride
-  with the uncertainty slice, where bands carry meaning.
+  perturbs the reactive run). It is scored over the windows between **realized**
+  decisions, so if a run discontinues (a `Stop`) the later, dose-free scheduled
+  windows are not counted — discontinuation is already its own metric, and folding
+  it in here too would double-count it; this keeps `auc_target_attainment` on the
+  same realized basis as `pct_time_in_window`. Population summaries **with
+  uncertainty bands** ride with the uncertainty slice, where bands carry meaning.
 
 ## Verification (on by default)
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -6144,6 +6144,17 @@ where
             // a clean "of the windows we dosed, how many hit target", on the same
             // realized basis as `pct_time_in_window`. For a run that never
             // discontinues the two decision lists are identical.
+            //
+            // Dropping the post-`Stop` windows loses no *dosed* window: a declarative
+            // `Stop` is dose-free (`adaptive_control::Controller::apply` maps it to
+            // `[DoseAction::Stop]`, never `[dose, Stop]`), so the last realized window
+            // already covers the last dose. The one controller that *can* dose-then-
+            // stop is the programmatic `Vec<DoseAction>` API, and that path runs with
+            // `auc_target = None` (the AUC pass is skipped) — so a dose issued *at* a
+            // stop never coincides with this metric. If that ever changes (a
+            // dose-on-stop reaching the AUC pass), the final dose's window would need
+            // explicit handling; the `..._after_discontinuation` test pins the
+            // dose-free-`Stop` invariant this relies on.
             let window_aucs: Vec<f64> = match (auc_target, monitors.first()) {
                 (Some(_), Some(mon)) => {
                     let realized_decision_times: Vec<f64> =
@@ -12191,7 +12202,15 @@ mod adaptive_sim_tests {
         // Only the realized decisions are logged (decision 0 dosed, decision 1
         // stopped); the 13 later scheduled decisions never occurred.
         assert_eq!(res.decisions.len(), 2, "only realized decisions logged");
-        assert_eq!(res.ledger.len(), 1, "one realized dose, at t=0");
+        // One realized dose, at t=0: the `Stop` at decision 1 is DOSE-FREE. This is
+        // the invariant that makes realized-window scoring lose no dosed window — a
+        // declarative `Stop` never carries a final dose, so there is no dose issued
+        // *at* the stop whose (dropped) post-stop window would have mattered.
+        assert_eq!(
+            res.ledger.len(),
+            1,
+            "one realized dose; the Stop dosed nothing"
+        );
 
         // Scored over the ONE realized window [0, 24] ⇒ 1.0. (Old planned-horizon
         // behavior: ~3 of 14 scheduled windows in band ⇒ ~0.214, so this fails on it.)

--- a/src/api.rs
+++ b/src/api.rs
@@ -6133,18 +6133,33 @@ where
             // `auc_target` is declared (its sole consumer) and a monitor exists. It
             // re-integrates the realized ledger on its own dense grid — separate from,
             // and never perturbing, the reactive run + verifier above.
+            //
+            // Windowed over the **realized** decision times (`run.decisions`), NOT the
+            // full scheduled `decision_times`: after a `Stop` the controller
+            // discontinues and the later scheduled decisions never happen, so scoring
+            // their dose-free, washed-out windows would fold discontinuation — already
+            // a first-class outcome (`discontinued` / `time_to_discontinuation`) — into
+            // the exposure metric as silent misses (double-counting one event into two
+            // metrics). Confining to realized decisions keeps `auc_target_attainment`
+            // a clean "of the windows we dosed, how many hit target", on the same
+            // realized basis as `pct_time_in_window`. For a run that never
+            // discontinues the two decision lists are identical.
             let window_aucs: Vec<f64> = match (auc_target, monitors.first()) {
-                (Some(_), Some(mon)) => crate::ode::adaptive_window_signal_aucs(
-                    ode,
-                    &pk.values,
-                    &params.theta,
-                    &eta_slice,
-                    subject,
-                    decision_times,
-                    &run.ledger,
-                    mon.observe,
-                    mon.spec.cmt,
-                ),
+                (Some(_), Some(mon)) => {
+                    let realized_decision_times: Vec<f64> =
+                        run.decisions.iter().map(|d| d.time).collect();
+                    crate::ode::adaptive_window_signal_aucs(
+                        ode,
+                        &pk.values,
+                        &params.theta,
+                        &eta_slice,
+                        subject,
+                        &realized_decision_times,
+                        &run.ledger,
+                        mon.observe,
+                        mon.spec.cmt,
+                    )
+                }
                 _ => Vec::new(),
             };
 
@@ -12107,6 +12122,80 @@ mod adaptive_sim_tests {
         // band *is* declared and there *are* windows).
         spec.auc_target = Some((1e18, f64::INFINITY));
         assert_eq!(run(&spec).metrics[0].auc_target_attainment, Some(0.0));
+    }
+
+    #[test]
+    fn auc_attainment_is_scored_over_realized_windows_after_discontinuation() {
+        // Regression: under discontinuation, `auc_target_attainment` must score only
+        // the windows between REALIZED decisions, not the full scheduled horizon.
+        // After a `Stop` the later scheduled decisions never happen; counting their
+        // dose-free, washed-out windows would fold discontinuation (already reported
+        // by `discontinued` / `time_to_discontinuation`) into the exposure metric as
+        // silent misses. Here the model doses once at decision 0; the pre-dose trough
+        // then rises above the stop threshold at decision 1 → discontinue. Of the 15
+        // SCHEDULED daily decisions only 2 are realized, so there is exactly ONE
+        // realized window [0, 24] — well above the one-sided `[1, ∞)` floor ⇒
+        // attainment 1.0. The old planned-horizon behavior scored all 14 scheduled
+        // windows, the washout tail dragging attainment to ~3/14, so it fails here.
+        let src = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central
+  at = every 24 from 0 to 336
+  start_dose = 100
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 5 : increase 25%
+  when signal > 5 : stop
+"#;
+        let parsed = parse_full_model(src).expect("parse stop block");
+        let mut spec = parsed.adaptive_dosing.clone().expect("block present");
+        // One-sided floor: every dosed window clears it; the post-stop washout windows
+        // (which the old behavior would have scored) fall below it.
+        spec.auc_target = Some((1.0, f64::INFINITY));
+
+        let pop = population(vec![subj("P", vec![342.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        };
+        let res = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            &spec,
+            &opts,
+        )
+        .expect("discontinuing run");
+
+        // It actually discontinues, at the second decision (t = 24).
+        let m = &res.metrics[0];
+        assert!(m.discontinued, "run should hit the stop rule");
+        assert_eq!(m.time_to_discontinuation, Some(24.0));
+        // Only the realized decisions are logged (decision 0 dosed, decision 1
+        // stopped); the 13 later scheduled decisions never occurred.
+        assert_eq!(res.decisions.len(), 2, "only realized decisions logged");
+        assert_eq!(res.ledger.len(), 1, "one realized dose, at t=0");
+
+        // Scored over the ONE realized window [0, 24] ⇒ 1.0. (Old planned-horizon
+        // behavior: ~3 of 14 scheduled windows in band ⇒ ~0.214, so this fails on it.)
+        assert_eq!(m.auc_target_attainment, Some(1.0));
     }
 
     #[test]

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -405,21 +405,24 @@ pub struct AdaptiveSubjectMetrics {
     /// under the latent monitored signal over the window) fell within the spec's
     /// `auc_target` band `[lo, hi]` (inclusive), in `[0, 1]` — e.g. the share of
     /// daily windows whose vancomycin AUC₂₄ is on target (#391 S2.5b). The
-    /// denominator is the number of windows between consecutive **scheduled**
-    /// decisions (`decisions − 1`), so a run with fewer than two decisions has no
-    /// window and the metric is `None`. `None` also when no `auc_target` is declared
-    /// (the signal-AUC pass is then skipped). Unlike the point summary above, this is
-    /// an **integrated-exposure** quantity: it is computed by re-integrating the
-    /// realized dose ledger on a dense grid (the AUC pass never perturbs the
+    /// denominator is the number of windows between consecutive **realized**
+    /// decisions (`realized_decisions − 1`), so a run with fewer than two decisions
+    /// has no window and the metric is `None`. `None` also when no `auc_target` is
+    /// declared (the signal-AUC pass is then skipped). Unlike the point summary above,
+    /// this is an **integrated-exposure** quantity: it is computed by re-integrating
+    /// the realized dose ledger on a dense grid (the AUC pass never perturbs the
     /// reactive run), not reduced from the decision-grid signals.
     ///
-    /// This is a **planned-horizon** measure: it scores every scheduled window,
-    /// including any after a `Stop`/discontinuation — those integrate the decaying
-    /// tail of the last realized dose, so they (correctly) read as under-exposed and
-    /// off-target. It therefore uses a different decision basis from the
-    /// realized-decision point metric [`Self::pct_time_in_window`]; the two agree
-    /// when the run never discontinues (the common case, and what the bundled
-    /// example exercises).
+    /// **Scored over realized decisions only.** If the controller `Stop`s, the later
+    /// *scheduled* decisions never happen, and their dose-free, washed-out windows are
+    /// **not** counted — discontinuation is already a first-class outcome
+    /// ([`Self::discontinued`] / [`Self::time_to_discontinuation`]), so folding it in
+    /// here too would double-count one event into two metrics and silently drag the
+    /// attainment down. So this stays a clean "of the windows we actually dosed, how
+    /// many hit the exposure target", on the same realized basis as the point metric
+    /// [`Self::pct_time_in_window`]. For a run that never discontinues, realized and
+    /// scheduled decisions coincide (the common case, and what the bundled example
+    /// exercises).
     pub auc_target_attainment: Option<f64>,
 }
 


### PR DESCRIPTION
## Why
Follow-up to #612 (S2.5b). The new `auc_target_attainment` metric scored **all
scheduled** inter-decision windows, while its sibling point metric
`pct_time_in_window` scores only **realized** decisions. The two therefore used
different decision bases under discontinuation, and — more importantly — scoring
post-`Stop` windows double-counts one event into two metrics: a `Stop` is already a
first-class outcome (`discontinued` / `time_to_discontinuation`), so also letting
its dose-free, washed-out windows drag `auc_target_attainment` down conflates
"dosing quality" with "did the patient complete the course". A run that dosed
perfectly for two days then stopped would report a poor attainment — punishing the
dosing for the discontinuation.

This only manifests when a run actually discontinues; the bundled vancomycin
example never does, so the merged behavior was correct for everything tested — it's
a latent semantics issue surfaced in review.

## What changed
- `run_adaptive_population` now passes the **realized** decision times
  (`run.decisions`), not the full scheduled `decision_times`, into the signal-AUC
  pass. So `auc_target_attainment` is scored over the windows between decisions that
  actually happened. For a run that never discontinues, realized == scheduled, so
  nothing changes (the mrgsolve anchor is bit-unchanged).
- Each metric now measures one orthogonal thing: `discontinued` /
  `time_to_discontinuation` → *did/when therapy stop*; `auc_target_attainment` → *of
  the windows we dosed, how many hit the exposure target* (same realized basis as
  `pct_time_in_window`).
- Doc updates: the `AdaptiveSubjectMetrics::auc_target_attainment` rustdoc and the
  adaptive-dosing docs page now state the realized-window basis and why.

## Alternatives considered
**Keep planned-horizon** (score all scheduled windows, post-stop washout as misses):
defensible as "exposure over the intended course", but it fuses two distinct
questions into one number and is better answered by reading `auc_target_attainment`
alongside the discontinuation fields. **Make it user-selectable**: rejected as
over-engineering for an edge case — adds API surface to the `#[non_exhaustive]`
options struct with no concrete use case.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No API change: `auc_target_attainment` is an existing field on the
`#[non_exhaustive]` `AdaptiveSubjectMetrics`; only its value under discontinuation
changes.

## Breaking changes
- [x] None (behavioral refinement of an unreleased metric; no API/format change).

## Numerical validation
- [x] Not applicable in the NONMEM sense — adaptive (feedback) dosing has no NONMEM
  comparator (epic #391 policy). The change is metrics-only and never touches the
  reactive trajectory or the frozen-replay verifier. The slow mrgsolve vancomycin
  anchor (`vanco_titration_matches_mrgsolve`) is **unchanged** (8/13), because that
  run never discontinues so realized == scheduled.

## Performance
- [x] No significant impact expected (same per-window AUC pass; on discontinuation
  it does *fewer* windows).

## Tests
- [x] Regression test added that fails without this fix:
  `auc_attainment_is_scored_over_realized_windows_after_discontinuation`
  (`src/api.rs`) — a model that doses once then discontinues at the 2nd of 15
  scheduled decisions. With a one-sided `[1, ∞)` band the single realized window is
  on target ⇒ attainment `1.0`; the old planned-horizon behavior scored all 14
  scheduled windows (washout tail ⇒ ~3/14), so it fails on the pre-fix code.
- [x] Existing `from_spec_reports_auc_target_attainment` and the slow vanco anchor
  still pass (no discontinuation ⇒ unchanged).

## Example (user-facing features only)
- [x] Not applicable (no new API surface; refines an existing metric's behavior).

## Docs
- [x] `docs/model-file/adaptive-dosing.qmd` updated (realized-window basis under
  discontinuation).
- [x] `CHANGELOG.md`: N/A — refines the unreleased #612 entry, whose wording
  ("inter-decision windows") remains accurate.
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (lib)
- [x] No `Dual2`-path code touched
- [x] No version bump

## Reviewer hints
The substance is one call-site change in `run_adaptive_population` (pass
`run.decisions` times instead of `decision_times`) plus the rationale in the
`auc_target_attainment` rustdoc. The regression test's model is constructed so
realized (1) and scheduled (14) window counts differ, with a band that only the
realized window clears.

## Open questions
None — this implements the realized-decision alignment chosen over planned-horizon
after review (the double-counting argument: discontinuation is already its own
metric).
