### PR TITLE
test(sim): assert the dose-free-Stop invariant behind realized-window AUC scoring [#391]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -6226,10 +6226,23 @@ where
             // `auc_target = None` (the AUC pass is skipped) — so a dose issued *at* a
             // stop never coincides with this metric. If that ever changes (a
             // dose-on-stop reaching the AUC pass), the final dose's window would need
-            // explicit handling; the `..._after_discontinuation` test pins the
+            // explicit handling — the `debug_assert!` in the match arm below is the
+            // tripwire for exactly that, and `sim::adaptive::run_has_dose_on_stop` (with
+            // its unit test plus the `..._after_discontinuation` test) pins the
             // dose-free-`Stop` invariant this relies on.
             let window_aucs: Vec<f64> = match (auc_target, monitors.first()) {
                 (Some(_), Some(mon)) => {
+                    // Tripwire (see the note above): realized-window scoring is exact only
+                    // while no `Stop` carries a dose. Unreachable today; this fires in
+                    // debug/test builds if a future change ever routes a dose-on-stop here,
+                    // rather than silently under-reporting that final dose's exposure.
+                    debug_assert!(
+                        !crate::sim::adaptive::run_has_dose_on_stop(&run.decisions),
+                        "auc_target_attainment: a Stop carried a final dose (`[dose, Stop]`); \
+                         its post-stop exposure window is unscored under realized-window \
+                         scoring — the dose-free-Stop invariant no longer holds, so that \
+                         window now needs explicit handling"
+                    );
                     let realized_decision_times: Vec<f64> =
                         run.decisions.iter().map(|d| d.time).collect();
                     crate::ode::adaptive_window_signal_aucs(

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -426,6 +426,24 @@ pub struct AdaptiveSubjectMetrics {
     pub auc_target_attainment: Option<f64>,
 }
 
+/// `true` if any logged decision is a `Stop` that *also* issued a dose — the
+/// `[dose, Stop]` shape (`DecisionOutcome::Stop { dosed > 0 }`).
+///
+/// The realized-window signal-AUC pass (`auc_target_attainment`) relies on this
+/// being **false**: it scores only the windows between realized decisions, so a
+/// dose issued *at* a stop has no following decision to bound its window and would
+/// be silently dropped. That case is currently unreachable on the AUC path — a
+/// declarative `Stop` is dose-free, and the only controller that can dose-then-stop
+/// (the programmatic API) runs with `auc_target = None` — so the call site
+/// `debug_assert!`s on this predicate rather than handling the window. If a future
+/// change lets a dose-on-stop reach the AUC pass, the assert trips in debug/test
+/// builds instead of quietly under-reporting exposure.
+pub(crate) fn run_has_dose_on_stop(decisions: &[DecisionLogEntry]) -> bool {
+    decisions
+        .iter()
+        .any(|d| matches!(d.outcome, DecisionOutcome::Stop { dosed } if dosed > 0))
+}
+
 /// Compute the [`AdaptiveSubjectMetrics`] for one realized run from its dose
 /// `ledger` and decision log alone (#391 S2.4).
 ///
@@ -1716,6 +1734,30 @@ mod tests {
         let no_band =
             compute_subject_metrics("S", 1, 1, &ledger, &decisions, None, None, &window_aucs);
         assert_eq!(no_band.auc_target_attainment, None);
+    }
+
+    #[test]
+    fn run_has_dose_on_stop_flags_only_dose_carrying_stops() {
+        // The invariant the realized-window AUC pass relies on: no `[dose, Stop]`. A
+        // declarative `Stop` is dose-free (`dosed: 0`); a dose issued *at* a stop
+        // (`dosed > 0`, the programmatic `[Bolus, Stop]` shape) is what would strand
+        // an unscored final-dose window — the call-site `debug_assert!` trips on it.
+        let dose_free_stop = vec![
+            decision(0.0, Some(10.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(24.0, Some(12.0), DecisionOutcome::Stop { dosed: 0 }),
+        ];
+        assert!(!run_has_dose_on_stop(&dose_free_stop));
+
+        let dose_then_stop = vec![
+            decision(0.0, Some(10.0), DecisionOutcome::Dosed { n: 1 }),
+            decision(24.0, Some(12.0), DecisionOutcome::Stop { dosed: 1 }),
+        ];
+        assert!(run_has_dose_on_stop(&dose_then_stop));
+
+        // No stop at all, and the empty run — both clear.
+        let no_stop = vec![decision(0.0, Some(10.0), DecisionOutcome::Dosed { n: 1 })];
+        assert!(!run_has_dose_on_stop(&no_stop));
+        assert!(!run_has_dose_on_stop(&[]));
     }
 
     #[test]


### PR DESCRIPTION
## Why
Follow-up to #628. Realized-window `auc_target_attainment` scoring is exact only
while no `Stop` carries a dose (`[dose, Stop]`): a dose issued *at* a stop has no
following realized decision to bound its window and would be silently dropped.
#628 documented that this is structurally unreachable on the AUC path (a
declarative `Stop` is dose-free; the only dose-then-stop controller runs with
`auc_target = None`). But a comment is a *soft* guard — a future change that adds a
dose-then-stop construct reaching the AUC pass wouldn't be forced to handle the
dropped final-dose window; nothing would fail. This converts the documented
assumption into an enforced one.

## What changed
- Extracted `sim::adaptive::run_has_dose_on_stop(&[DecisionLogEntry]) -> bool`
  (true iff any decision is `DecisionOutcome::Stop { dosed > 0 }`), with a unit
  test — the firing case can't be reached through the public API, so a named,
  directly-tested predicate is the way to verify the logic.
- The AUC call site `debug_assert!`s on it **inside** the `(Some(_), Some(mon))`
  match arm — i.e. only when the signal-AUC pass actually runs. (A pre-match assert
  would false-positive on a legitimate programmatic `[Bolus, Stop]` run that uses no
  `auc_target`.) No release-build cost; no behavior change on any reachable path.

## Alternatives considered
A release-build guard (taint the result / return `Err`): rejected as too heavy for
a structurally-unreachable case — `debug_assert!` catches the developer error in
debug/test builds, which is where a new dose-then-stop feature would be exercised.
An inline closure without the extracted predicate: rejected because the extracted
`fn` is unit-testable in isolation, whereas the inline assert's firing branch is
unreachable via the public API.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None.

## Numerical validation
- [x] Not applicable — no numerical change; the `debug_assert!` is a no-op on every
  reachable path (it never fires in the suite, including the slow vanco anchor).

## Performance
- [x] No significant impact — debug-only assertion; release builds unaffected.

## Tests
- [x] Unit test `run_has_dose_on_stop_flags_only_dose_carrying_stops`
  (`src/sim/adaptive.rs`): dose-free `Stop` ⇒ false; `[dose, Stop]` ⇒ true; no stop
  ⇒ false; empty ⇒ false.
- [x] The call-site assertion line is exercised (and stays silent) by the existing
  `auc_target` tests (`from_spec_reports_auc_target_attainment`, the discontinuation
  regression test).

## Example (user-facing features only)
- [x] Not applicable (internal hardening; no API surface).

## Docs
- [x] `CHANGELOG.md`: N/A — internal invariant guard, no user-facing behavior.
- [x] No user-visible change.

## Checklist
- [x] `cargo clippy` clean (lib)
- [x] No `Dual2`-path code touched
- [x] No version bump

## Reviewer hints
The one subtle point is assertion *placement*: it lives inside the
`(Some(_), Some(mon))` arm so it only checks when the AUC pass runs. Asserting
before the `match` would trip on a perfectly valid programmatic `[Bolus, Stop]`
run that never sets `auc_target`.

## Open questions
None.
