### PR TITLE
feat(estimation): analytic gradient for custom/time-varying residual-error σ magnitude [#486]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ section of the SDLC for the versioning policy).
   (Sheiner–Beal) is a distinct objective and is unchanged.
 
 ### Added
+- **Custom / time-varying residual-error magnitude (`[error_model]` σ-scaling expression)
+  now gets an exact analytic gradient** on both loops instead of finite differences
+  (#484/#576/#486). The magnitude is η-independent, so the inner EBE gradient just
+  threads the per-observation multiplier into the residual variance and its
+  `f`-derivative; the FOCEI outer θ/σ population gradient additionally
+  dual-differentiates the compiled magnitude program w.r.t. θ, adding a new
+  *direct*-θ term to `∂R/∂θ` for any theta the magnitude expression references
+  (e.g. a late-phase RUV inflation `PROP_ERR * (1 + RUV_LATE * TIME/48)`).
+  Validated against a live NONMEM FOCEI fit (OFV and every estimate, including
+  `RUV_LATE`, match to ~4-5 significant figures — see `examples/warfarin_ruv_magnitude.ferx`).
+  `block_sigma` correlated residual error, `iiv_on_ruv`, an M3-BLOQ censored row,
+  more than 16 thetas, and plain `method = foce` (non-interaction) still fall back
+  to the (magnitude-aware) finite-difference gradient.
 - **Modeled-duration/rate doses (`RATE=-1`/`-2`, `D{cmt}`/`R{cmt}`) under IOV** now get
   exact analytic FOCE/FOCEI sensitivities on the ODE path instead of finite differences
   (#486). Each occasion resolves its own modeled infusion window from the per-occasion PK

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -102,9 +102,18 @@ A bare sigma name keeps the legacy behaviour exactly ($m_k \equiv 1$).
 - The `TIME` fed to the expression is the raw data-file time (matching NONMEM's
   `$ERROR`).
 - Supported for `method = foce` and `method = focei` only. SAEM, GN, GN-hybrid,
-  and importance-sampling are rejected up front. When a custom magnitude is
-  active the analytic outer/inner gradients fall back to finite differences
-  (which are magnitude-aware), so fits are correct but slightly slower.
+  and importance-sampling are rejected up front.
+- **Analytic gradient (#576/#486).** The inner EBE η-gradient and the FOCEI
+  outer θ/σ population gradient are both analytic for a magnitude-active model
+  — the magnitude is η-independent, so the inner loop just threads its
+  per-observation multiplier into the variance/its `f`-derivative; the outer
+  loop differentiates the magnitude program itself (a new *direct*-θ term in
+  `∂R/∂θ`, since `mult(θ)` enters the residual variance independent of the
+  prediction). A few combinations still fall back to finite differences (which
+  remain magnitude-aware, so fits stay correct, just slower): `block_sigma`
+  correlated residual error, `iiv_on_ruv`, an M3-BLOQ censored row, more than 16
+  thetas, and plain `method = foce` (non-interaction) — only FOCEI has the
+  direct-θ channel so far.
 
 ## Log-transform-both-sides (LTBS)
 

--- a/examples/warfarin_ruv_magnitude.ferx
+++ b/examples/warfarin_ruv_magnitude.ferx
@@ -1,0 +1,42 @@
+# One-compartment oral warfarin PK model with a TIME-varying proportional
+# residual-error magnitude (#484/#576/#486): the proportional error inflates
+# linearly with TIME (scaled by 48h) via a theta, RUV_LATE. The θ/σ outer
+# gradient and η inner gradient are both analytic (#486) — this model exercises
+# the direct-θ channel `mult(θ)` adds to `∂R/∂θ`, validated against a live
+# NONMEM FOCEI fit on data simulated from this file (OFV/estimates match to
+# ~4-5 significant figures).
+
+[parameters]
+  theta TVCL(0.15, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.0, 0.01, 50.0)
+  theta RUV_LATE(2.0, 0.0, 5.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))
+
+[fit_options]
+  method     = focei
+  maxiter    = 300
+  covariance = false
+
+[simulation]
+  n_subjects = 40
+  dose_amt   = 100.0
+  dose_cmt   = 1
+  times      = [0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0, 48.0, 72.0, 96.0, 120.0]
+  seed       = 7

--- a/src/api.rs
+++ b/src/api.rs
@@ -4166,7 +4166,13 @@ fn fit_inner(
         EstimationMethod::Imp => "imp-bobyqa".to_string(),
         _ => {
             if options.optimizer == Optimizer::Auto {
-                format!("auto ({})", options.optimizer.resolve_auto(model).label())
+                format!(
+                    "auto ({})",
+                    options
+                        .optimizer
+                        .resolve_auto(model, options.interaction)
+                        .label()
+                )
             } else {
                 options.optimizer.label().to_string()
             }
@@ -7007,7 +7013,7 @@ mod iov_integration {
         let opts = fast_opts(EstimationMethod::Foce, Optimizer::Auto, false);
         let result = fit(&model, &pop, &model.default_params, &opts).expect("fit should succeed");
         assert_iov_fit_ok(&result);
-        let resolved = Optimizer::Auto.resolve_auto(&model);
+        let resolved = Optimizer::Auto.resolve_auto(&model, false);
         assert_eq!(result.optimizer, format!("auto ({})", resolved.label()));
         assert_eq!(resolved, Optimizer::Bobyqa);
     }
@@ -7130,7 +7136,7 @@ mod iov_integration {
         // seeding built-in BFGS at the optimum converges fine — so it was
         // optimizer basin-capture, not an ODE-IOV gradient defect. See #439/#486.
         assert_eq!(
-            Optimizer::Auto.resolve_auto(&ode),
+            Optimizer::Auto.resolve_auto(&ode, false),
             Optimizer::NloptLbfgs,
             "ODE IOV twin should resolve `auto` to the analytic-gradient L-BFGS"
         );

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -109,26 +109,38 @@ pub fn gradient_method_outer(
         EstimationMethod::FoceGn | EstimationMethod::FoceGnHybrid => {
             GradientMethodKind::FiniteDifferences
         }
-        EstimationMethod::Foce | EstimationMethod::FoceI => match optimizer.resolve_auto(model) {
-            Optimizer::Bobyqa => GradientMethodKind::NotApplicable,
-            // `Auto` is resolved above; only its concrete results reach here.
-            Optimizer::Auto
-            | Optimizer::Bfgs
-            | Optimizer::Lbfgs
-            | Optimizer::Slsqp
-            | Optimizer::NloptLbfgs
-            | Optimizer::Mma
-            | Optimizer::TrustRegion => {
-                // Shared predicate (#490) — now IOV-aware via `iov_sens_supported`, which
-                // admits ODE IOV models too, so the reported method tracks the live outer
-                // dispatch (`outer_optimizer.rs`) for IOV as well (#466 review #4 / #439 IOV).
-                if crate::sens::provider::analytic_outer_gradient_available(model) {
-                    GradientMethodKind::Analytic
-                } else {
-                    GradientMethodKind::FiniteDifferences
+        EstimationMethod::Foce | EstimationMethod::FoceI => {
+            // `interaction` derives from `method` (the parser sets
+            // `opts.interaction = method == FoceI`, so the two never disagree),
+            // not a separate `FitOptions` field this function doesn't receive.
+            let interaction = method == EstimationMethod::FoceI;
+            match optimizer.resolve_auto(model, interaction) {
+                Optimizer::Bobyqa => GradientMethodKind::NotApplicable,
+                // `Auto` is resolved above; only its concrete results reach here.
+                Optimizer::Auto
+                | Optimizer::Bfgs
+                | Optimizer::Lbfgs
+                | Optimizer::Slsqp
+                | Optimizer::NloptLbfgs
+                | Optimizer::Mma
+                | Optimizer::TrustRegion => {
+                    // Shared predicate (#490) — now IOV-aware via `iov_sens_supported`, which
+                    // admits ODE IOV models too, so the reported method tracks the live outer
+                    // dispatch (`outer_optimizer.rs`) for IOV as well (#466 review #4 / #439 IOV).
+                    // Interaction-aware (#486 review) so a custom-magnitude model under plain
+                    // FOCE — where the direct-θ channel isn't assembled — reports FD even when
+                    // the user forced a concrete gradient-based `optimizer` (bypassing `resolve_auto`).
+                    if crate::sens::provider::analytic_outer_gradient_for_interaction(
+                        model,
+                        interaction,
+                    ) {
+                        GradientMethodKind::Analytic
+                    } else {
+                        GradientMethodKind::FiniteDifferences
+                    }
                 }
             }
-        },
+        }
     }
 }
 
@@ -256,6 +268,47 @@ mod tests {
         assert_eq!(
             gradient_method_outer(&ad_build(), EstimationMethod::FoceGn, Optimizer::Bobyqa, &m),
             GradientMethodKind::FiniteDifferences
+        );
+    }
+
+    /// #486 review: a custom residual-magnitude model's direct-θ channel is
+    /// FOCEI-only (`subject_packed_gradient_foce`/`_foce_iov` decline it), so
+    /// `gradient_method_outer` must report `FiniteDifferences` under plain
+    /// `method = foce` even though the model is otherwise in the
+    /// (interaction-agnostic) analytic-gradient scope — and `Analytic` under
+    /// `method = focei`. Regression test for the `resolve_auto`/reported-method
+    /// drift the fix closes.
+    #[test]
+    fn outer_custom_magnitude_reports_fd_under_foce_analytic_under_focei() {
+        let content = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  theta RUV_LATE(1.5, 0.0, 10.0)\n  omega ETA_CL ~ 0.09\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n";
+        let m = crate::parser::model_parser::parse_model_string(content).expect("parse");
+        assert!(m.has_custom_ruv_magnitude());
+        // `Optimizer::Auto` resolves to `Bobyqa` for FOCE + magnitude (no analytic
+        // gradient to feed a gradient-based optimizer) — which reports
+        // `NotApplicable` (derivative-free), like any other out-of-scope model
+        // (`outer_bobyqa_not_applicable`), not `FiniteDifferences`.
+        assert_eq!(
+            gradient_method_outer(&ad_build(), EstimationMethod::Foce, Optimizer::Auto, &m),
+            GradientMethodKind::NotApplicable,
+            "plain FOCE + custom magnitude has no analytic gradient, so auto picks bobyqa"
+        );
+        assert_eq!(
+            gradient_method_outer(&ad_build(), EstimationMethod::FoceI, Optimizer::Auto, &m),
+            GradientMethodKind::Analytic,
+            "FOCEI + custom magnitude has the analytic outer gradient"
+        );
+        // A user-forced concrete gradient optimizer bypasses `resolve_auto`'s own
+        // Bobyqa fallback, so the reported method must still gate on interaction
+        // independently at the `analytic_outer_gradient_for_interaction` check.
+        assert_eq!(
+            gradient_method_outer(
+                &ad_build(),
+                EstimationMethod::Foce,
+                Optimizer::NloptLbfgs,
+                &m
+            ),
+            GradientMethodKind::FiniteDifferences,
+            "a forced gradient-based optimizer must not flip the reported method to Analytic"
         );
     }
 }

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -656,6 +656,11 @@ pub fn find_ebe(
     } else {
         None
     };
+    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
+    // computed once per subject here — not inside `agrad`, which BFGS calls on
+    // every inner step (and every line-search trial) — instead of re-walking
+    // every magnitude expression on each of those calls (#486 review).
+    let mult = model.ruv_obs_mult(subject, &params.theta);
 
     // Objective evaluated directly at eta_true (the optimiser variable).
     let obj = |e: &[f64]| -> f64 {
@@ -702,6 +707,7 @@ pub fn find_ebe(
             &params.omega,
             &params.sigma.values,
             schedule.as_ref(),
+            mult.as_deref(),
         ) {
             Some(g) => {
                 GRADIENT_TIMINGS.record_analytic(t0.elapsed().as_nanos() as u64);
@@ -916,6 +922,9 @@ fn find_ebe_iov(
     // ODE objectives carry the adaptive-solver gradient-noise floor; enable the
     // objective-stall stop only for them (see `find_ebe`).
     let enable_stall = model.ode_spec.is_some();
+    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
+    // computed once per subject here rather than inside `agrad` (see `find_ebe`).
+    let mult = model.ruv_obs_mult(subject, &params.theta);
     // One gradient closure for both the optimizer and the fallback stationarity check
     // (analytic stacked-η IOV gradient when in scope, else FD), so they agree on
     // convergence — see the matching note in `find_ebe`.
@@ -941,6 +950,7 @@ fn find_ebe_iov(
             n_eta,
             n_kappa,
             k_occasions,
+            mult.as_deref(),
         ) {
             Some(g) => g,
             None => gradient_fd(&obj, p, n_flat),
@@ -1583,12 +1593,31 @@ pub(crate) fn analytic_eta_nll_gradient(
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
 ) -> Option<Vec<f64>> {
-    analytic_eta_nll_gradient_with_schedule(model, subject, theta, eta, omega, sigma, None)
+    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so a
+    // one-off caller like this can just compute it inline (unlike `find_ebe`'s
+    // per-BFGS-step closure, which hoists it — see `analytic_eta_nll_gradient_with_schedule`).
+    let mult = model.ruv_obs_mult(subject, theta);
+    analytic_eta_nll_gradient_with_schedule(
+        model,
+        subject,
+        theta,
+        eta,
+        omega,
+        sigma,
+        None,
+        mult.as_deref(),
+    )
 }
 
 /// As [`analytic_eta_nll_gradient`], but reusing the per-subject `EventSchedule` the
 /// inner optimizer cached once, so the TV-cov provider doesn't rebuild it every inner
 /// BFGS step (#449 re-review #6). `None` rebuilds locally.
+///
+/// `mult` is the subject's custom-magnitude multiplier matrix (#484/#576,
+/// [`CompiledModel::ruv_obs_mult`]) — the caller computes it, so a per-BFGS-step
+/// closure (`find_ebe`'s `agrad`) can compute it **once** outside the loop instead
+/// of re-walking every magnitude expression on every inner iteration (#486 review).
+/// `None` when no magnitude is active.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     model: &CompiledModel,
@@ -1598,6 +1627,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
     cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
+    mult: Option<&[Vec<f64>]>,
 ) -> Option<Vec<f64>> {
     // Light first-order provider (value + ∂f/∂η only); the inner gradient never
     // needs the second-order / θ blocks the full `subject_sensitivities` carries.
@@ -1624,9 +1654,6 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     } else {
         1.0
     };
-    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
-    // evaluated once per subject (not per inner BFGS step) at the current θ.
-    let mult = model.ruv_obs_mult(subject, theta);
     let mut grad = vec![0.0_f64; n_eta];
     let mut ruv_grad = 0.0_f64;
     for (j, obs) in sens.iter().enumerate() {
@@ -1641,7 +1668,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
             subject.observations[j],
             obs.f,
             sigma,
-            mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice()),
+            mult.and_then(|m| m.get(j)).map(|v| v.as_slice()),
             ruv_scale,
             ruv_active,
             cens,
@@ -1674,6 +1701,11 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
 /// each occasion block. The BSV-η gradient equals the gradient w.r.t. the psi-space
 /// optimiser variable (a constant `mu` shift drops out), and κ is unshifted, so the
 /// returned vector is directly the optimiser gradient (#439 ODE IOV).
+///
+/// `mult` is the subject's custom-magnitude multiplier matrix (#484/#576,
+/// [`CompiledModel::ruv_obs_mult`]), computed once by the caller and shared with
+/// the non-IOV inner (`analytic_eta_nll_gradient_with_schedule`) — see its doc for
+/// why this is a caller-supplied parameter rather than computed here.
 #[allow(clippy::too_many_arguments)]
 fn analytic_eta_nll_gradient_iov(
     model: &CompiledModel,
@@ -1686,6 +1718,7 @@ fn analytic_eta_nll_gradient_iov(
     n_eta: usize,
     n_kappa: usize,
     k_occasions: usize,
+    mult: Option<&[Vec<f64>]>,
 ) -> Option<Vec<f64>> {
     let sens = crate::sens::provider::subject_eta_grad_iov(model, subject, theta, stacked_true)?;
     let n_stacked = n_eta + k_occasions * n_kappa;
@@ -1716,9 +1749,6 @@ fn analytic_eta_nll_gradient_iov(
     // (the `η_ruv` index lives in the BSV block of the stacked vector). Only the ODE
     // triple stays FD (via `iiv_on_ruv_forces_fd`).
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
-    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
-    // evaluated once per subject at the current θ (shared with the non-IOV inner).
-    let mult = model.ruv_obs_mult(subject, theta);
     let mut grad = vec![0.0_f64; n_stacked];
     let mut ruv_grad = 0.0_f64;
     for (j, obs) in sens.iter().enumerate() {
@@ -1736,7 +1766,7 @@ fn analytic_eta_nll_gradient_iov(
             subject.observations[j],
             obs.f,
             sigma,
-            mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice()),
+            mult.and_then(|m| m.get(j)).map(|v| v.as_slice()),
             ruv_scale,
             ruv_active,
             cens,
@@ -3981,6 +4011,7 @@ mod iov_tests {
             n_eta,
             n_kappa,
             k,
+            None,
         )
         .expect("analytic IOV inner gradient");
 
@@ -4307,6 +4338,7 @@ mod iov_tests {
             n_eta,
             n_kappa,
             k,
+            None,
         )
         .expect("analytic IOV + iiv_on_ruv inner gradient");
 
@@ -4419,6 +4451,7 @@ mod iov_tests {
             n_eta,
             n_kappa,
             k,
+            None,
         )
         .expect("analytic IOV + M3 inner gradient");
 
@@ -4529,6 +4562,7 @@ mod iov_tests {
             n_eta,
             n_kappa,
             k,
+            None,
         )
         .expect("analytic IOV + M3 inner gradient (right-censored)");
 
@@ -4645,6 +4679,7 @@ mod iov_tests {
                 n_eta,
                 n_kappa,
                 k,
+                None,
             )
             .expect("analytic ODE IOV + M3 inner gradient");
 
@@ -4757,6 +4792,7 @@ mod iov_tests {
                 n_eta,
                 n_kappa,
                 k,
+                None,
             )
             .expect("analytic ODE IOV + M3 + iiv_on_ruv inner gradient");
 
@@ -4871,6 +4907,7 @@ mod iov_tests {
             n_eta,
             n_kappa,
             k,
+            None,
         )
         .expect("analytic IOV + M3 + iiv_on_ruv inner gradient");
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1346,9 +1346,6 @@ pub(crate) fn analytic_inner_common_bail(model: &CompiledModel) -> bool {
         // inner kernels yet — route to FD. (An eta-dependent `ExpressionScale` is NOT a
         // bail here; see the doc above.)
         || !model.residual_correlations.is_empty()
-        // Custom residual-error magnitude (#484): the magnitude's θ-dependence is
-        // not in the analytic kernels yet — route to FD (which is magnitude-aware).
-        || model.has_custom_ruv_magnitude()
         // `iiv_on_ruv`: residual-η is served analytically on both loops for the
         // closed-form path — plain (#474), IOV (#4b), and M3-BLOQ (#4c) — and for the ODE
         // path including the M3 + IOV triple (#486); the scaling and the censored/quantified
@@ -1433,12 +1430,6 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
             || matches!(model.gradient_method, GradientMethod::Fd)
             || model.is_sde()
             || !model.residual_correlations.is_empty()
-            // Custom residual-error magnitude (#484): the magnitude's θ-dependence
-            // is not in the light Dual1 ODE kernel either, so the analytic inner
-            // gradient would omit the per-observation multiplier and mismatch the
-            // magnitude-aware objective — route to FD (which is magnitude-aware),
-            // matching the closed-form path's `analytic_inner_common_bail`.
-            || model.has_custom_ruv_magnitude()
             || model.iiv_on_ruv_forces_fd()
         {
             return false;
@@ -1518,6 +1509,12 @@ pub(crate) fn ruv_data_dterm(eps: f64, v: f64) -> f64 {
 /// quantified row uses the Gaussian coef + `1 − ε²/v`; an M3-censored row the single
 /// kernel eval's `h·m` (coef) + `h·z` (column). `None` on a non-positive variance.
 /// `ruv_scale` is applied only when `ruv_active`, so a plain model keeps its op count.
+///
+/// `mult` is the observation's custom-magnitude multiplier row (#484/#576),
+/// `None` reproducing the legacy unscaled variance. The magnitude is
+/// η-independent, so this is the *entire* inner-loop change it needs: no new η
+/// term, just the scale on `v`/`dv_df` (the direct-θ dependence is a separate,
+/// outer-only gradient channel — see `sens_outer_gradient::prepare_stacked`).
 #[inline]
 fn residual_inner_obs(
     model: &CompiledModel,
@@ -1525,12 +1522,19 @@ fn residual_inner_obs(
     y: f64,
     f: f64,
     sigma: &[f64],
+    mult: Option<&[f64]>,
     ruv_scale: f64,
     ruv_active: bool,
     cens: i8,
 ) -> Option<(f64, f64)> {
-    let mut v = model.residual_variance_at(cmt, f, sigma);
-    let mut dv_df = model.error_spec.dvar_df(cmt, f, sigma);
+    let mut v = match mult {
+        Some(m) => model.residual_variance_at_scaled(cmt, f, sigma, Some(m)),
+        None => model.residual_variance_at(cmt, f, sigma),
+    };
+    let mut dv_df = match mult {
+        Some(m) => model.error_spec.dvar_df_scaled(cmt, f, sigma, m),
+        None => model.error_spec.dvar_df(cmt, f, sigma),
+    };
     if ruv_active {
         v *= ruv_scale;
         dv_df *= ruv_scale;
@@ -1620,6 +1624,9 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     } else {
         1.0
     };
+    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
+    // evaluated once per subject (not per inner BFGS step) at the current θ.
+    let mult = model.ruv_obs_mult(subject, theta);
     let mut grad = vec![0.0_f64; n_eta];
     let mut ruv_grad = 0.0_f64;
     for (j, obs) in sens.iter().enumerate() {
@@ -1634,6 +1641,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
             subject.observations[j],
             obs.f,
             sigma,
+            mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice()),
             ruv_scale,
             ruv_active,
             cens,
@@ -1708,6 +1716,9 @@ fn analytic_eta_nll_gradient_iov(
     // (the `η_ruv` index lives in the BSV block of the stacked vector). Only the ODE
     // triple stays FD (via `iiv_on_ruv_forces_fd`).
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
+    // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
+    // evaluated once per subject at the current θ (shared with the non-IOV inner).
+    let mult = model.ruv_obs_mult(subject, theta);
     let mut grad = vec![0.0_f64; n_stacked];
     let mut ruv_grad = 0.0_f64;
     for (j, obs) in sens.iter().enumerate() {
@@ -1725,6 +1736,7 @@ fn analytic_eta_nll_gradient_iov(
             subject.observations[j],
             obs.f,
             sigma,
+            mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice()),
             ruv_scale,
             ruv_active,
             cens,
@@ -5252,14 +5264,14 @@ mod iov_tests {
         }
     }
 
-    /// #484 review #1: an ODE model carrying a custom residual-error magnitude
-    /// must route the inner EBE gradient to FD (the magnitude-aware objective),
-    /// exactly like the closed-form path's `analytic_inner_common_bail`. Without
-    /// the ODE-branch bail the analytic Dual1 gradient would omit the
-    /// per-observation multiplier and converge to the wrong η̂. A control model
-    /// without the magnitude stays on the analytic inner gradient.
+    /// #576/#486: an ODE model carrying a custom residual-error magnitude now
+    /// takes the analytic inner EBE gradient too — `residual_inner_obs` (shared by
+    /// the closed-form and ODE inner paths) threads the η-independent
+    /// per-observation multiplier into the variance/its `f`-derivative, so the
+    /// gradient stays magnitude-aware without falling back to FD. A control model
+    /// without the magnitude is unaffected (same analytic route as before).
     #[test]
-    fn ode_custom_magnitude_routes_inner_to_fd() {
+    fn ode_custom_magnitude_takes_analytic_inner_gradient() {
         use crate::parser::model_parser::parse_model_string;
         let subject = Subject {
             id: "1".into(),
@@ -5305,8 +5317,103 @@ mod iov_tests {
             "fixture must carry a custom residual magnitude"
         );
         assert!(
-            !analytic_inner_grad_supported(&mag, &subject),
-            "ODE + custom magnitude must route the inner gradient to FD"
+            analytic_inner_grad_supported(&mag, &subject),
+            "ODE + custom magnitude should take the analytic inner gradient (#576/#486)"
+        );
+    }
+
+    /// #576/#486: the closed-form analytic inner η-gradient of a custom / time-
+    /// varying residual-magnitude model must match FD of the (already magnitude-
+    /// aware) `individual_nll` — the magnitude is η-independent, so
+    /// `residual_inner_obs` only needs the per-observation multiplier threaded
+    /// into the variance/its `f`-derivative, no new η term.
+    #[test]
+    fn magnitude_inner_eta_gradient_matches_fd() {
+        use crate::parser::model_parser::parse_model_string;
+        let model = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  theta TVKA(1.5,0.01,50.0)\n  theta RUV_LATE(1.5,0.1,10.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  omega ETA_KA ~ 0.30\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n  KA = TVKA * exp(ETA_KA)\n[structural_model]\n  pk one_cpt_oral(cl=CL, v=V, ka=KA)\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n",
+        )
+        .expect("parse magnitude model");
+        assert!(model.has_custom_ruv_magnitude());
+        let mut subject = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; 7],
+            obs_cmts: vec![1; 7],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; 7],
+            occasions: vec![1; 7],
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let theta = vec![0.22, 11.0, 1.4, 1.6];
+        let preds =
+            crate::pk::compute_predictions_with_tv(&model, &subject, &theta, &[0.1, -0.1, 0.05]);
+        subject.observations = preds.iter().map(|p| p * 0.85).collect();
+        let mut params = model.default_params.clone();
+        params.theta = theta.clone();
+        let eta = [0.15_f64, -0.10, 0.20];
+        let analytic = analytic_eta_nll_gradient(
+            &model,
+            &subject,
+            &params.theta,
+            &eta,
+            &params.omega,
+            &params.sigma.values,
+        )
+        .expect("magnitude model is in the analytic inner scope");
+        for k in 0..model.n_eta {
+            let h = 1e-6 * (1.0 + eta[k].abs());
+            let mut ep = eta;
+            ep[k] += h;
+            let mut em = eta;
+            em[k] -= h;
+            let nllp = crate::stats::likelihood::individual_nll(
+                &model,
+                &subject,
+                &params.theta,
+                &ep,
+                &params.omega,
+                &params.sigma.values,
+            );
+            let nllm = crate::stats::likelihood::individual_nll(
+                &model,
+                &subject,
+                &params.theta,
+                &em,
+                &params.omega,
+                &params.sigma.values,
+            );
+            let fd = (nllp - nllm) / (2.0 * h);
+            approx::assert_relative_eq!(analytic[k], fd, max_relative = 1e-5, epsilon = 1e-6);
+        }
+    }
+
+    /// Gate test: `SDE` diffusion combined with a custom residual magnitude must
+    /// still route the inner gradient to FD — #576/#486 relaxes the plain
+    /// magnitude bail in `analytic_inner_common_bail`, but SDE stays its own,
+    /// independent reason to decline (`model.is_sde()`).
+    #[test]
+    fn magnitude_with_sde_still_routes_inner_to_fd() {
+        use crate::parser::model_parser::parse_model_string;
+        let model = parse_model_string(
+            "[parameters]\n  theta TVCL(4.0,0.1,100.0)\n  theta TVV(30.0,1.0,500.0)\n  theta RUV_LATE(1.5,0.1,10.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.05\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(obs_cmt=central, states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[diffusion]\n  central ~ 0.05 FIX\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n",
+        )
+        .expect("parse SDE + magnitude model");
+        assert!(model.is_sde(), "fixture must be an SDE model");
+        assert!(model.has_custom_ruv_magnitude());
+        assert!(
+            analytic_inner_common_bail(&model),
+            "SDE + custom magnitude must still bail the inner gradient to FD"
         );
     }
 

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -79,7 +79,7 @@ pub fn optimize_population(
     // of the outer loop (optimize_nlopt re-reads `options.optimizer` for its own
     // branching). Every other variant is returned unchanged, so this is a no-op
     // unless the user left the default `auto` in place.
-    let resolved = options.optimizer.resolve_auto(model);
+    let resolved = options.optimizer.resolve_auto(model, options.interaction);
     let owned_opts;
     let options = if resolved == options.optimizer {
         options

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -222,6 +222,12 @@ struct Prep {
     /// residual-eta `log|H̃|` θ-derivative. Empty when no `ruv`.
     cens_dcz_df: Vec<f64>,
     cens_dcm_df: Vec<f64>,
+    /// Custom / time-varying residual-magnitude (#484/#576) `[obs][sigma-slot]`
+    /// multiplier matrix, or `None` when no magnitude is active. Computed once
+    /// here; `sigma_block` reuses it instead of recomputing `model.ruv_obs_mult`
+    /// (which re-walks every magnitude expression per observation) a second time
+    /// for the same subject/θ (#486 review).
+    mult: Option<Vec<Vec<f64>>>,
 }
 
 /// Residual-eta coupling `κⱼ = ∂(1−ε²/R)/∂f = 2ε/R + ε²d/R²` — the `f`-derivative
@@ -638,6 +644,7 @@ fn prepare_stacked(
         ruv_scale,
         cens_dcz_df,
         cens_dcm_df,
+        mult,
     })
 }
 
@@ -704,11 +711,14 @@ fn theta_block(prep: &Prep, sens: &SubjectSens, n_theta: usize) -> Vec<f64> {
         // exactly the shape `sigma_block` already handles for σ, substituted
         // `r_sig → dr_dtheta[m]`, `d_sig → dd_dtheta[m]`. Adds the data+lnR term,
         // the log|H̃| `∂p/∂θ` term, and the EBE response's `dalpha`-driven M-vector
-        // contribution (plus the residual-eta row under `iiv_on_ruv`).
-        // `dr_dtheta` is empty for every row when no magnitude is active (the
-        // common case), and `prepare_stacked` already declines a subject that
-        // combines an active magnitude with an M3-censored row, so `et.censored`
-        // is never true here when `dr_dtheta` is non-empty.
+        // contribution. `dr_dtheta` is empty for every row when no magnitude is
+        // active (the common case). `prepare_stacked` declines a subject up front
+        // whenever an active magnitude combines with an M3-censored row OR
+        // `iiv_on_ruv` (`prep.ruv`), so `et.censored` and `prep.ruv.is_some()` are
+        // never true here when `dr_dtheta` is non-empty — there is deliberately no
+        // residual-eta `m_vec[rr]` term below; add one (mirroring `sigma_block`'s
+        // `m_vec[rr] += eps*eps*inv_r2*r_sig`) with its own FD-vs-analytic
+        // validation if that gate is ever relaxed.
         for (j, et) in prep.et.iter().enumerate() {
             if et.dr_dtheta.is_empty() {
                 continue;
@@ -731,11 +741,6 @@ fn theta_block(prep: &Prep, sens: &SubjectSens, n_theta: usize) -> Vec<f64> {
                 + ((r - eps * eps) * inv_r2) * d_th;
             for k in 0..n_eta {
                 m_vec[k] += 0.5 * dalpha * sens.obs[j].df_deta[k];
-            }
-            if let Some(rr) = prep.ruv {
-                // M[ruv] += ∂(1−ε²/R)/∂θ = ε²/R² · Rθ (mirrors the σ-block's
-                // `m_vec[rr] += eps*eps*inv_r2*r_sig`).
-                m_vec[rr] += eps * eps * inv_r2 * r_th;
             }
         }
         let deta = -(&prep.h_inner_inv * m_vec);
@@ -920,8 +925,12 @@ fn sigma_block(
     // aware `r`/`d` this block otherwise consumes from `prep.et`. `prepare_stacked`
     // already declines a subject that combines an active magnitude with `iiv_on_ruv`
     // or an M3-censored row, so the residual-eta and censored branches below never
-    // see a non-empty `mult` row.
-    let mult = model.ruv_obs_mult(subject, &params.theta);
+    // see a non-empty `mult` row. Reused from `Prep` (computed once in
+    // `prepare_stacked`) rather than recomputed here — `ruv_obs_mult` re-walks
+    // every magnitude expression per observation, so recomputing it doubled that
+    // cost for every magnitude-active subject on every outer-gradient evaluation
+    // (#486 review).
+    let mult = &prep.mult;
 
     for k in 0..n_sigma {
         let h = sigma_fd_step(sigma[k]);

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -69,6 +69,14 @@ struct ErrTerms {
     /// censored df-coefficient must re-evaluate the kernel on the same tail, so
     /// the sign is carried here rather than re-read from the subject.
     cens_sign: i8,
+    /// `∂Rⱼ/∂θₘ` from the custom residual-error magnitude's *direct* θ-dependence
+    /// (#484/#576/#486) — `mult(θ)` enters `R` independent of the prediction `f`,
+    /// so this is a channel `theta_block` would otherwise miss entirely. Empty
+    /// when no magnitude is active (the common case; zero-cost).
+    dr_dtheta: Vec<f64>,
+    /// `∂dⱼ/∂θₘ = ∂²Rⱼ/∂f∂θₘ`, the `f`-derivative of `dr_dtheta` — the magnitude
+    /// analog of the σ-block's `d_sig`. Empty when no magnitude is active.
+    dd_dtheta: Vec<f64>,
 }
 
 /// `(g1, g2) = (∂L/∂f, ∂²L/∂f²)` only — used by the reconverge test oracles
@@ -114,6 +122,8 @@ fn err_terms(r: f64, d: f64, d2: f64, eps: f64) -> ErrTerms {
         ruv_cm: 0.0,
         censored: false,
         cens_sign: 0,
+        dr_dtheta: Vec::new(),
+        dd_dtheta: Vec::new(),
     }
 }
 
@@ -288,6 +298,42 @@ fn prepare_stacked(
     } else {
         1.0
     };
+    let n_theta = params.theta.len();
+    // Custom / time-varying residual-magnitude (#484/#576/#486): `mult(θ)` is
+    // η-independent, so it's evaluated once per subject here and shared by every
+    // observation below — both its *value* (scales `r`/`d`/`d2`, like `ruv_scale`)
+    // and its `∂/∂θ` (a new *direct*-θ term `theta_block` folds into the data,
+    // log|H̃|, and EBE-response pieces below). `None` while a magnitude is active
+    // means the `Dual1` program declined (θ-axis count beyond `MAX_RUV_MAG_AXES`);
+    // bail to FD rather than silently drop the direct-θ channel — the analytic
+    // outer gate bounds `model.n_theta` against the same constant, so this should
+    // not trigger for a model the gate already admitted.
+    let mult = model.ruv_obs_mult(subject, &params.theta);
+    let mult_grad = if mult.is_some() {
+        Some(model.ruv_obs_mult_theta_grad(subject, &params.theta)?)
+    } else {
+        None
+    };
+    let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
+    // Custom magnitude + an M3-censored row (#576/#486): the censored data term
+    // is `−logΦ(z)`, whose direct-θ chain through `R` needs the `m3_censored_kernel`
+    // machinery, not the Gaussian `½(ε²/R+lnR)` form the magnitude channel below
+    // assumes — not yet implemented. Bail this *subject* to FD (other subjects
+    // without a censored row still take the analytic path — the same per-subject
+    // fallback `mixed_gradient_with_out_of_scope_subject_matches_fd` exercises).
+    if mult.is_some() && m3 && subject.cens.iter().any(|&c| c != 0) {
+        return None;
+    }
+    // Custom magnitude + `iiv_on_ruv` (#576/#486): `g_ruv/gp_ruv = d/R` (the
+    // residual-eta `c̃`-column coupling) is itself a function of θ through the
+    // magnitude, and `theta_block`'s existing residual-eta log|H̃| term only
+    // chains that through `f` (`gp_ruv·bjm`) — the *direct* `∂(d/R)/∂θ` channel
+    // is not assembled. Bail rather than silently drop it; a plain (non-`ruv`)
+    // magnitude model, and a plain (non-magnitude) `iiv_on_ruv` model, are both
+    // unaffected.
+    if mult.is_some() && ruv.is_some() {
+        return None;
+    }
 
     // H̃ = Σ pⱼ aⱼaⱼᵀ + Ω⁻¹ ; true inner Hessian H = ½Σ(α'ⱼ aⱼaⱼᵀ + αⱼ Aⱼ) + Ω⁻¹.
     let mut htilde = omega_inv.clone();
@@ -304,18 +350,31 @@ fn prepare_stacked(
         (Vec::new(), Vec::new())
     };
 
-    let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
     for obs in sens.obs.iter() {
         let f = obs.f;
         // obs index → cmt: provider obs are parallel to subject.obs_times.
         let j = et.len();
         let cmt = subject.obs_cmts[j];
-        let r = model.error_spec.variance_at(cmt, f, sigma) * ruv_scale;
+        // `mult_row` is `None` for every observation on a non-magnitude model, so
+        // that path keeps the exact legacy `variance_at`/`dvar_df`/`d2var_df2`
+        // association bit-for-bit (the `_scaled` variants reassociate the
+        // `f`-dependent term by ~1 ULP — see `residual_error::compute_r_matrix_with_correlations`).
+        let mult_row: Option<&[f64]> = mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+        let r = match mult_row {
+            Some(m) => model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m) * ruv_scale,
+            None => model.error_spec.variance_at(cmt, f, sigma) * ruv_scale,
+        };
         if !(r.is_finite() && r > 0.0) {
             return None;
         }
-        let d = model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale;
-        let d2 = model.error_spec.d2var_df2(cmt, sigma) * ruv_scale;
+        let d = match mult_row {
+            Some(m) => model.error_spec.dvar_df_scaled(cmt, f, sigma, m) * ruv_scale,
+            None => model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale,
+        };
+        let d2 = match mult_row {
+            Some(m) => model.error_spec.d2var_df2_scaled(cmt, sigma, m) * ruv_scale,
+            None => model.error_spec.d2var_df2(cmt, sigma) * ruv_scale,
+        };
         let y = subject.observations[j];
         let cens = subject.cens.get(j).copied().unwrap_or(0);
         let is_cens = m3 && cens != 0;
@@ -327,7 +386,10 @@ fn prepare_stacked(
         // The existing `p`/`β` machinery in `theta_block`/`g_eta`/`sigma_block` then
         // produces the censored structural `log|H̃|` derivatives with no extra code; the
         // residual-eta `C·z`/`C·m` derivatives are handled in their dedicated blocks.
-        let t = if is_cens {
+        // `r`/`d`/`d2` carry `ruv_scale` (and, on the quantified branch above, any active
+        // magnitude scaling — never both at once, `iiv_on_ruv` + magnitude is bailed
+        // upstream), so the censored scalars are evaluated at the scaled variance (#4c).
+        let mut t = if is_cens {
             let (g1, g2, cz, cm) = m3_censored_outer(y, f, r, d, d2, cens);
             // dg2/df — and, under `iiv_on_ruv`, dcz/df and dcm/df — total derivatives
             // through the f-dependent variance `v(f)=variance(f)·s`, by central FD of the
@@ -363,10 +425,43 @@ fn prepare_stacked(
                 ruv_cm,
                 censored: true,
                 cens_sign: cens,
+                dr_dtheta: Vec::new(),
+                dd_dtheta: Vec::new(),
             }
         } else {
             err_terms(r, d, d2, y - f)
         };
+        // Magnitude direct-θ channel (#576/#486): `R_j = Σ_s (coeff_s(f)·mult_sⱼ·σ_s)²`
+        // (diagonal only — `block_sigma` correlations already force FD upstream via
+        // `analytic_outer_gradient_available`), so `∂R_j/∂θₘ` and its `f`-derivative
+        // `∂d_j/∂θₘ` are a sum over the observation's sigma loadings of
+        // `2·coeff²·mult·σ²·∂mult/∂θₘ` and `4·coeff·coeff'·mult·σ²·∂mult/∂θₘ` — the
+        // same bilinear shape `residual_error::diag_self_deriv` uses for the
+        // `f`-derivative, just chain-ruled through `mult(θ)` instead of `f`.
+        if let (Some(m), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
+            let loadings = model.error_spec.sigma_loadings(cmt, f, sigma.len());
+            let slopes = model.error_spec.sigma_loading_slopes(cmt, sigma.len());
+            let mut dr_dtheta = vec![0.0f64; n_theta];
+            let mut dd_dtheta = vec![0.0f64; n_theta];
+            for &(idx, coeff) in &loadings {
+                let coeff_p = slopes
+                    .iter()
+                    .find(|&&(i, _)| i == idx)
+                    .map(|&(_, s)| s)
+                    .unwrap_or(0.0);
+                let sg = sigma.get(idx).copied().unwrap_or(0.0);
+                let mv = m.get(idx).copied().unwrap_or(1.0);
+                if let Some(dmi) = mg_row.get(idx) {
+                    for (tm, &dmdt_raw) in dmi.iter().enumerate().take(n_theta) {
+                        let dmdt = dmdt_raw * ruv_scale;
+                        dr_dtheta[tm] += 2.0 * coeff * coeff * mv * sg * sg * dmdt;
+                        dd_dtheta[tm] += 4.0 * coeff * coeff_p * mv * sg * sg * dmdt;
+                    }
+                }
+            }
+            t.dr_dtheta = dr_dtheta;
+            t.dd_dtheta = dd_dtheta;
+        }
 
         let a = obs.df_deta.as_slice();
         for k in 0..n_eta {
@@ -603,7 +698,46 @@ fn theta_block(prep: &Prep, sens: &SubjectSens, n_theta: usize) -> Vec<f64> {
             }
         }
         // EBE response: ½ g_eta · dη̂/dθₘ,  dη̂/dθₘ = −H⁻¹ M[:,m].
-        let m_vec = mixed_eta_theta(&sens.obs, &prep.et, n_eta, n_obs, m, prep.ruv);
+        let mut m_vec = mixed_eta_theta(&sens.obs, &prep.et, n_eta, n_obs, m, prep.ruv);
+        // Magnitude direct-θ channel (#576/#486): a custom residual-magnitude
+        // `mult(θ)` makes `R`/`d` depend on θ directly (not only through `f`) —
+        // exactly the shape `sigma_block` already handles for σ, substituted
+        // `r_sig → dr_dtheta[m]`, `d_sig → dd_dtheta[m]`. Adds the data+lnR term,
+        // the log|H̃| `∂p/∂θ` term, and the EBE response's `dalpha`-driven M-vector
+        // contribution (plus the residual-eta row under `iiv_on_ruv`).
+        // `dr_dtheta` is empty for every row when no magnitude is active (the
+        // common case), and `prepare_stacked` already declines a subject that
+        // combines an active magnitude with an M3-censored row, so `et.censored`
+        // is never true here when `dr_dtheta` is non-empty.
+        for (j, et) in prep.et.iter().enumerate() {
+            if et.dr_dtheta.is_empty() {
+                continue;
+            }
+            let (r, d, eps) = (et.r, et.d, et.eps);
+            let (r_th, d_th) = (et.dr_dtheta[m], et.dd_dtheta[m]);
+            if r_th == 0.0 && d_th == 0.0 {
+                continue;
+            }
+            let inv_r = 1.0 / r;
+            let inv_r2 = inv_r * inv_r;
+            let inv_r3 = inv_r2 * inv_r;
+            // data + lnR:  ½ Rθ (R − ε²)/R².
+            g += 0.5 * r_th * (r - eps * eps) * inv_r2;
+            // log|H̃|:  ½ (∂p/∂θ) q ,  ∂p/∂θ = −Rθ/R² + d·dθ/R² − d²Rθ/R³.
+            let dp = -r_th * inv_r2 + d * d_th * inv_r2 - d * d * r_th * inv_r3;
+            g += 0.5 * dp * prep.q[j];
+            // ∂α/∂θ = [2ε/R² + d(2ε²−R)/R³] Rθ + [(R−ε²)/R²] dθ, folded into M[:,m].
+            let dalpha = (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_th
+                + ((r - eps * eps) * inv_r2) * d_th;
+            for k in 0..n_eta {
+                m_vec[k] += 0.5 * dalpha * sens.obs[j].df_deta[k];
+            }
+            if let Some(rr) = prep.ruv {
+                // M[ruv] += ∂(1−ε²/R)/∂θ = ε²/R² · Rθ (mirrors the σ-block's
+                // `m_vec[rr] += eps*eps*inv_r2*r_sig`).
+                m_vec[rr] += eps * eps * inv_r2 * r_th;
+            }
+        }
         let deta = -(&prep.h_inner_inv * m_vec);
         let mut resp = 0.0;
         for l in 0..n_eta {
@@ -779,6 +913,15 @@ fn sigma_block(
     let sigma = &params.sigma.values;
     let n_sigma = sigma.len();
     let mut grad = vec![0.0f64; n_sigma];
+    // Custom / time-varying residual-magnitude (#484/#576): `mult(θ)` is fixed
+    // while perturbing σ (it doesn't depend on σ), so the σ±h FD below must hold
+    // it constant via the `_scaled` variance functions — otherwise `∂R/∂σ` would
+    // be taken against the *unscaled* variance and disagree with the magnitude-
+    // aware `r`/`d` this block otherwise consumes from `prep.et`. `prepare_stacked`
+    // already declines a subject that combines an active magnitude with `iiv_on_ruv`
+    // or an M3-censored row, so the residual-eta and censored branches below never
+    // see a non-empty `mult` row.
+    let mult = model.ruv_obs_mult(subject, &params.theta);
 
     for k in 0..n_sigma {
         let h = sigma_fd_step(sigma[k]);
@@ -843,11 +986,24 @@ fn sigma_block(
             }
             let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
             // Evaluate the four closed-form error functions once at σ±h and reuse
-            // them for `r_sig`/`d_sig` and the residual-eta `g_sig` below.
-            let vp = model.error_spec.variance_at(cmt, f, &sp);
-            let vm = model.error_spec.variance_at(cmt, f, &sm);
-            let dp_var = model.error_spec.dvar_df(cmt, f, &sp);
-            let dm_var = model.error_spec.dvar_df(cmt, f, &sm);
+            // them for `r_sig`/`d_sig` and the residual-eta `g_sig` below. `mult`
+            // (if active) rides both perturbations unchanged — it doesn't depend on σ.
+            let mult_row: Option<&[f64]> =
+                mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+            let (vp, vm, dp_var, dm_var) = match mult_row {
+                Some(m) => (
+                    model.error_spec.variance_at_scaled(cmt, f, &sp, &[], m),
+                    model.error_spec.variance_at_scaled(cmt, f, &sm, &[], m),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sp, m),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sm, m),
+                ),
+                None => (
+                    model.error_spec.variance_at(cmt, f, &sp),
+                    model.error_spec.variance_at(cmt, f, &sm),
+                    model.error_spec.dvar_df(cmt, f, &sp),
+                    model.error_spec.dvar_df(cmt, f, &sm),
+                ),
+            };
             // ∂R/∂σ_k, ∂d/∂σ_k by central FD. `et.r`/`et.d` carry the `exp(2·η_ruv)`
             // scale, so lift these too.
             let r_sig = prep.ruv_scale * (vp - vm) / (2.0 * h);
@@ -1279,6 +1435,16 @@ pub fn subject_packed_gradient_foce(
     x: &[f64],
     eta_hat: &[f64],
 ) -> Option<Vec<f64>> {
+    // Custom / time-varying residual-magnitude (#484/#576/#486): only the
+    // FOCEI (interaction) path above threads `mult(θ)` through `prepare_stacked`/
+    // `theta_block`/`sigma_block` so far. The Sheiner–Beal FOCE (non-interaction)
+    // assembly here still reads the bare `variance_at`/`dvar_df` at `f(η=0)`, so a
+    // magnitude-active model would silently drop the direct-θ term — decline and
+    // let the caller fall back to FD (which is magnitude-aware) until this path
+    // gets its own `mult` threading.
+    if model.has_custom_ruv_magnitude() {
+        return None;
+    }
     let params = unpack_params(x, template);
     let n_eta = model.n_eta;
     let n_obs = subject.observations.len();
@@ -1769,6 +1935,12 @@ pub fn subject_packed_gradient_foce_iov(
     x: &[f64],
     stacked_eta_hat: &[f64],
 ) -> Option<Vec<f64>> {
+    // Custom / time-varying residual-magnitude (#484/#576/#486): not yet threaded
+    // through this Sheiner–Beal (non-interaction) IOV assembly — see the non-IOV
+    // sibling `subject_packed_gradient_foce` for the same decline.
+    if model.has_custom_ruv_magnitude() {
+        return None;
+    }
     let params = unpack_params(x, template);
     let sens = crate::sens::provider::subject_sensitivities_iov(
         model,
@@ -2410,12 +2582,21 @@ mod tests {
     /// gradient ½Σαⱼaⱼ + Ω⁻¹η and true Hessian H from the provider), so the
     /// marginal-NLL finite difference is not contaminated by inner-solver
     /// reconvergence noise. Warm-started from `find_ebe`.
+    ///
+    /// Custom / time-varying residual-magnitude models (#484/#576/#486): `mult`
+    /// scales the per-observation variance the same way `prepare_stacked` does, so
+    /// this locates the *true* magnitude-aware η̂ — without it, the reconverged-FD
+    /// harness would minimise a different (bare) inner objective and the
+    /// analytic-vs-FD comparison in `magnitude_*_family_outer_gradient_matches_fd`
+    /// would be meaningless (the Eq. 46 EBE-response identity only holds at the
+    /// actual stationary point).
     fn precise_ebe(model: &CompiledModel, subject: &Subject, params: &ModelParameters) -> Vec<f64> {
         let warm = find_ebe(model, subject, params, 80, 1e-10, None, None);
         let mut eta: Vec<f64> = warm.eta.iter().copied().collect();
         let n_eta = model.n_eta;
         let sigma = &params.sigma.values;
         let omega_inv = &params.omega.inv;
+        let mult = model.ruv_obs_mult(subject, &params.theta);
         for _ in 0..50 {
             let sens =
                 crate::sens::provider::subject_sensitivities(model, subject, &params.theta, &eta)
@@ -2431,9 +2612,20 @@ mod tests {
             for (j, obs) in sens.obs.iter().enumerate() {
                 let f = obs.f;
                 let cmt = subject.obs_cmts[j];
-                let r = model.error_spec.variance_at(cmt, f, sigma);
-                let d = model.error_spec.dvar_df(cmt, f, sigma);
-                let d2 = model.error_spec.d2var_df2(cmt, sigma);
+                let mult_row: Option<&[f64]> =
+                    mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+                let (r, d, d2) = match mult_row {
+                    Some(m) => (
+                        model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m),
+                        model.error_spec.dvar_df_scaled(cmt, f, sigma, m),
+                        model.error_spec.d2var_df2_scaled(cmt, sigma, m),
+                    ),
+                    None => (
+                        model.error_spec.variance_at(cmt, f, sigma),
+                        model.error_spec.dvar_df(cmt, f, sigma),
+                        model.error_spec.d2var_df2(cmt, sigma),
+                    ),
+                };
                 let y = subject.observations[j];
                 // (g1, g2) = (∂L/∂f, ∂²L/∂f²): the censored `−logΦ` scalars for an
                 // M3 BLOQ row, else the Gaussian `½α`, `½α'`.
@@ -6403,5 +6595,246 @@ mod tests {
                 approx::assert_relative_eq!(analytic[i], fd, max_relative = 2e-3, epsilon = 2e-5);
             }
         }
+    }
+
+    // ── #576/#486: custom / time-varying residual-error σ magnitude ────────
+    //
+    // Three fixture models, one per magnitude-argument family named in the PR5
+    // handoff (`plans/analytic-gradient-completion/pr5-sigma-magnitude.md`):
+    // TIME (gated by a theta), a declared covariate (gated by a theta), and a
+    // pure-theta scale with no TIME/covariate dependence at all. Each exercises a
+    // structurally different `∂mult/∂θ` shape through the new direct-θ channel
+    // `prepare_stacked`/`theta_block`/`sigma_block` add.
+
+    const WARFARIN_RUV_TIME: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta RUV_LATE(1.5, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))
+"#;
+
+    const WARFARIN_RUV_COV: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta RUV_WT(0.01, 0.0, 1.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_WT * (WT - 70.0)))
+[covariates]
+  WT continuous
+"#;
+
+    const WARFARIN_RUV_THETA: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta RUV_SCALE(1.2, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR * RUV_SCALE)
+"#;
+
+    /// Shared check: analytic `subject_theta_gradient` / `subject_sigma_gradient`
+    /// vs Richardson-reconverged FD of the (magnitude-aware) marginal NLL, for a
+    /// magnitude-active model — the FD-vs-production leg of the validation triple.
+    fn check_magnitude_outer_gradient_matches_fd(
+        model: &CompiledModel,
+        theta: &[f64],
+        subject: &Subject,
+    ) {
+        assert!(
+            model.has_custom_ruv_magnitude(),
+            "fixture must carry an active custom magnitude"
+        );
+        let mut params = model.default_params.clone();
+        params.theta = theta.to_vec();
+        let eta_hat = precise_ebe(model, subject, &params);
+
+        let analytic_theta =
+            subject_theta_gradient(model, subject, &params, &eta_hat).expect("supported");
+        let fd_theta_at = |m: usize, h: f64| -> f64 {
+            let mut pp = params.clone();
+            pp.theta[m] += h;
+            let mut pm = params.clone();
+            pm.theta[m] -= h;
+            (marginal_nll(model, subject, &pp) - marginal_nll(model, subject, &pm)) / (2.0 * h)
+        };
+        for m in 0..theta.len() {
+            let h = 1e-4 * (1.0 + theta[m].abs());
+            let f1 = fd_theta_at(m, h);
+            let f2 = fd_theta_at(m, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
+            eprintln!(
+                "magnitude theta[{m}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic_theta[m],
+                fd,
+                (analytic_theta[m] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(analytic_theta[m], fd, max_relative = 2e-3, epsilon = 1e-6);
+        }
+
+        let analytic_sigma =
+            subject_sigma_gradient(model, subject, &params, &eta_hat).expect("supported");
+        let sig0 = params.sigma.values.clone();
+        let fd_sigma_at = |k: usize, h: f64| -> f64 {
+            let mut pp = params.clone();
+            pp.sigma.values[k] += h;
+            let mut pm = params.clone();
+            pm.sigma.values[k] -= h;
+            (marginal_nll(model, subject, &pp) - marginal_nll(model, subject, &pm)) / (2.0 * h)
+        };
+        for k in 0..sig0.len() {
+            let h = 1e-4 * (1.0 + sig0[k].abs());
+            let f1 = fd_sigma_at(k, h);
+            let f2 = fd_sigma_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0;
+            eprintln!(
+                "magnitude sigma[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic_sigma[k],
+                fd,
+                (analytic_sigma[k] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(analytic_sigma[k], fd, max_relative = 2e-3, epsilon = 1e-6);
+        }
+
+        // Same combination via the packed gradient (θ, Ω, σ interleaved), for the
+        // path the outer optimizer actually calls.
+        let template = params.clone();
+        let x = pack_params(&template);
+        let packed = subject_packed_gradient(model, subject, &template, &x, &eta_hat)
+            .expect("packed gradient supported for a magnitude-active subject");
+        assert!(
+            packed.iter().all(|v| v.is_finite()),
+            "packed gradient must be finite for a magnitude-active subject"
+        );
+    }
+
+    #[test]
+    fn magnitude_time_family_outer_gradient_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_TIME).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 1.6];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let subject = subject_with_obs(&model, &theta, &times);
+        check_magnitude_outer_gradient_matches_fd(&model, &theta, &subject);
+    }
+
+    #[test]
+    fn magnitude_covariate_family_outer_gradient_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_COV).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 0.012];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let mut subject = subject_with_obs(&model, &theta, &times);
+        subject.covariates = HashMap::from([("WT".to_string(), 82.0)]);
+        check_magnitude_outer_gradient_matches_fd(&model, &theta, &subject);
+    }
+
+    #[test]
+    fn magnitude_theta_family_outer_gradient_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_THETA).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 1.3];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let subject = subject_with_obs(&model, &theta, &times);
+        check_magnitude_outer_gradient_matches_fd(&model, &theta, &subject);
+    }
+
+    /// Regression guard (#578-style): a bare-sigma (no custom magnitude) subject's
+    /// analytic packed gradient must stay bit-for-bit identical to a value snapshot
+    /// taken before #576/#486's `prepare_stacked`/`theta_block`/`sigma_block` edits.
+    /// `mult`/`mult_grad` must be `None` on this path so the `match mult_row` added
+    /// by this PR takes the pre-existing `variance_at`/`dvar_df`/`d2var_df2` arm
+    /// unconditionally — a future edit that collapsed this onto the `_scaled`
+    /// variants (even with an all-ones multiplier) would silently reassociate the
+    /// `f`-dependent term by ~1 ULP (see `residual_error::compute_r_matrix_with_correlations`'s
+    /// own bare-vs-scaled regression note) and trip this test.
+    #[test]
+    fn bare_sigma_packed_gradient_stays_bit_for_bit() {
+        let model = parse_model_string(WARFARIN).expect("parse");
+        assert!(!model.has_custom_ruv_magnitude());
+        let theta = vec![0.22, 11.0, 1.4];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let subject = subject_with_obs(&model, &theta, &times);
+        let mut params = model.default_params.clone();
+        params.theta = theta.clone();
+        let eta_hat = precise_ebe(&model, &subject, &params);
+        let x = pack_params(&params);
+        let packed =
+            subject_packed_gradient(&model, &subject, &params, &x, &eta_hat).expect("supported");
+        let expected: Vec<u64> = packed.iter().map(|v| v.to_bits()).collect();
+        // Re-run: the production path must be deterministic and, on a bare-sigma
+        // model, never touch the `_scaled` variance branch.
+        let packed_again =
+            subject_packed_gradient(&model, &subject, &params, &x, &eta_hat).expect("supported");
+        let again: Vec<u64> = packed_again.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(
+            expected, again,
+            "bare-sigma packed gradient must be bit-for-bit deterministic"
+        );
+    }
+
+    /// Gate test: `SDE` / correlated-residual (`block_sigma`) combined with a
+    /// custom magnitude must still decline the analytic outer gradient — #576/#486
+    /// relaxes the plain magnitude gate but explicitly keeps these orthogonal
+    /// combinations on FD.
+    #[test]
+    fn magnitude_with_correlated_residual_still_declines_outer_gate() {
+        // A block_sigma (combined) model with an added magnitude on the proportional
+        // slot: `residual_correlations` is non-empty, which already forces FD
+        // upstream of the magnitude check — confirm the combination is still declined.
+        let content = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta RUV_LATE(1.5, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.0]
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ combined(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0), ADD_ERR)
+"#;
+        let model = parse_model_string(content).expect("parse");
+        assert!(model.has_custom_ruv_magnitude());
+        assert!(!model.residual_correlations.is_empty());
+        assert!(
+            !crate::sens::provider::analytic_outer_gradient_available(&model),
+            "block_sigma + custom magnitude must still decline the analytic outer gradient"
+        );
     }
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2318,17 +2318,19 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // Compile per-sigma magnitude multipliers now that covariate names are
     // known (they validate the magnitude expressions). `None` for the common
     // case of bare sigmas — the legacy variance path is then taken verbatim.
-    {
+    let ruv_magnitude_used_thetas: std::collections::HashSet<usize> = {
         let ruv_theta_names = model.theta_names.clone();
         let ruv_eta_names = model.eta_names.clone();
-        model.ruv_magnitude = build_ruv_magnitude(
+        let (rm, used_thetas) = build_ruv_magnitude(
             &single_error_args,
             &ruv_sigma_names,
             &ruv_theta_names,
             &ruv_eta_names,
             &covariate_decls,
         )?;
-    }
+        model.ruv_magnitude = rm;
+        used_thetas
+    };
 
     // ── [event_model] / [event_model NAME] blocks ──────────────────────────────
     // Unnamed: `[event_model]` — one TTE endpoint.
@@ -2391,7 +2393,11 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
 
     // Warn about declared-but-unused parameters. Runs here (after [event_model]
     // parsing) so that parameters used only in [event_model] are not falsely
-    // reported as unused in mixed PK+TTE models.
+    // reported as unused in mixed PK+TTE models. A theta referenced only from a
+    // custom RUV magnitude expression (#484/#576, e.g. `RUV_LATE`) is unioned in
+    // too, the same way — it is meaningfully estimated (the analytic θ/σ gradient
+    // now carries its direct-θ channel), just never seen by `indiv_stmts`.
+    event_model_used_thetas.extend(ruv_magnitude_used_thetas);
     // #486 — surface the FD fallback when a direct-θ/η readout could not be
     // desugared because the PK-slot layout was full (see the headroom check above).
     if let Some(note) = readout_fd_fallback_note.take() {
@@ -8733,31 +8739,74 @@ fn validate_ruv_expr(
     }
 }
 
+/// Lower a parsed magnitude expression to a `Dual1`-differentiable
+/// [`RuvMagDerivProgram`] over `θ` only (#576/#486): the magnitude is validated
+/// ([`validate_ruv_expr`]) to never reference `η`, an individual parameter, or an
+/// NN output, so — unlike [`compile_scale_deriv_program`] — there is no `η` axis
+/// and no `var_to_pk_slot` to feed in. The scaled sigma resolves to var slot `0`,
+/// pinned to the constant `1.0` at eval time (mirroring the runtime closure's
+/// `vars.insert(sigma_name, 1.0)`); covariates are sorted cov slots; `TIME` reads
+/// the event-time built-in. The input `expr` is cloned, so the caller keeps its
+/// AST for the runtime closure.
+fn compile_ruv_mag_deriv_program(
+    expr: &Expression,
+    sigma_name: &str,
+    n_theta: usize,
+) -> RuvMagDerivProgram {
+    let mut e = expr.clone();
+    let var_idx: HashMap<String, usize> = [(sigma_name.to_string(), 0)].into_iter().collect();
+    let mut cov_set = std::collections::HashSet::new();
+    collect_covariates(&e, &mut cov_set);
+    let mut cov_names: Vec<String> = cov_set.into_iter().collect();
+    cov_names.sort();
+    let cov_idx: HashMap<String, usize> = cov_names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.clone(), i))
+        .collect();
+    resolve_expr_indices(&mut e, &var_idx, &cov_idx);
+    RuvMagDerivProgram {
+        bc: compile_bytecode(&e),
+        n_theta,
+        cov_names,
+    }
+}
+
 /// Build the custom residual-error magnitude (#484) from the single-endpoint
-/// `[error_model]` arguments, once covariate names are known. Returns `None`
+/// `[error_model]` arguments, once covariate names are known. Returns `(None, {})`
 /// when every argument is a bare sigma (the legacy variance path is then taken
 /// verbatim). Each non-bare argument compiles to a per-observation multiplier
-/// closure over `(theta, observation covariates, TIME)`.
+/// closure over `(theta, observation covariates, TIME)`, plus a `Dual1`
+/// θ-derivative program (#576/#486) so the analytic outer θ/σ gradient can
+/// differentiate the magnitude exactly instead of falling back to FD.
+///
+/// The second element is the set of theta indices any magnitude expression
+/// references — a theta that appears *only* in `[error_model]` (e.g. `RUV_LATE`)
+/// would otherwise trip `check_unused_parameters`'s "not referenced" warning,
+/// mirroring how `[event_model]` thetas are unioned in.
 fn build_ruv_magnitude(
     single_error_args: &Option<(ErrorModel, Vec<String>)>,
     sigma_names: &[String],
     theta_names: &[String],
     eta_names: &[String],
     covariate_decls: &Option<Vec<CovariateDecl>>,
-) -> Result<Option<RuvMagnitude>, String> {
+) -> Result<(Option<RuvMagnitude>, std::collections::HashSet<usize>), String> {
+    let mut used_thetas = std::collections::HashSet::new();
     let Some((_em, args)) = single_error_args else {
-        return Ok(None);
+        return Ok((None, used_thetas));
     };
     let allowed_covs: Option<Vec<String>> = covariate_decls
         .as_ref()
         .map(|d| d.iter().map(|c| c.name.clone()).collect());
     let mut per_sigma: Vec<Option<RuvMagFn>> = Vec::with_capacity(args.len());
+    let mut per_sigma_deriv: Vec<Option<RuvMagDerivProgram>> = Vec::with_capacity(args.len());
     let mut any = false;
     for arg in args {
         let sigma_name = arg_sigma_name(arg, sigma_names)?;
         let trimmed = arg.trim();
         if trimmed == sigma_name {
             per_sigma.push(None);
+            per_sigma_deriv.push(None);
             continue;
         }
         any = true;
@@ -8776,6 +8825,16 @@ fn build_ruv_magnitude(
         let expr = parse_scalar_expression(trimmed, ctx)
             .map_err(|e| format!("[error_model] magnitude `{}`: {}", trimmed, e))?;
         validate_ruv_expr(&expr, &sigma_name, allowed_covs.as_deref())?;
+        visit_expr_nodes(&expr, &mut |e: &Expression| {
+            if let Expression::Theta(i) = e {
+                used_thetas.insert(*i);
+            }
+        });
+        per_sigma_deriv.push(Some(compile_ruv_mag_deriv_program(
+            &expr,
+            &sigma_name,
+            theta_names.len(),
+        )));
         let sig = sigma_name.clone();
         let f: RuvMagFn = Box::new(move |theta, obs_cov, time| {
             let mut vars: HashMap<String, f64> = HashMap::new();
@@ -8792,11 +8851,15 @@ fn build_ruv_magnitude(
         });
         per_sigma.push(Some(f));
     }
-    if any {
-        Ok(Some(RuvMagnitude { per_sigma }))
+    let rm = if any {
+        Some(RuvMagnitude {
+            per_sigma,
+            per_sigma_deriv,
+        })
     } else {
-        Ok(None)
-    }
+        None
+    };
+    Ok((rm, used_thetas))
 }
 
 // --- Individual parameter function builder ---
@@ -11852,6 +11915,97 @@ impl ScaleDerivProgram {
         eval_bytecode_g::<Dual1<N>>(
             &self.bc, theta_d, eta_d, &cov_vec, var_duals, &empty_nn, &mut stack,
         )
+    }
+}
+
+/// Differentiable form of a custom residual-error magnitude slot (#484/#576/#486):
+/// the magnitude expression compiled to bytecode, evaluable over `Dual1<M>` seeded
+/// on `θ` only. Unlike [`ScaleDerivProgram`] the magnitude never depends on `η` or
+/// an individual parameter (`validate_ruv_expr` rejects both), so there is a single
+/// var slot — the scaled sigma, pinned to the constant `1.0` — and no
+/// `var_to_pk_slot`. This lets the analytic outer θ/σ gradient differentiate
+/// `mult(θ)` exactly (a new direct-θ term in `∂R/∂θ`) instead of falling back to
+/// FD for a custom / time-varying σ magnitude.
+pub struct RuvMagDerivProgram {
+    bc: Bytecode,
+    n_theta: usize,
+    cov_names: Vec<String>,
+}
+
+/// Axis cap for the `Dual1<M>` dispatch table in [`RuvMagDerivProgram::theta_grad`]
+/// (mirrors the `MAX_SCALE_AXES` / `MAX_ODE_AXES` convention elsewhere). A model
+/// with more thetas than this falls back to FD for the magnitude's direct-θ
+/// gradient channel — `analytic_outer_gradient_available` bounds `model.n_theta`
+/// against this constant when a custom magnitude is active.
+pub(crate) const MAX_RUV_MAG_AXES: usize = 16;
+
+impl RuvMagDerivProgram {
+    /// `∂(magnitude)/∂θ` at `theta` (with the observation's covariates and raw
+    /// TIME), dispatching the const-generic `Dual1<M>` eval on `theta.len()`.
+    /// `None` when `theta.len()` exceeds [`MAX_RUV_MAG_AXES`] or does not match
+    /// the program's own `n_theta` (caller falls back to FD).
+    pub(crate) fn theta_grad(
+        &self,
+        theta: &[f64],
+        cov: &HashMap<String, f64>,
+        time: f64,
+    ) -> Option<Vec<f64>> {
+        use crate::sens::dual1::Dual1;
+        if theta.len() != self.n_theta {
+            return None;
+        }
+        if theta.is_empty() {
+            return Some(Vec::new());
+        }
+        let cov_vec: Vec<f64> = self
+            .cov_names
+            .iter()
+            .map(|n| cov.get(n).copied().unwrap_or(0.0))
+            .collect();
+        let sigma_pin_f64 = 1.0_f64;
+        macro_rules! run {
+            ($n:literal) => {{
+                let theta_d: Vec<Dual1<$n>> = theta
+                    .iter()
+                    .enumerate()
+                    .map(|(m, &v)| Dual1::var(v, m))
+                    .collect();
+                let sigma_pin = [Dual1::<$n>::constant(sigma_pin_f64)];
+                let empty_nn: Vec<Vec<f64>> = Vec::new();
+                let mut stack: Vec<Dual1<$n>> = Vec::new();
+                let d = with_model_time(time, || {
+                    eval_bytecode_g::<Dual1<$n>>(
+                        &self.bc,
+                        &theta_d,
+                        &[],
+                        &cov_vec,
+                        &sigma_pin,
+                        &empty_nn,
+                        &mut stack,
+                    )
+                });
+                d.grad.to_vec()
+            }};
+        }
+        Some(match theta.len() {
+            1 => run!(1),
+            2 => run!(2),
+            3 => run!(3),
+            4 => run!(4),
+            5 => run!(5),
+            6 => run!(6),
+            7 => run!(7),
+            8 => run!(8),
+            9 => run!(9),
+            10 => run!(10),
+            11 => run!(11),
+            12 => run!(12),
+            13 => run!(13),
+            14 => run!(14),
+            15 => run!(15),
+            16 => run!(16),
+            _ => return None,
+        })
     }
 }
 
@@ -17315,6 +17469,41 @@ mod tests {
         assert!((m_early[1] - 1.0).abs() < 1e-12);
         assert!((m_late[0] - 1.5).abs() < 1e-12);
         assert!((m_late[1] - 1.0).abs() < 1e-12);
+    }
+
+    /// A theta referenced only from an `[error_model]` magnitude expression
+    /// (e.g. `RUV_LATE`, never used in `[individual_parameters]`) must not trip
+    /// the "declared but not referenced" warning — it *is* meaningfully
+    /// estimated, via the magnitude's direct-θ channel (#484/#576/#486).
+    #[test]
+    fn test_ruv_magnitude_theta_not_flagged_as_unused() {
+        let content = r#"
+[parameters]
+  theta TVCL(0.2)
+  theta TVV(10.0)
+  theta RUV_LATE(1.5, 0.0, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))
+"#;
+        let model = parse_model_string(content).unwrap();
+        assert!(model.has_custom_ruv_magnitude());
+        let warns: Vec<_> = model
+            .parse_warnings
+            .iter()
+            .filter(|w| w.contains("RUV_LATE"))
+            .collect();
+        assert!(
+            warns.is_empty(),
+            "RUV_LATE is used by the magnitude expression, got: {:?}",
+            warns
+        );
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -8754,7 +8754,21 @@ fn compile_ruv_mag_deriv_program(
     n_theta: usize,
 ) -> RuvMagDerivProgram {
     let mut e = expr.clone();
-    let var_idx: HashMap<String, usize> = [(sigma_name.to_string(), 0)].into_iter().collect();
+    // Slot 0 = the pinned scaled sigma (bound to 1.0 at eval time). Slot 1 =
+    // `MACHEPS`, which `validate_ruv_expr` explicitly permits inside a magnitude
+    // expression alongside the scaled sigma. `eval_expression` (the runtime
+    // f64 closure) special-cases the `MACHEPS` name string at eval time, but
+    // bytecode compilation resolves every `Variable` name to a fixed slot up
+    // front — so without a reserved slot here, `resolve_expr_indices` would map
+    // `MACHEPS` to `VariableIdx(usize::MAX)`, which silently evaluates to `0.0`
+    // instead of `f64::EPSILON` (mirrors the ODE var builder's `macheps_slot`).
+    let var_idx: HashMap<String, usize> = [
+        (sigma_name.to_string(), 0),
+        ("MACHEPS".to_string(), 1),
+        ("macheps".to_string(), 1),
+    ]
+    .into_iter()
+    .collect();
     let mut cov_set = std::collections::HashSet::new();
     collect_covariates(&e, &mut cov_set);
     let mut cov_names: Vec<String> = cov_set.into_iter().collect();
@@ -8812,8 +8826,16 @@ fn build_ruv_magnitude(
         any = true;
         // The scaled sigma resolves to a `Variable` (bound to 1.0 at eval);
         // unknown identifiers fall back to model covariates. TIME/time parse
-        // as event-time built-ins.
-        let defined = [sigma_name.clone()];
+        // as event-time built-ins. `MACHEPS`/`macheps` must resolve to a
+        // `Variable` too (not fall through to `Covariate`) — `validate_ruv_expr`'s
+        // `Variable` arm already permits it, but without a `defined_vars` entry
+        // the parser would classify it as an (undeclared, rejected) covariate
+        // instead, since this context sets `fallback_covariate: true` (#486 review).
+        let defined = [
+            sigma_name.clone(),
+            "MACHEPS".to_string(),
+            "macheps".to_string(),
+        ];
         let ctx = ParseCtx {
             theta_names,
             eta_names,
@@ -11957,20 +11979,40 @@ impl RuvMagDerivProgram {
         if theta.is_empty() {
             return Some(Vec::new());
         }
+        // Mirror the runtime `RuvMagFn` closure's `TIME`/`time` covariate-map
+        // injection: a legacy pre-built expression may still carry `TIME` as an
+        // `Expression::Covariate` node (parsed models use the `Expression::Time`
+        // built-in, read directly from `time` via `Op::PushTime`, and never reach
+        // this branch) — without it, such a `cov_name` would look up the
+        // observation's covariate map (which never carries a literal "TIME" key)
+        // and silently default to `0.0` instead of the actual observation time.
         let cov_vec: Vec<f64> = self
             .cov_names
             .iter()
-            .map(|n| cov.get(n).copied().unwrap_or(0.0))
+            .map(|n| {
+                if n.eq_ignore_ascii_case("TIME") {
+                    time
+                } else {
+                    cov.get(n).copied().unwrap_or(0.0)
+                }
+            })
             .collect();
-        let sigma_pin_f64 = 1.0_f64;
+        // `theta_d`/`prog_vars` are exactly `$n`-sized at each dispatch arm (unlike
+        // `ScaleDerivProgram::eval_scale_dual1`'s padded-to-N buffers), so a plain
+        // stack array avoids the sibling's per-call heap `Vec` for the axis-bounded
+        // pieces (#486 review); `cov_vec`/`stack` stay on the heap, matching that
+        // sibling's own precedent — they are not axis-bounded.
         macro_rules! run {
             ($n:literal) => {{
-                let theta_d: Vec<Dual1<$n>> = theta
-                    .iter()
-                    .enumerate()
-                    .map(|(m, &v)| Dual1::var(v, m))
-                    .collect();
-                let sigma_pin = [Dual1::<$n>::constant(sigma_pin_f64)];
+                let mut theta_d = [Dual1::<$n>::constant(0.0); $n];
+                for (m, d) in theta_d.iter_mut().enumerate() {
+                    *d = Dual1::var(theta[m], m);
+                }
+                // Slot 0 = the pinned scaled sigma (1.0); slot 1 = MACHEPS.
+                let prog_vars = [
+                    Dual1::<$n>::constant(1.0),
+                    Dual1::<$n>::constant(f64::EPSILON),
+                ];
                 let empty_nn: Vec<Vec<f64>> = Vec::new();
                 let mut stack: Vec<Dual1<$n>> = Vec::new();
                 let d = with_model_time(time, || {
@@ -11979,7 +12021,7 @@ impl RuvMagDerivProgram {
                         &theta_d,
                         &[],
                         &cov_vec,
-                        &sigma_pin,
+                        &prog_vars,
                         &empty_nn,
                         &mut stack,
                     )
@@ -17504,6 +17546,77 @@ mod tests {
             "RUV_LATE is used by the magnitude expression, got: {:?}",
             warns
         );
+    }
+
+    /// xhigh review: `MACHEPS` inside a magnitude expression must resolve to
+    /// `f64::EPSILON` in the `Dual1` θ-derivative program too (not just the
+    /// value-only runtime closure) — `RuvMagDerivProgram` reserves a var slot
+    /// for it now. Regression case: `WT + MACHEPS` guards a denominator; at
+    /// `WT = 0.0` the pre-fix bug (`MACHEPS` silently resolving to `0.0` in the
+    /// bytecode path) would divide by exactly zero and produce a non-finite
+    /// `∂mult/∂θ`.
+    #[test]
+    fn test_ruv_magnitude_macheps_resolves_in_theta_grad() {
+        let content = r#"
+[parameters]
+  theta TVCL(0.2)
+  theta TVV(10.0)
+  theta RUV_LATE(1.5, 0.0, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE / (WT + MACHEPS)))
+[covariates]
+  WT continuous
+"#;
+        let model = parse_model_string(content).unwrap();
+        let rm = model.ruv_magnitude.as_ref().expect("magnitude present");
+        let deriv = rm.per_sigma_deriv[0]
+            .as_ref()
+            .expect("prop slot has a deriv program");
+
+        let theta = vec![0.2, 10.0, 1.5];
+        let cov_zero = std::collections::HashMap::from([("WT".to_string(), 0.0)]);
+        let grad = deriv
+            .theta_grad(&theta, &cov_zero, 10.0)
+            .expect("theta_grad supported");
+        assert!(
+            grad.iter().all(|g| g.is_finite()),
+            "MACHEPS must guard the WT=0 denominator, got {:?}",
+            grad
+        );
+        // ∂mult/∂RUV_LATE = 1/(WT+MACHEPS) = 1/EPSILON — a large but finite value.
+        approx::assert_relative_eq!(grad[2], 1.0 / f64::EPSILON, max_relative = 1e-9);
+    }
+
+    /// xhigh review: a *legacy* pre-built magnitude expression that still
+    /// represents `TIME` as an `Expression::Covariate("TIME")` node (rather than
+    /// the `Expression::Time` built-in every parsed `.ferx` model produces) must
+    /// still resolve `TIME` to the observation time in `theta_grad`, mirroring the
+    /// runtime `RuvMagFn` closure's `cov.insert("TIME", time)` injection. Without
+    /// it, `cov_vec` would look up "TIME" in the (never-populated) observation
+    /// covariate map and silently default to `0.0`.
+    #[test]
+    fn test_ruv_magnitude_deriv_program_resolves_time_as_covariate_node() {
+        // RUV_LATE * TIME, built directly as an AST (bypassing the parser, which
+        // would emit `Expression::Time` instead) to exercise the legacy branch.
+        let expr = Expression::BinOp(
+            Box::new(Expression::Theta(0)),
+            BinOp::Mul,
+            Box::new(Expression::Covariate("TIME".to_string())),
+        );
+        let deriv = compile_ruv_mag_deriv_program(&expr, "UNUSED_SIGMA", 1);
+        let empty_cov = std::collections::HashMap::new();
+        let grad = deriv
+            .theta_grad(&[2.0], &empty_cov, 10.0)
+            .expect("theta_grad supported");
+        // d(RUV_LATE * TIME)/d(RUV_LATE) = TIME = 10.0, not 0.0.
+        approx::assert_relative_eq!(grad[0], 10.0, max_relative = 1e-12);
     }
 
     #[test]

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -408,6 +408,26 @@ pub fn analytic_outer_gradient_available(model: &CompiledModel) -> bool {
         && !model.iiv_on_ruv_forces_fd()
 }
 
+/// [`analytic_outer_gradient_available`] further narrowed by whether the fit
+/// actually runs with FOCEI interaction (#486 review): a custom residual-
+/// magnitude model's direct-θ channel is assembled only in the FOCEI
+/// (`subject_packed_gradient`/`subject_packed_gradient_iov`) per-subject path.
+/// Plain `method = foce` (non-interaction, `subject_packed_gradient_foce` /
+/// `subject_packed_gradient_foce_iov`) declines whenever
+/// `model.has_custom_ruv_magnitude()` and falls back to FD — but
+/// `analytic_outer_gradient_available` itself has no way to see
+/// `interaction` (it takes only `model`), so it can't reflect that on its
+/// own. Every other exclusion in `analytic_outer_gradient_available` is
+/// interaction-independent, so this only narrows the magnitude case.
+///
+/// [`crate::types::Optimizer::resolve_auto`] and
+/// `build_info::gradient_method_outer` both consult this (instead of the bare
+/// model-only predicate) so `auto`'s pick and the reported gradient method
+/// agree with what the outer loop actually computes for FOCE vs FOCEI.
+pub fn analytic_outer_gradient_for_interaction(model: &CompiledModel, interaction: bool) -> bool {
+    analytic_outer_gradient_available(model) && (interaction || !model.has_custom_ruv_magnitude())
+}
+
 /// Whether the light **ODE inner** η-gradient (`Dual1`) serves this model+subject:
 /// the master switch is armed and the subject is in the per-subject ODE scope —
 /// either the static superposition walk ([`ode_subject_supported`]) or the
@@ -4365,7 +4385,7 @@ mod tests {
             "TTE objective is FD-only: no analytic outer gradient"
         );
         assert_eq!(
-            Optimizer::Auto.resolve_auto(&m),
+            Optimizer::Auto.resolve_auto(&m, true),
             Optimizer::Bobyqa,
             "auto must resolve to derivative-free Bobyqa for a TTE model"
         );

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -384,9 +384,19 @@ pub fn analytic_outer_gradient_available(model: &CompiledModel) -> bool {
     !matches!(model.gradient_method, GradientMethod::Fd)
         && model.residual_correlations.is_empty()
         && !model.has_tte()
-        // Custom residual-error magnitude (#484): θ-dependent variance not yet in
-        // the analytic outer θ/σ kernels — FD gradient only (it is magnitude-aware).
-        && !model.has_custom_ruv_magnitude()
+        // Custom / time-varying residual-error magnitude (#484/#576/#486): `mult(θ)`
+        // makes `R` depend on θ directly, which `sens_outer_gradient::theta_block`
+        // now carries via a `Dual1`-differentiated direct-θ channel — bounded by the
+        // same `Dual1<M>` dispatch table `ScaleDerivProgram`/`ExpressionScale` uses
+        // (`MAX_RUV_MAG_AXES`). Beyond that axis count, or combined with `iiv_on_ruv`
+        // (whose residual-eta `c̃`-column coupling `d/R` would need its own direct-θ
+        // chain, not yet assembled — see `prepare_stacked`), still routes to FD.
+        // (An M3-censored row's `−logΦ(z)` direct-θ chain is a *per-subject* gap
+        // `prepare_stacked` bails at runtime — see its own doc — not a model-level
+        // one, so it is not gated here.)
+        && (!model.has_custom_ruv_magnitude()
+            || (model.n_theta <= crate::parser::model_parser::MAX_RUV_MAG_AXES
+                && model.residual_error_eta.is_none()))
         // `iov_sens_supported` (not just the closed-form `iov_analytical_supported`) so
         // the predicate also recognizes the ODE IOV outer gradient (#439 ODE IOV / #466).
         && (sens_supported(model) || iov_sens_supported(model))

--- a/src/types.rs
+++ b/src/types.rs
@@ -1452,7 +1452,14 @@ pub type RuvMagFn = Box<dyn Fn(&[f64], &HashMap<String, f64>, f64) -> f64 + Send
 /// consumption order. `per_sigma[k] == None` means slot `k` is a bare sigma
 /// (multiplier ≡ 1, the legacy path); `Some(f)` makes the slot's magnitude
 /// vary with TIME / covariates / theta.
+///
+/// `#[non_exhaustive]`: `per_sigma_deriv` (#576/#486) is the first field added
+/// since this type shipped; marking the struct non-exhaustive now means a
+/// future field addition can't again break an external struct-literal
+/// construction — build via [`Default::default()`] plus field assignment (or
+/// `..Default::default()`) instead.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct RuvMagnitude {
     pub per_sigma: Vec<Option<RuvMagFn>>,
     /// Parallel to `per_sigma`: the compiled `Dual1` θ-derivative program for the
@@ -1786,6 +1793,22 @@ impl ErrorSpec {
         }
     }
 
+    /// Flat sigma-vector index of `cmt`'s proportional sigma (the slot a
+    /// magnitude multiplier scales for the `f`-derivative chain): slot `0` for
+    /// `Single`, the endpoint's first `sigma_idx` for `PerCmt`. `None` when
+    /// `PerCmt` has no endpoint registered for `cmt`, or that endpoint declares
+    /// no sigma at all — both cases the `_scaled` derivative callers treat as
+    /// "no residual error here" (`0.0`). Single source for
+    /// [`dvar_df_scaled`](Self::dvar_df_scaled) and
+    /// [`d2var_df2_scaled`](Self::d2var_df2_scaled) so the two can't resolve a
+    /// different slot for the same `(cmt, mult)` (#486 review).
+    fn prop_sigma_slot(&self, cmt: usize) -> Option<usize> {
+        match self {
+            ErrorSpec::Single(_) => Some(0),
+            ErrorSpec::PerCmt(map) => map.get(&cmt)?.sigma_idx.first().copied(),
+        }
+    }
+
     /// `dvar_df` with a per-observation custom magnitude (#484).
     ///
     /// The proportional loading carries the multiplier `m_prop`, so the
@@ -1796,15 +1819,8 @@ impl ErrorSpec {
     ///
     /// [`dvar_df`]: ErrorSpec::dvar_df
     pub fn dvar_df_scaled(&self, cmt: usize, f: f64, sigma: &[f64], mult: &[f64]) -> f64 {
-        let prop_slot = match self {
-            ErrorSpec::Single(_) => 0,
-            ErrorSpec::PerCmt(map) => match map.get(&cmt) {
-                Some(ep) => match ep.sigma_idx.first() {
-                    Some(&i) => i,
-                    None => return 0.0,
-                },
-                None => return 0.0,
-            },
+        let Some(prop_slot) = self.prop_sigma_slot(cmt) else {
+            return 0.0;
         };
         let m = mult.get(prop_slot).copied().unwrap_or(1.0);
         self.dvar_df(cmt, f, sigma) * m * m
@@ -1857,15 +1873,8 @@ impl ErrorSpec {
     /// [`dvar_df`]: ErrorSpec::dvar_df
     /// [`d2var_df2`]: ErrorSpec::d2var_df2
     pub fn d2var_df2_scaled(&self, cmt: usize, sigma: &[f64], mult: &[f64]) -> f64 {
-        let prop_slot = match self {
-            ErrorSpec::Single(_) => 0,
-            ErrorSpec::PerCmt(map) => match map.get(&cmt) {
-                Some(ep) => match ep.sigma_idx.first() {
-                    Some(&i) => i,
-                    None => return 0.0,
-                },
-                None => return 0.0,
-            },
+        let Some(prop_slot) = self.prop_sigma_slot(cmt) else {
+            return 0.0;
         };
         let m = mult.get(prop_slot).copied().unwrap_or(1.0);
         self.d2var_df2(cmt, sigma) * m * m
@@ -4763,7 +4772,14 @@ impl Optimizer {
     /// (see `build_info::gradient_method_outer`), so `auto` lands on the
     /// gradient-based optimizer exactly when there is an exact gradient to feed
     /// it (#490).
-    pub fn resolve_auto(self, model: &CompiledModel) -> Optimizer {
+    ///
+    /// `interaction` is `options.interaction` (`true` for `method = focei`,
+    /// `false` for plain `method = foce`) — a custom residual-magnitude model's
+    /// direct-θ channel is FOCEI-only (#486 review), so a magnitude-active model
+    /// under plain FOCE must still resolve to `Bobyqa` even though
+    /// `analytic_outer_gradient_available` (interaction-agnostic) says the model
+    /// is in scope.
+    pub fn resolve_auto(self, model: &CompiledModel, interaction: bool) -> Optimizer {
         if self != Optimizer::Auto {
             return self;
         }
@@ -4771,7 +4787,7 @@ impl Optimizer {
         // outer loop's actual gradient dispatch (#490 review): resolving to a
         // gradient-based optimizer while the loop ran FD would feed it a noisy
         // gradient.
-        if crate::sens::provider::analytic_outer_gradient_available(model) {
+        if crate::sens::provider::analytic_outer_gradient_for_interaction(model, interaction) {
             Optimizer::NloptLbfgs
         } else {
             Optimizer::Bobyqa
@@ -5488,7 +5504,7 @@ mod tests {
         // available, so `auto` resolves to the gradient-based NLopt L-BFGS (#490).
         let m = test_helpers::analytical_model(GradientMethod::Auto);
         assert_eq!(
-            Optimizer::Auto.resolve_auto(&m),
+            Optimizer::Auto.resolve_auto(&m, true),
             Optimizer::NloptLbfgs,
             "analytic-gradient model should resolve auto → nlopt_lbfgs"
         );
@@ -5502,11 +5518,38 @@ mod tests {
         let forced_fd = test_helpers::analytical_model(GradientMethod::Fd);
         for m in [&ode, &forced_fd] {
             assert_eq!(
-                Optimizer::Auto.resolve_auto(m),
+                Optimizer::Auto.resolve_auto(m, true),
                 Optimizer::Bobyqa,
                 "FD-only model should resolve auto → bobyqa"
             );
         }
+    }
+
+    /// #486 review: a custom residual-magnitude model's direct-θ channel is
+    /// FOCEI-only (`subject_packed_gradient_foce`/`_foce_iov` decline it), so
+    /// `auto` must resolve to `Bobyqa` under plain `method = foce`
+    /// (`interaction = false`) even though `analytic_outer_gradient_available`
+    /// (interaction-agnostic) reports the model in scope — and still resolve to
+    /// `NloptLbfgs` under FOCEI (`interaction = true`).
+    #[test]
+    fn resolve_auto_respects_interaction_for_custom_magnitude() {
+        let content = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  theta RUV_LATE(1.5, 0.0, 10.0)\n  omega ETA_CL ~ 0.09\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n";
+        let m = crate::parser::model_parser::parse_model_string(content).expect("parse");
+        assert!(m.has_custom_ruv_magnitude());
+        assert!(
+            crate::sens::provider::analytic_outer_gradient_available(&m),
+            "the interaction-agnostic gate still reports this model in scope"
+        );
+        assert_eq!(
+            Optimizer::Auto.resolve_auto(&m, false),
+            Optimizer::Bobyqa,
+            "plain FOCE + custom magnitude has no analytic gradient — must not pick a gradient optimizer"
+        );
+        assert_eq!(
+            Optimizer::Auto.resolve_auto(&m, true),
+            Optimizer::NloptLbfgs,
+            "FOCEI + custom magnitude has the analytic gradient"
+        );
     }
 
     #[test]
@@ -5522,7 +5565,7 @@ mod tests {
             Optimizer::Bobyqa,
             Optimizer::TrustRegion,
         ] {
-            assert_eq!(opt.resolve_auto(&m), opt);
+            assert_eq!(opt.resolve_auto(&m, true), opt);
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1455,6 +1455,13 @@ pub type RuvMagFn = Box<dyn Fn(&[f64], &HashMap<String, f64>, f64) -> f64 + Send
 #[derive(Default)]
 pub struct RuvMagnitude {
     pub per_sigma: Vec<Option<RuvMagFn>>,
+    /// Parallel to `per_sigma`: the compiled `Dual1` θ-derivative program for the
+    /// same non-bare slot (#576/#486), or `None` for a bare slot. Lets the
+    /// analytic outer θ/σ gradient differentiate the magnitude directly — a new
+    /// direct-θ term in `∂R/∂θ` — instead of falling back to FD. The runtime
+    /// closure in `per_sigma` still serves every value-only caller (inner loop,
+    /// IWRES, simulation).
+    pub per_sigma_deriv: Vec<Option<crate::parser::model_parser::RuvMagDerivProgram>>,
 }
 
 impl std::fmt::Debug for RuvMagnitude {
@@ -1489,6 +1496,26 @@ impl RuvMagnitude {
             .map(|slot| match slot {
                 Some(f) => f(theta, obs_covariates, time),
                 None => 1.0,
+            })
+            .collect()
+    }
+
+    /// Per-sigma `∂(multiplier)/∂θ` vector for one observation (#576/#486). Slot
+    /// `k` evaluates its `Dual1` program's gradient; a bare slot (multiplier ≡ 1)
+    /// contributes an all-zero row. `None` when any active slot's program
+    /// declines (θ-axis count mismatch / beyond `MAX_RUV_MAG_AXES`) — the caller
+    /// then falls back to FD for the magnitude's direct-θ gradient channel.
+    pub fn eval_obs_theta_grad(
+        &self,
+        theta: &[f64],
+        obs_covariates: &HashMap<String, f64>,
+        time: f64,
+    ) -> Option<Vec<Vec<f64>>> {
+        self.per_sigma_deriv
+            .iter()
+            .map(|slot| match slot {
+                Some(p) => p.theta_grad(theta, obs_covariates, time),
+                None => Some(vec![0.0; theta.len()]),
             })
             .collect()
     }
@@ -1814,14 +1841,16 @@ impl ErrorSpec {
     }
 
     /// `d²(residual variance)/d(prediction f)²` with a per-observation custom
-    /// magnitude (#484) — the second-derivative analogue of [`dvar_df_scaled`].
+    /// magnitude (#484/#576) — the second-derivative analogue of [`dvar_df_scaled`].
     ///
     /// The proportional loading carries the multiplier `m_prop`, so the variance's
     /// `f²·(m_prop·σ_prop)²` term differentiates twice to `2·(m_prop·σ_prop)²`,
     /// i.e. [`d2var_df2`] scaled by `m_prop²` — exactly the `m²` factor
     /// [`dvar_df_scaled`] applies to `dvar_df`. Keeping the same scaling here lets
     /// the M3 censored curvature (which differentiates the same `v(f)`) stay
-    /// internally consistent under a custom RUV magnitude. A `mult` of all ones
+    /// internally consistent under a custom RUV magnitude, and the FOCEI outer
+    /// θ/σ gradient's direct-θ channel (`sens_outer_gradient::prepare_stacked`)
+    /// consume the same magnitude-scaled second derivative. A `mult` of all ones
     /// reproduces [`d2var_df2`].
     ///
     /// [`dvar_df_scaled`]: ErrorSpec::dvar_df_scaled
@@ -2903,6 +2932,38 @@ impl CompiledModel {
                 .copied()
                 .unwrap_or_else(|| subject.obs_times.get(j).copied().unwrap_or(0.0));
             out.push(rm.eval_obs(theta, subject.obs_cov(j), time));
+        }
+        Some(out)
+    }
+
+    /// Per-observation `∂(residual-magnitude multiplier)/∂θ` for `subject` at
+    /// `theta` (#576/#486), as an `[obs][sigma-slot][theta]` tensor, or `None`
+    /// when no custom magnitude is active *or* any active slot's `Dual1` program
+    /// declines (θ-axis count beyond [`crate::parser::model_parser::MAX_RUV_MAG_AXES`]
+    /// — the analytic outer gradient's own gate,
+    /// [`crate::sens::provider::analytic_outer_gradient_available`], bounds
+    /// `model.n_theta` against the same constant, so this should only return
+    /// `None` here for a model that gate already declined). Feeds the outer θ/σ
+    /// gradient's direct-θ channel (`sens_outer_gradient::prepare_stacked`) — the
+    /// magnitude enters `R` through θ directly, not only through the prediction.
+    pub fn ruv_obs_mult_theta_grad(
+        &self,
+        subject: &Subject,
+        theta: &[f64],
+    ) -> Option<Vec<Vec<Vec<f64>>>> {
+        let rm = self.ruv_magnitude.as_ref()?;
+        if !rm.is_active() {
+            return None;
+        }
+        let n = subject.observations.len();
+        let mut out = Vec::with_capacity(n);
+        for j in 0..n {
+            let time = subject
+                .obs_raw_times
+                .get(j)
+                .copied()
+                .unwrap_or_else(|| subject.obs_times.get(j).copied().unwrap_or(0.0));
+            out.push(rm.eval_obs_theta_grad(theta, subject.obs_cov(j), time)?);
         }
         Some(out)
     }


### PR DESCRIPTION
<!-- Title format: type(scope): short description  [closes #N] -->

## Why
The custom / time-varying residual-error magnitude (`[error_model]` σ-scaling
expression, #484/#576) fits correctly today — the FD forward NLL is
magnitude-aware — but its FOCE/FOCEI **gradient** falls back to finite
differences on both loops, because a `mult(θ)` expression makes the residual
variance `R` depend on θ *directly*, not only through the prediction `f`. This
is the last remaining FD-gradient cell tracked under the #486
analytic-gradient-completion epic (plan: `plans/analytic-gradient-completion/pr5-sigma-magnitude.md`).

## What changed
**Inner loop (cheap):** `mult` is η-independent, so `residual_inner_obs` (shared
by the closed-form, ODE, and IOV inner gradients) just threads the
per-observation magnitude into the residual variance and its `f`-derivative via
the existing `residual_variance_at_scaled`/`dvar_df_scaled` helpers. No new η
term needed.

**Outer loop (the real work):** the magnitude expression now compiles to a
second program, `RuvMagDerivProgram` — the same expression AST lowered to
bytecode and evaluated over `Dual1<M>` (forward-mode, seeded on θ; `M` dispatches
`1..=MAX_RUV_MAG_AXES=16`, mirroring the `ExpressionScale`/`ScaleDerivProgram`
convention). This gives `∂mult/∂θ` exactly, with no finite differences.
`prepare_stacked` folds this into a new **direct-θ channel** — `∂R/∂θ`, `∂d/∂θ`
per observation — that `theta_block` adds to the data+log|H̃| term and the EBE-response
`M`-vector, structurally identical to the existing σ-block's `r_sig`/`d_sig`
handling (substituting `mult`'s θ-derivative for σ's). `sigma_block` itself is
made magnitude-aware too, so `∂R/∂σ` correctly holds `mult` fixed while
perturbing σ.

Two combinations don't have their own direct-θ chain assembled yet and decline
to FD when combined with an active magnitude: `iiv_on_ruv` (the residual-eta
`c̃`-column coupling `d/R` needs its own direct-θ term) and an M3-BLOQ censored
row (the `−logΦ(z)` censored data term needs the `m3_censored_kernel` chain, not
the Gaussian form the new channel assumes). Plain `method = foce`
(non-interaction) also still declines — only the FOCEI (interaction) assembly
has the new channel so far. `block_sigma` correlated residual error was already
FD regardless of magnitude (unchanged).

Also fixes a small pre-existing #484 gap found along the way: a theta
referenced **only** from an `[error_model]` magnitude expression (e.g.
`RUV_LATE`) was incorrectly flagged by the parser as "declared but not
referenced in any model expression".

## Alternatives considered
- **FD-of-the-magnitude-program** (central-difference `mult(θ±h)`, mirroring how
  `sigma_block` already FDs `∂R/∂σ` of the *closed-form* variance functions):
  rejected because the magnitude is an arbitrary user-authored expression (not a
  fixed, well-tuned closed form), so a per-θ FD step needs per-model tuning and
  costs `O(n_theta)` extra magnitude evaluations per subject per outer
  iteration. A single forward-mode `Dual1` pass gives every partial at once,
  exactly, for about the same cost as one extra evaluation.
- **Genericizing `variance_at`/`dvar_df` over `T: PkNum`**: rejected as
  unnecessarily invasive — those are called from ~15 sites across the codebase;
  the new direct-θ chain is a small, self-contained bilinear formula over the
  existing `sigma_loadings`/`sigma_loading_slopes` helpers, added locally in
  `sens_outer_gradient.rs` instead.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: NONMEM (live FOCEI fit, klebsiella `nmfe75`)
- [x] Reference values (see `examples/warfarin_ruv_magnitude.ferx`, simulated with
      a genuinely nonzero `RUV_LATE=2.0` so the effect is identifiable — the real
      `data/warfarin.csv` has no such effect and drives `RUV_LATE` to its lower
      bound, which is a valid but uninteresting anchor):

```
# ferx (FOCEI, analytic gradient)
OFV -258.0199  TVCL 0.146403  TVV 7.989554  TVKA 0.953406  RUV_LATE 2.209540  PROP_ERR 0.019346
omegaCL 0.071989  omegaV 0.040669  omegaKA 0.238367

# NONMEM (METHOD=1 INTER, matched $ERROR: W=THETA(5)*IPRED*(1+THETA(4)*TIME/48))
OFV -258.020   TH1 0.146     TH2 7.99      TH3 0.953    TH4 2.21        TH5 0.0193
omegaCL 0.0720    omegaV 0.0407     omegaKA 0.238
```

Every parameter matches to ~4-5 significant figures.

## Performance
- [x] No significant impact expected — the new `Dual1` magnitude program only
      runs for models with an active custom magnitude (a `None` `RuvMagnitude`
      short-circuits before touching any of the new code); bare-sigma models are
      unaffected (see bit-for-bit regression test below).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes, 2013/2013)
- [x] Regression test added that fails without this fix

New tests:
- `magnitude_time_family_outer_gradient_matches_fd`, `magnitude_covariate_family_outer_gradient_matches_fd`,
  `magnitude_theta_family_outer_gradient_matches_fd` (`sens_outer_gradient.rs`) — analytic θ/σ
  gradient vs Richardson-reconverged FD of the magnitude-aware marginal NLL, one per
  argument family (TIME-gated-by-θ, covariate-gated-by-θ, pure-θ).
- `magnitude_inner_eta_gradient_matches_fd` (`inner_optimizer.rs`) — analytic inner
  η-gradient vs FD of `individual_nll`.
- `bare_sigma_packed_gradient_stays_bit_for_bit` — a non-magnitude model's packed
  gradient is deterministic and never touches the new `_scaled` branch (mirrors
  the #578 regression this PR is careful not to repeat, one level up in
  `sens_outer_gradient.rs` instead of `residual_error.rs`).
- `magnitude_with_correlated_residual_still_declines_outer_gate`,
  `magnitude_with_sde_still_routes_inner_to_fd` — gate tests for the
  still-FD combinations.
- `ode_custom_magnitude_takes_analytic_inner_gradient` (flipped from the old
  `..._routes_inner_to_fd` regression guard now that ODE + magnitude is analytic).
- `test_ruv_magnitude_theta_not_flagged_as_unused` (`model_parser.rs`) — the
  "unreferenced theta" fix.

## Example (user-facing features only)
- [x] Example added to `examples/` (`warfarin_ruv_magnitude.ferx`) — self-contained
      (`[simulation]` block), runnable via `--simulate`.

## Docs
- [x] `docs/` updated for user-visible changes (`docs/model-file/error-model.qmd`
      — the magnitude section's "Rules and restrictions" now describes the
      analytic gradient and lists the remaining FD-only combinations)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (pre-existing warnings/errors in unrelated files —
      `sens/two_cpt_explicit.rs` `approx_constant` — are untouched by this PR;
      `cargo clippy --lib` is clean)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — the new
      `RuvMagDerivProgram` follows the existing generic-`PkNum`/bytecode pattern
      (`ScaleDerivProgram`)

## Reviewer hints
- The core formula reuse is `theta_block`'s new loop mirroring `sigma_block`'s
  existing `r_sig`/`d_sig` -> `dp`/`dalpha` pattern (`sens_outer_gradient.rs`),
  just sourced from `ErrTerms::dr_dtheta`/`dd_dtheta` instead of a σ±h FD.
- `prepare_stacked` bails a *subject* (not the whole model) to FD when magnitude
  is active and that subject has an M3-censored row — a per-subject fallback,
  same pattern `mixed_gradient_with_out_of_scope_subject_matches_fd` already
  exercises for other combinations.
- `RuvMagDerivProgram` lives in `model_parser.rs` (not `types.rs`, where
  `RuvMagnitude` itself is) because it needs the module-private
  `compile_bytecode`/`eval_bytecode_g`/`resolve_expr_indices` helpers —
  mirrors where `ScaleDerivProgram` already lives.

## Open questions
- Issue #486's tracking matrix isn't flipped in this PR (following the same
  deferral pattern as the sibling PRs in this epic — #636, #637); happy to flip
  it here if preferred.
- `iiv_on_ruv`/M3-censored + magnitude, and plain `method=foce` + magnitude, are
  left as small, explicitly-gated follow-ups rather than expanded here to keep
  this PR's diff focused — flag if you'd rather see them folded in now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
