### PR TITLE
feat(parser): analytic sensitivities for direct pk(...=TIME) mapping [#486]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ section of the SDLC for the versioning policy).
   with and without inter-occasion variability, including together with an
   η-dependent `obs_scale` expression (the event-driven walk now applies the scale
   quotient — which also makes time-varying-covariate + expression-scale models
-  analytic). Only the direct `pk(...=TIME)` mapping still falls back to finite
-  differences.
+  analytic). The direct `pk(...=TIME)` structural mapping is covered too: the parser
+  desugars the mapped slot into a hidden individual parameter (`__ferx_pktime_*`), so
+  it rides the same per-event analytic walk as an `[individual_parameters]` switch.
 - A Form-C ODE readout (`[scaling] y = <expr>`) that references a θ or η
   **directly** (e.g. `y = central/V1 * (1 + ETA_CL) + TVBASE`) now gets exact
   analytic FOCE/FOCEI sensitivities instead of falling back to finite differences

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -153,9 +153,12 @@ switch and 1-cpt oral), `iov_time_builtin_provider_matches_fd_of_predict_iov`
 `ode_time_builtin_provider_matches_fd_of_production` (non-IOV ODE), and
 `ode_iov_time_builtin_provider_matches_fd_of_predict_iov` (ODE IOV) — including in
 combination with an η-dependent `ExpressionScale` obs_scale (the event-driven walk
-now applies the subject-static scale quotient post-walk). The only fallback
-specific to `TIME` is the direct `pk(...=TIME)` mapping (its slot is not desugared
-into the individual-parameter program).
+now applies the subject-static scale quotient post-walk). A direct
+`pk(...=TIME)` structural mapping is served analytically too: the parser desugars
+the mapped slot into a hidden individual parameter (`__ferx_pktime_*`), so it is
+exactly the explicit `[individual_parameters]` form and rides the same per-event
+walk (`time_builtin_direct_pk_mapping_matches_fd_of_production`,
+`time_builtin_direct_pk_mapping_equivalent_to_explicit_indiv_param`).
 
 ### Interaction with mu-referencing
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1155,19 +1155,30 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     } else {
         Vec::new()
     };
-    // #486 — the `__ferx_ro_` prefix is reserved for these synthetic params.
-    // Reject a user/generated parameter that carries it rather than silently
-    // misclassifying it as internal (it would vanish from EBE/sdtab output and be
-    // rejected as an unknown output column by `is_synthetic_readout_param`).
+    // #486 — the `__ferx_ro_` (Form-C readout) and `__ferx_pktime_` (direct `pk(...=TIME)`
+    // mapping) prefixes are reserved for synthetic individual parameters. Reject a
+    // user/generated parameter that carries either rather than silently misclassifying it
+    // as internal (it would vanish from EBE/sdtab output and be rejected as an unknown
+    // output column by `is_synthetic_readout_param`). This runs before either desugaring
+    // appends its own synthetic params, so `all_assigned`/`theta_names`/`eta_names` hold
+    // only user names here.
     if let Some(bad) = all_assigned
         .iter()
         .chain(theta_names.iter())
         .chain(eta_names.iter())
         .find(|n| is_synthetic_readout_param(n.as_str()))
     {
+        let (prefix, reserved_for) = if bad.starts_with(PKTIME_SYNTH_PREFIX) {
+            (
+                PKTIME_SYNTH_PREFIX,
+                "internal `pk(...=TIME)` mapping parameters",
+            )
+        } else {
+            (READOUT_SYNTH_PREFIX, "internal Form-C readout parameters")
+        };
         return Err(format!(
-            "parameter name `{bad}` uses the reserved `{READOUT_SYNTH_PREFIX}` prefix, which ferx \
-             reserves for internal Form-C readout parameters (#486). Rename it."
+            "parameter name `{bad}` uses the reserved `{prefix}` prefix, which ferx \
+             reserves for {reserved_for} (#486). Rename it."
         ));
     }
     // #486 slot headroom: each synthetic readout param consumes a PK slot. A model
@@ -1369,19 +1380,9 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             .map(|(k, _)| k.clone())
             .collect();
         if !time_bound.is_empty() {
-            // Reserve the `__ferx_pktime_` prefix (like `__ferx_ro_`): reject a
-            // user/generated parameter carrying it rather than silently shadowing it.
-            if let Some(bad) = all_assigned
-                .iter()
-                .chain(theta_names.iter())
-                .chain(eta_names.iter())
-                .find(|n| n.starts_with(PKTIME_SYNTH_PREFIX))
-            {
-                return Err(format!(
-                    "parameter name `{bad}` uses the reserved `{PKTIME_SYNTH_PREFIX}` prefix, \
-                     which ferx reserves for internal `pk(...=TIME)` parameters (#486). Rename it."
-                ));
-            }
+            // A user parameter carrying the reserved `__ferx_pktime_` prefix is already
+            // rejected by the shared synthetic-prefix guard above (it runs before either
+            // desugaring adds its own synthetic params, so it sees only user names).
             // Sorted for deterministic slot/var order across runs.
             time_bound.sort();
             for pk_name in time_bound {
@@ -8917,7 +8918,6 @@ fn build_pk_param_fn(
     pk_entries.sort_by(|a, b| a.0.cmp(b.0));
     let mut pk_assignment_mapping: Vec<(usize, usize)> = Vec::with_capacity(pk_entries.len());
     let mut pk_const_mapping: Vec<(usize, f64)> = Vec::new();
-    let mut pk_time_mapping: Vec<usize> = Vec::new();
     for (pk_name, var_name) in pk_entries {
         let pk_slot = PkParams::name_to_index(pk_name).ok_or_else(|| {
             format!(
@@ -8931,9 +8931,11 @@ fn build_pk_param_fn(
             .get(var_name)
             .copied()
             .or_else(|| var_idx.get(&var_name.to_lowercase()).copied());
-        if var_name == "TIME" || var_name == "time" {
-            pk_time_mapping.push(pk_slot);
-        } else if let Some(var_slot) = var_slot {
+        // A direct `pk(...=TIME)` binding is desugared into a synthetic
+        // `__ferx_pktime_*` individual parameter upstream in `parse_full_model` (#486),
+        // so `var_name` is that synthetic name here (resolved via `var_idx` below), never
+        // a literal `TIME`.
+        if let Some(var_slot) = var_slot {
             pk_assignment_mapping.push((pk_slot, var_slot));
         } else if let Ok(c) = var_name.parse::<f64>() {
             // A numeric literal binds the slot to a constant — but `f64::from_str`
@@ -9020,7 +9022,10 @@ fn build_pk_param_fn(
         ode_assignment_mapping.clone()
     };
     let pk_slot_indices = pk_var_slots.iter().map(|&(slot, _)| slot).collect();
-    let uses_time_builtin = stmts_use_time || !pk_time_mapping.is_empty();
+    // A direct `pk(...=TIME)` mapping is desugared into a `__ferx_pktime_* = TIME`
+    // statement upstream (#486), so `stmts_use_time` already covers it — no separate
+    // literal-TIME-binding term is needed.
+    let uses_time_builtin = stmts_use_time;
     let indiv_param_program = IndivParamProgram {
         stmts: stmts_owned.clone(),
         n_vars,
@@ -9043,11 +9048,11 @@ fn build_pk_param_fn(
     let pk_param_fn: PkParamFn = Box::new(
         move |theta: &[f64], eta: &[f64], covariates: &HashMap<String, f64>, time: f64| {
             // Resolve the `TIME` built-in from the event time the caller passed.
-            // `Expression::Time` / `Op::PushTime` and the analytical
-            // `pk_time_mapping` slots read the model-time thread-local, so set
-            // it here for the duration of this evaluation. Gated on
-            // `uses_time_builtin` so models that don't use the built-in (the
-            // common case) pay nothing for the guard (#610).
+            // `Expression::Time` / `Op::PushTime` (including the desugared
+            // `__ferx_pktime_* = TIME` parameters, #486) read the model-time
+            // thread-local, so set it here for the duration of this evaluation. Gated
+            // on `uses_time_builtin` so models that don't use the built-in (the common
+            // case) pay nothing for the guard (#610).
             let _time_guard = uses_time_builtin.then(|| ModelTimeGuard::enter(time));
             // Pre-compute each NN's forward output once per call. The
             // indexed evaluator reads `nn_outputs[nn_idx][output_idx]` for
@@ -9113,9 +9118,6 @@ fn build_pk_param_fn(
                     // per-call evaluation, just write the parsed value.
                     for &(pk_slot, c) in &pk_const_mapping {
                         p.values[pk_slot] = c;
-                    }
-                    for &pk_slot in &pk_time_mapping {
-                        p.values[pk_slot] = current_model_time();
                     }
                     // Modeled infusion duration (`D{cmt}`, RATE=-2; #394): write
                     // each duration parameter into its reserved spare slot so the
@@ -14787,6 +14789,78 @@ mod tests {
                 .any(|w| w.contains("computed but never used") && w.contains("`KEL`")),
             "without the [derived] use KEL must be flagged dead: {:?}",
             p2.model.parse_warnings
+        );
+    }
+
+    /// #486 regression: the synthetic `__ferx_pktime_*` parameter a direct
+    /// `pk(...=TIME)` mapping desugars into must be exempt from the "computed but never
+    /// used" census (like the `__ferx_ro_*` readout synthetics). The census tokenizes the
+    /// raw block text, which still reads `q=TIME` (never `q=__ferx_pktime_q`), so the
+    /// synthetic name looks unreferenced — only the `is_synthetic_readout_param` prefix
+    /// match keeps it from being flagged. If that exemption is ever dropped, every direct
+    /// `pk(...=TIME)` model would tell users to remove a load-bearing parameter.
+    #[test]
+    fn direct_pk_time_synth_param_not_flagged_unused() {
+        let src = "
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV1(10.0, 0.1, 1000.0)
+  theta TVV2(20.0, 0.1, 1000.0)
+  omega ETA_CL ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  V2 = TVV2
+
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=TIME, v2=V2)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let p = super::parse_full_model(src).expect("parse ok");
+        assert!(
+            !p.model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("computed but never used")),
+            "direct pk(q=TIME) must not flag the synthetic __ferx_pktime_q as dead: {:?}",
+            p.model.parse_warnings
+        );
+    }
+
+    /// #486: a user parameter using the reserved `__ferx_pktime_` prefix is rejected, and
+    /// the message names the *correct* prefix and feature (`pk(...=TIME)`), not the Form-C
+    /// readout prefix — even though the shared guard also matches the readout prefix.
+    #[test]
+    fn reserved_pktime_prefix_rejected_with_correct_message() {
+        let src = "
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  omega ETA_CL ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  __ferx_pktime_cl = TVCL * exp(ETA_CL)
+
+[structural_model]
+  pk one_cpt_iv(cl=__ferx_pktime_cl, v=10.0)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let err = super::parse_full_model(src)
+            .err()
+            .expect("reserved prefix must be rejected");
+        assert!(
+            err.contains(PKTIME_SYNTH_PREFIX),
+            "message must name the pktime prefix: {err}"
+        );
+        assert!(
+            err.contains("pk(...=TIME)"),
+            "message must name the pk(...=TIME) feature, not Form-C readout: {err}"
         );
     }
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1242,7 +1242,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
 
     let (
         pk_model,
-        pk_param_map,
+        mut pk_param_map,
         mut ode_spec,
         diffusion_theta_names,
         diffusion_theta_inits,
@@ -1352,6 +1352,46 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             Vec::new(),
         )
     };
+
+    // #486 — desugar a direct `pk(...=TIME)` structural mapping into a synthetic
+    // individual parameter (`__ferx_pktime_<pk_name> = TIME`), mirroring the Form-C
+    // readout θ/η desugaring (#631). A bare `pk(v=TIME)` binding otherwise leaves the
+    // mapped PK slot out of the individual-parameter program's `pk_slots`, so
+    // `prog_covers_required_pk_slots` declines and the whole model routes to FD (#637
+    // follow-up). Rewriting the binding to reference the synthetic parameter makes the
+    // slot ride the validated per-event `TIME` sensitivity chain (value = event time via
+    // `Op::PushTime`, ∂/∂θ = ∂/∂η = 0). Runs before `pk_indices` / `build_pk_param_fn`
+    // consume `indiv_var_names` / `indiv_stmts`.
+    {
+        let mut time_bound: Vec<String> = pk_param_map
+            .iter()
+            .filter(|(_, v)| v.as_str() == "TIME" || v.as_str() == "time")
+            .map(|(k, _)| k.clone())
+            .collect();
+        if !time_bound.is_empty() {
+            // Reserve the `__ferx_pktime_` prefix (like `__ferx_ro_`): reject a
+            // user/generated parameter carrying it rather than silently shadowing it.
+            if let Some(bad) = all_assigned
+                .iter()
+                .chain(theta_names.iter())
+                .chain(eta_names.iter())
+                .find(|n| n.starts_with(PKTIME_SYNTH_PREFIX))
+            {
+                return Err(format!(
+                    "parameter name `{bad}` uses the reserved `{PKTIME_SYNTH_PREFIX}` prefix, \
+                     which ferx reserves for internal `pk(...=TIME)` parameters (#486). Rename it."
+                ));
+            }
+            // Sorted for deterministic slot/var order across runs.
+            time_bound.sort();
+            for pk_name in time_bound {
+                let synth = format!("{PKTIME_SYNTH_PREFIX}{}", pk_name.to_lowercase());
+                indiv_var_names.push(synth.clone());
+                indiv_stmts.push(Statement::Assign(synth.clone(), Expression::Time));
+                pk_param_map.insert(pk_name, synth);
+            }
+        }
+    }
 
     // Build the CovariateNn handles up front (before build_pk_param_fn, which
     // captures them in the pk_param_fn closure). The same vector is also
@@ -9505,11 +9545,17 @@ fn collect_theta_eta_in_stmts(
 /// suppress these internal parameters — they are not user-declared quantities.
 pub(crate) const READOUT_SYNTH_PREFIX: &str = "__ferx_ro_";
 
-/// True for an individual-parameter name synthesized by the Form-C readout θ/η
-/// desugaring (see [`READOUT_SYNTH_PREFIX`]). User-facing per-subject output skips
-/// these so the synthetic parameters never surface as sdtab / fit-output columns.
+/// Reserved prefix for the individual parameter synthesized by desugaring a direct
+/// `pk(...=TIME)` structural mapping (`__ferx_pktime_<pk_name> = TIME`, #486). Like the
+/// readout prefix, it lets EBE / diagnostic output suppress the internal parameter.
+pub(crate) const PKTIME_SYNTH_PREFIX: &str = "__ferx_pktime_";
+
+/// True for a ferx-internal synthetic individual parameter — either a Form-C readout θ/η
+/// desugaring ([`READOUT_SYNTH_PREFIX`]) or a direct `pk(...=TIME)` mapping desugaring
+/// ([`PKTIME_SYNTH_PREFIX`]). User-facing per-subject output skips these so the synthetic
+/// parameters never surface as sdtab / fit-output columns.
 pub(crate) fn is_synthetic_readout_param(name: &str) -> bool {
-    name.starts_with(READOUT_SYNTH_PREFIX)
+    name.starts_with(READOUT_SYNTH_PREFIX) || name.starts_with(PKTIME_SYNTH_PREFIX)
 }
 
 /// A θ/η reference desugared out of a Form-C readout into a synthetic individual

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -3668,12 +3668,16 @@ mod tests {
     /// event-driven walk applies the subject-static scale quotient post-walk (validated
     /// in `expression_scale_on_event_walk_matches_fd_closed_form`,
     /// `ode_expression_scale_on_event_walk_matches_production`, and
-    /// `ode_iov_time_expression_scale_matches_fd_of_predict_iov`). The only fallback
-    /// specific to `TIME` is the direct `pk(...=TIME)` mapping (not desugared into the
-    /// program's `pk_slots`); the pre-existing scale fallbacks (LTBS + `ExpressionScale`;
-    /// closed-form IOV + any scaling) are unchanged and independent of `TIME`. The
-    /// non-`TIME` twin of each model must stay supported, proving the guards are specific
-    /// (#486 / #610).
+    /// `ode_iov_time_expression_scale_matches_fd_of_predict_iov`). The direct
+    /// `pk(...=TIME)` mapping is now desugared into a synthetic `__ferx_pktime_*`
+    /// individual parameter and served analytically too (see the `ANALYTICAL_TIME_DIRECT`
+    /// block below and `time_builtin_direct_pk_mapping_matches_fd_of_production`); the only
+    /// remaining `TIME`-specific fallbacks are edge combinations the event-driven walk
+    /// itself cannot serve (an ODE `init(...)` baseline or a built-in input-rate forcing
+    /// under `TIME`, asserted below). The pre-existing scale fallbacks (LTBS +
+    /// `ExpressionScale`; closed-form IOV + any scaling) are unchanged and independent of
+    /// `TIME`. The non-`TIME` twin of each model must stay supported, proving the guards
+    /// are specific (#486 / #610).
     #[test]
     fn time_builtin_indiv_params_force_fd_fallback() {
         // Analytical 1-cpt IV: a `$PK IF(TIME...)`-style switch on CL.
@@ -3910,22 +3914,27 @@ mod tests {
             "TIME + init(...) ODE outer route must report FD, not analytic"
         );
 
-        // Direct `pk(...=TIME)` mapping (not an `[individual_parameters]`
-        // statement): the `pk_time_mapping` slot sets `uses_time_builtin` too, but
-        // it is NOT desugared into the individual-parameter program's `pk_slots`, so
-        // `prog_covers_required_pk_slots` does not see the mapped slot and the
-        // per-event analytic walk declines — the subject stays on FD. Analytic
-        // support for the direct-mapping form is a follow-up to #486 (it needs the
-        // mapped slot threaded into the program as a hidden, TIME-only parameter).
+        // Direct `pk(...=TIME)` mapping (not an `[individual_parameters]` statement): the
+        // parser now desugars the `=TIME` binding into a synthetic
+        // `__ferx_pktime_<slot> = TIME` individual parameter (mirroring the #631 Form-C
+        // readout desugaring), so the mapped slot enters the program's `pk_slots` and
+        // rides the same per-event analytic walk as an `[individual_parameters]` TIME
+        // switch — no longer FD (#486 direct-mapping follow-up). Use a 2-cpt `q=TIME`
+        // mapping so the mapped slot is not a denominator (a `v=TIME` model divides by
+        // `V = 0` at the `t = 0` dose — a user degeneracy, not a gate concern).
         const ANALYTICAL_TIME_DIRECT: &str = r#"
 [parameters]
   theta TVCL(10.0, 1.0, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVV2(100.0, 10.0, 1000.0)
   omega ETA_CL ~ 0.09
   sigma PROP_ERR ~ 0.04
 [individual_parameters]
   CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  V2 = TVV2
 [structural_model]
-  pk one_cpt_iv(cl=CL, v=TIME)
+  pk two_cpt_iv(cl=CL, v1=V1, q=TIME, v2=V2)
 [error_model]
   DV ~ proportional(PROP_ERR)
 "#;
@@ -3935,19 +3944,12 @@ mod tests {
             "direct pk(...=TIME) mapping sets the uses_time_builtin flag"
         );
         assert!(
-            !tvcov_analytical_supported(&direct),
-            "direct pk(...=TIME) mapping is not yet served by the analytic walk (FD follow-up)"
-        );
-        // #637 review #1: since the mapping falls back to FD on every subject, the
-        // model-level report predicates must ALSO say FD — otherwise the fit banner /
-        // `{model}-fit.yaml` would claim "analytic" for a 100%-FD fit.
-        assert!(
-            !analytical_supported(&direct),
-            "direct pk(...=TIME) must report non-analytic at the model level"
+            analytical_supported(&direct) && tvcov_analytical_supported(&direct),
+            "direct pk(...=TIME) mapping is now served by the per-event analytic walk (desugared)"
         );
         assert!(
-            !analytic_outer_gradient_available(&direct),
-            "direct pk(...=TIME) outer gradient route must report FD, not analytic"
+            analytic_outer_gradient_available(&direct),
+            "direct pk(...=TIME) outer gradient route is now analytic"
         );
     }
 
@@ -4116,6 +4118,115 @@ mod tests {
             approx::assert_relative_eq!(o.f, g.f, max_relative = 1e-12, epsilon = 1e-12);
             for (a, b) in o.df_deta.iter().zip(g.df_deta.iter()) {
                 approx::assert_relative_eq!(a, b, max_relative = 1e-10, epsilon = 1e-12);
+            }
+        }
+    }
+
+    /// #486: a **direct `pk(...=TIME)` structural mapping** (here `q=TIME` on a 2-cpt IV,
+    /// so the mapped slot is not a denominator — `v=TIME` would divide by `V = 0` at the
+    /// `t = 0` dose). The parser desugars it into a synthetic `__ferx_pktime_q = TIME`
+    /// individual parameter, so `Q` = event time per event (`∂Q/∂θ = ∂Q/∂η = 0`) while
+    /// `CL`/`V1`'s derivatives stay exact. value + ∂η + ∂²η + ∂θ + ∂²η∂θ must match central
+    /// FD of production (which threads the same per-event TIME through the desugared param).
+    #[test]
+    fn time_builtin_direct_pk_mapping_matches_fd_of_production() {
+        const DIRECT_Q_TIME: &str = r#"
+[parameters]
+  theta TVCL(10.0, 1.0, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVV2(100.0, 10.0, 1000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  V2 = TVV2
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=TIME, v2=V2)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+        let m = parse_model_string(DIRECT_Q_TIME).expect("parse direct q=TIME");
+        assert!(crate::parser::model_parser::compiled_model_uses_time_builtin(&m));
+        assert!(
+            tvcov_analytical_supported(&m),
+            "direct pk(q=TIME) desugars to an indiv-param → analytic"
+        );
+        let s = subject_with_doses_and_resets(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            &[1.0, 4.0, 10.0, 24.0, 48.0],
+            Vec::new(),
+        );
+        assert!(!s.has_tv_covariates());
+        check_full_provider_vs_fd(&m, &s, &[10.0, 50.0, 100.0], &[0.10, -0.05]);
+    }
+
+    /// #486: the direct `pk(q=TIME)` desugaring must be *exactly* the explicit
+    /// `[individual_parameters] QT = TIME; pk(q=QT)` form — a pure rename into a synthetic
+    /// parameter. This ties the direct mapping to the `[individual_parameters]` TIME path
+    /// that #637 validated live against NONMEM (`METHOD=1 INTER`, ~5 sig figs), so the
+    /// direct form inherits that numerical validation by transitivity. All sensitivity
+    /// outputs (value + ∂η + ∂θ + 2nd-order) must agree to 1e-12.
+    #[test]
+    fn time_builtin_direct_pk_mapping_equivalent_to_explicit_indiv_param() {
+        const DIRECT: &str = r#"
+[parameters]
+  theta TVCL(10.0, 1.0, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVV2(100.0, 10.0, 1000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  V2 = TVV2
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=TIME, v2=V2)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+        const EXPLICIT: &str = r#"
+[parameters]
+  theta TVCL(10.0, 1.0, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVV2(100.0, 10.0, 1000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  V2 = TVV2
+  QT = TIME
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=QT, v2=V2)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+        let m_direct = parse_model_string(DIRECT).expect("parse direct");
+        let m_explicit = parse_model_string(EXPLICIT).expect("parse explicit");
+        let s = subject_with_doses_and_resets(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            &[1.0, 4.0, 10.0, 24.0, 48.0],
+            Vec::new(),
+        );
+        let theta = [10.0, 50.0, 100.0];
+        let eta = [0.10, -0.05];
+        let sd = subject_sensitivities(&m_direct, &s, &theta, &eta).expect("direct sens");
+        let se = subject_sensitivities(&m_explicit, &s, &theta, &eta).expect("explicit sens");
+        assert_eq!(sd.obs.len(), se.obs.len());
+        for (a, b) in sd.obs.iter().zip(se.obs.iter()) {
+            approx::assert_relative_eq!(a.f, b.f, max_relative = 1e-12, epsilon = 1e-13);
+            for (x, y) in a.df_deta.iter().zip(b.df_deta.iter()) {
+                approx::assert_relative_eq!(x, y, max_relative = 1e-12, epsilon = 1e-13);
+            }
+            for (x, y) in a.df_dtheta.iter().zip(b.df_dtheta.iter()) {
+                approx::assert_relative_eq!(x, y, max_relative = 1e-12, epsilon = 1e-13);
+            }
+            for (x, y) in a.d2f_deta2.iter().zip(b.d2f_deta2.iter()) {
+                approx::assert_relative_eq!(x, y, max_relative = 1e-12, epsilon = 1e-13);
             }
         }
     }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -4228,6 +4228,11 @@ mod tests {
             for (x, y) in a.d2f_deta2.iter().zip(b.d2f_deta2.iter()) {
                 approx::assert_relative_eq!(x, y, max_relative = 1e-12, epsilon = 1e-13);
             }
+            // The mixed η-θ second derivative feeds the FOCEI Laplace `log|H̃|`
+            // θ-gradient this work targets, so it must match too.
+            for (x, y) in a.d2f_deta_dtheta.iter().zip(b.d2f_deta_dtheta.iter()) {
+                approx::assert_relative_eq!(x, y, max_relative = 1e-12, epsilon = 1e-13);
+            }
         }
     }
 


### PR DESCRIPTION
## Why
The `TIME`/`time` event-time built-in became analytic on FOCE/FOCEI in #637 — but only in its `[individual_parameters]` form (a `$PK IF (TIME.GE.t) CL=…` switch). The one remaining `TIME`-specific finite-difference fallback was the **direct structural mapping** `pk(param=TIME)` (e.g. `pk(cl=CL, q=TIME)`): its slot was carried in `pk_time_mapping` (value only) and never entered the individual-parameter program, so `prog_covers_required_pk_slots` declined and the whole model routed to FD. This PR closes that cell — the last `TIME` gap on the #486 matrix.

## What changed
A parser-only desugaring that mirrors #631 (which desugars a bare `THETA(i)`/`ETA(k)` in a Form-C readout into a hidden `__ferx_ro_*` individual parameter). Right after `pk_param_map` is built — and before `pk_indices` / `build_pk_param_fn` consume `indiv_var_names` / `indiv_stmts` — each `pk(param=TIME)` binding is rewritten to reference a synthetic `__ferx_pktime_<param> = TIME` individual parameter (`Statement::Assign(name, Expression::Time)`). The mapped slot then enters the program's `pk_slots` and rides the **exact same per-event analytic walk** as an `[individual_parameters]` TIME switch (value = event time via `Op::PushTime` under the per-event `ModelTimeGuard`; `∂/∂θ = ∂/∂η = 0`).

No changes to `sens/` — #637 already made an individual parameter reading `TIME` analytic on all four paths (closed-form ±IOV, ODE ±IOV). The synthetic parameter:
- carries the reserved `__ferx_pktime_` prefix (a user parameter using it is rejected, like `__ferx_ro_`);
- is suppressed from EBE / sdtab / fit-output via the shared `is_synthetic_readout_param` (extended to match both synthetic prefixes).

## Alternatives considered
Relaxing `prog_covers_required_pk_slots` to accept `pk_time_mapping` slots directly (constant-seeding them in the walk). Rejected: it would spread `TIME`-awareness across the seeders and gate code, whereas the desugaring makes the slot a first-class individual parameter that every existing walk already handles — zero `sens/` changes and identical to the already-validated explicit form.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API or output-field change (the synthetic parameter is internal and filtered from all output).

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: **prior ferx (#637) + NONMEM by transitivity**
- [x] Reference values:

The direct mapping desugars to *exactly* the explicit `[individual_parameters] QT = TIME; pk(q=QT)` form. `time_builtin_direct_pk_mapping_equivalent_to_explicit_indiv_param` asserts the two models produce **bit-identical** sensitivities (value + ∂η + ∂θ + 2nd-order, to 1e-12), so the direct form inherits the live NONMEM validation #637 already performed on the explicit `[individual_parameters]` TIME path (klebsiella, `METHOD=1 INTER`: ferx OFV −3737.39 vs NONMEM −3737.39, all θ/ω/σ to ~5 sig figs).

Independently, `time_builtin_direct_pk_mapping_matches_fd_of_production` pins the analytic gradient (value + ∂η + ∂²η + ∂θ + ∂²η∂θ) against central finite differences of the production predictor.

## Performance
- [x] Faster — a direct-mapping model now takes the analytic `Dual2`/`Dual1` gradient instead of per-parameter finite differences (same win as #637's `[individual_parameters]` path).

## Tests
- [x] Unit tests added in the same module (`cargo test --lib` passes — 2017)
- [x] Regression test added that fails without this fix (`time_builtin_direct_pk_mapping_matches_fd_of_production`; the flipped gate test `time_builtin_indiv_params_force_fd_fallback` also guards the model-level report)

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[structural_model]
  pk two_cpt_iv(cl=CL, v1=V1, q=TIME, v2=V2)
```

This is now exactly equivalent to, and as fast/accurate as:

```toml
[individual_parameters]
  QT = TIME
[structural_model]
  pk two_cpt_iv(cl=CL, v1=V1, q=QT, v2=V2)
```

Both fit with `gradient: analytic (Dual2)`.
</details>

## Docs
- [x] `docs/model-file/individual-parameters.qmd` updated (direct mapping now analytic)
- [x] `CHANGELOG.md` `[Unreleased]` entry updated (the #637 entry's "only the direct mapping stays FD" sentence now records it as covered)

## Checklist
- [x] `cargo clippy` clean (no new warnings; pre-existing baseline unchanged)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (no `sens/` change)
- [x] `Cargo.toml` version bump — not needed (non-breaking)

## Reviewer hints
The whole change is the desugar block in `parser/model_parser.rs` (right after the `pk_param_map` destructuring) plus the `PKTIME_SYNTH_PREFIX` constant and the one-line extension of `is_synthetic_readout_param`. Everything else is tests/docs. Key correctness point: the desugar runs **before** `pk_indices` / `build_pk_param_fn` consume `indiv_var_names`/`indiv_stmts`, and it makes `stmts_use_time` true (so `uses_time_builtin` stays set) while emptying `pk_time_mapping`.

## Open questions
The #486 matrix issue body still lists the direct mapping as the one `TIME` FD holdout; I'll flip it once this merges (consistent with how #637 was handled).
