### PR TITLE
test(estimation): tighten inner EBE tol in M3+IOV engine-consistency test

### DIFF
--- a/tests/iov_convergence.rs
+++ b/tests/iov_convergence.rs
@@ -679,6 +679,18 @@ fn iov_m3_ode_matches_closed_form_estimates() {
         opts.gradient_method = ferx_core::GradientMethod::Auto;
         opts.run_covariance_step = false;
         opts.verbose = false;
+        // Tighten the inner EBE tolerance (default 1e-5). This dataset has one
+        // heavily-censored subject whose M3 individual objective is extremely flat;
+        // at the default tolerance the inner optimizer stops short of that subject's
+        // EBE, and — because the two engines' predictions differ at the ~1e-10 level
+        // (closed form vs RK45) — the closed-form and ODE legs stop at *different*
+        // EBEs. Since #641 folds censored rows into log|H̃|, that EBE gap is amplified
+        // into a ~0.75 OFV / ~9% ω²_KA divergence between the two legs (a single-basin
+        // under-convergence, not two optima: at 1e-11 both legs converge to an
+        // identical minimum and every component agrees to ~5 s.f.). This is an
+        // engine-consistency test, so we tighten the inner loop to remove the
+        // under-convergence confound and compare the two engines at converged EBEs.
+        opts.inner_tol = 1e-11;
         fit(model, &pop, &model.default_params, &opts).expect("M3 + IOV fit runs")
     };
     let cf = run(&cf_model);
@@ -697,13 +709,13 @@ fn iov_m3_ode_matches_closed_form_estimates() {
         );
     }
 
-    // Same model, two prediction engines (closed form vs RK45) ⇒ the same optimum. Under
-    // the default L-BFGS both legs converge to identical estimates to ~6 sig figs
-    // (observed: TVCL/TVV/TVKA and ω_CL match to 6 decimals). Bands are kept at 1% on θ /
-    // 2% on variance components — far tighter than the ~2%/~20% an under-converging
-    // gradient optimizer produces on the flat CL valley, yet with enough slack to absorb
-    // platform/optimizer-version jitter. The OFV differs only by ~0.3 (fourth significant
-    // figure), the closed-form-vs-RK45 prediction difference through the censored marginal.
+    // Same model, two prediction engines (closed form vs RK45) ⇒ the same optimum. With
+    // the tightened inner EBE tolerance above, both legs converge to identical estimates
+    // to ~5 sig figs (observed: TVCL/TVV/TVKA, ω_CL, ω²_KA, Ω_iov, and σ all match to
+    // ~1e-4; OFV agrees to ~1e-5). Bands are kept at 1% on θ / 2% on variance components —
+    // far tighter than the ~2%/~9% an under-converged inner EBE produces on the flat
+    // censored subject at the default 1e-5 tolerance, yet with enough slack to absorb
+    // platform/optimizer-version jitter.
     assert!(
         (cf.ofv - ode.ofv).abs() < 0.5,
         "closed-form OFV {:.4} vs ODE OFV {:.4} must agree (same marginal, two engines)",


### PR DESCRIPTION
## Why

The nightly **slow-tests** job went red on `main` at #641 and has failed on every push since. The single failing test is `iov_m3_ode_matches_closed_form_estimates`, which checks that the closed-form and `[odes]` engines land on the same optimum for an M3 (BLOQ) + IOV fit:

```
M3+IOV closed-form vs ODE: OFV 383.26596 vs 382.49463   ← gap 0.771, band is < 0.5
  theta[0]: 0.174951 vs 0.173649  (0.74%)
  theta[2]: 1.166738 vs 1.176661  (0.85%)
```

The failure is deterministic (identical values across the #641/#643/#645 runs and reproduced locally).

## What changed

One line in the test's fit setup: `opts.inner_tol = 1e-11` (default is `1e-5`), plus an updated explanatory comment. No band changes, no core changes.

### Root cause (investigated, not a formula bug)

I decomposed the marginal objective term-by-term at matched population parameters. Findings:

- **The two engines are bit-identical on the non-censored objective** — dropping M3 makes them agree to `0.000000`. Censored-row predictions `f` also match to ~1e-10.
- **The entire gap comes from one heavily-censored subject.** 9 of 10 subjects match to ~1e-9; a single subject (`bloq≈19.5`) accounts for the whole 0.744 OFV gap. Its `eta_prior` differs by 0.46 (1.27 vs 0.81) — i.e. the two legs' **inner EBE landed at different points**.
- **It's inner-EBE under-convergence, single basin.** That subject's M3 individual objective is extremely flat; at `inner_tol=1e-5` the inner optimizer stops short, and the ~1e-10 closed-form-vs-RK45 prediction difference tips the two legs to different EBEs. #641 (which folds censored rows into `log|H̃|`) amplifies that EBE gap into the OFV/ω²_KA divergence. At `inner_tol=1e-11` both legs converge to an **identical** minimum:

```
inner_tol=1e-5  (default): OFV gap 0.771,  ω²_KA 9.21%   ← FAIL
inner_tol=1e-9           : OFV gap 0.054,  ω²_KA 4.48%   ← FAIL (flat ω²_KA direction)
inner_tol=1e-11          : OFV gap 0.00000, ω²_KA 0.01%  ← PASS, everything to ~5 s.f.
```

Since this is an *engine-consistency* test, tightening the inner loop removes the under-convergence confound and compares the two engines at converged EBEs — which is what the test means to check.

## Alternatives considered

- **Widen the OFV/variance bands** — rejected: the engines land ~9% apart on ω²_KA at the default tolerance, so widening would hide a real ~9% parameter discrepancy behind a green check.
- **Tighten the production default `inner_tol` globally (1e-5 → 1e-11)** — this would also fix the *production* under-convergence, but it's a 6-order change affecting every fit (perf + broad numerical re-validation). Out of scope for a red-test fix; see Open questions.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] The exact previously-failing test now passes with the original tight bands:

```
# before (main, inner_tol=1e-5)
M3+IOV closed-form vs ODE: OFV 383.26596 vs 382.49463   → gap 0.771 > 0.5  FAIL
ω²_KA: 0.029616 vs 0.026887 (9.21%)

# after (inner_tol=1e-11)
M3+IOV closed-form vs ODE: OFV 382.49463 vs 382.49463
  theta[0..2] all 0.00%;  ω²_KA 0.01%;  all bands pass
test result: ok. 1 passed
```

## Performance
- [x] No significant impact expected — change is confined to one slow-tests-gated test (already runs to convergence; the tighter inner loop converges within the default 200 inner iterations).

## Tests
- [x] The slow-gated `iov_m3_ode_matches_closed_form_estimates` passes locally under `--features slow-tests`.

## Docs & examples
- [x] No user-visible change.

## Reviewer hints

The whole change is `opts.inner_tol = 1e-11` in the `run` closure plus comment updates. The comment captures the root-cause chain (flat censored EBE → engine-dependent inner stop → amplified by #641's `log|H̃|` censored term).

## Open questions

The production default `inner_tol = 1e-5` genuinely under-converges heavily-censored M3+IOV EBEs (suboptimal OFV, ~9% ω²_KA on this dataset). Should we open a follow-up to consider tightening the default (or adding a censored-subject convergence polish), with its own perf + NONMEM re-validation? I kept it out of this PR deliberately.
