### PR TITLE
feat(estimation): analytic FOCE σ-magnitude gradient + raise theta cap to 32 [#486]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,12 @@ section of the SDLC for the versioning policy).
   (e.g. a late-phase RUV inflation `PROP_ERR * (1 + RUV_LATE * TIME/48)`).
   Validated against a live NONMEM FOCEI fit (OFV and every estimate, including
   `RUV_LATE`, match to ~4-5 significant figures — see `examples/warfarin_ruv_magnitude.ferx`).
-  `block_sigma` correlated residual error, `iiv_on_ruv`, an M3-BLOQ censored row,
-  more than 16 thetas, and plain `method = foce` (non-interaction) still fall back
+  Plain `method = foce` (non-interaction) now gets the analytic gradient too, on both
+  the non-IOV and IOV paths: the Sheiner–Beal marginal threads the magnitude into its
+  typical-value residual variance `R⁰` (value and direct-θ derivative), so `auto`
+  resolves a FOCE magnitude model to a gradient-based optimizer instead of BOBYQA. The
+  supported theta count is also raised from 16 to 32. `block_sigma` correlated residual
+  error, `iiv_on_ruv`, an M3-BLOQ censored row, and more than 32 thetas still fall back
   to the (magnitude-aware) finite-difference gradient.
 - **`init(...)` initial conditions with time-varying covariates** now get exact analytic
   FOCE/FOCEI sensitivities on the ODE path instead of finite differences (#486). The

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -103,17 +103,18 @@ A bare sigma name keeps the legacy behaviour exactly ($m_k \equiv 1$).
   `$ERROR`).
 - Supported for `method = foce` and `method = focei` only. SAEM, GN, GN-hybrid,
   and importance-sampling are rejected up front.
-- **Analytic gradient (#576/#486).** The inner EBE η-gradient and the FOCEI
-  outer θ/σ population gradient are both analytic for a magnitude-active model
-  — the magnitude is η-independent, so the inner loop just threads its
-  per-observation multiplier into the variance/its `f`-derivative; the outer
-  loop differentiates the magnitude program itself (a new *direct*-θ term in
-  `∂R/∂θ`, since `mult(θ)` enters the residual variance independent of the
-  prediction). A few combinations still fall back to finite differences (which
-  remain magnitude-aware, so fits stay correct, just slower): `block_sigma`
-  correlated residual error, `iiv_on_ruv`, an M3-BLOQ censored row, more than 16
-  thetas, and plain `method = foce` (non-interaction) — only FOCEI has the
-  direct-θ channel so far.
+- **Analytic gradient (#576/#486).** The inner EBE η-gradient and the outer
+  θ/σ population gradient are both analytic for a magnitude-active model under
+  **FOCE and FOCEI** — the magnitude is η-independent, so the inner loop just
+  threads its per-observation multiplier into the variance/its `f`-derivative;
+  the outer loop differentiates the magnitude program itself (a new *direct*-θ
+  term in `∂R/∂θ`, since `mult(θ)` enters the residual variance independent of
+  the prediction). For plain (non-interaction) **FOCE** the same magnitude enters
+  the Sheiner–Beal marginal through its typical-value residual variance `R⁰`
+  (value and direct-θ derivative), on both the non-IOV and IOV paths. A few
+  combinations still fall back to finite differences (which remain
+  magnitude-aware, so fits stay correct, just slower): `block_sigma` correlated
+  residual error, `iiv_on_ruv`, an M3-BLOQ censored row, and more than 32 thetas.
 
 ## Log-transform-both-sides (LTBS)
 

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -127,9 +127,9 @@ pub fn gradient_method_outer(
                     // Shared predicate (#490) — now IOV-aware via `iov_sens_supported`, which
                     // admits ODE IOV models too, so the reported method tracks the live outer
                     // dispatch (`outer_optimizer.rs`) for IOV as well (#466 review #4 / #439 IOV).
-                    // Interaction-aware (#486 review) so a custom-magnitude model under plain
-                    // FOCE — where the direct-θ channel isn't assembled — reports FD even when
-                    // the user forced a concrete gradient-based `optimizer` (bypassing `resolve_auto`).
+                    // Shared with `resolve_auto` so the reported method tracks the live outer
+                    // dispatch; a custom-magnitude model is analytic on both FOCE and FOCEI now
+                    // (#486 σ-magnitude FOCE port), so this no longer narrows by interaction.
                     if crate::sens::provider::analytic_outer_gradient_for_interaction(
                         model,
                         interaction,
@@ -271,35 +271,29 @@ mod tests {
         );
     }
 
-    /// #486 review: a custom residual-magnitude model's direct-θ channel is
-    /// FOCEI-only (`subject_packed_gradient_foce`/`_foce_iov` decline it), so
-    /// `gradient_method_outer` must report `FiniteDifferences` under plain
-    /// `method = foce` even though the model is otherwise in the
-    /// (interaction-agnostic) analytic-gradient scope — and `Analytic` under
-    /// `method = focei`. Regression test for the `resolve_auto`/reported-method
-    /// drift the fix closes.
+    /// #486 σ-magnitude FOCE port: a custom / time-varying residual-magnitude model
+    /// is now analytic on **both** loops (the Sheiner–Beal FOCE assembly threads
+    /// `mult(θ)` through its marginal `R⁰`), so `gradient_method_outer` reports
+    /// `Analytic` under plain `method = foce` as well as `method = focei`. Regression
+    /// test that FOCE no longer routes a magnitude model to FD.
     #[test]
-    fn outer_custom_magnitude_reports_fd_under_foce_analytic_under_focei() {
+    fn outer_custom_magnitude_reports_analytic_under_foce_and_focei() {
         let content = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  theta RUV_LATE(1.5, 0.0, 10.0)\n  omega ETA_CL ~ 0.09\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n";
         let m = crate::parser::model_parser::parse_model_string(content).expect("parse");
         assert!(m.has_custom_ruv_magnitude());
-        // `Optimizer::Auto` resolves to `Bobyqa` for FOCE + magnitude (no analytic
-        // gradient to feed a gradient-based optimizer) — which reports
-        // `NotApplicable` (derivative-free), like any other out-of-scope model
-        // (`outer_bobyqa_not_applicable`), not `FiniteDifferences`.
+        // `Optimizer::Auto` now resolves to a gradient-based optimizer under FOCE too,
+        // so the reported method is `Analytic` (not the old derivative-free bobyqa).
         assert_eq!(
             gradient_method_outer(&ad_build(), EstimationMethod::Foce, Optimizer::Auto, &m),
-            GradientMethodKind::NotApplicable,
-            "plain FOCE + custom magnitude has no analytic gradient, so auto picks bobyqa"
+            GradientMethodKind::Analytic,
+            "FOCE + custom magnitude now has the analytic outer gradient"
         );
         assert_eq!(
             gradient_method_outer(&ad_build(), EstimationMethod::FoceI, Optimizer::Auto, &m),
             GradientMethodKind::Analytic,
             "FOCEI + custom magnitude has the analytic outer gradient"
         );
-        // A user-forced concrete gradient optimizer bypasses `resolve_auto`'s own
-        // Bobyqa fallback, so the reported method must still gate on interaction
-        // independently at the `analytic_outer_gradient_for_interaction` check.
+        // A user-forced concrete gradient optimizer under FOCE also reports Analytic.
         assert_eq!(
             gradient_method_outer(
                 &ad_build(),
@@ -307,8 +301,8 @@ mod tests {
                 Optimizer::NloptLbfgs,
                 &m
             ),
-            GradientMethodKind::FiniteDifferences,
-            "a forced gradient-based optimizer must not flip the reported method to Analytic"
+            GradientMethodKind::Analytic,
+            "FOCE + magnitude with a forced gradient optimizer reports the analytic method"
         );
     }
 }

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -461,6 +461,11 @@ fn prepare(
 /// per-`(sigma, θ)` gradient. Diagonal-`R` only (`block_sigma` correlations force
 /// FD upstream via `analytic_outer_gradient_available`). Shared by the FOCEI
 /// (`prepare_stacked`) and FOCE (`subject_packed_gradient_foce{,_iov}`) paths.
+/// Returns `dr_dtheta` (the `∂R/∂θ` vector); if `dd_dtheta` is `Some`, also
+/// accumulates the `f`-derivative `∂d/∂θ` into it. The FOCEI `prepare_stacked`
+/// path needs both; the FOCE (Sheiner–Beal) marginal only reads `∂R/∂θ`, so it
+/// passes `None` and skips the `slopes` lookup and the `4·coeff·coeff'·…`
+/// accumulation entirely (#486 review).
 #[allow(clippy::too_many_arguments)]
 fn mag_variance_dtheta(
     error_spec: &crate::types::ErrorSpec,
@@ -471,28 +476,39 @@ fn mag_variance_dtheta(
     mult_grad_row: &[Vec<f64>],
     n_theta: usize,
     ruv_scale: f64,
-) -> (Vec<f64>, Vec<f64>) {
+    mut dd_dtheta: Option<&mut Vec<f64>>,
+) -> Vec<f64> {
     let loadings = error_spec.sigma_loadings(cmt, f, sigma.len());
-    let slopes = error_spec.sigma_loading_slopes(cmt, sigma.len());
+    let slopes = if dd_dtheta.is_some() {
+        error_spec.sigma_loading_slopes(cmt, sigma.len())
+    } else {
+        Vec::new()
+    };
     let mut dr_dtheta = vec![0.0f64; n_theta];
-    let mut dd_dtheta = vec![0.0f64; n_theta];
     for &(idx, coeff) in &loadings {
-        let coeff_p = slopes
-            .iter()
-            .find(|&&(i, _)| i == idx)
-            .map(|&(_, s)| s)
-            .unwrap_or(0.0);
         let sg = sigma.get(idx).copied().unwrap_or(0.0);
         let mv = mult_row.get(idx).copied().unwrap_or(1.0);
-        if let Some(dmi) = mult_grad_row.get(idx) {
-            for (tm, &dmdt_raw) in dmi.iter().enumerate().take(n_theta) {
-                let dmdt = dmdt_raw * ruv_scale;
-                dr_dtheta[tm] += 2.0 * coeff * coeff * mv * sg * sg * dmdt;
-                dd_dtheta[tm] += 4.0 * coeff * coeff_p * mv * sg * sg * dmdt;
+        let Some(dmi) = mult_grad_row.get(idx) else {
+            continue;
+        };
+        let coeff_p = if dd_dtheta.is_some() {
+            slopes
+                .iter()
+                .find(|&&(i, _)| i == idx)
+                .map(|&(_, s)| s)
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+        for (tm, &dmdt_raw) in dmi.iter().enumerate().take(n_theta) {
+            let dmdt = dmdt_raw * ruv_scale;
+            dr_dtheta[tm] += 2.0 * coeff * coeff * mv * sg * sg * dmdt;
+            if let Some(dd) = dd_dtheta.as_deref_mut() {
+                dd[tm] += 4.0 * coeff * coeff_p * mv * sg * sg * dmdt;
             }
         }
     }
-    (dr_dtheta, dd_dtheta)
+    dr_dtheta
 }
 
 /// The magnitude direct-θ derivative of the data-term coefficient `α` for one
@@ -707,7 +723,8 @@ fn prepare_stacked(
         // same bilinear shape `residual_error::diag_self_deriv` uses for the
         // `f`-derivative, just chain-ruled through `mult(θ)` instead of `f`.
         if let (Some(m), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
-            let (dr_dtheta, dd_dtheta) = mag_variance_dtheta(
+            let mut dd_dtheta = vec![0.0f64; n_theta];
+            let dr_dtheta = mag_variance_dtheta(
                 &model.error_spec,
                 cmt,
                 f,
@@ -716,6 +733,7 @@ fn prepare_stacked(
                 mg_row,
                 n_theta,
                 ruv_scale,
+                Some(&mut dd_dtheta),
             );
             t.dr_dtheta = dr_dtheta;
             t.dd_dtheta = dd_dtheta;
@@ -1781,8 +1799,9 @@ pub fn subject_packed_gradient_foce(
             None => model.error_spec.dvar_df(cmt, f0act, sigma),
         };
         if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
-            // `R⁰` at f(η=0), so `ruv_scale = 1` (no `iiv_on_ruv` on this path).
-            let (dr, _dd) = mag_variance_dtheta(
+            // `R⁰` at f(η=0), so `ruv_scale = 1` (no `iiv_on_ruv` on this path); the
+            // Sheiner–Beal marginal only needs `∂R/∂θ`, so skip the `∂d/∂θ` accumulation.
+            let dr = mag_variance_dtheta(
                 &model.error_spec,
                 cmt,
                 f0act,
@@ -1791,6 +1810,7 @@ pub fn subject_packed_gradient_foce(
                 mg_row,
                 n_theta,
                 1.0,
+                None,
             );
             dr0_dtheta[i] = dr;
         }
@@ -2080,7 +2100,9 @@ pub fn subject_eta_dx_iov(
     // Custom-magnitude support (#576/#486): `mult(θ)` adds a direct-θ term to the
     // inner `∂²l/∂η∂θ` (θ block) and makes `∂R/∂σ` magnitude-scaled (σ block below);
     // `None` for a bare-sigma model. See the non-IOV `subject_eta_dx` for the rationale.
-    let mult = model.ruv_obs_mult(subject, &params.theta);
+    // Reused from `Prep` (built once in `prepare_stacked`) — recomputing re-walks
+    // every magnitude expression per observation (#486 review).
+    let mult = &prep.mult;
 
     // θ coords.
     for m in 0..n_theta {
@@ -2325,7 +2347,8 @@ pub fn subject_packed_gradient_foce_iov(
             None => model.error_spec.dvar_df(cmt, f0act, sigma),
         };
         if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
-            let (dr, _dd) = mag_variance_dtheta(
+            // Sheiner–Beal marginal only needs `∂R/∂θ` → skip the `∂d/∂θ` accumulation.
+            let dr = mag_variance_dtheta(
                 &model.error_spec,
                 cmt,
                 f0act,
@@ -2334,6 +2357,7 @@ pub fn subject_packed_gradient_foce_iov(
                 mg_row,
                 n_theta,
                 1.0,
+                None,
             );
             dr0_dtheta[i] = dr;
         }
@@ -2553,7 +2577,9 @@ pub fn subject_eta_dx(
     // Custom-magnitude σ derivatives (#576/#486): `∂R/∂σ`/`∂d/∂σ` below must be taken
     // of the *scaled* variance (`et.r`/`et.d` already carry `mult`), else the σ
     // EBE-response is inconsistent for a magnitude model. `None` for a bare-sigma model.
-    let mult = model.ruv_obs_mult(subject, &params.theta);
+    // Reused from `Prep` (built once in `prepare`) rather than recomputed — `ruv_obs_mult`
+    // re-walks every magnitude expression per observation (#486 review).
+    let mult = &prep.mult;
 
     // Ω coords: M_L = −Ω⁻¹(e_row·(v·z) + v·z_row), v = L[:,col]; ×L_kk for diag-log.
     let z = &prep.omega_inv * DVector::from_column_slice(eta_hat);
@@ -7288,6 +7314,54 @@ mod tests {
             );
             approx::assert_relative_eq!(analytic[i], fd, max_relative = 3e-3, epsilon = 2e-5);
         }
+    }
+
+    /// A 1-cpt oral **user-`[odes]`** model with a TIME-varying proportional σ magnitude.
+    /// The closed-form magnitude tests above exercise only the *analytical* provider;
+    /// this pins the FOCE magnitude gradient on the **ODE provider path** — which the
+    /// gate change (`analytic_outer_gradient_for_interaction` no longer narrowing FOCE
+    /// magnitude to FD) newly routes to the analytic Sheiner–Beal gradient (#486 review).
+    const ONECPT_ODE_RUV_MAG: &str = r#"
+[parameters]
+  theta TVCL(0.2,  0.001, 10.0)
+  theta TVV(10.0,  0.1,  500.0)
+  theta TVKA(1.5,  0.01,  50.0)
+  theta RUV_LATE(1.5, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) =  KA * depot / V - (CL/V) * central
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))
+[fit_options]
+  method     = foce
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    /// FOCE σ-magnitude on the **ODE** provider path: the analytic packed gradient
+    /// (`population_gradient_sens_foce` over the event-driven `Dual1`/`Dual2` ODE walk)
+    /// must match reconverged-FD of the magnitude-aware FOCE marginal, every coordinate
+    /// — pins the path the gate change enabled but the closed-form tests don't cover.
+    #[test]
+    fn magnitude_foce_ode_packed_matches_fd() {
+        let model = parse_model_string(ONECPT_ODE_RUV_MAG).expect("parse ODE magnitude");
+        assert!(model.is_ode_based(), "must be on the ODE provider path");
+        assert!(model.has_custom_ruv_magnitude());
+        assert!(
+            crate::sens::provider::analytic_outer_gradient_available(&model),
+            "ODE FOCE magnitude must route to the analytic outer gradient"
+        );
+        run_packed_check_foce(&model, &[0.22, 11.0, 1.4, 1.6]);
     }
 
     /// Regression guard (#578-style): a bare-sigma (no custom magnitude) subject's

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -446,6 +446,80 @@ fn prepare(
     )
 }
 
+/// Direct-θ derivatives of a magnitude-scaled residual variance at prediction `f`.
+///
+/// A custom / time-varying σ magnitude `mult(θ)` (#484/#576/#486) makes the
+/// per-observation variance `R_j = Σ_s (coeff_s(f)·mult_sⱼ·σ_s)²` depend on θ
+/// **directly** (not only through `f`). Returns `(dr_dtheta, dd_dtheta)`, each
+/// length `n_theta`: the θ-gradient of `R_j` and of its `f`-derivative `d_j`,
+/// summed over the observation's sigma loadings as `2·coeff²·mult·σ²·∂mult/∂θ`
+/// and `4·coeff·coeff'·mult·σ²·∂mult/∂θ` — the same bilinear shape
+/// `residual_error::diag_self_deriv` uses for the `f`-derivative, chain-ruled
+/// through `mult(θ)` instead of `f`. `ruv_scale` folds the `iiv_on_ruv`
+/// `exp(2·η_ruv)` link (`1.0` on the FOCE / non-`ruv` path). `mult_row` is the
+/// per-sigma multiplier for this observation and `mult_grad_row` its
+/// per-`(sigma, θ)` gradient. Diagonal-`R` only (`block_sigma` correlations force
+/// FD upstream via `analytic_outer_gradient_available`). Shared by the FOCEI
+/// (`prepare_stacked`) and FOCE (`subject_packed_gradient_foce{,_iov}`) paths.
+#[allow(clippy::too_many_arguments)]
+fn mag_variance_dtheta(
+    error_spec: &crate::types::ErrorSpec,
+    cmt: usize,
+    f: f64,
+    sigma: &[f64],
+    mult_row: &[f64],
+    mult_grad_row: &[Vec<f64>],
+    n_theta: usize,
+    ruv_scale: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    let loadings = error_spec.sigma_loadings(cmt, f, sigma.len());
+    let slopes = error_spec.sigma_loading_slopes(cmt, sigma.len());
+    let mut dr_dtheta = vec![0.0f64; n_theta];
+    let mut dd_dtheta = vec![0.0f64; n_theta];
+    for &(idx, coeff) in &loadings {
+        let coeff_p = slopes
+            .iter()
+            .find(|&&(i, _)| i == idx)
+            .map(|&(_, s)| s)
+            .unwrap_or(0.0);
+        let sg = sigma.get(idx).copied().unwrap_or(0.0);
+        let mv = mult_row.get(idx).copied().unwrap_or(1.0);
+        if let Some(dmi) = mult_grad_row.get(idx) {
+            for (tm, &dmdt_raw) in dmi.iter().enumerate().take(n_theta) {
+                let dmdt = dmdt_raw * ruv_scale;
+                dr_dtheta[tm] += 2.0 * coeff * coeff * mv * sg * sg * dmdt;
+                dd_dtheta[tm] += 4.0 * coeff * coeff_p * mv * sg * sg * dmdt;
+            }
+        }
+    }
+    (dr_dtheta, dd_dtheta)
+}
+
+/// The magnitude direct-θ derivative of the data-term coefficient `α` for one
+/// observation `et` at θ-axis `m`:
+/// `∂α/∂θ = (2ε/R² + d(2ε²−R)/R³)·∂R/∂θ + ((R−ε²)/R²)·∂d/∂θ`, with `∂R/∂θ`,`∂d/∂θ`
+/// the magnitude's direct-θ terms (`et.dr_dtheta`/`et.dd_dtheta`). Zero when the
+/// observation carries no magnitude derivative. This is the EBE-response ingredient
+/// a custom / time-varying σ magnitude adds to the inner mixed derivative
+/// `∂²l/∂η∂θ` (#576/#486): FOCEI folds it into `theta_block`'s `m_vec`, FOCE picks
+/// it up through `subject_eta_dx{,_iov}`'s `dη̂/dθ` — this shared helper keeps the
+/// formula in one place.
+fn mag_alpha_dtheta(et: &ErrTerms, m: usize) -> f64 {
+    if et.dr_dtheta.is_empty() {
+        return 0.0;
+    }
+    let (r, d, eps) = (et.r, et.d, et.eps);
+    let (r_th, d_th) = (et.dr_dtheta[m], et.dd_dtheta[m]);
+    if r_th == 0.0 && d_th == 0.0 {
+        return 0.0;
+    }
+    let inv_r = 1.0 / r;
+    let inv_r2 = inv_r * inv_r;
+    let inv_r3 = inv_r2 * inv_r;
+    (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_th
+        + ((r - eps * eps) * inv_r2) * d_th
+}
+
 /// [`prepare`] generalized over the random-effect dimension and prior precision,
 /// so it serves both the non-IOV path (`n_eta = model.n_eta`, `Ω⁻¹ = params.omega.inv`)
 /// and the **IOV** path, where the random effects are the stacked
@@ -633,26 +707,16 @@ fn prepare_stacked(
         // same bilinear shape `residual_error::diag_self_deriv` uses for the
         // `f`-derivative, just chain-ruled through `mult(θ)` instead of `f`.
         if let (Some(m), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
-            let loadings = model.error_spec.sigma_loadings(cmt, f, sigma.len());
-            let slopes = model.error_spec.sigma_loading_slopes(cmt, sigma.len());
-            let mut dr_dtheta = vec![0.0f64; n_theta];
-            let mut dd_dtheta = vec![0.0f64; n_theta];
-            for &(idx, coeff) in &loadings {
-                let coeff_p = slopes
-                    .iter()
-                    .find(|&&(i, _)| i == idx)
-                    .map(|&(_, s)| s)
-                    .unwrap_or(0.0);
-                let sg = sigma.get(idx).copied().unwrap_or(0.0);
-                let mv = m.get(idx).copied().unwrap_or(1.0);
-                if let Some(dmi) = mg_row.get(idx) {
-                    for (tm, &dmdt_raw) in dmi.iter().enumerate().take(n_theta) {
-                        let dmdt = dmdt_raw * ruv_scale;
-                        dr_dtheta[tm] += 2.0 * coeff * coeff * mv * sg * sg * dmdt;
-                        dd_dtheta[tm] += 4.0 * coeff * coeff_p * mv * sg * sg * dmdt;
-                    }
-                }
-            }
+            let (dr_dtheta, dd_dtheta) = mag_variance_dtheta(
+                &model.error_spec,
+                cmt,
+                f,
+                sigma,
+                m,
+                mg_row,
+                n_theta,
+                ruv_scale,
+            );
             t.dr_dtheta = dr_dtheta;
             t.dd_dtheta = dd_dtheta;
         }
@@ -924,9 +988,8 @@ fn theta_block(prep: &Prep, sens: &SubjectSens, n_theta: usize) -> Vec<f64> {
             // log|H̃|:  ½ (∂p/∂θ) q ,  ∂p/∂θ = −Rθ/R² + d·dθ/R² − d²Rθ/R³.
             let dp = -r_th * inv_r2 + d * d_th * inv_r2 - d * d * r_th * inv_r3;
             g += 0.5 * dp * prep.q[j];
-            // ∂α/∂θ = [2ε/R² + d(2ε²−R)/R³] Rθ + [(R−ε²)/R²] dθ, folded into M[:,m].
-            let dalpha = (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_th
-                + ((r - eps * eps) * inv_r2) * d_th;
+            // ∂α/∂θ folded into M[:,m] (shared with the FOCE EBE-response).
+            let dalpha = mag_alpha_dtheta(et, m);
             for k in 0..n_eta {
                 m_vec[k] += 0.5 * dalpha * sens.obs[j].df_deta[k];
             }
@@ -1632,18 +1695,9 @@ pub fn subject_packed_gradient_foce(
     x: &[f64],
     eta_hat: &[f64],
 ) -> Option<Vec<f64>> {
-    // Custom / time-varying residual-magnitude (#484/#576/#486): only the
-    // FOCEI (interaction) path above threads `mult(θ)` through `prepare_stacked`/
-    // `theta_block`/`sigma_block` so far. The Sheiner–Beal FOCE (non-interaction)
-    // assembly here still reads the bare `variance_at`/`dvar_df` at `f(η=0)`, so a
-    // magnitude-active model would silently drop the direct-θ term — decline and
-    // let the caller fall back to FD (which is magnitude-aware) until this path
-    // gets its own `mult` threading.
-    if model.has_custom_ruv_magnitude() {
-        return None;
-    }
     let params = unpack_params(x, template);
     let n_eta = model.n_eta;
+    let n_theta = params.theta.len();
     let n_obs = subject.observations.len();
     if n_obs == 0 {
         return Some(vec![0.0; x.len()]);
@@ -1675,9 +1729,30 @@ pub fn subject_packed_gradient_foce(
         return None;
     }
 
+    // Custom / time-varying residual-magnitude (#484/#576/#486): thread `mult(θ)`
+    // into the Sheiner–Beal marginal — its *value* scales `R⁰` (`variance_at_scaled`
+    // below) and its `∂/∂θ` enters the θ-block's `∂R⁰/∂θ` term directly (not only
+    // through `f`). Magnitude + an M3-censored row keeps FD (the censored tail's
+    // direct-θ chain is unbuilt — mirrors the FOCEI carve-out in `prepare_stacked`);
+    // magnitude + `iiv_on_ruv` is excluded model-level (`analytic_outer_gradient_
+    // available` requires `residual_error_eta.is_none()` when a magnitude is active),
+    // so `R⁰` here carries no `iiv_on_ruv` `exp(2·η_ruv)` scaling (`ruv_scale ≡ 1`).
+    let mult = model.ruv_obs_mult(subject, &params.theta);
+    if mult.is_some() && m3 {
+        return None;
+    }
+    let mult_grad = if mult.is_some() {
+        Some(model.ruv_obs_mult_theta_grad(subject, &params.theta)?)
+    } else {
+        None
+    };
+
     // J = ∂f/∂η (nq×n_eta), ρ = y − f0 = ε + J·η̂, R⁰ and d⁰ at f(η=0) — quant rows.
+    // `dr0_dtheta[i]` is the magnitude's direct-θ derivative of `R⁰ᵢ` (empty when no
+    // magnitude), consumed by the θ-block below.
     let mut jmat = DMatrix::<f64>::zeros(nq, n_eta);
     let mut rho = DVector::<f64>::zeros(nq);
+    let mut dr0_dtheta: Vec<Vec<f64>> = vec![Vec::new(); nq];
     let mut r0 = vec![0.0f64; nq];
     let mut d0 = vec![0.0f64; nq];
     for (i, &j) in quant.iter().enumerate() {
@@ -1690,12 +1765,35 @@ pub fn subject_packed_gradient_foce(
         rho[i] = subject.observations[j] - (obs.f - jeta);
         let cmt = subject.obs_cmts[j];
         let f0act = sens0.obs[j].f;
-        let r = model.error_spec.variance_at(cmt, f0act, sigma);
+        let mult_row: Option<&[f64]> = mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+        let r = match mult_row {
+            Some(mm) => model
+                .error_spec
+                .variance_at_scaled(cmt, f0act, sigma, &[], mm),
+            None => model.error_spec.variance_at(cmt, f0act, sigma),
+        };
         if !(r.is_finite() && r > 0.0) {
             return None;
         }
         r0[i] = r;
-        d0[i] = model.error_spec.dvar_df(cmt, f0act, sigma);
+        d0[i] = match mult_row {
+            Some(mm) => model.error_spec.dvar_df_scaled(cmt, f0act, sigma, mm),
+            None => model.error_spec.dvar_df(cmt, f0act, sigma),
+        };
+        if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
+            // `R⁰` at f(η=0), so `ruv_scale = 1` (no `iiv_on_ruv` on this path).
+            let (dr, _dd) = mag_variance_dtheta(
+                &model.error_spec,
+                cmt,
+                f0act,
+                sigma,
+                mm,
+                mg_row,
+                n_theta,
+                1.0,
+            );
+            dr0_dtheta[i] = dr;
+        }
     }
 
     // R̃ = J Ω Jᵀ + diag(R⁰) over quant rows; u = R̃⁻¹ ρ; ΩJᵀ reused throughout.
@@ -1708,7 +1806,6 @@ pub fn subject_packed_gradient_foce(
     let u = &rtilde_inv * &rho;
     let ojt = omega * jmat.transpose(); // Ω Jᵀ (n_eta×nq)
 
-    let n_theta = params.theta.len();
     let n_sigma = sigma.len();
     let mut fixed = vec![0.0f64; x.len()];
 
@@ -1733,7 +1830,12 @@ pub fn subject_packed_gradient_foce(
                 bjeta += bjl_m * eta_hat[l];
             }
             qm[i] = -obs.df_dtheta[m] + bjeta;
-            let dr0 = d0[i] * sens0.obs[j].df_dtheta[m];
+            // ∂R⁰ᵢ/∂θₘ = d⁰ᵢ·∂f0ᵢ/∂θₘ (through the prediction) + the magnitude's
+            // *direct*-θ term `dr0_dtheta[i][m]` (empty ⇒ no magnitude, #576/#486).
+            let mut dr0 = d0[i] * sens0.obs[j].df_dtheta[m];
+            if !dr0_dtheta[i].is_empty() {
+                dr0 += dr0_dtheta[i][m];
+            }
             dvar += dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
         }
         let emojt = &em * &ojt;
@@ -1789,9 +1891,25 @@ pub fn subject_packed_gradient_foce(
         for (i, &j) in quant.iter().enumerate() {
             let cmt = subject.obs_cmts[j];
             let f0act = sens0.obs[j].f;
-            let dr0 = (model.error_spec.variance_at(cmt, f0act, &sp)
-                - model.error_spec.variance_at(cmt, f0act, &sm))
-                / (2.0 * hsig);
+            // ∂R⁰/∂σ carries the magnitude multiplier (`mult` scales the σ loading),
+            // so FD the *scaled* variance when a magnitude is active (#576/#486).
+            let mult_row: Option<&[f64]> =
+                mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+            let (vp, vm) = match mult_row {
+                Some(mm) => (
+                    model
+                        .error_spec
+                        .variance_at_scaled(cmt, f0act, &sp, &[], mm),
+                    model
+                        .error_spec
+                        .variance_at_scaled(cmt, f0act, &sm, &[], mm),
+                ),
+                None => (
+                    model.error_spec.variance_at(cmt, f0act, &sp),
+                    model.error_spec.variance_at(cmt, f0act, &sm),
+                ),
+            };
+            let dr0 = (vp - vm) / (2.0 * hsig);
             nat += 0.5 * dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
         }
         nat += cg.sigma[k];
@@ -1959,6 +2077,11 @@ pub fn subject_eta_dx_iov(
     let n_sigma = params.sigma.values.len();
     let mut out: Vec<DVector<f64>> = vec![DVector::zeros(n_st); x.len()];
 
+    // Custom-magnitude support (#576/#486): `mult(θ)` adds a direct-θ term to the
+    // inner `∂²l/∂η∂θ` (θ block) and makes `∂R/∂σ` magnitude-scaled (σ block below);
+    // `None` for a bare-sigma model. See the non-IOV `subject_eta_dx` for the rationale.
+    let mult = model.ruv_obs_mult(subject, &params.theta);
+
     // θ coords.
     for m in 0..n_theta {
         let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
@@ -1966,7 +2089,15 @@ pub fn subject_eta_dx_iov(
         } else {
             1.0
         };
-        let mvec = mixed_eta_theta(&sens.obs, &prep.et, n_st, prep.n_obs, m, prep.ruv);
+        let mut mvec = mixed_eta_theta(&sens.obs, &prep.et, n_st, prep.n_obs, m, prep.ruv);
+        for (j, et) in prep.et.iter().enumerate() {
+            let dalpha = mag_alpha_dtheta(et, m);
+            if dalpha != 0.0 {
+                for kk in 0..n_st {
+                    mvec[kk] += 0.5 * dalpha * sens.obs[j].df_deta[kk];
+                }
+            }
+        }
         out[m] = -(&prep.h_inner_inv * mvec) * dtheta_dx;
     }
 
@@ -2041,12 +2172,25 @@ pub fn subject_eta_dx_iov(
                 continue;
             }
             let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
-            let r_sig = (model.error_spec.variance_at(cmt, f, &sp)
-                - model.error_spec.variance_at(cmt, f, &sm))
-                / (2.0 * h);
-            let d_sig = (model.error_spec.dvar_df(cmt, f, &sp)
-                - model.error_spec.dvar_df(cmt, f, &sm))
-                / (2.0 * h);
+            // Magnitude-scaled `∂R/∂σ`,`∂d/∂σ` (consistent with the scaled `et.r`/`et.d`).
+            let mult_row: Option<&[f64]> =
+                mult.as_ref().and_then(|mm| mm.get(j)).map(|v| v.as_slice());
+            let (var_p, var_m, dvar_p, dvar_m) = match mult_row {
+                Some(mm) => (
+                    model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
+                    model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
+                ),
+                None => (
+                    model.error_spec.variance_at(cmt, f, &sp),
+                    model.error_spec.variance_at(cmt, f, &sm),
+                    model.error_spec.dvar_df(cmt, f, &sp),
+                    model.error_spec.dvar_df(cmt, f, &sm),
+                ),
+            };
+            let r_sig = (var_p - var_m) / (2.0 * h);
+            let d_sig = (dvar_p - dvar_m) / (2.0 * h);
             let inv_r = 1.0 / r;
             let inv_r2 = inv_r * inv_r;
             let inv_r3 = inv_r2 * inv_r;
@@ -2085,13 +2229,8 @@ pub fn subject_packed_gradient_foce_iov(
     x: &[f64],
     stacked_eta_hat: &[f64],
 ) -> Option<Vec<f64>> {
-    // Custom / time-varying residual-magnitude (#484/#576/#486): not yet threaded
-    // through this Sheiner–Beal (non-interaction) IOV assembly — see the non-IOV
-    // sibling `subject_packed_gradient_foce` for the same decline.
-    if model.has_custom_ruv_magnitude() {
-        return None;
-    }
     let params = unpack_params(x, template);
+    let n_theta = params.theta.len();
     let sens = crate::sens::provider::subject_sensitivities_iov(
         model,
         subject,
@@ -2139,11 +2278,27 @@ pub fn subject_packed_gradient_foce_iov(
         return None;
     }
 
+    // Custom / time-varying residual-magnitude (#484/#576/#486): thread `mult(θ)`
+    // into the stacked-`[η_bsv,κ]` Sheiner–Beal marginal — same shape as the non-IOV
+    // sibling `subject_packed_gradient_foce`. Magnitude + M3-censored keeps FD;
+    // magnitude + `iiv_on_ruv` is excluded model-level (`ruv_scale ≡ 1` here — IOV
+    // forces `ruv = None` and the analytic gate requires `residual_error_eta.is_none()`).
+    let mult = model.ruv_obs_mult(subject, &params.theta);
+    if mult.is_some() && m3 {
+        return None;
+    }
+    let mult_grad = if mult.is_some() {
+        Some(model.ruv_obs_mult_theta_grad(subject, &params.theta)?)
+    } else {
+        None
+    };
+
     // J = ∂f/∂[η,κ] (nq×n_st), ρ = ε + J·b̂, R⁰ and d⁰ at f(all-zero) — quant rows.
     let mut jmat = DMatrix::<f64>::zeros(nq, n_st);
     let mut rho = DVector::<f64>::zeros(nq);
     let mut r0 = vec![0.0f64; nq];
     let mut d0 = vec![0.0f64; nq];
+    let mut dr0_dtheta: Vec<Vec<f64>> = vec![Vec::new(); nq];
     for (i, &j) in quant.iter().enumerate() {
         let obs = &sens.obs[j];
         let mut jeta = 0.0;
@@ -2154,12 +2309,34 @@ pub fn subject_packed_gradient_foce_iov(
         rho[i] = subject.observations[j] - (obs.f - jeta);
         let cmt = subject.obs_cmts[j];
         let f0act = sens0.obs[j].f;
-        let r = model.error_spec.variance_at(cmt, f0act, sigma);
+        let mult_row: Option<&[f64]> = mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+        let r = match mult_row {
+            Some(mm) => model
+                .error_spec
+                .variance_at_scaled(cmt, f0act, sigma, &[], mm),
+            None => model.error_spec.variance_at(cmt, f0act, sigma),
+        };
         if !(r.is_finite() && r > 0.0) {
             return None;
         }
         r0[i] = r;
-        d0[i] = model.error_spec.dvar_df(cmt, f0act, sigma);
+        d0[i] = match mult_row {
+            Some(mm) => model.error_spec.dvar_df_scaled(cmt, f0act, sigma, mm),
+            None => model.error_spec.dvar_df(cmt, f0act, sigma),
+        };
+        if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
+            let (dr, _dd) = mag_variance_dtheta(
+                &model.error_spec,
+                cmt,
+                f0act,
+                sigma,
+                mm,
+                mg_row,
+                n_theta,
+                1.0,
+            );
+            dr0_dtheta[i] = dr;
+        }
     }
 
     let jo = &jmat * &omega_full;
@@ -2171,7 +2348,6 @@ pub fn subject_packed_gradient_foce_iov(
     let u = &rtilde_inv * &rho;
     let ojt = &omega_full * jmat.transpose();
 
-    let n_theta = params.theta.len();
     let n_sigma = sigma.len();
     let mut fixed = vec![0.0f64; x.len()];
 
@@ -2205,7 +2381,11 @@ pub fn subject_packed_gradient_foce_iov(
                 bjeta += bjl * stacked_eta_hat[l];
             }
             qm[i] = -obs.df_dtheta[m] + bjeta;
-            let dr0 = d0[i] * sens0.obs[j].df_dtheta[m];
+            // ∂R⁰ᵢ/∂θₘ = d⁰ᵢ·∂f0ᵢ/∂θₘ + the magnitude's direct-θ term (#576/#486).
+            let mut dr0 = d0[i] * sens0.obs[j].df_dtheta[m];
+            if !dr0_dtheta[i].is_empty() {
+                dr0 += dr0_dtheta[i][m];
+            }
             dvar += dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
         }
         let emojt = &em * &ojt;
@@ -2256,9 +2436,24 @@ pub fn subject_packed_gradient_foce_iov(
         for (i, &j) in quant.iter().enumerate() {
             let cmt = subject.obs_cmts[j];
             let f0act = sens0.obs[j].f;
-            let dr0 = (model.error_spec.variance_at(cmt, f0act, &sp)
-                - model.error_spec.variance_at(cmt, f0act, &sm))
-                / (2.0 * hsig);
+            // Magnitude-aware ∂R⁰/∂σ (the multiplier scales the σ loading) — #576/#486.
+            let mult_row: Option<&[f64]> =
+                mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+            let (vp, vm) = match mult_row {
+                Some(mm) => (
+                    model
+                        .error_spec
+                        .variance_at_scaled(cmt, f0act, &sp, &[], mm),
+                    model
+                        .error_spec
+                        .variance_at_scaled(cmt, f0act, &sm, &[], mm),
+                ),
+                None => (
+                    model.error_spec.variance_at(cmt, f0act, &sp),
+                    model.error_spec.variance_at(cmt, f0act, &sm),
+                ),
+            };
+            let dr0 = (vp - vm) / (2.0 * hsig);
             nat += 0.5 * dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
         }
         nat += cg.sigma[kk];
@@ -2337,9 +2532,28 @@ pub fn subject_eta_dx(
         } else {
             1.0
         };
-        let mvec = mixed_eta_theta(&sens.obs, &prep.et, n_eta, prep.n_obs, m, prep.ruv);
+        let mut mvec = mixed_eta_theta(&sens.obs, &prep.et, n_eta, prep.n_obs, m, prep.ruv);
+        // Custom / time-varying σ magnitude (#576/#486): `mult(θ)` makes the inner
+        // variance depend on θ directly, adding `½ ∂α/∂θ · a` to `∂²l/∂η∂θ` — the
+        // EBE-response term FOCEI folds into `theta_block`'s `m_vec`. FOCE reaches it
+        // only here, so without this its `dη̂/dθ` (and the coupling term built on it)
+        // silently drops the magnitude θ's contribution. No-op for a bare-sigma model
+        // (`dr_dtheta` empty ⇒ `mag_alpha_dtheta` returns 0).
+        for (j, et) in prep.et.iter().enumerate() {
+            let dalpha = mag_alpha_dtheta(et, m);
+            if dalpha != 0.0 {
+                for k in 0..n_eta {
+                    mvec[k] += 0.5 * dalpha * sens.obs[j].df_deta[k];
+                }
+            }
+        }
         out[m] = -(&prep.h_inner_inv * mvec) * dtheta_dx;
     }
+
+    // Custom-magnitude σ derivatives (#576/#486): `∂R/∂σ`/`∂d/∂σ` below must be taken
+    // of the *scaled* variance (`et.r`/`et.d` already carry `mult`), else the σ
+    // EBE-response is inconsistent for a magnitude model. `None` for a bare-sigma model.
+    let mult = model.ruv_obs_mult(subject, &params.theta);
 
     // Ω coords: M_L = −Ω⁻¹(e_row·(v·z) + v·z_row), v = L[:,col]; ×L_kk for diag-log.
     let z = &prep.omega_inv * DVector::from_column_slice(eta_hat);
@@ -2407,15 +2621,27 @@ pub fn subject_eta_dx(
                 continue;
             }
             let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
-            // `et.r`/`et.d` carry the `exp(2·η_ruv)` scale, so lift `∂R/∂σ`,`∂d/∂σ`
-            // too (mirrors `sigma_block`); `ruv_scale == 1` when there is no ruv.
-            let r_sig = prep.ruv_scale
-                * (model.error_spec.variance_at(cmt, f, &sp)
-                    - model.error_spec.variance_at(cmt, f, &sm))
-                / (2.0 * h);
-            let d_sig = prep.ruv_scale
-                * (model.error_spec.dvar_df(cmt, f, &sp) - model.error_spec.dvar_df(cmt, f, &sm))
-                / (2.0 * h);
+            // `et.r`/`et.d` carry the `exp(2·η_ruv)` scale *and* any custom-magnitude
+            // `mult`, so lift `∂R/∂σ`,`∂d/∂σ` the same way (mirrors `sigma_block`);
+            // `ruv_scale == 1` when there is no ruv, `mult_row = None` for bare sigma.
+            let mult_row: Option<&[f64]> =
+                mult.as_ref().and_then(|mm| mm.get(j)).map(|v| v.as_slice());
+            let (var_p, var_m, dvar_p, dvar_m) = match mult_row {
+                Some(mm) => (
+                    model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
+                    model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
+                    model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
+                ),
+                None => (
+                    model.error_spec.variance_at(cmt, f, &sp),
+                    model.error_spec.variance_at(cmt, f, &sm),
+                    model.error_spec.dvar_df(cmt, f, &sp),
+                    model.error_spec.dvar_df(cmt, f, &sm),
+                ),
+            };
+            let r_sig = prep.ruv_scale * (var_p - var_m) / (2.0 * h);
+            let d_sig = prep.ruv_scale * (dvar_p - dvar_m) / (2.0 * h);
             let inv_r = 1.0 / r;
             let inv_r2 = inv_r * inv_r;
             let inv_r3 = inv_r2 * inv_r;
@@ -5361,6 +5587,12 @@ mod tests {
         // returns `1.0` for non-`iiv_on_ruv` models, so this is a no-op there.
         let ruv_idx = model.residual_error_eta;
         let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
+        // Custom / time-varying σ magnitude (#576/#486): the Newton must minimise the
+        // *scaled* inner objective (like `precise_ebe`), else it converges to the bare
+        // EBE and the coupling identity the FOCE-IOV gradient relies on breaks (the
+        // reconverged-FD marginal would then disagree on the structural/Ω coordinates).
+        // `None` for a bare-sigma model → the non-scaled arm below (bit-identical).
+        let mult = model.ruv_obs_mult(subject, &params.theta);
         for _ in 0..50 {
             let ruv_scale = model.residual_var_scale(&stacked);
             let sens = crate::sens::provider::subject_sensitivities_iov(
@@ -5375,9 +5607,20 @@ mod tests {
             for (j, obs) in sens.obs.iter().enumerate() {
                 let cmt = subject.obs_cmts[j];
                 let f = obs.f;
-                let r = model.error_spec.variance_at(cmt, f, sigma) * ruv_scale;
-                let d = model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale;
-                let d2 = model.error_spec.d2var_df2(cmt, sigma) * ruv_scale;
+                let mult_row: Option<&[f64]> =
+                    mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+                let (r, d, d2) = match mult_row {
+                    Some(m) => (
+                        model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m) * ruv_scale,
+                        model.error_spec.dvar_df_scaled(cmt, f, sigma, m) * ruv_scale,
+                        model.error_spec.d2var_df2_scaled(cmt, sigma, m) * ruv_scale,
+                    ),
+                    None => (
+                        model.error_spec.variance_at(cmt, f, sigma) * ruv_scale,
+                        model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale,
+                        model.error_spec.d2var_df2(cmt, sigma) * ruv_scale,
+                    ),
+                };
                 let y = subject.observations[j];
                 let eps = y - f;
                 // (g1, g2) = (∂L/∂f, ∂²L/∂f²): the censored `−logΦ` scalars for an M3 BLOQ
@@ -6888,6 +7131,163 @@ mod tests {
         let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
         let subject = subject_with_obs(&model, &theta, &times);
         check_magnitude_outer_gradient_matches_fd(&model, &theta, &subject);
+    }
+
+    /// FOCE (non-interaction) analog of `check_magnitude_outer_gradient_matches_fd`:
+    /// the analytic FOCE packed gradient of a magnitude-active subject must match the
+    /// reconverged-FD of ferx's own (magnitude-aware) Sheiner–Beal marginal, across
+    /// every packed θ/Ω/σ coordinate. Exercises the direct-θ `∂R⁰/∂θ` term and the
+    /// magnitude-scaled `R⁰`/`∂R⁰/∂σ` the FOCE port threads in (#486).
+    fn check_magnitude_foce_packed_matches_fd(
+        model: &CompiledModel,
+        theta: &[f64],
+        subject: &Subject,
+    ) {
+        assert!(
+            model.has_custom_ruv_magnitude(),
+            "fixture must carry an active custom magnitude"
+        );
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let eta_hat = precise_ebe(model, subject, &params);
+        let analytic = subject_packed_gradient_foce(model, subject, &template, &x, &eta_hat)
+            .expect("FOCE magnitude packed gradient supported");
+        assert!(
+            analytic.iter().all(|v| v.is_finite()),
+            "FOCE magnitude packed gradient must be finite"
+        );
+        // FD of the (magnitude-aware) FOCE marginal, reconverging the EBE per point.
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            marginal_nll_foce(model, subject, &p)
+        };
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.clone();
+            xp[k] += h;
+            let mut xm = x.clone();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
+            eprintln!(
+                "foce magnitude x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic[k],
+                fd,
+                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
+        }
+    }
+
+    #[test]
+    fn magnitude_time_family_foce_packed_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_TIME).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 1.6];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let subject = subject_with_obs(&model, &theta, &times);
+        check_magnitude_foce_packed_matches_fd(&model, &theta, &subject);
+    }
+
+    #[test]
+    fn magnitude_covariate_family_foce_packed_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_COV).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 0.012];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let mut subject = subject_with_obs(&model, &theta, &times);
+        subject.covariates = HashMap::from([("WT".to_string(), 82.0)]);
+        check_magnitude_foce_packed_matches_fd(&model, &theta, &subject);
+    }
+
+    #[test]
+    fn magnitude_theta_family_foce_packed_matches_fd() {
+        let model = parse_model_string(WARFARIN_RUV_THETA).expect("parse");
+        let theta = vec![0.22, 11.0, 1.4, 1.3];
+        let times = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 48.0];
+        let subject = subject_with_obs(&model, &theta, &times);
+        check_magnitude_foce_packed_matches_fd(&model, &theta, &subject);
+    }
+
+    /// [`WARFARIN_IOV`] + a TIME-varying proportional σ magnitude — drives the
+    /// **FOCE-IOV** magnitude packed gradient (`subject_packed_gradient_foce_iov`).
+    const WARFARIN_IOV_RUV_MAG: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta RUV_LATE(1.5, 0.1, 10.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  kappa KAPPA_CL ~ 0.02
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))
+[fit_options]
+  method     = foce
+  iov_column = OCC
+"#;
+
+    /// FOCE-IOV magnitude: the analytic stacked-`[η_bsv,κ]` FOCE packed gradient must
+    /// match reconverged-FD of the (magnitude-aware) FOCE-IOV Sheiner–Beal marginal,
+    /// across every packed θ/Ω_bsv/σ/Ω_iov coordinate (#486, the IOV twin of the
+    /// non-IOV FOCE magnitude tests above).
+    #[test]
+    fn magnitude_foce_iov_packed_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        let model = parse_model_string(WARFARIN_IOV_RUV_MAG).expect("parse");
+        assert!(model.has_custom_ruv_magnitude());
+        assert!(model.n_kappa > 0, "fixture must carry IOV");
+        let theta = vec![0.22, 11.0, 1.4, 1.6];
+        let mut params = model.default_params.clone();
+        params.theta = theta.clone();
+        let subject = iov_subject_outer(&model, &theta);
+        let template = params.clone();
+        let x = pack_params(&params);
+        let (stacked, _e, _k, _h) = precise_ebe_iov(&model, &subject, &params);
+        let analytic = subject_packed_gradient_foce_iov(&model, &subject, &template, &x, &stacked)
+            .expect("FOCE-IOV magnitude packed gradient supported");
+        assert!(
+            analytic.iter().all(|v| v.is_finite()),
+            "FOCE-IOV magnitude packed gradient must be finite"
+        );
+        // FD reference must be the FOCE (non-interaction) marginal — matching the
+        // gradient under test (`marginal_nll_iov` is the FOCEI variant).
+        let f = |xx: &[f64]| -> f64 {
+            let p = unpack_params(xx, &template);
+            marginal_nll_iov_inter(&model, &subject, &p, false)
+        };
+        for i in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[i].abs());
+            let fd_at = |hh: f64| -> f64 {
+                let mut xp = x.clone();
+                xp[i] += hh;
+                let mut xm = x.clone();
+                xm[i] -= hh;
+                (f(&xp) - f(&xm)) / (2.0 * hh)
+            };
+            let f1 = fd_at(h);
+            let f2 = fd_at(h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
+            eprintln!(
+                "foce-iov magnitude x[{i}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic[i],
+                fd,
+                (analytic[i] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(analytic[i], fd, max_relative = 3e-3, epsilon = 2e-5);
+        }
     }
 
     /// Regression guard (#578-style): a bare-sigma (no custom magnitude) subject's

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -11955,11 +11955,14 @@ pub struct RuvMagDerivProgram {
 }
 
 /// Axis cap for the `Dual1<M>` dispatch table in [`RuvMagDerivProgram::theta_grad`]
-/// (mirrors the `MAX_SCALE_AXES` / `MAX_ODE_AXES` convention elsewhere). A model
+/// (same const-generic-dispatch convention as `MAX_SCALE_AXES` / `MAX_ODE_AXES`,
+/// but set higher — the magnitude program's bytecode evaluator is cheap to
+/// monomorphize, and covering realistic large-θ population models keeps the
+/// magnitude direct-θ channel analytic rather than dropping to FD, #486). A model
 /// with more thetas than this falls back to FD for the magnitude's direct-θ
 /// gradient channel — `analytic_outer_gradient_available` bounds `model.n_theta`
 /// against this constant when a custom magnitude is active.
-pub(crate) const MAX_RUV_MAG_AXES: usize = 16;
+pub(crate) const MAX_RUV_MAG_AXES: usize = 32;
 
 impl RuvMagDerivProgram {
     /// `∂(magnitude)/∂θ` at `theta` (with the observation's covariates and raw
@@ -12046,6 +12049,22 @@ impl RuvMagDerivProgram {
             14 => run!(14),
             15 => run!(15),
             16 => run!(16),
+            17 => run!(17),
+            18 => run!(18),
+            19 => run!(19),
+            20 => run!(20),
+            21 => run!(21),
+            22 => run!(22),
+            23 => run!(23),
+            24 => run!(24),
+            25 => run!(25),
+            26 => run!(26),
+            27 => run!(27),
+            28 => run!(28),
+            29 => run!(29),
+            30 => run!(30),
+            31 => run!(31),
+            32 => run!(32),
             _ => return None,
         })
     }
@@ -13673,6 +13692,56 @@ fn parse_if_statement(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #486: the residual-magnitude direct-θ program dispatches its `Dual1<M>`
+    /// evaluator for every axis count up to [`MAX_RUV_MAG_AXES`] (raised past 16),
+    /// and declines (`None`, caller → FD) only beyond it. `mult = θ_last · σ̂` (σ̂
+    /// pinned to 1.0), so `∂mult/∂θ_last = 1` and all other axes are 0 — a cheap
+    /// exact check that each newly-added dispatch arm is wired.
+    #[test]
+    fn ruv_mag_theta_grad_dispatches_up_to_axis_cap() {
+        use std::collections::HashMap;
+        assert!(MAX_RUV_MAG_AXES >= 17, "cap must be raised past the old 16");
+        let cov = HashMap::new();
+        for n in [1usize, 16, 17, 24, MAX_RUV_MAG_AXES] {
+            let expr = Expression::BinOp(
+                Box::new(Expression::Theta(n - 1)),
+                BinOp::Mul,
+                Box::new(Expression::Variable("PROP".to_string())),
+            );
+            let prog = compile_ruv_mag_deriv_program(&expr, "PROP", n);
+            let theta = vec![0.5f64; n];
+            let grad = prog
+                .theta_grad(&theta, &cov, 0.0)
+                .unwrap_or_else(|| panic!("theta_grad must dispatch for n_theta = {n}"));
+            assert_eq!(grad.len(), n);
+            assert!(
+                (grad[n - 1] - 1.0).abs() < 1e-9,
+                "∂mult/∂θ_last = 1 (n={n})"
+            );
+            for (i, g) in grad.iter().enumerate() {
+                if i != n - 1 {
+                    assert!(
+                        g.abs() < 1e-9,
+                        "off-axis derivative must be 0 (n={n}, i={i})"
+                    );
+                }
+            }
+        }
+        // Beyond the cap → None, so the outer gradient falls back to FD.
+        let over = MAX_RUV_MAG_AXES + 1;
+        let expr = Expression::BinOp(
+            Box::new(Expression::Theta(0)),
+            BinOp::Mul,
+            Box::new(Expression::Variable("PROP".to_string())),
+        );
+        let prog = compile_ruv_mag_deriv_program(&expr, "PROP", over);
+        assert!(
+            prog.theta_grad(&vec![0.5; over], &HashMap::new(), 0.0)
+                .is_none(),
+            "n_theta beyond MAX_RUV_MAG_AXES must decline to FD"
+        );
+    }
 
     // ── ode_template desugaring + error rule (#322 Phase 0b) ─────────────────
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13703,7 +13703,8 @@ mod tests {
         use std::collections::HashMap;
         assert!(MAX_RUV_MAG_AXES >= 17, "cap must be raised past the old 16");
         let cov = HashMap::new();
-        for n in [1usize, 16, 17, 24, MAX_RUV_MAG_AXES] {
+        // Every axis count up to the cap — exercises each `Dual1<M>` dispatch arm.
+        for n in 1..=MAX_RUV_MAG_AXES {
             let expr = Expression::BinOp(
                 Box::new(Expression::Theta(n - 1)),
                 BinOp::Mul,

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -408,24 +408,25 @@ pub fn analytic_outer_gradient_available(model: &CompiledModel) -> bool {
         && !model.iiv_on_ruv_forces_fd()
 }
 
-/// [`analytic_outer_gradient_available`] further narrowed by whether the fit
-/// actually runs with FOCEI interaction (#486 review): a custom residual-
-/// magnitude model's direct-θ channel is assembled only in the FOCEI
-/// (`subject_packed_gradient`/`subject_packed_gradient_iov`) per-subject path.
-/// Plain `method = foce` (non-interaction, `subject_packed_gradient_foce` /
-/// `subject_packed_gradient_foce_iov`) declines whenever
-/// `model.has_custom_ruv_magnitude()` and falls back to FD — but
-/// `analytic_outer_gradient_available` itself has no way to see
-/// `interaction` (it takes only `model`), so it can't reflect that on its
-/// own. Every other exclusion in `analytic_outer_gradient_available` is
-/// interaction-independent, so this only narrows the magnitude case.
+/// [`analytic_outer_gradient_available`], kept as the shared entry point that
+/// [`crate::types::Optimizer::resolve_auto`] and `build_info::gradient_method_outer`
+/// consult so `auto`'s pick and the reported gradient method can never disagree
+/// with the outer loop's actual dispatch.
 ///
-/// [`crate::types::Optimizer::resolve_auto`] and
-/// `build_info::gradient_method_outer` both consult this (instead of the bare
-/// model-only predicate) so `auto`'s pick and the reported gradient method
-/// agree with what the outer loop actually computes for FOCE vs FOCEI.
+/// As of the FOCE σ-magnitude work (#486), a custom / time-varying residual-error
+/// magnitude (`σ = expr(TIME, cov, θ)`) is analytic on **both** loops — the
+/// Sheiner–Beal FOCE (non-interaction) assembly (`subject_packed_gradient_foce` /
+/// `subject_packed_gradient_foce_iov`) now threads `mult(θ)` through its marginal
+/// `R⁰` (value + direct-θ derivative), matching the FOCEI direct-θ channel. So the
+/// predicate no longer narrows by `interaction`: every exclusion in
+/// `analytic_outer_gradient_available` is interaction-independent (a magnitude
+/// combined with an M3-censored row is a *per-subject* FD fallback, as under
+/// FOCEI, not a model-level decline). The `interaction` parameter is retained for
+/// call-site stability and in case a future interaction-only channel must
+/// re-narrow here.
 pub fn analytic_outer_gradient_for_interaction(model: &CompiledModel, interaction: bool) -> bool {
-    analytic_outer_gradient_available(model) && (interaction || !model.has_custom_ruv_magnitude())
+    let _ = interaction;
+    analytic_outer_gradient_available(model)
 }
 
 /// Whether the light **ODE inner** η-gradient (`Dual1`) serves this model+subject:

--- a/src/types.rs
+++ b/src/types.rs
@@ -5525,25 +5525,20 @@ mod tests {
         }
     }
 
-    /// #486 review: a custom residual-magnitude model's direct-θ channel is
-    /// FOCEI-only (`subject_packed_gradient_foce`/`_foce_iov` decline it), so
-    /// `auto` must resolve to `Bobyqa` under plain `method = foce`
-    /// (`interaction = false`) even though `analytic_outer_gradient_available`
-    /// (interaction-agnostic) reports the model in scope — and still resolve to
-    /// `NloptLbfgs` under FOCEI (`interaction = true`).
+    /// #486 σ-magnitude FOCE port: a custom residual-magnitude model is analytic on
+    /// **both** loops now (the Sheiner–Beal FOCE marginal threads `mult(θ)` through
+    /// its `R⁰`), so `auto` resolves to `NloptLbfgs` under plain `method = foce`
+    /// (`interaction = false`) as well as under FOCEI (`interaction = true`).
     #[test]
-    fn resolve_auto_respects_interaction_for_custom_magnitude() {
+    fn resolve_auto_analytic_for_custom_magnitude_both_loops() {
         let content = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  theta RUV_LATE(1.5, 0.0, 10.0)\n  omega ETA_CL ~ 0.09\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR * (1.0 + RUV_LATE * TIME / 48.0))\n";
         let m = crate::parser::model_parser::parse_model_string(content).expect("parse");
         assert!(m.has_custom_ruv_magnitude());
-        assert!(
-            crate::sens::provider::analytic_outer_gradient_available(&m),
-            "the interaction-agnostic gate still reports this model in scope"
-        );
+        assert!(crate::sens::provider::analytic_outer_gradient_available(&m));
         assert_eq!(
             Optimizer::Auto.resolve_auto(&m, false),
-            Optimizer::Bobyqa,
-            "plain FOCE + custom magnitude has no analytic gradient — must not pick a gradient optimizer"
+            Optimizer::NloptLbfgs,
+            "FOCE + custom magnitude now has the analytic gradient"
         );
         assert_eq!(
             Optimizer::Auto.resolve_auto(&m, true),


### PR DESCRIPTION
## Why

PR #644 made a custom / time-varying residual-error magnitude (`σ = expr(TIME, cov, θ)`,
e.g. a late-phase RUV inflation `PROP_ERR * (1 + RUV_LATE * TIME/48)`) analytic — but only
under **FOCEI**. Plain (non-interaction) **FOCE** routed its sensitivity gradient to finite
differences (`subject_packed_gradient_foce{,_iov}` declined a magnitude-active model), so
`auto` resolved such a model to derivative-free BOBYQA. The theta count was also capped at 16.
This PR closes both residual cells for issue #486: FOCE magnitude is now analytic on both the
non-IOV and IOV paths, and the cap is raised to 32.

## What changed

FOCE is *simpler* than FOCEI here: the Sheiner–Beal marginal `½[ρᵀR̃⁻¹ρ + log|R̃|]`,
`R̃ = JΩJᵀ + diag(R⁰)`, has no `log|H̃|` and no EBE-response, and the magnitude enters only
through the typical-value residual variance `R⁰ = R(f(η=0))`.

- **`subject_packed_gradient_foce` / `_foce_iov`** — thread `mult(θ)` into the marginal:
  scale `R⁰`/`d⁰` (`variance_at_scaled`/`dvar_df_scaled`), add the magnitude's *direct*-θ
  term to the θ-block `dvar` accumulator (`∂R⁰/∂θ = d⁰·∂f0/∂θ + dr0_dtheta`), and FD the
  *scaled* variance in the σ-block. Magnitude + an M3-censored row bails per-subject to FD
  (mirrors the FOCEI carve-out); magnitude + `iiv_on_ruv` is excluded model-level.
- **`subject_eta_dx` / `_iov`** — the FOCE coupling `c·dη̂/dx` relies on these (FOCEI folds
  its EBE-response into `theta_block` locally). Made magnitude-aware: the direct-θ term via a
  new shared `mag_alpha_dtheta` helper, and the σ-block FD switched to the scaled variance.
- **Gate/reporting** — `analytic_outer_gradient_for_interaction` no longer narrows a magnitude
  model to FD under FOCE, so `auto` picks a gradient optimizer and `build_info` reports
  `Analytic` for both loops.
- **Theta cap** — `MAX_RUV_MAG_AXES` 16 → 32, with the matching `Dual1<M>` dispatch arms.
- Shared helpers `mag_variance_dtheta` (the `∂R/∂θ`,`∂d/∂θ` bilinear) and `mag_alpha_dtheta`
  (the `∂α/∂θ` EBE-response term) dedup the formulae across the FOCEI and FOCE paths.

## Alternatives considered

Threading the magnitude through a bespoke FOCE marginal-`R̃` derivative was unnecessary — the
magnitude is diagonal in `R⁰`, so the existing `dvar` accumulator already had the exact shape;
only the `∂R⁰/∂θ` scalar and the EBE-response mixed-derivative needed the extra magnitude term.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API signature changed.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: reconverged finite differences of ferx's own FOCE (Sheiner–Beal)
      marginal — the gradient-only change leaves the objective (and therefore the fit) identical
      to the existing magnitude-aware FD path; #644 already NONMEM-anchors the FOCEI magnitude
      objective, which the FOCE marginal shares its residual-variance machinery with.
- Per-coordinate analytic-vs-Richardson-reconverged-FD agreement across every θ/Ω/σ/Ω_iov
  coordinate, for the TIME / covariate / theta magnitude families, non-IOV **and** IOV:

```
foce magnitude (theta family, non-IOV):   all coords rel < 2e-12 .. 3e-4
foce-iov magnitude (TIME family):         x[0..8] rel 5e-9 .. 1e-6   (all < 3e-3)
```

## Performance
- [x] Faster — a magnitude-active FOCE fit now runs the analytic gradient (one provider
      evaluation per inner step) instead of `~2·n_axes+1` FD predictions, and `auto` no longer
      falls back to derivative-free BOBYQA.

## Tests
- [x] Unit test(s) added (`cargo test --lib` passes — 2057 tests, 0 failed):
  - `magnitude_{time,covariate,theta}_family_foce_packed_matches_fd` (non-IOV FOCE, all
    magnitude-argument families) and `magnitude_foce_iov_packed_matches_fd` (IOV FOCE);
  - `ruv_mag_theta_grad_dispatches_up_to_axis_cap` (the raised dispatch table);
  - rewrote the two stale gate tests (`build_info::…reports_analytic_under_foce_and_focei`,
    `types::resolve_auto_analytic_for_custom_magnitude_both_loops`) to assert the new analytic
    routing.
- Also fixed a test-harness bug uncovered en route: `precise_ebe_iov` located the *bare* IOV
  EBE (its Newton refinement used the unscaled variance), so a magnitude FD reference was
  evaluated at the wrong stationary point — it now mirrors `precise_ebe`'s scaled objective.
  No-op (bit-identical) for every non-magnitude model.

## Example (user-facing features only)
- [x] Not applicable — reuses the existing `examples/warfarin_ruv_magnitude.ferx`; only the
      gradient path for `method = foce` changes (the objective and fit are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
