### PR TITLE
feat(sens): make init(...) fully analytic on the FOCE/FOCEI gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,19 @@ section of the SDLC for the versioning policy).
   moving infusion-end flows through the steady-state trough exactly as it does through the
   current pulse. Validated against finite differences of the production predictor and against
   the independently NONMEM-anchored ODE steady-state modeled-dose twin.
+- **Initial conditions (`init(...)` / `[initial_conditions]`) are now fully analytic on the
+  FOCE/FOCEI sensitivity gradient** — every remaining combination that previously fell back to
+  finite differences is closed (#486). A parameter-dependent baseline (e.g. an indirect-response
+  or disease-progression PD baseline, `init(central) = BASE/V`) now gets exact analytic
+  gradients when combined with: a finite infusion, a built-in input-rate forcing
+  (igd/transit/weibull/`first_order`/`zero_order`), an estimated lagtime, steady-state dosing, a
+  modeled-duration/rate dose, and an EVID 3/4 reset — on the ODE event-driven walk; the
+  closed-form (1-/2-/3-cpt) `init` baseline on the time-varying-covariate walk; and `init`
+  **under IOV** on both engines (the amount stays BSV-only while the decay kernel follows each
+  occasion's clearance, matching `predict_iov`). Previously `init` was analytic only on the
+  closed-form dose-superposition path (#527) and the ODE plain-bolus TV-cov subset (#649);
+  everything else finite-differenced. Fits are unchanged — only the gradient path is now exact
+  (and faster) for these models.
 - **Zero-order absorption (`zero_order(dur)`, and the `zero_order` leg of a `mixed` model)
   combined with time-varying covariates or an estimated lagtime** now gets exact analytic
   FOCE/FOCEI sensitivities on the ODE event-driven walk instead of finite differences

--- a/docs/model-file/initial-conditions.qmd
+++ b/docs/model-file/initial-conditions.qmd
@@ -96,14 +96,19 @@ above — numerically equivalent, and still allocation-free.
   reconstruction does not seed it, so `[derived]` expressions referencing
   `compartments[i]` evaluate to `NaN` for baseline models (`W_DERIVED_INIT_ANALYTICAL`).
   Use an ODE model if compartment amounts are required.
-- **IOV models fall back to finite differences.** A non-IOV
-  `[initial_conditions]` model uses exact analytic FOCE/FOCEI gradients under
-  `gradient = auto` (issue #524): the `Dual2`/`Dual1` sensitivity kernels carry
-  the init impulse and its θ/η dependence, so the baseline no longer forces FD.
-  An **IOV** model (kappa) with an init baseline still uses `gradient = fd`
-  automatically — the per-occasion analytic init gradient is a planned follow-up.
-  Results are correct in both cases; for an IOV init model the startup banner
-  reports `gradient: FD [requested: auto]`.
+- **Exact analytic gradients, including under IOV and time-varying covariates.**
+  An `[initial_conditions]` baseline uses exact analytic FOCE/FOCEI gradients
+  under `gradient = auto` (issue #524): the `Dual2`/`Dual1` sensitivity kernels
+  carry the init impulse and its θ/η dependence, so the baseline never forces FD.
+  As of issue #486 this holds for the full feature set — the closed-form baseline
+  on the time-varying-covariate walk, and the baseline **under IOV** (kappa) on
+  both the closed-form and ODE engines. For an IOV baseline the amount `A₀` is
+  driven by the between-subject (BSV) parameters while the decay kernel follows
+  each occasion's clearance, matching the `predict_iov` prediction. On ODE
+  `[odes]` models the same applies when the baseline is combined with a finite
+  infusion, an estimated lagtime, a built-in input-rate forcing, steady-state
+  dosing, a modeled-duration/rate dose, or an EVID 3/4 reset (production re-applies
+  `init` at each reset, and the sensitivity walk re-seeds it there).
 
 ## NONMEM comparison
 

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -5402,6 +5402,100 @@ mod tests {
         run_packed_check_foce(&model, &[5.0, 10.0, 2.0, 20.0, 1.5, 30.0, 1.0]);
     }
 
+    // 1-cpt IV ODE with a parameter-dependent `init(central) = BASE/V` baseline + a finite
+    // infusion — a headline `init` composition (#486). Exercises the full FOCE packed gradient
+    // `[θ, Ω, σ]` end to end: the analytic init impulse (seeded on the event-driven walk and
+    // decayed under the infusion forcing) must survive the outer θ/Ω/σ assembly and match a
+    // Richardson-reconverged FD of ferx's FOCE OFV.
+    const IV_INIT_INFUSION: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta TVBASE(300.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  omega ETA_BASE ~ 0.04
+  sigma PROP ~ 0.04 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV  * exp(ETA_V)
+  BASE = TVBASE * exp(ETA_BASE)
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central)  = -CL/V * central
+[error_model]
+  DV ~ proportional(PROP)
+[fit_options]
+  method     = foce
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    #[test]
+    fn population_packed_gradient_foce_init_infusion_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        use crate::types::Population;
+        let model = parse_model_string(IV_INIT_INFUSION).expect("parse init+infusion");
+        let theta = vec![1.0, 20.0, 300.0];
+        // Two subjects, each dosed by a finite IV infusion (rate 25 → 4 h window) on top of the
+        // init baseline; obs straddle the infusion end.
+        let mk = |times: &[f64]| -> Subject {
+            let mut s = subject_with_obs(&model, &theta, times);
+            s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 25.0, false, 0.0)];
+            assert!(s.doses[0].is_infusion());
+            let eta_ref = [0.12, -0.08, 0.15];
+            let preds = crate::pk::compute_predictions_with_tv(&model, &s, &theta, &eta_ref);
+            s.observations = preds.iter().map(|p| p * 0.85).collect();
+            s
+        };
+        let pop = Population {
+            subjects: vec![
+                mk(&[1.0, 2.0, 4.0, 6.0, 10.0]),
+                mk(&[0.5, 3.0, 5.0, 8.0, 24.0]),
+            ],
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+        let mut template = model.default_params.clone();
+        template.theta = theta.clone();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ehs: Vec<DVector<f64>> = pop
+            .subjects
+            .iter()
+            .map(|s| DVector::from_vec(precise_ebe(&model, s, &params)))
+            .collect();
+        let analytic =
+            population_gradient_sens_foce(&model, &pop, &template, &x, &ehs).expect("supported");
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            2.0 * pop
+                .subjects
+                .iter()
+                .map(|s| marginal_nll_foce(&model, s, &p))
+                .sum::<f64>()
+        };
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.clone();
+            xp[k] += h;
+            let mut xm = x.clone();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0;
+            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
+        }
+    }
+
     // --- Eq. 48 EBE warm-start predictor: is it correct & better than plain warm? ---
 
     /// The Eq. 48 predictor `η⁰ = η̂_prev + (dη̂/dx)·Δx` is a first-order Taylor

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -582,29 +582,45 @@ pub(crate) fn ode_tvcov_supported(model: &CompiledModel, subject: &Subject) -> b
     // as on the static walk — so there is no longer any dropped forcing to guard against.
     // `init(...)` initial conditions are seeded on the event-driven walk at the subject's
     // first-record covariate snapshot (`tvcov_init_state`, matching production's `init_pk`),
-    // so a TV-cov + `init(...)` **bolus** subject is analytic on both loops (#486). It stays
-    // on FD when combined with a feature whose saltation / equilibration / forcing branch was
-    // written for a **zero baseline** and is not yet validated against a parameter-dependent
-    // `init` seed — the analytic scope matches what the FD-vs-production tests cover:
-    //   • an EVID 3/4 **reset** — production re-seeds `init` at the reset-event snapshot
-    //     (`last_pk`), whereas the walk carries one subject-level init jet;
-    //   • an estimated **lagtime** — the dose-arrival saltation branch assumes `x⁻ = 0`;
-    //   • a **finite infusion** — the `active_infusions` accumulation isn't checked against
-    //     a non-zero baseline;
-    //   • a built-in **input-rate forcing** (igd/transit/weibull/first_order, #643);
-    //   • **steady-state** — the dual SS equilibration seeds from zero, not `init`;
-    //   • a **modeled-duration/rate dose** (#530 moving-window saltation).
-    // Each is a genuine analytic-scope extension behind its own validation (#486 follow-up).
-    if ode.init_fn.is_some()
-        && (!subject.reset_times.is_empty()
-            || model.has_lagtime()
-            || !ode.input_rate.is_empty()
-            || subject.has_periodic_ss_dose()
-            || !subject.all_doses_fixed()
-            || subject.doses.iter().any(|d| d.is_infusion()))
-    {
-        return false;
-    }
+    // so a TV-cov + `init(...)` **bolus** subject is analytic on both loops (#649). As of #486
+    // `init(...)` is **fully analytic** on this non-IOV event-driven walk — it composes with
+    // every dosing feature the walk carries (finite infusion, estimated lagtime, built-in
+    // input-rate forcing, steady-state, modeled-duration/rate dose, and EVID 3/4 reset), each
+    // validated by an FD-vs-production test (below). The one-line summary of why each is safe:
+    // A **finite infusion** now composes with `init` (#486): the walk seeds `init_state` and
+    // then accumulates the `active_infusions` forcing on top of the running (init-derived)
+    // state — the forcing is a `du/dt` additive term with no zero-baseline assumption, so the
+    // analytic gradient already matches FD-of-production on a non-zero baseline (validated by
+    // `ode_provider_tvcov_init_infusion_matches_production`).
+    // An estimated **lagtime** also composes with `init` (#486): the dose-arrival saltation
+    // reads the *actual* pre-arrival state `x⁻ = u` (the decaying `init` baseline) and its
+    // velocity `g(x⁻)` — the "`x⁻ = 0` first-dose reduction" in the comment there is only a
+    // reduction, not an assumption, so a non-zero `init` baseline flows through the saltation
+    // unchanged (validated by `ode_provider_tvcov_init_lagtime_matches_production`).
+    // A **modeled-duration/rate dose** (`RATE=-1/-2`) also composes with `init` (#486): the
+    // moving infusion-end boundary is carried by the rate-off saltation reading the live
+    // `inf_eff` jet, on top of the init-seeded running state — no zero-baseline assumption
+    // (validated by `ode_provider_tvcov_init_modeled_duration_matches_production`; the
+    // slot-presence invariant below still guards an undeclared `D{cmt}`/`R{cmt}`).
+    // A built-in **input-rate forcing** also composes with `init` (#486). For continuous kinds
+    // (igd/transit/weibull/first_order) `add_prepared_input_rate_forcing` adds `R_in(tad)` to
+    // `du/dt` on top of the init-seeded running state; for `ZeroOrder` (now carried on this walk
+    // since #653) the per-segment constant `active_zero` channel delivers `F·amt·frac/dur` and
+    // the moving-end rate-off saltation reads the same running state. Both are orthogonal to the
+    // starting-state offset (validated by `ode_provider_tvcov_init_input_rate_matches_production`
+    // and `ode_provider_tvcov_init_zero_order_matches_production`).
+    // **Steady-state** also composes with `init` (#486): production's `equilibrate_ss_state`
+    // seeds the SS trough from zero and *overwrites* the whole state at the SS dose, discarding
+    // `init` there — so the dual `equilibrate_ss_state_g` (which also seeds from zero) matches
+    // it; `init` only affects the pre-SS-dose segments, which the walk carries via `init_state`
+    // (validated by `ode_provider_tvcov_init_ss_matches_production`).
+    // An EVID 3/4 **reset** also composes with `init` (#486): production re-applies
+    // `init(&last_pk.values)` at each reset, and the `K_RESET` branch of `integrate_tvcov_g`
+    // now mirrors that by re-seeding the state from the reset-event snapshot (via the shared
+    // `init_taylor_seed_at`, carrying `∂init/∂(θ,η)` at that snapshot) instead of zeroing —
+    // validated by `ode_provider_tvcov_init_reset_matches_production`.
+    // With A–F all composing, `init(...)` is fully analytic on the non-IOV event-driven walk;
+    // no per-feature FD clause remains here (IOV is gated separately in `ode_iov_supported`).
     // #530: modeled-`RATE`/duration doses are resolved from their PK slot as a live jet
     // inside the walk (`inf_eff` reads `pk_at_dose[k][slot]`), so the moving infusion-end
     // boundary is analytic via the rate-off saltation. Modeled-dose × steady-state IS now
@@ -788,9 +804,14 @@ pub fn ode_iov_supported(model: &CompiledModel) -> bool {
     {
         return false;
     }
-    if ode.init_fn.is_some() {
-        return false;
-    }
+    // `init(...)` initial conditions are analytic on the ODE IOV walk too (#486): the IOV
+    // outer/inner (`run_subject_iov` / `_eta`) run through the SAME `integrate_tvcov_readout`
+    // the non-IOV walk uses, which seeds `init` via `tvcov_init_state` at the first-record
+    // snapshot and re-seeds it at each EVID 3/4 reset. Because that snapshot's PK duals carry
+    // the stacked `(θ, η_bsv, κ)` jets, the Taylor seed's deltas fold `∂init/∂κ` into the
+    // correct occasion axis with no IOV-specific seeding code — a κ-coupled baseline
+    // (`init(central) = C0·exp(η + κ)`) lands its derivative on the right axis. Validated by
+    // `ode_iov_init_provider_matches_fd_of_predict_iov`.
     // The η/θ/κ chain evaluates the individual-parameter program over the **combined**
     // `(θ, η_bsv, κ)` axes (`n_eff = n_eta + n_kappa`); require it present with matching
     // axes and a program-eval width within the dispatch table. (The per-subject stacked
@@ -1397,7 +1418,28 @@ fn tvcov_init_state<T: crate::sens::num::PkNum>(
         Some(p) => p,
         None => return vec![T::from_f64(0.0); n_states],
     };
+    init_taylor_seed_at::<T>(init_fn, snap, pk_indices, n_states)
+}
 
+/// Seed the ODE `init(...)` state on the walk's own dual basis from a **given** PK-param
+/// snapshot `snap` (already seeded on `(θ, η[, κ])`), as a second-order Taylor of `init` in the
+/// PK params about `snap.val()`. Shared by [`tvcov_init_state`] (which selects the first-record
+/// snapshot, production's `init_pk`) and the event-driven walk's **EVID 3/4 reset** re-seed
+/// (which uses the reset-event snapshot — production's `last_pk`, #486): production re-applies
+/// `init(&last_pk.values)` at each reset, so the dual walk must rebuild the seed from the params
+/// in effect there, not carry the one subject-level jet.
+///
+/// The `∂init/∂p` derivatives come from the shared [`init_fd_derivs`] stencil. Each delta
+/// `(p_i − p̄_i)` has value 0 and carries the snapshot's θ/η[/κ] jet, so `T`'s own product rule
+/// propagates it to the walk basis exactly. A `Dual1` inner walk (`T::SECOND_ORDER == false`)
+/// **skips the second-order block and term entirely** — its ε² is zero, so the quadratic term
+/// contributes nothing — leaving the same first-order gradient the `Dual2` outer walk carries.
+fn init_taylor_seed_at<T: crate::sens::num::PkNum>(
+    init_fn: &(dyn Fn(&[f64]) -> Vec<f64> + Send + Sync),
+    snap: &[T],
+    pk_indices: &[usize],
+    n_states: usize,
+) -> Vec<T> {
     // Central FD of `init_fn` at that snapshot via the shared stencil. The inner `Dual1`
     // walk (`T::SECOND_ORDER == false`) discards the quadratic term, so skip the `d2` block
     // entirely there rather than build a Hessian it drops.
@@ -2087,6 +2129,7 @@ fn integrate_tvcov_readout<T: crate::sens::num::PkNum>(
         pk_at_pk_only,
         &f_bio_at_dose,
         &init_state,
+        &model.pk_indices,
         first_dose_time,
         &dose_lag_slot,
         &dose_modeled_slot,
@@ -3697,6 +3740,9 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     pk_at_pk_only: &[Vec<T>],
     f_bio_at_dose: &[T],
     init_state: &[T],
+    // Differentiated PK slots, for re-seeding `init(...)` at an EVID 3/4 reset (#486). Only
+    // read when `ode.init_fn` is present; a no-`init` model zeros the state at a reset as before.
+    pk_indices: &[usize],
     first_dose_time: f64,
     dose_lag_slot: &[usize],
     dose_modeled_slot: &[Option<(crate::types::RateMode, usize)>],
@@ -3971,6 +4017,23 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     }
 
     let mut cur_t = tl[0].0;
+    // With an `init(...)` baseline the state is non-zero from the subject's true integration
+    // start (`subject_integration_start`, the earliest *record* time). If the first timeline
+    // event is later — e.g. a lagged first dose (whose event sits at `d.time + lag`) with a
+    // pre-arrival observation, or any pre-dose observation — the init baseline must first decay
+    // over the `[start, first_event]` gap, exactly as production's dense walk does (it always
+    // starts at `subject_integration_start`). Without this the pre-event obs reads the
+    // *undecayed* seed and every later segment inherits the wrong baseline. Gated on
+    // `init_fn`: with a zero baseline the gap integrates 0 → 0 (no dose is active before its
+    // own arrival), so the non-init walk is byte-identical. The first event's own segment
+    // `[start, t_event]` then integrates with that event's end-of-interval params, matching the
+    // convention every other segment uses.
+    if ode.init_fn.is_some() {
+        let start = crate::ode::predictions::subject_integration_start(subject);
+        if start.is_finite() && start < cur_t {
+            cur_t = start;
+        }
+    }
     let mut u = init_state.to_vec();
     let vars_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
     let stack_cell: RefCell<Vec<T>> = RefCell::new(Vec::new());
@@ -4844,14 +4907,26 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
                 }
             }
         } else {
-            // EVID 3/4 reset: zero every compartment's full jet (post-reset state is 0
-            // independent of the parameters, so its sensitivity is 0 too). `ode_tvcov_supported`
-            // routes `init(...)` + reset to FD, so whenever a reset fires here `init(...)` is
-            // absent and the reset baseline is zero (matches production's `initial_state` with
-            // no init). For EVID=4 the same-time dose sorts after the reset (`K_RESET < K_DOSE`),
-            // so it lands on the zeroed state.
-            for x in u.iter_mut() {
-                *x = T::from_f64(0.0);
+            // EVID 3/4 reset. Production re-applies the initial conditions here —
+            // `u = ode.initial_state(&last_pk.values)` — which restores each `init(...)`
+            // compartment to its value evaluated with the params in effect at the reset
+            // (`last_pk`) and zeros every compartment without an `init`. Mirror that on the dual
+            // walk (#486): with an `init(...)` present, re-seed the state from the reset-event
+            // snapshot via the shared Taylor seed — `params` is `last_params` for a `K_RESET`
+            // event (the `_` arm of the segment-params match), i.e. the most-recent record's PK,
+            // matching production's `last_pk` — so the post-reset jet carries the correct
+            // `∂init/∂(θ,η)` at *that* snapshot rather than the subject-level first-record seed.
+            // With no `init(...)` the seed's `base`/derivatives are all zero, so this reduces to
+            // the previous "zero every compartment" behaviour (byte-identical). For EVID=4 the
+            // same-time dose sorts after the reset (`K_RESET < K_DOSE`), so it lands on the
+            // re-seeded state.
+            match ode.init_fn.as_ref() {
+                Some(f) => u = init_taylor_seed_at::<T>(f.as_ref(), params, pk_indices, n_states),
+                None => {
+                    for x in u.iter_mut() {
+                        *x = T::from_f64(0.0);
+                    }
+                }
             }
             // Turn off any infusion that started before this reset (matches production's
             // `reset_floor`) — the active-set filter and the rate-off saltation below both
@@ -5716,6 +5791,93 @@ mod tests {
     /// production predictor, so the δlag² saltation coefficients (the rate-boundary `coef2`
     /// and the bolus `jg_cross` cross term) get no independent 2nd-order check otherwise
     /// (#472 review round 2 #3/#4).
+    /// Validate the analytic 2nd-order blocks (`d2f_deta2`, `d2f_deta_dtheta`) against
+    /// **double central finite differences of the production predictor** — the ground-truth
+    /// Hessian, not the self-FD of the analytic gradient. This is the check the #486
+    /// init-composition scope needs: a small Hessian element sitting between large neighbours
+    /// (e.g. `∂²f/∂η_V²` crossing zero mid-window for an `init = BASE/V` decay) makes the
+    /// he=1e-6 self-FD of `check_hessian_vs_fd_of_grad` catastrophically cancel, even though
+    /// the analytic Hessian is exact — double-FD of the predictor with an absolute floor is
+    /// robust there. The `epsilon` floor (`5e-3`) only relaxes elements whose magnitude is
+    /// below it (where a 4-point stencil is dominated by its own truncation/solver noise); a
+    /// genuinely wrong large element is still caught by `max_relative`.
+    fn check_hessian_vs_production_fd(
+        model: &CompiledModel,
+        subject: &Subject,
+        theta: &[f64],
+        eta: &[f64],
+    ) {
+        let n_eta = model.n_eta;
+        let n_theta = model.n_theta;
+        let base = ode_subject_sensitivities(model, subject, theta, eta).expect("supported");
+        let pred = |e: &[f64], th: &[f64], j: usize| -> f64 {
+            compute_predictions_with_tv(model, subject, th, e)[j]
+        };
+        let h = 1e-4;
+        // ∂²f/∂η_k∂η_p via a 4-point cross stencil.
+        for p in 0..n_eta {
+            for (j, o) in base.obs.iter().enumerate() {
+                for k in 0..n_eta {
+                    let mut epp = eta.to_vec();
+                    epp[k] += h;
+                    epp[p] += h;
+                    let mut epm = eta.to_vec();
+                    epm[k] += h;
+                    epm[p] -= h;
+                    let mut emp = eta.to_vec();
+                    emp[k] -= h;
+                    emp[p] += h;
+                    let mut emm = eta.to_vec();
+                    emm[k] -= h;
+                    emm[p] -= h;
+                    let fd = (pred(&epp, theta, j) - pred(&epm, theta, j) - pred(&emp, theta, j)
+                        + pred(&emm, theta, j))
+                        / (4.0 * h * h);
+                    approx::assert_relative_eq!(
+                        o.d2f_deta2[k * n_eta + p],
+                        fd,
+                        max_relative = 5e-3,
+                        epsilon = 5e-3
+                    );
+                }
+            }
+        }
+        // ∂²f/∂η_k∂θ_m via a 4-point cross stencil.
+        for m in 0..n_theta {
+            let sm = h * (1.0 + theta[m].abs());
+            for (j, o) in base.obs.iter().enumerate() {
+                for k in 0..n_eta {
+                    let mut epp = eta.to_vec();
+                    epp[k] += h;
+                    let mut tp = theta.to_vec();
+                    tp[m] += sm;
+                    let mut epm = eta.to_vec();
+                    epm[k] += h;
+                    let mut tm = theta.to_vec();
+                    tm[m] -= sm;
+                    let fd = (pred(&epp, &tp, j)
+                        - pred(&epp, &tm, j)
+                        - pred(&emm_eta(eta, k, h), &tp, j)
+                        + pred(&emm_eta(eta, k, h), &tm, j))
+                        / (4.0 * h * sm);
+                    approx::assert_relative_eq!(
+                        o.d2f_deta_dtheta[k * n_theta + m],
+                        fd,
+                        max_relative = 5e-3,
+                        epsilon = 5e-3
+                    );
+                }
+            }
+        }
+    }
+
+    /// `eta` with `eta[k] -= h` (helper for the mixed η×θ stencil above).
+    fn emm_eta(eta: &[f64], k: usize, h: f64) -> Vec<f64> {
+        let mut e = eta.to_vec();
+        e[k] -= h;
+        e
+    }
+
     fn check_hessian_vs_fd_of_grad(
         model: &CompiledModel,
         subject: &Subject,
@@ -8432,15 +8594,14 @@ mod tests {
         check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
     }
 
-    /// TV-cov + `init(...)` is admitted only for the validated **plain-bolus** scope (#486).
-    /// Combining `init(...)` with a feature whose saltation / equilibration / forcing branch
-    /// was written for a zero baseline — an EVID 3/4 reset, an estimated lagtime, a finite
-    /// infusion, a built-in input-rate forcing, steady-state, or a modeled-duration/rate dose
-    /// — routes to FD until each is separately validated. The two cases constructible from the
-    /// bolus fixture (reset, finite infusion) are pinned here; the rest share the same gate
-    /// clause in `ode_tvcov_supported`.
+    /// TV-cov + `init(...)` analytic scope (#486): `init(...)` is **fully analytic** on the
+    /// non-IOV event-driven walk — it composes with a finite infusion, an EVID 3/4 reset, and
+    /// (via their own model fixtures) lagtime / input-rate / SS / modeled-dose. This pins the
+    /// two compositions constructible from the plain bolus fixture (infusion, reset), which
+    /// previously routed to FD; the others are validated by their dedicated
+    /// `ode_provider_tvcov_init_*_matches_production` tests.
     #[test]
-    fn ode_tvcov_init_unvalidated_compositions_route_to_fd() {
+    fn ode_tvcov_init_compositions_are_analytic() {
         let model = parse_model_string(TVCOV_INIT_ODE).expect("parse");
         // Baseline: plain-bolus TV-cov + init is analytic.
         assert!(
@@ -8448,25 +8609,391 @@ mod tests {
             "init + bolus is analytic"
         );
 
-        // + EVID 3/4 reset → FD (production re-seeds init at the reset-event snapshot).
+        // + finite infusion → analytic (#486): the walk seeds init and adds the infusion
+        // forcing on top of the running state.
         let mut s = tvcov_subject();
-        s.reset_times = vec![4.0];
-        assert!(
-            !ode_tvcov_supported(&model, &s),
-            "init + EVID 3/4 reset must route to FD"
-        );
-
-        // + finite infusion → FD (active_infusions accumulation unvalidated vs a non-zero baseline).
-        let mut s = tvcov_subject();
-        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 5.0, false, 0.0)];
+        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 20.0, false, 0.0)];
         assert!(
             s.doses[0].is_infusion(),
             "fixture must be a finite infusion"
         );
         assert!(
-            !ode_tvcov_supported(&model, &s),
-            "init + finite infusion must route to FD"
+            ode_tvcov_supported(&model, &s),
+            "init + finite infusion is analytic (#486)"
         );
+
+        // + EVID 3/4 reset → analytic (#486): the K_RESET branch re-seeds init at the
+        // reset-event snapshot (matching production's `initial_state(&last_pk.values)`).
+        let mut s = tvcov_subject();
+        s.reset_times = vec![4.0];
+        assert!(
+            ode_tvcov_supported(&model, &s),
+            "init + EVID 3/4 reset is analytic (#486)"
+        );
+    }
+
+    // Tight-tolerance twin of `TVCOV_INIT_ODE` for the infusion branch: the `1e-11`/`1e-13`
+    // solver tolerance keeps the Dual2 Hessian's value-controlled step error far below the
+    // `2e-3` FD-of-gradient check. `F = 1` (bare slot), so the infusion is a fixed-boundary
+    // rate-defined window (`amt/rate`) — the branch-A question (does the forcing accumulate
+    // correctly on a non-zero init baseline?) without the rate-defined-under-`F` moving
+    // boundary, which is a separate (#419) mechanism.
+    const TVCOV_INIT_INF_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta THETA_WT(0.75, 0.01, 5.0)
+  theta TVBASE(500.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL   = TVCL * (WT / 70)^THETA_WT * exp(ETA_CL)
+  V    = TVV * exp(ETA_V)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central)  = -CL/V * central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+
+    /// **TV-cov + `init(...)` + finite infusion** (#486, branch A). A 5 h IV infusion
+    /// (amt 100, rate 20, `F = 1`) into the init-seeded `central` compartment, under a WT
+    /// covariate that makes CL time-varying. The walk seeds `init(central) = BASE/V` and then
+    /// accumulates the `rate` forcing over the infusion window on top of that non-zero running
+    /// state — so the analytic `SubjectSens` (value, `∂f/∂(θ,η)`, both Hessian blocks) must
+    /// match FD of the production TV-cov predictor, and the light inner `Dual1` walk must match
+    /// the outer `Dual2` walk. Confirms the forcing branch carries no zero-baseline assumption.
+    #[test]
+    fn ode_provider_tvcov_init_infusion_matches_production() {
+        let model = parse_model_string(TVCOV_INIT_INF_ODE).expect("parse");
+        assert_eq!(model.n_theta, 4);
+        assert_eq!(model.n_eta, 2);
+        let mut subject = tvcov_subject(); // obs at 1,2,4,8; infusion runs [0,5]
+        subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 20.0, false, 0.0)];
+        assert!(
+            subject.doses[0].is_infusion(),
+            "fixture must be an infusion"
+        );
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "TV-cov + init + infusion must be analytic (#486)"
+        );
+        let theta = vec![1.0, 20.0, 0.75, 500.0];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    // 1-cpt IV with an estimated lagtime carrying IIV and an `init(central) = BASE/V` baseline.
+    // The lagged bolus arrives at `t + lag`; before arrival the compartment decays from `init`,
+    // so the dose-arrival saltation's pre-arrival state `x⁻` is the *non-zero* init baseline.
+    // `CL` carries IIV (so the init decay — hence `x⁻` and its velocity `g(x⁻)`) depends on
+    // `ETA_CL`), and `LAGTIME` carries IIV (so the saltation's `∂/∂η_LAG` fires). Tight
+    // tolerance so the FD-of-predict Hessian check is clean.
+    const ONECPT_IV_LAG_INIT_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta TVLAG(0.5, 0.01, 5.0)
+  theta TVBASE(500.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_LAG ~ 0.05
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL      = TVCL * exp(ETA_CL)
+  V       = TVV
+  LAGTIME = TVLAG * exp(ETA_LAG)
+  BASE    = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central) = -CL/V * central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+
+    /// **`init(...)` + estimated lagtime** (#486, branch C). A lagged bolus (arrives at
+    /// `t + lag ≈ 0.5`) on top of an `init(central) = BASE/V` decaying baseline. The obs at
+    /// t=0.25 sits in the pre-arrival window (pure init decay), the rest after arrival. The
+    /// dose-arrival saltation must use the actual pre-arrival state `x⁻ = u` (the init
+    /// baseline) and its velocity — validated at all orders against FD of the production
+    /// predictor, plus inner/outer parity. Confirms the saltation makes no zero-baseline
+    /// assumption.
+    #[test]
+    fn ode_provider_tvcov_init_lagtime_matches_production() {
+        let model = parse_model_string(ONECPT_IV_LAG_INIT_ODE).expect("parse");
+        assert!(model.has_lagtime());
+        let subject = bolus_subject(&[0.25, 1.0, 2.0, 4.0]);
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + lagtime must be analytic on the event-driven walk (#486)"
+        );
+        let theta = vec![1.0, 20.0, 0.5, 500.0];
+        let eta = vec![0.1, 0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    /// **`init(...)` + modeled-duration dose** (#486, branch E). A `RATE=-2` / `D1`-modeled
+    /// infusion (window `[0, D1]`, moving boundary in `D1 = TVD1·exp(ETA_D1)`) delivering into
+    /// an `init(central) = BASE/V` compartment. The moving infusion-end saltation reads the
+    /// live `inf_eff` `D1` jet on top of the init-seeded running state; obs straddle the window
+    /// end (`D1 = 5`: t=1,3 inside; t=6,10 after). Validated at all orders against FD of the
+    /// production predictor (which resolves `D1` per evaluation), plus inner/outer parity.
+    #[test]
+    fn ode_provider_tvcov_init_modeled_duration_matches_production() {
+        const MODELED_DUR_INIT_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVD1(5.0, 0.1, 24.0)
+  theta TVBASE(200.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_D1 ~ 0.04
+  sigma PROP ~ 0.01 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV
+  D1   = TVD1 * exp(ETA_D1)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central) = -CL/V * central
+[error_model]
+  DV ~ proportional(PROP)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+        let model = parse_model_string(MODELED_DUR_INIT_ODE).expect("parse");
+        let mut subject = bolus_subject(&[1.0, 3.0, 6.0, 10.0]);
+        subject.doses = vec![DoseEvent::modeled(
+            0.0,
+            100.0,
+            1,
+            false,
+            0.0,
+            crate::types::RateMode::ModeledDuration,
+        )];
+        assert!(
+            ode_tvcov_supported(&model, &subject) && !ode_subject_supported(&model, &subject),
+            "init + modeled-duration dose must route to the event-driven walk (#486)"
+        );
+        let theta = vec![5.0, 50.0, 5.0, 200.0];
+        let eta = vec![0.12, -0.08];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    /// **`init(...)` + built-in `first_order` input-rate forcing + TV-cov** (#486, branch B).
+    /// A first-order absorption forcing `R_in = KA·(dose remaining)` feeds `central`, which also
+    /// carries an `init(central) = BASE/V` baseline; a WT covariate on CL makes the subject
+    /// time-varying (forcing the event-driven walk). `add_prepared_input_rate_forcing` adds
+    /// `R_in(tad)` to `du/dt` on top of the init-seeded state — validated at all orders against
+    /// FD of the production predictor, plus inner/outer parity.
+    #[test]
+    fn ode_provider_tvcov_init_input_rate_matches_production() {
+        const FIRST_ORDER_INIT_TVCOV_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta TVKA(1.0, 0.05, 10.0)
+  theta THETA_WT(0.75, 0.01, 5.0)
+  theta TVBASE(500.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_KA ~ 0.05
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL   = TVCL * (WT / 70)^THETA_WT * exp(ETA_CL)
+  V    = TVV
+  KA   = TVKA * exp(ETA_KA)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central)  = first_order(ka=KA) - CL/V * central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+        let model = parse_model_string(FIRST_ORDER_INIT_TVCOV_ODE).expect("parse");
+        assert!(!model.ode_spec.as_ref().unwrap().input_rate.is_empty());
+        let subject = tvcov_subject(); // WT covariate → TV-cov; obs at 1,2,4,8
+        assert!(subject.has_tv_covariates());
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + input-rate forcing + TV-cov must be analytic (#486)"
+        );
+        let theta = vec![1.0, 20.0, 1.0, 0.75, 500.0];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    /// **`init(...)` + `zero_order` absorption + TV-cov** (#486, branch B). `zero_order` was
+    /// ported to the event-driven walk by #653; with `init` its per-segment constant `active_zero`
+    /// delivery (`F·amt·frac/DUR` over `[dose, dose+DUR]`, moving end in `DUR`) rides on top of the
+    /// init-seeded state, and the moving-end rate-off saltation reads that running state. A WT
+    /// covariate makes the subject TV-cov. Obs straddle the window end (`DUR=4`). Validated at all
+    /// orders against FD of production, plus inner/outer parity.
+    #[test]
+    fn ode_provider_tvcov_init_zero_order_matches_production() {
+        const ZERO_ORDER_INIT_TVCOV_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVDUR(4.0, 0.05, 24.0)
+  theta THETA_WT(0.75, 0.01, 5.0)
+  theta TVBASE(2000.0, 10.0, 50000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_DUR ~ 0.04
+  sigma PROP ~ 0.01 (sd)
+[individual_parameters]
+  CL   = TVCL * (WT / 70)^THETA_WT * exp(ETA_CL)
+  V    = TVV
+  DUR  = TVDUR * exp(ETA_DUR)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central) = zero_order(dur=DUR) - CL/V*central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+        let model = parse_model_string(ZERO_ORDER_INIT_TVCOV_ODE).expect("parse");
+        let mut subject = tvcov_subject(); // WT covariate → TV-cov
+        subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        assert!(subject.has_tv_covariates());
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + zero_order + TV-cov must be analytic (#486/#653)"
+        );
+        let theta = vec![5.0, 50.0, 4.0, 0.75, 2000.0];
+        let eta = vec![0.12, -0.08];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    /// **`init(...)` + steady-state dose** (#486, branch D). Production's `equilibrate_ss_state`
+    /// seeds the SS trough from zero and *overwrites the whole state* at the SS dose — so it
+    /// discards `init` there, exactly as the dual `equilibrate_ss_state_g` does. `init` therefore
+    /// only affects the **pre-SS-dose** segments: here the SS bolus is at t=5 (`II=12`), with obs
+    /// at t=1,2 in the pre-dose window reading the decaying `init(central) = BASE/V` baseline
+    /// (their `∂/∂(θ,η)` carry the init seed's derivatives) and obs at t=8,14 reading the SS
+    /// decay (init-independent). The walk seeds `init_state`, decays it from the true integration
+    /// start (t=0) to t=5, then overwrites at the SS dose — matching production at all orders.
+    #[test]
+    fn ode_provider_tvcov_init_ss_matches_production() {
+        const ONECPT_IV_SS_INIT_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta TVBASE(500.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV * exp(ETA_V)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central)  = -CL/V * central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+        let model = parse_model_string(ONECPT_IV_SS_INIT_ODE).expect("parse");
+        let mut subject = bolus_subject(&[1.0, 2.0, 8.0, 14.0]);
+        // SS bolus at t=5, II=12: obs at 1,2 are pre-dose (init decay); 8,14 read the SS decay.
+        subject.doses = vec![DoseEvent::new(5.0, 100.0, 1, 0.0, true, 12.0)];
+        assert!(
+            subject.has_periodic_ss_dose(),
+            "fixture must be a periodic SS dose"
+        );
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + steady-state must be analytic on the event-driven walk (#486)"
+        );
+        let theta = vec![1.0, 20.0, 500.0];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    /// **`init(...)` + EVID 3/4 reset** (#486, branch F). Production re-applies
+    /// `init(&last_pk.values)` at each reset (the `K_RESET` branch re-seeds the state from the
+    /// reset-event snapshot rather than zeroing). Here an `init(central) = BASE/V` model under a
+    /// WT covariate (TV-cov, so the reset-time snapshot differs from the first-record one) takes
+    /// a bolus at t=0, a reset at t=4 (which restores the init baseline), and a second bolus at
+    /// t=5. Obs at t=2 (pre-reset decay), t=4.5 (post-reset init baseline, pre-2nd-dose), and
+    /// t=8,12 (2nd-dose decay on the re-seeded baseline). The re-seeded jet must carry
+    /// `∂init/∂(θ,η)` at the reset snapshot — validated at all orders against FD of production,
+    /// plus inner/outer parity.
+    #[test]
+    fn ode_provider_tvcov_init_reset_matches_production() {
+        let model = parse_model_string(TVCOV_INIT_ODE).expect("parse");
+        // tvcov_subject has a WT covariate (TV-cov) and a bolus at t=0. Add a reset + 2nd dose,
+        // and place obs around the reset. obs_covariates must match obs_times length.
+        let wt = |w: f64| HashMap::from([("WT".to_string(), w)]);
+        let mut subject = tvcov_subject();
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(5.0, 100.0, 1, 0.0, false, 0.0),
+        ];
+        subject.dose_covariates = vec![wt(60.0), wt(85.0)];
+        subject.obs_times = vec![2.0, 4.5, 8.0, 12.0];
+        subject.obs_covariates = vec![wt(65.0), wt(75.0), wt(80.0), wt(90.0)];
+        subject.observations = vec![1.0; 4];
+        subject.obs_cmts = vec![1; 4];
+        subject.cens = vec![0; 4];
+        subject.occasions = vec![1; 4];
+        subject.reset_times = vec![4.0];
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + reset must be analytic on the event-driven walk (#486)"
+        );
+        let theta = vec![1.0, 20.0, 0.75, 500.0];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
     }
 
     /// **Estimated lagtime × time-varying covariates.** A 1-cpt oral ODE with a WT

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -1391,9 +1391,27 @@ fn tvcov_init_state<T: crate::sens::num::PkNum>(
     pk_indices: &[usize],
     n_states: usize,
 ) -> Vec<T> {
-    // First-record snapshot (smallest record time), matching production's `init_pk`
-    // selection. Doses/obs/pk-only are scanned in that order, so at an exact tie the
-    // earliest-considered snapshot wins — identical to production's `consider` (`t < bt`).
+    // First-record snapshot (smallest record time), matching production's `init_pk` selection.
+    let snap = match first_record_pk::<T>(subject, pk_at_dose, pk_at_obs, pk_at_pk_only) {
+        Some(p) => p,
+        None => return vec![T::from_f64(0.0); n_states],
+    };
+    init_taylor_seed_at::<T>(init_fn, snap, pk_indices, n_states)
+}
+
+/// The PK-param snapshot at the subject's **first record** (smallest record time), matching
+/// production's `init_pk` selection (`ode/predictions.rs`) and its `last_pk` seed for a reset
+/// that is itself the first event. Doses / obs / pk-only are scanned in that order under a
+/// strict `t < best_t`, so at an exact tie the earliest-considered snapshot wins — dose over
+/// obs over pk-only, identical to production's `consider`. `None` when the subject has no
+/// records. Shared by [`tvcov_init_state`] (the initial `init` seed) and the event-driven
+/// walk's `last_params` seed (the reset re-seed's snapshot, #486 review) so the two can't drift.
+fn first_record_pk<'a, T: crate::sens::num::PkNum>(
+    subject: &Subject,
+    pk_at_dose: &'a [Vec<T>],
+    pk_at_obs: &'a [Vec<T>],
+    pk_at_pk_only: &'a [Vec<T>],
+) -> Option<&'a [T]> {
     let mut best_t = f64::INFINITY;
     let mut best: Option<&[T]> = None;
     for (k, d) in subject.doses.iter().enumerate() {
@@ -1414,11 +1432,7 @@ fn tvcov_init_state<T: crate::sens::num::PkNum>(
             best = Some(&pk_at_pk_only[m]);
         }
     }
-    let snap = match best {
-        Some(p) => p,
-        None => return vec![T::from_f64(0.0); n_states],
-    };
-    init_taylor_seed_at::<T>(init_fn, snap, pk_indices, n_states)
+    best
 }
 
 /// Seed the ODE `init(...)` state on the walk's own dual basis from a **given** PK-param
@@ -4163,15 +4177,17 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     let mut reset_floor = f64::NEG_INFINITY;
 
     // Most-recent record's params, used to integrate a segment ending at a **reset** or
-    // infusion-end (neither carries a PK record — mirrors production's `last_pk`). The first
-    // event's segment is empty (`cur_t == tl[0].0`), so this initial value is rarely read
-    // before a real record sets it; any available record snapshot is a defensive fallback.
-    let mut last_params: &[T] = pk_at_obs
-        .first()
-        .or_else(|| pk_at_dose.first())
-        .or_else(|| pk_at_pk_only.first())
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
+    // infusion-end (neither carries a PK record — mirrors production's `last_pk`). Seeded with
+    // the **first-record** snapshot (production's `init_pk`, dose-preferred on ties), not an
+    // arbitrary array-first slice: a reset that is itself the first event (an EVID=4 reset+dose
+    // at `t = 0`) re-seeds `init` from `last_params` here (`init_taylor_seed_at` in the
+    // `K_RESET` branch), and production re-applies `init(&last_pk.values)` with
+    // `last_pk = init_pk.unwrap_or_default()` there — so the snapshot must match production's
+    // `init_pk`, or the reset re-seed (hence its gradient) diverges for that edge case
+    // (#486 review — Copilot). For every later reset `last_params` is overwritten by the most
+    // recent record, exactly as production updates `last_pk` (#486).
+    let mut last_params: &[T] =
+        first_record_pk::<T>(subject, pk_at_dose, pk_at_obs, pk_at_pk_only).unwrap_or(&[]);
 
     for p in 0..tl.len() {
         let (t_event, kind, idx) = tl[p];
@@ -8990,6 +9006,65 @@ mod tests {
             "init + reset must be analytic on the event-driven walk (#486)"
         );
         let theta = vec![1.0, 20.0, 0.75, 500.0];
+        let eta = vec![0.1, -0.05];
+        check_vs_production(&model, &subject, &theta, &eta);
+        check_hessian_vs_production_fd(&model, &subject, &theta, &eta);
+        check_inner_outer_eta_parity(&model, &subject, &theta, &eta);
+    }
+
+    // 1-cpt IV with an `init(central) = BASE/V` baseline whose `V` (hence `init`) depends on a
+    // WT covariate — so the *snapshot* the reset re-seed reads is observable in the gradient.
+    const ONECPT_IV_INIT_WTV_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(20.0, 1.0, 200.0)
+  theta TVBASE(500.0, 10.0, 5000.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.04 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV * (WT / 70) * exp(ETA_V)
+  BASE = TVBASE
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE / V
+  d/dt(central)  = -CL/V * central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  ode_reltol = 1e-11
+  ode_abstol = 1e-13
+"#;
+
+    /// **`init(...)` + EVID=4 reset+dose at `t = 0` (the reset is the first timeline event)**
+    /// (#486 review — Copilot). Production re-applies `init(&last_pk.values)` at the reset with
+    /// `last_pk = init_pk` (the first-record snapshot, dose-preferred on ties). The walk seeds
+    /// `last_params` from the *same* `first_record_pk` selection, so the reset re-seed reads the
+    /// dose@0 snapshot — not an arbitrary array-first obs slice. Here `init = BASE/V` and `V`
+    /// depends on WT, and the dose@0 covariate (WT=60) differs from the observations' (WT=90),
+    /// so a wrong snapshot at the re-seed would shift the baseline and its `∂/∂(θ,η)`. Validated
+    /// against FD of the production predictor, plus inner/outer parity. (Before the fix
+    /// `last_params` was `pk_at_obs.first()` = the WT=90 obs snapshot → mismatch.)
+    #[test]
+    fn ode_provider_init_reset_dose_at_zero_matches_production() {
+        let model = parse_model_string(ONECPT_IV_INIT_WTV_ODE).expect("parse");
+        let wt = |w: f64| HashMap::from([("WT".to_string(), w)]);
+        let mut subject = bolus_subject(&[1.0, 2.0, 4.0]);
+        subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        subject.dose_covariates = vec![wt(60.0)]; // dose@0 snapshot: WT=60
+        subject.obs_covariates = vec![wt(90.0), wt(90.0), wt(90.0)]; // obs: WT=90
+        subject.covariates = wt(60.0);
+        subject.reset_times = vec![0.0]; // EVID=4 reset+dose at t=0 → reset is the first event
+        assert!(subject.has_tv_covariates());
+        assert!(
+            ode_tvcov_supported(&model, &subject),
+            "init + reset must be analytic (#486)"
+        );
+        let theta = vec![1.0, 20.0, 500.0];
         let eta = vec![0.1, -0.05];
         check_vs_production(&model, &subject, &theta, &eta);
         check_hessian_vs_production_fd(&model, &subject, &theta, &eta);

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -744,13 +744,20 @@ pub fn iov_analytical_supported(model: &CompiledModel) -> bool {
     if model.log_transform || model.has_lagtime() {
         return false;
     }
-    // Initial-compartment amounts (#521) ARE differentiable by the analytic kernels
-    // now (#524), but only on the dose-superposition path: the init impulse is
-    // layered per-subject in `subject_sensitivities` / `subject_eta_grad`, not in the
-    // IOV event-driven walk, which would have to re-seed the `A₀·kernel` baseline into
-    // each occasion block. Until that occasion-block seeding lands, an IOV + init
-    // model falls back to FD (see `analytical_supported` for the non-IOV exact path).
-    if !model.analytical_init.is_empty() {
+    // Initial-compartment amounts (#521) are now differentiable on the IOV event-driven walk
+    // too (#486): `run_obs_iov` / `run_obs_iov_eta` layer the `A₀·kernel(t, pk)` impulse per
+    // occasion — the amount `A₀` from the BSV-only snapshot (`bsv_amount`, κ = 0) and the decay
+    // kernel from each observation's occasion source — mirroring production's
+    // `add_analytical_init_with(..., amount_pk = BSV, Some(obs_params))` in `predict_iov`.
+    // A hand-built init with no `amount_deriv` program still routes to FD (the impulse loop
+    // would otherwise silently drop it), so require every init to carry its amount program; the
+    // stacked axis count `n_theta + n_stacked` is bounded by the walk's `1..=24` dispatch (out
+    // of range → the walk returns `None` → FD).
+    if model
+        .analytical_init
+        .iter()
+        .any(|i| i.amount_deriv.is_none())
+    {
         return false;
     }
     let n_eff = model.n_eta + model.n_kappa;
@@ -846,7 +853,7 @@ pub fn subject_sensitivities_iov(
                 $($m => run_obs_iov::<$m>(
                     model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
                     &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_eff, s.n_stacked,
-                    s.n_theta, s.scale_groups.as_deref(),
+                    s.n_theta, s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
                 ),)+
                 _ => None,
             }
@@ -883,6 +890,13 @@ struct IovSources {
     /// are per-event — the closed-form twin of the ODE-IOV `build_all_groups` scale seed
     /// (#575/#590, ported in #486).
     scale_groups: Option<Vec<(crate::types::PkParams, CombinedDerivs)>>,
+    /// For an `[initial_conditions]` baseline under IOV (#486): the `(pk, combined-derivs)`
+    /// at the **BSV-only** snapshot (`κ = 0`, subject-static covariates, `t = 0`), driving the
+    /// baseline *amount* `A₀`. Production's `predict_iov` evaluates the amount with `eta_bsv`
+    /// (no κ) while the *decay* kernel uses each observation's occasion PK params, so the amount
+    /// carries `∂A₀/∂(θ, η_bsv)` but zero `∂A₀/∂κ`. `None` when the model has no
+    /// `[initial_conditions]`.
+    bsv_amount: Option<(crate::types::PkParams, CombinedDerivs)>,
 }
 
 fn build_iov_sources(
@@ -1089,6 +1103,19 @@ fn build_iov_sources(
         }
     }
 
+    // `[initial_conditions]` baseline amount snapshot (#486): the BSV-only effect
+    // (`combined_pk_only` = `[η_bsv, κ = 0]`) at the subject-static covariates and `t = 0`,
+    // matching production's `add_analytical_init_with(..., amount_pk = pk_param_fn(θ, eta_bsv,
+    // subject.covariates, 0), ...)`. The decay kernel uses each observation's occasion source
+    // (built above); only the amount uses this κ-less snapshot.
+    let bsv_amount = if model.analytical_init.is_empty() {
+        None
+    } else {
+        let pk = (model.pk_param_fn)(theta, &combined_pk_only, cov_static, 0.0);
+        let cd = cd_at(0.0, &combined_pk_only, cov_static)?;
+        Some((pk, cd))
+    };
+
     Some(IovSources {
         sources,
         dose_src,
@@ -1101,6 +1128,7 @@ fn build_iov_sources(
         n_stacked,
         n_theta,
         scale_groups,
+        bsv_amount,
     })
 }
 
@@ -1127,7 +1155,7 @@ fn subject_eta_grad_iov_analytical(
                 $($n => run_obs_iov_eta::<$n>(
                     model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
                     &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_stacked,
-                    s.scale_groups.as_deref(),
+                    s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
                 ),)+
                 _ => None,
             }
@@ -1166,6 +1194,7 @@ fn run_obs_iov<const M: usize>(
     n_stacked: usize,
     n_theta: usize,
     scale_groups: Option<&[(crate::types::PkParams, CombinedDerivs)]>,
+    bsv_amount: Option<&(crate::types::PkParams, CombinedDerivs)>,
 ) -> Option<SubjectSens> {
     use crate::pk::event_driven::EventSchedule;
     use crate::sens::propagate::{event_driven_sens_with_doses_g, PkDual};
@@ -1324,6 +1353,89 @@ fn run_obs_iov<const M: usize>(
         });
     }
 
+    // Analytic `[initial_conditions]` impulse under IOV (#486): layer `A₀·kernel(t, pk)` onto
+    // every pre-reset observation BEFORE scaling — the closed-form IOV twin of the non-IOV
+    // `apply_analytical_init_outer` and of production's `add_analytical_init_with(..., amount_pk
+    // = BSV snapshot, Some(obs_params))`. The amount `A₀` is built from the BSV-only snapshot
+    // (`bsv_amount`, κ = 0), so it carries `∂A₀/∂(θ, η_bsv)` but zero `∂A₀/∂κ`; the decay kernel
+    // uses each observation's occasion source (`sources[obs_src[j]]`), so it carries the
+    // occasion κ. Their `Dual2<M>` product on the stacked axes is exact.
+    if let Some((pk_bsv, cd_bsv)) = bsv_amount {
+        let first_reset = subject
+            .reset_times
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let eta_bsv = &stacked_eta[..n_eta];
+        let cov = &subject.covariates;
+        for init in &model.analytical_init {
+            let Some(prog) = &init.amount_deriv else {
+                continue;
+            };
+            // Baseline amount `A₀` seeded on the stacked axes from the BSV snapshot (group
+            // `None` → κ axes dropped, matching production's κ-less amount). `eval_scale_dual`
+            // seeds direct θ/η references on axes `0..n_theta` / `n_theta..n_theta+n_eta` — the
+            // stacked η_bsv block — so the amount's jet lands on the correct axes.
+            let a0_var_duals: Vec<Dual2<M>> = prog
+                .var_to_pk_slot()
+                .iter()
+                .map(|&s| match slot_row[s] {
+                    Some(i) => seed(
+                        cd_bsv,
+                        None,
+                        i,
+                        pk_bsv.values.get(s).copied().unwrap_or(0.0),
+                    ),
+                    None => Dual2::<M>::constant(pk_bsv.values.get(s).copied().unwrap_or(0.0)),
+                })
+                .collect();
+            let a0 = prog.eval_scale_dual::<M>(theta, eta_bsv, cov, &a0_var_duals);
+            if !a0.value.is_finite() {
+                continue;
+            }
+            for (j, o) in obs_out.iter_mut().enumerate() {
+                let t = subject.obs_times[j];
+                if t < 0.0 || t >= first_reset {
+                    continue;
+                }
+                // Decay kernel PK duals at observation `j`'s own occasion source (κ carried).
+                let (pk_d, cd_d, group_d) = &sources[obs_src[j]];
+                let dv = |slot: usize, val: f64| -> Dual2<M> {
+                    match slot_row[slot] {
+                        Some(i) => seed(cd_d, *group_d, i, val),
+                        None => Dual2::<M>::constant(val),
+                    }
+                };
+                let c = crate::pk::analytical_init_concentration_g::<Dual2<M>>(
+                    model.pk_model,
+                    init.cmt,
+                    a0,
+                    Dual2::<M>::constant(t),
+                    dv(PK_IDX_CL, pk_d.cl()),
+                    dv(PK_IDX_V, pk_d.v()),
+                    dv(PK_IDX_Q, pk_d.q()),
+                    dv(PK_IDX_V2, pk_d.v2()),
+                    dv(PK_IDX_KA, pk_d.ka()),
+                    dv(PK_IDX_Q3, pk_d.q3()),
+                    dv(PK_IDX_V3, pk_d.v3()),
+                );
+                o.f += c.value;
+                for p in 0..n_stacked {
+                    o.df_deta[p] += c.grad[n_theta + p];
+                    for q in 0..n_stacked {
+                        o.d2f_deta2[p * n_stacked + q] += c.hess[n_theta + p][n_theta + q];
+                    }
+                    for m in 0..n_theta {
+                        o.d2f_deta_dtheta[p * n_theta + m] += c.hess[n_theta + p][m];
+                    }
+                }
+                for m in 0..n_theta {
+                    o.df_dtheta[m] += c.grad[m];
+                }
+            }
+        }
+    }
+
     // η-dependent `ExpressionScale` `obs_scale` divisor: one scale jet per occasion group
     // (the divisor depends on the group's κ through the PK params), applied as a post-walk
     // quotient over the stacked `(θ, η_bsv, κ)` axes — the closed-form twin of the ODE-IOV
@@ -1379,6 +1491,7 @@ fn run_obs_iov_eta<const N: usize>(
     n_kappa: usize,
     n_stacked: usize,
     scale_groups: Option<&[(crate::types::PkParams, CombinedDerivs)]>,
+    bsv_amount: Option<&(crate::types::PkParams, CombinedDerivs)>,
 ) -> Option<Vec<ObsGrad>> {
     use crate::pk::event_driven::EventSchedule;
     use crate::sens::propagate::{event_driven_sens_with_doses_g, PkDual};
@@ -1492,6 +1605,74 @@ fn run_obs_iov_eta<const N: usize>(
         });
     }
 
+    // Analytic `[initial_conditions]` impulse under IOV — η-gradient only (#486): the inner
+    // twin of the `run_obs_iov` outer impulse. Amount `A₀` from the BSV snapshot (`bsv_amount`,
+    // κ = 0) via `eval_scale_dual1` (seeds η_bsv on axes `0..n_eta`), decay kernel per obs from
+    // that observation's occasion source (κ carried); their `Dual1<N>` product's `∂/∂stacked-η`
+    // is folded onto every pre-reset observation's η-gradient, keeping the inner EBE gradient
+    // consistent with the outer walk and with production's `add_analytical_init_with`.
+    if let Some((pk_bsv, cd_bsv)) = bsv_amount {
+        let first_reset = subject
+            .reset_times
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let eta_bsv = &stacked_eta[..n_eta];
+        let cov = &subject.covariates;
+        for init in &model.analytical_init {
+            let Some(prog) = &init.amount_deriv else {
+                continue;
+            };
+            let a0_var_duals: Vec<Dual1<N>> = prog
+                .var_to_pk_slot()
+                .iter()
+                .map(|&s| match slot_row[s] {
+                    Some(i) => seed(
+                        cd_bsv,
+                        None,
+                        i,
+                        pk_bsv.values.get(s).copied().unwrap_or(0.0),
+                    ),
+                    None => Dual1::<N>::constant(pk_bsv.values.get(s).copied().unwrap_or(0.0)),
+                })
+                .collect();
+            let a0 = prog.eval_scale_dual1::<N>(theta, eta_bsv, cov, &a0_var_duals);
+            if !a0.value.is_finite() {
+                continue;
+            }
+            for (j, o) in out.iter_mut().enumerate() {
+                let t = subject.obs_times[j];
+                if t < 0.0 || t >= first_reset {
+                    continue;
+                }
+                let (pk_d, cd_d, group_d) = &sources[obs_src[j]];
+                let dv = |slot: usize, val: f64| -> Dual1<N> {
+                    match slot_row[slot] {
+                        Some(i) => seed(cd_d, *group_d, i, val),
+                        None => Dual1::<N>::constant(val),
+                    }
+                };
+                let c = crate::pk::analytical_init_concentration_g::<Dual1<N>>(
+                    model.pk_model,
+                    init.cmt,
+                    a0,
+                    Dual1::<N>::constant(t),
+                    dv(PK_IDX_CL, pk_d.cl()),
+                    dv(PK_IDX_V, pk_d.v()),
+                    dv(PK_IDX_Q, pk_d.q()),
+                    dv(PK_IDX_V2, pk_d.v2()),
+                    dv(PK_IDX_KA, pk_d.ka()),
+                    dv(PK_IDX_Q3, pk_d.q3()),
+                    dv(PK_IDX_V3, pk_d.v3()),
+                );
+                o.f += c.value;
+                for p in 0..n_stacked {
+                    o.df_deta[p] += c.grad[p];
+                }
+            }
+        }
+    }
+
     // η-only `ExpressionScale` `obs_scale` quotient, one scale jet per occasion group —
     // the first-order counterpart of the `run_obs_iov` post-walk step (#575/#590).
     if let Some(scale_groups) = scale_groups {
@@ -1544,17 +1725,16 @@ pub fn tvcov_analytical_supported(model: &CompiledModel) -> bool {
     if !analytical_supported_core(model) || model.has_lagtime() || model.log_transform {
         return false;
     }
-    // The TV-cov event-driven walk does not yet layer the analytic
-    // `[initial_conditions]` impulse — #524 added exact init gradients only to the
-    // dose-superposition path (`subject_sensitivities` / `subject_eta_grad`), not to
-    // `run_obs_tvcov`. Production's `compute_predictions_with_tv`, however, always
-    // adds the `A₀·kernel` baseline. Admitting an init model here would walk a
-    // gradient that omits the init while the objective keeps it — a silent mismatch
-    // that biases the FOCE/FOCEI gradient (outer and inner). Decline init models so
-    // their TV-cov / oral-infusion subjects fall back to FD (which differentiates the
-    // true objective); their non-TV-cov subjects still take the exact init path. Lift
-    // this once the walk carries the init impulse (#524 follow-up).
-    if !model.analytical_init.is_empty() {
+    // The TV-cov event-driven walk now layers the analytic `[initial_conditions]` impulse
+    // (#486, branch H): `subject_sensitivities_tvcov` / `subject_eta_grad_tvcov` fold in
+    // `A₀·kernel(t, pk)` via `apply_tvcov_init_{outer,inner}` — the exact `(θ,η)` jet at the
+    // subject-static `t = 0` snapshot — BEFORE scaling, matching production's
+    // `add_analytical_init` on `compute_predictions_with_tv` (which uses that same snapshot for
+    // both amount and decay, so the impulse is independent of the TV-cov switching). Require
+    // `init_supported` so the `(θ,η)` axis count fits the `dispatch_init_impulse!` table (the
+    // impulse dispatch's `_` arm would otherwise silently drop it); a hand-built init with no
+    // `amount_deriv` program still routes to FD there.
+    if !init_supported(model) {
         return false;
     }
     // Bound total axes to the dual-walk dispatch cap so the outer (`m_dim`) and inner
@@ -1741,6 +1921,124 @@ fn modeled_dose_inf_duals<T: crate::sens::num::PkNum>(
 /// `compute_predictions_with_tv` does over `f64`. EVID=2 (`pk_only`) covariate
 /// breakpoints between observations are seeded and walked too. Returns `None`
 /// outside the supported scope (caller falls back to FD).
+/// Layer the analytic `[initial_conditions]` impulse onto a **TV-cov walk**'s `SubjectSens`
+/// (#486, branch H — the closed-form analogue of #649's ODE `tvcov_init_state`). Production's
+/// `add_analytical_init` (`pk/mod.rs`) adds `A₀·kernel(t, pk)` with a single subject-static
+/// `t = 0` snapshot — `pk_param_fn(θ, η, subject.covariates, 0)` — for both the baseline amount
+/// and its decay kernel, even for a TV-cov subject (the init impulse is independent of the
+/// time-varying-covariate switching). So compute that snapshot's `ParamDerivs` and fold in the
+/// impulse via the SAME [`apply_analytical_init_outer`] the dose-superposition provider uses,
+/// BEFORE scaling. Returns `Some(())` (no-op) when the model has no `[initial_conditions]`, and
+/// `None` when the exact `∂p/∂(θ,η)` can't be built (non-log-normal η with no program) so the
+/// caller falls back to FD. `tvcov_analytical_supported`'s `init_supported` clause bounds the
+/// axis count to the `dispatch_init_impulse!` table, so the `_` arm never silently drops it.
+fn apply_tvcov_init_outer(
+    sens: &mut SubjectSens,
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<()> {
+    if model.analytical_init.is_empty() {
+        return Some(());
+    }
+    let n_theta = model.n_theta;
+    let n_eta = model.n_eta;
+    let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
+    let (pd, slots): (crate::sens::ode_provider::ParamDerivs, Vec<usize>) = match model
+        .indiv_param_partials
+        .indiv_param_program
+        .as_ref()
+        .filter(|prog| prog_covers_required_pk_slots(model, prog))
+        .and_then(|prog| {
+            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
+                .map(|pd| (pd, prog.pk_slots()))
+        }) {
+        Some(v) => v,
+        None => {
+            if !model
+                .eta_param_info
+                .iter()
+                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
+            {
+                return None;
+            }
+            let pd = lognormal_param_derivatives(model, subject, theta, &pk);
+            (pd, model.pk_indices.clone())
+        }
+    };
+    dispatch_init_impulse!(
+        n_theta + n_eta,
+        apply_analytical_init_outer,
+        sens,
+        model,
+        subject,
+        &pk,
+        &pd,
+        &slots,
+        theta,
+        eta,
+        &subject.covariates,
+        n_theta,
+        n_eta
+    );
+    Some(())
+}
+
+/// Inner (`Dual1`, η-gradient only) counterpart of [`apply_tvcov_init_outer`] — layers the
+/// analytic `[initial_conditions]` impulse onto a TV-cov walk's `ObsGrad` list before scaling,
+/// via [`apply_analytical_init_inner`] on the subject-static `t = 0` snapshot's `∂p/∂η`.
+fn apply_tvcov_init_inner(
+    out: &mut [ObsGrad],
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<()> {
+    if model.analytical_init.is_empty() {
+        return Some(());
+    }
+    let n_eta = model.n_eta;
+    let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
+    let (dp_deta, slots): (Vec<Vec<f64>>, Vec<usize>) = match model
+        .indiv_param_partials
+        .indiv_param_program
+        .as_ref()
+        .filter(|prog| prog_covers_required_pk_slots(model, prog))
+        .and_then(|prog| {
+            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
+                .map(|pd| (pd.dp_deta, prog.pk_slots()))
+        }) {
+        Some(v) => v,
+        None => {
+            if !model
+                .eta_param_info
+                .iter()
+                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
+            {
+                return None;
+            }
+            let pd = lognormal_param_derivatives(model, subject, theta, &pk);
+            (pd.dp_deta, model.pk_indices.clone())
+        }
+    };
+    dispatch_init_impulse!(
+        n_eta,
+        apply_analytical_init_inner,
+        out,
+        model,
+        subject,
+        &pk,
+        &dp_deta,
+        &slots,
+        theta,
+        eta,
+        &subject.covariates,
+        n_eta
+    );
+    Some(())
+}
+
 pub fn subject_sensitivities_tvcov(
     model: &CompiledModel,
     subject: &Subject,
@@ -1802,6 +2100,11 @@ pub fn subject_sensitivities_tvcov(
     let mut sens = disp!(
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
     )?;
+
+    // Analytic `[initial_conditions]` impulse (#486): layer `A₀·kernel(t, pk)` and its exact
+    // `(θ,η)` jet onto every pre-reset observation BEFORE scaling — the same insertion order as
+    // the f64 `pk::add_analytical_init` on the production TV-cov path (`compute_predictions_with_tv`).
+    apply_tvcov_init_outer(&mut sens, model, subject, theta, eta)?;
 
     // Constant `ScalarScale` output divisor `f_scaled = f/k`: every derivative is
     // linear in `f` and `k` is constant, so the whole jet divides by `k` — matches
@@ -2090,6 +2393,11 @@ pub(crate) fn subject_eta_grad_tvcov_with_schedule(
     let mut out = disp!(
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
     )?;
+
+    // Analytic `[initial_conditions]` impulse (#486): η-gradient only, layered BEFORE scaling —
+    // the inner twin of the outer TV-cov init impulse (keeps the inner EBE gradient consistent
+    // with the outer, and with production's `add_analytical_init`).
+    apply_tvcov_init_inner(&mut out, model, subject, theta, eta)?;
 
     // Constant `ScalarScale` divisor: `∂(f/k)/∂η = (∂f/∂η)/k` (η-independent `k`),
     // matching the outer TV-cov path and `pk::apply_scaling`. (LTBS keeps the FD inner —
@@ -5158,27 +5466,28 @@ mod tests {
   DV ~ proportional(PROP_ERR)
 "#;
 
-    /// #527/#524 review (finding #1): an `[initial_conditions]` model whose subject
-    /// has time-varying covariates must fall back to FD, because the TV-cov walk
-    /// never layers the init impulse. Before the fix `tvcov_analytical_supported`
-    /// returned `true` for the model and the walk silently dropped the `A₀·kernel`
-    /// baseline from the FOCE/FOCEI gradient (outer and inner) while the objective —
-    /// which uses the init-aware f64 predictor — kept it, biasing the estimates. The
-    /// non-TV-cov subjects of the same model must still take the exact init path.
+    /// **Closed-form `init(...)` on the event-driven TV-cov walk** (#486, branch H). An
+    /// `init(central) = TVC0·V` baseline under a WT covariate on CL (TV-cov). Production's
+    /// `compute_predictions_with_tv` layers `A₀·kernel(t, pk)` with the subject-static `t = 0`
+    /// snapshot; the TV-cov provider now folds in the same impulse via `apply_tvcov_init_outer` /
+    /// `apply_tvcov_init_inner`. The full provider's value / `∂η` / `∂²η` / `∂θ` / `∂²η∂θ` must
+    /// match FD of the production predictor (which keeps the init), the inner `∂f/∂η` must equal
+    /// the outer η-block, and a static-covariate subject of the same model still takes the exact
+    /// dose-superposition init path.
     #[test]
-    fn analytical_init_tvcov_subject_falls_back_to_fd() {
+    fn analytical_init_tvcov_subject_matches_fd() {
         let m = parse_model_string(ONECPT_IV_TVCOV_INIT).expect("parse");
         assert_eq!(m.analytical_init.len(), 1, "init parsed");
         assert!(
-            !tvcov_analytical_supported(&m),
-            "init model must decline TV-cov analytic support (walk omits the init)"
+            tvcov_analytical_supported(&m),
+            "init model is now analytic on the TV-cov walk (#486)"
         );
 
         let theta = vec![0.2, 10.0, 0.75, 4.0];
         let eta = vec![0.15, -0.10];
 
-        // TV-cov subject (WT changes across records): outer full provider AND inner
-        // η-gradient must decline so the caller falls back to FD.
+        // (a) TV-cov subject (WT changes across records): outer full provider matches FD of
+        // production (which includes the init), and the inner η-gradient matches the outer.
         let tv = tvcov_subject(
             vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
             &[70.0],
@@ -5190,16 +5499,44 @@ mod tests {
         );
         assert!(tv.has_tv_covariates(), "fixture must carry TV covariates");
         assert!(
-            subject_sensitivities(&m, &tv, &theta, &eta).is_none(),
-            "TV-cov init subject must fall back to FD, not the init-less walk"
+            subject_sensitivities(&m, &tv, &theta, &eta).is_some(),
+            "TV-cov init subject now takes the analytic provider (#486)"
         );
-        assert!(
-            subject_eta_grad(&m, &tv, &theta, &eta).is_none(),
-            "inner η-gradient must fall back to FD too"
-        );
+        check_full_provider_vs_fd(&m, &tv, &theta, &eta);
+        let outer = subject_sensitivities_tvcov(&m, &tv, &theta, &eta).expect("outer tvcov init");
+        let inner = subject_eta_grad_tvcov(&m, &tv, &theta, &eta).expect("inner tvcov init");
+        assert_eq!(outer.obs.len(), inner.len());
+        for (o, i) in outer.obs.iter().zip(inner.iter()) {
+            approx::assert_relative_eq!(o.f, i.f, max_relative = 1e-12, epsilon = 1e-12);
+            for k in 0..m.n_eta {
+                approx::assert_relative_eq!(
+                    o.df_deta[k],
+                    i.df_deta[k],
+                    max_relative = 1e-9,
+                    epsilon = 1e-10
+                );
+            }
+        }
 
-        // A static-covariate subject of the SAME model still takes the exact analytic
-        // init path (dose superposition + layered impulse).
+        // (b) TV-cov + EVID 3/4 reset: the closed-form init impulse contributes only to
+        // observations strictly before the first reset (production `add_analytical_init`), and
+        // the reset itself is carried by the TV-cov walk — the combination must still match FD.
+        let tv_reset = tvcov_subject(
+            vec![
+                DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+                DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+            ],
+            &[70.0, 90.0],
+            &[2.0, 6.0, 13.0, 18.0],
+            &[70.0, 70.0, 90.0, 90.0],
+            vec![12.0],
+            Vec::new(),
+            &[],
+        );
+        check_full_provider_vs_fd(&m, &tv_reset, &theta, &eta);
+
+        // (c) A static-covariate subject of the SAME model still takes the exact analytic init
+        // path (dose superposition + layered impulse).
         let mut stat = oral_subject(&[1.0, 2.0, 4.0, 8.0]);
         stat.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
         stat.covariates = wt_map(70.0);
@@ -7690,6 +8027,69 @@ mod tests {
         }
     }
 
+    // 1-cpt IV closed-form IOV with an `init(central) = TVC0·V` baseline (#486, branch
+    // G-closed-form). `CL = TVCL·exp(ETA_CL + KAPPA_CL)` carries the occasion κ, so the init
+    // *decay* kernel depends on κ (via each observation's occasion clearance) while the init
+    // *amount* `A₀ = TVC0·V` is BSV-only (no κ) — exactly production's split in `predict_iov`
+    // (`add_analytical_init_with(amount_pk = BSV, Some(obs_params))`).
+    const WARFARIN_IOV_INIT: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVC0(5.0, 0.1, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP_ERR ~ 0.2 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[initial_conditions]
+  init(central) = TVC0 * V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = foce
+  iov_column = OCC
+"#;
+
+    /// **`init(...)` × IOV on the closed-form walk** (#486, branch G-closed-form). The IOV
+    /// provider now layers the `A₀·kernel(t, pk)` init impulse per occasion: the amount from the
+    /// BSV snapshot (κ = 0), the decay from each observation's occasion clearance (κ carried).
+    /// The full provider's value / `∂(stacked-η)` / Hessian / `∂θ` must match FD of `predict_iov`
+    /// (which includes the init), and the inner η-gradient must equal the outer η-block.
+    #[test]
+    fn iov_init_provider_matches_fd_of_predict_iov() {
+        let model = parse_model_string(WARFARIN_IOV_INIT).expect("parse warfarin IOV+init");
+        assert_eq!(model.n_kappa, 1);
+        assert_eq!(model.analytical_init.len(), 1, "init parsed");
+        assert!(model.ode_spec.is_none(), "closed-form model");
+        assert!(
+            iov_analytical_supported(&model),
+            "closed-form IOV + init must be analytic (#486)"
+        );
+        let subject = iov_subject();
+        // θ = [TVCL, TVV, TVC0]; stacked = [η_cl, η_v, κ_g0, κ_g1].
+        check_iov_provider_vs_fd(
+            &model,
+            &subject,
+            &[0.2, 10.0, 5.0],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+    }
+
+    #[test]
+    fn iov_init_inner_eta_grad_matches_outer() {
+        check_iov_inner_matches_outer(
+            &parse_model_string(WARFARIN_IOV_INIT).expect("parse warfarin IOV+init"),
+            &iov_subject(),
+            &[0.2, 10.0, 5.0],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+    }
+
     const WARFARIN_IOV_2CPT: &str = r#"
 [parameters]
   theta TVCL(0.2, 0.001, 10.0)
@@ -9698,6 +10098,80 @@ mod tests {
             &parse_model_string(WARFARIN_IOV_TVCOV_ODE).expect("parse ODE IOV+TV-cov"),
             &iov_tvcov_subject(true),
             &[0.2, 10.0, 0.75],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+    }
+
+    // 1-cpt IV ODE IOV + TV-cov with a **κ-coupled `init(...)` baseline**: `init(central) =
+    // BASE` where `BASE = TVBASE·exp(ETA_V + KAPPA_CL)` carries η_v *and* the occasion κ, so the
+    // event-driven IOV walk's `tvcov_init_state` seed (built from the first-record snapshot's
+    // stacked `(θ, η_bsv, κ)` duals) must fold `∂init/∂κ` onto the correct occasion axis (#486).
+    const WARFARIN_IOV_ODE_INIT: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta THETA_WT(0.75, 0.01, 2.0)
+  theta TVBASE(40.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP_ERR ~ 0.2 (sd)
+[individual_parameters]
+  CL   = TVCL * (WT/70)^THETA_WT * exp(ETA_CL + KAPPA_CL)
+  V    = TVV  * exp(ETA_V)
+  BASE = TVBASE * exp(ETA_V + KAPPA_CL)
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE
+  d/dt(central) = -(CL/V) * central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  iov_column = OCC
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    /// **`init(...)` × IOV on the ODE walk** (#486, branch G-ODE). A κ-coupled `init(central) =
+    /// BASE` baseline (`BASE = TVBASE·exp(ETA_V + KAPPA_CL)`) on a 1-cpt IV ODE IOV + TV-cov
+    /// subject. The IOV outer/inner run through the same `integrate_tvcov_readout` the non-IOV
+    /// walk uses, so `tvcov_init_state` already seeds `init` from the first-record snapshot's
+    /// stacked `(θ, η_bsv, κ)` duals — the Taylor deltas carry `∂init/∂κ` onto the correct
+    /// occasion axis with no IOV-specific code. Validated against FD of `predict_iov` over the
+    /// full stacked layout, plus inner/outer η-parity.
+    #[test]
+    fn ode_iov_init_provider_matches_fd_of_predict_iov() {
+        let model = parse_model_string(WARFARIN_IOV_ODE_INIT).expect("parse ODE IOV+init");
+        assert_eq!(model.n_kappa, 1);
+        assert!(model.ode_spec.is_some());
+        assert!(
+            model.ode_spec.as_ref().unwrap().init_fn.is_some(),
+            "fixture must declare an init(...)"
+        );
+        assert!(
+            crate::sens::ode_provider::ode_iov_supported(&model),
+            "ODE IOV + init must be analytic (#486)"
+        );
+        let subject = iov_tvcov_subject(false);
+        // θ = [TVCL, TVV, THETA_WT, TVBASE]; stacked = [η_cl, η_v, κ_g0, κ_g1].
+        check_iov_provider_vs_fd(
+            &model,
+            &subject,
+            &[0.2, 10.0, 0.75, 40.0],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+    }
+
+    #[test]
+    fn ode_iov_init_inner_eta_grad_matches_outer() {
+        check_iov_inner_matches_outer(
+            &parse_model_string(WARFARIN_IOV_ODE_INIT).expect("parse ODE IOV+init"),
+            &iov_tvcov_subject(false),
+            &[0.2, 10.0, 0.75, 40.0],
             &[0.12, -0.08, 0.05, -0.10],
         );
     }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -10176,6 +10176,71 @@ mod tests {
         );
     }
 
+    // ODE IOV with a `first_order` input-rate forcing AND a κ-coupled `init(central) = BASE`
+    // baseline — the composition the #660 (`FirstOrder` under IOV) and #486 (`init` under IOV)
+    // gate relaxations jointly admit. Both ride the same `integrate_tvcov_readout` walk: the
+    // dose feeds `R_in = KA·(remaining)` and the init baseline is seeded from the first-record
+    // stacked snapshot, so the two are orthogonal. This pins that they compose correctly.
+    const WARFARIN_IOV_ODE_INIT_FO: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta THETA_WT(0.75, 0.01, 2.0)
+  theta TVBASE(40.0, 1.0, 500.0)
+  theta TVKA(1.2, 0.01, 20.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP_ERR ~ 0.2 (sd)
+[individual_parameters]
+  CL   = TVCL * (WT/70)^THETA_WT * exp(ETA_CL + KAPPA_CL)
+  V    = TVV  * exp(ETA_V)
+  KA   = TVKA
+  BASE = TVBASE * exp(ETA_V + KAPPA_CL)
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  init(central) = BASE
+  d/dt(central)  = first_order(ka=KA) - (CL/V) * central
+[covariates]
+  WT continuous
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  iov_column = OCC
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    /// **`init(...)` × `first_order` input-rate forcing × IOV on the ODE walk** (#486, the
+    /// combination the #660 and #486 IOV relaxations jointly admit). Validated against FD of
+    /// `predict_iov` over the stacked layout, plus inner/outer parity.
+    #[test]
+    fn ode_iov_init_first_order_provider_matches_fd_of_predict_iov() {
+        let model = parse_model_string(WARFARIN_IOV_ODE_INIT_FO).expect("parse ODE IOV+init+FO");
+        assert!(!model.ode_spec.as_ref().unwrap().input_rate.is_empty());
+        assert!(model.ode_spec.as_ref().unwrap().init_fn.is_some());
+        assert!(
+            crate::sens::ode_provider::ode_iov_supported(&model),
+            "ODE IOV + init + first_order must be analytic"
+        );
+        let subject = iov_tvcov_subject(false);
+        // θ = [TVCL, TVV, THETA_WT, TVBASE, TVKA]; stacked = [η_cl, η_v, κ_g0, κ_g1].
+        check_iov_provider_vs_fd(
+            &model,
+            &subject,
+            &[0.2, 10.0, 0.75, 40.0, 1.2],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+        check_iov_inner_matches_outer(
+            &model,
+            &subject,
+            &[0.2, 10.0, 0.75, 40.0, 1.2],
+            &[0.12, -0.08, 0.05, -0.10],
+        );
+    }
+
     /// **Static-covariate** ODE IOV subject with an EVID=2 pk-only breakpoint. The TV-cov
     /// pk-only tests above always take `seed_iov_events`' per-event (TV) branch; a subject
     /// with no dose/obs TV covariates **and an empty `pk_only_covariates`** instead takes the


### PR DESCRIPTION
## Why

`init(...)` / `[initial_conditions]` baselines (indirect-response, disease-progression, and
baseline-biomarker PD models) are among the most common real-world structures, and they
routinely combine a parameter-dependent baseline with IV infusion, IOV, or steady-state dosing.
Before this PR the analytic FOCE/FOCEI gradient carried `init` only on the closed-form
dose-superposition path (#527) and the ODE **plain-bolus** TV-cov subset (#649). **Every other
combination fell back to finite differences** — the model still fit correctly, but with a
2×n_eta-per-call FD gradient instead of the exact analytic one. This closes that gap: `init(...)`
is now fully analytic on the FOCE/FOCEI sensitivity gradient across both engines.

Closes the "Initial conditions" gaps tracked in #486.

## What changed

**One completion PR** spanning the ODE event-driven walk, the closed-form TV-cov walk, and both
IOV engines. The differentiation machinery already existed (`init_fd_derivs`, `tvcov_init_state`
#649, `apply_analytical_init_*` #527) — this reuses it, adding math only where a branch was
written for a zero baseline and wasn't yet validated against a parameter-dependent seed.

- **ODE non-IOV walk (`integrate_tvcov_g`), branches A–F.** `init` now composes with a finite
  infusion, a built-in input-rate forcing (igd/transit/weibull/`first_order`/`zero_order`), an
  estimated lagtime, steady-state dosing, a modeled-duration/rate dose, and an EVID 3/4 reset.
  Most were validation-only — the walk already seeds `init_state` (#649) and integrates the
  forcing / saltation on top of the running state, so the analytic gradient already matched
  FD-of-production. Two required real work:
  - **Pre-first-event integration.** The walk started `cur_t` at the first *timeline* event; with
    a lagged first dose and a pre-arrival observation, the `init` decay over `[integration_start,
    first_event]` was skipped (the pre-event obs read the *undecayed* seed). It now starts at
    `subject_integration_start` when `init` is present (a no-op for a zero baseline, so the
    non-init walk is byte-identical).
  - **Reset re-seed.** Production re-applies `init(&last_pk.values)` at each reset; the `K_RESET`
    branch now re-seeds the state from the reset-event snapshot via a shared `init_taylor_seed_at`
    helper (factored out of `tvcov_init_state`) instead of zeroing.
- **Closed-form TV-cov walk (`subject_sensitivities_tvcov` / `subject_eta_grad_tvcov`),
  branch H.** New `apply_tvcov_init_{outer,inner}` fold the `A₀·kernel(t, pk)` impulse (exact
  `(θ,η)` jet at the subject-static `t=0` snapshot) into the walked jet before scaling —
  matching production's `add_analytical_init` on `compute_predictions_with_tv`, which uses that
  same snapshot for both amount and decay.
- **IOV, branch G.**
  - *ODE IOV* was a one-line gate relaxation: `run_subject_iov` / `_eta` already route through
    `integrate_tvcov_readout`, so `tvcov_init_state`'s Taylor deltas carry `∂init/∂κ` onto the
    correct occasion axis with no IOV-specific code.
  - *Closed-form IOV* required an occasion-aware impulse in `run_obs_iov` / `run_obs_iov_eta`:
    the amount `A₀` from a BSV-only snapshot (κ=0) and the decay kernel from each observation's
    occasion source (κ carried) — exactly production's `add_analytical_init_with(amount_pk = BSV,
    Some(obs_params))` split. Threaded a `bsv_amount` source through `IovSources`.

Every gate clause was relaxed per-branch, each behind its own passing FD-vs-production test.

## Alternatives considered

The plan's §D speculated that `init` should *persist* on compartments a steady-state dose doesn't
reach. Empirically, production's `equilibrate_ss_state` seeds from zero and **overwrites the whole
state** at the SS dose — it discards `init` there — so preserving it would have *diverged* from the
objective the FD differentiates. The correct behaviour (which the dual walk already had) is to
match production: `init` only affects the pre-SS-dose segments. This is the "check empirically
before adding math" guidance paying off.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Crate-internal `sens/` work; no `pub` API surface changed.

## Breaking changes
- [x] None

## Numerical validation

**NONMEM comparison (matches the #649 precedent).** A NONMEM `ADVAN13 A_0(...)` with a
*parameter-dependent* baseline hits `LSODA CODE -3`, so a `init = f(θ,η)` gradient cannot be
anchored against a live NONMEM fit directly. Instead:

- The underlying `init` **prediction** is already NONMEM-validated — the 6-thioguanine model
  (`run14`, `ADVAN2 TRANS2`, `A_0(2) = CONC0·V`) is reproduced to the tolerances in
  `docs/model-file/initial-conditions.qmd` (#521/#523/#527).
- The new analytic **gradient** is validated against central finite differences of the exact
  production predictor (`compute_predictions_with_tv` / `predict_iov`) — which is the exact
  objective NONMEM's FOCE/FOCEI also differentiates — pointwise on value, `∂f/∂(θ,η[,κ])`, and
  **both Hessian blocks**, plus inner≡outer parity, for **every** A–H combination.

```
# analytic vs double-FD of the production predictor, init + infusion (ETA_V∂² crossing zero mid-window)
analytic d²f/dη_V²  = -0.03579408   prod-FD = -0.03568417   (0.31%, near a sign-crossing)
# all other Hessian elements agree to < 0.001%
```

`cargo test --lib --no-default-features --features ci` is green (2100+ tests).

## Performance
- [x] Faster for the affected models — the exact analytic gradient replaces a 2×n_eta-per-call
  FD gradient. No slowdown for non-init models (gated on `init_fn` / `analytical_init`).

## Tests
- [x] Unit tests added per combination (`cargo test --lib` passes): `ode_provider_tvcov_init_{infusion,lagtime,modeled_duration,ss,reset}_matches_production`, `ode_provider_tvcov_init_{input_rate,zero_order}_matches_production`, `analytical_init_tvcov_subject_matches_fd` (closed-form + reset), `ode_iov_init_provider_matches_fd_of_predict_iov`, `iov_init_provider_matches_fd_of_predict_iov`, plus inner/outer parity twins.
- [x] Gate scope test updated (`ode_tvcov_init_compositions_are_analytic`; the stale
  `analytical_init_tvcov_subject_falls_back_to_fd` became a FD-match test).

## Docs
- [x] `docs/model-file/initial-conditions.qmd` updated (the "IOV falls back to FD" limitation is
  removed; the full analytic scope is described).
- [x] `CHANGELOG.md` `[Unreleased] ### Added` entry added.

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] Functions on the `Dual2` path stay generic `*_g<T: PkNum>` (shared `init_taylor_seed_at`,
  `analytical_init_concentration_g`)

## Reviewer hints

- **`init_taylor_seed_at`** (`ode_provider.rs`) is the shared seed for both the first-record
  snapshot and the reset re-seed — the Taylor is exact to 2nd order because `δ = snap − snap.val()`
  carries `snap`'s full jet, so its `Dual2` hess equals the true `init(snap)` chain rule.
- **The pre-first-event integration-start fix** is the subtlest change: gated on `init_fn`, it only
  extends the walk backward when a baseline is present; verify it's a no-op for zero baselines.
- **Closed-form IOV** (`run_obs_iov`/`_eta`): the amount uses the κ-less `bsv_amount` snapshot; the
  decay uses `sources[obs_src[j]]` (occasion κ). This split is what makes `∂A₀/∂κ = 0` while
  `∂(decay)/∂κ ≠ 0`, matching `predict_iov`.

## Open questions

- The #486 matrix flip is deferred to post-merge (house rule): the dedicated "Initial conditions"
  row `🔶🔶🔶🔶` → `✅`, plus the `init` notes in the "Time-varying covariates" and "IOV (κ)" rows,
  and a one-liner in the Shipped list.
