### PR TITLE
fix(transit): route sdtab state columns to ODE equivalent + lazy build [#486]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,7 +586,9 @@ section of the SDLC for the versioning policy).
   scope (a `lagtime=`/`f=` mapping, a custom `[scaling]`, or an `[initial_conditions]` block)
   carry no equivalent and are still rejected up front (`fit()` errors; `predict()`/
   `simulate()` panic) rather than mis-predict — write the ODE `transit()` model directly for
-  those.
+  those. Follow-up: the sdtab compartment/state (`[derived]`) columns for such a subject now
+  come from the ODE equivalent too (previously they were `NaN` because the states path did
+  not route to the equivalent, even though IPRED did).
 - **Finite / modeled-duration infusions combined with a time-varying covariate that
   changes across the infusion's end** now get an exact analytic second-order gradient
   (#486). The rate-off boundary sits between records, so the RHS Jacobian jumps there;

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -975,22 +975,17 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // the rest of this function — including ODE detection below — sees a normal
     // ODE model with no special-casing.
     apply_ode_template(&mut extracted)?;
-    // Build the `one_cpt_transit` ODE-equivalent sub-model (#486): the transit closed form
-    // assumes constant parameters over each absorption window, so it cannot serve a subject
-    // whose parameters switch mid-profile (a `TIME`-dependent parameter or time-varying
-    // covariates). For a plain-form transit model we compile its exact ODE `transit()`
-    // equivalent here and stash it on the model; the runtime dispatch
-    // (`effective_model_for`) routes only the subjects that need it to this fallback, so a
-    // plain transit fit keeps its fast, exact closed form. Non-transit / out-of-scope forms
-    // yield `None`. Parsing the equivalent source recurses one level (it is a normal ODE
-    // model with no `pk one_cpt_transit`, so it does not re-enter this branch).
-    let transit_ode_equivalent: Option<Box<CompiledModel>> =
-        match transit_ode_equivalent_source(&extracted) {
-            Some(src) => Some(Box::new(parse_model_string(&src).map_err(|e| {
-                format!("internal error building one_cpt_transit ODE equivalent: {e}")
-            })?)),
-            None => None,
-        };
+    // Prepare the `one_cpt_transit` ODE-equivalent (#486): the transit closed form assumes
+    // constant parameters over each absorption window, so it cannot serve a subject whose
+    // parameters switch mid-profile (a `TIME`-dependent parameter or time-varying covariates).
+    // For a plain-form transit model we reconstruct its exact ODE `transit()` equivalent
+    // *source* here and stash it on the model; `CompiledModel::effective_for` compiles it
+    // lazily and routes only the subjects that need it to this fallback, so a plain transit
+    // fit whose subjects never need it keeps its fast, exact closed form at zero extra cost.
+    // Non-transit / out-of-scope forms yield `None`. (The equivalent is a normal ODE model
+    // with no `pk one_cpt_transit`, so building it later does not re-enter this branch.)
+    let transit_ode_equivalent: Option<crate::types::TransitOdeEquivalent> =
+        transit_ode_equivalent_source(&extracted).map(crate::types::TransitOdeEquivalent::new);
     // Keep the historical `blocks` binding for unnamed blocks so the rest of
     // this (large) function reads unchanged. Named blocks are pulled from
     // `extracted.named` directly where they're consumed below.
@@ -6139,7 +6134,7 @@ fn apply_ode_template(extracted: &mut ExtractedBlocks) -> Result<(), String> {
 /// those per-event through the event-driven walk (analytically for `TIME` since #664). The
 /// parser compiles this source into a sub-model stored on
 /// [`CompiledModel::transit_ode_equivalent`]; the runtime dispatch
-/// ([`crate::sens::provider::effective_model_for`]) uses it only for the subjects that need
+/// ([`CompiledModel::effective_for`]) uses it only for the subjects that need
 /// it, so a plain transit fit keeps its fast, exact closed form (#486).
 ///
 /// The equivalent shares the model's `[parameters]`/`[individual_parameters]`/… blocks
@@ -14313,7 +14308,8 @@ mod tests {
         let eq = model
             .transit_ode_equivalent
             .as_ref()
-            .expect("transit + TIME must carry an ODE equivalent");
+            .expect("transit + TIME must carry an ODE equivalent")
+            .get_or_build();
         let ode = eq
             .ode_spec
             .as_ref()

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1362,6 +1362,12 @@ pub fn compute_predictions_with_states(
     theta: &[f64],
     eta: &[f64],
 ) -> (Vec<f64>, Vec<Vec<f64>>) {
+    // A `one_cpt_transit` subject the closed form can't serve (TIME switch / TV covariates)
+    // routes to its ODE `transit()` equivalent — so the compartment/state columns come from
+    // the ODE integration (the `ode_spec` branch below) instead of the analytical
+    // superposition path, which has no valid states for those subjects and would otherwise
+    // return NaN. Matches the IPRED routing in `compute_predictions_with_tv` (#486).
+    let model = model.effective_for(subject);
     let uses_time = model_uses_time_builtin(model);
     if let Some(ref ode) = model.ode_spec {
         // ODE path: both ipred and states come from a single ODE integration.

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -8374,7 +8374,7 @@ mod tests {
         assert!(
             std::ptr::eq(
                 m.effective_for(&tv),
-                m.transit_ode_equivalent.as_deref().unwrap()
+                m.transit_ode_equivalent.as_ref().unwrap().get_or_build()
             ),
             "TV-cov transit subject must be served by the ODE equivalent"
         );

--- a/src/types.rs
+++ b/src/types.rs
@@ -2777,12 +2777,45 @@ pub struct CompiledModel {
     /// runtime fallback when the closed form cannot serve a particular subject. Currently
     /// only `one_cpt_transit`: the closed form assumes constant parameters over each
     /// absorption window, so a mid-profile `TIME` switch or time-varying covariates route to
-    /// this exact ODE `transit()` equivalent instead (kept a boxed full model so it reuses
-    /// the whole ODE prediction/sensitivity path unchanged). `None` when the model needs no
-    /// fallback (not transit, or a transit form outside the desugar's scope). See
-    /// [`crate::sens::provider::effective_model_for`] and the parser's
+    /// this exact ODE `transit()` equivalent instead (a full boxed sub-model, built lazily so
+    /// it reuses the whole ODE prediction/sensitivity path unchanged and costs nothing for a
+    /// transit fit whose subjects never need it). `None` when the model needs no fallback
+    /// (not transit, or a transit form outside the desugar's scope). See
+    /// [`CompiledModel::effective_for`] and the parser's
     /// `transit_ode_equivalent_source` (#486).
-    pub transit_ode_equivalent: Option<Box<CompiledModel>>,
+    pub transit_ode_equivalent: Option<TransitOdeEquivalent>,
+}
+
+/// A lazily-built ODE representation of an analytical model that carries one (currently only
+/// `one_cpt_transit`). Holds the equivalent's reconstructed `.ferx` source and compiles the
+/// boxed sub-model on first use, so a transit fit whose subjects never hit the fallback
+/// (constant-parameter, non-`TIME`) pays no extra parse or allocation. See
+/// [`CompiledModel::effective_for`] (#486).
+pub struct TransitOdeEquivalent {
+    source: String,
+    built: std::sync::OnceLock<Box<CompiledModel>>,
+}
+
+impl TransitOdeEquivalent {
+    pub(crate) fn new(source: String) -> Self {
+        Self {
+            source,
+            built: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Build (once, thread-safely) and return the ODE equivalent sub-model. The source is
+    /// reconstructed from already-validated model blocks, so parsing it is infallible in
+    /// practice; a failure is an internal reconstruction bug and panics loudly rather than
+    /// silently degrading the fit.
+    pub(crate) fn get_or_build(&self) -> &CompiledModel {
+        self.built.get_or_init(|| {
+            Box::new(
+                crate::parser::model_parser::parse_model_string(&self.source)
+                    .expect("internal: one_cpt_transit ODE equivalent failed to build"),
+            )
+        })
+    }
 }
 
 /// FREM (Full Random Effects Model) configuration.
@@ -2855,7 +2888,7 @@ impl CompiledModel {
             if crate::parser::model_parser::compiled_model_uses_time_builtin(self)
                 || subject.has_tv_covariates()
             {
-                return eq;
+                return eq.get_or_build();
             }
         }
         self

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -212,6 +212,33 @@ fn transit_time_desugar_matches_hand_written_ode() {
         ps.iter().any(|p| p.time > 6.0) && ps.iter().any(|p| p.time < 6.0),
         "observations must straddle the TIME switch"
     );
+
+    // Compartment/state columns (sdtab `[derived]`) must ALSO route to the equivalent — the
+    // analytical states path has no valid states for a TIME/TV-cov transit subject and would
+    // return NaN. They must be finite and match the hand-written ODE twin's states.
+    let subj = &pop.subjects[0];
+    let eta = vec![0.0; sh.n_eta];
+    let (_, sh_states) =
+        ferx_core::pk::compute_predictions_with_states(&sh, subj, &sh.default_params.theta, &eta);
+    let (_, hd_states) =
+        ferx_core::pk::compute_predictions_with_states(&hd, subj, &hd.default_params.theta, &eta);
+    assert!(
+        !sh_states.is_empty()
+            && sh_states
+                .iter()
+                .all(|s| !s.is_empty() && s.iter().all(|x| x.is_finite())),
+        "transit + TIME compartment states must be finite (not the NaN the analytical path returns)"
+    );
+    assert_eq!(sh_states.len(), hd_states.len());
+    for (a, b) in sh_states.iter().zip(hd_states.iter()) {
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!(
+                (x - y).abs() <= ATOL + RTOL * x.abs(),
+                "state mismatch: desugared {x:.6} vs hand ODE {y:.6}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

Follow-up review fixes for the `one_cpt_transit` ODE-equivalent feature merged in #663. A high-effort review flagged one real correctness bug plus two cleanup/efficiency items; #663 was already merged, so these land as a separate PR on top of it.

## What changed

1. **Correctness — NaN compartment/state columns (`src/pk/mod.rs`).** `compute_predictions_with_states` did not call `effective_for`, so a newly-permitted `one_cpt_transit` + `TIME` / TV-cov model got a correct IPRED (routed to the ODE equivalent via `compute_predictions_with_tv`) but emitted **NaN** compartment-amount / `[derived]` state columns in `sdtab` — the states path stayed on the primary closed-form model (`ode_spec == None`) and hit the `uses_time -> vec![]` branch. It now swaps to the effective model, so the state columns come from the ODE integration. The equivalence integration test is extended to assert the states are finite and match the hand-written ODE twin.

2. **Efficiency — lazy ODE-equivalent build (`src/types.rs`, `src/parser/model_parser.rs`).** The sub-model was eagerly parsed + boxed for *every* plain transit model, even one whose subjects never need it. It is now stored as a reconstructed `.ferx` source string and compiled lazily on first `effective_for` selection, via `TransitOdeEquivalent { source, OnceLock<Box<CompiledModel>> }`. A constant-parameter, non-`TIME` transit fit pays no extra parse or allocation.

3. **Cleanup — broken intra-doc link.** `crate::sens::provider::effective_model_for` (nonexistent) → `CompiledModel::effective_for` at both sites.

## Validation
- `cargo test --lib` → **2136 passed, 0 failed**; transit equivalence integration suite green; `fmt` clean.
- New assertion: transit + `TIME` compartment states are finite and match the hand-written ODE twin's states (previously NaN).

## Breaking changes
- [x] None (fixes an unreleased feature from #663).

## Reviewer hints
- The correctness fix is the one-line `effective_for` swap at the top of `compute_predictions_with_states`, mirroring the IPRED routing; the states test pins it.
