### PR TITLE
feat(error-model): block_sigma correlated residuals with covariate-selected [error_model] [closes #669]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ section of the SDLC for the versioning policy).
   per-row flag without recoding it into a synthetic `CMT` column. Works on
   analytical **and** ODE models, across FOCE/FOCEI, Gauss-Newton, SAEM, and
   importance sampling. The selector covariate becomes a required data column
-  (`E_MISSING_COVARIATE`). `block_sigma` correlated residuals with a selected
-  error model are rejected with a clear error for now. See
+  (`E_MISSING_COVARIATE`). `block_sigma` correlated residuals are supported
+  together with a selected error model (#669): co-temporal rows resolving to
+  different branches (e.g. a total/unbound assay pair) pick up the cross-branch
+  covariance `ρ·σ_i·σ_j` in the dense residual `R`, exactly as for per-CMT
+  endpoints. See
   [Error model → Covariate-selected error models](https://ferx-nlme.github.io/ferx-core/model-file/error-model.html).
 - **Full `[scaling] y = <expr>` output readouts (Form C) on analytical PK models** (#650).
   A closed-form (`pk one_cpt_iv(...)`, …) model can now replace the built-in

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -412,6 +412,14 @@ under `method = foce` / `method = focei` (the EKF variance is added to the dense
 `R`) but are rejected under `method = saem`, whose M-step data term does not yet
 include the process-noise inflation.
 
+`simulate()` draws each observation's residual independently and does **not**
+reproduce a `block_sigma` off-diagonal covariance — simulated total/unbound (or
+cross-branch, for a covariate-selected model) rows are uncorrelated even though
+the estimation objective honours the correlation. A VPC or posterior-predictive
+check of the correlated endpoints will therefore understate the residual
+covariance; this applies to every `block_sigma` model, per-CMT and
+covariate-selected alike.
+
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian
 becomes `H̃ = HᵀR⁻¹H + ½·B + Ω⁻¹` with `B_{kl} = tr(R⁻¹ ∂R/∂η_k R⁻¹ ∂R/∂η_l)`

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -287,10 +287,16 @@ Rules and restrictions:
 - **Estimation method.** Supported with FOCE/FOCEI, the Gauss-Newton
   optimizers, SAEM, and importance sampling — every likelihood/gradient path
   dispatches on the selected endpoint.
-- **`block_sigma` is not yet supported** together with a covariate-selected
-  error model: the correlated-residual pairing rule is not yet defined in terms
-  of the selector, so the combination is rejected with a clear error. Use
-  uncorrelated sigmas, or a per-CMT model, for correlated residuals.
+- **`block_sigma` correlated residuals are supported** together with a
+  covariate-selected error model (#669). Each observation resolves to a branch
+  per row, loads that branch's sigmas, and rows sharing a subject time and
+  occasion pick up the `block_sigma` cross covariance in the dense residual `R`
+  — exactly the pairing rule used for per-CMT endpoints. Two co-temporal rows
+  resolving to *different* branches (e.g. a total `FREE=0` and an unbound
+  `FREE=1` measurement of the same sample) get the honest cross-branch
+  covariance `ρ·σ_i·σ_j` from each row's own loadings. The method restrictions
+  on `block_sigma` (see the [Sigma scale](#sigma-scale) section) apply
+  unchanged.
 - **LTBS** (`log(DV) ~ ...` / `log_additive`) is not supported inside a branch.
 - **SDE / `[diffusion]` models are not supported.** The EKF measurement-noise
   path uses a single error model and cannot switch per observation, so the
@@ -389,10 +395,12 @@ $$
 The diagonal sigma SDs are estimated unless marked `FIX`; the off-diagonal
 covariance is always converted to a fixed correlation. A nonzero `block_sigma`
 covariance can connect sigmas that co-load on the same `combined(...)` endpoint,
-or sigmas used by different CMT endpoints measured at the same subject time and
-occasion. In the cross-endpoint case ferx builds a subject-level residual
-covariance matrix, so paired rows such as total/unbound assays receive the
-NONMEM-style covariance term `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
+or sigmas used by different endpoints measured at the same subject time and
+occasion — whether those endpoints are selected by the CMT column (per-CMT) or
+by a covariate `if/else` selector (#669). In the cross-endpoint case ferx builds
+a subject-level residual covariance matrix, so paired rows such as total/unbound
+assays receive the NONMEM-style covariance term
+`f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
 
 Current scope: `block_sigma` is supported for the Gaussian `method = foce`,
 `method = focei`, `method = saem`, and `method = imp` fits. The Gauss-Newton

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -418,7 +418,7 @@ cross-branch, for a covariate-selected model) rows are uncorrelated even though
 the estimation objective honours the correlation. A VPC or posterior-predictive
 check of the correlated endpoints will therefore understate the residual
 covariance; this applies to every `block_sigma` model, per-CMT and
-covariate-selected alike.
+covariate-selected alike (tracked in issue #672).
 
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -1974,7 +1974,11 @@ pub(crate) fn compute_posterior_hessian(
         let r = crate::stats::residual_error::compute_r_matrix_with_correlations(
             &model.error_spec,
             &ipreds,
-            &subject.obs_cmts,
+            // #669: selector-resolved endpoint keys (matches the diagonal
+            // fallback below), not the raw CMT column — a `Selected` spec keys
+            // endpoints by branch, so `obs_cmts` would build the proposal
+            // precision from the wrong branch's sigma.
+            model.error_spec.obs_keys(subject).as_ref(),
             &subject.obs_times,
             &subject.obs_raw_times,
             &subject.occasions,

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -447,9 +447,11 @@ fn ruv_kappa(eps: f64, r: f64, d: f64) -> f64 {
 ///
 /// A genuine cross-endpoint off-diagonal `R` (paired total/unbound rows) would need
 /// the full dense `M_k`/`B_{kl}` assembly, but such models require a per-CMT / Form-C
-/// readout that is out of analytic scope (they run FD). The off-diagonal check is a
-/// defensive guard: if one ever reaches here, bail to FD rather than silently drop the
-/// off-diagonals.
+/// or covariate-selected (#669) multi-endpoint readout that is out of analytic scope
+/// (they run FD). The off-diagonal check is a defensive guard: if one ever reaches
+/// here, bail to FD rather than silently drop the off-diagonals. The endpoint keys are
+/// resolved via `ErrorSpec::obs_keys` so a `Selected` spec's per-row branch — not the
+/// raw CMT column — drives the diagonal variance builders.
 fn corr_residual_diag(
     model: &CompiledModel,
     subject: &Subject,
@@ -461,12 +463,19 @@ fn corr_residual_diag(
     };
     let corr = &model.residual_correlations;
     let es = &model.error_spec;
+    // #669: per-observation endpoint keys must come from the covariate selector
+    // (`obs_keys`), not the raw CMT column — a `Selected` spec keys endpoints by
+    // branch index, decoupled from `obs_cmts` (typically all-1 on an analytical
+    // single-endpoint model). Passing `obs_cmts` here would score every row
+    // against the wrong branch's sigma. `PerCmt`/`Single` still get exactly the
+    // CMT column (`obs_keys` borrows it unchanged).
+    let err_keys = es.obs_keys(subject);
     let ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
     let n = ipreds.len();
     let r = compute_r_matrix_with_correlations(
         es,
         &ipreds,
-        &subject.obs_cmts,
+        err_keys.as_ref(),
         &subject.obs_times,
         &subject.obs_raw_times,
         &subject.occasions,
@@ -484,7 +493,7 @@ fn corr_residual_diag(
     let dr = compute_dr_df_matrices(
         es,
         &ipreds,
-        &subject.obs_cmts,
+        err_keys.as_ref(),
         &subject.obs_times,
         &subject.obs_raw_times,
         &subject.occasions,
@@ -495,7 +504,7 @@ fn corr_residual_diag(
     let d2 = compute_d2r_df2_matrices(
         es,
         &ipreds,
-        &subject.obs_cmts,
+        err_keys.as_ref(),
         &subject.obs_times,
         &subject.obs_raw_times,
         &subject.occasions,
@@ -528,10 +537,13 @@ fn corr_residual_rd_at_sigma(
     let corr = &model.residual_correlations;
     let es = &model.error_spec;
     let n = ipreds.len();
+    // #669: selector-resolved endpoint keys, not the raw CMT column (see
+    // `corr_residual_diag`).
+    let err_keys = es.obs_keys(subject);
     let dr = compute_dr_df_matrices(
         es,
         ipreds,
-        &subject.obs_cmts,
+        err_keys.as_ref(),
         &subject.obs_times,
         &subject.obs_raw_times,
         &subject.occasions,
@@ -542,7 +554,7 @@ fn corr_residual_rd_at_sigma(
     let mut rv = vec![0.0; n];
     let mut dv = vec![0.0; n];
     for j in 0..n {
-        rv[j] = es.variance_at_with_correlations(subject.obs_cmts[j], ipreds[j], sigma, corr);
+        rv[j] = es.variance_at_with_correlations(err_keys[j], ipreds[j], sigma, corr);
         dv[j] = dr[j][(j, j)];
     }
     (rv, dv)
@@ -3017,7 +3029,7 @@ mod tests {
     use crate::estimation::parameterization::pack_params;
     use crate::parser::model_parser::parse_model_string;
     use crate::stats::likelihood::{foce_subject_nll, foce_subject_nll_interaction};
-    use crate::types::{DoseEvent, OmegaMatrix, Subject};
+    use crate::types::{DoseEvent, ErrorSpec, OmegaMatrix, Subject};
     use std::collections::HashMap;
 
     const TWOCPT: &str = r#"
@@ -4025,6 +4037,116 @@ mod tests {
             let f1 = fd_at(k, h);
             let f2 = fd_at(k, h / 2.0);
             let fd = (4.0 * f2 - f1) / 3.0;
+            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
+        }
+    }
+
+    /// Covariate-selected (`if/else`) `block_sigma` fixture: each row's residual
+    /// branch is chosen by a per-row `FREE` flag, and the two branch sigmas are
+    /// correlated through one `block_sigma`. Distinct observation times mean no
+    /// two rows share a residual block, so `R` stays diagonal and the analytic
+    /// outer-gradient path (`corr_residual_diag`) proceeds rather than bailing to
+    /// FD — exactly the path that must resolve the endpoint via the selector
+    /// (`obs_keys`), not the raw CMT column (#669).
+    const SELECTED_BLOCK_SIGMA_1CPT: &str = "[parameters]\n  theta TVCL(1.0, 0.01, 10.0)\n  theta TVV(10.0, 0.1, 100.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.04, 0.03, 0.09]\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V  = TVV * exp(ETA_V)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  if (FREE == 0) {\n    DV ~ proportional(PROP_TOTAL)\n  } else {\n    DV ~ proportional(PROP_UNBOUND)\n  }\n[covariates]\n  FREE continuous\n[fit_options]\n  method = focei\n";
+
+    /// [`dense_subject`] with a per-row `FREE` covariate driving the selected
+    /// residual branch. `times` and `free_flags` must be equal length; times are
+    /// kept distinct by the caller so `R` is diagonal.
+    fn selected_dense_subject(
+        model: &CompiledModel,
+        theta: &[f64],
+        times: &[f64],
+        free_flags: &[f64],
+    ) -> Subject {
+        let mut subject = dense_subject(model, theta, times);
+        subject.obs_covariates = free_flags
+            .iter()
+            .map(|&f| HashMap::from([("FREE".to_string(), f)]))
+            .collect();
+        subject
+    }
+
+    /// #669 regression: with the `Selected` + `block_sigma` guard lifted, the
+    /// analytic FOCEI outer gradient must resolve each row's endpoint via the
+    /// covariate selector. If `corr_residual_diag` / `corr_residual_rd_at_sigma`
+    /// read the raw CMT column (all-1 here) instead of the branch, every `FREE=0`
+    /// row is scored against the `else` branch's sigma and the analytic gradient
+    /// diverges from FD of ferx's dense FOCEI marginal (which uses the correct
+    /// keys). Must match across every θ/Ω/σ coordinate.
+    #[test]
+    fn population_packed_gradient_selected_block_sigma_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        use crate::types::Population;
+
+        let model =
+            parse_model_string(SELECTED_BLOCK_SIGMA_1CPT).expect("parse selected block_sigma");
+        assert!(matches!(model.error_spec, ErrorSpec::Selected { .. }));
+        assert!(!model.residual_correlations.is_empty());
+        assert!(crate::sens::provider::analytic_outer_gradient_available(
+            &model
+        ));
+
+        // Distinct times → diagonal R (analytic path proceeds); alternating FREE
+        // flags route rows to both branches within one subject.
+        let theta = &[1.1, 11.0];
+        let s1 = selected_dense_subject(
+            &model,
+            theta,
+            &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0],
+            &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        );
+        let s2 = selected_dense_subject(
+            &model,
+            theta,
+            &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0],
+            &[1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+        );
+        let pop = Population {
+            subjects: vec![s1, s2],
+            covariate_names: vec!["FREE".into()],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ehs: Vec<DVector<f64>> = pop
+            .subjects
+            .iter()
+            .map(|s| DVector::from_vec(precise_ebe_corr(&model, s, &params)))
+            .collect();
+
+        let analytic = population_gradient_sens(&model, &pop, &template, &x, &ehs)
+            .expect("selected block_sigma is analytic");
+
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            2.0 * pop
+                .subjects
+                .iter()
+                .map(|s| {
+                    let eta = precise_ebe_corr(&model, s, &p);
+                    marginal_nll_dense_at(&model, s, &p, &eta)
+                })
+                .sum::<f64>()
+        };
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.clone();
+            xp[k] += h;
+            let mut xm = x.clone();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
             approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
         }
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -20917,12 +20917,10 @@ if (WT > 70) {
         );
     }
 
-    #[test]
-    fn test_selected_error_model_accepts_block_sigma() {
-        // #669: block_sigma correlated residuals now parse together with a
-        // covariate-selected [error_model]. The off-diagonal couples the two
-        // branches' sigmas, and `build_residual_correlations` records it.
-        let src = r"
+    /// Shared free/total covariate-selected model with the two branch sigmas in
+    /// one `block_sigma` (#669). Used by the accept-parse and the cross-branch
+    /// R-matrix tests so the two can't drift.
+    const SELECTED_BLOCK_SIGMA_MODEL: &str = r"
 [parameters]
   theta TVCL(5.0, 0.1, 50.0)
   theta TVV(50.0, 5.0, 500.0)
@@ -20946,7 +20944,13 @@ if (WT > 70) {
 [covariates]
   FREE continuous
 ";
-        let model = parse_full_model(src).unwrap().model;
+
+    #[test]
+    fn test_selected_error_model_accepts_block_sigma() {
+        // #669: block_sigma correlated residuals now parse together with a
+        // covariate-selected [error_model]. The off-diagonal couples the two
+        // branches' sigmas, and `build_residual_correlations` records it.
+        let model = parse_full_model(SELECTED_BLOCK_SIGMA_MODEL).unwrap().model;
         assert!(matches!(model.error_spec, ErrorSpec::Selected { .. }));
         // One off-diagonal correlation between the two branch sigmas (idx 0,1).
         assert_eq!(model.residual_correlations.len(), 1);
@@ -21004,34 +21008,7 @@ if (WT > 70) {
         // unbound). The dense R off-diagonal must carry the block_sigma
         // cross-branch covariance rho·σ_i·σ_j scaled by each row's proportional
         // loading (f·σ_i)(f·σ_j) — identical to the total/unbound PerCmt case.
-        let model = parse_full_model(
-            r"
-[parameters]
-  theta TVCL(5.0, 0.1, 50.0)
-  theta TVV(50.0, 5.0, 500.0)
-  omega ETA_CL ~ 0.09
-  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.01, 0.005, 0.09]
-
-[individual_parameters]
-  CL = TVCL * exp(ETA_CL)
-  V  = TVV
-
-[structural_model]
-  pk one_cpt_iv(cl=CL, v=V)
-
-[error_model]
-  if (FREE == 0) {
-    DV ~ proportional(PROP_TOTAL)
-  } else {
-    DV ~ proportional(PROP_UNBOUND)
-  }
-
-[covariates]
-  FREE continuous
-",
-        )
-        .unwrap()
-        .model;
+        let model = parse_full_model(SELECTED_BLOCK_SIGMA_MODEL).unwrap().model;
 
         let subject = crate::types::Subject {
             id: "S1".to_string(),

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -8515,18 +8515,17 @@ fn validate_residual_correlations(
     }
 
     // Covariate-selected residual error (#658) with block_sigma correlated
-    // residuals: the correlation pairing rule (same-time/occasion rows) is not
-    // yet defined in terms of the selector's per-observation endpoint, so reject
-    // the combination with a clear error rather than pairing ambiguously.
-    if matches!(error_spec, ErrorSpec::Selected { .. }) {
-        return Err(
-            "block_sigma correlated residuals are not yet supported together with a \
-             covariate-selected [error_model] (if/else). Use separate uncorrelated sigmas, \
-             or a per-CMT [error_model], for now (issue #658)."
-                .to_string(),
-        );
-    }
-
+    // residuals (#669): the pairing rule is the same as `PerCmt`. Each
+    // observation resolves to an endpoint per-row via the covariate selector
+    // (`ErrorSpec::obs_keys`), loads that endpoint's sigmas, and rows sharing a
+    // subject time+occasion receive the `block_sigma` cross covariance from
+    // `cross_observation_covariance`. Two paired rows resolving to *different*
+    // branches get the honest cross-branch covariance `rho·σ_i·σ_j` built from
+    // each row's own loadings — exactly the total/unbound cross-endpoint case
+    // the `PerCmt` path already handles. The whole residual runtime is generic
+    // over the endpoint key, so `Selected` needs no special casing here; the
+    // reference-validity check below already dispatches through the shared
+    // `PerCmt | Selected { endpoints: map, .. }` arm.
     let endpoint_loadings: Vec<Vec<usize>> = match error_spec {
         ErrorSpec::Single(_) => vec![error_spec
             .sigma_loadings(0, 1.0, sigma_names.len())
@@ -20919,8 +20918,10 @@ if (WT > 70) {
     }
 
     #[test]
-    fn test_selected_error_model_rejects_block_sigma() {
-        // block_sigma correlated residuals are deferred for the selector form.
+    fn test_selected_error_model_accepts_block_sigma() {
+        // #669: block_sigma correlated residuals now parse together with a
+        // covariate-selected [error_model]. The off-diagonal couples the two
+        // branches' sigmas, and `build_residual_correlations` records it.
         let src = r"
 [parameters]
   theta TVCL(5.0, 0.1, 50.0)
@@ -20945,11 +20946,146 @@ if (WT > 70) {
 [covariates]
   FREE continuous
 ";
+        let model = parse_full_model(src).unwrap().model;
+        assert!(matches!(model.error_spec, ErrorSpec::Selected { .. }));
+        // One off-diagonal correlation between the two branch sigmas (idx 0,1).
+        assert_eq!(model.residual_correlations.len(), 1);
+        let corr = model.residual_correlations[0];
+        let pair = (
+            corr.sigma_i.min(corr.sigma_j),
+            corr.sigma_i.max(corr.sigma_j),
+        );
+        assert_eq!(pair, (0, 1));
+        // rho = cov / (sd_i · sd_j) = 0.005 / sqrt(0.01·0.09).
+        let expected_rho = 0.005 / (0.01f64 * 0.09).sqrt();
+        assert!((corr.rho - expected_rho).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_selected_error_model_rejects_block_sigma_unused_sigma() {
+        // The reference-validity check still runs for Selected: a block_sigma
+        // off-diagonal touching a sigma no branch loads is rejected.
+        let src = r"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  omega ETA_CL ~ 0.09
+  block_sigma (PROP_TOTAL, PROP_UNUSED) = [0.01, 0.005, 0.09]
+  sigma PROP_UNBOUND ~ 0.30 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  if (FREE == 0) {
+    DV ~ proportional(PROP_TOTAL)
+  } else {
+    DV ~ proportional(PROP_UNBOUND)
+  }
+
+[covariates]
+  FREE continuous
+";
         let err = expect_parse_err(src);
         assert!(
-            err.contains("covariate-selected") && err.contains("block_sigma"),
-            "expected a block_sigma+Selected rejection, got: {err}"
+            err.contains("not used by [error_model]"),
+            "expected an unused-sigma rejection, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_selected_error_block_sigma_cross_branch_covariance() {
+        // #669 end-to-end: two rows at the same subject time+occasion but
+        // different `FREE` flags resolve to different branches (total vs.
+        // unbound). The dense R off-diagonal must carry the block_sigma
+        // cross-branch covariance rho·σ_i·σ_j scaled by each row's proportional
+        // loading (f·σ_i)(f·σ_j) — identical to the total/unbound PerCmt case.
+        let model = parse_full_model(
+            r"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  omega ETA_CL ~ 0.09
+  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.01, 0.005, 0.09]
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  if (FREE == 0) {
+    DV ~ proportional(PROP_TOTAL)
+  } else {
+    DV ~ proportional(PROP_UNBOUND)
+  }
+
+[covariates]
+  FREE continuous
+",
+        )
+        .unwrap()
+        .model;
+
+        let subject = crate::types::Subject {
+            id: "S1".to_string(),
+            doses: vec![crate::types::DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 1.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![10.0, 10.0],
+            obs_cmts: vec![1, 1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: vec![
+                HashMap::from([("FREE".to_string(), 0.0)]),
+                HashMap::from([("FREE".to_string(), 1.0)]),
+            ],
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0],
+            occasions: vec![1, 1],
+            dose_occasions: vec![1],
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+
+        // sigma = [SD_total, SD_unbound] from the block diagonal.
+        let sd_i = 0.01f64.sqrt();
+        let sd_j = 0.09f64.sqrt();
+        let sigma = [sd_i, sd_j];
+        let f = 10.0;
+        let ipreds = [f, f];
+        let keys = model.error_spec.obs_keys(&subject);
+
+        let r = crate::stats::residual_error::compute_r_matrix_with_correlations(
+            &model.error_spec,
+            &ipreds,
+            keys.as_ref(),
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            &sigma,
+            &model.residual_correlations,
+        );
+
+        // Diagonal: each row's own proportional variance from its branch sigma.
+        assert!((r[(0, 0)] - (f * sd_i).powi(2)).abs() < 1e-12);
+        assert!((r[(1, 1)] - (f * sd_j).powi(2)).abs() < 1e-12);
+        // Off-diagonal: cross-branch covariance (f·σ_i)(f·σ_j)·rho.
+        let rho = 0.005 / (sd_i * sd_j);
+        let expected_off = f * sd_i * f * sd_j * rho;
+        assert!((r[(0, 1)] - expected_off).abs() < 1e-12);
+        assert!((r[(1, 0)] - expected_off).abs() < 1e-12);
+        // Sanity: symmetric and equals the raw covariance times f².
+        assert!((r[(0, 1)] - f * f * 0.005).abs() < 1e-12);
     }
 
     /// End-to-end dispatch: `obs_keys` resolves each observation's covariate

--- a/tests/selected_error_model.rs
+++ b/tests/selected_error_model.rs
@@ -217,6 +217,84 @@ fn selected_error_model_with_sde_is_rejected_at_parse() {
     );
 }
 
+/// Same free/total selector as `FREE_TOTAL`, but the two branch sigmas are
+/// declared in one `block_sigma` so their residuals are *correlated* — the
+/// total and unbound assays of one sample co-vary (#669). A co-temporal
+/// total (FREE=0) / unbound (FREE=1) pair now resolves to different branches
+/// and picks up the cross-branch off-diagonal in the dense residual `R`.
+const FREE_TOTAL_BLOCK: &str = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.0025, 0.0075, 0.09]
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  if (FREE == 0) {
+    DV ~ proportional(PROP_TOTAL)
+  } else {
+    DV ~ proportional(PROP_UNBOUND)
+  }
+
+[covariates]
+  FREE continuous
+
+[fit_options]
+  method = focei
+";
+
+/// #669: a covariate-selected `[error_model]` combined with `block_sigma`
+/// correlated residuals now parses and fits. The parser records one
+/// cross-branch correlation, and a bounded FOCEI fit runs to a finite OFV with
+/// the dense residual `R` path active (the co-temporal total/unbound pair
+/// carries the off-diagonal covariance).
+#[test]
+fn selected_error_with_block_sigma_fits() {
+    let model = parse_model_string(FREE_TOTAL_BLOCK).expect("block_sigma + selected must parse");
+    assert!(
+        matches!(model.error_spec, ErrorSpec::Selected { .. }),
+        "expected a Selected error spec"
+    );
+    assert_eq!(
+        model.residual_correlations.len(),
+        1,
+        "one cross-branch residual correlation from the block_sigma off-diagonal"
+    );
+
+    // Simulate DVs at truth, then run a bounded FOCEI fit (Tier-2: no
+    // convergence loop, just a finite OFV out of the dense-R path).
+    let design = free_total_pop(8);
+    let truth = model.default_params.clone();
+    let sims = simulate_with_seed(&model, &design, &truth, 1, 669669);
+    let mut pop = design.clone();
+    for subj in pop.subjects.iter_mut() {
+        subj.observations = sims
+            .iter()
+            .filter(|r| r.id == subj.id)
+            .map(|r| r.outcome.continuous_value())
+            .collect();
+    }
+
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::FoceI;
+    opts.methods = vec![];
+    opts.interaction = true;
+    opts.run_covariance_step = false;
+    opts.outer_maxiter = 2;
+    opts.verbose = false;
+
+    let r = fit(&model, &pop, &model.default_params, &opts)
+        .expect("block_sigma + selected FOCEI fit must run");
+    assert!(r.ofv.is_finite(), "OFV must be finite, got {}", r.ofv);
+}
+
 /// End-to-end numerical validation: simulate with a known split
 /// (`σ_total = 0.05`, `σ_unbound = 0.30`) and recover it from a neutral start
 /// where both sigmas begin at 0.15. Recovery of the *ordered, separated* split


### PR DESCRIPTION
## Why

`validate_residual_correlations()` rejected any model combining a covariate-selected
`[error_model]` (`if/else`, `ErrorSpec::Selected`) with `block_sigma` correlated
residuals — a deliberate guard added under #658 because the correlation pairing rule
was not yet defined in terms of the selector's per-observation endpoint. #669 lifts it.

## What changed

The residual runtime was already fully generic over the per-observation endpoint key:

- `ErrorSpec::obs_keys()` resolves each observation through the covariate selector.
- `sigma_loadings()` / `variance_at*()` dispatch via the shared
  `PerCmt | Selected { endpoints: map, .. }` arms.
- `compute_r_matrix_with_correlations()` pairs rows by subject time + occasion and
  builds the off-diagonal from each row's own loadings.

So the pairing rule for `Selected` is **identical** to `PerCmt`, and no runtime change
was needed — only the parse-time guard blocked the combination. Removed the guard; the
reference-validity check immediately below it already dispatched through the shared
`PerCmt | Selected` `endpoint_loadings` arm, so an off-diagonal touching a sigma no
branch loads is still rejected.

**Open questions from the issue, resolved:**
- *Pairing semantics when the endpoint is per-observation:* same-time / same-occasion
  rows, each loading its selected branch's sigmas.
- *Two paired rows resolving to different branches:* honest cross-branch covariance
  `ρ·σ_i·σ_j` from each row's own loadings — the total/unbound cross-endpoint case the
  `PerCmt` path already handled.

## Alternatives considered

Defining a bespoke Selected-only pairing rule — unnecessary: the endpoint key is the
only thing that varies between `PerCmt` and `Selected`, and the runtime already keys on
it, so the per-CMT semantics apply verbatim.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change (guard removal only).

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: reuses the already-NONMEM-anchored per-CMT `block_sigma`
      path (`nonmem_anchor/correlated_residual_combined.ctl`). The
      `Selected` R off-diagonal is built by the identical
      `cross_observation_covariance()` machinery, so it equals the NONMEM
      cross-endpoint term `f_total·f_unbound·Cov(EPS_total, EPS_unbound)`.
- [x] Reference values / assertion:

```
# unit test test_selected_error_block_sigma_cross_branch_covariance
# block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.01, 0.005, 0.09], f = 10
R[0,1] == f * f * 0.005      (== f_total · f_unbound · Cov)   ✓
R[0,0] == (f · sqrt(0.01))^2                                  ✓
R[1,1] == (f · sqrt(0.09))^2                                  ✓
```

## Performance
- [x] No significant impact expected (parse-time guard removed; runtime unchanged)

## Tests
- [x] Unit test(s) added (`cargo test --lib` passes, 11 selected_error tests)
- [x] Regression test added that fails without this fix
      (`test_selected_error_model_accepts_block_sigma`,
       `test_selected_error_block_sigma_cross_branch_covariance`)

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[parameters]
  theta TVCL(5.0, 0.1, 50.0)
  theta TVV(50.0, 5.0, 500.0)
  omega ETA_CL ~ 0.09
  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.01, 0.005, 0.09]

[individual_parameters]
  CL = TVCL * exp(ETA_CL)
  V  = TVV

[structural_model]
  pk one_cpt_iv(cl=CL, v=V)

[error_model]
  if (FREE == 0) {
    DV ~ proportional(PROP_TOTAL)
  } else {
    DV ~ proportional(PROP_UNBOUND)
  }

[covariates]
  FREE continuous
```

Co-temporal total (`FREE=0`) / unbound (`FREE=1`) rows now correlate:
`Cov = f_total · f_unbound · 0.005`.

</details>

## Docs
- [x] `docs/model-file/error-model.qmd` updated (rule flipped from "not supported"
      to supported; cross-endpoint paragraph now names both CMT and covariate selectors)
- [x] `CHANGELOG.md` `[Unreleased]` entry updated (folded into the #658 bullet)

## Checklist
- [x] `cargo clippy` clean (no new warnings from this change)
- [x] No `Dual2`-path code touched
- [x] No version bump (non-breaking)

## Reviewer hints

The whole change is: delete the early-return guard in
`validate_residual_correlations()` and let the existing `endpoint_loadings` match
(which already had a `Selected { endpoints: map, .. }` arm) run. Everything else is
tests + docs. Worth confirming the pairing-semantics reasoning in the new guard-site
comment.

## Open questions

None.
