### PR TITLE
feat(api): prepare_frem() accepts a prior fit to seed FREM init values [closes #239]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **`prepare_frem()` accepts a prior fit to seed FREM init values** (#239). The new
+  optional `fit_init: Option<&FremFitInit>` parameter carries a completed fit's theta
+  and omega estimates; when supplied, the generated FREM model's PK theta inits and
+  PK-PK omega block are seeded from those converged values instead of the base
+  model file's declared inits, so a subsequent fit of the FREM model warm-starts
+  closer to convergence. Names are matched case-insensitively against the base
+  model; unmatched names fall back to the declared inits. `None` preserves the
+  prior behaviour unchanged.
 - **Covariate-selected residual error models (`if/else` in `[error_model]`)** (#658).
   The `[error_model]` block can now select a residual error model per observation
   by an arbitrary covariate condition — e.g. a free-vs-total assay switched by a

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -656,7 +656,10 @@ pub fn generate_frem_model(
 
 /// Look up the fitted omega value for an eta pair by name (case-insensitive).
 /// Returns `None` when either name is absent from `fit_init`, so the caller
-/// falls back to the base model's declared omega.
+/// falls back to the base model's declared omega. Also returns `None` (rather
+/// than panicking) when a matched name index falls outside `omega` — i.e. a
+/// malformed `FremFitInit` whose `eta_names` is longer than the matrix is
+/// dimensioned — so an inconsistent public-API input degrades gracefully.
 fn fit_omega_value(fit_init: &FremFitInit, name_i: &str, name_j: &str) -> Option<f64> {
     let idx_i = fit_init
         .eta_names
@@ -666,6 +669,9 @@ fn fit_omega_value(fit_init: &FremFitInit, name_i: &str, name_j: &str) -> Option
         .eta_names
         .iter()
         .position(|n| n.eq_ignore_ascii_case(name_j))?;
+    if idx_i >= fit_init.omega.nrows() || idx_j >= fit_init.omega.ncols() {
+        return None;
+    }
     Some(fit_init.omega[(idx_i, idx_j)])
 }
 
@@ -1396,6 +1402,90 @@ mod tests {
         );
         assert!(
             (rows[2][2] - 0.28).abs() < 1e-9,
+            "ETA_KA diag: {:?}",
+            rows[2]
+        );
+    }
+
+    #[test]
+    fn test_generate_frem_model_tolerates_fit_init_omega_dim_mismatch() {
+        // Regression: a malformed `FremFitInit` whose `eta_names` is longer than
+        // its `omega` is dimensioned must degrade gracefully (fall back to the
+        // declared omega) instead of panicking on an out-of-bounds index inside
+        // `fit_omega_value`. The base model has 3 PK etas; here `omega` is only
+        // 2x2, so the ETA_KA lookup (index 2) is out of range.
+        let base_text = r"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+";
+
+        let pop = make_test_population();
+        let model = make_test_model();
+        let covs = vec!["WT".to_string()];
+        let (_, info) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
+
+        // eta_names names all 3 PK etas, but omega is only 2x2 (ETA_KA -> idx 2
+        // is out of bounds).
+        let fit_init = FremFitInit {
+            theta: vec![("TVCL".to_string(), 0.321)],
+            eta_names: vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.11, 0.05])),
+        };
+
+        // Must not panic; the in-range ETA_CL/ETA_V entries are seeded from the
+        // fit, ETA_KA falls back to the declared 0.30.
+        let model_text = generate_frem_model(
+            base_text,
+            &model,
+            &info,
+            Path::new("test.csv"),
+            Some(&fit_init),
+        )
+        .unwrap();
+
+        let block_start = model_text.find("block_omega").unwrap();
+        let bracket_start = model_text[block_start..].find('[').unwrap() + block_start;
+        let bracket_end = model_text[bracket_start..].find(']').unwrap() + bracket_start;
+        let rows: Vec<Vec<f64>> = model_text[bracket_start + 1..bracket_end]
+            .lines()
+            .map(|l| l.trim().trim_end_matches(','))
+            .filter(|l| !l.is_empty())
+            .map(|l| {
+                l.split(',')
+                    .map(|v| v.trim().parse::<f64>().unwrap())
+                    .collect()
+            })
+            .collect();
+        assert!(
+            (rows[0][0] - 0.11).abs() < 1e-9,
+            "ETA_CL diag: {:?}",
+            rows[0]
+        );
+        assert!(
+            (rows[1][1] - 0.05).abs() < 1e-9,
+            "ETA_V diag: {:?}",
+            rows[1]
+        );
+        // ETA_KA out of range in fit omega -> declared 0.30 retained.
+        assert!(
+            (rows[2][2] - 0.30).abs() < 1e-9,
             "ETA_KA diag: {:?}",
             rows[2]
         );

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -675,6 +675,40 @@ fn fit_omega_value(fit_init: &FremFitInit, name_i: &str, name_j: &str) -> Option
     Some(fit_init.omega[(idx_i, idx_j)])
 }
 
+/// Advisory warnings for a `fit_init` that shares no theta / eta names with the
+/// base model — the likely sign a fit of a *different* model was passed in, so
+/// the generated FREM model silently fell back to the declared inits (issue
+/// #239). Returns one message per axis (theta, eta) that has candidate names on
+/// both sides yet matches none; an empty vec means the fit lines up (or has
+/// nothing to compare). Pure over its inputs so it is unit-testable without the
+/// file IO of [`prepare_frem`].
+fn fit_init_name_warnings(base_model: &CompiledModel, fi: &FremFitInit) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let theta_matched = base_model
+        .theta_names
+        .iter()
+        .any(|n| fi.theta.iter().any(|(fn_, _)| fn_.eq_ignore_ascii_case(n)));
+    if !base_model.theta_names.is_empty() && !fi.theta.is_empty() && !theta_matched {
+        warnings.push(
+            "FREM conversion: the supplied `fit` has no theta names matching the base \
+             model, so the model file's declared theta init values were used instead."
+                .to_string(),
+        );
+    }
+    let eta_matched = base_model
+        .eta_names
+        .iter()
+        .any(|n| fi.eta_names.iter().any(|fn_| fn_.eq_ignore_ascii_case(n)));
+    if !base_model.eta_names.is_empty() && !fi.eta_names.is_empty() && !eta_matched {
+        warnings.push(
+            "FREM conversion: the supplied `fit`'s omega has no eta names matching the \
+             base model, so the model file's declared omega init values were used instead."
+                .to_string(),
+        );
+    }
+    warnings
+}
+
 /// Rewrite a `theta NAME(init, ...)` declaration line, substituting `init`
 /// with the value from a prior fit (issue #239) when the fit has an entry
 /// for `NAME`. Bounds, `FIX` flags, and trailing comments are left byte-for-byte
@@ -914,28 +948,7 @@ pub fn prepare_frem(
     // model — most likely a fit of a different model was passed in, so the
     // generated FREM model silently fell back to the declared inits.
     if let Some(fi) = fit_init {
-        let theta_matched = base_model
-            .theta_names
-            .iter()
-            .any(|n| fi.theta.iter().any(|(fn_, _)| fn_.eq_ignore_ascii_case(n)));
-        if !base_model.theta_names.is_empty() && !fi.theta.is_empty() && !theta_matched {
-            warnings.push(
-                "FREM conversion: the supplied `fit` has no theta names matching the base \
-                 model, so the model file's declared theta init values were used instead."
-                    .to_string(),
-            );
-        }
-        let eta_matched = base_model
-            .eta_names
-            .iter()
-            .any(|n| fi.eta_names.iter().any(|fn_| fn_.eq_ignore_ascii_case(n)));
-        if !base_model.eta_names.is_empty() && !fi.eta_names.is_empty() && !eta_matched {
-            warnings.push(
-                "FREM conversion: the supplied `fit`'s omega has no eta names matching the \
-                 base model, so the model file's declared omega init values were used instead."
-                    .to_string(),
-            );
-        }
+        warnings.extend(fit_init_name_warnings(base_model, fi));
     }
 
     Ok(FremPrepareResult {
@@ -1489,6 +1502,98 @@ mod tests {
             "ETA_KA diag: {:?}",
             rows[2]
         );
+    }
+
+    #[test]
+    fn test_fit_init_name_warnings() {
+        let model = make_test_model(); // thetas TVCL/TVV/TVKA, etas ETA_CL/V/KA
+
+        // Names line up (case-insensitively) -> no advisory.
+        let ok = FremFitInit {
+            theta: vec![("tvcl".into(), 0.3)],
+            eta_names: vec!["eta_cl".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.1])),
+        };
+        assert!(fit_init_name_warnings(&model, &ok).is_empty());
+
+        // A different model's fit: no theta and no eta names match -> two
+        // advisories, one per axis.
+        let wrong = FremFitInit {
+            theta: vec![("FOO".into(), 1.0)],
+            eta_names: vec!["ETA_BAR".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.1])),
+        };
+        let w = fit_init_name_warnings(&model, &wrong);
+        assert_eq!(w.len(), 2, "{w:?}");
+        assert!(w[0].contains("theta names"));
+        assert!(w[1].contains("eta names"));
+
+        // Theta matches but eta does not -> only the eta advisory.
+        let theta_only = FremFitInit {
+            theta: vec![("TVCL".into(), 0.3)],
+            eta_names: vec!["ETA_BAR".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.1])),
+        };
+        let w = fit_init_name_warnings(&model, &theta_only);
+        assert_eq!(w.len(), 1, "{w:?}");
+        assert!(w[0].contains("eta names"));
+
+        // Nothing to compare (empty fit) -> no advisory.
+        let empty = FremFitInit {
+            theta: vec![],
+            eta_names: vec![],
+            omega: DMatrix::zeros(0, 0),
+        };
+        assert!(fit_init_name_warnings(&model, &empty).is_empty());
+    }
+
+    #[test]
+    fn test_override_theta_init_fallbacks() {
+        let re = Regex::new(r"(?i)^\s*theta\s+(\w+)\s*\(\s*([0-9eE.+-]+)").unwrap();
+        let fit = FremFitInit {
+            theta: vec![("TVCL".into(), 0.321)],
+            eta_names: vec![],
+            omega: DMatrix::zeros(0, 0),
+        };
+
+        // Matched name -> init token replaced, bounds untouched.
+        assert_eq!(
+            override_theta_init("theta TVCL(0.2, 0.001, 10.0)", &fit, &re),
+            "theta TVCL(0.321, 0.001, 10.0)"
+        );
+        // Name not present in the fit -> line returned unchanged.
+        assert_eq!(
+            override_theta_init("theta TVV(10.0, 0.1, 500.0)", &fit, &re),
+            "theta TVV(10.0, 0.1, 500.0)"
+        );
+        // Line the regex cannot parse -> returned unchanged.
+        assert_eq!(
+            override_theta_init("theta MALFORMED", &fit, &re),
+            "theta MALFORMED"
+        );
+    }
+
+    #[test]
+    fn test_fit_omega_value_lookup_and_bounds() {
+        let fit = FremFitInit {
+            theta: vec![],
+            eta_names: vec!["ETA_CL".into(), "ETA_V".into()],
+            omega: DMatrix::from_row_slice(2, 2, &[0.11, 0.02, 0.02, 0.05]),
+        };
+        // In-range, case-insensitive, symmetric.
+        assert_eq!(fit_omega_value(&fit, "eta_cl", "eta_v"), Some(0.02));
+        assert_eq!(fit_omega_value(&fit, "ETA_V", "ETA_V"), Some(0.05));
+        // Name absent -> None.
+        assert_eq!(fit_omega_value(&fit, "ETA_CL", "ETA_KA"), None);
+
+        // Name present but index outside the (smaller) omega -> None, no panic.
+        let mismatched = FremFitInit {
+            theta: vec![],
+            eta_names: vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.11, 0.05])),
+        };
+        assert_eq!(fit_omega_value(&mismatched, "ETA_KA", "ETA_KA"), None);
+        assert_eq!(fit_omega_value(&mismatched, "ETA_CL", "ETA_KA"), None);
     }
 
     #[test]

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -13,8 +13,29 @@
 //! 4. Fit the resulting FREM model normally
 
 use crate::types::{CompiledModel, Population};
+use nalgebra::DMatrix;
+use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
+
+/// Prior-fit parameter values used to seed a generated FREM model's initial
+/// values, instead of the base model's declared inits (issue #239). Typically
+/// built from a completed [`crate::types::FitResult`] of the base model: its
+/// `theta`/`theta_names` and `omega`/`eta_names` carry exactly this shape.
+///
+/// Names are matched case-insensitively against the base model's declared
+/// theta/eta names; a name with no match is left at its declared init value,
+/// so a fit from a slightly different model (extra or missing parameters)
+/// degrades gracefully rather than erroring.
+#[derive(Debug, Clone)]
+pub struct FremFitInit {
+    /// Theta name -> fitted value.
+    pub theta: Vec<(String, f64)>,
+    /// Eta names, parallel to the rows/columns of `omega`.
+    pub eta_names: Vec<String>,
+    /// Fitted omega (BSV) covariance matrix, indexed by `eta_names`.
+    pub omega: DMatrix<f64>,
+}
 
 /// Statistics and metadata from the FREM data transformation.
 #[derive(Debug, Clone)]
@@ -412,6 +433,7 @@ pub fn generate_frem_model(
     base_model: &CompiledModel,
     frem_info: &FremDataInfo,
     output_data_path: &Path,
+    fit_init: Option<&FremFitInit>,
 ) -> Result<String, String> {
     // Parse the base model text to extract blocks.
     let blocks = parse_blocks(base_model_text)?;
@@ -422,12 +444,20 @@ pub fn generate_frem_model(
     model.push_str("# FREM model (auto-generated)\n\n");
     model.push_str("[parameters]\n");
 
-    // Copy base thetas.
+    // Copy base thetas, substituting the init value with the prior fit's
+    // estimate when one is supplied (issue #239) so a subsequent fit of the
+    // FREM model warm-starts from converged PK parameters instead of the
+    // original declared inits.
+    let theta_init_re = Regex::new(r"(?i)^\s*theta\s+(\w+)\s*\(\s*([0-9eE.+-]+)").unwrap();
     if let Some(params_lines) = blocks.get("parameters") {
         for line in params_lines {
             let trimmed = line.trim();
             if trimmed.starts_with("theta ") {
-                model.push_str(&format!("  {}\n", trimmed));
+                let out = match fit_init {
+                    Some(fi) => override_theta_init(trimmed, fi, &theta_init_re),
+                    None => trimmed.to_string(),
+                };
+                model.push_str(&format!("  {}\n", out));
             }
         }
     }
@@ -456,10 +486,16 @@ pub fn generate_frem_model(
     // Build the omega matrix: PK diagonal from base, COV diagonal from variance,
     // off-diagonals = small scaled values.
     let mut omega_matrix = vec![vec![0.0f64; n_total]; n_total];
-    // PK-PK block from base model.
+    // PK-PK block from base model, overridden entry-by-entry with the prior
+    // fit's omega (issue #239) when a matching eta pair is present.
     for i in 0..n_pk {
         for j in 0..n_pk {
-            omega_matrix[i][j] = base_model.default_params.omega.matrix[(i, j)];
+            let declared = base_model.default_params.omega.matrix[(i, j)];
+            omega_matrix[i][j] = fit_init
+                .and_then(|fi| {
+                    fit_omega_value(fi, &base_model.eta_names[i], &base_model.eta_names[j])
+                })
+                .unwrap_or(declared);
         }
     }
     // COV-COV diagonal from sample variances.
@@ -618,6 +654,47 @@ pub fn generate_frem_model(
     Ok(model)
 }
 
+/// Look up the fitted omega value for an eta pair by name (case-insensitive).
+/// Returns `None` when either name is absent from `fit_init`, so the caller
+/// falls back to the base model's declared omega.
+fn fit_omega_value(fit_init: &FremFitInit, name_i: &str, name_j: &str) -> Option<f64> {
+    let idx_i = fit_init
+        .eta_names
+        .iter()
+        .position(|n| n.eq_ignore_ascii_case(name_i))?;
+    let idx_j = fit_init
+        .eta_names
+        .iter()
+        .position(|n| n.eq_ignore_ascii_case(name_j))?;
+    Some(fit_init.omega[(idx_i, idx_j)])
+}
+
+/// Rewrite a `theta NAME(init, ...)` declaration line, substituting `init`
+/// with the value from a prior fit (issue #239) when the fit has an entry
+/// for `NAME`. Bounds, `FIX` flags, and trailing comments are left byte-for-byte
+/// untouched — only the numeric init token matched by `re` is replaced.
+fn override_theta_init(line: &str, fit_init: &FremFitInit, re: &Regex) -> String {
+    let Some(caps) = re.captures(line) else {
+        return line.to_string();
+    };
+    let name = &caps[1];
+    let value = match fit_init
+        .theta
+        .iter()
+        .find(|(n, _)| n.eq_ignore_ascii_case(name))
+    {
+        Some((_, v)) => *v,
+        None => return line.to_string(),
+    };
+    let init_span = caps.get(2).unwrap();
+    format!(
+        "{}{}{}",
+        &line[..init_span.start()],
+        value,
+        &line[init_span.end()..]
+    )
+}
+
 /// Resolve which covariates (and their categorical/continuous split) go into the
 /// FREM model. The model's `[covariates]` block is the source of truth: it
 /// declares the covariates and tags each continuous or categorical.
@@ -736,6 +813,13 @@ fn resolve_frem_covariates(
 ///
 /// `categorical_covariates` is an optional override for the categorical split;
 /// when `None`/empty the split is taken from each selected declaration's `kind`.
+///
+/// `fit_init` optionally seeds the generated FREM model's PK theta and omega
+/// init values from a completed fit of the base model (issue #239), so a
+/// subsequent fit of the FREM model warm-starts from converged parameters
+/// instead of the base model file's declared inits. `None` preserves the
+/// prior behaviour of copying the declared inits verbatim.
+#[allow(clippy::too_many_arguments)]
 pub fn prepare_frem(
     model_path: &Path,
     data_path: &Path,
@@ -744,6 +828,7 @@ pub fn prepare_frem(
     output_model_path: Option<&Path>,
     output_data_path: Option<&Path>,
     missing_value: Option<f64>,
+    fit_init: Option<&FremFitInit>,
 ) -> Result<FremPrepareResult, String> {
     use crate::io::datareader::read_nonmem_csv;
     use crate::parser::model_parser::parse_full_model_file;
@@ -788,7 +873,7 @@ pub fn prepare_frem(
         .map_err(|e| format!("Failed to read model file: {}", e))?;
 
     // Generate FREM model.
-    let model_text = generate_frem_model(&base_text, base_model, &frem_info, out_data)?;
+    let model_text = generate_frem_model(&base_text, base_model, &frem_info, out_data, fit_init)?;
 
     // Write outputs.
     std::fs::write(out_data, &csv_content)
@@ -817,6 +902,34 @@ pub fn prepare_frem(
              fit with FOCEI.",
             no_eta.join(", ")
         ));
+    }
+
+    // Advise when `fit_init` was supplied but shares no names with the base
+    // model — most likely a fit of a different model was passed in, so the
+    // generated FREM model silently fell back to the declared inits.
+    if let Some(fi) = fit_init {
+        let theta_matched = base_model
+            .theta_names
+            .iter()
+            .any(|n| fi.theta.iter().any(|(fn_, _)| fn_.eq_ignore_ascii_case(n)));
+        if !base_model.theta_names.is_empty() && !fi.theta.is_empty() && !theta_matched {
+            warnings.push(
+                "FREM conversion: the supplied `fit` has no theta names matching the base \
+                 model, so the model file's declared theta init values were used instead."
+                    .to_string(),
+            );
+        }
+        let eta_matched = base_model
+            .eta_names
+            .iter()
+            .any(|n| fi.eta_names.iter().any(|fn_| fn_.eq_ignore_ascii_case(n)));
+        if !base_model.eta_names.is_empty() && !fi.eta_names.is_empty() && !eta_matched {
+            warnings.push(
+                "FREM conversion: the supplied `fit`'s omega has no eta names matching the \
+                 base model, so the model file's declared omega init values were used instead."
+                    .to_string(),
+            );
+        }
     }
 
     Ok(FremPrepareResult {
@@ -1112,7 +1225,13 @@ mod tests {
         let covs = vec!["WT".to_string(), "AGE".to_string()];
         let (_, info) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
 
-        let result = generate_frem_model(base_text, &model, &info, Path::new("test_frem_data.csv"));
+        let result = generate_frem_model(
+            base_text,
+            &model,
+            &info,
+            Path::new("test_frem_data.csv"),
+            None,
+        );
         assert!(result.is_ok());
 
         let model_text = result.unwrap();
@@ -1170,7 +1289,7 @@ mod tests {
         let (_, info) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
 
         let model_text =
-            generate_frem_model(base_text, &model, &info, Path::new("test.csv")).unwrap();
+            generate_frem_model(base_text, &model, &info, Path::new("test.csv"), None).unwrap();
 
         // 3 PK etas + 1 cov eta = 4 total, lower triangle has 4*(4+1)/2 = 10 values
         let block_start = model_text.find("block_omega").unwrap();
@@ -1182,6 +1301,104 @@ mod tests {
             .filter(|s| !s.trim().is_empty())
             .count();
         assert_eq!(n_values, 10); // 4*(4+1)/2
+    }
+
+    #[test]
+    fn test_generate_frem_model_uses_fit_init_theta_and_omega() {
+        // Issue #239: when a prior fit is supplied, its theta/omega estimates
+        // seed the generated FREM model's PK init values instead of the base
+        // model file's declared inits.
+        let base_text = r"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+";
+
+        let pop = make_test_population();
+        let model = make_test_model();
+        let covs = vec!["WT".to_string()];
+        let (_, info) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
+
+        let fit_init = FremFitInit {
+            theta: vec![
+                ("TVCL".to_string(), 0.321),
+                ("TVV".to_string(), 12.7),
+                ("TVKA".to_string(), 1.42),
+            ],
+            eta_names: vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+            omega: DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![0.11, 0.05, 0.28])),
+        };
+
+        let model_text = generate_frem_model(
+            base_text,
+            &model,
+            &info,
+            Path::new("test.csv"),
+            Some(&fit_init),
+        )
+        .unwrap();
+
+        // Fitted theta values replace the declared inits, bounds untouched.
+        assert!(
+            model_text.contains("theta TVCL(0.321, 0.001, 10.0)"),
+            "expected fitted TVCL init, got:\n{model_text}"
+        );
+        assert!(
+            model_text.contains("theta TVV(12.7, 0.1, 500.0)"),
+            "expected fitted TVV init, got:\n{model_text}"
+        );
+        assert!(
+            model_text.contains("theta TVKA(1.42, 0.01, 50.0)"),
+            "expected fitted TVKA init, got:\n{model_text}"
+        );
+
+        // Fitted omega diagonal (0.11, 0.05, 0.28) replaces the declared
+        // (0.09, 0.04, 0.30) on the PK-PK block of the block_omega lower
+        // triangle: rows 0, 2, 5 (1-indexed diagonal positions 1, 3, 6).
+        let block_start = model_text.find("block_omega").unwrap();
+        let bracket_start = model_text[block_start..].find('[').unwrap() + block_start;
+        let bracket_end = model_text[bracket_start..].find(']').unwrap() + bracket_start;
+        let rows: Vec<Vec<f64>> = model_text[bracket_start + 1..bracket_end]
+            .lines()
+            .map(|l| l.trim().trim_end_matches(','))
+            .filter(|l| !l.is_empty())
+            .map(|l| {
+                l.split(',')
+                    .map(|v| v.trim().parse::<f64>().unwrap())
+                    .collect()
+            })
+            .collect();
+        assert!(
+            (rows[0][0] - 0.11).abs() < 1e-9,
+            "ETA_CL diag: {:?}",
+            rows[0]
+        );
+        assert!(
+            (rows[1][1] - 0.05).abs() < 1e-9,
+            "ETA_V diag: {:?}",
+            rows[1]
+        );
+        assert!(
+            (rows[2][2] - 0.28).abs() < 1e-9,
+            "ETA_KA diag: {:?}",
+            rows[2]
+        );
     }
 
     #[test]
@@ -1220,7 +1437,7 @@ mod tests {
         let (_, info) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
 
         let model_text =
-            generate_frem_model(base_text, &model, &info, Path::new("test.csv")).unwrap();
+            generate_frem_model(base_text, &model, &info, Path::new("test.csv"), None).unwrap();
 
         assert!(
             model_text.contains("[scaling]"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use cancel::CancelFlag;
 pub use diagnostics::{CheckReport, Diagnostic, Severity};
 pub use estimation::run_sir::run_sir;
 pub use estimation::uncertainty_samples::UncertaintyMethod;
-pub use frem::{prepare_frem, FremDataInfo, FremPrepareResult};
+pub use frem::{prepare_frem, FremDataInfo, FremFitInit, FremPrepareResult};
 pub use io::datareader::{read_nonmem_csv, read_nonmem_csv_with_covariates};
 pub use parser::model_parser::{parse_full_model_file, parse_model_file, parse_model_string};
 pub use propensity_match::MatchMethod;

--- a/tests/frem_warfarin.rs
+++ b/tests/frem_warfarin.rs
@@ -96,6 +96,7 @@ fn setup_frem(dir: &Path) -> FremPrepareResult {
         None, // default output model path
         None, // default output data path
         None, // default missing value (-99)
+        None, // no prior fit to seed inits from
     )
     .expect("prepare_frem should succeed")
 }


### PR DESCRIPTION
## Why
`ferx_model_to_frem()` generates a FREM model from a base model's *declared*
`.ferx` file inits, ignoring any fit already run on the base model. Issue #239
(ferx-r): the fit object should be used for the initial parameters of
subsequent FREM fits, and the `fit` argument should be optional.

## What changed
- New public `FremFitInit { theta, eta_names, omega }` struct.
- `prepare_frem()` and `generate_frem_model()` take an additional
  `fit_init: Option<&FremFitInit>` parameter.
- When supplied, the generated FREM model's PK theta inits (matched by name via
  a regex-anchored substitution that leaves bounds/`FIX`/comments untouched)
  and the PK-PK block of the omega matrix (matched by eta name) are taken from
  `fit_init` instead of the base model's declared inits. A name with no match
  keeps its declared value.
- `prepare_frem()` surfaces an advisory warning when `fit_init` is supplied but
  shares no theta/eta names with the base model (likely the wrong model's fit
  was passed).
- `None` is fully backward compatible - no observable behaviour change.

## Alternatives considered
Considered having the R layer rewrite the generated `.ferx` text itself, but
that would duplicate the theta/omega line-format knowledge already in
`generate_frem_model()` and risk drifting from the parser's accepted syntax.
Doing the substitution here keeps one source of truth for the `.ferx` DSL
formatting.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#240 | open | after |

## Breaking changes
- [x] None

## Numerical validation
- [ ] Not applicable (docs / refactor / CI only) - new optional parameter,
  no change to existing numerical output when `fit_init = None`. New behaviour
  covered by `test_generate_frem_model_uses_fit_init_theta_and_omega`, which
  asserts exact theta/omega substitution.

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes) -
  `frem::tests::test_generate_frem_model_uses_fit_init_theta_and_omega`
- [x] Regression test added that fails without this fix
- [x] All existing `frem::tests::*` and `tests/frem_warfarin.rs` still pass

## Example (user-facing features only)
- [ ] Not applicable (internal / refactor / fix with no new API surface) -
  ferx-core has no end-user-facing DSL/CLI surface for this; the user-facing
  side is the `fit` argument on ferx-r's `ferx_model_to_frem()`.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (added `#[allow(clippy::too_many_arguments)]` on
  `prepare_frem`, consistent with existing precedent in `api.rs`/`pk/mod.rs`)
- [x] Not on the `Dual2` sensitivity path - this is model-file generation, not
  gradient-reachable code
- [ ] `Cargo.toml` version bumped if breaking - not breaking

## Reviewer hints
The interesting bits are `override_theta_init()` and `fit_omega_value()` in
`src/frem/mod.rs` - both fall back gracefully (declared init / base omega) on
a name that isn't found, so a `fit` from a slightly different model degrades
rather than errors.

## Open questions
None.