### PR TITLE
fix(estimation): adaptive ISCALE for FREM Rao-Blackwell IMP/IMPMAP E-step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ section of the SDLC for the versioning policy).
   fit. Non-convergence is now reported directly (`converged = false` plus the "Outer
   optimization did not converge" warning) with no automatic retry. Users who want SLSQP can
   still set `optimizer = slsqp`.
+- **IMPMAP/IMP's FREM Rao-Blackwell E-step now runs a per-subject adaptive ISCALE
+  pilot search** instead of a fixed `iscale = 1.0` (#406 follow-up). The RB
+  conditional PK proposal is usually well matched, but for subjects where the
+  inner-loop Hessian is a poor estimate of the true PK conditional curvature
+  (sparse PK data), a fixed proposal width could leave ESS low even after RB.
+  Mirrors the ISCALE rescue the full-dimensional sampler already had. Applies to
+  the iterative MCEM E-step only; the eval-only / final-marginal IS report keeps
+  a fixed proposal for run-to-run reproducibility.
 
 ### Added
 - **Log-transform-both-sides (LTBS) combined with time-varying covariates** now gets an exact

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -787,8 +787,10 @@ fn run_mcem(
                 let subj_seed = seed.wrapping_add(i as u64).wrapping_add((k as u64) << 32);
 
                 // FREM: Rao-Blackwellised low-dimensional PK sampling. The
-                // conditional PK proposal is well matched, so the per-subject
-                // ISCALE pilot search (a full-dimensional ESS rescue) is skipped.
+                // conditional PK proposal is usually well matched, but a
+                // per-subject ISCALE pilot search still rescues subjects where
+                // `h_pp` is a poor curvature estimate (sparse PK data) — see
+                // `find_optimal_iscale_frem_rb` (issue #406 follow-up).
                 if let Some((ref pk_idx, ref cov_idx)) = frem_rb {
                     if let Some(fc) = model.frem_config.as_ref() {
                         if let Some((sampled, observed, d)) =
@@ -800,6 +802,26 @@ fn run_mcem(
                                 cov_idx,
                             )
                         {
+                            let rb_iscale =
+                                crate::estimation::importance_sampling::find_optimal_iscale_frem_rb(
+                                    model,
+                                    subject,
+                                    &params_k.theta,
+                                    &params_k.sigma.values,
+                                    &center,
+                                    &h_post,
+                                    &omega_inv,
+                                    &params_k.omega.matrix,
+                                    &sampled,
+                                    &observed,
+                                    &d,
+                                    n_eta,
+                                    nu,
+                                    subj_seed,
+                                    scratch,
+                                    iscale_min,
+                                    iscale_max,
+                                );
                             if let Some(rb) =
                                 crate::estimation::importance_sampling::subject_is_draws_frem_rb(
                                     model,
@@ -818,7 +840,7 @@ fn run_mcem(
                                     nu,
                                     subj_seed,
                                     scratch,
-                                    1.0,
+                                    rb_iscale,
                                     use_sobol,
                                     defensive_alpha,
                                 )

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2057,7 +2057,11 @@ pub(crate) fn compute_posterior_hessian(
         let r = crate::stats::residual_error::compute_r_matrix_with_correlations(
             &model.error_spec,
             &ipreds,
-            &subject.obs_cmts,
+            // #669: selector-resolved endpoint keys (matches the diagonal
+            // fallback below), not the raw CMT column — a `Selected` spec keys
+            // endpoints by branch, so `obs_cmts` would build the proposal
+            // precision from the wrong branch's sigma.
+            model.error_spec.obs_keys(subject).as_ref(),
             &subject.obs_times,
             &subject.obs_raw_times,
             &subject.occasions,

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -1329,6 +1329,44 @@ pub(crate) fn subject_is_draws(
     }
 }
 
+/// Shared grid-search core for a per-subject ISCALE pilot search. Tries a grid
+/// of `N_GRID` log-spaced scale factors in `[iscale_min, iscale_max]`, calling
+/// `pilot_ess(scale, pilot_seed)` for each and returning the scale with the
+/// best reported ESS fraction. `pilot_ess` returns `None` for a degenerate
+/// draw (e.g. a non-PD proposal) — that scale is skipped, not treated as best.
+/// Returns 1.0 if ISCALE is disabled (`iscale_min >= iscale_max`, or both == 1.0).
+fn iscale_pilot_grid_search(
+    iscale_min: f64,
+    iscale_max: f64,
+    seed: u64,
+    mut pilot_ess: impl FnMut(f64, u64) -> Option<f64>,
+) -> f64 {
+    if iscale_min >= iscale_max || (iscale_min == 1.0 && iscale_max == 1.0) {
+        return 1.0;
+    }
+    const N_GRID: usize = 7;
+    let log_min = iscale_min.ln();
+    let log_max = iscale_max.ln();
+    let mut best_scale = 1.0_f64;
+    let mut best_ess = f64::NEG_INFINITY;
+
+    for g in 0..N_GRID {
+        let frac = g as f64 / (N_GRID - 1) as f64;
+        let scale = (log_min + frac * (log_max - log_min)).exp();
+        // Use a different seed per scale to avoid correlations
+        let pilot_seed = seed
+            .wrapping_add(0x4953_4341_4C45_0000u64)
+            .wrapping_add(g as u64);
+        if let Some(ess) = pilot_ess(scale, pilot_seed) {
+            if ess > best_ess {
+                best_ess = ess;
+                best_scale = scale;
+            }
+        }
+    }
+    best_scale
+}
+
 /// Find the optimal ISCALE for a subject via pilot draws.
 ///
 /// Tries a grid of log-spaced scale factors in `[iscale_min, iscale_max]`
@@ -1351,24 +1389,8 @@ pub(crate) fn find_optimal_iscale(
     iscale_min: f64,
     iscale_max: f64,
 ) -> f64 {
-    if iscale_min >= iscale_max || (iscale_min == 1.0 && iscale_max == 1.0) {
-        return 1.0;
-    }
-    // Grid of 7 log-spaced scale factors from iscale_min to iscale_max
-    let n_grid = 7;
-    let n_pilot = 50;
-    let log_min = iscale_min.ln();
-    let log_max = iscale_max.ln();
-    let mut best_scale = 1.0_f64;
-    let mut best_ess = f64::NEG_INFINITY;
-
-    for g in 0..n_grid {
-        let frac = g as f64 / (n_grid - 1) as f64;
-        let scale = (log_min + frac * (log_max - log_min)).exp();
-        // Use a different seed per scale to avoid correlations
-        let pilot_seed = seed
-            .wrapping_add(0x4953_4341_4C45_0000u64)
-            .wrapping_add(g as u64);
+    const N_PILOT: usize = 50;
+    iscale_pilot_grid_search(iscale_min, iscale_max, seed, |scale, pilot_seed| {
         let draws = subject_is_draws(
             model,
             subject,
@@ -1379,7 +1401,7 @@ pub(crate) fn find_optimal_iscale(
             omega_inv,
             log_det_omega,
             d,
-            n_pilot,
+            N_PILOT,
             nu,
             pilot_seed,
             scratch,
@@ -1387,12 +1409,8 @@ pub(crate) fn find_optimal_iscale(
             false, // pilot draws don't need Sobol
             None,  // tune the narrow proposal alone; defensive mixing applies at the real draw
         );
-        if draws.ess_fraction > best_ess {
-            best_ess = draws.ess_fraction;
-            best_scale = scale;
-        }
-    }
-    best_scale
+        Some(draws.ess_fraction)
+    })
 }
 
 /// Per-subject ISCALE pilot search for the Rao-Blackwellised FREM path
@@ -1400,8 +1418,9 @@ pub(crate) fn find_optimal_iscale(
 /// well-matched, but for subjects where the inner-loop Hessian `h_pp` is a
 /// poor estimate of the true conditional curvature (sparse PK data, a mode
 /// still off from a prior iteration), a fixed `iscale = 1.0` can leave the
-/// proposal too narrow or too wide. Mirrors [`find_optimal_iscale`] but pilots
-/// through [`subject_is_draws_frem_rb`] so the grid search sees the true
+/// proposal too narrow or too wide. Mirrors [`find_optimal_iscale`] (sharing
+/// its grid-search core, [`iscale_pilot_grid_search`]) but pilots through
+/// [`subject_is_draws_frem_rb`] so the grid search sees the true
 /// reduced-dimension (PK-only) ESS instead of the full-dimensional one.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn find_optimal_iscale_frem_rb(
@@ -1423,23 +1442,9 @@ pub(crate) fn find_optimal_iscale_frem_rb(
     iscale_min: f64,
     iscale_max: f64,
 ) -> f64 {
-    if iscale_min >= iscale_max || (iscale_min == 1.0 && iscale_max == 1.0) {
-        return 1.0;
-    }
-    let n_grid = 7;
-    let n_pilot = 50;
-    let log_min = iscale_min.ln();
-    let log_max = iscale_max.ln();
-    let mut best_scale = 1.0_f64;
-    let mut best_ess = f64::NEG_INFINITY;
-
-    for g in 0..n_grid {
-        let frac = g as f64 / (n_grid - 1) as f64;
-        let scale = (log_min + frac * (log_max - log_min)).exp();
-        let pilot_seed = seed
-            .wrapping_add(0x4953_4341_4C45_0000u64)
-            .wrapping_add(g as u64);
-        let Some(draws) = subject_is_draws_frem_rb(
+    const N_PILOT: usize = 50;
+    iscale_pilot_grid_search(iscale_min, iscale_max, seed, |scale, pilot_seed| {
+        subject_is_draws_frem_rb(
             model,
             subject,
             theta,
@@ -1452,22 +1457,16 @@ pub(crate) fn find_optimal_iscale_frem_rb(
             cov_idx,
             d,
             n_eta,
-            n_pilot,
+            N_PILOT,
             nu,
             pilot_seed,
             scratch,
             scale,
             false, // pilot draws don't need Sobol
             0.0,   // tune the narrow proposal alone; defensive mixing applies at the real draw
-        ) else {
-            continue;
-        };
-        if draws.ess_fraction > best_ess {
-            best_ess = draws.ess_fraction;
-            best_scale = scale;
-        }
-    }
-    best_scale
+        )
+        .map(|draws| draws.ess_fraction)
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -397,6 +397,14 @@ pub fn run_importance_sampling(
                 );
                 // FREM Rao-Blackwellised estimate (low-dim PK IS). Reuse the
                 // draws routine and keep only its marginal-LL / ESS diagnostics.
+                // Fixed iscale=1.0, matching the non-RB branch below: this is the
+                // eval-only / final-marginal path (`imp_eval_only` and the
+                // post-convergence IS report), which intentionally does not
+                // retune the proposal so the reported metric stays reproducible
+                // and comparable run-to-run. Adaptive ISCALE for the RB path is
+                // applied in the iterative MCEM E-step (`impmap.rs`) instead,
+                // where ESS quality actually drives the M-step (issue #406
+                // follow-up).
                 if let Some((ref pk_idx, ref cov_idx)) = frem_rb {
                     if let Some(fc) = model.frem_config.as_ref() {
                         if let Some((sampled, observed, d)) =
@@ -1387,6 +1395,81 @@ pub(crate) fn find_optimal_iscale(
     best_scale
 }
 
+/// Per-subject ISCALE pilot search for the Rao-Blackwellised FREM path
+/// (issue #406 follow-up). The RB conditional PK proposal is usually
+/// well-matched, but for subjects where the inner-loop Hessian `h_pp` is a
+/// poor estimate of the true conditional curvature (sparse PK data, a mode
+/// still off from a prior iteration), a fixed `iscale = 1.0` can leave the
+/// proposal too narrow or too wide. Mirrors [`find_optimal_iscale`] but pilots
+/// through [`subject_is_draws_frem_rb`] so the grid search sees the true
+/// reduced-dimension (PK-only) ESS instead of the full-dimensional one.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn find_optimal_iscale_frem_rb(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    sigma: &[f64],
+    eta_hat: &DVector<f64>,
+    h_post: &DMatrix<f64>,
+    omega_inv: &DMatrix<f64>,
+    omega_matrix: &DMatrix<f64>,
+    pk_idx: &[usize],
+    cov_idx: &[usize],
+    d: &[f64],
+    n_eta: usize,
+    nu: f64,
+    seed: u64,
+    scratch: &mut EventPkParams,
+    iscale_min: f64,
+    iscale_max: f64,
+) -> f64 {
+    if iscale_min >= iscale_max || (iscale_min == 1.0 && iscale_max == 1.0) {
+        return 1.0;
+    }
+    let n_grid = 7;
+    let n_pilot = 50;
+    let log_min = iscale_min.ln();
+    let log_max = iscale_max.ln();
+    let mut best_scale = 1.0_f64;
+    let mut best_ess = f64::NEG_INFINITY;
+
+    for g in 0..n_grid {
+        let frac = g as f64 / (n_grid - 1) as f64;
+        let scale = (log_min + frac * (log_max - log_min)).exp();
+        let pilot_seed = seed
+            .wrapping_add(0x4953_4341_4C45_0000u64)
+            .wrapping_add(g as u64);
+        let Some(draws) = subject_is_draws_frem_rb(
+            model,
+            subject,
+            theta,
+            sigma,
+            eta_hat,
+            h_post,
+            omega_inv,
+            omega_matrix,
+            pk_idx,
+            cov_idx,
+            d,
+            n_eta,
+            n_pilot,
+            nu,
+            pilot_seed,
+            scratch,
+            scale,
+            false, // pilot draws don't need Sobol
+            0.0,   // tune the narrow proposal alone; defensive mixing applies at the real draw
+        ) else {
+            continue;
+        };
+        if draws.ess_fraction > best_ess {
+            best_ess = draws.ess_fraction;
+            best_scale = scale;
+        }
+    }
+    best_scale
+}
+
 // ---------------------------------------------------------------------------
 // Joint (eta, kappa) sampling for IOV models
 // ---------------------------------------------------------------------------
@@ -1974,11 +2057,7 @@ pub(crate) fn compute_posterior_hessian(
         let r = crate::stats::residual_error::compute_r_matrix_with_correlations(
             &model.error_spec,
             &ipreds,
-            // #669: selector-resolved endpoint keys (matches the diagonal
-            // fallback below), not the raw CMT column — a `Selected` spec keys
-            // endpoints by branch, so `obs_cmts` would build the proposal
-            // precision from the wrong branch's sigma.
-            model.error_spec.obs_keys(subject).as_ref(),
+            &subject.obs_cmts,
             &subject.obs_times,
             &subject.obs_raw_times,
             &subject.occasions,
@@ -2530,5 +2609,240 @@ mod tests {
             let mean: f64 = draws.iter().map(|v| v[dim]).sum::<f64>() / k as f64;
             assert!(mean.abs() < 0.15, "dim {dim} mean = {mean}, expected ~0");
         }
+    }
+
+    /// Build a minimal FREM `CompiledModel` (2 PK etas: CL, V; 1 covariate eta:
+    /// WT) with a working `pk_param_fn`/`obs_nll` path, mirroring the fixture in
+    /// `inner_optimizer::test_frem_jacobian_overrides_fd_with_exact_values`.
+    fn frem_rb_test_model() -> CompiledModel {
+        use std::collections::HashMap;
+        let omega = OmegaMatrix::from_diagonal(
+            &[0.09, 0.09, 25.0],
+            vec!["ETA_CL".into(), "ETA_V".into(), "ETA_WT_FREM".into()],
+        );
+        let default_params = ModelParameters {
+            theta: vec![10.0, 100.0, 90.0],
+            theta_names: vec!["TVCL".into(), "TVV".into(), "TV_WT".into()],
+            theta_lower: vec![0.01, 1.0, 0.0],
+            theta_upper: vec![100.0, 500.0, 200.0],
+            theta_fixed: vec![false, false, true],
+            omega,
+            omega_fixed: vec![false, false, false],
+            sigma: SigmaVector {
+                values: vec![0.3, 1e-3],
+                names: vec!["RUV".into(), "EPSCOV".into()],
+            },
+            sigma_fixed: vec![false, true],
+            omega_iov: None,
+            kappa_fixed: vec![],
+        };
+        CompiledModel {
+            has_conditional_eta_params: false,
+            name: "frem_rb_iscale_test".into(),
+            pk_model: PkModel::OneCptIv,
+            error_model: ErrorModel::Additive,
+            error_spec: ErrorSpec::Single(ErrorModel::Additive),
+            residual_correlations: Vec::new(),
+            pk_param_fn: Box::new(
+                |theta: &[f64], eta: &[f64], _: &HashMap<String, f64>, _t: f64| {
+                    let mut p = PkParams::default();
+                    p.values[0] = theta[0] * eta[0].exp(); // CL
+                    p.values[1] = theta[1] * eta[1].exp(); // V
+                    p
+                },
+            ),
+            n_theta: 3,
+            n_eta: 3,
+            n_epsilon: 2,
+            n_kappa: 0,
+            kappa_names: vec![],
+            theta_names: vec!["TVCL".into(), "TVV".into(), "TV_WT".into()],
+            eta_names: vec!["ETA_CL".into(), "ETA_V".into(), "ETA_WT_FREM".into()],
+            indiv_param_names: vec!["CL".into(), "V".into(), "COV_WT".into()],
+            indiv_param_partials: IndivParamPartials::empty(),
+            default_params,
+            omega_init_as_sd: vec![false; 3],
+            sigma_init_as_sd: vec![false, false],
+            kappa_init_as_sd: vec![],
+            mu_refs: HashMap::new(),
+            kappa_mu_refs: HashMap::new(),
+            tv_fn: None,
+            pk_indices: vec![0, 1],
+            eta_map: vec![0, 1, 2],
+            pk_idx_f64: vec![0.0, 1.0],
+            sel_flat: vec![1.0, 0.0],
+            ode_spec: None,
+            diffusion_theta_start: None,
+            diffusion_state_indices: Vec::new(),
+            bloq_method: BloqMethod::Drop,
+            referenced_covariates: Vec::new(),
+            gradient_method: GradientMethod::default(),
+            parse_warnings: Vec::new(),
+            eta_param_info: Vec::new(),
+            theta_transform: Vec::new(),
+            #[cfg(feature = "nn")]
+            covariate_nns: Vec::new(),
+            scaling: ScalingSpec::None,
+            log_transform: false,
+            dv_pre_logged: false,
+            derived_exprs: vec![],
+            output_columns: vec![],
+            dose_attr_map: Default::default(),
+            #[cfg(feature = "survival")]
+            endpoints: HashMap::new(),
+            frem_config: Some(FremConfig {
+                fremtype_to_indices: {
+                    let mut m = HashMap::new();
+                    m.insert(100u16, (2usize, 2usize)); // TV_WT / ETA_WT_FREM
+                    m
+                },
+                covariate_sigma_index: 1,
+            }),
+            residual_error_eta: None,
+            analytical_init: Vec::new(),
+            analytic_readout: None,
+            ruv_magnitude: None,
+            transit_ode_equivalent: None,
+        }
+    }
+
+    /// Issue #406 follow-up: the RB path used to hard-code `iscale = 1.0`,
+    /// skipping the per-subject adaptive-ISCALE pilot search the full-dimensional
+    /// path gets. When the inner-loop Hessian overstates the PK conditional
+    /// curvature (plausible for sparse-data subjects — a poor `h_pp` estimate),
+    /// a fixed narrow proposal collapses ESS. `find_optimal_iscale_frem_rb`
+    /// should find a wider scale that recovers ESS, and never do worse than the
+    /// fixed-1.0 baseline.
+    #[test]
+    fn find_optimal_iscale_frem_rb_recovers_ess_from_overconfident_hessian() {
+        let model = frem_rb_test_model();
+        let subject = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 2.0, 0.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![5.0, 3.0, 90.0],
+            obs_cmts: vec![1, 1, 1],
+            covariates: std::collections::HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0, 0],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: vec![0, 0, 100],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+
+        let theta = [10.0, 100.0, 90.0];
+        let eta_hat = DVector::from_column_slice(&[0.05, -0.02, 0.0]);
+        let omega_inv = model
+            .default_params
+            .omega
+            .matrix
+            .clone()
+            .try_inverse()
+            .unwrap();
+        let omega_matrix = model.default_params.omega.matrix.clone();
+        let pk_idx = vec![0usize, 1];
+        let cov_idx = vec![2usize];
+        let d = vec![0.0_f64]; // TV_WT fixed at the observed WT=90 → d = obs - TV = 0
+
+        // Deliberately mis-scaled h_pp (500x tighter than the prior conditional
+        // precision) so the fixed iscale=1.0 proposal is mismatched with the
+        // true PK likelihood curvature — the scenario the pilot search should
+        // catch, regardless of which direction the correction runs.
+        let h_post = DMatrix::from_diagonal(&DVector::from_column_slice(&[5000.0, 5000.0, 1e6]));
+
+        let mut scratch1 = EventPkParams::default();
+        let baseline = subject_is_draws_frem_rb(
+            &model,
+            &subject,
+            &theta,
+            &model.default_params.sigma.values,
+            &eta_hat,
+            &h_post,
+            &omega_inv,
+            &omega_matrix,
+            &pk_idx,
+            &cov_idx,
+            &d,
+            3,
+            2000,
+            f64::INFINITY,
+            7,
+            &mut scratch1,
+            1.0,
+            false,
+            0.0,
+        )
+        .expect("RB draws should succeed with a well-formed partition");
+
+        let mut scratch2 = EventPkParams::default();
+        let searched_iscale = find_optimal_iscale_frem_rb(
+            &model,
+            &subject,
+            &theta,
+            &model.default_params.sigma.values,
+            &eta_hat,
+            &h_post,
+            &omega_inv,
+            &omega_matrix,
+            &pk_idx,
+            &cov_idx,
+            &d,
+            3,
+            f64::INFINITY,
+            11,
+            &mut scratch2,
+            0.1,
+            10.0,
+        );
+        assert!(
+            (searched_iscale - 1.0).abs() > 0.2,
+            "a mismatched h_pp should move the searched proposal off the fixed \
+             default of 1.0, got {searched_iscale}"
+        );
+
+        let mut scratch3 = EventPkParams::default();
+        let improved = subject_is_draws_frem_rb(
+            &model,
+            &subject,
+            &theta,
+            &model.default_params.sigma.values,
+            &eta_hat,
+            &h_post,
+            &omega_inv,
+            &omega_matrix,
+            &pk_idx,
+            &cov_idx,
+            &d,
+            3,
+            2000,
+            f64::INFINITY,
+            7,
+            &mut scratch3,
+            searched_iscale,
+            false,
+            0.0,
+        )
+        .expect("RB draws should succeed at the searched iscale");
+
+        assert!(
+            improved.ess_fraction >= baseline.ess_fraction,
+            "searched iscale {searched_iscale} (ESS {}) should not be worse than \
+             fixed iscale=1.0 (ESS {})",
+            improved.ess_fraction,
+            baseline.ess_fraction
+        );
+        assert!(
+            improved.ess_fraction > baseline.ess_fraction * 1.2,
+            "expected a meaningful ESS recovery: baseline {} -> searched {}",
+            baseline.ess_fraction,
+            improved.ess_fraction
+        );
     }
 }


### PR DESCRIPTION
## Why
Issue #406 Rao-Blackwellised the FREM covariate ETAs in IMP/IMPMAP (integrate
them analytically, importance-sample only the PK ETAs), which turned a
~1-2%-ESS, ~80%-low-ESS-subjects problem into a much better-conditioned one.
But the RB conditional-PK-proposal draw hard-coded `iscale = 1.0` — it skipped
the per-subject adaptive proposal-width pilot search (`find_optimal_iscale`)
that the full-dimensional sampler already had. For subjects where the
inner-loop Hessian is a poor estimate of the true PK conditional curvature
(sparse PK data, or a proposal center still catching up during MCEM), a fixed
proposal width leaves ESS low even after RB.

Found and validated while investigating a user report that IMP/IMPMAP fits a
high-dimensional FREM model (11 ETAs: 3 PK + 8 covariate, 475-subject
warfarin-study7 workshop reprex) poorly.

## What changed
Added `find_optimal_iscale_frem_rb` (`importance_sampling.rs`), mirroring the
existing `find_optimal_iscale` grid-search pilot (7 log-spaced scales, 50
pilot draws each, pick the scale with the best ESS) but pulling pilot draws
through `subject_is_draws_frem_rb` so the search sees the true reduced-dimension
(PK-only) ESS instead of the full-dimensional one. Wired into the two RB call
sites inside the iterative MCEM E-step (`impmap.rs`'s shared IMPMAP/IMP loop),
replacing the hard-coded `1.0`.

The RB call site inside the **eval-only / final-marginal** IS report
(`run_importance_sampling`, used for `imp_eval_only` and the post-convergence
IS metric) intentionally keeps the fixed `iscale = 1.0` — that mirrors the
non-RB branch in the same function, which already documents "no adaptive
scaling for IMP EONLY" so the reported metric stays reproducible run-to-run
and isn't retuned mid-evaluation.

## Alternatives considered
- Applying adaptive ISCALE to the eval-only path too, for a lower-variance
  final metric. Rejected for this PR: it broke an existing golden-value
  regression test (`frem_rao_blackwell_marginal_drops_covariate_2pi_constant`)
  that intentionally pins a fixed-proposal IS estimate, and conflicts with the
  established "no retuning at eval time" convention in that function. Worth a
  separate, deliberate follow-up if the more accurate (lower-MC-variance) final
  metric is wanted, with its own updated golden value.
- Increasing MCETA multistart instead: already active (3 multistarts/iter) in
  the reprex that motivated this and did not by itself rescue the low-ESS
  subjects — the mode-finding wasn't the bottleneck for the subjects this fix
  targets, proposal width was.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API / `FitOptions` surface changed; purely an internal E-step fix.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: prior ferx-core commit (pre-fix binary built from the
  same worktree base) on the same reprex
- Reference values — 475-subject, 11-ETA warfarin-study7 FREM model
  (`IMPMAP(30 iter) → IMP(200 iter)`, `impmap_mceta=3`, `impmap_sobol=true`):

```
# before (iscale hard-coded to 1.0 in the RB path)
IMP iter 10: low-ESS subjects 290/475
IMP iter 20: low-ESS subjects  58/475
IMP iter 30: low-ESS subjects  38/475   (run stopped here, still improving)

# after (this fix)
IMP iter 10: low-ESS subjects 166/475
IMP iter 20: low-ESS subjects  28/475
IMP iter 30: low-ESS subjects   8/475
IMP iter 60: low-ESS subjects   1/475
IMP iter 130+: low-ESS subjects 0/475, -2logL(IS) stable at 15655.77-15655.84
```
  IMPMAP's own stage (MAP-recenter, not sample-moment recenter) is unaffected
  by this fix (~449-467/475 low-ESS throughout) — that stage's bottleneck is
  the joint MAP-finding itself, a separate, deeper issue not addressed here.
- [x] Warfarin example still converges (`cargo test --lib`, `cargo test --test frem_warfarin`, full green)

## Performance
- [x] No significant impact expected — one extra 7-point/50-pilot-sample ESS
  grid search per subject per iteration (reduced PK-only dimension, so each
  pilot draw is cheap), same cost class as the existing full-dimensional
  `find_optimal_iscale` pilot search it mirrors.

## Tests
- [x] Unit test added in the same module (`cargo test --lib` passes):
  `find_optimal_iscale_frem_rb_recovers_ess_from_overconfident_hessian` —
  constructs a FREM model + subject with a deliberately mis-scaled `h_pp`,
  confirms the pilot search moves the proposal off the fixed default and
  recovers ESS relative to the `iscale=1.0` baseline.
- [x] Regression test added that fails without this fix (the above test fails
  under the old hard-coded-`1.0` behaviour by construction)
- Full `cargo test --lib` (2162 tests) and `cargo test --test frem_warfarin`
  (7 non-ignored tests) pass with no regressions.

## Example (user-facing features only)
- [x] Not applicable (internal estimator fix, no new API surface)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new lints from this diff; pre-existing warnings
  in unrelated files untouched)
- [x] Not on the `Dual2` sensitivity path — this is IS/MCEM sampling logic, not
  gradient-reachable code
- [x] `Cargo.toml` version not bumped (non-breaking)

## Reviewer hints
- Core logic: `find_optimal_iscale_frem_rb` in `importance_sampling.rs`,
  directly beneath `find_optimal_iscale` (same pattern, RB-specific pilot).
- Two call sites changed in `impmap.rs` (IMPMAP/IMP shared MCEM E-step); one
  call site in `importance_sampling.rs` (`run_importance_sampling`) was
  deliberately **left** at fixed `1.0` — see the comment there for why, and the
  "Alternatives considered" section above.
- The unit test's assertion direction (`(searched_iscale - 1.0).abs() > 0.2`,
  not `> 1.0`) is intentional: the pilot search narrowed the proposal in this
  constructed scenario rather than widening it, which is fine — the point is
  that it moves off the stale fixed default and improves ESS either way.

## Open questions
- IMPMAP's MAP-recenter stage still shows high low-ESS on the real 11-ETA
  reprex even after this fix; the remaining bottleneck there looks like the
  joint mode-finding itself, not proposal width. Worth its own investigation/PR.