### PR TITLE
refactor(estimation): remove vestigial iiv_on_ruv_forces_fd predicate [#486]

### DIFF
--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1393,13 +1393,10 @@ pub(crate) fn analytic_inner_common_bail(model: &CompiledModel) -> bool {
         // *combination* with a correlated residual bails: the dense-R inner kernel does
         // not carry the magnitude's θ-dependence, so route it to FD (magnitude-aware).
         || (model.has_custom_ruv_magnitude() && !model.residual_correlations.is_empty())
-        // `iiv_on_ruv`: residual-η is served analytically on both loops for the
-        // closed-form path — plain (#474), IOV (#4b), and M3-BLOQ (#4c) — and for the ODE
-        // path including the M3 + IOV triple (#486); the scaling and the censored/quantified
-        // `η_ruv` terms live in the shared, provider-agnostic gradient. Only **non-IOV ODE**
-        // M3 + `iiv_on_ruv` still bails here (via `iiv_on_ruv_forces_fd`, now
-        // M3-AND-`ode_spec`-AND-`n_kappa == 0`).
-        || model.iiv_on_ruv_forces_fd()
+    // `iiv_on_ruv` needs no bail here: residual-η is served analytically on both loops for
+    // every combination — closed-form and ODE, plain / IOV / M3-BLOQ including the triples
+    // (#474/#4b/#4c/#591/#623/#677); the scaling and the censored/quantified `η_ruv` terms
+    // live in the shared, provider-agnostic gradient.
 }
 
 /// True when the subject carries survival/TTE observation records, whose hazard-likelihood
@@ -1475,7 +1472,7 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
         // The ODE inner path does NOT bail on LTBS or `ExpressionScale`: the `Dual1` ODE
         // walk shares `solve_ode_g` with the objective, so ODE-LTBS takes the analytic
         // inner gradient (#474). Only the escape hatch / `gradient = fd` / SDE /
-        // `iiv_on_ruv`-forces-FD cases revert here.
+        // magnitude-×-`block_sigma` cases revert here.
         if no_analytic_inner_forced()
             || matches!(model.gradient_method, GradientMethod::Fd)
             || model.is_sde()
@@ -1487,7 +1484,6 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
             // with a correlated residual bails: the dense-R inner kernel does not carry
             // the magnitude's θ-dependence — matching `analytic_inner_common_bail`.
             || (model.has_custom_ruv_magnitude() && !model.residual_correlations.is_empty())
-            || model.iiv_on_ruv_forces_fd()
         {
             return false;
         }
@@ -1899,9 +1895,8 @@ fn analytic_eta_nll_gradient_iov(
     // so `v`/`dv_df` carry that factor and the `η_ruv` column gets the variance term
     // `Σ_j (1 − ε²/v)` — exactly the non-IOV treatment in
     // `analytic_eta_nll_gradient_with_schedule`. `residual_var_scale` returns `1.0` when
-    // no `iiv_on_ruv` is declared, so a plain IOV model is unaffected. (IOV + M3 still
-    // routes to FD via `iiv_on_ruv_forces_fd` / `iov_analytical_supported`, so no censored
-    // residual-eta branch is needed here.)
+    // no `iiv_on_ruv` is declared, so a plain IOV model is unaffected. (M3-censored rows are
+    // handled by the censored branch below, #580/#591.)
     // Only pay the `exp(2·η_ruv)` scaling + the `η_ruv` column when `iiv_on_ruv` is
     // active; a plain IOV model runs the original op count (no per-obs ×1.0 multiplies
     // and no residual-eta accumulation — #474 review).
@@ -1918,8 +1913,8 @@ fn analytic_eta_nll_gradient_iov(
     // Jacobian, so the EBE minimises the same censored objective. The triple
     // M3 + IOV + `iiv_on_ruv` is analytic too (#591): on a censored row with
     // `ruv_active`, `residual_inner_obs` also returns the `h·z` residual-eta column
-    // (the `η_ruv` index lives in the BSV block of the stacked vector). Only the ODE
-    // triple stays FD (via `iiv_on_ruv_forces_fd`).
+    // (the `η_ruv` index lives in the BSV block of the stacked vector). The ODE triple is
+    // analytic as well (#486/#623) — every `iiv_on_ruv` combination is served.
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
     let mut grad = vec![0.0_f64; n_stacked];
     let mut ruv_grad = 0.0_f64;
@@ -2950,7 +2945,7 @@ mod tests {
     /// Closed-form `iiv_on_ruv` + M3 BLOQ (#4c): the analytic non-IOV inner
     /// η-gradient must match central FD of `individual_nll`, exercising the censored
     /// `η_ruv` data column `h·z` and the `exp(2·η_ruv)` variance scaling on the
-    /// censored rows (which previously forced FD via `iiv_on_ruv_forces_fd`).
+    /// censored rows (which previously forced FD).
     #[test]
     fn analytic_inner_gradient_iiv_on_ruv_m3_matches_fd() {
         use std::cell::RefCell;
@@ -2961,7 +2956,6 @@ mod tests {
         .expect("parse closed-form iiv_on_ruv");
         model.bloq_method = crate::types::BloqMethod::M3;
         assert_eq!(model.residual_error_eta, Some(3));
-        assert!(!model.iiv_on_ruv_forces_fd());
 
         let subject = Subject {
             id: "1".into(),
@@ -3072,8 +3066,8 @@ mod tests {
     /// censored residual-eta data column `h·z` and the `exp(2·η_ruv)` variance scaling are
     /// applied by the provider-agnostic `residual_inner_obs` over the **event-driven ODE
     /// walk's** `ObsSens` (not the closed-form provider), so the analytic inner η-gradient
-    /// must match central FD of `individual_nll`. This is what flipping `iiv_on_ruv_forces_fd`
-    /// to a uniform `false` now admits on the inner loop.
+    /// must match central FD of `individual_nll` — the non-IOV ODE M3 + `iiv_on_ruv` combo
+    /// the inner loop now admits (#623).
     #[test]
     fn analytic_inner_gradient_m3_iiv_on_ruv_matches_fd_on_ode() {
         use std::cell::RefCell;
@@ -3085,10 +3079,6 @@ mod tests {
         model.bloq_method = crate::types::BloqMethod::M3;
         assert_eq!(model.residual_error_eta, Some(3));
         assert!(model.is_ode_based(), "model must be on the ODE path");
-        assert!(
-            !model.iiv_on_ruv_forces_fd(),
-            "non-IOV ODE M3 + iiv_on_ruv must no longer force FD (#486)"
-        );
 
         let subject = Subject {
             id: "1".into(),
@@ -4656,8 +4646,8 @@ mod iov_tests {
     /// (`analytic_eta_nll_gradient_iov`) must match central FD of the inner objective
     /// `individual_nll_iov` over `[η_bsv, η_ruv, κ₁..κ_K]` — including the `η_ruv` column
     /// (`Σ_j 1 − ε²/v`) and the `exp(2·η_ruv)` residual-variance scaling now woven into
-    /// the IOV inner gradient. Proves the gate flip (`iov_analytical_supported` /
-    /// `iiv_on_ruv_forces_fd`) ships a *correct* gradient, not just an enabled one.
+    /// the IOV inner gradient. Proves the gate flip (`iov_analytical_supported`) ships a
+    /// *correct* gradient, not just an enabled one.
     #[test]
     fn iov_iiv_on_ruv_inner_grad_matches_fd() {
         use crate::parser::model_parser::parse_model_string;
@@ -4670,7 +4660,6 @@ mod iov_tests {
         assert!(crate::sens::provider::iov_analytical_supported(&model));
         assert!(crate::sens::provider::iov_sens_supported(&model));
         assert!(!analytic_inner_common_bail(&model));
-        assert!(!model.iiv_on_ruv_forces_fd());
 
         let subject = Subject {
             id: "1".into(),
@@ -5111,10 +5100,8 @@ mod iov_tests {
         .expect("parse ODE IOV + M3 + iiv_on_ruv");
         assert_eq!(model.residual_error_eta, Some(3));
         assert!(model.is_ode_based(), "must be on the ODE path");
-        // The ODE triple is analytic on both loops as of #486 (n_kappa > 0, so
-        // `iiv_on_ruv_forces_fd` no longer trips).
+        // The ODE triple is analytic on both loops as of #486.
         assert!(crate::sens::provider::iov_sens_supported(&model));
-        assert!(!model.iiv_on_ruv_forces_fd());
         assert!(!analytic_inner_common_bail(&model));
 
         for cens_sign in [1i8, -1] {
@@ -5228,7 +5215,6 @@ mod iov_tests {
         assert!(crate::sens::provider::iov_analytical_supported(&model));
         assert!(crate::sens::provider::iov_sens_supported(&model));
         assert!(!analytic_inner_common_bail(&model));
-        assert!(!model.iiv_on_ruv_forces_fd());
 
         let mut subject = Subject {
             id: "1".into(),
@@ -5348,14 +5334,12 @@ mod iov_tests {
         assert!(!analytic_inner_common_bail(&model));
         // IIV on residual error is NO LONGER a blanket common bail (#4b): the inner
         // gradient now carries the `exp(2·η_ruv)` scaling and the `η_ruv` variance column.
-        // For this **IOV** model (`n_kappa > 0`), even the M3 triple is analytic as of #486
-        // (`iiv_on_ruv_forces_fd` no longer trips — its `n_kappa == 0` guard keeps only the
-        // *non-IOV* ODE M3 + `iiv_on_ruv` combo on FD).
+        // For this **IOV** model (`n_kappa > 0`), even the M3 triple is analytic as of #486;
+        // the non-IOV ODE M3 + `iiv_on_ruv` combo is analytic as well (#623).
         model.residual_error_eta = Some(0);
         assert!(!analytic_inner_common_bail(&model));
         model.bloq_method = crate::types::BloqMethod::M3;
         assert!(!analytic_inner_common_bail(&model));
-        assert!(!model.iiv_on_ruv_forces_fd());
         model.bloq_method = crate::types::BloqMethod::Drop;
         model.residual_error_eta = None;
         // LTBS × IOV now takes the FD *inner* gradient via `analytic_inner_common_bail`'s
@@ -5496,8 +5480,8 @@ mod iov_tests {
     /// IIV on residual error (#474): the closed-form inner η-gradient must match a
     /// The inner-gradient model gate accepts a closed-form `iiv_on_ruv` model AND
     /// closed-form **M3 BLOQ + `iiv_on_ruv`** (#4c — the censored × residual-eta
-    /// cross-terms are assembled). Only **non-IOV ODE** M3 + `iiv_on_ruv` still keeps FD
-    /// (gated via `iiv_on_ruv_forces_fd`; the ODE *IOV* triple is analytic as of #486).
+    /// cross-terms are assembled). The **non-IOV ODE** M3 + `iiv_on_ruv` combo is analytic
+    /// as well (#623), as is the ODE *IOV* triple (#486).
     #[test]
     fn analytic_inner_grad_gate_iiv_on_ruv() {
         use crate::parser::model_parser::parse_model_string;
@@ -5509,7 +5493,6 @@ mod iov_tests {
         // #4c: closed-form M3 + iiv_on_ruv is now analytic (was FD).
         model.bloq_method = crate::types::BloqMethod::M3;
         assert!(analytic_inner_grad_supported_model(&model));
-        assert!(!model.iiv_on_ruv_forces_fd());
     }
 
     /// central finite difference of the production `individual_nll` (which applies

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -4260,7 +4260,6 @@ mod tests {
         assert!(crate::sens::provider::analytic_outer_gradient_available(
             &model
         ));
-        assert!(!model.iiv_on_ruv_forces_fd());
 
         let theta = vec![0.22, 11.0, 1.4];
         // Censor the two latest (lowest-concentration) observations at an LLOQ above
@@ -5920,10 +5919,6 @@ mod tests {
         assert!(model.is_ode_based(), "must be on the ODE path");
         assert_eq!(model.residual_error_eta, Some(3));
         assert!(
-            !model.iiv_on_ruv_forces_fd(),
-            "non-IOV ODE M3 + iiv_on_ruv must no longer force FD (#486)"
-        );
-        assert!(
             crate::sens::provider::analytic_outer_gradient_available(&model),
             "non-IOV ODE M3 + iiv_on_ruv must route to the analytic outer gradient (#486)"
         );
@@ -7373,7 +7368,6 @@ mod tests {
         assert_eq!(model.residual_error_eta, Some(3));
         assert!(model.is_ode_based(), "must be on the ODE path");
         assert!(crate::sens::ode_provider::ode_iov_supported(&model));
-        assert!(!model.iiv_on_ruv_forces_fd(), "IOV triple not forced to FD");
         let theta = vec![0.22, 11.0, 1.4];
         let mut params = model.default_params.clone();
         params.theta = theta.clone();

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -616,12 +616,10 @@ pub fn analytic_outer_gradient_available(model: &CompiledModel) -> bool {
         // `iov_sens_supported` (not just the closed-form `iov_analytical_supported`) so
         // the predicate also recognizes the ODE IOV outer gradient (#439 ODE IOV / #466).
         && (sens_supported(model) || iov_sens_supported(model))
-        // IIV on residual error (#474): the analytic gradient (inner η-column +
-        // outer θ/Ω/σ variance terms) is provider-agnostic, so it serves the
-        // closed-form AND ODE paths — including IOV and the M3-BLOQ triple
-        // (closed-form #4b/#591, ODE IOV #486). Only **non-IOV** ODE M3 + `iiv_on_ruv`
-        // still routes to FD, which is all `iiv_on_ruv_forces_fd` gates now.
-        && !model.iiv_on_ruv_forces_fd()
+    // IIV on residual error (#474) needs no gate here: the analytic gradient (inner η-column +
+    // outer θ/Ω/σ variance terms) is provider-agnostic, so it serves every `iiv_on_ruv`
+    // combination — closed-form and ODE, plain / IOV / M3-BLOQ including the triples
+    // (#474/#4b/#591/#623/#677) — with no FD carve-out.
 }
 
 /// [`analytic_outer_gradient_available`], kept as the shared entry point that
@@ -910,8 +908,8 @@ pub fn iov_analytical_supported(model: &CompiledModel) -> bool {
     // all keyed on the residual-eta index, which lives in the BSV block of the stacked
     // layout. So opening the gate lights up both loops; the censored rows still leave
     // `H̃`/`log|H̃|` (no `c̃` residual-eta column), matching the objective. The ODE *IOV*
-    // triple is analytic too (#486); only the **non-IOV ODE** M3 + `iiv_on_ruv` combo stays
-    // FD (via `iiv_on_ruv_forces_fd`, `ode_spec`-AND-`n_kappa == 0`-gated).
+    // triple is analytic too (#486); the **non-IOV ODE** M3 + `iiv_on_ruv` combo is analytic
+    // as well (#623) — every `iiv_on_ruv` combination is served, with no FD carve-out.
     //
     // IIV on residual error (`iiv_on_ruv`) IS analytic for closed-form IOV models:
     // `η_ruv` enters only through the variance (`v = R(f)·exp(2·η_ruv)`, `∂f/∂η_ruv = 0`),
@@ -5058,9 +5056,8 @@ mod tests {
         ruv.residual_error_eta = Some(0);
         assert!(analytic_outer_gradient_available(&ruv));
         // …and closed-form M3 BLOQ + `iiv_on_ruv` is now analytic too (#4c — the
-        // censored × residual-eta cross-terms are assembled). Only ODE M3 +
-        // `iiv_on_ruv` keeps FD (via `iiv_on_ruv_forces_fd`, which gates on
-        // `ode_spec.is_some()`).
+        // censored × residual-eta cross-terms are assembled). The ODE M3 +
+        // `iiv_on_ruv` combo is analytic as well (#623), so every combination is served.
         let mut ruv_m3 = test_helpers::analytical_model(GradientMethod::Auto);
         ruv_m3.residual_error_eta = Some(0);
         ruv_m3.bloq_method = crate::types::BloqMethod::M3;
@@ -9272,9 +9269,8 @@ mod tests {
     /// **M3 + IOV + `iiv_on_ruv`** is analytic too as of #591 — the closed-form assembly
     /// already carried the censored residual-eta cross coefficients `(C·z, C·m)`, so
     /// `iov_analytical_supported` admits it (and `analytic_outer_gradient_available`
-    /// follows). The ODE IOV triple is analytic too (#486); only the *non-IOV ODE* triple
-    /// stays FD (via `iiv_on_ruv_forces_fd`). Plain IOV and IOV + `iiv_on_ruv` (no M3) stay
-    /// analytic.
+    /// follows). The ODE IOV triple is analytic too (#486), as is the *non-IOV ODE* triple
+    /// (#623). Plain IOV and IOV + `iiv_on_ruv` (no M3) stay analytic.
     #[test]
     fn iov_analytical_supported_admits_m3_but_not_the_ruv_triple() {
         let mut model = parse_model_string(WARFARIN_IOV).expect("parse warfarin IOV");
@@ -9289,9 +9285,6 @@ mod tests {
         model.residual_error_eta = Some(0);
         assert!(iov_analytical_supported(&model));
         assert!(analytic_outer_gradient_available(&model));
-        // Only the *non-IOV ODE* triple stays FD, gated by `iiv_on_ruv_forces_fd`
-        // (ode_spec-AND-n_kappa==0); the closed-form triple here does not trip it.
-        assert!(!model.iiv_on_ruv_forces_fd());
         // IOV + iiv_on_ruv without M3: analytic (#4b).
         model.bloq_method = crate::types::BloqMethod::Drop;
         assert!(iov_analytical_supported(&model));
@@ -11444,8 +11437,8 @@ mod tests {
     /// `ode_iov_supported` admits M3, `iiv_on_ruv`, and the full **triple** M3 + IOV +
     /// `iiv_on_ruv` — all provider-agnostic over the stacked `[η_bsv, κ]` layout (the ODE
     /// walk emits a zero `∂f/∂η_ruv` column; the shared assembly applies the variance
-    /// scaling and the residual-eta column). Only the **non-IOV** ODE M3 + `iiv_on_ruv`
-    /// combo stays FD, gated by `iiv_on_ruv_forces_fd` (`n_kappa == 0`). LTBS still declines.
+    /// scaling and the residual-eta column). The **non-IOV** ODE M3 + `iiv_on_ruv` combo is
+    /// analytic as well (#623), so every combination is served. LTBS still declines.
     #[test]
     fn ode_iov_supported_admits_m3_and_the_ruv_triple() {
         let mut model = parse_model_string(WARFARIN_IOV_ODE).expect("parse ODE IOV");
@@ -11459,19 +11452,11 @@ mod tests {
             crate::sens::ode_provider::ode_iov_supported(&model),
             "ODE IOV + iiv_on_ruv must be on the analytic path (#486)"
         );
-        assert!(
-            !model.iiv_on_ruv_forces_fd(),
-            "IOV (n_kappa > 0) is not forced to FD"
-        );
         // The full triple M3 + ODE IOV + iiv_on_ruv: analytic as of #486.
         model.bloq_method = crate::types::BloqMethod::M3;
         assert!(
             crate::sens::ode_provider::ode_iov_supported(&model),
             "ODE IOV + M3 + iiv_on_ruv (the triple) must be analytic (#486)"
-        );
-        assert!(
-            !model.iiv_on_ruv_forces_fd(),
-            "the IOV triple is not forced to FD"
         );
         assert!(
             iov_sens_supported(&model),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3263,55 +3263,6 @@ impl CompiledModel {
         }
     }
 
-    /// Multiplicative factor applied to the residual *variance* for a subject
-    /// whose random-effect vector is `eta`, from the IIV-on-RUV term
-    /// (`Y = IPRED + EPS*EXP(ETA)`). Returns `exp(2*eta[k])` when
-    /// `residual_error_eta == Some(k)` and `k` is in range, else `1.0`.
-    ///
-    /// Because every residual-error model writes the variance as
-    /// `(scale·σ)²` terms summed, multiplying the whole variance by
-    /// `exp(2*eta_k)` is exactly equivalent to scaling the residual SD by
-    /// `exp(eta_k)` — i.e. `EPS·EXP(ETA)` — for additive, proportional, and
-    /// combined alike.
-    /// One predicate in the `iiv_on_ruv` × {plain | IOV | M3} × {closed-form | ODE}
-    /// routing decision. **As of #486 this gate forces FD for no combination** — every
-    /// `iiv_on_ruv` model (closed-form / ODE, plain / IOV / M3 BLOQ, including the triples)
-    /// is served by the shared, provider-agnostic gradient assembly. The censored ×
-    /// residual-eta cross-terms (`h·z` inner column, `C·z`/`C·m·a` true-Hessian / mixed
-    /// blocks, the σ-cross) live in `residual_inner_obs` (inner) and `prepare` /
-    /// `prepare_stacked` (outer), keyed on `subject.cens[j]` and `residual_error_eta` over
-    /// whatever `ObsSens` the walk emits. So the **non-IOV ODE M3 BLOQ + `iiv_on_ruv`**
-    /// combination — the last holdout — is analytic too (the #547 pattern: the ODE walk
-    /// emits the same per-observation shape the closed-form M3 + `iiv_on_ruv` assembly
-    /// already handled; the ODE and closed-form packed gradients are bit-identical and both
-    /// match reconverged FD to ~1e-7, inner and outer, #486). The predicate is retained as
-    /// the canonical "does `iiv_on_ruv` force FD here?" marker — now uniformly `false` — so
-    /// the inner/outer gates and their tests document the closed frontier in one place.
-    ///
-    /// **This is NOT the single source of truth for the full routing** — the decision
-    /// is spread across several predicates that must move together, so a future scope
-    /// change has to touch all the relevant ones in lockstep or the inner and outer
-    /// loops desync:
-    /// - this gate (consulted by [`analytic_outer_gradient_available`](crate::sens::provider::analytic_outer_gradient_available)
-    ///   and the inner bails [`analytic_inner_common_bail`] / the ODE inner gate);
-    /// - [`iov_analytical_supported`](crate::sens::provider::iov_analytical_supported)
-    ///   (closed-form IOV: declines M3, served for plain/`iiv_on_ruv`);
-    /// - [`ode_iov_supported`](crate::sens::ode_provider::ode_iov_supported)
-    ///   (ODE IOV + `iiv_on_ruv`, including the M3 triple, routed here);
-    /// - [`analytical_supported`](crate::sens::provider::analytical_supported)
-    ///   (closed-form M3 + `iiv_on_ruv`, #4c).
-    ///
-    /// Net effect today: analytic for **every** `iiv_on_ruv` combination —
-    /// **closed-form M3 + `iiv_on_ruv`** (#4c), **closed-form IOV + `iiv_on_ruv`**
-    /// (#4b/#474), **ODE IOV + `iiv_on_ruv`** incl. the M3 triple (#486, via
-    /// `ode_iov_supported`), and **non-IOV ODE M3 + `iiv_on_ruv`** (#486).
-    #[inline]
-    pub fn iiv_on_ruv_forces_fd(&self) -> bool {
-        // No remaining `iiv_on_ruv` combination forces FD (#486); see the doc above.
-        let _ = self;
-        false
-    }
-
     /// Whether a custom residual-error magnitude (#484) is active. The
     /// per-observation magnitude expression makes the residual variance depend
     /// on θ directly (not only through the prediction `f`). The analytic gradient
@@ -3329,6 +3280,16 @@ impl CompiledModel {
         self.ruv_magnitude.as_ref().is_some_and(|m| m.is_active())
     }
 
+    /// Multiplicative factor applied to the residual *variance* for a subject
+    /// whose random-effect vector is `eta`, from the IIV-on-RUV term
+    /// (`Y = IPRED + EPS*EXP(ETA)`). Returns `exp(2*eta[k])` when
+    /// `residual_error_eta == Some(k)` and `k` is in range, else `1.0`.
+    ///
+    /// Because every residual-error model writes the variance as
+    /// `(scale·σ)²` terms summed, multiplying the whole variance by
+    /// `exp(2*eta_k)` is exactly equivalent to scaling the residual SD by
+    /// `exp(eta_k)` — i.e. `EPS·EXP(ETA)` — for additive, proportional, and
+    /// combined alike.
     #[inline]
     pub fn residual_var_scale(&self, eta: &[f64]) -> f64 {
         match self.residual_error_eta {


### PR DESCRIPTION
## Why

`Model::iiv_on_ruv_forces_fd()` has returned `false` unconditionally since #623 closed the last `iiv_on_ruv` finite-difference cell (non-IOV ODE M3 + `iiv_on_ruv`). It was dead weight: its two call sites were provable no-ops (`&& !false`, `|| false`), and ~15 comments/test-docs still described a *"non-IOV ODE M3 + `iiv_on_ruv` still routes to FD via `iiv_on_ruv_forces_fd`"* carve-out **that no longer exists**. Those stale comments repeatedly misled the #486 audits into re-verifying phantom gates — a lying comment is worse than a no-op function.

## What changed

- Delete the function (`types.rs`) and its two production call sites (`analytic_outer_gradient_available`, `analytic_inner_common_bail` + `analytic_inner_grad_supported_model`). **No behaviour change** — every removed usage was a no-op.
- Remove the 13 `assert!(!model.iiv_on_ruv_forces_fd())` sanity checks (all always-true) and correct the ~15 stale comments to state the real fact: **every `iiv_on_ruv` combination is analytic** — closed-form and ODE, plain / IOV / M3-BLOQ including the triples.
- Relocate a misplaced doc: the `exp(2·eta)` explanation was sitting above the deleted function; moved it onto `residual_var_scale` (which had no doc and is exactly what it describes).

Net **−77 lines**.

## Breaking changes
- [x] None — the removed `pub fn` is unused in `ferx-core` and `ferx-r` (grep-verified).

## Tests
- [x] `cargo test --lib` passes (2176).

## Docs
- [x] No user-visible change — internal refactor, no CHANGELOG entry (per repo policy).

## Note
Stacked on #680 (both touch adjacent lines in `types.rs`). Base retargets to `main` when #680 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)