### PR TITLE
fix(api): simulate() reproduces block_sigma cross-endpoint correlation [closes #672]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2157,6 +2157,14 @@ section of the SDLC for the versioning policy).
 - Autodiff inner gradients now flow through `EVID=3/4` resets and lag time,
   removing a large finite-difference fallback slowdown (#198).
 
+### Fixed
+- **`simulate()` now reproduces a fitted or fixed `block_sigma` cross-endpoint
+  correlation** (#672): paired rows sharing a subject time and occasion (e.g.
+  total/unbound assays, per-CMT or covariate-selected) are drawn from the dense
+  residual covariance `R` instead of independent per-row normals, so a VPC or
+  posterior-predictive check now recovers the specified residual covariance
+  instead of understating it.
+
 ## [0.1.5] - 2026-06-01
 
 Released before this changelog was started. See the

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -412,13 +412,15 @@ under `method = foce` / `method = focei` (the EKF variance is added to the dense
 `R`) but are rejected under `method = saem`, whose M-step data term does not yet
 include the process-noise inflation.
 
-`simulate()` draws each observation's residual independently and does **not**
-reproduce a `block_sigma` off-diagonal covariance — simulated total/unbound (or
-cross-branch, for a covariate-selected model) rows are uncorrelated even though
-the estimation objective honours the correlation. A VPC or posterior-predictive
-check of the correlated endpoints will therefore understate the residual
-covariance; this applies to every `block_sigma` model, per-CMT and
-covariate-selected alike (tracked in issue #672).
+`simulate()` draws the full residual vector for each subject's paired
+observations (same subject time and occasion) from the dense covariance `R`
+built by `compute_r_matrix_with_correlations` — the same matrix FOCE/FOCEI/SAEM/
+`imp` evaluate the likelihood against — so a fitted or fixed `block_sigma`
+off-diagonal is reproduced in simulated total/unbound (or cross-branch, for a
+covariate-selected model) rows, and a VPC or posterior-predictive check of the
+correlated endpoints recovers the specified correlation (#672). FREM covariate
+pseudo-observations are excluded from the correlated draw (mirroring the
+identical exclusion in the likelihood) and stay independent.
 
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian

--- a/src/api.rs
+++ b/src/api.rs
@@ -5945,8 +5945,14 @@ fn emit_subject_rows<R: rand::Rng>(
     // builds (`compute_r_matrix_with_correlations`), so the simulated data
     // reproduces the fitted covariance instead of independent per-row draws.
     // FREM covariate pseudo-observations don't participate in the correlation
-    // (mirrors the identical `has_frem_rows` gate in
-    // `stats/likelihood.rs::individual_nll_into_with_schedule`).
+    // (mirrors the `has_frem_rows` gate in
+    // `stats/likelihood.rs::individual_nll_into_with_schedule`). That gate also
+    // carries a `!has_censored_m3` term we deliberately drop here: it exists so
+    // the likelihood's M3 BLOQ integral falls back to the scalar path, whereas
+    // simulate() draws the residual first and applies censoring afterwards, so a
+    // to-be-censored row should still be drawn from the correlated R. (A
+    // `block_sigma` + M3 model is rejected at fit by `check_model_options`
+    // regardless, so the two paths can only differ on an unfitted fixed model.)
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
     if !model.residual_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
         emit_correlated_residual_rows(
@@ -6012,6 +6018,11 @@ fn emit_subject_rows<R: rand::Rng>(
 /// same matrix FOCE/FOCEI/SAEM/`imp` evaluate the likelihood against), instead
 /// of the per-row independent draw `emit_subject_rows` otherwise uses. Callers
 /// must already have excluded FREM rows and the empty-correlation case.
+///
+/// R is factored with a PSD-safe symmetric-eigen square root, so a singular
+/// (e.g. `rho = ±1`) or mildly indefinite fixed `block_sigma` yields a valid
+/// draw instead of a Cholesky panic. Subjects whose R is diagonal (no paired
+/// rows) take a cheap per-row draw and skip the factorization entirely.
 #[allow(clippy::too_many_arguments)]
 fn emit_correlated_residual_rows<R: rand::Rng>(
     model: &CompiledModel,
@@ -6054,15 +6065,35 @@ fn emit_correlated_residual_rows<R: rand::Rng>(
         r *= ruv_scale;
     }
     let n = ipreds.len();
-    let chol = r.clone().cholesky().unwrap_or_else(|| {
-        panic!(
-            "simulate: subject {} residual covariance R (block_sigma) is not \
-             positive-definite — check the fitted/fixed sigma and rho values",
-            subject.id
-        )
-    });
+    // z ~ N(0, Iₙ); the correlated residual is a matrix square-root factor of R
+    // times z (`Cov(F·z) = F·Fᵀ = R`).
     let z = DVector::from_iterator(n, (0..n).map(|_| rng.sample(normal)));
-    let eps = chol.l() * z;
+    // Fast path: if R has no nonzero off-diagonal the subject has no actually
+    // paired rows (every observation sits in its own residual block), so R is
+    // diagonal and the draw is the same independent per-row draw the scalar
+    // path uses. Skip the O(n³) factorization — this keeps a densely-sampled
+    // endpoint of a `block_sigma` model cheap, and reproduces the scalar path's
+    // RNG-for-RNG output for such subjects.
+    let has_offdiag = (0..n).any(|j| ((j + 1)..n).any(|k| r[(j, k)] != 0.0));
+    let eps = if !has_offdiag {
+        DVector::from_iterator(n, (0..n).map(|j| r[(j, j)].max(0.0).sqrt() * z[j]))
+    } else {
+        // A fitted or fixed `block_sigma` can be positive-SEMIdefinite rather
+        // than strictly positive-definite — a perfect cross-endpoint
+        // correlation (`rho = ±1`, which the parser accepts on the inclusive
+        // [-1, 1] range) makes R singular, so a Cholesky factor doesn't exist
+        // and would panic the whole simulation. Use the symmetric-eigen square
+        // root `V·diag(√max(λ,0))`, which is well defined for any PSD R and
+        // clamps tiny negative eigenvalues (round-off, or a mildly indefinite
+        // fixed R) to zero instead of aborting.
+        let eig = r.symmetric_eigen();
+        let mut factor = eig.eigenvectors;
+        for (k, &lambda) in eig.eigenvalues.iter().enumerate() {
+            let s = lambda.max(0.0).sqrt();
+            factor.column_mut(k).scale_mut(s);
+        }
+        factor * z
+    };
     for (j, &ipred) in ipreds.iter().enumerate() {
         let value = ipred + eps[j];
         results.push(SimulationResult {
@@ -8335,6 +8366,87 @@ mod iov_integration {
                  to within floating-point rounding"
             );
         }
+    }
+
+    // #672 regression: a fixed `block_sigma` with a perfect cross-endpoint
+    // correlation (`rho = 1`) makes each paired subject's R singular. The
+    // original Cholesky draw panicked the whole simulation; the PSD
+    // symmetric-eigen square root must instead produce a valid,
+    // perfectly-correlated draw (empirical rho ≈ 1).
+    #[test]
+    fn test_simulate_singular_rho_one_does_not_panic() {
+        let (mut model, population) = block_sigma_selected_model_and_population();
+        model.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 1.0,
+        }];
+
+        let n_sim = 20_000;
+        let results = simulate_with_seed(&model, &population, &model.default_params, n_sim, 11);
+        assert_eq!(results.len(), 2 * n_sim);
+
+        let mut resid_total = Vec::with_capacity(n_sim);
+        let mut resid_unbound = Vec::with_capacity(n_sim);
+        for pair in results.chunks(2) {
+            resid_total.push(pair[0].outcome.continuous_value() - pair[0].ipred);
+            resid_unbound.push(pair[1].outcome.continuous_value() - pair[1].ipred);
+        }
+        let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+        let (m0, m1) = (mean(&resid_total), mean(&resid_unbound));
+        let n = n_sim as f64;
+        let cov = resid_total
+            .iter()
+            .zip(&resid_unbound)
+            .map(|(a, b)| (a - m0) * (b - m1))
+            .sum::<f64>()
+            / n;
+        let var0 = resid_total.iter().map(|a| (a - m0).powi(2)).sum::<f64>() / n;
+        let var1 = resid_unbound.iter().map(|a| (a - m1).powi(2)).sum::<f64>() / n;
+        let empirical_rho = cov / (var0.sqrt() * var1.sqrt());
+        assert!(
+            (empirical_rho - 1.0).abs() < 0.01,
+            "rho=1 singular block_sigma must draw perfectly-correlated residuals \
+             (no panic), got empirical rho {empirical_rho}"
+        );
+    }
+
+    // Cover the custom-magnitude (`Some(mult)`) R-build branch and the
+    // `ruv_scale != 1.0` scaling inside `emit_correlated_residual_rows`. The
+    // model-driven simulate() path can't reach these for a supported
+    // `block_sigma` model (block_sigma + iiv_on_ruv is rejected at fit), so call
+    // the helper directly with a hand-built per-observation multiplier and a
+    // non-unit scale and assert it draws both rows without panicking.
+    #[test]
+    fn test_emit_correlated_residual_rows_magnitude_and_scale_paths() {
+        use rand::SeedableRng;
+        let (model, population) = block_sigma_selected_model_and_population();
+        let subject = &population.subjects[0];
+        let ipreds = vec![10.0_f64, 10.0];
+        // [obs][sigma-slot] multiplier (all ones here — the point is to exercise
+        // the `_scaled` builder and the `ruv_scale` multiply, not a specific
+        // magnitude value).
+        let mult = vec![vec![1.0_f64, 1.0], vec![1.0, 1.0]];
+        let normal = rand_distr::Normal::new(0.0, 1.0).unwrap();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(3);
+        let mut results = Vec::new();
+        super::emit_correlated_residual_rows(
+            &model,
+            subject,
+            &model.default_params,
+            &ipreds,
+            2.0, // ruv_scale != 1.0
+            Some(&mult),
+            0,
+            0,
+            normal,
+            &mut rng,
+            &mut results,
+        );
+        assert_eq!(results.len(), 2);
+        assert!(results
+            .iter()
+            .all(|r| r.outcome.continuous_value().is_finite()));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,10 @@ use crate::propensity_match::MatchMethod;
 use crate::stats::likelihood::{
     build_frem_r_override, compute_cwres, foce_subject_nll, foce_subject_nll_iov,
 };
-use crate::stats::residual_error::{compute_iwres_with_correlations, iwres_autocorrelation};
+use crate::stats::residual_error::{
+    compute_iwres_with_correlations, compute_r_matrix_with_correlations,
+    compute_r_matrix_with_correlations_scaled, iwres_autocorrelation,
+};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use std::collections::HashMap;
@@ -5937,32 +5940,56 @@ fn emit_subject_rows<R: rand::Rng>(
     // Per-observation custom residual magnitude (#484): η-independent, so build
     // the [obs][sigma-slot] matrix once per subject and index it per row.
     let ruv_mult = model.ruv_obs_mult(subject, &params.theta);
-    for (j, &ipred) in ipreds.iter().enumerate() {
-        // FREM covariate pseudo-observations (FREMTYPE>0) use the additive
-        // covariate sigma, not the PK error model applied to the θ+η override
-        // that `compute_predictions_with_tv` now writes into FREM rows.
-        let var = model.sim_residual_variance(
+    // `block_sigma` cross-endpoint correlations (#672): draw the full
+    // multivariate residual vector from the dense `R` that estimation already
+    // builds (`compute_r_matrix_with_correlations`), so the simulated data
+    // reproduces the fitted covariance instead of independent per-row draws.
+    // FREM covariate pseudo-observations don't participate in the correlation
+    // (mirrors the identical `has_frem_rows` gate in
+    // `stats/likelihood.rs::individual_nll_into_with_schedule`).
+    let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
+    if !model.residual_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
+        emit_correlated_residual_rows(
+            model,
             subject,
-            j,
-            ipred,
-            &params.sigma.values,
+            params,
+            &ipreds,
             ruv_scale,
-            ruv_mult.as_ref().map(|m| m[j].as_slice()),
-        );
-        let eps: f64 = rng.sample(normal);
-        let value = ipred + var.sqrt() * eps;
-
-        results.push(SimulationResult {
+            ruv_mult.as_deref(),
             draw,
             sim,
-            id: subject.id.clone(),
-            // Raw data TIME (matches sdtab / input); `obs_times` may be
-            // the internal shifted clock for stacked reset occasions.
-            time: obs_row_time(subject, j),
-            cmt: subject.obs_cmts[j],
-            ipred,
-            outcome: SimOutcome::Continuous { value },
-        });
+            normal,
+            rng,
+            results,
+        );
+    } else {
+        for (j, &ipred) in ipreds.iter().enumerate() {
+            // FREM covariate pseudo-observations (FREMTYPE>0) use the additive
+            // covariate sigma, not the PK error model applied to the θ+η override
+            // that `compute_predictions_with_tv` now writes into FREM rows.
+            let var = model.sim_residual_variance(
+                subject,
+                j,
+                ipred,
+                &params.sigma.values,
+                ruv_scale,
+                ruv_mult.as_ref().map(|m| m[j].as_slice()),
+            );
+            let eps: f64 = rng.sample(normal);
+            let value = ipred + var.sqrt() * eps;
+
+            results.push(SimulationResult {
+                draw,
+                sim,
+                id: subject.id.clone(),
+                // Raw data TIME (matches sdtab / input); `obs_times` may be
+                // the internal shifted clock for stacked reset occasions.
+                time: obs_row_time(subject, j),
+                cmt: subject.obs_cmts[j],
+                ipred,
+                outcome: SimOutcome::Continuous { value },
+            });
+        }
     }
 
     // TTE simulation path (requires survival feature)
@@ -5978,6 +6005,76 @@ fn emit_subject_rows<R: rand::Rng>(
         rng,
         results,
     );
+}
+
+/// Draw the correlated residual vector for one subject's Gaussian observation
+/// rows from the dense `R` built by [`compute_r_matrix_with_correlations`] (the
+/// same matrix FOCE/FOCEI/SAEM/`imp` evaluate the likelihood against), instead
+/// of the per-row independent draw `emit_subject_rows` otherwise uses. Callers
+/// must already have excluded FREM rows and the empty-correlation case.
+#[allow(clippy::too_many_arguments)]
+fn emit_correlated_residual_rows<R: rand::Rng>(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    ipreds: &[f64],
+    ruv_scale: f64,
+    ruv_mult: Option<&[Vec<f64>]>,
+    draw: usize,
+    sim: usize,
+    normal: rand_distr::Normal<f64>,
+    rng: &mut R,
+    results: &mut Vec<SimulationResult>,
+) {
+    let err_keys = model.error_spec.obs_keys(subject);
+    let mut r = match ruv_mult {
+        Some(mult) => compute_r_matrix_with_correlations_scaled(
+            &model.error_spec,
+            ipreds,
+            err_keys.as_ref(),
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            &params.sigma.values,
+            &model.residual_correlations,
+            mult,
+        ),
+        None => compute_r_matrix_with_correlations(
+            &model.error_spec,
+            ipreds,
+            err_keys.as_ref(),
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            &params.sigma.values,
+            &model.residual_correlations,
+        ),
+    };
+    if ruv_scale != 1.0 {
+        r *= ruv_scale;
+    }
+    let n = ipreds.len();
+    let chol = r.clone().cholesky().unwrap_or_else(|| {
+        panic!(
+            "simulate: subject {} residual covariance R (block_sigma) is not \
+             positive-definite — check the fitted/fixed sigma and rho values",
+            subject.id
+        )
+    });
+    let z = DVector::from_iterator(n, (0..n).map(|_| rng.sample(normal)));
+    let eps = chol.l() * z;
+    for (j, &ipred) in ipreds.iter().enumerate() {
+        let value = ipred + eps[j];
+        results.push(SimulationResult {
+            draw,
+            sim,
+            id: subject.id.clone(),
+            time: obs_row_time(subject, j),
+            cmt: subject.obs_cmts[j],
+            ipred,
+            outcome: SimOutcome::Continuous { value },
+        });
+    }
 }
 
 /// `matched`, when `Some((fitted_etas, omega_inv, method))`, reassigns each
@@ -7012,6 +7109,7 @@ mod survival_predict_tests {
 #[cfg(test)]
 mod iov_integration {
     use super::fit;
+    use super::simulate_with_seed;
     use crate::types::*;
 
     use std::collections::HashMap;
@@ -8084,6 +8182,159 @@ mod iov_integration {
             (focei_ofv - foce_ofv).abs() > 1e-4,
             "FOCEI OFV {focei_ofv} must differ from FOCE OFV {foce_ofv} (interaction dropped?)"
         );
+    }
+
+    /// Shared covariate-selected free/total `block_sigma` model + paired-row
+    /// subject for the `simulate()` cross-branch correlation tests (#672).
+    /// Mirrors `SELECTED_BLOCK_SIGMA_MODEL` in `parser/model_parser.rs`, which
+    /// pins the same off-diagonal on the estimation side.
+    fn block_sigma_selected_model_and_population() -> (CompiledModel, Population) {
+        use crate::parser::model_parser::parse_model_string;
+        use std::collections::HashMap;
+
+        let model = parse_model_string(
+            r"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0) FIX
+  theta TVV(50.0, 5.0, 500.0) FIX
+  omega ETA_CL ~ 0.09 FIX
+  block_sigma (PROP_TOTAL, PROP_UNBOUND) = [0.01, 0.005, 0.09] FIX
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  if (FREE == 0) {
+    DV ~ proportional(PROP_TOTAL)
+  } else {
+    DV ~ proportional(PROP_UNBOUND)
+  }
+
+[covariates]
+  FREE continuous
+",
+        )
+        .expect("selected-error block_sigma model parses");
+
+        // Two paired rows at the same subject time (total vs. unbound), the
+        // exact fixture `test_selected_error_block_sigma_cross_branch_covariance`
+        // uses to pin the estimation-side dense `R`.
+        let subject = Subject {
+            id: "S1".to_string(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 1.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0, 0.0],
+            obs_cmts: vec![1, 1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: vec![
+                HashMap::from([("FREE".to_string(), 0.0)]),
+                HashMap::from([("FREE".to_string(), 1.0)]),
+            ],
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0],
+            occasions: vec![1, 1],
+            dose_occasions: vec![1],
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: vec!["FREE".to_string()],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+        (model, population)
+    }
+
+    // #672: `simulate()` must draw the two paired rows (same subject time,
+    // different `FREE` branch) from the dense correlated `R`, not independent
+    // per-row normals — otherwise a VPC of the correlated endpoints understates
+    // the residual covariance. Large-N: the empirical correlation of the two
+    // rows' residuals (value − ipred) must recover the fixed `rho` implied by
+    // `block_sigma`'s off-diagonal.
+    #[test]
+    fn test_simulate_recovers_block_sigma_cross_branch_correlation() {
+        let (model, population) = block_sigma_selected_model_and_population();
+
+        let n_sim = 20_000;
+        let results = simulate_with_seed(&model, &population, &model.default_params, n_sim, 42);
+        assert_eq!(results.len(), 2 * n_sim);
+
+        let mut resid_total = Vec::with_capacity(n_sim);
+        let mut resid_unbound = Vec::with_capacity(n_sim);
+        for pair in results.chunks(2) {
+            resid_total.push(pair[0].outcome.continuous_value() - pair[0].ipred);
+            resid_unbound.push(pair[1].outcome.continuous_value() - pair[1].ipred);
+        }
+
+        let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+        let (m0, m1) = (mean(&resid_total), mean(&resid_unbound));
+        let n = n_sim as f64;
+        let cov = resid_total
+            .iter()
+            .zip(&resid_unbound)
+            .map(|(a, b)| (a - m0) * (b - m1))
+            .sum::<f64>()
+            / n;
+        let var0 = resid_total.iter().map(|a| (a - m0).powi(2)).sum::<f64>() / n;
+        let var1 = resid_unbound.iter().map(|a| (a - m1).powi(2)).sum::<f64>() / n;
+        let empirical_rho = cov / (var0.sqrt() * var1.sqrt());
+
+        let sd_i = 0.01f64.sqrt();
+        let sd_j = 0.09f64.sqrt();
+        let expected_rho = 0.005 / (sd_i * sd_j);
+
+        assert!(
+            (empirical_rho - expected_rho).abs() < 0.03,
+            "empirical rho {empirical_rho} should recover the specified block_sigma \
+             rho {expected_rho} (simulate() ignoring the correlation would give ~0)"
+        );
+    }
+
+    // Degenerate case (#672): a `residual_correlations` entry with `rho == 0.0`
+    // makes `R` exactly diagonal, so the new dense Cholesky draw
+    // (`emit_correlated_residual_rows`) must reproduce the untouched
+    // independent per-row draw (`emit_subject_rows`'s scalar branch, taken when
+    // `model.residual_correlations` is empty) — same seed, same per-row RNG
+    // draw order in both paths. Not bit-for-bit: `compute_r_matrix_with_correlations`'s
+    // diagonal goes through `variance_at_scaled`'s `((f·f)·σ)·σ` association
+    // whenever `correlations` is non-empty (even at rho=0), versus `variance_at`'s
+    // `(f·σ)·(f·σ)` when it's empty — a pre-existing, documented ~1-ULP
+    // reassociation difference (see `residual_error::compute_r_matrix_with_correlations`),
+    // not a regression from this draw path.
+    #[test]
+    fn test_simulate_zero_rho_matches_diagonal_draw_path() {
+        let (mut model, population) = block_sigma_selected_model_and_population();
+        model.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.0,
+        }];
+        let dense_path = simulate_with_seed(&model, &population, &model.default_params, 200, 7);
+
+        model.residual_correlations.clear();
+        let scalar_path = simulate_with_seed(&model, &population, &model.default_params, 200, 7);
+
+        assert_eq!(dense_path.len(), scalar_path.len());
+        for (a, b) in dense_path.iter().zip(scalar_path.iter()) {
+            let (va, vb) = (a.outcome.continuous_value(), b.outcome.continuous_value());
+            assert!(
+                (va - vb).abs() < 1e-9 * va.abs().max(1.0),
+                "rho=0 dense-R draw {va} must match the independent scalar draw {vb} \
+                 to within floating-point rounding"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why
`simulate()` drew each observation's residual error independently and never consulted `model.residual_correlations`, so a fitted or fixed `block_sigma` off-diagonal covariance was not reproduced in simulated data. A VPC / posterior-predictive check of correlated endpoints (paired total/unbound assays, per-CMT or covariate-selected) understated the residual covariance, even though the estimation objective (FOCE/FOCEI/SAEM/`imp`) already honours the correlation via `compute_r_matrix_with_correlations`. Issue #672.

## What changed
`emit_subject_rows` in `src/api.rs` now checks `model.residual_correlations` (and excludes FREM rows, mirroring the identical gate in `stats/likelihood.rs`). When correlations are present it delegates to a new `emit_correlated_residual_rows`, which:
- builds the dense subject-level `R` via the same `compute_r_matrix_with_correlations` / `_scaled` estimation uses,
- scales it by the IIV-on-RUV factor,
- Cholesky-factors it and draws the residual vector jointly (`R_chol · z`) for all paired rows sharing a subject time and occasion.

Models with no `block_sigma` correlation are unaffected — same scalar per-row draw, same RNG order as before.

## Numerical validation
- Not applicable (no estimator change; simulate()-only fix). Validated instead per issue #672's suggested approach:
  - `test_simulate_recovers_block_sigma_cross_branch_correlation`: 20k-replicate empirical correlation of paired total/unbound rows recovers the specified `rho` from the model's `block_sigma`.
  - `test_simulate_zero_rho_matches_diagonal_draw_path`: a `rho=0` correlation entry matches the independent scalar draw path to floating-point precision (the tiny residual diff is a pre-existing, documented ~1-ULP reassociation quirk between the correlated/uncorrelated variance formulas, unrelated to this change).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 2178 passed, 0 failed)
- [x] Regression test added that fails without this fix (both new tests fail on the pre-fix code path)

## Docs
- [x] `docs/model-file/error-model.qmd` known-limitation note updated to describe the new behavior
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added

## Breaking changes
- [x] None

## Checklist
- [x] `cargo clippy` clean (pre-existing unrelated `--tests` errors on `main` confirmed via stash-and-check, not touched by this change)

## Reviewer hints
- Core logic: `emit_correlated_residual_rows` in `src/api.rs` (new function, right after `emit_subject_rows`).
- The gating (`!model.residual_correlations.is_empty() && !has_frem_rows`) mirrors the exact same condition in `stats/likelihood.rs::individual_nll_into_with_schedule` line ~417 — kept intentionally identical so simulate/estimate never disagree on which subjects get the dense treatment.
- `simulate_adaptive` (reactive/feedback dosing, epic #391) is untouched — out of scope for this issue, which is specifically the Monte-Carlo VPC path (`emit_subject_rows`).