### PR TITLE
feat(cli): add `ferx summary <run.fitrx>` sumo-style report [closes #684]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **New `ferx summary <run.fitrx>` CLI subcommand** (#684): prints a concise,
+  `psn::sumo`-style summary (parameter estimates with SE / %RSE, OMEGA / SIGMA with
+  CV%, condition number, shrinkage, and run info) from a saved `.fitrx` bundle to
+  stdout — no re-fitting or data required.
 - **Log-transform-both-sides (LTBS) combined with IOV now gets an analytic *outer* (θ/Ω/σ)
   gradient** (#486): the closed-form IOV sensitivity walk applies the `ln(f)` jet after its
   in-walk scale quotient, reproducing production's scale-then-log order `ln(f/s)`, so LTBS × IOV

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -8,6 +8,7 @@ The `ferx` command-line tool runs population PK estimation from model files and 
 ferx <model.ferx> --data <data.csv> [--output <run.fitrx>] [--include-data] [--inits-from-nca[=METHOD]]
 ferx <model.ferx> --simulate          [--output <run.fitrx>]
 ferx check <model.ferx> [--data <data.csv>] [--json]
+ferx summary <run.fitrx>
 ```
 
 ## Commands
@@ -64,6 +65,43 @@ The exit code is `0` when no errors are found (warnings alone still exit `0`),
 `1` when any error is found, and `2` on a usage error. See the
 [check report reference](file-formats/check-report.qmd) for the JSON schema and
 the full error-code table.
+
+### Summarize a Saved Fit (`summary`)
+
+```bash
+ferx summary run1.fitrx
+```
+
+Loads a saved [`.fitrx` bundle](file-formats/fitrx.qmd) and prints a concise,
+[`psn::sumo`](https://uupharmacometrics.github.io/PsN/)-style summary of the run
+to **stdout** — no re-fitting, no data required. Handy for reviewing an old run,
+diffing two fits, or piping into a report. The summary covers:
+
+- **Run status** — estimation method (or chain), convergence, iterations, and
+  the subject / observation / parameter counts.
+- **Objective function** — OFV, AIC, BIC.
+- **Parameter estimates** — the THETA table with SE and %RSE, OMEGA variances
+  with CV% and off-diagonal correlations, and SIGMA (with CV% for the
+  proportional component). `[FIX]`-flagged parameters show `---` for SE.
+- **Diagnostics** — covariance status, condition number, and η / ε shrinkage.
+- **Run info** — wall time, ferx version, and any fit warnings.
+
+```text
+============================================================
+ferx run summary — warfarin
+============================================================
+Method:     FOCEI
+Converged:  YES
+Iterations: 28
+Subjects: 32   Observations: 251   Parameters: 7
+
+--- Objective Function ---
+  OFV:  -280.1838
+  ...
+```
+
+The exit code is `0` on success, `1` if the bundle cannot be loaded, and `2` on
+a usage error (missing path).
 
 ## Output Files
 
@@ -135,8 +173,8 @@ Elapsed: 0.496s
 | Code | Meaning |
 |------|---------|
 | 0 | Success (for `check`: no errors found) |
-| 1 | Error (parse failure, data error, convergence failure; for `check`: errors found) |
-| 2 | `check` usage error (e.g. missing model path) |
+| 1 | Error (parse failure, data error, convergence failure; for `check`: errors found; for `summary`: bundle failed to load) |
+| 2 | Usage error for `check` / `summary` (e.g. missing model or bundle path) |
 
 ## Examples
 

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -12,10 +12,18 @@ fn main() {
         std::process::exit(run_check(&args));
     }
 
+    // `ferx summary <run.fitrx>` is a read-only reporting subcommand (like
+    // psn::sumo): load a saved fit bundle and print parameter estimates plus
+    // basic run info to stdout. Dispatch before the fit/simulate path.
+    if args.get(1).map(String::as_str) == Some("summary") {
+        std::process::exit(run_summary(&args));
+    }
+
     if args.len() < 2 {
         eprintln!("Usage: ferx <model.ferx> --data <data.csv> [--threads N|auto] [--output <run.fitrx>] [--include-data] [--inits-from-nca[=nca|nca_sweep|nca_ebe]]");
         eprintln!("       ferx <model.ferx> --simulate          [--threads N|auto] [--output <run.fitrx>]");
         eprintln!("       ferx check <model.ferx> [--data <data.csv>] [--json]");
+        eprintln!("       ferx summary <run.fitrx>");
         eprintln!();
         eprintln!("Fits a NLME model and writes sdtab.csv with residuals.");
         eprintln!("Data must be in NONMEM format (ID, TIME, DV, EVID, AMT, CMT, ...)");
@@ -169,6 +177,33 @@ fn main() {
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);
+        }
+    }
+}
+
+/// Run the `summary` subcommand: load a `.fitrx` bundle and print a
+/// `psn::sumo`-style summary (parameter estimates + basic run info) to stdout.
+/// Returns the process exit code: `0` = printed, `1` = load failed,
+/// `2` = usage (missing/flag-looking path).
+fn run_summary(args: &[String]) -> i32 {
+    let path = match args.get(2) {
+        Some(p) if !p.starts_with("--") => p.as_str(),
+        _ => {
+            eprintln!("Usage: ferx summary <run.fitrx>");
+            eprintln!();
+            eprintln!("Prints a psn::sumo-style summary — parameter estimates with %RSE");
+            eprintln!("plus basic run info — from a saved .fitrx fit bundle.");
+            return 2;
+        }
+    };
+    match ferx_core::io::fitrx::load_fit(std::path::Path::new(path)) {
+        Ok(loaded) => {
+            print!("{}", ferx_core::io::output::format_summary(&loaded.fit));
+            0
+        }
+        Err(e) => {
+            eprintln!("Error: failed to load {}: {}", path, e);
+            1
         }
     }
 }
@@ -359,7 +394,7 @@ fn parse_inits_from_nca_flag(args: &[String]) -> Result<Option<NcaInit>, String>
 mod tests {
     use super::{
         parse_check_args, parse_inits_from_nca_flag, parse_output_flag, parse_threads_flag,
-        print_check_human, run_check, CheckArgsError,
+        print_check_human, run_check, run_summary, CheckArgsError,
     };
     use ferx_core::NcaInit;
 
@@ -536,6 +571,41 @@ mod tests {
         let bad_path = bad.to_str().unwrap();
         assert_eq!(run_check(&args(&["check", bad_path])), 1);
         assert_eq!(run_check(&args(&["check", bad_path, "--json"])), 1);
+    }
+
+    // ── run_summary: in-process coverage of the `summary` subcommand ──────────
+
+    const WARFARIN_MODEL: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/warfarin.ferx");
+
+    #[test]
+    fn run_summary_usage_errors_return_2() {
+        // No path, and a flag where the path should be — both usage (2).
+        assert_eq!(run_summary(&args(&["summary"])), 2);
+        assert_eq!(run_summary(&args(&["summary", "--json"])), 2);
+    }
+
+    #[test]
+    fn run_summary_missing_file_returns_1() {
+        assert_eq!(run_summary(&args(&["summary", "/no/such/file.fitrx"])), 1);
+    }
+
+    #[test]
+    fn run_summary_valid_fitrx_returns_0() {
+        // Produce a real .fitrx via simulate (fast — no optimization loop), then
+        // load and summarize it in-process so the success arm is covered.
+        let (fit, pop) = ferx_core::run_model_simulate(WARFARIN_MODEL).expect("simulate warfarin");
+        let src = std::fs::read_to_string(WARFARIN_MODEL).expect("read model");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("run.fitrx");
+        ferx_core::io::fitrx::save_fit(
+            &fit,
+            &pop,
+            &src,
+            &path,
+            ferx_core::io::fitrx::SaveFitOptions::default(),
+        )
+        .expect("save fitrx");
+        assert_eq!(run_summary(&args(&["summary", path.to_str().unwrap()])), 0);
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2134,6 +2134,36 @@ mod tests {
         assert!(yaml.contains("      max:"), "max stat missing:\n{yaml}");
     }
 
+    /// Regression: `format_summary` must exclude NN weight thetas from the
+    /// THETA table (they can number in the hundreds), matching the YAML writer
+    /// and `print_results`. Without the `nn_theta_indices` skip this dumps one
+    /// row per weight.
+    #[cfg(feature = "nn")]
+    #[test]
+    fn format_summary_excludes_nn_weight_thetas() {
+        let result = make_nn_result();
+        let s = format_summary(&result);
+
+        // The user-declared theta is still listed.
+        assert!(s.contains("TVKA"), "TVKA must appear in THETA table:\n{s}");
+
+        // None of the 17 NN-weight thetas appear.
+        for layer in 1..3 {
+            let n_l = if layer == 1 { 3 } else { 2 };
+            let n_lm1 = if layer == 1 { 2 } else { 3 };
+            for i in 1..=n_l {
+                for j in 1..=n_lm1 {
+                    let name = format!("W_TYPICAL_PK_{}_{}_{}", layer, i, j);
+                    assert!(
+                        !s.contains(&name),
+                        "NN weight `{}` should NOT appear in THETA table:\n{s}",
+                        name
+                    );
+                }
+            }
+        }
+    }
+
     /// Sanity: when no `[covariate_nn]` blocks are declared, the YAML
     /// should NOT have a `neural_networks:` section at all.
     #[cfg(feature = "nn")]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -518,6 +518,245 @@ pub fn print_results(result: &FitResult) {
     eprintln!("{}\n", "=".repeat(60));
 }
 
+/// Render a concise, `psn::sumo`-style summary of a completed fit as a
+/// `String`: parameter estimates plus basic run information. Unlike
+/// [`print_results`] (which streams the full, kitchen-sink report to stderr),
+/// this *returns text* so it can be sent to stdout, redirected to a file, or
+/// asserted on in a test. It stays focused on the headline numbers a modeller
+/// scans first — convergence, objective function, the parameter table with
+/// %RSE, key diagnostics (condition number, shrinkage) and run metadata — and
+/// is what the `ferx summary <run.fitrx>` subcommand prints.
+pub fn format_summary(result: &FitResult) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let bar = "=".repeat(60);
+
+    let _ = writeln!(out, "{bar}");
+    let _ = writeln!(out, "ferx run summary — {}", result.model_name);
+    let _ = writeln!(out, "{bar}");
+
+    // --- Run status ---
+    if result.method_chain.len() > 1 {
+        let chain: Vec<&str> = result.method_chain.iter().map(|m| m.label()).collect();
+        let _ = writeln!(out, "Method:     {}", chain.join(" → "));
+    } else {
+        let _ = writeln!(out, "Method:     {}", result.method.label());
+    }
+    let _ = writeln!(
+        out,
+        "Converged:  {}",
+        if result.converged { "YES" } else { "NO" }
+    );
+    let _ = writeln!(out, "Iterations: {}", result.n_iterations);
+    let _ = writeln!(
+        out,
+        "Subjects: {}   Observations: {}   Parameters: {}",
+        result.n_subjects, result.n_obs, result.n_parameters
+    );
+
+    // --- Objective function ---
+    let _ = writeln!(out, "\n--- Objective Function ---");
+    let _ = writeln!(out, "  OFV:  {:.4}", result.ofv);
+    let _ = writeln!(out, "  AIC:  {:.4}", result.aic);
+    let _ = writeln!(out, "  BIC:  {:.4}", result.bic);
+
+    // Failed / SIR-fallback covariance make the SE columns meaningless, so we
+    // suppress the derived CV% (mirrors `print_results`).
+    let show_cv = !matches!(
+        result.covariance_status,
+        CovarianceStatus::Failed | CovarianceStatus::SirFallback
+    );
+
+    // --- THETA ---
+    let _ = writeln!(out, "\n--- THETA ---");
+    let _ = writeln!(
+        out,
+        "  {:<16} {:>12} {:>12} {:>8}",
+        "Parameter", "Estimate", "SE", "%RSE"
+    );
+    for (i, name) in result.theta_names.iter().enumerate() {
+        let est = result.theta[i];
+        let is_fixed = result.theta_fixed.get(i).copied().unwrap_or(false);
+        let label = if is_fixed {
+            fixed_label(name)
+        } else {
+            name.clone()
+        };
+        let (se_str, rse_str) = if is_fixed {
+            ("---".to_string(), "---".to_string())
+        } else {
+            match &result.se_theta {
+                Some(se) => {
+                    let se_val = se[i];
+                    let rse = if est.abs() > 1e-12 {
+                        (se_val / est.abs()) * 100.0
+                    } else {
+                        f64::NAN
+                    };
+                    (format!("{:.6}", se_val), format!("{:.1}", rse))
+                }
+                None => ("N/A".to_string(), "N/A".to_string()),
+            }
+        };
+        let _ = writeln!(
+            out,
+            "  {:<16} {:>12.6} {:>12} {:>8}",
+            label, est, se_str, rse_str
+        );
+    }
+
+    // --- OMEGA ---
+    let n_eta = result.omega.nrows();
+    if n_eta > 0 {
+        let _ = writeln!(out, "\n--- OMEGA ---");
+        for i in 0..n_eta {
+            let var = result.omega[(i, i)];
+            let name = result.eta_names.get(i).map(|s| s.as_str()).unwrap_or("ETA");
+            let is_fixed = result.omega_fixed.get(i).copied().unwrap_or(false);
+            let label = if is_fixed {
+                fixed_label(name)
+            } else {
+                name.to_string()
+            };
+            let se_str = if is_fixed {
+                "---".to_string()
+            } else {
+                match crate::types::omega_se_at(&result.se_omega, n_eta, i, i) {
+                    Some(s) => format!("{:.6}", s),
+                    None => "N/A".to_string(),
+                }
+            };
+            if show_cv {
+                let cv = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+                let _ = writeln!(
+                    out,
+                    "  {:<16} = {:.6}  (CV% = {:.1})  SE = {}",
+                    label, var, cv, se_str
+                );
+            } else {
+                let _ = writeln!(out, "  {:<16} = {:.6}  SE = {}", label, var, se_str);
+            }
+        }
+        // Off-diagonal correlations (block omega).
+        let has_offdiag = (0..n_eta).any(|i| (0..i).any(|j| result.omega[(i, j)].abs() > 1e-15));
+        if has_offdiag {
+            for i in 0..n_eta {
+                for j in 0..i {
+                    let cov = result.omega[(i, j)];
+                    if cov.abs() <= 1e-15 {
+                        continue;
+                    }
+                    let ni = result.eta_names.get(i).map(|s| s.as_str()).unwrap_or("ETA");
+                    let nj = result.eta_names.get(j).map(|s| s.as_str()).unwrap_or("ETA");
+                    let corr = result
+                        .omega_param_corr
+                        .as_ref()
+                        .map(|m| m[(i, j)])
+                        .unwrap_or_else(|| {
+                            let vi = result.omega[(i, i)];
+                            let vj = result.omega[(j, j)];
+                            if vi > 0.0 && vj > 0.0 {
+                                cov / (vi.sqrt() * vj.sqrt())
+                            } else {
+                                0.0
+                            }
+                        });
+                    let _ = writeln!(out, "  corr({}, {}) = {:.4}", ni, nj, corr);
+                }
+            }
+        }
+    }
+
+    // --- SIGMA ---
+    let err_type = match result.error_model {
+        ErrorModel::Additive => "additive",
+        ErrorModel::Proportional => "proportional",
+        ErrorModel::Combined => "combined",
+    };
+    let _ = writeln!(out, "\n--- SIGMA ({}) ---", err_type);
+    for (i, &s) in result.sigma.iter().enumerate() {
+        let name = result
+            .sigma_names
+            .get(i)
+            .map(|n| n.as_str())
+            .unwrap_or("EPS");
+        let is_fixed = result.sigma_fixed.get(i).copied().unwrap_or(false);
+        let label = if is_fixed {
+            fixed_label(name)
+        } else {
+            name.to_string()
+        };
+        let se_str = if is_fixed {
+            "---".to_string()
+        } else {
+            match &result.se_sigma {
+                Some(se) if i < se.len() => format!("{:.6}", se[i]),
+                _ => "N/A".to_string(),
+            }
+        };
+        match result.sigma_types.get(i).copied() {
+            Some(SigmaType::Proportional) => {
+                let _ = writeln!(
+                    out,
+                    "  {:<16} = {:.6}  (CV% = {:.1})  SE = {}",
+                    label,
+                    s,
+                    s * 100.0,
+                    se_str
+                );
+            }
+            _ => {
+                let _ = writeln!(out, "  {:<16} = {:.6}  SE = {}", label, s, se_str);
+            }
+        }
+    }
+
+    // --- Diagnostics ---
+    let _ = writeln!(out, "\n--- Diagnostics ---");
+    let cov_str = match result.covariance_status {
+        CovarianceStatus::Computed => "computed",
+        CovarianceStatus::Failed => "FAILED",
+        CovarianceStatus::NotRequested => "not requested",
+        CovarianceStatus::SirFallback => "SIR fallback",
+    };
+    let _ = writeln!(out, "  Covariance: {}", cov_str);
+    if let Some(cn) = result.cov_condition_number {
+        let _ = writeln!(out, "  Condition number: {:.1}", cn);
+    }
+    if !result.shrinkage_eta.is_empty() {
+        let parts: Vec<String> = result
+            .shrinkage_eta
+            .iter()
+            .enumerate()
+            .filter(|(_, sh)| sh.is_finite())
+            .map(|(k, sh)| {
+                let name = result.eta_names.get(k).map(|s| s.as_str()).unwrap_or("ETA");
+                format!("{} {:.1}%", name, sh * 100.0)
+            })
+            .collect();
+        if !parts.is_empty() {
+            let _ = writeln!(out, "  Eta shrinkage: {}", parts.join(", "));
+        }
+    }
+    if result.shrinkage_eps.is_finite() {
+        let _ = writeln!(out, "  EPS shrinkage: {:.1}%", result.shrinkage_eps * 100.0);
+    }
+
+    // --- Run info ---
+    let _ = writeln!(out, "\n--- Run Info ---");
+    let _ = writeln!(out, "  Wall time: {:.1}s", result.wall_time_secs);
+    let _ = writeln!(out, "  ferx v{}", result.ferx_version);
+    if !result.warnings.is_empty() {
+        let _ = writeln!(out, "  Warnings: {}", result.warnings.len());
+        for w in &result.warnings {
+            let _ = writeln!(out, "    * {}", w);
+        }
+    }
+    let _ = writeln!(out, "{bar}");
+
+    out
+}
+
 /// Generate SDTAB-like output as vectors of (header, values) pairs
 pub fn sdtab(result: &FitResult, population: &Population) -> Vec<(String, Vec<f64>)> {
     let n_total: usize = result.subjects.iter().map(|s| s.ipred.len()).sum();
@@ -1654,6 +1893,111 @@ mod tests {
             covariate_table: None,
             exclusions: None,
         }
+    }
+
+    #[test]
+    fn format_summary_contains_key_sections() {
+        // Build a small-but-representative fit: two thetas (one fixed), a
+        // diagonal 2×2 omega, one proportional sigma, a condition number,
+        // shrinkage, and a warning — enough to exercise every section and the
+        // fixed-label / CV% / %RSE branches.
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.method = EstimationMethod::FoceI;
+        r.method_chain = vec![EstimationMethod::FoceI];
+        r.converged = true;
+        r.ofv = 123.45;
+        r.aic = 130.0;
+        r.bic = 140.0;
+        r.n_subjects = 12;
+        r.n_obs = 96;
+        r.n_parameters = 4;
+        r.n_iterations = 7;
+        r.theta = vec![1.5, 10.0];
+        r.theta_names = vec!["CL".into(), "V".into()];
+        r.theta_fixed = vec![false, true];
+        r.se_theta = Some(vec![0.15, 0.0]);
+        r.omega = DMatrix::from_row_slice(2, 2, &[0.09, 0.0, 0.0, 0.04]);
+        r.eta_names = vec!["ETA_CL".into(), "ETA_V".into()];
+        r.omega_fixed = vec![false, false];
+        r.covariance_status = CovarianceStatus::Computed;
+        r.cov_condition_number = Some(42.0);
+        r.shrinkage_eta = vec![0.05, 0.10];
+        r.shrinkage_eps = 0.08;
+        r.wall_time_secs = 3.2;
+        r.warnings = vec!["heads up".into()];
+
+        let s = format_summary(&r);
+        assert!(s.contains("ferx run summary — test"));
+        assert!(s.contains("Method:     FOCEI"));
+        assert!(s.contains("Converged:  YES"));
+        assert!(s.contains("Subjects: 12   Observations: 96   Parameters: 4"));
+        assert!(s.contains("OFV:  123.4500"));
+        assert!(s.contains("--- THETA ---"));
+        assert!(s.contains("%RSE"));
+        // Free theta shows an SE; fixed theta is labelled and SE-suppressed.
+        assert!(s.contains("CL"));
+        assert!(s.contains("V [FIX]"));
+        assert!(s.contains("--- OMEGA ---"));
+        assert!(s.contains("ETA_CL"));
+        assert!(s.contains("(CV% ="));
+        assert!(s.contains("--- SIGMA (proportional) ---"));
+        assert!(s.contains("Condition number: 42.0"));
+        assert!(s.contains("Eta shrinkage:"));
+        assert!(s.contains("EPS shrinkage: 8.0%"));
+        assert!(s.contains("Warnings: 1"));
+        assert!(s.contains("heads up"));
+    }
+
+    #[test]
+    fn format_summary_block_omega_shows_correlation() {
+        // A correlated (block) omega must surface a `corr(...)` line.
+        let mut r = make_sigma_only_result(ErrorModel::Additive, vec![1.0]);
+        r.theta = vec![2.0];
+        r.theta_names = vec!["CL".into()];
+        r.theta_fixed = vec![false];
+        r.omega = DMatrix::from_row_slice(2, 2, &[0.09, 0.03, 0.03, 0.04]);
+        r.eta_names = vec!["ETA_CL".into(), "ETA_V".into()];
+        r.omega_fixed = vec![false, false];
+
+        let s = format_summary(&r);
+        assert!(s.contains("corr(ETA_V, ETA_CL) ="));
+    }
+
+    #[test]
+    fn format_summary_no_cov_suppresses_cv_and_rse() {
+        // Failed covariance → no SE table, CV% suppressed, method chain shown,
+        // fixed omega/sigma labelled, no condition number, no warnings.
+        let mut r = make_sigma_only_result(ErrorModel::Additive, vec![0.5]);
+        r.method = EstimationMethod::FoceI;
+        r.method_chain = vec![EstimationMethod::Saem, EstimationMethod::FoceI];
+        r.converged = false;
+        r.theta = vec![1.5];
+        r.theta_names = vec!["CL".into()];
+        r.theta_fixed = vec![false];
+        r.se_theta = None;
+        r.omega = DMatrix::from_row_slice(1, 1, &[0.09]);
+        r.eta_names = vec!["ETA_CL".into()];
+        r.omega_fixed = vec![true];
+        r.sigma_fixed = vec![true];
+        r.covariance_status = CovarianceStatus::Failed;
+        r.cov_condition_number = None;
+        r.shrinkage_eta = vec![f64::NAN];
+        r.shrinkage_eps = f64::NAN;
+
+        let s = format_summary(&r);
+        // Method chain joined with the arrow.
+        assert!(s.contains("SAEM → FOCEI"));
+        assert!(s.contains("Converged:  NO"));
+        // No se_theta → N/A in the %RSE column, no CV% under failed covariance.
+        assert!(s.contains("N/A"));
+        assert!(!s.contains("CV% ="));
+        // Fixed omega/sigma are [FIX]-labelled; condition number omitted.
+        assert!(s.contains("ETA_CL [FIX]"));
+        assert!(!s.contains("Condition number"));
+        // No finite shrinkage or warnings → those lines are absent.
+        assert!(!s.contains("Eta shrinkage:"));
+        assert!(!s.contains("EPS shrinkage:"));
+        assert!(!s.contains("Warnings:"));
     }
 
     fn yaml_for(error_model: ErrorModel, sigma: Vec<f64>) -> String {

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -567,6 +567,17 @@ pub fn format_summary(result: &FitResult) -> String {
         CovarianceStatus::Failed | CovarianceStatus::SirFallback
     );
 
+    // NN weight thetas are excluded from the per-parameter table (they can
+    // number in the hundreds); `print_results` skips them the same way.
+    #[cfg(feature = "nn")]
+    let nn_theta_indices: std::collections::HashSet<usize> = result
+        .neural_networks
+        .iter()
+        .flat_map(|nn| nn.weights_offset..nn.weights_offset + nn.n_weights)
+        .collect();
+    #[cfg(not(feature = "nn"))]
+    let nn_theta_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
     // --- THETA ---
     let _ = writeln!(out, "\n--- THETA ---");
     let _ = writeln!(
@@ -575,6 +586,9 @@ pub fn format_summary(result: &FitResult) -> String {
         "Parameter", "Estimate", "SE", "%RSE"
     );
     for (i, name) in result.theta_names.iter().enumerate() {
+        if nn_theta_indices.contains(&i) {
+            continue;
+        }
         let est = result.theta[i];
         let is_fixed = result.theta_fixed.get(i).copied().unwrap_or(false);
         let label = if is_fixed {


### PR DESCRIPTION
## Why

Issue #684: the `ferx` CLI had no way to show parameter estimates and basic run
info from a saved fit — the equivalent of PsN's `sumo`. Once a run is done and
its `.fitrx` bundle is on disk, the only way to see the estimates again was to
re-fit or crack open the zip by hand.

## What changed

New read-only `ferx summary <run.fitrx>` subcommand: loads a saved `.fitrx`
bundle via `fitrx::load_fit` and prints a concise, `psn::sumo`-style summary to
**stdout** — no re-fitting, no data required. It reports:

- **Run status** — method (or chain), convergence, iterations, subject/obs/param counts
- **Objective function** — OFV, AIC, BIC
- **Parameter estimates** — THETA with SE/%RSE, OMEGA variances with CV% + off-diagonal correlations, SIGMA (CV% for the proportional component); `[FIX]` params show `---`
- **Diagnostics** — covariance status, condition number, η/ε shrinkage
- **Run info** — wall time, ferx version, fit warnings

The rendering lives in a new `output::format_summary(&FitResult) -> String` so
it is unit-testable (unlike the stderr-streaming `print_results`, which it
deliberately leaves untouched). The CLI glue mirrors the existing `check`
subcommand: dispatched early in `main`, exit codes `0` printed / `1` load
failure / `2` usage.

Sample output:

```text
============================================================
ferx run summary — warfarin
============================================================
Method:     FOCE
Converged:  NO
Iterations: 40
Subjects: 10   Observations: 110   Parameters: 7

--- Objective Function ---
  OFV:  -207.4368
  AIC:  -193.4368
  BIC:  -174.5334

--- THETA ---
  Parameter            Estimate           SE     %RSE
  TVCL                 0.216359     0.017327      8.0
  ...
--- OMEGA ---
  ETA_CL           = 0.096239  (CV% = 31.0)  SE = 0.042958
  ...
--- SIGMA (proportional) ---
  PROP_ERR         = 0.023720  (CV% = 2.4)  SE = 0.002431

--- Diagnostics ---
  Covariance: computed
  Condition number: 4.8
  ...
```

## Alternatives considered

Reusing `print_results` directly — rejected: it streams to stderr (can't be
piped/redirected as a report) and isn't unit-testable. Factoring the rendering
into a `String`-returning function both fixes that and keeps `print_results`
untouched.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API removed; `format_summary` is additive.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CLI reporting over already-computed estimates; no new numerics)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)

`output::format_summary` gets three `--lib` unit tests covering the THETA/OMEGA/
SIGMA tables, fixed-param labelling, %RSE, block-omega correlations, and the
failed-covariance branch (CV%/SE suppressed, method chain, no condition number).
`run_summary` gets three `--bin ferx` in-process tests: usage error (2), missing
file (1), and a valid-bundle happy path (0) that produces a real `.fitrx` via
`simulate` and summarizes it.

## Example (user-facing features only)
- [x] Example added inline above (`ferx summary run.fitrx`)

## Docs
- [x] `docs/cli.qmd` updated (new `summary` command section + exit-code table)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings from this change)
- [x] No `Dual2`/sensitivity-path code touched

## Reviewer hints

Focus on `output::format_summary` — it duplicates a subset of `print_results`'
formatting logic by design. Worth confirming the CV%/SE-suppression and
fixed-param branches match `print_results`.