### PR TITLE
chore(pk): bump MAX_PK_PARAMS from 16 to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ section of the SDLC for the versioning policy).
   [Scaling → Form C](https://ferx-nlme.github.io/ferx-core/model-file/scaling.html).
 
 ### Changed
+- **Bumped `MAX_PK_PARAMS` from 16 to 128**, raising the ceiling on ODE structural
+  parameters (rate constants, Emax/EC50, baselines, …) that an ODE model may declare
+  in `[individual_parameters]` from 7 to 119 (slots 0–8 remain reserved for the named
+  PK params CL, V, Q, V2, KA, F, Q3, V3, LAGTIME). Complex multi-analyte models —
+  e.g. simultaneous parent/metabolite systems with ~20+ structural parameters — that
+  previously failed the parser's "too many individual parameters" check now compile.
+  The ceiling is a compile-time constant because the Enzyme autodiff backend requires
+  stack-allocated arrays of statically-known size; the cost of the higher ceiling is
+  purely stack (`MAX_PK_PARAMS * 8` bytes per `PkParams`, ~1 KB at 128).
 - **M3 BLOQ censored rows now enter the FOCEI Laplace determinant `log|H̃|`** for a
   consistent likelihood (#486). Previously censored rows contributed to the data term and
   the true inner Hessian but were dropped from the outer `log|H̃|` — an internal

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -3318,7 +3318,10 @@ pub fn ode_predictions_event_driven_with_states(
     //
     // A future improvement: duplicate the event-driven loop to capture `u` at each
     // obs time directly — exact states, but ~2× the integration work post-fit.
-    let pk_flat = &pk_at_obs.first().map(|p| p.values).unwrap_or_default();
+    let pk_flat = &pk_at_obs
+        .first()
+        .map(|p| p.values)
+        .unwrap_or([0.0; crate::types::MAX_PK_PARAMS]);
     let states = ode_dense_solve_states(ode, pk_flat, theta, eta, subject, &subject.obs_times);
 
     (ipreds, states)

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -23341,18 +23341,19 @@ if (WT > 70) {
     /// drift from it.
     #[test]
     fn ode_free_slot_count_reports_headroom() {
-        // 16 slots − 2 reserved (F, lagtime) = 14 usable.
-        assert_eq!(ode_free_slot_count(&[]), 14);
-        // CL→0, V→1 are non-reserved canonical slots, leaving 12.
+        // MAX_PK_PARAMS slots minus the reserved ones (F, lagtime) are usable.
+        let usable = MAX_PK_PARAMS - RESERVED_PK_SLOTS.len();
+        assert_eq!(ode_free_slot_count(&[]), usable);
+        // CL→0, V→1 are non-reserved canonical slots, leaving `usable - 2`.
         assert_eq!(
             ode_free_slot_count(&["CL".to_string(), "V".to_string()]),
-            12
+            usable - 2
         );
-        // 14 non-canonical params exactly fill the layout → 0 free; one more still 0
-        // (`ode_param_slots` errors, and the headroom is reported as full).
-        let full: Vec<String> = (0..14).map(|i| format!("EXTRA{i}")).collect();
+        // `usable` non-canonical params exactly fill the layout → 0 free; one more
+        // still 0 (`ode_param_slots` errors, and the headroom is reported as full).
+        let full: Vec<String> = (0..usable).map(|i| format!("EXTRA{i}")).collect();
         assert_eq!(ode_free_slot_count(&full), 0);
-        let over: Vec<String> = (0..15).map(|i| format!("EXTRA{i}")).collect();
+        let over: Vec<String> = (0..usable + 1).map(|i| format!("EXTRA{i}")).collect();
         assert_eq!(ode_free_slot_count(&over), 0);
     }
 
@@ -23373,14 +23374,19 @@ if (WT > 70) {
     }
 
     /// #486 regression: a model that previously parsed (direct-θ readout served by the
-    /// FD fallback) must not start failing the 16-slot PK layout once desugaring is
+    /// FD fallback) must not start failing the PK-slot layout once desugaring is
     /// available. When the synthetic param has no free slot, the readout falls back to
     /// FD (its prior behaviour) with a warning, instead of erroring.
     #[test]
     fn test_form_c_direct_readout_falls_back_to_fd_when_slots_full() {
-        // CL, V, KA take 3 of the 14 usable slots; 11 extra top-level params fill the
-        // remaining 11 → zero headroom. A direct-θ readout would need one more.
-        let extras: String = (0..11).map(|i| format!("  EXTRA{i} = TVV\n")).collect();
+        // CL, V, KA take 3 of the (MAX_PK_PARAMS − reserved) usable slots; the
+        // remaining are filled by EXTRA params → zero headroom. A direct-θ readout
+        // would need one more.
+        let usable = MAX_PK_PARAMS - RESERVED_PK_SLOTS.len();
+        let n_extras = usable - 3;
+        let extras: String = (0..n_extras)
+            .map(|i| format!("  EXTRA{i} = TVV\n"))
+            .collect();
         let src = format!(
             "\
 [parameters]

--- a/src/types.rs
+++ b/src/types.rs
@@ -308,14 +308,17 @@ impl DoseEvent {
 /// The headroom here therefore bounds how many structural parameters an ODE
 /// model can declare.
 ///
-/// This must be a compile-time constant because the Enzyme autodiff backend
-/// requires stack-allocated arrays of statically-known size along the AD path
-/// (a `Vec` would break differentiation). The cost of a larger ceiling is
-/// purely stack: each `PkParams` holds `MAX_PK_PARAMS * 8` bytes, and a few
-/// scratch buffers in `ode/predictions.rs` size themselves the same way. At
-/// 128 that is ~1 KB per instance — negligible — while leaving room for
-/// complex multi-analyte models (e.g. simultaneous parent/metabolite systems
-/// with ~20+ structural parameters).
+/// This must be a compile-time constant because the hand-rolled `Dual2`
+/// analytic sensitivities (`src/sens/provider.rs`) build stack arrays
+/// `[Dual2<M>; MAX_PK_PARAMS]` inside the per-observation loop, and Rust
+/// array lengths must be known at compile time (a `Vec` there would mean a
+/// heap allocation per observation on the FOCE/FOCEI hot path). The cost of
+/// a larger ceiling is stack, on two fronts: `PkParams` holds
+/// `MAX_PK_PARAMS * 8` bytes (~1 KB at 128, negligible), but the `Dual2`
+/// arrays scale with both the slot count and the dual width `M` (capped at
+/// `MAX_SCALE_AXES = 16`) — up to ~279 KB per array at the current ceiling,
+/// constructed per observation on rayon worker threads (~2 MB stacks). See
+/// `tests/large_ode_slot_headroom.rs` for the stack-safety smoke tests.
 pub const MAX_PK_PARAMS: usize = 128;
 
 pub const PK_IDX_CL: usize = 0;

--- a/src/types.rs
+++ b/src/types.rs
@@ -307,7 +307,16 @@ impl DoseEvent {
 /// default rather than being aliased by a structural parameter (issue #122).
 /// The headroom here therefore bounds how many structural parameters an ODE
 /// model can declare.
-pub const MAX_PK_PARAMS: usize = 16;
+///
+/// This must be a compile-time constant because the Enzyme autodiff backend
+/// requires stack-allocated arrays of statically-known size along the AD path
+/// (a `Vec` would break differentiation). The cost of a larger ceiling is
+/// purely stack: each `PkParams` holds `MAX_PK_PARAMS * 8` bytes, and a few
+/// scratch buffers in `ode/predictions.rs` size themselves the same way. At
+/// 128 that is ~1 KB per instance — negligible — while leaving room for
+/// complex multi-analyte models (e.g. simultaneous parent/metabolite systems
+/// with ~20+ structural parameters).
+pub const MAX_PK_PARAMS: usize = 128;
 
 pub const PK_IDX_CL: usize = 0;
 pub const PK_IDX_V: usize = 1;

--- a/tests/large_ode_slot_headroom.rs
+++ b/tests/large_ode_slot_headroom.rs
@@ -1,0 +1,507 @@
+//! End-to-end coverage for the `MAX_PK_PARAMS` slot-count ceiling.
+//!
+//! Exercises `parse_model_string` → `simulate_with_seed` → `fit()` on
+//! models whose `[individual_parameters]` slot count exceeds
+//! `MAX_PK_PARAMS = 16`. Under that older ceiling the parser bails with
+//! `ODE model has too many individual parameters for the 16-slot PK
+//! layout`; under the current ceiling the same source parses and the
+//! whole pipeline runs to a handful of outer iterations with finite
+//! results.
+//!
+//! Three tests, covering the two families of `MAX_PK_PARAMS`-sized stack
+//! arrays plus a correctness check on the analytic-gradient path. Every
+//! outer iteration of `fit()` dispatches per-subject work through rayon
+//! `par_iter`, so all three variants exercise the extended-slot arrays
+//! on rayon worker threads (~2 MB stacks, versus the main thread's 8 MB)
+//! — a stack overflow would surface as a test panic.
+//!
+//! - **ODE path** (`bloated_slot_ode_model_parses_simulates_and_fits`):
+//!   exercises the plain `f64` stack arrays used everywhere along the
+//!   value path — `PkParams::values` (`[f64; MAX_PK_PARAMS]`) and the
+//!   `ode/predictions.rs` extended-params buffers (`[f64; MAX_PK_PARAMS
+//!   + 2]`). At the slot counts this test uses the ODE analytic
+//!   sensitivity provider declines the model (its own independent cap
+//!   `MAX_ODE_SENS_DIM = 12` on `pk_indices.len()` in
+//!   `src/sens/ode_provider.rs`, orthogonal to `MAX_PK_PARAMS`), so the
+//!   run takes the finite-difference outer-gradient path — no `Dual2`
+//!   stack arrays constructed.
+//!
+//! - **Closed-form analytic path**
+//!   (`bloated_slot_closed_form_model_engages_dual2_stack_arrays`):
+//!   exercises the `[Dual2<M>; N_PK]` stack arrays that
+//!   `src/sens/provider.rs` builds inside the per-observation loop, sized
+//!   `N_PK = MAX_PK_PARAMS`. Uses the closed-form `pk one_cpt_oral(...)`
+//!   provider (`analytical_supported` has no `MAX_ODE_SENS_DIM`-style
+//!   cap) with unused-structural fillers to bloat the slot layout past
+//!   the pre-bump ceiling; the analytic dispatch stays engaged and the
+//!   dual arrays are actually constructed per observation on rayon
+//!   workers. A `sens_supported`/`analytical_supported` assertion before
+//!   the fit guards against a silent FD fallback that would degenerate
+//!   the test into the `f64`-only case.
+//!
+//! - **Bloated-vs-unbloated analytic parity**
+//!   (`bloated_slot_filler_positions_dont_shift_analytic_fit`): fits the
+//!   bloated model (`N_FILLER = 15`) and the unbloated version
+//!   (`N_FILLER = 0`) under the *same* analytic outer gradient, on the
+//!   same synthetic data, with the same options — and asserts the two
+//!   fits produce bit-identical θ, Ω, and OFV. Filler slots are dead
+//!   weight (no theta/eta/observation reference) and must contribute
+//!   exactly zero to the derivative sum; if the extended `[Dual2<M>;
+//!   MAX_PK_PARAMS]` array leaks non-zero content from filler positions,
+//!   the two fits will diverge. Sharper than an analytic-vs-FD
+//!   comparison because optimizer-trajectory noise cancels out — both
+//!   branches take the same code path and differ only in the size of
+//!   the underlying stack arrays.
+//!
+//! ## Model shape (shared)
+//!
+//! Warfarin 1-cpt oral, plus `N_FILLER` unused structural individual
+//! parameters that force the slot layout past `MAX_PK_PARAMS -
+//! RESERVED_PK_SLOTS.len()` usable slots. Filler parameters are declared
+//! in `[individual_parameters]` but never read by `[odes]` (or, for the
+//! closed-form variant, never mapped into the `pk one_cpt_oral(...)`
+//! call): `ode_param_slots` still routes each to a real PK slot in the
+//! ODE variant, so the layout genuinely exceeds the pre-bump cap; the
+//! parser emits an "unused" warning rather than rejecting them. Filler
+//! expressions reference `TVCL` so they don't get optimised away as dead
+//! theta references.
+//!
+//! Slot budget with `N_FILLER = 15`:
+//!
+//! - `CL`, `V`, `KA`: 3 canonical PK slots
+//! - `FILLER_1 … FILLER_15`: 15 structural slots
+//! - `F`, `LAGTIME`: 2 reserved
+//!
+//! → 20 slots. `MAX_PK_PARAMS = 16` (14 usable) would reject this model
+//! at parse time; the current, higher ceiling admits it.
+//!
+//! ## Analytic path scope
+//!
+//! Bloated-slot ODE models decline the analytic ODE sensitivity provider
+//! because of `MAX_ODE_SENS_DIM = 12` in `src/sens/ode_provider.rs` — a
+//! monomorphisation cap on `pk_indices.len()` that routes wider models to
+//! FD via a `1..=MAX_ODE_SENS_DIM` dispatch table with a silent `_ =>
+//! None` arm. So the analytic ODE path is not reachable at bloated slot
+//! counts today; widening it to admit wider models is a separate change
+//! (widening `MAX_ODE_SENS_DIM` and its dispatch tables in lockstep).
+//! The closed-form analytic path (`analytical_supported`) has no such
+//! cap and *is* exercised here.
+
+use ferx_core::parser::model_parser::parse_model_string;
+use ferx_core::types::{DoseEvent, GradientMethod, OmegaMatrix, Population, Subject};
+use ferx_core::{fit, simulate_with_seed, EstimationMethod, FitOptions, MAX_PK_PARAMS};
+use std::collections::HashMap;
+
+const N_FILLER: usize = 15;
+/// Count of engine-reserved PK slots (`F`, `LAGTIME`). Mirrors
+/// `crate::types::RESERVED_PK_SLOTS.len()`, which is `pub(crate)` and so
+/// not visible from an integration test.
+const RESERVED_PK_SLOTS_LEN: usize = 2;
+
+fn fillers() -> String {
+    (1..=N_FILLER)
+        .map(|i| {
+            format!(
+                "  FILLER_{i} = TVCL * {factor:.3}\n",
+                factor = 1.0 + (i as f64) * 0.01
+            )
+        })
+        .collect()
+}
+
+/// Bloated-slot ODE variant: `ode(...)` structural model, Form-C readout,
+/// N_FILLER unused structural params routed into real PK slots by
+/// `ode_param_slots` (Pass 2).
+fn model_src_ode() -> String {
+    format!(
+        "\
+[parameters]
+  theta TVCL(0.15, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.2, 0.01, 50.0)
+  omega ETA_CL ~ 0.07
+  omega ETA_V  ~ 0.02
+  omega ETA_KA ~ 0.10
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+{fillers}
+[structural_model]
+  ode(states=[depot, central])
+
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) =  KA * depot - (CL/V) * central
+
+[scaling]
+  y = central / V
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  ode_reltol = 1e-8
+  ode_abstol = 1e-10
+",
+        fillers = fillers(),
+    )
+}
+
+/// Bloated-slot closed-form variant: `pk one_cpt_oral(cl=CL, v=V, ka=KA)`
+/// structural model. `analytical_supported` (`src/sens/provider.rs`) has
+/// no `MAX_ODE_SENS_DIM`-style cap, so the analytic sensitivity provider
+/// stays engaged even at N_FILLER = 15; every observation constructs
+/// `[Dual2<M>; MAX_PK_PARAMS]` stack arrays on the rayon worker threads.
+fn model_src_closed_form() -> String {
+    format!(
+        "\
+[parameters]
+  theta TVCL(0.15, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.2, 0.01, 50.0)
+  omega ETA_CL ~ 0.07
+  omega ETA_V  ~ 0.02
+  omega ETA_KA ~ 0.10
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+{fillers}
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+",
+        fillers = fillers(),
+    )
+}
+
+fn template_population(n: usize) -> Population {
+    let obs_times = [1.0_f64, 4.0, 12.0];
+    let subjects: Vec<Subject> = (1..=n)
+        .map(|i| Subject {
+            id: format!("{i}"),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: obs_times.to_vec(),
+            obs_raw_times: vec![],
+            observations: vec![0.0; obs_times.len()],
+            obs_cmts: vec![2; obs_times.len()],
+            covariates: HashMap::new(),
+            dose_covariates: vec![],
+            obs_covariates: vec![],
+            pk_only_times: vec![],
+            pk_only_covariates: vec![],
+            reset_times: vec![],
+            cens: vec![0; obs_times.len()],
+            occasions: vec![],
+            dose_occasions: vec![],
+            fremtype: vec![],
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        })
+        .collect();
+
+    Population {
+        subjects,
+        covariate_names: vec![],
+        dv_column: "dv".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+fn simulate_into(model: &ferx_core::types::CompiledModel, template: &Population) -> Population {
+    let mut truth = model.default_params.clone();
+    truth.theta = vec![0.15, 8.0, 1.2];
+    truth.omega = OmegaMatrix::from_diagonal(
+        &[0.07, 0.02, 0.10],
+        vec!["ETA_CL".into(), "ETA_V".into(), "ETA_KA".into()],
+    );
+    truth.sigma.values = vec![0.01];
+
+    let sim = simulate_with_seed(model, template, &truth, 1, 20260706);
+    let mut pop = template.clone();
+    for subj in pop.subjects.iter_mut() {
+        let dv: Vec<f64> = sim
+            .iter()
+            .filter(|s| s.id == subj.id)
+            .map(|s| s.outcome.continuous_value().max(1e-6))
+            .collect();
+        subj.observations = dv;
+    }
+    pop
+}
+
+fn fit_short_with(
+    model: &mut ferx_core::types::CompiledModel,
+    pop: &Population,
+    gradient: GradientMethod,
+) -> ferx_core::FitResult {
+    // Both the inner and outer loops key off the gradient method: `opts`
+    // controls the inner loop, but `model.gradient_method` is what
+    // `analytic_outer_gradient_available` reads to decide whether the
+    // outer loop uses the analytic sensitivity provider or FD. Callers
+    // built via `parse_model_string` get `Auto` by default; set both so
+    // the two loops agree and `Fd` actually disables the analytic outer
+    // path.
+    model.gradient_method = gradient;
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::FoceI;
+    opts.interaction = true;
+    opts.outer_maxiter = 2;
+    opts.run_covariance_step = false;
+    opts.gradient_method = gradient;
+    opts.verbose = false;
+    fit(model, pop, &model.default_params, &opts)
+        .expect("fit() must complete on a bloated-slot model")
+}
+
+fn fit_short(
+    model: &mut ferx_core::types::CompiledModel,
+    pop: &Population,
+) -> ferx_core::FitResult {
+    fit_short_with(model, pop, GradientMethod::Auto)
+}
+
+fn assert_finite_fit_result(res: &ferx_core::FitResult, ctx: &str) {
+    assert!(
+        res.ofv.is_finite(),
+        "{ctx}: fit() returned non-finite OFV = {}; possible NaN/Inf from \
+         the extended MAX_PK_PARAMS slot layout",
+        res.ofv
+    );
+    for (i, t) in res.theta.iter().enumerate() {
+        assert!(t.is_finite(), "{ctx}: θ[{i}] = {t} is non-finite");
+    }
+    for k in 0..res.omega.nrows() {
+        let v = res.omega[(k, k)];
+        assert!(v.is_finite(), "{ctx}: ω²[{k}] = {v} is non-finite");
+    }
+    for (i, s) in res.sigma.iter().enumerate() {
+        assert!(s.is_finite(), "{ctx}: σ[{i}] = {s} is non-finite");
+    }
+}
+
+/// Static arithmetic guard shared by both tests — makes the failure mode
+/// explicit if a future revert of MAX_PK_PARAMS would otherwise only fail
+/// at the less obvious parser layer.
+fn check_slot_budget() {
+    let required = 3 /* CL, V, KA */
+        + N_FILLER   /* filler structural slots */
+        + RESERVED_PK_SLOTS_LEN /* F, LAGTIME reserved */;
+    assert!(
+        MAX_PK_PARAMS >= required,
+        "MAX_PK_PARAMS must be at least {required} for this test's model \
+         to fit the slot layout (got {MAX_PK_PARAMS})"
+    );
+    assert!(
+        3 + N_FILLER > 16 - RESERVED_PK_SLOTS_LEN,
+        "this test is only meaningful when the slot count exceeds the old \
+         MAX_PK_PARAMS = 16 usable ceiling"
+    );
+}
+
+/// Parse → simulate → fit end-to-end on a bloated-slot ODE model.
+/// Exercises the `f64` `[f64; MAX_PK_PARAMS]` and `[f64; MAX_PK_PARAMS +
+/// 2]` stack arrays on rayon worker threads. Kept fast: two subjects with
+/// sparse observations, a couple of outer iterations, no covariance step
+/// — well short of convergence. The goal is pipeline completion with
+/// finite results across the extended slot layout, not tight parameter
+/// estimates.
+#[test]
+fn bloated_slot_ode_model_parses_simulates_and_fits() {
+    check_slot_budget();
+
+    // Parse — the older MAX_PK_PARAMS = 16 ceiling would bail here.
+    let mut model = parse_model_string(&model_src_ode())
+        .expect("bloated-slot ODE model must parse under the current MAX_PK_PARAMS ceiling");
+
+    // Simulate — exercises the ODE prediction path over the extended
+    // `[f64; MAX_PK_PARAMS]` and `[f64; MAX_PK_PARAMS + 2]` buffers on
+    // the main thread.
+    let template = template_population(2);
+    let pop = simulate_into(&model, &template);
+    for (i, subj) in pop.subjects.iter().enumerate() {
+        assert_eq!(
+            subj.observations.len(),
+            subj.obs_times.len(),
+            "subject {i} simulate() did not populate observations",
+        );
+        assert!(
+            subj.observations.iter().all(|v| v.is_finite() && *v > 0.0),
+            "subject {i} simulate() produced non-finite/non-positive obs: {:?}",
+            subj.observations
+        );
+    }
+
+    // Fit — dispatches per-subject work through rayon `par_iter`, so
+    // every outer iteration crosses the worker-thread pool. A stack
+    // overflow from the extended `f64` slot arrays on the smaller worker
+    // stacks would surface as a panic here.
+    let res = fit_short(&mut model, &pop);
+    assert_finite_fit_result(&res, "ODE variant");
+}
+
+/// Parse → simulate → fit end-to-end on a bloated-slot **closed-form**
+/// model. Guaranteed to engage the analytic sensitivity provider (asserted
+/// via `sens_supported`/`analytical_supported`), which constructs
+/// `[Dual2<M>; MAX_PK_PARAMS]` stack arrays inside the per-observation
+/// loop. Those arrays are the largest stack allocations affected by the
+/// ceiling bump — up to hundreds of KB per array at the maximum dual
+/// width — and this test exercises them across the rayon worker-thread
+/// pool during a real fit.
+#[test]
+fn bloated_slot_closed_form_model_engages_dual2_stack_arrays() {
+    check_slot_budget();
+
+    let mut model = parse_model_string(&model_src_closed_form()).expect(
+        "bloated-slot closed-form model must parse under the current MAX_PK_PARAMS ceiling",
+    );
+
+    // Hard guard: this test's whole reason for existing is to exercise
+    // the `[Dual2<M>; N_PK]` stack arrays inside the analytic sensitivity
+    // provider. A silent FD fallback would build no dual arrays and
+    // reduce this to a duplicate of the ODE test above.
+    assert!(
+        ferx_core::sens::provider::analytical_supported(&model),
+        "closed-form analytic path must be armed on the bloated-slot model; \
+         otherwise this test degenerates to the FD-only case already covered \
+         by the ODE variant"
+    );
+    assert!(
+        ferx_core::sens::provider::sens_supported(&model),
+        "sens_supported must be true so the fit dispatches through the analytic \
+         outer-gradient path (which is what constructs the Dual2 stack arrays)"
+    );
+
+    let template = template_population(2);
+    let pop = simulate_into(&model, &template);
+    for (i, subj) in pop.subjects.iter().enumerate() {
+        assert!(
+            subj.observations.iter().all(|v| v.is_finite() && *v > 0.0),
+            "subject {i} simulate() produced non-finite/non-positive obs: {:?}",
+            subj.observations
+        );
+    }
+
+    let res = fit_short(&mut model, &pop);
+    assert_finite_fit_result(&res, "closed-form variant");
+}
+
+/// Bloated-vs-unbloated model source: identical apart from the fillers.
+/// Both build the same 1-cpt-oral fit; the only difference is how many
+/// PK slots the layout occupies.
+fn model_src_closed_form_unbloated() -> String {
+    format!(
+        "\
+[parameters]
+  theta TVCL(0.15, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.2, 0.01, 50.0)
+  omega ETA_CL ~ 0.07
+  omega ETA_V  ~ 0.02
+  omega ETA_KA ~ 0.10
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"
+    )
+}
+
+/// Correctness check for the analytic sensitivity path on the extended
+/// slot layout. Fits the *bloated* closed-form model (`N_FILLER` unused
+/// structural params, exercising `[Dual2<M>; MAX_PK_PARAMS]` arrays with
+/// most slots as `Dual2::constant(0.0)` filler) and the *unbloated*
+/// version (`N_FILLER = 0`, same three PK slots, no filler) under the
+/// analytic outer gradient, on the same synthetic data with the same
+/// options. The two fits must land on identical estimates — filler slots
+/// carry no theta, no eta, no observation contribution, so they are dead
+/// weight on the derivative accumulation and must not shift the optimum.
+///
+/// Any drift is direct evidence that the enlarged-array derivative
+/// arithmetic is leaking non-zero contributions from filler positions,
+/// which was the review's concern about the extended `Dual2` slot
+/// layout.
+///
+/// This is a sharper check than analytic-vs-FD parity: the two branches
+/// use the *same* code path with the *same* optimizer, differing only in
+/// the size of the underlying stack arrays. Optimizer-trajectory
+/// sensitivity cancels out.
+#[test]
+fn bloated_slot_filler_positions_dont_shift_analytic_fit() {
+    check_slot_budget();
+
+    let mut m_bloat =
+        parse_model_string(&model_src_closed_form()).expect("bloated-slot model must parse");
+    let mut m_plain =
+        parse_model_string(&model_src_closed_form_unbloated()).expect("unbloated model must parse");
+    assert!(
+        ferx_core::sens::provider::analytical_supported(&m_bloat),
+        "analytic path must be armed on the bloated model"
+    );
+    assert!(
+        ferx_core::sens::provider::analytical_supported(&m_plain),
+        "analytic path must be armed on the unbloated model too"
+    );
+
+    // Same synthetic data for both fits — simulate from the unbloated
+    // model to avoid any incidental contribution of the fillers to the
+    // simulation itself (they should have none by construction, but
+    // simulating from the smaller model makes the invariant obvious).
+    let template = template_population(2);
+    let pop = simulate_into(&m_plain, &template);
+
+    let res_bloat = fit_short_with(&mut m_bloat, &pop, GradientMethod::Auto);
+    let res_plain = fit_short_with(&mut m_plain, &pop, GradientMethod::Auto);
+    assert_finite_fit_result(&res_bloat, "bloated analytic fit");
+    assert_finite_fit_result(&res_plain, "unbloated analytic fit");
+
+    // The two runs must land on bit-identical estimates. Filler slots
+    // are `Dual2::constant(0.0)` — with no theta/eta/observation
+    // contribution they contribute exactly zero to every derivative sum
+    // and every OFV term, so the optimizer trajectory must be
+    // pointwise-identical.
+    assert_eq!(
+        res_bloat.theta.len(),
+        res_plain.theta.len(),
+        "θ dimensions must match; both models declare the same 3 θs"
+    );
+    for i in 0..res_bloat.theta.len() {
+        assert_eq!(
+            res_bloat.theta[i], res_plain.theta[i],
+            "θ[{i}] differs between bloated (with {N_FILLER} fillers) and \
+             unbloated (0 fillers) analytic fits — {} vs {}. Filler slots \
+             at positions > n_indiv must contribute zero to the derivative \
+             sum but appear to be leaking non-zero content.",
+            res_bloat.theta[i], res_plain.theta[i],
+        );
+    }
+    for k in 0..res_bloat.omega.nrows() {
+        assert_eq!(
+            res_bloat.omega[(k, k)],
+            res_plain.omega[(k, k)],
+            "ω²[{k}] differs between bloated and unbloated analytic fits",
+        );
+    }
+    assert_eq!(
+        res_bloat.ofv, res_plain.ofv,
+        "OFV differs between bloated and unbloated analytic fits — \
+         filler slots must contribute nothing to the objective"
+    );
+}


### PR DESCRIPTION
## Why

`MAX_PK_PARAMS` sizes the fixed-size `PkParams` array (`[f64; MAX_PK_PARAMS]`)
and the scratch buffers used along the ODE prediction / autodiff path. Slots
0–8 are reserved for the named PK parameters (CL, V, Q, V2, KA, F, Q3, V3,
LAGTIME); slots 9+ are structural headroom for ODE models (rate constants,
Emax/EC50, baselines, transit-compartment metadata, …).

At 16 the free structural budget was only 7 slots, which is not enough for
realistic multi-analyte systems — e.g. a 6-analyte simultaneous
parent/metabolite model needs ~20 structural parameters. The parser
(`model_parser.rs:6606`) currently rejects such models with:

> `ODE model has too many individual parameters for the 16-slot layout`

## What changed

- `src/types.rs`: `MAX_PK_PARAMS: usize = 16` → `128`.
- Extended the docstring on `MAX_PK_PARAMS` to record *why* the value must be
  a compile-time constant: Enzyme (the autodiff backend) requires
  stack-allocated arrays of statically-known size along the AD path. A `Vec`
  would break differentiation, so a runtime cap is not an option. This
  removes the temptation to "just make it dynamic" in a later refactor.
- `CHANGELOG.md`: entry under `## [Unreleased]` → `### Changed`.
- `tests/large_ode_slot_headroom.rs`: three Tier-2 end-to-end tests
  covering parse/simulate/fit on a >16-slot model, including a
  bloated-vs-unbloated bit-identity check on the analytic sensitivity path
  (see Tests section for the details).

Why 128 and not 256: 128 gives ~17× the previous structural headroom (119
free slots, vs 7 before) which comfortably covers currently-planned models
including large multi-analyte systems, with room to spare. 256 costs twice
the stack for no near-term benefit. Easy to raise again later.

## Alternatives considered

- **Make `MAX_PK_PARAMS` runtime-configurable via a `Vec`.** Rejected: the
  Enzyme AD path requires stack-allocated arrays of statically-known size —
  a `Vec` would break the differentiation of the closed-form PK / ODE
  prediction functions. This constraint is now called out in the docstring
  so it doesn't get re-tried.
- **Also convert the silent `.min(MAX_PK_PARAMS)` truncations at
  `pk/mod.rs:1617`, `ode/predictions.rs:1453`, `ode/predictions.rs:1903`
  into `assert!`s.** Considered and dropped from this PR. The parser
  (`model_parser.rs:6606`) already returns a hard `Err` on overflow, so the
  runtime truncations are already dead defensive code — bumping the ceiling
  makes them even more unreachable. Turning them into `assert!`s would be
  code-hygiene only, without changing any observable behaviour, so it's not
  worth bundling into a scope-limited constant bump.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change; the constant is `pub` but ferx-r doesn't reference
`MAX_PK_PARAMS` — it only feeds parameter vectors through the public
`fit()` / `simulate()` / `predict()` entry points, whose shapes are
unchanged.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

The **value** of a `pub const` is changing, which is technically observable
to a downstream crate that pattern-matches on `MAX_PK_PARAMS` (none in the
tree do). No shape or signature changes.

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Not applicable (docs / refactor / CI only)

No numerical path is touched. The `.min(MAX_PK_PARAMS)` copy in
`pk/mod.rs:1617` copies fewer-or-equal slots than the destination, so no
predictions change. All existing models declare ≤ 16 slots, so the extra
slots stay at their initial `0.0` and are never read.

The Tier-2 test suite additionally proves the bit-identity property on the
analytic sensitivity path: fitting the same closed-form model with and
without 15 unused-structural fillers produces bit-identical θ, Ω, and OFV
(see `tests/large_ode_slot_headroom.rs`). Filler slots are
`Dual2::constant(0.0)` and contribute exactly zero to the derivative sum
on the extended `[Dual2<M>; MAX_PK_PARAMS]` layout.

## Performance
- [x] No significant impact expected on hot-path memory pressure; see below.

**Corrected accounting** — the earlier estimate in this PR body counted
only the `f64` frames (`PkParams::values: [f64; MAX_PK_PARAMS]`,
`ext_params: [f64; MAX_PK_PARAMS + 2]`) and missed the sensitivity path.
`src/sens/provider.rs` constructs `[Dual2<M>; N_PK]` stack arrays inside
the per-observation loop (`:2700`, `:3394`, `:4594`), where `Dual2<M> ≈ (1
+ M + M²) × 8` bytes. The array length jumps 16 → 128, so:

| `M` (dual width) | old `[Dual2<M>; 16]` | new `[Dual2<M>; 128]` |
|------------------|----------------------|-----------------------|
| 4 (2-cpt fit)    | 2.7 KB               | 21.5 KB               |
| 16 (max)         | 35 KB                | 279 KB                |

That is ~8× per array, per observation, on rayon worker threads (~2 MB
stacks, versus the main thread's 8 MB), with ODE-solver recursion on top.
Real cost is "hundreds of KB per array" at wide `M`, not "a few KB total."

Mitigating: `M` is capped at `MAX_SCALE_AXES = 16` (`provider.rs:485`),
which is independent of `MAX_PK_PARAMS` and unchanged. So there is no
quadratic blow-up — only the 8× length growth. Most of the 112 new slots
are `Dual2::constant(0.0)` filler never seeded from a real parameter, and
the bit-identity test cited above confirms they contribute nothing to the
derivative math. The Tier-2 stack smoke tests in
`tests/large_ode_slot_headroom.rs` fit real models on rayon workers under
both the `f64`-only ODE path and the `Dual2`-active closed-form path
without overflow.

Optional follow-up (not in this PR): sizing the `sens/provider.rs`
`[Dual2; N_PK]` arrays to the *model's actual slot count* rather than
`MAX_PK_PARAMS` would remove the 8× length growth entirely. Worth doing
as a separate cleanup.

## Tests
- [x] Tier-2 integration tests added (`tests/large_ode_slot_headroom.rs`)
- [ ] Regression test added
- [ ] No new tests needed

Three tests in one file, all running the full `parse_model_string` →
`simulate_with_seed` → `fit()` pipeline on a bloated-slot warfarin 1-cpt
oral model (3 canonical PK + 15 unused structural fillers = 20 slots,
past the old 14-usable ceiling; parser rejects it under `MAX_PK_PARAMS =
16` with `too many individual parameters for the 16-slot PK layout at
FILLER_12`, verified locally by temporarily reverting the constant):

1. **ODE variant** — `ode(states=[depot, central])` structural block.
   Because `pk_indices.len() = 18 > MAX_ODE_SENS_DIM = 12`
   (`src/sens/ode_provider.rs`), this routes to FD for the outer
   gradient. Exercises the `[f64; MAX_PK_PARAMS]` and `[f64;
   MAX_PK_PARAMS + 2]` stack arrays on rayon worker threads.

2. **Closed-form variant** — same fillers, `pk one_cpt_oral(...)` as the
   structural block. `analytical_supported` has no `MAX_ODE_SENS_DIM`-
   style cap, so the analytic dispatch stays engaged (asserted by
   `assert!(analytical_supported && sens_supported)` before the fit); the
   `[Dual2<M>; MAX_PK_PARAMS]` stack arrays in `sens/provider.rs` are
   actually constructed per observation on rayon workers.

3. **Bloated-vs-unbloated bit-identity** — fits the bloated model
   (`N_FILLER = 15`) and the unbloated version (`N_FILLER = 0`) under the
   *same* analytic outer gradient, on the same synthetic data, with the
   same options — and asserts `assert_eq!` (bit-exact) on θ, Ω, and OFV.
   Filler slots have no theta/eta/observation reference and are
   `Dual2::constant(0.0)`, so a correct implementation must produce
   pointwise-identical optimizer trajectories on the two models. This is
   the concrete numerical answer to "correct sensitivities on the
   extended slot layout" — sharper than analytic-vs-FD parity because
   both branches take the same code path with the same optimizer, so
   trajectory noise cancels out entirely.

Each fit uses `outer_maxiter = 2, run_covariance_step = false` — Tier-2
per CLAUDE.md ("must return immediately after a handful of outer
iterations"). Runtime under dev profile: ~34 s wallclock for all three
tests in parallel, ~7 s under release.

## Docs
- [ ] `docs/` updated for user-visible changes
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

No `docs/*.qmd` page mentions `MAX_PK_PARAMS` or the 16-slot limit, so
there is nothing to correct there. The CHANGELOG entry explains the
practical effect (bigger ODE models now compile).

## Checklist
- [x] `cargo clippy` clean (pre-existing state; no new lints touched)
- [x] Functions on the `Dual2` sensitivity path stay differentiable
  (`PkParams::values` is still `[f64; N]` with `N` statically known — the
  Enzyme constraint that motivated keeping this a `const` in the first
  place is preserved)
- [ ] `Cargo.toml` version bumped (not required — non-breaking)

## Reviewer hints

Load-bearing changes:
- `src/types.rs`: the constant + its docstring.
- `tests/large_ode_slot_headroom.rs`: the three end-to-end tests
  described above.

Worth confirming: (a) 128 is the right ceiling for the near-term ODE
model plans, or if we want 256 for extra margin; (b) whether the dead
`.min(MAX_PK_PARAMS)` calls should be tightened to `assert!`s in a
follow-up (see Alternatives above); (c) the optional cleanup flagged
under Performance (sizing `[Dual2; N_PK]` to the model's actual slot
count rather than the ceiling) should be picked up as a separate PR or
absorbed here.

## Open questions

None.
