### PR TITLE
chore(release): bump ferx-core to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-03
+
 ### Added
 - **New `ferx summary <run.fitrx>` CLI subcommand** (#684): prints a concise,
   `psn::sumo`-style summary (parameter estimates with SE / %RSE, OMEGA / SIGMA with
@@ -2200,6 +2202,7 @@ and `git log v0.1.0..v0.1.5` for details.
 Initial tagged release. See the
 [GitHub release](https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.0...v0.1.5
 [0.1.0]: https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferx-core"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "approx",
  "argmin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferx-core"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 description = "Nonlinear Mixed Effects modeling engine with FOCE/FOCEI estimation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump crate version 0.1.6 -> 0.2.0 for the 0.2.0 release cut (paired with ferx-r DESCRIPTION/NEWS.md, already at 0.2.0).
- CHANGELOG.md: rename `[Unreleased]` section to `[0.2.0] - 2026-07-03`, start a fresh empty `[Unreleased]`, update compare links.

## Test plan
- [x] Version-only diff to Cargo.toml/Cargo.lock; CHANGELOG restructure only reheads the existing entries under the new version.