### PR TITLE
fix(cli): accept --flag=value form for CLI args [closes #693]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ section of the SDLC for the versioning policy).
   and `ferx summary --help` now print usage to stdout and exit 0, matching standard
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
+### Fixed
+- **CLI flags in `--flag=value` form are no longer silently ignored** (#693):
+  `--data`, `--output`, `--threads` (and any other value-taking flag) now accept
+  `=` the same as a space, e.g. `ferx model.ferx --data=d.csv --threads=4`.
+
 ## [0.2.0] - 2026-07-03
 
 ### Added

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -35,8 +35,33 @@ fn is_help_flag(arg: Option<&String>) -> bool {
     matches!(arg.map(String::as_str), Some("-h") | Some("--help"))
 }
 
+/// Rewrites `--flag=value` into separate `--flag`, `value` elements so the
+/// rest of the parsing below (which matches flags by exact string, then reads
+/// the following element as the value) sees `--data=d.csv` the same way it
+/// already sees `--data d.csv` (#693 — `=`-style args were silently dropped).
+/// `--inits-from-nca=METHOD` is left untouched: `parse_inits_from_nca_flag`
+/// parses that combined form itself, deliberately never consuming a following
+/// positional for the bare-flag case.
+fn normalize_args(args: &[String]) -> Vec<String> {
+    args.iter()
+        .flat_map(|a| {
+            if a.starts_with("--inits-from-nca") {
+                return vec![a.clone()];
+            }
+            match a.strip_prefix("--").and_then(|rest| rest.find('=')) {
+                Some(eq) => {
+                    let (flag, value) = a.split_at(eq + 2);
+                    vec![flag.to_string(), value[1..].to_string()]
+                }
+                None => vec![a.clone()],
+            }
+        })
+        .collect()
+}
+
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let raw_args: Vec<String> = env::args().collect();
+    let args = normalize_args(&raw_args);
 
     if is_help_flag(args.get(1)) {
         print!("{MAIN_USAGE}");
@@ -445,8 +470,9 @@ fn parse_inits_from_nca_flag(args: &[String]) -> Result<Option<NcaInit>, String>
 #[cfg(test)]
 mod tests {
     use super::{
-        is_help_flag, parse_check_args, parse_inits_from_nca_flag, parse_output_flag,
-        parse_threads_flag, print_check_human, run_check, run_summary, CheckArgsError,
+        is_help_flag, normalize_args, parse_check_args, parse_inits_from_nca_flag,
+        parse_output_flag, parse_threads_flag, print_check_human, run_check, run_summary,
+        CheckArgsError,
     };
     use ferx_core::NcaInit;
 
@@ -455,6 +481,65 @@ mod tests {
             .chain(extra.iter().copied())
             .map(String::from)
             .collect()
+    }
+
+    #[test]
+    fn normalize_args_splits_eq_form() {
+        assert_eq!(
+            normalize_args(&args(&["model.ferx", "--data=d.csv", "--threads=4"])),
+            args(&["model.ferx", "--data", "d.csv", "--threads", "4"])
+        );
+    }
+
+    #[test]
+    fn normalize_args_leaves_space_form_and_bare_flags_alone() {
+        assert_eq!(
+            normalize_args(&args(&["model.ferx", "--data", "d.csv", "--simulate"])),
+            args(&["model.ferx", "--data", "d.csv", "--simulate"])
+        );
+    }
+
+    #[test]
+    fn normalize_args_preserves_extra_eq_signs_in_value() {
+        assert_eq!(
+            normalize_args(&args(&["--output=a=b.fitrx"])),
+            args(&["--output", "a=b.fitrx"])
+        );
+    }
+
+    #[test]
+    fn normalize_args_does_not_split_inits_from_nca() {
+        // parse_inits_from_nca_flag parses the combined `--inits-from-nca=X`
+        // form itself; normalize_args must leave it intact rather than
+        // splitting it like other `--flag=value` args.
+        assert_eq!(
+            normalize_args(&args(&["--inits-from-nca=nca_ebe"])),
+            args(&["--inits-from-nca=nca_ebe"])
+        );
+    }
+
+    #[test]
+    fn threads_flag_accepts_eq_form_after_normalize() {
+        assert_eq!(
+            parse_threads_flag(&normalize_args(&args(&["--threads=4"]))),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn output_flag_accepts_eq_form_after_normalize() {
+        assert_eq!(
+            parse_output_flag(&normalize_args(&args(&["--output=run1.fitrx"]))),
+            Some("run1.fitrx".to_string())
+        );
+    }
+
+    #[test]
+    fn check_args_data_accepts_eq_form_after_normalize() {
+        let argv = normalize_args(&args(&["check", "model.ferx", "--data=d.csv", "--json"]));
+        let a = parse_check_args(&argv).unwrap();
+        assert_eq!(a.data, Some("d.csv"));
+        assert!(a.json);
     }
 
     #[test]


### PR DESCRIPTION
## Why
CLI flags (`--data`, `--output`, `--threads`, etc.) were matched by exact
string equality against each `argv` element, so writing them in the common
`--flag=value` form (as opposed to `--flag value`) meant the flag never
matched and its value was silently dropped — the fit ran with the default
instead of erroring or picking up the value. Reported in #693.

## What changed
Added `normalize_args()`, run once at the top of `main()`, which rewrites any
`--flag=value` element into two elements (`--flag`, `value`) before any of the
existing flag-parsing logic runs. Existing parsers (`--data`, `--output`,
`--threads`, `ferx check --data`) all key off exact string match + "next
element is the value", so this makes both forms behave identically without
touching any of that logic.

`--inits-from-nca=METHOD` is left untouched — `parse_inits_from_nca_flag`
already parses that combined form itself, and deliberately never consumes a
following positional for the bare-flag case (to avoid swallowing an unrelated
arg after a bare `--inits-from-nca`).

## Alternatives considered
Teaching each individual parser (`parse_threads_flag`, `parse_output_flag`,
`parse_check_args`, the inline `--data`/`--simulate`/`--include-data` checks)
to additionally split on `=` was more invasive and would need to be repeated
per flag. Normalizing once up front is a single, easily-tested change point.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (CLI arg-parsing only, no estimation/PK/stats change)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix (`normalize_args_splits_eq_form`, plus `--data=`/`--threads=`/`--output=` coverage through the existing parsers)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

```
ferx model.ferx --data=d.csv --threads=4 --output=run1.fitrx
```
now behaves identically to the space-separated form.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (pre-existing warnings elsewhere unrelated to this change)

## Reviewer hints
All the logic is in `normalize_args()` in `src/bin/run_model.rs`; everything
downstream is unchanged. Worth double-checking the `--inits-from-nca` carve-out
test (`normalize_args_does_not_split_inits_from_nca`).