### PR TITLE
fix(api): validate absorption pathway fractions on simulate()/predict() [closes #588]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ section of the SDLC for the versioning policy).
   and `ferx summary --help` now print usage to stdout and exit 0, matching standard
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
+### Fixed
+- **Built-in absorption pathway-fraction validation now covers `simulate()` and
+  `predict()`** (#588): a multi-pathway model with malformed fractions — a bare term
+  alongside a fractioned one, a lone `FR*fn(...)`, a fraction outside `(0, 1]`, or
+  fractions not summing to 1 — was rejected by `fit()` / `ferx check` but could be
+  simulated or predicted with silently wrong dose delivery. The data-independent
+  *structural* rules now fire at parse time (so every entry point rejects them), and
+  the typical-value *value* checks are enforced on the `predict`/`simulate` paths too.
+
 ## [0.2.0] - 2026-07-03
 
 ### Added

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -117,11 +117,15 @@ mis-modeled:
   (`E_ABSORPTION_DIFFUSION`) — the EKF propagation does not yet carry the
   input-rate forcing.
 
-> **Note:** these guards run at `fit()` time (and via `ferx check`), which is
-> where model–data compatibility is validated. The lower-level `predict()` and
-> `simulate()` entry points assume an already-checked model and do not re-run
-> them, so run `ferx check` (or `fit()`) on a new model before relying on
-> `predict`/`simulate` output.
+> **Note:** these built-in-absorption guards run at `fit()` time and via `ferx
+> check` — where full model–data compatibility is validated — **and on the
+> lower-level `predict()` / `simulate()` paths too**: a combination `fit()` reports
+> as an `Err` becomes a **panic** there, since those `Vec`-returning entry points
+> cannot return an error (#588). The data-independent *structural* rules (e.g. the
+> pathway-fraction partition below) fire even earlier, at parse time, so *every*
+> entry point rejects a malformed model. Other, non-absorption data checks are
+> still only run by `fit()` / `ferx check`, so validate a new model there before
+> relying on `predict`/`simulate` output.
 
 ## Analytic closed form — `pk one_cpt_transit(cl, v, n, mtt)`
 
@@ -326,9 +330,13 @@ Rules for the fraction multiplier:
   (`FR2 = 1 - TVFR1`) so each term binds to one parameter. This also lets the
   fraction carry IIV/covariates and keeps its gradient exact (analytic `Dual2`).
 - The dose is **partitioned**, not duplicated: when more than one input-rate term
-  feeds a compartment, **each** must carry a fraction, and the fractions are
-  checked at fit-init to lie in `(0, 1]` and sum to ≈ 1 (`E_ABSORPTION_FRACTION`).
-  Two pathways together still deliver exactly `F·Dose` (`∫ Σ FRᵢ·R_inᵢ dt = F·Dose`).
+  feeds a compartment, **each** must carry a fraction (and a *lone* fractioned term
+  is rejected — a single pathway is written bare). This *structural* rule is checked
+  at **parse time**, so it fires for every entry point. The *value* checks — each
+  fraction in `(0, 1]` and the fractions summing to ≈ 1 (`E_ABSORPTION_FRACTION`) —
+  are evaluated at typical values by `fit()` / `ferx check`, and enforced on
+  `predict()` / `simulate()` as well (#588). Two pathways together still deliver
+  exactly `F·Dose` (`∫ Σ FRᵢ·R_inᵢ dt = F·Dose`).
 - The same multiplier works for `transit`/`weibull`/`first_order` terms, and on
   `zero_order(...)` as part of a `mixed` model — see
   [Parallel / mixed absorption](#parallel-mixed)

--- a/src/api.rs
+++ b/src/api.rs
@@ -976,25 +976,16 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
     // subject, so a covariate relationship that pushes a subject's typical
     // parameter out of range is caught too. Reported once — a single fatal
     // error already halts the fit.
-    // Pathway-fraction **value** checks (below) read a per-compartment term/fraction
-    // tally: `frac_count` maps each input-rate compartment to `(total terms,
-    // fractioned terms)`, and the Σ ≈ 1 gate uses it to run only on a genuine
-    // ≥2-pathway split. The companion **structural** rules — every term on a
-    // ≥2-pathway compartment must carry a fraction, and a *lone* fractioned term is
-    // rejected — are enforced earlier, in the parser's `build_ode_spec` (alongside
-    // the at-most-one-zero-order rule, #505), so they also guard the `simulate()` /
-    // `predict()` paths that never reach this data-level check (#388, #588). By the
-    // time a model reaches here its fractions are therefore structurally well-formed;
-    // only the value ranges remain.
+    // Pathway-fraction **value** checks (below): each fraction in (0, 1], and the
+    // fractions on a compartment sum to ≈ 1. The companion **structural** rules —
+    // every term on a ≥2-pathway compartment must carry a fraction, and a *lone*
+    // fractioned term is rejected — are enforced earlier, in the parser's
+    // `build_ode_spec` (alongside the at-most-one-zero-order rule, #505), so they
+    // also guard the `simulate()` / `predict()` paths that never reach this
+    // data-level check (#388, #588). By the time a model reaches here every
+    // *fractioned* compartment therefore has ≥2 partitioning terms, so the Σ ≈ 1
+    // check below runs unconditionally on any compartment that carries a fraction.
     use std::collections::BTreeMap;
-    let mut frac_count: BTreeMap<usize, (usize, usize)> = BTreeMap::new(); // cmt -> (total, fractioned)
-    for f in &ode.input_rate {
-        let e = frac_count.entry(f.cmt).or_insert((0, 0));
-        e.0 += 1;
-        if f.frac_slot.is_some() {
-            e.1 += 1;
-        }
-    }
 
     let zero_eta = vec![0.0_f64; model.n_eta + model.n_kappa];
     'subjects: for subject in &population.subjects {
@@ -1053,11 +1044,11 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
             *frac_sum.entry(forcing.cmt).or_insert(0.0) += fr;
         }
         for (&cmt, &sum) in &frac_sum {
-            // Only a genuine ≥2-pathway split is checked for Σ ≈ 1; a lone fractioned
-            // term is already rejected structurally above, so don't double-report it
-            // with the misleading "sum to <FR>, not 1" here (review #1).
-            let multi = frac_count.get(&cmt).is_some_and(|&(total, _)| total >= 2);
-            if multi && (sum - 1.0).abs() > 1e-4 {
+            // A lone fractioned term is rejected at parse (`build_ode_spec`), so every
+            // compartment reaching `frac_sum` has ≥2 partitioning terms — the Σ ≈ 1
+            // check needs no ≥2-pathway gate here (avoids the misleading "sum to <FR>,
+            // not 1" a lone term would otherwise trigger; #388 review #1, #588).
+            if (sum - 1.0).abs() > 1e-4 {
                 diags.push(
                     Diagnostic::error(
                         "E_ABSORPTION_FRACTION",
@@ -6010,8 +6001,13 @@ pub fn simulate_with_options(
     // release) or `resolve_rate`'s opaque `.expect` *before* the chokepoint
     // guard. Asserting here makes both branches fail with the same actionable
     // diagnostic; it is a no-op O(doses) scan on the common all-`Fixed` dataset.
+    // The built-in absorption input-rate guard (#588) is hoisted for the same
+    // reason: otherwise a malformed multi-pathway / SS / infusion absorption model
+    // integrates the whole warm-EBE pass first and fails only at the chokepoint,
+    // with a confusable "EBE did not converge" instead of the real cause.
     assert_modeled_doses_supported(model, population);
     assert_transit_support(model, population);
+    assert_absorption_dosing_supported(model, population);
 
     let method = match opts.match_method {
         Some(m) => m,

--- a/src/api.rs
+++ b/src/api.rs
@@ -976,17 +976,16 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
     // subject, so a covariate relationship that pushes a subject's typical
     // parameter out of range is caught too. Reported once — a single fatal
     // error already halts the fit.
-    // Pathway-fraction structural check (#388, model-level): fractions must
-    // *partition* the dose on a compartment. ≥2 input-rate terms on one compartment
-    // therefore must **each** carry a fraction (`FR*fn(...)`); a bare term alongside
-    // a fractioned one (or two bare terms) would deliver the full `F·Dose` more than
-    // once. A fraction is only meaningful across ≥2 partitioning terms, so a *lone*
-    // fractioned term is rejected too (a single pathway is written bare).
-    //
-    // (The companion structural rule — **at most one zero-order forcing per
-    // compartment** — is enforced earlier, in the parser's `build_ode_spec`, so it
-    // also guards the `simulate()` / `predict()` paths that never reach this
-    // data-level check; #505.)
+    // Pathway-fraction **value** checks (below) read a per-compartment term/fraction
+    // tally: `frac_count` maps each input-rate compartment to `(total terms,
+    // fractioned terms)`, and the Σ ≈ 1 gate uses it to run only on a genuine
+    // ≥2-pathway split. The companion **structural** rules — every term on a
+    // ≥2-pathway compartment must carry a fraction, and a *lone* fractioned term is
+    // rejected — are enforced earlier, in the parser's `build_ode_spec` (alongside
+    // the at-most-one-zero-order rule, #505), so they also guard the `simulate()` /
+    // `predict()` paths that never reach this data-level check (#388, #588). By the
+    // time a model reaches here its fractions are therefore structurally well-formed;
+    // only the value ranges remain.
     use std::collections::BTreeMap;
     let mut frac_count: BTreeMap<usize, (usize, usize)> = BTreeMap::new(); // cmt -> (total, fractioned)
     for f in &ode.input_rate {
@@ -994,45 +993,6 @@ fn check_absorption_dosing(model: &CompiledModel, population: &Population) -> Ve
         e.0 += 1;
         if f.frac_slot.is_some() {
             e.1 += 1;
-        }
-    }
-
-    for (&cmt, &(total, fractioned)) in &frac_count {
-        if total >= 2 && fractioned != total {
-            diags.push(
-                Diagnostic::error(
-                    "E_ABSORPTION_FRACTION",
-                    format!(
-                        "Compartment {} has {total} built-in absorption input-rate terms but \
-                         only {fractioned} carry a pathway fraction. When more than one term \
-                         feeds a compartment, each must be written `FR*fn(...)` with the \
-                         fractions summing to 1 — otherwise the dose mass is counted more than \
-                         once.",
-                        cmt + 1
-                    ),
-                )
-                .with_block("odes"),
-            );
-        } else if total == 1 && fractioned == 1 {
-            // A *lone* fractioned term can't partition anything: `FR*fn(...)` as the
-            // only input on a compartment is only ever valid at `FR = 1` (≡ a bare
-            // term), so reject it here with a precise message instead of letting the
-            // per-subject sum-check below report the confusing "fractions sum to 0.6,
-            // not 1" (review #1). A single pathway is written bare; `F` handles
-            // partial absorption.
-            diags.push(
-                Diagnostic::error(
-                    "E_ABSORPTION_FRACTION",
-                    format!(
-                        "Compartment {} has a single input-rate term carrying a pathway fraction \
-                         (`FR*fn(...)`). A pathway fraction only applies when ≥2 terms split the \
-                         dose across a compartment — write a single pathway as a bare \
-                         `+ fn(...)`, and use bioavailability `F` for partial absorption.",
-                        cmt + 1
-                    ),
-                )
-                .with_block("odes"),
-            );
         }
     }
 
@@ -1361,6 +1321,27 @@ pub(crate) fn assert_analytic_readout_support(model: &CompiledModel, population:
             "predict()/simulate() received a model/data combination the analytic Form C \
              readout cannot honour: {msg}\n(fit() reports this as an error rather than \
              panicking.)"
+        );
+    }
+}
+
+/// Panic on a malformed built-in **absorption input-rate** model/data combination —
+/// a pathway-fraction value out of `(0, 1]` or not summing to 1, an out-of-domain
+/// forcing parameter, or an SS / infusion / `[diffusion]` dose into an input-rate
+/// compartment — for the `Vec`-returning `predict()` / `simulate()` paths (mirrors
+/// [`assert_transit_support`]). `fit()` (and `ferx check`) surface these as an `Err`
+/// via [`check_model_data`], but the simulate/predict paths run no data-check, so
+/// without this a malformed multi-pathway model would be simulated with silently
+/// wrong dose delivery (#588). The data-independent *structural* fraction rules are
+/// enforced even earlier, at parse time in `build_ode_spec`; this reuses
+/// [`check_absorption_dosing`] for the *value* / domain checks that need data. A
+/// no-op for any model with no built-in input-rate forcing (the common case).
+pub(crate) fn assert_absorption_dosing_supported(model: &CompiledModel, population: &Population) {
+    if let Err(msg) = first_error(&check_absorption_dosing(model, population)) {
+        panic!(
+            "predict()/simulate() received a model/data combination the built-in absorption \
+             input-rate machinery cannot honour: {msg}\n(fit() reports this as an error rather \
+             than panicking.)"
         );
     }
 }
@@ -6353,6 +6334,7 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     // data-check otherwise. #324.
     assert_modeled_doses_supported(model, population);
     assert_transit_support(model, population);
+    assert_absorption_dosing_supported(model, population);
 
     // ODE-accumulated TTE simulation has preventable preconditions (finite horizon,
     // no resets / left truncation). `simulate_with_options` checks them first and
@@ -7117,6 +7099,7 @@ pub fn predict(
     assert_modeled_doses_supported(model, population);
     assert_transit_support(model, population);
     assert_analytic_readout_support(model, population);
+    assert_absorption_dosing_supported(model, population);
 
     let zero_eta = vec![0.0_f64; model.n_eta + model.n_kappa];
     let mut results = Vec::new();

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -7203,6 +7203,52 @@ fn build_ode_spec(
         }
     }
 
+    // Structural invariant (compile-time, #388/#588): built-in absorption **pathway
+    // fractions must partition the dose on a compartment**. When ≥2 input-rate terms
+    // feed one compartment they must *each* carry a fraction (`FR*fn(...)`) — a bare
+    // term alongside a fractioned one (or two bare terms) would deliver the full
+    // `F·Dose` more than once. And a *lone* fractioned term is rejected: a fraction
+    // only partitions across ≥2 terms, so a single pathway is written bare (`F`
+    // handles partial absorption). Enforced here, in the parser (mirroring the
+    // at-most-one-zero-order rule above), rather than only in the data-level
+    // `api::check_absorption_dosing`, so the `simulate()` / `predict()` paths — which
+    // never run that fit-init check — reject a malformed multi-pathway model too
+    // (every entry point parses the model first). The companion **value** checks
+    // (each fraction in (0, 1], Σ ≈ 1) depend on typical parameter values, so they
+    // stay data-level; the simulate/predict paths reach them via
+    // `assert_absorption_dosing_supported`.
+    {
+        let mut frac_count: std::collections::BTreeMap<usize, (usize, usize)> =
+            std::collections::BTreeMap::new(); // cmt -> (total, fractioned)
+        for f in &input_rate {
+            let e = frac_count.entry(f.cmt).or_insert((0, 0));
+            e.0 += 1;
+            if f.frac_slot.is_some() {
+                e.1 += 1;
+            }
+        }
+        for (&cmt, &(total, fractioned)) in &frac_count {
+            if total >= 2 && fractioned != total {
+                return Err(format!(
+                    "[odes]: compartment {} has {total} built-in absorption input-rate terms \
+                     but only {fractioned} carry a pathway fraction. When more than one term \
+                     feeds a compartment, each must be written `FR*fn(...)` with the fractions \
+                     summing to 1 — otherwise the dose mass is counted more than once.",
+                    cmt + 1
+                ));
+            }
+            if total == 1 && fractioned == 1 {
+                return Err(format!(
+                    "[odes]: compartment {} has a single input-rate term carrying a pathway \
+                     fraction (`FR*fn(...)`). A pathway fraction only applies when ≥2 terms \
+                     split the dose across a compartment — write a single pathway as a bare \
+                     `+ fn(...)`, and use bioavailability `F` for partial absorption.",
+                    cmt + 1
+                ));
+            }
+        }
+    }
+
     // For ODE RHS expressions, states + individual params get injected into the
     // `vars` map at eval time, so every bare identifier should resolve to a
     // Variable (not a Covariate). ParseCtx::ode() flips the fallback accordingly.

--- a/tests/absorption_fraction_features.rs
+++ b/tests/absorption_fraction_features.rs
@@ -1,0 +1,238 @@
+//! #588 feature-interaction probes: the pathway-fraction / absorption input-rate
+//! validation must behave identically on `predict()` / `simulate()` and `fit()`
+//! (`check_model_data`) when the model *also* uses bioavailability `F`, a dose
+//! `lagtime`, time-varying covariates, or IOV (`kappa`). These are the features
+//! that bit earlier absorption work (silent depot-init drop #611; transit + TV-cov
+//! silent zeros / IOV scope gaps #663), so a valid feature-rich model must not
+//! spuriously trip the new guard, and a genuinely malformed one must still be
+//! caught with those features present.
+
+mod common;
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::types::Population;
+use ferx_core::{check_model_data, predict, simulate_with_seed, DoseEvent};
+
+/// Does `check_model_data` raise any absorption diagnostic for this model+pop?
+fn has_absorption_err(model: &ferx_core::CompiledModel, pop: &Population) -> bool {
+    check_model_data(model, pop)
+        .iter()
+        .any(|d| d.code.starts_with("E_ABSORPTION"))
+}
+
+/// Biphasic IG into central (CL=5, V=50), two declared fractions, plus optional
+/// extra `[individual_parameters]` lines (F1 / LAGTIME1 / covariate / kappa refs)
+/// and extra `[parameters]` (thetas / kappa). `fr1`/`fr2` are the fraction defs.
+fn biphasic(extra_params: &str, indiv: &str) -> String {
+    format!(
+        r#"
+[parameters]
+  theta TVCL(5.0,    0.1, 100.0)
+  theta TVV(50.0,    5.0, 500.0)
+  theta TVMAT1(1.0, 0.05,  24.0)
+  theta TVMAT2(4.0, 0.05,  24.0)
+  theta TVCV2_1(0.3, 0.001, 10.0)
+  theta TVCV2_2(0.5, 0.001, 10.0)
+  theta TVFR1(0.6, 0.001, 0.999)
+{extra_params}
+  omega ETA_CL ~ 0.0
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL    = TVCL * exp(ETA_CL)
+  V     = TVV
+  MAT1  = TVMAT1
+  MAT2  = TVMAT2
+  CV2_1 = TVCV2_1
+  CV2_2 = TVCV2_2
+{indiv}
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = FR1*igd(mat=MAT1, cv2=CV2_1) + FR2*igd(mat=MAT2, cv2=CV2_2) - CL/V*central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+"#
+    )
+}
+
+fn pop_plain(cov_names: Vec<String>) -> Population {
+    let obs_times = vec![0.5, 1.0, 2.0, 4.0, 8.0, 16.0];
+    let n = obs_times.len();
+    let dose = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0);
+    let subj = common::subject("1", vec![dose], obs_times, vec![0.0; n], vec![1; n]);
+    Population {
+        covariate_names: cov_names,
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![subj],
+    }
+}
+
+#[test]
+fn fraction_validation_valid_with_f_and_lagtime() {
+    // Bioavailability `F1` scales the delivered mass and `LAGTIME1` shifts tad;
+    // neither touches the pathway-fraction slot. A valid split (FR1+FR2=1) must pass
+    // `check_model_data` AND not trip the predict/simulate guard.
+    let src = biphasic(
+        "  theta TVF(0.7, 0.01, 1.0)\n  theta TVLAG(1.5, 0.001, 12.0)",
+        "  FR1 = TVFR1\n  FR2 = 1 - TVFR1\n  F1 = TVF\n  LAGTIME1 = TVLAG",
+    );
+    let model = parse_full_model(&src)
+        .expect("biphasic igd + F + lag parses")
+        .model;
+    let pop = pop_plain(vec![]);
+    assert!(
+        !has_absorption_err(&model, &pop),
+        "valid F+lag flagged by fit-check"
+    );
+    // Must not panic:
+    let preds = predict(&model, &pop, &model.default_params);
+    assert!(
+        preds.iter().all(|p| p.pred.is_finite()),
+        "non-finite pred with F+lag"
+    );
+    let _ = simulate_with_seed(&model, &pop, &model.default_params, 1, 7);
+}
+
+#[test]
+#[should_panic(expected = "absorption input-rate machinery cannot honour")]
+fn fraction_error_still_caught_with_f_and_lagtime() {
+    // Same F+lag model but a malformed split (both fractions 0.6 → Σ=1.2). The
+    // features must not mask the error: predict() must still panic.
+    let src = biphasic(
+        "  theta TVF(0.7, 0.01, 1.0)\n  theta TVLAG(1.5, 0.001, 12.0)",
+        "  FR1 = TVFR1\n  FR2 = TVFR1\n  F1 = TVF\n  LAGTIME1 = TVLAG",
+    );
+    let model = parse_full_model(&src).expect("model parses").model;
+    let pop = pop_plain(vec![]);
+    assert!(
+        has_absorption_err(&model, &pop),
+        "fit-check should flag Σ≠1 too"
+    );
+    let _ = predict(&model, &pop, &model.default_params);
+}
+
+#[test]
+fn fraction_validation_valid_with_time_varying_covariate() {
+    // A fraction driven by a covariate that is *time-varying* in the data. The
+    // validation evaluates typical values at the baseline covariate (TIME=0), so a
+    // subject whose COVF baseline gives FR1=0.5 (⇒ FR2=0.5, Σ=1) is valid — the same
+    // as fit() sees. This is the transit+TV-cov class (#663): the guard must handle a
+    // `has_tv_covariates()==true` subject without choking.
+    let src = biphasic("", "  FR1 = COVF\n  FR2 = 1 - COVF");
+    let model = parse_full_model(&src)
+        .expect("biphasic igd + covariate fraction parses")
+        .model;
+
+    let mut pop = pop_plain(vec!["COVF".into()]);
+    let subj = &mut pop.subjects[0];
+    // Baseline COVF = 0.5 → typical FR1 = 0.5 (⇒ FR2 = 0.5, Σ = 1). The per-observation
+    // snapshots below make has_tv_covariates() == true (COVF drifts 0.50 → 0.60), but the
+    // check reads the baseline value, exactly as fit() does.
+    subj.covariates.insert("COVF".into(), 0.5);
+    let n = subj.obs_times.len();
+    subj.obs_covariates = (0..n)
+        .map(|i| {
+            let mut m = std::collections::HashMap::new();
+            m.insert("COVF".to_string(), 0.50 + 0.02 * i as f64);
+            m
+        })
+        .collect();
+    assert!(
+        subj.has_tv_covariates(),
+        "probe must exercise the TV-cov path"
+    );
+
+    assert!(
+        !has_absorption_err(&model, &pop),
+        "valid TV-cov fraction flagged"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert!(
+        preds.iter().all(|p| p.pred.is_finite()),
+        "non-finite pred with TV-cov"
+    );
+    let _ = simulate_with_seed(&model, &pop, &model.default_params, 1, 7);
+}
+
+#[test]
+fn fraction_validation_valid_with_iov() {
+    // IOV on a fraction: FR1 = TVFR1 * exp(KAPPA_FR). The check zeros kappa (as fit
+    // does), so it evaluates the typical FR1 = 0.6 (⇒ FR2 = 0.4, Σ = 1) — valid. The
+    // guard must not spuriously fire on a fitted IOV absorption model.
+    let src = format!(
+        r#"
+[parameters]
+  theta TVCL(5.0,    0.1, 100.0)
+  theta TVV(50.0,    5.0, 500.0)
+  theta TVMAT1(1.0, 0.05,  24.0)
+  theta TVMAT2(4.0, 0.05,  24.0)
+  theta TVCV2_1(0.3, 0.001, 10.0)
+  theta TVCV2_2(0.5, 0.001, 10.0)
+  theta TVFR1(0.6, 0.001, 0.999)
+  omega ETA_CL ~ 0.04
+  kappa KAPPA_FR ~ 0.02
+  sigma PROP_ERR ~ 0.01 (sd)
+
+[individual_parameters]
+  CL    = TVCL * exp(ETA_CL)
+  V     = TVV
+  MAT1  = TVMAT1
+  MAT2  = TVMAT2
+  CV2_1 = TVCV2_1
+  CV2_2 = TVCV2_2
+  FR1   = TVFR1 * exp(KAPPA_FR)
+  FR2   = 1 - TVFR1
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = FR1*igd(mat=MAT1, cv2=CV2_1) + FR2*igd(mat=MAT2, cv2=CV2_2) - CL/V*central
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+"#
+    );
+    let model = parse_full_model(&src)
+        .expect("biphasic igd + IOV parses")
+        .model;
+    assert!(model.n_kappa > 0, "probe must have IOV");
+
+    let obs_times = vec![0.5, 1.0, 2.0, 4.0, 8.0, 16.0];
+    let n = obs_times.len();
+    let dose = DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0);
+    let mut subj = common::subject("1", vec![dose], obs_times, vec![0.0; n], vec![1; n]);
+    subj.occasions = vec![1; n];
+    subj.dose_occasions = vec![1];
+
+    let pop = Population {
+        covariate_names: vec![],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+        subjects: vec![subj],
+    };
+    assert!(
+        !has_absorption_err(&model, &pop),
+        "valid IOV fraction flagged"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert!(
+        preds.iter().all(|p| p.pred.is_finite()),
+        "non-finite pred with IOV"
+    );
+}

--- a/tests/igd_absorption.rs
+++ b/tests/igd_absorption.rs
@@ -18,7 +18,7 @@
 mod common;
 
 use ferx_core::parser::model_parser::parse_full_model;
-use ferx_core::{predict, DoseEvent, Population};
+use ferx_core::{predict, simulate_with_seed, DoseEvent, Population};
 
 /// One-compartment model with built-in inverse-Gaussian absorption straight
 /// into central (no first-order `ka`). central (CMT 1) holds the drug AMOUNT
@@ -226,7 +226,14 @@ fn biphasic_igd_recovers_dose_auc() {
 }
 
 #[test]
-fn biphasic_igd_fraction_validation() {
+fn biphasic_igd_fraction_value_validation() {
+    // **Value** fraction checks — each fraction in (0, 1], and the fractions on a
+    // compartment sum to ≈ 1 — depend on the typical parameter values (η = 0), so
+    // they live in the data-level `check_model_data` (reached by `fit()` / `ferx
+    // check`, and now by `simulate()` / `predict()` via
+    // `assert_absorption_dosing_supported`, #588). Each model here is *structurally*
+    // well-formed (both pathways carry a fraction), so it parses; only the value is
+    // wrong.
     use ferx_core::check_model_data;
     let pop = pop_single_igd(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
     let has_fraction_err = |src: &str| {
@@ -251,17 +258,66 @@ fn biphasic_igd_fraction_validation() {
         BIPHASIC_ODES,
         "  FR1 = TVFR1 * 2.5\n  FR2 = TVFR2"
     )));
-    // (a) Structural: a bare term alongside a fractioned one on the same compartment
-    //     (the dose would be over-delivered) is rejected.
-    assert!(has_fraction_err(&biphasic_model(
+}
+
+#[test]
+fn biphasic_igd_fraction_structural_rejected_at_parse() {
+    // **Structural** fraction rules — every term on a ≥2-pathway compartment must
+    // carry a fraction, and a *lone* fractioned term is rejected — are data-independent,
+    // so they are enforced at parse time in `build_ode_spec` (mirroring the
+    // at-most-one-zero-order rule). This fires for *every* entry point, including the
+    // `simulate()` / `predict()` paths that never reach `check_model_data` (#388, #588).
+    let parse_err = |src: &str| {
+        parse_full_model(src)
+            .err()
+            .expect("structurally malformed pathway fractions must be rejected at parse")
+    };
+
+    // (a) A bare term alongside a fractioned one on the same compartment (the dose
+    //     would be over-delivered) is rejected.
+    let err = parse_err(&biphasic_model(
         "d/dt(central) = FR1*igd(mat=MAT1, cv2=CV2_1) + igd(mat=MAT2, cv2=CV2_2) - CL/V*central",
         "  FR1 = TVFR1",
-    )));
+    ));
+    assert!(
+        err.contains("pathway fraction") && err.contains("compartment 1"),
+        "all-or-none violation should name the fraction rule and compartment, got: {err}"
+    );
+
     // (d) A *lone* fractioned term (a single pathway carrying a fraction) is rejected:
     //     a fraction only partitions a dose across ≥2 terms, so a single pathway must
-    //     be written bare (review #1). Caught structurally, before the sum-check.
-    assert!(has_fraction_err(&biphasic_model(
+    //     be written bare.
+    let err = parse_err(&biphasic_model(
         "d/dt(central) = FR1*igd(mat=MAT1, cv2=CV2_1) - CL/V*central",
         "  FR1 = TVFR1",
-    )));
+    ));
+    assert!(
+        err.contains("single input-rate term carrying a pathway fraction"),
+        "lone fractioned term should be rejected with a precise message, got: {err}"
+    );
+}
+
+#[test]
+#[should_panic(expected = "absorption input-rate machinery cannot honour")]
+fn biphasic_igd_fraction_value_error_panics_on_predict() {
+    // #588: the value fraction checks now guard the `Vec`-returning `predict()` path.
+    // A structurally-valid but value-malformed multi-pathway model (both fractions
+    // 0.6 → Σ = 1.2, silently over-delivering the dose) is rejected loudly instead of
+    // predicted wrong. `fit()` reports the same as an `Err` via `check_model_data`.
+    let src = biphasic_model(BIPHASIC_ODES, "  FR1 = TVFR1\n  FR2 = TVFR1");
+    let model = parse_full_model(&src).expect("model parses").model;
+    let pop = pop_single_igd(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
+    let _ = predict(&model, &pop, &model.default_params);
+}
+
+#[test]
+#[should_panic(expected = "absorption input-rate machinery cannot honour")]
+fn biphasic_igd_fraction_value_error_panics_on_simulate() {
+    // #588 (simulate path): the same value-malformed multi-pathway model is rejected
+    // when *simulated*, via the `simulate_inner_with_draw` chokepoint guard — the exact
+    // path the fit-init-only `check_model_data` left open to silently-wrong delivery.
+    let src = biphasic_model(BIPHASIC_ODES, "  FR1 = TVFR1\n  FR2 = TVFR1");
+    let model = parse_full_model(&src).expect("model parses").model;
+    let pop = pop_single_igd(vec![0.5, 1.0, 2.0, 4.0, 8.0]);
+    let _ = simulate_with_seed(&model, &pop, &model.default_params, 1, 42);
 }


### PR DESCRIPTION
## Why

The built-in absorption pathway-fraction validation (`E_ABSORPTION_FRACTION`, #388)
lived only in `api::check_absorption_dosing`, reached via `check_model_data` from
`fit()` (and `ferx check`) but **not** from `simulate()`, `simulate_with_seed()`,
`predict()`, or the `--simulate` entry (`run_model_simulate()`). A multi-pathway
absorption model with malformed fractions could therefore be **simulated / predicted
with no error and silently wrong dose delivery** — whereas the same model under
`fit()` is rejected. Found during `/review` of #586.

This is the same class of gap as the zero-order-multi guard fixed in #586
(`89db5f61`), which was hoisted to the parser so it fires for every entry point; the
fraction checks were left out of that PR's scope because they predate #505.

## What changed

Two-part fix mirroring the #586 precedent:

1. **Structural checks → parser (`build_ode_spec`).** The data-independent rules —
   every term on a ≥2-pathway compartment must carry a fraction (all-or-none), and a
   *lone* `FR*fn(...)` is rejected — now run at parse time, right after the existing
   at-most-one-zero-order guard. They fire for **every** entry point, since every path
   parses the model first.
2. **Value checks → `predict()` / `simulate()` guard.** The typical-value checks (each
   fraction in `(0, 1]`, Σ ≈ 1) stay data-level in `check_absorption_dosing`, and a new
   `assert_absorption_dosing_supported(model, population)` runs
   `first_error(&check_absorption_dosing(...))` and **panics** on the `Vec`-returning
   `predict()` / `simulate()` paths — mirroring `assert_transit_support` /
   `assert_modeled_doses_supported`. `fit()` (and `ferx check`) still surface these as
   an `Err`. Because it reuses the whole `check_absorption_dosing`, the sibling
   domain / SS / infusion / `[diffusion]` guards are now enforced on those paths too.

The structural block is removed from `check_absorption_dosing` (the parser now
guarantees well-formedness); `frac_count` is retained there because the value `Σ ≈ 1`
gate still reads it.

## Alternatives considered

Calling the full `check_model_data` from the simulate/predict paths would drag in
unrelated data checks those paths deliberately skip; scoping to
`check_absorption_dosing` keeps the change to the absorption surface #588 is about.
Keeping the structural checks data-level (and only calling them from
`run_model_simulate`) was rejected in favour of the parser hoist, which the #586
precedent already established and which covers `predict()` too.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change (the new `assert_` fn is `pub(crate)`); no `.ferx` format
change; not consumed by the R glue.

## Breaking changes
- [x] None

A structurally-malformed multi-pathway model that previously failed at `fit()`/`check`
time now fails at *parse* time (earlier, same error class); a value-malformed one now
also fails loudly on `predict()`/`simulate()` instead of silently mis-delivering. No
valid model changes behaviour.

## Numerical validation
- [x] Not applicable (validation-only change; no estimates/residuals/OFV affected).
  Existing absorption fits/sims (igd, transit, parallel/mixed) are unchanged — a valid
  model is a no-op for the new guard.

## Performance
- [x] No significant impact expected — the guard early-returns for any model with no
  built-in input-rate forcing (the common case) and is O(subjects·forcings), run once
  per public call.

## Tests
- [x] Regression test added that fails without this fix
  (`biphasic_igd_fraction_value_error_panics_on_predict` / `_on_simulate`, both
  `#[should_panic]`)
- [x] Existing test split/updated (`cargo test --lib` + `--test igd_absorption` pass)

`tests/igd_absorption.rs`: the old combined `biphasic_igd_fraction_validation` is split
into `biphasic_igd_fraction_value_validation` (value checks via `check_model_data`) and
`biphasic_igd_fraction_structural_rejected_at_parse` (structural checks now assert a
parse `Err`), plus the two new `#[should_panic]` predict/simulate regression tests.

Local verification (worktree, pinned manifest):
- `cargo test --lib` → **2212 passed, 0 failed**
- `--test igd_absorption` 7/7, `--test parallel_mixed_absorption` 8/8
- rustfmt clean; clippy clean on changed lines

## Example (user-facing features only)
- [x] Not applicable (validation hardening; no new API surface)

The user-visible effect is a clearer/earlier error. E.g. this now fails at parse:

```
[odes]
  d/dt(central) = FR1*igd(mat=MAT1, cv2=CV2_1) + igd(mat=MAT2, cv2=CV2_2) - CL/V*central
```

> `[odes]: compartment 1 has 2 built-in absorption input-rate terms but only 1 carry a pathway fraction ...`

## Docs
- [x] `docs/model-file/absorption.qmd` updated (validation note + fraction-rules block)
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added (#588)
- [x] No new pages (no `_quarto.yml` change)

## Checklist
- [x] `cargo clippy` clean (no new warnings on changed lines)
- [x] `Dual2` sensitivity path untouched (validation-only; no gradient-reachable code modified)
- [x] No `Cargo.toml` version bump (non-breaking)

## Docs & examples

### ferx-site / ferx-book
- [x] No new DSL syntax, fit option, example, or data file — no site/book change needed.

### Example execution
- [x] No example execution step needed (validation-only change; existing examples unaffected)

## Reviewer hints
- The core move is in `src/parser/model_parser.rs` `build_ode_spec` (structural block,
  right after the zero-order-multi guard) and `src/api.rs`
  (`assert_absorption_dosing_supported` + two call sites: the `simulate_inner_with_draw`
  chokepoint and `predict()`).
- The structural block is removed from `check_absorption_dosing` but `frac_count` is
  retained because the value `Σ ≈ 1` gate still reads it — by the time a model reaches
  that function the parser guarantees its fractions are structurally well-formed.
- The parser error messages are plain `[odes]: ...` strings (no `E_ABSORPTION_FRACTION`
  code), matching the zero-order-multi precedent; the value errors keep the coded
  `Diagnostic`.

## Open questions
None — scope follows #588 and the #586 pattern exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
