### PR TITLE
fix(sim): reject IOV/TV-cov/reset/SDE in adaptive dosing instead of silent wrong answers [#391]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ section of the SDLC for the versioning policy).
   and `ferx summary --help` now print usage to stdout and exit 0, matching standard
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
+### Fixed
+- **Adaptive dosing now rejects models/data it cannot faithfully simulate**, instead
+  of silently returning wrong results (#391): a model with inter-occasion variability
+  (`kappa` / IOV) or a stochastic (`[diffusion]` / SDE) term, or a subject with a
+  time-varying covariate or a system reset (EVID=3/4), now raises a typed error rather
+  than being run with kappas held at zero, covariates frozen at their baseline value,
+  process noise dropped, or the reset ignored.
+
 ## [0.2.0] - 2026-07-03
 
 ### Added

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -329,11 +329,22 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   consults the controller, so it is rejected rather than run as a silent
   dose-free simulation.
 - **Dose-free base subjects** — the regimen is fully controller-driven; a subject
-  that already carries doses is rejected.
+  that already carries doses (including steady-state or loading regimens) is
+  rejected.
+- **Time-constant covariates only** — a subject carrying a *time-varying* covariate
+  is rejected: the driver resolves each subject's PK once from the baseline
+  snapshot, so a covariate that changes over the horizon would otherwise silently
+  drive CL/V/KA off its t=0 value. Per-event PK under adaptive dosing is a follow-up.
+- **No system resets** — a subject with an EVID=3/4 reset event is rejected (the
+  reactive driver does not apply resets).
+- **Between-subject variability only** — η is drawn per subject/replicate. A model
+  declaring **inter-occasion variability** (`kappa` / IOV) is rejected rather than
+  silently run with its kappas held at zero; parameter-uncertainty propagation and
+  IOV are later layers.
+- **Deterministic ODE only** — a stochastic (`[diffusion]` / SDE) model is rejected
+  (the reactive integrator carries no process noise).
 - **Diagonal assay noise** — each `Dv` monitor draws independently; correlated
   cross-endpoint (`block_sigma`) assay noise is a follow-up.
-- **Between-subject variability only** — η is drawn per subject/replicate;
-  parameter-uncertainty propagation is a later layer.
 - **One monitored signal per block** — the declarative block titrates on a single
   `observe`; multiple named per-analyte monitors (already supported by the
   programmatic engine) are a declarative-surface follow-up.

--- a/src/api.rs
+++ b/src/api.rs
@@ -652,7 +652,11 @@ fn reject_unsupported_adaptive(
         );
     }
     for subject in &population.subjects {
-        if subject.has_tv_covariates() {
+        // `has_tv_covariates()` only inspects the dose/obs snapshot vectors; a
+        // subject whose covariate varies solely on EVID=2 rows carries it in
+        // `pk_only_covariates`, which that predicate misses. Test it explicitly so
+        // a dose-free, zero-observation EVID=2 subject can't slip past frozen at t=0.
+        if subject.has_tv_covariates() || !subject.pk_only_covariates.is_empty() {
             return Err(format!(
                 "adaptive-dosing simulation does not yet support time-varying covariates \
                  (subject '{}'): the reactive driver resolves each subject's PK once from the \
@@ -5539,6 +5543,36 @@ mod tests {
         assert!(subject.has_tv_covariates());
         let err = reject_unsupported_adaptive(&model, &adaptive_pop(subject))
             .expect_err("a subject with time-varying covariates must be rejected");
+        assert!(
+            err.to_lowercase().contains("time-varying") && err.to_lowercase().contains("covariate"),
+            "error should cite time-varying covariates: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_pk_only_covariate_subject() {
+        use crate::parser::model_parser::parse_model_string;
+        // A covariate that varies only on EVID=2 rows lands in `pk_only_covariates`,
+        // which `has_tv_covariates()` does NOT inspect — so a dose-free, zero-obs
+        // subject built from such rows would slip past the guard and be silently
+        // simulated with PK frozen at t=0. The guard tests `pk_only_covariates`
+        // directly; this pins that (the `has_tv_covariates()` assert proves the
+        // check is load-bearing — without it this subject is wrongly accepted).
+        let model = parse_model_string(PLAIN_ADAPTIVE_MODEL).expect("plain model parses");
+        let mut subject = adaptive_base_subject();
+        subject.obs_times = Vec::new();
+        subject.observations = Vec::new();
+        subject.obs_cmts = Vec::new();
+        subject.cens = Vec::new();
+        subject.pk_only_times = vec![24.0];
+        subject.pk_only_covariates =
+            vec![std::collections::HashMap::from([("WT".to_string(), 90.0)])];
+        assert!(
+            !subject.has_tv_covariates(),
+            "pk_only snapshots must be invisible to has_tv_covariates() for this test to bite"
+        );
+        let err = reject_unsupported_adaptive(&model, &adaptive_pop(subject))
+            .expect_err("a subject with EVID=2 time-varying covariates must be rejected");
         assert!(
             err.to_lowercase().contains("time-varying") && err.to_lowercase().contains("covariate"),
             "error should cite time-varying covariates: {err}"

--- a/src/api.rs
+++ b/src/api.rs
@@ -612,6 +612,68 @@ fn reject_selected_error_for_adaptive(model: &CompiledModel) -> Result<(), Strin
     Ok(())
 }
 
+/// Reject the model / data combinations the reactive driver cannot yet simulate
+/// *faithfully*. The adaptive path integrates each subject from a single baseline
+/// (t=0) PK snapshot with between-subject variability only (kappas held at zero),
+/// and never re-derives PK, applies a reset, or carries process noise. So an IOV
+/// model, a time-varying covariate, a system reset (EVID=3/4), or an SDE
+/// `[diffusion]` model would each be **silently** wrong — a violation of the
+/// "never a silent wrong answer" contract this module promises. Until each is
+/// properly supported (#391 follow-ups), reject it with a typed error. This
+/// mirrors the `n_kappa > 0` guards `fit()` already applies (IMPMAP,
+/// trust-region). Both public entry points funnel through `run_adaptive_population`,
+/// so guarding there covers `simulate_adaptive` and `simulate_adaptive_from_spec`.
+///
+/// The covariate check is conservative: it rejects any subject that carries
+/// per-event covariate snapshots, even when the varying column is one the model
+/// never references. Pruning irrelevant time-varying columns first (as the fit
+/// path does via `Population::prune_irrelevant_tv_covariates`) is a follow-up;
+/// over-rejecting here stays on the safe side of the contract.
+fn reject_unsupported_adaptive(
+    model: &CompiledModel,
+    population: &Population,
+) -> Result<(), String> {
+    if model.n_kappa > 0 {
+        return Err(
+            "adaptive-dosing simulation does not yet support inter-occasion variability \
+             (IOV / `kappa`): the reactive driver integrates from a single baseline PK \
+             snapshot and would silently hold every kappa at zero, biasing the predictions, \
+             the reactive decisions, and the dose ledger. Simulate without IOV, or track \
+             #391 for occasion-aware adaptive support."
+                .to_string(),
+        );
+    }
+    if model.is_sde() {
+        return Err(
+            "adaptive-dosing simulation does not support stochastic (`[diffusion]` / SDE) \
+             models: the reactive integrator is deterministic and would silently drop the \
+             process-noise term. Use the deterministic ODE model for adaptive dosing."
+                .to_string(),
+        );
+    }
+    for subject in &population.subjects {
+        if subject.has_tv_covariates() {
+            return Err(format!(
+                "adaptive-dosing simulation does not yet support time-varying covariates \
+                 (subject '{}'): the reactive driver resolves each subject's PK once from the \
+                 baseline covariate snapshot, so a covariate that changes over the horizon would \
+                 silently drive CL/V/KA off its t=0 value. Use time-constant covariates, or track \
+                 #391 for per-event PK under adaptive dosing.",
+                subject.id
+            ));
+        }
+        if subject.has_resets() {
+            return Err(format!(
+                "adaptive-dosing simulation does not support system-reset events (EVID=3/4) \
+                 (subject '{}'): the reactive driver never applies the reset, so the compartment \
+                 state would silently fail to zero. Remove reset rows for adaptive runs.",
+                subject.id
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Covariates referenced by the model but missing from the `[covariates]`
 /// declaration. These are still read (leniently) so the model works; the parser
 /// has already warned that they ought to be declared.
@@ -5332,6 +5394,183 @@ mod tests {
         assert!(reject_selected_error_for_adaptive(&single).is_ok());
     }
 
+    // --- Adaptive-dosing "no silent wrong answer" guards (#391) --------------
+    // The reactive driver integrates from a single baseline PK snapshot (BSV
+    // only, kappas zeroed), so IOV / time-varying covariates / resets / SDE
+    // would each be silently wrong. Each must be a typed error, not a silent
+    // number. See `reject_unsupported_adaptive`.
+
+    const PLAIN_ADAPTIVE_MODEL: &str = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  sigma PROP ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+    // A dose-free base subject with one observation and no per-event covariate
+    // snapshots — the shape the reactive driver accepts. Tests mutate one field
+    // to trip a specific guard.
+    fn adaptive_base_subject() -> crate::types::Subject {
+        crate::types::Subject {
+            id: "1".into(),
+            doses: Vec::new(),
+            obs_times: vec![24.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0],
+            obs_cmts: vec![1],
+            covariates: std::collections::HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0],
+            occasions: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        }
+    }
+
+    fn adaptive_pop(subject: crate::types::Subject) -> Population {
+        Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn adaptive_rejects_iov_model() {
+        use crate::parser::model_parser::parse_model_string;
+        let iov = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  kappa KAPPA_CL ~ 0.09
+  sigma PROP ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+        let model = parse_model_string(iov).expect("IOV model parses");
+        assert!(model.n_kappa > 0, "test model must declare a kappa");
+        let err = reject_unsupported_adaptive(&model, &adaptive_pop(adaptive_base_subject()))
+            .expect_err("IOV model must be rejected for adaptive dosing");
+        assert!(
+            err.to_lowercase().contains("inter-occasion") || err.to_lowercase().contains("iov"),
+            "error should cite IOV: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_sde_model() {
+        use crate::parser::model_parser::parse_model_string;
+        let sde = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  sigma PROP ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[diffusion]
+  central ~ 0.01
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+        let model = parse_model_string(sde).expect("SDE model parses");
+        assert!(model.is_sde(), "test model must be an SDE model");
+        let err = reject_unsupported_adaptive(&model, &adaptive_pop(adaptive_base_subject()))
+            .expect_err("SDE model must be rejected for adaptive dosing");
+        assert!(
+            err.to_lowercase().contains("diffusion")
+                || err.to_lowercase().contains("sde")
+                || err.to_lowercase().contains("stochastic"),
+            "error should cite the SDE/diffusion restriction: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_time_varying_covariate_subject() {
+        use crate::parser::model_parser::parse_model_string;
+        let model = parse_model_string(PLAIN_ADAPTIVE_MODEL).expect("plain model parses");
+        let mut subject = adaptive_base_subject();
+        subject.obs_covariates = vec![std::collections::HashMap::from([("WT".to_string(), 70.0)])];
+        assert!(subject.has_tv_covariates());
+        let err = reject_unsupported_adaptive(&model, &adaptive_pop(subject))
+            .expect_err("a subject with time-varying covariates must be rejected");
+        assert!(
+            err.to_lowercase().contains("time-varying") && err.to_lowercase().contains("covariate"),
+            "error should cite time-varying covariates: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_reset_subject() {
+        use crate::parser::model_parser::parse_model_string;
+        let model = parse_model_string(PLAIN_ADAPTIVE_MODEL).expect("plain model parses");
+        let mut subject = adaptive_base_subject();
+        subject.reset_times = vec![48.0];
+        assert!(subject.has_resets());
+        let err = reject_unsupported_adaptive(&model, &adaptive_pop(subject))
+            .expect_err("a subject with system resets must be rejected");
+        assert!(
+            err.to_lowercase().contains("reset"),
+            "error should cite system resets: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_accepts_plain_bsv_model() {
+        use crate::parser::model_parser::parse_model_string;
+        let model = parse_model_string(PLAIN_ADAPTIVE_MODEL).expect("plain model parses");
+        // A BSV-only model with a dose-free, time-constant-covariate, reset-free
+        // subject is exactly the supported cut — no guard should fire.
+        assert!(
+            reject_unsupported_adaptive(&model, &adaptive_pop(adaptive_base_subject())).is_ok()
+        );
+    }
+
     fn make_subject(eta: Vec<f64>, iwres: Vec<f64>) -> SubjectResult {
         let n = iwres.len();
         SubjectResult {
@@ -6464,9 +6703,10 @@ pub struct AdaptiveSimulateOptions {
     /// Must be non-empty: an empty schedule never consults the controller and is
     /// rejected (it would otherwise be a silent dose-free run).
     pub decision_times: Vec<f64>,
-    /// Signals the controller may read at each decision. **Ipred only** here — a
-    /// [`crate::sim::adaptive::ObserveMode::Dv`] monitor is rejected (it needs
-    /// the per-subject RNG substreams of S1.5).
+    /// Signals the controller may read at each decision. Each monitor resolves on
+    /// its own [`crate::sim::adaptive::ObserveMode`]: `Ipred` reads the latent
+    /// prediction; `Dv` adds the endpoint's assay-noise draw (`IPRED + ε·√σ²`) on
+    /// the monitor's per-subject RNG substream (#391 S1.5).
     pub monitors: Vec<MonitorSpec>,
     /// Run the frozen-schedule replay verifier after each (subject, replicate)
     /// (default `true`). A divergence is a typed `Err` that taints the whole
@@ -6499,9 +6739,9 @@ impl Default for AdaptiveSimulateOptions {
 #[non_exhaustive]
 pub struct AdaptiveSimulationResult {
     /// Per-observation predictions: one row per (replicate, subject, obs time).
-    /// **Ipred only** in this slice — `ipred` and the `Continuous` value are both
-    /// the individual prediction; residual / assay error (the realized DV) and
-    /// its per-subject RNG substream arrive in S1.5.
+    /// `ipred` and the `Continuous` value are the individual prediction. Assay-
+    /// noised DV monitoring (used for the controller's decisions) is applied inside
+    /// the run via each `Dv` monitor's RNG substream, not emitted as a separate row.
     pub trajectories: Vec<SimulationResult>,
     /// Every dose the controllers actually issued, tagged by `(draw, sim)`.
     pub ledger: Vec<DoseLedgerEntry>,
@@ -6518,7 +6758,7 @@ pub struct AdaptiveSimulationResult {
 }
 
 /// Simulate state-reactive ("adaptive" / feedback) dosing over a population
-/// (epic #391, **experimental**).
+/// (epic #391, **beta**).
 ///
 /// For each subject and each of `n_sim` replicates: draw η ~ N(0, Ω), then run
 /// one integration driven by a **fresh** controller minted from
@@ -6666,6 +6906,11 @@ where
     F: Fn() -> C,
     C: FnMut(&ControllerCtx) -> crate::sim::adaptive::ControllerDecision,
 {
+    // Reject model/data the reactive driver cannot faithfully simulate (IOV,
+    // time-varying covariates, resets, SDE) with a typed error — never a silent
+    // wrong answer (#391). Both public entry points funnel through here.
+    reject_unsupported_adaptive(model, population)?;
+
     use rand::SeedableRng;
 
     let mut rng: rand::rngs::StdRng = match opts.seed {

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -5456,6 +5456,57 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_bolus_f_scaling_matches_static() {
+        // Coverage for the bolus emit-path multiply `u[cmt-1] += F*amt` under
+        // F != 1. The infusion-F seam is covered above, but no test drove the
+        // *bolus* F multiply with F != 1 (it shares the static engine's structure,
+        // but was unexercised). A bare-slot F = 0.5 halves every controller-issued
+        // bolus; the degenerate oracle (re-issue the same bolus at each decision)
+        // must reproduce the equivalent static bolus schedule (carrying the same F)
+        // bit-exact.
+        let ode = one_cpt_ode_spec();
+        let mut pk = pk_one(1.0, 10.0); // ke = 0.1
+        pk.values[crate::types::PK_IDX_F] = 0.5; // bare-slot F on all compartments
+        let decisions = [0.0, 24.0, 48.0];
+        // A dose is realized at every decision and the last observation (60) is the
+        // global maximum, so neither engine breaks at an interior observation — the
+        // condition under which the degenerate oracle is bit-exact.
+        let obs = vec![1.0, 12.0, 25.0, 36.0, 49.0, 60.0];
+        let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+        let base = make_subject(vec![], obs.clone());
+        let run = ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &[],
+            &mut controller,
+            100,
+            None,
+        )
+        .expect("driver runs");
+
+        let static_doses: Vec<DoseEvent> = decisions
+            .iter()
+            .map(|&t| DoseEvent::new(t, 100.0, 1, 0.0, false, 0.0))
+            .collect();
+        let static_subject = make_subject(static_doses, obs);
+        let static_preds = ode_predictions(&ode, &pk.values, &[], &[], &static_subject);
+
+        assert_eq!(run.predictions.len(), static_preds.len());
+        for (got, want) in run.predictions.iter().zip(static_preds.iter()) {
+            assert_relative_eq!(*got, *want, max_relative = 1e-9);
+        }
+        // F is actually applied to the bolus (u += F*amt), recorded per row.
+        assert_eq!(run.ledger.len(), 3);
+        for entry in &run.ledger {
+            assert_eq!(entry.f_applied, 0.5);
+        }
+    }
+
+    #[test]
     fn adaptive_reactive_infusion_titrates_against_closed_form() {
         // Genuine state-reactive infusion: infuse 100 mg @ 25 (4 h) only when the
         // monitored amount is below 50, else hold. Checked against the exact 1-cpt


### PR DESCRIPTION
## Why

An adversarial audit of the adaptive-dosing S1/S2 engine (#391) found four model/data
combinations that ran **silently wrong** — wrong numbers, no error, no warning, and
invisible to the frozen-replay verifier (which replays the same crippled engine). The
reactive driver integrates each subject from a single baseline (t=0) PK snapshot,
between-subject-variability only (kappas held at zero), and never re-derives PK, applies a
reset, or carries process noise:

- **IOV** (`kappa`) — all kappas forced to 0 (`api.rs`: `eta_slice.resize(n_eta + n_kappa, 0.0)`); biased predictions, reactive decisions, and dose ledger.
- **Time-varying covariates** — PK resolved once at t=0, so a covariate changing over the horizon drives CL/V/KA off its baseline value for the whole run.
- **System resets** (EVID=3/4) — the driver never applies the reset; compartment state silently fails to zero.
- **SDE `[diffusion]`** — the deterministic integrator drops the process-noise term.

This violates the module's own "never a silent wrong answer" contract.

> **Scope note — this PR only makes these cases fail *loudly*. It does not add support for
> any of them.** Actually running IOV / time-varying-covariate / reset / SDE models correctly
> under adaptive dosing is deferred future work, each tracked as a dedicated #391 follow-up
> issue — see [Future work](#future-work--real-support-not-in-this-pr) below.

## What changed

A single guard `reject_unsupported_adaptive(model, population)` at the
`run_adaptive_population` chokepoint (both public entry points — `simulate_adaptive` and
`simulate_adaptive_from_spec` — funnel through it) turns each of the four into a **typed
error**, mirroring the `n_kappa > 0` guards `fit()` already applies (IMPMAP / trust-region).
The low-level `ode_predictions_adaptive_impl` and its readout-covariate unit test are left
untouched: the guard is production-layer, so the internal readout-snapshot primitive that
future per-event PK support will build on is preserved.

Also in this PR:
- **Coverage backfill** — `adaptive_bolus_f_scaling_matches_static`: the bolus `u += F·amt` emit path was only ever exercised at F=1 (the infusion-F seam had a test; the bolus one did not).
- **Doc fixes** — the `AdaptiveSimulateOptions` / `AdaptiveSimulationResult` doc-comments still claimed "Ipred only / Dv rejected / arrives in S1.5" (Dv shipped in S1.5) and the fn was tagged "experimental" (beta since #609); `adaptive-dosing.qmd` "Current scope and limits" now lists the four rejections explicitly.

## Alternatives considered

Rejecting only when a **model-referenced** covariate is time-varying (via
`Population::prune_irrelevant_tv_covariates`) would avoid over-rejecting a stray varying
column; deferred as a refinement — the conservative reject-any-`has_tv_covariates()` stays
safely on the contract's side. Actually **supporting** these cases (rather than rejecting) is
the real fix but a much larger change (per-event PK recompute, occasion bookkeeping, reset
handling, stochastic propagation) — **not in this PR**; each is tracked as a dedicated #391
follow-up issue (see [Future work](#future-work--real-support-not-in-this-pr) below).

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-signature or `.ferx` format change, so no ferx-r bump.

## Breaking changes
- [x] Behavior change (not a signature change): an adaptive run on an IOV / time-varying-covariate / reset / SDE model now returns `Err` where it previously returned `Ok` with silently-wrong results.

<details>
<summary>Migration notes</summary>

Simulate adaptively without IOV / time-varying covariates / resets / SDE, or track the
[Future work](#future-work--real-support-not-in-this-pr) issues below for proper support. No
`.ferx` format or public-API signature change.

</details>

## Numerical validation
- [x] Not applicable in the estimation sense — this converts silently-wrong outputs into typed errors. The degenerate-oracle bit-exactness tests (bolus + infusion, including the new F≠1 bolus) still pass, anchoring the accepted path to the static engine.

## Performance
- [x] No significant impact expected (four cheap predicate checks per run).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes) — 132 adaptive lib tests pass.
- [x] Regression tests added that fail without this fix — `adaptive_rejects_{iov,sde,time_varying_covariate,reset}_*` each assert the specific typed error; `adaptive_accepts_plain_bsv_model` pins the accepted cut; `adaptive_bolus_f_scaling_matches_static` covers the F≠1 bolus emit path.

## Docs
- [x] `docs/` updated for user-visible changes (`adaptive-dosing.qmd` scope section).
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added.

## Checklist
- [x] `cargo clippy --no-default-features --features ci` clean on changed lib code.
- [x] No `Dual2` sensitivity-path code touched.
- [ ] `Cargo.toml` version bump — not needed (bug fix, no signature change).

## Reviewer hints

The guard is at `run_adaptive_population`, **not** the impl, on purpose: the impl's
readout-covariate primitive (`adaptive_decision_monitor_uses_observation_covariates`) is
correct for readout-only covariates at coincident decisions and is the seed for per-event PK,
so it stays permissive. The TV-cov rejection is deliberately conservative (any
`has_tv_covariates()` subject).

## Future work — real *support* (not in this PR)

This PR only makes the four unsupported cases **fail loudly**; it does **not** run any of
them. Correctly simulating each under adaptive dosing is deliberately deferred, and every
case now has a dedicated #391 follow-up issue so nothing is lost:

| Rejected in this PR | Real-support follow-up |
|---|---|
| Time-varying covariates | #700 — per-event PK recompute |
| Inter-occasion variability (IOV / `kappa`) | #701 — occasion bookkeeping (needs #700's infra) |
| System resets (EVID=3/4) | #716 — reset-aware driver + verifier |
| SDE (`[diffusion]`) | #717 — stochastic propagation |

Separately, the **dose-free base-subject** restriction (a pre-scheduled loading regimen
before adaptive TDM) is tracked as #702.

Each follow-up removes its matching branch from `reject_unsupported_adaptive` once the real
path is wired and anchored. Also deferred (correct-but-untested paths): `F{n}` and
η/covariate-on-F coverage tests.
