### PR TITLE
fix(estimation): deterministic per-subject NLL reduction across thread counts [closes #703]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ section of the SDLC for the versioning policy).
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
 ### Fixed
+- **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
+  SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel
+  reduction whose grouping depended on the number of rayon threads; because floating-point
+  addition is not associative, the objective (and, in non-converged runs, the final OFV and
+  estimates) differed between e.g. 4 and 15 threads. The per-subject contributions are now summed
+  in a fixed subject order, so a given fit returns bit-identical results at any thread count.
 - **CLI flags in `--flag=value` form are no longer silently ignored** (#693):
   `--data`, `--output`, `--threads` (and any other value-taking flag) now accept
   `=` the same as a space, e.g. `ferx model.ferx --data=d.csv --threads=4`.

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -1417,7 +1417,11 @@ fn theta_sigma_weighted_mstep(
     let obj = |xv: &[f64], _: Option<&mut [f64]>, _: &mut ()| -> f64 {
         let th: Vec<f64> = unpack_thetas(&xv[..n_theta]);
         let sg: Vec<f64> = xv[n_theta..].iter().map(|&v| v.exp()).collect();
-        let val: f64 = population
+        // Reduce in subject order (collect then serial sum) so the objective is
+        // reproducible regardless of rayon worker count — a parallel `.sum()`
+        // folds along thread-count-dependent split points and f64 addition is
+        // non-associative (#703).
+        let per_subj: Vec<f64> = population
             .subjects
             .par_iter()
             .zip(draws.par_iter())
@@ -1431,7 +1435,8 @@ fn theta_sigma_weighted_mstep(
                 }
                 s
             })
-            .sum();
+            .collect();
+        let val: f64 = per_subj.iter().sum();
         if val.is_finite() {
             val
         } else {

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -632,6 +632,22 @@ fn obs_nll_subject_grad_iov(
 // Gradient of conditional observation NLL w.r.t. log(theta) and log(sigma)
 // ---------------------------------------------------------------------------
 
+/// Serially fold per-subject `(nll, grad)` pairs, already collected in subject
+/// order, into a single `(nll, grad)` total. Deterministic regardless of the
+/// rayon worker count that produced `per_subj` (#703): a parallel `reduce`
+/// would combine partials along thread-count-dependent boundaries, and f64
+/// addition is non-associative.
+fn fold_nll_grad(per_subj: Vec<(f64, Vec<f64>)>, n: usize) -> (f64, Vec<f64>) {
+    per_subj
+        .into_iter()
+        .fold((0.0, vec![0.0f64; n]), |(nll_a, mut ga), (nll_b, gb)| {
+            for (a, b) in ga.iter_mut().zip(gb.iter()) {
+                *a += b;
+            }
+            (nll_a + nll_b, ga)
+        })
+}
+
 /// Lightweight M-step: run NLopt SLSQP for a few iterations in packed
 /// space, warm-started from the current packed theta / log-sigma.
 ///
@@ -707,8 +723,11 @@ fn theta_sigma_mstep_light(
 
         if let Some(g) = grad {
             use rayon::prelude::*;
+            // Collect in subject order, then fold serially (#703): a parallel
+            // `reduce` combines partial (nll, grad) pairs along thread-count-
+            // dependent boundaries, and f64 addition is non-associative.
             let (val, grad_vec) = if let Some(kappas) = kappas_opt {
-                population
+                let per_subj: Vec<(f64, Vec<f64>)> = population
                     .subjects
                     .par_iter()
                     .zip(etas.par_iter())
@@ -729,21 +748,10 @@ fn theta_sigma_mstep_light(
                             scratch,
                         )
                     })
-                    // Collect in subject order, then fold serially: rayon's
-                    // parallel `reduce` combines partial (nll, grad) pairs along
-                    // thread-count-dependent boundaries and f64 addition is
-                    // non-associative, so the objective and gradient would
-                    // otherwise depend on the worker count (#703).
-                    .collect::<Vec<(f64, Vec<f64>)>>()
-                    .into_iter()
-                    .fold((0.0, vec![0.0f64; n]), |(nll_a, mut ga), (nll_b, gb)| {
-                        for (a, b) in ga.iter_mut().zip(gb.iter()) {
-                            *a += b;
-                        }
-                        (nll_a + nll_b, ga)
-                    })
+                    .collect();
+                fold_nll_grad(per_subj, n)
             } else {
-                population
+                let per_subj: Vec<(f64, Vec<f64>)> = population
                     .subjects
                     .par_iter()
                     .zip(etas.par_iter())
@@ -762,17 +770,8 @@ fn theta_sigma_mstep_light(
                             scratch,
                         )
                     })
-                    // Deterministic reduction (collect in subject order, fold
-                    // serially) — a parallel `reduce` would make the objective
-                    // and gradient depend on the rayon worker count (#703).
-                    .collect::<Vec<(f64, Vec<f64>)>>()
-                    .into_iter()
-                    .fold((0.0, vec![0.0f64; n]), |(nll_a, mut ga), (nll_b, gb)| {
-                        for (a, b) in ga.iter_mut().zip(gb.iter()) {
-                            *a += b;
-                        }
-                        (nll_a + nll_b, ga)
-                    })
+                    .collect();
+                fold_nll_grad(per_subj, n)
             };
             for (gi, &gv) in g.iter_mut().zip(grad_vec.iter()) {
                 *gi = if gv.is_finite() { gv } else { 0.0 };

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -729,15 +729,19 @@ fn theta_sigma_mstep_light(
                             scratch,
                         )
                     })
-                    .reduce(
-                        || (0.0, vec![0.0f64; n]),
-                        |(nll_a, mut ga), (nll_b, gb)| {
-                            for (a, b) in ga.iter_mut().zip(gb.iter()) {
-                                *a += b;
-                            }
-                            (nll_a + nll_b, ga)
-                        },
-                    )
+                    // Collect in subject order, then fold serially: rayon's
+                    // parallel `reduce` combines partial (nll, grad) pairs along
+                    // thread-count-dependent boundaries and f64 addition is
+                    // non-associative, so the objective and gradient would
+                    // otherwise depend on the worker count (#703).
+                    .collect::<Vec<(f64, Vec<f64>)>>()
+                    .into_iter()
+                    .fold((0.0, vec![0.0f64; n]), |(nll_a, mut ga), (nll_b, gb)| {
+                        for (a, b) in ga.iter_mut().zip(gb.iter()) {
+                            *a += b;
+                        }
+                        (nll_a + nll_b, ga)
+                    })
             } else {
                 population
                     .subjects
@@ -758,15 +762,17 @@ fn theta_sigma_mstep_light(
                             scratch,
                         )
                     })
-                    .reduce(
-                        || (0.0, vec![0.0f64; n]),
-                        |(nll_a, mut ga), (nll_b, gb)| {
-                            for (a, b) in ga.iter_mut().zip(gb.iter()) {
-                                *a += b;
-                            }
-                            (nll_a + nll_b, ga)
-                        },
-                    )
+                    // Deterministic reduction (collect in subject order, fold
+                    // serially) — a parallel `reduce` would make the objective
+                    // and gradient depend on the rayon worker count (#703).
+                    .collect::<Vec<(f64, Vec<f64>)>>()
+                    .into_iter()
+                    .fold((0.0, vec![0.0f64; n]), |(nll_a, mut ga), (nll_b, gb)| {
+                        for (a, b) in ga.iter_mut().zip(gb.iter()) {
+                            *a += b;
+                        }
+                        (nll_a + nll_b, ga)
+                    })
             };
             for (gi, &gv) in g.iter_mut().zip(grad_vec.iter()) {
                 *gi = if gv.is_finite() { gv } else { 0.0 };
@@ -1045,14 +1051,18 @@ fn obs_nll_sum(
     etas: &[Vec<f64>],
 ) -> f64 {
     use rayon::prelude::*;
-    population
+    // Collect in subject order and sum serially so the objective does not
+    // depend on the rayon worker count (f64 addition is non-associative and a
+    // parallel `.sum()` splits by thread count) — #703.
+    let per_subj: Vec<f64> = population
         .subjects
         .par_iter()
         .enumerate()
         .map_init(EventPkParams::default, |scratch, (i, subject)| {
             obs_nll_subject_into(model, subject, theta, sigma_values, &etas[i], scratch)
         })
-        .sum()
+        .collect();
+    per_subj.iter().sum()
 }
 
 /// IOV variant of `obs_nll_sum`: per-occasion predictions using `[eta, kappa_k]`.
@@ -1065,7 +1075,10 @@ fn obs_nll_sum_iov(
     kappas: &[Vec<Vec<f64>>],
 ) -> f64 {
     use rayon::prelude::*;
-    population
+    // Deterministic reduction (collect in subject order, fold serially): a
+    // parallel `.sum()` would make the objective depend on the rayon worker
+    // count — #703.
+    let per_subj: Vec<f64> = population
         .subjects
         .par_iter()
         .enumerate()
@@ -1080,7 +1093,8 @@ fn obs_nll_sum_iov(
                 scratch,
             )
         })
-        .sum()
+        .collect();
+    per_subj.iter().sum()
 }
 
 /// True when a free (non-`FIX`) additive component of a `Combined` endpoint has

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2313,6 +2313,25 @@ mod tests {
     use crate::types::test_helpers::analytical_model;
     use crate::types::{GradientMethod, MuRef};
 
+    #[test]
+    fn fold_nll_grad_sums_nll_and_grad_elementwise_in_input_order() {
+        let per_subj = vec![
+            (1.0, vec![1.0, 10.0]),
+            (2.0, vec![2.0, 20.0]),
+            (3.0, vec![3.0, 30.0]),
+        ];
+        let (nll, grad) = fold_nll_grad(per_subj, 2);
+        assert_eq!(nll, 6.0);
+        assert_eq!(grad, vec![6.0, 60.0]);
+    }
+
+    #[test]
+    fn fold_nll_grad_of_empty_input_is_zero() {
+        let (nll, grad) = fold_nll_grad(vec![], 3);
+        assert_eq!(nll, 0.0);
+        assert_eq!(grad, vec![0.0, 0.0, 0.0]);
+    }
+
     /// Pin the SAEM M-step optimizer choice.
     ///
     /// BOBYQA (derivative-free trust-region) was chosen over the prior SLSQP

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2000,7 +2000,14 @@ pub fn foce_population_nll_iov(
     sigma_values: &[f64],
     interaction: bool,
 ) -> f64 {
-    population
+    // Compute each subject's NLL in parallel, then reduce in a fixed subject
+    // order. rayon's `ParallelIterator::sum` folds partial sums along split
+    // boundaries that depend on the worker-thread count, and f64 addition is
+    // not associative — so a bare `.sum()` yields a thread-count-dependent OFV
+    // (e.g. 4 vs 15 threads). Collecting into an ordered `Vec` and summing
+    // serially makes the objective bit-reproducible regardless of thread count
+    // while keeping the expensive per-subject work parallel (#703).
+    let per_subj: Vec<f64> = population
         .subjects
         .par_iter()
         .enumerate()
@@ -2023,7 +2030,8 @@ pub fn foce_population_nll_iov(
                 omega_iov,
             )
         })
-        .sum::<f64>()
+        .collect();
+    per_subj.iter().sum()
 }
 
 /// Population FOCE objective: sum over all subjects
@@ -2037,7 +2045,11 @@ pub fn foce_population_nll(
     sigma_values: &[f64],
     interaction: bool,
 ) -> f64 {
-    population
+    // Deterministic reduction: collect per-subject NLLs in subject order, then
+    // sum serially. A parallel `.sum()` would make the OFV depend on the
+    // thread count (f64 addition is non-associative; rayon splits by worker
+    // count). See `foce_population_nll_iov` and #703.
+    let per_subj: Vec<f64> = population
         .subjects
         .par_iter()
         .enumerate()
@@ -2053,7 +2065,8 @@ pub fn foce_population_nll(
                 interaction,
             )
         })
-        .sum::<f64>()
+        .collect();
+    per_subj.iter().sum()
 }
 
 /// Compute CWRES (Conditional Weighted Residuals) for a subject.

--- a/tests/thread_count_determinism.rs
+++ b/tests/thread_count_determinism.rs
@@ -1,0 +1,66 @@
+//! Regression test for #703: a fit's objective must not depend on the rayon
+//! worker-thread count.
+//!
+//! The per-subject FOCE/FOCEI likelihood is summed across subjects. The bug was
+//! a parallel `ParallelIterator::sum` whose reduction tree is split along
+//! boundaries that depend on the worker count; because f64 addition is not
+//! associative, the OFV differed between (e.g.) 4 and 15 threads. In a
+//! non-converged run those ULP-level differences steer the optimizer down
+//! divergent trajectories, giving visibly different OFVs. The fix collects the
+//! per-subject NLLs in subject order and sums them serially, so the objective is
+//! bit-reproducible regardless of thread count.
+//!
+//! `FitOptions::threads` runs the whole fit inside a scoped rayon pool of the
+//! requested size, so this exercises the exact user-facing knob from the issue.
+
+use std::path::Path;
+
+use ferx_core::parser::model_parser::parse_model_file;
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+
+fn warfarin() -> (
+    ferx_core::types::CompiledModel,
+    ferx_core::types::Population,
+) {
+    let model =
+        parse_model_file(Path::new("examples/warfarin.ferx")).expect("warfarin model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+        .expect("warfarin data must load");
+    (model, population)
+}
+
+fn run_with_threads(n: usize, outer_maxiter: usize) -> f64 {
+    let (model, population) = warfarin();
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::FoceI;
+    opts.outer_maxiter = outer_maxiter;
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+    opts.threads = Some(n);
+    let result =
+        fit(&model, &population, &model.default_params, &opts).expect("FOCEI fit must succeed");
+    result.ofv
+}
+
+/// The same FOCEI fit under 1, 4, and 15 worker threads must produce a
+/// bit-identical OFV. A short-but-nontrivial `outer_maxiter` keeps the run fast
+/// while giving the optimizer enough iterations that any thread-dependent
+/// rounding in the objective would have driven the trajectories apart.
+#[test]
+fn focei_ofv_is_independent_of_thread_count() {
+    let ofv_1 = run_with_threads(1, 40);
+    let ofv_4 = run_with_threads(4, 40);
+    let ofv_15 = run_with_threads(15, 40);
+
+    assert!(ofv_1.is_finite(), "OFV must be finite, got {ofv_1}");
+    assert_eq!(
+        ofv_1.to_bits(),
+        ofv_4.to_bits(),
+        "OFV differs between 1 and 4 threads: {ofv_1} vs {ofv_4}"
+    );
+    assert_eq!(
+        ofv_1.to_bits(),
+        ofv_15.to_bits(),
+        "OFV differs between 1 and 15 threads: {ofv_1} vs {ofv_15}"
+    );
+}

--- a/tests/thread_count_determinism.rs
+++ b/tests/thread_count_determinism.rs
@@ -13,11 +13,11 @@
 //! `FitOptions::threads` runs the whole fit inside a scoped rayon pool of the
 //! requested size, so this exercises the exact user-facing knob from the issue.
 //!
-//! Three tests cover the three estimators this PR patched: FOCEI
+//! Four tests cover every function this PR patched: FOCEI
 //! (`foce_population_nll`/`_iov` in `src/stats/likelihood.rs`), SAEM
-//! (`obs_nll_sum`/`_iov` and `theta_sigma_mstep_light` in
-//! `src/estimation/saem.rs`), and IMPMAP (`theta_sigma_weighted_mstep` in
-//! `src/estimation/impmap.rs`).
+//! non-IOV and IOV (`obs_nll_sum`/`_iov` and both branches of
+//! `theta_sigma_mstep_light` in `src/estimation/saem.rs`), and IMPMAP
+//! (`theta_sigma_weighted_mstep` in `src/estimation/impmap.rs`).
 
 use std::path::Path;
 
@@ -116,6 +116,44 @@ fn saem_ofv_is_independent_of_thread_count() {
     let ofv_4 = run_saem_with_threads(4);
     let ofv_15 = run_saem_with_threads(15);
     assert_bit_identical_across_threads("SAEM", ofv_1, ofv_4, ofv_15);
+}
+
+fn warfarin_iov() -> (
+    ferx_core::types::CompiledModel,
+    ferx_core::types::Population,
+) {
+    let model = parse_model_file(Path::new("examples/warfarin_iov_saem.ferx"))
+        .expect("warfarin_iov_saem model must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, Some("OCC"))
+        .expect("warfarin_iov data must load");
+    (model, population)
+}
+
+fn run_saem_iov_with_threads(n: usize) -> f64 {
+    let (model, population) = warfarin_iov();
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Saem;
+    opts.saem_n_exploration = 5;
+    opts.saem_n_convergence = 5;
+    opts.saem_seed = Some(267);
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+    opts.threads = Some(n);
+    let result =
+        fit(&model, &population, &model.default_params, &opts).expect("SAEM IOV fit must succeed");
+    result.ofv
+}
+
+/// IOV variant of the SAEM check above: exercises `obs_nll_sum_iov` and the
+/// `obs_nll_subject_grad_iov` branch of `theta_sigma_mstep_light`, the one
+/// pair of patched functions the non-IOV `warfarin.ferx` fixture above never
+/// reaches (it has no `kappa` block).
+#[test]
+fn saem_iov_ofv_is_independent_of_thread_count() {
+    let ofv_1 = run_saem_iov_with_threads(1);
+    let ofv_4 = run_saem_iov_with_threads(4);
+    let ofv_15 = run_saem_iov_with_threads(15);
+    assert_bit_identical_across_threads("SAEM IOV", ofv_1, ofv_4, ofv_15);
 }
 
 fn run_impmap_with_threads(n: usize) -> f64 {

--- a/tests/thread_count_determinism.rs
+++ b/tests/thread_count_determinism.rs
@@ -12,6 +12,12 @@
 //!
 //! `FitOptions::threads` runs the whole fit inside a scoped rayon pool of the
 //! requested size, so this exercises the exact user-facing knob from the issue.
+//!
+//! Three tests cover the three estimators this PR patched: FOCEI
+//! (`foce_population_nll`/`_iov` in `src/stats/likelihood.rs`), SAEM
+//! (`obs_nll_sum`/`_iov` and `theta_sigma_mstep_light` in
+//! `src/estimation/saem.rs`), and IMPMAP (`theta_sigma_weighted_mstep` in
+//! `src/estimation/impmap.rs`).
 
 use std::path::Path;
 
@@ -63,4 +69,81 @@ fn focei_ofv_is_independent_of_thread_count() {
         ofv_15.to_bits(),
         "OFV differs between 1 and 15 threads: {ofv_1} vs {ofv_15}"
     );
+}
+
+fn assert_bit_identical_across_threads(label: &str, ofv_1: f64, ofv_4: f64, ofv_15: f64) {
+    assert!(
+        ofv_1.is_finite(),
+        "{label}: OFV must be finite, got {ofv_1}"
+    );
+    assert_eq!(
+        ofv_1.to_bits(),
+        ofv_4.to_bits(),
+        "{label}: OFV differs between 1 and 4 threads: {ofv_1} vs {ofv_4}"
+    );
+    assert_eq!(
+        ofv_1.to_bits(),
+        ofv_15.to_bits(),
+        "{label}: OFV differs between 1 and 15 threads: {ofv_1} vs {ofv_15}"
+    );
+}
+
+fn run_saem_with_threads(n: usize) -> f64 {
+    let (model, population) = warfarin();
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Saem;
+    // Small, fixed-length exploration/convergence phases (no adaptive stop) —
+    // mirrors the fast SAEM setup in tests/importance_sampling_api.rs.
+    opts.saem_n_exploration = 5;
+    opts.saem_n_convergence = 5;
+    opts.saem_seed = Some(267);
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+    opts.threads = Some(n);
+    let result =
+        fit(&model, &population, &model.default_params, &opts).expect("SAEM fit must succeed");
+    result.ofv
+}
+
+/// SAEM routes its M-step objective/gradient through `obs_nll_sum` and
+/// `theta_sigma_mstep_light` (`src/estimation/saem.rs`), one of the sites this
+/// PR patched. Same bit-identical-OFV check as the FOCEI test above, so a
+/// regression in the SAEM-side fix fails here even if the FOCEI path stays
+/// correct.
+#[test]
+fn saem_ofv_is_independent_of_thread_count() {
+    let ofv_1 = run_saem_with_threads(1);
+    let ofv_4 = run_saem_with_threads(4);
+    let ofv_15 = run_saem_with_threads(15);
+    assert_bit_identical_across_threads("SAEM", ofv_1, ofv_4, ofv_15);
+}
+
+fn run_impmap_with_threads(n: usize) -> f64 {
+    let (model, population) = warfarin();
+    let mut opts = FitOptions::default();
+    opts.method = EstimationMethod::Impmap;
+    // Aggressively capped — wire-up/determinism check, not convergence quality
+    // (mirrors tests/impmap_api.rs's fast Tier-2 setup).
+    opts.impmap_iterations = 3;
+    opts.impmap_samples = 50;
+    opts.impmap_averaging = 2;
+    opts.impmap_seed = Some(7);
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+    opts.threads = Some(n);
+    let result =
+        fit(&model, &population, &model.default_params, &opts).expect("IMPMAP fit must succeed");
+    result.ofv
+}
+
+/// IMPMAP's weighted M-step objective (`theta_sigma_weighted_mstep` in
+/// `src/estimation/impmap.rs`) is the third site this PR patched. Same
+/// bit-identical-OFV check, seeded so the importance-sampling draws
+/// themselves are reproducible independent of thread count.
+#[test]
+fn impmap_ofv_is_independent_of_thread_count() {
+    let ofv_1 = run_impmap_with_threads(1);
+    let ofv_4 = run_impmap_with_threads(4);
+    let ofv_15 = run_impmap_with_threads(15);
+    assert_bit_identical_across_threads("IMPMAP", ofv_1, ofv_4, ofv_15);
 }


### PR DESCRIPTION
## Why

Reported in #703: the same FOCEI fit gave **different OFVs at different thread counts** (6031.6 with 4 threads vs 6005.7 with 15 threads on the pembrolizumab model066). A fit must be reproducible regardless of how many rayon workers run it.

Root cause: the population objective summed the per-subject log-likelihood with a rayon **parallel** reduction:

```rust
population.subjects.par_iter().enumerate().map(|(i, s)| foce_subject_nll(..)).sum::<f64>()
```

Rayon splits the reduction tree along boundaries set by the worker count, and f64 addition is not associative — so the summed OFV differs by a few ULPs between 4 and 15 threads. Each per-subject NLL is deterministic; only the *grouping of the sum* leaked the thread count. In a non-converged run (both reported fits hit `converged: false` at maxiter), those ULP differences steer BOBYQA down divergent trajectories, giving visibly different OFVs and estimates.

## What changed

Collect each subject's contribution into an ordered `Vec` and reduce **serially**. The expensive per-subject work stays parallel; only the final reduction is pinned to subject order. Sites fixed:

- `src/stats/likelihood.rs` — `foce_population_nll`, `foce_population_nll_iov` (the FOCE/FOCEI OFV)
- `src/estimation/saem.rs` — `obs_nll_sum`, `obs_nll_sum_iov`, and two M-step `reduce()` calls (nll + gradient)
- `src/estimation/impmap.rs` — the IMP optimizer objective closure

The gradient path, inner EBE loop, Gauss-Newton, covariance score matrix, and the SAEM MH sampler already used order-preserving `.collect()` (per-subject RNG is seeded by subject index, not worker), so they were already thread-count-independent — no change needed there.

## Alternatives considered

A pairwise / Kahan compensated parallel sum would reduce error but still isn't bit-stable across thread counts. Serial reduction of pre-collected per-subject values is exactly deterministic and the per-subject compute (the actual cost) stays parallel, so the wall-clock impact is negligible (one `Vec<f64>` of length n_subjects per objective eval).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API or output-field change.

## Breaking changes
- [x] None

## Numerical validation
- [x] New regression test `tests/thread_count_determinism.rs`: the same warfarin FOCEI fit under **1, 4, and 15** worker threads (`FitOptions::threads`) now produces a **bit-identical OFV** (`f64::to_bits` equality). Fails on `main` (thread-dependent OFV), passes with this fix.
- [x] `cargo test --lib` — 2209 passed, 0 failed.

## Performance
- [x] No significant impact expected (parallel per-subject compute unchanged; only the reduction is serialized over n_subjects values).

## Tests
- [x] Regression test added that fails without this fix (`tests/thread_count_determinism.rs`)
- [x] `cargo test --lib` passes

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added
- [x] No user-facing API/DSL change (behaviour is now *more* correct: reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)