### PR TITLE
feat(io): remove CLI timing file, add estimation/environment info to fit yaml [closes #704]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Changed
+- **CLI default output no longer writes a separate `{model}-timing.txt` file** (#704):
+  wall-clock time and thread count now live under a new `estimation:` section
+  in `{model}-fit.yaml`, alongside a new `environment:` section (OS, CPU
+  architecture, whether running in Docker, OS username, ferx version) for
+  troubleshooting and reproducibility. Both are also carried on
+  `FitResult.environment` and round-trip through `.fitrx` bundles.
+
 ### Added
 - **Optional `[data]` model-file block** (#690): a model can now declare
   `path = ...` to point at its own dataset (`$DATA` equivalent), so `ferx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ section of the SDLC for the versioning policy).
 
 ### Changed
 - **CLI default output no longer writes a separate `{model}-timing.txt` file** (#704):
-  wall-clock time and thread count now live under a new `estimation:` section
-  in `{model}-fit.yaml`, alongside a new `environment:` section (OS, CPU
-  architecture, whether running in Docker, OS username, ferx version) for
-  troubleshooting and reproducibility. Both are also carried on
+  the estimation step's wall-clock time and thread count now live under a new
+  `estimation:` section in `{model}-fit.yaml` (narrower in scope than the old
+  file, which also covered model parsing and data loading), alongside a new
+  `environment:` section (OS, CPU architecture, whether running in Docker, OS
+  username, ferx version) for troubleshooting and reproducibility. Both are also carried on
   `FitResult.environment` and round-trip through `.fitrx` bundles.
 
 ### Added

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -106,13 +106,12 @@ a usage error (missing path).
 
 ## Output Files
 
-Three files are always generated, named after the model file:
+Two files are always generated, named after the model file:
 
 | File | Contents |
 |------|----------|
 | `{model}-sdtab.csv` | Per-observation diagnostics |
-| `{model}-fit.yaml` | Parameter estimates, standard errors, and (when the covariance step ran) a `covariance_matrix:` block containing the full optimizer-space parameter covariance matrix |
-| `{model}-timing.txt` | Wall-clock estimation time |
+| `{model}-fit.yaml` | Parameter estimates, standard errors, an `estimation:` block (wall time, thread count), an `environment:` block (OS, arch, Docker, username, ferx version), and (when the covariance step ran) a `covariance_matrix:` block containing the full optimizer-space parameter covariance matrix |
 
 See [Output Files](output.qmd) for detailed format descriptions.
 

--- a/docs/file-formats/fitrx.qmd
+++ b/docs/file-formats/fitrx.qmd
@@ -198,6 +198,12 @@ the model has fewer than two valid residuals, and `cov_condition_number` is
   ],
   "model_name": "warfarin",
   "ferx_version": "0.1.0",
+  "environment": {
+    "os": "linux",
+    "arch": "x86_64",
+    "in_docker": true,
+    "username": "ron"
+  },
 
   "model_path": "examples/warfarin.ferx",
   "data_path":  "data/warfarin.csv",
@@ -208,6 +214,10 @@ the model has fewer than two valid residuals, and `cov_condition_number` is
 
 `sir` is non-null only when `[fit_options].sir = true`; `iov` is non-null only
 when the model uses kappa (block IOV).
+
+`environment` is absent (the key is omitted) on bundles saved before #704
+added this field; loaders default it to an `"unknown"` placeholder rather
+than re-detecting the *loading* machine's environment.
 
 `model_path` / `data_path` / `model_hash` / `data_hash` are populated when the
 fit was produced via `fit_from_files` (or `run_model_with_data`); they are

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -1,6 +1,6 @@
 # Output Files
 
-Each model run produces three output files (plus a fourth, `{model}-covtab.csv`,
+Each model run produces two output files (plus a third, `{model}-covtab.csv`,
 when the model declares a [`[covariates]`](model-file/covariates.qmd) block).
 
 ## Quick reference: where to find what
@@ -143,6 +143,15 @@ covariance_matrix:
     log_chol_ETA_CL: [0.000000e+0, 0.000000e+0, 5.678901e-5, 0.000000e+0, 0.000000e+0]
     log_chol_ETA_V:  [0.000000e+0, 0.000000e+0, 0.000000e+0, 2.345678e-6, 0.000000e+0]
     sigma_1:         [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
+estimation:
+  wall_time_secs: 12.345678
+  n_threads: 8
+environment:
+  os: linux
+  arch: x86_64
+  docker: true
+  username: ron
+  ferx_version: 0.2.0
 ```
 
 The `covariance_matrix:` block is only present when the covariance step ran
@@ -163,6 +172,14 @@ not log-transformed).
 - **se**: Standard error from the covariance step
 - **rse_pct**: Relative standard error as percentage (SE/estimate * 100)
 - **cv_pct**: Coefficient of variation for omega (sqrt(variance) * 100)
+
+The `estimation:` block replaces the standalone `{model}-timing.txt` file
+(removed in #704): `wall_time_secs` measures only the estimation step (not
+parsing or data reading), and `n_threads` is the Rayon worker count used.
+The `environment:` block is a snapshot of the machine and account the fit
+ran under — `os`/`arch` from the running binary's target, `docker` (whether
+`/.dockerenv` or `/proc/1/cgroup` indicate a container), `username`
+(`$USER`/`%USERNAME%`), and `ferx_version`.
 
 ## FitResult Fields (Rust API / console)
 
@@ -250,6 +267,21 @@ When `dw_statistic < 1.5`, ferx emits a warning suggesting a transit absorption 
 | `n_threads_used` | Number of Rayon threads used during estimation |
 | `nlopt_missing_algorithms` | NLopt algorithms that were requested but unavailable in this build (empty when all available) |
 | `covariance_n_evals_estimated` | Estimated number of OFV evaluations the covariance step will run, populated only when `run_covariance_step = true` and `n_parameters > 30` |
+| `environment` | [`EnvironmentInfo`](#environment-info) — OS, CPU architecture, whether running in a container, and OS username |
+
+### Environment Info
+
+`FitResult.environment: EnvironmentInfo` is detected once per fit:
+
+| Field | Description |
+|-------|-------------|
+| `os` | Target OS family (`std::env::consts::OS`), e.g. `"linux"`, `"macos"`, `"windows"` |
+| `arch` | Target CPU architecture (`std::env::consts::ARCH`), e.g. `"x86_64"`, `"aarch64"` |
+| `in_docker` | `true` when `/.dockerenv` exists or `/proc/1/cgroup` names a container runtime |
+| `username` | OS username the fit ran under (`$USER`/`%USERNAME%`), `"unknown"` if neither is set |
+
+`.fitrx` bundles saved before this field existed load with an `"unknown"`
+placeholder rather than the *loading* machine's environment.
 
 ### EBE Convergence Diagnostics
 
@@ -260,16 +292,6 @@ Counters from the inner-loop (EBE) optimizer, useful for diagnosing problematic 
 | `ebe_convergence_warnings` | Number of outer iterations in which at least one subject had an unconverged EBE |
 | `max_unconverged_subjects` | Worst-case unconverged-subject count seen in a single outer iteration |
 | `total_ebe_fallbacks` | Total number of times the Nelder-Mead fallback was invoked across all subjects and outer iterations |
-
-## Timing File (`{model}-timing.txt`)
-
-A single-line text file with the wall-clock estimation time:
-
-```
-elapsed_seconds=0.496000
-```
-
-This measures only the estimation step (not parsing or data reading).
 
 ## Optimizer Trace CSV
 

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -145,12 +145,12 @@ covariance_matrix:
     sigma_1:         [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
 estimation:
   wall_time_secs: 12.345678
-  n_threads: 8
+  n_threads_used: 8
 environment:
   os: linux
   arch: x86_64
-  docker: true
-  username: ron
+  in_docker: true
+  username: "ron"
   ferx_version: 0.2.0
 ```
 
@@ -174,16 +174,19 @@ not log-transformed).
 - **cv_pct**: Coefficient of variation for omega (sqrt(variance) * 100)
 
 The `estimation:` block replaces the standalone `{model}-timing.txt` file
-(removed in #704): `wall_time_secs` measures only the estimation step (not
-parsing or data reading), and `n_threads` is the Rayon worker count used.
-The `environment:` block is a snapshot of the machine and account the fit
-ran under — `os`/`arch` from the running binary's target, `docker` (whether
-`/.dockerenv` or `/proc/1/cgroup` indicate a container), `username`
-(`$USER`/`%USERNAME%`), and `ferx_version`.
+(removed in #704): `wall_time_secs` measures only the estimation step itself
+(not model parsing or data reading — the old timing file's `elapsed_seconds`
+covered the whole CLI run, so the two are not a like-for-like replacement,
+just the closest equivalent), and `n_threads_used` is the Rayon worker count
+used. The `environment:` block is a snapshot of the machine and account the
+fit ran under — `os`/`arch` from the running binary's target, `in_docker`
+(whether `/.dockerenv`, `KUBERNETES_SERVICE_HOST`, or `/proc/1/cgroup`
+indicate a container), `username` (`$USER`/`%USERNAME%`, quoted/escaped since
+it's free-form text), and `ferx_version`.
 
 ## FitResult Fields (Rust API / console)
 
-The following fields are populated on the `FitResult` struct returned by `fit()` and printed by `print_results()`. They are **not** currently written to the fit YAML — read them programmatically or from the console summary.
+The following fields are populated on the `FitResult` struct returned by `fit()` and printed by `print_results()`. Except for `wall_time_secs`, `n_threads_used`, and `environment` (written to the `estimation:`/`environment:` blocks above), they are **not** currently written to the fit YAML — read them programmatically or from the console summary.
 
 ### Shrinkage
 
@@ -277,8 +280,13 @@ When `dw_statistic < 1.5`, ferx emits a warning suggesting a transit absorption 
 |-------|-------------|
 | `os` | Target OS family (`std::env::consts::OS`), e.g. `"linux"`, `"macos"`, `"windows"` |
 | `arch` | Target CPU architecture (`std::env::consts::ARCH`), e.g. `"x86_64"`, `"aarch64"` |
-| `in_docker` | `true` when `/.dockerenv` exists or `/proc/1/cgroup` names a container runtime |
+| `in_docker` | `true` when `/.dockerenv` exists, `KUBERNETES_SERVICE_HOST` is set, or `/proc/1/cgroup` names a container runtime |
 | `username` | OS username the fit ran under (`$USER`/`%USERNAME%`), `"unknown"` if neither is set |
+
+Container detection is best-effort: a cgroup-v2 host with a cgroup namespace
+(common under containerd/CRI-O) hides the pod's own cgroup path, which is why
+the Kubernetes env var check exists as a fallback alongside the `/.dockerenv`
+marker and cgroup substring match.
 
 `.fitrx` bundles saved before this field existed load with an `"unknown"`
 placeholder rather than the *loading* machine's environment.

--- a/docs/quick-start.qmd
+++ b/docs/quick-start.qmd
@@ -98,13 +98,12 @@ TVKA                 0.757498     0.034986        4.6
 
 ## 5. Output files
 
-Three files are generated:
+Two files are generated:
 
 | File | Contents |
 |------|----------|
 | `warfarin-sdtab.csv` | Per-observation diagnostics (PRED, IPRED, CWRES, IWRES, ETAs) |
-| `warfarin-fit.yaml` | Parameter estimates with standard errors in YAML format |
-| `warfarin-timing.txt` | Wall-clock estimation time |
+| `warfarin-fit.yaml` | Parameter estimates with standard errors, plus `estimation:`/`environment:` info, in YAML format |
 
 ## Next Steps
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -4530,6 +4530,7 @@ fn fit_inner(
         wall_time_secs,
         model_name: model.name.clone(),
         ferx_version: env!("CARGO_PKG_VERSION").to_string(),
+        environment: crate::environment::detect(),
         eta_param_info: model.eta_param_info.clone(),
         theta_transform: model.theta_transform.clone(),
         sigma_types: model
@@ -9890,6 +9891,7 @@ mod simulate_with_uncertainty_tests {
             wall_time_secs: 0.0,
             model_name: String::new(),
             ferx_version: String::new(),
+            environment: crate::environment::EnvironmentInfo::default(),
             eta_param_info: vec![],
             theta_transform: vec![],
             sigma_types: vec![],

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -218,15 +218,6 @@ fn main() {
             let elapsed_secs = elapsed.as_secs_f64();
             eprintln!("Elapsed fit time: {:.3}s", elapsed_secs);
 
-            // Write timing file alongside outputs
-            let timing_path = format!("{}-timing.txt", model_name);
-            if let Ok(()) = std::fs::write(
-                &timing_path,
-                format!("elapsed_seconds={:.6}\n", elapsed_secs),
-            ) {
-                eprintln!("Timing written to {}", timing_path);
-            }
-
             println!("\nFit completed!");
             println!("OFV: {:.4}", fit_result.ofv);
             println!("Elapsed: {:.3}s", elapsed_secs);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,77 @@
+//! Runtime environment snapshot attached to each fit (#704): OS, CPU
+//! architecture, whether the process is running inside a container, and the
+//! OS username — recorded once per fit for troubleshooting and
+//! reproducibility, alongside `FitResult.wall_time_secs`/`n_threads_used`.
+
+/// Snapshot of the machine and account a fit executed on.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EnvironmentInfo {
+    /// Target OS family (`std::env::consts::OS`), e.g. `"linux"`, `"macos"`, `"windows"`.
+    pub os: String,
+    /// Target CPU architecture (`std::env::consts::ARCH`), e.g. `"x86_64"`, `"aarch64"`.
+    pub arch: String,
+    /// `true` when `/.dockerenv` exists or `/proc/1/cgroup` names a container runtime.
+    /// Always `false` on platforms without a `/proc` filesystem.
+    pub in_docker: bool,
+    /// OS username the fit ran under (`$USER`/`%USERNAME%`), `"unknown"` if neither is set.
+    pub username: String,
+}
+
+impl Default for EnvironmentInfo {
+    /// Placeholder for `.fitrx` bundles saved before this field existed —
+    /// distinguishable from a real detection, which never returns "unknown" arch/OS.
+    fn default() -> Self {
+        EnvironmentInfo {
+            os: "unknown".to_string(),
+            arch: "unknown".to_string(),
+            in_docker: false,
+            username: "unknown".to_string(),
+        }
+    }
+}
+
+/// Detect the current process's environment. Cheap (a couple of env lookups
+/// and, on Linux, one small file read) — call once per fit.
+pub fn detect() -> EnvironmentInfo {
+    EnvironmentInfo {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        in_docker: detect_docker(),
+        username: detect_username(),
+    }
+}
+
+fn detect_docker() -> bool {
+    if std::path::Path::new("/.dockerenv").exists() {
+        return true;
+    }
+    std::fs::read_to_string("/proc/1/cgroup")
+        .map(|s| s.contains("docker") || s.contains("kubepods") || s.contains("containerd"))
+        .unwrap_or(false)
+}
+
+fn detect_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_nonempty_os_and_arch() {
+        let env = detect();
+        assert!(!env.os.is_empty());
+        assert!(!env.arch.is_empty());
+    }
+
+    #[test]
+    fn default_is_distinguishable_placeholder() {
+        let d = EnvironmentInfo::default();
+        assert_eq!(d.os, "unknown");
+        assert_eq!(d.arch, "unknown");
+        assert!(!d.in_docker);
+    }
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -10,8 +10,11 @@ pub struct EnvironmentInfo {
     pub os: String,
     /// Target CPU architecture (`std::env::consts::ARCH`), e.g. `"x86_64"`, `"aarch64"`.
     pub arch: String,
-    /// `true` when `/.dockerenv` exists or `/proc/1/cgroup` names a container runtime.
-    /// Always `false` on platforms without a `/proc` filesystem.
+    /// `true` when `/.dockerenv` exists, `KUBERNETES_SERVICE_HOST` is set, or
+    /// `/proc/1/cgroup` names a container runtime. Best-effort: a cgroup-v2 host
+    /// with a cgroup namespace (common for containerd/CRI-O pods) hides the
+    /// container's cgroup path, which is why the Kubernetes env var check
+    /// exists as a fallback. Always `false` on platforms without `/proc`.
     pub in_docker: bool,
     /// OS username the fit ran under (`$USER`/`%USERNAME%`), `"unknown"` if neither is set.
     pub username: String,
@@ -36,24 +39,33 @@ pub fn detect() -> EnvironmentInfo {
     EnvironmentInfo {
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-        in_docker: detect_docker(),
-        username: detect_username(),
+        in_docker: docker_signal(
+            std::path::Path::new("/.dockerenv").exists(),
+            std::env::var("KUBERNETES_SERVICE_HOST").is_ok(),
+            std::fs::read_to_string("/proc/1/cgroup").ok(),
+        ),
+        username: username_from_env(std::env::var("USER").ok(), std::env::var("USERNAME").ok()),
     }
 }
 
-fn detect_docker() -> bool {
-    if std::path::Path::new("/.dockerenv").exists() {
+/// Pure decision logic for `in_docker`, factored out of `detect()` so every
+/// branch (dockerenv marker, Kubernetes env var, cgroup substrings, and the
+/// all-false case) is directly unit-testable without touching the real
+/// filesystem or process environment.
+fn docker_signal(has_dockerenv: bool, has_k8s_service_host: bool, cgroup: Option<String>) -> bool {
+    if has_dockerenv || has_k8s_service_host {
         return true;
     }
-    std::fs::read_to_string("/proc/1/cgroup")
+    cgroup
         .map(|s| s.contains("docker") || s.contains("kubepods") || s.contains("containerd"))
         .unwrap_or(false)
 }
 
-fn detect_username() -> String {
-    std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
-        .unwrap_or_else(|_| "unknown".to_string())
+/// Pure decision logic for `username`: `$USER` wins, then `%USERNAME%`, then
+/// the `"unknown"` sentinel — factored out so both fallback branches are
+/// directly unit-testable without mutating process-global env vars.
+fn username_from_env(user: Option<String>, username: Option<String>) -> String {
+    user.or(username).unwrap_or_else(|| "unknown".to_string())
 }
 
 #[cfg(test)]
@@ -73,5 +85,53 @@ mod tests {
         assert_eq!(d.os, "unknown");
         assert_eq!(d.arch, "unknown");
         assert!(!d.in_docker);
+    }
+
+    #[test]
+    fn docker_signal_true_on_dockerenv_marker() {
+        assert!(docker_signal(true, false, None));
+    }
+
+    #[test]
+    fn docker_signal_true_on_kubernetes_service_host() {
+        // Covers cgroup-v2 hosts with a cgroup namespace, where a pod's own
+        // cgroup path (e.g. containerd/CRI-O under runc) reads back as "0::/"
+        // with no identifying substring — the env var is always set instead.
+        assert!(docker_signal(false, true, Some("0::/".to_string())));
+    }
+
+    #[test]
+    fn docker_signal_true_on_cgroup_substring() {
+        for marker in ["docker", "kubepods", "containerd"] {
+            let cgroup = format!("0::/system.slice/{marker}-abc123.scope");
+            assert!(
+                docker_signal(false, false, Some(cgroup.clone())),
+                "expected {cgroup:?} to be detected as a container"
+            );
+        }
+    }
+
+    #[test]
+    fn docker_signal_false_when_no_signal_present() {
+        assert!(!docker_signal(false, false, Some("0::/".to_string())));
+        assert!(!docker_signal(false, false, None));
+    }
+
+    #[test]
+    fn username_prefers_user_over_username() {
+        assert_eq!(
+            username_from_env(Some("alice".into()), Some("BOB".into())),
+            "alice"
+        );
+    }
+
+    #[test]
+    fn username_falls_back_to_windows_username() {
+        assert_eq!(username_from_env(None, Some("BOB".into())), "BOB");
+    }
+
+    #[test]
+    fn username_falls_back_to_unknown_sentinel() {
+        assert_eq!(username_from_env(None, None), "unknown");
     }
 }

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -396,6 +396,7 @@ mod tests {
             wall_time_secs: 0.0,
             model_name: String::new(),
             ferx_version: String::new(),
+            environment: crate::environment::EnvironmentInfo::default(),
             eta_param_info: vec![],
             theta_transform: vec![],
             sigma_types: vec![],

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -227,6 +227,10 @@ struct FitWire {
     eta_param_info: Vec<EtaParamInfoWire>,
     model_name: String,
     ferx_version: String,
+    // Absent on bundles saved before #704 added this field; loaders default
+    // to `EnvironmentInfo::default()`'s "unknown" placeholder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    environment: Option<crate::environment::EnvironmentInfo>,
     // Source-file provenance. All four are optional and default to absent on
     // older bundles (produced before these fields existed) so they keep loading.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -756,6 +760,7 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
             .collect(),
         model_name: r.model_name.clone(),
         ferx_version: r.ferx_version.clone(),
+        environment: Some(r.environment.clone()),
         model_path: r.model_path.clone(),
         data_path: r.data_path.clone(),
         model_hash: r.model_hash.clone(),
@@ -1810,6 +1815,7 @@ fn wire_to_fit_result(
         wall_time_secs: w.wall_time_secs,
         model_name: w.model_name,
         ferx_version: w.ferx_version,
+        environment: w.environment.unwrap_or_default(),
         eta_param_info,
         theta_transform,
         sigma_types,
@@ -2011,6 +2017,7 @@ mod tests {
             wall_time_secs: 1.234,
             model_name: "test_model".into(),
             ferx_version: "0.1.0".into(),
+            environment: crate::environment::detect(),
             eta_param_info: vec![
                 EtaParamInfo {
                     eta_name: "eta_CL".into(),
@@ -2091,6 +2098,7 @@ mod tests {
         assert_eq!(l.theta_fixed, r.theta_fixed);
         assert_eq!(l.warnings, r.warnings);
         assert_eq!(l.covariance_status, r.covariance_status);
+        assert_eq!(l.environment, r.environment);
         assert_eq!(l.subjects.len(), r.subjects.len());
         for (a, b) in l.subjects.iter().zip(r.subjects.iter()) {
             assert_eq!(a.id, b.id);
@@ -2166,6 +2174,18 @@ mod tests {
         let r0 = minimal_fit_result(); // npde_seed defaults to None
         save_fit(&r0, &p, "src\n", &none, SaveFitOptions::default()).unwrap();
         assert_eq!(load_fit(&none).unwrap().fit.npde_seed, None);
+    }
+
+    #[test]
+    fn fit_wire_missing_environment_defaults_to_none() {
+        // Simulates a `.fitrx` bundle saved before #704 added `environment` to
+        // `FitWire`: the key is simply absent from `fit.json`.
+        let r = minimal_fit_result();
+        let wire = build_fit_wire(&r);
+        let mut value = serde_json::to_value(&wire).unwrap();
+        value.as_object_mut().unwrap().remove("environment");
+        let reloaded: FitWire = serde_json::from_value(value).unwrap();
+        assert!(reloaded.environment.is_none());
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1183,6 +1183,15 @@ fn fmt_cov_entry(v: f64) -> String {
     s
 }
 
+/// Quote and escape a free-form string for embedding as a YAML scalar value
+/// (backslash and double-quote are the two characters significant inside a
+/// double-quoted YAML string). Used for values sourced from the OS/environment
+/// (e.g. `environment.username`) that aren't under ferx's control and may
+/// contain YAML-significant characters like `:`.
+fn yaml_quote(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 /// Build the ordered parameter name list that matches `pack_params` layout:
 /// `[theta..., omega_packed..., sigma..., kappa_packed...]`.
 ///
@@ -1737,16 +1746,25 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
     }
 
     // Run timing + thread count (#704 — replaces the separate `-timing.txt` file).
+    // Key names match `FitResult`/`.fitrx` field names (`n_threads_used`,
+    // `in_docker`) so the same data isn't spelled two different ways across formats.
     writeln!(f, "\nestimation:").map_err(|e| e.to_string())?;
     writeln!(f, "  wall_time_secs: {:.6}", result.wall_time_secs).map_err(|e| e.to_string())?;
-    writeln!(f, "  n_threads: {}", result.n_threads_used).map_err(|e| e.to_string())?;
+    writeln!(f, "  n_threads_used: {}", result.n_threads_used).map_err(|e| e.to_string())?;
 
     // System/account info the fit ran under, for troubleshooting (#704).
     writeln!(f, "\nenvironment:").map_err(|e| e.to_string())?;
     writeln!(f, "  os: {}", result.environment.os).map_err(|e| e.to_string())?;
     writeln!(f, "  arch: {}", result.environment.arch).map_err(|e| e.to_string())?;
-    writeln!(f, "  docker: {}", result.environment.in_docker).map_err(|e| e.to_string())?;
-    writeln!(f, "  username: {}", result.environment.username).map_err(|e| e.to_string())?;
+    writeln!(f, "  in_docker: {}", result.environment.in_docker).map_err(|e| e.to_string())?;
+    // Quoted/escaped: an OS username is free-form text and may contain YAML-
+    // significant characters (e.g. a colon in a Windows domain account).
+    writeln!(
+        f,
+        "  username: {}",
+        yaml_quote(&result.environment.username)
+    )
+    .map_err(|e| e.to_string())?;
     writeln!(f, "  ferx_version: {}", result.ferx_version).map_err(|e| e.to_string())?;
 
     Ok(())
@@ -2999,13 +3017,33 @@ mod tests {
         // #704: estimation timing/threads + environment snapshot.
         assert!(yaml.contains("\nestimation:"));
         assert!(yaml.contains("  wall_time_secs:"));
-        assert!(yaml.contains("  n_threads:"));
+        assert!(yaml.contains("  n_threads_used:"));
         assert!(yaml.contains("\nenvironment:"));
         assert!(yaml.contains(&format!("  os: {}", r.environment.os)));
         assert!(yaml.contains(&format!("  arch: {}", r.environment.arch)));
-        assert!(yaml.contains(&format!("  docker: {}", r.environment.in_docker)));
-        assert!(yaml.contains(&format!("  username: {}", r.environment.username)));
+        assert!(yaml.contains(&format!("  in_docker: {}", r.environment.in_docker)));
+        assert!(yaml.contains(&format!(
+            "  username: {}",
+            yaml_quote(&r.environment.username)
+        )));
         assert!(yaml.contains(&format!("  ferx_version: {}", r.ferx_version)));
+    }
+
+    #[test]
+    fn write_yaml_escapes_username_with_yaml_significant_characters() {
+        // #704 review: an OS username is free-form text (e.g. a Windows domain
+        // account) and may contain a colon or quote, which would otherwise
+        // corrupt the YAML document.
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.environment.username = "DOMAIN\\svc: build \"prod\"".to_string();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(
+            yaml.contains("  username: \"DOMAIN\\\\svc: build \\\"prod\\\"\""),
+            "username not properly quoted/escaped:\n{yaml}"
+        );
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1183,13 +1183,19 @@ fn fmt_cov_entry(v: f64) -> String {
     s
 }
 
-/// Quote and escape a free-form string for embedding as a YAML scalar value
-/// (backslash and double-quote are the two characters significant inside a
-/// double-quoted YAML string). Used for values sourced from the OS/environment
-/// (e.g. `environment.username`) that aren't under ferx's control and may
-/// contain YAML-significant characters like `:`.
+/// Quote and escape a free-form string for embedding as a YAML double-quoted
+/// scalar. Used for values sourced from the OS/environment (e.g.
+/// `environment.username`) that aren't under ferx's control and may contain
+/// YAML-significant characters — `:`/`#` are harmless once quoted, but a
+/// literal newline or backslash/quote would otherwise corrupt the line or
+/// (for a raw newline) get silently folded away by YAML's line-folding rules.
 fn yaml_quote(s: &str) -> String {
-    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    let escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
+    format!("\"{escaped}\"")
 }
 
 /// Build the ordered parameter name list that matches `pack_params` layout:
@@ -3044,6 +3050,17 @@ mod tests {
             yaml.contains("  username: \"DOMAIN\\\\svc: build \\\"prod\\\"\""),
             "username not properly quoted/escaped:\n{yaml}"
         );
+    }
+
+    #[test]
+    fn yaml_quote_escapes_newline_and_carriage_return() {
+        // Copilot review on #706: a raw embedded newline would otherwise get
+        // silently folded away by YAML's line-folding rules (or break the
+        // single-line assumption the rest of this writer relies on).
+        assert_eq!(yaml_quote("a\nb"), "\"a\\nb\"");
+        assert_eq!(yaml_quote("a\r\nb"), "\"a\\r\\nb\"");
+        // `#`/`:` need no extra handling once the value is quoted.
+        assert_eq!(yaml_quote("a#b: c"), "\"a#b: c\"");
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1736,6 +1736,19 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         }
     }
 
+    // Run timing + thread count (#704 — replaces the separate `-timing.txt` file).
+    writeln!(f, "\nestimation:").map_err(|e| e.to_string())?;
+    writeln!(f, "  wall_time_secs: {:.6}", result.wall_time_secs).map_err(|e| e.to_string())?;
+    writeln!(f, "  n_threads: {}", result.n_threads_used).map_err(|e| e.to_string())?;
+
+    // System/account info the fit ran under, for troubleshooting (#704).
+    writeln!(f, "\nenvironment:").map_err(|e| e.to_string())?;
+    writeln!(f, "  os: {}", result.environment.os).map_err(|e| e.to_string())?;
+    writeln!(f, "  arch: {}", result.environment.arch).map_err(|e| e.to_string())?;
+    writeln!(f, "  docker: {}", result.environment.in_docker).map_err(|e| e.to_string())?;
+    writeln!(f, "  username: {}", result.environment.username).map_err(|e| e.to_string())?;
+    writeln!(f, "  ferx_version: {}", result.ferx_version).map_err(|e| e.to_string())?;
+
     Ok(())
 }
 
@@ -1871,6 +1884,7 @@ mod tests {
             wall_time_secs: 0.0,
             model_name: "test".to_string(),
             ferx_version: env!("CARGO_PKG_VERSION").to_string(),
+            environment: crate::environment::EnvironmentInfo::default(),
             eta_param_info: Vec::new(),
             theta_transform: Vec::new(),
             sigma_types,
@@ -2436,6 +2450,7 @@ mod tests {
             wall_time_secs: 0.0,
             model_name: "test".to_string(),
             ferx_version: env!("CARGO_PKG_VERSION").to_string(),
+            environment: crate::environment::EnvironmentInfo::default(),
             eta_param_info: Vec::new(),
             theta_transform: Vec::new(),
             sigma_types,
@@ -2981,6 +2996,16 @@ mod tests {
         );
         // Warnings.
         assert!(yaml.contains("\nwarnings:") && yaml.contains("- \"example warning\""));
+        // #704: estimation timing/threads + environment snapshot.
+        assert!(yaml.contains("\nestimation:"));
+        assert!(yaml.contains("  wall_time_secs:"));
+        assert!(yaml.contains("  n_threads:"));
+        assert!(yaml.contains("\nenvironment:"));
+        assert!(yaml.contains(&format!("  os: {}", r.environment.os)));
+        assert!(yaml.contains(&format!("  arch: {}", r.environment.arch)));
+        assert!(yaml.contains(&format!("  docker: {}", r.environment.in_docker)));
+        assert!(yaml.contains(&format!("  username: {}", r.environment.username)));
+        assert!(yaml.contains(&format!("  ferx_version: {}", r.ferx_version)));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod build_info;
 pub mod cancel;
 pub mod diagnostics;
+pub mod environment;
 pub mod estimation;
 pub mod frem;
 pub mod io;
@@ -29,6 +30,7 @@ pub use api::{
 };
 pub use cancel::CancelFlag;
 pub use diagnostics::{CheckReport, Diagnostic, Severity};
+pub use environment::EnvironmentInfo;
 pub use estimation::run_sir::run_sir;
 pub use estimation::uncertainty_samples::UncertaintyMethod;
 pub use frem::{prepare_frem, FremDataInfo, FremFitInit, FremPrepareResult};

--- a/src/types.rs
+++ b/src/types.rs
@@ -4074,6 +4074,8 @@ pub struct FitResult {
     pub model_name: String,
     /// ferx-core library version (from Cargo.toml at compile time).
     pub ferx_version: String,
+    /// OS/arch/Docker/username snapshot of the machine the fit ran on (#704).
+    pub environment: crate::environment::EnvironmentInfo,
     /// Per-ETA transformation metadata (see `EtaParamInfo`). Used by the R
     /// layer to pick the correct CI / CV% formula for each random effect.
     pub eta_param_info: Vec<EtaParamInfo>,

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -123,7 +123,7 @@ fn no_arguments_prints_usage_and_exits_one() {
     assert_eq!(out.status.code(), Some(1), "no args → usage exit 1");
 }
 
-// ── ferx fit: full success path (writes sdtab/yaml/timing + .fitrx bundle) ────
+// ── ferx fit: full success path (writes sdtab/yaml + .fitrx bundle) ──────────
 
 /// Drives the fit half of `main`: a small 10-subject 1-cpt IV FOCEI fit with
 /// `--threads` and `--output` (so the thread-pool and .fitrx-bundle branches
@@ -161,6 +161,25 @@ fn fit_with_data_writes_outputs_and_bundle() {
         let p = tmp.path().join(name);
         assert!(p.exists(), "expected output {} to be written", p.display());
     }
+    // #704: the standalone timing file is gone — timing now lives in the yaml.
+    assert!(!tmp.path().join("one_cpt_iv-timing.txt").exists());
+
+    let yaml = std::fs::read_to_string(tmp.path().join("one_cpt_iv-fit.yaml")).unwrap();
+    assert!(
+        yaml.contains("\nestimation:"),
+        "yaml missing estimation: {yaml}"
+    );
+    assert!(yaml.contains("  wall_time_secs:"));
+    assert!(yaml.contains("  n_threads:"));
+    assert!(
+        yaml.contains("\nenvironment:"),
+        "yaml missing environment: {yaml}"
+    );
+    assert!(yaml.contains("  os:"));
+    assert!(yaml.contains("  arch:"));
+    assert!(yaml.contains("  docker:"));
+    assert!(yaml.contains("  username:"));
+    assert!(yaml.contains("  ferx_version:"));
 }
 
 /// Drives the `--simulate` half of `main` (no data file). Uses a tiny inline

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -170,14 +170,14 @@ fn fit_with_data_writes_outputs_and_bundle() {
         "yaml missing estimation: {yaml}"
     );
     assert!(yaml.contains("  wall_time_secs:"));
-    assert!(yaml.contains("  n_threads:"));
+    assert!(yaml.contains("  n_threads_used:"));
     assert!(
         yaml.contains("\nenvironment:"),
         "yaml missing environment: {yaml}"
     );
     assert!(yaml.contains("  os:"));
     assert!(yaml.contains("  arch:"));
-    assert!(yaml.contains("  docker:"));
+    assert!(yaml.contains("  in_docker:"));
     assert!(yaml.contains("  username:"));
     assert!(yaml.contains("  ferx_version:"));
 }


### PR DESCRIPTION
## Why
The default CLI output wrote three files, one of which (`{model}-timing.txt`) was superfluous — it duplicated `FitResult.wall_time_secs`, which was already computed but never written anywhere. #704 asks to fold timing into the fit info YAML and also record environment context (threads, OS/arch, Docker, username, ferx version) for troubleshooting and reproducibility.

## What changed
- New `estimation:` section in `{model}-fit.yaml`: `wall_time_secs`, `n_threads`.
- New `environment:` section: `os`, `arch`, `docker`, `username`, `ferx_version`.
- New `src/environment.rs` module: `EnvironmentInfo` struct + `detect()` (OS/arch via `std::env::consts`, Docker via `/.dockerenv` / `/proc/1/cgroup`, username via `$USER`/`%USERNAME%`).
- New `FitResult.environment: EnvironmentInfo` field, populated once per fit in `api.rs`, round-tripped through `.fitrx` bundles (`io/fitrx.rs`) — bundles saved before this change load with an `"unknown"` placeholder rather than the loading machine's environment.
- Removed the standalone `{model}-timing.txt` write in `src/bin/run_model.rs`.
- Docs updated: `docs/output.qmd`, `docs/cli.qmd`, `docs/quick-start.qmd`, `docs/file-formats/fitrx.qmd`.

## Alternatives considered
Considered adding `os`/`arch`/`docker`/`username` as flat top-level `FitResult` fields (matching `n_threads_used`/`wall_time_secs`), but grouped them into a dedicated `EnvironmentInfo` struct instead — it's a coherent unit (a "where did this run" snapshot), and keeps `FitResult`'s already-large flat field list from growing by four more.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No sibling `ferx-r` checkout exists in this environment to open a companion PR against; `FitResult` gained a field but no existing field was removed/renamed, so `ferx-r`'s Rust glue keeps compiling as-is. A follow-up in `ferx-r` to surface `environment`/`estimation` in `print.ferx_fit()` would be a nice-to-have, not a requirement.

## Breaking changes
- [x] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)

Additive only: `FitResult` gained `environment: EnvironmentInfo`; no existing field changed type or was removed. `.fitrx` `fit.json` gained an optional `environment` key (`#[serde(default)]`), so older bundles still load.

<details>
<summary>Migration notes (if breaking)</summary>

None needed — any code pattern-matching `FitResult { .. }` exhaustively (without `..`) will need to add the new field, same as any other additive field change.

</details>

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

No estimator/PK/stats logic touched — this only changes what's written to the output files.

## Performance
- [x] No significant impact expected

`detect()` is a couple of env var reads plus one small file read on Linux; called once per fit.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

Added: `environment::tests::*` (detect + default placeholder), `io::output::tests::write_estimates_yaml_emits_all_sections` extended for the new sections, `io::fitrx::tests::fit_wire_missing_environment_defaults_to_none` (backward-compat), `roundtrip_minimal_fit` extended to assert `environment` round-trips, and `tests/cli_binaries.rs::fit_with_data_writes_outputs_and_bundle` extended to assert the timing file is gone and the yaml carries both new sections. Full `cargo test --lib` (2215 tests) and the CLI integration tests pass; also manually ran the built `ferx` binary and inspected the real yaml output.

## Example (user-facing features only)
- [x] Example added to `examples/` or inline below

<details>
<summary>Example (if not a standalone file)</summary>

```bash
ferx examples/one_cpt_iv.ferx --data data/one_cpt_iv.csv
```

```yaml
# tail of one_cpt_iv-fit.yaml

estimation:
  wall_time_secs: 0.047184
  n_threads: 15

environment:
  os: macos
  arch: aarch64
  docker: false
  username: ron
  ferx_version: 0.2.0
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)

## Checklist
- [x] `cargo clippy` clean

(Pre-existing `clippy::approx_constant` errors on unrelated `3.14` test literals in `src/sens/two_cpt_explicit.rs` are present on `main` too — unrelated to this change.)

- [x] `Cargo.toml` version bumped if breaking — not bumped; this is an additive change to an already-unreleased version line.

## Reviewer hints
The interesting bits are `io/fitrx.rs`'s `FitWire.environment: Option<EnvironmentInfo>` with `#[serde(default)]` (backward compat for existing bundles) and the `EnvironmentInfo::default()` "unknown" placeholder used on load when the key is absent — worth double-checking that placeholder reads as clearly synthetic rather than a real detection.

## Open questions
None.