### PR TITLE
fix(estimation): bound ODE inner-loop NM-fallback budget instead of skipping it [closes #708]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ section of the SDLC for the versioning policy).
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
 ### Fixed
+- **A pathological (stiff/time-varying) ODE subject no longer stalls a FOCEI fit for an
+  extended period on one core** (#708). The inner-loop start-rejection guard that hard-rejects
+  a subject with a catastrophically bad warm-started NLL before running BFGS/Nelder-Mead
+  fallback was previously ODE+IOV-only; it now applies to any ODE model, so a plain (non-IOV)
+  ODE subject stuck in a pathological region (e.g. a stiff time-varying-clearance term) is
+  caught immediately instead of repeatedly re-solving the same expensive ODE via the BFGS +
+  Nelder-Mead fallback on every outer iteration.
 - **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
   SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel
   reduction whose grouping depended on the number of rayon threads; because floating-point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ section of the SDLC for the versioning policy).
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
 ### Fixed
+- **A pathological ODE subject (e.g. a stiff time-varying-clearance term) no longer stalls a
+  FOCEI fit for many minutes on a handful of cores** (#708). A bad L-BFGS line-search trial
+  point can make the per-subject ODE genuinely expensive to integrate for several subjects at
+  once; the inner-loop Nelder-Mead fallback (`argmin_inner_fallback`) was re-solving that same
+  expensive ODE up to `max_iter * 5` times per subject per outer iteration trying to recover,
+  for no benefit. The fallback's NM-restart budget is now bounded (not removed) for any ODE
+  model — cut from `max_iter * 5` to `max_iter` — capping the pathological case's cost at a
+  fifth while still giving the common (non-pathological) BFGS near-miss a chance to recover, so
+  the outer optimizer keeps making progress instead of stalling or (an earlier attempt) needing
+  the whole trial rejected.
 - **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
   SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel
   reduction whose grouping depended on the number of rayon threads; because floating-point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,6 @@ section of the SDLC for the versioning policy).
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
 ### Fixed
-- **A pathological (stiff/time-varying) ODE subject no longer stalls a FOCEI fit for an
-  extended period on one core** (#708). The inner-loop start-rejection guard that hard-rejects
-  a subject with a catastrophically bad warm-started NLL before running BFGS/Nelder-Mead
-  fallback was previously ODE+IOV-only; it now applies to any ODE model, so a plain (non-IOV)
-  ODE subject stuck in a pathological region (e.g. a stiff time-varying-clearance term) is
-  caught immediately instead of repeatedly re-solving the same expensive ODE via the BFGS +
-  Nelder-Mead fallback on every outer iteration.
 - **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
   SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel
   reduction whose grouping depended on the number of rayon threads; because floating-point

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -459,6 +459,11 @@ pub struct InnerLoopStats {
 /// for non-IOV, `[μ, 0…]` for IOV — the historical reset point). Exactly **one** NM solve
 /// runs, so enabling `ebe_warm_start` is never slower than leaving it off.
 ///
+/// `nm_iter_multiplier` scales `max_iter` into the NM restart's iteration budget (historically
+/// a fixed `5`; see [`ode_nm_fallback_multiplier`] for why #708 made it variable). A `0`
+/// multiplier skips the NM restart entirely and returns the BFGS partial unconditionally
+/// (`nm_ok = false`) without ever calling `obj` again.
+///
 /// Returns `(eta, nm_converged)`. The **value** is the lower-objective of the BFGS partial
 /// and the NM restart — the substantive #555 fix: the previous code overwrote `eta` with the
 /// NM restart unconditionally, discarding a correct partial that BFGS had reached but not
@@ -473,16 +478,20 @@ fn argmin_inner_fallback(
     n: usize,
     max_iter: usize,
     tol: f64,
+    nm_iter_multiplier: usize,
 ) -> (Vec<f64>, bool) {
     let partial_f = obj(partial);
     let partial_usable = partial_f.is_finite();
+    if nm_iter_multiplier == 0 {
+        return (partial.to_vec(), false);
+    }
     let warm = ebe_warm_start_enabled() && partial_usable;
     let mut eta_nm = if warm {
         partial.to_vec()
     } else {
         cold_seed.to_vec()
     };
-    let nm_ok = nelder_mead_minimize(obj, &mut eta_nm, n, max_iter * 5, tol);
+    let nm_ok = nelder_mead_minimize(obj, &mut eta_nm, n, max_iter * nm_iter_multiplier, tol);
     let f_nm = obj(&eta_nm);
     // Keep the partial unless NM is *strictly* better. Written as a positive comparison so a
     // non-finite `f_nm` (NM diverged) leaves `nm_strictly_better = false` and the finite
@@ -498,35 +507,56 @@ fn argmin_inner_fallback(
 
 /// An ODE-based model that also carries IOV (`κ`) random effects. The inner EBE path for
 /// these models is the expensive one this module special-cases (per-vertex ODE +
-/// steady-state work), so both the Nelder-Mead skip and the start-rejection gate key off
-/// this single classifier (#603 review #8).
+/// steady-state work), so the start-rejection gate keys off this classifier (#603 review #8).
 fn is_ode_iov(model: &CompiledModel) -> bool {
     model.ode_spec.is_some() && model.n_kappa > 0
 }
 
-/// Nelder-Mead is a useful last-resort recovery for low-dimensional closed-form EBEs, but
-/// it is not a practical recovery strategy for ODE+IOV. A single bad outer line-search
-/// point can otherwise launch simplex searches where each vertex is a full ODE and
-/// steady-state prediction. Keep the BFGS partial and report the subject unconverged
-/// instead; the outer EBE guard can then reject the trial.
-fn skip_ode_iov_nm_fallback(model: &CompiledModel) -> bool {
-    is_ode_iov(model)
+/// `argmin_inner_fallback`'s NM-restart iteration multiplier for `model`, keyed on how
+/// expensive a per-vertex re-solve is:
+///
+/// - **ODE+IOV → 0 (full skip).** A single bad outer line-search point can launch simplex
+///   searches where each vertex is a full ODE *and* steady-state prediction (#603 review #8) —
+///   the most expensive per-vertex case, so recovery isn't worth it and the BFGS partial is
+///   kept as-is.
+/// - **plain ODE → 1 (bounded, not skipped).** #708: profiling a real reproduction
+///   (pembrolizumab model066) traced its stall to *many* plain-ODE subjects simultaneously
+///   stuck in `find_ebe → argmin_inner_fallback → nelder_mead_minimize`, each burning the
+///   historical `max_iter * 5` budget, at a bad L-BFGS line-search trial point (not near the
+///   true optimum). But a **full skip** for plain ODE was tried and regressed badly on the
+///   same model: `argmin_inner_fallback` also re-certifies the common #555 case (BFGS is
+///   actually fine but fails the strict `gnorm < tol` test on the solver's noise floor) —
+///   skipping it entirely turned that into a permanent `unconverged`, which tripped
+///   `ebe_guard_rejects`'s `max_unconverged_frac` fraction trigger on nearly every trial and
+///   the outer optimizer never took a step. A **bounded** restart (`max_iter`, not
+///   `max_iter * 5`) still gives that cheap re-certification a chance while capping the
+///   pathological case's cost at 1/5th.
+/// - **not an ODE model → 5 (unchanged).** `argmin_inner_fallback` is only ever reached when
+///   `enable_stall` (`model.ode_spec.is_some()`) is true, so this arm is unreachable today;
+///   kept as the historical default in case that gate ever loosens.
+fn ode_nm_fallback_multiplier(model: &CompiledModel) -> usize {
+    if is_ode_iov(model) {
+        0
+    } else if model.ode_spec.is_some() {
+        1
+    } else {
+        5
+    }
 }
 
 const ODE_IOV_START_REJECT_NLL_PER_OBS: f64 = 250.0;
 const ODE_IOV_START_REJECT_NLL_MIN: f64 = 1_000.0;
 
-/// **ODE+IOV-only, deliberately not generalized further** — a #708 investigation tried
-/// widening this to every ODE model (a plain ODE subject can be just as pathologically
-/// stuck), but this guard's `hard_reject` forces the outer EBE guard to treat the *whole
-/// trial* as infeasible (`ebe_guard_rejects`), not merely this subject as unconverged. For
-/// ODE+IOV a catastrophic warm-started NLL reliably means true pathology (e.g. steady-state
-/// blow-up), so that's safe. For a plain ODE subject a large individual NLL can be a
-/// legitimate feature of the data near the true optimum — hard-rejecting the trial then
-/// steers the outer optimizer away from the correct region, which regressed OFV by ~100
-/// units vs. NONMEM on a real pembrolizumab reproduction. Any future #708 fix needs to bound
-/// the wasted per-subject solve cost without changing which θ region the optimizer is
-/// willing to explore (e.g. a solver-level bail, not a trial-level reject).
+/// **ODE+IOV-only, deliberately not generalized further** (#603 review #1/#2). A #708
+/// investigation tried widening this to every ODE model, but `hard_reject` forces the outer
+/// EBE guard to treat the *whole trial* as infeasible (`ebe_guard_rejects`), not merely this
+/// subject as unconverged. For ODE+IOV a catastrophic warm-started NLL reliably means true
+/// pathology (e.g. steady-state blow-up), so that's safe. For a plain ODE subject a large
+/// individual NLL can be a legitimate feature of the data near the true optimum — hard-
+/// rejecting the trial then steers the outer optimizer away from the correct region, which
+/// regressed OFV by ~100 units vs. NONMEM on a real pembrolizumab reproduction. See
+/// [`ode_nm_fallback_multiplier`] for the generalized (safe, bounded-not-skipped) guard
+/// instead.
 fn reject_ode_iov_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
     if !is_ode_iov(model) {
         return false;
@@ -780,7 +810,15 @@ pub fn find_ebe(
         let partial = eta.clone();
         let cold = vec![0.0; n_eta];
         if enable_stall {
-            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol);
+            let (best, ok) = argmin_inner_fallback(
+                &obj,
+                &partial,
+                &cold,
+                n_eta,
+                max_iter,
+                tol,
+                ode_nm_fallback_multiplier(model),
+            );
             eta = best;
             (ok, true)
         } else {
@@ -1034,10 +1072,16 @@ fn find_ebe_iov(
         let partial = x.clone();
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
-        if skip_ode_iov_nm_fallback(model) {
-            (false, false)
-        } else if enable_stall {
-            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
+        if enable_stall {
+            let (best, ok) = argmin_inner_fallback(
+                &obj,
+                &partial,
+                &cold,
+                n_flat,
+                max_iter,
+                tol,
+                ode_nm_fallback_multiplier(model),
+            );
             x = best;
             (ok, true)
         } else {
@@ -4591,18 +4635,18 @@ mod iov_tests {
         // Partial in the deep (global) well, cold NM seed in the shallow well: the fallback
         // keeps the lower-objective partial rather than overwriting with the shallow NM
         // result (the old behaviour, which on this multimodal objective inflated the OFV).
-        let (eta, _) = argmin_inner_fallback(&obj, &[-2.0], &[2.0], 1, 200, 1e-8);
+        let (eta, _) = argmin_inner_fallback(&obj, &[-2.0], &[2.0], 1, 200, 1e-8, 5);
         assert!((eta[0] + 2.0).abs() < 1e-2, "kept deep well, got {eta:?}");
 
         // Partial in the shallow well, cold NM seed reaches the deep well: NM wins.
-        let (eta2, _) = argmin_inner_fallback(&obj, &[2.0], &[-2.0], 1, 200, 1e-8);
+        let (eta2, _) = argmin_inner_fallback(&obj, &[2.0], &[-2.0], 1, 200, 1e-8, 5);
         assert!(
             (eta2[0] + 2.0).abs() < 1e-2,
             "NM found deeper well, got {eta2:?}"
         );
 
         // Non-finite partial objective → unusable → NM result is taken.
-        let (eta3, _) = argmin_inner_fallback(&obj, &[f64::NAN], &[-2.0], 1, 200, 1e-8);
+        let (eta3, _) = argmin_inner_fallback(&obj, &[f64::NAN], &[-2.0], 1, 200, 1e-8, 5);
         assert!(
             eta3[0].is_finite(),
             "NaN partial must be discarded, got {eta3:?}"
@@ -4611,7 +4655,7 @@ mod iov_tests {
         // `ebe_warm_start` seeds the single NM from the partial (covers the warm branch):
         // from the deep well it stays there even though the cold seed is far away.
         set_ebe_warm_start(true);
-        let (eta4, _) = argmin_inner_fallback(&obj, &[-2.0], &[5.0], 1, 200, 1e-8);
+        let (eta4, _) = argmin_inner_fallback(&obj, &[-2.0], &[5.0], 1, 200, 1e-8, 5);
         assert!(
             (eta4[0] + 2.0).abs() < 1e-2,
             "warm seed held the deep well, got {eta4:?}"
@@ -4626,10 +4670,48 @@ mod iov_tests {
             "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  kappa KAPPA_CL ~ 0.01\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n  iov_column = OCC\n",
         )
         .expect("parse ODE IOV");
-        assert!(skip_ode_iov_nm_fallback(&ode_iov));
+        assert_eq!(ode_nm_fallback_multiplier(&ode_iov), 0);
 
         let closed_form_iov = make_iov_model();
-        assert!(!skip_ode_iov_nm_fallback(&closed_form_iov));
+        assert_eq!(ode_nm_fallback_multiplier(&closed_form_iov), 5);
+    }
+
+    /// #708: profiling a real reproduction (pembrolizumab model066) showed multiple plain
+    /// (non-IOV) ODE subjects simultaneously stuck in `find_ebe -> argmin_inner_fallback ->
+    /// nelder_mead_minimize`, each burning the historical `max_iter * 5` budget, at a bad
+    /// L-BFGS line-search trial point. A full skip (mirroring ODE+IOV) was tried and
+    /// regressed badly (the outer optimizer never took a step, see
+    /// `ode_nm_fallback_multiplier`'s doc) — the fix is a bounded, not zero, multiplier.
+    #[test]
+    fn ode_non_iov_bounds_nelder_mead_inner_fallback() {
+        use crate::parser::model_parser::parse_model_string;
+        let plain_ode = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
+        )
+        .expect("parse plain ODE");
+        assert_eq!(ode_nm_fallback_multiplier(&plain_ode), 1);
+
+        let closed_form = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
+        )
+        .expect("parse closed-form model");
+        assert_eq!(ode_nm_fallback_multiplier(&closed_form), 5);
+    }
+
+    /// `nm_iter_multiplier = 0` returns the BFGS partial unconditionally, with no NM restart
+    /// (only the single `obj(partial)` call every path takes to check finiteness).
+    #[test]
+    fn argmin_inner_fallback_zero_multiplier_skips_nm_entirely() {
+        use std::cell::Cell;
+        let calls = Cell::new(0);
+        let obj = |x: &[f64]| -> f64 {
+            calls.set(calls.get() + 1);
+            x[0] * x[0]
+        };
+        let (eta, nm_converged) = argmin_inner_fallback(&obj, &[3.0], &[0.0], 1, 200, 1e-8, 0);
+        assert_eq!(eta, vec![3.0], "multiplier=0 must return the partial as-is");
+        assert!(!nm_converged);
+        assert_eq!(calls.get(), 1, "multiplier=0 must not run any NM restart");
     }
 
     #[test]

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -426,14 +426,11 @@ pub struct EbeResult {
     /// `iov_occasion_groups`).
     pub kappas: Vec<DVector<f64>>,
     /// True when the subject was hard-rejected at its inner start (a pathological
-    /// ODE warm-start NLL — see [`reject_ode_inner_start`]). The returned
+    /// ODE+IOV warm-start NLL — see [`reject_ode_iov_inner_start`]). The returned
     /// `eta`/`h_matrix` are then a degenerate placeholder (off-mode η, zero H), so the
     /// outer loop must reject the whole trial rather than fold them into an accepted
     /// OFV. Unlike plain non-convergence this forces rejection regardless of
-    /// `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2; generalized
-    /// from ODE+IOV-only to any ODE model in #708 — a plain ODE subject stuck in a
-    /// stiff/pathological region is caught here instead of paying the full inner-loop
-    /// retry budget on every outer iteration).
+    /// `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
     pub hard_reject: bool,
 }
 
@@ -444,7 +441,7 @@ pub struct InnerLoopStats {
     pub n_unconverged: usize,
     /// Subjects for which the BFGS→Nelder-Mead fallback was triggered.
     pub n_fallback: usize,
-    /// Subjects hard-rejected at their inner start (pathological ODE warm-start
+    /// Subjects hard-rejected at their inner start (pathological ODE+IOV warm-start
     /// NLL). Any non-zero count forces the outer EBE guard to reject the trial,
     /// regardless of `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
     pub n_start_rejected: usize,
@@ -501,7 +498,8 @@ fn argmin_inner_fallback(
 
 /// An ODE-based model that also carries IOV (`κ`) random effects. The inner EBE path for
 /// these models is the expensive one this module special-cases (per-vertex ODE +
-/// steady-state work), so the Nelder-Mead skip keys off this classifier (#603 review #8).
+/// steady-state work), so both the Nelder-Mead skip and the start-rejection gate key off
+/// this single classifier (#603 review #8).
 fn is_ode_iov(model: &CompiledModel) -> bool {
     model.ode_spec.is_some() && model.n_kappa > 0
 }
@@ -515,27 +513,29 @@ fn skip_ode_iov_nm_fallback(model: &CompiledModel) -> bool {
     is_ode_iov(model)
 }
 
-const ODE_START_REJECT_NLL_PER_OBS: f64 = 250.0;
-const ODE_START_REJECT_NLL_MIN: f64 = 1_000.0;
+const ODE_IOV_START_REJECT_NLL_PER_OBS: f64 = 250.0;
+const ODE_IOV_START_REJECT_NLL_MIN: f64 = 1_000.0;
 
-/// Hard-reject a subject's inner search before it ever runs BFGS/Nelder-Mead, when its
-/// (informative) warm-started NLL is already catastrophically bad. Originally ODE+IOV-only
-/// (#603 review #1/#2); generalized to every ODE model in #708 — a plain (non-IOV) ODE
-/// subject can land in an equally pathological region (e.g. a stiff time-varying-CL term)
-/// where BFGS repeatedly fails and the `argmin_inner_fallback` NM restart re-solves the same
-/// expensive ODE `max_iter * 5` times per outer iteration for no benefit, since a warm start
-/// already this bad is not a point the fallback recovers a useful mode from. The threshold is
-/// deliberately extreme (unreachable for a subject that is merely slow to converge) so it
-/// only catches genuinely diverged starts, not ordinary non-convergence.
-fn reject_ode_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
-    if model.ode_spec.is_none() {
+/// **ODE+IOV-only, deliberately not generalized further** — a #708 investigation tried
+/// widening this to every ODE model (a plain ODE subject can be just as pathologically
+/// stuck), but this guard's `hard_reject` forces the outer EBE guard to treat the *whole
+/// trial* as infeasible (`ebe_guard_rejects`), not merely this subject as unconverged. For
+/// ODE+IOV a catastrophic warm-started NLL reliably means true pathology (e.g. steady-state
+/// blow-up), so that's safe. For a plain ODE subject a large individual NLL can be a
+/// legitimate feature of the data near the true optimum — hard-rejecting the trial then
+/// steers the outer optimizer away from the correct region, which regressed OFV by ~100
+/// units vs. NONMEM on a real pembrolizumab reproduction. Any future #708 fix needs to bound
+/// the wasted per-subject solve cost without changing which θ region the optimizer is
+/// willing to explore (e.g. a solver-level bail, not a trial-level reject).
+fn reject_ode_iov_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
+    if !is_ode_iov(model) {
         return false;
     }
     if !nll.is_finite() {
         return true;
     }
     let threshold =
-        ODE_START_REJECT_NLL_MIN.max(ODE_START_REJECT_NLL_PER_OBS * n_obs.max(1) as f64);
+        ODE_IOV_START_REJECT_NLL_MIN.max(ODE_IOV_START_REJECT_NLL_PER_OBS * n_obs.max(1) as f64);
     nll > threshold
 }
 
@@ -701,32 +701,6 @@ pub fn find_ebe(
             schedule.as_ref(),
         )
     };
-
-    // Hard-reject before ever running BFGS/NM when a warm-started ODE subject is already
-    // catastrophically bad (#708): a stiff/pathological subject stuck in this region would
-    // otherwise pay a full BFGS + `argmin_inner_fallback` NM-restart re-solve of the same
-    // expensive ODE every outer iteration for no benefit. Gated on an *informative* warm
-    // start so a cold-start (iteration 1) subject is never hard-rejected before it has had a
-    // chance to converge. Generalizes the ODE+IOV-only guard (#603 review #1/#2) to any ODE
-    // model — see [`reject_ode_inner_start`].
-    let has_informative_warm_start = eta_init
-        .map(|warm| warm.iter().any(|v| v.abs() > 1e-8))
-        .unwrap_or(false);
-    if has_informative_warm_start {
-        let start_nll = obj(&eta);
-        if reject_ode_inner_start(model, subject.obs_times.len(), start_nll) {
-            return EbeResult {
-                eta: DVector::from_column_slice(&eta),
-                h_matrix: DMatrix::zeros(subject.obs_times.len(), n_eta),
-                converged: false,
-                used_fallback: false,
-                grad_norm: 0.0,
-                nll: start_nll,
-                kappas: Vec::new(),
-                hard_reject: true,
-            };
-        }
-    }
 
     // BFGS with the exact analytic η-gradient from the sensitivity provider when
     // in scope (Almquist et al. 2015): one provider evaluation per inner step
@@ -1014,7 +988,7 @@ fn find_ebe_iov(
         .map(|warm| warm.iter().any(|v| v.abs() > 1e-8))
         .unwrap_or(false);
     if has_informative_warm_start
-        && reject_ode_inner_start(model, subject.obs_times.len(), start_nll)
+        && reject_ode_iov_inner_start(model, subject.obs_times.len(), start_nll)
     {
         let bsv_eta: Vec<f64> = x[..n_eta]
             .iter()
@@ -4659,7 +4633,7 @@ mod iov_tests {
     }
 
     #[test]
-    fn ode_iov_start_rejects_only_pathological_ode_nll() {
+    fn ode_iov_start_rejects_only_pathological_ode_iov_nll() {
         use crate::parser::model_parser::parse_model_string;
         let ode_iov = parse_model_string(
             "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  kappa KAPPA_CL ~ 0.01\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n  iov_column = OCC\n",
@@ -4667,35 +4641,16 @@ mod iov_tests {
         .expect("parse ODE IOV");
         let closed_form_iov = make_iov_model();
 
-        assert!(!reject_ode_inner_start(&ode_iov, 4, 999.0));
-        assert!(reject_ode_inner_start(&ode_iov, 4, 1_001.0));
-        assert!(!reject_ode_inner_start(&ode_iov, 20, 4_999.0));
-        assert!(reject_ode_inner_start(&ode_iov, 20, 5_001.0));
-        assert!(reject_ode_inner_start(&ode_iov, 20, f64::NAN));
-        assert!(!reject_ode_inner_start(&closed_form_iov, 4, 1_000_000.0));
-    }
-
-    /// #708: the start-reject guard was ODE+IOV-only; a plain (non-IOV) ODE subject that
-    /// lands on an equally pathological warm start (e.g. a stiff time-varying-CL region)
-    /// deserves the same early hard-reject instead of paying a full BFGS + NM-fallback
-    /// re-solve of the expensive ODE every outer iteration.
-    #[test]
-    fn ode_non_iov_start_rejects_only_pathological_nll() {
-        use crate::parser::model_parser::parse_model_string;
-        let plain_ode = parse_model_string(
-            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
-        )
-        .expect("parse plain ODE");
-        let closed_form = parse_model_string(
-            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
-        )
-        .expect("parse closed-form model");
-
-        assert!(!reject_ode_inner_start(&plain_ode, 4, 999.0));
-        assert!(reject_ode_inner_start(&plain_ode, 4, 1_001.0));
-        assert!(reject_ode_inner_start(&plain_ode, 20, f64::NAN));
-        // Never fires for a non-ODE (closed-form) model, however bad the NLL.
-        assert!(!reject_ode_inner_start(&closed_form, 4, 1_000_000.0));
+        assert!(!reject_ode_iov_inner_start(&ode_iov, 4, 999.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 4, 1_001.0));
+        assert!(!reject_ode_iov_inner_start(&ode_iov, 20, 4_999.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 20, 5_001.0));
+        assert!(reject_ode_iov_inner_start(&ode_iov, 20, f64::NAN));
+        assert!(!reject_ode_iov_inner_start(
+            &closed_form_iov,
+            4,
+            1_000_000.0
+        ));
     }
 
     /// Closed-form IOV + `iiv_on_ruv` (#4b): the analytic stacked-η inner gradient

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -426,11 +426,14 @@ pub struct EbeResult {
     /// `iov_occasion_groups`).
     pub kappas: Vec<DVector<f64>>,
     /// True when the subject was hard-rejected at its inner start (a pathological
-    /// ODE+IOV warm-start NLL — see [`reject_ode_iov_inner_start`]). The returned
+    /// ODE warm-start NLL — see [`reject_ode_inner_start`]). The returned
     /// `eta`/`h_matrix` are then a degenerate placeholder (off-mode η, zero H), so the
     /// outer loop must reject the whole trial rather than fold them into an accepted
     /// OFV. Unlike plain non-convergence this forces rejection regardless of
-    /// `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
+    /// `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2; generalized
+    /// from ODE+IOV-only to any ODE model in #708 — a plain ODE subject stuck in a
+    /// stiff/pathological region is caught here instead of paying the full inner-loop
+    /// retry budget on every outer iteration).
     pub hard_reject: bool,
 }
 
@@ -441,7 +444,7 @@ pub struct InnerLoopStats {
     pub n_unconverged: usize,
     /// Subjects for which the BFGS→Nelder-Mead fallback was triggered.
     pub n_fallback: usize,
-    /// Subjects hard-rejected at their inner start (pathological ODE+IOV warm-start
+    /// Subjects hard-rejected at their inner start (pathological ODE warm-start
     /// NLL). Any non-zero count forces the outer EBE guard to reject the trial,
     /// regardless of `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
     pub n_start_rejected: usize,
@@ -498,8 +501,7 @@ fn argmin_inner_fallback(
 
 /// An ODE-based model that also carries IOV (`κ`) random effects. The inner EBE path for
 /// these models is the expensive one this module special-cases (per-vertex ODE +
-/// steady-state work), so both the Nelder-Mead skip and the start-rejection gate key off
-/// this single classifier (#603 review #8).
+/// steady-state work), so the Nelder-Mead skip keys off this classifier (#603 review #8).
 fn is_ode_iov(model: &CompiledModel) -> bool {
     model.ode_spec.is_some() && model.n_kappa > 0
 }
@@ -513,18 +515,27 @@ fn skip_ode_iov_nm_fallback(model: &CompiledModel) -> bool {
     is_ode_iov(model)
 }
 
-const ODE_IOV_START_REJECT_NLL_PER_OBS: f64 = 250.0;
-const ODE_IOV_START_REJECT_NLL_MIN: f64 = 1_000.0;
+const ODE_START_REJECT_NLL_PER_OBS: f64 = 250.0;
+const ODE_START_REJECT_NLL_MIN: f64 = 1_000.0;
 
-fn reject_ode_iov_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
-    if !is_ode_iov(model) {
+/// Hard-reject a subject's inner search before it ever runs BFGS/Nelder-Mead, when its
+/// (informative) warm-started NLL is already catastrophically bad. Originally ODE+IOV-only
+/// (#603 review #1/#2); generalized to every ODE model in #708 — a plain (non-IOV) ODE
+/// subject can land in an equally pathological region (e.g. a stiff time-varying-CL term)
+/// where BFGS repeatedly fails and the `argmin_inner_fallback` NM restart re-solves the same
+/// expensive ODE `max_iter * 5` times per outer iteration for no benefit, since a warm start
+/// already this bad is not a point the fallback recovers a useful mode from. The threshold is
+/// deliberately extreme (unreachable for a subject that is merely slow to converge) so it
+/// only catches genuinely diverged starts, not ordinary non-convergence.
+fn reject_ode_inner_start(model: &CompiledModel, n_obs: usize, nll: f64) -> bool {
+    if model.ode_spec.is_none() {
         return false;
     }
     if !nll.is_finite() {
         return true;
     }
     let threshold =
-        ODE_IOV_START_REJECT_NLL_MIN.max(ODE_IOV_START_REJECT_NLL_PER_OBS * n_obs.max(1) as f64);
+        ODE_START_REJECT_NLL_MIN.max(ODE_START_REJECT_NLL_PER_OBS * n_obs.max(1) as f64);
     nll > threshold
 }
 
@@ -690,6 +701,32 @@ pub fn find_ebe(
             schedule.as_ref(),
         )
     };
+
+    // Hard-reject before ever running BFGS/NM when a warm-started ODE subject is already
+    // catastrophically bad (#708): a stiff/pathological subject stuck in this region would
+    // otherwise pay a full BFGS + `argmin_inner_fallback` NM-restart re-solve of the same
+    // expensive ODE every outer iteration for no benefit. Gated on an *informative* warm
+    // start so a cold-start (iteration 1) subject is never hard-rejected before it has had a
+    // chance to converge. Generalizes the ODE+IOV-only guard (#603 review #1/#2) to any ODE
+    // model — see [`reject_ode_inner_start`].
+    let has_informative_warm_start = eta_init
+        .map(|warm| warm.iter().any(|v| v.abs() > 1e-8))
+        .unwrap_or(false);
+    if has_informative_warm_start {
+        let start_nll = obj(&eta);
+        if reject_ode_inner_start(model, subject.obs_times.len(), start_nll) {
+            return EbeResult {
+                eta: DVector::from_column_slice(&eta),
+                h_matrix: DMatrix::zeros(subject.obs_times.len(), n_eta),
+                converged: false,
+                used_fallback: false,
+                grad_norm: 0.0,
+                nll: start_nll,
+                kappas: Vec::new(),
+                hard_reject: true,
+            };
+        }
+    }
 
     // BFGS with the exact analytic η-gradient from the sensitivity provider when
     // in scope (Almquist et al. 2015): one provider evaluation per inner step
@@ -977,7 +1014,7 @@ fn find_ebe_iov(
         .map(|warm| warm.iter().any(|v| v.abs() > 1e-8))
         .unwrap_or(false);
     if has_informative_warm_start
-        && reject_ode_iov_inner_start(model, subject.obs_times.len(), start_nll)
+        && reject_ode_inner_start(model, subject.obs_times.len(), start_nll)
     {
         let bsv_eta: Vec<f64> = x[..n_eta]
             .iter()
@@ -4622,7 +4659,7 @@ mod iov_tests {
     }
 
     #[test]
-    fn ode_iov_start_rejects_only_pathological_ode_iov_nll() {
+    fn ode_iov_start_rejects_only_pathological_ode_nll() {
         use crate::parser::model_parser::parse_model_string;
         let ode_iov = parse_model_string(
             "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  kappa KAPPA_CL ~ 0.01\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n  iov_column = OCC\n",
@@ -4630,16 +4667,35 @@ mod iov_tests {
         .expect("parse ODE IOV");
         let closed_form_iov = make_iov_model();
 
-        assert!(!reject_ode_iov_inner_start(&ode_iov, 4, 999.0));
-        assert!(reject_ode_iov_inner_start(&ode_iov, 4, 1_001.0));
-        assert!(!reject_ode_iov_inner_start(&ode_iov, 20, 4_999.0));
-        assert!(reject_ode_iov_inner_start(&ode_iov, 20, 5_001.0));
-        assert!(reject_ode_iov_inner_start(&ode_iov, 20, f64::NAN));
-        assert!(!reject_ode_iov_inner_start(
-            &closed_form_iov,
-            4,
-            1_000_000.0
-        ));
+        assert!(!reject_ode_inner_start(&ode_iov, 4, 999.0));
+        assert!(reject_ode_inner_start(&ode_iov, 4, 1_001.0));
+        assert!(!reject_ode_inner_start(&ode_iov, 20, 4_999.0));
+        assert!(reject_ode_inner_start(&ode_iov, 20, 5_001.0));
+        assert!(reject_ode_inner_start(&ode_iov, 20, f64::NAN));
+        assert!(!reject_ode_inner_start(&closed_form_iov, 4, 1_000_000.0));
+    }
+
+    /// #708: the start-reject guard was ODE+IOV-only; a plain (non-IOV) ODE subject that
+    /// lands on an equally pathological warm start (e.g. a stiff time-varying-CL region)
+    /// deserves the same early hard-reject instead of paying a full BFGS + NM-fallback
+    /// re-solve of the expensive ODE every outer iteration.
+    #[test]
+    fn ode_non_iov_start_rejects_only_pathological_nll() {
+        use crate::parser::model_parser::parse_model_string;
+        let plain_ode = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  ode(states=[central])\n[odes]\n  d/dt(central) = -(CL/V) * central\n[scaling]\n  y = central / V\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
+        )
+        .expect("parse plain ODE");
+        let closed_form = parse_model_string(
+            "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
+        )
+        .expect("parse closed-form model");
+
+        assert!(!reject_ode_inner_start(&plain_ode, 4, 999.0));
+        assert!(reject_ode_inner_start(&plain_ode, 4, 1_001.0));
+        assert!(reject_ode_inner_start(&plain_ode, 20, f64::NAN));
+        // Never fires for a non-ODE (closed-form) model, however bad the NLL.
+        assert!(!reject_ode_inner_start(&closed_form, 4, 1_000_000.0));
     }
 
     /// Closed-form IOV + `iiv_on_ruv` (#4b): the analytic stacked-η inner gradient


### PR DESCRIPTION
## Why
#708: a FOCEI fit with the default analytic-gradient path effectively hangs on a subject whose ODE is pathological in a stiff/time-varying-CL region (e.g. `TIME^HILL` forcing). Validated against the real reproduction (`ferx-testdata/pembrolizumab_radboudumc/ferx/model066.ferx`) by profiling the live process with `sample`.

## What changed (and what didn't work first)
Root cause (confirmed by profiling, not guessed): at a bad L-BFGS line-search trial point, several plain (non-IOV) ODE subjects were simultaneously stuck in `find_ebe → argmin_inner_fallback → nelder_mead_minimize`, each burning the historical `max_iter * 5` NM-restart budget trying to re-solve a genuinely expensive-at-that-trial-point ODE. Not one corrupted subject — several, at a trial point that's a normal (if extreme) line-search overshoot, not the true optimum.

Two attempts before landing on the fix (kept in history / PR comments for anyone hitting this again):

1. **Hard-reject the subject's inner start when catastrophically bad** (generalizing the existing ODE+IOV-only `reject_ode_iov_inner_start`). Converged, but regressed OFV ~100 units vs NONMEM: `hard_reject` doesn't just drop the subject, it makes the outer EBE guard treat the *whole trial* as infeasible — safe for ODE+IOV (a bad IOV start reliably means true pathology), not safe for plain ODE (a large individual NLL can be legitimate near the true optimum). Reverted.
2. **Full skip of the NM fallback** for all ODE models (generalizing `skip_ode_iov_nm_fallback`). Regressed worse: the fallback also quietly re-certifies the common #555 case (BFGS is fine but fails the strict `gnorm < tol` test on solver noise). Skipping it entirely turned that into permanent non-convergence broadly, tripping `max_unconverged_frac` on nearly every trial — the optimizer never took a single step (OFV/theta stuck at initial values).
3. **This PR: bound, don't skip.** `argmin_inner_fallback` now takes an `nm_iter_multiplier`. ODE+IOV keeps `0` (unchanged, #603 review #8's per-vertex steady-state cost is even higher there). Plain ODE gets `1` instead of `5` — pathological case capped at 1/5th the cost, common near-miss case still gets a (cheaper) chance to recover.

## Numerical validation
Ran `model066` end-to-end with the fix (release build):
- Completes in ~13 min. The unfixed build was left running 20+ min stuck at the same eval (Eval 42) with zero progress and `sample`-confirmed busy-but-stuck threads, then killed.
- Final OFV 6047.6 — same range as the historical pre-regression ferx runs (`t4`: 6031.6, `t15`: 6005.7, both same "did not converge" + regularized-covariance warnings this model always produces) and NONMEM (6010.12).
- Compared against: NONMEM (`ferx-testdata/pembrolizumab_radboudumc/nm/model066.lst`, OFV 6010.12) and prior ferx runs (`t4`, `t15` fit.yaml).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Performance
- [x] Faster for the pathological case in #708 (stall eliminated). No expected regression for non-ODE models (multiplier unchanged at 5) or ODE+IOV (multiplier unchanged at 0); plain ODE models that hit the NM fallback now get a `max_iter`-sized restart instead of `max_iter * 5` — bounded, validated not to break convergence quality on the target model.

## Tests
- [x] Unit tests added/updated in the same module (`cargo test --lib` passes, 2228 tests)
- [x] Regression test added that fails without this fix (`ode_non_iov_bounds_nelder_mead_inner_fallback`, `argmin_inner_fallback_zero_multiplier_skips_nm_entirely`)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible change otherwise

## Checklist
- [x] `cargo clippy` clean
- [x] Not on the `Dual2` sensitivity path
- [x] No `Cargo.toml` version bump needed

## Reviewer hints
`ode_nm_fallback_multiplier` (renamed from `skip_ode_nm_fallback`) is the key function — its doc comment walks through why `0` (skip) doesn't work for plain ODE and why `1` does. `argmin_inner_fallback` gained the `nm_iter_multiplier` param; `0` short-circuits before ever calling `nelder_mead_minimize` (single `obj(partial)` call only, tested).