### PR TITLE
feat(parser): warn when obs_scale double-divides by a pk block's volume [closes #712]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ section of the SDLC for the versioning policy).
   and `ferx summary --help` now print usage to stdout and exit 0, matching standard
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
 
+### Added
+- **`ferx check` warns when `[scaling] obs_scale` references the same individual
+  parameter bound to a built-in `pk <model>(...)` block's `v`/`v1` role** (#712):
+  the closed-form kernel already divides by that volume internally to produce
+  concentration, so an `obs_scale` referencing it divides by it a second
+  time — a common mistake when translating an `ode(...)` model (where that
+  division is required) to an equivalent closed-form `pk` block (where it
+  already happens). Not rejected — `obs_scale` referencing an individual
+  parameter is also a supported feature for an intentional additional
+  transform — just flagged, since ferx can't tell intent from mistake.
+  `docs/model-file/scaling.qmd` now documents the raw-output convention per
+  structural-model type.
+
 ### Fixed
 - **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
   SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@ section of the SDLC for the versioning policy).
 - **`-h`/`--help` flag for the `ferx` CLI** (#688): `ferx --help`, `ferx check --help`,
   and `ferx summary --help` now print usage to stdout and exit 0, matching standard
   CLI convention (previously only printed on no-args/bad-args, to stderr, exit 1).
-
-### Added
 - **`ferx check` warns when `[scaling] obs_scale` references the same individual
   parameter bound to a built-in `pk <model>(...)` block's `v`/`v1` role** (#712):
   the closed-form kernel already divides by that volume internally to produce

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -13,6 +13,21 @@ The convention is **divisive**: `pred_scaled = pred_raw / scale`. This
 matches the natural reading of `obs_scale = V/1000` as *"divide amount by
 V/1000 to get concentration in the user's units."*
 
+**What "raw output" is depends on the structural model.** For `ode(...)`/
+`ode_template(...)`, the raw output is the compartment amount — `obs_scale
+= V` is the required, standard way to convert it to concentration. For a
+**built-in `pk <model>(...)` block** (`pk one_cpt_iv(...)`, `pk
+two_cpt_oral(...)`, etc.), the raw output is **already concentration** —
+the closed-form kernel divides by the volume parameter (`v`/`v1`)
+internally, matching NONMEM's implicit `S1=V1`. Adding `obs_scale = V` (or
+`v1`) on top of a `pk` block therefore divides by the volume parameter a
+*second* time — a common mistake when translating an `ode(...)` model
+(where that division is needed) to an equivalent closed-form `pk` block
+(where it already happens). `ferx check` warns on this pattern, but does
+not reject it, since `obs_scale` referencing an individual parameter is
+also a real, supported feature (see Form B) for an intentional additional
+transform on top of the built-in concentration output.
+
 Three forms are supported. Each is optional; omitting `[scaling]` keeps
 the historical "raw prediction equals DV" behaviour.
 
@@ -45,7 +60,10 @@ Expressions may reference:
 - individual parameters declared in `[individual_parameters]` (e.g.
   `V`, `CL`) — these are resolved from a subject-static evaluation of
   `pk_param_fn` at scale-evaluation time, so `obs_scale = 1000 / V`
-  uses the per-subject V (typical value times the EBE eta).
+  uses the per-subject V (typical value times the EBE eta). On a
+  built-in `pk <model>(...)` block, referencing the same name bound to
+  its `v`/`v1` role divides by that volume a second time — see the note
+  above.
 
 The scale is evaluated **once per subject** with subject-level
 covariates (matching the no-TV path). Time-varying covariate support for

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -20,7 +20,8 @@ V/1000 to get concentration in the user's units."*
 two_cpt_oral(...)`, etc.), the raw output is **already concentration** —
 the closed-form kernel divides by the volume parameter (`v`/`v1`)
 internally, matching NONMEM's implicit `S1=V1`. Adding `obs_scale = V` (or
-`v1`) on top of a `pk` block therefore divides by the volume parameter a
+whatever individual parameter is bound to that `pk` block's `v`/`v1` role)
+on top of a `pk` block therefore divides by the volume parameter a
 *second* time — a common mistake when translating an `ode(...)` model
 (where that division is needed) to an equivalent closed-form `pk` block
 (where it already happens). `ferx check` warns on this pattern, but does

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2200,6 +2200,17 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             .map(|s| s.state_names.clone())
             .unwrap_or_default();
         let is_ode_model = model.ode_spec.is_some();
+        // Individual-parameter name bound to this `pk <model>(...)` block's `v`/`v1` role
+        // (`None` for `ode(...)`/`ode_template(...)`) — see `build_obs_scale_spec`'s doc (#712).
+        let volume_indiv_name_for_scaling: Option<String> = if is_ode_model {
+            None
+        } else {
+            pk_param_map
+                .get("v")
+                .or_else(|| pk_param_map.get("v1"))
+                .cloned()
+        };
+        let mut scaling_parse_warnings: Vec<String> = Vec::new();
 
         let (scaling, output_fn, output_program, scaling_covariates) = parse_scaling_block(
             scaling_lines,
@@ -2212,7 +2223,10 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             model.pk_model,
             &model.kappa_names,
             &readout_synth_params,
+            volume_indiv_name_for_scaling.as_deref(),
+            &mut scaling_parse_warnings,
         )?;
+        model.parse_warnings.extend(scaling_parse_warnings);
 
         // AD compatibility check (Phase 2.5):
         //
@@ -5304,12 +5318,27 @@ fn compile_scale_deriv_program(
 
 /// Build a `ScalingSpec` (None / ScalarScale / ExpressionScale) from one
 /// `obs_scale[…] = value` line. Shared between the uniform and per-CMT paths.
+///
+/// `volume_indiv_name` is the individual-parameter name bound to the built-in
+/// `pk <model>(...)` structural block's `v`/`v1` role (`None` for `ode(...)`/
+/// `ode_template(...)`, where there's no such built-in concentration divisor to
+/// collide with). Referencing that exact name in a Form B expression is a real,
+/// supported feature (an intentional additional transform on top of the
+/// built-in concentration output — see `docs/model-file/scaling.qmd` and
+/// `examples/scaling_expression.ferx`), not rejected. But it is *also* the
+/// signature of a common mistake: copying `obs_scale = V` from an `ode(...)`
+/// translation of the same model, where it's required (raw output there is
+/// amount, not concentration) — on a `pk` block it silently divides by `v` a
+/// second time. Since ferx can't tell intent from mistake here, it warns
+/// (`parse_warnings`) rather than erroring (#712).
 fn build_obs_scale_spec(
     value: &str,
     theta_names: &[String],
     eta_names: &[String],
     indiv_var_names: &[String],
     pk_indices: &[usize],
+    volume_indiv_name: Option<&str>,
+    parse_warnings: &mut Vec<String>,
 ) -> Result<ScalingSpec, String> {
     // Try scalar first (Form A). Otherwise parse as expression (Form B).
     if let Ok(k) = value.parse::<f64>() {
@@ -5326,6 +5355,29 @@ fn build_obs_scale_spec(
     let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
     let expr =
         parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] obs_scale: {}", e))?;
+    if let Some(vname) = volume_indiv_name {
+        let mut references_volume = false;
+        visit_expr_nodes(&expr, &mut |e| {
+            if let Expression::Variable(name) = e {
+                if name == vname {
+                    references_volume = true;
+                }
+            }
+        });
+        if references_volume {
+            parse_warnings.push(format!(
+                "[scaling]: obs_scale = `{value}` references `{vname}`, which is also this \
+                 model's `pk` structural block volume parameter. A built-in analytical `pk` \
+                 block already outputs concentration (divides by `{vname}` internally) — this \
+                 `obs_scale` divides by `{vname}` again on top. If that's intentional (a \
+                 deliberate additional transform), ignore this warning. If `obs_scale = {vname}` \
+                 was copied from an `ode(...)` translation of this model (where it converts raw \
+                 compartment amount to concentration and is required), remove `[scaling]` here — \
+                 the `pk` block's built-in concentration output is already what that conversion \
+                 was for."
+            ));
+        }
+    }
     // Pre-resolve indiv param name → PK slot so the closure can look up
     // `pk.values[slot]` for each `Expression::Variable(name)`. Mirrors
     // the analytical Form B path from Phase 1.5.
@@ -5818,6 +5870,11 @@ pub(crate) fn build_y_output_fn(
 /// - Mixing uniform (`obs_scale = K`) with per-CMT (`obs_scale[CMT=N] = K`)
 ///   within the same group → error.
 /// - Duplicate `[CMT=N]` keys → error.
+/// - `obs_scale` referencing the same individual parameter bound to a built-in
+///   `pk <model>(...)` block's `v`/`v1` role → **warning** (`parse_warnings`),
+///   not an error: it's a supported feature, but also the signature of a
+///   common mistake (a leftover `obs_scale = V` from an `ode(...)`
+///   translation) — see [`build_obs_scale_spec`] (#712).
 #[allow(clippy::too_many_arguments)]
 fn parse_scaling_block(
     lines: &[String],
@@ -5830,6 +5887,8 @@ fn parse_scaling_block(
     pk_model: PkModel,
     kappa_names: &[String],
     readout_synth: &[ReadoutSynthParam],
+    volume_indiv_name: Option<&str>,
+    parse_warnings: &mut Vec<String>,
 ) -> Result<
     (
         ScalingSpec,
@@ -5872,6 +5931,8 @@ fn parse_scaling_block(
                     eta_names,
                     indiv_var_names,
                     pk_indices,
+                    volume_indiv_name,
+                    parse_warnings,
                 )?;
                 match cmt_opt {
                     None => {
@@ -23212,6 +23273,79 @@ if (WT > 70) {
             }
             other => panic!("expected ExpressionScale, got {:?}", other),
         }
+    }
+
+    /// #712: `obs_scale` referencing the same individual parameter bound to the
+    /// `pk <model>(...)` block's `v` role is a supported feature (see the test
+    /// above) but also the signature of a common mistake (a leftover `obs_scale
+    /// = V` copied from an `ode(...)` translation, where it's required but on a
+    /// `pk` block double-divides). It must still parse — warn, not error.
+    #[test]
+    fn test_obs_scale_referencing_pk_volume_warns_not_errors() {
+        let src = analytical_model_with_scaling(Some("  obs_scale = V\n"));
+        let model = parse_model_string(&src).expect("must still parse (warning, not error)");
+        assert!(
+            model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("obs_scale") && w.contains("volume parameter")),
+            "expected a volume-collision warning, got {:?}",
+            model.parse_warnings
+        );
+    }
+
+    /// A pure unit-conversion constant (Form A) never references any individual
+    /// parameter, so it must never trigger the #712 volume-collision warning.
+    #[test]
+    fn test_obs_scale_scalar_constant_on_pk_block_does_not_warn() {
+        let src = analytical_model_with_scaling(Some("  obs_scale = 1000\n"));
+        let model = parse_model_string(&src).expect("scalar obs_scale parses");
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("volume parameter")),
+            "scalar obs_scale must not warn, got {:?}",
+            model.parse_warnings
+        );
+    }
+
+    /// An expression referencing an individual parameter that is *not* the
+    /// `pk` block's volume role (here `CL`, not `V`) is not the double-scaling
+    /// pattern #712 targets — no warning.
+    #[test]
+    fn test_obs_scale_referencing_non_volume_indiv_param_does_not_warn() {
+        let src = analytical_model_with_scaling(Some("  obs_scale = CL / 10\n"));
+        let model = parse_model_string(&src).expect("CL-referencing obs_scale parses");
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("volume parameter")),
+            "obs_scale referencing a non-volume indiv param must not warn, got {:?}",
+            model.parse_warnings
+        );
+    }
+
+    /// On an `ode(...)` model there's no built-in concentration divisor to
+    /// collide with — `obs_scale = V` is the documented, required way to
+    /// convert raw compartment amount to concentration, not a mistake pattern.
+    /// Must never warn.
+    #[test]
+    fn test_obs_scale_referencing_volume_on_ode_model_does_not_warn() {
+        let src = ode_model_with_scaling(
+            "ode(obs_cmt=central, states=[depot, central])",
+            Some("  obs_scale = V\n"),
+        );
+        let model = parse_model_string(&src).expect("ODE obs_scale = V parses");
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("volume parameter")),
+            "ODE obs_scale = V must not warn, got {:?}",
+            model.parse_warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why
#712: `[scaling] obs_scale = V` on a built-in `pk <model>(...)` structural block silently double-divides by the volume parameter — the closed-form kernel already divides by it internally to produce concentration. This is a common mistake when translating an `ode(...)` model (where `obs_scale = V` is required, since raw output there is compartment amount) to an equivalent closed-form `pk` block (where the division already happens). `ferx check` reported no errors or warnings on this pattern.

Found while helping a user translate `ferx-testdata/pembrolizumab_radboudumc` from ODE to closed-form (#708, #710): a stray `obs_scale = V1` left over from the ODE version caused a ~2x OFV inflation. An earlier investigation (#711, closed) misdiagnosed this as an event-driven infusion-boundary bug before the actual (much simpler) cause was found.

## What changed (and what didn't work first)
Initially implemented a **hard parser error** for `obs_scale` referencing an individual parameter on a `pk` block. This broke 26 existing tests plus a shipped example (`examples/scaling_expression.ferx`) — `obs_scale` referencing an individual parameter on a `pk` block is a real, deeply-tested feature (Form B, issue #367), not always a mistake. Proof it's load-bearing: `iov_analytical_expr_scale_equals_ode_twin` compares a closed-form model's `obs_scale = V` against an ODE twin that needs `obs_scale = V*V` — the second `V` exists *specifically because* the closed-form side's `obs_scale = V` is already a deliberate second division on top of the automatic one. So double-dividing by an individual parameter is sometimes intentional; ferx can't statically tell intent from mistake.

**This PR instead**:
1. Narrows the check to specifically the individual parameter bound to the `pk <model>(...)` block's own `v`/`v1` role (not any individual parameter) — that's the exact collision that causes the "leftover from ODE translation" mistake.
2. Downgrades it from an error to a **warning** (`CompiledModel.parse_warnings`, surfaced by `ferx check` and at fit time) — doesn't block the legitimate use case, just flags the ambiguous pattern.
3. Documents the actual raw-output convention in `docs/model-file/scaling.qmd` (this was the real gap: the docs never stated that a `pk` block's raw output is concentration, only implied "amount" via the `ode(...)`-flavored intro examples) — this alone would have prevented the original confusion.

## Numerical validation
Not applicable — this is a warning-only diagnostic change, no behavior/numerics affected. Verified the warning fires correctly on the real reproduction (`model066` translated to closed-form with the leftover `obs_scale = V1`) via `ferx check`.

## Breaking changes
- [x] None (warning is additive; no existing model file's fit behavior changes)

## Tests
- [x] Unit tests added (`test_obs_scale_referencing_pk_volume_warns_not_errors`, `test_obs_scale_scalar_constant_on_pk_block_does_not_warn`, `test_obs_scale_referencing_non_volume_indiv_param_does_not_warn`, `test_obs_scale_referencing_volume_on_ode_model_does_not_warn`)
- [x] Full `cargo test --lib` passes (2230 tests, 0 failures) — including all 26 tests that broke under the first (reverted) hard-error attempt

## Docs
- [x] `docs/model-file/scaling.qmd` updated: explicit raw-output convention per structural-model type
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings on touched code)
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
`build_obs_scale_spec`'s doc comment (src/parser/model_parser.rs) walks through why this is a warning, not an error, and cites the exact test that proves the feature is intentionally supported. The volume-parameter name is threaded in via `parse_scaling_block`'s new `volume_indiv_name` param, computed at the call site from `pk_param_map.get("v").or_else(|| pk_param_map.get("v1"))` — `None` for `ode(...)`/`ode_template(...)` (no built-in divisor to collide with).