### PR TITLE
feat(parser): 2-cpt transit ODE-equivalent twin (fix 1-/2-cpt asymmetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,14 @@ section of the SDLC for the versioning policy).
   with a clear error rather than silently producing a wrong answer;
   `predict_survival()` reports first-event survival for RTTE (use its `cum_hazard`
   field for the recurrent `E[N(t)]`).
+- **`two_cpt_transit` now supports time-varying covariates and `TIME`-dependent parameters** (#724):
+  a 2-cpt transit model whose disposition switches mid-profile is transparently routed to an exact
+  ODE `transit()` twin (`central` + `periph`), exactly as `one_cpt_transit` already was — instead
+  of being rejected. This removes the 1-cpt/2-cpt asymmetry. IOV, steady-state, infusion, and reset
+  doses on a transit closed form remain rejected (use an explicit ODE `transit()` model for those).
+  A non-depot (`CMT≠1`) dose on either transit closed form is now also rejected with a clear error
+  rather than silently mis-predicted — the closed form transits every dose into central regardless
+  of compartment, so it would disagree with the ODE twin (which honours the dose compartment).
 - **Optional `[data]` model-file block** (#690): a model can now declare
   `path = ...` to point at its own dataset (`$DATA` equivalent), so `ferx
   model.ferx`, `ferx check model.ferx`, and the public `fit_from_files()`

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -158,9 +158,12 @@ absorption with `ka = 1/MTT`.
 optimiser is kept inside this region automatically.
 
 **Scope (first version).** This analytic model supports single and multiple
-**bolus** doses, bioavailability, lag time, and a `central` initial amount.
-**Steady-state doses, IOV, time-varying covariates, infusions, system resets
-(EVID=3/4), and a `depot` initial amount are rejected** with an actionable message
+**bolus** doses into the depot (`CMT=1`), bioavailability, lag time, and a `central`
+initial amount. A model whose disposition switches mid-profile — a **time-varying
+covariate** or a `TIME`-dependent structural parameter — is transparently rerouted at
+parse time to an exact ODE `transit()` twin, so it is **supported**, not rejected.
+**Steady-state doses, IOV, infusions, system resets (EVID=3/4), a non-depot (`CMT≠1`)
+dose, and a `depot` initial amount are rejected** with an actionable message
 — use the `transit()` ODE forcing above for those. The two paths agree to ODE-solver
 tolerance (`tests/transit_analytic_equivalence.rs`), so the forcing model is the
 drop-in choice when you need a feature the closed form does not yet cover.
@@ -200,9 +203,10 @@ with `cα = (α−k21)/(α−β)`, `cβ = (k21−β)/(α−β)` (`cα + cβ = 1`
 **exact `Dual2` FOCE/FOCEI sensitivities** `∂C/∂{CL, V1, Q, V2, N, MTT, F, η}`, and
 with `N = 0` reduces exactly to 2-cpt first-order oral absorption with `ka = 1/MTT`.
 The **domain** (`α < KTR`, since `α ≥ β`) and **scope/limits** are identical to
-`one_cpt_transit` (bolus doses, bioavailability, lag time; SS / IOV / time-varying
-covariates / infusions / resets / `depot`-init rejected, and the same flip-flop
-`α ≥ KTR` warning — use an ODE transit model for those).
+`one_cpt_transit` (bolus doses into the depot, bioavailability, lag time; time-varying
+covariates and `TIME`-dependent parameters transparently rerouted to an exact 2-cpt ODE
+`transit()` twin; SS / IOV / infusions / resets / non-depot (`CMT≠1`) doses / `depot`-init
+rejected, with the same flip-flop `α ≥ KTR` warning — use an ODE transit model for those).
 
 [`examples/two_cpt_transit.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/two_cpt_transit.ferx)
 is a complete self-contained example:

--- a/src/api.rs
+++ b/src/api.rs
@@ -1428,10 +1428,13 @@ pub(crate) fn assert_modeled_doses_supported(model: &CompiledModel, population: 
 
 /// Features the analytic transit models (`one_cpt_transit`, `two_cpt_transit`) do
 /// not support in their first version (#386): the exponential-tilting closed form
-/// is a constant-parameter bolus superposition, so steady-state doses, IOV,
-/// within-subject time-varying covariates, and infusion doses are rejected up
+/// is a constant-parameter depot-bolus superposition, so steady-state doses, IOV,
+/// infusion doses, system resets, and non-depot (`CMT≠1`) doses are rejected up
 /// front — otherwise they would silently mis-predict or hit an `unreachable!` in
-/// the superposition dispatch. `fit()` surfaces this as an `Err`;
+/// the superposition dispatch. (Time-varying covariates and a `TIME`-dependent
+/// parameter are instead transparently rerouted to the plain form's ODE `transit()`
+/// twin via [`CompiledModel::effective_for`]; only a form outside that twin's scope
+/// rejects them.) `fit()` surfaces this as an `Err`;
 /// `predict()`/`simulate()` panic via [`assert_transit_support`], mirroring
 /// [`assert_modeled_doses_supported`]. Returns the first offending feature's
 /// message, or `None` when compatible.
@@ -1493,6 +1496,26 @@ pub(crate) fn check_transit_support(
             ));
         }
         for dose in &subject.doses {
+            if dose.cmt != 1 {
+                // The closed form folds *every* dose through the absorption chain into
+                // central ignoring `dose.cmt` (the `sens/provider.rs` superposition loop),
+                // while the ODE twin honours the compartment — a `CMT≠1` dose there falls to
+                // the direct-bolus branch and lands in a disposition compartment. So the two
+                // paths would silently disagree on a non-depot dose, and `effective_for`
+                // routes only TV-cov/`TIME` subjects to the twin, so a mixed population would
+                // even disagree with itself. A transit closed form only supports dosing the
+                // depot (`CMT=1`); reject anything else up front.
+                return Some(format!(
+                    "{name} does not support dosing into a non-depot compartment (subject \
+                     {}, CMT={}): the transit closed form routes every dose through the \
+                     absorption chain into central regardless of compartment, so a CMT≠1 dose \
+                     would be silently mistreated — and its ODE twin would instead bolus it \
+                     into a disposition compartment, so the two paths would disagree. Dose the \
+                     depot (CMT=1), or use an ODE transit model for direct central/peripheral \
+                     dosing.",
+                    subject.id, dose.cmt
+                ));
+            }
             if dose.ss {
                 return Some(format!(
                     "{name} does not support steady-state (SS) doses yet (subject \

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6601,43 +6601,54 @@ fn apply_ode_template(extracted: &mut ExtractedBlocks) -> Result<(), String> {
 /// The equivalent shares the model's `[parameters]`/`[individual_parameters]`/… blocks
 /// verbatim and swaps only the disposition, so its θ/η layout matches the closed-form model
 /// exactly (the dispatch can hand it the same parameter vector). Scoped to the plain
-/// `cl/v/n/mtt` form with no `lagtime=`/`f=` mapping and no user `[odes]`/`[scaling]` block;
-/// anything else returns `None` (and stays closed-form, still rejected up front for the
-/// features it cannot serve) — extending it is a follow-up.
+/// `one_cpt_transit(cl,v,n,mtt)` and `two_cpt_transit(cl,v1,q,v2,n,mtt)` forms with no
+/// `lagtime=`/`f=` mapping and no user `[odes]`/`[scaling]` block; anything else returns
+/// `None` (and stays closed-form, still rejected up front for the features it cannot serve).
 fn transit_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<String> {
-    let transit_re = Regex::new(r"^pk\s+one_cpt_transit\s*\(([^)]*)\)\s*$").unwrap();
-    let args_str = extracted
-        .unnamed
-        .get("structural_model")?
-        .iter()
-        .find_map(|l| transit_re.captures(l.trim()))?
-        .get(1)?
-        .as_str()
-        .to_string();
+    // Match the plain closed-form transit disposition — 1-cpt `cl/v/n/mtt` or
+    // 2-cpt `cl/v1/q/v2/n/mtt`. Any other structural form stays closed-form.
+    let structural = extracted.unnamed.get("structural_model")?;
+    let one_re = Regex::new(r"^pk\s+one_cpt_transit\s*\(([^)]*)\)\s*$").unwrap();
+    let two_re = Regex::new(r"^pk\s+two_cpt_transit\s*\(([^)]*)\)\s*$").unwrap();
+    let (args_str, is_two_cpt, pk_label) =
+        if let Some(caps) = structural.iter().find_map(|l| one_re.captures(l.trim())) {
+            (
+                caps.get(1)?.as_str().to_string(),
+                false,
+                "pk one_cpt_transit",
+            )
+        } else if let Some(caps) = structural.iter().find_map(|l| two_re.captures(l.trim())) {
+            (
+                caps.get(1)?.as_str().to_string(),
+                true,
+                "pk two_cpt_transit",
+            )
+        } else {
+            return None;
+        };
     // A user-written [odes]/[scaling] block is outside the plain-form scope. An
-    // [initial_conditions] block is too: the equivalent's single `central` state cannot carry
-    // a transit `depot` seed, and transit-init has its own parse-time validation on the
-    // primary model — building the equivalent would pre-empt that with a confusing error.
+    // [initial_conditions] block is too: the equivalent's disposition states (central,
+    // and periph for 2-cpt) cannot carry a transit `depot` seed, and transit-init has its
+    // own parse-time validation on the primary model — building the equivalent would
+    // pre-empt that with a confusing error.
     if extracted.unnamed.contains_key("odes")
         || extracted.unnamed.contains_key("scaling")
         || extracted.unnamed.contains_key("initial_conditions")
     {
         return None;
     }
-    let roles = parse_role_pairs(&args_str, "pk one_cpt_transit").ok()?;
-    let allowed = ["cl", "v", "n", "mtt"];
+    let roles = parse_role_pairs(&args_str, pk_label).ok()?;
+    let allowed: &[&str] = if is_two_cpt {
+        &["cl", "v1", "q", "v2", "n", "mtt"]
+    } else {
+        &["cl", "v", "n", "mtt"]
+    };
     if roles.keys().any(|k| !allowed.contains(&k.as_str())) {
         return None; // a lagtime=/f= (or other) mapping — outside the scope.
     }
-    let (cl, v, n, mtt) = (
-        roles.get("cl")?,
-        roles.get("v")?,
-        roles.get("n")?,
-        roles.get("mtt")?,
-    );
     // Re-emit every block verbatim except the disposition (deterministic order), then append
     // the ODE twin. Parsing this source yields a normal ODE model — it contains no
-    // `pk one_cpt_transit`, so it does not recurse into this desugar.
+    // `pk one_cpt_transit`/`pk two_cpt_transit`, so it does not recurse into this desugar.
     let mut src = String::new();
     let mut names: Vec<&String> = extracted.unnamed.keys().collect();
     names.sort();
@@ -6666,11 +6677,38 @@ fn transit_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<String> 
         }
         src.push('\n');
     }
-    src.push_str("[structural_model]\n  ode(obs_cmt=central, states=[central])\n\n");
-    src.push_str(&format!(
-        "[odes]\n  d/dt(central) = transit(n={n}, mtt={mtt}) - ({cl}/{v}) * central\n\n"
-    ));
-    src.push_str(&format!("[scaling]\n  obs_scale = {v}\n\n"));
+    // Disposition twin. The micro-constant flux mirrors `ode_template::generate`'s
+    // matching case exactly — 1-cpt: `ke = cl/v`; 2-cpt: `k10 = cl/v1`, `k12 = q/v1`,
+    // `k21 = q/v2`, observed on `central` — so the ODE twin describes the same linear
+    // system as the exponential-tilting closed form (pinned by the closed-form↔ODE
+    // equivalence test, `tests/transit_analytic_equivalence.rs`).
+    if is_two_cpt {
+        let (cl, v1, q, v2, n, mtt) = (
+            roles.get("cl")?,
+            roles.get("v1")?,
+            roles.get("q")?,
+            roles.get("v2")?,
+            roles.get("n")?,
+            roles.get("mtt")?,
+        );
+        src.push_str("[structural_model]\n  ode(obs_cmt=central, states=[central, periph])\n\n");
+        src.push_str(&format!(
+            "[odes]\n  d/dt(central) = transit(n={n}, mtt={mtt}) - ({cl}/{v1} + {q}/{v1}) * central + ({q}/{v2}) * periph\n  d/dt(periph) = ({q}/{v1}) * central - ({q}/{v2}) * periph\n\n"
+        ));
+        src.push_str(&format!("[scaling]\n  obs_scale = {v1}\n\n"));
+    } else {
+        let (cl, v, n, mtt) = (
+            roles.get("cl")?,
+            roles.get("v")?,
+            roles.get("n")?,
+            roles.get("mtt")?,
+        );
+        src.push_str("[structural_model]\n  ode(obs_cmt=central, states=[central])\n\n");
+        src.push_str(&format!(
+            "[odes]\n  d/dt(central) = transit(n={n}, mtt={mtt}) - ({cl}/{v}) * central\n\n"
+        ));
+        src.push_str(&format!("[scaling]\n  obs_scale = {v}\n\n"));
+    }
     Some(src)
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2958,8 +2958,8 @@ pub struct CompiledModel {
     pub transit_ode_equivalent: Option<TransitOdeEquivalent>,
 }
 
-/// A lazily-built ODE representation of an analytical model that carries one (currently only
-/// `one_cpt_transit`). Holds the equivalent's reconstructed `.ferx` source and compiles the
+/// A lazily-built ODE representation of an analytical model that carries one (a plain
+/// `one_cpt_transit` or `two_cpt_transit`). Holds the equivalent's reconstructed `.ferx` source and compiles the
 /// boxed sub-model on first use, so a transit fit whose subjects never hit the fallback
 /// (constant-parameter, non-`TIME`) pays no extra parse or allocation. See
 /// [`CompiledModel::effective_for`] (#486).
@@ -2984,7 +2984,7 @@ impl TransitOdeEquivalent {
         self.built.get_or_init(|| {
             Box::new(
                 crate::parser::model_parser::parse_model_string(&self.source)
-                    .expect("internal: one_cpt_transit ODE equivalent failed to build"),
+                    .expect("internal: transit ODE equivalent failed to build"),
             )
         })
     }
@@ -3048,7 +3048,8 @@ impl CompiledModel {
 
     /// The model that should actually serve `subject`'s predictions / sensitivities.
     ///
-    /// For a `one_cpt_transit` model whose closed form cannot cope with this subject — a
+    /// For a transit closed form (`one_cpt_transit` / `two_cpt_transit`) whose closed form
+    /// cannot cope with this subject — a
     /// `TIME`-dependent structural parameter or time-varying covariates make the disposition
     /// switch mid-absorption, which the per-dose Gamma convolution assumes constant — return
     /// its exact ODE `transit()` equivalent (`transit_ode_equivalent`, built at parse time);

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -406,6 +406,21 @@ fn transit_reset_rejected() {
     );
 }
 
+/// A non-depot (`CMT≠1`) dose is rejected on the transit closed form. The closed form
+/// folds every dose through the absorption chain into central ignoring `dose.cmt`, while
+/// the single-state ODE twin would *drop* a `CMT=2` dose (no such state) — so the two
+/// paths would silently disagree. The shared `check_transit_support` guard rejects it up
+/// front (the 2-cpt counterpart is `two_cpt_transit_non_depot_dose_rejected`).
+#[test]
+fn transit_non_depot_dose_rejected() {
+    let central_dose = DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0); // CMT=2, plain bolus
+    let e = transit_fit_err(&population(vec![central_dose], vec![1.0, 4.0, 8.0]));
+    assert!(
+        e.contains("non-depot") && e.contains("CMT=2"),
+        "expected a non-depot-dose rejection message, got: {e}"
+    );
+}
+
 /// `ode_template one_cpt_transit(...)` desugars to the `transit()` forcing ODE
 /// (#386), so it must `predict()` identically to the analytic `pk` form. Covers the
 /// `ode_template` transit arm and pins the lowering to the closed form.
@@ -725,6 +740,83 @@ fn two_cpt_transit_with_bioavailability_matches_ode() {
 /// Fixed-parameter population OFV at several eta values — drives the analytic
 /// **sensitivity** path (`run_obs` two_cpt_transit branch, the exact
 /// `∂f/∂{cl,v1,q,v2,n,mtt,η}` jets), the 2-cpt counterpart of `transit_ofv_matches_ode`.
+/// Regression (2-cpt asymmetry): a `two_cpt_transit` model with a mid-profile `TIME`
+/// switch used to be **rejected** — the ODE-equivalent desugar was 1-cpt only — while
+/// the identical 1-cpt model transparently rerouted (cf.
+/// `transit_time_desugar_matches_hand_written_ode`). It now carries a 2-cpt ODE twin
+/// (`central` + `periph`) that predict() / the gradient route TIME/TV-cov subjects to,
+/// matching a hand-written 2-cpt transit ODE.
+#[test]
+fn two_cpt_transit_time_desugar_matches_hand_written_ode() {
+    let header = "\
+[parameters]
+  theta TVCL(0.13, 0.001, 10.0)
+  theta TVCL_LATE(0.30, 0.001, 10.0)
+  theta TVV1(8.0, 0.1, 500.0)
+  theta TVQ(0.5, 0.001, 50.0)
+  theta TVV2(4.0, 0.1, 500.0)
+  theta TVNTR(3.0, 0.0, 20.0)
+  theta TVMTT(1.5, 0.05, 50.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  if (TIME > 6.0) {
+    CL = TVCL_LATE * exp(ETA_CL)
+  } else {
+    CL = TVCL * exp(ETA_CL)
+  }
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  NTR = TVNTR
+  MTT = TVMTT
+";
+    let shorthand = format!(
+        "{header}\n[structural_model]\n  pk two_cpt_transit(cl=CL, v1=V1, q=Q, v2=V2, n=NTR, mtt=MTT)\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let hand_ode = format!(
+        "{header}\n[structural_model]\n  ode(obs_cmt=central, states=[central, periph])\n\n\
+         [odes]\n  \
+         d/dt(central) = transit(n=NTR, mtt=MTT) - (CL/V1 + Q/V1) * central + (Q/V2) * periph\n  \
+         d/dt(periph)  = (Q/V1) * central - (Q/V2) * periph\n\n\
+         [scaling]\n  obs_scale = V1\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let sh = parse_full_model(&shorthand)
+        .expect("2-cpt transit + TIME parses (was rejected before the twin existed)")
+        .model;
+    let hd = parse_full_model(&hand_ode)
+        .expect("hand 2-cpt ODE parses")
+        .model;
+    assert!(
+        sh.ode_spec.is_none() && sh.transit_ode_equivalent.is_some(),
+        "2-cpt transit + TIME shorthand must carry an ODE equivalent (primary stays closed-form)"
+    );
+    let pop = population(
+        vec![bolus(0.0, 100.0)],
+        vec![0.5, 2.0, 4.0, 5.9, 6.1, 8.0, 12.0, 24.0],
+    );
+    let ps = predict(&sh, &pop, &sh.default_params);
+    let ph = predict(&hd, &pop, &hd.default_params);
+    assert_eq!(ps.len(), ph.len());
+    assert!(!ps.is_empty());
+    for (x, y) in ps.iter().zip(ph.iter()) {
+        assert!(
+            (x.pred - y.pred).abs() <= 1e-9 + 1e-9 * x.pred.abs(),
+            "t={:.3}: desugared {:.6} vs hand ODE {:.6}",
+            x.time,
+            x.pred,
+            y.pred
+        );
+    }
+    assert!(
+        ps.iter().any(|p| p.time > 6.0) && ps.iter().any(|p| p.time < 6.0),
+        "observations must straddle the TIME switch"
+    );
+}
+
 #[test]
 fn two_cpt_transit_ofv_matches_ode() {
     use ferx_core::stats::likelihood::individual_nll;
@@ -871,6 +963,80 @@ fn two_cpt_transit_reset_rejected() {
         e.contains("two_cpt_transit") && e.contains("reset"),
         "expected a two_cpt_transit reset-rejection message, got: {e}"
     );
+}
+
+/// A non-depot (`CMT≠1`) dose is rejected on the 2-cpt transit closed form. The closed
+/// form transits every dose into central ignoring `dose.cmt`, while the ODE twin honours
+/// it — a `CMT=2` dose there falls to the direct-bolus branch and lands in `periph`, so the
+/// two paths would silently disagree (plausible-but-wrong, unlike the 1-cpt twin which
+/// drops it). The shared `check_transit_support` guard rejects it up front, naming the model.
+#[test]
+fn two_cpt_transit_non_depot_dose_rejected() {
+    let (an_src, _) = build_pair_2cpt(false, false);
+    let model = parse_full_model(&an_src).expect("parses").model;
+    let central_dose = DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0); // CMT=2, plain bolus
+    let pop = population(vec![central_dose], vec![1.0, 4.0, 8.0]);
+    let e = fit(&model, &pop, &model.default_params, &FitOptions::default())
+        .expect_err("2cpt transit + non-depot (CMT=2) dose should be rejected");
+    assert!(
+        e.contains("two_cpt_transit") && e.contains("non-depot") && e.contains("CMT=2"),
+        "expected a two_cpt_transit non-depot-dose rejection message, got: {e}"
+    );
+}
+
+/// The IOV guard also covers the 2-cpt model, naming it (shared `check_transit_support`,
+/// the 2-cpt counterpart of `transit_iov_rejected`).
+#[test]
+fn two_cpt_transit_iov_rejected() {
+    let (an_src, _) = build_pair_2cpt(false, false);
+    let mut model = parse_full_model(&an_src).expect("parses").model;
+    model.n_kappa = 1;
+    let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0]);
+    let e = fit(&model, &pop, &model.default_params, &FitOptions::default())
+        .expect_err("2cpt transit + IOV should be rejected");
+    assert!(
+        e.contains("two_cpt_transit") && e.contains("IOV"),
+        "expected a two_cpt_transit IOV-rejection message, got: {e}"
+    );
+}
+
+/// The infusion guard also covers the 2-cpt model, naming it (shared `check_transit_support`,
+/// the 2-cpt counterpart of `transit_infusion_dose_rejected`).
+#[test]
+fn two_cpt_transit_infusion_dose_rejected() {
+    let (an_src, _) = build_pair_2cpt(false, false);
+    let model = parse_full_model(&an_src).expect("parses").model;
+    let inf = DoseEvent::new(0.0, 100.0, 1, 50.0, false, 0.0); // rate > 0 → infusion
+    let pop = population(vec![inf], vec![1.0, 4.0, 8.0]);
+    let e = fit(&model, &pop, &model.default_params, &FitOptions::default())
+        .expect_err("2cpt transit + infusion should be rejected");
+    assert!(
+        e.contains("two_cpt_transit") && e.contains("infusion"),
+        "expected a two_cpt_transit infusion-rejection message, got: {e}"
+    );
+}
+
+/// A plain `two_cpt_transit` model with time-varying covariates now **works**: the runtime
+/// dispatch routes the TV-cov subject to the model's exact 2-cpt ODE `transit()` equivalent
+/// (the non-`TIME` reroute leg of `effective_for`, the 2-cpt counterpart of
+/// `transit_tv_covariate_now_served_by_ode_equivalent`).
+#[test]
+fn two_cpt_transit_tv_covariate_now_served_by_ode_equivalent() {
+    let (an_src, _) = build_pair_2cpt(false, false);
+    let model = parse_full_model(&an_src).expect("parses").model;
+    assert!(
+        model.transit_ode_equivalent.is_some(),
+        "plain 2-cpt transit carries an ODE equivalent"
+    );
+    let mut pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0]);
+    // Give the subject time-varying covariates (non-empty per-observation maps).
+    pop.subjects[0].obs_covariates = vec![
+        std::collections::HashMap::from([("WT".to_string(), 70.0)]),
+        std::collections::HashMap::from([("WT".to_string(), 72.0)]),
+    ];
+    assert!(pop.subjects[0].has_tv_covariates());
+    fit(&model, &pop, &model.default_params, &FitOptions::default())
+        .expect("2cpt transit + time-varying covariates now fits via the ODE equivalent");
 }
 
 /// Committed slow benchmark: analytic `pk two_cpt_transit` and the ODE `transit()`


### PR DESCRIPTION
## Why
`transit_ode_equivalent_source` matched only `one_cpt_transit`, so a `two_cpt_transit` model with time-varying covariates or a `TIME`-dependent structural parameter was **rejected** by `check_transit_support`, while the identical 1-cpt model transparently rerouted to its ODE twin — a 1-/2-cpt asymmetry.

## What changed
Extend the desugar to the plain `two_cpt_transit(cl,v1,q,v2,n,mtt)` form, emitting the canonical 2-cpt disposition (`central` + `periph`; `k10=cl/v1`, `k12=q/v1`, `k21=q/v2`; observed on central) — the exact form `ode_template::generate`'s `TwoCptTransit` case and the existing `build_pair_2cpt` equivalence tests already validate against the closed form. `effective_for` / `check_transit_support` are generic (gated on `transit_ode_equivalent.is_none()`), so the twin now routes 2-cpt TV-cov/`TIME` subjects automatically; IOV / SS / infusion / reset stay rejected.

## Relationship to #719
Unblocks **#719 gap 3 (analytic-transit IOV), route (b), for 2-cpt transit**: the "reuse the ODE-equivalent dispatch for IOV subjects" route was 1-cpt only until now. With the 2-cpt twin in place, IOV support reduces to dropping the `n_kappa > 0` reject (`api.rs:1261`) + adding occasion-presence to the `effective_for` reroute condition — for both compartment counts. (Prerequisite, not a close.)

## Breaking changes
- [x] None (previously-rejected models now work)

## Numerical validation
- [x] Transitively NONMEM-anchored: the twin's `transit()` forcing is anchored (`tests/transit_nonmem_anchor.rs`) and its form matches the closed form via the existing `two_cpt_transit_*_matches_ode` equivalence tests.
- [x] New `two_cpt_transit_time_desugar_matches_hand_written_ode` (asserts `transit_ode_equivalent.is_some()` + reroute PRED matches a hand-written 2-cpt ODE across a mid-profile `TIME` switch). All 27 `transit_analytic_equivalence` tests pass.

## Tests
- [x] `cargo test --test transit_analytic_equivalence` (27 pass); parser module (527) + all examples parse; rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
