### PR TITLE
feat(estimation): split estimation wall time by method-chain stage and covariance step [closes #713]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ section of the SDLC for the versioning policy).
   `FitResult.environment` and round-trip through `.fitrx` bundles.
 
 ### Added
+- **`estimation:` block in `{model}-fit.yaml` now splits wall time by stage** (#713):
+  a `{method}_wall_time_secs` entry (e.g. `focei_wall_time_secs`, `imp_wall_time_secs`)
+  is reported for each stage of `method`/`methods`, plus a `covariance_wall_time_secs`
+  for the post-estimation FD-Hessian / SIR-fallback step, alongside the existing
+  `wall_time_secs` total. Also carried on `FitResult.method_wall_times_secs` /
+  `FitResult.covariance_wall_time_secs` and round-trips through `.fitrx` bundles.
 - **Optional `[data]` model-file block** (#690): a model can now declare
   `path = ...` to point at its own dataset (`$DATA` equivalent), so `ferx
   model.ferx`, `ferx check model.ferx`, and the public `fit_from_files()`

--- a/docs/file-formats/fitrx.qmd
+++ b/docs/file-formats/fitrx.qmd
@@ -142,6 +142,8 @@ the model has fewer than two valid residuals, and `cov_condition_number` is
   "n_iterations": 42,
   "interaction": true,
   "wall_time_secs": 1.234,
+  "method_wall_times_secs": [1.134],
+  "covariance_wall_time_secs": 0.1,
   "n_threads_used": 4,
   "uses_ode_solver": false,
   "gradient_method_inner": "analytic (Dual2)",

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -144,6 +144,8 @@ covariance_matrix:
     log_chol_ETA_V:  [0.000000e+0, 0.000000e+0, 0.000000e+0, 2.345678e-6, 0.000000e+0]
     sigma_1:         [0.000000e+0, 0.000000e+0, 0.000000e+0, 0.000000e+0, 7.890123e-7]
 estimation:
+  focei_wall_time_secs: 11.845678
+  covariance_wall_time_secs: 0.500000
   wall_time_secs: 12.345678
   n_threads_used: 8
 environment:
@@ -178,7 +180,13 @@ The `estimation:` block replaces the standalone `{model}-timing.txt` file
 (not model parsing or data reading — the old timing file's `elapsed_seconds`
 covered the whole CLI run, so the two are not a like-for-like replacement,
 just the closest equivalent), and `n_threads_used` is the Rayon worker count
-used. The `environment:` block is a snapshot of the machine and account the
+used. `wall_time_secs` is further broken down (#713) into a `{method}_wall_time_secs`
+entry for each stage of `method = ...`/`methods = [...]` (e.g. `focei_wall_time_secs`,
+`imp_wall_time_secs` for a `[focei, imp]` chain) plus `covariance_wall_time_secs`
+for the post-estimation FD-Hessian / SIR-fallback step, which only ever runs
+once, on the last estimating stage (#615). The per-stage keys measure
+convergence only and exclude the covariance step. The `environment:` block is
+a snapshot of the machine and account the
 fit ran under — `os`/`arch` from the running binary's target, `in_docker`
 (whether `/.dockerenv`, `KUBERNETES_SERVICE_HOST`, or `/proc/1/cgroup`
 indicate a container), `username` (`$USER`/`%USERNAME%`, quoted/escaped since
@@ -186,7 +194,7 @@ it's free-form text), and `ferx_version`.
 
 ## FitResult Fields (Rust API / console)
 
-The following fields are populated on the `FitResult` struct returned by `fit()` and printed by `print_results()`. Except for `wall_time_secs`, `n_threads_used`, and `environment` (written to the `estimation:`/`environment:` blocks above), they are **not** currently written to the fit YAML — read them programmatically or from the console summary.
+The following fields are populated on the `FitResult` struct returned by `fit()` and printed by `print_results()`. Except for `wall_time_secs`, `method_wall_times_secs`, `covariance_wall_time_secs`, `n_threads_used`, and `environment` (written to the `estimation:`/`environment:` blocks above), they are **not** currently written to the fit YAML — read them programmatically or from the console summary.
 
 ### Shrinkage
 
@@ -264,6 +272,8 @@ When `dw_statistic < 1.5`, ferx emits a warning suggesting a transit absorption 
 | `model_name` | Name from the `.ferx` file (or `"Unnamed"`) |
 | `ferx_version` | Version of ferx-core that produced the result |
 | `wall_time_secs` | Wall-clock time for the complete fit (seconds) |
+| `method_wall_times_secs` | Wall-clock convergence time per stage, parallel to `method_chain` (seconds); excludes the covariance step |
+| `covariance_wall_time_secs` | Wall-clock time spent on the post-estimation covariance step; `0.0` when not run |
 | `gradient_method_inner` | Gradient method used in the inner (EBE) loop, e.g. `analytic (Dual2)` or `finite differences` |
 | `gradient_method_outer` | Gradient method used in the outer loop, e.g. `finite differences` |
 | `uses_ode_solver` | `true` if the model uses the ODE solver, `false` for analytical PK |

--- a/src/api.rs
+++ b/src/api.rs
@@ -3804,11 +3804,17 @@ fn fit_inner(
 
     let mut total_iterations: usize = 0;
     let mut is_result: Option<ImportanceSamplingResult> = None;
+    // Per-stage convergence wall time, parallel to `chain`/`method_chain`
+    // (#713). Excludes the covariance step, which is timed separately below
+    // and only ever runs on the last estimating stage.
+    let mut method_wall_times_secs: Vec<f64> = Vec::with_capacity(n_stages);
+    let mut covariance_wall_time_secs: f64 = 0.0;
 
     for (stage_idx, &method) in chain.iter().enumerate() {
         if crate::cancel::is_cancelled(&options.cancel) {
             return Err("cancelled by user".to_string());
         }
+        let stage_start = std::time::Instant::now();
         let is_last = stage_idx + 1 == n_stages;
         let mut stage_opts = options.clone();
         stage_opts.method = method;
@@ -3890,6 +3896,7 @@ fn fit_inner(
                     h_matrices,
                     kappas,
                     covariance_matrix: None,
+                    covariance_wall_time_secs: 0.0,
                     warnings: Vec::new(),
                     saem_mu_ref_m_step_evals_saved: None,
                     saem_n_subjects_hmc: None,
@@ -3960,6 +3967,7 @@ fn fit_inner(
                     });
                 }
             }
+            method_wall_times_secs.push(stage_start.elapsed().as_secs_f64());
             continue;
         }
 
@@ -4006,6 +4014,11 @@ fn fit_inner(
             }
             _ => optimize_population(model, population, &stage_params, &stage_opts),
         };
+
+        let stage_cov_secs = stage_result.covariance_wall_time_secs;
+        method_wall_times_secs
+            .push((stage_start.elapsed().as_secs_f64() - stage_cov_secs).max(0.0));
+        covariance_wall_time_secs += stage_cov_secs;
 
         stage_params = stage_result.params.clone();
         total_iterations += stage_result.n_iterations;
@@ -4486,6 +4499,8 @@ fn fit_inner(
     let fit_result = FitResult {
         method: final_method,
         method_chain: chain.clone(),
+        method_wall_times_secs,
+        covariance_wall_time_secs,
         converged: result.converged,
         ofv,
         aic,
@@ -10083,6 +10098,8 @@ mod simulate_with_uncertainty_tests {
         FitResult {
             method: EstimationMethod::FoceI,
             method_chain: vec![EstimationMethod::FoceI],
+            method_wall_times_secs: vec![0.0],
+            covariance_wall_time_secs: 0.0,
             converged: true,
             ofv: 0.0,
             aic: 0.0,

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -1285,6 +1285,7 @@ pub fn run_bayes(
         h_matrices,
         kappas,
         covariance_matrix: None,
+        covariance_wall_time_secs: 0.0,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -364,6 +364,7 @@ pub fn run_foce_gn(
     if !do_polish {
         // Pure GN — skip FOCEI polish, go directly to covariance step
         let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+        let cov_timer = std::time::Instant::now();
         let covariance_matrix =
             if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
                 if verbose {
@@ -399,6 +400,7 @@ pub fn run_foce_gn(
             } else {
                 None
             };
+        let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
         if verbose {
             eprintln!("FOCE-GN completed. Final OFV = {:.4}", ofv);
@@ -413,6 +415,7 @@ pub fn run_foce_gn(
             h_matrices,
             kappas,
             covariance_matrix,
+            covariance_wall_time_secs,
             warnings,
             saem_mu_ref_m_step_evals_saved: None,
             saem_n_subjects_hmc: None,
@@ -480,6 +483,7 @@ pub fn run_foce_gn(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if verbose {
@@ -516,6 +520,7 @@ pub fn run_foce_gn(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if verbose {
         eprintln!("FOCE-GN completed. Final OFV = {:.4}", final_ofv);
@@ -530,6 +535,7 @@ pub fn run_foce_gn(
         h_matrices: final_h_mats,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -364,13 +364,13 @@ pub fn run_foce_gn(
     if !do_polish {
         // Pure GN — skip FOCEI polish, go directly to covariance step
         let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-        let cov_timer = std::time::Instant::now();
-        let covariance_matrix =
+        let (covariance_matrix, covariance_wall_time_secs) =
             if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
                 if verbose {
                     eprintln!("Running covariance step...");
                 }
-                match compute_covariance(
+                let cov_timer = std::time::Instant::now();
+                let cm = match compute_covariance(
                     &x,
                     &gn_params,
                     model,
@@ -396,11 +396,11 @@ pub fn run_foce_gn(
                         sir_fallback_proposal = Some(fallback_proposal);
                         None
                     }
-                }
+                };
+                (cm, cov_timer.elapsed().as_secs_f64())
             } else {
-                None
+                (None, 0.0)
             };
-        let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
         if verbose {
             eprintln!("FOCE-GN completed. Final OFV = {:.4}", ofv);
@@ -483,14 +483,14 @@ pub fn run_foce_gn(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if verbose {
                 eprintln!("Running covariance step...");
             }
+            let cov_timer = std::time::Instant::now();
             let packed = pack_params(&final_params);
-            match compute_covariance(
+            let cm = match compute_covariance(
                 &packed,
                 &final_params,
                 model,
@@ -516,11 +516,11 @@ pub fn run_foce_gn(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if verbose {
         eprintln!("FOCE-GN completed. Final OFV = {:.4}", final_ofv);

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -1215,11 +1215,11 @@ fn run_mcem(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
+            let cov_timer = std::time::Instant::now();
             let packed = pack_params(&final_params);
-            match compute_covariance(
+            let cm = match compute_covariance(
                 &packed,
                 &final_params,
                 model,
@@ -1245,11 +1245,11 @@ fn run_mcem(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     // ---- Finalize trace ----
     let impmap_trace = if collect_trace {

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -1215,6 +1215,7 @@ fn run_mcem(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             let packed = pack_params(&final_params);
@@ -1248,6 +1249,7 @@ fn run_mcem(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     // ---- Finalize trace ----
     let impmap_trace = if collect_trace {
@@ -1335,6 +1337,7 @@ fn run_mcem(
         h_matrices,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -19,6 +19,10 @@ pub struct OuterResult {
     /// Per-occasion kappa EBEs for each subject. Empty vecs when `n_kappa == 0`.
     pub kappas: Vec<Vec<DVector<f64>>>,
     pub covariance_matrix: Option<DMatrix<f64>>,
+    /// Wall-clock time spent inside this stage's covariance-step block
+    /// (`compute_covariance` / SIR-fallback construction), in seconds.
+    /// `0.0` when `run_covariance_step` was false for this stage.
+    pub covariance_wall_time_secs: f64,
     pub warnings: Vec<String>,
     /// Estimated OFV evaluations saved by the SAEM mu-ref gradient step M-step.
     /// Non-None only when method=saem and mu_referencing=true.
@@ -163,6 +167,7 @@ fn evaluate_at_initial_params(
 
     let mut warnings = Vec::new();
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
@@ -198,6 +203,7 @@ fn evaluate_at_initial_params(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     OuterResult {
         params,
@@ -208,6 +214,7 @@ fn evaluate_at_initial_params(
         h_matrices,
         kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,
@@ -1307,6 +1314,7 @@ fn optimize_nlopt(
     // Covariance step (skip if user cancelled — it's expensive and the result
     // will be discarded by the top-level fit() anyway).
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
@@ -1342,6 +1350,7 @@ fn optimize_nlopt(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if !converged {
         warnings.push("Outer optimization did not converge".to_string());
@@ -1364,6 +1373,7 @@ fn optimize_nlopt(
         h_matrices: final_hms,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,
@@ -1734,6 +1744,7 @@ fn optimize_bfgs(
     let final_ofv = ofv_at_fixed(&x_final, &final_ehs, &final_hms, &final_kappas);
 
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
@@ -1769,6 +1780,7 @@ fn optimize_bfgs(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if !converged {
         warnings.push("Outer optimization did not converge".to_string());
@@ -1783,6 +1795,7 @@ fn optimize_bfgs(
         h_matrices: final_hms,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -167,13 +167,13 @@ fn evaluate_at_initial_params(
 
     let mut warnings = Vec::new();
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
                 eprintln!("Computing covariance matrix...");
             }
-            match compute_covariance(
+            let cov_timer = std::time::Instant::now();
+            let cm = match compute_covariance(
                 &x,
                 init_params,
                 model,
@@ -199,11 +199,11 @@ fn evaluate_at_initial_params(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     OuterResult {
         params,
@@ -1314,13 +1314,13 @@ fn optimize_nlopt(
     // Covariance step (skip if user cancelled — it's expensive and the result
     // will be discarded by the top-level fit() anyway).
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
                 eprintln!("Computing covariance matrix...");
             }
-            match compute_covariance(
+            let cov_timer = std::time::Instant::now();
+            let cm = match compute_covariance(
                 &x0,
                 init_params,
                 model,
@@ -1346,11 +1346,11 @@ fn optimize_nlopt(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if !converged {
         warnings.push("Outer optimization did not converge".to_string());
@@ -1744,13 +1744,13 @@ fn optimize_bfgs(
     let final_ofv = ofv_at_fixed(&x_final, &final_ehs, &final_hms, &final_kappas);
 
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
                 eprintln!("Computing covariance matrix...");
             }
-            match compute_covariance(
+            let cov_timer = std::time::Instant::now();
+            let cm = match compute_covariance(
                 &x_final,
                 init_params,
                 model,
@@ -1776,11 +1776,11 @@ fn optimize_bfgs(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if !converged {
         warnings.push("Outer optimization did not converge".to_string());
@@ -5554,6 +5554,10 @@ mod tests {
             result.ofv.is_finite(),
             "presearch run produced non-finite OFV"
         );
+        // #713: with `run_covariance_step = false` the covariance block never
+        // runs, so its timer must report exactly 0.0, not a stray near-zero
+        // `Instant::now()` reading.
+        assert_eq!(result.covariance_wall_time_secs, 0.0);
     }
 
     // ── Covariance Hessian throughput benchmark (issue #209) ─────────────────

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2204,6 +2204,7 @@ pub fn run_saem(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if verbose {
@@ -2240,6 +2241,7 @@ pub fn run_saem(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if verbose {
         eprintln!("SAEM completed. Final OFV = {:.4}", ofv);
@@ -2293,6 +2295,7 @@ pub fn run_saem(
         h_matrices,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved,
         saem_n_subjects_hmc,

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2204,14 +2204,14 @@ pub fn run_saem(
 
     // ---- Covariance step ----
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if verbose {
                 eprintln!("Running covariance step...");
             }
+            let cov_timer = std::time::Instant::now();
             let packed = pack_params(&final_params);
-            match compute_covariance(
+            let cm = match compute_covariance(
                 &packed,
                 &final_params,
                 model,
@@ -2237,11 +2237,11 @@ pub fn run_saem(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     if verbose {
         eprintln!("SAEM completed. Final OFV = {:.4}", ofv);

--- a/src/estimation/trust_region.rs
+++ b/src/estimation/trust_region.rs
@@ -398,13 +398,13 @@ pub fn optimize_trust_region(
     }
 
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
-    let cov_timer = std::time::Instant::now();
-    let covariance_matrix =
+    let (covariance_matrix, covariance_wall_time_secs) =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
                 eprintln!("Computing covariance matrix...");
             }
-            match compute_covariance(
+            let cov_timer = std::time::Instant::now();
+            let cm = match compute_covariance(
                 &best_x,
                 init_params,
                 model,
@@ -430,11 +430,11 @@ pub fn optimize_trust_region(
                     sir_fallback_proposal = Some(fallback_proposal);
                     None
                 }
-            }
+            };
+            (cm, cov_timer.elapsed().as_secs_f64())
         } else {
-            None
+            (None, 0.0)
         };
-    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     OuterResult {
         params: final_params,

--- a/src/estimation/trust_region.rs
+++ b/src/estimation/trust_region.rs
@@ -398,6 +398,7 @@ pub fn optimize_trust_region(
     }
 
     let mut sir_fallback_proposal: Option<DMatrix<f64>> = None;
+    let cov_timer = std::time::Instant::now();
     let covariance_matrix =
         if options.run_covariance_step && !crate::cancel::is_cancelled(&options.cancel) {
             if options.verbose {
@@ -433,6 +434,7 @@ pub fn optimize_trust_region(
         } else {
             None
         };
+    let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     OuterResult {
         params: final_params,
@@ -443,6 +445,7 @@ pub fn optimize_trust_region(
         h_matrices: final_hms,
         kappas: final_kappas,
         covariance_matrix,
+        covariance_wall_time_secs,
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -330,6 +330,8 @@ mod tests {
         FitResult {
             method: crate::types::EstimationMethod::FoceI,
             method_chain: vec![],
+            method_wall_times_secs: vec![],
+            covariance_wall_time_secs: 0.0,
             converged: true,
             ofv: 0.0,
             aic: 0.0,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -189,6 +189,12 @@ struct FitWire {
     n_iterations: usize,
     interaction: bool,
     wall_time_secs: f64,
+    // Absent on bundles saved before #713 split out per-method / covariance
+    // timing; loaders default to an empty Vec / 0.0.
+    #[serde(default)]
+    method_wall_times_secs: Vec<f64>,
+    #[serde(default)]
+    covariance_wall_time_secs: f64,
     n_threads_used: usize,
     uses_ode_solver: bool,
     uses_sde: bool,
@@ -671,6 +677,8 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
         n_iterations: r.n_iterations,
         interaction: r.interaction,
         wall_time_secs: r.wall_time_secs,
+        method_wall_times_secs: r.method_wall_times_secs.clone(),
+        covariance_wall_time_secs: r.covariance_wall_time_secs,
         n_threads_used: r.n_threads_used,
         uses_ode_solver: r.uses_ode_solver,
         uses_sde: r.uses_sde,
@@ -1741,6 +1749,8 @@ fn wire_to_fit_result(
     Ok(FitResult {
         method,
         method_chain,
+        method_wall_times_secs: w.method_wall_times_secs,
+        covariance_wall_time_secs: w.covariance_wall_time_secs,
         converged: w.converged,
         ofv: w.ofv,
         aic: w.aic,
@@ -1951,6 +1961,8 @@ mod tests {
         FitResult {
             method: EstimationMethod::FoceI,
             method_chain: vec![EstimationMethod::FoceI],
+            method_wall_times_secs: vec![1.234],
+            covariance_wall_time_secs: 0.0,
             converged: true,
             ofv: 100.0,
             aic: 110.0,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1758,11 +1758,11 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
     // separately (#713) so a chain like `[focei, imp]` reports where the wall
     // time actually went instead of one opaque total.
     writeln!(f, "\nestimation:").map_err(|e| e.to_string())?;
-    for (m, secs) in result
-        .method_chain
-        .iter()
-        .zip(result.method_wall_times_secs.iter())
-    {
+    // Index explicitly rather than `.zip()`: a length mismatch (only expected
+    // for a pre-#713 `.fitrx` bundle, where `method_wall_times_secs` defaults
+    // to empty) must not silently drop trailing `method_chain` keys.
+    for (i, m) in result.method_chain.iter().enumerate() {
+        let secs = result.method_wall_times_secs.get(i).copied().unwrap_or(0.0);
         let key = m.label().to_lowercase().replace('-', "_");
         writeln!(f, "  {}_wall_time_secs: {:.6}", key, secs).map_err(|e| e.to_string())?;
     }
@@ -3078,6 +3078,24 @@ mod tests {
             yaml.contains("  covariance_wall_time_secs: 8.300000"),
             "{yaml}"
         );
+    }
+
+    #[test]
+    fn write_yaml_timing_survives_short_method_wall_times_secs() {
+        // #713 review: a `.fitrx` bundle saved before this field existed
+        // deserializes `method_wall_times_secs` to an empty Vec (`#[serde(default)]`)
+        // while `method_chain` is unaffected. Indexing with `.get(i)` must still
+        // emit every `{method}_wall_time_secs` key (at 0.0) rather than silently
+        // truncating via `.zip()`.
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.method_chain = vec![EstimationMethod::FoceI, EstimationMethod::Imp];
+        r.method_wall_times_secs = vec![];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(yaml.contains("  focei_wall_time_secs: 0.000000"), "{yaml}");
+        assert!(yaml.contains("  imp_wall_time_secs: 0.000000"), "{yaml}");
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1754,7 +1754,24 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
     // Run timing + thread count (#704 — replaces the separate `-timing.txt` file).
     // Key names match `FitResult`/`.fitrx` field names (`n_threads_used`,
     // `in_docker`) so the same data isn't spelled two different ways across formats.
+    // Per-method convergence time and the covariance step are broken out
+    // separately (#713) so a chain like `[focei, imp]` reports where the wall
+    // time actually went instead of one opaque total.
     writeln!(f, "\nestimation:").map_err(|e| e.to_string())?;
+    for (m, secs) in result
+        .method_chain
+        .iter()
+        .zip(result.method_wall_times_secs.iter())
+    {
+        let key = m.label().to_lowercase().replace('-', "_");
+        writeln!(f, "  {}_wall_time_secs: {:.6}", key, secs).map_err(|e| e.to_string())?;
+    }
+    writeln!(
+        f,
+        "  covariance_wall_time_secs: {:.6}",
+        result.covariance_wall_time_secs
+    )
+    .map_err(|e| e.to_string())?;
     writeln!(f, "  wall_time_secs: {:.6}", result.wall_time_secs).map_err(|e| e.to_string())?;
     writeln!(f, "  n_threads_used: {}", result.n_threads_used).map_err(|e| e.to_string())?;
 
@@ -1842,6 +1859,8 @@ mod tests {
         FitResult {
             method: EstimationMethod::Foce,
             method_chain: vec![EstimationMethod::Foce],
+            method_wall_times_secs: vec![0.0],
+            covariance_wall_time_secs: 0.0,
             converged: true,
             ofv: 0.0,
             aic: 0.0,
@@ -2408,6 +2427,8 @@ mod tests {
         FitResult {
             method: EstimationMethod::Foce,
             method_chain: vec![EstimationMethod::Foce],
+            method_wall_times_secs: vec![0.0],
+            covariance_wall_time_secs: 0.0,
             converged: true,
             ofv: 0.0,
             aic: 0.0,
@@ -3021,7 +3042,10 @@ mod tests {
         // Warnings.
         assert!(yaml.contains("\nwarnings:") && yaml.contains("- \"example warning\""));
         // #704: estimation timing/threads + environment snapshot.
+        // #713: per-method convergence time + covariance step broken out.
         assert!(yaml.contains("\nestimation:"));
+        assert!(yaml.contains("  foce_wall_time_secs:"));
+        assert!(yaml.contains("  covariance_wall_time_secs:"));
         assert!(yaml.contains("  wall_time_secs:"));
         assert!(yaml.contains("  n_threads_used:"));
         assert!(yaml.contains("\nenvironment:"));
@@ -3033,6 +3057,27 @@ mod tests {
             yaml_quote(&r.environment.username)
         )));
         assert!(yaml.contains(&format!("  ferx_version: {}", r.ferx_version)));
+    }
+
+    #[test]
+    fn write_yaml_splits_timing_per_method_chain_stage() {
+        // #713: a chained fit (e.g. `[focei, imp]`) should report each stage's
+        // convergence time under its own key, plus the covariance step
+        // separately, instead of one opaque `wall_time_secs` total.
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.method_chain = vec![EstimationMethod::FoceI, EstimationMethod::Imp];
+        r.method_wall_times_secs = vec![32.5, 15.3];
+        r.covariance_wall_time_secs = 8.3;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(yaml.contains("  focei_wall_time_secs: 32.500000"), "{yaml}");
+        assert!(yaml.contains("  imp_wall_time_secs: 15.300000"), "{yaml}");
+        assert!(
+            yaml.contains("  covariance_wall_time_secs: 8.300000"),
+            "{yaml}"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4070,6 +4070,15 @@ pub struct FitResult {
     pub dw_statistic: f64,
     /// Wall-clock time for the complete fit in seconds.
     pub wall_time_secs: f64,
+    /// Wall-clock time spent converging each stage of `method_chain`, parallel
+    /// to it, in seconds. Excludes the covariance step (see
+    /// `covariance_wall_time_secs`), which only ever runs on the last
+    /// estimating stage (#615).
+    pub method_wall_times_secs: Vec<f64>,
+    /// Wall-clock time spent on the post-estimation covariance step (FD
+    /// Hessian / SIR-fallback proposal construction), in seconds. `0.0` when
+    /// the covariance step was not run (#713).
+    pub covariance_wall_time_secs: f64,
     /// Model name (from the `.ferx` file or "Unnamed").
     pub model_name: String,
     /// ferx-core library version (from Cargo.toml at compile time).

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -169,6 +169,10 @@ fn fit_with_data_writes_outputs_and_bundle() {
         yaml.contains("\nestimation:"),
         "yaml missing estimation: {yaml}"
     );
+    // #713: convergence time is broken out per method-chain stage (this fit
+    // is a single-stage FOCEI run), plus the covariance step separately.
+    assert!(yaml.contains("  focei_wall_time_secs:"));
+    assert!(yaml.contains("  covariance_wall_time_secs:"));
     assert!(yaml.contains("  wall_time_secs:"));
     assert!(yaml.contains("  n_threads_used:"));
     assert!(


### PR DESCRIPTION
## Why
`{model}-fit.yaml`'s `estimation:` block reported one opaque `wall_time_secs`
total. For a chained fit (e.g. `method_chain = [focei, imp]`) or any fit with
`covariance = true`, there was no way to tell whether the time went into
convergence or into the (often expensive) FD-Hessian / SIR-fallback
covariance step. #713 asks for that breakdown.

## What changed
- `OuterResult` (each estimator's return type) gains `covariance_wall_time_secs`,
  timed around the existing `compute_covariance` block in every estimator that
  runs one (`outer_optimizer.rs` ×3, `gauss_newton.rs` ×2, `impmap.rs`,
  `saem.rs`, `trust_region.rs`). `0.0` for estimators that never run it
  (Bayes, the synthetic IMP-eval-only stage).
- `fit_inner`'s method-chain loop times each stage and subtracts the stage's
  own `covariance_wall_time_secs` (only nonzero on the last estimating stage,
  per #615) to get pure convergence time, accumulated into
  `FitResult.method_wall_times_secs: Vec<f64>` (parallel to `method_chain`)
  and `FitResult.covariance_wall_time_secs: f64`.
- The YAML writer emits one `{method}_wall_time_secs` key per chain stage
  (e.g. `focei_wall_time_secs`, `imp_wall_time_secs`) plus
  `covariance_wall_time_secs`, alongside the existing `wall_time_secs` total.
- `.fitrx` wire format carries both new fields, `#[serde(default)]`'d so
  older bundles still load.

## Breaking changes
- [x] `FitResult` / sdtab fields changed (additive only — two new fields,
      nothing removed or renamed)
- [ ] Public Rust API (`api.rs` / `types.rs`) — no signature changes, additive fields only

## Numerical validation
- [x] Not applicable (adds timing metadata only; no change to estimates, OFV, or convergence behavior)

## Performance
- [x] No significant impact expected (a few `Instant::now()`/`elapsed()` calls around existing code paths)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 2242 passed)
- [x] Regression test added that fails without this fix (`write_yaml_splits_timing_per_method_chain_stage`, plus extended `cli_binaries::fit_with_data_writes_outputs_and_bundle` for an end-to-end FOCEI fit)
- [ ] No new tests needed

## Docs
- [x] `docs/` updated for user-visible changes (`docs/output.qmd`, `docs/file-formats/fitrx.qmd`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings/errors vs. `main`; 4 pre-existing `two_cpt_explicit.rs` clippy errors are untouched/unrelated)
- [ ] N/A — no gradient-reachable code touched
- [ ] N/A — no breaking change, no version bump

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not opened | not needed (additive fields; R layer can pick them up in a follow-up whenever it wants to surface them) |

## Reviewer hints
The interesting bit is in `fit_inner`'s stage loop in `src/api.rs`: each
stage's wall time is `stage_start.elapsed() - stage_result.covariance_wall_time_secs`,
clamped to `0.0`. Since `run_covariance_step` is only ever `true` on the last
*estimating* stage (#615), summing `covariance_wall_time_secs` across stages
is safe (all but one are `0.0`) rather than needing a "which stage ran it"
lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)