### PR TITLE
fix(io): reject SS=2 steady-state records instead of silently collapsing to SS=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,14 @@ section of the SDLC for the versioning policy).
   from `ferx check` or at fit time. Such an out-of-order reference is now rejected loudly,
   naming the offending variable; reorder the block so each name is declared before it is
   used. This mirrors the existing `[odes]` undefined-reference guard (#314).
+- **`SS=2` steady-state dose records are now rejected instead of silently run as
+  `SS=1`** (#729): NONMEM `SS=2` (superimpose the steady state of a regimen on top
+  of the compartment's existing amounts, without resetting) was collapsed to the
+  same internal `ss = true` flag as `SS=1` (reset then equilibrate) — every
+  `SS >= 0.5` cell became `SS=1` — so an `SS=2` dataset fitted, predicted, and
+  simulated with the wrong (reset) initial conditions and no warning. The data
+  reader now accepts only `SS=0`/`SS=1` and rejects `SS=2` (and any other code)
+  with a clear message. Full `SS=2` support is tracked in #694.
 - **Fits are now reproducible regardless of the worker-thread count** (#703). The FOCE/FOCEI,
   SAEM, and importance-sampling objectives summed the per-subject log-likelihood with a parallel
   reduction whose grouping depended on the number of rayon threads; because floating-point

--- a/docs/examples/steady-state.qmd
+++ b/docs/examples/steady-state.qmd
@@ -78,6 +78,7 @@ Estimates should be close to the single-dose warfarin values (`TVCL ≈ 0.134`, 
 ## Tips
 
 - **`SS` requires `II`**: every row with `SS=1` must also have a non-zero `II` (dosing interval in the same time units as `TIME`).
+- **`SS=1` only**: ferx implements `SS=1` (reset the compartment, then initialise it at the steady state of the given regimen). NONMEM's `SS=2` (superimpose that steady state *on top of* the compartment's existing amounts, without a reset) is **not** supported — a dataset with `SS=2` is rejected at read time with a clear error rather than silently treated as `SS=1`. Full `SS=2` support is tracked in [issue #694](https://github.com/FeRx-NLME/ferx-core/issues/694).
 - **Analytical solvers only**: the `SS=1` initialisation is currently implemented for the analytical 1-cpt and 2-cpt solvers. For ODE models at steady state, use a long ADDL pre-dosing sequence to approximate it.
 - **TAD at steady state**: `TAD` is computed relative to the SS dose row, so the first observation at `TIME=0.5` has `TAD=0.5`. TAFD is measured from the same row.
 - **Mixed designs**: a dataset may contain some subjects with `SS=1` and others without (e.g. a cross-over study). Each subject's dose rows are handled independently.

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1025,6 +1025,59 @@ fn validate_dose_rate(rate: f64, id: &str, time: f64) -> Result<RateMode, String
     ))
 }
 
+/// Validate a `SS` (steady-state) dataset cell.
+///
+/// NONMEM overloads `SS`: `0` = not steady state, `1` = reset the dose
+/// compartment to zero and initialise it at the steady state of the given
+/// regimen, `2` = *superimpose* that steady state on top of the compartment's
+/// pre-existing amounts (no reset). ferx implements `SS=1` only.
+///
+/// The engine carries steady state as a single `DoseEvent.ss: bool`, so once a
+/// cell is reduced to that flag the `1`-vs-`2` distinction is gone. Previously
+/// any `SS >= 0.5` — including `SS=2` — was collapsed to `ss = true` and run
+/// with `SS=1` (reset) semantics, so an `SS=2` record produced a wrong (reset)
+/// profile with no error. `0` maps to `false`, `1` to `true`; every other value
+/// (including `SS=2`) is rejected here. Full `SS=2` support is tracked in #694.
+///
+/// A missing / blank / non-numeric cell arrives as `0.0` (via [`parse_f64`]) and
+/// is treated as "not steady state", matching the NONMEM default. `time` is the
+/// user-written (`raw_time`) value so the message names the row's own time.
+fn validate_ss(ss: f64, id: &str, time: f64) -> Result<bool, String> {
+    if !ss.is_finite() {
+        return Err(format!(
+            "subject {id}, time {time}: SS={ss} is not finite; expected 0 (not \
+             steady state) or 1 (reset then dose to steady state)."
+        ));
+    }
+    // `SS` is a NONMEM integer code. Match on the integer form (mirrors
+    // `validate_dose_rate`); a non-integer `SS` is not a code. `ss as i64`
+    // saturates, so an out-of-range integer can't alias 0/1. Comparison against
+    // `0.0` is exempt from clippy::float_cmp.
+    let code = if ss.fract() == 0.0 {
+        Some(ss as i64)
+    } else {
+        None
+    };
+    match code {
+        Some(0) => Ok(false),
+        Some(1) => Ok(true),
+        _ => {
+            let hint = if code == Some(2) {
+                " SS=2 (superimpose the steady state without resetting the \
+                 compartment) is not yet supported — only SS=1 (reset then dose \
+                 to steady state) is implemented; see issue #694."
+            } else {
+                ""
+            };
+            Err(format!(
+                "subject {id}, time {time}: SS={ss} is not a supported \
+                 steady-state code; expected 0 (not steady state) or 1 (reset \
+                 then dose to steady state).{hint}"
+            ))
+        }
+    }
+}
+
 /// Compute a record's effective EVID.
 ///
 /// When an `EVID` column is present its value governs (a blank / `.` /
@@ -1424,10 +1477,19 @@ fn parse_subject(
                 .and_then(|c| row.get(c))
                 .map(|s| parse_f64(s))
                 .unwrap_or(0.0);
-            let ss = ss_col
-                .and_then(|c| row.get(c))
-                .map(|s| parse_f64(s.trim()) >= 0.5)
-                .unwrap_or(false);
+            // Validate the `SS` cell: only `SS=0`/`SS=1` are supported. A missing
+            // or blank cell parses to `0.0` (not steady state). `SS=2` and other
+            // codes are rejected here (via `validate_ss`) rather than silently
+            // collapsed into the single `ss = true` flag and run with `SS=1`
+            // (reset) semantics. `raw_time` names the value the user wrote.
+            let ss = validate_ss(
+                ss_col
+                    .and_then(|c| row.get(c))
+                    .map(|s| parse_f64(s.trim()))
+                    .unwrap_or(0.0),
+                id,
+                raw_time,
+            )?;
 
             doses.push(match rate_mode {
                 RateMode::Fixed => DoseEvent::new(time, amt, cmt, rate, ss, ii),
@@ -1882,6 +1944,28 @@ mod tests {
     }
 
     #[test]
+    fn ss2_dose_row_is_rejected() {
+        // An `SS=2` dose (superimpose steady state without reset) must not load
+        // silently as `SS=1` (reset) — reading the dataset fails end-to-end with a
+        // message that identifies the row and points at the tracking issue. This
+        // is the wiring test for `validate_ss` on the real parse path.
+        let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II\n\
+                   1,0,.,1,100,1,0,1,2,24\n\
+                   1,1,5.0,0,.,1,0,0,0,0\n";
+        let f = write_csv(csv);
+        let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
+        assert!(err.contains("SS=2") && err.contains("#694"), "{err}");
+
+        // SS=1 on the same layout still loads (the regimen ferx does support).
+        let ok = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II\n\
+                  1,0,.,1,100,1,0,1,1,24\n\
+                  1,1,5.0,0,.,1,0,0,0,0\n";
+        let f = write_csv(ok);
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        assert!(pop.subjects[0].doses[0].ss);
+    }
+
+    #[test]
     fn unknown_iov_column_is_rejected() {
         // A requested IOV column that isn't in the header is a hard error, not a
         // silent "no occasions" — otherwise an IOV model would quietly collapse.
@@ -2225,6 +2309,44 @@ mod tests {
         // Ordinary data-driven rates classify as Fixed.
         assert_eq!(validate_dose_rate(0.0, "1", 0.0).unwrap(), RateMode::Fixed);
         assert_eq!(validate_dose_rate(50.0, "1", 0.0).unwrap(), RateMode::Fixed);
+    }
+
+    // ── NONMEM SS codes: only 0/1 supported ──────────────────────────────────
+    // The engine stores steady state as a single `DoseEvent.ss: bool`. `SS=1`
+    // (reset then equilibrate) and `SS=2` (superimpose without reset) are
+    // *different* regimens, but both used to collapse to `ss = true` (`SS >= 0.5`)
+    // and run with SS=1 semantics — so an SS=2 record silently produced a wrong
+    // (reset) profile. `validate_ss` is the unit under test: 0/1 pass, everything
+    // else (SS=2, other codes, non-integers, non-finite) is rejected loudly.
+    #[test]
+    fn validate_ss_accepts_0_and_1_rejects_others() {
+        // The only supported codes: 0 = not steady state, 1 = reset then dose to
+        // steady state.
+        assert!(!validate_ss(0.0, "1", 0.0).unwrap());
+        assert!(validate_ss(1.0, "1", 0.0).unwrap());
+
+        // SS=2 (superimpose without reset) is not supported — rejected loudly,
+        // not silently collapsed to SS=1. The message names the value, the row,
+        // and the tracking issue so the offending record is identifiable.
+        let e = validate_ss(2.0, "7", 12.0).unwrap_err();
+        assert!(
+            e.contains("SS=2") && e.contains("#694") && e.contains("subject 7"),
+            "{e}"
+        );
+
+        // Other codes and non-integers are not rounded into 0/1 — a stray SS is
+        // malformed, not a silent steady-state regimen.
+        for s in [3.0, -1.0, 0.5, 1.5] {
+            let e = validate_ss(s, "1", 0.0).unwrap_err();
+            assert!(e.contains(&format!("SS={s}")), "s={s}: {e}");
+        }
+
+        // Non-finite SS on a dose row is malformed (old code: `inf >= 0.5` was a
+        // silent steady-state dose).
+        for s in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            let e = validate_ss(s, "1", 0.0).unwrap_err();
+            assert!(e.contains("not finite"), "s={s}: {e}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

NONMEM overloads the `SS` column. `SS=1` resets the dose compartment to zero and
initialises it at the steady state of the given regimen; `SS=2` **superimposes**
that steady state on top of the compartment's *existing* amounts, without a
reset. ferx implements `SS=1` only.

The data reader reduced every `SS` cell to a single boolean with
`parse_f64(cell) >= 0.5`, so `SS=2` — and `SS=3`, fractional codes, `inf` —
collapsed to the same internal `ss = true` flag as `SS=1` and ran with `SS=1`
(reset) semantics. An `SS=2` dataset therefore **fitted, predicted, and
simulated with the wrong (reset) initial conditions and no warning** — a
silent-wrong-answer footgun when porting a NONMEM dataset that uses `SS=2`.

This is the steady-state half of the absorption × functionality audit. It was
re-scoped from "implement true `SS=2`" down to a **guard**: stop the silent
collapse now; full `SS=2` (superimpose-without-reset) semantics are tracked in
#694 (S5).

## What changed

- New `validate_ss(ss, id, time)` in `io/datareader.rs`, mirroring the existing
  `validate_dose_rate`: it accepts `SS=0` → `false` and `SS=1` → `true`, and
  rejects `SS=2` (with a message that names the superimpose-without-reset
  semantics and points at #694), any other integer code, non-integers, and
  non-finite values.
- The dose-parse call site routes the `SS` cell through `validate_ss` and bubbles
  the error with `?` (exactly like `validate_dose_rate`), so **every** entry
  point that reads a dataset rejects `SS=2`.
- A missing / blank / non-numeric `SS` cell still parses to `0.0` = "not steady
  state" (unchanged), so only real unsupported codes are affected.

## Alternatives considered

Warn-and-continue (run `SS=2` as `SS=1`, emit a `FitResult.warnings`) — rejected.
It keeps producing a wrong profile, just with a note, which is exactly the
silent-wrong-answer class the recent #696 / #699 / #725 guards close. Rejecting
at read time is consistent with those and fails loudly on the offending row. See
Open questions if a migration-window warning is preferred.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API or `.ferx` change; nothing for ferx-r to track.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None *(on the `.ferx` / API axes)*

<details>
<summary>Migration notes (dataset behaviour)</summary>

A dataset with `SS=2` (or another unsupported code) that previously loaded — and
silently ran as `SS=1` — now errors at read time. This is intended: those runs
were already wrong. Replace `SS=2` with the regimen you actually want; if you
need genuine superimpose-without-reset, follow #694, or model the pre-existing
amounts explicitly (e.g. an ADDL pre-dose history) instead of `SS=2`.

</details>

## Numerical validation
- [x] Not applicable (parse-time input guard, not a numeric change to a supported
  path). `SS=1` behaviour is **bit-identical** — the accepted `true` branch is the
  same flag the engine already used.

Verified by tests instead:
- `validate_ss_accepts_0_and_1_rejects_others` (Tier-1 unit): `0`/`1` accepted;
  `SS=2/3/-1/0.5/1.5/inf/nan` rejected, each message naming the offending value
  (and `#694` for `SS=2`).
- `ss2_dose_row_is_rejected` (Tier-1, full parse path): an `SS=2` CSV fails
  `read_nonmem_csv` with a message naming `SS=2` and `#694`; the identical layout
  with `SS=1` still loads with `ss = true`.

## Performance
- [x] No significant impact expected (one integer classify per dose row at parse).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix (old `>= 0.5` accepted
  `SS=2` as `ss=true`; new path rejects it)

## Docs
- [x] `docs/` updated — `docs/examples/steady-state.qmd` gains an "SS=1 only" tip
  documenting the rejection + link to #694
- [x] `CHANGELOG.md` `[Unreleased]` → Fixed

## Checklist
- [x] `cargo clippy` clean
- [x] No `Dual2` / gradient-path code touched
- [x] No version bump (not breaking on `.ferx` / API)

## Reviewer hints

- `validate_ss` deliberately mirrors `validate_dose_rate` (integer-code match via
  `fract() == 0.0`, non-finite guard, `raw_time` in the message).
- The `>= 0.5` → `validate_ss` swap is the behavioural core; the rest is message,
  tests, and docs.
- Full `SS=2` (superimpose without reset) is out of scope and tracked in #694
  (S5) — this PR only stops the silent collapse.

## Open questions

- **Reject vs warn:** I chose reject (loud fail), consistent with #696 / #699 /
  #725. If you'd prefer warn-and-continue for `SS=2` during a migration window,
  I'll switch it to a `FitResult.warnings` + still-run-as-`SS=1` (less safe).
