### PR TITLE
feat(sim): support IOV (per-occasion kappa) in adaptive/feedback dosing [#701]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,10 @@ section of the SDLC for the versioning policy).
   is drawn on a dedicated per-(subject, replicate) substream, so a non-IOV run is
   byte-identical to before and enabling a `Dv` monitor never shifts the draws. The
   `auc_target_attainment` metric is not yet available for IOV subjects and is rejected
-  with a typed error rather than reported from a κ-frozen snapshot.
+  with a typed error rather than reported from a κ-frozen snapshot. A non-ascending or
+  duplicated adaptive `decision_times` schedule (programmatic `simulate_adaptive`) is now
+  rejected with a typed error, matching the declarative `[adaptive_dosing]` path — an
+  out-of-order schedule would otherwise mis-map a record to the wrong occasion.
 - **`estimation:` block in `{model}-fit.yaml` now splits wall time by stage** (#713):
   a `{method}_wall_time_secs` entry (e.g. `focei_wall_time_secs`, `imp_wall_time_secs`)
   is reported for each stage of `method`/`methods`, plus a `covariance_wall_time_secs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ section of the SDLC for the versioning policy).
   also silently frozen at `TIME=0`). The `auc_target_attainment` metric is not yet
   available for time-varying-covariate subjects and is rejected with a typed error
   rather than reported from a frozen snapshot.
+- **Adaptive (feedback) dosing now supports inter-occasion variability (IOV)** (#701):
+  the reactive driver draws a fresh occasion `kappa` per **decision window** (occasion =
+  decision index) and threads it through the per-event PK — instead of silently holding
+  every kappa at zero — so occasion-to-occasion shifts in CL/V correctly drive the
+  predictions, the monitored signal, and every reactive dose decision, and the
+  frozen-replay verifier validates the per-occasion bookkeeping. Composes with the #700
+  time-varying-covariate path (a model with both is per-event correct in each). `kappa`
+  is drawn on a dedicated per-(subject, replicate) substream, so a non-IOV run is
+  byte-identical to before and enabling a `Dv` monitor never shifts the draws. The
+  `auc_target_attainment` metric is not yet available for IOV subjects and is rejected
+  with a typed error rather than reported from a κ-frozen snapshot.
 - **`estimation:` block in `{model}-fit.yaml` now splits wall time by stage** (#713):
   a `{method}_wall_time_secs` entry (e.g. `focei_wall_time_secs`, `imp_wall_time_secs`)
   is reported for each stage of `method`/`methods`, plus a `covariance_wall_time_secs`

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -342,10 +342,17 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   time-varying-covariate subject is a typed error rather than a frozen-snapshot AUC.
 - **No system resets** — a subject with an EVID=3/4 reset event is rejected (the
   reactive driver does not apply resets).
-- **Between-subject variability only** — η is drawn per subject/replicate. A model
-  declaring **inter-occasion variability** (`kappa` / IOV) is rejected rather than
-  silently run with its kappas held at zero; parameter-uncertainty propagation and
-  IOV are later layers.
+- **Inter-occasion variability (IOV) is supported** — a fresh occasion `kappa` is
+  drawn per **decision window** (occasion = decision index) and threaded through the
+  per-event PK, so occasion-to-occasion shifts in CL/V drive the trajectory, the
+  monitored signal, and every reactive dose; the frozen-replay verifier validates the
+  per-occasion bookkeeping, and it composes with time-varying covariates. `kappa` is
+  drawn on a dedicated per-(subject, replicate) substream (disjoint from the η and
+  assay streams), so a non-IOV run is unchanged and enabling a `Dv` monitor never
+  shifts the draws. *Caveat:* as with time-varying covariates, `auc_target` on an IOV
+  model is a typed error (the exposure metric is not yet computed per-occasion).
+  Between-subject η is still drawn per subject/replicate; parameter-uncertainty
+  propagation is a later layer.
 - **Deterministic ODE only** — a stochastic (`[diffusion]` / SDE) model is rejected
   (the reactive integrator carries no process noise).
 - **Diagonal assay noise** — each `Dv` monitor draws independently; correlated

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -346,7 +346,10 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   drawn per **decision window** (occasion = decision index) and threaded through the
   per-event PK, so occasion-to-occasion shifts in CL/V drive the trajectory, the
   monitored signal, and every reactive dose; the frozen-replay verifier validates the
-  per-occasion bookkeeping, and it composes with time-varying covariates. `kappa` is
+  per-occasion bookkeeping, and it composes with time-varying covariates — the
+  composition (`CL = TVCL·(CRCL/100)·exp(η + κ)` under a declining covariate *and* a
+  per-occasion κ) is cross-validated dose-for-dose against an independent **mrgsolve**
+  run (`tests/reference/vanco_renal_iov_mrgsolve/`). `kappa` is
   drawn on a dedicated per-(subject, replicate) substream (disjoint from the η and
   assay streams), so a non-IOV run is unchanged and enabling a `Dv` monitor never
   shifts the draws. *Caveat:* as with time-varying covariates, `auc_target` on an IOV

--- a/examples/adaptive_vanco_iov.ferx
+++ b/examples/adaptive_vanco_iov.ferx
@@ -1,0 +1,86 @@
+# Adaptive (feedback) dosing — vancomycin trough-TDM titration with
+# inter-occasion variability (IOV) on clearance (epic #391 / #701)
+#
+# The IOV counterpart of adaptive_vanco_auc.ferx. A 1-cpt IV vancomycin model is
+# dosed once daily by a 1-h infusion, and the pre-dose trough (CENT/V) is titrated
+# +/-25% to hold it in a target band — the same trough control law as the
+# constant-covariate example. What differs here is that clearance carries a fresh
+# per-occasion random effect: KAPPA_CL ~ N(0, omega_iov) is redrawn for each
+# decision window (occasion = decision index, #701), held until the next decision,
+# and applied to CL for that window:
+#
+#   CL = TVCL * exp(ETA_CL + KAPPA_CL)
+#
+# So each day the patient's true CL jumps to a new value, drug clears faster or
+# slower, and the controller must re-titrate off the trough it observes — the
+# occasion-varying κ genuinely drives every decision.
+#
+# This is the #701 analogue of the #700 renal-decline anchor: instead of a smooth
+# covariate trajectory, the per-occasion κ makes CL switch discretely at each
+# decision window. The reactive driver threads occasion g's κ through the segments
+# of window g (#701) — exactly the mechanism cross-validated here against an
+# independent mrgsolve run fed the same reconstructed κ.
+#
+# `auc_target` is deliberately absent: the exposure metric integrates a dense grid
+# from a single frozen PK snapshot, which is silently wrong when CL switches per
+# occasion, so `auc_target` is a typed error for an IOV (`kappa`) subject (#701).
+# `target_window` (the pct-in-band trough metric) stays — it is a decision-grid
+# summary evaluated at each occasion's own κ and is fully per-occasion aware.
+#
+# Run with `simulate_adaptive_from_spec()` (not the plain forward `simulate()`).
+# Validated against an independent mrgsolve run (mrgsolve, not NONMEM, is the
+# feedback-dosing comparator): ferx's realized doses + reconstructed per-occasion κ
+# are injected into an occasion-indexed mrgsolve model and the trough trajectory is
+# compared dose-for-dose. See tests/reference/vanco_iov_mrgsolve/.
+#
+# Non-degenerate IOV: KAPPA_CL carries SD ~ 0.3 (variance 0.09) so the per-occasion
+# κ is genuinely nonzero and CL really switches per window — the anchor would be
+# vacuous with a vanishing κ. The between-subject ETA_CL is negligible (SD ~ 1e-5):
+# the engine requires at least one omega, but BSV is not the point here — the
+# per-occasion κ is the sole (intended) source of PK variation.
+#
+# See docs/model-file/adaptive-dosing.qmd for the block reference.
+
+[parameters]
+  theta TVCL(4.0,  0.1,  50.0)   # vancomycin clearance (L/h)
+  theta TVV(80.0,  5.0, 300.0)   # central volume (L); CENT/V is the concentration
+
+  # Negligible between-subject variability: the engine requires at least one omega,
+  # so CL's BSV carries a vanishing variance (SD ~ 1e-5). The IOV κ below is the
+  # intended (and dominant) source of PK variation.
+  omega ETA_CL ~ 1e-10
+
+  # Inter-occasion variability on CL (#701): a fresh KAPPA_CL is drawn per decision
+  # window (occasion = decision index) from N(0, 0.09) — SD ~ 0.3, so CL swings by
+  # roughly +/-35% window to window. This is what the mrgsolve anchor injects.
+  kappa KAPPA_CL ~ 0.09
+
+  sigma ADD ~ 1.0                # nominal additive error (concentration); the latent
+                                 # `observe` signal is un-noised, so it never enters
+                                 # the dose decisions.
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)   # per-occasion κ switches clearance each window
+  V  = TVV
+
+[structural_model]
+  ode(states=[CENT])
+
+[odes]
+  d/dt(CENT) = -(CL / V) * CENT  # 1-cpt IV; infusions enter CENT via the route
+
+[scaling]
+  y = CENT / V                   # observed/predicted endpoint: concentration (mg/L)
+
+[error_model]
+  DV ~ additive(ADD)
+
+[adaptive_dosing]
+  observe       = CENT / V               # titrate on the latent trough concentration
+  at            = every 24 from 0 to 312 # a decision at the start of each day
+  start_dose    = 500                    # empiric start (mg/day): subtherapeutic -> climbs
+  route         = infuse(cmt=1, over=1)  # 1-h IV infusion into the drug compartment
+  dose_bounds   = [250, 4000]            # mg/day
+  target_window = [10, 15]               # report % of days with trough in [10, 15] mg/L
+  when signal < 10 : increase 25%        # subtherapeutic trough -> raise the dose
+  when signal > 15 : decrease 25%        # supratherapeutic trough -> lower the dose

--- a/examples/adaptive_vanco_renal_iov.ferx
+++ b/examples/adaptive_vanco_renal_iov.ferx
@@ -1,0 +1,85 @@
+# Adaptive (feedback) dosing — vancomycin trough-TDM titration under BOTH a
+# time-varying renal covariate AND inter-occasion variability on clearance
+# (epic #391 / #700 x #701)
+#
+# This is the COMPOSITION of the two adaptive anchors:
+#   - adaptive_vanco_renal.ferx (#700): a declining CRCL covariate drives CL, and
+#     the reactive driver recomputes PK per event/segment from the covariate active
+#     in that segment (NONMEM end-of-interval convention).
+#   - adaptive_vanco_iov.ferx  (#701): a fresh per-occasion KAPPA_CL is drawn per
+#     decision window (occasion = decision index) and threaded through the segments.
+#
+# Here clearance depends on BOTH at once:
+#
+#   CL = TVCL * (CRCL / 100) * exp(ETA_CL + KAPPA_CL)
+#
+# so each day CL is set by (a) the renal function active in that segment (a smooth
+# decline from ~120 to ~40 mL/min over the horizon) and (b) that window's occasion
+# kappa. The controller titrates the once-daily 1-h infusion +/-25% to hold the
+# pre-dose trough (CENT/V) in a target band. Both effects move CL, so the realized
+# dose ladder reflects the two composed — the #700 per-event PK path and the #701
+# per-occasion kappa are each per-event correct, and correct TOGETHER.
+#
+# `auc_target` is deliberately absent: its exposure metric integrates a dense grid
+# from a single frozen PK snapshot, which is silently wrong when CL changes across
+# the horizon (a drifting covariate OR a per-occasion kappa), so it is a typed error
+# for a time-varying-covariate / IOV subject (#700/#701). `target_window` (the
+# pct-in-band trough metric) is per-event / per-occasion aware and retained.
+#
+# Run with `simulate_adaptive_from_spec()` (not the plain forward `simulate()`).
+# Validated dose-for-dose against an independent mrgsolve run (mrgsolve, not NONMEM,
+# is the feedback-dosing comparator): ferx's realized doses + reconstructed
+# per-occasion kappa + the CRCL trajectory are injected into an mrgsolve model whose
+# per-segment CL is TVCL*(CRCL/100)*exp(kappa), and the trough trajectory is compared
+# dose-for-dose. See tests/reference/vanco_renal_iov_mrgsolve/.
+#
+# Negligible BSV: ETA_CL carries a vanishing variance (SD ~ 1e-5) so the two
+# INTENDED sources of PK variation — the CRCL decline and the per-occasion kappa —
+# are what drive every decision. KAPPA_CL carries SD ~ 0.3 (variance 0.09), genuinely
+# nonzero, so CL really switches per window on top of the covariate trend.
+#
+# See docs/model-file/adaptive-dosing.qmd for the block reference.
+
+[parameters]
+  theta TVCL(4.0,  0.1,  50.0)   # vancomycin clearance at CRCL = 100 mL/min (L/h)
+  theta TVV(80.0,  5.0, 300.0)   # central volume (L); CENT/V is the concentration
+
+  # Negligible between-subject variability: the engine requires at least one omega,
+  # so CL's BSV carries a vanishing variance (SD ~ 1e-5). The CRCL covariate and the
+  # IOV kappa below are the intended sources of PK variation.
+  omega ETA_CL ~ 1e-10
+
+  # Inter-occasion variability on CL (#701): a fresh KAPPA_CL is drawn per decision
+  # window (occasion = decision index) from N(0, 0.09) — SD ~ 0.3. This is what the
+  # mrgsolve anchor injects, composed with the CRCL covariate below.
+  kappa KAPPA_CL ~ 0.09
+
+  sigma ADD ~ 1.0                # nominal additive error (concentration); the latent
+                                 # `observe` signal is un-noised, so it never enters
+                                 # the dose decisions.
+
+[individual_parameters]
+  CL = TVCL * (CRCL / 100.0) * exp(ETA_CL + KAPPA_CL)  # renal covariate x IOV kappa
+  V  = TVV                       # (CRCL is the time-varying covariate that declines)
+
+[structural_model]
+  ode(states=[CENT])
+
+[odes]
+  d/dt(CENT) = -(CL / V) * CENT  # 1-cpt IV; infusions enter CENT via the route
+
+[scaling]
+  y = CENT / V                   # observed/predicted endpoint: concentration (mg/L)
+
+[error_model]
+  DV ~ additive(ADD)
+
+[adaptive_dosing]
+  observe       = CENT / V               # titrate on the latent trough concentration
+  at            = every 24 from 0 to 312 # a decision at the start of each day
+  start_dose    = 500                    # empiric start (mg/day): subtherapeutic -> climbs
+  route         = infuse(cmt=1, over=1)  # 1-h IV infusion into the drug compartment
+  dose_bounds   = [250, 4000]            # mg/day
+  target_window = [10, 15]               # report % of days with trough in [10, 15] mg/L
+  when signal < 10 : increase 25%        # subtherapeutic trough -> raise the dose
+  when signal > 15 : decrease 25%        # supratherapeutic trough -> lower the dose

--- a/src/api.rs
+++ b/src/api.rs
@@ -671,32 +671,23 @@ fn reject_selected_error_for_adaptive(model: &CompiledModel) -> Result<(), Strin
 }
 
 /// Reject the model / data combinations the reactive driver cannot yet simulate
-/// *faithfully*. The adaptive path carries between-subject variability only (kappas
-/// held at zero) and never applies a reset or carries process noise. So an IOV
-/// model, a system reset (EVID=3/4), or an SDE `[diffusion]` model would each be
+/// *faithfully*. The adaptive path never applies a reset or carries process noise,
+/// so a system reset (EVID=3/4) or an SDE `[diffusion]` model would each be
 /// **silently** wrong — a violation of the "never a silent wrong answer" contract
 /// this module promises. Until each is properly supported (#391 follow-ups), reject
-/// it with a typed error. This mirrors the `n_kappa > 0` guards `fit()` already
-/// applies (IMPMAP, trust-region). Both public entry points funnel through
+/// it with a typed error. Both public entry points funnel through
 /// `run_adaptive_population`, so guarding there covers `simulate_adaptive` and
 /// `simulate_adaptive_from_spec`.
 ///
 /// Time-varying covariates (and a `TIME`-in-PK model) are **no longer** rejected:
-/// the driver now recomputes PK per event/segment from the covariate active in that
-/// segment (#700), the same way the static `predict()` / `simulate()` path does.
+/// the driver recomputes PK per event/segment from the covariate active in that
+/// segment (#700). Inter-occasion variability (IOV / `kappa`) is **no longer**
+/// rejected either: a fresh κ is drawn per decision window and threaded through the
+/// per-segment eta (#701), with occasion = decision index.
 fn reject_unsupported_adaptive(
     model: &CompiledModel,
     population: &Population,
 ) -> Result<(), String> {
-    if model.n_kappa > 0 {
-        return Err(
-            "adaptive-dosing simulation does not yet support inter-occasion variability \
-             (IOV / `kappa`): the reactive driver would silently hold every kappa at zero, \
-             biasing the predictions, the reactive decisions, and the dose ledger. Simulate \
-             without IOV, or track #391 for occasion-aware adaptive support."
-                .to_string(),
-        );
-    }
     if model.is_sde() {
         return Err(
             "adaptive-dosing simulation does not support stochastic (`[diffusion]` / SDE) \
@@ -5770,7 +5761,9 @@ mod tests {
     }
 
     #[test]
-    fn adaptive_rejects_iov_model() {
+    fn adaptive_accepts_iov_model() {
+        // IOV is now supported (#701): a fresh κ is drawn per decision window and
+        // threaded through the per-segment eta, so the guard no longer rejects it.
         use crate::parser::model_parser::parse_model_string;
         let iov = r"
 [parameters]
@@ -5795,11 +5788,9 @@ mod tests {
 ";
         let model = parse_model_string(iov).expect("IOV model parses");
         assert!(model.n_kappa > 0, "test model must declare a kappa");
-        let err = reject_unsupported_adaptive(&model, &adaptive_pop(adaptive_base_subject()))
-            .expect_err("IOV model must be rejected for adaptive dosing");
         assert!(
-            err.to_lowercase().contains("inter-occasion") || err.to_lowercase().contains("iov"),
-            "error should cite IOV: {err}"
+            reject_unsupported_adaptive(&model, &adaptive_pop(adaptive_base_subject())).is_ok(),
+            "IOV model is now supported for adaptive dosing (#701)"
         );
     }
 
@@ -7322,17 +7313,19 @@ where
     // adaptive output — predictions, decisions, the dose ledger, `target_window` — is
     // fully per-event covariate-aware; only this one exposure metric is deferred.
     if auc_target.is_some()
-        && population
-            .subjects
-            .iter()
-            .any(|s| crate::pk::subject_needs_per_event_pk(model, s))
+        && (model.n_kappa > 0
+            || population
+                .subjects
+                .iter()
+                .any(|s| crate::pk::subject_needs_per_event_pk(model, s)))
     {
         return Err(
-            "adaptive-dosing `auc_target` is not yet supported for time-varying-covariate \
-             (or TIME-in-PK) subjects: its exposure metric integrates a dense grid from a \
-             single frozen PK snapshot, which would be silently wrong under a changing \
-             covariate. Drop `auc_target` (all other outputs remain per-event \
-             covariate-aware), or track #700 for a per-event AUC."
+            "adaptive-dosing `auc_target` is not yet supported for time-varying-covariate, \
+             TIME-in-PK, or IOV (`kappa`) subjects: its exposure metric integrates a dense grid \
+             from a single frozen PK snapshot, which would be silently wrong when the PK changes \
+             across the horizon (a drifting covariate or a per-occasion κ). Drop `auc_target` (all \
+             other outputs remain per-event / per-occasion aware), or track #700/#701 for a \
+             per-event AUC."
                 .to_string(),
         );
     }
@@ -7347,21 +7340,91 @@ where
     for sim_idx in 0..n_sim {
         let sim = sim_idx + 1;
         for subject in &population.subjects {
-            // Draw η ~ N(0, Ω); append zero kappas for IOV models (the reactive
-            // driver is BSV-only in this slice).
+            // Draw η ~ N(0, Ω). `eta_slice` (η with κ appended as zeros) is the
+            // **baseline** window — the parameters before the first decision, and
+            // the reactive driver's fixed eta on a non-IOV run.
             let z: Vec<f64> = (0..n_eta).map(|_| rng.sample(normal)).collect();
             let eta = &params.omega.chol * DVector::from_column_slice(&z);
             let mut eta_slice: Vec<f64> = eta.iter().copied().collect();
             eta_slice.resize(n_eta + model.n_kappa, 0.0);
 
-            // Per-event PK when the subject's covariates (dose / obs / pk-only rows)
-            // or a `TIME` built-in vary PK across the horizon (#700); the reactive
-            // driver then resolves PK per segment from these snapshots. `None` ⇒
-            // constant PK, driven from the frozen `pk` snapshot below. One shared
-            // predicate (`subject_needs_per_event_pk`) gates the materialiser, this
-            // gate, and the `auc_target` guard so they cannot drift apart.
+            // Inter-occasion variability (#701): draw a fresh κ per decision window
+            // and build the per-window eta `[η_bsv | κ_g]` the driver threads through
+            // each segment, plus `decision_pk[g]` = the PK at decision g under
+            // occasion g's κ. Occasion = decision index (per-decision-window). κ is
+            // drawn on a dedicated substream keyed by (subject, replicate), disjoint
+            // from the η and assay streams, so a non-IOV model (`n_kappa == 0`) draws
+            // nothing and this whole block is skipped — the path stays byte-identical.
+            let (eta_occ, decision_pk): (
+                Option<Vec<Vec<f64>>>,
+                Option<Vec<crate::types::PkParams>>,
+            ) = if model.n_kappa > 0 {
+                let omega_iov = params
+                    .omega_iov
+                    .as_ref()
+                    .expect("omega_iov present when n_kappa > 0");
+                let kappa_base =
+                    crate::sim::adaptive::subject_kappa_base_seed(assay_root, &subject.id, sim);
+                let n_occ = decision_times.len();
+                let mut eta_occ = Vec::with_capacity(n_occ);
+                let mut decision_pk = Vec::with_capacity(n_occ);
+                for g in 0..n_occ {
+                    let zk: Vec<f64> = (0..model.n_kappa)
+                        .map(|k| crate::sim::adaptive::kappa_standard_normal(kappa_base, g, k))
+                        .collect();
+                    let kappa_g = &omega_iov.chol * DVector::from_column_slice(&zk);
+                    let mut e: Vec<f64> = eta_slice[..n_eta].to_vec();
+                    e.extend(kappa_g.iter().copied());
+                    // PK at decision g under occasion g's κ, at the covariate the
+                    // driver sees at that decision (its `decision_cov`: the
+                    // obs-coincident snapshot if the decision lands on an
+                    // observation row, else the subject-static covariates). Gives
+                    // occasion g's parameters to the pre-dose readout and the
+                    // injected dose's F even when the decision is not a record
+                    // (where LOCF would carry the previous occasion's PK).
+                    let dcov = subject
+                        .obs_times
+                        .iter()
+                        .position(|&ot| ot.to_bits() == decision_times[g].to_bits())
+                        .map(|i| subject.obs_cov(i))
+                        .unwrap_or(&subject.covariates);
+                    decision_pk.push((model.pk_param_fn)(
+                        &params.theta,
+                        &e,
+                        dcov,
+                        decision_times[g],
+                    ));
+                    eta_occ.push(e);
+                }
+                (Some(eta_occ), Some(decision_pk))
+            } else {
+                (None, None)
+            };
+
+            // Per-event PK when PK varies across the horizon: an IOV κ that switches
+            // per occasion (#701), or a time-varying covariate / pk-only row / `TIME`
+            // built-in (#700). The reactive driver then resolves PK per segment from
+            // these snapshots. `None` ⇒ constant PK, driven from the frozen `pk`
+            // snapshot below. The IOV snapshot is owned (recomputed per replicate as κ
+            // is redrawn); the #700-only path reuses `event_pk_buf`. One shared
+            // predicate (`subject_needs_per_event_pk`) gates the #700 branch, the
+            // materialiser, and the `auc_target` guard so they cannot drift apart.
+            let event_pk_iov: Option<crate::pk::EventPkParams> = eta_occ.as_ref().map(|eo| {
+                // IOV: each obs / pk-only record carries its occasion's κ (and any
+                // #700 covariate); records before the first decision use the baseline.
+                crate::pk::compute_event_pk_params_iov(
+                    model,
+                    subject,
+                    &params.theta,
+                    &eta_slice,
+                    eo,
+                    decision_times,
+                )
+            });
             let event_pk: Option<&crate::pk::EventPkParams> =
-                if crate::pk::subject_needs_per_event_pk(model, subject) {
+                if let Some(ev) = event_pk_iov.as_ref() {
+                    Some(ev)
+                } else if crate::pk::subject_needs_per_event_pk(model, subject) {
                     crate::pk::compute_event_pk_params_into(
                         model,
                         subject,
@@ -7405,6 +7468,8 @@ where
                 ode,
                 &pk.values,
                 event_pk,
+                decision_pk.as_deref(),
+                eta_occ.as_deref(),
                 &params.theta,
                 &eta_slice,
                 subject,
@@ -7421,6 +7486,8 @@ where
                     ode,
                     &pk.values,
                     event_pk,
+                    decision_pk.as_deref(),
+                    eta_occ.as_deref(),
                     &params.theta,
                     &eta_slice,
                     subject,
@@ -12871,6 +12938,27 @@ mod adaptive_sim_tests {
   DV ~ proportional(PROP)
 "#;
 
+    // IOV ODE model (#701): a per-occasion κ on CL over a near-degenerate BSV η
+    // (the parser requires an omega). A seeded run's η and per-occasion κ are both
+    // reconstructed exactly and checked against `predict_iov`.
+    const ODE_IOV: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 1e-10
+  kappa KAPPA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
     // Analytical (non-ODE) twin — used to assert simulate_adaptive rejects it.
     const ANALYTICAL: &str = r#"
 [parameters]
@@ -12965,6 +13053,102 @@ mod adaptive_sim_tests {
                 "adaptive IPRED {} != static predict {} at t={}",
                 traj.ipred,
                 pred.pred,
+                traj.time
+            );
+        }
+    }
+
+    #[test]
+    fn adaptive_iov_matches_predict_iov_with_reconstructed_kappa() {
+        // Full-stack IOV oracle (#701): run the reactive driver on a real IOV model
+        // (κ drawn per decision window from the seeded substream), then reconstruct the
+        // exact per-occasion κ and confirm the trajectory equals `predict_iov` on the
+        // realized doses with occasions = decision windows. Obs coincide with decisions,
+        // so every dosing occasion appears in predict_iov's obs-derived groups. The
+        // default-on frozen-replay verifier also runs (bit-exact); its Ok is part of the
+        // assertion. This is the api-level counterpart of the driver-level degenerate
+        // oracle, exercising the real `pk_param_fn` → κ path end to end.
+        let model = parse_model_string(ODE_IOV).expect("parse IOV ODE model");
+        assert!(model.n_kappa == 1 && model.n_eta == 1);
+        let decisions = vec![0.0, 24.0, 48.0, 72.0];
+        let obs = decisions.clone();
+        let seed = 20260708u64;
+        let pop = population(vec![subj("1", obs.clone(), vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(seed),
+            decision_times: decisions.clone(),
+            ..Default::default() // verify = true
+        };
+        let res = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
+            .expect("adaptive IOV sim runs and passes the default verifier");
+        assert_eq!(res.ledger.len(), 4, "a dose at every decision");
+
+        // Reconstruct the BSV η exactly as `run_adaptive_population` drew it: the same
+        // seeded `StdRng`, one N(0,1) per η for this single (sim 1, subject "1"), then
+        // Ω's Cholesky. (With `seed` set, the assay/κ streams don't touch this rng, so
+        // the η draw is the only consumer — reproducible here.)
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let normal = rand_distr::Normal::new(0.0, 1.0).unwrap();
+        let z_eta: Vec<f64> = (0..model.n_eta).map(|_| rng.sample(normal)).collect();
+        let eta_bsv: Vec<f64> = (&model.default_params.omega.chol
+            * nalgebra::DVector::from_column_slice(&z_eta))
+        .iter()
+        .copied()
+        .collect();
+
+        // Reconstruct the exact per-occasion κ from the seeded substream (the same
+        // derivation `run_adaptive_population` uses: κ_g = chol(Ω_IOV) · z, z keyed by
+        // (occasion, component); root = the run seed; replicate = 1).
+        let omega_iov = model.default_params.omega_iov.as_ref().expect("omega_iov");
+        let base = crate::sim::adaptive::subject_kappa_base_seed(seed, "1", 1);
+        let kappas: Vec<Vec<f64>> = (0..decisions.len())
+            .map(|g| {
+                let z: Vec<f64> = (0..model.n_kappa)
+                    .map(|k| crate::sim::adaptive::kappa_standard_normal(base, g, k))
+                    .collect();
+                (&omega_iov.chol * nalgebra::DVector::from_column_slice(&z))
+                    .iter()
+                    .copied()
+                    .collect()
+            })
+            .collect();
+        assert!(
+            kappas.iter().any(|k| k[0].abs() > 1e-6),
+            "the reconstructed κ must be genuinely nonzero, else the oracle is vacuous"
+        );
+
+        // Static reference: predict_iov on the realized doses with occasion = window.
+        let static_doses: Vec<DoseEvent> = res
+            .ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0))
+            .collect();
+        let mut static_subject = subj("1", obs.clone(), static_doses);
+        static_subject.occasions = obs
+            .iter()
+            .map(|&t| crate::pk::occasion_of(&decisions, t).expect("obs in a window") as u32)
+            .collect();
+        static_subject.dose_occasions = res
+            .ledger
+            .iter()
+            .map(|e| crate::pk::occasion_of(&decisions, e.time).expect("dose in a window") as u32)
+            .collect();
+        let preds = crate::pk::predict_iov(
+            &model,
+            &static_subject,
+            &model.default_params.theta,
+            &eta_bsv,
+            &kappas,
+        );
+
+        assert_eq!(res.trajectories.len(), preds.len());
+        for (traj, &pred) in res.trajectories.iter().zip(preds.iter()) {
+            assert!(
+                (traj.ipred - pred).abs() <= 1e-9 + 1e-9 * pred.abs(),
+                "adaptive IOV IPRED {} != predict_iov {} at t={}",
+                traj.ipred,
+                pred,
                 traj.time
             );
         }
@@ -13576,6 +13760,64 @@ mod adaptive_sim_tests {
         pop
     }
 
+    // IOV declarative spec (#701): a per-occasion κ on CL, no covariate (the parser
+    // requires an omega, so a near-degenerate BSV η rides along).
+    const SPEC_IOV: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 1e-10
+  kappa KAPPA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central
+  at = every 24 from 0 to 96
+  start_dose = 100
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 8 : increase 25%
+"#;
+
+    // #700 × #701 co-occurrence: CL depends on BOTH a time-varying covariate (CRCL)
+    // and a per-occasion κ.
+    const SPEC_TV_IOV: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 1e-10
+  kappa KAPPA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * (CRCL / 100.0) * exp(KAPPA_CL)
+  V  = TVV
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+[adaptive_dosing]
+  observe = central
+  at = every 24 from 0 to 96
+  start_dose = 100
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 8 : increase 25%
+"#;
+
     #[test]
     fn from_spec_supports_time_varying_covariate() {
         // End-to-end #700: a covariate-dependent CL (CRCL declining — e.g. renal
@@ -13695,6 +13937,82 @@ mod adaptive_sim_tests {
             err.to_lowercase().contains("auc_target")
                 && err.to_lowercase().contains("time-varying"),
             "error should cite auc_target + time-varying: {err}"
+        );
+    }
+
+    #[test]
+    fn from_spec_supports_time_varying_covariate_with_iov() {
+        // #700 × #701 co-occurrence: CL depends on BOTH a declining covariate (CRCL,
+        // #700 LOCF) and a per-occasion κ (#701 decision window). Both fold into the
+        // per-event PK in the reactive driver AND the frozen-replay engine, so the
+        // default-on verifier passing is the bit-exact proof they compose. The run is
+        // reproducible for a fixed seed and κ-sensitive across seeds.
+        let parsed = parse_full_model(SPEC_TV_IOV).expect("model + block parse");
+        assert!(parsed.model.n_kappa == 1);
+        let spec = parsed.adaptive_dosing.as_ref().expect("[adaptive_dosing]");
+        let obs = vec![0.0, 24.0, 48.0, 72.0, 96.0];
+        let pop = tv_cov_pop(&[100.0, 80.0, 60.0, 45.0, 35.0], &obs);
+        let run = |seed: u64| {
+            let opts = AdaptiveSimulateOptions {
+                seed: Some(seed),
+                ..Default::default()
+            };
+            simulate_adaptive_from_spec(
+                &parsed.model,
+                &pop,
+                &parsed.model.default_params,
+                1,
+                spec,
+                &opts,
+            )
+            .expect("TV+IOV adaptive sim runs + verifies")
+        };
+        let a = run(1);
+        assert!(!a.ledger.is_empty());
+        let a_last = a.trajectories.last().unwrap().ipred;
+        // Reproducible for a fixed seed (κ + η both seeded).
+        assert_eq!(
+            a_last,
+            run(1).trajectories.last().unwrap().ipred,
+            "same seed ⇒ identical trajectory"
+        );
+        // κ genuinely perturbs the trajectory across seeds.
+        assert!(
+            (a_last - run(999).trajectories.last().unwrap().ipred).abs() > 1e-9,
+            "different seed ⇒ different κ ⇒ different trajectory"
+        );
+    }
+
+    #[test]
+    fn adaptive_auc_target_rejects_iov() {
+        // #701: like the TV-covariate case, the exposure metric can't yet be computed
+        // per-occasion, so declaring `auc_target` on an IOV model is a typed error
+        // rather than a silently κ-frozen AUC.
+        let mut parsed = parse_full_model(SPEC_IOV).expect("model + block parse");
+        parsed
+            .adaptive_dosing
+            .as_mut()
+            .expect("[adaptive_dosing]")
+            .auc_target = Some((400.0, 600.0));
+        let spec = parsed.adaptive_dosing.as_ref().unwrap();
+        let obs = vec![0.0, 24.0, 48.0, 72.0, 96.0];
+        let pop = population(vec![subj("1", obs, vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        };
+        let err = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect_err("auc_target on an IOV model must be rejected");
+        assert!(
+            err.to_lowercase().contains("auc_target") && err.to_lowercase().contains("iov"),
+            "error should cite auc_target + IOV: {err}"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -7277,6 +7277,19 @@ where
     // wrong answer (#391). Both public entry points funnel through here.
     reject_unsupported_adaptive(model, population)?;
 
+    // The occasion bookkeeping assumes a strictly-increasing decision schedule:
+    // `occasion_of` (per-decision-window κ selection) scans ascending and stops at the
+    // first later time, and `decision_index_of` keys windows by exact time bits. An
+    // unsorted schedule would mis-map a record to the wrong occasion's κ, and a
+    // duplicated time would split the window-open index from the materialiser's
+    // occasion — both silently, since the frozen-replay verifier reuses the same
+    // occasion arrays and cannot catch a shared-wrong-input (#701 review). The
+    // declarative `[adaptive_dosing]` path already enforces this on its `at` list via
+    // `validate_increasing_finite`; guard the programmatic `simulate_adaptive` path
+    // here too, at the shared funnel, with the *same* validator (finite + strictly
+    // ascending ⇒ no duplicates) so the two paths cannot drift.
+    crate::sim::adaptive::validate_increasing_finite(decision_times, "`decision_times`")?;
+
     use rand::SeedableRng;
 
     let mut rng: rand::rngs::StdRng = match opts.seed {
@@ -7376,18 +7389,22 @@ where
                     let mut e: Vec<f64> = eta_slice[..n_eta].to_vec();
                     e.extend(kappa_g.iter().copied());
                     // PK at decision g under occasion g's κ, at the covariate the
-                    // driver sees at that decision (its `decision_cov`: the
-                    // obs-coincident snapshot if the decision lands on an
-                    // observation row, else the subject-static covariates). Gives
-                    // occasion g's parameters to the pre-dose readout and the
-                    // injected dose's F even when the decision is not a record
-                    // (where LOCF would carry the previous occasion's PK).
-                    let dcov = subject
-                        .obs_times
-                        .iter()
-                        .position(|&ot| ot.to_bits() == decision_times[g].to_bits())
-                        .map(|i| subject.obs_cov(i))
-                        .unwrap_or(&subject.covariates);
+                    // driver actually sees at that decision. This MUST match the
+                    // driver's live `decision_cov` (predictions.rs) exactly: the
+                    // obs-coincident snapshot on a record, else the LOCF covariate of
+                    // the most-recent record carried forward — NOT the frozen t=0
+                    // baseline. On a time-varying-covariate + IOV model whose decision
+                    // lands between records, a baseline fallback here would freeze the
+                    // decision's covariate at t=0 (the exact #700 defect) while the
+                    // driver's readout uses LOCF — and the frozen-replay verifier,
+                    // which reuses this same `decision_pk`, could not catch it. Sharing
+                    // the one `locf_decision_cov` helper the driver uses makes the two
+                    // covariate resolutions a single source of truth (#701 review).
+                    let dcov = crate::ode::predictions::locf_decision_cov(
+                        decision_times[g],
+                        subject,
+                        &subject.covariates,
+                    );
                     decision_pk.push((model.pk_param_fn)(
                         &params.theta,
                         &e,
@@ -14013,6 +14030,126 @@ mod adaptive_sim_tests {
         assert!(
             err.to_lowercase().contains("auc_target") && err.to_lowercase().contains("iov"),
             "error should cite auc_target + IOV: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_iov_decision_pk_uses_locf_covariate_off_grid() {
+        // #701 review regression (verifier-blind): on a TV-covariate + IOV model, an
+        // off-record decision must resolve its PK snapshot (`decision_pk[g]`) at the
+        // LOCF covariate — the most-recent record carried forward — exactly as the
+        // driver's live `decision_cov` does, NOT the frozen t=0 baseline. Before the
+        // fix, `run_adaptive_population` fell back to `subject.covariates` (t=0) for a
+        // decision off the obs grid, re-introducing the #700 "decision covariate frozen
+        // at t=0" defect on the IOV decision-PK path — and the frozen-replay verifier,
+        // which reuses the same `decision_pk`, could not catch it.
+        //
+        // F (bioavailability) depends on CRCL and never enters the ODE, so each injected
+        // dose's realized `f_applied` is an *unconfounded* readout of the covariate the
+        // decision saw: F = CRCL/200 ⇒ 0.5 at CRCL=100, 1.0 at CRCL=200.
+        let iov_tvf = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 1e-10
+  kappa KAPPA_CL ~ 0.09
+  sigma PROP ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+  f  = CRCL / 200.0
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL / V) * central
+[scaling]
+  y = central
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+        let model = parse_model_string(iov_tvf).expect("parse TV-F + IOV model");
+        assert!(model.n_kappa == 1, "must be an IOV model");
+
+        // obs at 0 (CRCL 100) and 24 (CRCL 200): the covariate jumps at t=24.
+        let mut s = subj("1", vec![0.0, 24.0], vec![]);
+        s.covariates = HashMap::from([("CRCL".to_string(), 100.0)]);
+        s.obs_covariates = vec![
+            HashMap::from([("CRCL".to_string(), 100.0)]),
+            HashMap::from([("CRCL".to_string(), 200.0)]),
+        ];
+        let mut pop = population(vec![s]);
+        pop.covariate_names = vec!["CRCL".to_string()];
+
+        // Decisions at 0, 12, 24, 36. t=12 is off-record but *before* the jump
+        // (LOCF == baseline == 100, a control); t=36 is off-record and *after* the jump
+        // (LOCF = 200, baseline = 100) — the discriminator. A fixed bolus doses at each.
+        let decisions = vec![0.0, 12.0, 24.0, 36.0];
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            decision_times: decisions.clone(),
+            ..Default::default()
+        };
+        let res = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
+            .expect("adaptive TV-F + IOV sim runs and passes the default verifier");
+        assert_eq!(res.ledger.len(), 4, "a dose at every decision");
+
+        let f_at = |t: f64| {
+            res.ledger
+                .iter()
+                .find(|e| e.time == t)
+                .map(|e| e.f_applied)
+                .unwrap_or_else(|| panic!("no dose at t={t}"))
+        };
+        // t=0 coincides with obs CRCL=100 → F=0.5; t=24 coincides with obs CRCL=200 → F=1.0.
+        assert!((f_at(0.0) - 0.5).abs() < 1e-9, "t=0 F={}", f_at(0.0));
+        assert!((f_at(24.0) - 1.0).abs() < 1e-9, "t=24 F={}", f_at(24.0));
+        // t=12 off-record but before the jump → LOCF == baseline == 100 → F=0.5 (the
+        // buggy and fixed code agree here; the control).
+        assert!((f_at(12.0) - 0.5).abs() < 1e-9, "t=12 F={}", f_at(12.0));
+        // t=36 off-record and AFTER the jump → LOCF CRCL=200 → F=1.0. The bug froze it
+        // at the t=0 baseline CRCL=100 → F=0.5. This assertion fails without the fix.
+        assert!(
+            (f_at(36.0) - 1.0).abs() < 1e-9,
+            "off-record decision at t=36 must use the LOCF covariate (CRCL=200 ⇒ F=1.0), \
+             not the frozen t=0 baseline (CRCL=100 ⇒ F=0.5); got F={}",
+            f_at(36.0)
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_non_ascending_or_duplicate_decision_times() {
+        // #701 review: the occasion bookkeeping (`occasion_of`, `decision_index_of`)
+        // assumes a strictly-increasing decision schedule. An unsorted or duplicated
+        // `decision_times` would silently mis-map a record's occasion κ — and the
+        // frozen-replay verifier, reusing the same occasion arrays, could not catch it.
+        // The programmatic `simulate_adaptive` path must reject it loudly at the shared
+        // funnel, matching the declarative path's `validate_increasing_finite`.
+        let model = parse_model_string(ODE_IOV).expect("parse IOV model");
+        let pop = population(vec![subj("1", vec![0.0, 24.0, 48.0], vec![])]);
+        let run = |dts: Vec<f64>| {
+            let opts = AdaptiveSimulateOptions {
+                seed: Some(1),
+                decision_times: dts,
+                ..Default::default()
+            };
+            simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
+        };
+        // Out of order.
+        let err = run(vec![0.0, 48.0, 24.0]).expect_err("unsorted schedule must be rejected");
+        assert!(
+            err.to_lowercase().contains("increasing"),
+            "error should cite the ordering: {err}"
+        );
+        // Duplicate time (strictly-increasing rejects equality).
+        let err = run(vec![0.0, 24.0, 24.0, 48.0]).expect_err("duplicate time must be rejected");
+        assert!(
+            err.to_lowercase().contains("increasing"),
+            "error should cite the ordering: {err}"
+        );
+        // The ascending control still runs.
+        assert!(
+            run(vec![0.0, 24.0, 48.0]).is_ok(),
+            "ascending schedule runs"
         );
     }
 

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1796,7 +1796,12 @@ fn earliest_record_pk(
 /// record wins a tie with a pk-only record at the same time (matching
 /// [`segment_pk_at`]). Falls back to `baseline` only for a decision that precedes
 /// the first record. The constant-covariate path never calls this.
-fn locf_decision_cov<'a>(
+///
+/// Also called by `run_adaptive_population` to resolve the covariate for each IOV
+/// `decision_pk[g]` snapshot (#701), so the precomputed decision PK and this driver's
+/// live `decision_cov` share **one** covariate rule and cannot silently diverge — the
+/// reason this is `pub(crate)` rather than private.
+pub(crate) fn locf_decision_cov<'a>(
     t: f64,
     subject: &'a Subject,
     baseline: &'a HashMap<String, f64>,
@@ -5644,6 +5649,80 @@ mod tests {
             max_rel <= 1e-12,
             "IOV frozen replay not bit-aligned: max_rel={max_rel}"
         );
+    }
+
+    #[test]
+    fn adaptive_iov_threads_occasion_eta_into_readout() {
+        // #701 review (coverage): in every other IOV test the per-occasion κ reaches
+        // the trajectory only through the precomputed PK array (event_pk / decision_pk),
+        // so the *separate* `eta_for` threading of the occasion eta into
+        // `read_observable` / `integrate_segment` — load-bearing only when an expression
+        // references κ or η *directly* — was never exercised end to end. Here the
+        // monitored `observe` returns the κ component (eta[1]) it is handed, so the
+        // recorded decision signal must equal that occasion's κ. If `eta_for` /
+        // `segment_occ_at` threaded the wrong occasion (e.g. the fixed baseline eta),
+        // the signals would be the baseline value, not the per-occasion κ.
+        let ode = one_cpt_ode_spec();
+        let v = 10.0;
+        let times = [0.0, 24.0, 48.0]; // 3 decisions = 3 occasions; obs coincide.
+        let occ_pk: Vec<PkParams> = vec![pk_one(1.0, v); times.len()];
+        let event_pk = crate::pk::EventPkParams {
+            dose: Vec::new(),
+            obs: occ_pk.clone(),
+            pk_only: Vec::new(),
+        };
+        let decision_pk = occ_pk.clone();
+        // Distinct κ per occasion in eta[1]; eta[0] is a dummy η_bsv.
+        let eta_occ: Vec<Vec<f64>> = vec![vec![0.0, 10.0], vec![0.0, 20.0], vec![0.0, 30.0]];
+        // A non-empty *baseline* eta with a sentinel κ=999: a wrong occasion (falling
+        // back to baseline) would surface 999, not the per-occasion κ — a clean miss
+        // rather than an index panic.
+        let baseline_eta = [0.0, 999.0];
+
+        // `observe` returns the κ component (eta[1]) it is handed — the occasion's κ.
+        let obs_fn: OdeOutputFn = Box::new(
+            |_u: &[f64], _pk: &[f64], _th: &[f64], eta: &[f64], _cov: &HashMap<String, f64>| eta[1],
+        );
+        let spec = MonitorSpec::new("K", 1, ObserveMode::Ipred);
+        let mons = vec![AdaptiveMonitor {
+            spec: &spec,
+            observe: Some(&obs_fn),
+        }];
+        let mut decide = |_ctx: &ControllerCtx| ControllerDecision {
+            actions: vec![DoseAction::Hold],
+            rule: None,
+        };
+        let base = make_subject(vec![], times.to_vec());
+        let run = ode_predictions_adaptive_impl(
+            &ode,
+            &occ_pk[0].values,
+            Some(&event_pk),
+            Some(&decision_pk),
+            Some(&eta_occ),
+            &[],
+            &baseline_eta,
+            &base,
+            &times,
+            &mons,
+            &mut decide,
+            100,
+            None,
+        )
+        .expect("driver runs");
+
+        let sig_at = |t: f64| {
+            run.decisions
+                .iter()
+                .find(|d| d.time == t)
+                .and_then(|d| d.observed_signals.first())
+                .map(|s| s.value)
+                .unwrap_or(f64::NAN)
+        };
+        // Each decision's readout must carry its own occasion's κ (eta[1]), threaded by
+        // `eta_for(segment_occ_at(...))` — not the baseline sentinel 999.
+        assert_eq!(sig_at(0.0), 10.0, "occasion 0 κ");
+        assert_eq!(sig_at(24.0), 20.0, "occasion 1 κ");
+        assert_eq!(sig_at(48.0), 30.0, "occasion 2 κ");
     }
 
     #[test]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1820,6 +1820,43 @@ fn locf_decision_cov<'a>(
     best.map(|(_, c)| c).unwrap_or(baseline)
 }
 
+/// Occasion (decision window) governing the segment ending at `t` — the IOV twin of
+/// [`segment_pk_at`] (#701). Deliberately the **same** end-of-interval / LOCF
+/// structure, so the per-window eta threaded into `integrate_segment` always agrees
+/// with the occasion of the PK `segment_pk_at` returns for the same `t`: the
+/// record-at-`t`'s occasion (obs / pk-only), else the carried-forward `last_occ`.
+/// `None` = the baseline window (before the first decision), whose κ is zero.
+fn segment_occ_at(
+    t: f64,
+    obs_map: &HashMap<u64, Vec<usize>>,
+    obs_occ: &[Option<usize>],
+    pk_only_map: &HashMap<u64, usize>,
+    pk_only_occ: &[Option<usize>],
+    last_occ: Option<usize>,
+) -> Option<usize> {
+    if let Some(&j) = obs_map.get(&t.to_bits()).and_then(|idxs| idxs.first()) {
+        return obs_occ[j];
+    }
+    if let Some(&m) = pk_only_map.get(&t.to_bits()) {
+        return pk_only_occ[m];
+    }
+    last_occ
+}
+
+/// The eta to evaluate model expressions with for occasion `occ` (#701): the
+/// per-window `[η_bsv | κ_g]` from `eta_occ` when IOV is active and a window is
+/// open, else the fixed baseline `eta` (non-IOV runs, and the pre-first-decision
+/// window where κ = 0). `read_observable` / `integrate_segment` take `eta`
+/// directly — their `[derived]` / observation / ODE-RHS expressions can reference κ,
+/// not only the PK params — so the whole eta, not just the PK snapshot, must be
+/// occasion-correct.
+fn eta_for<'a>(eta_occ: Option<&'a [Vec<f64>]>, eta: &'a [f64], occ: Option<usize>) -> &'a [f64] {
+    match (eta_occ, occ) {
+        (Some(eo), Some(g)) => eo[g].as_slice(),
+        _ => eta,
+    }
+}
+
 /// Reactive ("adaptive" / feedback) ODE prediction over a single subject (#391
 /// S1.3). Walks a fixed `decision_times` schedule, and at each decision lets
 /// `controller` read the current state (through the declared `monitors`) and
@@ -1910,6 +1947,8 @@ pub(crate) fn ode_predictions_adaptive(
         ode,
         pk_params_flat,
         None,
+        None,
+        None,
         theta,
         eta,
         subject,
@@ -1943,6 +1982,16 @@ pub(crate) fn ode_predictions_adaptive_impl(
     // is unused; controller-injected doses take their PK from the carried-forward
     // (LOCF) snapshot at injection time.
     event_pk: Option<&crate::pk::EventPkParams>,
+    // Per-decision occasion PK + per-window eta for the IOV path (#701). `Some` ⇒
+    // draw-time κ varies by decision window: `decision_pk[g]` is the PK at decision g
+    // under occasion g's κ (drives the pre-dose readout, the injected dose's F, and
+    // the LOCF carry into the following segment), and `eta_occ[g]` is the full
+    // `[η_bsv | κ_g]` threaded into `read_observable` / `integrate_segment` for every
+    // event in window g. `None` on both ⇒ no IOV, byte-identical to the pre-#701 path
+    // (the fixed `eta` is used throughout). IOV implies `event_pk = Some` (κ makes PK
+    // per-occasion, so obs / pk-only records carry their occasion snapshot).
+    decision_pk: Option<&[PkParams]>,
+    eta_occ: Option<&[Vec<f64>]>,
     theta: &[f64],
     eta: &[f64],
     subject: &Subject,
@@ -1954,6 +2003,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
 ) -> Result<AdaptiveRun, String> {
     let n = ode.n_states;
     let tv = event_pk.is_some();
+    let iov = eta_occ.is_some();
 
     // --- Preconditions (typed errors, never silent) ----------------------
     if !subject.doses.is_empty() {
@@ -2003,6 +2053,11 @@ pub(crate) fn ode_predictions_adaptive_impl(
     // Most-recent real record's PK, carried forward (LOCF) across non-record
     // breaks and updated as the loop crosses obs / pk-only records. Unused (`!tv`).
     let mut last_pk: PkParams = init_pk;
+    // IOV twin of `last_pk` (#701): the occasion (decision window) of the most-recent
+    // record / decision crossed, carried forward for non-record breaks. Starts at the
+    // baseline window (`None`, κ = 0) and advances as the loop crosses decisions and
+    // records. Unused (`!iov`).
+    let mut last_occ: Option<usize> = None;
 
     let mut u = if tv {
         ode.initial_state(&init_pk.values)
@@ -2044,6 +2099,28 @@ pub(crate) fn ode_predictions_adaptive_impl(
             pk_only_map.entry(t.to_bits()).or_insert(m);
         }
     }
+
+    // Per-record occasion (decision window) for the IOV path (#701), parallel to
+    // `obs_times` / `pk_only_times`; empty on the non-IOV path. Resolved from the
+    // decision schedule exactly as the occasion-aware `event_pk` was built in
+    // `run_adaptive_population`, so `segment_occ_at` and the precomputed PK snapshots
+    // agree on each record's occasion.
+    let (obs_occ, pk_only_occ): (Vec<Option<usize>>, Vec<Option<usize>>) = if iov {
+        (
+            subject
+                .obs_times
+                .iter()
+                .map(|&t| crate::pk::occasion_of(decision_times, t))
+                .collect(),
+            subject
+                .pk_only_times
+                .iter()
+                .map(|&t| crate::pk::occasion_of(decision_times, t))
+                .collect(),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     // Decision time -> 0-based index, for the in-loop hook.
     let mut decision_index_of: HashMap<u64, usize> = HashMap::new();
@@ -2124,6 +2201,18 @@ pub(crate) fn ode_predictions_adaptive_impl(
     while k < break_times.len() {
         let t_start = break_times[k];
 
+        // #701 (IOV): a decision break opens its occasion window `g`. Set the LOCF PK
+        // + occasion to occasion g's snapshot so the pre-dose readout, the injected
+        // dose's F, and any following non-record segment all use occasion g's
+        // parameters — not the previous occasion carried in `last_pk`/`last_occ`.
+        // Unconditional (every decision break, including holds and post-`Stop`, so
+        // every event reads its window's κ). `segment_pk_at`/`segment_occ_at` below
+        // then return this snapshot for a decision that is not itself a record.
+        if let (Some(dp), Some(&g)) = (decision_pk, decision_index_of.get(&t_start.to_bits())) {
+            last_pk = dp[g];
+            last_occ = Some(g);
+        }
+
         // PK snapshot in effect at this break's left boundary `t_start`: the record
         // there (obs / pk-only) or the LOCF carry-forward (`last_pk`) on the TV path
         // (#700), the frozen `pk_params_flat` on the constant path. Drives the
@@ -2138,6 +2227,25 @@ pub(crate) fn ode_predictions_adaptive_impl(
         } else {
             pk_params_flat
         };
+        // Eta to evaluate the pre-dose readouts with — paired to `readout_pk`'s
+        // occasion (#701): occasion g's `[η_bsv | κ_g]` at a decision, else the fixed
+        // baseline `eta`. Byte-identical to `eta` on the non-IOV path.
+        let readout_eta = eta_for(
+            eta_occ,
+            eta,
+            if iov {
+                segment_occ_at(
+                    t_start,
+                    &obs_map,
+                    &obs_occ,
+                    &pk_only_map,
+                    &pk_only_occ,
+                    last_occ,
+                )
+            } else {
+                None
+            },
+        );
 
         // --- Decision hook: observe (pre-dose trough) -> decide -> dose. ---
         if !stopped {
@@ -2168,10 +2276,16 @@ pub(crate) fn ode_predictions_adaptive_impl(
                     // compiled `observe` expression for the latent value; absent
                     // one (the programmatic path), read the model's cmt readout.
                     let latent = match am.observe {
-                        Some(f) => f(&u, pk_readout, theta, eta, decision_cov),
-                        None => {
-                            read_observable(ode, &u, pk_readout, theta, eta, decision_cov, m.cmt)
-                        }
+                        Some(f) => f(&u, pk_readout, theta, readout_eta, decision_cov),
+                        None => read_observable(
+                            ode,
+                            &u,
+                            pk_readout,
+                            theta,
+                            readout_eta,
+                            decision_cov,
+                            m.cmt,
+                        ),
                     };
                     // Resolve the monitored signal on its own mode: Ipred is the
                     // latent readout; Dv adds the endpoint's assay residual draw on
@@ -2403,8 +2517,18 @@ pub(crate) fn ode_predictions_adaptive_impl(
                     Some(ev) => &ev.obs[obs_idx].values,
                     None => pk_params_flat,
                 };
-                predictions[obs_idx] =
-                    read_observable(ode, &u, obs_pk, theta, eta, shadow.obs_cov(obs_idx), cmt);
+                // Eta paired to this observation's occasion (#701), consistent with
+                // its per-occasion `event_pk.obs` snapshot; baseline `eta` otherwise.
+                let obs_eta = eta_for(eta_occ, eta, if iov { obs_occ[obs_idx] } else { None });
+                predictions[obs_idx] = read_observable(
+                    ode,
+                    &u,
+                    obs_pk,
+                    theta,
+                    obs_eta,
+                    shadow.obs_cov(obs_idx),
+                    cmt,
+                );
             }
         }
 
@@ -2428,6 +2552,22 @@ pub(crate) fn ode_predictions_adaptive_impl(
                 Some(ev) => segment_pk_at(t_end, &obs_map, &pk_only_map, ev, last_pk),
                 None => PkParams::default(),
             };
+            // Occasion governing this segment (#701) — the twin of `seg_pk`'s
+            // end-of-interval / LOCF resolution, so the eta threaded into
+            // `integrate_segment` carries the same occasion's κ as `seg_pk`.
+            let seg_occ = if iov {
+                segment_occ_at(
+                    t_end,
+                    &obs_map,
+                    &obs_occ,
+                    &pk_only_map,
+                    &pk_only_occ,
+                    last_occ,
+                )
+            } else {
+                None
+            };
+            let seg_eta = eta_for(eta_occ, eta, seg_occ);
             let seg_pk_values: &[f64] = if tv { &seg_pk.values } else { pk_params_flat };
             if tv {
                 ext_params[..crate::types::MAX_PK_PARAMS]
@@ -2454,7 +2594,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
                 &mut ext_params,
                 seg_pk_values,
                 theta,
-                eta,
+                seg_eta,
                 &obs_map,
                 &mut predictions,
                 None,
@@ -2464,8 +2604,11 @@ pub(crate) fn ode_predictions_adaptive_impl(
             // Advance the LOCF carry: after integrating into `t_end`, the record
             // there (if any) is the most-recent PK. `segment_pk_at` returns `last_pk`
             // unchanged for a non-record break, so this is a no-op in that case.
+            // `last_occ` advances in lockstep (#701) so the next non-record segment
+            // reads this occasion's κ.
             if tv {
                 last_pk = seg_pk;
+                last_occ = seg_occ;
             }
         }
 
@@ -2529,6 +2672,11 @@ pub(crate) fn verify_adaptive_frozen_replay(
     ode: &OdeSpec,
     pk_params_flat: &[f64],
     event_pk: Option<&crate::pk::EventPkParams>,
+    // Per-decision occasion PK + per-window eta for the IOV path (#701); see
+    // `ode_predictions_adaptive_impl`. Reused directly from the driver so the replay
+    // applies the identical per-occasion κ over the identical windows — bit-aligned.
+    decision_pk: Option<&[PkParams]>,
+    eta_occ: Option<&[Vec<f64>]>,
     theta: &[f64],
     eta: &[f64],
     base_subject: &Subject,
@@ -2556,6 +2704,8 @@ pub(crate) fn verify_adaptive_frozen_replay(
             adaptive_frozen_replay_tv(
                 ode,
                 ev,
+                decision_pk,
+                eta_occ,
                 theta,
                 eta,
                 &static_subject,
@@ -2620,10 +2770,18 @@ pub(crate) fn verify_adaptive_frozen_replay(
 /// `f_applied`), so a delivered dose's F is taken as given rather than re-derived —
 /// F correctness is pinned separately by the degenerate oracle against
 /// `ode_predictions_event_driven`.
+///
+/// IOV (#701): when `eta_occ` / `decision_pk` are `Some`, the replay threads the
+/// **same** per-window eta and per-decision occasion PK as the driver — occasion is
+/// resolved from `extra_breaks` (the decision schedule) exactly as the driver
+/// resolves it, so the two apply identical per-occasion κ over identical windows and
+/// stay bit-aligned.
 #[allow(clippy::too_many_arguments)]
 fn adaptive_frozen_replay_tv(
     ode: &OdeSpec,
     event_pk: &crate::pk::EventPkParams,
+    decision_pk: Option<&[PkParams]>,
+    eta_occ: Option<&[Vec<f64>]>,
     theta: &[f64],
     eta: &[f64],
     subject: &Subject,
@@ -2632,6 +2790,7 @@ fn adaptive_frozen_replay_tv(
 ) -> Vec<f64> {
     let n = ode.n_states;
     let n_obs = subject.obs_times.len();
+    let iov = eta_occ.is_some();
 
     let mut obs_map: HashMap<u64, Vec<usize>> = HashMap::new();
     for (i, &t) in subject.obs_times.iter().enumerate() {
@@ -2641,6 +2800,33 @@ fn adaptive_frozen_replay_tv(
     for (m, &t) in subject.pk_only_times.iter().enumerate() {
         pk_only_map.entry(t.to_bits()).or_insert(m);
     }
+
+    // Occasion bookkeeping for the IOV path (#701), mirroring the driver: per-record
+    // occasion resolved from the decision schedule (`extra_breaks`), a decision-time
+    // → index map to open windows at decision breaks, and the LOCF `last_occ` carry.
+    let (obs_occ, pk_only_occ): (Vec<Option<usize>>, Vec<Option<usize>>) = if iov {
+        (
+            subject
+                .obs_times
+                .iter()
+                .map(|&t| crate::pk::occasion_of(extra_breaks, t))
+                .collect(),
+            subject
+                .pk_only_times
+                .iter()
+                .map(|&t| crate::pk::occasion_of(extra_breaks, t))
+                .collect(),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let mut decision_index_of: HashMap<u64, usize> = HashMap::new();
+    if iov {
+        for (i, &t) in extra_breaks.iter().enumerate() {
+            decision_index_of.entry(t.to_bits()).or_insert(i);
+        }
+    }
+    let mut last_occ: Option<usize> = None;
 
     // Seed PK / state from the earliest record, mirroring the driver's init via the
     // shared `earliest_record_pk` so the two seed identically. A record-free subject
@@ -2701,6 +2887,14 @@ fn adaptive_frozen_replay_tv(
     for k in 0..break_times.len() {
         let t_start = break_times[k];
 
+        // #701: open a decision window here, mirroring the driver — set the LOCF PK +
+        // occasion to this decision's occasion snapshot so the coincident observation,
+        // and any following non-record segment, read occasion g's κ.
+        if let (Some(dp), Some(&g)) = (decision_pk, decision_index_of.get(&t_start.to_bits())) {
+            last_pk = dp[g];
+            last_occ = Some(g);
+        }
+
         // Apply boluses landing at t_start (lag 0) with their realized F — at EVERY
         // break, including the last. The driver's while-loop processes the final
         // break too (so a decision at the maximum time still doses and its coincident
@@ -2725,12 +2919,13 @@ fn adaptive_frozen_replay_tv(
         if let Some(obs_idxs) = obs_map.get(&t_start.to_bits()) {
             for &obs_idx in obs_idxs {
                 let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
+                let obs_eta = eta_for(eta_occ, eta, if iov { obs_occ[obs_idx] } else { None });
                 predictions[obs_idx] = read_observable(
                     ode,
                     &u,
                     &event_pk.obs[obs_idx].values,
                     theta,
-                    eta,
+                    obs_eta,
                     subject.obs_cov(obs_idx),
                     cmt,
                 );
@@ -2744,6 +2939,21 @@ fn adaptive_frozen_replay_tv(
             // Segment PK = record at t_end (NONMEM end-of-interval) or LOCF carry —
             // the identical `segment_pk_at` the driver used.
             let seg_pk = segment_pk_at(t_end, &obs_map, &pk_only_map, event_pk, last_pk);
+            // Occasion twin of `seg_pk` (#701), so the threaded eta carries the same
+            // occasion's κ — the identical `segment_occ_at` the driver used.
+            let seg_occ = if iov {
+                segment_occ_at(
+                    t_end,
+                    &obs_map,
+                    &obs_occ,
+                    &pk_only_map,
+                    &pk_only_occ,
+                    last_occ,
+                )
+            } else {
+                None
+            };
+            let seg_eta = eta_for(eta_occ, eta, seg_occ);
             ext_params[..crate::types::MAX_PK_PARAMS]
                 .copy_from_slice(&seg_pk.values[..crate::types::MAX_PK_PARAMS]);
 
@@ -2758,7 +2968,7 @@ fn adaptive_frozen_replay_tv(
                 &mut ext_params,
                 &seg_pk.values,
                 theta,
-                eta,
+                seg_eta,
                 &obs_map,
                 &mut predictions,
                 None,
@@ -2766,6 +2976,7 @@ fn adaptive_frozen_replay_tv(
             );
 
             last_pk = seg_pk;
+            last_occ = seg_occ;
         }
     }
 
@@ -4792,6 +5003,8 @@ mod tests {
             &ode,
             &obs_pk[0].values, // t=0 baseline — unused on the TV path
             Some(&event_pk),
+            None,
+            None,
             &[],
             &[],
             &base,
@@ -4837,6 +5050,8 @@ mod tests {
         let frozen_run = ode_predictions_adaptive_impl(
             &ode,
             &obs_pk[0].values,
+            None,
+            None,
             None,
             &[],
             &[],
@@ -4895,6 +5110,8 @@ mod tests {
             &ode,
             &obs_pk[0].values,
             Some(&event_pk),
+            None,
+            None,
             &[],
             &[],
             &base,
@@ -4911,6 +5128,8 @@ mod tests {
             &ode,
             &obs_pk[0].values,
             Some(&event_pk),
+            None,
+            None,
             &[],
             &[],
             &base,
@@ -4930,6 +5149,8 @@ mod tests {
         let replay = adaptive_frozen_replay_tv(
             &ode,
             &event_pk,
+            None,
+            None,
             &[],
             &[],
             &static_subject,
@@ -5065,6 +5286,8 @@ mod tests {
             &ode,
             &event_pk.obs[0].values,
             Some(&event_pk),
+            None,
+            None,
             &[],
             &[],
             &base,
@@ -5118,6 +5341,8 @@ mod tests {
             &ode,
             &event_pk.obs[0].values,
             Some(&event_pk),
+            None,
+            None,
             &[],
             &[],
             &base,
@@ -5167,6 +5392,8 @@ mod tests {
                 &ode,
                 &event_pk.obs[0].values,
                 Some(&event_pk),
+                None,
+                None,
                 &[],
                 &[],
                 &base,
@@ -5183,6 +5410,8 @@ mod tests {
                 &ode,
                 &event_pk.obs[0].values,
                 Some(&event_pk),
+                None,
+                None,
                 &[],
                 &[],
                 &base,
@@ -5200,6 +5429,220 @@ mod tests {
         assert!(
             fast < slow - 1e-6,
             "pk-only per-event CL must drive the trajectory: slow={slow}, fast={fast}"
+        );
+    }
+
+    #[test]
+    fn adaptive_iov_controller_matches_static_event_driven() {
+        // Degenerate oracle for IOV (#701): a fixed-regimen controller under a
+        // per-decision-window κ (occasion = decision index) must reproduce the trusted
+        // static event-driven engine on the same realized doses with the same
+        // per-occasion PK. Decisions coincide with observations here (every dose lands
+        // on an obs row), so each event's occasion snapshot is unambiguous and the two
+        // engines share the end-of-interval convention exactly.
+        let ode = one_cpt_ode_spec();
+        let v = 10.0;
+        // Four decisions = four occasions; CL shifts each occasion (the κ effect).
+        let times = [0.0, 24.0, 48.0, 72.0];
+        let occ_cls = [1.0, 0.7, 0.5, 0.3];
+        let occ_pk: Vec<PkParams> = occ_cls.iter().map(|&cl| pk_one(cl, v)).collect();
+        // event_pk.obs[j]: obs j coincides with decision j → occasion j's PK.
+        let event_pk = crate::pk::EventPkParams {
+            dose: Vec::new(),
+            obs: occ_pk.clone(),
+            pk_only: Vec::new(),
+        };
+        // decision_pk[g] = occasion g's PK; eta_occ activates the IOV path (the plain
+        // ODE reads PK from the params array, so the eta *values* are immaterial here —
+        // the eta *threading* is exercised end-to-end by the api-level IOV test).
+        let decision_pk = occ_pk.clone();
+        let eta_occ: Vec<Vec<f64>> = vec![Vec::new(); times.len()];
+
+        let mut decide = |_ctx: &ControllerCtx| ControllerDecision {
+            actions: vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+            rule: None,
+        };
+        let base = make_subject(vec![], times.to_vec());
+        let run = ode_predictions_adaptive_impl(
+            &ode,
+            &occ_pk[0].values,
+            Some(&event_pk),
+            Some(&decision_pk),
+            Some(&eta_occ),
+            &[],
+            &[],
+            &base,
+            &times,
+            &[],
+            &mut decide,
+            100,
+            None,
+        )
+        .expect("driver runs");
+
+        // Trusted static engine: same realized doses, per-dose / per-obs occasion PK.
+        let static_doses: Vec<DoseEvent> = times
+            .iter()
+            .map(|&t| DoseEvent::new(t, 100.0, 1, 0.0, false, 0.0))
+            .collect();
+        let static_subject = make_subject(static_doses, times.to_vec());
+        let static_preds = ode_predictions_event_driven(
+            &ode,
+            &static_subject,
+            &[],
+            &[],
+            &occ_pk, // pk_at_dose: dose g coincides with occasion g
+            &occ_pk, // pk_at_obs
+            &[],
+        );
+
+        assert_eq!(run.predictions.len(), static_preds.len());
+        for (got, want) in run.predictions.iter().zip(static_preds.iter()) {
+            assert_relative_eq!(*got, *want, max_relative = 1e-9);
+        }
+        assert_eq!(run.ledger.len(), 4);
+
+        // Guard against a silent regression to a single-occasion (κ-frozen) path: the
+        // same run with every occasion pinned to CL=1.0 clears faster in the later
+        // occasions, so its final concentration is materially lower.
+        let frozen_pk: Vec<PkParams> = vec![pk_one(1.0, v); times.len()];
+        let frozen_event = crate::pk::EventPkParams {
+            dose: Vec::new(),
+            obs: frozen_pk.clone(),
+            pk_only: Vec::new(),
+        };
+        let frozen_eta: Vec<Vec<f64>> = vec![Vec::new(); times.len()];
+        let mut decide2 = |_ctx: &ControllerCtx| ControllerDecision {
+            actions: vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+            rule: None,
+        };
+        let frozen_run = ode_predictions_adaptive_impl(
+            &ode,
+            &frozen_pk[0].values,
+            Some(&frozen_event),
+            Some(&frozen_pk),
+            Some(&frozen_eta),
+            &[],
+            &[],
+            &base,
+            &times,
+            &[],
+            &mut decide2,
+            100,
+            None,
+        )
+        .expect("frozen driver runs");
+        let iov_last = *run.predictions.last().unwrap();
+        let frozen_last = *frozen_run.predictions.last().unwrap();
+        assert!(
+            iov_last > frozen_last * (1.0 + 1e-6),
+            "per-occasion κ must differ from a single-occasion path: iov={iov_last}, frozen={frozen_last}"
+        );
+    }
+
+    #[test]
+    fn adaptive_iov_frozen_replay_is_bit_exact() {
+        // The occasion-aware frozen replay (#701) must be BIT-aligned with the reactive
+        // driver, exactly as the constant and #700 TV paths are. A decision that falls
+        // *between* observations (t=12) exercises `decision_pk` + the occasion LOCF
+        // carry — the case where a naive LOCF would read the previous occasion's PK.
+        let ode = one_cpt_ode_spec();
+        let v = 10.0;
+        let obs_times = [6.0, 30.0, 54.0, 78.0];
+        // Five decisions = five occasions; t=12 falls between obs rows. CL per occasion.
+        let decisions = [0.0, 12.0, 24.0, 48.0, 72.0];
+        let occ_cls = [1.2, 1.0, 0.8, 0.6, 0.4];
+        let occ_pk: Vec<PkParams> = occ_cls.iter().map(|&cl| pk_one(cl, v)).collect();
+        // obs occasion = decision window containing the obs time:
+        //   6→occ0([0,12)), 30→occ2([24,48)), 54→occ3([48,72)), 78→occ4([72,∞)).
+        let event_pk = crate::pk::EventPkParams {
+            dose: Vec::new(),
+            obs: vec![occ_pk[0], occ_pk[2], occ_pk[3], occ_pk[4]],
+            pk_only: Vec::new(),
+        };
+        let decision_pk = occ_pk.clone();
+        let eta_occ: Vec<Vec<f64>> = vec![Vec::new(); decisions.len()];
+        let monitors = [MonitorSpec::new("A", 1, ObserveMode::Ipred)];
+        let mut decide = |ctx: &ControllerCtx| ControllerDecision {
+            actions: if ctx.signal("A").expect("monitor A declared") < 50.0 {
+                vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }]
+            } else {
+                vec![DoseAction::Hold]
+            },
+            rule: None,
+        };
+        let mons: Vec<AdaptiveMonitor> = monitors
+            .iter()
+            .map(|s| AdaptiveMonitor {
+                spec: s,
+                observe: None,
+            })
+            .collect();
+        let base = make_subject(vec![], obs_times.to_vec());
+        let run = ode_predictions_adaptive_impl(
+            &ode,
+            &occ_pk[0].values,
+            Some(&event_pk),
+            Some(&decision_pk),
+            Some(&eta_occ),
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &mons,
+            &mut decide,
+            100,
+            None,
+        )
+        .expect("driver runs");
+        assert!(!run.ledger.is_empty(), "the run must dose at least once");
+
+        // The default-tolerance verifier accepts it...
+        verify_adaptive_frozen_replay(
+            &ode,
+            &occ_pk[0].values,
+            Some(&event_pk),
+            Some(&decision_pk),
+            Some(&eta_occ),
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &run,
+        )
+        .expect("IOV run matches the occasion-aware static replay");
+
+        // ...and the agreement is bit-exact, not merely within the verifier's slack.
+        let mut static_subject = base.clone();
+        static_subject.doses = run
+            .ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0))
+            .collect();
+        let dose_f: Vec<f64> = run.ledger.iter().map(|e| e.f_applied).collect();
+        let replay = adaptive_frozen_replay_tv(
+            &ode,
+            &event_pk,
+            Some(&decision_pk),
+            Some(&eta_occ),
+            &[],
+            &[],
+            &static_subject,
+            &dose_f,
+            &decisions,
+        );
+        let mut max_rel = 0.0_f64;
+        for (got, want) in run.predictions.iter().zip(replay.iter()) {
+            if got.is_nan() && want.is_nan() {
+                continue;
+            }
+            let d = (got - want).abs();
+            let r = if want.abs() > 0.0 { d / want.abs() } else { d };
+            max_rel = max_rel.max(r);
+        }
+        assert!(
+            max_rel <= 1e-12,
+            "IOV frozen replay not bit-aligned: max_rel={max_rel}"
         );
     }
 
@@ -5230,14 +5673,27 @@ mod tests {
         .expect("driver runs");
 
         // A dose at every decision aligns the segment structure → exact match.
-        verify_adaptive_frozen_replay(&ode, &pk.values, None, &[], &[], &base, &decisions, &run)
-            .expect("aligned run matches the static replay");
+        verify_adaptive_frozen_replay(
+            &ode,
+            &pk.values,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &run,
+        )
+        .expect("aligned run matches the static replay");
 
         let mut perturbed = run.clone();
         perturbed.predictions[0] += 10.0;
         let err = verify_adaptive_frozen_replay(
             &ode,
             &pk.values,
+            None,
+            None,
             None,
             &[],
             &[],
@@ -5253,6 +5709,8 @@ mod tests {
         let err = verify_adaptive_frozen_replay(
             &ode,
             &pk.values,
+            None,
+            None,
             None,
             &[],
             &[],
@@ -5304,8 +5762,19 @@ mod tests {
         assert_eq!(run.ledger.len(), 1, "only the t=0 decision should dose");
 
         // Passes the tight (aligned) verifier — the whole point of the fix.
-        verify_adaptive_frozen_replay(&ode, &pk.values, None, &[], &[], &base, &decisions, &run)
-            .expect("held-decision run matches the aligned static replay");
+        verify_adaptive_frozen_replay(
+            &ode,
+            &pk.values,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            &run,
+        )
+        .expect("held-decision run matches the aligned static replay");
     }
 
     #[test]
@@ -9008,6 +9477,8 @@ mod tests {
         let run = ode_predictions_adaptive_impl(
             model.ode_spec.as_ref().unwrap(),
             &pk.values,
+            None,
+            None,
             None,
             &theta,
             &eta,

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -585,7 +585,18 @@ pub fn compute_event_pk_params_into(
 /// κ is zero). `decision_times` is the ascending reactive schedule. A record that
 /// coincides with a decision (within a tiny tolerance) belongs to that decision's
 /// window — matching the driver, which opens window `g` at the decision break and
-/// records the coincident observation post-open.
+/// records the coincident observation post-open. Requires `decision_times` strictly
+/// ascending (enforced at the funnel by `validate_increasing_finite`); the scan stops
+/// at the first later time, so an unsorted schedule would return a wrong index.
+///
+/// The 1e-9 tolerance is deliberately looser than the exact-`to_bits` decision/record
+/// lookups (`decision_index_of`, `segment_pk_at`) and the #700 break-collision guard
+/// (1e-15). On a non-integer grid, a record within (1e-15, 1e-9) of a decision is
+/// grouped into that decision's window here. That never breaks bit-alignment: the
+/// driver, the frozen-replay verifier, and the `compute_event_pk_params_iov`
+/// materialiser all resolve a record's occasion through *this one function*, so they
+/// cannot disagree with each other — and integer-valued time grids (every test and
+/// example) never land in that window at all.
 pub(crate) fn occasion_of(decision_times: &[f64], t: f64) -> Option<usize> {
     let mut occ = None;
     for (g, &d) in decision_times.iter().enumerate() {
@@ -611,6 +622,16 @@ pub(crate) fn occasion_of(decision_times: &[f64], t: f64) -> Option<usize> {
 /// record's *covariate* snapshot (`obs_cov` / `pk_only_cov`) is used alongside its
 /// occasion eta, so a model with both a TV covariate and IOV κ is per-event correct
 /// in both.
+///
+/// **pk-only (EVID=2) convention — deliberately different from [`predict_iov`].** Here
+/// a pk-only record takes the κ of the decision window containing its time (like any
+/// obs record), because in the reactive setting that observation genuinely occurs
+/// *during* that occasion. The static [`predict_iov`] instead maps pk-only rows to no
+/// occasion (`u32::MAX` ⇒ κ = 0, BSV-only), following the OCC-column semantics of #104.
+/// The two are consistent *within* their own path (the adaptive driver's
+/// `segment_occ_at` also uses [`occasion_of`], so materialiser and driver agree), but a
+/// future oracle that validates an adaptive IOV run *with EVID=2 rows* against
+/// `predict_iov` must account for this — they will disagree on the pk-only κ by design.
 pub(crate) fn compute_event_pk_params_iov(
     model: &CompiledModel,
     subject: &Subject,

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -579,6 +579,76 @@ pub fn compute_event_pk_params_into(
     }
 }
 
+/// The decision window (occasion) active at time `t` under the per-decision-window
+/// IOV convention for adaptive dosing (#701): the index of the latest decision at
+/// or before `t`, or `None` before the first decision (the baseline window, whose
+/// κ is zero). `decision_times` is the ascending reactive schedule. A record that
+/// coincides with a decision (within a tiny tolerance) belongs to that decision's
+/// window — matching the driver, which opens window `g` at the decision break and
+/// records the coincident observation post-open.
+pub(crate) fn occasion_of(decision_times: &[f64], t: f64) -> Option<usize> {
+    let mut occ = None;
+    for (g, &d) in decision_times.iter().enumerate() {
+        if d <= t + 1e-9 {
+            occ = Some(g);
+        } else {
+            break;
+        }
+    }
+    occ
+}
+
+/// Occasion-aware per-event PK for the adaptive IOV path (#701).
+///
+/// Like [`compute_event_pk_params`] but each observation / pk-only record is
+/// evaluated with the eta of the **occasion (decision window)** active at its time
+/// ([`occasion_of`]): `eta_occ[g]` for the window `g` containing the record, or
+/// `eta_baseline` (BSV η with κ = 0) before the first decision. This is the IOV
+/// analogue of [`predict_iov`]'s per-event occasion-κ selection, with occasion =
+/// decision window instead of the OCC column. Doses stay empty — the adaptive base
+/// subject is dose-free; controller-injected doses take their PK from the driver's
+/// per-decision snapshot. It composes with #700's time-varying covariates: each
+/// record's *covariate* snapshot (`obs_cov` / `pk_only_cov`) is used alongside its
+/// occasion eta, so a model with both a TV covariate and IOV κ is per-event correct
+/// in both.
+pub(crate) fn compute_event_pk_params_iov(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta_baseline: &[f64],
+    eta_occ: &[Vec<f64>],
+    decision_times: &[f64],
+) -> EventPkParams {
+    let mut out = EventPkParams::with_capacity_for(subject);
+    let eta_at = |t: f64| -> &[f64] {
+        match occasion_of(decision_times, t) {
+            Some(g) => eta_occ[g].as_slice(),
+            None => eta_baseline,
+        }
+    };
+    for j in 0..subject.obs_times.len() {
+        let t = subject.obs_times[j];
+        out.obs.push(pk_params_at_time(
+            model,
+            theta,
+            eta_at(t),
+            subject.obs_cov(j),
+            t,
+        ));
+    }
+    for m in 0..subject.pk_only_times.len() {
+        let t = subject.pk_only_times[m];
+        out.pk_only.push(pk_params_at_time(
+            model,
+            theta,
+            eta_at(t),
+            subject.pk_only_cov(m),
+            t,
+        ));
+    }
+    out
+}
+
 /// IOV predictions with proper per-dose occasion accounting (issue #104).
 ///
 /// Builds per-event PK parameters carrying **each event's occasion kappa** and

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -575,6 +575,12 @@ pub(crate) fn compute_subject_metrics(
 /// disjoint from any other stream derived from the same run seed (η, output).
 const ASSAY_PURPOSE_SALT: u64 = 0xA55A_E155_0DE0_0001;
 
+/// Purpose tag folded into the IOV-kappa seed so the per-occasion κ draw stream
+/// is disjoint from the assay stream, the η stream, and the output stream derived
+/// from the same run seed (#701). A distinct salt is what guarantees enabling a
+/// `Dv` monitor never shifts the κ draws, and vice versa.
+const KAPPA_PURPOSE_SALT: u64 = 0xCA99_0CCA_5104_0001;
+
 /// 64-bit golden-ratio odd constant for seed mixing (same family as the
 /// per-chain seeding in `estimation/bayes.rs`).
 const GOLDEN64: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -620,6 +626,32 @@ pub(crate) fn assay_standard_normal(base_seed: u64, decision_index: usize, analy
         combine_seed(base_seed, decision_index as u64),
         stable_hash_str(analyte),
     );
+    let mut rng = rand::rngs::StdRng::seed_from_u64(key);
+    Normal::new(0.0, 1.0).unwrap().sample(&mut rng)
+}
+
+/// Per-(subject, replicate) base seed for the IOV-kappa substream (#701), rooted
+/// at the run-level `root` seed and keyed by the subject *id* (permutation-
+/// invariant, like the assay stream). The [`KAPPA_PURPOSE_SALT`] keeps it disjoint
+/// from the assay substream that shares this root, so enabling a `Dv` monitor never
+/// perturbs the κ draws (and the reverse). A model with no IOV never calls this, so
+/// the η stream stays byte-identical whether or not κ is present.
+pub(crate) fn subject_kappa_base_seed(root: u64, subject_id: &str, replicate: usize) -> u64 {
+    let s = combine_seed(root ^ KAPPA_PURPOSE_SALT, stable_hash_str(subject_id));
+    combine_seed(s, replicate as u64)
+}
+
+/// One standard-normal draw for kappa `component` on `occasion`, on the substream
+/// rooted at `base_seed` ([`subject_kappa_base_seed`]). A fresh RNG is seeded per
+/// draw from the full `(occasion, component)` key, so — exactly like
+/// [`assay_standard_normal`] — the draw depends on nothing else in the run: adding
+/// an occasion, a monitor, or another κ component never shifts any other draw. The
+/// caller assembles `n_kappa` such draws into a z-vector and applies the IOV
+/// Cholesky factor to obtain the correlated κ for that occasion.
+pub(crate) fn kappa_standard_normal(base_seed: u64, occasion: usize, component: usize) -> f64 {
+    use rand::SeedableRng;
+    use rand_distr::{Distribution, Normal};
+    let key = combine_seed(combine_seed(base_seed, occasion as u64), component as u64);
     let mut rng = rand::rngs::StdRng::seed_from_u64(key);
     Normal::new(0.0, 1.0).unwrap().sample(&mut rng)
 }
@@ -1442,6 +1474,53 @@ mod tests {
         assert_ne!(
             x,
             assay_standard_normal(101, 0, "A"),
+            "base seed keys the draw"
+        );
+    }
+
+    // ----- #701: IOV-kappa substream seed helpers -----------------------
+
+    #[test]
+    fn subject_kappa_base_seed_separates_and_is_disjoint_from_assay() {
+        let a = subject_kappa_base_seed(42, "subj-1", 1);
+        assert_eq!(a, subject_kappa_base_seed(42, "subj-1", 1), "deterministic");
+        assert_ne!(
+            a,
+            subject_kappa_base_seed(42, "subj-2", 1),
+            "subject id keys"
+        );
+        assert_ne!(
+            a,
+            subject_kappa_base_seed(42, "subj-1", 2),
+            "replicate keys"
+        );
+        assert_ne!(a, subject_kappa_base_seed(7, "subj-1", 1), "root seed keys");
+        // Disjoint from the assay stream that shares the same run root: the
+        // purpose salt is what keeps enabling a `Dv` monitor from perturbing κ.
+        assert_ne!(
+            a,
+            subject_assay_base_seed(42, "subj-1", 1),
+            "kappa and assay substreams are disjoint under the same root"
+        );
+    }
+
+    #[test]
+    fn kappa_standard_normal_is_deterministic_and_key_separated() {
+        let x = kappa_standard_normal(100, 0, 0);
+        assert_eq!(x, kappa_standard_normal(100, 0, 0), "deterministic");
+        assert_ne!(
+            x,
+            kappa_standard_normal(100, 1, 0),
+            "occasion keys the draw"
+        );
+        assert_ne!(
+            x,
+            kappa_standard_normal(100, 0, 1),
+            "component keys the draw"
+        );
+        assert_ne!(
+            x,
+            kappa_standard_normal(101, 0, 0),
             "base seed keys the draw"
         );
     }

--- a/tests/adaptive_vanco_iov_anchor.rs
+++ b/tests/adaptive_vanco_iov_anchor.rs
@@ -1,0 +1,277 @@
+//! mrgsolve cross-check for the reactive `[adaptive_dosing]` **inter-occasion
+//! variability** path — a fresh per-occasion κ on clearance drives a vancomycin
+//! trough-TDM titration (epic #391 / **#701**).
+//!
+//! NONMEM has no native feedback dosing, so the apples-to-apples external anchor
+//! for this feature family is **mrgsolve** (which does do feedback dosing). This is
+//! the IOV analogue of the constant-covariate vanco anchor (`adaptive_vanco_anchor`)
+//! and the time-varying-covariate one (`adaptive_vanco_renal_anchor`, #700); the
+//! reference kit lives in `tests/reference/vanco_iov_mrgsolve/`:
+//!
+//!   - `vanco_iov_mrgsolve.R` builds the identical structural model (1-cpt IV
+//!     vancomycin, once-daily 1-h infusion, `CL = TVCL·exp(η + κ)`) in mrgsolve
+//!     1.7.2, **injects ferx's exact per-occasion κ** (reconstructed from the seeded
+//!     substream), replays ferx's realized dose ladder, and records the pre-dose
+//!     trough at each decision. Each day is integrated as two segments — the
+//!     infusion on THIS occasion's CL, the decay on the NEXT occasion's CL
+//!     (end-of-interval convention ferx's per-segment IOV PK uses).
+//!   - `expected.md` is the frozen mrgsolve ladder (κ, CL, trough, dose per
+//!     decision). Regenerate with `Rscript vanco_iov_mrgsolve.R`.
+//!
+//! ## Anchor form — deterministic dose-for-dose replay with reconstructed κ
+//!
+//! κ is *random* (drawn per decision window on a seeded RNG substream), so an
+//! independent mrgsolve draw could never match. The anchor reconstructs ferx's
+//! EXACT per-occasion κ (the Rust reconstruction is pinned by the unit test
+//! `adaptive_iov_matches_predict_iov_with_reconstructed_kappa` in `src/api.rs`) and
+//! injects the SAME per-occasion clearance into mrgsolve, replaying ferx's realized
+//! doses. What is cross-validated is the occasion → CL → trajectory *mechanism*:
+//! ferx's RK45 and mrgsolve's LSODA integrate the identical piecewise-constant
+//! system and must reach the same trough trajectory. This test runs the ferx
+//! reactive driver **live** at the anchor seed and asserts its troughs (and its
+//! realized dose ladder) match the frozen mrgsolve ladder.
+//!
+//! ## Regenerating the ferx-side inputs baked into the R kit
+//!
+//! The κ / CL / dose constants in `vanco_iov_mrgsolve.R` are ferx's, from the
+//! seed-20260708 run. To regenerate them, un-`#[ignore]` and run the in-crate
+//! harness `temp_print_vanco_iov_anchor_coordination` (or reconstruct via the
+//! api.rs unit test's recipe): it prints, per occasion, the reconstructed κ, the
+//! resolved CL, the realized dose, and the live trough — the exact numbers frozen
+//! into the R script and `expected.md`. The reconstruction (`subject_kappa_base_seed`
+//! + `kappa_standard_normal` + `chol(Ω_IOV)`) is `pub(crate)`, so it lives in the
+//! crate; this integration test consumes only public API (`simulate_adaptive_from_spec`)
+//! and the frozen reference, which is the whole point of an *external* anchor.
+
+use ferx_core::parser::model_parser::parse_full_model_file;
+use ferx_core::{
+    simulate_adaptive_from_spec, AdaptiveSimulateOptions, DoseEvent, Population, Subject,
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// The anchor seed. Must match the seed the frozen κ / troughs in
+/// `tests/reference/vanco_iov_mrgsolve/{vanco_iov_mrgsolve.R,expected.md}` were
+/// generated at — the reconstruction is seed-deterministic, so a different seed
+/// draws different κ and the frozen mrgsolve troughs would no longer apply.
+const ANCHOR_SEED: u64 = 20260708;
+
+/// mrgsolve 1.7.2 reference, frozen in `tests/reference/vanco_iov_mrgsolve/expected.md`.
+/// Per daily decision: `(time_h, trough_mg_per_L, dose_mg)`. The troughs are the
+/// mrgsolve LSODA values under ferx's reconstructed per-occasion κ; ferx's RK45
+/// agrees within `SIGNAL_TOL`. The doses are ferx's realized ladder (exact f64
+/// titration), so ferx reproduces them bit-for-bit.
+const REF_LADDER: [(f64, f64, f64); 14] = [
+    (0.0, 0.000000, 625.000000),
+    (24.0, 2.960637, 781.250000),
+    (48.0, 3.697443, 976.562500),
+    (72.0, 3.174336, 1220.703125),
+    (96.0, 5.578850, 1525.878906),
+    (120.0, 10.761070, 1525.878906),
+    (144.0, 5.932958, 1907.348633),
+    (168.0, 11.376082, 1907.348633),
+    (192.0, 6.447514, 2384.185791),
+    (216.0, 13.606025, 2384.185791),
+    (240.0, 12.646158, 2384.185791),
+    (264.0, 16.481410, 1788.139343),
+    (288.0, 16.646880, 1341.104507),
+    (312.0, 12.439516, 1341.104507),
+];
+
+/// Cross-solver trough tolerance (mg/L). ferx (RK45) vs mrgsolve (LSODA) integrate
+/// the SAME piecewise-constant per-occasion-CL system, so the observed gap is tiny
+/// (max ~5e-4 over the horizon). `2e-3` is a safe but meaningful guard — a
+/// trajectory mismatch from a broken occasion → CL hand-off (e.g. the wrong
+/// occasion's κ on a segment, which the two other plausible conventions produce)
+/// would blow past it by 1–3 orders of magnitude.
+const SIGNAL_TOL: f64 = 2e-3;
+
+/// The realized dose ladder is exact f64 (the mrgsolve `expected.md` doses are
+/// rounded to 6 dp, but ferx's are the un-rounded titration), so compare doses to
+/// a tolerance that admits the 6-dp rounding of the frozen table but nothing more.
+const DOSE_TOL: f64 = 1e-3;
+
+/// Build the dose-free anchor subject: an EVID=0 observation at each of the 14
+/// daily decision times (t = 0, 24, …, 312 h). The reactive driver injects the
+/// doses; the subject only carries the readout grid so the pre-dose trough is
+/// recorded at each decision. No covariates — the per-occasion κ is the sole source
+/// of PK variation.
+fn anchor_subject(decision_times: &[f64]) -> Subject {
+    let n = decision_times.len();
+    Subject {
+        id: "1".to_string(),
+        doses: Vec::<DoseEvent>::new(),
+        obs_times: decision_times.to_vec(),
+        obs_raw_times: Vec::new(),
+        observations: vec![0.0; n],
+        obs_cmts: vec![1; n],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1u32; n],
+        dose_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        #[cfg(feature = "survival")]
+        obs_records: vec![],
+    }
+}
+
+/// Fast PR-time guard (NOT slow-gated). The cross-engine check below only runs
+/// nightly, so without this a typo in `adaptive_vanco_iov.ferx` — which exercises
+/// the #701 IOV adaptive surface — would slip past the per-PR job.
+/// `parse_full_model_file` runs the full `[adaptive_dosing]` `validate()`, so a
+/// successful parse plus these spot-checks pin the scenario the anchor relies on:
+/// exactly one κ (the IOV effect), the trough control law, and that `auc_target` is
+/// **absent** (it is a typed error for an IOV subject, #701). A short seeded run of
+/// the reactive driver then confirms it is `Ok` — the default frozen-replay verifier
+/// validating the realized run — without waiting for the nightly cross-check.
+#[test]
+fn vanco_iov_example_parses_and_runs_the_verifier() {
+    let parsed = parse_full_model_file(Path::new("examples/adaptive_vanco_iov.ferx"))
+        .expect("vanco IOV model must parse");
+    assert_eq!(
+        parsed.model.n_kappa, 1,
+        "exactly one IOV effect (κ on CL) — the #701 surface under test"
+    );
+    assert_eq!(parsed.model.n_eta, 1, "one (negligible) BSV η on CL");
+    let spec = parsed
+        .adaptive_dosing
+        .as_ref()
+        .expect("[adaptive_dosing] block present");
+    assert_eq!(spec.start_dose, 500.0, "empiric start dose");
+    assert_eq!(spec.dose_bounds, (250.0, 4000.0));
+    assert_eq!(
+        spec.target_window,
+        Some((10.0, 15.0)),
+        "trough target band (per-occasion-aware point metric)"
+    );
+    assert_eq!(
+        spec.auc_target, None,
+        "auc_target must be absent — it is a typed error for an IOV (`kappa`) \
+         subject (#701), so the IOV example never declares it"
+    );
+    assert_eq!(spec.at.len(), 14, "14 daily decisions, t = 0..=312 h");
+    assert_eq!(spec.levels, None, "continuous (percentage) titration");
+    assert_eq!(
+        spec.rules.len(),
+        2,
+        "increase / decrease rungs (the per-occasion κ drives both)"
+    );
+
+    // A short seeded reactive run must pass the default frozen-replay verifier.
+    let pop = Population {
+        subjects: vec![anchor_subject(&spec.at)],
+        covariate_names: Vec::new(),
+        dv_column: "DV".to_string(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    };
+    let mut opts = AdaptiveSimulateOptions::default();
+    opts.seed = Some(ANCHOR_SEED);
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("adaptive IOV sim runs and passes the default verifier");
+    assert_eq!(res.decisions.len(), 14, "one decision per day");
+    assert_eq!(res.ledger.len(), 14, "every decision issued a dose");
+}
+
+/// Slow + mrgsolve-anchored. Runs the ferx reactive driver live at `ANCHOR_SEED`
+/// (which draws the exact per-occasion κ the R kit injects), then asserts every
+/// per-decision trough matches the frozen mrgsolve trough within the cross-solver
+/// band and every realized dose matches the frozen ladder — the dose-for-dose IOV
+/// occasion → CL → trajectory cross-check against an independent engine.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + mrgsolve-anchored vanco IOV (per-occasion κ) TDM titration (#701): opt in with --features slow-tests"
+)]
+fn vanco_iov_titration_matches_mrgsolve() {
+    let parsed = parse_full_model_file(Path::new("examples/adaptive_vanco_iov.ferx"))
+        .expect("vanco IOV model must parse");
+    let spec = parsed
+        .adaptive_dosing
+        .as_ref()
+        .expect("[adaptive_dosing] present");
+
+    let pop = Population {
+        subjects: vec![anchor_subject(&spec.at)],
+        covariate_names: Vec::new(),
+        dv_column: "DV".to_string(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    };
+
+    // `AdaptiveSimulateOptions` is `#[non_exhaustive]`: build from `default()`.
+    let mut opts = AdaptiveSimulateOptions::default();
+    opts.seed = Some(ANCHOR_SEED);
+
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("adaptive vanco IOV sim runs (+ frozen-replay verifier)");
+
+    // Every decision dosed (no hold/stop here), so the ledger is 14 long.
+    assert_eq!(res.decisions.len(), 14, "one decision per day");
+    assert_eq!(res.ledger.len(), 14, "every decision issued a dose");
+
+    // Per-decision: the live ferx trough matches mrgsolve within the cross-solver
+    // band, and the realized dose matches the frozen ladder. This is the dose-for-
+    // dose match under per-occasion IOV κ — both engines integrate the identical
+    // piecewise-constant CL and reach the same trough trajectory.
+    for (i, &(t_ref, trough_ref, dose_ref)) in REF_LADDER.iter().enumerate() {
+        let d = &res.decisions[i];
+        assert_eq!(d.time, t_ref, "decision {i} time");
+        let sig = d
+            .observed_signals
+            .first()
+            .map(|s| s.value)
+            .unwrap_or(f64::NAN);
+        assert!(
+            (sig - trough_ref).abs() < SIGNAL_TOL,
+            "decision {i}: ferx trough {sig:.6} vs mrgsolve {trough_ref:.6} \
+             (|Δ| {:.6} >= {SIGNAL_TOL}); a mismatch this large signals a broken \
+             per-occasion κ → CL hand-off",
+            (sig - trough_ref).abs()
+        );
+        let e = &res.ledger[i];
+        assert!(
+            (e.amt - dose_ref).abs() < DOSE_TOL,
+            "decision {i}: ferx dose {} != mrgsolve {dose_ref} (titration divergence)",
+            e.amt
+        );
+    }
+
+    // The per-occasion κ is genuinely nonzero (it swings CL ~2.8 → 5.8 L/h across
+    // the horizon): the frozen CL column in expected.md spans that range, so the
+    // realized trough trajectory is *not* the degenerate constant-CL one — the
+    // anchor actually exercises the IOV mechanism rather than trivially passing.
+    let troughs: Vec<f64> = REF_LADDER.iter().map(|&(_, tr, _)| tr).collect();
+    let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+    for &tr in troughs.iter().skip(1) {
+        lo = lo.min(tr);
+        hi = hi.max(tr);
+    }
+    assert!(
+        hi - lo > 5.0,
+        "the trough trajectory must vary substantially under the per-occasion κ \
+         (spread {:.3} mg/L) — else the anchor would not bite",
+        hi - lo
+    );
+}

--- a/tests/adaptive_vanco_renal_iov_anchor.rs
+++ b/tests/adaptive_vanco_renal_iov_anchor.rs
@@ -1,0 +1,269 @@
+//! mrgsolve cross-check for the **composition** of the two reactive
+//! `[adaptive_dosing]` PK-variation paths — a declining renal covariate (**#700**)
+//! AND a per-occasion κ on clearance (**#701**) driving CL together (epic #391).
+//!
+//! NONMEM has no native feedback dosing, so the apples-to-apples external anchor for
+//! this feature family is **mrgsolve**. This is the composition of the two single-
+//! effect anchors (`adaptive_vanco_renal_anchor`, #700; `adaptive_vanco_iov_anchor`,
+//! #701): here `CL = TVCL·(CRCL/100)·exp(η + κ)`, so each day's clearance is set by
+//! BOTH the renal function active in that segment and that window's occasion κ. The
+//! reference kit lives in `tests/reference/vanco_renal_iov_mrgsolve/`:
+//!
+//!   - `vanco_renal_iov_mrgsolve.R` builds the identical structural model in mrgsolve
+//!     1.7.2, feeds the SAME declining CRCL trajectory AND ferx's exact per-occasion κ
+//!     (reconstructed from the seeded substream — identical to the #701 anchor's, as
+//!     the κ stream is model-independent), replays ferx's realized dose ladder, and
+//!     records the pre-dose trough at each decision. Each day is two segments — the
+//!     infusion on THIS occasion's (CRCL_g, κ_g), the decay on the NEXT occasion's
+//!     (CRCL_{g+1}, κ_{g+1}) — the end-of-interval convention ferx's per-segment PK
+//!     uses, now with BOTH effects composed into the piecewise-constant CL.
+//!   - `expected.md` is the frozen mrgsolve ladder. Regenerate with
+//!     `Rscript vanco_renal_iov_mrgsolve.R`.
+//!
+//! ## What this adds over the two single-effect anchors
+//!
+//! The renal anchor proves a covariate-driven CL matches mrgsolve; the IOV anchor
+//! proves a κ-driven CL matches mrgsolve. This anchor proves they are correct
+//! **together** — the #700 per-event PK recompute and the #701 per-occasion κ compose
+//! into one piecewise-constant CL that an independent LSODA engine reproduces
+//! dose-for-dose. (The off-record-decision covariate LOCF edge is pinned separately,
+//! and fail-without-fix, by `adaptive_iov_decision_pk_uses_locf_covariate_off_grid`
+//! in `src/api.rs`.)
+
+use ferx_core::parser::model_parser::parse_full_model_file;
+use ferx_core::{
+    simulate_adaptive_from_spec, AdaptiveSimulateOptions, DoseEvent, Population, Subject,
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// The anchor seed. Must match the seed the frozen κ / troughs in the R kit were
+/// generated at (the κ reconstruction is seed-deterministic). Identical to the #701
+/// IOV anchor's seed, so the per-occasion κ is the same model-independent stream.
+const ANCHOR_SEED: u64 = 20260708;
+
+/// Declining renal function over the horizon (one CRCL per daily decision/obs),
+/// CRCL(0)=120 down to CRCL(312)=40 mL/min. MUST match the `crcl` vector in
+/// `tests/reference/vanco_renal_iov_mrgsolve/vanco_renal_iov_mrgsolve.R` exactly.
+const CRCL: [f64; 14] = [
+    120.0, 115.0, 108.0, 98.0, 88.0, 78.0, 68.0, 60.0, 54.0, 49.0, 45.0, 42.0, 41.0, 40.0,
+];
+
+/// mrgsolve 1.7.2 reference, frozen in
+/// `tests/reference/vanco_renal_iov_mrgsolve/expected.md`. Per daily decision:
+/// `(time_h, trough_mg_per_L, dose_mg)`. Troughs are the mrgsolve LSODA values under
+/// ferx's declining CRCL × reconstructed per-occasion κ; ferx's RK45 agrees within
+/// `SIGNAL_TOL`. Doses are ferx's realized ladder (exact f64 titration), reproduced
+/// bit-for-bit.
+const REF_LADDER: [(f64, f64, f64); 14] = [
+    (0.0, 0.000000, 625.000000),
+    (24.0, 2.556064, 781.250000),
+    (48.0, 3.239114, 976.562500),
+    (72.0, 3.175663, 1220.703125),
+    (96.0, 6.413905, 1525.878906),
+    (120.0, 13.302792, 1525.878906),
+    (144.0, 10.762650, 1525.878906),
+    (168.0, 16.631220, 1144.409180),
+    (192.0, 12.316018, 1144.409180),
+    (216.0, 16.342389, 858.306885),
+    (240.0, 15.479172, 643.730164),
+    (264.0, 15.727982, 482.797623),
+    (288.0, 15.334823, 362.098217),
+    (312.0, 13.346793, 362.098217),
+];
+
+/// Cross-solver trough tolerance (mg/L). ferx (RK45) vs mrgsolve (LSODA) integrate
+/// the SAME piecewise-constant composed-CL system, so the gap is tiny; `2e-3` is a
+/// safe but meaningful guard.
+const SIGNAL_TOL: f64 = 2e-3;
+
+/// Realized doses are exact f64; the mrgsolve `expected.md` doses are 6-dp rounded,
+/// so admit that rounding but nothing more.
+const DOSE_TOL: f64 = 1e-3;
+
+/// Build the dose-free anchor subject: an EVID=0 observation at each of the 14 daily
+/// decision times (t = 0, 24, …, 312 h) carrying that day's CRCL. The reactive driver
+/// injects the doses; the covariate declines over the horizon and — composed with the
+/// per-occasion κ — drives the pre-dose trough at each decision.
+fn anchor_subject(decision_times: &[f64]) -> Subject {
+    let n = decision_times.len();
+    let obs_covariates: Vec<HashMap<String, f64>> = CRCL
+        .iter()
+        .map(|&c| HashMap::from([("CRCL".to_string(), c)]))
+        .collect();
+    Subject {
+        id: "1".to_string(),
+        doses: Vec::<DoseEvent>::new(),
+        obs_times: decision_times.to_vec(),
+        obs_raw_times: Vec::new(),
+        observations: vec![0.0; n],
+        obs_cmts: vec![1; n],
+        covariates: HashMap::from([("CRCL".to_string(), CRCL[0])]),
+        dose_covariates: Vec::new(),
+        obs_covariates,
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1u32; n],
+        dose_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        #[cfg(feature = "survival")]
+        obs_records: vec![],
+    }
+}
+
+fn anchor_population(decision_times: &[f64]) -> Population {
+    Population {
+        subjects: vec![anchor_subject(decision_times)],
+        covariate_names: vec!["CRCL".to_string()],
+        dv_column: "DV".to_string(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+/// Coordination harness (ignored): prints ferx's realized ladder (time, trough, dose)
+/// at `ANCHOR_SEED`, the numbers baked into `vanco_renal_iov_mrgsolve.R` and
+/// `REF_LADDER`. Run with `cargo test --test adaptive_vanco_renal_iov_anchor -- --ignored print_coordination --nocapture`.
+#[test]
+#[ignore = "coordination harness: prints the ferx ladder to bake into the R kit"]
+fn print_coordination() {
+    let parsed = parse_full_model_file(Path::new("examples/adaptive_vanco_renal_iov.ferx"))
+        .expect("model parses");
+    let spec = parsed.adaptive_dosing.as_ref().expect("[adaptive_dosing]");
+    let pop = anchor_population(&spec.at);
+    let mut opts = AdaptiveSimulateOptions::default();
+    opts.seed = Some(ANCHOR_SEED);
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("sim runs");
+    println!("=== ferx renal x IOV ladder (seed {ANCHOR_SEED}) ===");
+    for (i, d) in res.decisions.iter().enumerate() {
+        let sig = d
+            .observed_signals
+            .first()
+            .map(|s| s.value)
+            .unwrap_or(f64::NAN);
+        let dose = res.ledger[i].amt;
+        println!(
+            "g={i} t={} crcl={} trough={sig:.9} dose={dose:.9}",
+            d.time, CRCL[i]
+        );
+    }
+}
+
+/// Fast PR-time guard (NOT slow-gated): a typo in the composed example must not slip
+/// past the per-PR job. Parses the model (full `[adaptive_dosing]` validate), pins the
+/// scenario (one κ, the CRCL covariate referenced, trough control law, `auc_target`
+/// absent), and runs a short seeded reactive run through the default frozen-replay
+/// verifier.
+#[test]
+fn vanco_renal_iov_example_parses_and_runs_the_verifier() {
+    let parsed = parse_full_model_file(Path::new("examples/adaptive_vanco_renal_iov.ferx"))
+        .expect("vanco renal×IOV model must parse");
+    assert_eq!(parsed.model.n_kappa, 1, "one IOV effect (κ on CL)");
+    assert_eq!(parsed.model.n_eta, 1, "one (negligible) BSV η on CL");
+    let spec = parsed
+        .adaptive_dosing
+        .as_ref()
+        .expect("[adaptive_dosing] block present");
+    assert_eq!(
+        spec.auc_target, None,
+        "auc_target is a typed error here (#700/#701)"
+    );
+    assert_eq!(spec.at.len(), 14, "14 daily decisions");
+
+    let pop = anchor_population(&spec.at);
+    let mut opts = AdaptiveSimulateOptions::default();
+    opts.seed = Some(ANCHOR_SEED);
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("adaptive renal×IOV sim runs and passes the default verifier");
+    assert_eq!(res.decisions.len(), 14, "one decision per day");
+    assert_eq!(res.ledger.len(), 14, "every decision issued a dose");
+}
+
+/// Slow + mrgsolve-anchored. Runs the ferx reactive driver live at `ANCHOR_SEED`
+/// (declining CRCL × the exact per-occasion κ the R kit injects) and asserts every
+/// per-decision trough matches the frozen mrgsolve trough within the cross-solver band
+/// and every realized dose matches the frozen ladder — the dose-for-dose composition
+/// cross-check against an independent engine.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + mrgsolve-anchored vanco renal×IOV (covariate × per-occasion κ) TDM titration (#700×#701): opt in with --features slow-tests"
+)]
+fn vanco_renal_iov_titration_matches_mrgsolve() {
+    let parsed = parse_full_model_file(Path::new("examples/adaptive_vanco_renal_iov.ferx"))
+        .expect("vanco renal×IOV model must parse");
+    let spec = parsed
+        .adaptive_dosing
+        .as_ref()
+        .expect("[adaptive_dosing] present");
+    let pop = anchor_population(&spec.at);
+    let mut opts = AdaptiveSimulateOptions::default();
+    opts.seed = Some(ANCHOR_SEED);
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("adaptive vanco renal×IOV sim runs (+ frozen-replay verifier)");
+
+    assert_eq!(res.decisions.len(), 14, "one decision per day");
+    assert_eq!(res.ledger.len(), 14, "every decision issued a dose");
+
+    for (i, &(t_ref, trough_ref, dose_ref)) in REF_LADDER.iter().enumerate() {
+        let d = &res.decisions[i];
+        assert_eq!(d.time, t_ref, "decision {i} time");
+        let sig = d
+            .observed_signals
+            .first()
+            .map(|s| s.value)
+            .unwrap_or(f64::NAN);
+        assert!(
+            (sig - trough_ref).abs() < SIGNAL_TOL,
+            "decision {i}: ferx trough {sig:.6} vs mrgsolve {trough_ref:.6} \
+             (|Δ| {:.6} >= {SIGNAL_TOL}); a mismatch this large signals a broken \
+             covariate × occasion CL composition",
+            (sig - trough_ref).abs()
+        );
+        let e = &res.ledger[i];
+        assert!(
+            (e.amt - dose_ref).abs() < DOSE_TOL,
+            "decision {i}: ferx dose {} != mrgsolve {dose_ref} (titration divergence)",
+            e.amt
+        );
+    }
+
+    // Anti-triviality: both the CRCL decline AND the per-occasion κ move CL, so the
+    // trough trajectory must vary substantially — else the anchor would not bite.
+    let troughs: Vec<f64> = REF_LADDER.iter().map(|&(_, tr, _)| tr).collect();
+    let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+    for &tr in troughs.iter().skip(1) {
+        lo = lo.min(tr);
+        hi = hi.max(tr);
+    }
+    assert!(
+        hi - lo > 5.0,
+        "the trough trajectory must vary substantially under CRCL × κ (spread {:.3} mg/L)",
+        hi - lo
+    );
+}

--- a/tests/reference/vanco_iov_mrgsolve/expected.md
+++ b/tests/reference/vanco_iov_mrgsolve/expected.md
@@ -1,0 +1,55 @@
+# Vancomycin IOV (per-occasion κ on CL) TDM titration reference (mrgsolve)
+
+Frozen output of `vanco_iov_mrgsolve.R` (mrgsolve 1.7.2). External anchor for
+the reactive `[adaptive_dosing]` **inter-occasion variability** path (a fresh
+per-occasion κ on clearance, #701) in `examples/adaptive_vanco_iov.ferx`. NONMEM
+has no feedback dosing, so mrgsolve is the comparator.
+
+## Anchor form: deterministic dose-for-dose replay with reconstructed κ
+
+κ is *random* (drawn per decision window on a seeded RNG substream), so an
+independent mrgsolve draw could never match ferx. Instead this anchor
+reconstructs ferx's EXACT per-occasion κ (seed 20260708; the Rust reconstruction
+is pinned by the `adaptive_iov_matches_predict_iov_with_reconstructed_kappa` unit
+test) and injects the SAME per-occasion clearance into mrgsolve, replaying ferx's
+realized dose ladder. What is cross-validated is therefore the occasion → CL →
+trajectory *mechanism*: an independent ODE engine (LSODA) integrating the
+identical piecewise-constant system ferx's RK45 does. This is the #701 analogue
+of the #700 renal-covariate anchor — same two-segment-per-day integration, but
+the piecewise-constant CL comes from the per-occasion κ instead of a covariate.
+
+1-cpt IV vancomycin, once-daily 1-h infusion. Params (identical in the ferx
+model): TVCL=4 L/h at κ=0, V=80 L, CL = TVCL * exp(η_CL + κ_CL), Ω_IOV=0.09.
+Each day's infusion runs on THIS occasion's CL and the decay runs on the NEXT
+occasion's CL (end-of-interval convention ferx's per-segment IOV PK uses). The
+per-occasion κ swings CL across the horizon, so the controller re-titrates each
+day off the trough it observes.
+
+`auc_target` is intentionally absent: its exposure metric integrates a dense grid
+from a single frozen PK snapshot, which is silently wrong when CL switches per
+occasion, so it is a typed error for an IOV (`kappa`) subject (#701). The
+pct-in-window trough metric (`target_window`) is per-occasion aware and retained.
+
+## Realized ladder (ferx doses + reconstructed κ, mrgsolve troughs)
+
+| decision | time (h) | kappa_CL | CL (L/h) | trough (mg/L) | dose (mg) |
+|---:|---:|---:|---:|---:|---:|
+| 0 | 0 | 0.132745 | 4.567830 | 0.000000 | 625.000000 |
+| 1 | 24 | -0.199609 | 3.276200 | 2.960637 | 781.250000 |
+| 2 | 48 | 0.051585 | 4.211748 | 3.697443 | 976.562500 |
+| 3 | 72 | 0.317164 | 5.492904 | 3.174336 | 1220.703125 |
+| 4 | 96 | 0.004488 | 4.017986 | 5.578850 | 1525.878906 |
+| 5 | 120 | -0.365059 | 2.776619 | 10.761070 | 1525.878906 |
+| 6 | 144 | 0.324978 | 5.535993 | 5.932958 | 1907.348633 |
+| 7 | 168 | -0.222152 | 3.203169 | 11.376082 | 1907.348633 |
+| 8 | 192 | 0.373939 | 5.813787 | 6.447514 | 2384.185791 |
+| 9 | 216 | -0.204405 | 3.260525 | 13.606025 | 2384.185791 |
+| 10 | 240 | 0.048067 | 4.196956 | 12.646158 | 2384.185791 |
+| 11 | 264 | -0.231695 | 3.172749 | 16.481410 | 1788.139343 |
+| 12 | 288 | -0.339564 | 2.848319 | 16.646880 | 1341.104507 |
+| 13 | 312 | -0.179133 | 3.343973 | 12.439516 | 1341.104507 |
+
+ferx (`tests/adaptive_vanco_iov_anchor.rs`) reconstructs the same per-occasion κ,
+computes its troughs live (RK45), and asserts they match these mrgsolve troughs
+(LSODA) to a small cross-solver tolerance. Both engines integrate the identical
+piecewise-constant CL, so the whole trough trajectory agrees.

--- a/tests/reference/vanco_iov_mrgsolve/vanco_iov_mrgsolve.R
+++ b/tests/reference/vanco_iov_mrgsolve/vanco_iov_mrgsolve.R
@@ -1,0 +1,196 @@
+#!/usr/bin/env Rscript
+# Vancomycin trough-TDM titration with INTER-OCCASION VARIABILITY on clearance
+# (epic #391 / #701).
+#
+# External comparator for ferx-core's reactive `[adaptive_dosing]` IOV path. NONMEM
+# has no native feedback dosing, so mrgsolve (which does) is the apples-to-apples
+# anchor for this feature family (see docs/model-file/adaptive-dosing.qmd,
+# "Validation"). The ferx model under test is examples/adaptive_vanco_iov.ferx;
+# this script reproduces its structural model in mrgsolve, INJECTS the exact
+# per-occasion clearance ferx used (reconstructed from the seeded κ substream, see
+# below), replays ferx's realized dose ladder, and freezes the resulting trough
+# trajectory to expected.md. tests/adaptive_vanco_iov_anchor.rs asserts ferx's
+# live troughs match these mrgsolve troughs dose-for-dose.
+#
+# --- why the κ must be INJECTED (not redrawn) ---------------------------------
+# ferx draws a fresh per-occasion κ_g ~ N(0, Ω_IOV) for each decision window
+# (occasion = decision index, #701) on a dedicated seeded RNG substream:
+#   base = subject_kappa_base_seed(seed, id, replicate); κ_g = chol(Ω_IOV)·z,
+#   z = kappa_standard_normal(base, occasion=g, component=0).
+# That κ is *random*, so an independent mrgsolve draw would use different numbers
+# and could never match. The tractable, reliable cross-check is to reconstruct
+# ferx's exact κ (the Rust reconstruction is pinned by the api.rs unit test
+# `adaptive_iov_matches_predict_iov_with_reconstructed_kappa`) and feed mrgsolve
+# the SAME per-occasion clearance. Then the only thing being cross-validated is the
+# occasion → CL → trajectory *mechanism* — an independent ODE engine (LSODA)
+# integrating the identical piecewise-constant system ferx's RK45 does — which is
+# exactly the #701 surface. The κ / CL / dose constants below are ferx's, produced
+# by the seed-20260708 run and reproducible from it (see the header block of
+# tests/adaptive_vanco_iov_anchor.rs, which documents how to regenerate them).
+#
+# --- ferx end-of-interval / per-occasion convention (the subtle part) ---------
+# ferx assigns each obs record to the occasion of the latest decision at-or-before
+# its time (`occasion_of`), and its event-driven solver uses the end-of-interval
+# (current-record) parameter convention: the integration segment ENDING at a record
+# is governed by that record's CL. A decision at t_g with a 1-h infusion splits the
+# day into two segments because the infusion end (t_g + 1) is a break that is NOT a
+# data record:
+#   * the infusion window (t_g, t_g + 1] carries LOCF PK forward from the obs at
+#     t_g, which belongs to occasion g -> CL_g;
+#   * the decay window (t_g + 1, t_{g+1}] ends at the next obs record (t_{g+1}),
+#     which belongs to occasion g+1 -> CL_{g+1} (the end-of-interval value).
+# So each day's infusion runs on THIS occasion's CL and the between-dose decay runs
+# on the NEXT occasion's CL. (This is the exact per-occasion analogue of the
+# renal-covariate anchor `vanco_renal_mrgsolve.R`, which does the same two-segment
+# split with a covariate-driven CL instead of an occasion-driven one; empirically
+# it is the only one of the three plausible conventions that reproduces ferx's
+# troughs — the other two miss by ~1e-2 to ~1 mg/L.) The R loop below integrates
+# each day as those two windows with the matching piecewise-constant CL, so
+# mrgsolve's CL trajectory is identical to ferx's per-segment PK and the two engines
+# see the same trough trajectory.
+#
+# Regenerate:  Rscript vanco_iov_mrgsolve.R   (run from this directory)
+# Requires:    mrgsolve (tested with 1.7.2) + a C/C++ toolchain (JIT compile).
+
+suppressMessages(library(mrgsolve))
+
+# ---- structural model: identical params to adaptive_vanco_iov.ferx -----------
+# CL is a $PARAM set per window from the injected per-occasion κ; the ferx model
+# writes CL = TVCL * exp(ETA_CL + KAPPA_CL) and resolves it per segment, i.e. a
+# piecewise-constant CL fed in at each window with that occasion's κ.
+code <- '
+$PARAM CL=4.0, V=80.0
+$CMT CENT
+$ODE
+  dxdt_CENT = -(CL/V)*CENT;
+'
+mod <- mcode("vanco_iov", code, rtol = 1e-12, atol = 1e-12, maxsteps = 1000000)
+
+TVCL     <- 4.0                  # vancomycin clearance at κ = 0 (L/h)
+V        <- 80.0                 # central volume (L); CENT/V is the concentration
+cycle_h  <- 24                   # once-daily dosing interval
+tinf     <- 1.0                  # 1-h infusion
+n_dec    <- 14                   # 14 daily decisions, t = 0 .. 312 h
+dec_t    <- seq(0, by = cycle_h, length.out = n_dec)
+
+# ---- ferx-reconstructed inputs (seed = 20260708, subject "1", replicate 1) ----
+# Per-occasion κ on CL, reconstructed EXACTLY as ferx drew it (chol(Ω_IOV)·z with
+# z = kappa_standard_normal(base, g, 0)); Ω_IOV = 0.09 so chol = 0.3. The api.rs
+# unit test pins this reconstruction; the anchor test regenerates these live and
+# asserts they equal the values frozen here (so a drift is caught, not hidden).
+kappa <- c( 0.132745299519163, -0.199608898954969,  0.051584702721856,
+            0.317164048542595,  0.004487691977174, -0.365058863049860,
+            0.324978035712011, -0.222152229448614,  0.373939120663444,
+           -0.204404711179451,  0.048066611668395, -0.231694715887291,
+           -0.339563867546508, -0.179133441179247)
+stopifnot(length(kappa) == n_dec)
+
+# ferx's BSV η_CL for this subject (Ω_CL = 1e-10 -> SD 1e-5, negligible by design;
+# carried so CL = TVCL * exp(η + κ) matches ferx's individual-parameter formula to
+# the last ulp rather than dropping a ~1e-6 term).
+eta_cl <- -0.000001382570411
+
+# Per-occasion clearance CL_g = TVCL * exp(η + κ_g) — the piecewise-constant CL fed
+# to mrgsolve. cl_at[g] governs day g's infusion window and, at index g+1, the
+# preceding day's decay window (end-of-interval; see the header).
+cl_at <- TVCL * exp(eta_cl + kappa)
+
+# ferx's REALIZED dose ladder (mg/day) from the seed-20260708 reactive run. The
+# controller titrated on the latent trough it observed under the occasion-varying
+# CL; we replay those exact doses so mrgsolve integrates ferx's realized regimen.
+dose_at <- c( 625.000000000000000,  781.250000000000000,  976.562500000000000,
+             1220.703125000000000, 1525.878906250000000, 1525.878906250000000,
+             1907.348632812500000, 1907.348632812500000, 2384.185791015625000,
+             2384.185791015625000, 2384.185791015625000, 1788.139343261718750,
+             1341.104507446289062, 1341.104507446289062)
+stopifnot(length(dose_at) == n_dec)
+
+# ---- replay loop (carry CENT across days) ------------------------------------
+# Deterministic dose-for-dose replay: ferx's realized doses + reconstructed κ. Each
+# day advances as two segments with the piecewise-constant CL described above; the
+# pre-dose trough recorded at each decision is CENT/V at that time (occasion g's
+# window has just opened, so the readout matches ferx's pre-dose observed signal).
+st_cent <- 0
+rows    <- list()
+for (k in seq_along(dec_t)) {
+  t0     <- dec_t[k]
+  trough <- st_cent / V           # pre-dose trough the controller saw
+  rows[[k]] <- data.frame(decision = k - 1, time = t0, kappa = kappa[k],
+                          cl = cl_at[k], trough = trough, dose = dose_at[k])
+  # Advance state across this day as TWO segments (matches ferx's per-segment PK):
+  #   1. infusion window [t0, t0 + tinf] on THIS occasion's CL (cl_at[k]),
+  #   2. decay window    [t0 + tinf, t0 + 24] on the NEXT occasion's CL (cl_at[k+1],
+  #      end-of-interval). The last decision has no following window.
+  if (k < length(dec_t)) {
+    seg1 <- as.data.frame(mod |>
+      param(CL = cl_at[k], V = V) |>
+      init(CENT = st_cent) |>
+      ev(amt = dose_at[k], rate = dose_at[k] / tinf, cmt = 1) |>
+      mrgsim(start = 0, end = tinf, delta = tinf))
+    cent_after_inf <- seg1[nrow(seg1), ]$CENT
+    seg2 <- as.data.frame(mod |>
+      param(CL = cl_at[k + 1], V = V) |>
+      init(CENT = cent_after_inf) |>
+      mrgsim(start = tinf, end = cycle_h, delta = cycle_h - tinf))
+    st_cent <- seg2[nrow(seg2), ]$CENT
+  }
+}
+ladder <- do.call(rbind, rows)
+
+cat("=== vancomycin IOV TDM titration ladder (mrgsolve 1.7.2) ===\n")
+print(ladder, row.names = FALSE, digits = 10)
+
+# ---- freeze expected.md ------------------------------------------------------
+fmt <- function(x) formatC(x, format = "f", digits = 6)
+ladder_tbl <- c(
+  "| decision | time (h) | kappa_CL | CL (L/h) | trough (mg/L) | dose (mg) |",
+  "|---:|---:|---:|---:|---:|---:|",
+  apply(ladder, 1, function(r) sprintf(
+    "| %d | %d | %s | %s | %s | %s |",
+    as.integer(r["decision"]), as.integer(r["time"]),
+    formatC(as.numeric(r["kappa"]), format = "f", digits = 6),
+    fmt(as.numeric(r["cl"])), fmt(as.numeric(r["trough"])),
+    fmt(as.numeric(r["dose"])))))
+md <- c(
+  "# Vancomycin IOV (per-occasion κ on CL) TDM titration reference (mrgsolve)",
+  "",
+  "Frozen output of `vanco_iov_mrgsolve.R` (mrgsolve 1.7.2). External anchor for",
+  "the reactive `[adaptive_dosing]` **inter-occasion variability** path (a fresh",
+  "per-occasion κ on clearance, #701) in `examples/adaptive_vanco_iov.ferx`. NONMEM",
+  "has no feedback dosing, so mrgsolve is the comparator.",
+  "",
+  "## Anchor form: deterministic dose-for-dose replay with reconstructed κ",
+  "",
+  "κ is *random* (drawn per decision window on a seeded RNG substream), so an",
+  "independent mrgsolve draw could never match ferx. Instead this anchor",
+  "reconstructs ferx's EXACT per-occasion κ (seed 20260708; the Rust reconstruction",
+  "is pinned by the `adaptive_iov_matches_predict_iov_with_reconstructed_kappa` unit",
+  "test) and injects the SAME per-occasion clearance into mrgsolve, replaying ferx's",
+  "realized dose ladder. What is cross-validated is therefore the occasion → CL →",
+  "trajectory *mechanism*: an independent ODE engine (LSODA) integrating the",
+  "identical piecewise-constant system ferx's RK45 does. This is the #701 analogue",
+  "of the #700 renal-covariate anchor — same two-segment-per-day integration, but",
+  "the piecewise-constant CL comes from the per-occasion κ instead of a covariate.",
+  "",
+  "1-cpt IV vancomycin, once-daily 1-h infusion. Params (identical in the ferx",
+  sprintf("model): TVCL=%g L/h at κ=0, V=%g L, CL = TVCL * exp(η_CL + κ_CL), Ω_IOV=0.09.", TVCL, V),
+  "Each day's infusion runs on THIS occasion's CL and the decay runs on the NEXT",
+  "occasion's CL (end-of-interval convention ferx's per-segment IOV PK uses). The",
+  "per-occasion κ swings CL across the horizon, so the controller re-titrates each",
+  "day off the trough it observes.",
+  "",
+  "`auc_target` is intentionally absent: its exposure metric integrates a dense grid",
+  "from a single frozen PK snapshot, which is silently wrong when CL switches per",
+  "occasion, so it is a typed error for an IOV (`kappa`) subject (#701). The",
+  "pct-in-window trough metric (`target_window`) is per-occasion aware and retained.",
+  "",
+  "## Realized ladder (ferx doses + reconstructed κ, mrgsolve troughs)",
+  "",
+  ladder_tbl,
+  "",
+  "ferx (`tests/adaptive_vanco_iov_anchor.rs`) reconstructs the same per-occasion κ,",
+  "computes its troughs live (RK45), and asserts they match these mrgsolve troughs",
+  "(LSODA) to a small cross-solver tolerance. Both engines integrate the identical",
+  "piecewise-constant CL, so the whole trough trajectory agrees.")
+writeLines(md, "expected.md")
+cat("\nwrote expected.md\n")

--- a/tests/reference/vanco_renal_iov_mrgsolve/expected.md
+++ b/tests/reference/vanco_renal_iov_mrgsolve/expected.md
@@ -1,0 +1,55 @@
+# Vancomycin renal-decline x IOV (CRCL covariate x per-occasion kappa on CL) TDM titration reference (mrgsolve)
+
+Frozen output of `vanco_renal_iov_mrgsolve.R` (mrgsolve 1.7.2). External anchor for
+the COMPOSITION of the reactive `[adaptive_dosing]` time-varying-covariate (#700)
+and inter-occasion-variability (#701) paths in `examples/adaptive_vanco_renal_iov.ferx`.
+NONMEM has no feedback dosing, so mrgsolve is the comparator.
+
+## Anchor form: deterministic dose-for-dose replay with declining CRCL + reconstructed kappa
+
+Clearance depends on BOTH a declining renal covariate and a per-occasion kappa:
+CL = TVCL * (CRCL/100) * exp(eta_CL + kappa_CL), TVCL=4 L/h, V=80 L, Omega_IOV=0.09.
+The kappa is *random* (drawn per decision window on a seeded RNG substream) and its
+substream is model-independent, so it is IDENTICAL to the #701 IOV anchor's kappa
+(seed 20260708; the Rust reconstruction is pinned by the
+`adaptive_iov_matches_predict_iov_with_reconstructed_kappa` unit test). This anchor
+feeds mrgsolve the SAME declining CRCL AND the SAME per-occasion clearance and
+replays ferx's realized dose ladder, so the cross-validated thing is the
+covariate x occasion -> CL -> trajectory *mechanism* composed: an independent ODE
+engine (LSODA) integrating the identical piecewise-constant system ferx's RK45 does.
+
+This is the composition of the two single-effect anchors (renal #700, IOV #701):
+same two-segment-per-day integration, but the piecewise-constant CL now folds in
+BOTH the covariate decline and the per-occasion kappa. Each day's infusion runs on
+THIS occasion's (CRCL, kappa) and the decay on the NEXT occasion's (CRCL, kappa)
+(end-of-interval convention ferx's per-segment PK uses).
+
+`auc_target` is intentionally absent: its exposure metric integrates a dense grid
+from a single frozen PK snapshot, which is silently wrong when CL changes across the
+horizon (a drifting covariate OR a per-occasion kappa), so it is a typed error for a
+time-varying-covariate / IOV subject (#700/#701).
+
+## Realized ladder (ferx doses + declining CRCL + reconstructed kappa, mrgsolve troughs)
+
+| decision | time (h) | CRCL | kappa_CL | CL (L/h) | trough (mg/L) | dose (mg) |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 0 | 120 | 0.132745 | 5.481396 | 0.000000 | 625.000000 |
+| 1 | 24 | 115 | -0.199609 | 3.767629 | 2.556064 | 781.250000 |
+| 2 | 48 | 108 | 0.051585 | 4.548687 | 3.239114 | 976.562500 |
+| 3 | 72 | 98 | 0.317164 | 5.383046 | 3.175663 | 1220.703125 |
+| 4 | 96 | 88 | 0.004488 | 3.535827 | 6.413905 | 1525.878906 |
+| 5 | 120 | 78 | -0.365059 | 2.165763 | 13.302792 | 1525.878906 |
+| 6 | 144 | 68 | 0.324978 | 3.764475 | 10.762650 | 1525.878906 |
+| 7 | 168 | 60 | -0.222152 | 1.921902 | 16.631220 | 1144.409180 |
+| 8 | 192 | 54 | 0.373939 | 3.139445 | 12.316018 | 1144.409180 |
+| 9 | 216 | 49 | -0.204405 | 1.597657 | 16.342389 | 858.306885 |
+| 10 | 240 | 45 | 0.048067 | 1.888630 | 15.479172 | 643.730164 |
+| 11 | 264 | 42 | -0.231695 | 1.332554 | 15.727982 | 482.797623 |
+| 12 | 288 | 41 | -0.339564 | 1.167811 | 15.334823 | 362.098217 |
+| 13 | 312 | 40 | -0.179133 | 1.337589 | 13.346793 | 362.098217 |
+
+ferx (`tests/adaptive_vanco_renal_iov_anchor.rs`) runs the reactive driver live at
+the same seed (declining CRCL x reconstructed kappa), computes its troughs (RK45),
+and asserts they match these mrgsolve troughs (LSODA) to a small cross-solver
+tolerance. Both engines integrate the identical composed piecewise-constant CL, so
+the whole trough trajectory agrees.

--- a/tests/reference/vanco_renal_iov_mrgsolve/vanco_renal_iov_mrgsolve.R
+++ b/tests/reference/vanco_renal_iov_mrgsolve/vanco_renal_iov_mrgsolve.R
@@ -1,0 +1,203 @@
+#!/usr/bin/env Rscript
+# Vancomycin trough-TDM titration under BOTH a declining renal covariate AND
+# inter-occasion variability on clearance (epic #391 / #700 x #701).
+#
+# External comparator for ferx-core's reactive `[adaptive_dosing]` COMPOSITION path.
+# NONMEM has no native feedback dosing, so mrgsolve (which does) is the
+# apples-to-apples anchor for this feature family (see
+# docs/model-file/adaptive-dosing.qmd, "Validation"). The ferx model under test is
+# examples/adaptive_vanco_renal_iov.ferx; this script reproduces its structural model
+# in mrgsolve, feeds the SAME declining CRCL trajectory AND the exact per-occasion
+# clearance ferx used (reconstructed from the seeded kappa substream, see below),
+# replays ferx's realized dose ladder, and freezes the resulting trough trajectory to
+# expected.md. tests/adaptive_vanco_renal_iov_anchor.rs asserts ferx's live troughs
+# match these mrgsolve troughs dose-for-dose.
+#
+# --- the composition: CL = TVCL * (CRCL/100) * exp(eta + kappa) ----------------
+# This is the merge of the two single-effect anchors. vanco_renal_mrgsolve.R drives
+# CL from a declining CRCL; vanco_iov_mrgsolve.R drives it from a per-occasion kappa.
+# Here BOTH move CL at once: each segment's CL is set by the renal function active in
+# that segment AND that window's occasion kappa. The two-segment-per-day integration
+# is identical to both single-effect anchors; only the piecewise-constant CL now
+# folds in both effects.
+#
+# --- why kappa is INJECTED (not redrawn) --------------------------------------
+# ferx draws a fresh per-occasion kappa_g ~ N(0, Omega_IOV) for each decision window
+# (occasion = decision index, #701) on a dedicated seeded RNG substream:
+#   base = subject_kappa_base_seed(seed, id, replicate); kappa_g = chol(Omega_IOV)*z,
+#   z = kappa_standard_normal(base, occasion=g, component=0).
+# That kappa is *random* and its substream is model-independent, so it is IDENTICAL
+# to the #701 IOV anchor's kappa (same seed 20260708, subject "1", replicate 1) — the
+# Rust reconstruction is pinned by the api.rs unit test
+# `adaptive_iov_matches_predict_iov_with_reconstructed_kappa`. Reconstructing ferx's
+# exact kappa and feeding mrgsolve the SAME per-occasion clearance makes the only
+# cross-validated thing the covariate x occasion -> CL -> trajectory *mechanism* — an
+# independent LSODA engine integrating the identical piecewise-constant system ferx's
+# RK45 does.
+#
+# --- ferx end-of-interval / per-segment convention ----------------------------
+# ferx uses the end-of-interval (current-record) parameter convention: the segment
+# ENDING at a record is governed by that record's PK. A decision at t_g with a 1-h
+# infusion splits the day into two segments:
+#   * the infusion window (t_g, t_g + 1] carries LOCF PK forward from the obs at t_g,
+#     which belongs to occasion g -> (CRCL_g, kappa_g);
+#   * the decay window (t_g + 1, t_{g+1}] ends at the next obs record (t_{g+1}), which
+#     belongs to occasion g+1 -> (CRCL_{g+1}, kappa_{g+1}) (the end-of-interval value).
+# So each day's infusion runs on THIS occasion's (CRCL, kappa) and the between-dose
+# decay runs on the NEXT occasion's (CRCL, kappa). The R loop below integrates each
+# day as those two windows with the matching composed piecewise-constant CL.
+#
+# Regenerate:  Rscript vanco_renal_iov_mrgsolve.R   (run from this directory)
+# Requires:    mrgsolve (tested with 1.7.2) + a C/C++ toolchain (JIT compile).
+
+suppressMessages(library(mrgsolve))
+
+# ---- structural model: identical params to adaptive_vanco_renal_iov.ferx ------
+# CL is a $PARAM set per window from CRCL and the injected per-occasion kappa; the
+# ferx model writes CL = TVCL * (CRCL/100) * exp(ETA_CL + KAPPA_CL) and resolves it
+# per segment, i.e. a piecewise-constant CL fed in at each window.
+code <- '
+$PARAM CL=4.0, V=80.0
+$CMT CENT
+$ODE
+  dxdt_CENT = -(CL/V)*CENT;
+'
+mod <- mcode("vanco_renal_iov", code, rtol = 1e-12, atol = 1e-12, maxsteps = 1000000)
+
+TVCL     <- 4.0                  # vancomycin clearance at CRCL = 100 mL/min, kappa = 0 (L/h)
+V        <- 80.0                 # central volume (L); CENT/V is the concentration
+cycle_h  <- 24                   # once-daily dosing interval
+tinf     <- 1.0                  # 1-h infusion
+n_dec    <- 14                   # 14 daily decisions, t = 0 .. 312 h
+dec_t    <- seq(0, by = cycle_h, length.out = n_dec)
+
+# Declining renal function over the horizon (one CRCL per decision/obs time),
+# CRCL(0) = 120 down to CRCL(312) = 40 mL/min. MUST match the CRCL constant in
+# tests/adaptive_vanco_renal_iov_anchor.rs exactly.
+crcl <- c(120, 115, 108, 98, 88, 78, 68, 60, 54, 49, 45, 42, 41, 40)
+stopifnot(length(crcl) == n_dec)
+
+# ---- ferx-reconstructed per-occasion kappa (seed 20260708, subject "1", rep 1) --
+# IDENTICAL to the #701 IOV anchor's kappa (the substream is model-independent):
+# chol(Omega_IOV)*z with z = kappa_standard_normal(base, g, 0); Omega_IOV = 0.09 so
+# chol = 0.3. The anchor test regenerates ferx's realized ladder live at this seed and
+# asserts its troughs equal the mrgsolve troughs frozen here, so a drift is caught.
+kappa <- c( 0.132745299519163, -0.199608898954969,  0.051584702721856,
+            0.317164048542595,  0.004487691977174, -0.365058863049860,
+            0.324978035712011, -0.222152229448614,  0.373939120663444,
+           -0.204404711179451,  0.048066611668395, -0.231694715887291,
+           -0.339563867546508, -0.179133441179247)
+stopifnot(length(kappa) == n_dec)
+
+# ferx's BSV eta_CL for this subject (Omega_CL = 1e-10 -> SD 1e-5, negligible by
+# design; carried so CL = TVCL * (CRCL/100) * exp(eta + kappa) matches ferx's
+# individual-parameter formula to the last ulp).
+eta_cl <- -0.000001382570411
+
+# Composed per-occasion clearance CL_g = TVCL * (CRCL_g/100) * exp(eta + kappa_g) —
+# the piecewise-constant CL fed to mrgsolve. cl_at[g] governs day g's infusion window
+# and, at index g+1, the preceding day's decay window (end-of-interval; see header).
+cl_at <- TVCL * (crcl / 100) * exp(eta_cl + kappa)
+
+# ferx's REALIZED dose ladder (mg/day) from the seed-20260708 reactive run. The
+# controller titrated on the latent trough it observed under the composed CL; we
+# replay those exact doses so mrgsolve integrates ferx's realized regimen. Doses are
+# exact binary fractions (625 * 1.25^a * 0.75^b), representable to the last ulp.
+dose_at <- c( 625.000000000000000,          781.250000000000000,
+              976.562500000000000,         1220.703125000000000,
+             1525.878906250000000,         1525.878906250000000,
+             1525.878906250000000,         1144.409179687500000,
+             1144.409179687500000,          858.306884765625000,
+              643.730163574218750,          482.797622680664062,
+              362.098217010498047,          362.098217010498047)
+stopifnot(length(dose_at) == n_dec)
+
+# ---- replay loop (carry CENT across days) ------------------------------------
+# Deterministic dose-for-dose replay: ferx's realized doses + declining CRCL +
+# reconstructed kappa. Each day advances as two segments with the composed
+# piecewise-constant CL; the pre-dose trough recorded at each decision is CENT/V.
+st_cent <- 0
+rows    <- list()
+for (k in seq_along(dec_t)) {
+  t0     <- dec_t[k]
+  trough <- st_cent / V           # pre-dose trough the controller saw
+  rows[[k]] <- data.frame(decision = k - 1, time = t0, crcl = crcl[k],
+                          kappa = kappa[k], cl = cl_at[k], trough = trough,
+                          dose = dose_at[k])
+  # Advance state across this day as TWO segments (matches ferx's per-segment PK):
+  #   1. infusion window [t0, t0 + tinf] on THIS occasion's composed CL (cl_at[k]),
+  #   2. decay window    [t0 + tinf, t0 + 24] on the NEXT occasion's composed CL
+  #      (cl_at[k+1], end-of-interval). The last decision has no following window.
+  if (k < length(dec_t)) {
+    seg1 <- as.data.frame(mod |>
+      param(CL = cl_at[k], V = V) |>
+      init(CENT = st_cent) |>
+      ev(amt = dose_at[k], rate = dose_at[k] / tinf, cmt = 1) |>
+      mrgsim(start = 0, end = tinf, delta = tinf))
+    cent_after_inf <- seg1[nrow(seg1), ]$CENT
+    seg2 <- as.data.frame(mod |>
+      param(CL = cl_at[k + 1], V = V) |>
+      init(CENT = cent_after_inf) |>
+      mrgsim(start = tinf, end = cycle_h, delta = cycle_h - tinf))
+    st_cent <- seg2[nrow(seg2), ]$CENT
+  }
+}
+ladder <- do.call(rbind, rows)
+
+cat("=== vancomycin renal-decline x IOV TDM titration ladder (mrgsolve 1.7.2) ===\n")
+print(ladder, row.names = FALSE, digits = 10)
+
+# ---- freeze expected.md ------------------------------------------------------
+fmt <- function(x) formatC(x, format = "f", digits = 6)
+ladder_tbl <- c(
+  "| decision | time (h) | CRCL | kappa_CL | CL (L/h) | trough (mg/L) | dose (mg) |",
+  "|---:|---:|---:|---:|---:|---:|---:|",
+  apply(ladder, 1, function(r) sprintf(
+    "| %d | %d | %d | %s | %s | %s | %s |",
+    as.integer(r["decision"]), as.integer(r["time"]), as.integer(r["crcl"]),
+    formatC(as.numeric(r["kappa"]), format = "f", digits = 6),
+    fmt(as.numeric(r["cl"])), fmt(as.numeric(r["trough"])),
+    fmt(as.numeric(r["dose"])))))
+md <- c(
+  "# Vancomycin renal-decline x IOV (CRCL covariate x per-occasion kappa on CL) TDM titration reference (mrgsolve)",
+  "",
+  "Frozen output of `vanco_renal_iov_mrgsolve.R` (mrgsolve 1.7.2). External anchor for",
+  "the COMPOSITION of the reactive `[adaptive_dosing]` time-varying-covariate (#700)",
+  "and inter-occasion-variability (#701) paths in `examples/adaptive_vanco_renal_iov.ferx`.",
+  "NONMEM has no feedback dosing, so mrgsolve is the comparator.",
+  "",
+  "## Anchor form: deterministic dose-for-dose replay with declining CRCL + reconstructed kappa",
+  "",
+  "Clearance depends on BOTH a declining renal covariate and a per-occasion kappa:",
+  sprintf("CL = TVCL * (CRCL/100) * exp(eta_CL + kappa_CL), TVCL=%g L/h, V=%g L, Omega_IOV=0.09.", TVCL, V),
+  "The kappa is *random* (drawn per decision window on a seeded RNG substream) and its",
+  "substream is model-independent, so it is IDENTICAL to the #701 IOV anchor's kappa",
+  "(seed 20260708; the Rust reconstruction is pinned by the",
+  "`adaptive_iov_matches_predict_iov_with_reconstructed_kappa` unit test). This anchor",
+  "feeds mrgsolve the SAME declining CRCL AND the SAME per-occasion clearance and",
+  "replays ferx's realized dose ladder, so the cross-validated thing is the",
+  "covariate x occasion -> CL -> trajectory *mechanism* composed: an independent ODE",
+  "engine (LSODA) integrating the identical piecewise-constant system ferx's RK45 does.",
+  "",
+  "This is the composition of the two single-effect anchors (renal #700, IOV #701):",
+  "same two-segment-per-day integration, but the piecewise-constant CL now folds in",
+  "BOTH the covariate decline and the per-occasion kappa. Each day's infusion runs on",
+  "THIS occasion's (CRCL, kappa) and the decay on the NEXT occasion's (CRCL, kappa)",
+  "(end-of-interval convention ferx's per-segment PK uses).",
+  "",
+  "`auc_target` is intentionally absent: its exposure metric integrates a dense grid",
+  "from a single frozen PK snapshot, which is silently wrong when CL changes across the",
+  "horizon (a drifting covariate OR a per-occasion kappa), so it is a typed error for a",
+  "time-varying-covariate / IOV subject (#700/#701).",
+  "",
+  "## Realized ladder (ferx doses + declining CRCL + reconstructed kappa, mrgsolve troughs)",
+  "",
+  ladder_tbl,
+  "",
+  "ferx (`tests/adaptive_vanco_renal_iov_anchor.rs`) runs the reactive driver live at",
+  "the same seed (declining CRCL x reconstructed kappa), computes its troughs (RK45),",
+  "and asserts they match these mrgsolve troughs (LSODA) to a small cross-solver",
+  "tolerance. Both engines integrate the identical composed piecewise-constant CL, so",
+  "the whole trough trajectory agrees.")
+writeLines(md, "expected.md")
+cat("\nwrote expected.md\n")


### PR DESCRIPTION
## Why

The adaptive / feedback-dosing reactive driver held **every IOV kappa (κ) at zero** (`eta_slice.resize(n_eta + model.n_kappa, 0.0)`) — so an IOV model's occasion-to-occasion CL/V shifts silently vanished, biasing the trajectory, the monitored signal, every reactive decision, and the dose ledger, with a frozen-replay verifier blind to it (it replayed the same zero-κ engine). #699 guarded this with a typed error; **#701 is the real support**, and the second slice of the #391 audit-support track. It rides directly on the #700 per-event-PK infrastructure.

A key finding: **no simulate path applies IOV κ today** — the static `simulate()` path zeroes κ too, and `predict_iov` applies per-occasion κ only from pre-fitted EBEs. So #701 introduces the first per-occasion κ draw for the *adaptive* path (the static `simulate()` path is fixed separately, and concurrently, by #723).

## What changed

**Occasion = decision window** (one fresh κ per reactive decision, held LOCF until the next; occasion index = decision index). Uniform across both entry points, no new DSL, matches the clinical "each dosing/monitoring visit is an occasion" norm.

- **κ draw (new):** per `(subject, replicate)`, `n_occ = decision_times.len()` vectors κ_g ~ N(0, Ω_IOV) via the IOV Cholesky, on a **dedicated RNG substream** (`subject_kappa_base_seed` / `kappa_standard_normal`, distinct purpose salt) — disjoint from the η and assay streams, so a non-IOV run is byte-identical and enabling a `Dv` monitor never shifts the draws.
- **The load-bearing idea:** #700 made *PK* per-segment from the LOCF covariate; #701 additionally makes the *κ part of the eta* per-segment from the LOCF occasion. Because `read_observable` / `integrate_segment` take `eta` directly (their `[derived]` / observation / ODE-RHS expressions can reference κ, not only the PK params), the whole per-window eta `[η_bsv | κ_g]` is threaded, not just occasion-aware PK.
- Precomputed once in `run_adaptive_population` (keeps the driver taking **data, not `CompiledModel`**): `eta_occ` (per-window eta), occasion-aware `event_pk` (obs/pk-only per their occasion), and `decision_pk[g]` (the PK at decision g under occasion g's κ — needed because a decision need not land on a record, where LOCF would carry the *previous* occasion's PK).
- **`segment_occ_at`** is the exact IOV twin of #700's `segment_pk_at` (same end-of-interval / LOCF resolution) so the threaded eta always agrees with the occasion of the PK snapshot at every event — driver and frozen-replay share both, staying **bit-aligned by construction**.
- **Occasion-aware frozen replay** (`adaptive_frozen_replay_tv` + verifier) applies the identical per-occasion κ over the identical windows.
- Guard: the IOV rejection is removed (SDE / reset stay). `auc_target` + IOV is a typed error (the exposure metric integrates a single frozen snapshot per window; per-occasion AUC is a follow-up), mirroring #700's `auc_target` + TV guard.
- **Composes with #700:** a model with both a time-varying covariate and IOV κ is per-event correct in each (both fold into the same per-event eta / PK).

## Alternatives considered

A full event-driven rewrite of the driver, or folding κ only into the PK snapshot (not the eta). Rejected: the frozen-replay verifier is bit-exact today *because* driver and replay share `integrate_segment` over identical segments — the surgical retrofit + shared `segment_occ_at`/`eta_for` keeps that. Folding κ into PK only would silently zero κ in any `[derived]`/observation expression that references it (the exact silent-wrong-answer class this track closes).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`simulate_adaptive_from_spec` signature unchanged — the lifted restriction is behavioural. No lock bump.

## Breaking changes
- [x] None

## Numerical validation  (adaptive → no NONMEM, per CLAUDE.md)

- **Degenerate oracle** (driver-level): a fixed-regimen controller under per-occasion κ ≡ the trusted static `ode_predictions_event_driven` on the same doses + per-occasion PK (`max_relative = 1e-9`); and provably differs from a single-occasion (κ-frozen) path.
- **Full-stack `predict_iov` oracle**: a *real* seeded IOV model run through `simulate_adaptive` — with the exact η and per-occasion κ reconstructed from the seeded streams — equals `predict_iov` (the shipped occasion-aware event-driven engine) on the realized doses with occasions = decision windows (`1e-9`). This exercises the real `pk_param_fn` → κ path end to end.
- **Bit-exact frozen replay** (`rel_aligned ≤ 1e-12`) for IOV, including a decision that falls *between* observations (exercising `decision_pk` + the occasion LOCF carry).
- **#700 × #701 co-occurrence**: a model with a declining covariate *and* per-occasion κ runs, verifies (bit-exact), is reproducible for a fixed seed, and is κ-sensitive across seeds.
- **Non-IOV path byte-identical**: full lib suite **2253/0**; the shipped constant + #700 TV bit-exact canaries stay green.
- **External mrgsolve anchor:** deterministic reconstructed-κ vancomycin trough-TDM (`tests/reference/vanco_iov_mrgsolve/`). κ is random, so ferx's exact per-occasion κ is seed-reconstructed and injected into mrgsolve 1.7.2, replaying the realized dose ladder — ferx (RK45) vs mrgsolve (LSODA) troughs agree to **max 5.1e-4 mg/L** (tol 2e-3), **dose-for-dose** across 14 daily decisions, with κ swinging CL 2.78→5.81 L/h so the anchor bites. `expected.md` regenerates byte-identically from `Rscript vanco_iov_mrgsolve.R`. (The reactive behaviour itself is already anchored by the two internal oracles + #700's vanco anchor; this adds the independent-engine cross-check of the occasion→CL→trajectory mechanism.)

- [x] Compared against: `ode_predictions_event_driven` + `predict_iov` (independent occasion-aware engines) + prior ferx per-event bit-exact replay

## Performance
- [x] No significant impact expected (per-occasion κ draw + per-event PK only on the new IOV path; non-IOV byte-identical)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix (degenerate oracle, full-stack `predict_iov` oracle, bit-exact IOV replay, TV×IOV co-occurrence, guard flip reject→accept, `auc_target`+IOV guard, κ-substream determinism/decoupling) + a fast + slow-gated mrgsolve anchor (`tests/adaptive_vanco_iov_anchor.rs`)

## Example (user-facing features only)
- [x] Example added to `examples/` (`examples/adaptive_vanco_iov.ferx` — vancomycin trough-TDM under per-occasion κ)

## Docs
- [x] `docs/` updated (`docs/model-file/adaptive-dosing.qmd` — IOV limitation → per-decision-window IOV support + `auc_target` caveat)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new gating lints vs the codebase's existing warnings)
- [x] No `Dual2` / sensitivity-path code touched (simulation-only)
- [x] `Cargo.toml` version bump not needed (non-breaking)

## Reviewer hints
- The load-bearing pieces are **`segment_occ_at`** + **`eta_for`** (predictions.rs) and their pairing with `segment_pk_at` at every event site — they must resolve the same occasion or the threaded eta and the PK snapshot disagree at a boundary record. The `iov` gate keeps the constant / #700 paths byte-identical (the shipped `rel_aligned ≤ 1e-12` canary is the tripwire).
- `decision_pk[g]` is the subtle correctness point: a decision that is not itself a record must read occasion g's PK, not the LOCF previous occasion's.

## Open questions
- `auc_target` + IOV is a deliberate **loud-fail** (no per-occasion AUC yet) — a clean follow-up.
- The **static `simulate()` κ-zeroing** is a pre-existing sibling gap of the same class, fixed separately (and concurrently) by **#723** (out of scope here; `simulate()` should *support* IOV, not reject it).
