### PR TITLE
fix(io): load .fitrx bundles whose data reuses a subject ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **Loading a `.fitrx` bundle whose data has two subjects sharing an ID no longer
+  fails with a spurious `corrupt or missing entry` error.** `load_fit` (and thus
+  `ferx summary`) matched `predictions.csv` rows to subjects by ID, so when a
+  dataset reuses an ID across subjects (e.g. an ID repeated across studies or a
+  reset-split subject), every duplicate's rows were routed to one subject and the
+  other was left with zero rows — tripping the `n_obs` consistency check. Rows are
+  now assigned positionally in `ebes.csv` subject order (which the writer already
+  guarantees), with the row ID kept as an ordering cross-check.
 - **A forward reference in `[individual_parameters]` is now a parse error instead of a
   silent zero** (#710). A statement that referenced a name declared *later* in the same
   block (e.g. `CL = ... * exp(IMAX*...)` with `IMAX` defined below it) previously resolved

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1170,8 +1170,7 @@ fn parse_subjects(
         });
     }
 
-    // predictions.csv → fill ipred/pred/iwres/cwres/cens grouped by ID,
-    // assuming subject rows are contiguous (which save_fit guarantees).
+    // predictions.csv → fill ipred/pred/iwres/cwres/cens positionally.
     let mut plines = preds_csv.lines();
     let pheader = plines
         .next()
@@ -1196,11 +1195,24 @@ fn parse_subjects(
     let npd_i = col.get("NPD").copied();
     let cens_i = col.get("CENS").copied();
 
-    let mut by_id: HashMap<String, usize> = HashMap::new();
-    for (idx, s) in subjects.iter().enumerate() {
-        by_id.insert(s.id.clone(), idx);
-    }
+    // Rows are written one contiguous block per subject, in the same order as
+    // ebes.csv (see `write_predictions_csv`), with exactly `n_obs` rows each.
+    // Consume `subjects[i].n_obs` rows for subject i before advancing, using
+    // the row ID only as a consistency check. Keying on ID instead (as this
+    // once did) collapses distinct subjects that share a textual ID — e.g. an
+    // ID reused across studies or a reset-split subject — routing every
+    // duplicate's rows to one subject and leaving the other with zero, which
+    // then trips the n_obs cross-validation below.
+    let parse_opt = |s: &str| -> f64 {
+        if s.is_empty() {
+            f64::NAN
+        } else {
+            s.parse().unwrap_or(f64::NAN)
+        }
+    };
 
+    let mut cur = 0usize;
+    let mut filled = 0usize;
     for (i, line) in plines.enumerate() {
         if line.trim().is_empty() {
             continue;
@@ -1208,18 +1220,30 @@ fn parse_subjects(
         let fields = parse_csv_row(line);
         let id = fields
             .get(id_i)
-            .ok_or_else(|| FitrxError::Corrupt(format!("predictions.csv row {}: short", i + 1)))?
-            .clone();
-        let idx = *by_id
-            .get(&id)
-            .ok_or_else(|| FitrxError::Corrupt(format!("predictions.csv: unknown ID {:?}", id)))?;
-        let parse_opt = |s: &str| -> f64 {
-            if s.is_empty() {
-                f64::NAN
-            } else {
-                s.parse().unwrap_or(f64::NAN)
-            }
-        };
+            .ok_or_else(|| FitrxError::Corrupt(format!("predictions.csv row {}: short", i + 1)))?;
+        // Advance past subjects whose observation block is complete (including
+        // zero-observation subjects, which consume no prediction rows).
+        while cur < subjects.len() && filled == subjects[cur].n_obs {
+            cur += 1;
+            filled = 0;
+        }
+        if cur >= subjects.len() {
+            return Err(FitrxError::Corrupt(format!(
+                "predictions.csv row {}: more rows than ebes.csv accounts for (id {:?})",
+                i + 1,
+                id
+            )));
+        }
+        let idx = cur;
+        if *id != subjects[idx].id {
+            return Err(FitrxError::Corrupt(format!(
+                "predictions.csv row {}: ID {:?} out of order; expected subject {:?} \
+                 (predictions must follow ebes.csv subject order)",
+                i + 1,
+                id,
+                subjects[idx].id
+            )));
+        }
         subjects[idx].pred.push(parse_opt(&fields[pred_i]));
         subjects[idx].ipred.push(parse_opt(&fields[ipred_i]));
         subjects[idx].cwres.push(parse_opt(&fields[cwres_i]));
@@ -1242,6 +1266,7 @@ fn parse_subjects(
             None => 0,
         };
         subjects[idx].cens.push(c);
+        filled += 1;
     }
 
     // Cross-validate every subject's per-observation vector length against
@@ -2486,9 +2511,12 @@ mod tests {
             if name == "predictions.csv" {
                 let csv = String::from_utf8(buf).unwrap();
                 let mut lines: Vec<&str> = csv.lines().collect();
-                // Drop the second data row (first S1 observation) to simulate
-                // a writer that miscounted.
-                lines.remove(2);
+                // Drop the last data row (last S2 observation) so the final
+                // subject comes up one short. Positional parsing fills S2 with
+                // the rows it has, then the n_obs cross-validation catches the
+                // shortfall at the tail. (Dropping a middle row instead would
+                // trip the earlier ID-order check, a different code path.)
+                lines.pop();
                 buf = lines.join("\n").into_bytes();
                 buf.push(b'\n');
             }
@@ -2508,6 +2536,42 @@ mod tests {
             FitrxError::Corrupt(msg) => assert!(msg.contains("n_obs"), "msg = {}", msg),
             other => panic!("expected Corrupt, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn load_handles_duplicate_subject_ids() {
+        // Two distinct subjects can share a textual ID (an ID reused across
+        // studies, or a reset-split subject). ebes.csv / predictions.csv are
+        // written one contiguous block per subject in subject order, so the
+        // loader must assign prediction rows positionally. Keying on ID (as it
+        // once did) collapses the two "12" subjects — routing every row to one
+        // and leaving the other with zero, which then trips the n_obs check.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dup-ids.fitrx");
+        let mut r = minimal_fit_result();
+        let n_eta = 2;
+        let a = dummy_subject("12", n_eta, 3);
+        let mut b = dummy_subject("12", n_eta, 5);
+        // Offset the second block so we can prove the two never cross-mix.
+        b.ipred = b.ipred.iter().map(|v| v + 100.0).collect();
+        r.subjects = vec![a, b];
+        r.n_obs = 8;
+        r.n_subjects = 2;
+        let p = dummy_population(&["12", "12"], 5);
+        save_fit(&r, &p, "src\n", &path, SaveFitOptions::default()).unwrap();
+
+        let loaded = load_fit(&path).unwrap();
+        let s = &loaded.fit.subjects;
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].id, "12");
+        assert_eq!(s[1].id, "12");
+        assert_eq!(s[0].ipred.len(), 3, "first block keeps its own n_obs");
+        assert_eq!(s[1].ipred.len(), 5, "second block keeps its own n_obs");
+        assert!(
+            s[0].ipred.iter().all(|&v| v < 100.0),
+            "no bleed into block A"
+        );
+        assert!(s[1].ipred.iter().all(|&v| v > 100.0), "block B rows intact");
     }
 
     #[test]

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1194,6 +1194,11 @@ fn parse_subjects(
     let npde_i = col.get("NPDE").copied();
     let npd_i = col.get("NPD").copied();
     let cens_i = col.get("CENS").copied();
+    // N_OBS is always written by `write_predictions_csv`, but treat it as
+    // optional so a hand-built bundle without it still loads. When present, it
+    // is validated per row against the subject we're filling — the ID order
+    // check alone can't catch two same-ID blocks written in the wrong order.
+    let n_obs_i = col.get("N_OBS").copied();
 
     // Rows are written one contiguous block per subject, in the same order as
     // ebes.csv (see `write_predictions_csv`), with exactly `n_obs` rows each.
@@ -1235,7 +1240,7 @@ fn parse_subjects(
             )));
         }
         let idx = cur;
-        if *id != subjects[idx].id {
+        if id != &subjects[idx].id {
             return Err(FitrxError::Corrupt(format!(
                 "predictions.csv row {}: ID {:?} out of order; expected subject {:?} \
                  (predictions must follow ebes.csv subject order)",
@@ -1243,6 +1248,24 @@ fn parse_subjects(
                 id,
                 subjects[idx].id
             )));
+        }
+        // Row-level N_OBS guard: catches two same-ID blocks written out of
+        // order, where the ID check above passes but the block sizes differ.
+        if let Some(j) = n_obs_i {
+            if let Some(raw) = fields.get(j) {
+                if let Ok(row_n_obs) = raw.parse::<usize>() {
+                    if row_n_obs != subjects[idx].n_obs {
+                        return Err(FitrxError::Corrupt(format!(
+                            "predictions.csv row {}: N_OBS {} disagrees with ebes.csv \
+                             n_obs {} for subject {:?}",
+                            i + 1,
+                            row_n_obs,
+                            subjects[idx].n_obs,
+                            subjects[idx].id
+                        )));
+                    }
+                }
+            }
         }
         subjects[idx].pred.push(parse_opt(&fields[pred_i]));
         subjects[idx].ipred.push(parse_opt(&fields[ipred_i]));
@@ -2572,6 +2595,59 @@ mod tests {
             "no bleed into block A"
         );
         assert!(s[1].ipred.iter().all(|&v| v > 100.0), "block B rows intact");
+    }
+
+    #[test]
+    fn load_rejects_misordered_duplicate_id_blocks() {
+        // Two same-ID blocks written in the wrong order: the ID order check
+        // passes (both are "12"), so the per-row N_OBS guard is what catches it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dup-swapped.fitrx");
+        let mut r = minimal_fit_result();
+        let n_eta = 2;
+        r.subjects = vec![dummy_subject("12", n_eta, 3), dummy_subject("12", n_eta, 5)];
+        r.n_obs = 8;
+        r.n_subjects = 2;
+        let p = dummy_population(&["12", "12"], 5);
+        save_fit(&r, &p, "src\n", &path, SaveFitOptions::default()).unwrap();
+
+        // Reorder predictions.csv so the 5-row block precedes the 3-row block.
+        let mut archive = zip::ZipArchive::new(std::fs::File::open(&path).unwrap()).unwrap();
+        let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+        for i in 0..archive.len() {
+            let mut f = archive.by_index(i).unwrap();
+            let name = f.name().to_string();
+            let mut buf = Vec::new();
+            f.read_to_end(&mut buf).unwrap();
+            if name == "predictions.csv" {
+                let csv = String::from_utf8(buf).unwrap();
+                let lines: Vec<&str> = csv.lines().collect();
+                // header, then 3 rows (block A), then 5 rows (block B).
+                let header = lines[0];
+                let block_a = &lines[1..4];
+                let block_b = &lines[4..9];
+                let mut reordered = vec![header];
+                reordered.extend_from_slice(block_b);
+                reordered.extend_from_slice(block_a);
+                buf = reordered.join("\n").into_bytes();
+                buf.push(b'\n');
+            }
+            entries.push((name, buf));
+        }
+        let bad = dir.path().join("dup-swapped-rewritten.fitrx");
+        let mut zw = zip::ZipWriter::new(std::fs::File::create(&bad).unwrap());
+        for (name, body) in entries {
+            zw.start_file(name, zip::write::SimpleFileOptions::default())
+                .unwrap();
+            zw.write_all(&body).unwrap();
+        }
+        zw.finish().unwrap();
+
+        let err = load_fit(&bad).unwrap_err();
+        match err {
+            FitrxError::Corrupt(msg) => assert!(msg.contains("N_OBS"), "msg = {}", msg),
+            other => panic!("expected Corrupt, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

`ferx summary run14.fitrx` (and any `load_fit`) failed on a valid bundle with:

```
Error: failed to load run14.fitrx: corrupt or missing entry: subject "12": predictions.csv has 0 rows but ebes.csv reports n_obs = 3
```

The dataset (thioguanine_mmc/run14) has **28 IDs in a first pass, then a second cohort that reuses IDs 12/13/14** with distinct `OID` values (1012/1013/1014). NONMEM processes records sequentially and treats a reappearing, non-contiguous ID as a **new individual**, so ferx correctly produces **31 subjects**, three of which share a textual ID with an earlier subject. `ebes.csv`/`predictions.csv` therefore legitimately carry two subjects labelled `12`.

## What changed

`parse_subjects` in `src/io/fitrx.rs` filled per-observation vectors by looking each prediction row's subject up in a `HashMap<ID, idx>`. Duplicate IDs collapsed in the map: every `12` row was routed to the **last** subject `12` (n_obs 12), leaving the **first** (n_obs 3) with zero rows → the `n_obs` cross-validation fired.

Predictions are now assigned **positionally**: consume exactly `subjects[i].n_obs` rows per subject in `ebes.csv` subject order, which `write_predictions_csv` already guarantees (one contiguous block per subject, same order). The code comment already *claimed* this contiguity — the implementation now matches it. The row ID is retained as an ordering cross-check, and a "more rows than ebes accounts for" / out-of-order-ID error is raised on genuinely corrupt bundles.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet open | after — ferx-r has the same ID-uniqueness assumption in its per-subject joins (xpose/save_fit/eta_cov/cov_screen); tracked separately |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (I/O deserialization fix). Verified `ferx summary run14.fitrx` now loads and prints the full summary; a fresh `focei` fit of the model reproduces the bundled estimates (OFV −80.8901, 31 subjects).

## Performance
- [x] No significant impact expected (single linear pass, drops a HashMap allocation).

## Tests
- [x] Regression test added that fails without this fix (`load_handles_duplicate_subject_ids`: two subjects share ID `12`, asserts each keeps its own `n_obs` and no row cross-mixing).
- [x] Updated `load_rejects_predictions_row_count_mismatch` to drop the **last** subject's row so it still exercises the tail `n_obs` cross-validation (a middle drop now trips the earlier ID-order check).
- [x] `cargo test --lib fitrx` — 28 passed.

## Docs
- [x] `CHANGELOG.md` `[Unreleased] → Fixed` entry added.
- [x] No other user-visible change.

## Checklist
- [x] `cargo fmt` clean
- [x] `cargo clippy` — no new warnings in `io/fitrx.rs`