### PR TITLE
feat(io): rename any input data column in [data] block [closes #742]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,15 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
-- **`[data]` block column mapping** (#730): map a canonical column role to a
-  differently-named dataset header with `canonical = actual` entries (e.g.
-  `TIME = TAFD`, `DV = CONC`), the ferx equivalent of NONMEM's
-  `$INPUT TIME=TAFD`. Header matching is case-insensitive, mapped headers are
-  excluded from covariate auto-detection, and typos (absent header, duplicate
-  role, duplicate target) fail loudly. See
+- **`[data]` block column renaming** (#730, #742): rename any dataset header to
+  any new name with `new-name = actual` entries (e.g. `TIME = TAFD`,
+  `DV = CONC`), the ferx equivalent of NONMEM's `$INPUT TIME=TAFD`. Targets are
+  not limited to canonical roles — arbitrary columns and covariates can be
+  renamed too, and a column can be renamed *aside* to free its name for another
+  (e.g. `ODV = dv` then `DV = lndv`). Header matching is case-insensitive,
+  renamed headers are excluded from covariate auto-detection under their old
+  name, and typos (absent header, duplicate target, or a target colliding with a
+  surviving column) fail loudly. See
   [Data → Column mapping](https://ferx-nlme.github.io/ferx-core/model-file/data.html).
 
 ### Changed

--- a/docs/model-file/data.qmd
+++ b/docs/model-file/data.qmd
@@ -12,7 +12,7 @@ fit against, so `ferx model.ferx` (no `--data`) and `ferx check model.ferx`
 ```
 [data]
   path = <path-to-csv>
-  <canonical-role> = <actual-header>   # optional column mappings
+  <new-name> = <actual-header>   # optional column renames
 ```
 
 `path` is the only required key. A relative path is resolved **relative to the
@@ -31,9 +31,9 @@ running `ferx` — so a model and its dataset can be moved together as a pair.
 By default ferx recognises the canonical NONMEM columns (`ID`, `TIME`, `DV`,
 `EVID`, `AMT`, `CMT`, `RATE`, `MDV`, `II`, `SS`, `CENS`, `ADDL`) by name,
 case-insensitively. When a dataset stores a role under a different header —
-e.g. `TAFD` for time or `CONC` for the response — you can map it in the `[data]`
-block instead of pre-editing the CSV. The direction is
-`canonical = actual-header`, the ferx equivalent of NONMEM's
+e.g. `TAFD` for time or `CONC` for the response — you can rename it in the
+`[data]` block instead of pre-editing the CSV. The direction is
+`new-name = actual-header`, the ferx equivalent of NONMEM's
 `$INPUT TIME=TAFD`:
 
 ```
@@ -43,18 +43,38 @@ block instead of pre-editing the CSV. The direction is
   DV   = CONC
 ```
 
+The target need not be a canonical role: **any** column can be renamed to **any**
+new name, including covariates. Because renames are resolved against the
+original headers all at once, a column can be renamed *aside* to free its name
+for another — e.g. keep the raw `dv` under a new name while promoting a log-DV
+column into the `DV` role:
+
+```
+[data]
+  path = mydata.csv
+  ODV = dv         # keep the original DV under a new name
+  DV  = lndv       # promote the log-DV column into the DV role
+  WT  = weight     # rename an arbitrary covariate
+```
+
 - The **actual header** is matched case-insensitively (`TIME = tafd` finds a
   `TAFD` column).
-- A mapped header is treated **only** as its canonical role — it is never also
-  picked up as a covariate by auto-detection.
-- Mappable roles are the canonical columns above plus `TENTRY` and `FREMTYPE`.
+- A target naming a canonical role is upper-cased to the standard spelling
+  (`time = TAFD` → `TIME`); any other target keeps its exact case, since
+  covariate lookups are case-sensitive.
+- A renamed header is treated **only** under its new name — the original header
+  no longer leaks in under its old name (so `TIME = TAFD` stops `TAFD` from being
+  auto-detected as a covariate).
 
 Validation is strict, so a typo fails loudly rather than silently reading the
 wrong column:
 
 - a mapped header that is **absent** from the dataset is an error;
-- mapping the **same role twice**, or mapping **two roles to the same header**,
-  is an error.
+- renaming to the **same target twice**, or mapping **two targets to the same
+  header**, is an error;
+- a rename whose target collides with a **surviving** (non-renamed) column is an
+  error — e.g. `DV = lndv` while the dataset still has its own `dv` column is
+  ambiguous and rejected (rename the old `dv` aside, as above).
 
 The IOV occasion column is *not* set here — keep using
 [`iov_column`](iov.qmd) in `[fit_options]`, and covariate columns

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -455,16 +455,17 @@ fn read_nonmem_csv_impl(
         .map(|h| h.trim().to_string())
         .collect();
 
-    // Apply `[data]` column remapping (#730): rename each mapped actual header
-    // to its canonical role (case-insensitive match). Downstream canonical
-    // lookups (`col_idx_ci("time")`) and covariate auto-detection (`is_standard`)
-    // then treat the column as that role with no further special-casing, and the
-    // original header no longer leaks in as a covariate. Resolve every target
-    // against the *original* headers first, then apply the renames, so one
-    // mapping can never shadow another's lookup.
+    // Apply `[data]` column remapping (#730, #742): rename each mapped actual
+    // header to its target name (case-insensitive match on the actual header).
+    // Downstream canonical lookups (`col_idx_ci("time")`) and covariate
+    // auto-detection (`is_standard`) then treat a renamed column as that role /
+    // covariate with no further special-casing, and the original header no
+    // longer leaks in under its old name. Resolve every actual header against
+    // the *original* headers first, then apply the renames, so one mapping can
+    // never shadow another's lookup.
     if !column_map.is_empty() {
         let mut planned: Vec<(usize, String)> = Vec::with_capacity(column_map.len());
-        for (canonical, actual) in column_map {
+        for (target, actual) in column_map {
             // A mapped header that is absent is a hard error — the mapping would
             // silently do nothing (e.g. TIME would still be reported missing).
             let idx = headers
@@ -472,36 +473,37 @@ fn read_nonmem_csv_impl(
                 .position(|h| h.eq_ignore_ascii_case(actual))
                 .ok_or_else(|| {
                     format!(
-                        "[data]: mapped column `{actual}` (for role `{canonical}`) not found in \
+                        "[data]: mapped column `{actual}` (for role `{target}`) not found in \
                          dataset headers: {}",
                         headers.join(", ")
                     )
                 })?;
-            // Reject when the dataset already carries this canonical role under a
-            // *different* header — the role would be ambiguous after renaming.
-            if let Some(other) = headers
-                .iter()
-                .position(|h| h.eq_ignore_ascii_case(canonical))
-            {
-                if other != idx {
-                    return Err(format!(
-                        "[data]: role `{canonical}` maps to `{actual}`, but the dataset already \
-                         has a `{}` column",
-                        headers[other]
-                    ));
-                }
-            }
             // Reject clobbering the IOV occasion column: renaming it would make
             // the later `iov_column` lookup fail with a misleading "not found".
             if let Some(iov) = iov_column {
                 if actual.eq_ignore_ascii_case(iov) {
                     return Err(format!(
-                        "[data]: mapped column `{actual}` (for role `{canonical}`) is also the \
+                        "[data]: mapped column `{actual}` (for role `{target}`) is also the \
                          iov_column `{iov}`"
                     ));
                 }
             }
-            planned.push((idx, canonical.to_ascii_uppercase()));
+            planned.push((idx, target.clone()));
+        }
+        // A column being renamed *away* frees its old name — the raw `dv` column
+        // renamed to `ODV` no longer collides with a `DV = lndv` mapping (#742).
+        // So a target may collide only with a *surviving* (non-source) header.
+        let sources: std::collections::HashSet<usize> = planned.iter().map(|(i, _)| *i).collect();
+        for (idx, target) in &planned {
+            if let Some(other) = headers.iter().position(|h| h.eq_ignore_ascii_case(target)) {
+                if other != *idx && !sources.contains(&other) {
+                    return Err(format!(
+                        "[data]: renaming to `{target}` collides — the dataset already has a `{}` \
+                         column",
+                        headers[other]
+                    ));
+                }
+            }
         }
         for (idx, name) in planned {
             headers[idx] = name;
@@ -3113,9 +3115,61 @@ mod tests {
                    1,0,0,.,1,100\n\
                    1,1,2,5.0,0,.\n";
         let f = write_csv(csv);
-        let map = vec![("time".to_string(), "TAFD".to_string())];
+        let map = vec![("TIME".to_string(), "TAFD".to_string())];
         let err = read_nonmem_csv_mapped(f.path(), None, None, &map).unwrap_err();
         assert!(err.contains("already has a `TIME` column"), "{err}");
+    }
+
+    #[test]
+    fn test_column_map_renames_arbitrary_column() {
+        // #742: a `[data]` target need not be a canonical role — an arbitrary
+        // column can be renamed (e.g. a covariate). `weight` → `WT` and the new
+        // name is the one that surfaces as a covariate.
+        let csv = "ID,TIME,DV,EVID,AMT,weight\n\
+                   1,0,.,1,100,70\n\
+                   1,1,5.0,0,.,70\n";
+        let f = write_csv(csv);
+        let map = vec![("WT".to_string(), "weight".to_string())];
+        let pop = read_nonmem_csv_mapped(f.path(), None, None, &map).unwrap();
+        assert!(pop.covariate_names.contains(&"WT".to_string()));
+        assert!(!pop.covariate_names.contains(&"weight".to_string()));
+        assert_eq!(pop.subjects[0].covariates["WT"], 70.0);
+    }
+
+    #[test]
+    fn test_column_map_frees_renamed_away_column_for_role() {
+        // #742: the dataset's raw `dv` is renamed aside to `ODV`, freeing the DV
+        // role for the log-DV column `lndv`. Both renames must succeed — the old
+        // `dv` no longer collides with the `DV` target because it is being
+        // renamed away in the same block.
+        let csv = "ID,TIME,dv,lndv,EVID,AMT\n\
+                   1,0,.,.,1,100\n\
+                   1,1,5.0,1.609,0,.\n";
+        let f = write_csv(csv);
+        let map = vec![
+            ("ODV".to_string(), "dv".to_string()),
+            ("DV".to_string(), "lndv".to_string()),
+        ];
+        let pop = read_nonmem_csv_mapped(f.path(), None, None, &map).unwrap();
+        let subj = &pop.subjects[0];
+        // DV now carries the log-DV values.
+        assert_eq!(subj.observations, vec![1.609]);
+        // The raw DV survives as the `ODV` covariate.
+        assert!(pop.covariate_names.contains(&"ODV".to_string()));
+        assert_eq!(subj.covariates["ODV"], 5.0);
+    }
+
+    #[test]
+    fn test_column_map_target_collides_with_surviving_column_errors() {
+        // #742 boundary: promoting `lndv` to DV without renaming the existing
+        // `dv` away leaves two DV columns — ambiguous, so it must error.
+        let csv = "ID,TIME,dv,lndv,EVID,AMT\n\
+                   1,0,.,.,1,100\n\
+                   1,1,5.0,1.609,0,.\n";
+        let f = write_csv(csv);
+        let map = vec![("DV".to_string(), "lndv".to_string())];
+        let err = read_nonmem_csv_mapped(f.path(), None, None, &map).unwrap_err();
+        assert!(err.contains("already has a `dv` column"), "{err}");
     }
 
     #[test]

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -473,7 +473,7 @@ fn read_nonmem_csv_impl(
                 .position(|h| h.eq_ignore_ascii_case(actual))
                 .ok_or_else(|| {
                     format!(
-                        "[data]: mapped column `{actual}` (for role `{target}`) not found in \
+                        "[data]: mapped column `{actual}` (renamed to `{target}`) not found in \
                          dataset headers: {}",
                         headers.join(", ")
                     )
@@ -483,7 +483,7 @@ fn read_nonmem_csv_impl(
             if let Some(iov) = iov_column {
                 if actual.eq_ignore_ascii_case(iov) {
                     return Err(format!(
-                        "[data]: mapped column `{actual}` (for role `{target}`) is also the \
+                        "[data]: mapped column `{actual}` (renamed to `{target}`) is also the \
                          iov_column `{iov}`"
                     ));
                 }
@@ -3104,7 +3104,7 @@ mod tests {
         let map = vec![("dv".to_string(), "CONC".to_string())];
         let err = read_nonmem_csv_mapped(f.path(), None, None, &map).unwrap_err();
         assert!(err.contains("mapped column `CONC`"), "{err}");
-        assert!(err.contains("role `dv`"), "{err}");
+        assert!(err.contains("renamed to `dv`"), "{err}");
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4753,10 +4753,11 @@ const DATA_BLOCK_ROLES: &[&str] = &[
 ///   WT  = weight   # rename an arbitrary covariate
 /// ```
 ///
-/// Validated here: empty target names, a target mapped twice, and two targets
-/// mapped to the same actual header. Whether a mapped header actually exists in
-/// the dataset — and whether a rename collides with a surviving column — can
-/// only be checked when the CSV is read, so that lives in the datareader.
+/// Validated here: an empty `path`, empty target names, a target mapped twice,
+/// and two targets mapped to the same actual header. Whether a mapped header
+/// actually exists in the dataset — and whether a rename collides with a
+/// surviving column — can only be checked when the CSV is read, so that lives in
+/// the datareader.
 fn parse_data_block(lines: &[String]) -> Result<(String, Vec<(String, String)>), String> {
     let mut path: Option<String> = None;
     let mut column_map: Vec<(String, String)> = Vec::new();
@@ -4768,6 +4769,9 @@ fn parse_data_block(lines: &[String]) -> Result<(String, Vec<(String, String)>),
         let (key, value) = (parts[0], parts[1].trim_matches(|c| c == '"' || c == '\''));
         let key_lc = key.to_ascii_lowercase();
         if key_lc == "path" {
+            if value.is_empty() {
+                return Err("[data]: empty `path` — write `path = <path-to-csv>`".to_string());
+            }
             path = Some(value.to_string());
             continue;
         }
@@ -17813,6 +17817,14 @@ mod tests {
                 ("DV".to_string(), "CONC".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_data_block_empty_path_is_error() {
+        // A bare `path =` fails loudly here rather than surfacing later as an
+        // opaque CSV-open error.
+        let err = parse_data_block(&["path =".to_string()]).unwrap_err();
+        assert!(err.contains("empty `path`"), "{err}");
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4724,9 +4724,11 @@ fn parse_method_token(token: &str) -> Result<EstimationMethod, String> {
     }
 }
 
-/// Canonical column roles that a `[data]` block may remap to an actual CSV
-/// header (#730, NONMEM `$INPUT TIME=TAFD` analogue). Kept in sync with the
-/// standard columns recognised by [`crate::io::datareader`].
+/// Canonical column roles a `[data]` block may remap (#730, NONMEM
+/// `$INPUT TIME=TAFD` analogue). A target naming one of these is upper-cased to
+/// the standard header spelling; any other target is an arbitrary column rename
+/// (#742) kept in its written case. Stays in sync with the standard columns
+/// recognised by [`crate::io::datareader`].
 const DATA_BLOCK_ROLES: &[&str] = &[
     "id", "time", "dv", "evid", "amt", "cmt", "rate", "mdv", "ii", "ss", "cens", "addl", "tentry",
     "fremtype",
@@ -4734,13 +4736,27 @@ const DATA_BLOCK_ROLES: &[&str] = &[
 
 /// Parse a `[data]` block (#690, NONMEM `$DATA` analogue). Returns the raw
 /// `path` value as written (resolved relative to the model file's directory by
-/// `parse_full_model_file`) plus any `canonical = actual` column remappings
-/// (#730). Each map entry is `(canonical_role_lowercase, actual_header)`.
+/// `parse_full_model_file`) plus any `target = actual` column remappings.
+/// Each map entry is `(target_header, actual_header)`: the dataset's
+/// `actual_header` column is renamed to `target_header` when the CSV is read.
 ///
-/// Validated here: unknown keys, empty target names, a role mapped twice, and
-/// two roles mapped to the same actual header (duplicate targets). Whether a
-/// mapped header actually exists in the dataset can only be checked when the
-/// CSV is read, so that lives in the datareader.
+/// A `target` that names a canonical role (#730, DATA_BLOCK_ROLES) is upper-cased
+/// to the standard header spelling; any other target (#742 — arbitrary column /
+/// covariate rename) keeps the exact case written, since covariate lookups are
+/// case-sensitive. This lets a dataset's own `dv` column be renamed aside so a
+/// different column can take the `DV` role, e.g.
+///
+/// ```text
+/// [data]
+///   ODV = dv       # keep the raw DV under a new name
+///   DV  = lndv     # promote the log-DV column to the DV role
+///   WT  = weight   # rename an arbitrary covariate
+/// ```
+///
+/// Validated here: empty target names, a target mapped twice, and two targets
+/// mapped to the same actual header. Whether a mapped header actually exists in
+/// the dataset — and whether a rename collides with a surviving column — can
+/// only be checked when the CSV is read, so that lives in the datareader.
 fn parse_data_block(lines: &[String]) -> Result<(String, Vec<(String, String)>), String> {
     let mut path: Option<String> = None;
     let mut column_map: Vec<(String, String)> = Vec::new();
@@ -4753,31 +4769,36 @@ fn parse_data_block(lines: &[String]) -> Result<(String, Vec<(String, String)>),
         let key_lc = key.to_ascii_lowercase();
         if key_lc == "path" {
             path = Some(value.to_string());
-        } else if DATA_BLOCK_ROLES.contains(&key_lc.as_str()) {
-            if value.is_empty() {
-                return Err(format!(
-                    "[data]: empty column name for role `{key_lc}` — write `{key_lc} = <header>`"
-                ));
-            }
-            if column_map.iter().any(|(role, _)| role == &key_lc) {
-                return Err(format!("[data]: role `{key_lc}` mapped more than once"));
-            }
-            column_map.push((key_lc, value.to_string()));
-        } else {
+            continue;
+        }
+        if value.is_empty() {
             return Err(format!(
-                "[data]: unknown key `{key}` — valid keys are: path, or a canonical column role \
-                 ({})",
-                DATA_BLOCK_ROLES.join(", ")
+                "[data]: empty column name for `{key}` — write `{key} = <header>`"
             ));
         }
+        // Canonical roles use the standard upper-case spelling; arbitrary
+        // targets (#742) keep their exact case for case-sensitive covariate
+        // lookups.
+        let target = if DATA_BLOCK_ROLES.contains(&key_lc.as_str()) {
+            key_lc.to_ascii_uppercase()
+        } else {
+            key.to_string()
+        };
+        if column_map
+            .iter()
+            .any(|(t, _)| t.eq_ignore_ascii_case(&target))
+        {
+            return Err(format!("[data]: target `{target}` mapped more than once"));
+        }
+        column_map.push((target, value.to_string()));
     }
-    // Reject two roles pointing at the same actual header (case-insensitive):
-    // the reader would rename one header to two roles, silently dropping one.
+    // Reject two targets pointing at the same actual header (case-insensitive):
+    // the reader would rename one header to two targets, silently dropping one.
     for i in 0..column_map.len() {
         for j in (i + 1)..column_map.len() {
             if column_map[i].1.eq_ignore_ascii_case(&column_map[j].1) {
                 return Err(format!(
-                    "[data]: roles `{}` and `{}` both map to column `{}`",
+                    "[data]: targets `{}` and `{}` both map to column `{}`",
                     column_map[i].0, column_map[j].0, column_map[i].1
                 ));
             }
@@ -17760,18 +17781,27 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_data_block_unknown_key_is_error() {
-        let err = parse_data_block(&["bogus = 1".to_string()]).unwrap_err();
-        assert!(err.contains("unknown key `bogus`"), "{err}");
+    fn test_parse_data_block_arbitrary_target_is_accepted() {
+        // #742: a non-canonical target renames an arbitrary column. Its case is
+        // preserved (covariate lookups are case-sensitive), unlike canonical
+        // roles which are upper-cased.
+        let (_, map) =
+            parse_data_block(&["path = d.csv".to_string(), "WT = weight".to_string()]).unwrap();
+        assert_eq!(map, vec![("WT".to_string(), "weight".to_string())]);
+        // Mixed-case arbitrary target kept verbatim.
+        let (_, map) =
+            parse_data_block(&["path = d.csv".to_string(), "MyCov = raw".to_string()]).unwrap();
+        assert_eq!(map, vec![("MyCov".to_string(), "raw".to_string())]);
     }
 
     #[test]
     fn test_parse_data_block_column_mapping() {
-        // `canonical = actual` remappings (#730). Roles are lowercased; the
-        // actual header is preserved verbatim. `path` still parses alongside.
+        // `target = actual` remappings. Canonical roles are upper-cased to the
+        // standard spelling; the actual header is preserved verbatim. `path`
+        // still parses alongside.
         let (path, map) = parse_data_block(&[
             "path = mydata.csv".to_string(),
-            "TIME = TAFD".to_string(),
+            "time = TAFD".to_string(),
             "DV = CONC".to_string(),
         ])
         .unwrap();
@@ -17779,8 +17809,8 @@ mod tests {
         assert_eq!(
             map,
             vec![
-                ("time".to_string(), "TAFD".to_string()),
-                ("dv".to_string(), "CONC".to_string()),
+                ("TIME".to_string(), "TAFD".to_string()),
+                ("DV".to_string(), "CONC".to_string()),
             ]
         );
     }
@@ -17789,24 +17819,24 @@ mod tests {
     fn test_parse_data_block_empty_target_is_error() {
         let err =
             parse_data_block(&["path = d.csv".to_string(), "time =".to_string()]).unwrap_err();
-        assert!(err.contains("empty column name for role `time`"), "{err}");
+        assert!(err.contains("empty column name for `time`"), "{err}");
     }
 
     #[test]
-    fn test_parse_data_block_role_mapped_twice_is_error() {
+    fn test_parse_data_block_target_mapped_twice_is_error() {
         let err = parse_data_block(&[
             "path = d.csv".to_string(),
             "TIME = TAFD".to_string(),
             "time = T2".to_string(),
         ])
         .unwrap_err();
-        assert!(err.contains("role `time` mapped more than once"), "{err}");
+        assert!(err.contains("target `TIME` mapped more than once"), "{err}");
     }
 
     #[test]
     fn test_parse_data_block_duplicate_target_is_error() {
-        // Two roles pointing at the same actual header (case-insensitive) is
-        // rejected: the reader would rename one header to two roles.
+        // Two targets pointing at the same actual header (case-insensitive) is
+        // rejected: the reader would rename one header to two targets.
         let err = parse_data_block(&[
             "path = d.csv".to_string(),
             "TIME = X".to_string(),
@@ -17825,8 +17855,8 @@ mod tests {
         assert_eq!(
             parsed.column_map,
             vec![
-                ("time".to_string(), "TAFD".to_string()),
-                ("dv".to_string(), "CONC".to_string()),
+                ("TIME".to_string(), "TAFD".to_string()),
+                ("DV".to_string(), "CONC".to_string()),
             ]
         );
     }

--- a/tests/data_block.rs
+++ b/tests/data_block.rs
@@ -163,6 +163,34 @@ fn fit_reads_dataset_through_data_block_column_mapping() {
 }
 
 #[test]
+fn fit_renames_arbitrary_covariate_column_through_data_block() {
+    // #742: a `[data]` target need not be a canonical role. A dataset carrying a
+    // lowercase `wgt` covariate is renamed to `WT`, and the new name is what
+    // surfaces in the fitted population — the original `wgt` no longer leaks.
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Append a constant `wgt` covariate column to every row of the base CSV.
+    let src = std::fs::read_to_string("data/one_cpt_iv.csv").expect("read one_cpt_iv.csv");
+    let mut lines = src.lines();
+    let header = format!("{},wgt", lines.next().expect("header"));
+    let body: Vec<String> = lines.map(|l| format!("{l},70")).collect();
+    let out = std::iter::once(header)
+        .chain(body)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(dir.path().join("cov.csv"), out).expect("write cov csv");
+
+    let data_block = "[data]\n  path = cov.csv\n  WT = wgt\n";
+    let model_src = MODEL_TEMPLATE.replace("{data}", data_block);
+    let model_path = dir.path().join("m.ferx");
+    std::fs::write(&model_path, model_src).expect("write model file");
+
+    let (_result, population) = run_model_with_data_inits(model_path.to_str().unwrap(), None, None)
+        .expect("fit should succeed with the renamed WT covariate");
+    assert!(population.covariate_names.contains(&"WT".to_string()));
+    assert!(!population.covariate_names.contains(&"wgt".to_string()));
+}
+
+#[test]
 fn fit_errors_when_mapped_column_absent_from_dataset() {
     // Mapping to a header the dataset lacks is a hard, clear error.
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Why

The `[data]` block (#730) could remap only the canonical NONMEM roles (`ID`, `TIME`,
`DV`, …). Issue #742 asks to rename **any** input column — arbitrary covariates, and
in particular to move a dataset's own `dv` aside so a different column can take the
`DV` role:

```
[data]
  ODV = dv
  DV  = lndv
  WT  = weight
```

Previously `DV = lndv` was rejected because the dataset still carried a `dv` column
("already has a DV column"), so the rename-aside pattern was impossible.

## What changed

- **Parser (`model_parser.rs`)** — `[data]` accepts any key as a rename target, not
  just canonical roles. A target naming a canonical role is upper-cased to the
  standard spelling; any other target keeps its written case (covariate lookups are
  case-sensitive). Validation still rejects an empty target, a target used twice, and
  two targets pointing at the same source header.
- **Reader (`datareader.rs`)** — replaced the per-mapping "role already present under
  a different header" check (which blocked rename-aside) with a collision check
  against the *surviving* (non-renamed) headers only, computed after resolving every
  source index against the original headers. A column renamed away frees its old
  name. Renames now write the target verbatim (no forced upper-case), since the
  parser already supplies the final name.

Column map tuple semantics unchanged (`Vec<(target, source)>`); all consumers just
forward it to the reader.

## Alternatives considered

Post-rename duplicate scan over the whole final header set (simpler) — rejected to
preserve the existing, more specific error message ("already has a `X` column") and
to keep per-target error attribution.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API surface changed — the feature is entirely inside the `[data]` parse →
read path.

## Breaking changes
- [x] None

`[data]` gains capability; all existing `canonical = actual` mappings parse and
behave exactly as before.

## Numerical validation
- [x] Not applicable (I/O column-naming change; no estimation/PK/stats math touched)

## Performance
- [x] No significant impact expected (one extra `HashSet<usize>` of the mapped
  columns, built once at CSV read)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

New tests:
- `datareader::test_column_map_renames_arbitrary_column` — non-canonical target
  renames a covariate; new name surfaces, old name gone.
- `datareader::test_column_map_frees_renamed_away_column_for_role` — the #742
  headline: `ODV = dv` + `DV = lndv` both succeed; DV carries the log values, raw DV
  survives as `ODV`.
- `datareader::test_column_map_target_collides_with_surviving_column_errors` —
  `DV = lndv` while `dv` still present is rejected.
- `data_block::fit_renames_arbitrary_covariate_column_through_data_block` — Tier-2
  fit-through-API rename of a covariate.
- Existing #730 parser tests updated for the new canonical-uppercasing and reworded
  error messages.

## Example (user-facing features only)
- [x] Not applicable (inline below)

<details>
<summary>Example</summary>

```toml
[data]
  path = mydata.csv
  ODV = dv         # keep the raw DV under a new name
  DV  = lndv       # promote the log-DV column into the DV role
  WT  = weight     # rename an arbitrary covariate
```

Result: `DV` is read from the `lndv` column; the original `dv` values are available
as the `ODV` covariate; `weight` is read as `WT`.
</details>

## Docs
- [x] `docs/` updated for user-visible changes (`docs/model-file/data.qmd`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (one pre-existing `unwrap`-after-`is_some` warning at
  `datareader.rs:541` is untouched by this PR)
- [x] Not on the `Dual2` sensitivity path (I/O only)
- [x] No version bump needed (non-breaking)

## Reviewer hints

Focus on the reader's rename+collision block in `datareader.rs`: source indices are
resolved against the *original* headers first, then a target may collide only with a
header that is neither its own source nor another mapping's source. This is what makes
rename-aside safe while still rejecting a genuine ambiguity (`DV = lndv` with `dv`
still present).

## Open questions

None.
