### PR TITLE
feat(estimation): trace per-parameter estimates + gradients per iteration [closes #640]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Per-parameter estimates + gradients in the optimizer trace** (#640): when
+  `optimizer_trace = true`, each CSV row now also records the full parameter
+  vector (`val:<name>` columns, natural/reporting scale) for every method and
+  the full gradient vector (`grad:<name>` columns, optimizer-scaled space) for
+  the gradient methods (FOCE/FOCEI/GN; `NA` for SAEM). Columns are named after
+  the declared parameters (`TVCL`, `ETA_CL`, `ETA_V~ETA_CL`, `PROP_ERR`) with
+  `THETA1` / `OMEGA(2,1)` / `SIGMA(1)` fallbacks, and reconstruct `grad_norm`
+  as `sqrt(sum(grad:<name>^2))`. This powers a per-parameter convergence view
+  in the ferx-r trace UI.
 - **`[data]` block column renaming** (#730, #742): rename any dataset header to
   any new name with `new-name = actual` entries (e.g. `TIME = TAFD`,
   `DV = CONC`), the ferx equivalent of NONMEM's `$INPUT TIME=TAFD`. Targets are

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -452,7 +452,7 @@ When `optimizer_trace = true`, a CSV is written to `/tmp/ferx_trace_<pid>_<ts>.c
 | `phase` | gn_hybrid, saem | `focei` (polish) or `explore`/`converge` |
 | `ofv` | all | Objective function value |
 | `wall_ms` | all | Wall time for this iteration (ms) |
-| `grad_norm` | BFGS, NLopt gradient-mode | Gradient norm |
+| `grad_norm` | BFGS, NLopt gradient-mode, GN | Gradient norm |
 | `step_norm` | BFGS | Step size |
 | `inner_iter_count` | (reserved) | Reserved for future per-iteration inner-loop count; currently `NA` |
 | `optimizer` | FOCE/FOCEI | Active NLopt algorithm |
@@ -476,7 +476,10 @@ per optimized coordinate (thetas, Ω diagonals **and** off-diagonal covariances,
 containing a comma is CSV-quoted). The column set is fixed across a method chain
 (e.g. `saem -> focei`), so one header serves the whole run. `grad:*` columns are
 `NA` on any iteration without an OFV gradient (SAEM, and derivative-free BOBYQA
-evals). This powers the per-parameter convergence view in ferx-r's trace UI
+evals). The `val:*`/`grad:*` cells are written in scientific notation
+(`{:.6e}`) — unlike the fixed-decimal scalar columns — so small variances and
+near-converged gradient coordinates keep their precision instead of rounding to
+`0`. This powers the per-parameter convergence view in ferx-r's trace UI
 (#640).
 
 Unused columns contain `NA`. The trace is buffered and flushed when the fit ends; if a run is killed mid-iteration the buffered tail may be lost.

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -464,5 +464,19 @@ When `optimizer_trace = true`, a CSV is written to `/tmp/ferx_trace_<pid>_<ts>.c
 | `mh_accept_rate` | SAEM | Mean acceptance rate across all subjects (MH or HMC). In mixed HMC/MH runs (`n_leapfrog > 0` with some MH-fallback subjects) this is an aggregate across both samplers. |
 | `n_ebe_unconverged` | FOCE/FOCEI | Subjects whose inner optimizer did not converge |
 | `n_ebe_fallback` | FOCE/FOCEI | Subjects that fell back to Nelder-Mead |
+| `val:<name>` | all | Per-parameter estimate, one column per optimized coordinate, in **natural / reporting scale** (θ as values, Ω as variances/covariances, Σ as variances) |
+| `grad:<name>` | FOCE/FOCEI/GN | Per-parameter gradient, in the optimizer's **transformed/scaled** space (`NA` for SAEM); `sqrt(sum(grad:<name>^2)) == grad_norm` |
+
+After the fixed columns above, the trace appends two blocks of per-parameter
+columns — all `val:<name>` columns, then all `grad:<name>` columns — one pair
+per optimized coordinate (thetas, Ω diagonals **and** off-diagonal covariances,
+Σ, plus any IOV Ω). Headers use the declared parameter names where available
+(`val:TVCL`, `val:ETA_CL`, an Ω off-diagonal as `val:ETA_V~ETA_CL`,
+`val:PROP_ERR`), with `THETA1` / `OMEGA(2,1)` / `SIGMA(1)` fallbacks (a name
+containing a comma is CSV-quoted). The column set is fixed across a method chain
+(e.g. `saem -> focei`), so one header serves the whole run. `grad:*` columns are
+`NA` on any iteration without an OFV gradient (SAEM, and derivative-free BOBYQA
+evals). This powers the per-parameter convergence view in ferx-r's trace UI
+(#640).
 
 Unused columns contain `NA`. The trace is buffered and flushed when the fit ends; if a run is killed mid-iteration the buffered tail may be lost.

--- a/src/api.rs
+++ b/src/api.rs
@@ -3861,7 +3861,11 @@ fn fit_inner(
             .map(|d| d.as_secs())
             .unwrap_or(0);
         let path = format!("/tmp/ferx_trace_{}_{}.csv", pid, ts);
-        if let Err(e) = crate::estimation::trace::init(path.clone()) {
+        // Header carries one `val:<name>`/`grad:<name>` column per optimized
+        // coordinate. The coordinate structure (and hence the names) is fixed
+        // across a method chain, so the template's names serve every stage.
+        let coord_names = crate::estimation::parameterization::coordinate_names(init_params);
+        if let Err(e) = crate::estimation::trace::init(path.clone(), &coord_names) {
             eprintln!("[ferx] warning: could not open trace file {}: {}", path, e);
         } else {
             eprintln!("[ferx] optimizer trace → {}", path);

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -158,6 +158,11 @@ pub fn run_foce_gn(
         // With identity scale (scale_params=false) this is a no-op.
         let grad_s: DVector<f64> =
             DVector::from_iterator(n_packed, (0..n_packed).map(|i| grad[i] * gn_scale[i]));
+        // Per-coordinate scaled gradient for the trace's `grad:*` columns (#640),
+        // in the same space as the FOCE `grad_norm`. Snapshot at the iteration's
+        // evaluation point; accepted-step rows log the current estimate with this
+        // pre-step gradient (a one-iter lag, mirroring the FOCE trace).
+        let grad_s_trace: Vec<f64> = grad_s.iter().copied().collect();
         let mut h_s = DMatrix::zeros(n_packed, n_packed);
         for i in 0..n_packed {
             for j in 0..n_packed {
@@ -259,6 +264,11 @@ pub fn run_foce_gn(
             // with accepted-step rows (which also log the post-accept radius).
             if crate::estimation::trace::is_active() {
                 let (gn_method, gn_phase) = gn_trace_method_phase(options.method);
+                // Rejected step: `x` is unchanged, so the estimate and the
+                // gradient share the same point.
+                let values = crate::estimation::parameterization::coordinate_values(
+                    &unpack_params(&x, init_params),
+                );
                 crate::estimation::trace::write_gn(
                     iter,
                     gn_method,
@@ -269,6 +279,8 @@ pub fn run_foce_gn(
                     false,
                     None,
                     None,
+                    &values,
+                    Some(&grad_s_trace),
                 );
             }
 
@@ -302,6 +314,12 @@ pub fn run_foce_gn(
         // Trace: accepted step (lm_lambda column carries trust_radius for GN-TR)
         if crate::estimation::trace::is_active() {
             let (gn_method, gn_phase) = gn_trace_method_phase(options.method);
+            // Accepted step: `x` now holds the new point (`x_try`); its estimate
+            // is logged with this iteration's (pre-step) scaled gradient.
+            let values = crate::estimation::parameterization::coordinate_values(&unpack_params(
+                &x,
+                init_params,
+            ));
             crate::estimation::trace::write_gn(
                 iter,
                 gn_method,
@@ -312,6 +330,8 @@ pub fn run_foce_gn(
                 true,
                 None,
                 None,
+                &values,
+                Some(&grad_s_trace),
             );
         }
 

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -163,6 +163,9 @@ pub fn run_foce_gn(
         // evaluation point; accepted-step rows log the current estimate with this
         // pre-step gradient (a one-iter lag, mirroring the FOCE trace).
         let grad_s_trace: Vec<f64> = grad_s.iter().copied().collect();
+        // Scalar norm of the same scaled gradient, for the `grad_norm` column —
+        // so `sqrt(sum(grad:*^2)) == grad_norm` holds for GN rows.
+        let grad_norm_trace = grad_s.norm();
         let mut h_s = DMatrix::zeros(n_packed, n_packed);
         for i in 0..n_packed {
             for j in 0..n_packed {
@@ -274,6 +277,7 @@ pub fn run_foce_gn(
                     gn_method,
                     gn_phase,
                     ofv,
+                    Some(grad_norm_trace),
                     radius_before,
                     0.0,
                     false,
@@ -325,6 +329,7 @@ pub fn run_foce_gn(
                 gn_method,
                 gn_phase,
                 ofv,
+                Some(grad_norm_trace),
                 trust_radius,
                 ofv - prev_ofv,
                 true,
@@ -3506,5 +3511,70 @@ mod tests {
                  off={g_off:.17e} on={g_on:.17e} (mu-ref shortcut not fully removed)"
             );
         }
+    }
+
+    /// GN with the optimizer trace active must emit the per-parameter `val:*` /
+    /// `grad:*` columns (#640) via the two `write_gn` call sites, and — after the
+    /// review fix — populate the `grad_norm` column so it reconstructs from the
+    /// `grad:*` block. This is the fast test that registers PR coverage for the
+    /// GN trace lines (the site is otherwise reached only by slow fits).
+    #[test]
+    fn gn_trace_emits_per_param_columns_and_grad_norm() {
+        use crate::types::{EstimationMethod, Optimizer};
+        let model = make_model();
+        let population = make_population();
+        let coord_names =
+            crate::estimation::parameterization::coordinate_names(&model.default_params);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = format!(
+            "/tmp/ferx_trace_gn_param_{}_{}.csv",
+            std::process::id(),
+            nanos
+        );
+        crate::estimation::trace::init(path.clone(), &coord_names).unwrap();
+        let opts = FitOptions {
+            method: EstimationMethod::FoceGn,
+            optimizer: Optimizer::Bfgs,
+            outer_maxiter: 4,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+        let _ = run_foce_gn(&model, &population, &model.default_params, &opts);
+        crate::estimation::trace::finish();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines = contents.lines();
+        let header: Vec<String> = lines.next().unwrap().split(',').map(String::from).collect();
+        assert!(header.iter().any(|c| c.starts_with("val:")));
+        assert!(header.iter().any(|c| c.starts_with("grad:")));
+        let n_coords = coord_names.len();
+        let fixed = 17;
+        let gn_idx = header.iter().position(|c| c == "grad_norm").unwrap();
+        let mut checked = false;
+        for row in lines {
+            let c: Vec<String> = row.split(',').map(String::from).collect();
+            assert_eq!(c.len(), fixed + 2 * n_coords, "GN row column count");
+            // GN rows must now carry a finite grad_norm (the review fix).
+            let gn: f64 = c[gn_idx]
+                .parse()
+                .expect("GN grad_norm must be finite, not NA");
+            let mut sq = 0.0;
+            for i in (fixed + n_coords)..(fixed + 2 * n_coords) {
+                sq += c[i].parse::<f64>().unwrap().powi(2);
+            }
+            assert!(
+                (sq.sqrt() - gn).abs() <= 1e-6 * gn.abs().max(1.0),
+                "GN grad:* must reconstruct grad_norm: recon={} grad_norm={}",
+                sq.sqrt(),
+                gn
+            );
+            checked = true;
+        }
+        assert!(checked, "expected at least one GN trace row");
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1023,6 +1023,10 @@ fn optimize_nlopt(
 
         // Compute gradient if requested (central FD with fixed EBEs)
         let mut grad_norm_for_trace: Option<f64> = None;
+        // Per-coordinate scaled gradient for the trace (#640); only populated
+        // for a genuine OFV gradient (not the guard-penalty push), so it is
+        // present exactly when `grad_norm_for_trace` is.
+        let mut grad_vec_for_trace: Option<Vec<f64>> = None;
         if let Some(g) = grad {
             // A rejected or non-finite point has no useful population gradient: steepest
             // ascent toward bounds center nudges the optimizer back. Fall through (no early
@@ -1059,6 +1063,7 @@ fn optimize_nlopt(
                     sq += gi * gi;
                 }
                 grad_norm_for_trace = Some(sq.sqrt());
+                grad_vec_for_trace = Some(g.to_vec());
                 if matches!(algo, nlopt::Algorithm::Slsqp) {
                     cap_slsqp_gradient(g, &lower_s, &upper_s);
                 }
@@ -1136,6 +1141,7 @@ fn optimize_nlopt(
                 nlopt::Algorithm::Lbfgs => "nlopt_lbfgs",
                 _ => "slsqp",
             };
+            let values = crate::estimation::parameterization::coordinate_values(&params);
             crate::estimation::trace::write_foce(
                 state.n_evals,
                 method_str,
@@ -1145,6 +1151,8 @@ fn optimize_nlopt(
                 optimizer_str,
                 Some(ebe_stats.n_unconverged),
                 Some(ebe_stats.n_fallback),
+                &values,
+                grad_vec_for_trace.as_deref(),
             );
         }
         state.prev_x = xs.to_vec();
@@ -1586,6 +1594,11 @@ fn optimize_bfgs(
         }
 
         let g_norm: f64 = g.iter().map(|v| v * v).sum::<f64>().sqrt();
+        // Snapshot the scaled gradient that `g_norm` is taken from, before the
+        // step overwrites `g` with `g_new`. The trace's `grad:*` columns log
+        // this vector so `sqrt(Σ gᵢ²) == grad_norm` holds (#640). Like the
+        // existing `grad_norm` column, it reflects the pre-step point.
+        let g_for_trace: Vec<f64> = g.to_vec();
         if g_norm < options.outer_gtol {
             if options.verbose {
                 eprintln!("Converged at iteration {} (|g| = {:.2e})", iter, g_norm);
@@ -1701,6 +1714,14 @@ fn optimize_bfgs(
                 Optimizer::Lbfgs => "lbfgs",
                 _ => "bfgs",
             };
+            // Recompute the real (unscaled) point rather than reuse
+            // `x_new_real`, which may already have been moved into the
+            // predictor's anchor above.
+            let x_real: Vec<f64> = (0..n).map(|i| xs[i] * scale[i]).collect();
+            let values = crate::estimation::parameterization::coordinate_values(&unpack_params(
+                &x_real,
+                init_params,
+            ));
             crate::estimation::trace::write_foce(
                 iter,
                 method_str,
@@ -1710,6 +1731,8 @@ fn optimize_bfgs(
                 optimizer_str,
                 None,
                 None,
+                &values,
+                Some(&g_for_trace),
             );
         }
 
@@ -5525,6 +5548,76 @@ mod tests {
             "BFGS worsened OFV: init={init_ofv:.4} final={:.4}",
             result.ofv
         );
+    }
+
+    /// Built-in BFGS with the optimizer trace active must emit the per-parameter
+    /// `val:*` / `grad:*` columns (#640) via the second `write_foce` call site,
+    /// and the gradient columns must reconstruct the `grad_norm` column.
+    #[test]
+    fn bfgs_trace_emits_per_param_columns() {
+        use crate::types::{EstimationMethod, FitOptions, Optimizer};
+        let model = make_model();
+        let population = make_population(4);
+        let coord_names =
+            crate::estimation::parameterization::coordinate_names(&model.default_params);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = format!(
+            "/tmp/ferx_trace_bfgs_param_{}_{}.csv",
+            std::process::id(),
+            nanos
+        );
+        crate::estimation::trace::init(path.clone(), &coord_names).unwrap();
+        let opts = FitOptions {
+            method: EstimationMethod::Foce,
+            optimizer: Optimizer::Bfgs,
+            outer_maxiter: 3,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+        let _ = optimize_population(&model, &population, &model.default_params, &opts);
+        crate::estimation::trace::finish();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines = contents.lines();
+        let header = lines.next().unwrap();
+        assert!(
+            header.contains("val:"),
+            "header missing val columns: {header}"
+        );
+        assert!(header.contains("grad:"), "header missing grad columns");
+        let n_coords = coord_names.len();
+        let fixed = 17;
+        // Find a data row with a finite grad_norm and check the invariant.
+        let cols_of = |l: &str| l.split(',').map(String::from).collect::<Vec<_>>();
+        let hdr = cols_of(header);
+        let gn_idx = hdr.iter().position(|c| c == "grad_norm").unwrap();
+        let mut checked = false;
+        for row in lines {
+            let c = cols_of(row);
+            assert_eq!(c.len(), fixed + 2 * n_coords, "row column count");
+            if c[gn_idx] == "NA" {
+                continue;
+            }
+            let gn: f64 = c[gn_idx].parse().unwrap();
+            let mut sq = 0.0;
+            for i in (fixed + n_coords)..(fixed + 2 * n_coords) {
+                if let Ok(v) = c[i].parse::<f64>() {
+                    sq += v * v;
+                }
+            }
+            assert!(
+                (sq.sqrt() - gn).abs() < 1e-4,
+                "grad cols must reconstruct grad_norm"
+            );
+            checked = true;
+            break;
+        }
+        assert!(checked, "expected at least one row with a finite grad_norm");
+        std::fs::remove_file(&path).ok();
     }
 
     // ── global pre-search (CRS2-LM) ──────────────────────────────────────────

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1063,7 +1063,14 @@ fn optimize_nlopt(
                     sq += gi * gi;
                 }
                 grad_norm_for_trace = Some(sq.sqrt());
-                grad_vec_for_trace = Some(g.to_vec());
+                // Clone the scaled gradient for the trace only when a trace is
+                // open — this runs on every gradient eval (the hot path), so an
+                // unconditional `to_vec` would waste an allocation per eval on
+                // the default trace-off path (#640 review). Snapshot before the
+                // SLSQP cap below so it matches `grad_norm_for_trace`.
+                if crate::estimation::trace::is_active() {
+                    grad_vec_for_trace = Some(g.to_vec());
+                }
                 if matches!(algo, nlopt::Algorithm::Slsqp) {
                     cap_slsqp_gradient(g, &lower_s, &upper_s);
                 }
@@ -5610,8 +5617,78 @@ mod tests {
                 }
             }
             assert!(
-                (sq.sqrt() - gn).abs() < 1e-4,
-                "grad cols must reconstruct grad_norm"
+                (sq.sqrt() - gn).abs() <= 1e-6 * gn.abs().max(1.0),
+                "grad cols must reconstruct grad_norm: recon={} grad_norm={}",
+                sq.sqrt(),
+                gn
+            );
+            checked = true;
+            break;
+        }
+        assert!(checked, "expected at least one row with a finite grad_norm");
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Gradient-mode NLopt (SLSQP) with the trace active must emit the
+    /// per-parameter columns via the *nlopt* `write_foce` call site — the branch
+    /// that snapshots `grad_vec_for_trace` (now guarded by `is_active`). The
+    /// built-in-BFGS test above covers a different site; SLSQP is otherwise only
+    /// reached by slow fits, so this registers PR coverage for the nlopt path.
+    #[test]
+    fn nlopt_gradient_trace_emits_per_param_columns() {
+        use crate::types::{EstimationMethod, FitOptions, Optimizer};
+        let model = make_model();
+        let population = make_population(4);
+        let coord_names =
+            crate::estimation::parameterization::coordinate_names(&model.default_params);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = format!(
+            "/tmp/ferx_trace_slsqp_param_{}_{}.csv",
+            std::process::id(),
+            nanos
+        );
+        crate::estimation::trace::init(path.clone(), &coord_names).unwrap();
+        let opts = FitOptions {
+            method: EstimationMethod::Foce,
+            optimizer: Optimizer::Slsqp,
+            outer_maxiter: 3,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+        let _ = optimize_population(&model, &population, &model.default_params, &opts);
+        crate::estimation::trace::finish();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines = contents.lines();
+        let header: Vec<String> = lines.next().unwrap().split(',').map(String::from).collect();
+        assert!(header.iter().any(|c| c.starts_with("val:")));
+        assert!(header.iter().any(|c| c.starts_with("grad:")));
+        let n_coords = coord_names.len();
+        let fixed = 17;
+        let gn_idx = header.iter().position(|c| c == "grad_norm").unwrap();
+        let mut checked = false;
+        for row in lines {
+            let c: Vec<String> = row.split(',').map(String::from).collect();
+            assert_eq!(c.len(), fixed + 2 * n_coords, "row column count");
+            if c[gn_idx] == "NA" {
+                continue;
+            }
+            let gn: f64 = c[gn_idx].parse().unwrap();
+            let mut sq = 0.0;
+            for i in (fixed + n_coords)..(fixed + 2 * n_coords) {
+                if let Ok(v) = c[i].parse::<f64>() {
+                    sq += v * v;
+                }
+            }
+            assert!(
+                (sq.sqrt() - gn).abs() <= 1e-6 * gn.abs().max(1.0),
+                "grad cols must reconstruct grad_norm: recon={} grad_norm={}",
+                sq.sqrt(),
+                gn
             );
             checked = true;
             break;

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -434,6 +434,114 @@ pub fn compute_bounds(template: &ModelParameters) -> PackedBounds {
     PackedBounds { lower, upper }
 }
 
+/// Per-coordinate **display names** for the optimizer trace, in the same order
+/// as [`pack_params`]: `[theta…, Ω (lower-tri col-major)…, sigma…, Ω_IOV…]`.
+///
+/// Declared names are preferred (`TVCL`, `ETA_CL`, `EPS_PROP`); an Ω
+/// off-diagonal couples two etas as `ETA_i~ETA_j` (row eta ~ column eta). When a
+/// name is missing the NONMEM-style fallback is used: `THETA1`, `OMEGA(2,1)`,
+/// `SIGMA(1)`.
+pub fn coordinate_names(params: &ModelParameters) -> Vec<String> {
+    let mut names = Vec::with_capacity(packed_len(params));
+    for i in 0..params.theta.len() {
+        names.push(named_or(&params.theta_names, i, || {
+            format!("THETA{}", i + 1)
+        }));
+    }
+    push_omega_names(&mut names, &params.omega);
+    for i in 0..params.sigma.values.len() {
+        names.push(named_or(&params.sigma.names, i, || {
+            format!("SIGMA({})", i + 1)
+        }));
+    }
+    if let Some(ref iov) = params.omega_iov {
+        push_omega_names(&mut names, iov);
+    }
+    names
+}
+
+fn named_or(v: &[String], i: usize, fallback: impl FnOnce() -> String) -> String {
+    match v.get(i) {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => fallback(),
+    }
+}
+
+fn push_omega_names(names: &mut Vec<String>, om: &OmegaMatrix) {
+    let n = om.dim();
+    let diag_name = |i: usize| named_or(&om.eta_names, i, || format!("OMEGA({},{})", i + 1, i + 1));
+    if om.diagonal {
+        for i in 0..n {
+            names.push(diag_name(i));
+        }
+    } else {
+        // Column-major lower triangle — mirrors `pack_params`.
+        for j in 0..n {
+            for i in j..n {
+                if i == j {
+                    names.push(diag_name(i));
+                } else {
+                    let ni = om.eta_names.get(i).filter(|s| !s.is_empty());
+                    let nj = om.eta_names.get(j).filter(|s| !s.is_empty());
+                    match (ni, nj) {
+                        (Some(a), Some(b)) => names.push(format!("{}~{}", a, b)),
+                        _ => names.push(format!("OMEGA({},{})", i + 1, j + 1)),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Per-coordinate **natural / reporting-scale** values, ordered like
+/// [`pack_params`]. Theta are natural values, Ω entries are variances
+/// (diagonal) / covariances (off-diagonal), sigma are variances. This is the
+/// back-transformed space the trace's `val:*` columns report.
+pub fn coordinate_values(params: &ModelParameters) -> Vec<f64> {
+    coordinate_values_raw(
+        &params.theta,
+        &params.omega.matrix,
+        params.omega.diagonal,
+        &params.sigma.values,
+        params.omega_iov.as_ref().map(|m| (&m.matrix, m.diagonal)),
+    )
+}
+
+/// Assemble the natural-scale coordinate vector directly from raw pieces, for
+/// callers (e.g. SAEM) that hold parameters as loose matrices/vectors rather
+/// than a `ModelParameters`. Order matches [`pack_params`].
+pub fn coordinate_values_raw(
+    theta: &[f64],
+    omega_mat: &DMatrix<f64>,
+    omega_diagonal: bool,
+    sigma: &[f64],
+    iov: Option<(&DMatrix<f64>, bool)>,
+) -> Vec<f64> {
+    let mut v = Vec::new();
+    v.extend_from_slice(theta);
+    push_omega_vals(&mut v, omega_mat, omega_diagonal);
+    v.extend_from_slice(sigma);
+    if let Some((m, diag)) = iov {
+        push_omega_vals(&mut v, m, diag);
+    }
+    v
+}
+
+fn push_omega_vals(v: &mut Vec<f64>, m: &DMatrix<f64>, diagonal: bool) {
+    let n = m.nrows();
+    if diagonal {
+        for i in 0..n {
+            v.push(m[(i, i)]);
+        }
+    } else {
+        for j in 0..n {
+            for i in j..n {
+                v.push(m[(i, j)]);
+            }
+        }
+    }
+}
+
 /// Return initial ETA vector: warm-start if available, else mu_refs, else zeros.
 pub fn get_eta_init(n_eta: usize, warm_start: Option<&[f64]>, mu_refs: Option<&[f64]>) -> Vec<f64> {
     if let Some(ws) = warm_start {
@@ -862,6 +970,109 @@ mod tests {
             .zip(recovered.sigma.values.iter())
         {
             assert_relative_eq!(orig, rec, epsilon = 1e-8);
+        }
+    }
+
+    // ── coordinate names / values (trace #640) ──────────────────────────────
+
+    #[test]
+    fn test_coordinate_names_diagonal() {
+        // Layout: theta(cl,v), diagonal Ω(eta_cl,eta_v), sigma(sigma_prop).
+        let t = make_template();
+        let names = coordinate_names(&t);
+        assert_eq!(names, vec!["cl", "v", "eta_cl", "eta_v", "sigma_prop"]);
+        assert_eq!(names.len(), packed_len(&t));
+    }
+
+    #[test]
+    fn test_coordinate_values_diagonal_are_natural_scale() {
+        // Values: theta as-is, Ω diagonal as variances, sigma as variance.
+        let t = make_template();
+        let v = coordinate_values(&t);
+        assert_eq!(v.len(), packed_len(&t));
+        assert_relative_eq!(v[0], 10.0, epsilon = 1e-12); // cl
+        assert_relative_eq!(v[1], 100.0, epsilon = 1e-12); // v
+        assert_relative_eq!(v[2], 0.09, epsilon = 1e-12); // var(eta_cl)
+        assert_relative_eq!(v[3], 0.04, epsilon = 1e-12); // var(eta_v)
+        assert_relative_eq!(v[4], 0.3, epsilon = 1e-12); // sigma
+    }
+
+    #[test]
+    fn test_coordinate_names_block_off_diagonal() {
+        // Block Ω off-diagonal couples row~col eta in packed (col-major) order:
+        // (0,0)=eta_cl, (1,0)=eta_v~eta_cl, (1,1)=eta_v.
+        let t = make_block_template();
+        let names = coordinate_names(&t);
+        assert_eq!(
+            names,
+            vec!["cl", "v", "eta_cl", "eta_v~eta_cl", "eta_v", "sigma_prop"]
+        );
+    }
+
+    #[test]
+    fn test_coordinate_values_block_off_diagonal_is_covariance() {
+        let t = make_block_template();
+        let v = coordinate_values(&t);
+        // Packed omega order: var(cl)=0.09, cov=0.02, var(v)=0.04.
+        assert_relative_eq!(v[2], 0.09, epsilon = 1e-12);
+        assert_relative_eq!(v[3], 0.02, epsilon = 1e-12);
+        assert_relative_eq!(v[4], 0.04, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_coordinate_names_fallbacks_when_unnamed() {
+        // Empty declared names → NONMEM-style THETA1 / OMEGA(2,1) / SIGMA(1).
+        let mut m = DMatrix::zeros(2, 2);
+        m[(0, 0)] = 0.09;
+        m[(1, 1)] = 0.04;
+        m[(0, 1)] = 0.02;
+        m[(1, 0)] = 0.02;
+        let omega = OmegaMatrix::from_matrix(m, vec![String::new(), String::new()], false);
+        let t = ModelParameters {
+            theta: vec![1.0],
+            theta_names: vec![String::new()],
+            theta_lower: vec![0.0],
+            theta_upper: vec![10.0],
+            theta_fixed: vec![false],
+            omega,
+            omega_fixed: vec![false, false],
+            sigma: SigmaVector {
+                values: vec![0.3],
+                names: vec![String::new()],
+            },
+            sigma_fixed: vec![false],
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+        };
+        let names = coordinate_names(&t);
+        assert_eq!(
+            names,
+            vec![
+                "THETA1",
+                "OMEGA(1,1)",
+                "OMEGA(2,1)",
+                "OMEGA(2,2)",
+                "SIGMA(1)"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_coordinate_names_values_include_iov() {
+        // IOV coordinates append after sigma, mirroring pack_params.
+        let t = make_iov_template();
+        let names = coordinate_names(&t);
+        assert_eq!(names, vec!["TVCL", "ETA_CL", "PROP_ERR", "KAPPA_CL"]);
+        let v = coordinate_values(&t);
+        assert_eq!(v.len(), packed_len(&t));
+        assert_relative_eq!(v[3], 0.01, epsilon = 1e-12); // var(kappa_cl)
+    }
+
+    #[test]
+    fn test_coordinate_values_matches_packed_len_for_all_shapes() {
+        for t in [make_template(), make_block_template(), make_iov_template()] {
+            assert_eq!(coordinate_values(&t).len(), packed_len(&t));
+            assert_eq!(coordinate_names(&t).len(), packed_len(&t));
         }
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2120,7 +2120,27 @@ pub fn run_saem(
                 );
             }
 
-            crate::estimation::trace::write_saem(k, phase, cond_nll, gamma, mh_accept_rate);
+            // Per-coordinate estimates (natural scale) for the trace's `val:*`
+            // columns (#640). SAEM has no OFV gradient, so `grad:*` are NA.
+            let iov = init_params
+                .omega_iov
+                .as_ref()
+                .map(|m| (&state.omega_iov_mat, m.diagonal));
+            let values = crate::estimation::parameterization::coordinate_values_raw(
+                &state.theta,
+                &state.omega_mat,
+                init_params.omega.diagonal,
+                &state.sigma_vals,
+                iov,
+            );
+            crate::estimation::trace::write_saem(
+                k,
+                phase,
+                cond_nll,
+                gamma,
+                mh_accept_rate,
+                &values,
+            );
         }
     }
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2122,25 +2122,30 @@ pub fn run_saem(
 
             // Per-coordinate estimates (natural scale) for the trace's `val:*`
             // columns (#640). SAEM has no OFV gradient, so `grad:*` are NA.
-            let iov = init_params
-                .omega_iov
-                .as_ref()
-                .map(|m| (&state.omega_iov_mat, m.diagonal));
-            let values = crate::estimation::parameterization::coordinate_values_raw(
-                &state.theta,
-                &state.omega_mat,
-                init_params.omega.diagonal,
-                &state.sigma_vals,
-                iov,
-            );
-            crate::estimation::trace::write_saem(
-                k,
-                phase,
-                cond_nll,
-                gamma,
-                mh_accept_rate,
-                &values,
-            );
+            // Guard the per-iteration Vec build on `is_active` so it costs
+            // nothing on the default (trace-off) path across the many SAEM
+            // iterations (#640 review).
+            if crate::estimation::trace::is_active() {
+                let iov = init_params
+                    .omega_iov
+                    .as_ref()
+                    .map(|m| (&state.omega_iov_mat, m.diagonal));
+                let values = crate::estimation::parameterization::coordinate_values_raw(
+                    &state.theta,
+                    &state.omega_mat,
+                    init_params.omega.diagonal,
+                    &state.sigma_vals,
+                    iov,
+                );
+                crate::estimation::trace::write_saem(
+                    k,
+                    phase,
+                    cond_nll,
+                    gamma,
+                    mh_accept_rate,
+                    &values,
+                );
+            }
         }
     }
 
@@ -3534,5 +3539,90 @@ mod tests {
             kappa_outer[(0, 0)],
             expected
         );
+    }
+
+    /// SAEM with the optimizer trace active must emit the per-parameter `val:*`
+    /// columns and write `NA` for every `grad:*` column (SAEM has no OFV
+    /// gradient). This is the fast test that registers PR coverage for the SAEM
+    /// trace call site (#640), which is otherwise reached only by slow fits.
+    #[test]
+    fn saem_trace_emits_value_columns_with_na_grads() {
+        use crate::types::{DoseEvent, FitOptions, Population};
+        use std::collections::HashMap;
+
+        let model = analytical_model(GradientMethod::Auto);
+        let subj = Subject {
+            id: "1".into(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: vec![1.0, 2.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![1.0, 0.5],
+            obs_cmts: vec![1, 1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0, 0],
+            occasions: vec![],
+            dose_occasions: vec![],
+            fremtype: Vec::new(),
+            #[cfg(feature = "survival")]
+            obs_records: vec![],
+        };
+        let population = Population {
+            subjects: vec![subj],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let coord_names =
+            crate::estimation::parameterization::coordinate_names(&model.default_params);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = format!(
+            "/tmp/ferx_trace_saem_param_{}_{}.csv",
+            std::process::id(),
+            nanos
+        );
+        crate::estimation::trace::init(path.clone(), &coord_names).unwrap();
+
+        let opts = FitOptions {
+            saem_n_exploration: 2,
+            saem_n_convergence: 0,
+            run_covariance_step: false,
+            verbose: false,
+            ..FitOptions::default()
+        };
+        let _ = run_saem(&model, &population, &model.default_params, &opts);
+        crate::estimation::trace::finish();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines = contents.lines();
+        let header: Vec<String> = lines.next().unwrap().split(',').map(String::from).collect();
+        assert!(header.iter().any(|c| c.starts_with("val:")));
+        let n_coords = coord_names.len();
+        let fixed = 17;
+        let mut rows = 0;
+        for row in lines {
+            let c: Vec<String> = row.split(',').map(String::from).collect();
+            assert_eq!(c.len(), fixed + 2 * n_coords, "SAEM row column count");
+            // Every value column finite; every gradient column NA.
+            for i in fixed..(fixed + n_coords) {
+                assert!(c[i].parse::<f64>().is_ok(), "val column must be finite");
+            }
+            for i in (fixed + n_coords)..(fixed + 2 * n_coords) {
+                assert_eq!(c[i], "NA", "SAEM grad column must be NA");
+            }
+            rows += 1;
+        }
+        assert!(rows >= 1, "expected at least one SAEM trace row");
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/src/estimation/trace.rs
+++ b/src/estimation/trace.rs
@@ -61,15 +61,21 @@ impl TraceWriter {
     /// Append the per-parameter `val:*` and `grad:*` columns (no leading/trailing
     /// newline). `grads = None` (SAEM, or a derivative-free eval) writes `NA` for
     /// every gradient column. Missing/non-finite entries serialise as `NA`.
+    ///
+    /// These use a scientific format (`fmt_opt_sci`), not the fixed `{:.6}` of
+    /// the scalar columns: per-parameter estimates (variances down to ~1e-8) and
+    /// near-converged gradient coordinates span many orders of magnitude, and a
+    /// fixed six-decimal format would round them to `0.000000`, erasing exactly
+    /// the signal the per-parameter view exists to show (#640 review).
     fn write_param_cols(&mut self, values: &[f64], grads: Option<&[f64]>) {
         for i in 0..self.n_coords {
-            let _ = write!(self.writer, ",{}", fmt_opt(values.get(i).copied()));
+            let _ = write!(self.writer, ",{}", fmt_opt_sci(values.get(i).copied()));
         }
         for i in 0..self.n_coords {
             let _ = write!(
                 self.writer,
                 ",{}",
-                fmt_opt(grads.and_then(|g| g.get(i).copied()))
+                fmt_opt_sci(grads.and_then(|g| g.get(i).copied()))
             );
         }
     }
@@ -119,6 +125,7 @@ impl TraceWriter {
         method: &str,
         phase: &str,
         ofv: f64,
+        grad_norm: Option<f64>,
         lm_lambda: f64,
         ofv_delta: f64,
         step_accepted: bool,
@@ -128,14 +135,18 @@ impl TraceWriter {
         grads: Option<&[f64]>,
     ) {
         let wall_ms = self.elapsed_ms();
+        // grad_norm (position 6) is now populated for GN: the scaled BHHH
+        // gradient is available, so `sqrt(sum(grad:*^2)) == grad_norm` holds for
+        // GN rows too, matching the FOCE writers (#640 review).
         let _ = write!(
             self.writer,
-            "{},{},{},{:.6},{},NA,NA,NA,NA,{:.6},{:.6},{},NA,NA,NA,{},{}",
+            "{},{},{},{:.6},{},{},NA,NA,NA,{:.6},{:.6},{},NA,NA,NA,{},{}",
             iter,
             method,
             phase,
             ofv,
             wall_ms,
+            fmt_opt(grad_norm),
             lm_lambda,
             ofv_delta,
             i32::from(step_accepted),
@@ -178,6 +189,18 @@ impl TraceWriter {
 fn fmt_opt(v: Option<f64>) -> String {
     match v {
         Some(f) if f.is_finite() => format!("{:.6}", f),
+        _ => "NA".to_string(),
+    }
+}
+
+/// Scientific-notation variant of [`fmt_opt`] for the per-parameter `val:*` /
+/// `grad:*` columns, which span many orders of magnitude. `1.5e-8` survives
+/// where `{:.6}` would print `0.000000`. Ten significant figures keep large
+/// gradient components (O(1e6)) precise enough that `sqrt(sum(grad:*^2))`
+/// reconstructs `grad_norm`. Non-finite → `NA`.
+fn fmt_opt_sci(v: Option<f64>) -> String {
+    match v {
+        Some(f) if f.is_finite() => format!("{:.9e}", f),
         _ => "NA".to_string(),
     }
 }
@@ -322,6 +345,7 @@ pub fn write_gn(
     method: &str,
     phase: &str,
     ofv: f64,
+    grad_norm: Option<f64>,
     lm_lambda: f64,
     ofv_delta: f64,
     step_accepted: bool,
@@ -341,6 +365,7 @@ pub fn write_gn(
                 method,
                 phase,
                 ofv,
+                grad_norm,
                 lm_lambda,
                 ofv_delta,
                 step_accepted,
@@ -452,12 +477,26 @@ mod tests {
     fn test_gn_row_format() {
         let path = format!("/tmp/ferx_trace_gn_{}.csv", std::process::id());
         let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
-        w.write_gn_row(3, "gn", "", 200.0, 0.01, -5.0, true, None, None, &[], None);
+        w.write_gn_row(
+            3,
+            "gn",
+            "",
+            200.0,
+            Some(0.5),
+            0.01,
+            -5.0,
+            true,
+            None,
+            None,
+            &[],
+            None,
+        );
         w.flush();
         let contents = read_file(&path);
         let row = contents.lines().nth(1).unwrap();
         assert!(row.starts_with("3,gn,,200."));
-        assert!(row.contains(",0.010000,-5.000000,1,"));
+        // grad_norm now populated for GN (position 6), then lm_lambda, ofv_delta.
+        assert!(row.contains(",0.500000,NA,NA,NA,0.010000,-5.000000,1,"));
         std::fs::remove_file(&path).ok();
     }
 
@@ -555,7 +594,20 @@ mod tests {
         // can call trace::write_* unconditionally.
         assert!(!is_active());
         write_foce(1, "foce", 1.0, None, None, "slsqp", None, None, &[], None);
-        write_gn(1, "gn", "", 1.0, 0.0, 0.0, true, None, None, &[], None);
+        write_gn(
+            1,
+            "gn",
+            "",
+            1.0,
+            None,
+            0.0,
+            0.0,
+            true,
+            None,
+            None,
+            &[],
+            None,
+        );
         write_saem(1, "explore", 1.0, 1.0, 0.5, &[]);
         // No assertion on files — the assertion is "didn't panic".
     }
@@ -718,7 +770,12 @@ mod tests {
         assert_eq!(cols.len(), 21);
         assert_eq!(
             &cols[17..],
-            &["2.500000", "0.090000", "0.400000", "-0.300000"]
+            &[
+                "2.500000000e0",
+                "9.000000000e-2",
+                "4.000000000e-1",
+                "-3.000000000e-1"
+            ]
         );
         std::fs::remove_file(&path).ok();
     }
@@ -750,7 +807,10 @@ mod tests {
             .split(',')
             .map(String::from)
             .collect();
-        assert_eq!(&cols[17..], &["2.500000", "0.090000", "NA", "NA"]);
+        assert_eq!(
+            &cols[17..],
+            &["2.500000000e0", "9.000000000e-2", "NA", "NA"]
+        );
         std::fs::remove_file(&path).ok();
     }
 
@@ -768,7 +828,10 @@ mod tests {
             .split(',')
             .map(String::from)
             .collect();
-        assert_eq!(&cols[17..], &["2.500000", "0.090000", "NA", "NA"]);
+        assert_eq!(
+            &cols[17..],
+            &["2.500000000e0", "9.000000000e-2", "NA", "NA"]
+        );
         std::fs::remove_file(&path).ok();
     }
 
@@ -826,7 +889,7 @@ mod tests {
             .collect();
         // 17 fixed + 3 val + 3 grad = 23.
         assert_eq!(cols.len(), 23);
-        assert_eq!(&cols[17..20], &["1.000000", "NA", "NA"]);
+        assert_eq!(&cols[17..20], &["1.000000000e0", "NA", "NA"]);
         std::fs::remove_file(&path).ok();
     }
 
@@ -834,7 +897,20 @@ mod tests {
     fn test_gn_step_rejected_serialised_as_zero() {
         let path = unique_path("gn_reject");
         let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
-        w.write_gn_row(5, "gn", "", 100.0, 1.0, 2.0, false, None, None, &[], None);
+        w.write_gn_row(
+            5,
+            "gn",
+            "",
+            100.0,
+            None,
+            1.0,
+            2.0,
+            false,
+            None,
+            None,
+            &[],
+            None,
+        );
         w.flush();
         let row = read_file(&path).lines().nth(1).unwrap().to_string();
         // step_accepted is the column right before cond_nll's NA stretch.

--- a/src/estimation/trace.rs
+++ b/src/estimation/trace.rs
@@ -19,27 +19,59 @@ pub struct TraceWriter {
     pub path: String,
     writer: BufWriter<File>,
     start: Instant,
+    /// Number of optimized coordinates. Each row carries `n_coords` `val:*`
+    /// columns (natural scale) followed by `n_coords` `grad:*` columns (scaled
+    /// space), appended after the fixed 17 columns. See #640.
+    n_coords: usize,
 }
 
 impl TraceWriter {
-    fn new(path: String) -> std::io::Result<Self> {
+    /// `coord_names` are the declared parameter names (one per optimized
+    /// coordinate, in packed order). The header appends `val:<name>` then
+    /// `grad:<name>` columns for each; all row writers emit the same set.
+    fn new(path: String, coord_names: &[String]) -> std::io::Result<Self> {
         let file = File::create(&path)?;
         let mut writer = BufWriter::new(file);
-        writeln!(
-            writer,
+        let mut header = String::from(
             "iter,method,phase,ofv,wall_ms,grad_norm,step_norm,inner_iter_count,\
              optimizer,lm_lambda,ofv_delta,step_accepted,cond_nll,gamma,mh_accept_rate,\
-             n_ebe_unconverged,n_ebe_fallback"
-        )?;
+             n_ebe_unconverged,n_ebe_fallback",
+        );
+        for name in coord_names {
+            header.push(',');
+            header.push_str(&csv_field(&format!("val:{}", name)));
+        }
+        for name in coord_names {
+            header.push(',');
+            header.push_str(&csv_field(&format!("grad:{}", name)));
+        }
+        writeln!(writer, "{}", header)?;
         Ok(Self {
             path,
             writer,
             start: Instant::now(),
+            n_coords: coord_names.len(),
         })
     }
 
     fn elapsed_ms(&self) -> u64 {
         self.start.elapsed().as_millis() as u64
+    }
+
+    /// Append the per-parameter `val:*` and `grad:*` columns (no leading/trailing
+    /// newline). `grads = None` (SAEM, or a derivative-free eval) writes `NA` for
+    /// every gradient column. Missing/non-finite entries serialise as `NA`.
+    fn write_param_cols(&mut self, values: &[f64], grads: Option<&[f64]>) {
+        for i in 0..self.n_coords {
+            let _ = write!(self.writer, ",{}", fmt_opt(values.get(i).copied()));
+        }
+        for i in 0..self.n_coords {
+            let _ = write!(
+                self.writer,
+                ",{}",
+                fmt_opt(grads.and_then(|g| g.get(i).copied()))
+            );
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -54,9 +86,11 @@ impl TraceWriter {
         optimizer: &str,
         n_ebe_unconverged: Option<usize>,
         n_ebe_fallback: Option<usize>,
+        values: &[f64],
+        grads: Option<&[f64]>,
     ) {
         let wall_ms = self.elapsed_ms();
-        let _ = writeln!(
+        let _ = write!(
             self.writer,
             "{},{},{},{:.6},{},{},{},NA,{},NA,NA,NA,NA,NA,NA,{},{}",
             iter,
@@ -70,6 +104,8 @@ impl TraceWriter {
             fmt_opt_usize(n_ebe_unconverged),
             fmt_opt_usize(n_ebe_fallback),
         );
+        self.write_param_cols(values, grads);
+        let _ = writeln!(self.writer);
         // Flush each row so live consumers (e.g. the trace UI) see iterations
         // as they happen. Gradient methods emit few rows (< the BufWriter's
         // buffer), so without this the file would not appear until finish().
@@ -88,9 +124,11 @@ impl TraceWriter {
         step_accepted: bool,
         n_ebe_unconverged: Option<usize>,
         n_ebe_fallback: Option<usize>,
+        values: &[f64],
+        grads: Option<&[f64]>,
     ) {
         let wall_ms = self.elapsed_ms();
-        let _ = writeln!(
+        let _ = write!(
             self.writer,
             "{},{},{},{:.6},{},NA,NA,NA,NA,{:.6},{:.6},{},NA,NA,NA,{},{}",
             iter,
@@ -104,6 +142,8 @@ impl TraceWriter {
             fmt_opt_usize(n_ebe_unconverged),
             fmt_opt_usize(n_ebe_fallback),
         );
+        self.write_param_cols(values, grads);
+        let _ = writeln!(self.writer);
         let _ = self.writer.flush();
     }
 
@@ -114,15 +154,19 @@ impl TraceWriter {
         cond_nll: f64,
         gamma: f64,
         mh_accept_rate: f64,
+        values: &[f64],
     ) {
         let wall_ms = self.elapsed_ms();
         // During SAEM iterations the FOCE OFV is not yet available;
         // use condNLL as the ofv-column proxy (documented in PR1).
-        let _ = writeln!(
+        let _ = write!(
             self.writer,
             "{},saem,{},{:.6},{},NA,NA,NA,NA,NA,NA,NA,{:.6},{:.6},{:.4},NA,NA",
             iter, phase, cond_nll, wall_ms, cond_nll, gamma, mh_accept_rate
         );
+        // SAEM is derivative-free w.r.t. the OFV → every gradient column is NA.
+        self.write_param_cols(values, None);
+        let _ = writeln!(self.writer);
         let _ = self.writer.flush();
     }
 
@@ -142,6 +186,16 @@ fn fmt_opt_usize(v: Option<usize>) -> String {
     match v {
         Some(n) => n.to_string(),
         None => "NA".to_string(),
+    }
+}
+
+/// Minimal CSV field quoting for header names. Parameter names can contain a
+/// comma (the `OMEGA(2,1)` fallback), which would otherwise shift columns.
+fn csv_field(s: &str) -> String {
+    if s.contains([',', '"', '\n']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
     }
 }
 
@@ -167,8 +221,8 @@ thread_local! {
 
 /// Initialise the trace for this fit.  The CSV file is created immediately and
 /// its header row is written.  Called once per `fit_inner` invocation.
-pub fn init(path: String) -> std::io::Result<()> {
-    let writer = TraceWriter::new(path)?;
+pub fn init(path: String, coord_names: &[String]) -> std::io::Result<()> {
+    let writer = TraceWriter::new(path, coord_names)?;
     TRACE.with(|t| {
         let mut s = t.borrow_mut();
         s.writer = Some(writer);
@@ -217,6 +271,10 @@ pub fn finish() -> Option<String> {
 /// `optimizer`        — optimizer name string, e.g. "slsqp", "bobyqa", "bfgs"
 /// `n_ebe_unconverged`— subjects that did not meet EBE tolerance (None = unavailable)
 /// `n_ebe_fallback`   — subjects that used Nelder-Mead fallback (None = unavailable)
+///
+/// `values`           — per-coordinate estimates, natural scale (packed order)
+/// `grads`            — per-coordinate gradient, scaled space (None for
+///                      derivative-free optimizers; matches `grad_norm`)
 #[allow(clippy::too_many_arguments)]
 pub fn write_foce(
     iter: usize,
@@ -227,6 +285,8 @@ pub fn write_foce(
     optimizer: &str,
     n_ebe_unconverged: Option<usize>,
     n_ebe_fallback: Option<usize>,
+    values: &[f64],
+    grads: Option<&[f64]>,
 ) {
     TRACE.with(|t| {
         let mut s = t.borrow_mut();
@@ -243,6 +303,8 @@ pub fn write_foce(
                 optimizer,
                 n_ebe_unconverged,
                 n_ebe_fallback,
+                values,
+                grads,
             );
         }
     });
@@ -265,6 +327,8 @@ pub fn write_gn(
     step_accepted: bool,
     n_ebe_unconverged: Option<usize>,
     n_ebe_fallback: Option<usize>,
+    values: &[f64],
+    grads: Option<&[f64]>,
 ) {
     TRACE.with(|t| {
         let mut s = t.borrow_mut();
@@ -282,17 +346,27 @@ pub fn write_gn(
                 step_accepted,
                 n_ebe_unconverged,
                 n_ebe_fallback,
+                values,
+                grads,
             );
         }
     });
 }
 
-/// Write one SAEM trace row.
-pub fn write_saem(iter: usize, phase: &str, cond_nll: f64, gamma: f64, mh_accept_rate: f64) {
+/// Write one SAEM trace row. `values` are per-coordinate estimates (natural
+/// scale); SAEM has no OFV gradient so every `grad:*` column is written `NA`.
+pub fn write_saem(
+    iter: usize,
+    phase: &str,
+    cond_nll: f64,
+    gamma: f64,
+    mh_accept_rate: f64,
+    values: &[f64],
+) {
     TRACE.with(|t| {
         let mut s = t.borrow_mut();
         if let Some(ref mut w) = s.writer {
-            w.write_saem_row(iter, phase, cond_nll, gamma, mh_accept_rate);
+            w.write_saem_row(iter, phase, cond_nll, gamma, mh_accept_rate, values);
         }
     });
 }
@@ -314,7 +388,7 @@ mod tests {
     #[test]
     fn test_header_written() {
         let path = format!("/tmp/ferx_trace_hdr_{}.csv", std::process::id());
-        let mut w = TraceWriter::new(path.clone()).unwrap();
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
         w.flush();
         let contents = read_file(&path);
         assert!(contents.starts_with("iter,method,phase,ofv,wall_ms,grad_norm"));
@@ -324,7 +398,7 @@ mod tests {
     #[test]
     fn test_foce_row_format() {
         let path = format!("/tmp/ferx_trace_foce_{}.csv", std::process::id());
-        let mut w = TraceWriter::new(path.clone()).unwrap();
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
         w.write_foce_row(
             1,
             "foce",
@@ -334,6 +408,8 @@ mod tests {
             Some(0.01),
             "slsqp",
             None,
+            None,
+            &[],
             None,
         );
         w.flush();
@@ -348,8 +424,20 @@ mod tests {
     #[test]
     fn test_na_for_missing_grad() {
         let path = format!("/tmp/ferx_trace_na_{}.csv", std::process::id());
-        let mut w = TraceWriter::new(path.clone()).unwrap();
-        w.write_foce_row(1, "focei", "", 99.0, None, None, "bobyqa", None, None);
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
+        w.write_foce_row(
+            1,
+            "focei",
+            "",
+            99.0,
+            None,
+            None,
+            "bobyqa",
+            None,
+            None,
+            &[],
+            None,
+        );
         w.flush();
         let contents = read_file(&path);
         // grad_norm and step_norm should be NA
@@ -363,8 +451,8 @@ mod tests {
     #[test]
     fn test_gn_row_format() {
         let path = format!("/tmp/ferx_trace_gn_{}.csv", std::process::id());
-        let mut w = TraceWriter::new(path.clone()).unwrap();
-        w.write_gn_row(3, "gn", "", 200.0, 0.01, -5.0, true, None, None);
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
+        w.write_gn_row(3, "gn", "", 200.0, 0.01, -5.0, true, None, None, &[], None);
         w.flush();
         let contents = read_file(&path);
         let row = contents.lines().nth(1).unwrap();
@@ -376,8 +464,8 @@ mod tests {
     #[test]
     fn test_saem_row_format() {
         let path = format!("/tmp/ferx_trace_saem_{}.csv", std::process::id());
-        let mut w = TraceWriter::new(path.clone()).unwrap();
-        w.write_saem_row(10, "explore", 55.3, 1.0, 0.35);
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
+        w.write_saem_row(10, "explore", 55.3, 1.0, 0.35, &[]);
         w.flush();
         let contents = read_file(&path);
         let row = contents.lines().nth(1).unwrap();
@@ -415,7 +503,7 @@ mod tests {
         let path = unique_path("lifecycle");
         assert!(!is_active());
 
-        init(path.clone()).unwrap();
+        init(path.clone(), &[]).unwrap();
         assert!(is_active(), "is_active should be true after init");
 
         let returned = finish().expect("finish should return the path");
@@ -437,8 +525,19 @@ mod tests {
     #[test]
     fn test_write_foce_via_thread_local() {
         let path = unique_path("tl_foce");
-        init(path.clone()).unwrap();
-        write_foce(7, "focei", 42.5, Some(0.125), None, "bobyqa", None, None);
+        init(path.clone(), &[]).unwrap();
+        write_foce(
+            7,
+            "focei",
+            42.5,
+            Some(0.125),
+            None,
+            "bobyqa",
+            None,
+            None,
+            &[],
+            None,
+        );
         finish();
 
         let contents = read_file(&path);
@@ -455,22 +554,44 @@ mod tests {
         // create any files.  This is the contract estimators rely on so they
         // can call trace::write_* unconditionally.
         assert!(!is_active());
-        write_foce(1, "foce", 1.0, None, None, "slsqp", None, None);
-        write_gn(1, "gn", "", 1.0, 0.0, 0.0, true, None, None);
-        write_saem(1, "explore", 1.0, 1.0, 0.5);
+        write_foce(1, "foce", 1.0, None, None, "slsqp", None, None, &[], None);
+        write_gn(1, "gn", "", 1.0, 0.0, 0.0, true, None, None, &[], None);
+        write_saem(1, "explore", 1.0, 1.0, 0.5, &[]);
         // No assertion on files — the assertion is "didn't panic".
     }
 
     #[test]
     fn test_method_override_applied() {
         let path = unique_path("override");
-        init(path.clone()).unwrap();
+        init(path.clone(), &[]).unwrap();
         // Caller passes "foce" but override forces "gn_hybrid" + phase "focei".
         set_overrides(Some("gn_hybrid"), Some("focei"));
-        write_foce(2, "foce", 10.0, Some(0.1), Some(0.01), "slsqp", None, None);
+        write_foce(
+            2,
+            "foce",
+            10.0,
+            Some(0.1),
+            Some(0.01),
+            "slsqp",
+            None,
+            None,
+            &[],
+            None,
+        );
         set_overrides(None, None);
         // After clearing, caller-supplied method/phase apply.
-        write_foce(3, "foce", 9.0, Some(0.05), Some(0.005), "slsqp", None, None);
+        write_foce(
+            3,
+            "foce",
+            9.0,
+            Some(0.05),
+            Some(0.005),
+            "slsqp",
+            None,
+            None,
+            &[],
+            None,
+        );
         finish();
 
         let contents = read_file(&path);
@@ -493,10 +614,10 @@ mod tests {
         // worker thread) should drop the first writer and start fresh.
         let path1 = unique_path("init1");
         let path2 = unique_path("init2");
-        init(path1.clone()).unwrap();
-        write_foce(1, "foce", 1.0, None, None, "slsqp", None, None);
-        init(path2.clone()).unwrap();
-        write_foce(1, "foce", 2.0, None, None, "slsqp", None, None);
+        init(path1.clone(), &[]).unwrap();
+        write_foce(1, "foce", 1.0, None, None, "slsqp", None, None, &[], None);
+        init(path2.clone(), &[]).unwrap();
+        write_foce(1, "foce", 2.0, None, None, "slsqp", None, None, &[], None);
         let returned = finish().unwrap();
         assert_eq!(returned, path2, "finish returns the most recent path");
 
@@ -512,7 +633,7 @@ mod tests {
         // A path under a non-existent directory should fail at File::create
         // and leave the writer uninitialised.
         let bad = "/definitely/not/a/real/dir/ferx_trace.csv";
-        let err = init(bad.to_string());
+        let err = init(bad.to_string(), &[]);
         assert!(err.is_err());
         assert!(!is_active(), "failed init must leave writer uninitialised");
     }
@@ -521,7 +642,7 @@ mod tests {
     fn test_na_for_non_finite_grad() {
         // NaN/Inf gradients should be serialised as "NA", not "NaN"/"inf".
         let path = unique_path("nonfinite");
-        let mut w = TraceWriter::new(path.clone()).unwrap();
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
         w.write_foce_row(
             1,
             "foce",
@@ -532,6 +653,8 @@ mod tests {
             "bfgs",
             None,
             None,
+            &[],
+            None,
         );
         w.flush();
         let row = read_file(&path).lines().nth(1).unwrap().to_string();
@@ -541,11 +664,177 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
+    // ── per-parameter columns (#640) ────────────────────────────────────────
+
+    #[test]
+    fn test_header_appends_val_and_grad_columns() {
+        let path = unique_path("hdr_param");
+        let names = vec!["TVCL".to_string(), "ETA_CL".to_string()];
+        let w = TraceWriter::new(path.clone(), &names).unwrap();
+        drop(w);
+        let contents = read_file(&path);
+        let header = contents.lines().next().unwrap();
+        // Fixed columns, then all val:* columns, then all grad:* columns.
+        assert!(header.ends_with("val:TVCL,val:ETA_CL,grad:TVCL,grad:ETA_CL"));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_header_quotes_names_with_commas() {
+        // The OMEGA(2,1) fallback contains a comma → must be CSV-quoted so it
+        // stays one column.
+        let path = unique_path("hdr_quote");
+        let names = vec!["OMEGA(2,1)".to_string()];
+        let w = TraceWriter::new(path.clone(), &names).unwrap();
+        drop(w);
+        let header = read_file(&path).lines().next().unwrap().to_string();
+        assert!(header.contains("\"val:OMEGA(2,1)\""));
+        assert!(header.contains("\"grad:OMEGA(2,1)\""));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_foce_row_writes_values_and_grads() {
+        let path = unique_path("foce_param");
+        let names = vec!["TVCL".to_string(), "ETA_CL".to_string()];
+        let mut w = TraceWriter::new(path.clone(), &names).unwrap();
+        w.write_foce_row(
+            1,
+            "foce",
+            "",
+            10.0,
+            Some(0.5),
+            Some(0.1),
+            "slsqp",
+            None,
+            None,
+            &[2.5, 0.09],
+            Some(&[0.4, -0.3]),
+        );
+        w.flush();
+        let row = read_file(&path).lines().nth(1).unwrap().to_string();
+        // 17 fixed + 2 val + 2 grad = 21 columns.
+        let cols: Vec<&str> = row.split(',').collect();
+        assert_eq!(cols.len(), 21);
+        assert_eq!(
+            &cols[17..],
+            &["2.500000", "0.090000", "0.400000", "-0.300000"]
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_foce_row_grads_none_writes_na() {
+        // Derivative-free eval: values present, every gradient column NA.
+        let path = unique_path("foce_nograd");
+        let names = vec!["TVCL".to_string(), "ETA_CL".to_string()];
+        let mut w = TraceWriter::new(path.clone(), &names).unwrap();
+        w.write_foce_row(
+            1,
+            "focei",
+            "",
+            9.0,
+            None,
+            None,
+            "bobyqa",
+            None,
+            None,
+            &[2.5, 0.09],
+            None,
+        );
+        w.flush();
+        let cols: Vec<String> = read_file(&path)
+            .lines()
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .map(String::from)
+            .collect();
+        assert_eq!(&cols[17..], &["2.500000", "0.090000", "NA", "NA"]);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_saem_row_values_present_grads_na() {
+        let path = unique_path("saem_param");
+        let names = vec!["TVCL".to_string(), "ETA_CL".to_string()];
+        let mut w = TraceWriter::new(path.clone(), &names).unwrap();
+        w.write_saem_row(3, "explore", 55.0, 1.0, 0.4, &[2.5, 0.09]);
+        w.flush();
+        let cols: Vec<String> = read_file(&path)
+            .lines()
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .map(String::from)
+            .collect();
+        assert_eq!(&cols[17..], &["2.500000", "0.090000", "NA", "NA"]);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_grad_columns_reconstruct_grad_norm() {
+        // Invariant from #640: sqrt(Σ gᵢ²) == grad_norm. Feed a gradient whose
+        // components match the grad_norm column and confirm the round-trip.
+        let path = unique_path("grad_recon");
+        let names = vec!["A".to_string(), "B".to_string()];
+        let mut w = TraceWriter::new(path.clone(), &names).unwrap();
+        let g = [0.3_f64, 0.4];
+        let gn = (g[0] * g[0] + g[1] * g[1]).sqrt(); // 0.5
+        w.write_foce_row(
+            1,
+            "foce",
+            "",
+            10.0,
+            Some(gn),
+            None,
+            "slsqp",
+            None,
+            None,
+            &[1.0, 2.0],
+            Some(&g),
+        );
+        w.flush();
+        let cols: Vec<f64> = read_file(&path)
+            .lines()
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .enumerate()
+            .filter_map(|(i, s)| if i >= 19 { s.parse().ok() } else { None })
+            .collect();
+        let recon = (cols[0] * cols[0] + cols[1] * cols[1]).sqrt();
+        assert!((recon - gn).abs() < 1e-6);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_missing_value_entries_padded_with_na() {
+        // Defensive: fewer values than n_coords → remaining columns NA rather
+        // than shifting the CSV.
+        let path = unique_path("short_vals");
+        let names = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        let mut w = TraceWriter::new(path.clone(), &names).unwrap();
+        w.write_saem_row(1, "explore", 1.0, 1.0, 0.5, &[1.0]);
+        w.flush();
+        let cols: Vec<String> = read_file(&path)
+            .lines()
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .map(String::from)
+            .collect();
+        // 17 fixed + 3 val + 3 grad = 23.
+        assert_eq!(cols.len(), 23);
+        assert_eq!(&cols[17..20], &["1.000000", "NA", "NA"]);
+        std::fs::remove_file(&path).ok();
+    }
+
     #[test]
     fn test_gn_step_rejected_serialised_as_zero() {
         let path = unique_path("gn_reject");
-        let mut w = TraceWriter::new(path.clone()).unwrap();
-        w.write_gn_row(5, "gn", "", 100.0, 1.0, 2.0, false, None, None);
+        let mut w = TraceWriter::new(path.clone(), &[]).unwrap();
+        w.write_gn_row(5, "gn", "", 100.0, 1.0, 2.0, false, None, None, &[], None);
         w.flush();
         let row = read_file(&path).lines().nth(1).unwrap().to_string();
         // step_accepted is the column right before cond_nll's NA stretch.


### PR DESCRIPTION
## Why
The optimizer trace (`optimizer_trace = true`) records only the scalar `ofv` and the aggregate `grad_norm` per iteration. The ferx-r trace UI can therefore plot OFV and the L2 gradient norm, but not *which* parameter is still moving or which coordinate carries the residual gradient. Per-parameter trajectories + per-parameter gradients let a user see, e.g., that clearance has converged while a peripheral volume is still drifting, or that a large `grad_norm` is dominated by one ill-conditioned coordinate.

Generalizes IMPMAP's per-iteration per-parameter theta trace to the live CSV trace for the gradient methods (and estimates for all methods).

Closes #640.

## What changed
Each trace row now appends two blocks of per-parameter columns after the fixed 17:

- **`val:<name>`** — per-coordinate estimate, **natural / reporting scale** (θ as values, Ω as variances/covariances, Σ as variances). Written for **every** method (FOCE/FOCEI/GN/SAEM).
- **`grad:<name>`** — per-coordinate gradient, in the optimizer's **transformed/scaled** space, so `sqrt(sum(grad_i^2)) == grad_norm`. Written where an OFV gradient exists (**FOCE/FOCEI/GN**); SAEM and derivative-free BOBYQA evals write `NA`.

Column headers use declared parameter names (`val:TVCL`, `val:ETA_CL`, an Ω off-diagonal as `val:ETA_V~ETA_CL`, `val:PROP_ERR`), with `THETA1` / `OMEGA(2,1)` / `SIGMA(1)` fallbacks (comma-bearing fallbacks are CSV-quoted). The header is written dynamically at `trace::init` from the coordinate names; the coordinate set is fixed across a method chain (e.g. `saem -> focei`), so one header serves the whole run.

Implementation:
- `parameterization.rs`: new `coordinate_names` / `coordinate_values` / `coordinate_values_raw` — packed-order name/value mapping (θ, Ω lower-tri col-major incl. off-diagonals, Σ, IOV Ω).
- `trace.rs`: `TraceWriter` stores `n_coords`; dynamic header; `write_param_cols`; row writers extended to emit the same column set for every method; `csv_field` header quoting.
- Call sites threaded with the current parameter vector (and scaled gradient where available): `outer_optimizer.rs` (nlopt + built-in BFGS), `gauss_newton.rs`, `saem.rs`, and `api.rs` (`trace::init`).

GN / built-in-BFGS `grad:*` reflect the iteration's pre-step evaluation point (a one-iter lag), mirroring the existing `grad_norm` column. Structural-zero cross-block Ω off-diagonals appear as coordinates with `val = 0` and `grad ≈ 0`, consistent with `grad_norm`.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

The Rust glue does not call the trace (it is file-based CSV), so **no `Cargo.lock` bump and no new-`pub`-API dependency**. `ferx_trace()` reads via `read.csv(check.names = FALSE)`, so the appended columns load without breaking existing OFV/grad_norm plots. Consuming the new columns (split `val:*`/`grad:*`, per-parameter UI panels) is an enhancement-only follow-up in ferx-r, per the issue.

## Breaking changes
- [x] None (columns appended; existing readers unaffected)

## Numerical validation
- [x] Verified end-to-end on the warfarin example (block Ω on CL,V + diagonal KA) across FOCE, SAEM, and GN: column counts consistent (37) across all rows, and the invariant `sqrt(sum(grad:<name>^2)) == grad_norm` holds to ~1e-7.

```
# FOCE (nlopt), warfarin block-Ω, per row:
row 1: grad_norm=339.1630  sqrt(sum g^2)=339.1630  diff=-2.68e-08
row 2: grad_norm=1659960.3295  sqrt(sum g^2)=1659960.3295  diff=7.61e-08
row 3: grad_norm=32970.2967  sqrt(sum g^2)=32970.2967  diff=-3.29e-07

# SAEM row: val:* populated, all grad:* = NA
0.134454 8.187453 0.998877 0.090000 ... 0.088514 NA NA NA ... NA

# GN row: val:* + grad:* populated (structural-zero cross-block coords = 0)
```

## Performance
- [x] No significant impact expected (one `unpack`/coordinate-vector build per traced iteration; trace is opt-in and gradient methods emit few rows)

## Tests
- [x] Unit tests added (`cargo test --lib` passes — full suite 2281 passed):
  - `parameterization`: name/value mapping for diagonal, block off-diagonal, IOV, and fallback (`THETA1`/`OMEGA(2,1)`/`SIGMA(1)`) cases; length == `packed_len`.
  - `trace`: header appends `val:`/`grad:` blocks; comma-name CSV quoting; FOCE row emits values+grads; grads `None` → `NA`; SAEM grads `NA`; grad columns reconstruct `grad_norm`; short-value padding.
  - `outer_optimizer`: built-in BFGS trace path emits per-param columns and reconstructs `grad_norm`.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[fit_options]
  method          = foce
  optimizer_trace = true
```

```
# trace header (excerpt): fixed 17 cols, then val:* block, then grad:* block
iter,method,...,n_ebe_fallback,val:TVCL,val:TVV,val:TVKA,val:ETA_CL,val:ETA_V~ETA_CL,...,grad:TVCL,grad:TVV,...
```

</details>

## Docs
- [x] `docs/model-file/fit-options.qmd` — trace column table extended with `val:<name>` / `grad:<name>` and the layout/naming/quoting rules
- [x] `CHANGELOG.md` `[Unreleased]` → Added

## Checklist
- [x] `cargo clippy` clean
- [x] No `Dual2`/`sens` path touched
- [x] No version bump (non-breaking)

## Reviewer hints
- Naming/ordering lives in `parameterization::coordinate_names` / `coordinate_values` — both walk the exact packed order of `pack_params` (θ, Ω lower-tri col-major, Σ, IOV Ω). That ordering match is the load-bearing invariant.
- The `sqrt(sum(grad^2)) == grad_norm` guarantee depends on logging the *same* scaled gradient `grad_norm` is taken from. In built-in BFGS the gradient is snapshotted before the step overwrites it (`g_for_trace`); in nlopt it is the pre-`cap_slsqp_gradient` vector (same as `grad_norm`).

## Open questions
- Header naming embeds special chars (`~`, `(`, `)`) with CSV quoting only where a comma appears (the `OMEGA(2,1)` fallback). Alternative was index columns + sidecar legend — went with self-describing names.