### PR TITLE
feat(cli): compare multiple runs with `ferx summary` [closes #749]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **`ferx summary` compares multiple runs** (#749): pass two or more `.fitrx`
+  bundles (`ferx summary run1.fitrx run2.fitrx run3.fitrx`) to print a Markdown
+  table comparing them side by side — method, convergence, OFV/AIC/BIC, ΔOFV,
+  runtime, subject/observation/parameter counts, and THETA/OMEGA/SIGMA
+  estimates. A single bundle still prints the detailed `psn::sumo`-style report.
 - **`[data]` block column renaming** (#730, #742): rename any dataset header to
   any new name with `new-name = actual` entries (e.g. `TIME = TAFD`,
   `DV = CONC`), the ferx equivalent of NONMEM's `$INPUT TIME=TAFD`. Targets are

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -8,7 +8,7 @@ The `ferx` command-line tool runs population PK estimation from model files and 
 ferx <model.ferx> --data <data.csv> [--output <run.fitrx>] [--include-data] [--inits-from-nca[=METHOD]]
 ferx <model.ferx> --simulate          [--output <run.fitrx>]
 ferx check <model.ferx> [--data <data.csv>] [--json]
-ferx summary <run.fitrx>
+ferx summary <run.fitrx> [<run2.fitrx> ...]
 ferx --help                    # or -h; also: ferx check --help, ferx summary --help
 ```
 
@@ -103,6 +103,37 @@ Subjects: 32   Observations: 251   Parameters: 7
 
 The exit code is `0` on success, `1` if the bundle cannot be loaded, and `2` on
 a usage error (missing path).
+
+#### Compare Multiple Runs
+
+Pass two or more bundles to compare them side by side. Instead of the single-run
+report above, `summary` prints a **Markdown table** — method, convergence,
+OFV / AIC / BIC, ΔOFV (relative to the first run), runtime, and the subject /
+observation / parameter counts, followed by THETA (with %RSE), OMEGA, and SIGMA
+estimate tables. Each column is labelled with the bundle's file stem, and a `—`
+marks a parameter absent from a run. Handy for pasting into a report or a PR.
+
+```bash
+ferx summary run1.fitrx run2.fitrx run3.fitrx
+```
+
+```markdown
+| Run | run1 | run2 | run3 |
+| --- | --- | --- | --- |
+| Model | warfarin | warfarin | warfarin |
+| Method | FOCE | FOCEI | SAEM → IMP |
+| Converged | yes | yes | yes |
+| OFV | -280.3639 | -281.0102 | -280.9998 |
+| ΔOFV | +0.0000 | -0.6463 | -0.6359 |
+| ... | ... | ... | ... |
+
+**THETA**
+
+| Parameter | run1 | run2 | run3 |
+| --- | --- | --- | --- |
+| TVCL | 0.1330 (5.0%) | 0.1332 (4.9%) | 0.1331 (5.1%) |
+| ... | ... | ... | ... |
+```
 
 ## Output Files
 

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -8,7 +8,7 @@ const MAIN_USAGE: &str = "\
 Usage: ferx <model.ferx> --data <data.csv> [--threads N|auto] [--output <run.fitrx>] [--include-data] [--inits-from-nca[=nca|nca_sweep|nca_ebe]]
        ferx <model.ferx> --simulate          [--threads N|auto] [--output <run.fitrx>]
        ferx check <model.ferx> [--data <data.csv>] [--json]
-       ferx summary <run.fitrx>
+       ferx summary <run.fitrx> [<run2.fitrx> ...]
 
 Fits a NLME model and writes sdtab.csv with residuals.
 Data must be in NONMEM format (ID, TIME, DV, EVID, AMT, CMT, ...)
@@ -231,38 +231,73 @@ fn main() {
 }
 
 const SUMMARY_USAGE: &str = "\
-Usage: ferx summary <run.fitrx>
+Usage: ferx summary <run.fitrx> [<run2.fitrx> ...]
 
-Prints a psn::sumo-style summary — parameter estimates with %RSE
-plus basic run info — from a saved .fitrx fit bundle.
+With one bundle: prints a psn::sumo-style summary — parameter estimates
+with %RSE plus basic run info.
+
+With two or more bundles: prints a Markdown table comparing the runs
+(method, convergence, OFV/AIC/BIC, ΔOFV, runtime, sizes, and parameter
+estimates) side by side.
 ";
 
-/// Run the `summary` subcommand: load a `.fitrx` bundle and print a
-/// `psn::sumo`-style summary (parameter estimates + basic run info) to stdout.
-/// Returns the process exit code: `0` = printed (incl. `--help`), `1` = load
+/// Run the `summary` subcommand: load one or more `.fitrx` bundles.
+///
+/// A single bundle prints a `psn::sumo`-style summary (parameter estimates +
+/// basic run info). Two or more bundles print a Markdown comparison table.
+/// The column label for each run is the bundle's file stem.
+///
+/// Returns the process exit code: `0` = printed (incl. `--help`), `1` = a load
 /// failed, `2` = usage (missing/flag-looking path).
 fn run_summary(args: &[String]) -> i32 {
     if is_help_flag(args.get(2)) {
         print!("{SUMMARY_USAGE}");
         return 0;
     }
-    let path = match args.get(2) {
-        Some(p) if !p.starts_with("--") => p.as_str(),
-        _ => {
-            eprint!("{SUMMARY_USAGE}");
-            return 2;
-        }
-    };
-    match ferx_core::io::fitrx::load_fit(std::path::Path::new(path)) {
-        Ok(loaded) => {
-            print!("{}", ferx_core::io::output::format_summary(&loaded.fit));
-            0
-        }
-        Err(e) => {
-            eprintln!("Error: failed to load {}: {}", path, e);
-            1
+    // Collect every positional (non-flag) argument after `summary`.
+    let paths: Vec<&str> = args[2..]
+        .iter()
+        .take_while(|a| !a.starts_with("--"))
+        .map(String::as_str)
+        .collect();
+    if paths.is_empty() {
+        eprint!("{SUMMARY_USAGE}");
+        return 2;
+    }
+
+    // Load all bundles up front so a bad path fails before any output.
+    let mut loaded = Vec::with_capacity(paths.len());
+    for path in &paths {
+        match ferx_core::io::fitrx::load_fit(std::path::Path::new(path)) {
+            Ok(l) => loaded.push((*path, l)),
+            Err(e) => {
+                eprintln!("Error: failed to load {}: {}", path, e);
+                return 1;
+            }
         }
     }
+
+    if loaded.len() == 1 {
+        print!(
+            "{}",
+            ferx_core::io::output::format_summary(&loaded[0].1.fit)
+        );
+    } else {
+        // Column label = file stem (e.g. `run1.fitrx` → `run1`).
+        let runs: Vec<(String, &ferx_core::FitResult)> = loaded
+            .iter()
+            .map(|(path, l)| {
+                let label = std::path::Path::new(path)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(path)
+                    .to_string();
+                (label, &l.fit)
+            })
+            .collect();
+        print!("{}", ferx_core::io::output::format_comparison(&runs));
+    }
+    0
 }
 
 /// Parsed `ferx check` arguments.

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -250,16 +250,23 @@ estimates) side by side.
 /// Returns the process exit code: `0` = printed (incl. `--help`), `1` = a load
 /// failed, `2` = usage (missing/flag-looking path).
 fn run_summary(args: &[String]) -> i32 {
-    if is_help_flag(args.get(2)) {
-        print!("{SUMMARY_USAGE}");
-        return 0;
+    // `summary` takes only bundle paths plus `-h`/`--help`. Scan every argument:
+    // help anywhere prints usage (exit 0); any other flag-looking argument is a
+    // usage error (exit 2) rather than being silently ignored or mistaken for a
+    // file path. Everything else is a bundle path.
+    let mut paths: Vec<&str> = Vec::new();
+    for arg in &args[2..] {
+        if is_help_flag(Some(arg)) {
+            print!("{SUMMARY_USAGE}");
+            return 0;
+        }
+        if arg.starts_with('-') {
+            eprintln!("Error: unknown option {}", arg);
+            eprint!("{SUMMARY_USAGE}");
+            return 2;
+        }
+        paths.push(arg.as_str());
     }
-    // Collect every positional (non-flag) argument after `summary`.
-    let paths: Vec<&str> = args[2..]
-        .iter()
-        .take_while(|a| !a.starts_with("--"))
-        .map(String::as_str)
-        .collect();
     if paths.is_empty() {
         eprint!("{SUMMARY_USAGE}");
         return 2;
@@ -763,6 +770,26 @@ mod tests {
         // No path, and a flag where the path should be — both usage (2).
         assert_eq!(run_summary(&args(&["summary"])), 2);
         assert_eq!(run_summary(&args(&["summary", "--json"])), 2);
+        // An unknown flag *after* a path is rejected, not silently ignored.
+        assert_eq!(
+            run_summary(&args(&["summary", "/no/such/file.fitrx", "--bogus"])),
+            2
+        );
+        // A short unknown flag (single dash) is rejected too.
+        assert_eq!(run_summary(&args(&["summary", "-x"])), 2);
+    }
+
+    #[test]
+    fn run_summary_help_anywhere_returns_0() {
+        // Help is recognized even when it follows a path (before any load).
+        assert_eq!(
+            run_summary(&args(&["summary", "/no/such/file.fitrx", "-h"])),
+            0
+        );
+        assert_eq!(
+            run_summary(&args(&["summary", "/no/such/file.fitrx", "--help"])),
+            0
+        );
     }
 
     #[test]
@@ -770,23 +797,45 @@ mod tests {
         assert_eq!(run_summary(&args(&["summary", "/no/such/file.fitrx"])), 1);
     }
 
-    #[test]
-    fn run_summary_valid_fitrx_returns_0() {
-        // Produce a real .fitrx via simulate (fast — no optimization loop), then
-        // load and summarize it in-process so the success arm is covered.
+    /// Simulate the warfarin model and write it to a `.fitrx` at `path` (fast —
+    /// no optimization loop), so `run_summary`'s success arms can be covered.
+    fn write_warfarin_fitrx(path: &std::path::Path) {
         let (fit, pop) = ferx_core::run_model_simulate(WARFARIN_MODEL).expect("simulate warfarin");
         let src = std::fs::read_to_string(WARFARIN_MODEL).expect("read model");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("run.fitrx");
         ferx_core::io::fitrx::save_fit(
             &fit,
             &pop,
             &src,
-            &path,
+            path,
             ferx_core::io::fitrx::SaveFitOptions::default(),
         )
         .expect("save fitrx");
+    }
+
+    #[test]
+    fn run_summary_valid_fitrx_returns_0() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("run.fitrx");
+        write_warfarin_fitrx(&path);
         assert_eq!(run_summary(&args(&["summary", path.to_str().unwrap()])), 0);
+    }
+
+    #[test]
+    fn run_summary_multiple_fitrx_returns_0() {
+        // Two bundles → the comparison-table arm.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p1 = dir.path().join("run1.fitrx");
+        let p2 = dir.path().join("run2.fitrx");
+        write_warfarin_fitrx(&p1);
+        write_warfarin_fitrx(&p2);
+        assert_eq!(
+            run_summary(&args(&[
+                "summary",
+                p1.to_str().unwrap(),
+                p2.to_str().unwrap()
+            ])),
+            0
+        );
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -771,6 +771,261 @@ pub fn format_summary(result: &FitResult) -> String {
     out
 }
 
+/// Render a Markdown table comparing several runs side by side.
+///
+/// Each element of `runs` is `(label, fit)`, where `label` names the run
+/// (typically the `.fitrx` file stem) and becomes a column header. Backs
+/// `ferx summary` when given two or more bundles: one run-info table (method,
+/// convergence, OFV/AIC/BIC, ΔOFV vs the first run, runtime, sizes) followed
+/// by THETA / OMEGA / SIGMA estimate tables whose rows are the union of
+/// parameter names across all runs (a `—` marks a parameter absent from a run).
+pub fn format_comparison(runs: &[(String, &FitResult)]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    if runs.is_empty() {
+        return out;
+    }
+
+    // Emit one Markdown table row: `| head | c0 | c1 | ... |`.
+    fn row(out: &mut String, head: &str, cells: &[String]) {
+        let mut line = format!("| {} |", head);
+        for c in cells {
+            let _ = write!(line, " {} |", c);
+        }
+        let _ = writeln!(out, "{}", line);
+    }
+
+    let labels: Vec<&str> = runs.iter().map(|(l, _)| l.as_str()).collect();
+    let n = runs.len();
+
+    // --- Header + run-info block ---
+    row(
+        &mut out,
+        "Run",
+        &labels.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    );
+    // Separator: one `---` per column, including the leading metric column.
+    {
+        let seps: Vec<String> = std::iter::repeat("---".to_string()).take(n).collect();
+        row(&mut out, "---", &seps);
+    }
+
+    let method_label = |r: &FitResult| -> String {
+        if r.method_chain.len() > 1 {
+            r.method_chain
+                .iter()
+                .map(|m| m.label())
+                .collect::<Vec<_>>()
+                .join(" → ")
+        } else {
+            r.method.label().to_string()
+        }
+    };
+
+    row(
+        &mut out,
+        "Model",
+        &runs
+            .iter()
+            .map(|(_, r)| r.model_name.clone())
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Method",
+        &runs
+            .iter()
+            .map(|(_, r)| method_label(r))
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Converged",
+        &runs
+            .iter()
+            .map(|(_, r)| {
+                if r.converged {
+                    "yes".to_string()
+                } else {
+                    "no".to_string()
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "OFV",
+        &runs
+            .iter()
+            .map(|(_, r)| format!("{:.4}", r.ofv))
+            .collect::<Vec<_>>(),
+    );
+    // ΔOFV relative to the first run (0 for the reference column).
+    let ref_ofv = runs[0].1.ofv;
+    row(
+        &mut out,
+        "ΔOFV",
+        &runs
+            .iter()
+            .map(|(_, r)| format!("{:+.4}", r.ofv - ref_ofv))
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "AIC",
+        &runs
+            .iter()
+            .map(|(_, r)| format!("{:.4}", r.aic))
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "BIC",
+        &runs
+            .iter()
+            .map(|(_, r)| format!("{:.4}", r.bic))
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Runtime (s)",
+        &runs
+            .iter()
+            .map(|(_, r)| format!("{:.1}", r.wall_time_secs))
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Iterations",
+        &runs
+            .iter()
+            .map(|(_, r)| r.n_iterations.to_string())
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Subjects",
+        &runs
+            .iter()
+            .map(|(_, r)| r.n_subjects.to_string())
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Observations",
+        &runs
+            .iter()
+            .map(|(_, r)| r.n_obs.to_string())
+            .collect::<Vec<_>>(),
+    );
+    row(
+        &mut out,
+        "Parameters",
+        &runs
+            .iter()
+            .map(|(_, r)| r.n_parameters.to_string())
+            .collect::<Vec<_>>(),
+    );
+
+    // --- Parameter estimate tables ---
+    // Build the union of parameter names in first-seen order across runs.
+    let union_names = |get: &dyn Fn(&FitResult) -> Vec<String>| -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut names = Vec::new();
+        for (_, r) in runs {
+            for name in get(r) {
+                if seen.insert(name.clone()) {
+                    names.push(name);
+                }
+            }
+        }
+        names
+    };
+
+    // Estimate cell for parameter `name` in run `r`, `—` if the run lacks it.
+    // `%RSE` is appended in parens when a standard error is available.
+    let theta_cell = |r: &FitResult, name: &str| -> String {
+        match r.theta_names.iter().position(|n| n == name) {
+            None => "—".to_string(),
+            Some(i) => {
+                let est = r.theta[i];
+                match r.se_theta.as_ref().and_then(|se| se.get(i)) {
+                    Some(&se) if est.abs() > 1e-12 => {
+                        format!("{:.4} ({:.1}%)", est, (se / est.abs()) * 100.0)
+                    }
+                    _ => format!("{:.4}", est),
+                }
+            }
+        }
+    };
+
+    let theta_names = union_names(&|r| r.theta_names.clone());
+    if !theta_names.is_empty() {
+        let _ = writeln!(out, "\n**THETA**\n");
+        row(
+            &mut out,
+            "Parameter",
+            &labels.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        );
+        let seps: Vec<String> = std::iter::repeat("---".to_string()).take(n).collect();
+        row(&mut out, "---", &seps);
+        for name in &theta_names {
+            let cells: Vec<String> = runs.iter().map(|(_, r)| theta_cell(r, name)).collect();
+            row(&mut out, name, &cells);
+        }
+    }
+
+    let omega_names = union_names(&|r| r.eta_names.clone());
+    if !omega_names.is_empty() {
+        let _ = writeln!(out, "\n**OMEGA** (variances)\n");
+        row(
+            &mut out,
+            "Parameter",
+            &labels.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        );
+        let seps: Vec<String> = std::iter::repeat("---".to_string()).take(n).collect();
+        row(&mut out, "---", &seps);
+        for name in &omega_names {
+            let cells: Vec<String> = runs
+                .iter()
+                .map(
+                    |(_, r)| match r.eta_names.iter().position(|nm| nm == name) {
+                        Some(i) => format!("{:.4}", r.omega[(i, i)]),
+                        None => "—".to_string(),
+                    },
+                )
+                .collect();
+            row(&mut out, name, &cells);
+        }
+    }
+
+    let sigma_names = union_names(&|r| r.sigma_names.clone());
+    if !sigma_names.is_empty() {
+        let _ = writeln!(out, "\n**SIGMA**\n");
+        row(
+            &mut out,
+            "Parameter",
+            &labels.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        );
+        let seps: Vec<String> = std::iter::repeat("---".to_string()).take(n).collect();
+        row(&mut out, "---", &seps);
+        for name in &sigma_names {
+            let cells: Vec<String> = runs
+                .iter()
+                .map(
+                    |(_, r)| match r.sigma_names.iter().position(|nm| nm == name) {
+                        Some(i) => format!("{:.4}", r.sigma[i]),
+                        None => "—".to_string(),
+                    },
+                )
+                .collect();
+            row(&mut out, name, &cells);
+        }
+    }
+
+    out
+}
+
 /// Generate SDTAB-like output as vectors of (header, values) pairs
 pub fn sdtab(result: &FitResult, population: &Population) -> Vec<(String, Vec<f64>)> {
     let n_total: usize = result.subjects.iter().map(|s| s.ipred.len()).sum();
@@ -2897,6 +3152,59 @@ mod tests {
         let cl = table.lines().find(|l| l.starts_with("CL")).expect("CL row");
         // No covariance run → SE/%RSE rendered as "---".
         assert!(cl.contains("---"), "{cl}");
+    }
+
+    // ── format_comparison: multi-run Markdown table ──────────────────────────
+
+    #[test]
+    fn format_comparison_tabulates_runs_side_by_side() {
+        let mut a = full_param_result(Some(vec![0.2, 0.0]));
+        a.model_name = "run_a".into();
+        a.ofv = 100.0;
+        a.wall_time_secs = 12.5;
+        let mut b = full_param_result(Some(vec![0.3, 0.0]));
+        b.model_name = "run_b".into();
+        b.ofv = 90.0;
+        b.wall_time_secs = 8.0;
+
+        let md = format_comparison(&[("run_a".into(), &a), ("run_b".into(), &b)]);
+
+        // Header row carries both run labels.
+        assert!(md.contains("| Run | run_a | run_b |"), "{md}");
+        // Markdown separator row present.
+        assert!(md.contains("| --- | --- | --- |"), "{md}");
+        // Run-info rows.
+        assert!(md.contains("| OFV | 100.0000 | 90.0000 |"), "{md}");
+        // ΔOFV is relative to the first run (0 for the reference column).
+        assert!(md.contains("| ΔOFV | +0.0000 | -10.0000 |"), "{md}");
+        assert!(md.contains("| Runtime (s) | 12.5 | 8.0 |"), "{md}");
+        // Section headers + a THETA estimate with %RSE (SE 0.2 / est 2.0 = 10%).
+        assert!(md.contains("**THETA**"), "{md}");
+        assert!(md.contains("| CL | 2.0000 (10.0%)"), "{md}");
+        assert!(md.contains("**OMEGA**"), "{md}");
+        assert!(md.contains("**SIGMA**"), "{md}");
+    }
+
+    #[test]
+    fn format_comparison_marks_missing_parameters() {
+        let a = full_param_result(None); // thetas: CL, ZERO
+        let mut b = full_param_result(None);
+        b.theta = vec![2.0];
+        b.theta_names = vec!["CL".into()]; // no ZERO
+        b.theta_fixed = vec![false];
+
+        let md = format_comparison(&[("a".into(), &a), ("b".into(), &b)]);
+        // ZERO exists only in run `a`; run `b`'s cell is an em dash.
+        let zero_row = md
+            .lines()
+            .find(|l| l.starts_with("| ZERO |"))
+            .expect("ZERO row");
+        assert!(zero_row.contains("—"), "{zero_row}");
+    }
+
+    #[test]
+    fn format_comparison_empty_is_empty() {
+        assert!(format_comparison(&[]).is_empty());
     }
 
     // ── print_results: stderr smoke test (exercises both header branches) ────


### PR DESCRIPTION
## Why
Issue #749: users want to compare several fits at once. Previously `ferx summary`
accepted a single `.fitrx` bundle only; comparing runs meant eyeballing multiple
reports.

## What changed
`ferx summary` now accepts two or more `.fitrx` bundles:

```
ferx summary run1.fitrx run2.fitrx run3.fitrx
```

With ≥2 bundles it prints a **Markdown** comparison table via a new
`output::format_comparison`:

- Run-info rows: Model, Method (or chain), Converged, OFV, ΔOFV (vs the first
  run), AIC, BIC, Runtime (s), Iterations, Subjects, Observations, Parameters.
- THETA (estimate + %RSE when SE available), OMEGA (variances), SIGMA tables.
- Rows are the union of parameter names across runs; `—` marks a parameter
  absent from a given run. Each column is labelled with the bundle's file stem.

All bundles load up front, so a bad path fails (exit 1) before any output.
A **single** bundle still prints the detailed `psn::sumo`-style report — existing
behaviour unchanged.

## Alternatives considered
Separate `ferx compare` subcommand — rejected; overloading `summary` on argument
count is simpler and matches the issue's `ferx summary run1 run2 run3` phrasing.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API used by ferx-r changed (`format_comparison` is new/additive).

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (reporting only — re-tabulates existing stored estimates,
  no new numerics, so no NONMEM anchor per CLAUDE.md)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes) —
  `format_comparison_tabulates_runs_side_by_side`,
  `format_comparison_marks_missing_parameters`, `format_comparison_empty_is_empty`

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```
ferx summary run1.fitrx run2.fitrx
```

```markdown
| Run | run1 | run2 |
| --- | --- | --- |
| Model | warfarin | warfarin |
| Method | FOCE | FOCE |
| Converged | yes | yes |
| OFV | -280.3639 | -280.3639 |
| ΔOFV | +0.0000 | +0.0000 |
| AIC | -266.3639 | -266.3639 |
| BIC | -247.4605 | -247.4605 |
| Runtime (s) | 0.6 | 0.6 |
| Iterations | 53 | 53 |
| Subjects | 10 | 10 |
| Observations | 110 | 110 |
| Parameters | 7 | 7 |

**THETA**

| Parameter | run1 | run2 |
| --- | --- | --- |
| TVCL | 0.1330 (5.0%) | 0.1330 (5.0%) |
| TVV | 7.7307 (3.0%) | 7.7307 (3.0%) |
| TVKA | 0.7252 (17.1%) | 0.7252 (17.1%) |
```

</details>

## Docs
- [x] `docs/cli.qmd` updated (new "Compare Multiple Runs" subsection + usage snippet)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean
- [x] No `Dual2`/gradient-path code touched

## Reviewer hints
Focus: `output::format_comparison` (table layout, union-of-names, missing-param
`—`) and `run_summary` dispatch in `src/bin/run_model.rs` (multi-path parsing,
load-all-before-print).

🤖 Generated with [Claude Code](https://claude.com/claude-code)