### PR TITLE
fix(io): error on dose rows with no AMT column; warn on all-zero AMT [closes #753]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,14 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **A dataset with dose rows but no `AMT` column is now a hard error instead of a
+  silent bad fit** (#753). When the amount column is named something other than
+  `AMT` (e.g. a NONMEM export using `DOSE`), every dose parsed with amount 0, so no
+  drug entered the system, the objective was flat, and the fit "converged" with
+  every parameter pinned at its initial estimate. The reader now rejects such data
+  with `E_DOSE_NO_AMT`, naming the fix (rename the column to `AMT`). A companion
+  warning `W_ALL_DOSES_ZERO` fires when an `AMT` column *is* present but every dose
+  amount is 0 (e.g. a mis-scaled column).
 - **Loading a `.fitrx` bundle whose data has two subjects sharing an ID no longer
   fails with a spurious `corrupt or missing entry` error.** `load_fit` (and thus
   `ferx summary`) matched `predictions.csv` rows to subjects by ID, so when a

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -62,9 +62,19 @@ observations. Inference keys on `AMT` only — a dose always carries a nonzero
 amount (for infusions, `AMT` is the amount and `RATE` the rate). When an `EVID`
 column **is** present, its values govern and nothing is inferred.
 
-Two non-fatal warnings (collected into the fit's warnings) guard against a
-silently dose-free fit:
+One hard error and three warnings guard against a silently dose-free (or
+zero-dose) fit:
 
+- **`E_DOSE_NO_AMT`** *(error)* — the dataset has dose rows (`EVID=1`/`4`) but
+  **no `AMT` column**, so every dose amount is zero and the fit would run with no
+  drug in the system (a flat objective that pins every parameter at its initial
+  estimate). This usually means the amount column is named something other than
+  `AMT` (e.g. a NONMEM export using `DOSE`); rename it to `AMT` in the CSV header
+  or via a rename in the `[data]` block.
+- **`W_ALL_DOSES_ZERO`** — an `AMT` column **is** present but every parsed dose
+  has `AMT = 0` (e.g. a placebo-only typo or a mis-scaled amount column). Same
+  flat-objective symptom as the error above, but the column exists so it is a
+  warning rather than a hard stop.
 - **`W_AMT_NOT_DOSED`** — one or more **non-observation** rows carry `AMT != 0`
   but were not treated as doses: an `EVID` column is present and codes a dose row
   as something other than `1`/`4` (e.g. a dose row mistyped `EVID=0` with

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -855,7 +855,7 @@ fn read_nonmem_csv_impl(
 
     // All-zero-dose warning (#753): an `AMT` column exists (so E_DOSE_NO_AMT did not
     // fire) but every parsed dose amount is exactly zero — e.g. a placebo-only typo
-    // or a mis-scaled amount column. Like the all-zero-AMT error, this yields a flat
+    // or a mis-scaled amount column. Like the `E_DOSE_NO_AMT` error above, this yields a flat
     // objective; here we warn rather than error because the column is present and a
     // genuinely dose-free-but-AMT-columned dataset is conceivable. Only fires when at
     // least one dose event exists (else W_NO_DOSES already covered it).

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -778,6 +778,25 @@ fn read_nonmem_csv_impl(
         subjects.push(subject);
     }
 
+    // Hard error (#753): dose rows are present (EVID=1/4 classified as doses) but
+    // the dataset has no `AMT` column, so every dose was created with `amt = 0`.
+    // The fit would run silently with no drug in the system — a flat objective
+    // that pins every parameter at its initial estimate. This most often means the
+    // amount column is named something other than `AMT` (e.g. a NONMEM export using
+    // `DOSE`); rename it in the [data] block or the CSV header. Scoped to dose rows
+    // present + no AMT column: dose-free models (#262) and TTE/survival have no dose
+    // events, and the EVID-absent path infers no doses without an AMT column, so
+    // none of them trip this.
+    if amt_col.is_none() && subjects.iter().any(|s| !s.doses.is_empty()) {
+        return Err(
+            "E_DOSE_NO_AMT: the dataset has dose records (EVID=1/4) but no `AMT` column, so \
+             every dose amount is zero and the fit would run with no drug in the system. If the \
+             amount column has a different name (e.g. `DOSE`), rename it to `AMT` in the CSV \
+             header or via a rename in the [data] block."
+                .to_string(),
+        );
+    }
+
     // Accumulate OCC warning into population_warnings (surfaced via FitResult.warnings).
     if let Some(name) = iov_column {
         if total_occ_failures > 0 {
@@ -831,6 +850,27 @@ fn read_nonmem_csv_impl(
                  AMT column with EVID=1/4 dose rows (or a nonzero AMT when EVID is absent).",
                 subjects.len()
             ));
+        }
+    }
+
+    // All-zero-dose warning (#753): an `AMT` column exists (so E_DOSE_NO_AMT did not
+    // fire) but every parsed dose amount is exactly zero — e.g. a placebo-only typo
+    // or a mis-scaled amount column. Like the all-zero-AMT error, this yields a flat
+    // objective; here we warn rather than error because the column is present and a
+    // genuinely dose-free-but-AMT-columned dataset is conceivable. Only fires when at
+    // least one dose event exists (else W_NO_DOSES already covered it).
+    if amt_col.is_some() {
+        let any_dose = subjects.iter().any(|s| !s.doses.is_empty());
+        let all_zero = subjects
+            .iter()
+            .all(|s| s.doses.iter().all(|d| d.amt == 0.0));
+        if any_dose && all_zero {
+            population_warnings.push(
+                "W_ALL_DOSES_ZERO: every dose record has AMT = 0, so no drug enters the system \
+                 and the objective is flat (parameters will not move from their initial values). \
+                 Check the `AMT` column values and scaling."
+                    .to_string(),
+            );
         }
     }
 
@@ -1794,6 +1834,51 @@ mod tests {
         let f = write_csv("ID,TIME,EVID,AMT\n1,0,1,100\n");
         let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
         assert!(err.contains("Missing DV column"), "{err}");
+    }
+
+    #[test]
+    fn dose_rows_without_amt_column_are_rejected() {
+        // #753: EVID=1 dose rows but the amount column is named `DOSE`, not `AMT`.
+        // Every dose parses to amt=0 → flat objective → fit pinned at init. This is
+        // a hard error naming the fix, not a silent bad fit.
+        let f = write_csv("ID,TIME,DV,EVID,DOSE\n1,0,.,1,100\n1,1,5.0,0,.\n");
+        let err = read_nonmem_csv(f.path(), None, None).unwrap_err();
+        assert!(err.contains("E_DOSE_NO_AMT"), "{err}");
+    }
+
+    #[test]
+    fn dose_free_dataset_without_amt_column_is_ok() {
+        // The E_DOSE_NO_AMT guard must be scoped to *dose rows present*: a dataset
+        // with only observations (EVID=0) and no AMT column is a legitimate
+        // dose-free fit (#262) and must not error.
+        let f = write_csv("ID,TIME,DV,EVID\n1,0,1.0,0\n1,1,2.0,0\n");
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        assert!(pop.subjects.iter().all(|s| s.doses.is_empty()));
+    }
+
+    #[test]
+    fn all_zero_amt_doses_warn() {
+        // #753: an `AMT` column exists (so E_DOSE_NO_AMT does not fire) but every
+        // dose amount is 0 → flat objective. Warn rather than error.
+        let f = write_csv("ID,TIME,DV,EVID,AMT\n1,0,.,1,0\n1,1,5.0,0,.\n");
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        assert!(
+            pop.warnings.iter().any(|w| w.contains("W_ALL_DOSES_ZERO")),
+            "{:?}",
+            pop.warnings
+        );
+    }
+
+    #[test]
+    fn nonzero_amt_doses_do_not_warn_all_zero() {
+        // Guard against a false-positive W_ALL_DOSES_ZERO on a normal dataset.
+        let f = write_csv("ID,TIME,DV,EVID,AMT\n1,0,.,1,100\n1,1,5.0,0,.\n");
+        let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+        assert!(
+            !pop.warnings.iter().any(|w| w.contains("W_ALL_DOSES_ZERO")),
+            "{:?}",
+            pop.warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

The infliximab (Buurman) model fit far worse in ferx than in NONMEM — OFV 1310.7 vs 662.97, with every ferx θ pinned at its initial estimate. Root cause: the dataset's amount column is named `DOSE`, not `AMT`. ferx keys dose amount on `AMT`, so `DOSE` was treated as a covariate and **every dose parsed with amount 0** — no drug entered the system, the objective was flat, and the outer optimizer exited immediately at the initial values.

The failure was silent. Neither existing dose-coverage guard caught it:
- `W_NO_DOSES` fires only when `subjects.all(|s| s.doses.is_empty())` — but EVID=1/4 rows still classify as doses (with amt=0), so `doses` was non-empty.
- `W_AMT_NOT_DOSED` fires only for a **nonzero** AMT that wasn't dosed — the amounts were 0.

The only tell was the covariance step reporting "zero diagonal — flat objective" for every parameter, which is buried.

## What changed

Two-tier guard in `src/io/datareader.rs`:

1. **Error `E_DOSE_NO_AMT`** — dose rows present (`EVID=1/4`) but no `AMT` column. Unambiguous (dose events with nowhere to read magnitude), so a hard error that names the fix (rename the column to `AMT`). Scoped to *dose rows present + no AMT column*, so dose-free models (#262) and TTE/survival (no dose rows) are untouched; the EVID-absent path infers no doses without an AMT column, so it does not trip either.
2. **Warning `W_ALL_DOSES_ZERO`** — an `AMT` column *is* present but every parsed dose amount is 0 (placebo-only typo / mis-scaled column). Column exists, so warn rather than error.

## Breaking changes
- [x] None (rejects previously-silently-broken input; valid datasets unaffected)

## Numerical validation
- [x] Compared against: NONMEM. Remapping `DOSE → AMT` on the infliximab dataset makes ferx reproduce the NONMEM estimates (OFV 662.97; θ CL 0.198, V1 4.976, Q 0.061, V2 3.328, …). This PR turns the mis-named-column case into a loud error instead of that silent 1310.7 fit.
- [ ] Not applicable

## Tests
- [x] Unit test(s) added (`cargo test --lib` passes — full suite 2320 passed)
- [x] Regression test added that fails without this fix (`dose_rows_without_amt_column_are_rejected`)

Tier-1 tests in `datareader.rs`:
- `dose_rows_without_amt_column_are_rejected` — `E_DOSE_NO_AMT` fires.
- `dose_free_dataset_without_amt_column_is_ok` — obs-only + no AMT does **not** error.
- `all_zero_amt_doses_warn` — `W_ALL_DOSES_ZERO` fires.
- `nonzero_amt_doses_do_not_warn_all_zero` — false-positive guard.

## Docs
- [x] `docs/data-format.qmd` updated (new error + warning documented alongside `W_NO_DOSES`/`W_AMT_NOT_DOSED`)
- [x] `CHANGELOG.md` `[Unreleased]` → Fixed entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings on changed lines)
- [x] No gradient-path (`Dual2`) code touched

## Reviewer hints
Focus on the scope of `E_DOSE_NO_AMT` (datareader.rs, just after the subject-parse loop): the condition `amt_col.is_none() && subjects.any(|s| !s.doses.is_empty())` must not catch dose-free (#262) or TTE datasets — both covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)