### PR TITLE
fix(parser): register [initial_conditions] covariates so a missing one fails loudly [closes #765]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,16 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **An `[initial_conditions]` covariate that matches no data column now fails the
+  fit loudly instead of silently dropping the baseline** (#765). A covariate named
+  only inside an init expression (e.g. `init(central) = CONC0 * V`) was never
+  registered as a required data column, so with a `[covariates]` block it was never
+  read, and under auto-detect a case mismatch (`CONC0` vs a `conc0` header) resolved
+  to `0` — zeroing the initial amount with no diagnostic (identical OFV with and
+  without the block). Init-expression covariates are now registered like every other
+  model covariate, so a missing or miscased name raises `E_MISSING_COVARIATE` listing
+  the available columns. Rename the column in `[data]` (`CONC0 = conc0`) or match the
+  header's case in the expression.
 - **A dataset with dose rows but no `AMT` column is now a hard error instead of a
   silent bad fit** (#753). When the amount column is named something other than
   `AMT` (e.g. a NONMEM export using `DOSE`), every dose parsed with amount 0, so no

--- a/docs/model-file/initial-conditions.qmd
+++ b/docs/model-file/initial-conditions.qmd
@@ -36,6 +36,16 @@ Each line is `init(NAME) = <expr>`, where:
   expression sees. So `init(central) = CONC0 * V` reads the data column `CONC0`
   and the per-subject `V`.
 
+::: {.callout-important}
+A covariate named in the init expression is a **required data column**, matched
+**case-sensitively**. `init(central) = CONC0 * V` needs a `CONC0` column; if the
+dataset header is `conc0`, either rename it in the `[data]` block
+(`CONC0 = conc0`) or lowercase the expression (`init(central) = conc0 * V`). A
+name that matches no column now fails the fit loudly with `E_MISSING_COVARIATE`
+listing the available columns — earlier versions silently evaluated the missing
+covariate to `0`, dropping the baseline with no warning (issue #765).
+:::
+
 ## How it works
 
 For a **linear** disposition, an initial amount $A_0$ in compartment $c$ is

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2333,7 +2333,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     // init impulses layered onto the dose-driven prediction by
     // `pk::add_analytical_init`.
     if let Some(ic_lines) = blocks.get("initial_conditions") {
-        model.analytical_init = parse_initial_conditions_block(
+        let (analytical_init, init_covariates) = parse_initial_conditions_block(
             ic_lines,
             model.pk_model,
             model.ode_spec.is_some(),
@@ -2343,6 +2343,17 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             &model.pk_indices,
             &model.kappa_names,
         )?;
+        model.analytical_init = analytical_init;
+        // Register init-expression covariates as required data columns, mirroring
+        // the scaling (`scaling_covariates`) and error-selector blocks above. Without
+        // this, a `[covariates]`-declared model never reads the column, and a miscased
+        // /absent init covariate silently evaluates to 0 (issue #765).
+        for cov in init_covariates {
+            if !model.referenced_covariates.contains(&cov) {
+                model.referenced_covariates.push(cov);
+            }
+        }
+        model.referenced_covariates.sort();
     }
 
     // ODE validation: the `NEEDS_FORM_C = usize::MAX` sentinel from
@@ -5743,6 +5754,13 @@ fn analytical_init_cmt(pk_model: PkModel, name: &str) -> Result<usize, String> {
 /// Mirrors the Form-B `obs_scale` expression closure in [`build_obs_scale_spec`]:
 /// individual-parameter names resolve from the subject-static `pk_params`, so
 /// `init(central) = CONC0 * V` reads `V` from its PK slot.
+///
+/// The third tuple element is the covariate names the expression references (an
+/// identifier that is not a theta/eta/individual parameter parses as a
+/// `Covariate` leaf). The caller registers these in
+/// `CompiledModel.referenced_covariates` so they become required data columns —
+/// otherwise a miscased or absent init covariate silently evaluates to `0` and
+/// the baseline vanishes with no diagnostic (issue #765).
 #[allow(clippy::type_complexity)]
 fn build_init_amount_fn(
     value: &str,
@@ -5751,7 +5769,7 @@ fn build_init_amount_fn(
     indiv_var_names: &[String],
     pk_indices: &[usize],
     kappa_names: &[String],
-) -> Result<(ScaleFn, Option<ScaleDerivProgram>), String> {
+) -> Result<(ScaleFn, Option<ScaleDerivProgram>, Vec<String>), String> {
     // Build the differentiable `A₀` program from a (possibly resolved) expression
     // AST. Shares the `obs_scale` lowering (`compile_scale_deriv_program`) so the
     // init impulse and the scale divisor differentiate on the same ABI; this lets
@@ -5767,7 +5785,7 @@ fn build_init_amount_fn(
         let deriv = build_deriv(&Expression::Literal(k));
         let scale_fn: ScaleFn =
             Box::new(move |_: &[f64], _: &[f64], _: &HashMap<String, f64>, _: &PkParams| k);
-        return Ok((scale_fn, Some(deriv)));
+        return Ok((scale_fn, Some(deriv), Vec::new()));
     }
     let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
     let expr = parse_scalar_expression(value, ctx)
@@ -5789,6 +5807,12 @@ fn build_init_amount_fn(
         ));
     }
     let deriv = build_deriv(&expr);
+    // Covariate leaves (identifiers not resolved as theta/eta/individual param)
+    // must become required data columns — see the fn doc (issue #765).
+    let mut cov_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    collect_covariates(&expr, &mut cov_set);
+    let mut covariates_ref: Vec<String> = cov_set.into_iter().collect();
+    covariates_ref.sort();
     let indiv_to_pk_slot: HashMap<String, usize> = indiv_var_names
         .iter()
         .enumerate()
@@ -5810,7 +5834,7 @@ fn build_init_amount_fn(
             eval_expression(&expr, theta, eta, covariates, &vars, &empty_nn)
         },
     );
-    Ok((scale_fn, Some(deriv)))
+    Ok((scale_fn, Some(deriv), covariates_ref))
 }
 
 /// Parse the `[initial_conditions]` block (issue #521) into the analytical
@@ -5826,7 +5850,7 @@ fn parse_initial_conditions_block(
     indiv_var_names: &[String],
     pk_indices: &[usize],
     kappa_names: &[String],
-) -> Result<Vec<crate::types::AnalyticalInit>, String> {
+) -> Result<(Vec<crate::types::AnalyticalInit>, Vec<String>), String> {
     if is_ode {
         return Err(
             "[initial_conditions]: this block is for analytical PK models; for an \
@@ -5836,6 +5860,9 @@ fn parse_initial_conditions_block(
     }
     let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut out = Vec::new();
+    // Covariate names referenced across all init expressions; the caller
+    // registers these as required data columns (issue #765).
+    let mut cov_refs: std::collections::HashSet<String> = std::collections::HashSet::new();
     for line in lines {
         let (name, expr) = parse_init_line(line).ok_or_else(|| {
             format!(
@@ -5850,7 +5877,7 @@ fn parse_initial_conditions_block(
                 name
             ));
         }
-        let (amount_fn, amount_deriv) = build_init_amount_fn(
+        let (amount_fn, amount_deriv, covariates_ref) = build_init_amount_fn(
             &expr,
             theta_names,
             eta_names,
@@ -5858,13 +5885,16 @@ fn parse_initial_conditions_block(
             pk_indices,
             kappa_names,
         )?;
+        cov_refs.extend(covariates_ref);
         out.push(crate::types::AnalyticalInit {
             cmt,
             amount_fn,
             amount_deriv,
         });
     }
-    Ok(out)
+    let mut cov_refs: Vec<String> = cov_refs.into_iter().collect();
+    cov_refs.sort();
+    Ok((out, cov_refs))
 }
 
 /// Build an `OdeOutputFn` from one `y[…] = value` line. Shared between
@@ -24063,6 +24093,82 @@ if (WT > 70) {
         let cov = HashMap::new();
         let y = out_fn(&state, &pk, &[], &[], &cov);
         assert!((y - 2.0).abs() < 1e-12, "expected 100/50 = 2, got {}", y);
+    }
+
+    /// A covariate referenced only inside an `[initial_conditions]` expression
+    /// must be registered in `referenced_covariates` so it becomes a required
+    /// data column. Without this, a `[covariates]`-declared model never reads
+    /// the column and a miscased/absent init covariate silently evaluates to 0
+    /// (issue #765).
+    #[test]
+    fn test_initial_conditions_covariate_is_registered() {
+        let content = r#"
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+  F  = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA, f=F)
+
+[initial_conditions]
+  init(central) = CONC0 * V
+
+[error_model]
+  DV ~ proportional(EPS)
+"#;
+        let model = parse_model_string(content).expect("model parses");
+        assert_eq!(model.analytical_init.len(), 1, "init block parsed");
+        assert!(
+            model.referenced_covariates.iter().any(|c| c == "CONC0"),
+            "init covariate CONC0 must be registered, got: {:?}",
+            model.referenced_covariates
+        );
+    }
+
+    /// An `[initial_conditions]` expression built only from parameters (no free
+    /// identifier) registers no covariate — `V` is an individual parameter, not
+    /// a data column, so it must not leak into `referenced_covariates` (#765).
+    #[test]
+    fn test_initial_conditions_param_only_registers_no_covariate() {
+        let content = r#"
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+  F  = 1.0
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA, f=F)
+
+[initial_conditions]
+  init(central) = 0.5 * V
+
+[error_model]
+  DV ~ proportional(EPS)
+"#;
+        let model = parse_model_string(content).expect("model parses");
+        assert_eq!(model.analytical_init.len(), 1, "init block parsed");
+        assert!(
+            model.referenced_covariates.is_empty(),
+            "a param-only init must register no covariate, got: {:?}",
+            model.referenced_covariates
+        );
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -979,6 +979,23 @@ pub fn parse_model_string(content: &str) -> Result<CompiledModel, String> {
     Ok(parsed.model)
 }
 
+/// Register covariate names as required data columns: push each name not
+/// already present, then re-sort. Shared by the `[scaling]`, error-model
+/// selector, and `[initial_conditions]` blocks so all three declare their
+/// covariates identically — the divergence that let an unregistered init
+/// covariate silently evaluate to 0 (issue #765).
+fn register_referenced_covariates(
+    referenced: &mut Vec<String>,
+    covs: impl IntoIterator<Item = String>,
+) {
+    for cov in covs {
+        if !referenced.contains(&cov) {
+            referenced.push(cov);
+        }
+    }
+    referenced.sort();
+}
+
 /// Parse a full model string including all optional blocks.
 pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     let mut extracted = extract_blocks(content)?;
@@ -2307,24 +2324,14 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             }
         }
 
-        for cov in scaling_covariates {
-            if !model.referenced_covariates.contains(&cov) {
-                model.referenced_covariates.push(cov);
-            }
-        }
-        model.referenced_covariates.sort();
+        register_referenced_covariates(&mut model.referenced_covariates, scaling_covariates);
         model.scaling = scaling;
     }
 
     // Covariate-selected [error_model] (issue #658): the selector's covariates
     // are required data columns, so register them like scaling covariates.
     if !selector_covariates.is_empty() {
-        for cov in &selector_covariates {
-            if !model.referenced_covariates.contains(cov) {
-                model.referenced_covariates.push(cov.clone());
-            }
-        }
-        model.referenced_covariates.sort();
+        register_referenced_covariates(&mut model.referenced_covariates, selector_covariates);
     }
 
     // ── [initial_conditions] block (issue #521) ──
@@ -2347,13 +2354,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         // Register init-expression covariates as required data columns, mirroring
         // the scaling (`scaling_covariates`) and error-selector blocks above. Without
         // this, a `[covariates]`-declared model never reads the column, and a miscased
-        // /absent init covariate silently evaluates to 0 (issue #765).
-        for cov in init_covariates {
-            if !model.referenced_covariates.contains(&cov) {
-                model.referenced_covariates.push(cov);
-            }
-        }
-        model.referenced_covariates.sort();
+        // or absent init covariate silently evaluates to 0 (issue #765).
+        register_referenced_covariates(&mut model.referenced_covariates, init_covariates);
     }
 
     // ODE validation: the `NEEDS_FORM_C = usize::MAX` sentinel from
@@ -5811,8 +5813,9 @@ fn build_init_amount_fn(
     // must become required data columns — see the fn doc (issue #765).
     let mut cov_set: std::collections::HashSet<String> = std::collections::HashSet::new();
     collect_covariates(&expr, &mut cov_set);
-    let mut covariates_ref: Vec<String> = cov_set.into_iter().collect();
-    covariates_ref.sort();
+    // Order is irrelevant: the caller pools these into a HashSet and the final
+    // `register_referenced_covariates` re-sorts, so don't sort here.
+    let covariates_ref: Vec<String> = cov_set.into_iter().collect();
     let indiv_to_pk_slot: HashMap<String, usize> = indiv_var_names
         .iter()
         .enumerate()
@@ -5892,9 +5895,9 @@ fn parse_initial_conditions_block(
             amount_deriv,
         });
     }
-    let mut cov_refs: Vec<String> = cov_refs.into_iter().collect();
-    cov_refs.sort();
-    Ok((out, cov_refs))
+    // Return unsorted: the caller re-sorts via `register_referenced_covariates`.
+    let init_covariates: Vec<String> = cov_refs.into_iter().collect();
+    Ok((out, init_covariates))
 }
 
 /// Build an `OdeOutputFn` from one `y[…] = value` line. Shared between


### PR DESCRIPTION
## Why

A covariate referenced only inside an `[initial_conditions]` block silently produced a **dead baseline**. Found on the thioguanine PK model (`ferx-testdata/thioguanine_mmc/ferx/run14_focei.ferx`), where `init(central) = CONC0 * V` gave **identical OFVs with and without the block**.

Root cause chain:
1. `build_init_amount_fn` parses the unknown identifier `CONC0` as an `Expression::Covariate` leaf, but its name was never added to `model.referenced_covariates`.
2. So with a `[covariates]` block the column is never read (`undeclared_referenced` derives extras from `referenced_covariates`); under **auto-detect** the data column is read under its original lowercase header `conc0`, while the expression looks up `CONC0`.
3. Covariate lookup is case-sensitive with a silent default — `covariates.get("CONC0").copied().unwrap_or(0.0)` → `0.0` → `a0 = 0 * V = 0` → `add_analytical_init_with` hits `if a0 == 0.0 { continue }` and drops the impulse for every observation.

Unlike `[scaling]` and the error-model selector, the init block never registered its covariates, so none of the existing covariate validation fired.

## What changed

- `build_init_amount_fn` now returns the covariate names referenced in the init expression (via `collect_covariates` over the parsed AST; empty for the constant fast-path).
- `parse_initial_conditions_block` accumulates them across all `init(...)` lines and returns them.
- The call site registers them into `model.referenced_covariates`, mirroring the scaling (`scaling_covariates`) and error-selector blocks.

Effect: a missing or miscased init covariate now trips the **existing** `check_covariates` guard → `E_MISSING_COVARIATE` (case-sensitive, lists available columns) instead of silently evaluating to 0. No new error path invented — the fix routes init covariates through the same validation every other model covariate already uses.

Users fix the thioguanine model by either renaming in `[data]` (`CONC0 = conc0`) or lowercasing the expression (`init(central) = conc0 * V`).

## Alternatives considered

Adding a bespoke parse-time warning for unresolved init identifiers — rejected: at parse time the data columns aren't known, and registration reuses the existing, already-tested `check_covariates` fit-time guard for free.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change (both edited fns are private to `model_parser`).

## Breaking changes
- [x] None

A model whose init covariate never resolved was already silently wrong; it now errors loudly. Any model whose init covariate *does* resolve is unaffected.

## Numerical validation
- [x] Not applicable (parser correctness; no estimator/PK math changed)

Manual end-to-end check on the thioguanine model:
```
# before: init(central) = CONC0 * V, header is conc0, auto-detect
#   -> block silently dead, OFV identical with/without block
# after:
Error: Model references covariate(s) not found in data (case-sensitive): CONC0.
  Available covariate columns: oid, ODV, l2, sex, age, disease, duration, WT, geno, ASA, reason, conc0.
# with CONC0 = conc0 in [data]: fits normally (block now fires)
```

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 2353 pass)
- [x] Regression test added that fails without this fix (`test_initial_conditions_covariate_is_registered`; plus `test_initial_conditions_param_only_registers_no_covariate` guards against param leakage)

## Docs
- [x] `docs/model-file/initial-conditions.qmd` — added a case-sensitivity callout
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added

## Reviewer hints

Focus on the call site in `parse_model` (registration + sort) and `build_init_amount_fn`'s new tuple element. `collect_covariates` runs on the parsed AST where identifiers not in `{theta, eta, indiv}` are `Covariate` leaves, so individual parameters (e.g. `V`) never leak in — covered by the param-only test.
