### PR TITLE
feat(io): add discrete-state/count observation plumbing (Phase 4.0) [refs #760 #759]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -477,6 +477,11 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
                     cmt,
                 })
                 .collect(),
+            // `obs_records` is unconditional since Phase 4.0, but the only records
+            // this synthetic TTE subject carries are `Event`s (survival-gated); with
+            // the feature off there is no TTE endpoint, so the vec is empty.
+            #[cfg(not(feature = "survival"))]
+            obs_records: Vec::new(),
         })
         .collect();
     let template = Population {
@@ -1588,7 +1593,11 @@ fn check_rtte_records(model: &CompiledModel, population: &Population) -> Option<
                     event_type,
                     entry_time,
                     ..
-                } = r;
+                } = r
+                else {
+                    // Non-TTE records are handled by their own endpoint; skip them.
+                    continue;
+                };
                 if *c != cmt {
                     continue;
                 }
@@ -5964,7 +5973,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -6751,7 +6759,10 @@ fn validate_tte_simulatable(
             for r in &subject.obs_records {
                 let ObsRecord::Event {
                     cmt, entry_time, ..
-                } = r;
+                } = r
+                else {
+                    continue;
+                };
                 if is_rtte(cmt) {
                     rtte_cmts.insert(*cmt);
                     if *entry_time > 0.0 {
@@ -6910,7 +6921,9 @@ pub fn simulate_with_options(
         #[cfg(feature = "survival")]
         for subject in &population.subjects {
             for record in &subject.obs_records {
-                let crate::types::ObsRecord::Event { entry_time, .. } = record;
+                let crate::types::ObsRecord::Event { entry_time, .. } = record else {
+                    continue;
+                };
                 if *entry_time > h {
                     return Err(format!(
                         "SimulateOptions.horizon ({h}) is below subject '{}' entry_time \
@@ -8879,7 +8892,6 @@ mod iov_integration {
                 occasions: occasions.clone(),
                 dose_occasions: dose_occ.clone(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();
@@ -9756,7 +9768,6 @@ mod iov_integration {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             });
         }
@@ -9845,7 +9856,6 @@ mod iov_integration {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             });
         }
@@ -9932,7 +9942,6 @@ mod iov_integration {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             });
         }
@@ -10027,7 +10036,6 @@ mod iov_integration {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             });
         }
@@ -10123,7 +10131,6 @@ mod iov_integration {
             occasions: vec![1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -10471,7 +10478,6 @@ mod iov_integration {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let pop = Population {
@@ -11429,7 +11435,6 @@ mod simulate_with_uncertainty_tests {
                 occasions: vec![1, 1, 1],
                 dose_occasions: vec![1],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();
@@ -11809,7 +11814,6 @@ mod sde_integration {
                 occasions: vec![1u32; 3],
                 dose_occasions: vec![1u32],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();
@@ -11940,7 +11944,6 @@ mod sde_integration {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             };
             Population {
@@ -12263,7 +12266,6 @@ mod tests_sdtab_tv_cov {
             occasions: vec![1, 1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // Sanity: this subject must be classified TV — that's the regime the
@@ -12433,7 +12435,6 @@ mod tests_sdtab_tv_cov {
             occasions: vec![1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let eta = DVector::from_vec(vec![0.0]);
@@ -12589,7 +12590,6 @@ mod tests_sdtab_tv_cov {
             occasions: vec![1, 1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(subject.has_tv_covariates());
@@ -12751,7 +12751,6 @@ mod tests_derived_session_clock {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -12990,7 +12989,6 @@ mod tests_derived_session_clock {
             occasions: vec![1, 1, 1],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13133,7 +13131,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0; 4],
             occasions: vec![1, 1, 2, 2],
             dose_occasions: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -13314,7 +13311,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0, 0],
             occasions: vec![1, 2],
             dose_occasions: vec![1, 2],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13406,7 +13402,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0],
             occasions: vec![1],
             dose_occasions: vec![1],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13477,7 +13472,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0],
             occasions: vec![1],
             dose_occasions: vec![1],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13538,7 +13532,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0],
             occasions: vec![1],
             dose_occasions: vec![1],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13610,7 +13603,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0, 0],
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13673,7 +13665,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0],
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13732,7 +13723,6 @@ mod tests_derived_iov_kappa {
             cens: vec![0],
             occasions: vec![1],
             dose_occasions: vec![1],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -13871,7 +13861,6 @@ mod adaptive_sim_tests {
             occasions: vec![1u32; n],
             dose_occasions: vec![1u32; n_dose],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -15801,7 +15790,6 @@ mod adaptive_snapshot_verify_tests {
             occasions: vec![1, 1],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -16129,7 +16117,6 @@ mod adaptive_snapshot_verify_tests {
             occasions: vec![1; decisions.len()],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let pop = Population {

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -107,7 +107,6 @@ fn simulate_subjects(
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             }
         })
@@ -553,7 +552,6 @@ fn generate_two_cpt_oral_cov() {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         })
         .collect();

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -2075,7 +2075,6 @@ mod tests {
                 occasions: vec![1, 1, 1],
                 dose_occasions: vec![1],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();
@@ -3333,7 +3332,6 @@ mod tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         Population {

--- a/src/estimation/hmc.rs
+++ b/src/estimation/hmc.rs
@@ -287,7 +287,6 @@ mod tests {
             occasions: vec![1; times.len()],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2186,7 +2186,6 @@ mod tests {
             dose_occasions: Vec::new(),
             // 3rd row is a FREM covariate pseudo-observation.
             fremtype: vec![0, 0, 5],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let ipreds = vec![9.0, 7.0, 99.0];
@@ -2520,7 +2519,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype,
-            #[cfg(feature = "survival")]
             obs_records: Vec::new(),
         }
     }
@@ -2736,7 +2734,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: vec![0, 0, 100],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2871,7 +2871,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -2975,7 +2974,6 @@ mod tests {
             occasions: vec![1; 6],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -3098,7 +3096,6 @@ mod tests {
             occasions: vec![1; 6],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -3531,7 +3528,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: vec![0, 0, 100], // last obs is FREM
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -3654,7 +3650,6 @@ mod iov_tests {
                 occasions: vec![1, 1, 2, 2],
                 dose_occasions: vec![1, 2],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             }],
             covariate_names: Vec::new(),
@@ -3782,7 +3777,6 @@ mod iov_tests {
             occasions: vec![1; 5],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let subject = tvcov_subj();
@@ -3849,7 +3843,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // FD subject: more occasion groups than the widened ODE IOV dispatch serves.
@@ -3873,7 +3866,6 @@ mod iov_tests {
             occasions: (1..=n_wide as u32).collect(),
             dose_occasions: (1..=n_wide as u32).collect(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -3919,7 +3911,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -3969,7 +3960,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -4012,7 +4002,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -4055,7 +4044,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -4094,7 +4082,6 @@ mod iov_tests {
             occasions: vec![1, 1, 2, 2],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -4208,7 +4195,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -4268,7 +4254,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -4357,7 +4342,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -4457,7 +4441,6 @@ mod iov_tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -4681,7 +4664,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -4782,7 +4764,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -4895,7 +4876,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -5012,7 +4992,6 @@ mod iov_tests {
                 occasions: vec![1, 1, 1, 2, 2, 2],
                 dose_occasions: vec![1, 2],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             };
             let params = model.default_params.clone();
@@ -5125,7 +5104,6 @@ mod iov_tests {
                 occasions: vec![1, 1, 1, 2, 2, 2],
                 dose_occasions: vec![1, 2],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             };
             let params = model.default_params.clone();
@@ -5237,7 +5215,6 @@ mod iov_tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -5455,7 +5432,6 @@ mod iov_tests {
             occasions: vec![1; 6],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -5523,7 +5499,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // A genuinely non-zero η, including the residual-error component.
@@ -5560,7 +5535,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         check_inner_ruv_grad(&model, &subject, &[0.15, -0.10, 0.25]);
@@ -5643,7 +5617,6 @@ mod iov_tests {
             occasions: vec![1; 5],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // Nonzero residuals: predictions at η=0.1 nudged, scored at a different η.
@@ -5687,7 +5660,6 @@ mod iov_tests {
             occasions: vec![1; 5],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -5738,7 +5710,6 @@ mod iov_tests {
             occasions: vec![1; 5],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(
@@ -5780,7 +5751,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(
@@ -5863,7 +5833,6 @@ mod iov_tests {
             occasions: vec![1; 5],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -5925,7 +5894,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let theta = vec![0.22, 11.0, 1.4, 1.6];
@@ -6017,7 +5985,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(
@@ -6093,7 +6060,6 @@ mod iov_tests {
             occasions: vec![1; 7],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(
@@ -6250,7 +6216,6 @@ mod iov_tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();
@@ -6361,7 +6326,6 @@ mod iov_tests {
             cens: vec![0; 3],
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let params = model.default_params.clone();

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -4628,7 +4628,6 @@ mod tests {
                 occasions: vec![1, 1, 1],
                 dose_occasions: vec![1],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();
@@ -5308,7 +5307,6 @@ mod tests {
                 cens: vec![0; 6],
                 occasions: vec![1, 1, 1, 2, 2, 2],
                 dose_occasions: vec![1],
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             })
             .collect();

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -2636,7 +2636,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let omega = OmegaMatrix::from_diagonal(&[1.0], vec!["ETA_CL".into()]);
@@ -2751,7 +2750,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -2849,7 +2847,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -3056,7 +3053,6 @@ mod tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: Vec::new(),
         };
 
@@ -3212,7 +3208,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -3354,7 +3349,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {
@@ -3454,7 +3448,6 @@ mod tests {
             occasions: vec![1u32, 1, 2, 2],
             dose_occasions: vec![1u32],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -3568,7 +3561,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let population = Population {

--- a/src/estimation/saem_conddist.rs
+++ b/src/estimation/saem_conddist.rs
@@ -359,7 +359,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -3131,7 +3131,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let eta_ref = [0.12, -0.08, 0.2];
@@ -3592,7 +3591,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let eta_ref = [0.12, -0.08, 0.2, 0.0];
@@ -3836,7 +3834,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(model, &subject, theta, &[0.12, -0.08]);
@@ -4410,7 +4407,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::predict_iov(
@@ -4450,7 +4446,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::compute_predictions_with_tv(model, &subject, theta, eta_ref);
@@ -4865,7 +4860,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(subject.has_resets(), "fixture must carry a reset");
@@ -4936,7 +4930,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -5303,7 +5296,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         assert!(
@@ -5497,7 +5489,6 @@ mod tests {
                 occasions: vec![1; n],
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             };
             let preds = crate::pk::compute_predictions_with_tv(&model, &s, &theta, &eta_ref);
@@ -5623,7 +5614,6 @@ mod tests {
                 occasions: vec![1; n],
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             };
             let eta_ref = [0.12, -0.08, 0.2, 0.1];
@@ -6344,7 +6334,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // Reference (η_bsv, κ_g0, κ_g1) → realistic ε ≠ 0.
@@ -6629,7 +6618,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::predict_iov(
@@ -7918,7 +7906,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let preds = crate::pk::predict_iov(

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1026,7 +1026,6 @@ mod tests {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: Vec::new(),
             },
             Subject {
@@ -1051,7 +1050,6 @@ mod tests {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: Vec::new(),
             },
         ];
@@ -1906,7 +1904,6 @@ mod tests {
                 occasions: Vec::new(),
                 dose_occasions: Vec::new(),
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: Vec::new(),
             });
         }
@@ -2069,7 +2066,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: Vec::new(),
         });
         // Subject 1: RACE=1, Subject 2: RACE=-99

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -170,7 +170,7 @@ pub(crate) fn read_nonmem_csv_mapped(
         iov_column,
         None,
         None,
-        &HashSet::new(),
+        &ObsRouting::default(),
         column_map,
     )
     .map(|(pop, _)| pop)
@@ -222,7 +222,7 @@ pub(crate) fn read_nonmem_csv_with_covariates_mapped(
         iov_column,
         Some(decls),
         None,
-        &HashSet::new(),
+        &ObsRouting::default(),
         column_map,
     )?;
     Ok((
@@ -274,7 +274,7 @@ pub(crate) fn read_nonmem_csv_filtered_mapped(
         iov_column,
         None,
         Some(filter),
-        &HashSet::new(),
+        &ObsRouting::default(),
         column_map,
     )
     .map(|(pop, _)| pop)
@@ -332,13 +332,74 @@ pub(crate) fn read_nonmem_csv_with_covariates_filtered_mapped(
         iov_column,
         Some(decls),
         Some(filter),
-        &HashSet::new(),
+        &ObsRouting::default(),
         column_map,
     )?;
     Ok((
         pop,
         table.expect("covariate table is built whenever table_decls is Some"),
     ))
+}
+
+/// Which non-Gaussian [`ObsRecord`](crate::types::ObsRecord) variant each CMT's
+/// EVID=0 observation rows route to. Empty sets ⇒ every observation row takes the
+/// Gaussian parallel-Vec path (the all-Gaussian default).
+///
+/// The three sets must be pairwise disjoint — a CMT has exactly one endpoint kind
+/// (§8.1: routing is by the CMT's declared endpoint, never guessed from the DV).
+/// [`ObsRouting::validate`] enforces disjointness before any row is read.
+///
+/// Phase 4.0 introduces the discrete/count routing but no parser yet populates
+/// those sets; `discrete`/`count` are reachable only through
+/// [`read_nonmem_csv_filtered_routed`] (used by the reader unit tests). The
+/// production `api::read_population_for` path still builds a TTE-only routing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ObsRouting {
+    /// CMTs whose rows become `ObsRecord::Event` (TTE / RTTE; `survival` feature).
+    pub tte: HashSet<usize>,
+    /// CMTs whose integer-DV rows become `ObsRecord::DiscreteState`
+    /// (binary / ordinal / Markov state index).
+    pub discrete: HashSet<usize>,
+    /// CMTs whose non-negative-integer-DV rows become `ObsRecord::Count`
+    /// (Poisson / negative-binomial).
+    pub count: HashSet<usize>,
+}
+
+impl ObsRouting {
+    /// TTE-only routing (the pre-Phase-4.0 behaviour): every CMT in `tte_cmts`
+    /// routes to `ObsRecord::Event`; nothing routes to discrete/count.
+    pub(crate) fn tte_only(tte_cmts: &HashSet<usize>) -> Self {
+        Self {
+            tte: tte_cmts.clone(),
+            ..Default::default()
+        }
+    }
+
+    /// Reject a CMT declared under more than one endpoint kind — that would make
+    /// row routing ambiguous (one endpoint per CMT, §8.1).
+    fn validate(&self) -> Result<(), String> {
+        let overlap =
+            |a: &HashSet<usize>, b: &HashSet<usize>| a.iter().find(|c| b.contains(c)).copied();
+        if let Some(cmt) = overlap(&self.tte, &self.discrete) {
+            return Err(format!(
+                "CMT={cmt} is routed to both a TTE and a discrete-state endpoint; \
+                 each CMT may have only one endpoint type"
+            ));
+        }
+        if let Some(cmt) = overlap(&self.tte, &self.count) {
+            return Err(format!(
+                "CMT={cmt} is routed to both a TTE and a count endpoint; \
+                 each CMT may have only one endpoint type"
+            ));
+        }
+        if let Some(cmt) = overlap(&self.discrete, &self.count) {
+            return Err(format!(
+                "CMT={cmt} is routed to both a discrete-state and a count endpoint; \
+                 each CMT may have only one endpoint type"
+            ));
+        }
+        Ok(())
+    }
 }
 
 // ── TTE-aware readers (pub(crate) — used by api::read_population_for) ────────
@@ -375,7 +436,7 @@ pub(crate) fn read_nonmem_csv_filtered_tte(
         iov_column,
         None,
         filter,
-        tte_cmts,
+        &ObsRouting::tte_only(tte_cmts),
         column_map,
     )
     .map(|(pop, _)| pop)
@@ -412,13 +473,25 @@ pub(crate) fn read_nonmem_csv_with_covariates_tte(
         iov_column,
         Some(decls),
         filter,
-        tte_cmts,
+        &ObsRouting::tte_only(tte_cmts),
         column_map,
     )?;
     Ok((
         pop,
         table.expect("covariate table is built whenever table_decls is Some"),
     ))
+}
+
+/// Reader entry point taking a full [`ObsRouting`] — the general form behind
+/// [`read_nonmem_csv_filtered_tte`]. Phase 4.0 exposes it so the discrete-state /
+/// count routing can be exercised directly from unit tests (no parser produces
+/// those sets yet). Disjointness is validated inside [`read_nonmem_csv_impl`].
+#[cfg(test)]
+pub(crate) fn read_nonmem_csv_filtered_routed(
+    path: &Path,
+    routing: &ObsRouting,
+) -> Result<Population, String> {
+    read_nonmem_csv_impl(path, None, None, None, None, routing, &[]).map(|(pop, _)| pop)
 }
 
 /// Shared CSV reader. `table_decls`, when `Some`, requests building a
@@ -428,17 +501,19 @@ pub(crate) fn read_nonmem_csv_with_covariates_tte(
 /// undeclared covariates) are read into the [`Population`] leniently. `None` on
 /// both is the legacy auto-detect [`read_nonmem_csv`] path.
 ///
-/// `tte_cmts`: CMTs whose EVID=0 rows should be routed to `Subject::obs_records`
-/// (TTE endpoint) instead of the Gaussian parallel Vecs. Empty for all-Gaussian models.
+/// `routing`: per-CMT non-Gaussian endpoint routing (`ObsRecord::Event` /
+/// `DiscreteState` / `Count`). Default (all sets empty) ⇒ every observation row
+/// takes the Gaussian parallel-Vec path. Disjointness is validated up front.
 fn read_nonmem_csv_impl(
     path: &Path,
     covariate_columns: Option<&[&str]>,
     iov_column: Option<&str>,
     table_decls: Option<&[CovariateDecl]>,
     filter: Option<&SelectionFilter>,
-    tte_cmts: &HashSet<usize>,
+    routing: &ObsRouting,
     column_map: &[(String, String)],
 ) -> Result<(Population, Option<CovariateTable>), String> {
+    routing.validate()?;
     let mut rdr = csv::ReaderBuilder::new()
         .flexible(true)
         .has_headers(true)
@@ -527,7 +602,7 @@ fn read_nonmem_csv_impl(
     let cens_col = col_idx_ci("cens");
     let addl_col = col_idx_ci("addl");
     // TENTRY column: left-truncation / delayed-entry time for TTE rows.
-    // Absent in Gaussian-only datasets; only used when tte_cmts is non-empty.
+    // Absent in Gaussian-only datasets; only read for `routing.tte` (Event) rows.
     let tentry_col = col_idx_ci("tentry");
 
     // FREMTYPE column (case-insensitive)
@@ -713,7 +788,7 @@ fn read_nonmem_csv_impl(
                 fremtype_col,
                 &cov_indices,
                 filter,
-                tte_cmts,
+                routing,
                 tentry_col,
             )?;
         total_occ_failures += occ_failures;
@@ -836,14 +911,13 @@ fn read_nonmem_csv_impl(
     } else if subjects.iter().all(|s| s.doses.is_empty()) {
         // Zero dose events across the whole population. Warn only when scored
         // observations are present (an all-EVID=2 / covariate-only dataset is not
-        // a fit) and the dataset isn't TTE/survival (which legitimately has no PK
-        // doses) — otherwise this would be a noisy false positive.
+        // a fit) and the dataset carries no non-Gaussian observations — TTE/survival
+        // and discrete/count endpoints legitimately have no PK doses, so suppressing
+        // the warning for them avoids a noisy false positive. `obs_records` is
+        // unconditional since Phase 4.0, so this needs no feature split.
         let total_scored_obs: usize = subjects.iter().map(|s| s.observations.len()).sum();
-        #[cfg(feature = "survival")]
-        let any_tte = subjects.iter().any(|s| !s.obs_records.is_empty());
-        #[cfg(not(feature = "survival"))]
-        let any_tte = false;
-        if total_scored_obs > 0 && !any_tte {
+        let any_nongaussian_obs = subjects.iter().any(|s| !s.obs_records.is_empty());
+        if total_scored_obs > 0 && !any_nongaussian_obs {
             population_warnings.push(format!(
                 "W_NO_DOSES: parsed zero dose events across all {} subject(s) although scored \
                  observations are present. If this is a PK model, check that the dataset has an \
@@ -1174,10 +1248,10 @@ fn parse_subject(
     fremtype_col: Option<usize>,
     cov_indices: &[(String, usize)],
     filter: Option<&SelectionFilter>,
-    // CMTs to route to `obs_records` instead of the Gaussian parallel Vecs.
-    // Empty for Gaussian-only models. Always available; feature-gated routing
-    // runs inside `#[cfg(feature = "survival")]` blocks.
-    tte_cmts: &HashSet<usize>,
+    // Per-CMT non-Gaussian endpoint routing (Event / DiscreteState / Count).
+    // Empty for Gaussian-only models. Always available; the TTE (`Event`) arm is
+    // feature-gated behind `survival`, the discrete/count arms compile unconditionally.
+    routing: &ObsRouting,
     // Column index of the TENTRY (left-truncation time) column, if present.
     _tentry_col: Option<usize>,
 ) -> Result<(Subject, usize, usize, SubjectExclusion, Vec<String>, usize), String> {
@@ -1212,13 +1286,14 @@ fn parse_subject(
     // dose rows don't trip the warning.
     let mut amt_ignored_rows: usize = 0;
 
-    // TTE state — only meaningful when tte_cmts is non-empty.
-    // obs_records: finalised TTE observation records for this subject.
+    // Non-Gaussian observation records for this subject. Holds TTE `Event`s
+    // (pushed only under `survival`) and, unconditionally, discrete-state / count
+    // rows. Unconditional since Phase 4.0 so the categorical (Track C) and Markov
+    // (Track D) endpoints share one stream on the default build.
+    let mut obs_records: Vec<crate::types::ObsRecord> = Vec::new();
     // tte_pending_left: per-CMT pending DV=0 row (may be a left-bound for an interval
     //   or a right-censored event, depending on whether the next row is DV=2).
-    //   Map value is (time, entry_time).
-    #[cfg(feature = "survival")]
-    let mut tte_obs_records: Vec<crate::types::ObsRecord> = Vec::new();
+    //   Map value is (time, entry_time). TTE-only, hence `survival`-gated.
     #[cfg(feature = "survival")]
     let mut tte_pending_left: HashMap<usize, (f64, f64)> = HashMap::new();
 
@@ -1615,11 +1690,12 @@ fn parse_subject(
                 })
                 .unwrap_or(1);
 
-            // TTE row routing: when this CMT belongs to a TTE endpoint, route to
-            // obs_records instead of the Gaussian parallel Vecs.
-            // The `tte_cmts.contains` check is always compiled (HashSet is not
-            // feature-gated); the inner ObsRecord construction is cfg-gated.
-            if tte_cmts.contains(&cmt) {
+            // Non-Gaussian row routing: when this CMT belongs to a declared TTE /
+            // discrete-state / count endpoint, route the row to `obs_records`
+            // instead of the Gaussian parallel Vecs. The routing `.contains`
+            // checks are always compiled; only the TTE `Event` construction is
+            // `survival`-gated. The routing sets are disjoint (validated up front).
+            if routing.tte.contains(&cmt) {
                 #[cfg(feature = "survival")]
                 {
                     use crate::types::{EventType, ObsRecord};
@@ -1656,7 +1732,7 @@ fn parse_subject(
                             // interval-censored pair. Save as pending; flush on next row.
                             // Flush any existing pending for this CMT first.
                             if let Some((t_left, e_left)) = tte_pending_left.remove(&cmt) {
-                                tte_obs_records.push(ObsRecord::Event {
+                                obs_records.push(ObsRecord::Event {
                                     time: t_left,
                                     event_type: EventType::RightCensored,
                                     entry_time: e_left,
@@ -1668,14 +1744,14 @@ fn parse_subject(
                         1 => {
                             // DV=1: exact event. Flush any pending left for this CMT.
                             if let Some((t_left, e_left)) = tte_pending_left.remove(&cmt) {
-                                tte_obs_records.push(ObsRecord::Event {
+                                obs_records.push(ObsRecord::Event {
                                     time: t_left,
                                     event_type: EventType::RightCensored,
                                     entry_time: e_left,
                                     cmt,
                                 });
                             }
-                            tte_obs_records.push(ObsRecord::Event {
+                            obs_records.push(ObsRecord::Event {
                                 time,
                                 event_type: EventType::Exact,
                                 entry_time,
@@ -1692,7 +1768,7 @@ fn parse_subject(
                                 )
                             })?;
                             let (t_left, e_left) = left;
-                            tte_obs_records.push(ObsRecord::Event {
+                            obs_records.push(ObsRecord::Event {
                                 time,
                                 event_type: EventType::IntervalCensored {
                                     left: t_left,
@@ -1711,9 +1787,53 @@ fn parse_subject(
                         }
                     }
                 }
-                // Note: no fallback needed here. `tte_cmts` is always empty when the
-                // `survival` feature is off (callers pass `&HashSet::new()`), so this
-                // branch is never entered in that build. The dead cfg block was removed.
+                // No fallback arm needed: `routing.tte` is always empty when the
+                // `survival` feature is off (its only producer is a TTE endpoint),
+                // so this branch is never entered in that build.
+            } else if routing.discrete.contains(&cmt) {
+                // Discrete-state observation (binary / ordinal / Markov state).
+                // The DV is a non-negative integer state index; reject fractional
+                // or negative values rather than silently truncating (mirrors the
+                // TTE integer-code rule, #192). No endpoint math here (Phase 4.0).
+                let dv_rounded = dv.round();
+                if (dv - dv_rounded).abs() > 1e-9 {
+                    return Err(format!(
+                        "Subject {id}: discrete-state endpoint CMT={cmt} has non-integer \
+                         DV={dv} at TIME={time}; the DV must be a non-negative integer state index"
+                    ));
+                }
+                if dv_rounded < 0.0 {
+                    return Err(format!(
+                        "Subject {id}: discrete-state endpoint CMT={cmt} has negative \
+                         DV={dv} at TIME={time}; the DV must be a non-negative integer state index"
+                    ));
+                }
+                obs_records.push(crate::types::ObsRecord::DiscreteState {
+                    time,
+                    state: dv_rounded as usize,
+                    cmt,
+                });
+            } else if routing.count.contains(&cmt) {
+                // Count observation (Poisson / negative-binomial). The DV is a
+                // non-negative integer count that must fit u32.
+                let dv_rounded = dv.round();
+                if (dv - dv_rounded).abs() > 1e-9 {
+                    return Err(format!(
+                        "Subject {id}: count endpoint CMT={cmt} has non-integer DV={dv} \
+                         at TIME={time}; the DV must be a non-negative integer count"
+                    ));
+                }
+                if dv_rounded < 0.0 || dv_rounded > u32::MAX as f64 {
+                    return Err(format!(
+                        "Subject {id}: count endpoint CMT={cmt} has out-of-range DV={dv} \
+                         at TIME={time}; the DV must be a non-negative integer count (0..=4294967295)"
+                    ));
+                }
+                obs_records.push(crate::types::ObsRecord::Count {
+                    time,
+                    count: dv_rounded as u32,
+                    cmt,
+                });
             } else {
                 // Gaussian path.
                 // Missing DV (`.` / `NA` / blank) on a scored observation row
@@ -1850,7 +1970,7 @@ fn parse_subject(
     // following DV=2 — the subject was censored at its last observation time.
     #[cfg(feature = "survival")]
     for (cmt, (t_left, e_left)) in tte_pending_left {
-        tte_obs_records.push(crate::types::ObsRecord::Event {
+        obs_records.push(crate::types::ObsRecord::Event {
             time: t_left,
             event_type: crate::types::EventType::RightCensored,
             entry_time: e_left,
@@ -1876,8 +1996,7 @@ fn parse_subject(
             occasions,
             dose_occasions: sorted_dose_occ,
             fremtype,
-            #[cfg(feature = "survival")]
-            obs_records: tte_obs_records,
+            obs_records,
         },
         occ_parse_failures,
         missing_dv_skipped,
@@ -2770,13 +2889,165 @@ mod tests {
             event_type,
             entry_time,
             ..
-        } = &recs[0];
+        } = &recs[0]
+        else {
+            panic!("expected a TTE Event record");
+        };
         assert_eq!(*time, 100.0, "event time stays on the raw data clock");
         assert_eq!(
             *entry_time, 90.0,
             "TENTRY must be the raw value, not shifted to first-row origin or clamped to 0"
         );
         assert!(matches!(event_type, EventType::Exact));
+    }
+
+    // ── Phase 4.0: discrete-state / count observation routing ────────────────
+    // The reader routes EVID=0 rows on a declared discrete/count CMT into
+    // `obs_records` as `DiscreteState` / `Count`, with an integer + non-negative
+    // guard (mirrors the TTE integer-code rule). No endpoint math yet — these
+    // exercise only the plumbing, via the `_routed` entry point (no parser
+    // populates the discrete/count sets in Phase 4.0). Default-features tests so
+    // the per-PR coverage gate measures them.
+
+    #[test]
+    fn discrete_state_cmt_routes_integer_dv_into_obs_records() {
+        use crate::types::ObsRecord;
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                   1,0,0,0,0,.,3\n\
+                   1,1,2,0,0,.,3\n\
+                   1,2,1,0,0,.,3\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+        let subj = &pop.subjects[0];
+        assert!(
+            subj.observations.is_empty(),
+            "discrete rows must route to obs_records, not the Gaussian observation vec"
+        );
+        let states: Vec<(f64, usize)> = subj
+            .obs_records
+            .iter()
+            .map(|r| match r {
+                ObsRecord::DiscreteState { time, state, cmt } => {
+                    assert_eq!(*cmt, 3);
+                    (*time, *state)
+                }
+                other => panic!("expected DiscreteState, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(states, vec![(0.0, 0), (1.0, 2), (2.0, 1)]);
+    }
+
+    #[test]
+    fn count_cmt_routes_nonneg_integer_dv_into_obs_records() {
+        use crate::types::ObsRecord;
+        let routing = ObsRouting {
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                   1,0,5,0,0,.,4\n\
+                   1,1,0,0,0,.,4\n\
+                   1,2,12,0,0,.,4\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+        let counts: Vec<(f64, u32)> = pop.subjects[0]
+            .obs_records
+            .iter()
+            .map(|r| match r {
+                ObsRecord::Count { time, count, cmt } => {
+                    assert_eq!(*cmt, 4);
+                    (*time, *count)
+                }
+                other => panic!("expected Count, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(counts, vec![(0.0, 5), (1.0, 0), (2.0, 12)]);
+    }
+
+    #[test]
+    fn discrete_state_endpoint_rejects_noninteger_dv() {
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,1.5,0,0,.,3\n";
+        let f = write_csv(csv);
+        let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+        assert!(err.contains("non-integer"), "got: {err}");
+        assert!(err.contains("discrete-state"), "got: {err}");
+    }
+
+    #[test]
+    fn discrete_state_endpoint_rejects_negative_dv() {
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,-1,0,0,.,3\n";
+        let f = write_csv(csv);
+        let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+        assert!(err.contains("negative"), "got: {err}");
+    }
+
+    #[test]
+    fn count_endpoint_rejects_noninteger_dv() {
+        let routing = ObsRouting {
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,2.5,0,0,.,4\n";
+        let f = write_csv(csv);
+        let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+        assert!(err.contains("non-integer"), "got: {err}");
+        assert!(err.contains("count"), "got: {err}");
+    }
+
+    #[test]
+    fn count_endpoint_rejects_negative_or_overflow_dv() {
+        let routing = ObsRouting {
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        };
+        // Below 0 and above u32::MAX both fail the count range check.
+        for bad in ["-3", "5000000000"] {
+            let csv = format!("ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,{bad},0,0,.,4\n");
+            let f = write_csv(&csv);
+            let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+            assert!(err.contains("out-of-range"), "DV={bad} got: {err}");
+        }
+    }
+
+    #[test]
+    fn obs_routing_rejects_cmt_in_two_endpoint_kinds() {
+        // A CMT declared under two endpoint kinds is ambiguous; rejected before
+        // any row is read (ObsRouting::validate). Cover all three pairings.
+        let cases = [
+            ObsRouting {
+                tte: [3].into_iter().collect(),
+                discrete: [3].into_iter().collect(),
+                ..Default::default()
+            },
+            ObsRouting {
+                tte: [3].into_iter().collect(),
+                count: [3].into_iter().collect(),
+                ..Default::default()
+            },
+            ObsRouting {
+                discrete: [3].into_iter().collect(),
+                count: [3].into_iter().collect(),
+                ..Default::default()
+            },
+        ];
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,1,0,0,.,3\n";
+        for routing in cases {
+            let f = write_csv(csv);
+            let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+            assert!(err.contains("only one endpoint type"), "got: {err}");
+        }
     }
 
     #[test]

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -375,6 +375,19 @@ impl ObsRouting {
         }
     }
 
+    /// The integer-coded non-Gaussian endpoint kind (discrete-state or count) a
+    /// CMT routes to, if any. `None` ⇒ the CMT is TTE or Gaussian. The routing
+    /// sets are pairwise disjoint (validated up front), so this is unambiguous.
+    fn integer_kind(&self, cmt: usize) -> Option<IntDvKind> {
+        if self.discrete.contains(&cmt) {
+            Some(IntDvKind::DiscreteState)
+        } else if self.count.contains(&cmt) {
+            Some(IntDvKind::Count)
+        } else {
+            None
+        }
+    }
+
     /// Reject a CMT declared under more than one endpoint kind — that would make
     /// row routing ambiguous (one endpoint per CMT, §8.1).
     fn validate(&self) -> Result<(), String> {
@@ -400,6 +413,98 @@ impl ObsRouting {
         }
         Ok(())
     }
+}
+
+/// An integer-coded non-Gaussian observation endpoint: a discrete-state index
+/// (binary / ordinal / Markov state — unbounded `usize`) or a `u32` count
+/// (Poisson / negative-binomial). Selects the DV upper bound and the error
+/// wording in [`checked_integer_dv`].
+#[derive(Debug, Clone, Copy)]
+enum IntDvKind {
+    DiscreteState,
+    Count,
+}
+
+impl IntDvKind {
+    fn label(self) -> &'static str {
+        match self {
+            IntDvKind::DiscreteState => "discrete-state",
+            IntDvKind::Count => "count",
+        }
+    }
+
+    fn unit(self) -> &'static str {
+        match self {
+            IntDvKind::DiscreteState => "state index",
+            IntDvKind::Count => "count",
+        }
+    }
+
+    /// Exclusive upper bound on the rounded DV: a value `>=` this overflows the
+    /// `as usize` / `as u32` cast and is rejected (no domain cap in Phase 4.0 —
+    /// the bound only rejects values the cast could not represent). `type::MAX as
+    /// f64 + 1.0` is exact on both 32- and 64-bit: when `type::MAX` is
+    /// f64-representable the `+1` lands on the next integer; when it rounds up
+    /// (`usize::MAX` on 64-bit: `2^64 - 1` → `2^64`) the `+1` is absorbed, leaving
+    /// exactly the first saturating value. So `u32::MAX` / `usize::MAX` themselves
+    /// are accepted and only genuine overflow is rejected. Non-finite DVs are
+    /// rejected earlier.
+    fn exclusive_max(self) -> f64 {
+        match self {
+            IntDvKind::DiscreteState => usize::MAX as f64 + 1.0,
+            IntDvKind::Count => u32::MAX as f64 + 1.0,
+        }
+    }
+
+    /// Human-readable valid-range suffix for the out-of-range message; empty for
+    /// the state index (its `usize::MAX` bound is not a meaningful domain limit).
+    fn range_hint(self) -> &'static str {
+        match self {
+            IntDvKind::DiscreteState => "",
+            IntDvKind::Count => " (0..=4294967295)",
+        }
+    }
+}
+
+/// Validate a non-Gaussian integer-coded DV (discrete-state index or count) and
+/// return the rounded, non-negative magnitude. Rejects — with a caller-shaped
+/// message — non-finite, fractional, negative, and out-of-range (cast-overflowing)
+/// DVs (§8.1 integer-code rule, #192).
+///
+/// A **missing** DV (`.`/`NA`/blank) is skipped by the caller as MDV=1 (#258) and
+/// never reaches here. This function is the guard that stops the three silent
+/// mis-records a raw `dv.round() as usize`/`as u32` cast would otherwise produce:
+/// a `.`-coerced `0.0` → phantom `state:0`/`count:0`; an `inf` → saturated
+/// `usize::MAX`/`u32::MAX`; a `NaN` (whose every comparison is false) → `0`.
+fn checked_integer_dv(
+    dv: f64,
+    kind: IntDvKind,
+    id: &str,
+    cmt: usize,
+    time: f64,
+) -> Result<f64, String> {
+    let (label, unit) = (kind.label(), kind.unit());
+    if !dv.is_finite() {
+        return Err(format!(
+            "Subject {id}: {label} endpoint CMT={cmt} has non-finite DV={dv} at \
+             TIME={time}; the DV must be a non-negative integer {unit}"
+        ));
+    }
+    let dv_rounded = dv.round();
+    if (dv - dv_rounded).abs() > 1e-9 {
+        return Err(format!(
+            "Subject {id}: {label} endpoint CMT={cmt} has non-integer DV={dv} at \
+             TIME={time}; the DV must be a non-negative integer {unit}"
+        ));
+    }
+    if dv_rounded < 0.0 || dv_rounded >= kind.exclusive_max() {
+        return Err(format!(
+            "Subject {id}: {label} endpoint CMT={cmt} has out-of-range DV={dv} at \
+             TIME={time}; the DV must be a non-negative integer {unit}{hint}",
+            hint = kind.range_hint()
+        ));
+    }
+    Ok(dv_rounded)
 }
 
 // ── TTE-aware readers (pub(crate) — used by api::read_population_for) ────────
@@ -1690,6 +1795,15 @@ fn parse_subject(
                 })
                 .unwrap_or(1);
 
+            // A missing DV cell (`.` / `NA` / blank) means "no observation":
+            // `parse_f64` coerced it to `0.0` above, so without this guard a
+            // forgotten MDV would inject a phantom scored row. NONMEM convention
+            // marks such rows MDV=1; treat a forgotten one the same way — skip it
+            // and count it for the single W_MISSING_DV summary (#258). Applied to
+            // every scored endpoint below (Gaussian, discrete-state, count); the
+            // TTE `Event` arm keeps its own DV-code semantics and does not use it.
+            let dv_missing = is_missing_cell(row.get(dv_col).map(|s| s.as_str()).unwrap_or(""));
+
             // Non-Gaussian row routing: when this CMT belongs to a declared TTE /
             // discrete-state / count endpoint, route the row to `obs_records`
             // instead of the Gaussian parallel Vecs. The routing `.contains`
@@ -1790,60 +1904,35 @@ fn parse_subject(
                 // No fallback arm needed: `routing.tte` is always empty when the
                 // `survival` feature is off (its only producer is a TTE endpoint),
                 // so this branch is never entered in that build.
-            } else if routing.discrete.contains(&cmt) {
-                // Discrete-state observation (binary / ordinal / Markov state).
-                // The DV is a non-negative integer state index; reject fractional
-                // or negative values rather than silently truncating (mirrors the
-                // TTE integer-code rule, #192). No endpoint math here (Phase 4.0).
-                let dv_rounded = dv.round();
-                if (dv - dv_rounded).abs() > 1e-9 {
-                    return Err(format!(
-                        "Subject {id}: discrete-state endpoint CMT={cmt} has non-integer \
-                         DV={dv} at TIME={time}; the DV must be a non-negative integer state index"
-                    ));
+            } else if let Some(kind) = routing.integer_kind(cmt) {
+                // Non-Gaussian integer-coded observation (discrete-state index or
+                // count). A missing DV is skipped as MDV=1 — the same #258
+                // phantom-zero guard the Gaussian branch uses — so a forgotten MDV
+                // never records a spurious `state:0` / `count:0`. Otherwise the DV
+                // must be a finite, non-negative, in-range integer (`checked_integer_dv`,
+                // #192); no endpoint math here (Phase 4.0).
+                if dv_missing {
+                    missing_dv_skipped += 1;
+                    continue;
                 }
-                if dv_rounded < 0.0 {
-                    return Err(format!(
-                        "Subject {id}: discrete-state endpoint CMT={cmt} has negative \
-                         DV={dv} at TIME={time}; the DV must be a non-negative integer state index"
-                    ));
-                }
-                obs_records.push(crate::types::ObsRecord::DiscreteState {
-                    time,
-                    state: dv_rounded as usize,
-                    cmt,
-                });
-            } else if routing.count.contains(&cmt) {
-                // Count observation (Poisson / negative-binomial). The DV is a
-                // non-negative integer count that must fit u32.
-                let dv_rounded = dv.round();
-                if (dv - dv_rounded).abs() > 1e-9 {
-                    return Err(format!(
-                        "Subject {id}: count endpoint CMT={cmt} has non-integer DV={dv} \
-                         at TIME={time}; the DV must be a non-negative integer count"
-                    ));
-                }
-                if dv_rounded < 0.0 || dv_rounded > u32::MAX as f64 {
-                    return Err(format!(
-                        "Subject {id}: count endpoint CMT={cmt} has out-of-range DV={dv} \
-                         at TIME={time}; the DV must be a non-negative integer count (0..=4294967295)"
-                    ));
-                }
-                obs_records.push(crate::types::ObsRecord::Count {
-                    time,
-                    count: dv_rounded as u32,
-                    cmt,
+                let magnitude = checked_integer_dv(dv, kind, id, cmt, time)?;
+                obs_records.push(match kind {
+                    IntDvKind::DiscreteState => crate::types::ObsRecord::DiscreteState {
+                        time,
+                        state: magnitude as usize,
+                        cmt,
+                    },
+                    IntDvKind::Count => crate::types::ObsRecord::Count {
+                        time,
+                        count: magnitude as u32,
+                        cmt,
+                    },
                 });
             } else {
-                // Gaussian path.
-                // Missing DV (`.` / `NA` / blank) on a scored observation row
-                // (EVID=0, MDV=0): NONMEM convention is to mark these MDV=1, but
-                // if the user didn't, `parse_f64` would coerce the cell to 0.0
-                // and inject a phantom zero observation into the likelihood.
-                // Treat a missing DV as MDV=1 — skip the row — and count it for a
-                // single summary warning (W_MISSING_DV; issue #258).
-                let dv_cell = row.get(dv_col).map(|s| s.as_str()).unwrap_or("");
-                if is_missing_cell(dv_cell) {
+                // Gaussian path. A missing DV (`.`/`NA`/blank) is skipped as MDV=1
+                // (see the `dv_missing` note above; #258) so a forgotten MDV never
+                // injects a phantom zero observation.
+                if dv_missing {
                     missing_dv_skipped += 1;
                     continue;
                 }
@@ -3048,6 +3137,167 @@ mod tests {
             let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
             assert!(err.contains("only one endpoint type"), "got: {err}");
         }
+    }
+
+    // ── Phase 4.0 regression: DV guard gaps on discrete/count endpoints ───────
+    // A missing / non-finite DV must NOT silently become a phantom record. The
+    // integer guard `(dv - dv.round()).abs() > 1e-9` can't reject a non-finite
+    // `dv` (every NaN/inf comparison is false), and `parse_f64` coerces a missing
+    // cell to `0.0`; without the finiteness guard and the shared missing-DV skip,
+    // `.` → `state:0`/`count:0`, `inf` → saturated `usize::MAX`, `NaN` → `0`.
+
+    #[test]
+    fn discrete_and_count_endpoints_skip_missing_dv() {
+        // A missing DV on a discrete/count row is treated as MDV=1 (#258): the row
+        // is skipped (no phantom `state:0`/`count:0`) and folded into the single
+        // W_MISSING_DV summary, exactly like the Gaussian path. `.`, `NA`, and
+        // `NaN` (case-insensitive) are all missing tokens (`is_missing_cell`).
+        use crate::types::ObsRecord;
+        for set_name in ["discrete", "count"] {
+            for missing in [".", "NA", "NaN", "na", "nan"] {
+                let routing = match set_name {
+                    "discrete" => ObsRouting {
+                        discrete: [3].into_iter().collect(),
+                        ..Default::default()
+                    },
+                    _ => ObsRouting {
+                        count: [3].into_iter().collect(),
+                        ..Default::default()
+                    },
+                };
+                // Row at t=1 is missing; the t=0 and t=2 rows are valid.
+                let csv = format!(
+                    "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                     1,0,2,0,0,.,3\n\
+                     1,1,{missing},0,0,.,3\n\
+                     1,2,1,0,0,.,3\n"
+                );
+                let f = write_csv(&csv);
+                let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+                let subj = &pop.subjects[0];
+                // Exactly the two valid rows survive — the missing one is dropped,
+                // not recorded as a spurious zero at t=1.
+                let times: Vec<f64> =
+                    subj.obs_records
+                        .iter()
+                        .map(|r| match r {
+                            ObsRecord::DiscreteState { time, .. }
+                            | ObsRecord::Count { time, .. } => *time,
+                            other => panic!("{set_name}/{missing}: unexpected record {other:?}"),
+                        })
+                        .collect();
+                assert_eq!(
+                    times,
+                    vec![0.0, 2.0],
+                    "{set_name}/{missing}: missing-DV row must be skipped, not a phantom zero"
+                );
+                let warns = pop
+                    .warnings
+                    .iter()
+                    .filter(|w| w.starts_with("W_MISSING_DV"))
+                    .count();
+                assert_eq!(
+                    warns, 1,
+                    "{set_name}/{missing}: expected one W_MISSING_DV summary"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn discrete_state_endpoint_rejects_nonfinite_dv() {
+        // `±inf` (including an overflow like `1e999`) must be rejected, not cast:
+        // `inf as usize` saturates to usize::MAX and `-inf as usize` is 0. The
+        // integer guard alone misses these because comparisons against a
+        // non-finite value are always false. (A literal `NaN`/`NA` cell is a
+        // *missing* token — covered by the skip test above, not here.)
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        for bad in ["inf", "-inf", "1e999"] {
+            let csv = format!("ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,{bad},0,0,.,3\n");
+            let f = write_csv(&csv);
+            let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+            assert!(err.contains("non-finite"), "DV={bad} got: {err}");
+            assert!(err.contains("discrete-state"), "DV={bad} got: {err}");
+        }
+    }
+
+    #[test]
+    fn count_endpoint_rejects_nonfinite_dv() {
+        let routing = ObsRouting {
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        };
+        for bad in ["inf", "-inf", "1e999"] {
+            let csv = format!("ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,{bad},0,0,.,4\n");
+            let f = write_csv(&csv);
+            let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+            assert!(err.contains("non-finite"), "DV={bad} got: {err}");
+            assert!(err.contains("count"), "DV={bad} got: {err}");
+        }
+    }
+
+    #[test]
+    fn discrete_state_endpoint_rejects_dv_above_usize_range() {
+        // A finite but astronomically large integer-valued DV (`1e300`) is beyond
+        // usize; without the upper-bound check `1e300 as usize` saturates to
+        // usize::MAX silently. Count already had this guard (via `> u32::MAX`);
+        // discrete now mirrors it (via the shared exclusive_max bound).
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,1e300,0,0,.,3\n";
+        let f = write_csv(csv);
+        let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+        assert!(err.contains("out-of-range"), "got: {err}");
+    }
+
+    #[test]
+    fn count_endpoint_accepts_u32_max() {
+        // The upper bound is exclusive at `u32::MAX + 1`, so the full u32 range —
+        // including `u32::MAX` itself — is accepted, not rejected. (Locks the
+        // boundary against a future "tighten `>=`" that would drop `u32::MAX`.)
+        use crate::types::ObsRecord;
+        let routing = ObsRouting {
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = format!("ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,{},0,0,.,4\n", u32::MAX);
+        let f = write_csv(&csv);
+        let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+        assert!(
+            matches!(
+                pop.subjects[0].obs_records.as_slice(),
+                [ObsRecord::Count { count, .. }] if *count == u32::MAX
+            ),
+            "u32::MAX must be an accepted count, got {:?}",
+            pop.subjects[0].obs_records
+        );
+    }
+
+    #[test]
+    fn discrete_state_endpoint_accepts_large_valid_index() {
+        // A large but in-`usize` state index (`1e18` < 2^64) is a legitimate value
+        // and must be recorded exactly, not rejected by the overflow guard.
+        use crate::types::ObsRecord;
+        let routing = ObsRouting {
+            discrete: [3].into_iter().collect(),
+            ..Default::default()
+        };
+        let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n1,0,1e18,0,0,.,3\n";
+        let f = write_csv(csv);
+        let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+        assert!(
+            matches!(
+                pop.subjects[0].obs_records.as_slice(),
+                [ObsRecord::DiscreteState { state, .. }] if *state == 1_000_000_000_000_000_000
+            ),
+            "1e18 must be an accepted state index, got {:?}",
+            pop.subjects[0].obs_records
+        );
     }
 
     #[test]

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1998,7 +1998,6 @@ mod tests {
                 occasions: vec![],
                 dose_occasions: vec![],
                 fremtype: Vec::new(),
-                #[cfg(feature = "survival")]
                 obs_records: vec![],
             });
         }

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2672,7 +2672,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -399,7 +399,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let ode_spec = OdeSpec {

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -4512,7 +4512,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -21896,7 +21896,6 @@ if (WT > 70) {
             occasions: vec![1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -21964,7 +21963,6 @@ if (WT > 70) {
             occasions: vec![1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -1047,7 +1047,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -2191,7 +2191,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let pk = make_pk_params(10.0, 100.0);
@@ -2246,7 +2245,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -2436,7 +2434,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let pk = make_pk_params(10.0, 100.0);
@@ -3273,7 +3270,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let pk_dose: Vec<PkParams> = vec![pk.clone(); doses.len()];

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -5434,7 +5434,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -1333,7 +1333,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -5984,7 +5984,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -6437,7 +6436,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -7408,7 +7406,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -8271,7 +8268,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         // θ = [TVCL, TVV, TVKA, TVLAG]; η = [ETA_CL, ETA_V, ETA_KA, ETA_LAG] (lag carries IIV).
@@ -8884,7 +8880,6 @@ mod tests {
             occasions: vec![1; n],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -9325,7 +9320,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -10524,7 +10518,6 @@ mod tests {
             occasions,
             dose_occasions: (1..=n_occ as u32).collect(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let theta = vec![0.2, 10.0];
@@ -10602,7 +10595,6 @@ mod tests {
             occasions,
             dose_occasions: (1..=n_occ as u32).collect(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let theta = vec![0.2, 10.0];
@@ -12452,7 +12444,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -12744,7 +12735,6 @@ mod tests {
             occasions,
             dose_occasions: vec![1, 2],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -140,7 +140,11 @@ fn tte_ode_nll(
             event_type,
             entry_time,
             ..
-        } = r;
+        } = r
+        else {
+            // Non-TTE records don't contribute hazard times; skip them.
+            continue;
+        };
         if *entry_time > 0.0 {
             times.push(*entry_time);
         }
@@ -270,7 +274,11 @@ fn try_joint_pktte_shared_solve(
                 event_type,
                 entry_time,
                 cmt: rc,
-            } = r;
+            } = r
+            else {
+                // Non-TTE records don't contribute hazard times; skip them.
+                continue;
+            };
             if rc != cmt {
                 continue;
             }
@@ -2452,7 +2460,6 @@ mod tests {
             occasions: vec![1, 1, 1, 2, 2, 2],
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         }
     }
@@ -3274,7 +3281,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: vec![0, 100],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let ipreds = vec![10.0, 20.0];
@@ -3326,7 +3332,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: vec![0, 0],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let ipreds = vec![10.0, 20.0];

--- a/src/suggest_start/nca.rs
+++ b/src/suggest_start/nca.rs
@@ -685,7 +685,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
             covariates: HashMap::new(),
             dose_covariates: vec![],

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -177,7 +177,12 @@ pub fn tte_nll_from_curves(
             event_type,
             entry_time,
             ..
-        } = record;
+        } = record
+        else {
+            // Non-TTE records (discrete-state / count endpoints) don't contribute
+            // to the survival likelihood; skip them.
+            continue;
+        };
 
         let h_entry = if *entry_time > 0.0 {
             cumhaz_at(*entry_time)
@@ -297,7 +302,12 @@ pub fn rtte_forward_nll_from_curves(
             event_type,
             entry_time,
             ..
-        } = record;
+        } = record
+        else {
+            // Non-TTE records (discrete-state / count endpoints) don't contribute
+            // to the survival likelihood; skip them.
+            continue;
+        };
 
         if !seeded {
             h_lo = if *entry_time > 0.0 {
@@ -378,7 +388,12 @@ pub fn rtte_reset_nll_from_curves(
             event_type,
             entry_time,
             ..
-        } = record;
+        } = record
+        else {
+            // Non-TTE records (discrete-state / count endpoints) don't contribute
+            // to the survival likelihood; skip them.
+            continue;
+        };
 
         let gap = time - prev_time.unwrap_or(*entry_time);
         // A negative gap means out-of-order records (guarded at data load); the H(Δ) with
@@ -739,7 +754,9 @@ fn rtte_cause(
 ) -> Option<(usize, RtteClock, HazardFamily, Vec<f64>)> {
     let mut found: Option<(usize, RtteClock, HazardFamily, Vec<f64>)> = None;
     for record in &subject.obs_records {
-        let ObsRecord::Event { cmt, .. } = record;
+        let ObsRecord::Event { cmt, .. } = record else {
+            continue;
+        };
         let Some(EndpointLikelihood::Tte {
             hazard,
             recurrence: TteRecurrence::Repeated { clock },
@@ -965,7 +982,11 @@ pub fn simulate_tte<R: rand::Rng>(
             entry_time,
             time,
             event_type,
-        } = record;
+        } = record
+        else {
+            // Non-TTE records don't contribute a competing-risk cause; skip them.
+            continue;
+        };
         let Some(EndpointLikelihood::Tte { hazard, .. }) = model.endpoints.get(cmt) else {
             continue;
         };
@@ -1309,6 +1330,116 @@ mod tests {
             nll, 1e20,
             "non-monotone CHZ on an exact event must be sentinel-guarded"
         );
+    }
+
+    /// Phase 4.0 coexistence contract: a subject may carry non-TTE records
+    /// (discrete-state / count endpoints on other CMTs). The TTE NLL must skip
+    /// them — the `let ObsRecord::Event {..} = record else { continue }` guard —
+    /// so a mixed record slice yields exactly the Event-only NLL.
+    #[test]
+    fn tte_nll_from_curves_skips_non_event_records() {
+        let event = ObsRecord::Event {
+            time: 5.0,
+            event_type: EventType::Exact,
+            entry_time: 0.0,
+            cmt: 2,
+        };
+        let cumhaz = |t: f64| 0.1 * t;
+        let hazard = |_t: f64| 0.1;
+        let event_only = tte_nll_from_curves(&[event.clone()], cumhaz, hazard, MonoTol::default());
+        assert!(
+            event_only.is_finite() && event_only < 1e20,
+            "sanity: a well-posed exact event gives a finite NLL"
+        );
+        let mixed = tte_nll_from_curves(
+            &[
+                event,
+                ObsRecord::DiscreteState {
+                    time: 1.0,
+                    state: 0,
+                    cmt: 3,
+                },
+                ObsRecord::Count {
+                    time: 2.0,
+                    count: 4,
+                    cmt: 4,
+                },
+            ],
+            cumhaz,
+            hazard,
+            MonoTol::default(),
+        );
+        assert_eq!(
+            event_only, mixed,
+            "discrete-state / count records must be skipped by the TTE NLL"
+        );
+    }
+
+    /// Same coexistence contract for the RTTE clock-forward NLL: interleaved
+    /// non-TTE records are skipped, so the mixed slice equals the Event-only NLL.
+    #[test]
+    fn rtte_forward_nll_from_curves_skips_non_event_records() {
+        let events = [
+            ObsRecord::Event {
+                time: 2.0,
+                event_type: EventType::Exact,
+                entry_time: 0.0,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 5.0,
+                event_type: EventType::RightCensored,
+                entry_time: 0.0,
+                cmt: 2,
+            },
+        ];
+        let cumhaz = |t: f64| 0.1 * t;
+        let hazard = |_t: f64| 0.1;
+        let event_only = rtte_forward_nll_from_curves(&events, cumhaz, hazard, MonoTol::default());
+        let mut mixed = events.to_vec();
+        mixed.insert(
+            1,
+            ObsRecord::DiscreteState {
+                time: 3.0,
+                state: 1,
+                cmt: 3,
+            },
+        );
+        let mixed_nll = rtte_forward_nll_from_curves(&mixed, cumhaz, hazard, MonoTol::default());
+        assert_eq!(event_only, mixed_nll, "non-TTE records must be skipped");
+    }
+
+    /// Same coexistence contract for the RTTE clock-reset (gap-time) NLL.
+    #[test]
+    fn rtte_reset_nll_from_curves_skips_non_event_records() {
+        let events = [
+            ObsRecord::Event {
+                time: 2.0,
+                event_type: EventType::Exact,
+                entry_time: 0.0,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 5.0,
+                event_type: EventType::RightCensored,
+                entry_time: 0.0,
+                cmt: 2,
+            },
+        ];
+        let cumhaz = |t: f64| 0.1 * t;
+        let hazard = |_t: f64| 0.1;
+        let event_only = rtte_reset_nll_from_curves(&events, cumhaz, hazard, MonoTol::default());
+        let mut mixed = events.to_vec();
+        mixed.insert(
+            1,
+            ObsRecord::Count {
+                time: 3.0,
+                count: 2,
+                cmt: 4,
+            },
+        );
+        let mixed_nll = rtte_reset_nll_from_curves(&mixed, cumhaz, hazard, MonoTol::default());
+        assert_eq!(event_only, mixed_nll, "non-TTE records must be skipped");
     }
 
     /// The monotonicity guard tolerates ODE quadrature round-off on a (near-)flat

--- a/src/types.rs
+++ b/src/types.rs
@@ -711,7 +711,11 @@ pub struct Subject {
     /// Non-Gaussian observation records (TTE events, discrete states, counts).
     /// Empty for all-Gaussian subjects. Populated by the data reader when the
     /// model declares a non-Gaussian endpoint for the row's CMT.
-    #[cfg(feature = "survival")]
+    ///
+    /// Compiled unconditionally (Phase 4.0): the discrete-state / count plumbing
+    /// is the shared foundation for the categorical (Track C) and Markov
+    /// (Track D) endpoints, so it must be present on the default build. Only the
+    /// TTE `Event` variant it can hold stays behind the `survival` feature.
     pub obs_records: Vec<ObsRecord>,
 }
 
@@ -2529,10 +2533,17 @@ pub enum EventType {
     },
 }
 
-#[cfg(feature = "survival")]
 /// A single non-Gaussian observation record on a subject.
+///
+/// Compiled unconditionally (Phase 4.0) so the categorical/count (Track C) and
+/// Markov (Track D) endpoints share one observation stream on the default build.
+/// Only the TTE `Event` variant stays behind the `survival` feature — the same
+/// mixed-`cfg` shape `SimOutcome` already uses. The record variant is chosen by
+/// the CMT's declared endpoint, never guessed from the DV value (§8.1).
 #[derive(Debug, Clone)]
 pub enum ObsRecord {
+    /// TTE / survival event observation (gated behind the `survival` feature).
+    #[cfg(feature = "survival")]
     Event {
         time: f64,
         event_type: EventType,
@@ -2542,7 +2553,12 @@ pub enum ObsRecord {
         entry_time: f64,
         cmt: usize,
     },
-    // DiscreteState and Count variants deferred to Phase 4/5
+    /// Discrete-state observation: an integer category or Markov state index.
+    /// Serves binary/ordinal (Track C) and DTMM/CTMM state observations
+    /// (Track D); the CMT's declared endpoint disambiguates the meaning.
+    DiscreteState { time: f64, state: usize, cmt: usize },
+    /// Non-negative integer count observation (Poisson / negative-binomial, Track C).
+    Count { time: f64, count: u32, cmt: usize },
 }
 
 #[cfg(feature = "survival")]
@@ -2658,6 +2674,8 @@ impl std::fmt::Debug for EndpointLikelihood {
 ///
 /// `Continuous` preserves the existing Gaussian path unchanged.
 /// `Event` carries TTE-specific outputs (gated behind `survival` feature).
+/// `Category`/`Count` (Phase 4.0) are the shared categorical/count/Markov draw
+/// shapes; they compile unconditionally but have no producer until Track C/D.
 #[derive(Debug, Clone)]
 pub enum SimOutcome {
     /// Gaussian continuous prediction + residual noise (the only variant before Phase 1).
@@ -2665,6 +2683,10 @@ pub enum SimOutcome {
     /// TTE event: simulated event time and whether it occurred before the censoring horizon.
     #[cfg(feature = "survival")]
     Event { time: f64, observed: bool },
+    /// Categorical / discrete-state draw (binary, ordinal, DTMM/CTMM state) — Phase 4+.
+    Category { state: usize },
+    /// Count draw (Poisson / negative-binomial) — Phase 4+.
+    Count { count: u32 },
 }
 
 impl SimOutcome {
@@ -2680,6 +2702,13 @@ impl SimOutcome {
                 debug_assert!(
                     false,
                     "continuous_value() called on a TTE Event row — filter by CMT type first"
+                );
+                f64::NAN
+            }
+            SimOutcome::Category { .. } | SimOutcome::Count { .. } => {
+                debug_assert!(
+                    false,
+                    "continuous_value() called on a categorical/count row — filter by CMT type first"
                 );
                 f64::NAN
             }
@@ -5822,7 +5851,6 @@ pub(crate) mod test_helpers {
             occasions: vec![1, 1, 1],
             dose_occasions: vec![1],
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         (model, subject)
@@ -5833,6 +5861,49 @@ pub(crate) mod test_helpers {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    /// Phase 4.0: the `Category` / `Count` `SimOutcome` variants compile
+    /// unconditionally (shared categorical/count/Markov draw shapes) and derive
+    /// Debug/Clone. The Gaussian path is unchanged.
+    #[test]
+    fn sim_outcome_category_and_count_variants_construct() {
+        let c = SimOutcome::Category { state: 2 };
+        let n = SimOutcome::Count { count: 5 };
+        assert!(format!("{c:?}").contains("Category"));
+        assert!(format!("{n:?}").contains("Count"));
+        let _ = c.clone();
+        let _ = n.clone();
+        assert_eq!(
+            SimOutcome::Continuous { value: 4.25 }.continuous_value(),
+            4.25
+        );
+    }
+
+    /// `continuous_value()` returns NAN for the non-Gaussian outcomes. The
+    /// misuse `debug_assert` fires in debug builds, so this is asserted only when
+    /// debug-assertions are off — the profile CI and coverage use (`ci-test`,
+    /// which inherits `release`), where the NAN branch is actually taken.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn sim_outcome_category_and_count_continuous_value_is_nan() {
+        assert!(SimOutcome::Category { state: 3 }
+            .continuous_value()
+            .is_nan());
+        assert!(SimOutcome::Count { count: 9 }.continuous_value().is_nan());
+    }
+
+    /// The TTE `Event` outcome likewise has no continuous value. Same profile
+    /// caveat as above (the debug-assert fires in debug builds).
+    #[test]
+    #[cfg(all(feature = "survival", not(debug_assertions)))]
+    fn sim_outcome_event_continuous_value_is_nan() {
+        assert!(SimOutcome::Event {
+            time: 1.0,
+            observed: true,
+        }
+        .continuous_value()
+        .is_nan());
+    }
 
     /// `effective_cov_inner_tol` resolves the covariance-step reconvergence tolerance:
     /// an explicit `cov_inner_tol` wins; otherwise the fit's `inner_tol`, tightened to
@@ -5945,7 +6016,6 @@ mod tests {
             dose_occasions: vec![],
             // Row 0 = PK observation, row 1 = covariate pseudo-observation.
             fremtype: vec![0, 100],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
 
@@ -5995,7 +6065,6 @@ mod tests {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: vec![0],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         };
         let sigma = vec![0.3];
@@ -7108,7 +7177,6 @@ mod tests {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: Vec::new(),
         }
     }

--- a/tests/adaptive_vanco_iov_anchor.rs
+++ b/tests/adaptive_vanco_iov_anchor.rs
@@ -115,7 +115,6 @@ fn anchor_subject(decision_times: &[f64]) -> Subject {
         occasions: vec![1u32; n],
         dose_occasions: Vec::new(),
         fremtype: Vec::new(),
-        #[cfg(feature = "survival")]
         obs_records: vec![],
     }
 }

--- a/tests/adaptive_vanco_renal_iov_anchor.rs
+++ b/tests/adaptive_vanco_renal_iov_anchor.rs
@@ -108,7 +108,6 @@ fn anchor_subject(decision_times: &[f64]) -> Subject {
         occasions: vec![1u32; n],
         dose_occasions: Vec::new(),
         fremtype: Vec::new(),
-        #[cfg(feature = "survival")]
         obs_records: vec![],
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -47,7 +47,6 @@ pub fn subject(
         occasions: vec![],
         dose_occasions: vec![],
         fremtype: vec![],
-        #[cfg(feature = "survival")]
         obs_records: vec![],
     }
 }

--- a/tests/imp_init_defensive_slow.rs
+++ b/tests/imp_init_defensive_slow.rs
@@ -118,7 +118,9 @@ fn simulate_dv(
             let row = iter.next().expect("one sim row per scheduled observation");
             match row.outcome {
                 SimOutcome::Continuous { value } => *obs = value,
-                #[cfg(feature = "survival")]
+                // Non-Continuous outcomes (Event under `survival`, plus the
+                // unconditional Category/Count) never occur for this Gaussian
+                // model; ignore them.
                 _ => {}
             }
         }

--- a/tests/large_ode_slot_headroom.rs
+++ b/tests/large_ode_slot_headroom.rs
@@ -202,7 +202,6 @@ fn template_population(n: usize) -> Population {
             occasions: vec![],
             dose_occasions: vec![],
             fremtype: vec![],
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         })
         .collect();

--- a/tests/saem_conddist_api.rs
+++ b/tests/saem_conddist_api.rs
@@ -54,7 +54,6 @@ fn template_population(n: usize) -> Population {
             occasions: Vec::new(),
             dose_occasions: Vec::new(),
             fremtype: Vec::new(),
-            #[cfg(feature = "survival")]
             obs_records: vec![],
         })
         .collect();

--- a/tests/tte_convergence.rs
+++ b/tests/tte_convergence.rs
@@ -435,6 +435,9 @@ fn joint_pktte_pop_from_sims(template: &Population, sims: &[SimulationResult]) -
             SimOutcome::Event { time, observed } => {
                 ev_by_id.insert(r.id.clone(), (time, observed, r.cmt));
             }
+            SimOutcome::Category { .. } | SimOutcome::Count { .. } => {
+                unreachable!("TTE simulation does not produce categorical/count outcomes")
+            }
         }
     }
     let mut pop = template.clone();

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -823,7 +823,9 @@ mod survival_smoke {
         use ferx_core::{simulate_with_options, SimulateOptions};
         let model = parse_model_string(RTTE_EXP_FIT_MODEL).expect("RTTE model must parse");
         let mut pop = rtte_pop();
-        let ObsRecord::Event { entry_time, .. } = &mut pop.subjects[0].obs_records[0];
+        let ObsRecord::Event { entry_time, .. } = &mut pop.subjects[0].obs_records[0] else {
+            panic!("expected a TTE Event record");
+        };
         *entry_time = 2.0;
         let opts = SimulateOptions {
             seed: Some(1),
@@ -1478,7 +1480,10 @@ mod survival_smoke {
                         entry_time,
                         time,
                         ..
-                    } = r;
+                    } = r
+                    else {
+                        panic!("expected a TTE Event record");
+                    };
                     assert_eq!(
                         *entry_time, 0.0,
                         "synthetic subjects have no left truncation"
@@ -1494,7 +1499,9 @@ mod survival_smoke {
                 .obs_records
                 .iter()
                 .filter(|r| {
-                    let ObsRecord::Event { event_type, .. } = r;
+                    let ObsRecord::Event { event_type, .. } = r else {
+                        return false;
+                    };
                     matches!(event_type, EventType::Exact)
                 })
                 .count();
@@ -1506,7 +1513,10 @@ mod survival_smoke {
                 for r in &subj.obs_records {
                     let ObsRecord::Event {
                         time, event_type, ..
-                    } = r;
+                    } = r
+                    else {
+                        panic!("expected a TTE Event record");
+                    };
                     assert!(matches!(event_type, EventType::RightCensored));
                     assert!(
                         (time - H).abs() < 1e-9,
@@ -1573,7 +1583,10 @@ mod survival_smoke {
                 event_type,
                 entry_time,
                 cmt,
-            } = &subj.obs_records[0];
+            } = &subj.obs_records[0]
+            else {
+                panic!("expected a TTE Event record");
+            };
             assert_eq!(*cmt, 2, "row on the cause CMT");
             assert_eq!(
                 *entry_time, 0.0,
@@ -1690,7 +1703,9 @@ mod survival_smoke {
             // One TTE row on the cause CMT, written by the TTE write-back. Reaching
             // this also drives the non-`Event` `filter_map` arm (the continuous rows).
             assert_eq!(subj.obs_records.len(), 1, "one TTE event row");
-            let ObsRecord::Event { time, cmt, .. } = &subj.obs_records[0];
+            let ObsRecord::Event { time, cmt, .. } = &subj.obs_records[0] else {
+                panic!("expected a TTE Event record");
+            };
             assert_eq!(*cmt, 2, "TTE row on the cause CMT");
             assert!(*time <= 14.0 + 1e-9, "TTE outcome within the horizon");
         }
@@ -1876,6 +1891,138 @@ mod survival_smoke {
         assert!(
             censored > 0,
             "some subjects must survive to the horizon (got {censored})"
+        );
+    }
+
+    // ── Phase 4.0 coexistence: TTE code paths skip non-Event records ─────────
+    // Once discrete/count endpoints coexist, a subject may carry non-TTE records
+    // on other CMTs. Every TTE fit/sim path iterating `obs_records` skips them
+    // (the `let ObsRecord::Event {..} = record else { continue }` guard), so
+    // adding one must not change the OFV or the simulated events. These exercise
+    // the guard end-to-end via the public `fit`/`simulate` APIs.
+
+    /// RTTE fit path (`check_rtte_records` + the telescoping NLL).
+    #[test]
+    fn rtte_fit_tolerates_interleaved_non_event_records() {
+        let model = parse_model_string(RTTE_EXP_FIT_MODEL).expect("RTTE model must parse");
+        let opts = FitOptions::default();
+        let baseline = fit(&model, &rtte_pop(), &model.default_params, &opts)
+            .expect("baseline RTTE fit")
+            .ofv;
+        let mut pop = rtte_pop();
+        pop.subjects[0].obs_records.insert(
+            1,
+            ObsRecord::DiscreteState {
+                time: 7.0,
+                state: 1,
+                cmt: 3,
+            },
+        );
+        let mixed = fit(&model, &pop, &model.default_params, &opts)
+            .expect("RTTE fit must tolerate a non-TTE record")
+            .ofv;
+        assert_eq!(
+            baseline, mixed,
+            "a discrete-state record must not change the RTTE OFV"
+        );
+    }
+
+    /// ODE-accumulated-hazard fit path (`tte_ode_nll`).
+    #[test]
+    fn ode_tte_fit_tolerates_interleaved_non_event_records() {
+        let model = parse_model_string(ODE_TTE_MODEL).expect("ODE-TTE model parses");
+        let build_pop = || {
+            let mut pop = common::tte_pop_from_pairs(&vec![(15.0, 1u8); 10]);
+            for s in pop.subjects.iter_mut() {
+                s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+                s.obs_records = vec![ObsRecord::Event {
+                    time: 15.0,
+                    event_type: EventType::Exact,
+                    entry_time: 0.0,
+                    cmt: 3,
+                }];
+            }
+            pop
+        };
+        let opts = FitOptions::default();
+        let baseline = fit(&model, &build_pop(), &model.default_params, &opts)
+            .expect("baseline ODE-TTE fit")
+            .ofv;
+        let mut pop = build_pop();
+        pop.subjects[0].obs_records.insert(
+            0,
+            ObsRecord::DiscreteState {
+                time: 5.0,
+                state: 0,
+                cmt: 4,
+            },
+        );
+        let mixed = fit(&model, &pop, &model.default_params, &opts)
+            .expect("ODE-TTE fit must tolerate a non-TTE record")
+            .ofv;
+        assert_eq!(
+            baseline, mixed,
+            "a discrete-state record must not change the ODE-TTE OFV"
+        );
+    }
+
+    /// ODE-hazard simulation path (`simulate_tte`, `draw_ode_tte_latent`,
+    /// `validate_tte_simulatable`, `simulate_with_options`).
+    #[test]
+    fn simulate_ode_tte_tolerates_interleaved_non_event_records() {
+        use ferx_core::{simulate_with_options, SimOutcome, SimulateOptions};
+        const H: f64 = 30.0;
+        let model = parse_model_string(ODE_TTE_MODEL).expect("ODE-TTE model parses");
+        let build_pop = || {
+            let mut pop = common::tte_pop_from_pairs(&vec![(H, 0u8); 20]);
+            for s in pop.subjects.iter_mut() {
+                s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+                s.obs_records = vec![ObsRecord::Event {
+                    time: H,
+                    event_type: EventType::RightCensored,
+                    entry_time: 0.0,
+                    cmt: 3,
+                }];
+            }
+            pop
+        };
+        let opts = SimulateOptions {
+            seed: Some(17),
+            match_method: None,
+            horizon: Some(H),
+        };
+        let baseline = simulate_with_options(&model, &build_pop(), &model.default_params, 1, &opts)
+            .expect("baseline ODE-TTE sim");
+        let mut pop = build_pop();
+        pop.subjects[0].obs_records.insert(
+            0,
+            ObsRecord::Count {
+                time: 12.0,
+                count: 2,
+                cmt: 4,
+            },
+        );
+        let mixed = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
+            .expect("ODE-TTE sim must tolerate a non-TTE record");
+        // Same seed + same TTE design ⇒ bit-identical simulated events on CMT 3.
+        let events = |sims: &[ferx_core::api::SimulationResult]| {
+            let mut v: Vec<(String, u64, bool)> = sims
+                .iter()
+                .filter(|r| r.cmt == 3)
+                .map(|r| match r.outcome {
+                    SimOutcome::Event { time, observed } => {
+                        (r.id.clone(), time.to_bits(), observed)
+                    }
+                    ref o => panic!("expected an Event outcome, got {o:?}"),
+                })
+                .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(
+            events(&baseline),
+            events(&mixed),
+            "a non-TTE record must not change the simulated TTE events"
         );
     }
 
@@ -2623,7 +2770,9 @@ mod survival_smoke {
                 "subject {} has 1 TTE record (CMT 3)",
                 s.id
             );
-            let ObsRecord::Event { cmt, .. } = &s.obs_records[0];
+            let ObsRecord::Event { cmt, .. } = &s.obs_records[0] else {
+                panic!("expected a TTE Event record");
+            };
             assert_eq!(*cmt, 3, "the TTE record is routed to CMT 3");
         }
     }


### PR DESCRIPTION
## Why

Phase 4.0 of the TTE/Markov plan (`plans/tte-survival-markov.md` §19) is the shared foundation that lets the **categorical track (C, #760)** and the **Markov track (D, #759)** build in parallel. It carves the discrete-state / count observation **plumbing** out of the front of Phase 4 so the Markov phases (4c/5/6) depend only on this thin slice — not on the whole categorical distribution phase.

No user-facing behaviour changes here: this is record types, reader routing, and output shapes only. The likelihood math, DSL blocks, and `simulate()`/`predict()` producers land in Tracks C/D.

## What changed

- **`types.rs`** — ungate `ObsRecord` and `Subject.obs_records` to **default-on**, keeping the `Event` variant `#[cfg(feature = "survival")]` (the same mixed-`cfg` shape `SimOutcome` already uses). Add `ObsRecord::{DiscreteState, Count}` and `SimOutcome::{Category, Count}` (+ `continuous_value()` arms).
- **`io/datareader.rs`** — new `ObsRouting { tte, discrete, count }` replaces the single `tte_cmts` set, giving 3 routing targets. Integer-DV routing for discrete-state / count CMTs with a non-integer, negative, and `u32`-overflow guard (mirrors the TTE integer-code rule, #192), plus a disjointness guard (`validate()`). Test-facing `read_nonmem_csv_filtered_routed` entry (no parser populates the discrete/count sets in Phase 4.0). The TTE wrappers keep their `tte_cmts` signature and wrap via `ObsRouting::tte_only()`, so `api::read_population_for` is untouched.
- **Ungate cascade** (the cost of making the plumbing default-on): 130 mechanical `#[cfg(survival)]` strips on empty `obs_records` field-inits, and **19 refutable-pattern fixes** — adding enum variants made `let ObsRecord::Event {..} = record;` refutable in survival code (`survival/mod.rs`, `stats/likelihood.rs`, `api.rs`) and tests (`tte_smoke.rs`, `tte_convergence.rs`). Each became `let-else { continue; }` (production loops skip non-Event records) or `panic!` (test assertions); one non-exhaustive `SimOutcome` match got a Category/Count arm. Behaviour-identical today — nothing produces non-Event records yet — and exactly the coexistence Tracks C/D will need.

## Alternatives considered

Gating strategy was the one real decision. Rejected: **(a)** keep the plumbing under `survival` — but Track C is default-on and Track D is `markov`-gated, so `survival` (a TTE/Track-A flag) is the wrong home; **(b)** promote `survival` to a default feature — zero churn but flips all TTE estimation on in the default build, a trunk-level change out of 4.0's scope. Chose the **surgical ungate**: make only the obs-plumbing default-on, keep the heavy TTE math survival-gated.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r consumes `SimOutcome` via `outcome.continuous_value()` (not an exhaustive `match`), so the additive variants don't break it.

## Breaking changes
- [x] Public Rust API (`api.rs` / `types.rs`)

Additive only: new variants on `ObsRecord` and `SimOutcome` (neither is `#[non_exhaustive]`). No fields removed, no signatures changed on the public surface. ferx-r unaffected (verified above); internal exhaustive matches all updated.

## Numerical validation
- [x] Not applicable (plumbing produces no estimates/residuals/diagnostics — no numbers to anchor)

## Performance
- [x] No significant impact expected (an extra empty `Vec<ObsRecord>` per subject when unused; routing is per-row `HashSet` membership already present for TTE)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)

9 default-features tests: discrete/count routing happy paths, non-integer / negative / overflow / disjointness rejections, and `SimOutcome::{Category,Count}` construction + NAN `continuous_value`. Default-features so the per-PR coverage gate measures them.

Verified: `--lib` under `ci` and `ci,survival` green (the single failing `run_covariance_matches_inline_covariance` is a **pre-existing macOS-LAPACK local flake**, byte-identical file to `main`, CI-green); `--tests --features ci,survival,slow-tests` compiles clean; `tte_smoke` (survival) 74/74; clippy + rustfmt clean.

## Example (user-facing features only)
- [x] Not applicable (internal / no new user-visible API surface)

## Docs
- [x] No user-visible change · `CHANGELOG.md` N/A (internal plumbing)

## Checklist
- [x] `cargo clippy` clean (no new warnings in changed code)
- [x] `Dual2` sensitivity path untouched
- [x] No version bump (additive, non-breaking in practice)

## Reviewer hints

Focus on **`io/datareader.rs`** (`ObsRouting`, the `tte → discrete → count → gaussian` routing chain, and the DV guards) and the **`types.rs`** enum/field ungate. The bulk of the diff is mechanical: the 130 `#[cfg]` strips and the 19 `let-else { continue }` conversions are uniform and can be skimmed — the semantic question for each is only "should a TTE loop skip a non-Event record?" (yes).

## Open questions

None blocking. The `let-else { continue }` conversions quietly establish "TTE code skips non-Event records" as the coexistence contract; Tracks C/D will build the actual per-endpoint dispatch on top.
