### PR TITLE
feat(io): complete machine-readable JSON serialization of FitResult [closes #777]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Machine-readable JSON fit output** (#777): `ferx <model> --data <csv>
+  --output-format json` (or `both`) writes `{model}-fit.json` — the *complete*
+  fit result (every estimate, standard error, diagnostic, per-subject record,
+  and provenance field), not the curated human YAML. It carries a top-level
+  `schema_version` so programmatic/agent consumers can pin, matrices serialize
+  as `{rows, cols, data}` (row-major) and vectors as flat arrays, and non-finite
+  floats become JSON `null`. `--output-format yaml` (the default) is unchanged.
+  Library callers can get the same payload in-process via
+  `FitResult::to_json_value()`. See the
+  [output documentation](https://ferx-nlme.github.io/ferx-core/output.html).
 - **Experimental `markov` feature — CTMM matrix-exponential foundation**
   (#759): a new default-off `markov` cargo feature adds the numerical core for
   continuous-time Markov models — transition probabilities

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -5,7 +5,7 @@ The `ferx` command-line tool runs population PK estimation from model files and 
 ## Usage
 
 ```bash
-ferx <model.ferx> --data <data.csv> [--output <run.fitrx>] [--include-data] [--inits-from-nca[=METHOD]]
+ferx <model.ferx> --data <data.csv> [--output <run.fitrx>] [--include-data] [--inits-from-nca[=METHOD]] [--output-format yaml|json|both]
 ferx <model.ferx> --simulate          [--output <run.fitrx>]
 ferx check <model.ferx> [--data <data.csv>] [--json]
 ferx summary <run.fitrx> [<run2.fitrx> ...]
@@ -156,6 +156,26 @@ default).
 ```bash
 ferx model.ferx --data data.csv --output run1.fitrx --include-data
 ```
+
+## Estimates format (`--output-format`)
+
+The human-readable estimates file defaults to YAML (`{model}-fit.yaml`). Pass
+`--output-format` to control it:
+
+| Value | Writes |
+|-------|--------|
+| `yaml` (default) | `{model}-fit.yaml` — curated, human-readable |
+| `json` | `{model}-fit.json` — the complete `FitResult`, machine-readable |
+| `both` | both files |
+
+```bash
+ferx model.ferx --data data.csv --output-format json
+```
+
+The JSON is the full fit under a versioned schema — intended for scripts, the R
+wrapper, or an agentic model-development loop. It is unrelated to the `--output`
+`.fitrx` bundle above (which packages a whole run for archival/interchange). See
+[Output Files](output.qmd#fit-json-modelfitjson) for the schema.
 
 ## NCA-based starting values (`--inits-from-nca`)
 

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -2,6 +2,9 @@
 
 Each model run produces two output files (plus a third, `{model}-covtab.csv`,
 when the model declares a [`[covariates]`](model-file/covariates.qmd) block).
+The human-readable fit estimates default to YAML; pass
+[`--output-format json` or `both`](#fit-json-modelfitjson) to additionally emit
+a complete, machine-readable JSON result for programmatic or agentic consumers.
 
 ## Quick reference: where to find what
 
@@ -92,6 +95,57 @@ ID,TIME,EVID,WT,CRCL
 1,0.500000,0,70.600000,73.700000
 1,1.000000,0,70.600000,73.700000
 ```
+
+## Fit JSON (`{model}-fit.json`) {#fit-json-modelfitjson}
+
+The YAML above is a *curated, human-oriented* view of a fit. For programmatic
+consumers — a script, the R wrapper, or an **agentic model-development loop**
+that reads diagnostics and decides the next step — pass `--output-format` to get
+the **complete** `FitResult` as JSON:
+
+```bash
+ferx warfarin.ferx --data warfarin.csv --output-format json   # {model}-fit.json only
+ferx warfarin.ferx --data warfarin.csv --output-format both   # both YAML and JSON
+```
+
+`--output-format yaml` is the default and leaves current behaviour unchanged.
+The flag controls only the estimates file; the sdtab/covtab/conddist CSVs are
+written regardless.
+
+Unlike the YAML, the JSON is **not curated**: every field of the fit — all
+estimates, standard errors, the covariance matrix, condition number, shrinkage,
+per-subject records (`eta`, `ipred`, residuals, …), warnings, and provenance
+(model/data hashes, `ferx` version, environment) — is present.
+
+**Schema guarantees** (so consumers can pin against it):
+
+- A top-level `schema_version` integer. It is bumped only on a *breaking* change
+  (renamed/removed field, changed nesting); additive fields do not bump it.
+- Matrices (`omega`, `covariance_matrix`, …) serialize as
+  `{ "rows": r, "cols": c, "data": [..] }` with `data` in **row-major** order.
+  Vectors (a subject's `eta`, …) serialize as flat JSON arrays.
+- Enums serialize as their variant name (e.g. `"method": "FoceI"`); structured
+  warnings carry `{severity, category, message, source_method}`.
+- Non-finite floats (`NaN`, `±Inf`) serialize as JSON `null`, matching the
+  empty-cell convention of the YAML/CSV writers.
+
+```json
+{
+  "schema_version": 1,
+  "converged": true,
+  "method": "FoceI",
+  "ofv": -280.36,
+  "theta": [0.133, 7.73, 0.725],
+  "theta_names": ["TVCL", "TVV", "TVKA"],
+  "omega": { "rows": 3, "cols": 3, "data": [0.0286, 0.0, 0.0, 0.0, 0.0096, 0.0, 0.0, 0.0, 0.349] },
+  "cov_condition_number": 2.64,
+  "shrinkage_eta": [0.0002, 0.0011, 0.0019],
+  "subjects": [ { "id": "1", "eta": [0.028, 0.066, 0.482], "ipred": [/* … */] } ]
+}
+```
+
+Library callers get the identical payload in-process, without touching the
+filesystem, via `FitResult::to_json_value() -> serde_json::Value`.
 
 ## Fit YAML (`{model}-fit.yaml`)
 

--- a/src/bin/run_model.rs
+++ b/src/bin/run_model.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 /// Top-level usage/help text, shared by the no-args error path (stderr, exit 1)
 /// and `ferx -h`/`--help` (stdout, exit 0) so the two can't drift apart.
 const MAIN_USAGE: &str = "\
-Usage: ferx <model.ferx> --data <data.csv> [--threads N|auto] [--output <run.fitrx>] [--include-data] [--inits-from-nca[=nca|nca_sweep|nca_ebe]]
+Usage: ferx <model.ferx> --data <data.csv> [--threads N|auto] [--output <run.fitrx>] [--include-data] [--inits-from-nca[=nca|nca_sweep|nca_ebe]] [--output-format yaml|json|both]
        ferx <model.ferx> --simulate          [--threads N|auto] [--output <run.fitrx>]
        ferx check <model.ferx> [--data <data.csv>] [--json]
        ferx summary <run.fitrx> [<run2.fitrx> ...]
@@ -22,6 +22,10 @@ Data must be in NONMEM format (ID, TIME, DV, EVID, AMT, CMT, ...)
 
 --output PATH  also write a portable .fitrx fit bundle (zip of JSON+CSV)
 --include-data embed the input --data CSV inside the .fitrx (off by default)
+
+--output-format yaml|json|both  which estimates file to write (default yaml).
+               json writes {model}-fit.json: the complete FitResult under a
+               versioned schema, for programmatic/agent consumers.
 
 --inits-from-nca[=METHOD]  derive NCA-based starting values before fitting,
                overriding the model file. METHOD is nca, nca_sweep (default),
@@ -102,6 +106,7 @@ fn main() {
         }
     };
     let output_path = parse_output_flag(&args);
+    let estimates_format = parse_output_format(&args);
     let include_data = args.iter().any(|a| a == "--include-data");
     if include_data && output_path.is_none() {
         eprintln!("Warning: --include-data has no effect without --output");
@@ -175,10 +180,19 @@ fn main() {
                 eprintln!("{}", msg);
             }
 
-            let yaml_path = format!("{}-fit.yaml", model_name);
-            match ferx_core::io::output::write_estimates_yaml(&fit_result, &yaml_path) {
-                Ok(()) => eprintln!("Estimates written to {}", yaml_path),
-                Err(e) => eprintln!("Warning: failed to write estimates: {}", e),
+            if estimates_format.wants_yaml() {
+                let yaml_path = format!("{}-fit.yaml", model_name);
+                match ferx_core::io::output::write_estimates_yaml(&fit_result, &yaml_path) {
+                    Ok(()) => eprintln!("Estimates written to {}", yaml_path),
+                    Err(e) => eprintln!("Warning: failed to write estimates: {}", e),
+                }
+            }
+            if estimates_format.wants_json() {
+                let json_path = format!("{}-fit.json", model_name);
+                match ferx_core::io::output::write_result_json(&fit_result, &json_path) {
+                    Ok(()) => eprintln!("Estimates (JSON) written to {}", json_path),
+                    Err(e) => eprintln!("Warning: failed to write JSON estimates: {}", e),
+                }
             }
 
             if let Some(out) = &output_path {
@@ -444,6 +458,41 @@ fn parse_output_flag(args: &[String]) -> Option<String> {
     }
 }
 
+/// Which estimates file(s) to write for a completed fit.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum EstimatesFormat {
+    Yaml,
+    Json,
+    Both,
+}
+
+impl EstimatesFormat {
+    fn wants_yaml(self) -> bool {
+        matches!(self, EstimatesFormat::Yaml | EstimatesFormat::Both)
+    }
+    fn wants_json(self) -> bool {
+        matches!(self, EstimatesFormat::Json | EstimatesFormat::Both)
+    }
+}
+
+/// Parse `--output-format yaml|json|both` (default `yaml`, current behaviour).
+/// Controls only the estimates file (`{model}-fit.yaml` / `-fit.json`); the
+/// sdtab/covtab/conddist CSVs are unaffected.
+fn parse_output_format(args: &[String]) -> EstimatesFormat {
+    let Some(idx) = args.iter().position(|a| a == "--output-format") else {
+        return EstimatesFormat::Yaml;
+    };
+    match args.get(idx + 1).map(String::as_str) {
+        Some("yaml") => EstimatesFormat::Yaml,
+        Some("json") => EstimatesFormat::Json,
+        Some("both") => EstimatesFormat::Both,
+        _ => {
+            eprintln!("Error: --output-format requires one of: yaml, json, both");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// Parse the optional `--threads` flag. Returns `None` when the flag is
 /// absent, when its value is `0`, or when its value is `auto` — all of which
 /// mean "leave rayon's default pool alone". Exits the process on a missing
@@ -502,8 +551,8 @@ fn parse_inits_from_nca_flag(args: &[String]) -> Result<Option<NcaInit>, String>
 mod tests {
     use super::{
         is_help_flag, normalize_args, parse_check_args, parse_inits_from_nca_flag,
-        parse_output_flag, parse_threads_flag, print_check_human, run_check, run_summary,
-        CheckArgsError,
+        parse_output_flag, parse_output_format, parse_threads_flag, print_check_human, run_check,
+        run_summary, CheckArgsError, EstimatesFormat,
     };
     use ferx_core::NcaInit;
 
@@ -512,6 +561,25 @@ mod tests {
             .chain(extra.iter().copied())
             .map(String::from)
             .collect()
+    }
+
+    #[test]
+    fn parse_output_format_defaults_to_yaml() {
+        let f = parse_output_format(&args(&["model.ferx", "--data", "d.csv"]));
+        assert!(f.wants_yaml() && !f.wants_json());
+    }
+
+    #[test]
+    fn parse_output_format_reads_explicit_values() {
+        let yaml = parse_output_format(&args(&["m.ferx", "--output-format", "yaml"]));
+        assert!(yaml.wants_yaml() && !yaml.wants_json());
+
+        let json = parse_output_format(&args(&["m.ferx", "--output-format", "json"]));
+        assert!(json.wants_json() && !json.wants_yaml());
+
+        let both = parse_output_format(&args(&["m.ferx", "--output-format", "both"]));
+        assert!(both.wants_yaml() && both.wants_json());
+        assert_eq!(both, EstimatesFormat::Both);
     }
 
     #[test]

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -2141,6 +2141,43 @@ mod tests {
     }
 
     #[test]
+    fn json_result_has_versioned_schema_and_round_trips() {
+        // #777: the JSON output must be the *complete* FitResult under a
+        // versioned schema. Idempotent round-trip (serialize → deserialize →
+        // re-serialize equals the first serialization) proves every serialized
+        // field also deserializes back, i.e. no field is write-only / lossy.
+        let fit = minimal_fit_result();
+        let v1 = fit.to_json_value();
+
+        // Top-level schema_version is present and pinned.
+        assert_eq!(v1["schema_version"], FitResult::JSON_SCHEMA_VERSION);
+
+        // A few representative fields survive with the agent-friendly shapes.
+        assert_eq!(v1["ofv"], 100.0);
+        assert_eq!(v1["omega"]["rows"], 2);
+        assert_eq!(v1["omega"]["cols"], 2);
+        assert_eq!(v1["omega"]["data"], serde_json::json!([0.1, 0.0, 0.0, 0.2]));
+        assert_eq!(v1["subjects"][0]["eta"].as_array().unwrap().len(), 2);
+
+        // Round-trip: unknown `schema_version` is ignored on the way back in.
+        let back: FitResult = serde_json::from_value(v1.clone()).unwrap();
+        let v2 = back.to_json_value();
+        assert_eq!(v1, v2, "JSON round-trip is not idempotent (lossy field?)");
+    }
+
+    #[test]
+    fn write_result_json_writes_parseable_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run-fit.json");
+        let fit = minimal_fit_result();
+        crate::io::output::write_result_json(&fit, path.to_str().unwrap()).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["schema_version"], FitResult::JSON_SCHEMA_VERSION);
+        assert_eq!(parsed["converged"], true);
+    }
+
+    #[test]
     fn roundtrip_minimal_fit() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("run1.fitrx");

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -2166,6 +2166,44 @@ mod tests {
     }
 
     #[test]
+    fn json_result_maps_non_finite_floats_to_null() {
+        // #777 review: guarantee that non-finite floats serialize to JSON
+        // `null` and never panic `to_json_value()` / `write_result_json()`.
+        // serde_json's `Value`/string serializers map non-finite f64 to null
+        // (no `arbitrary_precision` feature here), so this holds without a
+        // sanitizing pass — this test locks that contract in.
+        let mut fit = minimal_fit_result();
+        fit.ofv = f64::INFINITY;
+        fit.shrinkage_eps = f64::NAN;
+        fit.iwres_lag1_r = f64::NEG_INFINITY;
+        // A missing covariate value is stored as NaN in the covariate table.
+        fit.covariate_table = Some(crate::types::CovariateTable {
+            names: vec!["WT".into()],
+            kinds: vec![crate::types::CovariateKind::Continuous],
+            rows: vec![crate::types::CovariateRow {
+                id: "S1".into(),
+                time: 0.0,
+                evid: 0,
+                values: vec![f64::NAN],
+            }],
+        });
+
+        let v = fit.to_json_value(); // must not panic
+        assert!(v["ofv"].is_null());
+        assert!(v["shrinkage_eps"].is_null());
+        assert!(v["iwres_lag1_r"].is_null());
+        assert!(v["covariate_table"]["rows"][0]["values"][0].is_null());
+
+        // Full write path also succeeds (pretty-printer never panics on null).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nan-fit.json");
+        crate::io::output::write_result_json(&fit, path.to_str().unwrap()).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(parsed["ofv"].is_null());
+    }
+
+    #[test]
     fn write_result_json_writes_parseable_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("run-fit.json");

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1555,6 +1555,20 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
 }
 
 /// Write parameter estimates and uncertainty as YAML
+/// Write the complete fit result as machine-readable JSON to `path` (#777).
+///
+/// Unlike the curated human YAML, this is the *entire* [`FitResult`] — every
+/// estimate, standard error, diagnostic, per-subject record, and provenance
+/// field — under a stable, versioned schema (top-level `schema_version`). It is
+/// the channel an agentic / programmatic consumer reads. Pretty-printed for
+/// readability; the shape is defined by `FitResult`'s serde derives and the
+/// `crate::serde_nalgebra` matrix/vector shims.
+pub fn write_result_json(result: &FitResult, path: &str) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(&result.to_json_value())
+        .map_err(|e| format!("Failed to serialize fit to JSON: {}", e))?;
+    std::fs::write(path, json).map_err(|e| format!("Failed to write {}: {}", path, e))
+}
+
 pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String> {
     use std::io::Write;
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1554,7 +1554,6 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     names
 }
 
-/// Write parameter estimates and uncertainty as YAML
 /// Write the complete fit result as machine-readable JSON to `path` (#777).
 ///
 /// Unlike the curated human YAML, this is the *entire* [`FitResult`] — every

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1569,6 +1569,9 @@ pub fn write_result_json(result: &FitResult, path: &str) -> Result<(), String> {
     std::fs::write(path, json).map_err(|e| format!("Failed to write {}: {}", path, e))
 }
 
+/// Write the curated, human-readable parameter estimates and uncertainty as
+/// YAML to `path` (`{model}-fit.yaml`). This is a selected subset for reading;
+/// for the complete machine-readable result use [`write_result_json`].
 pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String> {
     use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod parser;
 pub mod pk;
 pub mod propensity_match;
 pub mod sens;
+pub(crate) mod serde_nalgebra;
 pub mod sim;
 pub mod stats;
 pub mod suggest_start;

--- a/src/serde_nalgebra.rs
+++ b/src/serde_nalgebra.rs
@@ -1,0 +1,180 @@
+//! serde shims for `nalgebra` `DMatrix`/`DVector`.
+//!
+//! nalgebra's own `serde-serialize` feature is off in this crate, and its
+//! internal representation would serialize as an opaque storage blob anyway.
+//! For the machine-readable JSON fit output (#777) we want a stable, agent-
+//! friendly shape instead:
+//!
+//! - a matrix serializes as `{ "rows": r, "cols": c, "data": [..] }`, with
+//!   `data` laid out **row-major**;
+//! - a vector serializes as a flat JSON array.
+//!
+//! Use via `#[serde(with = "crate::serde_nalgebra::<module>")]` on a field.
+
+use nalgebra::{DMatrix, DVector};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Wire representation of a dense matrix. `data` is row-major.
+#[derive(Serialize, Deserialize)]
+struct MatrixRepr {
+    rows: usize,
+    cols: usize,
+    data: Vec<f64>,
+}
+
+fn to_repr(m: &DMatrix<f64>) -> MatrixRepr {
+    let (rows, cols) = (m.nrows(), m.ncols());
+    let mut data = Vec::with_capacity(rows * cols);
+    for r in 0..rows {
+        for c in 0..cols {
+            data.push(m[(r, c)]);
+        }
+    }
+    MatrixRepr { rows, cols, data }
+}
+
+fn from_repr<E: serde::de::Error>(repr: MatrixRepr) -> Result<DMatrix<f64>, E> {
+    if repr.data.len() != repr.rows * repr.cols {
+        return Err(E::custom(format!(
+            "matrix data length {} does not match rows*cols = {}*{}",
+            repr.data.len(),
+            repr.rows,
+            repr.cols
+        )));
+    }
+    // `from_row_slice` consumes the slice row-major, matching `to_repr`.
+    Ok(DMatrix::from_row_slice(repr.rows, repr.cols, &repr.data))
+}
+
+/// `#[serde(with)]` module for a plain `DMatrix<f64>` field.
+pub mod dmatrix {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(m: &DMatrix<f64>, s: S) -> Result<S::Ok, S::Error> {
+        to_repr(m).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DMatrix<f64>, D::Error> {
+        from_repr(MatrixRepr::deserialize(d)?)
+    }
+}
+
+/// `#[serde(with)]` module for an `Option<DMatrix<f64>>` field.
+pub mod option_dmatrix {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(m: &Option<DMatrix<f64>>, s: S) -> Result<S::Ok, S::Error> {
+        m.as_ref().map(to_repr).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<DMatrix<f64>>, D::Error> {
+        match Option::<MatrixRepr>::deserialize(d)? {
+            Some(repr) => Ok(Some(from_repr(repr)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// `#[serde(with)]` module for a plain `DVector<f64>` field (flat array).
+pub mod dvector {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(v: &DVector<f64>, s: S) -> Result<S::Ok, S::Error> {
+        v.as_slice().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DVector<f64>, D::Error> {
+        Ok(DVector::from_vec(Vec::<f64>::deserialize(d)?))
+    }
+}
+
+/// `#[serde(with)]` module for a `Vec<Vec<DVector<f64>>>` field (per-subject,
+/// per-occasion IOV EBEs). Serializes as a nested array of flat arrays.
+pub mod vec_vec_dvector {
+    use super::*;
+
+    #[allow(clippy::ptr_arg)]
+    pub fn serialize<S: Serializer>(v: &Vec<Vec<DVector<f64>>>, s: S) -> Result<S::Ok, S::Error> {
+        let nested: Vec<Vec<&[f64]>> = v
+            .iter()
+            .map(|inner| inner.iter().map(|dv| dv.as_slice()).collect())
+            .collect();
+        nested.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Vec<Vec<DVector<f64>>>, D::Error> {
+        let nested = Vec::<Vec<Vec<f64>>>::deserialize(d)?;
+        Ok(nested
+            .into_iter()
+            .map(|inner| inner.into_iter().map(DVector::from_vec).collect())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Holder {
+        #[serde(with = "dmatrix")]
+        m: DMatrix<f64>,
+        #[serde(with = "option_dmatrix")]
+        om: Option<DMatrix<f64>>,
+        #[serde(with = "dvector")]
+        v: DVector<f64>,
+        #[serde(with = "vec_vec_dvector")]
+        vv: Vec<Vec<DVector<f64>>>,
+    }
+
+    #[test]
+    fn matrix_is_row_major_and_round_trips() {
+        // 2x3 with distinct entries so a transpose bug would show.
+        let m = DMatrix::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let h = Holder {
+            m: m.clone(),
+            om: Some(m.clone()),
+            v: DVector::from_vec(vec![7.0, 8.0]),
+            vv: vec![vec![DVector::from_vec(vec![1.0, 2.0])], vec![]],
+        };
+        let json = serde_json::to_value(&h).unwrap();
+        // Row-major: first row [1,2,3] precedes second row [4,5,6].
+        assert_eq!(json["m"]["rows"], 2);
+        assert_eq!(json["m"]["cols"], 3);
+        assert_eq!(
+            json["m"]["data"],
+            serde_json::json!([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        );
+        assert_eq!(json["v"], serde_json::json!([7.0, 8.0]));
+
+        let back: Holder = serde_json::from_value(json).unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn none_option_round_trips() {
+        let h = Holder {
+            m: DMatrix::zeros(1, 1),
+            om: None,
+            v: DVector::zeros(0),
+            vv: vec![],
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        let back: Holder = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn mismatched_length_errors() {
+        let bad = serde_json::json!({
+            "m": {"rows": 2, "cols": 2, "data": [1.0, 2.0, 3.0]},
+            "om": null,
+            "v": [],
+            "vv": []
+        });
+        assert!(serde_json::from_value::<Holder>(bad).is_err());
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -832,7 +832,7 @@ impl Subject {
 }
 
 /// Summary of records excluded by `[data_selection]` `ignore`/`accept` rules.
-#[derive(Debug, Clone, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 pub struct ExclusionSummary {
     /// Subject IDs that had all records removed (zero doses and observations remaining).
     pub excluded_subject_ids: Vec<String>,
@@ -965,7 +965,7 @@ pub struct CovariateDecl {
 }
 
 /// A single row of the [`CovariateTable`], echoing one input dataset record.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
 pub struct CovariateRow {
     pub id: String,
     pub time: f64,
@@ -981,7 +981,7 @@ pub struct CovariateRow {
 /// sdtab). Produced at data-read time when a `[covariates]` block is present,
 /// and attached to [`FitResult::covariate_table`]. Missing values are
 /// `f64::NAN`. Restricted to declared columns to bound memory.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct CovariateTable {
     /// Declared covariate names, in declaration order. Parallel to each row's
     /// `values` and to `kinds`.
@@ -1413,7 +1413,7 @@ impl PkModel {
 }
 
 /// Supported residual error models
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorModel {
     Additive,
     Proportional,
@@ -1421,7 +1421,7 @@ pub enum ErrorModel {
 }
 
 /// How a sigma parameter enters the residual error model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SigmaType {
     Proportional,
     Additive,
@@ -2132,7 +2132,7 @@ pub struct EndpointError {
 }
 
 /// Transformation applied to a theta on the natural scale.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThetaTransform {
     /// Theta is on the natural scale (no transformation).
     Identity,
@@ -2147,7 +2147,7 @@ pub enum ThetaTransform {
 }
 
 /// Distribution / parameterisation of an ETA random effect.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EtaParamType {
     /// `TVCL * exp(ETA)` or `exp(THETA + ETA)` — log-normal.
     LogNormal,
@@ -2162,7 +2162,7 @@ pub enum EtaParamType {
 }
 
 /// Per-ETA transformation metadata, carried in `FitResult`.
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct EtaParamInfo {
     pub eta_name: String,
     pub param_type: EtaParamType,
@@ -3508,9 +3508,10 @@ impl std::fmt::Debug for CompiledModel {
 }
 
 /// Per-subject estimation results
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct SubjectResult {
     pub id: String,
+    #[serde(with = "crate::serde_nalgebra::dvector")]
     pub eta: DVector<f64>,
     pub ipred: Vec<f64>,
     pub pred: Vec<f64>,
@@ -3555,7 +3556,7 @@ pub struct SubjectResult {
 /// This is the SAEM analogue of saemix `conddist.saemix` / Monolix's
 /// "Conditional Distribution" task — the distribution `p(η_i | y_i; θ̂)` rather
 /// than just its mode (the EBE on `SubjectResult.eta`).
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct CondDist {
     /// Conditional mean of η per subject: `cond_mean[i]` has length `n_eta`.
     pub cond_mean: Vec<Vec<f64>>,
@@ -3677,7 +3678,7 @@ pub enum IntegralStep {
 /// *partial* marginal likelihood that ignores κ uncertainty. (Legacy; no longer
 /// used for IOV models.)
 /// `NotApplicable` — model has no kappa declarations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KappaTreatment {
     NotApplicable,
     FixedAtMode,
@@ -3688,7 +3689,7 @@ pub enum KappaTreatment {
 ///
 /// Produced by the `Imp` stage in a method chain (`methods = [..., imp]`).
 /// Surfaced on `FitResult.importance_sampling`.
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct ImportanceSamplingResult {
     /// `−2 · Σᵢ log p(yᵢ | θ)` estimated by importance sampling. Lower-bias
     /// alternative to the FOCE/Laplace OFV when subject posteriors are
@@ -3721,7 +3722,7 @@ pub struct ImportanceSamplingResult {
 /// Analogous to one line in NONMEM's `.ext` file for `METHOD=IMPMAP`.
 /// Positive `iteration` values are EM iterations; special negative values
 /// mark the final (averaged) estimate and standard errors.
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct ImpmapTraceRow {
     /// EM iteration number (1-based). Special values:
     /// `-1_000_000_000` = final averaged estimate,
@@ -3739,7 +3740,7 @@ pub struct ImpmapTraceRow {
 ///
 /// Surfaced on `FitResult.impmap_trace` when the final estimating stage is
 /// IMPMAP. Column names follow NONMEM convention (`THETA1`, `OMEGA(1,1)`, …).
-#[derive(Debug, Clone, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 pub struct ImpmapTrace {
     pub rows: Vec<ImpmapTraceRow>,
     pub theta_names: Vec<String>,
@@ -3750,7 +3751,7 @@ pub struct ImpmapTrace {
 
 /// Posterior summary for a single scalar parameter, computed across all
 /// post-warmup, post-thinning draws from every chain.
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct PosteriorSummary {
     /// Parameter name (e.g. `TVCL`, `OMEGA(1,1)`, `SIGMA(1)`).
     pub name: String,
@@ -3777,7 +3778,7 @@ pub struct PosteriorSummary {
 /// instead of a single point estimate; the optimizer-style fields on
 /// `FitResult` (theta/omega/sigma) are populated with the posterior means so
 /// downstream consumers that expect a point estimate still work.
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct BayesResult {
     /// Per-parameter posterior summaries, ordered θ, then Ω entries, then Σ.
     pub summaries: Vec<PosteriorSummary>,
@@ -3799,7 +3800,7 @@ pub struct BayesResult {
 }
 
 /// Outcome of the post-estimation covariance step.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
 pub enum CovarianceStatus {
     /// User set `covariance = false`; step was not attempted.
     NotRequested,
@@ -4008,7 +4009,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
 }
 
 /// Full fit result
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct FitResult {
     /// Final method in the chain (same as `method_chain.last()`).
     pub method: EstimationMethod,
@@ -4022,6 +4023,7 @@ pub struct FitResult {
     pub theta_names: Vec<String>,
     /// Names of the random effects (etas), parallel to the omega diagonal.
     pub eta_names: Vec<String>,
+    #[serde(with = "crate::serde_nalgebra::dmatrix")]
     pub omega: DMatrix<f64>,
     pub sigma: Vec<f64>,
     /// Names of the sigma parameters, parallel to `sigma`.
@@ -4034,6 +4036,7 @@ pub struct FitResult {
     /// per-sigma classification and should be preferred by consumers that need
     /// to distinguish endpoints.
     pub error_model: ErrorModel,
+    #[serde(with = "crate::serde_nalgebra::option_dmatrix")]
     pub covariance_matrix: Option<DMatrix<f64>>,
     pub se_theta: Option<Vec<f64>>,
     /// Standard errors for omega elements.
@@ -4093,6 +4096,7 @@ pub struct FitResult {
     /// carries posterior summaries + convergence diagnostics. See [`BayesResult`].
     pub bayes: Option<BayesResult>,
     // IOV results (present when kappa declarations exist in the model)
+    #[serde(with = "crate::serde_nalgebra::option_dmatrix")]
     pub omega_iov: Option<DMatrix<f64>>,
     pub kappa_names: Vec<String>,
     pub kappa_fixed: Vec<bool>,
@@ -4115,6 +4119,7 @@ pub struct FitResult {
     /// Per-subject, per-occasion kappa EBEs.
     /// `ebe_kappas[i][k]` is the kappa vector for subject i, occasion k.
     /// Outer vec is empty when `n_kappa == 0`.
+    #[serde(with = "crate::serde_nalgebra::vec_vec_dvector")]
     pub ebe_kappas: Vec<Vec<DVector<f64>>>,
     /// Estimated OFV evaluations saved by the SAEM mu-ref gradient step M-step.
     /// Non-None only when method=saem and mu_referencing=true.
@@ -4209,9 +4214,11 @@ pub struct FitResult {
     /// the lognormal formula `(exp(ω_ij)−1)/√((exp(ω_ii)−1)(exp(ω_jj)−1))`
     /// when both etas are lognormal, otherwise falls back to
     /// `ω_ij/√(ω_ii·ω_jj)`.  `None` when omega is diagonal (no off-diagonals).
+    #[serde(with = "crate::serde_nalgebra::option_dmatrix")]
     pub omega_param_corr: Option<DMatrix<f64>>,
     /// Parameter-level correlation matrix for IOV block kappa, analogous to
     /// `omega_param_corr`.  `None` when `omega_iov` is absent or diagonal.
+    #[serde(with = "crate::serde_nalgebra::option_dmatrix")]
     pub omega_iov_param_corr: Option<DMatrix<f64>>,
     /// Path to the `.ferx` model file used for this fit, as supplied by the
     /// caller. `Some` when the fit was launched via `fit_from_files` or
@@ -4238,6 +4245,7 @@ pub struct FitResult {
     /// and `theta_names`.
     pub theta_init: Vec<f64>,
     /// Initial omega matrix (variance scale), same layout as `omega`.
+    #[serde(with = "crate::serde_nalgebra::dmatrix")]
     pub omega_init: DMatrix<f64>,
     /// Initial sigma values, parallel to `sigma` and `sigma_names`.
     pub sigma_init: Vec<f64>,
@@ -4322,6 +4330,33 @@ pub struct FitResult {
     /// were active during the fit (or the caller supplied `ignore`/`accept`
     /// expressions).  `None` means no filtering was requested.
     pub exclusions: Option<ExclusionSummary>,
+}
+
+impl FitResult {
+    /// Schema version for the machine-readable JSON serialization (#777).
+    ///
+    /// Bump on any breaking change to the JSON shape (renamed/removed fields,
+    /// changed nesting). Additive fields do not require a bump. Agent/tool
+    /// consumers pin on this via the top-level `schema_version` key.
+    pub const JSON_SCHEMA_VERSION: u32 = 1;
+
+    /// Serialize this fit to a complete, agent-friendly `serde_json::Value`,
+    /// with a top-level `schema_version` key injected alongside every field.
+    ///
+    /// This is the in-process counterpart to writing `{model}-fit.json`:
+    /// Rust/R callers get the structured payload without a file round-trip.
+    /// Non-finite floats (`NaN`/`±Inf`) serialize to JSON `null`, matching the
+    /// empty-cell convention of the YAML/CSV writers.
+    pub fn to_json_value(&self) -> serde_json::Value {
+        let mut v = serde_json::to_value(self).expect("FitResult is serializable");
+        if let serde_json::Value::Object(map) = &mut v {
+            map.insert(
+                "schema_version".to_string(),
+                serde_json::json!(Self::JSON_SCHEMA_VERSION),
+            );
+        }
+        v
+    }
 }
 
 /// Look up the SE for omega element (i, j) from the `se_omega` vector.
@@ -5200,7 +5235,7 @@ impl Optimizer {
 }
 
 /// Estimation method
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EstimationMethod {
     Foce,
     FoceI,


### PR DESCRIPTION
## Why

We want to drive ferx from an **agentic PK/PD model-development loop** (a planner proposes a model → ferx fits → an evaluator reads diagnostics → decides the next step). The blocker for any machine consumer is output: `{model}-fit.yaml` is hand-written and curated, and drops most of `FitResult`. An agent (or the R wrapper, or a script) is left regex-parsing text with no schema.

Closes #777. Ships a single, complete, versioned JSON serialization of a fit.

## What changed

- **serde on the result graph.** `#[derive(Serialize, Deserialize)]` on `FitResult` + 18 nested types (enums + structs). Four nested types already had serde and are untouched.
- **`src/serde_nalgebra.rs` (new).** `#[serde(with)]` shims for the 8 `DMatrix`/`DVector` fields: a matrix serializes as `{ "rows": r, "cols": c, "data": [..] }` (row-major), a vector as a flat array. nalgebra's own `serde-serialize` feature stays **off** — its representation is an opaque storage blob, useless to an agent.
- **`FitResult::to_json_value()`** — the complete payload in-process (Rust/R callers, no file round-trip), injecting a top-level `schema_version`.
- **`write_result_json()`** in `io/output.rs` — pretty-printed `{model}-fit.json`.
- **`--output-format yaml|json|both`** on the `ferx` CLI (default `yaml`). Controls only the estimates file; sdtab/covtab/conddist CSVs are unaffected.
- **Schema guarantees:** top-level `schema_version` (bumped only on breaking shape change; additive fields don't bump); enums serialize as variant names; structured warnings carry `{severity, category, message, source_method}`; non-finite floats → JSON `null` (matches the empty-cell convention of the YAML/CSV writers).
- Docs (`output.qmd` schema section + example, `cli.qmd` flag) + `CHANGELOG.md`.

## Alternatives considered

- **Enable nalgebra's `serde-serialize` feature** instead of custom shims — rejected: it serializes the internal `VecStorage`, an opaque shape a consumer can't rely on. `{rows, cols, data}` is explicit and stable.
- **A curated JSON DTO** (hand-picked fields) — rejected: the whole point is a lossless, complete result. Completeness is enforced by an idempotent round-trip test.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

New `pub` API is **additive** (`write_result_json`, `FitResult::to_json_value`, `FitResult::JSON_SCHEMA_VERSION`); ferx-r builds from the pinned lock and is unaffected. An R accessor for the JSON payload can follow later.

## Breaking changes
- [x] None (additive `pub` API + new opt-in CLI flag; YAML default unchanged)

## Numerical validation
- [x] Not applicable (serialization only — no change to estimates, OFV, or residuals). Verified end-to-end that a real warfarin fit with `--output-format both` produces identical YAML plus a valid 34 KB JSON (`omega` as `{rows,cols,data}`, `eta` flat arrays, typed `warnings_structured`, `method` as a string).

## Performance
- [x] No significant impact expected (JSON is written once per run, only when opted in).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
  - `serde_nalgebra`: row-major layout, `Option`/`None`, length-mismatch error.
  - `io::fitrx`: **idempotent round-trip** (serialize → deserialize → re-serialize equals the first serialization) proving no field is write-only/lossy; `schema_version` present; file parses.
  - `run_model`: `--output-format` default + explicit parsing.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```bash
ferx warfarin.ferx --data warfarin.csv --output-format both
# writes warfarin-fit.yaml (unchanged) and warfarin-fit.json
```

```json
{
  "schema_version": 1,
  "converged": true,
  "method": "FoceI",
  "ofv": -280.36,
  "theta": [0.133, 7.73, 0.725],
  "theta_names": ["TVCL", "TVV", "TVKA"],
  "omega": { "rows": 3, "cols": 3, "data": [0.0286, 0.0, 0.0, 0.0, 0.0096, 0.0, 0.0, 0.0, 0.349] },
  "cov_condition_number": 2.64,
  "shrinkage_eta": [0.0002, 0.0011, 0.0019],
  "warnings_structured": [{ "severity": "Warning", "category": "dw_autocorrelation", "message": "…", "source_method": null }],
  "subjects": [{ "id": "1", "eta": [0.028, 0.066, 0.482] }]
}
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes (`output.qmd`, `cli.qmd`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] New pages linked in `docs/_quarto.yml` — N/A (edited existing pages)

## Checklist
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path (serialization only)
- [ ] `Cargo.toml` version bumped — N/A (non-breaking)

### Example execution
- [x] Affected example runs cleanly via CLI: `ferx warfarin.ferx --data data/warfarin.csv --output-format both`
- [x] No ferx-site / ferx-book example changes needed (no new `.ferx` DSL, example file, or data file)

## Reviewer hints
- Focus on `src/serde_nalgebra.rs` (row-major invariant — `to_repr` writes row-major, `from_row_slice` reads row-major) and the field-attribute wiring in `types.rs`.
- The completeness guarantee rides on the idempotent round-trip test in `io::fitrx` — if a future field is added without serde-friendly handling, that test catches a lossy round-trip.

## Open questions
- Bikeshed: flag name `--output-format` and file name `{model}-fit.json`. Open to `--fit-format` / other spellings.
