### PR TITLE
feat(diagnostics): typed WarningCode taxonomy for structured warnings [closes #778]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Typed warning taxonomy** (#778): structured warnings
+  (`FitResult.warnings_structured`, surfaced in the JSON output) now carry a
+  typed `WarningCode` instead of a free-text category string — a stable,
+  exhaustive vocabulary an agent or the R wrapper can branch on. Each code
+  serializes as a fixed snake_case token (unchanged from the previous category
+  strings, so JSON consumers are unaffected), and each entry gains an optional
+  `details` payload for machine-readable numbers behind the message. See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **Machine-readable JSON fit output** (#777): `ferx <model> --data <csv>
   --output-format json` (or `both`) writes `{model}-fit.json` — the *complete*
   fit result (every estimate, standard error, diagnostic, per-subject record,

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -96,6 +96,8 @@ website:
         href: cli.qmd
       - text: "Output Files"
         href: output.qmd
+      - text: "Warnings"
+        href: warnings.qmd
       - text: "File Formats"
         href: file-formats/index.qmd
         contents:

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -125,7 +125,9 @@ per-subject records (`eta`, `ipred`, residuals, …), warnings, and provenance
   `{ "rows": r, "cols": c, "data": [..] }` with `data` in **row-major** order.
   Vectors (a subject's `eta`, …) serialize as flat JSON arrays.
 - Enums serialize as their variant name (e.g. `"method": "FoceI"`); structured
-  warnings carry `{severity, category, message, source_method}`.
+  warnings carry `{severity, category, message, source_method}` plus an optional
+  `details` payload, where `category` is a stable typed
+  [`WarningCode`](warnings.qmd#warning-codes) token.
 - Non-finite floats (`NaN`, `±Inf`) serialize as JSON `null`, matching the
   empty-cell convention of the YAML/CSV writers.
 

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -68,4 +68,5 @@ source of the taxonomy — the `WarningCode` enum is exhaustive, so the vocabula
 can no longer drift as a free string. Native at-source emission (each site
 constructing its own typed `WarningEntry` with a populated `details` payload) is
 being migrated incrementally; until a site is converted, its entry is classified
-from the message and carries `details: null`.
+from the message and has no `details` payload (the `details` key is omitted from
+the JSON; the Rust field is `None`).

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -1,0 +1,71 @@
+# Warnings
+
+A fit collects non-fatal issues into two parallel channels on `FitResult`:
+
+- `warnings` — a `Vec<String>` of human-readable messages, shown by the CLI and
+  written to the YAML / `.fitrx` bundle. This is the display channel.
+- `warnings_structured` — a `Vec<WarningEntry>`, the **machine-branchable**
+  channel. Each entry carries a typed [`WarningCode`](#warning-codes), a
+  severity, the message, an optional originating method, and an optional
+  numeric `details` payload. This is what a script, the R wrapper, or an
+  **agentic model-development loop** should read — it is serialized in the
+  [JSON output](output.qmd#fit-json-modelfitjson).
+
+```json
+{
+  "severity": "Warning",
+  "category": "dw_autocorrelation",
+  "message": "Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).",
+  "source_method": null
+}
+```
+
+`category` is the stable snake_case token of a `WarningCode`. It is a public API
+surface: tokens never change or get repurposed once released, so a consumer can
+branch on them safely (new warning classes get new tokens). `details` is omitted
+when empty.
+
+## Severity {#severity}
+
+| Severity | Meaning | Typical agent response |
+|----------|---------|------------------------|
+| `Critical` | The result is untrustworthy as-is (no convergence, failed covariance, ill-conditioning). | Do not accept the model; change structure/inits and refit. |
+| `Warning` | The result stands but a caveat applies (autocorrelation, shrinkage, data quality). | Inspect; often iterate on error model, IIV structure, or data. |
+| `Info` | Informational note, no action implied. | Log; no action. |
+
+## Warning codes {#warning-codes}
+
+Each `WarningCode` token, what it flags, and a typical response.
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
+| `convergence` | Critical | Optimizer did not converge. | Reject; adjust inits / method / bounds and refit. |
+| `covariance_step` | Critical / Warning / Info | Covariance step failed, was regularized, or is a cost note. | If failed: SEs unreliable — try `covariance_fallback = sir` or refit. |
+| `condition_number` | Critical | Ill-conditioned covariance / high condition number. | Over-parameterized — drop a random effect or covariate. |
+| `optimizer_health` | Warning | Trust-radius collapse / degeneracy. | Try a different optimizer or re-scale parameters. |
+| `dw_autocorrelation` | Warning | IWRES autocorrelation (Durbin–Watson out of range). | Revisit the residual-error / structural model. |
+| `eta_normality` | Warning | ETA departs from normality. | Consider a mixture or transform. |
+| `experimental` | Warning | An experimental feature (SDE, neural-network) was used. | Treat results with caution; validate. |
+| `bloq_method` | Warning | BLOQ / M3 censoring caveat. | Confirm the censoring semantics match intent. |
+| `sir` | Warning | SIR failed or was requested without a covariance. | Ensure a covariance exists before requesting SIR. |
+| `importance_sampling` | Warning | ESS = 0 / proposal collapse. | Increase samples or improve the proposal. |
+| `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
+| `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
+| `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
+| `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
+| `mu_referencing` | Warning / Info | Missing or partial mu-referencing. | Prefer `CL = TVCL * exp(ETA_CL)` forms for SAEM/Bayes. |
+| `optimizer_config` | Warning / Info | `global_search` config note or failure. | Check the global-search setup if disabled unexpectedly. |
+| `multi_start` | Info | Multi-start note. | Inspect which start won. |
+| `cancelled` | Info | Run cancelled by the user. | None. |
+| `threads` | Info | Thread-count efficiency note. | Optionally tune `threads`. |
+| `general` | Warning | Unrecognised message (fallback bucket). | Read the message text. |
+
+## How codes are assigned
+
+Codes today are assigned centrally by `classify_warning()`, which maps each
+engine message to its `WarningCode` and severity. It is the single, type-checked
+source of the taxonomy — the `WarningCode` enum is exhaustive, so the vocabulary
+can no longer drift as a free string. Native at-source emission (each site
+constructing its own typed `WarningEntry` with a populated `details` payload) is
+being migrated incrementally; until a site is converted, its entry is classified
+from the message and carries `details: null`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -12008,7 +12008,9 @@ mod sde_integration {
             .expect("SDE model should emit W_EXPERIMENTAL_SDE");
         assert_eq!(exp.severity, crate::diagnostics::Severity::Warning);
         assert_eq!(
-            crate::types::classify_warning(&exp.message).category,
+            crate::types::classify_warning(&exp.message)
+                .category
+                .as_str(),
             "experimental"
         );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3852,21 +3852,104 @@ pub enum WarningSeverity {
     Info,
 }
 
-/// A structured warning with severity, category, and message.
+/// Stable, typed taxonomy for a structured warning (issue #778).
+///
+/// Each variant is the machine-branchable *code* an agent or the R wrapper keys
+/// off — a stable contract, unlike free-text message wording. Serialized (and
+/// via [`WarningCode::as_str`]) as a fixed snake_case token; those tokens are a
+/// public API surface and must not change once released. Add variants as new
+/// warning classes appear; never repurpose an existing token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WarningCode {
+    /// Optimizer did not reach the convergence criterion.
+    Convergence,
+    /// Covariance step failed, was regularized, or is informational (see message).
+    CovarianceStep,
+    /// Correlation / condition-number problem in the covariance.
+    ConditionNumber,
+    /// Optimizer-health issue (trust-radius collapse, degeneracy).
+    OptimizerHealth,
+    /// Residual (IWRES) autocorrelation — Durbin–Watson out of range.
+    DwAutocorrelation,
+    /// ETA distribution departs from normality (Shapiro–Wilk).
+    EtaNormality,
+    /// An experimental feature (SDE, neural-network components) was used.
+    Experimental,
+    /// BLOQ / M3 censoring handling caveat.
+    BloqMethod,
+    /// Sampling-importance-resampling (SIR) issue.
+    Sir,
+    /// Importance-sampling issue (ESS = 0, proposal collapse).
+    ImportanceSampling,
+    /// EPS (residual) shrinkage is notably high / negative.
+    EpsShrinkage,
+    /// Dataset-quality issue (missing DV, ADDL/II, non-positive DV, …).
+    DataQuality,
+    /// Omega structure caveat (mixed lognormal / additive block).
+    OmegaStructure,
+    /// A gradient / sampler fallback was taken (e.g. HMC → Metropolis-Hastings).
+    GradientFallback,
+    /// Mu-referencing note or missing-mu-reference caveat.
+    MuReferencing,
+    /// Optimizer-configuration note (`global_search`).
+    OptimizerConfig,
+    /// Multi-start informational note.
+    MultiStart,
+    /// The run was cancelled by the user.
+    Cancelled,
+    /// Thread-count efficiency note.
+    Threads,
+    /// Unrecognised message — fallback bucket.
+    General,
+}
+
+impl WarningCode {
+    /// The stable snake_case token (identical to the serde representation).
+    /// This is the string an agent / the R wrapper branches on.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WarningCode::Convergence => "convergence",
+            WarningCode::CovarianceStep => "covariance_step",
+            WarningCode::ConditionNumber => "condition_number",
+            WarningCode::OptimizerHealth => "optimizer_health",
+            WarningCode::DwAutocorrelation => "dw_autocorrelation",
+            WarningCode::EtaNormality => "eta_normality",
+            WarningCode::Experimental => "experimental",
+            WarningCode::BloqMethod => "bloq_method",
+            WarningCode::Sir => "sir",
+            WarningCode::ImportanceSampling => "importance_sampling",
+            WarningCode::EpsShrinkage => "eps_shrinkage",
+            WarningCode::DataQuality => "data_quality",
+            WarningCode::OmegaStructure => "omega_structure",
+            WarningCode::GradientFallback => "gradient_fallback",
+            WarningCode::MuReferencing => "mu_referencing",
+            WarningCode::OptimizerConfig => "optimizer_config",
+            WarningCode::MultiStart => "multi_start",
+            WarningCode::Cancelled => "cancelled",
+            WarningCode::Threads => "threads",
+            WarningCode::General => "general",
+        }
+    }
+}
+
+impl std::fmt::Display for WarningCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A structured warning with severity, typed code, and message.
 ///
 /// Populated in parallel with `FitResult.warnings` (which remains for
-/// backward compatibility). The `category` is a fixed lowercase vocabulary:
-/// `convergence`, `covariance_step`, `optimizer_health`, `dw_autocorrelation`,
-/// `bloq_method`, `sir`, `importance_sampling`, `data_quality`,
-/// `omega_structure`, `ebe_convergence`, `gradient_fallback`,
-/// `mu_referencing`, `optimizer_config`, `multi_start`, `cancelled`,
-/// `threads`, `condition_number`, `eta_normality`, `eps_shrinkage`,
-/// `experimental`, `general` (fallback for unrecognised messages).
+/// backward compatibility). The `category` is a typed [`WarningCode`] — the
+/// stable, machine-branchable taxonomy — replacing the former free-text
+/// category string (issue #778).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WarningEntry {
     pub severity: WarningSeverity,
-    /// Fixed lowercase category string (see type-level docs).
-    pub category: String,
+    /// Typed warning code (stable snake_case serde token).
+    pub category: WarningCode,
     /// Human-readable message. For messages that carry a multi-stage chain
     /// prefix such as `[FOCEI] ...`, only the body after the prefix is stored
     /// here; the method tag is moved into `source_method`. For unprefixed
@@ -3875,6 +3958,13 @@ pub struct WarningEntry {
     pub message: String,
     /// For multi-stage chains, the method that produced this warning.
     pub source_method: Option<String>,
+    /// Optional structured payload with machine-readable numbers behind the
+    /// message (e.g. `{"durbin_watson": 1.2}` or `{"condition_number": 1.4e6}`),
+    /// so an agent reads the value directly instead of parsing prose. Populated
+    /// by native at-source emitters; `None` on the string-classified fallback
+    /// path ([`classify_warning`]). Omitted from JSON when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 
 /// Classify a free-text warning message into a structured `WarningEntry`.
@@ -3907,7 +3997,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         || lower.contains("without convergence")
         || lower.contains("no multi-start run converged")
     {
-        (WarningSeverity::Critical, "convergence")
+        (WarningSeverity::Critical, WarningCode::Convergence)
     } else if lower.contains("covariance step failed")
         || lower.contains("covariance failed")
         || (lower.contains("covariance step") && lower.contains("not positive definite"))
@@ -3917,7 +4007,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // Hessian is not positive definite") whose prefix differs from "failed:"
         // messages. It must be compound so that "SIR failed: covariance not
         // positive definite" (no "covariance step" token) still routes to "sir".
-        (WarningSeverity::Critical, "covariance_step")
+        (WarningSeverity::Critical, WarningCode::CovarianceStep)
     } else if lower.contains("covariance step regularized")
         || lower.contains("off-diagonal fd stencil")
     {
@@ -3925,43 +4015,43 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // degraded-but-present covariance step result. Severity within the message
         // (minor/moderate/severe, or "over-optimistic") informs guidance; the
         // category is always covariance_step.
-        (WarningSeverity::Warning, "covariance_step")
+        (WarningSeverity::Warning, WarningCode::CovarianceStep)
     } else if lower.contains("ill-conditioned") || lower.contains("condition number") {
         // Note: "covariance step failed: Hessian has ill-conditioned entries" contains
         // "ill-conditioned" but is caught by "covariance step failed" above (else-if chain).
         // Any future covariance message that contains "ill-conditioned" but NOT "failed:"
         // would land here instead — keep this ordering in mind when adding new messages.
-        (WarningSeverity::Critical, "condition_number")
+        (WarningSeverity::Critical, WarningCode::ConditionNumber)
     } else if lower.contains("trust radius") || lower.contains("degenerate") {
-        (WarningSeverity::Warning, "optimizer_health")
+        (WarningSeverity::Warning, WarningCode::OptimizerHealth)
     } else if lower.contains("autocorrelation") || lower.contains("durbin") {
-        (WarningSeverity::Warning, "dw_autocorrelation")
+        (WarningSeverity::Warning, WarningCode::DwAutocorrelation)
     } else if lower.contains("shapiro") || lower.contains("non-normal") {
-        (WarningSeverity::Warning, "eta_normality")
+        (WarningSeverity::Warning, WarningCode::EtaNormality)
     } else if lower.contains("experimental feature") {
         // Experimental-feature notices (issue #175): SDE and neural-network
         // components emit a runtime warning so results are applied with caution.
-        (WarningSeverity::Warning, "experimental")
+        (WarningSeverity::Warning, WarningCode::Experimental)
     } else if lower.contains("m3 bloq")
         || lower.contains("bloq handling")
         || lower.contains("m3 censoring")
         || lower.contains("censoring handling")
     {
-        (WarningSeverity::Warning, "bloq_method")
+        (WarningSeverity::Warning, WarningCode::BloqMethod)
     } else if lower.contains("sir failed") || lower.contains("sir requested") {
-        (WarningSeverity::Warning, "sir")
+        (WarningSeverity::Warning, WarningCode::Sir)
     } else if lower.contains("ess = 0") || lower.contains("proposal collapse") {
-        (WarningSeverity::Warning, "importance_sampling")
+        (WarningSeverity::Warning, WarningCode::ImportanceSampling)
     } else if lower.contains("eps shrinkage") {
-        (WarningSeverity::Warning, "eps_shrinkage")
+        (WarningSeverity::Warning, WarningCode::EpsShrinkage)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
-        (WarningSeverity::Warning, "data_quality")
+        (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_iov_occ_missing")
         || lower.contains("missing or unparseable values in iov_column")
     {
-        (WarningSeverity::Warning, "data_quality")
+        (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_missing_dv") {
-        (WarningSeverity::Warning, "data_quality")
+        (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.contains("ltbs")
         || lower.contains("non-positive dv")
         || lower.contains("ss=1 dose")
@@ -3969,42 +4059,43 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         || lower.contains("evid=3/4")
         || lower.contains("lagtime evaluates")
     {
-        (WarningSeverity::Warning, "data_quality")
+        (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.contains("mixed lognormal") || lower.contains("mixed log-normal") {
-        (WarningSeverity::Warning, "omega_structure")
+        (WarningSeverity::Warning, WarningCode::OmegaStructure)
     } else if lower.contains("hmc is unavailable") {
         // "falls back to" intentionally removed: no emitted message uses that exact
         // phrase. The SAEM HMC message is fully covered by "hmc is unavailable".
-        (WarningSeverity::Info, "gradient_fallback")
+        (WarningSeverity::Info, WarningCode::GradientFallback)
     } else if lower.contains("not mu-referenced") {
-        (WarningSeverity::Warning, "mu_referencing")
+        (WarningSeverity::Warning, WarningCode::MuReferencing)
     } else if lower.contains("mu-ref") || lower.contains("mu-referencing") {
-        (WarningSeverity::Info, "mu_referencing")
+        (WarningSeverity::Info, WarningCode::MuReferencing)
     } else if lower.contains("global_search disabled") {
         // Runtime failure: CRS2-LM init failed — the optimiser ran without global search.
-        (WarningSeverity::Warning, "optimizer_config")
+        (WarningSeverity::Warning, WarningCode::OptimizerConfig)
     } else if lower.contains("global_search") {
-        (WarningSeverity::Info, "optimizer_config")
+        (WarningSeverity::Info, WarningCode::OptimizerConfig)
     } else if lower.contains("multi-start") {
-        (WarningSeverity::Info, "multi_start")
+        (WarningSeverity::Info, WarningCode::MultiStart)
     } else if lower.contains("cancelled by user") {
-        (WarningSeverity::Info, "cancelled")
+        (WarningSeverity::Info, WarningCode::Cancelled)
     } else if lower.contains("threads configured") || lower.contains("threads than subjects") {
-        (WarningSeverity::Info, "threads")
+        (WarningSeverity::Info, WarningCode::Threads)
     } else if lower.contains("n\u{00b2} ofv")
         || lower.contains("n^2 ofv")
         || (lower.contains("parameters") && lower.contains("covariance step:"))
     {
-        (WarningSeverity::Info, "covariance_step")
+        (WarningSeverity::Info, WarningCode::CovarianceStep)
     } else {
-        (WarningSeverity::Warning, "general")
+        (WarningSeverity::Warning, WarningCode::General)
     };
 
     WarningEntry {
         severity,
-        category: category.to_string(),
+        category,
         message: msg,
         source_method,
+        details: None,
     }
 }
 
@@ -6342,7 +6433,7 @@ mod tests {
     fn classify_warning_convergence_is_critical() {
         let w = classify_warning("Outer optimization did not converge");
         assert_eq!(w.severity, WarningSeverity::Critical);
-        assert_eq!(w.category, "convergence");
+        assert_eq!(w.category.as_str(), "convergence");
         assert!(w.source_method.is_none());
     }
 
@@ -6350,21 +6441,21 @@ mod tests {
     fn classify_warning_covariance_is_critical() {
         let w = classify_warning("Covariance step failed");
         assert_eq!(w.severity, WarningSeverity::Critical);
-        assert_eq!(w.category, "covariance_step");
+        assert_eq!(w.category.as_str(), "covariance_step");
     }
 
     #[test]
     fn classify_warning_dw_is_warning() {
         let w = classify_warning("Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).");
         assert_eq!(w.severity, WarningSeverity::Warning);
-        assert_eq!(w.category, "dw_autocorrelation");
+        assert_eq!(w.category.as_str(), "dw_autocorrelation");
     }
 
     #[test]
     fn classify_warning_mu_ref_is_info() {
         let w = classify_warning("mu-ref: CL, V");
         assert_eq!(w.severity, WarningSeverity::Info);
-        assert_eq!(w.category, "mu_referencing");
+        assert_eq!(w.category.as_str(), "mu_referencing");
     }
 
     #[test]
@@ -6374,7 +6465,7 @@ mod tests {
              affect convergence; prefer forms such as `CL = TVCL * exp(ETA_CL)` when possible.",
         );
         assert_eq!(w.severity, WarningSeverity::Warning);
-        assert_eq!(w.category, "mu_referencing");
+        assert_eq!(w.category.as_str(), "mu_referencing");
     }
 
     #[test]
@@ -6383,14 +6474,81 @@ mod tests {
         assert_eq!(w.source_method.as_deref(), Some("FOCEI"));
         assert_eq!(w.message, "Covariance step failed");
         assert_eq!(w.severity, WarningSeverity::Critical);
-        assert_eq!(w.category, "covariance_step");
+        assert_eq!(w.category.as_str(), "covariance_step");
     }
 
     #[test]
     fn classify_warning_unknown_falls_back_to_general() {
         let w = classify_warning("some entirely novel message");
         assert_eq!(w.severity, WarningSeverity::Warning);
-        assert_eq!(w.category, "general");
+        assert_eq!(w.category.as_str(), "general");
+    }
+
+    /// #778: the `WarningCode` serde token is a public API an agent / the R
+    /// wrapper pins against. This snapshot fails loudly if a variant's token
+    /// drifts, and asserts `as_str()` and the serde representation agree.
+    #[test]
+    fn warning_code_tokens_are_stable() {
+        use WarningCode::*;
+        let expected: &[(WarningCode, &str)] = &[
+            (Convergence, "convergence"),
+            (CovarianceStep, "covariance_step"),
+            (ConditionNumber, "condition_number"),
+            (OptimizerHealth, "optimizer_health"),
+            (DwAutocorrelation, "dw_autocorrelation"),
+            (EtaNormality, "eta_normality"),
+            (Experimental, "experimental"),
+            (BloqMethod, "bloq_method"),
+            (Sir, "sir"),
+            (ImportanceSampling, "importance_sampling"),
+            (EpsShrinkage, "eps_shrinkage"),
+            (DataQuality, "data_quality"),
+            (OmegaStructure, "omega_structure"),
+            (GradientFallback, "gradient_fallback"),
+            (MuReferencing, "mu_referencing"),
+            (OptimizerConfig, "optimizer_config"),
+            (MultiStart, "multi_start"),
+            (Cancelled, "cancelled"),
+            (Threads, "threads"),
+            (General, "general"),
+        ];
+        for (code, token) in expected {
+            assert_eq!(code.as_str(), *token, "as_str drift for {code:?}");
+            // serde token == as_str token (rename_all = "snake_case").
+            assert_eq!(
+                serde_json::to_value(code).unwrap(),
+                serde_json::json!(token),
+                "serde token drift for {code:?}"
+            );
+            // and it round-trips back to the same variant.
+            let back: WarningCode = serde_json::from_value(serde_json::json!(token)).unwrap();
+            assert_eq!(back, *code);
+        }
+    }
+
+    /// #778: the optional `details` payload serializes when present (the
+    /// at-source numeric channel) and is omitted when `None`.
+    #[test]
+    fn warning_entry_details_serialize_when_present() {
+        let with = WarningEntry {
+            severity: WarningSeverity::Warning,
+            category: WarningCode::DwAutocorrelation,
+            message: "Positive IWRES autocorrelation".to_string(),
+            source_method: None,
+            details: Some(serde_json::json!({ "durbin_watson": 1.2 })),
+        };
+        let v = serde_json::to_value(&with).unwrap();
+        assert_eq!(v["category"], "dw_autocorrelation");
+        assert_eq!(v["details"]["durbin_watson"], 1.2);
+        // round-trips
+        let back: WarningEntry = serde_json::from_value(v).unwrap();
+        assert_eq!(back.details, with.details);
+        assert_eq!(back.category, WarningCode::DwAutocorrelation);
+
+        // None -> key omitted entirely.
+        let without = classify_warning("some novel message");
+        let vo = serde_json::to_value(&without).unwrap();
+        assert!(vo.get("details").is_none());
     }
 
     /// Round-trip table covering every literal warning message emitted by the
@@ -6650,7 +6808,7 @@ mod tests {
         let mut failures: Vec<String> = Vec::new();
         for (msg, want_sev, want_cat) in table {
             let got = classify_warning(msg);
-            if got.severity != *want_sev || got.category != *want_cat {
+            if got.severity != *want_sev || got.category.as_str() != *want_cat {
                 failures.push(format!(
                     "  {msg:?} -> expected ({:?}, {:?}), got ({:?}, {:?})",
                     want_sev, want_cat, got.severity, got.category

--- a/src/types.rs
+++ b/src/types.rs
@@ -3861,6 +3861,7 @@ pub enum WarningSeverity {
 /// warning classes appear; never repurpose an existing token.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WarningCode {
     /// Optimizer did not reach the convergence criterion.
     Convergence,


### PR DESCRIPTION
## Why

For an agentic model-development loop (and the R wrapper, and any script), a fit's warnings must be **branchable by machine** — "did this fail to converge / is the covariance singular / is shrinkage high?" — without matching English. Today `FitResult.warnings_structured[].category` is a free-text `String`, reconstructed post-hoc by string-matching. The vocabulary is implicit and can drift, and the same wording can map to different intents.

Closes #778. Makes the structured-warning category a **typed, stable taxonomy**.

## What changed

Scope (agreed up front): **typed taxonomy first**. The ~80 warning push sites across estimation/parser/io are large enough that inverting them to native at-source emission is its own follow-up; this PR delivers the agent-facing win — a stable, exhaustive, type-checked code — without that risk.

- **New `WarningCode` enum** (`src/types.rs`) — one variant per category the classifier produces, `#[serde(rename_all = "snake_case")]` with a `DwAutocorrelation` variant so every token is **byte-identical to the previous category string**. Result: the JSON output shipped in #777 is unchanged on the wire — `category` is now a typed code, same token.
- **`WarningEntry.category: String` → `WarningCode`**, plus a new optional **`details: Option<serde_json::Value>`** (omitted from JSON when `None`) — the machine-readable numeric channel (e.g. `{"durbin_watson": 1.2}`) that native at-source emitters will populate later.
- **`classify_warning()`** now returns typed codes — the single, exhaustive, type-checked source of the taxonomy (a `WarningCode` can't silently drift the way a free string could). Added `WarningCode::as_str()` + `Display`.
- **Docs:** new `docs/warnings.qmd` (every code + severity + typical agent response), linked in the sidebar and cross-referenced from `output.qmd`; `CHANGELOG` entry.

## Alternatives considered

- **Rename the field `category` → `code`** — rejected: `category` is the key already shipped in #777's JSON; keeping the name (typed value) preserves that shape while still delivering the type. The Rust *type* is `WarningCode`.
- **Full at-source emission now** (each of ~80 sites builds its own typed entry, human strings derived from structured) — deferred: ~15 files, high regression risk. The issue explicitly sanctions keeping `classify_warning()` as the classifier until sites migrate.
- **Drop `classify_warning()`** — no: it is now the typed classifier and still the fallback for any string-only path (e.g. `.fitrx` bundles that store raw message strings).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

JSON/`.fitrx` tokens are unchanged, so the R wrapper (which consumes the serialized output) is unaffected. `WarningEntry.category`'s Rust *type* changed, but ferx-r builds from the pinned lock and does not match on the Rust enum.

## Breaking changes
- [x] `FitResult` fields changed — `WarningEntry.category` is now `WarningCode` instead of `String` (Rust API). **JSON/serialized token is unchanged**, so data consumers are not affected; only in-process Rust callers that read `.category` as a string need `.as_str()`.

<details>
<summary>Migration notes</summary>

In-process Rust: `entry.category == "convergence"` → `entry.category == WarningCode::Convergence` (or `entry.category.as_str() == "convergence"`). JSON consumers: no change.
</details>

## Numerical validation
- [x] Not applicable (diagnostics typing only — no change to estimates/OFV/residuals). Verified end-to-end: a warfarin fit's `--output-format json` emits `warnings_structured[].category` as the same tokens as before (`"convergence"`, `"dw_autocorrelation"`), with `details` omitted.

## Performance
- [x] No significant impact expected.

## Tests
- [x] Unit tests added (`cargo test --lib` passes):
  - `warning_code_tokens_are_stable`: every variant's serde token == `as_str()` and round-trips — the stable-token snapshot an agent pins against.
  - `warning_entry_details_serialize_when_present`: `details` serializes when `Some`, key omitted when `None`.
  - The existing engine-message round-trip table (`classify_warning_roundtrips_every_engine_message`) and per-branch tests now assert via `as_str()`, still covering the full classifier contract.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt):
```json
"warnings_structured": [
  { "severity": "Critical", "category": "convergence",
    "message": "Outer optimization did not converge", "source_method": null },
  { "severity": "Warning", "category": "dw_autocorrelation",
    "message": "Negative IWRES autocorrelation detected (Durbin-Watson = 2.61)...",
    "source_method": null }
]
```
`category` is a stable `WarningCode` token; an agent branches on it directly.
</details>

## Docs
- [x] `docs/` updated (`warnings.qmd` new, `output.qmd` cross-link)
- [x] New page linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean on changed files (pre-existing warnings in sir.rs / api.rs unrelated)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- The token-stability contract is the crux: `WarningCode` serde tokens must equal the old category strings (verified by `warning_code_tokens_are_stable` + the round-trip table). This is what keeps #777's JSON back-compatible.
- `classify_warning()` logic is unchanged; only its return type (string → typed code). The big engine-message table proves no message reclassifies.

## Open questions
- Follow-up scope: native at-source emission (populate `details` with numbers, derive human strings from structured) across the ~80 push sites — worth a tracking issue?
