### PR TITLE
feat(diagnostics): populate warning details for numeric diagnostics (#781 increment 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Warning `details` payloads for numeric diagnostics** (#781): structured
+  warnings for `dw_autocorrelation`, `eps_shrinkage`, and `condition_number` now
+  carry a `details` object with the value behind the message (e.g.
+  `{"durbin_watson": 1.20, "iwres_lag1_autocorr": 0.40}`), sourced from the
+  fit's typed fields so an agent reads the number directly instead of parsing
+  prose. First increment of the at-source warning work; other codes omit
+  `details` until converted. See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html#details).
 - **Typed warning taxonomy** (#778): structured warnings
   (`FitResult.warnings_structured`, surfaced in the JSON output) now carry a
   typed `WarningCode` instead of a free-text category string — a stable,

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -60,13 +60,39 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `threads` | Info | Thread-count efficiency note. | Optionally tune `threads`. |
 | `general` | Warning | Unrecognised message (fallback bucket). | Read the message text. |
 
+## Details payloads {#details}
+
+Numeric diagnostics also carry a `details` object with the value behind the
+message, so a consumer reads the number directly instead of parsing prose. The
+numbers are sourced from the fit's typed fields, not from the message text.
+
+| Code | `details` keys |
+|------|----------------|
+| `dw_autocorrelation` | `durbin_watson`, `iwres_lag1_autocorr` |
+| `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
+| `condition_number` | `condition_number` |
+
+```json
+{
+  "severity": "Warning",
+  "category": "dw_autocorrelation",
+  "message": "Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).",
+  "source_method": null,
+  "details": { "durbin_watson": 1.20, "iwres_lag1_autocorr": 0.40 }
+}
+```
+
+Codes without an associated stored statistic omit the `details` key entirely
+(the Rust field is `None`).
+
 ## How codes are assigned
 
-Codes today are assigned centrally by `classify_warning()`, which maps each
-engine message to its `WarningCode` and severity. It is the single, type-checked
-source of the taxonomy — the `WarningCode` enum is exhaustive, so the vocabulary
-can no longer drift as a free string. Native at-source emission (each site
-constructing its own typed `WarningEntry` with a populated `details` payload) is
-being migrated incrementally; until a site is converted, its entry is classified
-from the message and has no `details` payload (the `details` key is omitted from
-the JSON; the Rust field is `None`).
+Codes are assigned centrally by `classify_warning()`, which maps each engine
+message to its `WarningCode` and severity, then `details` is attached from the
+fit's typed numeric fields for the codes above. `classify_warning()` is the
+single, type-checked source of the taxonomy — the `WarningCode` enum is
+exhaustive, so the vocabulary can no longer drift as a free string. Full native
+at-source emission (each site constructing its own typed `WarningEntry` with a
+`details` payload, and the human `warnings` strings derived from the structured
+list) is being migrated incrementally; `details` for the numeric diagnostics is
+the first step.

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -62,9 +62,10 @@ Each `WarningCode` token, what it flags, and a typical response.
 
 ## Details payloads {#details}
 
-Numeric diagnostics also carry a `details` object with the value behind the
+Numeric diagnostics **may** carry a `details` object with the value behind the
 message, so a consumer reads the number directly instead of parsing prose. The
 numbers are sourced from the fit's typed fields, not from the message text.
+Treat `details` as optional: check for its presence rather than assuming it.
 
 | Code | `details` keys |
 |------|----------------|
@@ -82,8 +83,9 @@ numbers are sourced from the fit's typed fields, not from the message text.
 }
 ```
 
-Codes without an associated stored statistic omit the `details` key entirely
-(the Rust field is `None`).
+A code omits the `details` key entirely (Rust field `None`) when it has no
+associated stored statistic, or when any contributing statistic is non-finite
+(`NaN`/`±Inf` — e.g. the condition number of a near-singular parameter space).
 
 ## How codes are assigned
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -3177,8 +3177,11 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
 
 /// Machine-readable `details` payload for the numeric diagnostic warning codes,
 /// sourced from the typed `FitResult` fields rather than parsed from the
-/// message text. Returns `None` for codes with no associated stored statistic
-/// (their `details` key is then omitted from the JSON).
+/// message text. Returns `None` for a code with no associated stored statistic,
+/// or when **any** contributing statistic is non-finite (`NaN`/`±Inf`) — the
+/// `details` key is then omitted from the JSON entirely, rather than emitting a
+/// `null` value (`serde_json` maps non-finite floats to `null`). `cov_condition_number`
+/// in particular is documented as `+Inf` for a near-singular parameter space.
 fn diagnostic_details(
     code: &crate::types::WarningCode,
     dw_statistic: f64,
@@ -3188,17 +3191,20 @@ fn diagnostic_details(
 ) -> Option<serde_json::Value> {
     use crate::types::WarningCode;
     match code {
-        WarningCode::DwAutocorrelation if dw_statistic.is_finite() => Some(serde_json::json!({
-            "durbin_watson": dw_statistic,
-            "iwres_lag1_autocorr": iwres_lag1_r,
-        })),
+        WarningCode::DwAutocorrelation if dw_statistic.is_finite() && iwres_lag1_r.is_finite() => {
+            Some(serde_json::json!({
+                "durbin_watson": dw_statistic,
+                "iwres_lag1_autocorr": iwres_lag1_r,
+            }))
+        }
         WarningCode::EpsShrinkage if shrinkage_eps.is_finite() => Some(serde_json::json!({
             "eps_shrinkage": shrinkage_eps,
             "eps_shrinkage_pct": 100.0 * shrinkage_eps,
         })),
-        WarningCode::ConditionNumber => {
-            cov_condition_number.map(|c| serde_json::json!({ "condition_number": c }))
-        }
+        WarningCode::ConditionNumber => match cov_condition_number {
+            Some(c) if c.is_finite() => Some(serde_json::json!({ "condition_number": c })),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -11879,6 +11885,27 @@ mod simulate_with_uncertainty_tests {
             super::diagnostic_details(&WarningCode::Convergence, 1.0, 0.0, 0.0, Some(1.0))
                 .is_none()
         );
+
+        // Non-finite *contributing* stats omit details rather than emit a
+        // null-valued payload (serde_json maps non-finite floats to null).
+        // cov_condition_number = +Inf (documented for near-singular spaces):
+        assert!(super::diagnostic_details(
+            &WarningCode::ConditionNumber,
+            f64::NAN,
+            0.0,
+            f64::NAN,
+            Some(f64::INFINITY)
+        )
+        .is_none());
+        // finite Durbin-Watson but non-finite lag-1 autocorrelation:
+        assert!(super::diagnostic_details(
+            &WarningCode::DwAutocorrelation,
+            1.20,
+            f64::NAN,
+            f64::NAN,
+            None
+        )
+        .is_none());
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3149,12 +3149,58 @@ pub fn fit(
 ///
 /// Called after all late-injected warnings (LTBS splice, multi-start metadata)
 /// have been appended so the structured field is always in sync with the flat list.
+///
+/// Each message is classified into a typed [`crate::types::WarningCode`] +
+/// severity and — for the numeric diagnostics whose values are already stored
+/// as typed fields on the `FitResult` — enriched with a machine-readable
+/// `details` payload sourced from those fields (issue #781, increment 1). The
+/// numbers thus come from typed state, not from re-parsing the message prose;
+/// converting the remaining ~80 string push-sites to full at-source emission is
+/// a later increment.
 fn rebuild_warnings_structured(result: &mut FitResult) {
-    result.warnings_structured = result
+    let mut entries: Vec<crate::types::WarningEntry> = result
         .warnings
         .iter()
         .map(|w| crate::types::classify_warning(w))
         .collect();
+    for e in &mut entries {
+        e.details = diagnostic_details(
+            &e.category,
+            result.dw_statistic,
+            result.iwres_lag1_r,
+            result.shrinkage_eps,
+            result.cov_condition_number,
+        );
+    }
+    result.warnings_structured = entries;
+}
+
+/// Machine-readable `details` payload for the numeric diagnostic warning codes,
+/// sourced from the typed `FitResult` fields rather than parsed from the
+/// message text. Returns `None` for codes with no associated stored statistic
+/// (their `details` key is then omitted from the JSON).
+fn diagnostic_details(
+    code: &crate::types::WarningCode,
+    dw_statistic: f64,
+    iwres_lag1_r: f64,
+    shrinkage_eps: f64,
+    cov_condition_number: Option<f64>,
+) -> Option<serde_json::Value> {
+    use crate::types::WarningCode;
+    match code {
+        WarningCode::DwAutocorrelation if dw_statistic.is_finite() => Some(serde_json::json!({
+            "durbin_watson": dw_statistic,
+            "iwres_lag1_autocorr": iwres_lag1_r,
+        })),
+        WarningCode::EpsShrinkage if shrinkage_eps.is_finite() => Some(serde_json::json!({
+            "eps_shrinkage": shrinkage_eps,
+            "eps_shrinkage_pct": 100.0 * shrinkage_eps,
+        })),
+        WarningCode::ConditionNumber => {
+            cov_condition_number.map(|c| serde_json::json!({ "condition_number": c }))
+        }
+        _ => None,
+    }
 }
 
 /// Probe whether NLopt CRS2-LM (used for global_search) is available.
@@ -11791,6 +11837,69 @@ mod simulate_with_uncertainty_tests {
             err.contains("LTBS") && err.contains("Additive"),
             "expected LTBS+proportional rejection, got: {err}"
         );
+    }
+
+    #[test]
+    fn diagnostic_details_covers_numeric_codes() {
+        use crate::types::WarningCode;
+        // Durbin–Watson: both stored stats surface.
+        let d =
+            super::diagnostic_details(&WarningCode::DwAutocorrelation, 1.2, 0.4, f64::NAN, None)
+                .expect("DW details");
+        assert_eq!(d["durbin_watson"], 1.2);
+        assert_eq!(d["iwres_lag1_autocorr"], 0.4);
+        // EPS shrinkage: fraction + percent.
+        let d = super::diagnostic_details(&WarningCode::EpsShrinkage, f64::NAN, 0.0, -0.083, None)
+            .expect("eps details");
+        assert_eq!(d["eps_shrinkage"], -0.083);
+        assert!((d["eps_shrinkage_pct"].as_f64().unwrap() + 8.3).abs() < 1e-9);
+        // Condition number: from the Option.
+        let d = super::diagnostic_details(
+            &WarningCode::ConditionNumber,
+            f64::NAN,
+            0.0,
+            f64::NAN,
+            Some(1.4e6),
+        )
+        .expect("cond details");
+        assert_eq!(d["condition_number"], 1.4e6);
+        // None cases: missing stat, non-finite stat, and non-numeric code.
+        assert!(
+            super::diagnostic_details(&WarningCode::ConditionNumber, 0.0, 0.0, 0.0, None).is_none()
+        );
+        assert!(super::diagnostic_details(
+            &WarningCode::DwAutocorrelation,
+            f64::INFINITY,
+            0.0,
+            0.0,
+            None
+        )
+        .is_none());
+        assert!(
+            super::diagnostic_details(&WarningCode::Convergence, 1.0, 0.0, 0.0, Some(1.0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rebuild_attaches_details_from_typed_fields() {
+        let model = tiny_model();
+        let mut fit = synthetic_fit(&model.default_params);
+        fit.warnings = vec![
+            "Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).".to_string(),
+            "Outer optimization did not converge".to_string(),
+        ];
+        fit.dw_statistic = 1.20;
+        fit.iwres_lag1_r = 0.4;
+        super::rebuild_warnings_structured(&mut fit);
+
+        let dw = &fit.warnings_structured[0];
+        assert_eq!(dw.category, crate::types::WarningCode::DwAutocorrelation);
+        let details = dw.details.as_ref().expect("DW warning carries details");
+        assert_eq!(details["durbin_watson"], 1.20);
+        assert_eq!(details["iwres_lag1_autocorr"], 0.4);
+        // A non-numeric code keeps details omitted.
+        assert!(fit.warnings_structured[1].details.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Why

#778 added the typed `WarningCode` taxonomy and an optional `WarningEntry.details` field, but `details` was always `None`. For an agentic loop, the *numbers* behind a diagnostic (Durbin–Watson, shrinkage, condition number) are the actionable signal — and today they're trapped inside prose. This is the first #781 increment: **populate `details`** for the numeric diagnostics, so a consumer reads `details.durbin_watson` directly instead of regexing the message.

Part of #781 (kept open — this is one increment; the full String→typed at-source inversion of the ~80 push sites is later work).

## What changed

- `rebuild_warnings_structured` now attaches a `details` payload after classifying each message, via a new pure `diagnostic_details(code, dw, lag1, eps, cond)`:
  - `dw_autocorrelation` → `{"durbin_watson", "iwres_lag1_autocorr"}`
  - `eps_shrinkage` → `{"eps_shrinkage", "eps_shrinkage_pct"}`
  - `condition_number` → `{"condition_number"}`
- The numbers are sourced from the fit's **typed fields** (`dw_statistic`, `iwres_lag1_r`, `shrinkage_eps`, `cov_condition_number`) — **not re-parsed from the message**. That's the point: the value comes from typed state, so it carries full precision and can't drift from the prose.
- Codes with no stored statistic (or a non-finite one) omit `details` (key absent in JSON, per `skip_serializing_if`).

## Alternatives considered

- **Parse the number out of the message string** — rejected: that's the exact brittleness #778/#781 move away from. Sourcing from typed `FitResult` fields is robust and full-precision.
- **Convert the push sites to full at-source `WarningEntry` emission now** — deferred: ~80 sites / ~15 files. This increment delivers the agent-visible `details` win centrally and low-risk; the inversion follows.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Purely additive to the JSON (`details` appears where it didn't before); no token or field-type change. ferx-r unaffected.

## Breaking changes
- [x] None (additive `details` payload on existing structured warnings)

## Numerical validation
- [x] Not applicable (diagnostics payload only). Verified end-to-end: a warfarin fit's `--output-format json` now emits the DW warning with `"details": {"durbin_watson": 2.6088…, "iwres_lag1_autocorr": -0.3651…}` (full precision vs the message's rounded "2.61"); the convergence warning correctly has no `details`.

## Performance
- [x] No significant impact expected (runs once per fit during structured-warning rebuild).

## Tests
- [x] Unit tests added (`cargo test --lib` passes):
  - `diagnostic_details_covers_numeric_codes`: every numeric code's payload, plus the None paths (missing Option, non-finite stat, non-numeric code).
  - `rebuild_attaches_details_from_typed_fields`: a `FitResult` with a DW warning + typed fields → the structured entry carries `details.durbin_watson`; a non-numeric code keeps `details` omitted.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt):
```json
{
  "severity": "Warning",
  "category": "dw_autocorrelation",
  "message": "Negative IWRES autocorrelation detected (Durbin-Watson = 2.61)...",
  "source_method": null,
  "details": { "durbin_watson": 2.6088, "iwres_lag1_autocorr": -0.3651 }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — new "Details payloads" section (schema per code) + refreshed "How codes are assigned"
- [x] `CHANGELOG.md` `[Unreleased]` entry
- [x] No new page (existing page updated)

## Checklist
- [x] `cargo clippy` clean (changed code)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- `diagnostic_details()` is pure and keyed on `WarningCode`; the guard is `.is_finite()` / `Option` so a missing/NaN stat yields no `details` rather than a `null` or `NaN`.
- Sourcing from typed fields (not the string) is the design choice — see the `rebuild_attaches_details_from_typed_fields` test.

## Open questions
- Next increments on #781: which theme first — covariance-step (condition number / eigenvalues at source) or data-quality? Happy to sequence per your preference.
