### PR TITLE
feat(diagnostics): high ETA-shrinkage warning with details (#781 increment 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **High ETA-shrinkage warning** (#781): a fit now emits an `eta_shrinkage`
+  warning when any random-effect (ETA) shrinkage exceeds ~30% (the Savic &
+  Karlsson rule of thumb) — the data poorly inform that IIV, so EBE-based
+  diagnostics for it are unreliable and removing the IIV is often warranted.
+  The structured warning carries `details` listing the affected ETAs and their
+  shrinkage percent. See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **Warning `details` payloads for numeric diagnostics** (#781): structured
   warnings for `dw_autocorrelation`, `eps_shrinkage`, and `condition_number` now
   carry a `details` object with the value behind the message (e.g.

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -50,6 +50,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `sir` | Warning | SIR failed or was requested without a covariance. | Ensure a covariance exists before requesting SIR. |
 | `importance_sampling` | Warning | ESS = 0 / proposal collapse. | Increase samples or improve the proposal. |
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
+| `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
@@ -71,6 +72,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 |------|----------------|
 | `dw_autocorrelation` | `durbin_watson`, `iwres_lag1_autocorr` |
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
+| `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
 | `condition_number` | `condition_number` |
 
 ```json

--- a/src/api.rs
+++ b/src/api.rs
@@ -3213,7 +3213,7 @@ fn diagnostic_details(
                 .into_iter()
                 .map(|i| {
                     serde_json::json!({
-                        "eta": eta_names.get(i).cloned().unwrap_or_default(),
+                        "eta": eta_label(eta_names, i),
                         "shrinkage_pct": 100.0 * shrinkage_eta[i],
                     })
                 })
@@ -5982,6 +5982,16 @@ pub(crate) fn high_shrinkage_eta_indices(shrinkage: &[f64]) -> Vec<usize> {
         .collect()
 }
 
+/// Label for the `i`-th ETA, falling back to a non-empty `eta_{i}` placeholder
+/// when the name is missing — so both the message and the `details` payload
+/// stay unambiguous.
+fn eta_label(eta_names: &[String], i: usize) -> String {
+    eta_names
+        .get(i)
+        .cloned()
+        .unwrap_or_else(|| format!("eta_{i}"))
+}
+
 /// Build the user-facing warning for high ETA shrinkage, or `None` when no ETA
 /// exceeds the threshold. `shrinkage` is per-ETA shrinkage as a fraction;
 /// `eta_names` labels them in the same order.
@@ -5992,10 +6002,7 @@ pub(crate) fn eta_shrinkage_warning(shrinkage: &[f64], eta_names: &[String]) -> 
     }
     let list = high
         .iter()
-        .map(|&i| {
-            let name = eta_names.get(i).map(String::as_str).unwrap_or("?");
-            format!("{} ({:.0}%)", name, 100.0 * shrinkage[i])
-        })
+        .map(|&i| format!("{} ({:.0}%)", eta_label(eta_names, i), 100.0 * shrinkage[i]))
         .collect::<Vec<_>>()
         .join(", ");
     Some(format!(
@@ -12032,6 +12039,19 @@ mod simulate_with_uncertainty_tests {
             &names,
         )
         .is_none());
+
+        // Missing name → non-empty `eta_{i}` placeholder, not "".
+        let d = super::diagnostic_details(
+            &WarningCode::EtaShrinkage,
+            f64::NAN,
+            0.0,
+            f64::NAN,
+            None,
+            &[0.42],
+            &[], // no names
+        )
+        .expect("details");
+        assert_eq!(d["high_shrinkage_etas"][0]["eta"], "eta_0");
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3170,6 +3170,8 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
             result.iwres_lag1_r,
             result.shrinkage_eps,
             result.cov_condition_number,
+            &result.shrinkage_eta,
+            &result.eta_names,
         );
     }
     result.warnings_structured = entries;
@@ -3182,12 +3184,15 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
 /// `details` key is then omitted from the JSON entirely, rather than emitting a
 /// `null` value (`serde_json` maps non-finite floats to `null`). `cov_condition_number`
 /// in particular is documented as `+Inf` for a near-singular parameter space.
+#[allow(clippy::too_many_arguments)]
 fn diagnostic_details(
     code: &crate::types::WarningCode,
     dw_statistic: f64,
     iwres_lag1_r: f64,
     shrinkage_eps: f64,
     cov_condition_number: Option<f64>,
+    shrinkage_eta: &[f64],
+    eta_names: &[String],
 ) -> Option<serde_json::Value> {
     use crate::types::WarningCode;
     match code {
@@ -3201,6 +3206,27 @@ fn diagnostic_details(
             "eps_shrinkage": shrinkage_eps,
             "eps_shrinkage_pct": 100.0 * shrinkage_eps,
         })),
+        WarningCode::EtaShrinkage => {
+            // The high-shrinkage ETAs behind the message, with each shrinkage
+            // as a percent — sourced from the typed `shrinkage_eta` field.
+            let high: Vec<serde_json::Value> = high_shrinkage_eta_indices(shrinkage_eta)
+                .into_iter()
+                .map(|i| {
+                    serde_json::json!({
+                        "eta": eta_names.get(i).cloned().unwrap_or_default(),
+                        "shrinkage_pct": 100.0 * shrinkage_eta[i],
+                    })
+                })
+                .collect();
+            if high.is_empty() {
+                None
+            } else {
+                Some(serde_json::json!({
+                    "threshold_pct": 100.0 * ETA_SHRINKAGE_WARN_THRESHOLD,
+                    "high_shrinkage_etas": high,
+                }))
+            }
+        }
         WarningCode::ConditionNumber => match cov_condition_number {
             Some(c) if c.is_finite() => Some(serde_json::json!({ "condition_number": c })),
             _ => None,
@@ -5066,6 +5092,9 @@ fn fit_inner(
     if let Some(w) = eps_shrinkage_warning(shrinkage_eps) {
         warnings.push(w);
     }
+    if let Some(w) = eta_shrinkage_warning(&shrinkage_eta, &result.params.omega.eta_names) {
+        warnings.push(w);
+    }
 
     let (iwres_lag1_r, dw_statistic) = iwres_autocorrelation(&subjects);
 
@@ -5932,6 +5961,50 @@ pub(crate) fn eps_shrinkage_warning(shrinkage_eps: f64) -> Option<String> {
          of subjects; sigma at a bound. Inspect the IWRES distribution in the \
          sdtab.",
         100.0 * shrinkage_eps
+    ))
+}
+
+/// ETA-shrinkage warning threshold (fraction). 0.30 is the classic
+/// Savic & Karlsson (2009) 30% rule of thumb: above it, an EBE-based
+/// diagnostic — and the individual estimates of that random effect — are
+/// poorly informed by the data (η shrinks toward 0).
+const ETA_SHRINKAGE_WARN_THRESHOLD: f64 = 0.30;
+
+/// Indices of the ETAs whose shrinkage meets/exceeds the warning threshold.
+/// `shrinkage` is per-ETA shrinkage as a fraction (0..1); non-finite entries
+/// are ignored.
+pub(crate) fn high_shrinkage_eta_indices(shrinkage: &[f64]) -> Vec<usize> {
+    shrinkage
+        .iter()
+        .enumerate()
+        .filter(|(_, &s)| s.is_finite() && s >= ETA_SHRINKAGE_WARN_THRESHOLD)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Build the user-facing warning for high ETA shrinkage, or `None` when no ETA
+/// exceeds the threshold. `shrinkage` is per-ETA shrinkage as a fraction;
+/// `eta_names` labels them in the same order.
+pub(crate) fn eta_shrinkage_warning(shrinkage: &[f64], eta_names: &[String]) -> Option<String> {
+    let high = high_shrinkage_eta_indices(shrinkage);
+    if high.is_empty() {
+        return None;
+    }
+    let list = high
+        .iter()
+        .map(|&i| {
+            let name = eta_names.get(i).map(String::as_str).unwrap_or("?");
+            format!("{} ({:.0}%)", name, 100.0 * shrinkage[i])
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "High ETA shrinkage (\u{2265} {:.0}%): {}. EBE-based diagnostics for these \
+         random effects are unreliable and the data poorly inform their individual \
+         estimates; consider removing the IIV on the affected parameter(s) or \
+         collecting more informative data.",
+        100.0 * ETA_SHRINKAGE_WARN_THRESHOLD,
+        list
     ))
 }
 
@@ -11848,19 +11921,26 @@ mod simulate_with_uncertainty_tests {
     #[test]
     fn diagnostic_details_covers_numeric_codes() {
         use crate::types::WarningCode;
+        // Shim for the non-ETA codes (empty ETA inputs).
+        fn dd(
+            code: &crate::types::WarningCode,
+            dw: f64,
+            lag1: f64,
+            eps: f64,
+            cond: Option<f64>,
+        ) -> Option<serde_json::Value> {
+            super::diagnostic_details(code, dw, lag1, eps, cond, &[], &[])
+        }
         // Durbin–Watson: both stored stats surface.
-        let d =
-            super::diagnostic_details(&WarningCode::DwAutocorrelation, 1.2, 0.4, f64::NAN, None)
-                .expect("DW details");
+        let d = dd(&WarningCode::DwAutocorrelation, 1.2, 0.4, f64::NAN, None).expect("DW details");
         assert_eq!(d["durbin_watson"], 1.2);
         assert_eq!(d["iwres_lag1_autocorr"], 0.4);
         // EPS shrinkage: fraction + percent.
-        let d = super::diagnostic_details(&WarningCode::EpsShrinkage, f64::NAN, 0.0, -0.083, None)
-            .expect("eps details");
+        let d = dd(&WarningCode::EpsShrinkage, f64::NAN, 0.0, -0.083, None).expect("eps details");
         assert_eq!(d["eps_shrinkage"], -0.083);
         assert!((d["eps_shrinkage_pct"].as_f64().unwrap() + 8.3).abs() < 1e-9);
         // Condition number: from the Option.
-        let d = super::diagnostic_details(
+        let d = dd(
             &WarningCode::ConditionNumber,
             f64::NAN,
             0.0,
@@ -11870,10 +11950,8 @@ mod simulate_with_uncertainty_tests {
         .expect("cond details");
         assert_eq!(d["condition_number"], 1.4e6);
         // None cases: missing stat, non-finite stat, and non-numeric code.
-        assert!(
-            super::diagnostic_details(&WarningCode::ConditionNumber, 0.0, 0.0, 0.0, None).is_none()
-        );
-        assert!(super::diagnostic_details(
+        assert!(dd(&WarningCode::ConditionNumber, 0.0, 0.0, 0.0, None).is_none());
+        assert!(dd(
             &WarningCode::DwAutocorrelation,
             f64::INFINITY,
             0.0,
@@ -11881,15 +11959,12 @@ mod simulate_with_uncertainty_tests {
             None
         )
         .is_none());
-        assert!(
-            super::diagnostic_details(&WarningCode::Convergence, 1.0, 0.0, 0.0, Some(1.0))
-                .is_none()
-        );
+        assert!(dd(&WarningCode::Convergence, 1.0, 0.0, 0.0, Some(1.0)).is_none());
 
         // Non-finite *contributing* stats omit details rather than emit a
         // null-valued payload (serde_json maps non-finite floats to null).
         // cov_condition_number = +Inf (documented for near-singular spaces):
-        assert!(super::diagnostic_details(
+        assert!(dd(
             &WarningCode::ConditionNumber,
             f64::NAN,
             0.0,
@@ -11898,12 +11973,63 @@ mod simulate_with_uncertainty_tests {
         )
         .is_none());
         // finite Durbin-Watson but non-finite lag-1 autocorrelation:
-        assert!(super::diagnostic_details(
+        assert!(dd(
             &WarningCode::DwAutocorrelation,
             1.20,
             f64::NAN,
             f64::NAN,
             None
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn eta_shrinkage_warning_fires_above_threshold_only() {
+        let names = vec![
+            "eta_CL".to_string(),
+            "eta_V".to_string(),
+            "eta_KA".to_string(),
+        ];
+        // All low → no warning.
+        assert!(super::eta_shrinkage_warning(&[0.01, 0.05, 0.10], &names).is_none());
+        // NaN is ignored (not treated as high).
+        assert!(super::eta_shrinkage_warning(&[0.01, f64::NAN, 0.20], &names).is_none());
+        // One above the 30% threshold → warning names it with its percent.
+        let w = super::eta_shrinkage_warning(&[0.02, 0.42, 0.10], &names).expect("warning");
+        assert!(w.contains("eta_V (42%)"), "got: {w}");
+        assert!(w.to_lowercase().contains("eta shrinkage"));
+        // Boundary: exactly at threshold counts.
+        assert!(super::eta_shrinkage_warning(&[0.30], &["eta_CL".into()]).is_some());
+    }
+
+    #[test]
+    fn eta_shrinkage_details_lists_high_etas() {
+        use crate::types::WarningCode;
+        let names = vec!["eta_CL".to_string(), "eta_V".to_string()];
+        let d = super::diagnostic_details(
+            &WarningCode::EtaShrinkage,
+            f64::NAN,
+            0.0,
+            f64::NAN,
+            None,
+            &[0.05, 0.42],
+            &names,
+        )
+        .expect("eta details");
+        assert_eq!(d["threshold_pct"], 30.0);
+        let high = d["high_shrinkage_etas"].as_array().unwrap();
+        assert_eq!(high.len(), 1);
+        assert_eq!(high[0]["eta"], "eta_V");
+        assert!((high[0]["shrinkage_pct"].as_f64().unwrap() - 42.0).abs() < 1e-9);
+        // No high eta → no details payload.
+        assert!(super::diagnostic_details(
+            &WarningCode::EtaShrinkage,
+            f64::NAN,
+            0.0,
+            f64::NAN,
+            None,
+            &[0.05, 0.10],
+            &names,
         )
         .is_none());
     }
@@ -11915,9 +12041,14 @@ mod simulate_with_uncertainty_tests {
         fit.warnings = vec![
             "Positive IWRES autocorrelation detected (Durbin-Watson = 1.20).".to_string(),
             "Outer optimization did not converge".to_string(),
+            "High ETA shrinkage (\u{2265} 30%): eta_V (42%). EBE-based diagnostics \
+             for these random effects are unreliable."
+                .to_string(),
         ];
         fit.dw_statistic = 1.20;
         fit.iwres_lag1_r = 0.4;
+        fit.shrinkage_eta = vec![0.05, 0.42];
+        fit.eta_names = vec!["eta_CL".to_string(), "eta_V".to_string()];
         super::rebuild_warnings_structured(&mut fit);
 
         let dw = &fit.warnings_structured[0];
@@ -11927,6 +12058,11 @@ mod simulate_with_uncertainty_tests {
         assert_eq!(details["iwres_lag1_autocorr"], 0.4);
         // A non-numeric code keeps details omitted.
         assert!(fit.warnings_structured[1].details.is_none());
+        // ETA shrinkage classifies + attaches its high-eta details.
+        let eta = &fit.warnings_structured[2];
+        assert_eq!(eta.category, crate::types::WarningCode::EtaShrinkage);
+        let ed = eta.details.as_ref().expect("ETA shrinkage details");
+        assert_eq!(ed["high_shrinkage_etas"][0]["eta"], "eta_V");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4049,7 +4049,8 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, WarningCode::ImportanceSampling)
     } else if lower.contains("eps shrinkage") {
         (WarningSeverity::Warning, WarningCode::EpsShrinkage)
-    } else if lower.contains("eta shrinkage") {
+    } else if lower.starts_with("eta shrinkage") || lower.contains(" eta shrinkage") {
+        // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
         (WarningSeverity::Warning, WarningCode::DataQuality)
@@ -6489,6 +6490,24 @@ mod tests {
         let w = classify_warning("some entirely novel message");
         assert_eq!(w.severity, WarningSeverity::Warning);
         assert_eq!(w.category.as_str(), "general");
+    }
+
+    #[test]
+    fn classify_warning_eta_shrinkage_is_word_bounded() {
+        // The real message classifies to eta_shrinkage.
+        assert_eq!(
+            classify_warning("High ETA shrinkage (>= 30%): eta_V (42%)")
+                .category
+                .as_str(),
+            "eta_shrinkage"
+        );
+        // A substring like "beta shrinkage" must NOT collide.
+        assert_ne!(
+            classify_warning("beta shrinkage looks odd")
+                .category
+                .as_str(),
+            "eta_shrinkage"
+        );
     }
 
     /// #778: the `WarningCode` serde token is a public API an agent / the R

--- a/src/types.rs
+++ b/src/types.rs
@@ -3885,6 +3885,9 @@ pub enum WarningCode {
     ImportanceSampling,
     /// EPS (residual) shrinkage is notably high / negative.
     EpsShrinkage,
+    /// One or more ETA (random-effect) shrinkages exceed the threshold — the
+    /// data poorly inform those individual random effects.
+    EtaShrinkage,
     /// Dataset-quality issue (missing DV, ADDL/II, non-positive DV, …).
     DataQuality,
     /// Omega structure caveat (mixed lognormal / additive block).
@@ -3921,6 +3924,7 @@ impl WarningCode {
             WarningCode::Sir => "sir",
             WarningCode::ImportanceSampling => "importance_sampling",
             WarningCode::EpsShrinkage => "eps_shrinkage",
+            WarningCode::EtaShrinkage => "eta_shrinkage",
             WarningCode::DataQuality => "data_quality",
             WarningCode::OmegaStructure => "omega_structure",
             WarningCode::GradientFallback => "gradient_fallback",
@@ -4045,6 +4049,8 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, WarningCode::ImportanceSampling)
     } else if lower.contains("eps shrinkage") {
         (WarningSeverity::Warning, WarningCode::EpsShrinkage)
+    } else if lower.contains("eta shrinkage") {
+        (WarningSeverity::Warning, WarningCode::EtaShrinkage)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
         (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_iov_occ_missing")
@@ -6503,6 +6509,7 @@ mod tests {
             (Sir, "sir"),
             (ImportanceSampling, "importance_sampling"),
             (EpsShrinkage, "eps_shrinkage"),
+            (EtaShrinkage, "eta_shrinkage"),
             (DataQuality, "data_quality"),
             (OmegaStructure, "omega_structure"),
             (GradientFallback, "gradient_fallback"),
@@ -6649,6 +6656,12 @@ mod tests {
                 "IMP: 2 subject(s) had ESS = 0 (proposal collapse)",
                 Warning,
                 "importance_sampling",
+            ),
+            (
+                "High ETA shrinkage (\u{2265} 30%): eta_CL (42%). EBE-based diagnostics \
+                 for these random effects are unreliable.",
+                Warning,
+                "eta_shrinkage",
             ),
             (
                 "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",


### PR DESCRIPTION
## Why

High ETA (random-effect) shrinkage is a top-tier model-development signal: when an ETA's shrinkage exceeds ~30%, the data don't inform that individual random effect, so its EBE-based diagnostics are misleading and the IIV is often better removed. ferx warned on EPS (residual) shrinkage but **not** ETA shrinkage — a notable gap for an agentic loop deciding whether to prune IIV.

Second increment of #781 (kept open): a new typed warning + `details`, in the same low-risk pattern as increment 1.

## What changed

- **New `eta_shrinkage` warning**, emitted at source next to the eps-shrinkage warning, firing when any `shrinkage_eta[i] ≥ 30%` (the Savic & Karlsson 2009 rule of thumb — a `const ETA_SHRINKAGE_WARN_THRESHOLD`). The message names each high-shrinkage ETA and its percent.
- **New `WarningCode::EtaShrinkage`** (stable token `eta_shrinkage`) + classifier branch + round-trip table entry.
- **`details` payload** `{ "threshold_pct": 30.0, "high_shrinkage_etas": [{"eta": "eta_V", "shrinkage_pct": 42.0}] }`, sourced from the typed `shrinkage_eta` field (not parsed from prose), consistent with increment 1.

## Alternatives considered

- **Covariance-step / data-quality at-source first** — deferred: `covariance_step` is an overloaded code (Critical failures + Info cost-notes) so eigenvalue-details there are messy, and data-quality inversion is mostly invisible internal hygiene. A new high-value diagnostic (ETA shrinkage) delivers more agent value at lower risk.
- **Threshold** — 30% is the standard Savic–Karlsson rule; mirrors the existing eps-shrinkage threshold convention.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Additive: a new warning + a new `WarningCode` token (non-breaking — `WarningCode` is `#[non_exhaustive]` from #778) and a new `details` shape. ferx-r consumes the JSON tokens and is unaffected.

## Breaking changes
- [x] None (additive warning + additive `WarningCode` variant behind `#[non_exhaustive]`)

## Numerical validation
- [x] The shrinkage *values* are unchanged (existing `compute_eta_shrinkage`, already validated); this PR only adds a threshold warning + `details` on top. Verified end-to-end: warfarin (ETA shrinkage 0.02–0.19%) correctly emits **no** `eta_shrinkage` warning. NONMEM anchor N/A (a diagnostic threshold, not a new estimate).

## Performance
- [x] No significant impact (one threshold scan over the ETA vector per fit).

## Tests
- [x] `cargo test --lib` passes (full suite: 2381 ok, 0 failed — no spurious warnings on existing fixtures):
  - `eta_shrinkage_warning_fires_above_threshold_only`: fires above 30%, names the ETA + percent, boundary (=30%) counts, NaN ignored, all-low → none.
  - `eta_shrinkage_details_lists_high_etas`: `details` lists only high ETAs; none → omitted.
  - `diagnostic_details_covers_numeric_codes` (updated arity) + `warning_code_tokens_are_stable` + `classify_warning_roundtrips_every_engine_message` (new token/message).
  - `rebuild_attaches_details_from_typed_fields`: an `eta_shrinkage` message classifies to `EtaShrinkage` and gets its details through the rebuild path.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt) when ETA_V shrinks 42%:
```json
{
  "severity": "Warning",
  "category": "eta_shrinkage",
  "message": "High ETA shrinkage (≥ 30%): eta_V (42%). EBE-based diagnostics for these random effects are unreliable ...",
  "source_method": null,
  "details": { "threshold_pct": 30.0, "high_shrinkage_etas": [ { "eta": "eta_V", "shrinkage_pct": 42.0 } ] }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — `eta_shrinkage` added to the codes table and the details-schema table
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (changed code)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- `eta_shrinkage_warning()` and `high_shrinkage_eta_indices()` share the finite-and-≥-threshold predicate, so the message and the `details` always agree on which ETAs are "high".
- `shrinkage_eta` is a fraction (0..1); warfarin's ~0.0002–0.0019 is far below 0.30, hence no warning.

## Open questions
- Next #781 increment after this: split the overloaded `covariance_step` code (→ `CovarianceFailed` + eigenvalue details) or start the data-quality at-source inversion?
