### PR TITLE
feat(diagnostics): split covariance_step warning code + eigenvalue details (#781 increment 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Finer covariance-step warning codes** (#781): the overloaded
+  `covariance_step` warning code is split by severity into `covariance_failed`
+  (Critical — no standard errors), `covariance_regularized` (Warning — SEs
+  degraded but present), and `covariance_step` (Info — cost notes), so an agent
+  can branch on the outcome. The failure/regularized codes carry `details` with
+  `condition_number`, `min_eigenvalue`, and `n_negative_eigenvalues` when those
+  were computed. See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **High ETA-shrinkage warning** (#781): a fit now emits an `eta_shrinkage`
   warning when any random-effect (ETA) shrinkage exceeds ~30% (the Savic &
   Karlsson rule of thumb) — the data poorly inform that IIV, so EBE-based

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -40,7 +40,9 @@ Each `WarningCode` token, what it flags, and a typical response.
 | Code (`category`) | Severity | Flags | Typical agent response |
 |-------------------|----------|-------|------------------------|
 | `convergence` | Critical | Optimizer did not converge. | Reject; adjust inits / method / bounds and refit. |
-| `covariance_step` | Critical / Warning / Info | Covariance step failed, was regularized, or is a cost note. | If failed: SEs unreliable — try `covariance_fallback = sir` or refit. |
+| `covariance_failed` | Critical | Covariance step failed — no standard errors. | SEs unavailable — try `covariance_fallback = sir` or refit with different inits. |
+| `covariance_regularized` | Warning | Covariance step succeeded but was regularized / degraded. | SEs may be over-optimistic — inspect eigenvalues; consider SIR intervals. |
+| `covariance_step` | Info | Covariance-step informational note (e.g. evaluation cost). | None. |
 | `condition_number` | Critical | Ill-conditioned covariance / high condition number. | Over-parameterized — drop a random effect or covariate. |
 | `optimizer_health` | Warning | Trust-radius collapse / degeneracy. | Try a different optimizer or re-scale parameters. |
 | `dw_autocorrelation` | Warning | IWRES autocorrelation (Durbin–Watson out of range). | Revisit the residual-error / structural model. |
@@ -73,6 +75,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `dw_autocorrelation` | `durbin_watson`, `iwres_lag1_autocorr` |
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
+| `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 
 ```json

--- a/src/api.rs
+++ b/src/api.rs
@@ -3163,18 +3163,33 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
         .iter()
         .map(|w| crate::types::classify_warning(w))
         .collect();
+    let stats = DiagStats {
+        dw_statistic: result.dw_statistic,
+        iwres_lag1_r: result.iwres_lag1_r,
+        shrinkage_eps: result.shrinkage_eps,
+        cov_condition_number: result.cov_condition_number,
+        cov_eigenvalues: result.cov_eigenvalues.as_deref(),
+        shrinkage_eta: &result.shrinkage_eta,
+        eta_names: &result.eta_names,
+    };
     for e in &mut entries {
-        e.details = diagnostic_details(
-            &e.category,
-            result.dw_statistic,
-            result.iwres_lag1_r,
-            result.shrinkage_eps,
-            result.cov_condition_number,
-            &result.shrinkage_eta,
-            &result.eta_names,
-        );
+        e.details = diagnostic_details(&e.category, &stats);
     }
     result.warnings_structured = entries;
+}
+
+/// Typed inputs for [`diagnostic_details`], sourced from `FitResult`'s fields.
+/// `Default` gives finite-zero scalars, `None` options, and empty slices, so a
+/// test can set only the fields a case needs via struct-update syntax.
+#[derive(Default)]
+struct DiagStats<'a> {
+    dw_statistic: f64,
+    iwres_lag1_r: f64,
+    shrinkage_eps: f64,
+    cov_condition_number: Option<f64>,
+    cov_eigenvalues: Option<&'a [f64]>,
+    shrinkage_eta: &'a [f64],
+    eta_names: &'a [String],
 }
 
 /// Machine-readable `details` payload for the numeric diagnostic warning codes,
@@ -3184,37 +3199,33 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
 /// `details` key is then omitted from the JSON entirely, rather than emitting a
 /// `null` value (`serde_json` maps non-finite floats to `null`). `cov_condition_number`
 /// in particular is documented as `+Inf` for a near-singular parameter space.
-#[allow(clippy::too_many_arguments)]
 fn diagnostic_details(
     code: &crate::types::WarningCode,
-    dw_statistic: f64,
-    iwres_lag1_r: f64,
-    shrinkage_eps: f64,
-    cov_condition_number: Option<f64>,
-    shrinkage_eta: &[f64],
-    eta_names: &[String],
+    s: &DiagStats,
 ) -> Option<serde_json::Value> {
     use crate::types::WarningCode;
     match code {
-        WarningCode::DwAutocorrelation if dw_statistic.is_finite() && iwres_lag1_r.is_finite() => {
+        WarningCode::DwAutocorrelation
+            if s.dw_statistic.is_finite() && s.iwres_lag1_r.is_finite() =>
+        {
             Some(serde_json::json!({
-                "durbin_watson": dw_statistic,
-                "iwres_lag1_autocorr": iwres_lag1_r,
+                "durbin_watson": s.dw_statistic,
+                "iwres_lag1_autocorr": s.iwres_lag1_r,
             }))
         }
-        WarningCode::EpsShrinkage if shrinkage_eps.is_finite() => Some(serde_json::json!({
-            "eps_shrinkage": shrinkage_eps,
-            "eps_shrinkage_pct": 100.0 * shrinkage_eps,
+        WarningCode::EpsShrinkage if s.shrinkage_eps.is_finite() => Some(serde_json::json!({
+            "eps_shrinkage": s.shrinkage_eps,
+            "eps_shrinkage_pct": 100.0 * s.shrinkage_eps,
         })),
         WarningCode::EtaShrinkage => {
             // The high-shrinkage ETAs behind the message, with each shrinkage
             // as a percent — sourced from the typed `shrinkage_eta` field.
-            let high: Vec<serde_json::Value> = high_shrinkage_eta_indices(shrinkage_eta)
+            let high: Vec<serde_json::Value> = high_shrinkage_eta_indices(s.shrinkage_eta)
                 .into_iter()
                 .map(|i| {
                     serde_json::json!({
-                        "eta": eta_label(eta_names, i),
-                        "shrinkage_pct": 100.0 * shrinkage_eta[i],
+                        "eta": eta_label(s.eta_names, i),
+                        "shrinkage_pct": 100.0 * s.shrinkage_eta[i],
                     })
                 })
                 .collect();
@@ -3227,11 +3238,48 @@ fn diagnostic_details(
                 }))
             }
         }
-        WarningCode::ConditionNumber => match cov_condition_number {
+        WarningCode::ConditionNumber => match s.cov_condition_number {
             Some(c) if c.is_finite() => Some(serde_json::json!({ "condition_number": c })),
             _ => None,
         },
+        WarningCode::CovarianceFailed | WarningCode::CovarianceRegularized => {
+            covariance_details(s.cov_condition_number, s.cov_eigenvalues)
+        }
         _ => None,
+    }
+}
+
+/// `details` for the covariance-step warning codes: the condition number and,
+/// when the covariance matrix was produced (so eigenvalues exist — typically
+/// the regularized case, not a hard failure), the smallest eigenvalue and the
+/// count of negative ones (which diagnose a non-PD Hessian). Non-finite values
+/// are skipped; returns `None` if nothing usable is available.
+fn covariance_details(
+    cov_condition_number: Option<f64>,
+    cov_eigenvalues: Option<&[f64]>,
+) -> Option<serde_json::Value> {
+    let mut obj = serde_json::Map::new();
+    if let Some(c) = cov_condition_number {
+        if c.is_finite() {
+            obj.insert("condition_number".to_string(), serde_json::json!(c));
+        }
+    }
+    if let Some(eigs) = cov_eigenvalues {
+        let finite: Vec<f64> = eigs.iter().copied().filter(|v| v.is_finite()).collect();
+        if !finite.is_empty() {
+            let min = finite.iter().copied().fold(f64::INFINITY, f64::min);
+            let n_neg = finite.iter().filter(|&&v| v < 0.0).count();
+            obj.insert("min_eigenvalue".to_string(), serde_json::json!(min));
+            obj.insert(
+                "n_negative_eigenvalues".to_string(),
+                serde_json::json!(n_neg),
+            );
+        }
+    }
+    if obj.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(obj))
     }
 }
 
@@ -11928,7 +11976,7 @@ mod simulate_with_uncertainty_tests {
     #[test]
     fn diagnostic_details_covers_numeric_codes() {
         use crate::types::WarningCode;
-        // Shim for the non-ETA codes (empty ETA inputs).
+        // Shim for the scalar codes (no ETA/eigenvalue inputs).
         fn dd(
             code: &crate::types::WarningCode,
             dw: f64,
@@ -11936,7 +11984,16 @@ mod simulate_with_uncertainty_tests {
             eps: f64,
             cond: Option<f64>,
         ) -> Option<serde_json::Value> {
-            super::diagnostic_details(code, dw, lag1, eps, cond, &[], &[])
+            super::diagnostic_details(
+                code,
+                &super::DiagStats {
+                    dw_statistic: dw,
+                    iwres_lag1_r: lag1,
+                    shrinkage_eps: eps,
+                    cov_condition_number: cond,
+                    ..Default::default()
+                },
+            )
         }
         // Durbin–Watson: both stored stats surface.
         let d = dd(&WarningCode::DwAutocorrelation, 1.2, 0.4, f64::NAN, None).expect("DW details");
@@ -12012,46 +12069,62 @@ mod simulate_with_uncertainty_tests {
     #[test]
     fn eta_shrinkage_details_lists_high_etas() {
         use crate::types::WarningCode;
+        let ed = |shrink: &[f64], names: &[String]| {
+            super::diagnostic_details(
+                &WarningCode::EtaShrinkage,
+                &super::DiagStats {
+                    shrinkage_eta: shrink,
+                    eta_names: names,
+                    ..Default::default()
+                },
+            )
+        };
         let names = vec!["eta_CL".to_string(), "eta_V".to_string()];
-        let d = super::diagnostic_details(
-            &WarningCode::EtaShrinkage,
-            f64::NAN,
-            0.0,
-            f64::NAN,
-            None,
-            &[0.05, 0.42],
-            &names,
-        )
-        .expect("eta details");
+        let d = ed(&[0.05, 0.42], &names).expect("eta details");
         assert_eq!(d["threshold_pct"], 30.0);
         let high = d["high_shrinkage_etas"].as_array().unwrap();
         assert_eq!(high.len(), 1);
         assert_eq!(high[0]["eta"], "eta_V");
         assert!((high[0]["shrinkage_pct"].as_f64().unwrap() - 42.0).abs() < 1e-9);
         // No high eta → no details payload.
-        assert!(super::diagnostic_details(
-            &WarningCode::EtaShrinkage,
-            f64::NAN,
-            0.0,
-            f64::NAN,
-            None,
-            &[0.05, 0.10],
-            &names,
-        )
-        .is_none());
-
+        assert!(ed(&[0.05, 0.10], &names).is_none());
         // Missing name → non-empty `eta_{i}` placeholder, not "".
-        let d = super::diagnostic_details(
-            &WarningCode::EtaShrinkage,
-            f64::NAN,
-            0.0,
-            f64::NAN,
-            None,
-            &[0.42],
-            &[], // no names
-        )
-        .expect("details");
+        let d = ed(&[0.42], &[]).expect("details");
         assert_eq!(d["high_shrinkage_etas"][0]["eta"], "eta_0");
+    }
+
+    #[test]
+    fn covariance_details_reports_eigenvalues_and_condition() {
+        use crate::types::WarningCode;
+        let cd = |cond: Option<f64>, eigs: Option<&[f64]>| {
+            super::diagnostic_details(
+                &WarningCode::CovarianceRegularized,
+                &super::DiagStats {
+                    cov_condition_number: cond,
+                    cov_eigenvalues: eigs,
+                    ..Default::default()
+                },
+            )
+        };
+        // Regularized (or failed) with eigenvalues present: min + negative count.
+        let d = cd(Some(1.4e6), Some(&[0.5, -1.0e-3, 2.1])).expect("cov details");
+        assert_eq!(d["condition_number"], 1.4e6);
+        assert!((d["min_eigenvalue"].as_f64().unwrap() + 1.0e-3).abs() < 1e-12);
+        assert_eq!(d["n_negative_eigenvalues"], 1);
+        // CovarianceFailed shares the same payload builder.
+        assert!(super::diagnostic_details(
+            &WarningCode::CovarianceFailed,
+            &super::DiagStats {
+                cov_condition_number: Some(9.9),
+                ..Default::default()
+            },
+        )
+        .is_some());
+        // Nothing available (hard failure: no matrix → no eigenvalues, no cond)
+        // → details omitted.
+        assert!(cd(None, None).is_none());
+        // Non-finite condition number is skipped.
+        assert!(cd(Some(f64::INFINITY), None).is_none());
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3193,12 +3193,19 @@ struct DiagStats<'a> {
 }
 
 /// Machine-readable `details` payload for the numeric diagnostic warning codes,
-/// sourced from the typed `FitResult` fields rather than parsed from the
-/// message text. Returns `None` for a code with no associated stored statistic,
-/// or when **any** contributing statistic is non-finite (`NaN`/`±Inf`) — the
-/// `details` key is then omitted from the JSON entirely, rather than emitting a
-/// `null` value (`serde_json` maps non-finite floats to `null`). `cov_condition_number`
-/// in particular is documented as `+Inf` for a near-singular parameter space.
+/// sourced from the typed `FitResult` fields rather than parsed from the message
+/// text. A non-finite (`NaN`/`±Inf`) statistic is never emitted as a JSON `null`
+/// (`serde_json` maps non-finite floats to `null`) — instead:
+///
+/// - the single/paired-stat codes (`DwAutocorrelation`, `EpsShrinkage`,
+///   `ConditionNumber`) return `None` (whole `details` key omitted) when a
+///   required statistic is missing or non-finite;
+/// - the covariance codes (`CovarianceFailed`, `CovarianceRegularized`) build a
+///   partial object, **skipping** individual non-finite/absent fields and
+///   emitting whatever is available; they return `None` only when nothing is.
+///
+/// `cov_condition_number` in particular is documented as `+Inf` for a
+/// near-singular parameter space, so it is dropped from the payload there.
 fn diagnostic_details(
     code: &crate::types::WarningCode,
     s: &DiagStats,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3865,8 +3865,14 @@ pub enum WarningSeverity {
 pub enum WarningCode {
     /// Optimizer did not reach the convergence criterion.
     Convergence,
-    /// Covariance step failed, was regularized, or is informational (see message).
+    /// Informational note about the covariance step (e.g. its evaluation cost).
     CovarianceStep,
+    /// The covariance step failed — no standard errors are available.
+    CovarianceFailed,
+    /// The covariance step succeeded but was regularized / degraded (eigenvalue
+    /// floor applied, or a non-finite off-diagonal stencil); SEs may be
+    /// over-optimistic.
+    CovarianceRegularized,
     /// Correlation / condition-number problem in the covariance.
     ConditionNumber,
     /// Optimizer-health issue (trust-radius collapse, degeneracy).
@@ -3915,6 +3921,8 @@ impl WarningCode {
         match self {
             WarningCode::Convergence => "convergence",
             WarningCode::CovarianceStep => "covariance_step",
+            WarningCode::CovarianceFailed => "covariance_failed",
+            WarningCode::CovarianceRegularized => "covariance_regularized",
             WarningCode::ConditionNumber => "condition_number",
             WarningCode::OptimizerHealth => "optimizer_health",
             WarningCode::DwAutocorrelation => "dw_autocorrelation",
@@ -4012,15 +4020,14 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // Hessian is not positive definite") whose prefix differs from "failed:"
         // messages. It must be compound so that "SIR failed: covariance not
         // positive definite" (no "covariance step" token) still routes to "sir".
-        (WarningSeverity::Critical, WarningCode::CovarianceStep)
+        (WarningSeverity::Critical, WarningCode::CovarianceFailed)
     } else if lower.contains("covariance step regularized")
         || lower.contains("off-diagonal fd stencil")
     {
         // Regularisation warning and off-diagonal NaN soft warning both indicate a
         // degraded-but-present covariance step result. Severity within the message
-        // (minor/moderate/severe, or "over-optimistic") informs guidance; the
-        // category is always covariance_step.
-        (WarningSeverity::Warning, WarningCode::CovarianceStep)
+        // (minor/moderate/severe, or "over-optimistic") informs guidance.
+        (WarningSeverity::Warning, WarningCode::CovarianceRegularized)
     } else if lower.contains("ill-conditioned") || lower.contains("condition number") {
         // Note: "covariance step failed: Hessian has ill-conditioned entries" contains
         // "ill-conditioned" but is caught by "covariance step failed" above (else-if chain).
@@ -6449,7 +6456,7 @@ mod tests {
     fn classify_warning_covariance_is_critical() {
         let w = classify_warning("Covariance step failed");
         assert_eq!(w.severity, WarningSeverity::Critical);
-        assert_eq!(w.category.as_str(), "covariance_step");
+        assert_eq!(w.category.as_str(), "covariance_failed");
     }
 
     #[test]
@@ -6482,7 +6489,7 @@ mod tests {
         assert_eq!(w.source_method.as_deref(), Some("FOCEI"));
         assert_eq!(w.message, "Covariance step failed");
         assert_eq!(w.severity, WarningSeverity::Critical);
-        assert_eq!(w.category.as_str(), "covariance_step");
+        assert_eq!(w.category.as_str(), "covariance_failed");
     }
 
     #[test]
@@ -6519,6 +6526,8 @@ mod tests {
         let expected: &[(WarningCode, &str)] = &[
             (Convergence, "convergence"),
             (CovarianceStep, "covariance_step"),
+            (CovarianceFailed, "covariance_failed"),
+            (CovarianceRegularized, "covariance_regularized"),
             (ConditionNumber, "condition_number"),
             (OptimizerHealth, "optimizer_health"),
             (DwAutocorrelation, "dw_autocorrelation"),
@@ -6600,7 +6609,7 @@ mod tests {
                 Critical,
                 "convergence",
             ),
-            ("Covariance step failed", Critical, "covariance_step"),
+            ("Covariance step failed", Critical, "covariance_failed"),
             // global_search has two arms: explicit "disabled" is a runtime
             // failure (Warning); a bare mention without "disabled" is
             // informational.
@@ -6631,7 +6640,7 @@ mod tests {
             (
                 "Covariance step failed \u{2014} SEs not available",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             (
                 "saem_n_leapfrog > 0 but HMC is unavailable (requires an analytical PK model \
@@ -6742,7 +6751,7 @@ mod tests {
                 "Covariance step: Hessian is not positive definite. \
                  Eigenvalues: [8.4000, 2.1000, -0.0100]. SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             // Covariance step regularised — present in all three severity tiers.
             (
@@ -6750,7 +6759,7 @@ mod tests {
                  (1 of 3 free-block eigenvalues clipped; min eig = 1.2e-6, floor = 8.4e-14; \
                  severity: minor). Standard errors are likely reliable.",
                 Warning,
-                "covariance_step",
+                "covariance_regularized",
             ),
             (
                 "Covariance step regularized: eigenvalue floor applied to FD Hessian \
@@ -6758,7 +6767,7 @@ mod tests {
                  severity: severe). Standard errors are likely unreliable; \
                  SIR-based confidence intervals are recommended.",
                 Warning,
-                "covariance_step",
+                "covariance_regularized",
             ),
             // Off-diagonal NaN soft warning — Success result, but correlation missing.
             (
@@ -6766,7 +6775,7 @@ mod tests {
                  Cross-partial correlation set to 0; SE for these parameter(s) \
                  may be over-optimistic. Try tuning fd_hessian_step.",
                 Warning,
-                "covariance_step",
+                "covariance_regularized",
             ),
             // Chain-prefixed off-diagonal warning.
             (
@@ -6774,7 +6783,7 @@ mod tests {
                  Cross-partial correlation set to 0; SE for these parameter(s) \
                  may be over-optimistic. Try tuning fd_hessian_step.",
                 Warning,
-                "covariance_step",
+                "covariance_regularized",
             ),
             // Unusable messages introduced in commit 2.
             (
@@ -6782,14 +6791,14 @@ mod tests {
                  (likely numerical overflow or underflow in model evaluation). \
                  SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             (
                 "Covariance step failed: Hessian has ill-conditioned entries for the \
                  following parameter(s) — theta[CL] (non-finite diagonal); \
                  sigma[1] (non-finite off-diagonal). SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             // Omega near-singular (tiny positive eigenvalue) — "near-singular" descriptor.
             (
@@ -6797,7 +6806,7 @@ mod tests {
                  convergence (min eigenvalue = 1.2e-10; eigenvalues: [0.5000, 1.2e-10]). \
                  SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             // Omega truly non-PD (negative eigenvalue) — "not positive definite" descriptor.
             (
@@ -6805,7 +6814,7 @@ mod tests {
                  convergence (min eigenvalue = -1.0e-3; eigenvalues: [0.5000, -1.0e-3]). \
                  SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             // SIR message that also contains "not positive definite" — must
             // still route to "sir", NOT to covariance_step.
@@ -6818,13 +6827,13 @@ mod tests {
             (
                 "[FOCEI] Covariance step failed",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             (
                 "[FOCEI] Covariance step: Hessian is not positive definite. \
                  Eigenvalues: [2.1000, -0.0100]. SE estimates not available.",
                 Critical,
-                "covariance_step",
+                "covariance_failed",
             ),
             (
                 "[SAEM] individual parameter(s) not mu-referenced: V",


### PR DESCRIPTION
## Why

The `covariance_step` warning code was overloaded across three different outcomes — a Critical **failure** (no SEs), a Warning **regularized** result (SEs degraded but present), and an Info **cost note** — all sharing one token. An agent can't act on that: "covariance failed → reject the fit" and "covariance regularized → SEs slightly optimistic" demand opposite responses. Split it by severity.

Third increment of #781 (kept open).

## What changed

- **Split `covariance_step`** into three typed codes by severity:
  - `covariance_failed` (Critical) — the step failed; no standard errors.
  - `covariance_regularized` (Warning) — succeeded but regularized/degraded (eigenvalue floor applied, or a non-finite off-diagonal stencil); SEs may be over-optimistic.
  - `covariance_step` (Info) — retained for the benign cost notes (e.g. "n² OFV evaluations").
- `classify_warning` routes the existing Critical / Warning covariance branches to the new codes (the compound "SIR failed: … not positive definite" guard is preserved, so SIR messages still route to `sir`).
- **Eigenvalue `details`** for the failure/regularized codes: `{condition_number, min_eigenvalue, n_negative_eigenvalues}`, sourced from the typed `cov_eigenvalues` / `cov_condition_number` fields. Present for the regularized case (matrix exists); a hard failure (no matrix → no eigenvalues) omits the eigenvalue keys.
- Refactored `diagnostic_details`'s argument list into a `DiagStats` struct (it had grown past the `too_many_arguments` lint with the new eigenvalue input); added `covariance_details`.

## Alternatives considered

- **Keep one `covariance_step` code, disambiguate via severity only** — rejected: an agent filtering `warnings_structured` by `category` wants a stable code per outcome, not a (code, severity) tuple it must interpret.
- **A single positional arg for `cov_eigenvalues`** — rejected: pushed `diagnostic_details` to 8 args; the `DiagStats` struct reads better and future increments extend it cleanly.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

`WarningCode` is `#[non_exhaustive]` (from #778), so the new variants are additive. Tokens are unreleased (all this work is under `[Unreleased]`), and ferx-r consumes JSON tokens. **Note for consumers:** messages that were `covariance_step` now emit `covariance_failed` / `covariance_regularized` — the finer split is the intended behaviour.

## Breaking changes
- [x] `FitResult` structured-warning tokens: some `covariance_step` warnings now carry `covariance_failed` / `covariance_regularized` (all unreleased; additive variants behind `#[non_exhaustive]`).

## Numerical validation
- [x] N/A (diagnostics typing; no estimate/OFV change). Verified: warfarin (covariance succeeds) emits no covariance warning — categories `["convergence","dw_autocorrelation"]`, unchanged.

## Performance
- [x] No significant impact.

## Tests
- [x] `cargo test --lib` passes (full suite 2383 ok, 0 failed):
  - `covariance_details_reports_eigenvalues_and_condition`: min eigenvalue + negative count, both covariance codes, non-finite condition skipped, nothing-available → omitted.
  - `classify_warning_covariance_is_critical` / `_strips_chain_prefix` updated to `covariance_failed`; the engine-message round-trip table reclassified by severity; `warning_code_tokens_are_stable` covers the two new tokens.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

A regularized covariance step:
```json
{
  "severity": "Warning",
  "category": "covariance_regularized",
  "message": "Covariance step regularized: eigenvalue floor applied ...",
  "source_method": null,
  "details": { "condition_number": 1.4e6, "min_eigenvalue": -0.001, "n_negative_eigenvalues": 1 }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — covariance rows split; details schema row added
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean on changed code (pre-existing `too_many_arguments` in gauss_newton/outer_optimizer are unrelated)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- The classify split is severity-preserving: Critical covariance messages → `covariance_failed`, Warning → `covariance_regularized`, Info (n² cost) → `covariance_step`. The round-trip table is the contract; it was reclassified per entry.
- Eigenvalue details mostly populate for the *regularized* case (matrix present). Hard failures usually have no matrix, so `cov_eigenvalues` is `None` and only `condition_number` (if any) appears — by design.

## Open questions
- Next #781 increment: data-quality at-source inversion (datareader `W_*`), or the SIR / importance-sampling family?
