### PR TITLE
docs(api): note why predict_survival needs no transit-flip-flop guard (#776)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -8953,6 +8953,12 @@ pub fn predict_survival(
     params: &ModelParameters,
     time_grid: &[f64],
 ) -> Vec<SurvivalPredictionResult> {
+    // Deliberately no `assert_transit_flip_flop_no_twin` guard here (unlike
+    // `predict`/`simulate`): a survival prediction cannot be corrupted by a degenerate
+    // twin-less-flip-flop transit PK. A hazard that reads the PK is ODE-accumulated (the
+    // model then carries `ode_spec` and never takes the closed-form transit path), and a
+    // closed-form-family hazard does not read the PK at all — so the closed form's
+    // clamped `0` can never reach `S(t)`. See #776.
     use crate::survival::{
         cif_curves, hazard_and_cum_hazard, mean_survival, median_survival, tte_cause_params,
     };


### PR DESCRIPTION
## Why
Fresh-review follow-up to #776. The review flagged that `predict_survival` is the one prediction entry point without an `assert_transit_flip_flop_no_twin` guard. It is genuinely unreachable — but that was undocumented, so a future reader/reviewer could re-flag it or "fix" it by adding a dead guard.

## What changed
A short comment at the top of `predict_survival` explaining why no guard is needed: a hazard that reads PK is ODE-accumulated (`ode_spec` set → never the closed-form transit path), and a closed-form-family hazard does not read PK — so a degenerate twin-less-flip-flop transit PK can never corrupt `S(t)`.

## Alternatives considered
Adding the guard for uniformity — rejected: it would be **dead, untestable code** (an uncovered line with no case that can trigger it).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None (comment only).

## Numerical validation
- [x] Not applicable (comment only).

## Tests
- [x] No new tests needed (comment only — no behaviour change).

## Docs
- [x] No user-visible change (internal code comment).

## Checklist
- [x] `cargo clippy` clean (no code change).
- [x] `Dual2` sensitivity path unaffected.

Related: #776, #785, #786.