### PR TITLE
feat(diagnostics): boundary-estimate warning, emitted typed at source (#781 increment 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Boundary-estimate warning** (#781): a fit now emits a `boundary_estimate`
+  warning when a free THETA estimate is pinned to an optimizer bound (evaluated
+  in the optimizer's packed/log space) — a sign of non-identifiability or a
+  too-tight bound. The structured warning carries `details` listing each
+  `{parameter, estimate, bound, side}`, and is emitted **typed at its source**
+  (the first warning to use the native at-source path rather than string
+  classification). See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **Finer covariance-step warning codes** (#781): the overloaded
   `covariance_step` warning code is split by severity into `covariance_failed`
   (Critical — no standard errors), `covariance_regularized` (Warning — SEs

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -53,6 +53,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `importance_sampling` | Warning | ESS = 0 / proposal collapse. | Increase samples or improve the proposal. |
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
+| `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
@@ -75,6 +76,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `dw_autocorrelation` | `durbin_watson`, `iwres_lag1_autocorr` |
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
+| `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
 | `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 
@@ -94,12 +96,15 @@ associated stored statistic, or when any contributing statistic is non-finite
 
 ## How codes are assigned
 
-Codes are assigned centrally by `classify_warning()`, which maps each engine
-message to its `WarningCode` and severity, then `details` is attached from the
-fit's typed numeric fields for the codes above. `classify_warning()` is the
-single, type-checked source of the taxonomy — the `WarningCode` enum is
-exhaustive, so the vocabulary can no longer drift as a free string. Full native
-at-source emission (each site constructing its own typed `WarningEntry` with a
-`details` payload, and the human `warnings` strings derived from the structured
-list) is being migrated incrementally; `details` for the numeric diagnostics is
-the first step.
+Most codes are assigned centrally by `classify_warning()`, which maps each
+engine message to its `WarningCode` and severity, after which `details` is
+attached from the fit's typed numeric fields for the codes above.
+`classify_warning()` is the single, type-checked source of the taxonomy — the
+`WarningCode` enum is exhaustive, so the vocabulary can no longer drift as a
+free string.
+
+Some warnings are instead emitted **typed at their source**: the site
+constructs a `WarningEntry` (code, severity, message, and a `details` payload)
+directly — `boundary_estimate` is the first — and that entry takes precedence
+over re-classifying the message string. Migrating the remaining string
+push-sites to this at-source form is ongoing.

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -99,9 +99,11 @@ associated stored statistic, or when any contributing statistic is non-finite
 Most codes are assigned centrally by `classify_warning()`, which maps each
 engine message to its `WarningCode` and severity, after which `details` is
 attached from the fit's typed numeric fields for the codes above.
-`classify_warning()` is the single, type-checked source of the taxonomy — the
-`WarningCode` enum is exhaustive, so the vocabulary can no longer drift as a
-free string.
+`classify_warning()` is the single, type-checked source of the taxonomy: codes
+are `WarningCode` enum variants rather than free strings, so the vocabulary is
+centrally defined and cannot drift. The enum is `#[non_exhaustive]` — new codes
+may be added over time, so consumers should treat an unrecognised token as a
+generic warning rather than assuming a fixed, closed set.
 
 Some warnings are instead emitted **typed at their source**: the site
 constructs a `WarningEntry` (code, severity, message, and a `details` payload)

--- a/src/api.rs
+++ b/src/api.rs
@@ -3162,10 +3162,20 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
     // `details` payload) are keyed by message and take precedence; every other
     // message is string-classified and then field-enriched. Keying by message
     // keeps this idempotent — a second rebuild re-captures the native entries.
+    // Key by the *original* warning string: `classify_warning` strips a
+    // `[METHOD]` chain prefix into `source_method`, so a native entry produced
+    // in a multi-stage chain must reconstruct that prefix to match the raw
+    // `warnings` entry (an unprefixed entry keys by its message unchanged).
     let native: std::collections::HashMap<String, crate::types::WarningEntry> =
         std::mem::take(&mut result.warnings_structured)
             .into_iter()
-            .map(|e| (e.message.clone(), e))
+            .map(|e| {
+                let key = match &e.source_method {
+                    Some(m) => format!("[{m}] {}", e.message),
+                    None => e.message.clone(),
+                };
+                (key, e)
+            })
             .collect();
     let stats = DiagStats {
         dw_statistic: result.dw_statistic,
@@ -6098,22 +6108,25 @@ pub(crate) fn eta_shrinkage_warning(shrinkage: &[f64], eta_names: &[String]) -> 
 /// theta estimate counts as sitting on its lower/upper optimizer bound.
 const BOUNDARY_REL_TOL: f64 = 1e-3;
 
-/// Which bound (`"lower"`/`"upper"`) a theta estimate is pinned to, or `None`
-/// when it is interior. Evaluated in the optimizer's *packed* space (log when
-/// the lower bound is `>= 0`, else identity) so the proximity test is
-/// scale-appropriate — a log-scaled parameter is "at" its bound within a
-/// constant factor, not a constant absolute gap. Degenerate/non-finite bounds
-/// yield `None`.
-fn theta_boundary_side(est: f64, lower: f64, upper: f64) -> Option<&'static str> {
+/// Which bound a theta estimate is pinned to and the **effective** natural-space
+/// bound value the optimizer actually constrains to, or `None` when the estimate
+/// is interior. Evaluated in the optimizer's *packed* space (log when the lower
+/// bound is `>= 0`, else identity) so the proximity test is scale-appropriate —
+/// a log-scaled parameter is "at" its bound within a constant factor, not a
+/// constant absolute gap.
+///
+/// The floors/caps mirror `compute_bounds` / `pack_params`: a log-packed theta
+/// floors its estimate and lower bound at `1e-10` and caps the upper at `1e9`,
+/// so the reported bound matches the constraint that was actually active (and
+/// agrees with the estimate). Degenerate/non-finite bounds yield `None`.
+fn theta_boundary_side(est: f64, lower: f64, upper: f64) -> Option<(&'static str, f64)> {
     use crate::estimation::parameterization::theta_packs_log;
-    let (pe, pl, pu) = if theta_packs_log(lower) {
-        (
-            est.max(1e-300).ln(),
-            lower.max(1e-10).ln(),
-            upper.min(1e9).ln(),
-        )
+    let (lo_eff, hi_eff, pe, pl, pu) = if theta_packs_log(lower) {
+        let lo = lower.max(1e-10);
+        let hi = upper.min(1e9);
+        (lo, hi, est.max(1e-10).ln(), lo.ln(), hi.ln())
     } else {
-        (est, lower, upper)
+        (lower, upper, est, lower, upper)
     };
     let range = pu - pl;
     if !range.is_finite() || range <= 0.0 || !pe.is_finite() {
@@ -6121,16 +6134,16 @@ fn theta_boundary_side(est: f64, lower: f64, upper: f64) -> Option<&'static str>
     }
     let frac = (pe - pl) / range;
     if frac <= BOUNDARY_REL_TOL {
-        Some("lower")
+        Some(("lower", lo_eff))
     } else if frac >= 1.0 - BOUNDARY_REL_TOL {
-        Some("upper")
+        Some(("upper", hi_eff))
     } else {
         None
     }
 }
 
 /// Free (non-fixed) theta estimates pinned to an optimizer bound, as
-/// `(name, estimate, bound_value, side)` per hit.
+/// `(name, estimate, effective_bound, side)` per hit.
 fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'static str)> {
     let mut hits = Vec::new();
     for i in 0..params.theta.len() {
@@ -6138,10 +6151,9 @@ fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'stat
             continue;
         }
         let est = params.theta[i];
-        let lo = params.theta_lower[i];
-        let hi = params.theta_upper[i];
-        if let Some(side) = theta_boundary_side(est, lo, hi) {
-            let bound = if side == "lower" { lo } else { hi };
+        if let Some((side, bound)) =
+            theta_boundary_side(est, params.theta_lower[i], params.theta_upper[i])
+        {
             let name = params
                 .theta_names
                 .get(i)
@@ -12257,18 +12269,45 @@ mod simulate_with_uncertainty_tests {
 
     #[test]
     fn theta_boundary_side_detects_bounds() {
+        let side = |e, l, u| super::theta_boundary_side(e, l, u).map(|(s, _)| s);
         // Identity-packed (lower < 0): interior, at-lower, at-upper.
-        assert_eq!(super::theta_boundary_side(0.0, -1.0, 1.0), None);
-        assert_eq!(super::theta_boundary_side(-1.0, -1.0, 1.0), Some("lower"));
-        assert_eq!(super::theta_boundary_side(1.0, -1.0, 1.0), Some("upper"));
+        assert_eq!(side(0.0, -1.0, 1.0), None);
+        assert_eq!(side(-1.0, -1.0, 1.0), Some("lower"));
+        assert_eq!(side(1.0, -1.0, 1.0), Some("upper"));
         // Log-packed (lower >= 0): "at bound" is within a constant factor.
-        assert_eq!(super::theta_boundary_side(1.0, 0.001, 1000.0), None);
-        assert_eq!(
-            super::theta_boundary_side(0.001, 0.001, 1000.0),
-            Some("lower")
-        );
+        assert_eq!(side(1.0, 0.001, 1000.0), None);
+        assert_eq!(side(0.001, 0.001, 1000.0), Some("lower"));
         // Degenerate bounds → None.
-        assert_eq!(super::theta_boundary_side(1.0, 5.0, 5.0), None);
+        assert_eq!(side(1.0, 5.0, 5.0), None);
+        // Effective bound: a user lower bound of 0 (log-packed) is reported as
+        // the optimizer's 1e-10 floor, agreeing with the pinned estimate.
+        let (s, bound) = super::theta_boundary_side(1e-10, 0.0, 100.0).unwrap();
+        assert_eq!(s, "lower");
+        assert_eq!(bound, 1e-10);
+    }
+
+    #[test]
+    fn rebuild_native_key_reconstructs_chain_prefix() {
+        let model = tiny_model();
+        let mut fit = synthetic_fit(&model.default_params);
+        // A native entry produced inside a `[FOCEI]` chain: message is the
+        // stripped body, source_method carries the tag; the raw warning is the
+        // full prefixed string.
+        fit.warnings = vec!["[FOCEI] pinned to an optimizer bound: X".to_string()];
+        fit.warnings_structured = vec![crate::types::WarningEntry {
+            severity: crate::types::WarningSeverity::Warning,
+            category: crate::types::WarningCode::BoundaryEstimate,
+            message: "pinned to an optimizer bound: X".to_string(),
+            source_method: Some("FOCEI".to_string()),
+            details: Some(serde_json::json!({ "k": 1 })),
+        }];
+        super::rebuild_warnings_structured(&mut fit);
+        // Native entry (with details) is preferred despite the prefix.
+        assert_eq!(
+            fit.warnings_structured[0].category,
+            crate::types::WarningCode::BoundaryEstimate
+        );
+        assert_eq!(fit.warnings_structured[0].details.as_ref().unwrap()["k"], 1);
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3158,11 +3158,15 @@ pub fn fit(
 /// converting the remaining ~80 string push-sites to full at-source emission is
 /// a later increment.
 fn rebuild_warnings_structured(result: &mut FitResult) {
-    let mut entries: Vec<crate::types::WarningEntry> = result
-        .warnings
-        .iter()
-        .map(|w| crate::types::classify_warning(w))
-        .collect();
+    // Entries emitted typed at source (`native_warnings`, already carrying a
+    // `details` payload) are keyed by message and take precedence; every other
+    // message is string-classified and then field-enriched. Keying by message
+    // keeps this idempotent — a second rebuild re-captures the native entries.
+    let native: std::collections::HashMap<String, crate::types::WarningEntry> =
+        std::mem::take(&mut result.warnings_structured)
+            .into_iter()
+            .map(|e| (e.message.clone(), e))
+            .collect();
     let stats = DiagStats {
         dw_statistic: result.dw_statistic,
         iwres_lag1_r: result.iwres_lag1_r,
@@ -3172,9 +3176,19 @@ fn rebuild_warnings_structured(result: &mut FitResult) {
         shrinkage_eta: &result.shrinkage_eta,
         eta_names: &result.eta_names,
     };
-    for e in &mut entries {
-        e.details = diagnostic_details(&e.category, &stats);
-    }
+    let entries: Vec<crate::types::WarningEntry> = result
+        .warnings
+        .iter()
+        .map(|w| {
+            if let Some(entry) = native.get(w) {
+                entry.clone()
+            } else {
+                let mut e = crate::types::classify_warning(w);
+                e.details = diagnostic_details(&e.category, &stats);
+                e
+            }
+        })
+        .collect();
     result.warnings_structured = entries;
 }
 
@@ -4942,6 +4956,10 @@ fn fit_inner(
 
     // Optional SIR step
     let mut warnings = result.warnings;
+    // Warnings emitted *typed at source* (with a `details` payload) rather than
+    // string-classified. Seeded into `FitResult.warnings_structured`;
+    // `rebuild_warnings_structured` prefers these over re-classifying the string.
+    let mut native_warnings: Vec<WarningEntry> = Vec::new();
 
     // Warn when [derived] expressions that reference compartments[i] will
     // silently evaluate to NaN due to unsupported model/subject configurations.
@@ -5150,6 +5168,12 @@ fn fit_inner(
     if let Some(w) = eta_shrinkage_warning(&shrinkage_eta, &result.params.omega.eta_names) {
         warnings.push(w);
     }
+    // Theta estimates pinned to an optimizer bound — emitted typed at source
+    // with a `details` payload (#781).
+    if let Some((msg, entry)) = boundary_estimate_warning(&result.params) {
+        warnings.push(msg);
+        native_warnings.push(entry);
+    }
 
     let (iwres_lag1_r, dw_statistic) = iwres_autocorrelation(&subjects);
 
@@ -5294,7 +5318,7 @@ fn fit_inner(
         n_iterations: result.n_iterations,
         interaction: options.interaction,
         warnings,
-        warnings_structured: vec![],
+        warnings_structured: native_warnings,
         // If the normal SIR ran, use that; otherwise use the fallback result.
         sir_ci_theta: sir_result
             .as_ref()
@@ -6068,6 +6092,103 @@ pub(crate) fn eta_shrinkage_warning(shrinkage: &[f64], eta_names: &[String]) -> 
         100.0 * ETA_SHRINKAGE_WARN_THRESHOLD,
         list
     ))
+}
+
+/// Relative tolerance (a fraction of the packed bound range) within which a
+/// theta estimate counts as sitting on its lower/upper optimizer bound.
+const BOUNDARY_REL_TOL: f64 = 1e-3;
+
+/// Which bound (`"lower"`/`"upper"`) a theta estimate is pinned to, or `None`
+/// when it is interior. Evaluated in the optimizer's *packed* space (log when
+/// the lower bound is `>= 0`, else identity) so the proximity test is
+/// scale-appropriate — a log-scaled parameter is "at" its bound within a
+/// constant factor, not a constant absolute gap. Degenerate/non-finite bounds
+/// yield `None`.
+fn theta_boundary_side(est: f64, lower: f64, upper: f64) -> Option<&'static str> {
+    use crate::estimation::parameterization::theta_packs_log;
+    let (pe, pl, pu) = if theta_packs_log(lower) {
+        (
+            est.max(1e-300).ln(),
+            lower.max(1e-10).ln(),
+            upper.min(1e9).ln(),
+        )
+    } else {
+        (est, lower, upper)
+    };
+    let range = pu - pl;
+    if !range.is_finite() || range <= 0.0 || !pe.is_finite() {
+        return None;
+    }
+    let frac = (pe - pl) / range;
+    if frac <= BOUNDARY_REL_TOL {
+        Some("lower")
+    } else if frac >= 1.0 - BOUNDARY_REL_TOL {
+        Some("upper")
+    } else {
+        None
+    }
+}
+
+/// Free (non-fixed) theta estimates pinned to an optimizer bound, as
+/// `(name, estimate, bound_value, side)` per hit.
+fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'static str)> {
+    let mut hits = Vec::new();
+    for i in 0..params.theta.len() {
+        if params.theta_fixed.get(i).copied().unwrap_or(false) {
+            continue;
+        }
+        let est = params.theta[i];
+        let lo = params.theta_lower[i];
+        let hi = params.theta_upper[i];
+        if let Some(side) = theta_boundary_side(est, lo, hi) {
+            let bound = if side == "lower" { lo } else { hi };
+            let name = params
+                .theta_names
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| format!("THETA{}", i + 1));
+            hits.push((name, est, bound, side));
+        }
+    }
+    hits
+}
+
+/// Build the human message + native structured entry (with `details`) for
+/// theta estimates pinned to an optimizer bound, or `None` when none are.
+fn boundary_estimate_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
+    let hits = boundary_estimates(params);
+    if hits.is_empty() {
+        return None;
+    }
+    let list = hits
+        .iter()
+        .map(|(name, est, _bound, side)| format!("{name} ({est:.4} at {side} bound)"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let msg = format!(
+        "Parameter estimate(s) pinned to an optimizer bound: {list}. This often \
+         indicates non-identifiability or a too-tight bound; inspect the affected \
+         parameter(s) and consider relaxing the bound or simplifying the model."
+    );
+    let params_json: Vec<serde_json::Value> = hits
+        .iter()
+        .map(|(name, est, bound, side)| {
+            serde_json::json!({
+                "parameter": name,
+                "estimate": est,
+                "bound": bound,
+                "side": side,
+            })
+        })
+        .collect();
+    let entry = WarningEntry {
+        severity: WarningSeverity::Warning,
+        category: WarningCode::BoundaryEstimate,
+        message: msg.clone(),
+        source_method: None,
+        details: Some(serde_json::json!({ "parameters": params_json })),
+    };
+    Some((msg, entry))
 }
 
 #[cfg(test)]
@@ -12132,6 +12253,80 @@ mod simulate_with_uncertainty_tests {
         assert!(cd(None, None).is_none());
         // Non-finite condition number is skipped.
         assert!(cd(Some(f64::INFINITY), None).is_none());
+    }
+
+    #[test]
+    fn theta_boundary_side_detects_bounds() {
+        // Identity-packed (lower < 0): interior, at-lower, at-upper.
+        assert_eq!(super::theta_boundary_side(0.0, -1.0, 1.0), None);
+        assert_eq!(super::theta_boundary_side(-1.0, -1.0, 1.0), Some("lower"));
+        assert_eq!(super::theta_boundary_side(1.0, -1.0, 1.0), Some("upper"));
+        // Log-packed (lower >= 0): "at bound" is within a constant factor.
+        assert_eq!(super::theta_boundary_side(1.0, 0.001, 1000.0), None);
+        assert_eq!(
+            super::theta_boundary_side(0.001, 0.001, 1000.0),
+            Some("lower")
+        );
+        // Degenerate bounds → None.
+        assert_eq!(super::theta_boundary_side(1.0, 5.0, 5.0), None);
+    }
+
+    #[test]
+    fn boundary_estimate_warning_emits_typed_entry_with_details() {
+        use crate::types::WarningCode;
+        let mut params = tiny_model().default_params;
+        // No hit initially (estimates interior) — or at least assert whatever
+        // tiny_model starts with, then force a hit on theta 0 at its lower bound.
+        params.theta_fixed = vec![false; params.theta.len()];
+        params.theta[0] = params.theta_lower[0];
+        let (msg, entry) =
+            super::boundary_estimate_warning(&params).expect("expected a boundary hit");
+        assert!(msg.contains("optimizer bound"));
+        assert_eq!(entry.category, WarningCode::BoundaryEstimate);
+        let d = entry.details.as_ref().expect("details");
+        assert_eq!(d["parameters"][0]["side"], "lower");
+        assert_eq!(
+            d["parameters"][0]["parameter"],
+            params.theta_names[0].as_str()
+        );
+
+        // A fixed theta at its bound is not reported.
+        params.theta_fixed[0] = true;
+        assert!(super::boundary_estimate_warning(&params).is_none());
+    }
+
+    #[test]
+    fn rebuild_prefers_native_entry_and_is_idempotent() {
+        let model = tiny_model();
+        let mut fit = synthetic_fit(&model.default_params);
+        let msg = "Parameter estimate(s) pinned to an optimizer bound: CL (0.0010 at lower bound)."
+            .to_string();
+        fit.warnings = vec![msg.clone()];
+        // Native entry (with details) seeded as the fit pipeline would.
+        fit.warnings_structured = vec![crate::types::WarningEntry {
+            severity: crate::types::WarningSeverity::Warning,
+            category: crate::types::WarningCode::BoundaryEstimate,
+            message: msg.clone(),
+            source_method: None,
+            details: Some(serde_json::json!({ "parameters": [{ "parameter": "CL" }] })),
+        }];
+        super::rebuild_warnings_structured(&mut fit);
+        // Native entry preferred over re-classifying the string (details kept).
+        assert_eq!(fit.warnings_structured.len(), 1);
+        assert_eq!(
+            fit.warnings_structured[0].category,
+            crate::types::WarningCode::BoundaryEstimate
+        );
+        assert_eq!(
+            fit.warnings_structured[0].details.as_ref().unwrap()["parameters"][0]["parameter"],
+            "CL"
+        );
+        // Idempotent: a second rebuild re-captures the native entry, details intact.
+        super::rebuild_warnings_structured(&mut fit);
+        assert_eq!(
+            fit.warnings_structured[0].details.as_ref().unwrap()["parameters"][0]["parameter"],
+            "CL"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3894,6 +3894,9 @@ pub enum WarningCode {
     /// One or more ETA (random-effect) shrinkages exceed the threshold — the
     /// data poorly inform those individual random effects.
     EtaShrinkage,
+    /// One or more THETA estimates are pinned to an optimizer bound — a sign of
+    /// non-identifiability or a too-tight bound.
+    BoundaryEstimate,
     /// Dataset-quality issue (missing DV, ADDL/II, non-positive DV, …).
     DataQuality,
     /// Omega structure caveat (mixed lognormal / additive block).
@@ -3933,6 +3936,7 @@ impl WarningCode {
             WarningCode::ImportanceSampling => "importance_sampling",
             WarningCode::EpsShrinkage => "eps_shrinkage",
             WarningCode::EtaShrinkage => "eta_shrinkage",
+            WarningCode::BoundaryEstimate => "boundary_estimate",
             WarningCode::DataQuality => "data_quality",
             WarningCode::OmegaStructure => "omega_structure",
             WarningCode::GradientFallback => "gradient_fallback",
@@ -4059,6 +4063,10 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
     } else if lower.starts_with("eta shrinkage") || lower.contains(" eta shrinkage") {
         // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
+    } else if lower.contains("optimizer bound") {
+        // Distinctive phrase; the eps-shrinkage message's "sigma at a bound" is
+        // matched earlier and never reaches here.
+        (WarningSeverity::Warning, WarningCode::BoundaryEstimate)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
         (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_iov_occ_missing")
@@ -6538,6 +6546,7 @@ mod tests {
             (ImportanceSampling, "importance_sampling"),
             (EpsShrinkage, "eps_shrinkage"),
             (EtaShrinkage, "eta_shrinkage"),
+            (BoundaryEstimate, "boundary_estimate"),
             (DataQuality, "data_quality"),
             (OmegaStructure, "omega_structure"),
             (GradientFallback, "gradient_fallback"),
@@ -6690,6 +6699,11 @@ mod tests {
                  for these random effects are unreliable.",
                 Warning,
                 "eta_shrinkage",
+            ),
+            (
+                "Parameter estimate(s) pinned to an optimizer bound: CL (0.0010 at lower bound).",
+                Warning,
+                "boundary_estimate",
             ),
             (
                 "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",


### PR DESCRIPTION
## Why

A parameter estimate pinned to its bound is a classic model-development red flag — non-identifiability, or a bound set too tight. ferx surfaced no signal for it. Add a `boundary_estimate` warning so an agentic loop can catch it and act (relax the bound / simplify the model).

Fourth increment of #781 (kept open). Also the **first warning emitted typed at its source** — establishing the reusable at-source path that avoids the invasive `Population`/estimator plumbing the string-inversion themes need.

## What changed

- **New `boundary_estimate` warning**: the post-fit stage flags any free (non-fixed) THETA whose estimate sits on its lower/upper optimizer bound. Proximity is judged in the optimizer's **packed space** — log when the lower bound is `>= 0`, else identity — so a log-scaled parameter counts as "at" its bound within a constant *factor*, not a constant absolute gap. Tolerance is a small fraction (`1e-3`) of the packed bound range.
- **Emitted typed at source**: instead of pushing a string and re-classifying it later, the site builds the full `WarningEntry` (code + severity + message + `details` listing each `{parameter, estimate, bound, side}`) and seeds it into `warnings_structured`. `rebuild_warnings_structured` now **prefers native entries** (keyed by message) over classification, and is idempotent across repeat calls (multi-start / entry-point rebuilds).
- A `classify_warning` branch (`"optimizer bound"`, a distinct phrase) is also added so string-only re-derivation — e.g. reloading a `.fitrx` bundle — still yields the typed code (details are only present on the native path).
- New `WarningCode::BoundaryEstimate` (token `boundary_estimate`).

## Alternatives considered

- **Data-quality at-source (the previously-planned increment)** — deferred: it needs `Population.warnings_structured`, and `Population` has ~230 literal construction sites, so the plumbing cost is large for modest incremental value (those codes already classify correctly). `boundary_estimate` is net-new, high-value, and lives entirely in api.rs post-fit.
- **A new typed `FitResult` field to carry boundary hits** (like `shrinkage_eta` drives `eta_shrinkage`) — rejected: `FitResult` has 29 construction sites; the native-entry mechanism touches only the one real construction site and doubles as the reusable at-source path.
- **Distinguishing user-set vs default bounds** — not needed: sitting on *any* active bound (including the wide defaults, where it means the estimate wants ~0 or ~1e9) is the signal worth flagging.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Additive: a new warning + a new `WarningCode` token (behind `#[non_exhaustive]`). ferx-r consumes JSON tokens, unaffected.

## Breaking changes
- [x] None (additive warning + variant)

## Numerical validation
- [x] No estimate/OFV change — a diagnostic layer over the converged estimates. NONMEM likewise reports parameters "near a boundary"; this mirrors that concept. Verified end-to-end:
  - normal warfarin (interior thetas) → **no** `boundary_estimate` warning;
  - warfarin with a tight `TVCL(0.12, 0.001, 0.125)` upper bound → estimate pins to `0.125`, warning fires with `details.parameters[0] = {parameter: TVCL, estimate: 0.125, bound: 0.125, side: "upper"}`.

## Performance
- [x] No significant impact (one scan over the theta vector per fit).

## Tests
- [x] `cargo test --lib` passes (full suite 2386 ok, 0 failed — no fixture spuriously trips it):
  - `theta_boundary_side_detects_bounds`: identity + log packing, interior, at-lower/at-upper, degenerate bounds.
  - `boundary_estimate_warning_emits_typed_entry_with_details`: message + `details`, fixed-theta excluded.
  - `rebuild_prefers_native_entry_and_is_idempotent`: native entry beats re-classification and survives a second rebuild with details intact.
  - `warning_code_tokens_are_stable` + round-trip table cover the new token/message.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt), TVCL pinned to its upper bound:
```json
{
  "severity": "Warning",
  "category": "boundary_estimate",
  "message": "Parameter estimate(s) pinned to an optimizer bound: TVCL (0.1250 at upper bound). ...",
  "source_method": null,
  "details": { "parameters": [ { "parameter": "TVCL", "estimate": 0.125, "bound": 0.125, "side": "upper" } ] }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — codes table, details schema, and a rewritten "How codes are assigned" describing the native at-source path
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (changed code)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- The native-entry precedence in `rebuild_warnings_structured` is keyed by message string. Boundary messages are unprefixed, so `entry.message == warnings[i]`; idempotency holds because each rebuild re-captures the existing structured entries before rebuilding.
- `theta_boundary_side` is the crux — it converts to packed/log space so the proximity test matches the optimizer's actual active constraints.

## Open questions
- Next #781 increment: the `Population.warnings_structured` plumbing for data-quality (bounded via a constructor/Default to limit the 230-site churn), or another api.rs-local at-source diagnostic?
