### PR TITLE
fix(parser): reject a hazard that names an IOV kappa directly [closes #770]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,15 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **A time-to-event hazard that references an inter-occasion (IOV) `kappa` by name
+  is now rejected at parse instead of silently using zero** (#770). A hazard is
+  evaluated once per subject with no occasion context, so an IOV `kappa` has no
+  well-defined value there. Referencing one *through* an `[individual_parameters]`
+  value was already rejected (#442); a hazard expression that names a `kappa`
+  **directly** (e.g. `scale = TVLAMBDA * exp(KAPPA_CL)`) previously fell back to a
+  leniently-read `0.0` covariate, silently dropping the IOV term. It now fails
+  loud, naming the offending random effect — write the hazard in terms of θ/η, or
+  reference an IOV-free parameter.
 - **An `[initial_conditions]` covariate that matches no data column now fails the
   fit loudly instead of silently dropping the baseline** (#765). A covariate named
   only inside an init expression (e.g. `init(central) = CONC0 * V`) was never

--- a/docs/estimation/tte.qmd
+++ b/docs/estimation/tte.qmd
@@ -37,10 +37,11 @@ Add one `[event_model]` block per TTE endpoint.
 > theta / eta / covariate namespace, and may also reference names defined in
 > `[individual_parameters]` (e.g. `LAMBDA`); those are resolved per subject at
 > evaluation time. Writing the full expression in terms of `theta` and `eta`
-> names directly also works. A referenced individual parameter may **not** depend
-> on an inter-occasion (IOV/kappa) random effect — the hazard is evaluated once
-> per subject, with no occasion context — and such a reference is rejected with an
-> error.
+> names directly also works. A hazard may **not** depend on an inter-occasion
+> (IOV/kappa) random effect — whether by referencing an `[individual_parameters]`
+> value that uses one, or by naming a `kappa` directly in the hazard expression —
+> because it is evaluated once per subject, with no occasion context; either is
+> rejected with an error.
 
 For Weibull, a `shape` parameter is also required:
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4002,6 +4002,35 @@ fn parse_event_model_block(
         event_model_etas = eta_set;
     }
 
+    // A hazard expression that references an IOV kappa **by name directly**
+    // (e.g. `scale = TVLAMBDA * exp(KAPPA_CL)`) is as ill-defined as one that
+    // reaches a kappa through an [individual_parameters] value (rejected just
+    // below, #442): the hazard is evaluated once per subject, with no occasion
+    // context. The hazard parse scope is BSV-only, so a kappa name here parses as
+    // an unresolved identifier (Variable/Covariate) rather than `Eta(i)` and would
+    // otherwise fall back to a leniently-read 0.0 covariate (see the "read
+    // leniently" note above), silently dropping the IOV term. Reject it fail-loud
+    // instead (#770).
+    for expr in [
+        &scale_expr,
+        &shape_expr,
+        &alpha_expr,
+        &gamma_expr,
+        &loghr_expr,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Some(k) = expr_references_kappa(expr, kappa_names) {
+            return Err(format!(
+                "[event_model]: a hazard expression references the inter-occasion (IOV) \
+                 random effect `{k}` directly. The hazard is evaluated once per subject, with \
+                 no occasion context, so an IOV kappa has no well-defined value here — write \
+                 the hazard in terms of θ/η, or reference an IOV-free parameter."
+            ));
+        }
+    }
+
     // Restrict the individual-parameter statements the hazard closures evaluate to
     // just those the hazard references, transitively. This bounds the per-eval work
     // and scopes the IOV/NN checks below to what the hazard actually depends on (an

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3999,11 +3999,9 @@ fn parse_event_model_block(
         let mut cov_set = std::collections::HashSet::new();
         let mut theta_set = std::collections::HashSet::new();
         let mut eta_set = std::collections::HashSet::new();
-        for expr_opt in hazard_param_exprs {
-            if let Some(expr) = expr_opt {
-                collect_covariates(expr, &mut cov_set);
-                collect_theta_eta(expr, &mut theta_set, &mut eta_set);
-            }
+        for expr in hazard_param_exprs.into_iter().flatten() {
+            collect_covariates(expr, &mut cov_set);
+            collect_theta_eta(expr, &mut theta_set, &mut eta_set);
         }
         let mut v: Vec<String> = cov_set.into_iter().collect();
         v.sort();

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3983,17 +3983,23 @@ fn parse_event_model_block(
     let mut event_model_covariates: Vec<String>;
     let event_model_thetas: std::collections::HashSet<usize>;
     let event_model_etas: std::collections::HashSet<usize>;
+    // The hazard's parameter expressions in optimizer-parameter order, bound once
+    // and reused by the three scans below — reference collection, the direct-kappa
+    // reject (#770), and the transitive needed-statement collection (#442) — so a
+    // future family parameter can't be added to one walk and silently forgotten in
+    // another.
+    let hazard_param_exprs = [
+        &scale_expr,
+        &shape_expr,
+        &alpha_expr,
+        &gamma_expr,
+        &loghr_expr,
+    ];
     {
         let mut cov_set = std::collections::HashSet::new();
         let mut theta_set = std::collections::HashSet::new();
         let mut eta_set = std::collections::HashSet::new();
-        for expr_opt in [
-            &scale_expr,
-            &shape_expr,
-            &alpha_expr,
-            &gamma_expr,
-            &loghr_expr,
-        ] {
+        for expr_opt in hazard_param_exprs {
             if let Some(expr) = expr_opt {
                 collect_covariates(expr, &mut cov_set);
                 collect_theta_eta(expr, &mut theta_set, &mut eta_set);
@@ -4015,16 +4021,7 @@ fn parse_event_model_block(
     // otherwise fall back to a leniently-read 0.0 covariate (see the "read
     // leniently" note above), silently dropping the IOV term. Reject it fail-loud
     // instead (#770).
-    for expr in [
-        &scale_expr,
-        &shape_expr,
-        &alpha_expr,
-        &gamma_expr,
-        &loghr_expr,
-    ]
-    .into_iter()
-    .flatten()
-    {
+    for expr in hazard_param_exprs.into_iter().flatten() {
         if let Some(k) = expr_references_kappa(expr, kappa_names) {
             return Err(format!(
                 "[event_model]: a hazard expression references the inter-occasion (IOV) \
@@ -4047,16 +4044,7 @@ fn parse_event_model_block(
     // `visit_stmt_nodes`).
     let needed_indiv_stmts: Vec<Statement> = {
         let mut needed: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for expr in [
-            &scale_expr,
-            &shape_expr,
-            &alpha_expr,
-            &gamma_expr,
-            &loghr_expr,
-        ]
-        .into_iter()
-        .flatten()
-        {
+        for expr in hazard_param_exprs.into_iter().flatten() {
             collect_variable_names(expr, &mut needed);
         }
         let mut keep: Vec<Statement> = Vec::new();

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -2515,6 +2515,48 @@ mod survival_smoke {
         );
     }
 
+    /// Issue #770: a hazard that references an IOV **kappa by name directly**
+    /// (not through an [individual_parameters] value) must also be rejected at
+    /// parse. The hazard parse scope is BSV-only, so `KAPPA_CL` here would
+    /// otherwise fall back to a leniently-read 0.0 covariate — silently dropping
+    /// the IOV term instead of failing loud. Sibling to
+    /// `event_model_referencing_kappa_indiv_param_is_rejected`, which covers the
+    /// *indirect* case (`scale = CL` with `CL = TVCL * exp(ETA_CL + KAPPA_CL)`).
+    #[test]
+    fn event_model_referencing_kappa_by_name_is_rejected() {
+        let src = r"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  theta TVLAMBDA(0.05, 0.001, 5.0)
+  omega ETA_CL ~ 0.09
+  kappa KAPPA_CL ~ 0.04
+  sigma SIGMA_ADD ~ 0.1
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ additive(SIGMA_ADD)
+
+[event_model]
+  cmt    = 2
+  family = exponential
+  scale  = TVLAMBDA * exp(KAPPA_CL)
+";
+        let err = parse_model_string(src).expect_err(
+            "a hazard referencing an IOV kappa by name must be rejected, not read as 0.0",
+        );
+        assert!(
+            err.contains("inter-occasion") && err.contains("KAPPA_CL"),
+            "the error should name the offending IOV random effect; got: {err}"
+        );
+    }
+
     /// Issue #442 (review #2): a hazard may reference an `[individual_parameters]`
     /// value defined by a NONMEM-style `if (...) { ... } else { ... }` block. Before
     /// the fix, such a name was classified as a covariate and silently resolved to


### PR DESCRIPTION
## Why

[#770](https://github.com/FeRx-NLME/ferx-core/issues/770) (filed from the post-merge review of #723) flagged that `simulate()` draws IOV κ for continuous observations but the TTE hazard path holds κ = 0 — an internal inconsistency for joint PK-TTE + IOV.

On investigation, the primary scenarios are **already prevented on `main`**:

- A hazard reaching an IOV κ *through* an `[individual_parameters]` value is rejected at parse (**#442**, `model_parser.rs`).
- An ODE-accumulated hazard under IOV is rejected at parse (`model_parser.rs` ~L3904).
- Both fit *and* simulate evaluate the analytic hazard κ-less **by design** — `stats/likelihood.rs`: *"Kappas are PK-only; the hazard param_fn uses BSV eta, not kappas."* So a model whose hazard genuinely depends on κ never reaches simulation; it is rejected first, and the described obs-carry-κ / events-κ-free mismatch is unreachable for those models.

The **one remaining gap**: a hazard that names a κ **directly** in its own expression — `scale = TVLAMBDA * exp(KAPPA_CL)` — rather than via an individual parameter. The hazard parse scope is BSV-only, so `KAPPA_CL` fell back to an *undeclared covariate*, read leniently as `0.0` with only a warning — silently dropping the IOV term instead of failing loud. This PR closes that last edge, completing #770's "fail loud" intent.

## What changed

- **`parser/model_parser.rs`** — in the analytic `[event_model]` branch, after collecting the hazard's covariate/θ/η references, scan the five hazard parameter expressions (`scale` / `shape` / `alpha` / `gamma` / `loghr`) for a direct reference to a declared `kappa` name via the existing `expr_references_kappa` helper (the same helper used for the Form C IOV rejection, #107/#650). Reject with an error naming the offending κ. Placed as a sibling to — and just before — the existing #442 indirect-reference guard.
- **`tests/tte_smoke.rs`** — `event_model_referencing_kappa_by_name_is_rejected`: a `scale = TVLAMBDA * exp(KAPPA_CL)` hazard must parse-error naming `KAPPA_CL`. Fails without the guard (the model previously parsed).
- **`CHANGELOG.md`** — Fixed entry.
- **`docs/estimation/tte.qmd`** — the existing "a referenced individual parameter may not depend on IOV" note broadened to also cover naming a κ directly.

## Alternatives considered

Making `simulate_tte` occasion-aware (draw per-occasion κ, thread it through the hazard / augmented-ODE solve) — #770 option 1. Rejected: it is a large `sens/`-adjacent change to *support* a construct the engine intentionally treats as ill-defined (a hazard has no occasion context), and it contradicts the existing `likelihood.rs` "Kappas are PK-only" fit-path design. Fail-loud is consistent with the #442 and ODE guards already in place.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Parser-internal; no `pub` API change.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

A model with a directly-named κ in a hazard previously *parsed* but was silently wrong (IOV term dropped to `0.0`, with only a warning). It now errors with guidance. No `.ferx` format change; no valid model is affected.

## Numerical validation
- [x] Not applicable (parse-time guard; no numerical change to any valid model)

The allowed κ-free IOV+TTE fit (`iov_tte_focei_returns_finite_ofv`) still returns a finite OFV — the guard does not over-reject a legitimate κ-free hazard in an IOV model.

## Performance
- [x] No significant impact expected

One extra AST walk over ≤5 small hazard expressions, at parse time only.

## Tests
- [x] Regression test added that fails without this fix
- [x] Unit/Tier-2 test(s) added (`--features ci,survival` passes)

`event_model_referencing_kappa_by_name_is_rejected` (Tier-2, `tests/tte_smoke.rs`). Also confirmed unchanged: `event_model_referencing_kappa_indiv_param_is_rejected` (#442 indirect rejection) and `iov_tte_focei_returns_finite_ofv` (no over-rejection). All three green.

## Example (user-facing features only)
- [x] Not applicable (fail-loud guard; no new API surface) — the newly-rejected model is shown below

<details>
<summary>Model that now errors instead of silently using 0.0</summary>

```toml
[parameters]
  kappa KAPPA_CL ~ 0.04
  ...
[event_model]
  cmt    = 2
  family = exponential
  scale  = TVLAMBDA * exp(KAPPA_CL)   # error: hazard references IOV kappa `KAPPA_CL` directly
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes (`docs/estimation/tte.qmd`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change)
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new findings on the diff)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (N/A — parser only)
- [x] `Cargo.toml` version bumped if breaking (N/A — not breaking)

## Reviewer hints

The guard is a ~10-line scan mirroring the #442 block immediately below it. The one correctness point: it must not over-reject a legitimate κ-free hazard in an IOV model — `expr_references_kappa` matches only a *declared kappa name* as a `Variable`/`Covariate` leaf, and a κ-free hazard (e.g. `exp(ETA_CL)`) references a BSV eta, not a κ name; `iov_tte_focei_returns_finite_ofv` covers that.

## Open questions

None. **Closes #770** — the primary scenarios were already covered by #442 + the ODE guard; this closes the last (direct-name) edge and the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
