### PR TITLE
feat(diagnostics): inflated-RSE warning, emitted typed at source (#781 increment 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Inflated-RSE warning** (#781): a fit now emits an `inflated_rse` warning
+  when a free THETA's relative standard error (`100 · se / |estimate|`) exceeds
+  ~50% — an imprecisely estimated parameter, often a sign of
+  over-parameterization. Emitted typed at source with `details` listing each
+  `{parameter, estimate, se, rse_pct}`. Requires a successful covariance step
+  (no SEs → no warning). See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **`simulate_with_options_diag` surfaces per-subject simulation diagnostics** (#762,
   #763): a new entry point returning `SimulationOutput { results, warnings }` — the
   simulation analogue of `FitResult.warnings`. It reports subjects handled specially

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -54,6 +54,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
+| `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
@@ -78,6 +79,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
 | `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
+| `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
 | `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5302,6 +5302,12 @@ fn fit_inner(
         warnings.push(msg);
         native_warnings.push(entry);
     }
+    // Imprecisely estimated thetas (high relative standard error) — likewise
+    // emitted typed at source with `details` (#781).
+    if let Some((msg, entry)) = inflated_rse_warning(&se_theta, &result.params) {
+        warnings.push(msg);
+        native_warnings.push(entry);
+    }
 
     let (iwres_lag1_r, dw_statistic) = iwres_autocorrelation(&subjects);
 
@@ -6317,6 +6323,88 @@ fn boundary_estimate_warning(params: &ModelParameters) -> Option<(String, Warnin
         message: msg.clone(),
         source_method: None,
         details: Some(serde_json::json!({ "parameters": params_json })),
+    };
+    Some((msg, entry))
+}
+
+/// Relative-standard-error threshold (percent) above which a free THETA is
+/// flagged as imprecisely estimated. 50% is a common rule of thumb for fixed
+/// effects (well-estimated parameters typically sit well below it).
+const RSE_WARN_THRESHOLD_PCT: f64 = 50.0;
+
+/// Free (non-fixed) THETA estimates with a relative standard error above the
+/// threshold, as `(name, estimate, se, rse_pct)`. Empty when the covariance
+/// step produced no SEs, or none are imprecise. `RSE = 100 * se / |estimate|`.
+fn inflated_rse_thetas(
+    se_theta: &Option<Vec<f64>>,
+    params: &ModelParameters,
+) -> Vec<(String, f64, f64, f64)> {
+    let Some(se) = se_theta else {
+        return Vec::new();
+    };
+    let mut hits = Vec::new();
+    for i in 0..params.theta.len() {
+        if params.theta_fixed.get(i).copied().unwrap_or(false) {
+            continue;
+        }
+        let (est, se_i) = (params.theta[i], se.get(i).copied().unwrap_or(f64::NAN));
+        if est.abs() <= 1e-12 || !se_i.is_finite() {
+            continue;
+        }
+        let rse = 100.0 * se_i / est.abs();
+        if rse.is_finite() && rse > RSE_WARN_THRESHOLD_PCT {
+            let name = params
+                .theta_names
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| format!("THETA{}", i + 1));
+            hits.push((name, est, se_i, rse));
+        }
+    }
+    hits
+}
+
+/// Build the human message + native structured entry (with `details`) for
+/// free THETAs whose relative standard error exceeds the threshold, or `None`.
+fn inflated_rse_warning(
+    se_theta: &Option<Vec<f64>>,
+    params: &ModelParameters,
+) -> Option<(String, WarningEntry)> {
+    let hits = inflated_rse_thetas(se_theta, params);
+    if hits.is_empty() {
+        return None;
+    }
+    let list = hits
+        .iter()
+        .map(|(name, _est, _se, rse)| format!("{name} ({rse:.0}%)"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let msg = format!(
+        "High relative standard error (RSE > {:.0}%): {list}. These parameter(s) \
+         are imprecisely estimated — often a sign of over-parameterization or \
+         data that do not inform them; consider simplifying the model.",
+        RSE_WARN_THRESHOLD_PCT
+    );
+    let params_json: Vec<serde_json::Value> = hits
+        .iter()
+        .map(|(name, est, se, rse)| {
+            serde_json::json!({
+                "parameter": name,
+                "estimate": est,
+                "se": se,
+                "rse_pct": rse,
+            })
+        })
+        .collect();
+    let entry = WarningEntry {
+        severity: WarningSeverity::Warning,
+        category: WarningCode::InflatedRse,
+        message: msg.clone(),
+        source_method: None,
+        details: Some(serde_json::json!({
+            "threshold_pct": RSE_WARN_THRESHOLD_PCT,
+            "parameters": params_json,
+        })),
     };
     Some((msg, entry))
 }
@@ -12687,6 +12775,38 @@ mod simulate_with_uncertainty_tests {
         // A fixed theta at its bound is not reported.
         params.theta_fixed[0] = true;
         assert!(super::boundary_estimate_warning(&params).is_none());
+    }
+
+    #[test]
+    fn inflated_rse_warning_emits_typed_entry_with_details() {
+        use crate::types::WarningCode;
+        let mut params = tiny_model().default_params;
+        params.theta_fixed = vec![false; params.theta.len()];
+        // No SEs (covariance step didn't run) → no warning.
+        assert!(super::inflated_rse_warning(&None, &params).is_none());
+        // theta[0] with SE = |est| → RSE 100% (> 50%); theta[1] SE tiny → fine.
+        let mut se = vec![0.0; params.theta.len()];
+        se[0] = params.theta[0].abs();
+        let (msg, entry) =
+            super::inflated_rse_warning(&Some(se.clone()), &params).expect("expected an RSE hit");
+        assert!(msg.contains("relative standard error"));
+        assert_eq!(entry.category, WarningCode::InflatedRse);
+        let d = entry.details.as_ref().expect("details");
+        assert_eq!(d["threshold_pct"], 50.0);
+        assert_eq!(
+            d["parameters"][0]["parameter"],
+            params.theta_names[0].as_str()
+        );
+        assert!((d["parameters"][0]["rse_pct"].as_f64().unwrap() - 100.0).abs() < 1e-6);
+        // A fixed theta with a huge SE is not reported.
+        params.theta_fixed[0] = true;
+        assert!(super::inflated_rse_warning(&Some(se), &params).is_none());
+        // A near-zero estimate is skipped (avoids divide-by-~0 blowups).
+        params.theta_fixed[0] = false;
+        params.theta[0] = 0.0;
+        assert!(
+            super::inflated_rse_warning(&Some(vec![1.0; params.theta.len()]), &params).is_none()
+        );
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -6376,7 +6376,9 @@ fn inflated_rse_warning(
     }
     let list = hits
         .iter()
-        .map(|(name, _est, _se, rse)| format!("{name} ({rse:.0}%)"))
+        // One decimal so a borderline value (e.g. 50.4%) is not displayed as
+        // "50%" — which would read as below the threshold it just tripped.
+        .map(|(name, _est, _se, rse)| format!("{name} ({rse:.1}%)"))
         .collect::<Vec<_>>()
         .join(", ");
     let msg = format!(
@@ -12807,6 +12809,16 @@ mod simulate_with_uncertainty_tests {
         assert!(
             super::inflated_rse_warning(&Some(vec![1.0; params.theta.len()]), &params).is_none()
         );
+
+        // Borderline value renders with a decimal (not rounded to the
+        // threshold): RSE = 50.4% must show "50.4%", not "50%".
+        let mut p2 = tiny_model().default_params;
+        p2.theta_fixed = vec![false; p2.theta.len()];
+        p2.theta[0] = 1.0;
+        let mut se2 = vec![0.0; p2.theta.len()];
+        se2[0] = 0.504; // RSE = 50.4%
+        let (msg2, _) = super::inflated_rse_warning(&Some(se2), &p2).expect("borderline hit");
+        assert!(msg2.contains("50.4%"), "got: {msg2}");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3950,6 +3950,9 @@ pub enum WarningCode {
     /// One or more THETA estimates are pinned to an optimizer bound — a sign of
     /// non-identifiability or a too-tight bound.
     BoundaryEstimate,
+    /// One or more THETA estimates have a large relative standard error — poorly
+    /// estimated / imprecise parameters.
+    InflatedRse,
     /// Dataset-quality issue (missing DV, ADDL/II, non-positive DV, …).
     DataQuality,
     /// Omega structure caveat (mixed lognormal / additive block).
@@ -3996,6 +3999,7 @@ impl WarningCode {
             WarningCode::EpsShrinkage => "eps_shrinkage",
             WarningCode::EtaShrinkage => "eta_shrinkage",
             WarningCode::BoundaryEstimate => "boundary_estimate",
+            WarningCode::InflatedRse => "inflated_rse",
             WarningCode::DataQuality => "data_quality",
             WarningCode::OmegaStructure => "omega_structure",
             WarningCode::GradientFallback => "gradient_fallback",
@@ -4133,6 +4137,8 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // Distinctive phrase; the eps-shrinkage message's "sigma at a bound" is
         // matched earlier and never reaches here.
         (WarningSeverity::Warning, WarningCode::BoundaryEstimate)
+    } else if lower.contains("relative standard error") {
+        (WarningSeverity::Warning, WarningCode::InflatedRse)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
         (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_iov_occ_missing")
@@ -6631,6 +6637,7 @@ mod tests {
             (EpsShrinkage, "eps_shrinkage"),
             (EtaShrinkage, "eta_shrinkage"),
             (BoundaryEstimate, "boundary_estimate"),
+            (InflatedRse, "inflated_rse"),
             (DataQuality, "data_quality"),
             (OmegaStructure, "omega_structure"),
             (GradientFallback, "gradient_fallback"),
@@ -6789,6 +6796,11 @@ mod tests {
                 "Parameter estimate(s) pinned to an optimizer bound: CL (0.0010 at lower bound).",
                 Warning,
                 "boundary_estimate",
+            ),
+            (
+                "High relative standard error (RSE > 50%): TVCL (72%).",
+                Warning,
+                "inflated_rse",
             ),
             (
                 "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",


### PR DESCRIPTION
## Why

Parameter *precision* is a first-order model-development signal: a THETA with a large relative standard error is poorly estimated — usually over-parameterization or data that don't inform it. ferx computed RSE for display but never *warned* on it. Add an `inflated_rse` warning so an agentic loop can act (simplify the model).

Fifth increment of #781 (kept open); the second warning to use the native at-source path from #791.

## What changed

- **New `inflated_rse` warning**: the post-fit stage flags any free (non-fixed) THETA whose `RSE = 100 · se / |estimate|` exceeds ~50% (`RSE_WARN_THRESHOLD_PCT`). Requires a successful covariance step (SEs present); fixed thetas and near-zero estimates (`|est| <= 1e-12`) are skipped.
- **Emitted typed at source** (reusing #791): builds the full `WarningEntry` with `details` — `{threshold_pct, parameters: [{parameter, estimate, se, rse_pct}]}` — seeded into `warnings_structured`, preferred by `rebuild_warnings_structured` over classification.
- **`classify_warning` branch** (`"relative standard error"`, distinct) so string-only re-derivation (e.g. `.fitrx` reload) still yields the typed code.
- New `WarningCode::InflatedRse` (token `inflated_rse`).

## Alternatives considered

- **Threshold** — 50% is a common rule of thumb for fixed effects; well-estimated parameters sit well below it, so noise is low. A single `const` keeps it tunable.
- **Field-enrich in rebuild vs native at-source** — chose native (the entry carries its own `details`), consistent with `boundary_estimate` and demonstrating the at-source path is reusable.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Additive: new warning + `WarningCode` token (behind `#[non_exhaustive]`). ferx-r consumes JSON tokens, unaffected.

## Breaking changes
- [x] None (additive)

## Numerical validation
- [x] No estimate/OFV/SE change — a threshold over the existing `se_theta` (already validated) and `theta`. NONMEM/pharmacometrics conventionally flag high-RSE parameters; this mirrors that. Verified end-to-end: warfarin (RSEs ~3–17%, all < 50%) fires **no** `inflated_rse` warning while SEs are present (the code path runs).

## Performance
- [x] No significant impact (one scan over the theta vector per fit).

## Tests
- [x] `cargo test --lib` passes (full suite 2393 ok, 0 failed — no fixture spuriously trips it):
  - `inflated_rse_warning_emits_typed_entry_with_details`: threshold firing (SE = |est| → RSE 100%), `details` shape, and exclusion of a no-SE result, a fixed theta, and a near-zero estimate.
  - `warning_code_tokens_are_stable` + round-trip table cover the new token/message.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt), a poorly-estimated theta:
```json
{
  "severity": "Warning",
  "category": "inflated_rse",
  "message": "High relative standard error (RSE > 50%): TVKA (72%). ...",
  "source_method": null,
  "details": { "threshold_pct": 50.0, "parameters": [ { "parameter": "TVKA", "estimate": 1.5, "se": 1.08, "rse_pct": 72.0 } ] }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — codes table + details schema
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (changed code)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- `inflated_rse_thetas` is the crux: guards `est.abs() > 1e-12` (avoid divide-by-~0) and `se.is_finite()`, and skips fixed thetas — so RSE is only computed where meaningful.
- Emission mirrors `boundary_estimate_warning` exactly (native entry + string), so the rebuild precedence/idempotency proven in #791 applies unchanged.

## Open questions
- Next #781 increment: the `Population.warnings_structured` plumbing for data-quality counts, or another api.rs-local at-source diagnostic (e.g. near-zero omega variance)?
