### PR TITLE
feat(diagnostics): high parameter-correlation warning (#781 increment 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **High parameter-correlation warning** (#781): a fit now emits a
+  `high_correlation` warning when a parameter pair's estimate correlation
+  (from the covariance matrix, in packed space) has |r| ≥ 0.95 — a sign of
+  over-parameterization / non-identifiability that names the specific culprits
+  (complementing the aggregate `condition_number`). Emitted typed at source with
+  `details` listing each `{parameter_a, parameter_b, correlation}`. See the
+  [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
 - **Inflated-RSE warning** (#781): a fit now emits an `inflated_rse` warning
   when a free THETA's relative standard error (`100 · se / |estimate|`) exceeds
   ~50% — an imprecisely estimated parameter, often a sign of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ section of the SDLC for the versioning policy).
 
 ### Added
 - **High parameter-correlation warning** (#781): a fit now emits a
-  `high_correlation` warning when a parameter pair's estimate correlation
-  (from the covariance matrix, in packed space) has |r| ≥ 0.95 — a sign of
+  `high_correlation` warning when a THETA (fixed-effect) pair's estimate
+  correlation (from the covariance matrix) has |r| ≥ 0.95 — a sign of
   over-parameterization / non-identifiability that names the specific culprits
   (complementing the aggregate `condition_number`). Emitted typed at source with
   `details` listing each `{parameter_a, parameter_b, correlation}`. See the

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -55,7 +55,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
-| `high_correlation` | Warning | One or more parameter pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
+| `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -55,6 +55,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
+| `high_correlation` | Warning | One or more parameter pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
@@ -80,6 +81,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
 | `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
 | `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
+| `high_correlation` | `threshold`, `pairs` (array of `{parameter_a, parameter_b, correlation}`) |
 | `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -6424,40 +6424,39 @@ fn inflated_rse_warning(
 /// collinear/non-identified. `0.95` is a common rule of thumb.
 const CORRELATION_WARN_THRESHOLD: f64 = 0.95;
 
-/// Parameter pairs whose estimate correlation exceeds the threshold, as
-/// `(name_a, name_b, correlation)`. The correlation is computed over the free
-/// (positive-variance) entries of the parameter covariance matrix, in the
-/// optimizer's packed space. Empty when there is no covariance matrix or fewer
-/// than two free parameters.
+/// THETA (fixed-effect) pairs whose estimate correlation exceeds the threshold,
+/// as `(name_a, name_b, correlation)`. Restricted to the THETA block — it
+/// occupies the first `theta_names.len()` packed entries with unambiguous names,
+/// and fixed-effect collinearity is the most actionable/interpretable case
+/// (omega/sigma live in Cholesky space, where both the correlation and the
+/// packed labels are murkier). Fixed / zero-variance thetas (diagonal `<= 0`)
+/// are skipped. Empty when there is no covariance matrix.
 fn high_correlation_pairs(
     cov: Option<&DMatrix<f64>>,
-    names: &[String],
+    theta_names: &[String],
 ) -> Vec<(String, String, f64)> {
     let Some(cov) = cov else {
         return Vec::new();
     };
-    let n = cov.nrows();
-    let free: Vec<usize> = (0..n).filter(|&i| cov[(i, i)] > 0.0).collect();
-    if free.len() < 2 {
-        return Vec::new();
-    }
-    let label = |i: usize| {
-        names
-            .get(i)
-            .cloned()
-            .unwrap_or_else(|| format!("P{}", i + 1))
-    };
+    let n_theta = theta_names.len().min(cov.nrows());
     let mut pairs = Vec::new();
-    for a in 0..free.len() {
-        for b in (a + 1)..free.len() {
-            let (ia, ib) = (free[a], free[b]);
-            let denom = (cov[(ia, ia)] * cov[(ib, ib)]).sqrt();
+    for a in 0..n_theta {
+        if cov[(a, a)] <= 0.0 {
+            continue;
+        }
+        for b in (a + 1)..n_theta {
+            if cov[(b, b)] <= 0.0 {
+                continue;
+            }
+            // sqrt(var_a) * sqrt(var_b) avoids the overflow/underflow that
+            // `(var_a * var_b).sqrt()` can hit for extreme variances.
+            let denom = cov[(a, a)].sqrt() * cov[(b, b)].sqrt();
             if denom <= 0.0 || !denom.is_finite() {
                 continue;
             }
-            let r = cov[(ia, ib)] / denom;
+            let r = cov[(a, b)] / denom;
             if r.is_finite() && r.abs() >= CORRELATION_WARN_THRESHOLD {
-                pairs.push((label(ia), label(ib), r));
+                pairs.push((theta_names[a].clone(), theta_names[b].clone(), r));
             }
         }
     }
@@ -6465,11 +6464,9 @@ fn high_correlation_pairs(
 }
 
 /// Build the human message + native structured entry (with `details`) for
-/// highly correlated parameter pairs in the fit's covariance matrix, or `None`.
+/// highly correlated THETA pairs in the fit's covariance matrix, or `None`.
 fn high_correlation_warning(result: &FitResult) -> Option<(String, WarningEntry)> {
-    let cov = result.covariance_matrix.as_ref()?;
-    let names = crate::io::output::packed_param_names(result, cov.nrows());
-    let pairs = high_correlation_pairs(Some(cov), &names);
+    let pairs = high_correlation_pairs(result.covariance_matrix.as_ref(), &result.theta_names);
     if pairs.is_empty() {
         return None;
     }
@@ -12839,6 +12836,14 @@ mod simulate_with_uncertainty_tests {
         assert!(super::high_correlation_pairs(Some(&cov2), &names).is_empty());
         // No covariance matrix → nothing.
         assert!(super::high_correlation_pairs(None, &names).is_empty());
+        // Theta-only scope: a strong correlation involving a non-theta packed
+        // entry (index >= n_theta) is NOT flagged. With 2 theta names but a 3x3
+        // covariance, the (0,2) correlation lies outside the theta block.
+        let mut cov3 = DMatrix::identity(3, 3) * 0.01;
+        cov3[(0, 2)] = 0.0099;
+        cov3[(2, 0)] = 0.0099;
+        let theta2 = vec!["A".to_string(), "B".to_string()];
+        assert!(super::high_correlation_pairs(Some(&cov3), &theta2).is_empty());
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -5420,7 +5420,7 @@ fn fit_inner(
         }
     };
 
-    let fit_result = FitResult {
+    let mut fit_result = FitResult {
         method: final_method,
         method_chain: chain.clone(),
         method_wall_times_secs,
@@ -5603,6 +5603,15 @@ fn fit_inner(
             ms(jac_fd_n),
             avg_us(jac_fd_n, jac_fd_c)
         );
+    }
+
+    // Highly correlated parameter pairs — emitted typed at source with a
+    // `details` payload (#781). Appended post-construction because it needs the
+    // packed parameter names, which are derived from the assembled `FitResult`;
+    // `rebuild_warnings_structured` preserves this native entry by message.
+    if let Some((msg, entry)) = high_correlation_warning(&fit_result) {
+        fit_result.warnings.push(msg);
+        fit_result.warnings_structured.push(entry);
     }
 
     Ok(fit_result)
@@ -6406,6 +6415,88 @@ fn inflated_rse_warning(
         details: Some(serde_json::json!({
             "threshold_pct": RSE_WARN_THRESHOLD_PCT,
             "parameters": params_json,
+        })),
+    };
+    Some((msg, entry))
+}
+
+/// Absolute correlation above which a parameter pair is flagged as
+/// collinear/non-identified. `0.95` is a common rule of thumb.
+const CORRELATION_WARN_THRESHOLD: f64 = 0.95;
+
+/// Parameter pairs whose estimate correlation exceeds the threshold, as
+/// `(name_a, name_b, correlation)`. The correlation is computed over the free
+/// (positive-variance) entries of the parameter covariance matrix, in the
+/// optimizer's packed space. Empty when there is no covariance matrix or fewer
+/// than two free parameters.
+fn high_correlation_pairs(
+    cov: Option<&DMatrix<f64>>,
+    names: &[String],
+) -> Vec<(String, String, f64)> {
+    let Some(cov) = cov else {
+        return Vec::new();
+    };
+    let n = cov.nrows();
+    let free: Vec<usize> = (0..n).filter(|&i| cov[(i, i)] > 0.0).collect();
+    if free.len() < 2 {
+        return Vec::new();
+    }
+    let label = |i: usize| {
+        names
+            .get(i)
+            .cloned()
+            .unwrap_or_else(|| format!("P{}", i + 1))
+    };
+    let mut pairs = Vec::new();
+    for a in 0..free.len() {
+        for b in (a + 1)..free.len() {
+            let (ia, ib) = (free[a], free[b]);
+            let denom = (cov[(ia, ia)] * cov[(ib, ib)]).sqrt();
+            if denom <= 0.0 || !denom.is_finite() {
+                continue;
+            }
+            let r = cov[(ia, ib)] / denom;
+            if r.is_finite() && r.abs() >= CORRELATION_WARN_THRESHOLD {
+                pairs.push((label(ia), label(ib), r));
+            }
+        }
+    }
+    pairs
+}
+
+/// Build the human message + native structured entry (with `details`) for
+/// highly correlated parameter pairs in the fit's covariance matrix, or `None`.
+fn high_correlation_warning(result: &FitResult) -> Option<(String, WarningEntry)> {
+    let cov = result.covariance_matrix.as_ref()?;
+    let names = crate::io::output::packed_param_names(result, cov.nrows());
+    let pairs = high_correlation_pairs(Some(cov), &names);
+    if pairs.is_empty() {
+        return None;
+    }
+    let list = pairs
+        .iter()
+        .map(|(a, b, r)| format!("{a} ~ {b} ({r:.2})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let msg = format!(
+        "Highly correlated parameter pair(s) (|r| >= {CORRELATION_WARN_THRESHOLD:.2}): \
+         {list}. Highly correlated estimates indicate over-parameterization or \
+         non-identifiability; consider fixing or removing one of each pair."
+    );
+    let pairs_json: Vec<serde_json::Value> = pairs
+        .iter()
+        .map(
+            |(a, b, r)| serde_json::json!({ "parameter_a": a, "parameter_b": b, "correlation": r }),
+        )
+        .collect();
+    let entry = WarningEntry {
+        severity: WarningSeverity::Warning,
+        category: WarningCode::HighCorrelation,
+        message: msg.clone(),
+        source_method: None,
+        details: Some(serde_json::json!({
+            "threshold": CORRELATION_WARN_THRESHOLD,
+            "pairs": pairs_json,
         })),
     };
     Some((msg, entry))
@@ -12729,6 +12820,50 @@ mod simulate_with_uncertainty_tests {
         let (s, bound) = super::theta_boundary_side(1e-10, 0.0, 100.0).unwrap();
         assert_eq!(s, "lower");
         assert_eq!(bound, 1e-10);
+    }
+
+    #[test]
+    fn high_correlation_pairs_flags_collinear_estimates() {
+        let names = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        // 3x3 covariance: A~B correlation 0.99 (0.0099/0.01), A~C and B~C ~0.
+        let mut cov = DMatrix::identity(3, 3) * 0.01;
+        cov[(0, 1)] = 0.0099;
+        cov[(1, 0)] = 0.0099;
+        let pairs = super::high_correlation_pairs(Some(&cov), &names);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!((pairs[0].0.as_str(), pairs[0].1.as_str()), ("A", "B"));
+        assert!((pairs[0].2 - 0.99).abs() < 1e-9);
+        // A fixed / zero-variance parameter (diag == 0) is excluded.
+        let mut cov2 = DMatrix::identity(2, 2) * 0.01;
+        cov2[(1, 1)] = 0.0;
+        assert!(super::high_correlation_pairs(Some(&cov2), &names).is_empty());
+        // No covariance matrix → nothing.
+        assert!(super::high_correlation_pairs(None, &names).is_empty());
+    }
+
+    #[test]
+    fn high_correlation_warning_emits_typed_entry_with_details() {
+        use crate::types::WarningCode;
+        let model = tiny_model();
+        let mut fit = synthetic_fit(&model.default_params);
+        // synthetic_fit's covariance is a scaled identity (no correlation) →
+        // no warning.
+        assert!(super::high_correlation_warning(&fit).is_none());
+        // Inject a strong theta0~theta1 correlation into the packed covariance.
+        let n = fit.covariance_matrix.as_ref().unwrap().nrows();
+        assert!(n >= 2);
+        let mut cov = DMatrix::identity(n, n) * 0.01;
+        cov[(0, 1)] = 0.0098; // r = 0.98
+        cov[(1, 0)] = 0.0098;
+        fit.covariance_matrix = Some(cov);
+        let (msg, entry) = super::high_correlation_warning(&fit).expect("expected a pair");
+        assert!(msg.contains("highly correlated") || msg.contains("Highly correlated"));
+        assert_eq!(entry.category, WarningCode::HighCorrelation);
+        let d = entry.details.as_ref().expect("details");
+        assert_eq!(d["threshold"], 0.95);
+        assert!((d["pairs"][0]["correlation"].as_f64().unwrap() - 0.98).abs() < 1e-9);
+        // The labels are the packed parameter names (first two thetas here).
+        assert_eq!(d["pairs"][0]["parameter_a"], fit.theta_names[0].as_str());
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1461,7 +1461,7 @@ fn yaml_quote(s: &str) -> String {
 /// For a full-block omega/kappa the column-major lower-triangle entries are
 /// `log_chol_{eta_i}` on the diagonal (`log(L_ii)`) and `chol_{eta_i}_{eta_j}`
 /// (i > j) off-diagonal (`L_ij`, not log-transformed).
-pub(crate) fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
+fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     let n_theta = result.theta_names.len();
     let n_eta = result.omega.nrows();
     let n_sigma = result.sigma_names.len();

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1461,7 +1461,7 @@ fn yaml_quote(s: &str) -> String {
 /// For a full-block omega/kappa the column-major lower-triangle entries are
 /// `log_chol_{eta_i}` on the diagonal (`log(L_ii)`) and `chol_{eta_i}_{eta_j}`
 /// (i > j) off-diagonal (`L_ij`, not log-transformed).
-fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
+pub(crate) fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     let n_theta = result.theta_names.len();
     let n_eta = result.omega.nrows();
     let n_sigma = result.sigma_names.len();

--- a/src/types.rs
+++ b/src/types.rs
@@ -3953,6 +3953,9 @@ pub enum WarningCode {
     /// One or more THETA estimates have a large relative standard error — poorly
     /// estimated / imprecise parameters.
     InflatedRse,
+    /// One or more parameter pairs are highly correlated in the covariance —
+    /// over-parameterization / non-identifiability.
+    HighCorrelation,
     /// Dataset-quality issue (missing DV, ADDL/II, non-positive DV, …).
     DataQuality,
     /// Omega structure caveat (mixed lognormal / additive block).
@@ -4000,6 +4003,7 @@ impl WarningCode {
             WarningCode::EtaShrinkage => "eta_shrinkage",
             WarningCode::BoundaryEstimate => "boundary_estimate",
             WarningCode::InflatedRse => "inflated_rse",
+            WarningCode::HighCorrelation => "high_correlation",
             WarningCode::DataQuality => "data_quality",
             WarningCode::OmegaStructure => "omega_structure",
             WarningCode::GradientFallback => "gradient_fallback",
@@ -4139,6 +4143,8 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         (WarningSeverity::Warning, WarningCode::BoundaryEstimate)
     } else if lower.contains("relative standard error") {
         (WarningSeverity::Warning, WarningCode::InflatedRse)
+    } else if lower.contains("highly correlated") {
+        (WarningSeverity::Warning, WarningCode::HighCorrelation)
     } else if lower.starts_with("w_addl_missing_ii") || lower.contains("addl > 0 but ii") {
         (WarningSeverity::Warning, WarningCode::DataQuality)
     } else if lower.starts_with("w_iov_occ_missing")
@@ -6638,6 +6644,7 @@ mod tests {
             (EtaShrinkage, "eta_shrinkage"),
             (BoundaryEstimate, "boundary_estimate"),
             (InflatedRse, "inflated_rse"),
+            (HighCorrelation, "high_correlation"),
             (DataQuality, "data_quality"),
             (OmegaStructure, "omega_structure"),
             (GradientFallback, "gradient_fallback"),
@@ -6801,6 +6808,11 @@ mod tests {
                 "High relative standard error (RSE > 50%): TVCL (72%).",
                 Warning,
                 "inflated_rse",
+            ),
+            (
+                "Highly correlated parameter pair(s) (|r| >= 0.95): TVCL ~ TVV (0.98).",
+                Warning,
+                "high_correlation",
             ),
             (
                 "LTBS (log(DV) ~ ...): 3 observation(s) with non-positive DV",


### PR DESCRIPTION
## Why

The condition number is an *aggregate* collinearity measure — it tells you the covariance is ill-conditioned but not *which* parameters are the problem. High pairwise correlation names the specific culprits, which is what an agent (or a modeller) acts on: "CL and V are correlated 0.98 → the model is over-parameterized, drop one." ferx surfaced neither a warning nor the pairs. Add a `high_correlation` warning.

Sixth increment of #781 (kept open); the third warning on the native at-source path from #791.

## What changed

- **New `high_correlation` warning**: flags parameter pairs whose estimate correlation — computed from the parameter covariance matrix over its free (positive-variance) entries, in the optimizer's packed space — has `|r| >= 0.95` (`CORRELATION_WARN_THRESHOLD`).
- **Emitted typed at source** (reusing #791), with `details` = `{threshold, pairs: [{parameter_a, parameter_b, correlation}]}`. Appended *after* `FitResult` construction because the packed parameter labels come from the assembled result — reuses `output::packed_param_names` (now `pub(crate)`); `rebuild_warnings_structured` preserves the native entry by message.
- **`classify_warning` branch** (`"highly correlated"`) so string-only re-derivation (e.g. `.fitrx` reload) still yields the typed code.
- New `WarningCode::HighCorrelation` (token `high_correlation`).

## Alternatives considered

- **Fold into the existing `condition_number` warning** — rejected: condition number and pairwise correlation are complementary (aggregate vs specific). NONMEM users read both; an agent wants the named pairs.
- **Correlation in natural vs packed space** — used packed (the optimizer's estimate covariance), which is where the joint non-identifiability actually lives and where `condition_number` is already computed. Documented as such.
- **Threshold** — 0.95 is a common rule of thumb; a single `const` keeps it tunable.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Additive: new warning + `WarningCode` token (behind `#[non_exhaustive]`). ferx-r consumes JSON tokens, unaffected.

## Breaking changes
- [x] None (additive)

## Numerical validation
- [x] No estimate/OFV/covariance change — a threshold over the existing covariance matrix. Complements the already-validated `condition_number`/`cov_eigenvalues`. Verified end-to-end: warfarin (uncorrelated estimates) fires **no** `high_correlation` warning while the covariance is present (path runs).

## Performance
- [x] No significant impact (one O(k²) pass over free covariance entries per fit).

## Tests
- [x] `cargo test --lib` passes (full suite 2395 ok, 0 failed):
  - `high_correlation_pairs_flags_collinear_estimates`: a 0.99-correlated pair is flagged, a zero-variance parameter and a missing covariance are excluded.
  - `high_correlation_warning_emits_typed_entry_with_details`: an injected 0.98 correlation yields the warning with `details` and packed-name labels; a scaled-identity covariance yields none.
  - `warning_code_tokens_are_stable` + round-trip table cover the new token/message.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

`{model}-fit.json` (excerpt), CL/V collinear:
```json
{
  "severity": "Warning",
  "category": "high_correlation",
  "message": "Highly correlated parameter pair(s) (|r| >= 0.95): TVCL ~ TVV (0.98). ...",
  "source_method": null,
  "details": { "threshold": 0.95, "pairs": [ { "parameter_a": "TVCL", "parameter_b": "TVV", "correlation": 0.98 } ] }
}
```
</details>

## Docs
- [x] `docs/warnings.qmd` — codes table + details schema
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (changed code)
- [x] `cargo fmt --check` clean
- [x] Not on the `Dual2` sensitivity path

## Reviewer hints
- `high_correlation_pairs` mirrors the correlation computation already in `cov_diagnostics` (free = positive-diagonal entries), so it agrees with the condition-number diagnostic's view of the matrix.
- The warning is appended after construction and relies on `rebuild_warnings_structured` preferring native entries by message — the same mechanism proven in #791 — so it survives the entry-point rebuilds idempotently.

## Open questions
- Remaining #781: the upstream string→native migration (data-quality needs `Population.warnings_structured` plumbing; convergence; SIR; NCA/FREM). Worth continuing, or pause the epic here — the high-value api.rs-local diagnostics are now covered?
