### PR TITLE
fix(pk): flip-flop absorption guard completeness — EBE degeneration (#785) + uncertainty panic (#786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,8 +302,10 @@ section of the SDLC for the versioning policy).
   flip-flop regime** (#786). For a twin-less transit / IG closed form whose point
   estimate is in-domain, a sampled uncertainty draw that crossed the flip-flop
   boundary previously aborted the *entire* simulation via a panic. Such draws are
-  now skipped (recorded as a simulation warning) so the remaining draws still yield
-  results; the single-shot `predict()` / `simulate()` panic paths are unchanged.
+  now skipped so the remaining draws still yield results (the run no longer panics;
+  this aggregated-uncertainty entry point returns only the rows, so a skipped draw is
+  not surfaced as a warning — use `simulate_with_options` when a skip must be
+  visible). The single-shot `predict()` / `simulate()` panic paths are unchanged.
 - **A time-to-event hazard that references an inter-occasion (IOV) `kappa` by name
   is now rejected at parse instead of silently using zero** (#770). A hazard is
   evaluated once per subject with no occasion context, so an IOV `kappa` has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,23 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **A twin-less transit / inverse-Gaussian absorption fit no longer silently
+  degenerates a subject whose fitted random effects reach the flip-flop regime**
+  (#785). An analytic `one_cpt_transit`/`two_cpt_transit` (or `one_cpt_ig`/
+  `two_cpt_ig`) model carrying a `lagtime` / `f` / user-`[odes]` mapping declines the
+  ODE-twin desugar, and was only checked for the flip-flop regime at typical (η = 0)
+  values at fit start. A subject whose empirical-Bayes estimate drove `ke = CL/V`
+  past the tilting abscissa still hit the closed form's identically-zero profile,
+  silently collapsing that subject's likelihood contribution. The fit now emits a
+  typed `flip_flop` warning naming the affected subject(s) and pointing at the ODE
+  `transit()`/`igd()` forcing form (which reroutes per subject at the actual η). See
+  the [warnings documentation](https://ferx-nlme.github.io/ferx-core/warnings.html).
+- **`simulate_with_uncertainty` no longer panics when a parameter draw enters the
+  flip-flop regime** (#786). For a twin-less transit / IG closed form whose point
+  estimate is in-domain, a sampled uncertainty draw that crossed the flip-flop
+  boundary previously aborted the *entire* simulation via a panic. Such draws are
+  now skipped (recorded as a simulation warning) so the remaining draws still yield
+  results; the single-shot `predict()` / `simulate()` panic paths are unchanged.
 - **A time-to-event hazard that references an inter-occasion (IOV) `kappa` by name
   is now rejected at parse instead of silently using zero** (#770). A hazard is
   evaluated once per subject with no occasion context, so an IOV `kappa` has no

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -65,6 +65,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `cancelled` | Info | Run cancelled by the user. | None. |
 | `threads` | Info | Thread-count efficiency note. | Optionally tune `threads`. |
 | `simulation` | Warning | A simulated subject was handled specially — a degenerate hazard draw (censored, no event) or an over-large recurrent-event stream (skipped/truncated). Surfaced by `simulate_with_options_diag` and on `--simulate` runs (#762/#763). | Inspect the named subject's hazard parameters / covariate values; the estimated model is unaffected. |
+| `flip_flop` | Warning | A transit / inverse-Gaussian absorption closed form entered the flip-flop regime (disposition rate ≥ the tilting abscissa). Either auto-rerouted to the ODE twin (informational) or — for a twin-less model at a subject's fitted EBE (#785) — a silently degenerate likelihood contribution. | Rewrite as an explicit ODE `transit()`/`igd()` model (which reroutes per subject), or check the named subject's MTT/CL (transit) or MAT/CV²/CL (IG) estimates. |
 | `general` | Warning | Unrecognised message (fallback bucket). | Read the message text. |
 
 ## Details payloads {#details}
@@ -82,6 +83,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
 | `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
 | `high_correlation` | `threshold`, `pairs` (array of `{parameter_a, parameter_b, correlation}`) |
+| `flip_flop` | `phase` (`"ebe"`), `model`, `subjects` (array of affected subject IDs) |
 | `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -6610,13 +6610,15 @@ fn absorption_flip_flop_ebe_warning(
     };
     let id_list = crossers.join(", ");
     let msg = format!(
-        "{} subject(s) [{}] reach the flip-flop regime (disposition rate ≥ {}) at their \
-         fitted empirical-Bayes estimates, where the analytic absorption closed form returns an \
-         identically-zero concentration profile — silently degenerating those subjects' \
+        "{} subject(s) [{}] enter the analytic absorption closed form's clamp region — the \
+         flip-flop regime (disposition rate ≥ {}), or (for a 2-cpt model) coincident disposition \
+         eigenvalues — at their fitted empirical-Bayes estimates, where the closed form returns \
+         an identically-zero concentration profile, silently degenerating those subjects' \
          likelihood contributions. The typical-value (η = 0) parameters are in-domain, so this \
          is not caught at fit start, and this twin-less model (a `lagtime`, `f`, or user \
-         `[odes]` form) has no ODE twin to reroute to. Rewrite it as an explicit ODE `{}` model \
-         (which reroutes per-eval at the actual η), or check the {} starting estimates.",
+         `[odes]` / `[scaling]` / `[initial_conditions]` form) has no ODE twin to reroute to. \
+         Rewrite it as an explicit ODE `{}` model (which reroutes per-eval at the actual η), or \
+         check the {} starting estimates.",
         model.pk_model.canonical_name(),
         id_list,
         abscissa_label,
@@ -12819,6 +12821,12 @@ mod simulate_with_uncertainty_tests {
             !msg.contains("S1"),
             "must not name the in-domain subject: {msg}"
         );
+        // The real emitter's message must itself classify to `flip_flop` — pins the
+        // classify branch against wording drift (not a hand-copied proxy string).
+        assert_eq!(
+            crate::types::classify_warning(&msg).category,
+            crate::types::WarningCode::FlipFlop
+        );
         let details = entry.details.expect("native entry carries details");
         assert_eq!(details["phase"], "ebe");
         assert_eq!(details["subjects"], serde_json::json!(["S2"]));
@@ -12895,6 +12903,25 @@ mod simulate_with_uncertainty_tests {
         .is_none());
     }
 
+    /// #785: an EBE whose length ≠ `n_eta + n_kappa` is defensively skipped rather
+    /// than fed to `pk_params_at_time` (which would panic reading `eta[0]` of a
+    /// zero-length vector). Even a would-be crosser given the wrong shape yields no
+    /// warning — proving the guard, not a panic.
+    #[test]
+    fn flip_flop_ebe_warning_skips_wrong_length_eta() {
+        let model = parse_fixture(INDOMAIN_TWINLESS_TRANSIT_SRC);
+        let pop = tiny_population();
+        // S1 valid (in-domain, len 1); S2 has a zero-length eta (≠ n_eta = 1).
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[])];
+        assert!(absorption_flip_flop_ebe_warning(
+            &model,
+            &pop,
+            &model.default_params.theta,
+            &eta_hats
+        )
+        .is_none());
+    }
+
     /// #786: `simulate_with_uncertainty` on a twin-less transit model whose point
     /// estimate is in-domain but whose covariance spreads some draws into the
     /// flip-flop regime must NOT panic (pre-fix: the per-draw
@@ -12930,6 +12957,21 @@ mod simulate_with_uncertainty_tests {
             draws.len() < 30,
             "some flip-flop draws must be skipped (got {} of 30)",
             draws.len()
+        );
+
+        // The per-draw skip warning is pushed into `sim_warnings`, which this
+        // aggregated-uncertainty entry point discards (it returns only the row vec),
+        // so the message is not observable here. Pin the skip *predicate* directly:
+        // a flip-flop-theta draw is flagged, the in-domain point estimate is not.
+        let mut crossing = model.default_params.theta.clone();
+        crossing[0] = 1.0; // TVCL = 1.0 → ke = 1.0/4 = 0.25 ≥ KTR = 0.2 (flip-flop)
+        assert!(
+            check_absorption_flip_flop_no_twin(&model, &pop, &crossing).is_some(),
+            "a flip-flop-theta draw must be flagged for skipping"
+        );
+        assert!(
+            check_absorption_flip_flop_no_twin(&model, &pop, &model.default_params.theta).is_none(),
+            "the in-domain point estimate must not be flagged"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5351,6 +5351,15 @@ fn fit_inner(
         warnings.push(msg);
         native_warnings.push(entry);
     }
+    // Twin-less transit/IG absorption closed form whose fitted per-subject EBE crosses
+    // into the flip-flop regime — a silently degenerate subject the η = 0 fit-start
+    // reject could not catch (#785). Emitted typed at source.
+    if let Some((msg, entry)) =
+        absorption_flip_flop_ebe_warning(model, population, &result.params.theta, &result.eta_hats)
+    {
+        warnings.push(msg);
+        native_warnings.push(entry);
+    }
 
     let (iwres_lag1_r, dw_statistic) = iwres_autocorrelation(&subjects);
 
@@ -6537,6 +6546,92 @@ fn high_correlation_warning(result: &FitResult) -> Option<(String, WarningEntry)
         details: Some(serde_json::json!({
             "threshold": CORRELATION_WARN_THRESHOLD,
             "pairs": pairs_json,
+        })),
+    };
+    Some((msg, entry))
+}
+
+/// Build the human message + native structured entry for a **twin-less** transit /
+/// IG absorption closed form whose *fitted* per-subject EBE crosses into the
+/// flip-flop regime, or `None`.
+///
+/// The up-front [`check_absorption_flip_flop_no_twin`] reject only samples η = 0
+/// typical values. The flip-flop boundary is parameter-dependent, so a subject
+/// whose empirical-Bayes CL/V (or MTT/N, MAT/CV²) drives `ke` past the tilting
+/// abscissa passes that check but still hits the closed form's clamp — an
+/// identically-zero profile that silently degenerates *that subject's* likelihood
+/// contribution (#785). A twin-*carrying* model reroutes such subjects to the ODE
+/// twin per-eval (correct), so this fires only when there is no twin (a `lagtime` /
+/// `f` / user-`[odes]` form declined the desugar).
+///
+/// Runs at fit end, once the EBEs are known, and *warns* rather than erroring — the
+/// fit already completed — pointing at the ODE `transit()`/`igd()` forcing form,
+/// which reroutes per-eval at the actual η.
+fn absorption_flip_flop_ebe_warning(
+    model: &CompiledModel,
+    population: &Population,
+    theta: &[f64],
+    eta_hats: &[DVector<f64>],
+) -> Option<(String, WarningEntry)> {
+    // Only a twin-less transit/IG closed form can degenerate this way: a twin-carrying
+    // model reroutes per-eval, a non-absorption model has no flip-flop regime.
+    if !matches!(
+        model.pk_model,
+        PkModel::OneCptTransit | PkModel::TwoCptTransit | PkModel::OneCptIg | PkModel::TwoCptIg
+    ) || model.absorption_ode_equivalent.is_some()
+    {
+        return None;
+    }
+    // Twin-less transit/IG closed forms reject IOV up front, so `eta_hats` carry exactly
+    // the `n_eta` BSV etas (`n_kappa == 0`). Guard the length so an unexpected shape
+    // skips the subject rather than panicking inside `pk_params_at_time`.
+    let expected = model.n_eta + model.n_kappa;
+    let crossers: Vec<String> = population
+        .subjects
+        .iter()
+        .zip(eta_hats)
+        .filter(|(subject, eta)| {
+            eta.len() == expected
+                && crate::pk::absorption_flip_flop_at(model, subject, theta, eta.as_slice())
+        })
+        .map(|(subject, _)| subject.id.clone())
+        .collect();
+    if crossers.is_empty() {
+        return None;
+    }
+    let is_transit = matches!(
+        model.pk_model,
+        PkModel::OneCptTransit | PkModel::TwoCptTransit
+    );
+    let (abscissa_label, ode_fn, params) = if is_transit {
+        ("transit rate KTR = (n+1)/mtt", "transit()", "MTT / CL")
+    } else {
+        ("IG abscissa 1/(2·MAT·CV²)", "igd()", "MAT / CV² / CL")
+    };
+    let id_list = crossers.join(", ");
+    let msg = format!(
+        "{} subject(s) [{}] reach the flip-flop regime (disposition rate ≥ {}) at their \
+         fitted empirical-Bayes estimates, where the analytic absorption closed form returns an \
+         identically-zero concentration profile — silently degenerating those subjects' \
+         likelihood contributions. The typical-value (η = 0) parameters are in-domain, so this \
+         is not caught at fit start, and this twin-less model (a `lagtime`, `f`, or user \
+         `[odes]` form) has no ODE twin to reroute to. Rewrite it as an explicit ODE `{}` model \
+         (which reroutes per-eval at the actual η), or check the {} starting estimates.",
+        model.pk_model.canonical_name(),
+        id_list,
+        abscissa_label,
+        ode_fn,
+        params
+    );
+    let entry = WarningEntry {
+        severity: WarningSeverity::Warning,
+        category: WarningCode::FlipFlop,
+        message: msg.clone(),
+        source_method: None,
+        details: Some(serde_json::json!({
+            "phase": "ebe",
+            "model": model.pk_model.canonical_name(),
+            "subjects": crossers,
         })),
     };
     Some((msg, entry))
@@ -9305,6 +9400,18 @@ pub fn simulate_with_uncertainty(
     // applies. Use `simulate_with_options` when the warnings matter.
     let mut sim_warnings: Vec<String> = Vec::new();
     for (k, params) in draws.iter().enumerate() {
+        // A parameter draw can land in the flip-flop regime even when the point
+        // estimate is in-domain. For a twin-less transit/IG closed form,
+        // `simulate_inner_with_draw`'s `assert_absorption_flip_flop_no_twin` would then
+        // panic — aborting the *entire* uncertainty run. Skip such a draw with a
+        // recorded warning instead, so the remaining draws still yield results (#786).
+        // The single-shot `predict()`/`simulate()` paths keep the panic (their
+        // Vec-returning contract). Twin-carrying models return `None` here and proceed
+        // (they reroute per-eval), so this only skips genuinely un-simulatable draws.
+        if let Some(msg) = check_absorption_flip_flop_no_twin(model, population, &params.theta) {
+            sim_warnings.push(format!("uncertainty draw {} skipped — {}", k + 1, msg));
+            continue;
+        }
         let mut rows = simulate_inner_with_draw(
             model,
             population,
@@ -12594,6 +12701,236 @@ mod simulate_with_uncertainty_tests {
             covariate_table: None,
             exclusions: None,
         }
+    }
+
+    // ── #785 / #786 flip-flop follow-up fixtures & tests ─────────────────────────
+    // A twin-*less* (a `lagtime=` mapping declines the ODE-twin desugar) transit /
+    // IG closed form whose *typical* parameters are IN-DOMAIN (`ke = CL/V` below the
+    // tilting abscissa) — so it passes the η=0 fit-start reject — but which a large
+    // positive `ETA_CL` drives into the flip-flop regime. ke0 = 0.5/4 = 0.125 < KTR =
+    // (3+1)/20 = 0.2.
+    const INDOMAIN_TWINLESS_TRANSIT_SRC: &str = "\
+[parameters]
+  theta TVCL(0.5, 0.001, 50.0)
+  theta TVV(4.0, 0.1, 500.0)
+  theta TVNTR(3.0, 0.0, 20.0)
+  theta TVMTT(20.0, 0.05, 200.0)
+  theta TVLAG(0.3, 0.0, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  NTR = TVNTR
+  MTT = TVMTT
+  LAGTIME = TVLAG
+
+[structural_model]
+  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime=LAGTIME)
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+    // IG analogue: ke0 = 5/50 = 0.1 < 1/(2·MAT·CV²) = 1/(2·2·0.3) = 0.833 (in-domain);
+    // the `lagtime=` mapping declines the twin.
+    const INDOMAIN_TWINLESS_IG_SRC: &str = "\
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVMAT(2.0, 0.05, 24.0)
+  theta TVCV2(0.3, 0.001, 10.0)
+  theta TVLAG(0.2, 0.0, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.15 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  MAT = TVMAT
+  CV2 = TVCV2
+  LAGTIME = TVLAG
+
+[structural_model]
+  pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2, lagtime=LAGTIME)
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+    // Plain transit — no lagtime, so the ODE-twin desugar succeeds (twin-*carrying*):
+    // a flip-flop subject reroutes per-eval, so the EBE warning must NOT fire.
+    const PLAIN_TWIN_TRANSIT_SRC: &str = "\
+[parameters]
+  theta TVCL(0.5, 0.001, 50.0)
+  theta TVV(4.0, 0.1, 500.0)
+  theta TVNTR(3.0, 0.0, 20.0)
+  theta TVMTT(20.0, 0.05, 200.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  NTR = TVNTR
+  MTT = TVMTT
+
+[structural_model]
+  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+    fn parse_fixture(src: &str) -> CompiledModel {
+        crate::parser::model_parser::parse_full_model(src)
+            .expect("fixture model parses")
+            .model
+    }
+
+    fn eta_vec(values: &[f64]) -> nalgebra::DVector<f64> {
+        nalgebra::DVector::from_column_slice(values)
+    }
+
+    /// #785: a twin-less transit closed form in-domain at η=0 but whose second
+    /// subject's fitted EBE (`ETA_CL = 0.6` → CL/V = 0.911/4 = 0.228 ≥ KTR = 0.2)
+    /// crosses the flip-flop boundary must surface a typed `FlipFlop` warning naming
+    /// that subject — the silent-degeneration case the η=0 reject cannot catch.
+    #[test]
+    fn flip_flop_ebe_warning_fires_for_twinless_transit_crosser() {
+        let model = parse_fixture(INDOMAIN_TWINLESS_TRANSIT_SRC);
+        assert!(
+            model.absorption_ode_equivalent.is_none(),
+            "a lagtime= transit model is twin-less"
+        );
+        let pop = tiny_population();
+        // Subject S1 in-domain (η=0), subject S2 crosses.
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[0.6])];
+        let (msg, entry) =
+            absorption_flip_flop_ebe_warning(&model, &pop, &model.default_params.theta, &eta_hats)
+                .expect("a crossing EBE must warn");
+        assert_eq!(entry.category, crate::types::WarningCode::FlipFlop);
+        assert_eq!(entry.message, msg);
+        assert!(msg.contains("flip-flop regime"), "wording: {msg}");
+        assert!(msg.contains("transit()"), "transit ODE hint: {msg}");
+        assert!(msg.contains("S2"), "must name the crossing subject: {msg}");
+        assert!(
+            !msg.contains("S1"),
+            "must not name the in-domain subject: {msg}"
+        );
+        let details = entry.details.expect("native entry carries details");
+        assert_eq!(details["phase"], "ebe");
+        assert_eq!(details["subjects"], serde_json::json!(["S2"]));
+    }
+
+    /// #785: the IG closed form takes the same path, with IG-specific wording.
+    /// ke crosses when CL/V ≥ 1/(2·MAT·CV²) = 0.833; `ETA_CL = 2.3` → CL/V ≈ 0.998.
+    #[test]
+    fn flip_flop_ebe_warning_fires_for_twinless_ig_crosser() {
+        let model = parse_fixture(INDOMAIN_TWINLESS_IG_SRC);
+        assert!(model.absorption_ode_equivalent.is_none());
+        let pop = tiny_population();
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[2.3])];
+        let (msg, entry) =
+            absorption_flip_flop_ebe_warning(&model, &pop, &model.default_params.theta, &eta_hats)
+                .expect("a crossing IG EBE must warn");
+        assert_eq!(entry.category, crate::types::WarningCode::FlipFlop);
+        assert!(msg.contains("igd()"), "IG ODE hint: {msg}");
+        assert!(msg.contains("S2"), "must name the crossing subject: {msg}");
+    }
+
+    /// #785: every subject in-domain at its EBE → no warning.
+    #[test]
+    fn flip_flop_ebe_warning_silent_when_all_in_domain() {
+        let model = parse_fixture(INDOMAIN_TWINLESS_TRANSIT_SRC);
+        let pop = tiny_population();
+        // CL/V = 0.5·e^{0.1}/4 = 0.138 < 0.2 for both.
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[0.1])];
+        assert!(absorption_flip_flop_ebe_warning(
+            &model,
+            &pop,
+            &model.default_params.theta,
+            &eta_hats
+        )
+        .is_none());
+    }
+
+    /// #785: a twin-*carrying* model reroutes per-eval, so even a crossing EBE must
+    /// not warn (the fit is correct for it).
+    #[test]
+    fn flip_flop_ebe_warning_silent_for_twin_carrying() {
+        let model = parse_fixture(PLAIN_TWIN_TRANSIT_SRC);
+        assert!(
+            model.absorption_ode_equivalent.is_some(),
+            "a plain transit model carries an ODE twin"
+        );
+        let pop = tiny_population();
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[0.6])];
+        assert!(absorption_flip_flop_ebe_warning(
+            &model,
+            &pop,
+            &model.default_params.theta,
+            &eta_hats
+        )
+        .is_none());
+    }
+
+    /// #785: a non-absorption model has no flip-flop regime → no warning.
+    #[test]
+    fn flip_flop_ebe_warning_silent_for_non_absorption() {
+        let model = tiny_model();
+        assert!(!matches!(
+            model.pk_model,
+            PkModel::OneCptTransit | PkModel::TwoCptTransit | PkModel::OneCptIg | PkModel::TwoCptIg
+        ));
+        let pop = tiny_population();
+        let eta_hats = [eta_vec(&[0.0]), eta_vec(&[3.0])];
+        assert!(absorption_flip_flop_ebe_warning(
+            &model,
+            &pop,
+            &model.default_params.theta,
+            &eta_hats
+        )
+        .is_none());
+    }
+
+    /// #786: `simulate_with_uncertainty` on a twin-less transit model whose point
+    /// estimate is in-domain but whose covariance spreads some draws into the
+    /// flip-flop regime must NOT panic (pre-fix: the per-draw
+    /// `assert_absorption_flip_flop_no_twin` aborted the whole run). The crossing
+    /// draws are skipped; the rest still yield rows.
+    #[test]
+    fn uncertainty_skips_flip_flop_draws_without_panicking() {
+        let model = parse_fixture(INDOMAIN_TWINLESS_TRANSIT_SRC);
+        let pop = tiny_population();
+        let mut fit = synthetic_fit(&model.default_params);
+        // Inflate the log-TVCL variance (packed index 0) so a good fraction of draws
+        // push ke = CL/V past KTR = 0.2 (needs TVCL ≥ 0.8, a +0.47 log-shift).
+        if let Some(cov) = fit.covariance_matrix.as_mut() {
+            cov[(0, 0)] = 4.0;
+        }
+        let opts = SimulateUncertaintyOptions {
+            n_uncertainty_draws: 30,
+            n_sim_per_draw: 1,
+            method: UncertaintyMethod::Asymptotic,
+            seed: Some(7),
+        };
+        // Must return Ok rather than panicking (the #786 regression).
+        let rows = simulate_with_uncertainty(&model, &pop, &fit, &opts)
+            .expect("flip-flop draws must be skipped, not panic the run");
+        assert!(
+            !rows.is_empty(),
+            "surviving in-domain draws must still yield rows"
+        );
+        let mut draws: Vec<usize> = rows.iter().map(|r| r.draw).collect();
+        draws.sort();
+        draws.dedup();
+        assert!(
+            draws.len() < 30,
+            "some flip-flop draws must be skipped (got {} of 30)",
+            draws.len()
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -6691,18 +6691,21 @@ mod tests {
     fn classify_warning_flip_flop_beats_optimizer_health() {
         // Both absorption flip-flop warnings — the twin-carrying heads-up (#776) and
         // the twin-less EBE warning (#785) — say "flip-flop regime". The EBE message
-        // also contains "degenerate", which the generic optimizer-health branch keys
-        // on, so the flip-flop branch must precede it to type these `flip_flop`.
+        // also contains "degenerating", which the generic optimizer-health branch keys
+        // on ("degenerate"), so the flip-flop branch must precede it to type these
+        // `flip_flop`. These are representative proxies of the real emitters
+        // (src/api.rs ~2596 and ~6613); the drift-proof end-to-end check on the actual
+        // emitted string lives in `flip_flop_ebe_warning_fires_for_twinless_transit_crosser`.
         for msg in [
             "one_cpt_transit disposition rate (0.5000) ≥ transit rate KTR = (n+1)/mtt \
              (0.2000) at typical values (subject 3): the flip-flop regime, outside the \
              analytic absorption closed form's convergence domain. ferx automatically \
              evaluates the equivalent ODE transit model for such parameters.",
-            "one_cpt_transit subject(s) [3] reach the flip-flop regime (disposition rate \
-             ≥ transit rate KTR = (n+1)/mtt) at their fitted empirical-Bayes estimates, \
-             where the analytic absorption closed form returns an identically-zero \
-             concentration profile — silently degenerating those subjects' likelihood \
-             contributions.",
+            "one_cpt_transit subject(s) [3] enter the analytic absorption closed form's \
+             clamp region — the flip-flop regime (disposition rate ≥ transit rate KTR = \
+             (n+1)/mtt), or (for a 2-cpt model) coincident disposition eigenvalues — at \
+             their fitted empirical-Bayes estimates, silently degenerating those \
+             subjects' likelihood contributions.",
         ] {
             let w = classify_warning(msg);
             assert_eq!(w.category, WarningCode::FlipFlop, "misclassified: {msg:?}");

--- a/src/types.rs
+++ b/src/types.rs
@@ -4040,6 +4040,13 @@ pub enum WarningCode {
     /// `--simulate` run (#762, #763). Distinct from the fit-time optimizer/data codes:
     /// it flags a pathological simulated subject, not an estimation problem.
     Simulation,
+    /// A transit / inverse-Gaussian absorption closed form entered the flip-flop
+    /// regime (disposition rate ≥ the tilting abscissa), where it returns an
+    /// identically-zero profile. Either auto-rerouted to the ODE twin (an
+    /// informational heads-up, #776) or — for a twin-less model at a subject's
+    /// fitted EBE — a silently degenerate likelihood contribution the η = 0
+    /// fit-start reject could not catch (#785).
+    FlipFlop,
     /// Unrecognised message — fallback bucket.
     General,
 }
@@ -4075,6 +4082,7 @@ impl WarningCode {
             WarningCode::Cancelled => "cancelled",
             WarningCode::Threads => "threads",
             WarningCode::Simulation => "simulation",
+            WarningCode::FlipFlop => "flip_flop",
             WarningCode::General => "general",
         }
     }
@@ -4174,6 +4182,12 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // otherwise match — these flag a pathological *simulated subject*, not an
         // estimation/optimizer problem.
         (WarningSeverity::Warning, WarningCode::Simulation)
+    } else if lower.contains("flip-flop regime") {
+        // Transit / IG absorption closed form in the flip-flop regime (#776/#785):
+        // auto-rerouted to the ODE twin (informational) or, twin-less at a fitted
+        // EBE, a silently degenerate subject. Precedes the generic "degenerate"
+        // branch so a flip-flop message never misroutes to optimizer-health.
+        (WarningSeverity::Warning, WarningCode::FlipFlop)
     } else if lower.contains("trust radius") || lower.contains("degenerate") {
         (WarningSeverity::Warning, WarningCode::OptimizerHealth)
     } else if lower.contains("autocorrelation") || lower.contains("durbin") {
@@ -6668,6 +6682,31 @@ mod tests {
         ] {
             let w = classify_warning(msg);
             assert_eq!(w.category.as_str(), "simulation", "misclassified: {msg:?}");
+            assert_eq!(w.severity, WarningSeverity::Warning);
+            assert_ne!(w.category, WarningCode::OptimizerHealth);
+        }
+    }
+
+    #[test]
+    fn classify_warning_flip_flop_beats_optimizer_health() {
+        // Both absorption flip-flop warnings — the twin-carrying heads-up (#776) and
+        // the twin-less EBE warning (#785) — say "flip-flop regime". The EBE message
+        // also contains "degenerate", which the generic optimizer-health branch keys
+        // on, so the flip-flop branch must precede it to type these `flip_flop`.
+        for msg in [
+            "one_cpt_transit disposition rate (0.5000) ≥ transit rate KTR = (n+1)/mtt \
+             (0.2000) at typical values (subject 3): the flip-flop regime, outside the \
+             analytic absorption closed form's convergence domain. ferx automatically \
+             evaluates the equivalent ODE transit model for such parameters.",
+            "one_cpt_transit subject(s) [3] reach the flip-flop regime (disposition rate \
+             ≥ transit rate KTR = (n+1)/mtt) at their fitted empirical-Bayes estimates, \
+             where the analytic absorption closed form returns an identically-zero \
+             concentration profile — silently degenerating those subjects' likelihood \
+             contributions.",
+        ] {
+            let w = classify_warning(msg);
+            assert_eq!(w.category, WarningCode::FlipFlop, "misclassified: {msg:?}");
+            assert_eq!(w.category.as_str(), "flip_flop");
             assert_eq!(w.severity, WarningSeverity::Warning);
             assert_ne!(w.category, WarningCode::OptimizerHealth);
         }


### PR DESCRIPTION
Closes #785. Closes #786.

## Why

Two follow-ups to the Phase-3 flip-flop→ODE-twin reroute (#733/#776), which #790 generalized from transit to transit **and** inverse-Gaussian (IG) absorption. Both are gaps in the twin-less flip-flop guard, which only samples one parameter point:

- **#785** — a twin-less transit/IG closed form (a `lagtime` / `f` / user-`[odes]` form that declines the ODE-twin desugar) is checked for the flip-flop regime only at typical (η = 0) values at fit start. A subject whose fitted empirical-Bayes estimate drives `ke = CL/V` past the tilting abscissa still hit the closed form's identically-zero profile, **silently degenerating that subject's likelihood contribution** — the exact class #588/#699/#776 set out to make loud.
- **#786** — `simulate_with_uncertainty` **panicked, aborting the entire run**, when a sampled parameter draw crossed the flip-flop boundary even though the point estimate was in-domain.

## What changed

- **#785 (fit-end EBE check).** New `absorption_flip_flop_ebe_warning` (mirrors the #781 native at-source emitters like `inflated_rse`/`high_correlation`): after convergence, for a twin-less transit/IG closed form, it evaluates `pk::absorption_flip_flop_at` at each subject's **final EBE** and, if any crossed, emits a typed `flip_flop` warning naming the subject(s) and pointing at the ODE `transit()`/`igd()` forcing form (which reroutes per-subject at the actual η). Wired into the fit-end native-warning block. New `WarningCode::FlipFlop` + a `classify_warning` branch (which also upgrades the existing twin-carrying heads-up from `general` → `flip_flop`).
- **#786 (skip, don't panic).** `simulate_with_uncertainty`'s per-draw loop now pre-checks each draw with the `Option`-returning `check_absorption_flip_flop_no_twin` and skips + records a crossing draw (into the existing `sim_warnings` buffer), so the remaining draws still yield results. The panicking `assert_*` on the single-shot `predict()` / `simulate()` / `simulate_inner_with_draw` paths is left unchanged (their Vec-returning contract).

Both fixes are written against the generalized `absorption_*` machinery, so they cover transit **and** IG.

## Alternatives considered

- **#785 per-eval reject** (inside `effective_model_for_eval`): rejected — that returns `&CompiledModel`, not a `Result`, so it can't signal on the hot path; a fit-end pass over the already-computed EBEs is cheaper and non-intrusive.
- **#786 whole-sim `Err`**: rejected in favour of skip-and-continue (the issue's preferred option), matching the #762/#763 per-subject "run continues, degenerate cases named" precedent on this exact path.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API signature change (a new warning + a non-panic); ferx-r needs no bump.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable — pure diagnostics / robustness. #785 adds a warning; #786 prevents a panic. Neither changes any estimate, OFV, residual, or prediction, so there is no NONMEM-anchorable numeric output. (`transit`/`ig` numeric behaviour is unchanged and still covered by `tests/{transit,ig}_analytic_equivalence.rs`.)

## Performance
- [x] No significant impact expected — the #785 helper early-returns for any non-twin-less-absorption model (the common case) before touching subjects; the #786 per-draw check is one `CL/V` comparison per subject per draw.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

New tests (in `api.rs` / `types.rs`):
- `flip_flop_ebe_warning_fires_for_twinless_transit_crosser` / `..._ig_crosser` — a crossing EBE surfaces a typed `flip_flop` warning naming the subject; the transit test also feeds the **real emitted message** through `classify_warning` and asserts `FlipFlop` (drift-proof, not a proxy).
- `flip_flop_ebe_warning_silent_when_all_in_domain` / `..._for_twin_carrying` / `..._for_non_absorption` — the three silence cases.
- `flip_flop_ebe_warning_skips_wrong_length_eta` — the defensive `eta.len() != n_eta + n_kappa` guard (a zero-length eta is skipped, not panicked on).
- `uncertainty_skips_flip_flop_draws_without_panicking` — #786 regression (pre-fix: panic; post-fix: `Ok`, surviving draws present, some draws skipped) — also pins the skip *predicate* (`check_absorption_flip_flop_no_twin` `Some` for a flip-flop θ, `None` for the in-domain point estimate).
- `classify_warning_flip_flop_beats_optimizer_health` — the `flip-flop regime` branch precedes the generic `degenerate` branch.

**Adversarial review**: three independent fresh-context reviewers (correctness, semantics/docs, tests) audited this diff; correctness found no High/Medium defects (verified: `n_kappa==0` guaranteed upstream, `eta_hats` is subject-aligned & final, the #786 pre-check matches the panic exactly, classify ordering is sound). Their message-accuracy and test-hardening findings are folded in above and in the message reword below.

## Example (user-facing features only)
- [x] Not applicable — no new API surface (a new warning code + a non-panic).

## Docs
- [x] `docs/warnings.qmd` updated — new `flip_flop` row in the codes and details-payload tables.
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entries for #785 and #786.
- [x] No new pages (no `_quarto.yml` change).

## Checklist
- [x] `cargo clippy` clean (no new warnings in `api.rs` / `types.rs`)
- [x] `Dual2` sensitivity path untouched (this is diagnostics / control-flow only)
- [x] No version bump (non-breaking)

## Reviewer hints

- **Scope is deliberately twin-*less* only.** `absorption_flip_flop_ebe_warning` and the #786 pre-check both return `None` for a twin-*carrying* model — those reroute per-eval and are already correct. Confirm the `absorption_ode_equivalent.is_some()` guard in both.
- **`classify_warning` ordering**: the `flip-flop regime` branch is placed *before* the generic `trust radius || degenerate` branch, because the #785 message also contains "degenerate" (`classify_warning_flip_flop_beats_optimizer_health` pins this).
- **#785 is emitted natively** (`WarningCode::FlipFlop` + `details`), so `rebuild_warnings_structured` keeps it verbatim; the `classify_warning` branch exists for the twin-carrying heads-up (string path) and for robustness.
- **Coverage note**: the fit-end wiring (`warnings.push` / `native_warnings.push`) is exercised by pattern (identical to `inflated_rse`); a deterministic fit-level test is impractical because the inner optimizer actively avoids the degenerate (clamped-to-zero) region, so the helper is unit-tested directly with constructed EBEs instead.

## Open questions

- **#786 warning surfacing**: skipped draws are recorded into `sim_warnings`, which `simulate_with_uncertainty` currently *discards* (a pre-existing, documented limitation of that Vec-returning path — `simulate_with_options_diag` is the surfacing entry point). Surfacing them on the uncertainty path (an additive `_diag` variant, per #762/#763) is out of scope here — flag if you'd want it folded in.
