### PR TITLE
fix(sim): run shared dose-precondition guards on the adaptive path [closes #721]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,15 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **Adaptive/feedback dosing now runs the same dose-precondition guards as the
+  static paths, instead of silently mis-delivering a dose** (#721). The reactive
+  entry points (`simulate_adaptive()` / `simulate_adaptive_from_spec()`) skipped the
+  modeled-`RATE` (#324), analytic-absorption closed-form, and built-in-absorption
+  (#588) checks that `simulate()` / `predict()` / `fit()` all run before integrating,
+  so a feedback-dosed model with malformed built-in-absorption pathway fractions or an
+  out-of-domain absorption parameter simulated with a silently wrong absorbed dose.
+  The guards now run at the adaptive chokepoint and fail with the same typed error
+  before any decision is taken.
 - **A twin-less transit / inverse-Gaussian absorption fit no longer silently
   degenerates a subject whose fitted random effects reach the flip-flop regime**
   (#785). An analytic `one_cpt_transit`/`two_cpt_transit` (or `one_cpt_ig`/

--- a/src/api.rs
+++ b/src/api.rs
@@ -8576,6 +8576,27 @@ where
     // wrong answer (#391). Both public entry points funnel through here.
     reject_unsupported_adaptive(model, population)?;
 
+    // #721: the reactive path skipped the shared dose-precondition guards that
+    // `simulate()` / `predict()` / `fit()` all run before integrating — modeled `RATE`
+    // (#324), analytic-absorption closed-form model/data compatibility, and built-in
+    // absorption input-rate pathway fractions / SS / infusion / domain (#588). Without
+    // them a feedback-dosed model with, e.g., malformed absorption fractions, an
+    // out-of-domain absorption parameter, or (once base regimens are supported, #702) a
+    // modeled `RATE` would silently mis-deliver the dose — the exact class #588 closed
+    // for the static paths. Surface them as a typed error (the `check_*` form `fit()`
+    // uses, and the form `reject_unsupported_adaptive` just above already uses) rather
+    // than the panic `simulate()` / `predict()` raise via `assert_*`: this
+    // `Result`-returning chokepoint — and its ferx-r FFI surface — then fails with one
+    // uniform, recoverable error contract instead of aborting the process.
+    // (`check_absorption_closed_form_support` is a no-op here — it returns `None` unless
+    // the model is an analytic absorption closed form, which this ODE-only path rejects
+    // up front — but is wired for parity and #702 base-regimen support.)
+    first_error(&check_modeled_dose_rates(model, population))?;
+    if let Some(msg) = check_absorption_closed_form_support(model, population) {
+        return Err(msg);
+    }
+    first_error(&check_absorption_dosing(model, population))?;
+
     // The occasion bookkeeping assumes a strictly-increasing decision schedule:
     // `occasion_of` (per-decision-window κ selection) scans ascending and stops at the
     // first later time, and `decision_index_of` keys windows by exact time bits. An
@@ -16594,6 +16615,70 @@ mod adaptive_sim_tests {
             err.to_lowercase().contains("auc_target")
                 && err.to_lowercase().contains("time-varying"),
             "error should cite auc_target + time-varying: {err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_rejects_malformed_absorption_fractions() {
+        // #721: `run_adaptive_population` now runs the same built-in-absorption
+        // dose-precondition guard (#588) that `simulate()` / `predict()` / `fit()`
+        // enforce. This parallel-first-order model's pathway fractions sum to 1.2
+        // (FR1 = FR2 = 0.6), not 1 — the input rate would deliver 1.2× the dose. The
+        // fraction check evaluates typical parameters (η = 0) with no dose, so it fires
+        // on the dose-free adaptive base at the chokepoint, before any decision — the
+        // same typed error the static paths raise, instead of a silent 1.2× run.
+        const SPEC: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV  * exp(ETA_V)
+  FR1 = TVFR1
+  FR2 = TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[adaptive_dosing]
+  observe = central
+  at = [0, 24, 48]
+  start_dose = 100
+  route = bolus(cmt=1)
+  dose_bounds = [0, 1000]
+  when signal < 5 : increase 25%
+"#;
+        let parsed = parse_full_model(SPEC).expect("malformed-fraction model still parses");
+        let spec = parsed.adaptive_dosing.as_ref().expect("[adaptive_dosing]");
+        let pop = population(vec![subj("1", vec![0.0, 24.0, 48.0], vec![])]);
+        let opts = AdaptiveSimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        };
+        let err = simulate_adaptive_from_spec(
+            &parsed.model,
+            &pop,
+            &parsed.model.default_params,
+            1,
+            spec,
+            &opts,
+        )
+        .expect_err("malformed absorption fractions must be rejected on the adaptive path");
+        assert!(
+            err.to_lowercase().contains("fraction"),
+            "expected an absorption-fraction error, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Why
The two adaptive/feedback-dosing entry points — `simulate_adaptive()` and
`simulate_adaptive_from_spec()`, both funnelling through `run_adaptive_population`
— skipped the three shared **dose-precondition guards** that every static entry
point (`simulate()`, `simulate_inner_with_draw()`, `predict()`, `fit()`) runs
before integrating:

- `check_modeled_dose_rates` — modeled `RATE` (#324)
- `check_absorption_closed_form_support` — analytic-absorption (transit / IG)
  closed-form model/data compatibility
- `check_absorption_dosing` — built-in-absorption input-rate pathway fractions in
  `(0,1]` / Σ≈1, plus SS / infusion / `[diffusion]` / parameter-domain (#588)

(The static paths' guard set has since grown to also include
`assert_absorption_flip_flop_no_twin` and the survival-gated
`assert_survival_tv_covariates`; both are no-ops on the ODE-only adaptive path —
the former gates on an analytic closed-form `pk_model`, which adaptive rejects up
front. Mirroring the three above matches this issue's scope; the extras are a
trivial follow-up if full parity is wanted.)

So a feedback-dosed model with malformed absorption pathway fractions or an
out-of-domain absorption parameter simulated with a **silently wrong absorbed
dose** — the exact class #588 closed for the static paths. This is the fifth
silent-input class in the #699 family (the loud-fail step that precedes real
support). Tracked under #391.

## What changed
Call the three guards at the `run_adaptive_population` chokepoint, right after the
existing `reject_unsupported_adaptive` guard, as **typed `Err`** (the `check_*`
form `fit()` uses), not the panic `simulate()` / `predict()` raise via `assert_*`.

Rationale for typed `Err` over mirroring the static panic: `run_adaptive_population`
is `Result`-returning and its first line is already a typed-`Err` guard
(`reject_unsupported_adaptive`) for the same category of problem, so panicking
beside it would be two failure modes for "this model can't be adaptively dosed."
The deciding trait is the error-handling shape of *this* function, which matches
`fit()` (also `Result`-returning → `check_*` → `Err`), not `simulate()`/`predict()`.
A typed `Err` is also recoverable across the ferx-r FFI (the declarative block's R
surface) rather than aborting the process. No guard's behaviour changes on any
other path — this selects the already-existing `Err`-returning member of each
pair.

**Live effect today:** the built-in-absorption model-level checks (#588 fractions
/ domain) fire on the dose-free adaptive base. The data-level dose checks (SS /
infusion / modeled `RATE`) are no-ops on today's dose-free base and pre-position
for #702's pre-scheduled base regimens. `check_absorption_closed_form_support` is a guaranteed
no-op (it returns `None` unless `pk_model` is an *analytical* transit closed form,
which the adaptive path rejects up front for being non-ODE) — wired for parity and
future-proofing, and it cannot falsely reject a valid ODE adaptive run.

## Alternatives considered
Mirror the static paths' `assert_*` panic. Rejected — see rationale above (forks
the failure mode on the one `Result`-returning path whose sibling is `fit()`, and
panics across the R FFI).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API signature changes (existing `pub` entry points, existing guard
functions); the new behaviour is a typed error for previously-malformed input.

## Breaking changes
- [x] None

A model that previously ran with a silently-wrong absorbed dose now returns a
typed error; valid adaptive runs are unaffected.

## Numerical validation
- [x] Not applicable (loud-fail guard; no numerical results change for valid input)

Per CLAUDE.md, adaptive dosing is validated in-house (no NONMEM). The guard
produces the **same typed error the static paths already raise** for the same
malformed model.

## Performance
- [x] No significant impact expected — three O(doses)/O(states) scans once per
  adaptive call, before the integration loop.

## Tests
- [x] Regression test added that fails without this fix
  (`adaptive_rejects_malformed_absorption_fractions`): a parallel-first-order model
  whose fractions sum to 1.2 is now rejected at the adaptive chokepoint with the
  same absorption-fraction error the static paths raise.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible DSL / option change (a new rejection message only)

## Reviewer hints
The change is the three `check_*` calls at the chokepoint. The one place to
scrutinise is false rejection of a *valid* adaptive run: `check_absorption_dosing`
returns empty for non-absorption models and for valid fractions/domain;
`check_absorption_closed_form_support` returns `None` for any non-analytical-transit `pk_model`
(the adaptive path is ODE-only); `check_modeled_dose_rates` scans doses and the
adaptive base is dose-free. No existing adaptive test uses a built-in-absorption
input-rate model, so none is affected.

## Open questions
None.
