### PR TITLE
feat(estimation): left-truncation (delayed entry) for clock-reset RTTE [closes #740]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Left truncation (delayed entry) for clock-reset RTTE** (#740): repeated
+  time-to-event models with `clock = reset` now accept a `TENTRY > 0` entry time
+  instead of rejecting it. The first inter-event sojourn is conditioned on survival
+  to entry in absolute time (`H(t₁) − H(TENTRY)`), then the renewal clock takes over
+  for later gaps — the same delayed-entry convention already used for single-event
+  and clock-forward RTTE, so `TENTRY` means one thing across every survival endpoint
+  (condition on survival past entry, never restart the clock at entry). Assumes the
+  time origin `t = 0` is the renewal origin of the first sojourn; coincides with the
+  pure renewal form (and with clock-forward) for a memoryless exponential hazard.
+  Simulation of left-truncated RTTE streams remains a separate follow-up.
 - **Analytic inverse-Gaussian (IG) absorption closed form** (#790): the Freijer &
   Post inverse-Gaussian absorption model is now available as the analytic
   structural models `pk one_cpt_ig(cl, v, mat, cv2)` and

--- a/docs/estimation/tte.qmd
+++ b/docs/estimation/tte.qmd
@@ -413,6 +413,19 @@ time) restarts the hazard clock at each event (`Σ_k log h(Δ_k) − Σ_k H(Δ_k
 inter-event gaps). For a time-homogeneous hazard the two coincide. See
 [Repeated events](../model-file/event-model.qmd#rtte) for the DSL details.
 
+Both clocks accept **left truncation** (a `TENTRY` column; see [above](#left-truncation-delayed-entry)).
+Under `clock = forward` the cumulative hazard integrates from `H(TENTRY)`. Under
+`clock = reset` the *first* sojourn is measured from the time origin and conditioned on
+survival to entry — `H(t₁) − H(TENTRY) − log h(t₁)` — after which the renewal clock takes
+over for later gaps. This is the same delayed-entry conditioning across every survival
+endpoint: `TENTRY` always means "condition on survival past entry", never "restart the
+clock at entry" (the two would differ for a time-varying hazard, and only the former is a
+standard, anchorable left-truncation model). Reset left truncation assumes the time origin
+`t = 0` is the renewal origin of the first sojourn (the subject was event-free and at risk
+from 0); it coincides with clock-forward for a memoryless (exponential) hazard. Simulating
+a left-truncated RTTE stream is a separate follow-up — `simulate()` still requires
+`TENTRY = 0` for repeated events.
+
 ::: {.callout-warning}
 ## Prefer SAEM/IMP for RTTE
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1588,10 +1588,11 @@ pub(crate) fn check_absorption_closed_form_support(
 ///     renewal is a later slice.
 ///   * **tied event times** — two events at the same `TIME` give a zero gap `Δ = 0`, which
 ///     the gap-time hazard cannot represent (`h(0)` folds to the sentinel).
-///   * **left truncation (`entry_time > 0`)** — delayed entry is not yet supported for
-///     gap-time RTTE: the first-gap conditioning convention (renewal clock from entry vs.
-///     clock from 0 conditioned on survival to entry) is unratified and unanchored, and the
-///     two differ for a time-varying hazard. Clock-forward supports it via `H(entry)`.
+///
+/// Left truncation (`entry_time > 0`) is **accepted** for clock-reset (#740): the first
+/// sojourn is conditioned on survival to `entry` in absolute time (`H(t₁) − H(entry)`,
+/// convention B), identical to the single-event and clock-forward delayed-entry handling —
+/// see [`crate::survival::rtte_reset_nll_from_curves`].
 ///
 /// Returns `None` when there is no RTTE endpoint or every subject's rows are valid.
 #[cfg(feature = "survival")]
@@ -1707,24 +1708,12 @@ fn check_rtte_records(model: &CompiledModel, population: &Population) -> Option<
                             subject.id
                         ));
                     }
-                    // Left truncation (delayed entry, entry_time > 0) is not yet supported for
-                    // gap-time RTTE. The first gap's convention is unratified — renewal clock
-                    // restarts at entry (`Δ = time − entry`, H from 0) vs. clock from 0
-                    // conditioned on survival to entry (`H(t) − H(entry)`) — and the two differ
-                    // for a time-varying hazard (they coincide only for the memoryless
-                    // exponential). There is no NONMEM/survreg anchor for either, so fail loud
-                    // rather than silently pick one. Clock-forward *does* support left truncation
-                    // (it conditions via `H(entry)`), so route such data there or set TENTRY=0.
-                    if *entry_time > 0.0 {
-                        return Some(format!(
-                            "Subject '{}': RTTE endpoint CMT={cmt} (clock=reset) has a \
-                             left-truncation entry_time={entry_time} > 0. Delayed entry is not \
-                             yet supported for gap-time RTTE (the first-gap conditioning \
-                             convention is unratified). Use clock=forward, which supports left \
-                             truncation, or set the entry time to 0.",
-                            subject.id
-                        ));
-                    }
+                    // Left truncation (delayed entry, entry_time > 0) IS supported for
+                    // clock-reset (#740): the first sojourn is conditioned on survival to
+                    // entry in absolute time (H(t₁) − H(entry), convention B), matching the
+                    // single-event and clock-forward delayed-entry handling. No guard here —
+                    // `rtte_reset_nll_from_curves` applies the conditioning. (An `entry > TIME`
+                    // is still rejected above, shared with clock-forward.)
                     if matches!(event_type, EventType::RightCensored) {
                         seen_censor = true;
                     }

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -387,6 +387,13 @@ pub fn rtte_forward_nll_from_curves(
 /// (enforced at data load), `IntervalCensored` unsupported (folds to the `1e20`
 /// sentinel). Returns the sentinel on a non-positive hazard at an event, a non-monotone
 /// cumulative hazard on a gap, or a non-finite total.
+///
+/// As on the clock-forward path, only the **first** record's `entry_time` conditions the
+/// likelihood; a per-record `entry_time` on a *later* record is ignored (that gap is a fresh
+/// renewal from 0, so re-conditioning on entry would double-count survival to entry). Real
+/// left-truncated data carries a single subject-level `TENTRY`, for which this is exactly
+/// convention B; an inconsistent per-row `TENTRY` is silently reduced to the first record's
+/// value rather than rejected — matching clock-forward, not the pre-#740 loud rejection.
 pub fn rtte_reset_nll_from_curves(
     records: &[ObsRecord],
     cumhaz_at: impl Fn(f64) -> f64,
@@ -2060,8 +2067,11 @@ mod tests {
     fn rtte_reset_left_truncation_equals_forward_for_exponential() {
         // A constant hazard is memoryless, so convention B's entry-conditioned first sojourn
         // (H(t₁) − H(entry)) coincides with the pure renewal form AND with clock-forward even
-        // under delayed entry. This pins that reset left truncation conditions via H(entry) —
-        // the same lower limit clock-forward uses — rather than restarting the clock at entry.
+        // under delayed entry. This pins B ≡ clock-forward for a memoryless hazard (the
+        // reduction-to-anchored-machinery invariant). It does NOT by itself discriminate B from
+        // the rejected convention A — the two are numerically identical when the hazard is
+        // memoryless; that discrimination is pinned by the time-varying Weibull test
+        // `rtte_reset_left_truncation_conditions_on_entry` (where B differs from A by > 1 nat).
         let lambda = 0.05_f64;
         let entry = 4.0;
         let records = vec![

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -357,15 +357,31 @@ pub fn rtte_forward_nll_from_curves(
 /// from cumulative-hazard / hazard curves:
 ///
 /// ```text
-///   −log L = Σ_k [ H(Δ_k) − log h(Δ_k) ]  +  H(Δ_censor)
+///   −log L = [ H(t₁) − H(entry) − log h(t₁) ]      first sojourn, absolute clock from 0
+///          + Σ_{k≥2} [ H(Δ_k) − log h(Δ_k) ]       renewal gaps, Δ_k = t_k − t_{k−1}
+///          + H(Δ_censor)
 /// ```
 ///
-/// The hazard clock **resets to 0 at each event**, so each inter-event gap
-/// `Δ_k = t_k − t_{k−1}` (with `t_0` = the subject's `entry_time`) is an independent
-/// single-event contribution evaluated on its own *duration* — `cumhaz_at`/`hazard_at`
-/// are called at `Δ_k`, not at absolute time. This is the renewal-process form (§3.3);
-/// for a time-homogeneous hazard (exponential) it coincides with the clock-forward
-/// likelihood, and differs once the hazard varies with time (Weibull/Gompertz).
+/// The hazard clock **resets to 0 at each event**, so each *inter-event* gap
+/// `Δ_k = t_k − t_{k−1}` (k ≥ 2) is an independent single-event contribution evaluated on
+/// its own *duration* — `cumhaz_at`/`hazard_at` are called at `Δ_k`, not at absolute time.
+/// This is the renewal-process form (§3.3); for a time-homogeneous hazard (exponential) it
+/// coincides with the clock-forward likelihood, and differs once the hazard varies with
+/// time (Weibull/Gompertz).
+///
+/// **Left truncation (delayed entry, `entry_time > 0`), convention B (#740).** The *first*
+/// sojourn is the interval from the time origin (`t = 0`) to the first record, measured in
+/// **absolute** time and **conditioned on survival to `entry`**: its contribution is
+/// `H(t₁) − H(entry) [− log h(t₁)]` — the exact clock-forward first-record term, and the
+/// same delayed-entry conditioning used for single-event TTE and clock-forward RTTE (one
+/// left-truncation semantics across every path: `entry` always means "condition on survival
+/// past entry", never "restart the clock at entry"). For a memoryless (exponential) hazard
+/// this collapses to `H(t₁ − entry)` and coincides with the pure renewal form; for a
+/// time-varying hazard it does **not** — the rejected alternative (renewal clock restarting
+/// at `entry`, first gap `Δ = t₁ − entry` from 0) is a different, unanchored model. This
+/// convention assumes the time origin `t = 0` is the renewal origin of the first sojourn
+/// (the subject was event-free and at risk from 0); when `entry == 0` the term is exactly
+/// the pure renewal `H(t₁)` and this function is bit-identical to a clock from 0.
 ///
 /// Preconditions match [`rtte_forward_nll_from_curves`]: records nondecreasing in `time`
 /// (enforced at data load), `IntervalCensored` unsupported (folds to the `1e20`
@@ -378,8 +394,7 @@ pub fn rtte_reset_nll_from_curves(
     tol: MonoTol,
 ) -> f64 {
     let mut nll = 0.0_f64;
-    // Start of the current gap: the previous record's time, or the subject's entry on
-    // the first record.
+    // End of the previous sojourn (a renewal point): `None` until the first record.
     let mut prev_time: Option<f64> = None;
 
     for record in records {
@@ -395,31 +410,50 @@ pub fn rtte_reset_nll_from_curves(
             continue;
         };
 
-        let gap = time - prev_time.unwrap_or(*entry_time);
-        // A negative gap means out-of-order records (guarded at data load); the H(Δ) with
-        // Δ<0 is meaningless, so fail closed.
-        if gap < 0.0 {
+        // Where to evaluate the hazard clock for this record (`arg`) and the lower
+        // cumulative-hazard limit to subtract (`h_lo`):
+        //   * first record  → absolute time `t₁` on the clock from the origin, lower limit
+        //     H(entry) (delayed-entry conditioning, convention B); reduces to (t₁, 0) when
+        //     entry == 0.
+        //   * later records → gap `t − t_prev` on a clock reset at the previous event,
+        //     lower limit H(0) = 0.
+        let (arg, h_lo) = match prev_time {
+            None => {
+                let h_entry = if *entry_time > 0.0 {
+                    cumhaz_at(*entry_time)
+                } else {
+                    0.0
+                };
+                (*time, h_entry)
+            }
+            Some(prev) => (*time - prev, 0.0),
+        };
+        // A negative clock argument means out-of-order records (a later record's gap); the
+        // H(Δ) with Δ<0 is meaningless, so fail closed. An `entry > t₁` on the first record
+        // leaves `arg = t₁ ≥ 0` but drives `H(arg) < h_lo`, caught by the monotone check
+        // below (same fold as the clock-forward path).
+        if arg < 0.0 {
             return 1e20;
         }
 
         match event_type {
             EventType::RightCensored => {
-                let h_gap = cumhaz_at(gap); // H(Δ) from a reset clock (lower limit 0)
-                if cumhaz_monotone_violation(h_gap, 0.0, tol) {
+                let h_arg = cumhaz_at(arg);
+                if cumhaz_monotone_violation(h_arg, h_lo, tol) {
                     return 1e20;
                 }
-                nll += h_gap;
+                nll += h_arg - h_lo;
             }
             EventType::Exact => {
-                let h_val = hazard_at(gap);
+                let h_val = hazard_at(arg);
                 if h_val <= 0.0 {
                     return 1e20;
                 }
-                let h_gap = cumhaz_at(gap);
-                if cumhaz_monotone_violation(h_gap, 0.0, tol) {
+                let h_arg = cumhaz_at(arg);
+                if cumhaz_monotone_violation(h_arg, h_lo, tol) {
                     return 1e20;
                 }
-                nll += h_gap - h_val.ln();
+                nll += (h_arg - h_lo) - h_val.ln();
             }
             // RTTE + interval censoring is unsupported (rejected at parse); sentinel.
             EventType::IntervalCensored { .. } => return 1e20,
@@ -1969,6 +2003,121 @@ mod tests {
             (reset - forward).abs() > 1.0,
             "reset ({reset}) and forward ({forward}) must differ for a time-varying hazard"
         );
+    }
+
+    #[test]
+    fn rtte_reset_left_truncation_conditions_on_entry() {
+        // Convention B (#740): with delayed entry the FIRST sojourn is measured in absolute
+        // time from the origin and conditioned on survival to `entry` — H(t₁) − H(entry) −
+        // log h(t₁), exactly the clock-forward first-record term. Every later gap is a fresh
+        // renewal draw from 0. Weibull scale=10, shape=2 is time-varying, so B differs from
+        // the rejected alternative (renewal clock restarting at entry, first gap t₁ − entry).
+        let cumhaz_at = |t: f64| (t / 10.0).powi(2);
+        let hazard_at = |t: f64| 0.2 * (t / 10.0);
+        let entry = 8.0;
+        // Enter the risk set at 8; events at 10 and 13; administrative censor at 20.
+        let records = vec![
+            ObsRecord::Event {
+                time: 10.0,
+                event_type: EventType::Exact,
+                entry_time: entry,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 13.0,
+                event_type: EventType::Exact,
+                entry_time: entry,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 20.0,
+                event_type: EventType::RightCensored,
+                entry_time: entry,
+                cmt: 2,
+            },
+        ];
+        let reset = rtte_reset_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+
+        // B: first sojourn conditioned on entry (absolute clock), then renewal gaps 3 and 7.
+        let expected_b = (cumhaz_at(10.0) - cumhaz_at(entry) - hazard_at(10.0).ln()) // first sojourn
+            + (cumhaz_at(3.0) - hazard_at(3.0).ln())                                 // gap 13−10
+            + cumhaz_at(7.0); // censor gap 20−13
+        assert_abs_diff_eq!(reset, expected_b, epsilon = 1e-12);
+
+        // The rejected convention A (renewal clock restarts at entry: first gap Δ = t₁ −
+        // entry evaluated from 0) would use the residual 2.0 for the first term — materially
+        // different for a time-varying hazard. Pin that the implementation is B, not A.
+        let convention_a = (cumhaz_at(10.0 - entry) - hazard_at(10.0 - entry).ln())
+            + (cumhaz_at(3.0) - hazard_at(3.0).ln())
+            + cumhaz_at(7.0);
+        assert!(
+            (reset - convention_a).abs() > 1.0,
+            "reset NLL ({reset}) must use convention B, not the renewal-from-entry A ({convention_a})"
+        );
+    }
+
+    #[test]
+    fn rtte_reset_left_truncation_equals_forward_for_exponential() {
+        // A constant hazard is memoryless, so convention B's entry-conditioned first sojourn
+        // (H(t₁) − H(entry)) coincides with the pure renewal form AND with clock-forward even
+        // under delayed entry. This pins that reset left truncation conditions via H(entry) —
+        // the same lower limit clock-forward uses — rather than restarting the clock at entry.
+        let lambda = 0.05_f64;
+        let entry = 4.0;
+        let records = vec![
+            ObsRecord::Event {
+                time: 6.0,
+                event_type: EventType::Exact,
+                entry_time: entry,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 12.0,
+                event_type: EventType::Exact,
+                entry_time: entry,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 30.0,
+                event_type: EventType::RightCensored,
+                entry_time: entry,
+                cmt: 2,
+            },
+        ];
+        let cumhaz_at = |t: f64| lambda * t;
+        let hazard_at = |_t: f64| lambda;
+        let reset = rtte_reset_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+        let forward =
+            rtte_forward_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+        assert_abs_diff_eq!(reset, forward, epsilon = 1e-12);
+        // Closed form: λ(T − entry) − 2·log λ = 0.05·(30 − 4) − 2·log(0.05).
+        assert_abs_diff_eq!(
+            reset,
+            lambda * (30.0 - entry) - 2.0 * lambda.ln(),
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn rtte_reset_left_truncation_censored_first_record() {
+        // A late entrant censored before any event: the single contribution is the entry-
+        // conditioned survival H(t) − H(entry) (convention B), exactly the clock-forward
+        // censored term. Guards the RightCensored-first-record path with a nonzero lower
+        // limit H(entry) (the other reset-truncation tests fire an event first).
+        let cumhaz_at = |t: f64| (t / 10.0).powi(2);
+        let hazard_at = |t: f64| 0.2 * (t / 10.0);
+        let entry = 5.0;
+        let records = vec![ObsRecord::Event {
+            time: 12.0,
+            event_type: EventType::RightCensored,
+            entry_time: entry,
+            cmt: 2,
+        }];
+        let reset = rtte_reset_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+        assert_abs_diff_eq!(reset, cumhaz_at(12.0) - cumhaz_at(entry), epsilon = 1e-12);
+        let forward =
+            rtte_forward_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+        assert_abs_diff_eq!(reset, forward, epsilon = 1e-12);
     }
 
     #[test]

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -852,6 +852,56 @@ mod survival_smoke {
         );
     }
 
+    /// The shared `entry_time > TIME` guard (`api::check_rtte_records`) is the sole remaining
+    /// loud gate for clock-reset left truncation now that `entry_time > 0` is *accepted* (#740):
+    /// an entry after the record's own event/censoring time drives `H(t₁) < H(entry)` and would
+    /// otherwise fold to the silent `1e20` sentinel (a poisoned fit). It must reject up front for
+    /// a RESET endpoint too — not only the clock-forward path — so a future refactor that
+    /// rescoped that guard cannot silently regress reset into sentinel poisoning. Companion to
+    /// the forward-clock `rtte_entry_time_after_time_is_rejected`.
+    #[test]
+    fn rtte_reset_entry_time_after_time_is_rejected() {
+        use ferx_core::types::{HazardFamily, HazardParamFn, HazardSpec, RtteClock, TteRecurrence};
+        let mut model = parse_model_string(RTTE_EXP_FIT_MODEL).expect("RTTE model must parse");
+        let param_fn: HazardParamFn = Box::new(|theta: &[f64], _eta, _cov| vec![theta[0]]);
+        model.endpoints.insert(
+            2,
+            EndpointLikelihood::Tte {
+                hazard: HazardSpec::Analytic {
+                    family: HazardFamily::Exponential,
+                    param_fn,
+                },
+                recurrence: TteRecurrence::Repeated {
+                    clock: RtteClock::Reset,
+                },
+                hazard_covariates: Vec::new(),
+            },
+        );
+        let mut pop = rtte_pop();
+        // First record's entry (12.0) is after its event TIME (5.0), under clock=reset.
+        pop.subjects[0].obs_records = vec![
+            ObsRecord::Event {
+                time: 5.0,
+                event_type: EventType::Exact,
+                entry_time: 12.0,
+                cmt: 2,
+            },
+            ObsRecord::Event {
+                time: 30.0,
+                event_type: EventType::RightCensored,
+                entry_time: 0.0,
+                cmt: 2,
+            },
+        ];
+        let opts = FitOptions::default();
+        let err = fit(&model, &pop, &model.default_params, &opts)
+            .expect_err("entry_time after TIME under clock=reset must be rejected");
+        assert!(
+            err.contains("entry_time") && err.contains("CMT=2"),
+            "error should flag the entry-after-time record on the reset endpoint, got: {err}"
+        );
+    }
+
     /// Left truncation (delayed entry, entry_time > 0) IS supported for clock-reset RTTE
     /// (#740, convention B): the first sojourn is conditioned on survival to `entry` in
     /// absolute time (H(t₁) − H(entry)), matching single-event and clock-forward delayed

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -852,13 +852,14 @@ mod survival_smoke {
         );
     }
 
-    /// Left truncation (delayed entry, entry_time > 0) is not yet supported for clock-reset
-    /// RTTE: the first-gap conditioning convention (renewal clock from entry vs. clock from 0
-    /// conditioned on survival to entry) is unratified and unanchored, and the two differ for
-    /// a time-varying hazard. Fail loud rather than silently pick one; clock-forward supports
-    /// left truncation and is the documented route for such data.
+    /// Left truncation (delayed entry, entry_time > 0) IS supported for clock-reset RTTE
+    /// (#740, convention B): the first sojourn is conditioned on survival to `entry` in
+    /// absolute time (H(t₁) − H(entry)), matching single-event and clock-forward delayed
+    /// entry. The fit boundary must accept such data and produce a real objective rather than
+    /// reject it or fold to the 1e20 sentinel. (The closed-form conditioning is pinned in the
+    /// Tier-1 `rtte_reset_left_truncation_*` unit tests; this is the end-to-end boundary.)
     #[test]
-    fn rtte_reset_left_truncation_is_rejected() {
+    fn rtte_reset_left_truncation_fits() {
         use ferx_core::types::{HazardFamily, HazardParamFn, HazardSpec, RtteClock, TteRecurrence};
         let mut model = parse_model_string(RTTE_EXP_FIT_MODEL).expect("RTTE model must parse");
         let param_fn: HazardParamFn = Box::new(|theta: &[f64], _eta, _cov| vec![theta[0]]);
@@ -892,11 +893,15 @@ mod survival_smoke {
             },
         ];
         let opts = FitOptions::default();
-        let err = fit(&model, &pop, &model.default_params, &opts)
-            .expect_err("left-truncated clock=reset must be rejected");
+        let result = fit(&model, &pop, &model.default_params, &opts)
+            .expect("left-truncated clock=reset RTTE must fit, not error");
+        // A real objective, not the sentinel: a poisoned fit sums per-subject 1e20 to ~n·1e20
+        // (still finite), so `< 1e6` cleanly separates a genuine conditioned fit from one
+        // folded to the sentinel (cf. `rtte_clock_reset_hand_built_fits`).
         assert!(
-            err.contains("left-truncation") && err.contains("CMT=2"),
-            "error should flag the delayed entry, got: {err}"
+            result.ofv.is_finite() && result.ofv < 1e6,
+            "left-truncated clock-reset OFV must be a real objective (finite, < 1e6); got {}",
+            result.ofv
         );
     }
 


### PR DESCRIPTION
## Why

Clock-reset (gap-time / renewal) RTTE **rejected** left-truncated data (`TENTRY > 0`) at
the fit boundary (`api::check_rtte_records`), a guard added in the Slice 3.2 review to avoid
silently baking in an unratified first-gap convention. #740 is the ratification and the real
support.

With delayed entry only the **first** inter-event interval is ambiguous — what does "the
subject entered at `entry`" mean for a clock that measures gaps? Two conventions were on the
table:

- **A — renewal-from-entry** (what the code did implicitly, via `prev_time.unwrap_or(entry)`):
  first gap `Δ = t₁ − entry`, contribution `H(Δ) − log h(Δ)` from 0. Does **not** condition on
  survival to entry.
- **B — clock-from-0, conditioned on survival to entry**: contribution `H(t₁) − H(entry) −
  log h(t₁)` in absolute time.

They coincide for a memoryless (exponential) hazard and diverge for Weibull/Gompertz. This PR
ratifies **B**.

## What changed

- `survival::rtte_reset_nll_from_curves` — the **first** sojourn is now measured from the time
  origin and conditioned on survival to `entry` (`H(t₁) − H(entry) [− log h(t₁)]`), i.e. the
  clock-forward first-record term; every later gap is unchanged (renewal clock from 0). Framing:
  **B = the clock-forward first-sojourn term, then reset gaps thereafter.** For `entry == 0`
  (the only case previously reachable through `fit()`) the result is **bit-identical** to before.
- `api::check_rtte_records` — removed the `entry_time > 0` reset rejection; updated the doc
  bullets. The `entry > TIME` guard (shared with clock-forward) and the other reset contracts
  (mid-stream censor, tied events) are untouched.
- Docs (`docs/estimation/tte.qmd`) + `CHANGELOG.md`.

## Alternatives considered

**Convention A was rejected**, on three grounds:

1. **One meaning for `entry` across the codebase.** `TENTRY`/`entry_time` means *left-truncation*
   everywhere else — the datareader labels it so, single-event TTE conditions via `H(t) − H(entry)`
   (`parametric.rs::left_truncation_regression`), and clock-forward RTTE seeds its lower limit from
   `H(entry)`. A would make one struct field mean "condition on survival to entry" for two paths and
   "restart the clock at entry" for a third. B keeps it single-valued.
2. **B reduces to already-anchored machinery; A does not.** B's first term *is* a left-truncated
   parametric-survival observation (`flexsurv::Surv(entry, t₁, 1)`) and its later gaps are ordinary
   observations from 0 — every piece is individually validated. A ("shift the origin to `entry`,
   drop the pre-entry at-risk window without conditioning") has no standard estimator to check
   against.
3. **A is either wrong or redundant.** If `entry` is a genuine left-truncation, A omits the
   survival-to-entry conditioning → classic left-truncation selection bias. If `entry` genuinely
   *renews* the process, the clean encoding is an origin shift (`TENTRY = 0`, times measured from
   entry), under which A and "reset from 0" coincide anyway.

**Assumption B still makes, documented loudly:** B is correct only when the time origin `t = 0` is
the renewal origin of the first sojourn (subject event-free and at risk from 0). If `t = 0` is
arbitrary calendar time the correct object is the backward-recurrence-time correction — a harder,
out-of-scope model, and undetectable from data, so it is a documented contract, not a runtime
check. Users whose origin is unknown should use clock-forward (unambiguous under delayed entry).

## Breaking changes
- [x] None for the `fit()` path — `entry_time > 0` reset was **rejected** before, so no fit could
  reach the old A behavior. A direct caller of the `pub fn rtte_reset_nll_from_curves` with
  `entry_time > 0` now gets B instead of A (different numbers, same signature). No new/changed
  public *signature*; no `FitResult`/sdtab field change → no ferx-r lock bump.

## Numerical validation

There is deliberately **no NONMEM/survreg anchor for recurrent left truncation as a single object**
— that is the premise of #740. B is validated by (a) exact closed forms and (b) reduction to the
already-anchored single-event left-truncation term.

**Reproduces the issue's worked example** (Weibull scale 10, shape 2; enter at 8, first event at 10):

```
first-sojourn −logL term
  B = H(10) − H(8) − log h(10) = (1.0 − 0.64) − log(0.2) ≈ 1.9694
  A = H(2)        − log h(2)   =  0.04        − log(0.04) ≈ 3.2589   (rejected)
```

Tier-1 unit tests (`src/survival/mod.rs`, exact to 1e-12), all discriminate B from A:

- `rtte_reset_left_truncation_conditions_on_entry` — pins the full B closed form on a Weibull
  (event/event/censor stream) and asserts it is **not** the renewal-from-entry A value.
- `rtte_reset_left_truncation_equals_forward_for_exponential` — memoryless invariance: B-reset ≡
  clock-forward with delayed entry (`λ(T − entry) − 2·log λ`).
- `rtte_reset_left_truncation_censored_first_record` — late entrant censored before any event:
  contribution `H(t) − H(entry)`, equal to the clock-forward censored term.

**Reduction anchor:** B's first-sojourn term is identical to the single-event delayed-entry term in
`parametric.rs::left_truncation_regression` (the `H(t) − H(entry)` conditioning survreg/flexsurv use
and that clock-forward RTTE already relies on). So B inherits that path's validation rather than
introducing a new formula to anchor from scratch.

- [x] Compared against: exact closed forms + reduction to the anchored single-event left-truncation
  term (no direct NONMEM equivalent exists for this endpoint).

## Tests
- [x] Unit tests added in the same module (`cargo test --lib --features survival` passes)
- [x] Behavior-flip test: `tests/tte_smoke.rs::rtte_reset_left_truncation_is_rejected` →
  `rtte_reset_left_truncation_fits` (now asserts a real objective, not the error). Sibling reset
  guards (`mid_stream_censor`, `tied_event_times`, `entry_time_after_time`) still reject — confirms
  the removal was scoped.

## Docs
- [x] `docs/estimation/tte.qmd` — reset left-truncation, the `TENTRY` one-meaning rule, and the
  `t = 0`-is-origin contract.
- [x] `CHANGELOG.md` `[Unreleased]` → Added.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Reviewer hints
- The whole change in `rtte_reset_nll_from_curves` is the first-record `(arg, h_lo)` selection;
  everything downstream is unchanged. Check that `entry == 0` stays bit-identical (it does — `h_lo`
  collapses to 0 and `arg = t₁`).
- The `entry > t₁` case on the first record leaves `arg = t₁ ≥ 0` but drives `H(arg) < h_lo`; it is
  caught by the existing `cumhaz_monotone_violation` fold (same as clock-forward), and also rejected
  up-front in `check_rtte_records`.

## Open questions
- **Simulation of left-truncated reset streams is intentionally still rejected** (`validate_tte_simulatable`),
  as it is for clock-forward — a separate follow-up (conditional first-gap draw via
  `sample_conditional_event_time`, which already exists). Fit and simulate stay symmetric (both
  clocks: fit supports delayed entry, simulate does not yet).
- **Committed Tier-3 reference dataset** (issue #740 step 3: a `TENTRY > 0` reset CSV with a
  flexsurv reduction anchor + convergence test) is the remaining follow-up. flexsurv is not
  installed in this environment; the exact Tier-1 closed forms + the reduction argument cover
  correctness in the meantime. Happy to add it as a fast-follow if you'd like it in-scope here.

## Post-review update (`65bfdc27`)

Reviewed at **xhigh** (`/review` + `/code-review`: 5 parallel adversarial finders + an
independent cross-file trace + numerical/Python verification + a full local test run).
**No correctness bugs.** Highlights:

- Convention B verified three independent ways — by hand, in Python, and by the closed-form
  Tier-1 tests.
- **Objective/gradient consistency proven.** There is exactly one f64 `rtte_reset_nll_from_curves`;
  every derivative (inner EBE, FOCE/FOCEI Laplace η-Hessian, outer-θ, SAEM) finite-differences that
  same closure, with records filtered per-CMT — so the fit's gradient cannot silently disagree with
  the objective. There is no Dual2/analytic twin of the reset formula to keep in sync.
- Guard-removal scope re-confirmed safe: the shared `entry > TIME`, mid-stream-censor, and
  tied-event guards are intact; `simulate()` still rejects left truncation; and `type = rtte` +
  ODE-accumulated hazard is parse-rejected, so removing the reset `entry_time > 0` guard exposes
  only the handled analytic path.

**Review fixes pushed in `65bfdc27` (tests/docs only — no behaviour change):**

1. Added `rtte_reset_entry_time_after_time_is_rejected`: the shared `entry > TIME` gate is the sole
   remaining loud gate for reset left truncation but was only exercised via a forward-clock model;
   it is now regression-locked on a RESET endpoint too.
2. Corrected the `rtte_reset_left_truncation_equals_forward_for_exponential` docstring: it validates
   `B ≡ clock-forward` for a memoryless hazard (A ≡ B when memoryless, so this test does *not*
   discriminate B from A — the time-varying Weibull `conditions_on_entry` test is that pin).
3. Documented that only the first record's `entry_time` conditions the reset likelihood (a later-row
   `TENTRY` is ignored — a fresh renewal from 0 — matching clock-forward, not the pre-#740 rejection).

Optional follow-up left out to keep the diff scoped: a shared `entry_lower_limit` helper to
de-triplicate the `H(entry)` lower-limit across the three NLL functions.

