### PR TITLE
feat(pk): flip-flop transit/IG absorption with lagtime/f auto-routes to its ODE twin [closes #735]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,21 @@ section of the SDLC for the versioning policy).
   [Data → Column mapping](https://ferx-nlme.github.io/ferx-core/model-file/data.html).
 
 ### Changed
+- **Flip-flop transit / inverse-Gaussian models with `lagtime` / `f` now auto-route
+  to their ODE twin** (#735) instead of being rejected. The analytic
+  `pk one_cpt_transit` / `two_cpt_transit` / `one_cpt_ig` / `two_cpt_ig` closed forms
+  clamp to an identically-zero profile outside their tilting-convergence domain (the
+  flip-flop regime) and are transparently rerouted to the equivalent ODE `transit()` /
+  `igd()` model — but previously only when the model carried no `lagtime=` / `f=`
+  mapping. Those mappings now carry into the generated twin (via reserved-name
+  individual parameters), so a flip-flop model with absorption lag or bioavailability —
+  including a `TIME` / time-varying-covariate model that *requires* the twin — now fits
+  and predicts correctly instead of erroring or returning zero. Validated by
+  closed-form↔ODE equivalence tests (`tests/transit_analytic_equivalence.rs`,
+  `tests/ig_analytic_equivalence.rs`) for lag, f, and both, and a silent-divergence
+  guard declines the twin if a disposition parameter's name shadows a reserved F/lagtime
+  slot. User `[odes]` / `[scaling]` / `[initial_conditions]` forms remain twin-less (no
+  unique desugar) and are still rejected up front in the flip-flop regime.
 - **Default thread count capped at 8** (#707): when `threads` is unset (or
   `0`/`auto`) — via `[fit_options] threads`, the CLI `--threads` flag, or the R
   binding — the engine now defaults to `available cores - 1` (floored at 1),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,14 @@ section of the SDLC for the versioning policy).
   including a `TIME` / time-varying-covariate model that *requires* the twin — now fits
   and predicts correctly instead of erroring or returning zero. Validated by
   closed-form↔ODE equivalence tests (`tests/transit_analytic_equivalence.rs`,
-  `tests/ig_analytic_equivalence.rs`) for lag, f, and both, and a silent-divergence
-  guard declines the twin if a disposition parameter's name shadows a reserved F/lagtime
-  slot. User `[odes]` / `[scaling]` / `[initial_conditions]` forms remain twin-less (no
-  unique desugar) and are still rejected up front in the flip-flop regime.
+  `tests/ig_analytic_equivalence.rs`) for lag, f, and both. A guard declines the twin
+  (keeping the model closed-form, and rejected up front if flip-flop) whenever building it
+  would misbehave: a parameter name that *shadows* a reserved F/lagtime slot it was not
+  mapped to (which would silently apply an extra F/lag), or an `f=`/`lagtime=` parameter
+  whose name *collides* with a disposition slot (e.g. a bioavailability parameter named
+  `V1`, which would otherwise make the twin fail to build). User `[odes]` / `[scaling]` /
+  `[initial_conditions]` forms remain twin-less (no unique desugar) and are still rejected
+  up front in the flip-flop regime.
 - **Default thread count capped at 8** (#707): when `threads` is unset (or
   `0`/`auto`) — via `[fit_options] threads`, the CLI `--threads` flag, or the R
   binding — the engine now defaults to `available cores - 1` (floored at 1),

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -176,12 +176,14 @@ this *per evaluation* and routes the model to its exact ODE `transit()` twin, wh
 is valid in both regimes (matched to a NONMEM ADVAN13 transit simulation to ~1e-4),
 so a flip-flop model fits and predicts correctly instead of returning a zero
 profile. A `W_TRANSIT_FLIP_FLOP` note still flags the regime at the typical-value
-estimates. The reroute needs an ODE twin: a closed-form transit model that also
-carries a `lagtime`, bioavailability `f`, or a user `[odes]` / `[scaling]` /
-`[initial_conditions]` block cannot be desugared, so there is no twin to route to. Rather than silently returning a zero profile that
-degenerates the objective, such a model is **rejected with a hard error**
-(`E_TRANSIT_FLIP_FLOP`) on `fit`, `predict`, `simulate`, and `ferx check` — rewrite
-it as an explicit ODE `transit()` model, or adjust the MTT / CL starting estimates.
+estimates. The reroute needs an ODE twin. A closed-form transit model that carries a
+`lagtime` or bioavailability `f` mapping is desugared to a twin that applies them too
+(since #735), so it auto-routes just like the plain form. Only a model with a user
+`[odes]` / `[scaling]` / `[initial_conditions]` block cannot be desugared (no unique
+twin); rather than silently returning a zero profile that degenerates the objective,
+such a twin-less model is **rejected with a hard error** (`E_TRANSIT_FLIP_FLOP`) on
+`fit`, `predict`, `simulate`, and `ferx check` — rewrite it as an explicit ODE
+`transit()` model, or adjust the MTT / CL starting estimates.
 
 [`examples/one_cpt_transit.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/one_cpt_transit.ferx)
 is a complete self-contained analytic transit model:

--- a/src/api.rs
+++ b/src/api.rs
@@ -1930,9 +1930,11 @@ pub(crate) fn check_absorption_flip_flop_no_twin(
                  or (2-cpt) coincident disposition eigenvalues — so it returns an \
                  identically-zero concentration profile, which silently degenerates the objective \
                  (a proportional error model collapses `(σ·pred)²` to 0). This model has no ODE \
-                 twin to fall back on (a `lagtime`, bioavailability `f`, or a user `[odes]` / \
-                 `[scaling]` / `[initial_conditions]` block declines the desugar) — rewrite it as \
-                 an explicit ODE `{ode_fn}` model, or check the {params} starting estimates.",
+                 twin to fall back on (a user `[odes]` / `[scaling]` / `[initial_conditions]` \
+                 block, or a parameter whose name collides with a reserved `f`/`lagtime` slot, \
+                 declines the desugar — a `lagtime=`/`f=` mapping alone now auto-routes, #735) — \
+                 rewrite it as an explicit ODE `{ode_fn}` model, or check the {params} starting \
+                 estimates.",
                 model.pk_model.canonical_name(),
                 subject.id
             ));
@@ -6615,8 +6617,9 @@ fn absorption_flip_flop_ebe_warning(
          eigenvalues — at their fitted empirical-Bayes estimates, where the closed form returns \
          an identically-zero concentration profile, silently degenerating those subjects' \
          likelihood contributions. The typical-value (η = 0) parameters are in-domain, so this \
-         is not caught at fit start, and this twin-less model (a `lagtime`, `f`, or user \
-         `[odes]` / `[scaling]` / `[initial_conditions]` form) has no ODE twin to reroute to. \
+         is not caught at fit start, and this twin-less model (a user `[odes]` / `[scaling]` / \
+         `[initial_conditions]` form, or a parameter whose name collides with a reserved \
+         `f`/`lagtime` slot) has no ODE twin to reroute to. \
          Rewrite it as an explicit ODE `{}` model (which reroutes per-eval at the actual η), or \
          check the {} starting estimates.",
         model.pk_model.canonical_name(),
@@ -12810,7 +12813,7 @@ mod simulate_with_uncertainty_tests {
         let model = parse_fixture(INDOMAIN_TWINLESS_TRANSIT_SRC);
         assert!(
             model.absorption_ode_equivalent.is_none(),
-            "a lagtime= transit model is twin-less"
+            "a [scaling] transit model is twin-less"
         );
         let pop = tiny_population();
         // Subject S1 in-domain (η=0), subject S2 crosses.

--- a/src/api.rs
+++ b/src/api.rs
@@ -12708,11 +12708,10 @@ mod simulate_with_uncertainty_tests {
     }
 
     // ── #785 / #786 flip-flop follow-up fixtures & tests ─────────────────────────
-    // A twin-*less* (a `lagtime=` mapping declines the ODE-twin desugar) transit /
-    // IG closed form whose *typical* parameters are IN-DOMAIN (`ke = CL/V` below the
-    // tilting abscissa) — so it passes the η=0 fit-start reject — but which a large
-    // positive `ETA_CL` drives into the flip-flop regime. ke0 = 0.5/4 = 0.125 < KTR =
-    // (3+1)/20 = 0.2.
+    // A twin-*less* transit / IG closed form whose *typical* parameters are IN-DOMAIN
+    // (`ke = CL/V` below the tilting abscissa) — so it passes the η=0 fit-start reject —
+    // but which a large positive `ETA_CL` drives into the flip-flop regime. ke0 = 0.5/4 =
+    // 0.125 < KTR = (3+1)/20 = 0.2.
     // Genuinely twin-less: a user `[scaling]` block declines the ODE-twin desugar. (A
     // `lagtime=`/`f=` mapping no longer declines it — those auto-route now, #735 — so a
     // `[scaling]` form is what keeps this the twin-less case the #785 EBE warning targets.)

--- a/src/api.rs
+++ b/src/api.rs
@@ -12358,13 +12358,12 @@ mod simulate_with_uncertainty_tests {
         }
     }
 
-    /// A `one_cpt_transit` + `TIME` model that the ODE desugar does NOT cover — here because
-    /// of a `lagtime=` mapping (the desugar is scoped to the plain `cl/v/n/mtt` form) — stays
-    /// on the closed form and must be rejected up front rather than silently freezing `TIME`
-    /// at the first record. (The plain form is instead rewritten to the ODE `transit()`
-    /// equivalent and works; see the parser test `transit_time_desugars_to_ode_equivalent`.)
+    /// #735: a `one_cpt_transit` + `TIME` model carrying a `lagtime=` mapping now AUTO-ROUTES
+    /// to its ODE twin instead of being rejected. Before #735 the lagtime form declined the
+    /// twin, so the `TIME` switch had nothing to route to and was rejected up front; now the
+    /// twin is built (carrying the lagtime), so the `TIME` / lagtime subjects are served by it.
     #[test]
-    fn transit_with_time_and_lagtime_is_rejected() {
+    fn transit_with_time_and_lagtime_autoroutes() {
         use crate::parser::model_parser::parse_model_string;
         const TRANSIT_TIME_LAG: &str = r#"
 [parameters]
@@ -12397,17 +12396,20 @@ mod simulate_with_uncertainty_tests {
         assert_eq!(
             model.pk_model,
             crate::types::PkModel::OneCptTransit,
-            "the lagtime= form is outside the desugar scope, so it stays closed-form"
+            "the closed-form shorthand stays OneCptTransit; the twin serves TIME/lagtime subjects"
         );
         assert!(
             crate::parser::model_parser::compiled_model_uses_time_builtin(&model),
             "fixture must use the TIME built-in"
         );
-        let msg = check_absorption_closed_form_support(&model, &tiny_population())
-            .expect("transit + TIME (lagtime form) must be rejected up front");
         assert!(
-            msg.contains("TIME"),
-            "rejection message must name the TIME limitation: {msg}"
+            model.absorption_ode_equivalent.is_some(),
+            "#735: a lagtime= transit model now carries an ODE twin (auto-routes)"
+        );
+        // No longer rejected — the twin handles both the TIME switch and the lagtime.
+        assert!(
+            check_absorption_closed_form_support(&model, &tiny_population()).is_none(),
+            "transit + TIME + lagtime is now served via the twin, not rejected up front"
         );
     }
 
@@ -12711,13 +12713,15 @@ mod simulate_with_uncertainty_tests {
     // tilting abscissa) — so it passes the η=0 fit-start reject — but which a large
     // positive `ETA_CL` drives into the flip-flop regime. ke0 = 0.5/4 = 0.125 < KTR =
     // (3+1)/20 = 0.2.
+    // Genuinely twin-less: a user `[scaling]` block declines the ODE-twin desugar. (A
+    // `lagtime=`/`f=` mapping no longer declines it — those auto-route now, #735 — so a
+    // `[scaling]` form is what keeps this the twin-less case the #785 EBE warning targets.)
     const INDOMAIN_TWINLESS_TRANSIT_SRC: &str = "\
 [parameters]
   theta TVCL(0.5, 0.001, 50.0)
   theta TVV(4.0, 0.1, 500.0)
   theta TVNTR(3.0, 0.0, 20.0)
   theta TVMTT(20.0, 0.05, 200.0)
-  theta TVLAG(0.3, 0.0, 5.0)
   omega ETA_CL ~ 0.09
   sigma PROP ~ 0.01 (sd)
 
@@ -12726,24 +12730,25 @@ mod simulate_with_uncertainty_tests {
   V = TVV
   NTR = TVNTR
   MTT = TVMTT
-  LAGTIME = TVLAG
 
 [structural_model]
-  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime=LAGTIME)
+  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
+
+[scaling]
+  obs_scale = V
 
 [error_model]
   DV ~ proportional(PROP)
 ";
 
     // IG analogue: ke0 = 5/50 = 0.1 < 1/(2·MAT·CV²) = 1/(2·2·0.3) = 0.833 (in-domain);
-    // the `lagtime=` mapping declines the twin.
+    // the `[scaling]` block declines the twin (twin-less).
     const INDOMAIN_TWINLESS_IG_SRC: &str = "\
 [parameters]
   theta TVCL(5.0, 0.1, 100.0)
   theta TVV(50.0, 5.0, 500.0)
   theta TVMAT(2.0, 0.05, 24.0)
   theta TVCV2(0.3, 0.001, 10.0)
-  theta TVLAG(0.2, 0.0, 5.0)
   omega ETA_CL ~ 0.09
   sigma PROP ~ 0.15 (sd)
 
@@ -12752,10 +12757,12 @@ mod simulate_with_uncertainty_tests {
   V = TVV
   MAT = TVMAT
   CV2 = TVCV2
-  LAGTIME = TVLAG
 
 [structural_model]
-  pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2, lagtime=LAGTIME)
+  pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2)
+
+[scaling]
+  obs_scale = V
 
 [error_model]
   DV ~ proportional(PROP)

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6718,14 +6718,66 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
         return None;
     }
     let roles = parse_role_pairs(&args_str, pk_label).ok()?;
-    let allowed: &[&str] = match (is_two_cpt, is_ig) {
+    let disposition: &[&str] = match (is_two_cpt, is_ig) {
         (false, false) => &["cl", "v", "n", "mtt"],
         (true, false) => &["cl", "v1", "q", "v2", "n", "mtt"],
         (false, true) => &["cl", "v", "mat", "cv2"],
         (true, true) => &["cl", "v1", "q", "v2", "mat", "cv2"],
     };
-    if roles.keys().any(|k| !allowed.contains(&k.as_str())) {
-        return None; // a lagtime=/f= (or other) mapping — outside the scope.
+    // #735: absorption `f=` / `lagtime=` (`alag=`) are now carried into the twin (alias
+    // emission below); any *other* unrecognised role stays outside the plain-form scope.
+    const ABS_ATTRS: &[&str] = &["f", "lagtime", "alag"];
+    if roles
+        .keys()
+        .any(|k| !disposition.contains(&k.as_str()) && !ABS_ATTRS.contains(&k.as_str()))
+    {
+        return None; // an unknown mapping — outside the plain-form scope.
+    }
+    // The ODE twin routes F / lagtime by an individual parameter *named* `f` / `lagtime`
+    // / `alag` (`ode_param_slots`), whereas the closed form binds them via this pk() role
+    // map under arbitrary names. Bridge with reserved-name alias lines — but only when the
+    // mapped parameter does not already self-route (a param literally named `F` / `LAGTIME`
+    // / `ALAG` lowercases to the canonical slot name, so an alias would double-bind it and
+    // `ode_param_slots` would reject). #735.
+    let mut alias_lines: Vec<String> = Vec::new();
+    if let Some(fp) = roles.get("f") {
+        if fp.to_lowercase() != "f" {
+            alias_lines.push(format!("  f = {fp}"));
+        }
+    }
+    if let Some(lp) = roles.get("lagtime").or_else(|| roles.get("alag")) {
+        if !matches!(lp.to_lowercase().as_str(), "lagtime" | "alag") {
+            alias_lines.push(format!("  lagtime = {lp}"));
+        }
+    }
+    // Silent-divergence guard (#735): the ODE twin routes *any* individual parameter whose
+    // lowercased name is a reserved slot name (`f` / `lagtime` / `alag`) into that F/lagtime
+    // slot (`ode_param_slots`), even one the closed form never treated as F/lag. The only
+    // params that may occupy those slots are the intended `f=` / `lagtime=` / `alag=`
+    // mappings. If any *other* declared parameter shadows a reserved name — a disposition
+    // role bound to such a param (`mtt=ALAG`), or a stray covariate/derived param literally
+    // named `f` — decline the twin: the model stays closed-form (matching the closed form,
+    // which never applied that param as F/lag) and, if it is also flip-flop, is rejected up
+    // front, rather than the twin silently applying an extra F/lagtime the closed form did not.
+    let intended: std::collections::HashSet<&str> = ["f", "lagtime", "alag"]
+        .iter()
+        .filter_map(|r| roles.get(*r).map(String::as_str))
+        .collect();
+    if let Some(ip_lines) = extracted.unnamed.get("individual_parameters") {
+        for line in ip_lines {
+            let lhs = line
+                .split(|c| c == '=' || c == '#')
+                .next()
+                .unwrap_or("")
+                .trim();
+            if !lhs.is_empty()
+                && lhs.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                && matches!(lhs.to_lowercase().as_str(), "f" | "lagtime" | "alag")
+                && !intended.contains(lhs)
+            {
+                return None; // shadows a reserved F/lagtime slot — decline (see above).
+            }
+        }
     }
     // The absorption forcing term, `transit(n, mtt)` or `igd(mat, cv2)`.
     let forcing = if is_ig {
@@ -6748,6 +6800,15 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
         for line in &extracted.unnamed[name] {
             src.push_str(line);
             src.push('\n');
+        }
+        // #735: append the reserved-name F/lagtime aliases to [individual_parameters]
+        // so the ODE twin applies them (the closed form's pk() role map has no ODE
+        // analogue — see `ode_param_slots`).
+        if name == "individual_parameters" {
+            for alias in &alias_lines {
+                src.push_str(alias);
+                src.push('\n');
+            }
         }
         src.push('\n');
     }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6752,17 +6752,22 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
     }
     // Silent-divergence guard (#735): the ODE twin routes *any* individual parameter whose
     // lowercased name is a reserved slot name (`f` / `lagtime` / `alag`) into that F/lagtime
-    // slot (`ode_param_slots`), even one the closed form never treated as F/lag. The only
-    // params that may occupy those slots are the intended `f=` / `lagtime=` / `alag=`
-    // mappings. If any *other* declared parameter shadows a reserved name — a disposition
-    // role bound to such a param (`mtt=ALAG`), or a stray covariate/derived param literally
-    // named `f` — decline the twin: the model stays closed-form (matching the closed form,
-    // which never applied that param as F/lag) and, if it is also flip-flop, is rejected up
-    // front, rather than the twin silently applying an extra F/lagtime the closed form did not.
-    let intended: std::collections::HashSet<&str> = ["f", "lagtime", "alag"]
-        .iter()
-        .filter_map(|r| roles.get(*r).map(String::as_str))
-        .collect();
+    // slot (`ode_param_slots`), even one the closed form never treated as F/lag. A param name
+    // that lowercases to a reserved slot is allowed only when it IS the intended mapping for
+    // *that specific* slot: a param named `f` must be the `f=` mapping; a param named
+    // `lagtime`/`alag` must be the `lagtime=`/`alag=` mapping. Anything else declines the twin —
+    // a disposition role bound to such a param (`mtt=ALAG`), a stray covariate/derived param
+    // literally named `f`, OR a cross-role mapping whose param name routes to a *different*
+    // reserved slot than its role (`f=LAGTIME`: the `LAGTIME` param name-routes to the lagtime
+    // slot the closed form never used it for, so the twin would apply it as both F and lag).
+    // Declining keeps the model closed-form (matching the closed form, which never applied that
+    // param as the shadowed F/lag) and, if it is also flip-flop, rejected up front — rather than
+    // the twin silently applying an extra F/lagtime the closed form did not.
+    let f_param = roles.get("f").map(String::as_str);
+    let lag_param = roles
+        .get("lagtime")
+        .or_else(|| roles.get("alag"))
+        .map(String::as_str);
     if let Some(ip_lines) = extracted.unnamed.get("individual_parameters") {
         for line in ip_lines {
             let lhs = line
@@ -6770,11 +6775,15 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
                 .next()
                 .unwrap_or("")
                 .trim();
-            if !lhs.is_empty()
-                && lhs.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-                && matches!(lhs.to_lowercase().as_str(), "f" | "lagtime" | "alag")
-                && !intended.contains(lhs)
-            {
+            if lhs.is_empty() || !lhs.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                continue;
+            }
+            let shadows = match lhs.to_lowercase().as_str() {
+                "f" => f_param != Some(lhs),
+                "lagtime" | "alag" => lag_param != Some(lhs),
+                _ => false,
+            };
+            if shadows {
                 return None; // shadows a reserved F/lagtime slot — decline (see above).
             }
         }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6637,6 +6637,16 @@ fn apply_ode_template(extracted: &mut ExtractedBlocks) -> Result<(), String> {
     Ok(())
 }
 
+/// The reserved F / lagtime PK slot a parameter or `pk(...)` role name routes to in the ODE
+/// twin — `Some(PK_IDX_F)` / `Some(PK_IDX_LAGTIME)` — or `None` if it routes to a disposition /
+/// structural slot. Derived from the real routing (`PkParams::name_to_index` filtered by
+/// `RESERVED_PK_SLOTS`) so the twin-builder's F/lagtime allowlist, alias emission, and
+/// shadow guard can never drift from `ode_param_slots`. #735.
+fn reserved_flag_slot(name: &str) -> Option<usize> {
+    crate::types::PkParams::name_to_index(&name.to_lowercase())
+        .filter(|s| crate::types::RESERVED_PK_SLOTS.contains(s))
+}
+
 /// For a closed-form `pk one_cpt_transit(cl, v, n, mtt)` / `pk one_cpt_ig(cl, v, mat, cv2)`
 /// model (and the 2-cpt forms), build the full `.ferx` source of its exact ODE equivalent
 /// (`transit()` / `igd()` forcing) — otherwise `None`.
@@ -6656,9 +6666,12 @@ fn apply_ode_template(extracted: &mut ExtractedBlocks) -> Result<(), String> {
 /// The equivalent shares the model's `[parameters]`/`[individual_parameters]`/… blocks
 /// verbatim and swaps only the disposition, so its θ/η layout matches the closed-form model
 /// exactly (the dispatch can hand it the same parameter vector). Scoped to the plain
-/// `one_cpt_transit(cl,v,n,mtt)` / `one_cpt_ig(cl,v,mat,cv2)` (and 2-cpt) forms with no
-/// `lagtime=`/`f=` mapping and no user `[odes]`/`[scaling]` block; anything else returns
-/// `None` (and stays closed-form, still rejected up front for the features it cannot serve).
+/// `one_cpt_transit(cl,v,n,mtt)` / `one_cpt_ig(cl,v,mat,cv2)` (and 2-cpt) forms, optionally
+/// with a `lagtime=`/`f=` (`alag=`) mapping carried into the twin as a reserved-name alias
+/// (#735), and with no user `[odes]`/`[scaling]`/`[initial_conditions]` block. Anything else —
+/// an unknown role, a parameter name that shadows or collides with a reserved F/lagtime slot,
+/// or a user disposition block — returns `None` (and stays closed-form, still rejected up front
+/// for the features it cannot serve).
 fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<String> {
     // Match a plain closed-form transit or IG disposition — 1-cpt `cl/v/<abs>` or 2-cpt
     // `cl/v1/q/v2/<abs>`, where `<abs>` is `n/mtt` (transit) or `mat/cv2` (IG). Any other
@@ -6726,10 +6739,11 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
     };
     // #735: absorption `f=` / `lagtime=` (`alag=`) are now carried into the twin (alias
     // emission below); any *other* unrecognised role stays outside the plain-form scope.
-    const ABS_ATTRS: &[&str] = &["f", "lagtime", "alag"];
+    // `reserved_flag_slot` recognises exactly the role names that route to the F/lagtime slots
+    // (derived from the real routing, so this can never drift from `ode_param_slots`).
     if roles
         .keys()
-        .any(|k| !disposition.contains(&k.as_str()) && !ABS_ATTRS.contains(&k.as_str()))
+        .any(|k| !disposition.contains(&k.as_str()) && reserved_flag_slot(k).is_none())
     {
         return None; // an unknown mapping — outside the plain-form scope.
     }
@@ -6737,56 +6751,82 @@ fn absorption_ode_equivalent_source(extracted: &ExtractedBlocks) -> Option<Strin
     // / `alag` (`ode_param_slots`), whereas the closed form binds them via this pk() role
     // map under arbitrary names. Bridge with reserved-name alias lines — but only when the
     // mapped parameter does not already self-route (a param literally named `F` / `LAGTIME`
-    // / `ALAG` lowercases to the canonical slot name, so an alias would double-bind it and
+    // / `ALAG` routes to the canonical slot already, so an alias would double-bind it and
     // `ode_param_slots` would reject). #735.
     let mut alias_lines: Vec<String> = Vec::new();
+    let mut alias_names: Vec<&str> = Vec::new();
     if let Some(fp) = roles.get("f") {
-        if fp.to_lowercase() != "f" {
+        if reserved_flag_slot(fp) != Some(crate::types::PK_IDX_F) {
             alias_lines.push(format!("  f = {fp}"));
+            alias_names.push("f");
         }
     }
     if let Some(lp) = roles.get("lagtime").or_else(|| roles.get("alag")) {
-        if !matches!(lp.to_lowercase().as_str(), "lagtime" | "alag") {
+        if reserved_flag_slot(lp) != Some(crate::types::PK_IDX_LAGTIME) {
             alias_lines.push(format!("  lagtime = {lp}"));
+            alias_names.push("lagtime");
         }
     }
     // Silent-divergence guard (#735): the ODE twin routes *any* individual parameter whose
-    // lowercased name is a reserved slot name (`f` / `lagtime` / `alag`) into that F/lagtime
-    // slot (`ode_param_slots`), even one the closed form never treated as F/lag. A param name
-    // that lowercases to a reserved slot is allowed only when it IS the intended mapping for
-    // *that specific* slot: a param named `f` must be the `f=` mapping; a param named
-    // `lagtime`/`alag` must be the `lagtime=`/`alag=` mapping. Anything else declines the twin —
-    // a disposition role bound to such a param (`mtt=ALAG`), a stray covariate/derived param
-    // literally named `f`, OR a cross-role mapping whose param name routes to a *different*
-    // reserved slot than its role (`f=LAGTIME`: the `LAGTIME` param name-routes to the lagtime
-    // slot the closed form never used it for, so the twin would apply it as both F and lag).
-    // Declining keeps the model closed-form (matching the closed form, which never applied that
-    // param as the shadowed F/lag) and, if it is also flip-flop, rejected up front — rather than
-    // the twin silently applying an extra F/lagtime the closed form did not.
+    // name routes to a reserved slot (`f` / `lagtime` / `alag`) into that F/lagtime slot
+    // (`ode_param_slots`), even one the closed form never treated as F/lag. A param whose name
+    // routes to a reserved slot is allowed only when it IS the intended mapping for *that
+    // specific* slot: a param named `f` must be the `f=` mapping; a param named `lagtime`/`alag`
+    // must be the `lagtime=`/`alag=` mapping. Anything else declines the twin — a disposition
+    // role bound to such a param (`mtt=ALAG`), a stray covariate/derived param literally named
+    // `f`, OR a cross-role mapping whose param name routes to a *different* reserved slot than
+    // its role (`f=LAGTIME`: the `LAGTIME` param name-routes to the lagtime slot the closed form
+    // never used it for, so the twin would apply it as both F and lag). Declining keeps the model
+    // closed-form (matching the closed form, which never applied that param as the shadowed
+    // F/lag) and, if it is also flip-flop, rejected up front — rather than the twin silently
+    // applying an extra F/lagtime the closed form did not.
+    //
+    // The same pass records the twin's individual-parameter names for the collision guard below.
     let f_param = roles.get("f").map(String::as_str);
     let lag_param = roles
         .get("lagtime")
         .or_else(|| roles.get("alag"))
         .map(String::as_str);
+    let mut twin_param_names: Vec<String> = Vec::new();
     if let Some(ip_lines) = extracted.unnamed.get("individual_parameters") {
         for line in ip_lines {
-            let lhs = line
-                .split(|c| c == '=' || c == '#')
-                .next()
-                .unwrap_or("")
-                .trim();
+            // `extract_blocks` has already stripped `#`/`//` comments, so the LHS is the text
+            // before the first `=`; the alphanumeric check skips `if`/`else`/brace lines.
+            let lhs = line.split('=').next().unwrap_or("").trim();
             if lhs.is_empty() || !lhs.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
                 continue;
             }
-            let shadows = match lhs.to_lowercase().as_str() {
-                "f" => f_param != Some(lhs),
-                "lagtime" | "alag" => lag_param != Some(lhs),
-                _ => false,
+            let shadows = match reserved_flag_slot(lhs) {
+                Some(slot) if slot == crate::types::PK_IDX_F => f_param != Some(lhs),
+                Some(_) => lag_param != Some(lhs), // PK_IDX_LAGTIME
+                None => false,
             };
             if shadows {
                 return None; // shadows a reserved F/lagtime slot — decline (see above).
             }
+            twin_param_names.push(lhs.to_string());
         }
+    }
+    // Collision guard (#735): a `f=`/`lagtime=` value that is an individual parameter whose
+    // *name* routes to an already-taken *disposition* slot (e.g. `f=V1`, where `V1` name-routes
+    // to the V slot held by `v=V`) is not a reserved-name shadow, so it passes the guard above —
+    // but the generated twin's `ode_param_slots` would reject it as two parameters mapping to one
+    // slot, which `AbsorptionOdeEquivalent::get_or_build` surfaces as a *panic*. The closed form
+    // binds F/lagtime by role, so the collision is harmless there. Dry-run the real slot
+    // assignment on the twin's projected parameter names. This list is a superset of the twin's
+    // real (filtered) parameter set, so it catches every real collision — at worst it declines an
+    // *unused* colliding name the real twin would not hit, which is harmless (the model stays
+    // closed-form). If it fails, decline the twin so the model stays closed-form — and, if
+    // flip-flop, is rejected up front with a clean error rather than panicking at eval time.
+    twin_param_names.extend(alias_names.iter().map(|s| s.to_string()));
+    // A parameter assigned in several `if`/`else` branches appears once in the twin's real
+    // parameter list (`unconditionally_assigned_vars` de-duplicates), so counting each raw LHS
+    // occurrence would be a spurious self-collision (`CL` in both branches of a `TIME` switch).
+    // De-duplicate by exact name, preserving first-occurrence order, before the slot check.
+    let mut seen = std::collections::HashSet::new();
+    twin_param_names.retain(|n| seen.insert(n.clone()));
+    if ode_param_slots(&twin_param_names).is_err() {
+        return None;
     }
     // The absorption forcing term, `transit(n, mtt)` or `igd(mat, cv2)`.
     let forcing = if is_ig {

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -115,9 +115,10 @@ pub(crate) fn absorption_flip_flop_at(
 /// sensitivity dispatchers route through here, and within an iteration they evaluate at
 /// the same `(theta, eta)`, so they agree on the decision.
 ///
-/// A flip-flop absorption model with no ODE twin (one carrying a lagtime, `f`, or a
-/// user `[odes]` / `[scaling]` / `[initial_conditions]` block, which the desugar
-/// declines) has nothing to reroute to, and is rejected up front at η = 0 typical
+/// A flip-flop absorption model with no ODE twin (one with a user `[odes]` / `[scaling]` /
+/// `[initial_conditions]` block, or a parameter name that shadows / collides with a reserved
+/// F/lagtime slot, which the desugar declines — a `lagtime=`/`f=` mapping alone now auto-routes,
+/// #735) has nothing to reroute to, and is rejected up front at η = 0 typical
 /// values by [`crate::api::check_absorption_flip_flop_no_twin`] (`fit()` → `Err`,
 /// `predict()`/`simulate()` panic) rather than silently returning the closed form's
 /// `0`. (This function still returns the closed form for it — the guard runs first.)
@@ -128,8 +129,9 @@ pub(crate) fn effective_model_for_eval<'a>(
     eta: &[f64],
 ) -> &'a CompiledModel {
     let structural = model.effective_for(subject);
-    // No twin to route to (a non-absorption model, or a lagtime / `f` / user-`[odes]`
-    // transit/IG whose desugar declined): nothing parameter-dependent to decide.
+    // No twin to route to (a non-absorption model, or a transit/IG whose desugar declined —
+    // a user `[odes]`/`[scaling]`/`[initial_conditions]` block or a reserved-slot shadow/
+    // collision): nothing parameter-dependent to decide.
     let Some(twin) = &model.absorption_ode_equivalent else {
         return structural;
     };

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -398,9 +398,10 @@ fn report_serializes_to_json() {
     assert!(json.contains("\"diagnostics\":[]"));
 }
 
-/// A twin-less flip-flop transit model (`lagtime=` declines the ODE-twin desugar;
-/// ke = CL/V = 0.5 ≥ KTR = (3+1)/20 = 0.2) is rejected by `ferx check` with a hard
-/// `E_TRANSIT_FLIP_FLOP` error, mirroring `fit()` (#776).
+/// A twin-less flip-flop transit model (a user `[scaling]` block declines the ODE-twin
+/// desugar; ke = CL/V = 0.5 ≥ KTR = (3+1)/20 = 0.2) is rejected by `ferx check` with a hard
+/// `E_TRANSIT_FLIP_FLOP` error, mirroring `fit()` (#776). (A `lagtime=`/`f=` form now gets a
+/// twin and auto-routes instead — see #735.)
 #[test]
 fn twin_less_flip_flop_transit_is_rejected_by_check() {
     let model = temp_model(
@@ -411,7 +412,6 @@ fn twin_less_flip_flop_transit_is_rejected_by_check() {
   theta TVV(4.0, 0.1, 500.0)
   theta TVNTR(3.0, 0.0, 20.0)
   theta TVMTT(20.0, 0.05, 200.0)
-  theta TVLAG(0.3, 0.0, 5.0)
   omega ETA_CL ~ 0.09
   sigma PROP ~ 0.01 (sd)
 
@@ -420,10 +420,12 @@ fn twin_less_flip_flop_transit_is_rejected_by_check() {
   V = TVV
   NTR = TVNTR
   MTT = TVMTT
-  LAGTIME = TVLAG
 
 [structural_model]
-  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime=LAGTIME)
+  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
+
+[scaling]
+  obs_scale = V
 
 [error_model]
   DV ~ proportional(PROP)

--- a/tests/ig_analytic_equivalence.rs
+++ b/tests/ig_analytic_equivalence.rs
@@ -213,6 +213,59 @@ fn ig_1cpt_lag_and_fbio_match_ode() {
     assert_equiv(&a, &o, "1cpt-lag+f", &pop, ACCUM_RTOL);
 }
 
+/// #735: a FLIP-FLOP inverse-Gaussian model carrying `lagtime=` and `f=` now auto-routes to
+/// its ODE `igd()` twin (instead of being rejected) and matches the hand-written ODE
+/// reference with the same lag/F. Flip-flop: ke = CL/V = 5/4 = 1.25 ≥ 1/(2·MAT·CV²) =
+/// 1/(2·2·0.3) = 0.833.
+#[test]
+fn ig_flipflop_lag_f_autoroutes_and_matches_twin() {
+    let header = "\
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(4.0, 0.1, 500.0)
+  theta TVMAT(2.0, 0.05, 24.0)
+  theta TVCV2(0.3, 0.001, 10.0)
+  theta TVLAG(0.4, 0.0, 5.0)
+  theta TVF(0.7, 0.01, 1.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  MAT = TVMAT
+  CV2 = TVCV2
+  LAGTIME = TVLAG
+  F = TVF
+";
+    let an_src = format!(
+        "{header}\n[structural_model]\n  \
+         pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2, lagtime=LAGTIME, f=F)\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let ode_src = format!(
+        "{header}\n[structural_model]\n  ode(obs_cmt=central, states=[central])\n\n\
+         [odes]\n  d/dt(central) = igd(mat=MAT, cv2=CV2) - (CL/V) * central\n\n\
+         [scaling]\n  obs_scale = V\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let an = parse_full_model(&an_src).expect("analytic IG parses").model;
+    assert!(
+        an.absorption_ode_equivalent.is_some(),
+        "a flip-flop lag/f IG closed form must now auto-route to an ODE twin (#735)"
+    );
+    let pop = population(
+        vec![bolus(0.0, 100.0)],
+        vec![1.0, 2.0, 4.0, 8.0, 12.0, 24.0],
+    );
+    let pa = predict(&an, &pop, &an.default_params);
+    assert!(
+        pa.iter().map(|p| p.pred).fold(0.0_f64, f64::max) > 0.01,
+        "the IG twin must produce a non-zero profile (not the closed form's flip-flop clamp)"
+    );
+    assert_equiv(&an_src, &ode_src, "ig-flipflop-lag+f", &pop, ACCUM_RTOL);
+}
+
 // ── 2-cpt ────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/ig_analytic_equivalence.rs
+++ b/tests/ig_analytic_equivalence.rs
@@ -266,6 +266,54 @@ fn ig_flipflop_lag_f_autoroutes_and_matches_twin() {
     assert_equiv(&an_src, &ode_src, "ig-flipflop-lag+f", &pop, ACCUM_RTOL);
 }
 
+/// #735: the IG alias path — a non-canonically-named mapping (`lagtime=LAG`, `f=FBIO`) must route
+/// into the twin's reserved slots via the emitted `lagtime = LAG` / `f = FBIO` alias lines, so it
+/// predicts identically to the same flip-flop IG model whose params ARE named canonically
+/// (`LAGTIME`/`F`, which self-route). If the alias were missing (or the `is_ig` branch diverged),
+/// LAG/FBIO would not reach the F/lagtime slots and the profiles would diverge. Mirrors the
+/// transit alias test so IG alias emission is not left unexercised.
+#[test]
+fn ig_flipflop_noncanonical_lag_f_alias_matches_canonical() {
+    let mk = |lag_name: &str, f_name: &str| {
+        format!(
+            "[parameters]\n  \
+             theta TVCL(5.0, 0.1, 100.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+             theta TVMAT(2.0, 0.05, 24.0)\n  theta TVCV2(0.3, 0.001, 10.0)\n  \
+             theta TVLAG(0.4, 0.0, 5.0)\n  theta TVF(0.7, 0.01, 1.0)\n  \
+             omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+             [individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  \
+             MAT = TVMAT\n  CV2 = TVCV2\n  {lag_name} = TVLAG\n  {f_name} = TVF\n\n\
+             [structural_model]\n  \
+             pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2, lagtime={lag_name}, f={f_name})\n\n\
+             [error_model]\n  DV ~ proportional(PROP)\n"
+        )
+    };
+    let canonical = parse_full_model(&mk("LAGTIME", "F"))
+        .expect("canonical parses")
+        .model;
+    let aliased = parse_full_model(&mk("LAG", "FBIO"))
+        .expect("aliased parses")
+        .model;
+    assert!(aliased.absorption_ode_equivalent.is_some());
+    let pop = population(
+        vec![bolus(0.0, 100.0)],
+        vec![1.0, 2.0, 4.0, 8.0, 12.0, 24.0],
+    );
+    let pc = predict(&canonical, &pop, &canonical.default_params);
+    let pl = predict(&aliased, &pop, &aliased.default_params);
+    assert_eq!(pc.len(), pl.len());
+    assert!(pc.iter().map(|p| p.pred).fold(0.0_f64, f64::max) > 0.01);
+    for (x, y) in pc.iter().zip(pl.iter()) {
+        assert!(
+            (x.pred - y.pred).abs() <= ATOL + ACCUM_RTOL * x.pred.abs(),
+            "t={:.3}: canonical-name {:.6} vs aliased-name {:.6} — IG alias failed to route lag/f",
+            x.time,
+            x.pred,
+            y.pred
+        );
+    }
+}
+
 // ── 2-cpt ────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -1410,6 +1410,70 @@ LAGTIME = TVF\n\n\
     );
 }
 
+/// #735 collision guard (regression): a `f=` value that is an individual parameter whose *name*
+/// routes to an already-taken *disposition* slot (`f=V1`, where `V1` name-routes to the V slot
+/// held by `v=V`) is not a reserved-name shadow, so the shadow guard passes it — but the
+/// generated twin's `ode_param_slots` rejects the duplicate V slot. Before the collision guard
+/// the twin was built (`is_some`) and `predict`/`fit`/`simulate` PANICKED in
+/// `get_or_build().expect(...)`. It must now decline the twin (`is_none`).
+#[test]
+fn transit_flipflop_f_param_named_disposition_slot_declines_twin() {
+    // Flip-flop: ke = CL/V = 2.0/4.0 = 0.5 ≥ KTR = (3+1)/20 = 0.2.
+    let src = "\
+[parameters]\n  theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  theta TVF(0.7, 0.01, 1.0)\n  \
+omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  NTR = TVNTR\n  MTT = TVMTT\n  \
+V1 = TVF\n\n\
+[structural_model]\n  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, f=V1)\n\n\
+[error_model]\n  DV ~ proportional(PROP)\n";
+    let model = parse_full_model(src).expect("parses").model;
+    assert!(
+        model.absorption_ode_equivalent.is_none(),
+        "an `f=` param named `V1` collides with the twin's V disposition slot — the twin must be \
+         declined (not built into a source that panics in ode_param_slots)"
+    );
+}
+
+/// #735 collision guard: the declined-twin flip-flop `f=V1` model reaches the *clean* twin-less
+/// flip-flop rejection (`predict()` panics with "flip-flop regime"), NOT the internal
+/// "same PK slot" build panic it hit before the guard.
+#[test]
+#[should_panic(expected = "flip-flop regime")]
+fn transit_flipflop_f_param_named_disposition_slot_predict_panics_cleanly() {
+    let src = "\
+[parameters]\n  theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  theta TVF(0.7, 0.01, 1.0)\n  \
+omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  NTR = TVNTR\n  MTT = TVMTT\n  \
+V1 = TVF\n\n\
+[structural_model]\n  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, f=V1)\n\n\
+[error_model]\n  DV ~ proportional(PROP)\n";
+    let model = parse_full_model(src).expect("parses").model;
+    let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0, 12.0]);
+    let _ = predict(&model, &pop, &model.default_params);
+}
+
+/// #735 shadow guard, **stray reserved-name** case (exercises the `f` arm's decline branch): an
+/// individual parameter literally named `F` bound to a *disposition* role (`n=F`, not the `f=`
+/// mapping) would name-route to the F/bioavailability slot in the ODE twin — applying an F the
+/// closed form (which reads it as the transit count) never did. The guard declines the twin.
+#[test]
+fn transit_stray_f_named_param_declines_twin() {
+    let src = "\
+[parameters]\n  theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  \
+omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  F = TVNTR\n  MTT = TVMTT\n\n\
+[structural_model]\n  pk one_cpt_transit(cl=CL, v=V, n=F, mtt=MTT)\n\n\
+[error_model]\n  DV ~ proportional(PROP)\n";
+    let model = parse_full_model(src).expect("parses").model;
+    assert!(
+        model.absorption_ode_equivalent.is_none(),
+        "a param literally named `F` bound to the n= role must decline the twin (shadow guard `f` arm)"
+    );
+}
+
 /// A twin-less `one_cpt_transit` whose typical parameters put `ke = CL/V` at or above the
 /// transit rate `KTR = (n+1)/mtt` — the flip-flop regime the closed form cannot serve, made
 /// twin-less by a user `[scaling]` block that declines the ODE-twin desugar (#776; the

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -1193,20 +1193,23 @@ fn two_cpt_transit_flip_flop_routes_to_ode_twin() {
     );
 }
 
-/// A flip-flop transit model carrying a `lagtime=` (or `f=`) mapping cannot be
-/// desugared to an ODE twin, so there is nothing to reroute to. Rather than silently
-/// returning a zero profile, it is a **hard error** at every entry point (#776):
-/// `fit()` returns `Err` and no `W_TRANSIT_FLIP_FLOP` warning fires (that
-/// informational note is reserved for the twin-carrying, auto-rerouted case).
+/// A flip-flop transit model made twin-less by a user `[scaling]` block (or `[odes]` /
+/// `[initial_conditions]`) cannot be desugared to an ODE twin, so there is nothing to reroute
+/// to. Rather than silently returning a zero profile, it is a **hard error** at every entry
+/// point (#776): `fit()` returns `Err` and no `W_TRANSIT_FLIP_FLOP` warning fires (that
+/// informational note is reserved for the twin-carrying, auto-rerouted case). (A `lagtime=` /
+/// `f=` transit model now gets a twin and auto-routes instead — see #735.)
 #[test]
 fn transit_flip_flop_without_twin_is_rejected() {
-    // ke = CL/V = 0.5 ≥ KTR = 4/20 = 0.2 (flip-flop); the lagtime declines the desugar,
-    // so there is no ODE twin to reroute to — now a hard error (#776), not a warning.
+    // ke = CL/V = 0.5 ≥ KTR = 4/20 = 0.2 (flip-flop); the [scaling] block declines the
+    // desugar, so there is no ODE twin to reroute to — a hard error (#776), not a warning.
     let src = TWIN_LESS_FLIP_FLOP_SRC;
-    let model = parse_full_model(src).expect("lagtime transit parses").model;
+    let model = parse_full_model(src)
+        .expect("[scaling] transit parses")
+        .model;
     assert!(
         model.absorption_ode_equivalent.is_none(),
-        "a lagtime= transit model has no ODE twin (the desugar declines it)"
+        "a [scaling] transit model has no ODE twin (the desugar declines it)"
     );
     let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0, 12.0]);
 
@@ -1233,7 +1236,7 @@ fn transit_flip_flop_without_twin_is_rejected() {
 #[should_panic(expected = "flip-flop regime")]
 fn transit_flip_flop_without_twin_panics_in_predict() {
     let model = parse_full_model(TWIN_LESS_FLIP_FLOP_SRC)
-        .expect("lagtime transit parses")
+        .expect("[scaling] transit parses")
         .model;
     let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0, 12.0]);
     let _ = predict(&model, &pop, &model.default_params);
@@ -1246,22 +1249,28 @@ fn transit_flip_flop_without_twin_panics_in_predict() {
 #[should_panic(expected = "flip-flop regime")]
 fn transit_flip_flop_without_twin_panics_in_simulate() {
     let model = parse_full_model(TWIN_LESS_FLIP_FLOP_SRC)
-        .expect("lagtime transit parses")
+        .expect("[scaling] transit parses")
         .model;
     let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0, 12.0]);
     let _ = ferx_core::simulate_with_seed(&model, &pop, &model.default_params, 1, 42);
 }
 
-/// A twin-less `one_cpt_transit` whose typical parameters put `ke = CL/V` at or above the
-/// transit rate `KTR = (n+1)/mtt` — the flip-flop regime the closed form cannot serve, with
-/// a `lagtime=` mapping that declines the ODE-twin desugar (#776).
-const TWIN_LESS_FLIP_FLOP_SRC: &str = "\
+/// #735: a FLIP-FLOP transit model carrying `lagtime=` and `f=` now auto-routes to its
+/// ODE twin (instead of being rejected) and predicts identically to the hand-written ODE
+/// `transit()` reference carrying the same lag/F — proving the twin applies both. Params
+/// named `LAGTIME`/`F` self-route in the ODE (their lowercased names are the canonical
+/// slot names), so this pins the allowlist change + twin build.
+#[test]
+fn transit_flipflop_lag_f_autoroutes_and_matches_twin() {
+    // Flip-flop: ke = CL/V = 2.0/4.0 = 0.5 ≥ KTR = (3+1)/20 = 0.2 (closed form clamps to 0).
+    let header = "\
 [parameters]
   theta TVCL(2.0, 0.001, 50.0)
   theta TVV(4.0, 0.1, 500.0)
   theta TVNTR(3.0, 0.0, 20.0)
   theta TVMTT(20.0, 0.05, 200.0)
-  theta TVLAG(0.3, 0.0, 5.0)
+  theta TVLAG(0.5, 0.0, 5.0)
+  theta TVF(0.7, 0.01, 1.0)
   omega ETA_CL ~ 0.09
   sigma PROP ~ 0.01 (sd)
 
@@ -1271,9 +1280,139 @@ const TWIN_LESS_FLIP_FLOP_SRC: &str = "\
   NTR = TVNTR
   MTT = TVMTT
   LAGTIME = TVLAG
+  F = TVF
+";
+    let an_src = format!(
+        "{header}\n[structural_model]\n  \
+         pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime=LAGTIME, f=F)\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let ode_src = format!(
+        "{header}\n[structural_model]\n  ode(obs_cmt=central, states=[central])\n\n\
+         [odes]\n  d/dt(central) = transit(n=NTR, mtt=MTT) - (CL/V) * central\n\n\
+         [scaling]\n  obs_scale = V\n\n\
+         [error_model]\n  DV ~ proportional(PROP)\n"
+    );
+    let an = parse_full_model(&an_src).expect("analytic parses").model;
+    assert!(
+        an.absorption_ode_equivalent.is_some(),
+        "a flip-flop lag/f transit closed form must now auto-route to an ODE twin (#735)"
+    );
+    let ode = parse_full_model(&ode_src).expect("ODE parses").model;
+    let pop = population(
+        vec![bolus(0.0, 100.0)],
+        vec![1.0, 2.0, 4.0, 8.0, 12.0, 24.0],
+    );
+    let pa = predict(&an, &pop, &an.default_params);
+    let po = predict(&ode, &pop, &ode.default_params);
+    assert_eq!(pa.len(), po.len());
+    assert!(
+        pa.iter().map(|p| p.pred).fold(0.0_f64, f64::max) > 0.01,
+        "the twin must produce a non-zero profile (not the closed form's flip-flop clamp)"
+    );
+    for (x, y) in pa.iter().zip(po.iter()) {
+        assert!(
+            (x.pred - y.pred).abs() <= ATOL + ACCUM_RTOL * x.pred.abs(),
+            "t={:.3}: analytic(twin) {:.6} vs hand ODE {:.6}",
+            x.time,
+            x.pred,
+            y.pred
+        );
+    }
+}
+
+/// #735: the alias path — a non-canonically-named mapping (`lagtime=LAG`, `f=FBIO`) must
+/// route into the twin's reserved slots via the emitted `lagtime = LAG` / `f = FBIO` alias
+/// lines, so it predicts identically to the same flip-flop model whose params ARE named
+/// canonically (`LAGTIME`/`F`, which self-route). If the alias were missing, LAG/FBIO would
+/// not reach the F/lagtime slots and the profiles would diverge.
+#[test]
+fn transit_flipflop_noncanonical_lag_f_alias_matches_canonical() {
+    let mk = |lag_name: &str, f_name: &str| {
+        format!(
+            "[parameters]\n  \
+             theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+             theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  \
+             theta TVLAG(0.5, 0.0, 5.0)\n  theta TVF(0.7, 0.01, 1.0)\n  \
+             omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+             [individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  \
+             NTR = TVNTR\n  MTT = TVMTT\n  {lag_name} = TVLAG\n  {f_name} = TVF\n\n\
+             [structural_model]\n  \
+             pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime={lag_name}, f={f_name})\n\n\
+             [error_model]\n  DV ~ proportional(PROP)\n"
+        )
+    };
+    let canonical = parse_full_model(&mk("LAGTIME", "F"))
+        .expect("canonical parses")
+        .model;
+    let aliased = parse_full_model(&mk("LAG", "FBIO"))
+        .expect("aliased parses")
+        .model;
+    assert!(aliased.absorption_ode_equivalent.is_some());
+    let pop = population(
+        vec![bolus(0.0, 100.0)],
+        vec![1.0, 2.0, 4.0, 8.0, 12.0, 24.0],
+    );
+    let pc = predict(&canonical, &pop, &canonical.default_params);
+    let pl = predict(&aliased, &pop, &aliased.default_params);
+    assert_eq!(pc.len(), pl.len());
+    assert!(pc.iter().map(|p| p.pred).fold(0.0_f64, f64::max) > 0.01);
+    for (x, y) in pc.iter().zip(pl.iter()) {
+        assert!(
+            (x.pred - y.pred).abs() <= ATOL + ACCUM_RTOL * x.pred.abs(),
+            "t={:.3}: canonical-name {:.6} vs aliased-name {:.6} — alias failed to route lag/f",
+            x.time,
+            x.pred,
+            y.pred
+        );
+    }
+}
+
+/// #735 silent-divergence guard: a transit model binding a disposition role to a param whose
+/// name shadows a reserved F/lagtime slot (`mtt=ALAG`) declines the ODE twin — the twin would
+/// otherwise route `ALAG` to the lagtime slot (`ode_param_slots`) and apply a lag the closed
+/// form never did. It stays closed-form (matching the closed form, which reads `ALAG` as MTT).
+#[test]
+fn transit_reserved_name_shadow_declines_twin() {
+    let src = "\
+[parameters]\n  theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  \
+omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  NTR = TVNTR\n  \
+ALAG = TVMTT\n\n\
+[structural_model]\n  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=ALAG)\n\n\
+[error_model]\n  DV ~ proportional(PROP)\n";
+    let model = parse_full_model(src).expect("parses").model;
+    assert!(
+        model.absorption_ode_equivalent.is_none(),
+        "a param named ALAG bound to a disposition role must decline the twin (shadow guard)"
+    );
+}
+
+/// A twin-less `one_cpt_transit` whose typical parameters put `ke = CL/V` at or above the
+/// transit rate `KTR = (n+1)/mtt` — the flip-flop regime the closed form cannot serve, made
+/// twin-less by a user `[scaling]` block that declines the ODE-twin desugar (#776; the
+/// `lagtime=` form now auto-routes instead, #735).
+const TWIN_LESS_FLIP_FLOP_SRC: &str = "\
+[parameters]
+  theta TVCL(2.0, 0.001, 50.0)
+  theta TVV(4.0, 0.1, 500.0)
+  theta TVNTR(3.0, 0.0, 20.0)
+  theta TVMTT(20.0, 0.05, 200.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  NTR = TVNTR
+  MTT = TVMTT
 
 [structural_model]
-  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, lagtime=LAGTIME)
+  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
+
+[scaling]
+  obs_scale = V
 
 [error_model]
   DV ~ proportional(PROP)

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -1389,6 +1389,27 @@ ALAG = TVMTT\n\n\
     );
 }
 
+/// #735 shadow guard, **cross-role** case: the `f=` mapping's param is *named* `LAGTIME`, so in
+/// the ODE twin it name-routes to the *lagtime* slot (`ode_param_slots`) — applying a lag the
+/// closed form never did — in addition to the `f = LAGTIME` alias. The intended-mapping
+/// exemption is per-slot, so this declines the twin too (it is not the `lagtime=` mapping).
+#[test]
+fn transit_cross_role_shadow_declines_twin() {
+    let src = "\
+[parameters]\n  theta TVCL(2.0, 0.001, 50.0)\n  theta TVV(4.0, 0.1, 500.0)\n  \
+theta TVNTR(3.0, 0.0, 20.0)\n  theta TVMTT(20.0, 0.05, 200.0)\n  theta TVF(0.7, 0.01, 1.0)\n  \
+omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
+[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV\n  NTR = TVNTR\n  MTT = TVMTT\n  \
+LAGTIME = TVF\n\n\
+[structural_model]\n  pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT, f=LAGTIME)\n\n\
+[error_model]\n  DV ~ proportional(PROP)\n";
+    let model = parse_full_model(src).expect("parses").model;
+    assert!(
+        model.absorption_ode_equivalent.is_none(),
+        "an `f=` param named LAGTIME shadows the lagtime slot — the twin must be declined"
+    );
+}
+
 /// A twin-less `one_cpt_transit` whose typical parameters put `ke = CL/V` at or above the
 /// transit rate `KTR = (n+1)/mtt` — the flip-flop regime the closed form cannot serve, made
 /// twin-less by a user `[scaling]` block that declines the ODE-twin desugar (#776; the


### PR DESCRIPTION
Closes #735.

## Why

The analytic transit / inverse-Gaussian closed forms clamp to an identically-zero profile outside their tilting-convergence domain (the **flip-flop** regime, `ke ≥ KTR` / `ke ≥ 1/(2·MAT·CV²)`), and ferx transparently reroutes such a model to its exact ODE `transit()`/`igd()` **twin** — but the twin-builder (`absorption_ode_equivalent_source`) only accepted the plain `cl/v/n/mtt` (or IG `cl/v/mat/cv2`) form. A model that also carried a `lagtime=` / `f=` mapping declined the desugar, so it had **no twin to route to** and was rejected (or, worse for a `TIME` / time-varying-covariate model that *requires* the twin, unfittable). #735 removes that limitation.

## What changed

- **Twin-builder carries `lagtime=` / `f=` into the generated twin** (`src/parser/model_parser.rs`). `f` / `lagtime` / `alag` are added to the allowlist; the ODE twin routes F/lag by an individual parameter *named* `f`/`lagtime`/`alag` (`ode_param_slots`), whereas the closed form binds them via the `pk(...)` role map under arbitrary names — so the builder emits **reserved-name alias lines** (`f = <param>`, `lagtime = <param>`) into the generated `[individual_parameters]`, but only when the mapped param does not already self-route (a param literally named `F`/`LAGTIME` lowercases to the canonical slot name).
- **Silent-divergence guard.** If any *other* declared parameter's name shadows a reserved F/lagtime slot (a disposition role bound to a param named `ALAG`, or a stray param literally named `f`), the twin would route it to that slot and apply an F/lag the closed form never did. Such a model **declines the twin** (stays closed-form — matching the closed form, which never applied it as F/lag — and is rejected up front if also flip-flop) rather than diverging silently.

## Alternatives considered

- **Require canonical param names** (reject `f=FBIO`, force `f=F`): refuses valid input it can handle, and still needs the shadow guard.
- **Add a `pk(...)` role-map to ODE models**: a whole new DSL surface (parser + validation) for one internal use; more attack surface, not more robust.
Chosen the alias approach: works for any param name, reuses the proven `ode_param_slots` routing, no new DSL surface. (See the review thread for the full "no happy paths" rationale.)

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | optional pin bump | after |

No new `pub` API or DSL syntax (users already write `lagtime=`/`f=`); this is a behaviour change. ferx-r compiles against a stale pin unchanged — an optional pin bump surfaces the new behaviour to R users, as a follow-up.

## Breaking changes
- [x] None — a previously-rejected/zero-returning model now fits correctly. Strictly an improvement.

## Numerical validation
- [x] Compared against: **closed-form ↔ ODE-twin equivalence** (the internal anchor).
- New tests assert a **flip-flop** transit / IG model carrying `lagtime` and/or `f` auto-routes to its twin and predicts **identically** to a hand-written ODE `transit()`/`igd()` reference carrying the same lag/F (`tests/transit_analytic_equivalence.rs::transit_flipflop_lag_f_autoroutes_and_matches_twin`, `..._noncanonical_lag_f_alias_matches_canonical`; `tests/ig_analytic_equivalence.rs::ig_flipflop_lag_f_autoroutes_and_matches_twin`), to closed-form↔ODE tolerance.
- **NONMEM**: transitive, per the existing playbook. #735 changes *routing*, not the numeric engine — the ODE `transit()`/`igd()` forcing and the 1-/2-cpt disposition are already NONMEM-anchored (`tests/transit_nonmem_anchor.rs` #385, `tests/igd_nonmem_anchor.rs`/#790), and lag (a `tad` shift) / F (a mass scale) are applied identically on the ODE and analytic paths (in-domain equivalence covered by `build_pair(lag, fbio)`). The equivalence tests match the flip-flop twin to those anchored ODE forms. A dedicated flip-flop-transit-with-lag `$DES` anchor can be added if you want belt-and-suspenders — flag it.

## Performance
- [x] No significant impact — the twin is built lazily and only for subjects that need it (flip-flop / TIME / TV-cov); a plain in-domain fit keeps its fast closed form. The alias emission is parse-time only.

## Tests
- [x] Unit / Tier-2 test(s) added (`cargo test --lib` + the equivalence binaries pass)
- [x] Regression test added that fails without this fix (the auto-route + match-twin tests; the shadow-guard test)

Also **reworked the ripple**: making `lagtime=`/`f=` models twin-*carrying* means they are no longer *twin-less*, which is the precondition for #785's EBE-degeneration warning and for the `..._without_twin_*` reject/panic tests. Those fixtures moved to a genuinely twin-less `[scaling]` form; the previously-rejected `transit + TIME + lagtime` case is now an **auto-routes** test (a fix).

## Example (user-facing features only)
- [x] Not applicable — no new syntax; an existing model that errored now works.

## Docs
- [x] `docs/model-file/absorption.qmd` — the flip-flop note now says `lagtime`/`f` models auto-route (only `[odes]`/`[scaling]`/`[initial_conditions]` stay twin-less).
- [x] `CHANGELOG.md` `[Unreleased] → Changed`.

## Checklist
- [x] `cargo clippy` clean
- [x] `Dual2` sensitivity path untouched (parser-side desugar + test changes only)
- [x] No version bump (non-breaking)

## Reviewer hints

- **The alias emission** (`absorption_ode_equivalent_source`): the self-route skip is load-bearing — a param named `F` already routes, so emitting `f = F` would double-bind the slot and `ode_param_slots` rejects. Confirm the `!= "f"` / `!matches!(…, "lagtime"|"alag")` conditions.
- **The shadow guard**: scans `[individual_parameters]` LHS names (role params are declared params, so one scan covers both `mtt=ALAG` and a stray `f`). Raw LHS parse is best-effort (splits on `=`/`#`, requires an all-alphanumeric ident) — worth a look.
- **The ripple**: the twin-less fixtures moved from `lagtime=` → `[scaling]`; the `transit_with_time_and_lagtime_is_rejected` test became `..._autoroutes`. Sanity-check those still assert the intended behaviour.

## Open questions

- A dedicated **flip-flop-transit-with-lag NONMEM `$DES` anchor** — worth adding, or is the transitive validation (equivalence to the already-anchored ODE forms) enough? (I lean enough, given #735 is routing, not new math.)
