### PR TITLE
feat(api): left-truncation (delayed entry) for RTTE simulation (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,13 @@ section of the SDLC for the versioning policy).
   (condition on survival past entry, never restart the clock at entry). Assumes the
   time origin `t = 0` is the renewal origin of the first sojourn; coincides with the
   pure renewal form (and with clock-forward) for a memoryless exponential hazard.
-  Simulation of left-truncated RTTE streams remains a separate follow-up.
+- **Left truncation for RTTE _simulation_** (#740): `simulate()` now accepts
+  `TENTRY > 0` for repeated events on both clocks, drawing the stream on the time
+  origin conditioned on survival to entry (clock-forward seeds its conditioning clock
+  at `TENTRY`; clock-reset draws its first sojourn conditional on entry, then renews
+  from 0) — the simulate dual of the fit-side conditioning, so a simulated
+  left-truncated stream refits under the same convention. `TENTRY = 0` stays
+  byte-identical to the non-truncated draw.
 - **Analytic inverse-Gaussian (IG) absorption closed form** (#790): the Freijer &
   Post inverse-Gaussian absorption model is now available as the analytic
   structural models `pk one_cpt_ig(cl, v, mat, cv2)` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,20 @@ These run nightly via `slow-tests.yml` and on any push to `main` that touches es
 
 > **Exception — adaptive / feedback dosing simulations (epic #391) do not use NONMEM.** NONMEM has no native feedback dosing (a controller reading simulated state to choose the next dose), so there is no equivalent NONMEM run to anchor against. Validate these features instead with: (c) a **degenerate oracle** — a controller that re-emits a fixed regimen must equal `simulate()` on that regimen bit-for-bit; the **frozen-schedule replay verifier** — rebuild a static subject from the realized dose ledger and assert bit-equality with the static engine (the exact internal analogue of a NONMEM dose-bookkeeping anchor); and, for genuinely reactive behaviour, (b) reproduction of a published **mrgsolve** dynamic-dosing example (e.g. vancomycin AUC-target TDM, the platelet ladder). mrgsolve — not NONMEM — is the external comparator for this family, since it actually does feedback dosing. See issue #391's Validation section.
 
+> **Exception — survival-likelihood terms with no equivalent NONMEM/survreg estimator.** A few
+> recurrent-event objects have no standard tool to anchor against as a single object — e.g.
+> recurrent **left truncation** under gap-time (clock-reset) RTTE (#740), which NONMEM / survreg
+> / flexsurv have no native estimator for. Validate these instead with: (a) **exact closed
+> forms** — Tier-1 unit tests pinning the −log L (or the simulated stream) on hand-computed
+> values; (b) **reduction to an already-anchored term** — the delayed-entry first sojourn
+> `H(t₁) − H(entry)` *is* the single-event left-truncation contribution that single-event / clock-
+> forward TTE already validate against NONMEM, so no new formula is anchored from scratch; and,
+> for the simulate side, (c) a **round-trip / degenerate oracle** — `entry = 0` must be
+> bit-identical to the non-truncated draw, and a simulated left-truncated stream must refit under
+> the same convention it was drawn from. A committed external reference dataset (e.g. flexsurv) is
+> added when that tool is available in the environment; its absence does not block the closed-form
+> + reduction validation above.
+
 **Coverage is gated per PR.** A PR's changed lines must carry their own tests — the Codecov `patch` status enforces ≥90% coverage on the diff, and a 90% project floor is enforced on the weekly `main` run (see `codecov.yml`). This is the automated backstop to the rules above; slow-tests never run on PRs, so unit / Tier-2 tests are what register coverage. When excluding code from coverage, **scope `ignore`s by role, not by coverage %**: leave code out for *what it is* — dev-only tooling (e.g. `src/bin/generate_data.rs`), generated code (`build.rs`), or test scaffolding (`tests/`) — never because it reads red. (Feature-gated code that the coverage build doesn't compile reads as "missed" but is a measurement gap, not an ignore target — see #293.)
 
 ## Documentation

--- a/docs/estimation/tte.qmd
+++ b/docs/estimation/tte.qmd
@@ -422,9 +422,15 @@ endpoint: `TENTRY` always means "condition on survival past entry", never "resta
 clock at entry" (the two would differ for a time-varying hazard, and only the former is a
 standard, anchorable left-truncation model). Reset left truncation assumes the time origin
 `t = 0` is the renewal origin of the first sojourn (the subject was event-free and at risk
-from 0); it coincides with clock-forward for a memoryless (exponential) hazard. Simulating
-a left-truncated RTTE stream is a separate follow-up — `simulate()` still requires
-`TENTRY = 0` for repeated events.
+from 0); it coincides with clock-forward for a memoryless (exponential) hazard.
+
+`simulate()` accepts left truncation for repeated events too (#740): the stream is drawn on
+the same time origin conditioned on survival to `TENTRY` — clock-forward seeds its
+conditioning clock at `TENTRY`, clock-reset draws its first sojourn conditional on survival to
+entry and renews from 0 thereafter — so a simulated left-truncated stream refits under the same
+convention it was drawn from. `TENTRY = 0` is byte-identical to the non-truncated draw. (The
+simulated event rows carry the drawn times; as with single-event TTE simulation, `TENTRY`
+itself is a property of the input design, not re-emitted onto the output rows.)
 
 ::: {.callout-warning}
 ## Prefer SAEM/IMP for RTTE

--- a/src/api.rs
+++ b/src/api.rs
@@ -7551,8 +7551,10 @@ pub struct SimulateOptions {
 /// re-raise the same message as a panic):
 /// - a **finite, positive horizon** is required — the recurrent stream is generated up
 ///   to that administrative window; there is no implicit one;
-/// - **left truncation** (`entry_time > 0`) is a deferred follow-up (conditional
-///   first-gap sampling past entry), so `entry_time == 0` is required;
+/// - **left truncation** (`entry_time > 0`) *is* supported (#740): the stream is drawn on
+///   the time origin conditioned on survival to entry, the simulate dual of the fit-side
+///   conditioning (clock-forward seeds its clock at entry; clock-reset conditions its first
+///   sojourn, convention B). `entry_time == 0` is byte-identical to the non-truncated draw;
 /// - exactly **one recurrent stream per subject** — multiple RTTE CMTs, or an RTTE
 ///   cause mixed with a competing single-event TTE cause, are a later slice (they need
 ///   a shared-horizon multi-stream draw);
@@ -7634,22 +7636,17 @@ fn validate_tte_simulatable(
             let mut rtte_cmts = std::collections::BTreeSet::new();
             let mut has_single_tte_sibling = false;
             for r in &subject.obs_records {
-                let ObsRecord::Event {
-                    cmt, entry_time, ..
-                } = r
-                else {
+                let ObsRecord::Event { cmt, .. } = r else {
                     continue;
                 };
+                // Left truncation (delayed entry, entry_time > 0) IS supported for RTTE
+                // simulation (#740): the stream is drawn on the time origin conditioned on
+                // survival to entry — clock-forward seeds its conditioning clock at entry,
+                // clock-reset conditions its first sojourn (convention B). This is the
+                // simulate dual of the fit-side conditioning; see
+                // [`crate::survival::simulate_rtte_stream`].
                 if is_rtte(cmt) {
                     rtte_cmts.insert(*cmt);
-                    if *entry_time > 0.0 {
-                        return Err(format!(
-                            "RTTE (`type = rtte`) simulation does not support left truncation \
-                             (entry_time={entry_time} for subject '{}' on CMT={cmt}); conditional \
-                             first-gap sampling past entry is a deferred follow-up",
-                            subject.id
-                        ));
-                    }
                 } else if is_single_tte(cmt) {
                     has_single_tte_sibling = true;
                 }

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -945,7 +945,7 @@ fn simulate_rtte_stream<R: rand::Rng>(
             };
             cum_hazard(family, horizon, params) - h_entry
         }
-        RtteClock::Reset => (horizon - entry) / sample_event_time(family, params, 0.5),
+        RtteClock::Reset => (horizon - entry.max(0.0)) / sample_event_time(family, params, 0.5),
     };
     if !expected.is_finite() || expected > MAX_EVENTS as f64 {
         warnings.push(format!(
@@ -962,8 +962,11 @@ fn simulate_rtte_stream<R: rand::Rng>(
     // clock, so left truncation just seeds that clock at `entry` (`entry == 0` ⇒ `0`,
     // identical to before). Clock-reset renews each gap from 0, so its FIRST sojourn is the
     // only one conditioned on survival to `entry` (handled in the loop via `n_events == 0`).
+    // A non-positive `entry` means "no truncation" — clamp to 0 so it can never seed a
+    // pre-origin clock (matching the `expected` estimate above, the reset arm's `entry > 0.0`
+    // gate, and the fit side's `entry_lower_limit`; `entry == 0` stays `0.0`, bit-identical).
     let mut t_prev = match clock {
-        RtteClock::Forward => entry,
+        RtteClock::Forward => entry.max(0.0),
         RtteClock::Reset => 0.0_f64,
     };
     let mut n_events = 0usize;
@@ -2986,6 +2989,94 @@ mod tests {
             "left-truncated stream must fit, got {nll}"
         );
         assert_abs_diff_eq!(nll, expected, epsilon = 1e-9);
+    }
+
+    /// The discriminating pin (simulate dual of the fit-side `..._conditions_on_entry`): the
+    /// FIRST simulated sojourn under delayed entry must equal convention B's closed form
+    /// `sample_conditional_event_time(entry, u₁)` and must NOT equal the rejected
+    /// renewal-from-entry A (`entry + sample_event_time(u₁)`). A time-varying (Weibull) hazard
+    /// is essential — for the memoryless exponential A ≡ B, so the shift test cannot see this,
+    /// and the round-trip test above is convention-agnostic (it recomputes B on whatever was
+    /// drawn). Pins BOTH clocks (both draw the first event conditional on survival to entry).
+    #[test]
+    fn rtte_left_truncation_first_sojourn_is_convention_b_not_a() {
+        use rand::SeedableRng;
+        let params = [40.0_f64, 1.6_f64]; // Weibull scale=40, shape=1.6 (time-varying)
+        let entry = 15.0_f64;
+        let horizon = 300.0_f64;
+        let seed = 0xB17E_5EED_u64;
+        for clock in [RtteClock::Forward, RtteClock::Reset] {
+            // The exact first uniform the stream will consume (same seed + same Open01 draw).
+            let mut probe = rand::rngs::StdRng::seed_from_u64(seed);
+            let u1: f64 = probe.sample(rand::distr::Open01);
+            let b = sample_conditional_event_time(HazardFamily::Weibull, &params, entry, u1);
+            let a = entry + sample_event_time(HazardFamily::Weibull, &params, u1);
+            assert!(
+                b < horizon,
+                "setup: first B event must land before the horizon"
+            );
+            assert!(
+                (a - b).abs() > 0.5,
+                "setup: A ({a}) and B ({b}) must differ materially for a time-varying hazard"
+            );
+            let mut stream = rand::rngs::StdRng::seed_from_u64(seed);
+            let events = collect_rtte_events(
+                HazardFamily::Weibull,
+                &params,
+                clock,
+                horizon,
+                entry,
+                &mut stream,
+            );
+            assert!(!events.is_empty(), "{clock:?}: expected a first event");
+            assert_abs_diff_eq!(events[0], b, epsilon = 1e-12);
+            assert!(
+                (events[0] - a).abs() > 0.5,
+                "{clock:?}: first sojourn must be convention B ({b}), not renewal-from-entry A ({a}); got {}",
+                events[0]
+            );
+        }
+    }
+
+    /// A non-positive `entry` means "no truncation" everywhere — the datareader clamps `TENTRY`
+    /// to `≥ 0`, and the fit's `entry_lower_limit` / the reset draw gate on `entry > 0`. A
+    /// hand-built `Population` can bypass the datareader and pass a negative entry straight to
+    /// `simulate()`; it must then behave exactly as `entry == 0` for BOTH clocks — never seed a
+    /// pre-origin clock or emit a negative-time event. (Guards the forward-clock `entry.max(0.0)`
+    /// clamp and the reset estimate clamp.)
+    #[test]
+    fn rtte_left_truncation_negative_entry_is_no_truncation() {
+        use rand::SeedableRng;
+        let params = [40.0_f64, 1.6_f64];
+        let horizon = 300.0_f64;
+        for clock in [RtteClock::Forward, RtteClock::Reset] {
+            let mut r_neg = rand::rngs::StdRng::seed_from_u64(0x0000_DEAD);
+            let mut r_zero = rand::rngs::StdRng::seed_from_u64(0x0000_DEAD);
+            let neg = collect_rtte_events(
+                HazardFamily::Weibull,
+                &params,
+                clock,
+                horizon,
+                -5.0,
+                &mut r_neg,
+            );
+            let zero = collect_rtte_events(
+                HazardFamily::Weibull,
+                &params,
+                clock,
+                horizon,
+                0.0,
+                &mut r_zero,
+            );
+            assert_eq!(
+                neg, zero,
+                "{clock:?}: a negative entry must produce exactly the no-truncation stream"
+            );
+            assert!(
+                neg.iter().all(|&t| t > 0.0),
+                "{clock:?}: no simulated event may land at or before the origin"
+            );
+        }
     }
 
     // ── resolve_competing_risks: earliest cause wins, else administrative censor ──

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -184,11 +184,7 @@ pub fn tte_nll_from_curves(
             continue;
         };
 
-        let h_entry = if *entry_time > 0.0 {
-            cumhaz_at(*entry_time)
-        } else {
-            0.0
-        };
+        let h_entry = entry_lower_limit(*entry_time, &cumhaz_at);
 
         match event_type {
             EventType::RightCensored => {
@@ -256,6 +252,21 @@ fn cumhaz_monotone_violation(hi: f64, lo: f64, tol: MonoTol) -> bool {
     hi - lo < -crate::ode::scale_tol(tol.abstol, tol.reltol, hi, lo)
 }
 
+/// Lower cumulative-hazard limit contributed by a left-truncation entry: `H(entry)` when the
+/// subject entered late (`entry > 0`), else `0` (no truncation). One definition of the
+/// delayed-entry conditioning shared by the single-event ([`tte_nll_from_curves`]),
+/// clock-forward ([`rtte_forward_nll_from_curves`]) and clock-reset first-sojourn
+/// ([`rtte_reset_nll_from_curves`]) paths, so `entry` means exactly one thing across every
+/// survival endpoint — condition on survival past entry, never restart the clock (#740).
+#[inline]
+fn entry_lower_limit(entry_time: f64, cumhaz_at: impl Fn(f64) -> f64) -> f64 {
+    if entry_time > 0.0 {
+        cumhaz_at(entry_time)
+    } else {
+        0.0
+    }
+}
+
 /// Clock-forward (Andersen–Gill) **recurrent-event** (RTTE) negative log-likelihood
 /// from cumulative-hazard / hazard curves:
 ///
@@ -310,11 +321,7 @@ pub fn rtte_forward_nll_from_curves(
         };
 
         if !seeded {
-            h_lo = if *entry_time > 0.0 {
-                cumhaz_at(*entry_time)
-            } else {
-                0.0
-            };
+            h_lo = entry_lower_limit(*entry_time, &cumhaz_at);
             seeded = true;
         }
 
@@ -426,11 +433,7 @@ pub fn rtte_reset_nll_from_curves(
         //     lower limit H(0) = 0.
         let (arg, h_lo) = match prev_time {
             None => {
-                let h_entry = if *entry_time > 0.0 {
-                    cumhaz_at(*entry_time)
-                } else {
-                    0.0
-                };
+                let h_entry = entry_lower_limit(*entry_time, &cumhaz_at);
                 (*time, h_entry)
             }
             Some(prev) => (*time - prev, 0.0),
@@ -795,10 +798,13 @@ fn rtte_cause(
     subject: &crate::types::Subject,
     theta: &[f64],
     eta: &[f64],
-) -> Option<(usize, RtteClock, HazardFamily, Vec<f64>)> {
-    let mut found: Option<(usize, RtteClock, HazardFamily, Vec<f64>)> = None;
+) -> Option<(usize, RtteClock, HazardFamily, Vec<f64>, f64)> {
+    let mut found: Option<(usize, RtteClock, HazardFamily, Vec<f64>, f64)> = None;
     for record in &subject.obs_records {
-        let ObsRecord::Event { cmt, .. } = record else {
+        let ObsRecord::Event {
+            cmt, entry_time, ..
+        } = record
+        else {
             continue;
         };
         let Some(EndpointLikelihood::Tte {
@@ -824,6 +830,7 @@ fn rtte_cause(
                     *clock,
                     *family,
                     param_fn(theta, eta, &subject.covariates),
+                    *entry_time,
                 ));
             }
             // Additional rows on the same CMT belong to the same recurrent stream;
@@ -852,6 +859,21 @@ fn rtte_cause(
 ///   from `t = 0` via [`sample_event_time`]; event times accumulate the gaps. The
 ///   hazard clock restarts at every event.
 ///
+/// **Left truncation (delayed entry, `entry > 0`), convention B (#740).** The stream
+/// is generated on the same time origin `t = 0`, conditioned on the subject having
+/// survived event-free to `entry` — the simulate-side dual of the fit-side
+/// [`rtte_reset_nll_from_curves`]. Under **clock-forward** the running conditioning
+/// limit simply starts at `entry` (`t_prev = entry`) so the first event is drawn from
+/// `H(t₁) − H(entry) = −log U`. Under **clock-reset** the *first* sojourn is the one
+/// conditioned on survival to `entry` (an absolute-time draw via
+/// [`sample_conditional_event_time`]); every later gap is a fresh renewal from 0. For
+/// `entry == 0` both clocks reduce to the pure-renewal / from-origin draws above and
+/// the RNG sequence is byte-identical (each iteration still consumes exactly one
+/// uniform, and the `entry > 0` branch is not taken). As on the fit side, only the
+/// subject-level entry conditions the first sojourn; the emitted rows carry the drawn
+/// event times (the trailing censor sits at `horizon`), matching single-event TTE
+/// simulation, which likewise conditions on `entry` without stamping it onto output.
+///
 /// Emits one `Event { observed = true }` row per event strictly before `horizon`,
 /// then one `Event { observed = false }` administrative-censoring row **at**
 /// `horizon`. A subject with no event before the horizon yields just the censor
@@ -873,6 +895,7 @@ fn simulate_rtte_stream<R: rand::Rng>(
     params: &[f64],
     clock: RtteClock,
     horizon: f64,
+    entry: f64,
     cmt: usize,
     id: &str,
     draw: usize,
@@ -911,9 +934,18 @@ fn simulate_rtte_stream<R: rand::Rng>(
     //     gap → `+∞` estimate → skip; a rate-0 (infinite) gap → `~0` estimate → not skipped
     //     (correctly: no events, not a flood). It is a pure computation on the fixed `0.5`, so
     //     it draws no RNG and leaves the sequence (and the SSE tests) untouched.
+    // Left truncation (#740): count only the observable, at-risk window past `entry`.
+    // `entry == 0` reduces each arm to the original expression bit-for-bit.
     let expected = match clock {
-        RtteClock::Forward => cum_hazard(family, horizon, params),
-        RtteClock::Reset => horizon / sample_event_time(family, params, 0.5),
+        RtteClock::Forward => {
+            let h_entry = if entry > 0.0 {
+                cum_hazard(family, entry, params)
+            } else {
+                0.0
+            };
+            cum_hazard(family, horizon, params) - h_entry
+        }
+        RtteClock::Reset => (horizon - entry) / sample_event_time(family, params, 0.5),
     };
     if !expected.is_finite() || expected > MAX_EVENTS as f64 {
         warnings.push(format!(
@@ -926,24 +958,40 @@ fn simulate_rtte_stream<R: rand::Rng>(
         return;
     }
 
-    let mut t_prev = 0.0_f64;
+    // Clock-forward conditions every event on survival past the previous one on a single
+    // clock, so left truncation just seeds that clock at `entry` (`entry == 0` ⇒ `0`,
+    // identical to before). Clock-reset renews each gap from 0, so its FIRST sojourn is the
+    // only one conditioned on survival to `entry` (handled in the loop via `n_events == 0`).
+    let mut t_prev = match clock {
+        RtteClock::Forward => entry,
+        RtteClock::Reset => 0.0_f64,
+    };
     let mut n_events = 0usize;
     loop {
         let u: f64 = rng.sample(rand::distr::Open01);
         let t_next = match clock {
             // Absolute-time hazard: condition the next event on survival past the
-            // previous one. From `t_prev = 0` this equals a fresh draw, and for a
-            // memoryless (Exponential) hazard it equals the reset draw below.
+            // previous one. From `t_prev = 0` this equals a fresh draw, from `t_prev =
+            // entry` the delayed-entry first draw, and for a memoryless (Exponential)
+            // hazard it equals the reset draw below.
             RtteClock::Forward => sample_conditional_event_time(family, params, t_prev, u),
             // Renewal: a fresh gap from 0, accumulated onto the previous event. A
             // degenerate `f64::MAX` gap must stay `≥ horizon` (not overflow to a
-            // finite value), so guard the addition.
+            // finite value), so guard the addition. Under left truncation (#740,
+            // convention B) the *first* sojourn (`n_events == 0`) is instead drawn from
+            // the origin conditioned on survival to `entry` (absolute time ≥ entry) — the
+            // simulate dual of the fit's `H(t₁) − H(entry)`; `entry == 0` skips this
+            // branch and is byte-identical to the pure renewal draw.
             RtteClock::Reset => {
-                let gap = sample_event_time(family, params, u);
-                if gap >= f64::MAX - t_prev {
-                    f64::MAX
+                if n_events == 0 && entry > 0.0 {
+                    sample_conditional_event_time(family, params, entry, u)
                 } else {
-                    t_prev + gap
+                    let gap = sample_event_time(family, params, u);
+                    if gap >= f64::MAX - t_prev {
+                        f64::MAX
+                    } else {
+                        t_prev + gap
+                    }
                 }
             }
         };
@@ -1024,9 +1072,10 @@ pub fn simulate_tte<R: rand::Rng>(
     // single events: a subject's rows at the RTTE CMT are one stream to be
     // regenerated to the horizon. Detect and route it first, so the single /
     // competing path below stays byte-identical for non-RTTE models. The tight-scope
-    // invariants (single RTTE CMT, no competing single-TTE sibling, finite horizon,
-    // entry_time == 0) are enforced fail-loud in `api::validate_tte_simulatable`.
-    if let Some((cmt, clock, family, params)) = rtte_cause(model, subject, theta, eta) {
+    // invariants (single RTTE CMT, no competing single-TTE sibling, finite horizon) are
+    // enforced fail-loud in `api::validate_tte_simulatable`; left truncation (entry > 0)
+    // is supported (#740) and threaded through as `entry`.
+    if let Some((cmt, clock, family, params, entry)) = rtte_cause(model, subject, theta, eta) {
         let horizon = horizon.expect(
             "RTTE simulation requires a finite horizon; the simulate entry points validate this \
              before sampling",
@@ -1036,6 +1085,7 @@ pub fn simulate_tte<R: rand::Rng>(
             &params,
             clock,
             horizon,
+            entry,
             cmt,
             &subject.id,
             draw,
@@ -2365,6 +2415,7 @@ mod tests {
             params,
             clock,
             horizon,
+            0.0,
             2,
             "1",
             0,
@@ -2424,6 +2475,7 @@ mod tests {
                 &[1.0e7], // λ·horizon = 3e8 ≫ MAX_EVENTS
                 clock,
                 horizon,
+                0.0,
                 2,
                 "S1",
                 0,
@@ -2482,6 +2534,7 @@ mod tests {
             &params,
             RtteClock::Reset,
             horizon,
+            0.0,
             2,
             "S1",
             0,
@@ -2514,6 +2567,7 @@ mod tests {
             &params,
             RtteClock::Forward,
             horizon,
+            0.0,
             2,
             "S1",
             0,
@@ -2751,6 +2805,7 @@ mod tests {
                 &[0.0],
                 clock,
                 horizon,
+                0.0,
                 2,
                 "s",
                 0,
@@ -2768,6 +2823,169 @@ mod tests {
                 _ => panic!("expected an Event outcome"),
             }
         }
+    }
+
+    // ── simulate_rtte_stream: left truncation (delayed entry, #740) ──
+
+    /// Observed event times of one RTTE stream with a given left-truncation `entry`
+    /// (excludes the trailing administrative-censor row).
+    fn collect_rtte_events<R: rand::Rng>(
+        family: HazardFamily,
+        params: &[f64],
+        clock: RtteClock,
+        horizon: f64,
+        entry: f64,
+        rng: &mut R,
+    ) -> Vec<f64> {
+        let mut results = Vec::new();
+        let mut warnings = Vec::new();
+        simulate_rtte_stream(
+            family,
+            params,
+            clock,
+            horizon,
+            entry,
+            2,
+            "lt",
+            0,
+            1,
+            rng,
+            &mut results,
+            &mut warnings,
+        );
+        results
+            .iter()
+            .filter_map(|r| match r.outcome {
+                SimOutcome::Event { time, observed } if observed => Some(time),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Left truncation on a **memoryless** (exponential) hazard is a pure time shift: under
+    /// the same RNG seed the entry-conditioned stream is the non-truncated stream translated
+    /// by `entry` (convention B, #740). This pins the simulate-side conditioning — clock-forward
+    /// seeds its clock at `entry`, clock-reset conditions its first sojourn — for both clocks,
+    /// and that every event lands past `entry`. (Exponential residual life past `entry` is again
+    /// exponential with the same rate, so the shift is exact; a time-varying hazard is covered by
+    /// the Weibull test below.)
+    #[test]
+    fn rtte_left_truncation_exponential_is_entry_shift() {
+        use rand::SeedableRng;
+        let lambda = 0.03_f64;
+        let entry = 12.0_f64;
+        let horizon = 200.0_f64;
+        for clock in [RtteClock::Forward, RtteClock::Reset] {
+            let mut r_e = rand::rngs::StdRng::seed_from_u64(0x5117_7740);
+            let mut r_0 = rand::rngs::StdRng::seed_from_u64(0x5117_7740);
+            let events_e = collect_rtte_events(
+                HazardFamily::Exponential,
+                &[lambda],
+                clock,
+                horizon,
+                entry,
+                &mut r_e,
+            );
+            let events_0 = collect_rtte_events(
+                HazardFamily::Exponential,
+                &[lambda],
+                clock,
+                horizon,
+                0.0,
+                &mut r_0,
+            );
+            assert!(
+                !events_e.is_empty(),
+                "{clock:?}: a left-truncated stream should still produce events before the horizon"
+            );
+            // The non-truncated stream isn't shifted toward the horizon, so it has at least as
+            // many events; each entry-conditioned event equals its counterpart plus `entry`.
+            assert!(events_0.len() >= events_e.len());
+            for (k, &t_e) in events_e.iter().enumerate() {
+                assert_abs_diff_eq!(t_e, events_0[k] + entry, epsilon = 1e-9);
+                assert!(
+                    t_e >= entry,
+                    "{clock:?}: no simulated event may precede entry"
+                );
+            }
+        }
+    }
+
+    /// Clock-reset left truncation on a **time-varying** (Weibull) hazard, where convention B is
+    /// NOT a simple shift: the first simulated sojourn must land past `entry` (drawn conditional
+    /// on survival to entry), the stream must differ from the non-truncated one (the entry path is
+    /// genuinely exercised, not a no-op), and — round-tripping to the fit side — the realized
+    /// stream must be a valid convention-B likelihood input whose hand-recomputed value (first
+    /// term `H(t₁) − H(entry)`, then renewal gaps) matches `rtte_reset_nll_from_curves`.
+    #[test]
+    fn rtte_reset_left_truncation_weibull_conditions_on_entry() {
+        use rand::SeedableRng;
+        let params = [40.0_f64, 1.6_f64]; // Weibull scale=40, shape=1.6 (increasing hazard)
+        let entry = 15.0_f64;
+        let horizon = 300.0_f64;
+        let mut r_e = rand::rngs::StdRng::seed_from_u64(0xB17E_5EED);
+        let mut r_0 = rand::rngs::StdRng::seed_from_u64(0xB17E_5EED);
+        let events_e = collect_rtte_events(
+            HazardFamily::Weibull,
+            &params,
+            RtteClock::Reset,
+            horizon,
+            entry,
+            &mut r_e,
+        );
+        let events_0 = collect_rtte_events(
+            HazardFamily::Weibull,
+            &params,
+            RtteClock::Reset,
+            horizon,
+            0.0,
+            &mut r_0,
+        );
+        assert!(
+            !events_e.is_empty(),
+            "expected at least one event before the horizon"
+        );
+        assert!(
+            events_e[0] >= entry,
+            "first sojourn must be conditioned past entry: {} < {entry}",
+            events_e[0]
+        );
+        // A time-varying hazard means conditioning on entry is not a shift, so the streams differ.
+        assert!(
+            events_e != events_0,
+            "entry conditioning must change a time-varying-hazard stream"
+        );
+        // Round-trip: the realized stream is a valid convention-B fit input, and its fit NLL
+        // equals the hand-recomposed convention-B objective on the same event times.
+        let cumhaz_at = |t: f64| cum_hazard(HazardFamily::Weibull, t, &params);
+        let hazard_at = |t: f64| hazard_and_cum_hazard(HazardFamily::Weibull, t, &params).0;
+        let mut records: Vec<ObsRecord> = events_e
+            .iter()
+            .map(|&t| ObsRecord::Event {
+                time: t,
+                event_type: EventType::Exact,
+                entry_time: entry,
+                cmt: 2,
+            })
+            .collect();
+        records.push(ObsRecord::Event {
+            time: horizon,
+            event_type: EventType::RightCensored,
+            entry_time: entry,
+            cmt: 2,
+        });
+        let nll = rtte_reset_nll_from_curves(&records, cumhaz_at, hazard_at, MonoTol::analytic());
+        let mut expected = cumhaz_at(events_e[0]) - cumhaz_at(entry) - hazard_at(events_e[0]).ln();
+        for w in events_e.windows(2) {
+            let gap = w[1] - w[0];
+            expected += cumhaz_at(gap) - hazard_at(gap).ln();
+        }
+        expected += cumhaz_at(horizon - *events_e.last().unwrap());
+        assert!(
+            nll.is_finite() && nll < 1e20,
+            "left-truncated stream must fit, got {nll}"
+        );
+        assert_abs_diff_eq!(nll, expected, epsilon = 1e-9);
     }
 
     // ── resolve_competing_risks: earliest cause wins, else administrative censor ──

--- a/tests/tte_smoke.rs
+++ b/tests/tte_smoke.rs
@@ -1029,28 +1029,53 @@ mod survival_smoke {
         );
     }
 
-    /// Left truncation (`entry_time > 0`) on an RTTE record is a deferred follow-up
-    /// (conditional first-gap sampling); simulation must reject it, not silently sample
-    /// the first gap from 0.
+    /// Left truncation (`entry_time > 0`) on an RTTE record IS supported for simulation
+    /// (#740): the stream is drawn conditioned on survival to entry (convention B for
+    /// clock-reset; the conditioning clock seeded at entry for clock-forward), not rejected.
+    /// Exercises the public boundary — the relaxed `validate_tte_simulatable` guard — and
+    /// asserts a valid stream whose observed events all land at or past the entry time.
+    /// (The Tier-1 `rtte_left_truncation_*` unit tests pin the draw distribution; this is the
+    /// end-to-end boundary, the simulate dual of `rtte_reset_left_truncation_fits`.)
     #[test]
-    fn rtte_simulate_left_truncation_is_rejected() {
-        use ferx_core::{simulate_with_options, SimulateOptions};
+    fn rtte_simulate_left_truncation_is_accepted() {
+        use ferx_core::{simulate_with_options, SimOutcome, SimulateOptions};
         let model = parse_model_string(RTTE_EXP_FIT_MODEL).expect("RTTE model must parse");
         let mut pop = rtte_pop();
-        let ObsRecord::Event { entry_time, .. } = &mut pop.subjects[0].obs_records[0] else {
-            panic!("expected a TTE Event record");
-        };
-        *entry_time = 2.0;
+        let entry = 6.0_f64;
+        // Stamp the delayed entry on every RTTE row (a subject-level property).
+        for subject in &mut pop.subjects {
+            for r in &mut subject.obs_records {
+                if let ObsRecord::Event { entry_time, .. } = r {
+                    *entry_time = entry;
+                }
+            }
+        }
         let opts = SimulateOptions {
             seed: Some(1),
             match_method: None,
-            horizon: Some(30.0),
+            horizon: Some(60.0),
         };
-        let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
-            .expect_err("RTTE simulation with left truncation must be rejected");
+        let sims = simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
+            .expect("left-truncated RTTE simulation must now succeed (#740)");
+        let mut observed = 0usize;
+        for r in &sims {
+            if let SimOutcome::Event {
+                time,
+                observed: obs,
+            } = r.outcome
+            {
+                if obs {
+                    assert!(
+                        time >= entry,
+                        "a left-truncated simulated event must not precede entry {entry}: {time}"
+                    );
+                    observed += 1;
+                }
+            }
+        }
         assert!(
-            err.contains("left truncation"),
-            "error should flag left truncation, got: {err}"
+            observed > 0,
+            "left-truncated RTTE simulation should still fire events before the horizon"
         );
     }
 


### PR DESCRIPTION
## Why

The fit side gained left truncation (delayed entry, `TENTRY > 0`) for clock-reset RTTE in
#799; `simulate()` still **rejected** it, leaving fit and simulate asymmetric. #799 flagged
the simulate-side conditional first-gap draw as the deferred follow-up. This PR closes that
gap so a left-truncated RTTE design can be both fit and simulated under the same convention.

## What changed

- **`simulate()` accepts `TENTRY > 0` for RTTE on both clocks** (convention B, the simulate
  dual of the fit-side conditioning):
  - **clock-forward** seeds its conditioning clock at `entry` (`t_prev = entry`), so the first
    event is drawn from `H(t₁) − H(entry) = −log U`;
  - **clock-reset** draws its *first* sojourn conditional on survival to `entry` (an
    absolute-time draw via the existing `sample_conditional_event_time`), then renews from 0.
  - `entry == 0` takes the original branch and draws the **same RNG sequence**, so existing
    simulation output is byte-identical (verified by the unchanged Tier-1 stream tests).
- `survival::simulate_rtte_stream` takes an `entry` argument (threaded from `rtte_cause`); the
  degeneracy pre-flight (#762) counts only the observable window past `entry`.
- `api::validate_tte_simulatable` no longer rejects `entry > 0` for RTTE.
- **Refactor (review follow-up #4 from #799):** the `H(entry)` delayed-entry lower limit —
  now used at four sites — is extracted into `entry_lower_limit`, shared by the single-event,
  clock-forward, and clock-reset fit paths, so `entry` means one thing everywhere.

## Alternatives considered

- **Both clocks vs reset-only.** Did both. Fit already supports both clocks under delayed
  entry, so enabling simulate for both keeps fit/simulate symmetric; forward is also the
  simpler case (just seed the conditioning clock at `entry`).
- **Carrying `TENTRY` onto simulated output rows.** Not done — consistent with single-event
  TTE simulation, which likewise conditions the draw on `entry` without re-emitting `entry`
  onto the output. `TENTRY` is a property of the input design; a user re-fitting supplies it
  the same way they supplied it to simulate.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust **signature** changes (`simulate_rtte_stream` / `rtte_cause` /
`validate_tte_simulatable` are private; `simulate()` / `simulate_with_options()` keep their
signatures). No `FitResult`/sdtab field change → no ferx-r lock bump.

## Breaking changes
- [x] None — a previously-rejected input (`TENTRY > 0` RTTE simulation) now succeeds; no
  signature change and `TENTRY = 0` is byte-identical to before.

## Numerical validation

Recurrent left truncation has **no native NONMEM / survreg / flexsurv estimator** to anchor
against as a single object (the premise of #740). Per the CLAUDE.md exception added here (a
separate commit, parallel to the #391 carve-out), it is validated by:

- **Exponential entry-shift invariant** (Tier-1, both clocks, deterministic): a memoryless
  hazard's residual life past `entry` is again exponential, so under the same seed the
  left-truncated stream is exactly the non-truncated stream translated by `entry`. Pins that
  the conditioning is applied (and that `entry == 0` is a no-op).
- **Weibull round-trip to the fit** (Tier-1): a simulated time-varying-hazard reset stream
  lands its first sojourn past `entry`, differs from the non-truncated stream (the conditioning
  is not a no-op), and — reconstructed as fit records — reproduces the convention-B
  `rtte_reset_nll_from_curves` value exactly.
- **Reduction anchor:** the first sojourn `H(t₁) − H(entry)` is the single-event
  left-truncation term already validated against NONMEM on the fit side (#799), so no new
  formula is anchored from scratch.

- [x] Compared against: exact closed forms + reduction to the anchored single-event
  left-truncation term + a simulate→fit round-trip (no direct NONMEM equivalent exists).

## Performance
- [x] No significant impact expected — one extra `match`/branch per stream; `entry == 0` is
  unchanged and draws the identical RNG sequence.

## Tests
- [x] Unit tests added (`src/survival/mod.rs`): `rtte_left_truncation_exponential_is_entry_shift`,
  `rtte_reset_left_truncation_weibull_conditions_on_entry`.
- [x] Behaviour-flip boundary test: `tests/tte_smoke.rs::rtte_simulate_left_truncation_is_rejected`
  → `rtte_simulate_left_truncation_is_accepted` (now asserts a valid stream, all events ≥ entry).
- Local: `cargo test --lib --features survival` (2522 pass) and `--test tte_smoke` (86 pass).
  The one lib failure locally is the pre-existing macOS-LAPACK `run_covariance` flake (#751),
  green on Linux CI, untouched by this diff.

## Example (user-facing features only)
- [x] Not applicable as a standalone file — the behaviour is enabled by an existing `TENTRY`
  column plus a simulation `horizon`; covered by the tests above and `docs/estimation/tte.qmd`.

## Docs
- [x] `docs/estimation/tte.qmd` — RTTE simulation now supports left truncation.
- [x] `CHANGELOG.md` `[Unreleased]` → Added.
- Second commit adds the CLAUDE.md validation-exception for survival-likelihood terms with no
  NONMEM equivalent; it is **separable** — drop it if you'd rather ratify the convention
  another way.


## Post-review update (`52d24e27`)

Reviewed at **xhigh** (4 independent adversarial finders + verification): the loop / RNG
byte-identity, the relaxed `validate_tte_simulatable` guard, fit↔simulate convention-B
duality, the `entry_lower_limit` refactor, and test quality. Two in-scope items were found
and fixed; one pre-existing issue is filed separately.

**Confirmed sound:** `entry == 0` byte-identity (every branch bit-identical, one uniform per
iteration); convention-B duality **exact for Weibull and Gompertz(γ>0)**, not just exponential;
the `entry_lower_limit` refactor is behaviour-preserving at all three fit sites.

**Fixed in `52d24e27`:**
1. **Forward-clock negative-entry.** Forward seeded `t_prev = entry` unconditionally, so a
   negative `entry_time` (only reachable via a hand-built `Population` — the datareader clamps
   `TENTRY ≥ 0`) produced pre-origin / NaN events, inconsistent with the reset arm, the
   degeneracy estimate, and the fit's `entry_lower_limit`. Now clamps `entry.max(0.0)` (and the
   reset estimate likewise); `entry ≥ 0` stays bit-identical. Guarded by
   `rtte_left_truncation_negative_entry_is_no_truncation`.
2. **Tests didn't pin convention B over convention A for simulate.** The exponential shift test
   can't discriminate (A≡B when memoryless) and the round-trip recomputes B on whatever was
   drawn, so a convention-A regression would have passed. Added
   `rtte_left_truncation_first_sojourn_is_convention_b_not_a`, pinning the first simulated
   sojourn to `sample_conditional_event_time(entry, u₁)` and rejecting `entry + sample_event_time(u₁)`,
   both clocks — the simulate dual of the fit-side discrimination test.

**Filed separately (pre-existing, out of scope):** #803 — the Gompertz `γ < 0` samplers censor
every draw (`inner <= 1.0` should be `inner <= 0.0`), breaking simulate↔fit round-trip for a
declining hazard. Independent of left truncation; this PR does not worsen it.
