### PR TITLE
test(pk): inert obs_scale=1 for twin-less flip-flop fixtures (avoid #712 double-scale) [#735 follow-up]

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -12872,6 +12872,15 @@ mod simulate_with_uncertainty_tests {
     fn flip_flop_ebe_warning_fires_for_twinless_ig_crosser() {
         let model = parse_fixture(INDOMAIN_TWINLESS_IG_SRC);
         assert!(model.absorption_ode_equivalent.is_none());
+        // The inert `obs_scale = 1` must not double-scale the IG closed form (no #712 warning).
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("divides by")),
+            "twin-less IG fixture must not emit the obs_scale double-scale warning: {:?}",
+            model.parse_warnings
+        );
         let pop = tiny_population();
         let eta_hats = [eta_vec(&[0.0]), eta_vec(&[2.3])];
         let (msg, entry) =

--- a/src/api.rs
+++ b/src/api.rs
@@ -12728,6 +12728,10 @@ mod simulate_with_uncertainty_tests {
     // Genuinely twin-less: a user `[scaling]` block declines the ODE-twin desugar. (A
     // `lagtime=`/`f=` mapping no longer declines it — those auto-route now, #735 — so a
     // `[scaling]` form is what keeps this the twin-less case the #785 EBE warning targets.)
+    // `obs_scale = 1` is an inert identity divisor — it declines the twin without perturbing the
+    // `pk` block's built-in concentration output. (Using the volume `V` would divide by V a
+    // second time and emit the #712 double-scale warning; the flip-flop detection keys off
+    // `CL/V`, so the scale value is otherwise immaterial here.)
     const INDOMAIN_TWINLESS_TRANSIT_SRC: &str = "\
 [parameters]
   theta TVCL(0.5, 0.001, 50.0)
@@ -12747,14 +12751,14 @@ mod simulate_with_uncertainty_tests {
   pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
 
 [scaling]
-  obs_scale = V
+  obs_scale = 1
 
 [error_model]
   DV ~ proportional(PROP)
 ";
 
     // IG analogue: ke0 = 5/50 = 0.1 < 1/(2·MAT·CV²) = 1/(2·2·0.3) = 0.833 (in-domain);
-    // the `[scaling]` block declines the twin (twin-less).
+    // the inert `[scaling] obs_scale = 1` block declines the twin (twin-less; see above).
     const INDOMAIN_TWINLESS_IG_SRC: &str = "\
 [parameters]
   theta TVCL(5.0, 0.1, 100.0)
@@ -12774,7 +12778,7 @@ mod simulate_with_uncertainty_tests {
   pk one_cpt_ig(cl=CL, v=V, mat=MAT, cv2=CV2)
 
 [scaling]
-  obs_scale = V
+  obs_scale = 1
 
 [error_model]
   DV ~ proportional(PROP)
@@ -12824,6 +12828,17 @@ mod simulate_with_uncertainty_tests {
         assert!(
             model.absorption_ode_equivalent.is_none(),
             "a [scaling] transit model is twin-less"
+        );
+        // The inert `obs_scale = 1` must not double-scale the `pk` block's built-in concentration
+        // output: no #712 volume double-scale warning (reverting to `obs_scale = V` would
+        // reintroduce it and this pins that regression).
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("divides by")),
+            "twin-less fixture must not emit the obs_scale double-scale warning: {:?}",
+            model.parse_warnings
         );
         let pop = tiny_population();
         // Subject S1 in-domain (η=0), subject S2 crosses.

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -398,9 +398,9 @@ fn report_serializes_to_json() {
     assert!(json.contains("\"diagnostics\":[]"));
 }
 
-/// A twin-less flip-flop transit model (a user `[scaling]` block declines the ODE-twin
-/// desugar; ke = CL/V = 0.5 ≥ KTR = (3+1)/20 = 0.2) is rejected by `ferx check` with a hard
-/// `E_TRANSIT_FLIP_FLOP` error, mirroring `fit()` (#776). (A `lagtime=`/`f=` form now gets a
+/// A twin-less flip-flop transit model (an inert `[scaling] obs_scale = 1` block declines the
+/// ODE-twin desugar; ke = CL/V = 0.5 ≥ KTR = (3+1)/20 = 0.2) is rejected by `ferx check` with a
+/// hard `E_TRANSIT_FLIP_FLOP` error, mirroring `fit()` (#776). (A `lagtime=`/`f=` form now gets a
 /// twin and auto-routes instead — see #735.)
 #[test]
 fn twin_less_flip_flop_transit_is_rejected_by_check() {
@@ -425,7 +425,7 @@ fn twin_less_flip_flop_transit_is_rejected_by_check() {
   pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
 
 [scaling]
-  obs_scale = V
+  obs_scale = 1
 
 [error_model]
   DV ~ proportional(PROP)

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -1211,6 +1211,15 @@ fn transit_flip_flop_without_twin_is_rejected() {
         model.absorption_ode_equivalent.is_none(),
         "a [scaling] transit model has no ODE twin (the desugar declines it)"
     );
+    // The inert `obs_scale = 1` must not double-scale the closed form (no #712 warning).
+    assert!(
+        !model
+            .parse_warnings
+            .iter()
+            .any(|w| w.contains("divides by")),
+        "twin-less fixture must not emit the obs_scale double-scale warning: {:?}",
+        model.parse_warnings
+    );
     let pop = population(vec![bolus(0.0, 100.0)], vec![1.0, 4.0, 12.0]);
 
     // fit() rejects it with a clear, actionable error (not a silent zero-degenerate fit).

--- a/tests/transit_analytic_equivalence.rs
+++ b/tests/transit_analytic_equivalence.rs
@@ -1477,7 +1477,8 @@ omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.01 (sd)\n\n\
 /// A twin-less `one_cpt_transit` whose typical parameters put `ke = CL/V` at or above the
 /// transit rate `KTR = (n+1)/mtt` — the flip-flop regime the closed form cannot serve, made
 /// twin-less by a user `[scaling]` block that declines the ODE-twin desugar (#776; the
-/// `lagtime=` form now auto-routes instead, #735).
+/// `lagtime=` form now auto-routes instead, #735). `obs_scale = 1` is an inert identity divisor
+/// (using `V` would double-scale the closed form's built-in concentration and warn, #712).
 const TWIN_LESS_FLIP_FLOP_SRC: &str = "\
 [parameters]
   theta TVCL(2.0, 0.001, 50.0)
@@ -1497,7 +1498,7 @@ const TWIN_LESS_FLIP_FLOP_SRC: &str = "\
   pk one_cpt_transit(cl=CL, v=V, n=NTR, mtt=MTT)
 
 [scaling]
-  obs_scale = V
+  obs_scale = 1
 
 [error_model]
   DV ~ proportional(PROP)


### PR DESCRIPTION
## Why

Follow-up to #800 (flip-flop trio #735). That PR's ripple moved the twin-less flip-flop fixtures (#785/#786 EBE-warning + #776 reject tests) from a `lagtime=` mapping to `[scaling] obs_scale = V` on a **closed-form** `pk one_cpt_transit` / `one_cpt_ig` model — because a `lagtime=`/`f=` mapping now auto-routes (#735) and no longer declines the twin, so a different twin-decliner was needed.

But an analytical `pk` block already outputs concentration (divides by `V` internally), so `obs_scale = V` divides by `V` **a second time** and emits the #712 double-scale parse warning. It's inert for the current tests (the flip-flop decision keys off `CL/V`, and none of these fixtures assert `pred`/OFV), but it's a latent hazard flagged during the #800 review: a future numeric assertion on one of these "known-good twin-less" fixtures would silently get half the concentration, and a maintainer copying one as a template inherits a physically-wrong model.

## What changed

Switch the four closed-form twin-less fixtures to `[scaling] obs_scale = 1` — a scalar identity divisor:

- `src/api.rs` — `INDOMAIN_TWINLESS_TRANSIT_SRC`, `INDOMAIN_TWINLESS_IG_SRC` (#785/#786)
- `tests/transit_analytic_equivalence.rs` — `TWIN_LESS_FLIP_FLOP_SRC` (#776 reject/panic tests)
- `tests/check_command.rs` — `twin_less_flip_flop_transit_is_rejected_by_check`

`obs_scale = 1` still declines the ODE-twin desugar (any `[scaling]` block does), but divides by 1 (no double-scale) and — being a scalar literal, not a volume reference — emits no #712 warning, so predictions match a plain closed form. Added a regression-lock in `flip_flop_ebe_warning_fires_for_twinless_transit_crosser` asserting the fixture parses with **no** double-scale warning, so reverting to `obs_scale = V` fails a test.

The ODE-reference `obs_scale = V` / `obs_scale = V1` in the equivalence-test pairs is **unchanged** — there it is required (an `ode(...)` model outputs raw compartment amount).

## Alternatives considered

- `[initial_conditions]` as the twin-decliner: it has its own parse-time validation on closed-form absorption models and can't carry a depot seed — more surface than a scalar `obs_scale`.
- A "realistic" scalar (`obs_scale = 1000` unit conversion): also clean, but perturbs prediction magnitude; `obs_scale = 1` keeps the fixtures identical to a plain closed form (most faithful to what they represent).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None — test-only.

## Numerical validation
- [x] Not applicable (test-only; no production code or behaviour changes).

## Performance
- [x] No significant impact expected.

## Tests
- [x] Existing #785/#786 EBE + #776 reject/panic + `ferx check` tests still pass with the new fixtures.
- [x] Regression-lock added (fixture parses without the #712 double-scale warning).

## Example (user-facing features only)
- [x] Not applicable (internal test cleanup).

## Docs
- [x] Not applicable.

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo fmt --check` clean
- [x] No CHANGELOG entry (test-only — per CLAUDE.md)
- [x] No version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
