### PR TITLE
fix(sim): declining-hazard (γ<0) Gompertz event sampler no longer censors every draw [closes #803]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,16 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **Declining-hazard (`γ < 0`) Gompertz simulation no longer censors every event**
+  (#803): the analytic inverse-CDF event-time samplers guarded the Gompertz draw with
+  `inner ≤ 1`, which fires for *every* `u ∈ (0,1)` when the shape `γ < 0`, so a
+  declining-hazard Gompertz simulated an empty / all-censored stream even though `fit()`
+  scored the same `γ < 0` with finite density — simulate was not the inverse of fit for
+  this family, breaking simulate→fit round-trips (VPC/SBC). A `γ < 0` Gompertz has a
+  finite limiting cumulative hazard `H(∞) = −α·e^{loghr}/γ`, i.e. a genuine cure fraction
+  `S(∞) = e^{−H(∞)}`; the guard now rejects only that true cure fraction (`inner ≤ 0`), so
+  a draw above it produces a valid finite event. Affects single-event TTE, clock-forward
+  RTTE, and the clock-reset first sojourn for any `γ < 0`.
 - **A dose landing exactly on a subject's last observation is now applied before that
   observation is read (post-dose) on the constant-parameter ODE engine, fixing a
   false rejection by the adaptive frozen-replay verifier** (#731). The engine applied

--- a/src/survival/parametric.rs
+++ b/src/survival/parametric.rs
@@ -213,8 +213,14 @@ pub fn sample_event_time(family: HazardFamily, params: &[f64], u: f64) -> f64 {
             // H(T) = -log U  =>  (alpha/gamma)*(exp(gamma*T)-1)*exp(loghr) = neg_log_u
             // exp(gamma*T) = 1 + neg_log_u * gamma / (alpha * exp(loghr))
             let inner = 1.0 + neg_log_u * gamma / (alpha * exp_loghr);
-            if inner <= 1.0 {
-                // Numerically degenerate (should not happen for valid params)
+            // γ < 0 is a declining hazard with a finite limiting cumulative hazard
+            // H(∞) = −α·exp(loghr)/γ, i.e. a genuine cure fraction S(∞) = exp(−H(∞)) > 0.
+            // A draw whose −log U exceeds H(∞) (u below the cure fraction) yields inner ≤ 0 and
+            // has no event; inner ∈ (0, 1) is a valid finite event (T = ln(inner)/γ > 0). For
+            // γ > 0 the hazard grows unboundedly and inner > 1 always, so this guard then only
+            // catches numerically degenerate draws. Rejecting inner ≤ 1 would wrongly censor
+            // *every* γ < 0 event (#803).
+            if inner <= 0.0 {
                 return f64::MAX;
             }
             inner.ln() / gamma
@@ -270,7 +276,11 @@ pub fn sample_conditional_event_time(
             // exp(gamma*T) = exp(gamma*entry) + neg_log_u * gamma / (alpha * exp_loghr)
             let exp_entry = (gamma * entry_time).exp();
             let inner = exp_entry + neg_log_u * gamma / (alpha * exp_loghr);
-            if inner <= 1.0 {
+            // As in `sample_event_time`, γ < 0 has a cure fraction beyond `entry`: inner ≤ 0 means
+            // −log U exceeds the remaining cumulative hazard H(∞) − H(entry), so there is no event.
+            // inner ∈ (0, exp_entry) is a valid event with T > entry; γ > 0 keeps inner > 1. The
+            // old inner ≤ 1 guard censored every γ < 0 event (#803).
+            if inner <= 0.0 {
                 return f64::MAX;
             }
             inner.ln() / gamma
@@ -347,6 +357,90 @@ mod tests {
         assert!(
             (cum - expected).abs() < 1e-9,
             "H = {cum}, expected {expected}"
+        );
+    }
+
+    #[test]
+    fn gompertz_gamma_negative_samples_events_and_cure_fraction() {
+        // Declining-hazard Gompertz (#803): γ < 0 has a finite limiting cumulative hazard
+        // H(∞) = −α·exp(loghr)/γ and a genuine cure fraction S(∞) = exp(−H(∞)).
+        //   α = 0.002, γ = −0.005, loghr = 0  ⇒  H(∞) = 0.002/0.005 = 0.4, S(∞) = e^{-0.4} ≈ 0.6703.
+        let params = &[0.002, -0.005, 0.0];
+        let cure = (-0.4_f64).exp();
+
+        // u above the cure fraction ⇒ a valid finite event that round-trips H(T) = −ln u.
+        // Under the old `inner <= 1.0` guard this returned the `f64::MAX` no-event sentinel
+        // for every draw. The `t < f64::MAX` bound is the direct regression signal (an actual
+        // event was produced, not the sentinel — note `f64::MAX` is itself finite and > 0, so
+        // the earlier checks alone would not catch it); the round-trip below then confirms the
+        // event time is numerically correct.
+        let u = 0.8_f64;
+        assert!(u > cure, "test setup: u must exceed the cure fraction");
+        let t = sample_event_time(HazardFamily::Gompertz, params, u);
+        assert!(
+            t.is_finite() && t > 0.0 && t < f64::MAX,
+            "γ<0 above-cure draw must yield a real event, not the no-event sentinel; got {t}"
+        );
+        let (_, cum) = hazard_and_cum_hazard(HazardFamily::Gompertz, t, params);
+        assert!(
+            (cum - (-u.ln())).abs() < 1e-9,
+            "H(T) = {cum}, expected {}",
+            -u.ln()
+        );
+
+        // u below the cure fraction ⇒ no event (the true cure fraction), sentinel returned.
+        let u_cured = 0.5_f64;
+        assert!(
+            u_cured < cure,
+            "test setup: u must be below the cure fraction"
+        );
+        let t_cured = sample_event_time(HazardFamily::Gompertz, params, u_cured);
+        assert_eq!(t_cured, f64::MAX, "γ<0 below-cure draw must be censored");
+    }
+
+    #[test]
+    fn gompertz_gamma_negative_conditional_events_and_cure_fraction() {
+        // Conditional (left-truncated) declining-hazard Gompertz (#803). The remaining cumulative
+        // hazard beyond `entry` is H(∞) − H(entry); a draw with −ln u above it has no event.
+        let params = &[0.002, -0.005, 0.0];
+        let entry = 20.0_f64;
+        let h_entry = cum_hazard(HazardFamily::Gompertz, entry, params);
+        let remaining = 0.4 - h_entry; // H(∞) = 0.4 for these params
+        let cond_cure = (-remaining).exp();
+
+        // u above the conditional cure fraction ⇒ finite event later than entry, round-tripping
+        // H(T) − H(entry) = −ln u. The old guard returned the `f64::MAX` sentinel for all of
+        // these; `t < f64::MAX` is the direct regression signal (the sentinel is finite and
+        // > entry, so it would otherwise slip past), the round-trip confirms correctness.
+        let u = 0.9_f64;
+        assert!(
+            u > cond_cure,
+            "test setup: u must exceed the conditional cure fraction"
+        );
+        let t = sample_conditional_event_time(HazardFamily::Gompertz, params, entry, u);
+        assert!(
+            t.is_finite() && t > entry && t < f64::MAX,
+            "conditional γ<0 above-cure draw must yield a real event > entry, not the sentinel; got {t}"
+        );
+        let h_t = cum_hazard(HazardFamily::Gompertz, t, params);
+        assert!(
+            (h_t - h_entry - (-u.ln())).abs() < 1e-8,
+            "H(T)-H(entry) = {}, expected {}",
+            h_t - h_entry,
+            -u.ln()
+        );
+
+        // u below the conditional cure fraction ⇒ censored at the sentinel.
+        let u_cured = 0.5_f64;
+        assert!(
+            u_cured < cond_cure,
+            "test setup: u must be below the conditional cure fraction"
+        );
+        let t_cured = sample_conditional_event_time(HazardFamily::Gompertz, params, entry, u_cured);
+        assert_eq!(
+            t_cured,
+            f64::MAX,
+            "conditional γ<0 below-cure draw must be censored"
         );
     }
 

--- a/tests/tte_convergence.rs
+++ b/tests/tte_convergence.rs
@@ -122,6 +122,45 @@ const RTTE_WEIBULL_FWD_PIT_TRUTH: &str = r"
   shape  = TVSHAPE
 ";
 
+/// RTTE **declining-hazard Gompertz** truth (#803): fixed-effects (no frailty),
+/// clock-forward, with a NEGATIVE shape `γ = −0.03`. The intensity `h(t) =
+/// α·exp(γt)` decays, so the cumulative hazard has a finite limit `H(∞) =
+/// −α/γ = 5` and only `H(40) = 5·(1 − e^{−1.2}) ≈ 3.49` events are expected per
+/// subject over the horizon. `γ` uses a lower bound of `−1.0` (identity packing,
+/// see `parameterization::theta_packs_log`) and an upper bound of `+1.0` so the
+/// fit is free to (wrongly) cross into a growing hazard — the recovery of a
+/// clearly negative `γ` is then a real result, not a bound artefact.
+const RTTE_GOMPERTZ_DECLINING_TRUTH: &str = r"
+[parameters]
+  theta TVALPHA(0.15, 1e-4, 5.0)
+  theta TVGAMMA(-0.03, -1.0, 1.0)
+
+[event_model]
+  cmt    = 2
+  type   = rtte
+  clock  = forward
+  family = gompertz
+  alpha  = TVALPHA
+  gamma  = TVGAMMA
+";
+
+/// RTTE declining-Gompertz **fit** model, started away from the truth (α ~2/3,
+/// γ ~1/3 toward zero) so recovering `α ≈ 0.15` and a clearly negative `γ` is a
+/// genuine test that the simulate→fit round-trip is intact for `γ < 0`.
+const RTTE_GOMPERTZ_DECLINING_FIT: &str = r"
+[parameters]
+  theta TVALPHA(0.10, 1e-4, 5.0)
+  theta TVGAMMA(-0.01, -1.0, 1.0)
+
+[event_model]
+  cmt    = 2
+  type   = rtte
+  clock  = forward
+  family = gompertz
+  alpha  = TVALPHA
+  gamma  = TVGAMMA
+";
+
 /// Competing-risks "truth" model: two exponential causes (CMT 2, CMT 3) linked
 /// by a shared log-frailty `ETA_F` (ω²=0.25). The cause-specific *rates* are
 /// well-identified and recover tightly; the shared frailty ω² is weakly
@@ -986,6 +1025,90 @@ fn rtte_sse_forward_exponential_recovers_rate() {
         "FOCEI ω² {omega2:.5} outside the expected bracket for this realization"
     );
     assert!(r.ofv.is_finite(), "RTTE SSE OFV must be finite");
+}
+
+/// **#803 regression — declining-hazard (γ < 0) Gompertz RTTE round-trip.** The
+/// bug: the analytic inverse-CDF samplers guarded the Gompertz draw with
+/// `inner <= 1.0`, which fires on *every* `u ∈ (0,1)` when `γ < 0`, so `simulate()`
+/// returned an empty (all-censored) stream while `fit()` still scored `γ < 0` with
+/// finite density — simulate was not the inverse of fit for this family.
+///
+/// This simulates a fixed-effects clock-forward Gompertz RTTE with `γ = −0.03`,
+/// then (a) asserts the streams actually carry events — the direct symptom, since
+/// the pre-fix sampler produced *zero* — and (b) refits, recovering `α ≈ 0.15` and a
+/// clearly negative `γ` (not a collapse toward 0). Fixed effects (no frailty) keep it
+/// a clean MLE-style recovery with no weakly-identified `ω²` noise. Bands are set to
+/// this seed's realized fit; a re-broken guard drops the event count to zero and trips
+/// the first assertion long before the parameter bands.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn rtte_sse_forward_gompertz_declining_recovers_negative_gamma() {
+    use ferx_core::{simulate_with_options, SimulateOptions};
+    const N: usize = 1200;
+    const HORIZON: f64 = 40.0;
+    const SEED: u64 = 20260711;
+
+    let truth =
+        parse_model_string(RTTE_GOMPERTZ_DECLINING_TRUTH).expect("Gompertz truth model must parse");
+    let template = common::tte_pop_from_pairs(&vec![(HORIZON, 0u8); N]);
+    let opts = SimulateOptions {
+        seed: Some(SEED),
+        match_method: None,
+        horizon: Some(HORIZON),
+    };
+    let sims = simulate_with_options(&truth, &template, &truth.default_params, 1, &opts)
+        .expect("declining-Gompertz RTTE simulation must succeed");
+
+    // (a) Regression core: the streams must carry events. Under the old `inner <= 1.0`
+    // guard EVERY γ<0 draw was censored, so `total` was exactly 0.
+    let counts = rtte_event_counts(&sims, N);
+    let total: f64 = counts.iter().sum();
+    let mean_c = total / N as f64;
+    let max_events = counts.iter().cloned().fold(0.0_f64, f64::max);
+    eprintln!("[SSE-RTTE-GOMPERTZ] total={total} mean/subj={mean_c:.3} (~3.49) max={max_events}");
+    assert!(
+        total > 0.0,
+        "declining-hazard Gompertz RTTE produced ZERO events — the γ<0 sampler censored \
+         every draw (#803 regression)"
+    );
+    // Clock-forward E[N] over [0,H] = H(H) = (α/γ)(e^{γH}−1) = 5·(1−e^{−1.2}) ≈ 3.49.
+    assert!(
+        (3.1..3.9).contains(&mean_c),
+        "mean events/subject {mean_c:.3} off H(40) ≈ 3.49 for the declining hazard"
+    );
+    assert!(
+        max_events >= 6.0,
+        "a declining recurrent stream should still reach several events; got {max_events}"
+    );
+
+    // (b) Refit must recover α ≈ 0.15 and a clearly NEGATIVE γ (declining hazard).
+    let fit_pop = rtte_pop_from_sims(&sims);
+    let model =
+        parse_model_string(RTTE_GOMPERTZ_DECLINING_FIT).expect("Gompertz fit model must parse");
+    let r = fit(&model, &fit_pop, &model.default_params, &fit_opts())
+        .expect("declining-Gompertz RTTE SSE fit must succeed");
+    let alpha = r.theta[0];
+    let gamma = r.theta[1];
+    eprintln!(
+        "[SSE-RTTE-GOMPERTZ] FOCEI α={alpha:.5} (truth 0.15) γ={gamma:.5} (truth −0.03) OFV={:.4}",
+        r.ofv
+    );
+    assert!(
+        (0.11..0.19).contains(&alpha),
+        "α not recovered: got {alpha:.5}, expected ~0.15"
+    );
+    assert!(
+        (-0.06..-0.012).contains(&gamma),
+        "γ not recovered as a declining hazard: got {gamma:.5}, expected ~−0.03 — it must stay \
+         clearly negative, not collapse toward 0 (the pre-fix simulate→fit inconsistency)"
+    );
+    assert!(
+        r.ofv.is_finite(),
+        "declining-Gompertz RTTE SSE OFV must be finite"
+    );
 }
 
 const RTTE_SIM_ANCHOR_CSV: &str = concat!(


### PR DESCRIPTION
## Why

`simulate()` was not the inverse of `fit()` for a **declining-hazard (`γ < 0`) Gompertz**
(#803). Both analytic inverse-CDF event-time samplers
(`sample_event_time`, `sample_conditional_event_time` in `src/survival/parametric.rs`)
guarded the Gompertz draw with

```rust
let inner = 1.0 + neg_log_u * gamma / (alpha * exp_loghr); // = exp(γT)
if inner <= 1.0 { return f64::MAX; }                       // no-event sentinel
```

For `γ < 0`, `neg_log_u · γ / (α·e^{loghr}) < 0` for **every** `u ∈ (0,1)`, so `inner < 1`
always → the guard fires on every draw → the stream is empty / all-censored. But `fit()`
scores the same `γ < 0` with finite density (`hazard_and_cum_hazard` is correct for `γ < 0`),
so a simulate→fit round-trip (VPC / SBC) was broken. `γ` is a free expression with no
positivity constraint and `validate_tte_simulatable` does not reject `γ < 0`, so this is
reachable from ordinary models.

The behaviour is **pre-existing** and independent of left truncation; it was found during the
xhigh review of #801.

## What changed

A `γ < 0` Gompertz has a *declining* hazard with a **finite** limiting cumulative hazard
`H(∞) = −α·e^{loghr}/γ`, i.e. a genuine cure fraction `S(∞) = e^{−H(∞)} > 0`. Only draws whose
`−log U` exceeds `H(∞)` (i.e. `u` below the cure fraction) have no event; for those `inner ≤ 0`.
A draw above the cure fraction gives `inner ∈ (0, 1)` and a valid finite event
`T = ln(inner)/γ > 0`.

The guard is changed in both samplers from `inner <= 1.0` to **`inner <= 0.0`**, so it now
rejects only the true cure fraction. This is safe for `γ > 0` (there `inner > 1` always; the
trailing `t > 0` / `t > entry_time` checks still catch any degenerate `T`). Fixing the two
samplers fixes every caller — single-event TTE (`draw_tte_latent`), clock-forward RTTE, and the
clock-reset first sojourn.

No public API change (both samplers were already `pub`, signatures unchanged) → **no ferx-r
follow-up**.

## Alternatives considered

Statically rejecting `γ < 0` at parse / `validate_tte_simulatable` — wrong: a declining-hazard
Gompertz is a legitimate, useful model (cure-fraction survival), `fit()` already handles it, and
`γ` depends on covariates/etas so it can't be checked statically anyway. The samplers must handle
it, which they now do.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
Sampler correctness is anchored by the analytic inverse-CDF identity `H(T) = −ln u` (Tier-1) and a
statistical simulate→fit round-trip (Tier-3). No NONMEM anchor: the ground truth here is the
closed-form cumulative hazard the round-trip inverts, not an external engine.

- Tier-1 (`src/survival/parametric.rs`): a `γ = −0.005` Gompertz — a draw above the cure fraction
  round-trips `H(T) = −ln u` to `<1e-9` (and `H(T)−H(entry) = −ln u` for the conditional sampler);
  a draw below the cure fraction returns the `f64::MAX` sentinel. Both **fail under the old
  `inner <= 1.0` guard** (every draw censored).
- Tier-3 (`tests/tte_convergence.rs`, `slow-tests`): fixed-effects clock-forward Gompertz RTTE,
  `α = 0.15, γ = −0.03`, N=1200, horizon=40. Simulated stream carries events (was zero pre-fix);
  FOCEI refit recovers:

```
# TRUTH:  α = 0.15,   γ = −0.03      (E[N] = H(40) = 5·(1−e^{−1.2}) ≈ 3.49 events/subject)
# SIM:    4286 events over 1200 subjects (mean 3.572/subj, max 10) — pre-fix this was 0
# FIT:    α = 0.14610, γ = −0.02704   OFV = 28874.88   (FOCEI recovers a clearly negative γ)
```

## Performance
- [x] No significant impact expected (one comparison constant changed)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change)
- [x] No other user-visible surface (bug fix, no new API/DSL)

## Checklist
- [x] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path unaffected (samplers are `f64`-only, not gradient-reachable)

## Reviewer hints
The whole fix is the two `inner <= 1.0` → `inner <= 0.0` guard changes; the math justifying it is
in the code comments and the Tier-1 test. Focus there. The Tier-3 bands are pinned to the fixed
seed's realized fit; a re-broken guard drops the event count to zero and trips the first assertion
long before the parameter bands.
