### PR TITLE
fix(survival): declining-hazard (γ<0) Gompertz median/mean survival diagnostics [closes #805]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,17 @@ section of the SDLC for the versioning policy).
   structural-model type.
 
 ### Fixed
+- **Declining-hazard (`γ < 0`) Gompertz median/mean survival diagnostics** (#805):
+  `median_survival` returned `NaN` for *every* `γ < 0` Gompertz, even when a finite median
+  genuinely exists — the closed form generalizes to `γ < 0`, so the reported TTE median is
+  now finite whenever the cure fraction `S(∞) = e^{−α·e^{loghr}/|γ|} < 0.5` (and stays
+  `NaN` when `S(∞) ≥ 0.5`, where more than half never event and the median is undefined).
+  `mean_survival` now returns `NaN` for any `γ < 0` Gompertz via an explicit guard: its
+  mean is genuinely infinite (a positive cure fraction leaves a non-decaying survival
+  tail), which the previous code reported correctly only by coincidence through the `NaN`
+  median. Diagnostic/reporting only (`predict_survival` summaries); does not touch
+  estimation or simulation numerics. Same `γ < 0` boundary fixed for the samplers in
+  #803 / #804.
 - **Declining-hazard (`γ < 0`) Gompertz simulation no longer censors every event**
   (#803): the analytic inverse-CDF event-time samplers guarded the Gompertz draw with
   `inner ≤ 1`, which fires for *every* `u ∈ (0,1)` when the shape `γ < 0`, so a

--- a/src/survival/parametric.rs
+++ b/src/survival/parametric.rs
@@ -74,8 +74,11 @@ pub fn cum_hazard(family: HazardFamily, t: f64, params: &[f64]) -> f64 {
 
 /// Median survival time: the unique T satisfying H(T) = ln 2.
 ///
-/// Computed analytically for all three families.  Returns `f64::NAN` if
-/// the parameters are degenerate (e.g. `alpha ≤ 0` for Gompertz).
+/// Computed analytically for all three families.  Returns `f64::NAN` if the
+/// parameters are degenerate (e.g. `alpha ≤ 0` for Gompertz) or the median is
+/// undefined — a declining-hazard (`γ < 0`) Gompertz has no median when its cure
+/// fraction `S(∞) = exp(−α·e^{loghr}/|γ|) ≥ 0.5` (more than half never event); when
+/// `S(∞) < 0.5` the median is finite and returned (#805).
 pub fn median_survival(family: HazardFamily, params: &[f64]) -> f64 {
     use std::f64::consts::LN_2;
     match family {
@@ -115,12 +118,21 @@ pub fn median_survival(family: HazardFamily, params: &[f64]) -> f64 {
             if gamma == 0.0 {
                 // γ=0: Gompertz degenerates to Exponential with rate α·exp(loghr)
                 LN_2 / (alpha * exp_lhr)
-            } else if gamma > 0.0 {
-                // ln_1p is numerically stable when γ is small (avoids cancellation in (1+x).ln())
-                let x = LN_2 * gamma / (alpha * exp_lhr);
-                x.ln_1p() / gamma
             } else {
-                f64::NAN
+                // γ ≠ 0: exp(γT) = 1 + x with x = ln2·γ/(α·e^{loghr}). ln_1p is numerically
+                // stable when |γ| is small (avoids cancellation in (1+x).ln()).
+                //   γ > 0 ⇒ x > 0, so x > −1 always: finite median (behavior unchanged).
+                //   γ < 0 ⇒ x < 0, with a finite limiting cumulative hazard H(∞)=α·e^{loghr}/|γ|.
+                //     The median exists iff ln2 < H(∞) ⟺ x > −1 ⟺ cure fraction S(∞) < 0.5
+                //     (then ln_1p(x) < 0 and γ < 0 give T > 0); otherwise it is +∞/undefined
+                //     → NaN. Same γ<0 boundary as the samplers (#803/#804); here in the
+                //     diagnostic path (#805).
+                let x = LN_2 * gamma / (alpha * exp_lhr);
+                if x > -1.0 {
+                    x.ln_1p() / gamma
+                } else {
+                    f64::NAN
+                }
             }
         }
     }
@@ -130,7 +142,9 @@ pub fn median_survival(family: HazardFamily, params: &[f64]) -> f64 {
 ///
 /// Uses the analytic form `1 / (λ · exp(loghr))` for the Exponential family and
 /// the midpoint rule (2 000 steps to 40 × median) for Weibull and Gompertz.
-/// Returns `f64::NAN` for degenerate parameters.
+/// Returns `f64::NAN` for degenerate parameters, and for a declining-hazard
+/// (`γ < 0`) Gompertz — whose positive cure fraction makes the mean genuinely
+/// infinite (#805).
 pub fn mean_survival(family: HazardFamily, params: &[f64]) -> f64 {
     match family {
         HazardFamily::Exponential => {
@@ -157,6 +171,15 @@ pub fn mean_survival(family: HazardFamily, params: &[f64]) -> f64 {
                 } else {
                     f64::NAN
                 };
+            }
+            // Gompertz γ<0 is a declining hazard with a positive cure fraction
+            // S(∞)=exp(−α·e^{loghr}/|γ|) > 0, so S(t) never decays to 0 and the mean
+            // E[T]=∫₀^∞ S diverges. Return NaN explicitly: since #805 median_survival now
+            // yields a *finite* γ<0 median (when S(∞)<0.5), the median-based integration
+            // below would otherwise run over [0, 40·median], miss the non-decaying tail,
+            // and report a bogus finite mean.
+            if matches!(family, HazardFamily::Gompertz) && params[1] < 0.0 {
+                return f64::NAN;
             }
             let t_med = median_survival(family, params);
             if !t_med.is_finite() || t_med <= 0.0 {
@@ -664,6 +687,97 @@ mod tests {
             ((-cum).exp() - 0.5).abs() < 1e-8,
             "S(median)={} for small-γ Gompertz",
             (-cum).exp()
+        );
+    }
+
+    #[test]
+    fn median_gompertz_gamma_negative_finite_when_cure_below_half() {
+        // Declining-hazard Gompertz (#805): γ<0 has a finite limiting cumulative hazard
+        // H(∞)=α·e^{loghr}/|γ| and cure fraction S(∞)=exp(−H(∞)). When S(∞)<0.5 (fewer than
+        // half are "cured") a finite median genuinely exists and must be returned — the old
+        // code blanket-returned NaN for every γ<0.
+        //   α=0.002, γ=−0.001, loghr=0 ⇒ H(∞)=2.0, S(∞)=e^{−2}≈0.1353 < 0.5.
+        let params = [0.002_f64, -0.001_f64, 0.0_f64];
+        let s_inf = (-(0.002_f64 / 0.001)).exp(); // exp(−H(∞))
+        assert!(s_inf < 0.5, "test setup: cure fraction must be below 0.5");
+        let t_50 = median_survival(HazardFamily::Gompertz, &params);
+        assert!(
+            t_50.is_finite() && t_50 > 0.0,
+            "γ<0 median must be finite and positive when S(∞)<0.5, got {t_50}"
+        );
+        // Round-trips the defining equation H(median)=ln2 ⟺ S(median)=0.5.
+        let (_, cum) = hazard_and_cum_hazard(HazardFamily::Gompertz, t_50, &params);
+        assert!(
+            (cum - std::f64::consts::LN_2).abs() < 1e-10,
+            "H(median)={cum}, expected ln2"
+        );
+        assert!(
+            ((-cum).exp() - 0.5).abs() < 1e-10,
+            "S(median)={} for γ<0 Gompertz",
+            (-cum).exp()
+        );
+    }
+
+    #[test]
+    fn median_gompertz_gamma_negative_nan_when_cure_at_least_half() {
+        // γ<0 with S(∞)≥0.5: more than half never event, so the median is genuinely
+        // +∞/undefined and NaN is correct.
+        //   α=0.002, γ=−0.005, loghr=0 ⇒ H(∞)=0.4, S(∞)=e^{−0.4}≈0.6703 ≥ 0.5.
+        let params = [0.002_f64, -0.005_f64, 0.0_f64];
+        let s_inf = (-(0.002_f64 / 0.005)).exp();
+        assert!(s_inf >= 0.5, "test setup: cure fraction must be ≥ 0.5");
+        let t_50 = median_survival(HazardFamily::Gompertz, &params);
+        assert!(
+            t_50.is_nan(),
+            "γ<0 median must be NaN when S(∞)≥0.5, got {t_50}"
+        );
+    }
+
+    #[test]
+    fn median_gompertz_gamma_negative_boundary_s_inf_half() {
+        // Boundary S(∞)=0.5 (⟺ x=−1): the median is undefined (+∞). Bracket it — a cure
+        // fraction a hair below 0.5 (H(∞) just above ln2) yields a large finite median; a hair
+        // above 0.5 (H(∞) just below ln2) yields NaN. Construct α from a target H(∞) via
+        // α = H(∞)·|γ| (loghr=0).
+        let gamma = -0.001_f64;
+        let just_below_half = {
+            let h_inf = std::f64::consts::LN_2 * (1.0 + 1e-6); // S(∞) just below 0.5
+            [h_inf * 0.001, gamma, 0.0_f64]
+        };
+        let just_above_half = {
+            let h_inf = std::f64::consts::LN_2 * (1.0 - 1e-6); // S(∞) just above 0.5
+            [h_inf * 0.001, gamma, 0.0_f64]
+        };
+        let m_below = median_survival(HazardFamily::Gompertz, &just_below_half);
+        assert!(
+            m_below.is_finite() && m_below > 0.0,
+            "S(∞) just below 0.5 must give a finite median, got {m_below}"
+        );
+        let m_above = median_survival(HazardFamily::Gompertz, &just_above_half);
+        assert!(
+            m_above.is_nan(),
+            "S(∞) just above 0.5 must give NaN median, got {m_above}"
+        );
+    }
+
+    #[test]
+    fn mean_gompertz_gamma_negative_is_nan_even_with_finite_median() {
+        // The #805 trap: a γ<0 Gompertz with S(∞)<0.5 has a *finite median* (so the
+        // median-based integration bound would fire) but an *infinite mean* — S(t) floors at
+        // S(∞)>0 and never decays, so ∫₀^∞ S diverges. mean_survival must return NaN via its
+        // explicit γ<0 guard, NOT a finite value from integrating [0, 40·median]. Uses the same
+        // finite-median params as `median_gompertz_gamma_negative_finite_when_cure_below_half`,
+        // so this test fails the moment that guard is removed.
+        let params = [0.002_f64, -0.001_f64, 0.0_f64];
+        // Precondition: the median really is finite here (else this wouldn't guard the trap).
+        assert!(
+            median_survival(HazardFamily::Gompertz, &params).is_finite(),
+            "test precondition: median must be finite for the trap to bite"
+        );
+        let m = mean_survival(HazardFamily::Gompertz, &params);
+        assert!(
+            m.is_nan(),
+            "γ<0 Gompertz mean is infinite (positive cure fraction) ⇒ must be NaN, got {m}"
         );
     }
 

--- a/src/survival/parametric.rs
+++ b/src/survival/parametric.rs
@@ -719,6 +719,32 @@ mod tests {
     }
 
     #[test]
+    fn median_gompertz_gamma_negative_finite_with_loghr() {
+        // γ<0 with a NONZERO loghr: exp_lhr must thread through x = ln2·γ/(α·e^{loghr}), so the
+        // S(∞)=0.5 boundary shifts with the PH covariate term. Guards a regression that drops
+        // exp_lhr from the γ<0 median (invisible to every loghr=0 test above). The round-trip is
+        // the teeth — hazard_and_cum_hazard re-applies loghr independently, so H(median)=ln2
+        // holds only if both the median and H use exp_lhr.
+        //   α=0.002, γ=−0.001, loghr=ln2 ⇒ α·e^{loghr}=0.004, H(∞)=4.0, S(∞)=e^{−4}≈0.0183 < 0.5.
+        let params = [0.002_f64, -0.001_f64, std::f64::consts::LN_2];
+        let a_eff = 0.002_f64 * std::f64::consts::LN_2.exp(); // α·e^{loghr} = 0.004
+        assert!(
+            (-(a_eff / 0.001)).exp() < 0.5,
+            "test setup: cure fraction must be below 0.5"
+        );
+        let t_50 = median_survival(HazardFamily::Gompertz, &params);
+        assert!(
+            t_50.is_finite() && t_50 > 0.0,
+            "γ<0 median with loghr must be finite and positive, got {t_50}"
+        );
+        let (_, cum) = hazard_and_cum_hazard(HazardFamily::Gompertz, t_50, &params);
+        assert!(
+            (cum - std::f64::consts::LN_2).abs() < 1e-10,
+            "H(median)={cum}, expected ln2 (loghr must thread through both median and H)"
+        );
+    }
+
+    #[test]
     fn median_gompertz_gamma_negative_nan_when_cure_at_least_half() {
         // γ<0 with S(∞)≥0.5: more than half never event, so the median is genuinely
         // +∞/undefined and NaN is correct.
@@ -757,6 +783,16 @@ mod tests {
         assert!(
             m_above.is_nan(),
             "S(∞) just above 0.5 must give NaN median, got {m_above}"
+        );
+
+        // Exact knife-edge x == −1.0 (S(∞)=0.5 exactly). With α=LN_2, γ=−1.0, loghr=0 the ratio
+        // x = LN_2·(−1.0)/(LN_2·1.0) folds to exactly −1.0 in IEEE (−d/d). The strict `x > -1.0`
+        // gate must reject it → NaN (the true median is +∞, not a finite value).
+        let ln2 = std::f64::consts::LN_2;
+        let m_exact = median_survival(HazardFamily::Gompertz, &[ln2, -1.0_f64, 0.0_f64]);
+        assert!(
+            m_exact.is_nan(),
+            "x=−1.0 exactly (S(∞)=0.5) must give NaN, got {m_exact}"
         );
     }
 


### PR DESCRIPTION
## Why

`median_survival` (`src/survival/parametric.rs`) returned `f64::NAN` for **every**
declining-hazard (`γ < 0`) Gompertz, even when a **finite median genuinely exists** — the
same `γ < 0` blind spot fixed for the event-time samplers in #803 / #804, but in the
diagnostic/reporting path. A `γ < 0` Gompertz has a finite limiting cumulative hazard
`H(∞) = α·e^{loghr}/|γ|` and cure fraction `S(∞) = e^{−H(∞)}`; when `S(∞) < 0.5` the median
`H(T) = ln2` is a real, finite number that was being reported as `NaN`.

`mean_survival` inherited that `NaN` for `γ < 0`. The `NaN` is *correct* — a positive cure
fraction leaves a non-decaying `S(∞) > 0` tail, so `E[T] = ∫₀^∞ S` genuinely diverges — but
it was correct **only coincidentally**, because it derived its integration bound from
`median_survival`, which was `NaN`. Fixing the median without also guarding the mean would
have silently regressed the mean to a **bogus finite value**.

`γ` is a free expression with no positivity constraint, so a declining-hazard Gompertz is
reachable from ordinary models. Found during the adversarial review of #804 (three
independent reviewers flagged it); deliberately left out of #803's scope. Closes #805.

## What changed

1. **`median_survival`** — collapsed the `γ > 0` / `else NaN` split into one `γ ≠ 0` branch.
   With `x = ln2·γ/(α·e^{loghr})`, the median is `x.ln_1p()/γ` gated on `x > −1`
   (⟺ `ln2 < H(∞)` ⟺ `S(∞) < 0.5`), else `NaN`. For `γ > 0`, `x > 0` so `x > −1` always
   holds — **behavior byte-identical**. The `ln_1p` stability note and the `α`/`e^{loghr}`
   degeneracy guards are preserved.
2. **`mean_survival`** — an explicit `γ < 0` Gompertz guard returning `NaN` (infinite mean),
   placed **before** the median-based integration so it no longer depends on the median
   being `NaN`.

Diagnostic/reporting only (`predict_survival` summaries feed `SurvivalPredictionResult`);
does **not** touch estimation or simulation numerics.

## Alternatives considered

- **Return `+∞` instead of `NaN`** for the undefined-median case (`S(∞) ≥ 0.5`). Rejected —
  `NaN` matches this module's existing degenerate-returns-`NaN` convention and the ODE
  `grid_median` "no crossing → `NaN`" convention, so callers keep a single sentinel.
- **Restructure `mean_survival`'s Gompertz handling into one block.** Rejected in favour of
  the minimal targeted guard for a smaller, lower-risk diff.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API or struct-schema change. `SurvivalPredictionResult.median_survival` /
`.mean_survival` already exist and are surfaced; only their **value** changes for `γ < 0`
models (previously `NA`/`NaN`, now a finite median where one exists). R users get the fix
for free — no ferx-r code change required.

## Breaking changes
- [x] None

Values within existing `f64` fields change for `γ < 0` Gompertz; no field, format, or API
signature changes.

## Numerical validation

Per the CLAUDE.md **survival-likelihood exception** (a closed-form summary with no
equivalent NONMEM/`survreg` estimator — NONMEM emits no Gompertz median/mean summary),
validated by **exact closed forms**, not a NONMEM anchor:

- [x] Compared against: hand-computed closed form + independent Python reference
- [x] Reference values:

```
Gompertz α=0.002, γ=−0.001, loghr=0   (H(∞)=2.0, S(∞)=e^{−2}≈0.1353 < 0.5)
  median_survival:  before = NaN        after = 425.5254   (round-trips H(median)=ln2 to 1e-10)
  mean_survival:    before = NaN        after = NaN        (E[T]=∞: positive cure fraction)

Gompertz α=0.002, γ=−0.005, loghr=0   (H(∞)=0.4, S(∞)=e^{−0.4}≈0.6703 ≥ 0.5)
  median_survival:  before = NaN        after = NaN        (median genuinely undefined)

γ > 0 (e.g. α=0.002, γ=+0.005): unchanged — x>0 ⇒ x>−1 always.
```

**Regression proof** (both fixes shown load-bearing by temporarily reverting each):
- Revert median fix → the two finite-median tests fail with `got NaN`.
- Keep median fix, remove mean guard → `mean_survival` returns a **bogus finite 2802.10**
  (integrating `[0, 40·median]` and missing the non-decaying tail); the trap-guard test
  catches it.

## Performance
- [x] No significant impact expected — one extra branch on the diagnostic path.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib --features survival` passes: 28/28)
- [x] Regression test added that fails without this fix (proven for **both** the median fix
  and the mean guard, independently)

Tier-1 tests added: (a) `γ<0`, `S(∞)<0.5` → finite median round-tripping `H(median)=ln2`;
(b) `γ<0`, `S(∞)≥0.5` → `NaN`; (c) `S(∞)=0.5` boundary bracket (a hair either side);
(d) `mean_survival` stays `NaN` with a *finite* median (the trap guard).

## Example (user-facing features only)
- [x] Not applicable (fix with no new API surface — existing `predict_survival` summary
  fields, corrected values for `γ < 0`)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (under `Fixed`, #805)
- [x] No docs page change needed — the only `median/mean_survival` mention in `docs/` is
  ODE-hazard-specific (`docs/estimation/tte.qmd`) and makes no `γ<0` claim, so nothing is
  stale; this is a narrow numerical edge case covered by the CHANGELOG + docstrings.

## Checklist
- [x] `cargo clippy` clean — no new warnings (the one `parametric.rs:113` finding,
  `!(exp_lhr > 0.0)`, is pre-existing code this PR does not touch)
- [x] `Dual2` sensitivity path — N/A: `median_survival`/`mean_survival` are `f64`-only
  diagnostics, not on the `sens/` / `*_g<T: PkNum>` gradient path
- [x] `Cargo.toml` version — not breaking, no bump

## Docs & examples

### ferx-site / ferx-book
- [x] No DSL syntax, `[fit_options]` key, example `.ferx`, or data file changed

### Example execution
- [x] No example execution step needed (fix with no user-visible `.ferx`/data surface)

## Reviewer hints

- The coupling is the subtle part: the `mean_survival` `γ<0` guard **must** precede the
  median-based integration. The commit proves that removing it yields a bogus finite mean
  (`2802.10`) once the median is finite.
- The median gate is `x > -1.0` (**strict**): `x = −1` is exactly `S(∞) = 0.5`, where the
  median is `+∞` — correctly excluded. The boundary-bracket test pins both sides.
- `γ > 0` is intentionally untouched behaviorally: `x > 0 ⇒ x > −1`, so the merged branch
  returns exactly what the old `else if gamma > 0.0` branch did.

## Open questions

None. (`NaN` vs `+∞` for the undefined-median case was a deliberate convention choice — see
Alternatives.)
