### PR TITLE
refactor(estimation): unified non-Gaussian dispatch + shared parser helper [closes #808]

### DIFF
--- a/src/categorical/mod.rs
+++ b/src/categorical/mod.rs
@@ -87,16 +87,19 @@ pub(crate) fn binary_data_term(
     nll
 }
 
-/// Sum the binary-endpoint NLL over all `Binary` CMTs for one subject, mirroring the
-/// per-endpoint TTE dispatch. Returns `0.0` when the model has no binary endpoint or the
-/// subject has no binary records for it. Callers apply the site's OFV-scale factor (`2·`
-/// on the halved FOCEI/IOV `data_ll`, `1·` on the raw SAEM / non-interaction paths) — the
-/// same factor they apply to `tte_endpoint_nll` / `tte_data_term`.
+/// Sum the per-subject NLL of every **discrete** (non-Gaussian, non-TTE) endpoint — the
+/// binary / Bernoulli term today; ordinal / Poisson / negative-binomial are future arms of
+/// the same match. Returns `0.0` when the model has no discrete endpoint or the subject has
+/// no records for one. Callers apply the site's OFV-scale factor (`2·` on the halved
+/// FOCEI/IOV `data_ll`, `1·` on the raw SAEM / non-interaction paths) — the same factor they
+/// apply to the TTE term.
 ///
-/// This doubles as the FD-Hessian closure at the FOCEI interaction site: evaluated at a
-/// perturbed η it re-scores every binary record, so `data_term_hessian_fd` picks up the
-/// logit curvature w.r.t. η.
-pub(crate) fn binary_subject_nll(
+/// A new discrete endpoint family adds **one arm here** and needs no new likelihood
+/// dispatch-site edit: every FOCEI / IOV / SAEM path, the FD-Hessian closure, and IMP reach
+/// it through the single `non_gaussian_subject_nll` seam. It also doubles as the FD-Hessian
+/// closure at the FOCEI interaction site: evaluated at a perturbed η it re-scores every
+/// discrete record, so `data_term_hessian_fd` picks up the curvature w.r.t. η.
+pub(crate) fn discrete_subject_nll(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],
@@ -107,9 +110,12 @@ pub(crate) fn binary_subject_nll(
     }
     let mut nll = 0.0;
     for (cmt, endpoint) in &model.endpoints {
+        // Binary today; a new discrete family (ordinal / Poisson / negative-binomial …) adds
+        // its branch here — reached through this one function, so no likelihood dispatch site
+        // changes. (Gaussian is scored by the residual path, TTE by the hazard dispatch.)
         if let EndpointLikelihood::Binary { link, lp_fn, .. } = endpoint {
             // `binary_data_term` filters `obs_records` by `cmt` itself — no per-call
-            // allocation, even inside the FD-Hessian closure (site 921).
+            // allocation, even inside the FD-Hessian closure.
             nll += binary_data_term(
                 *link,
                 lp_fn,

--- a/src/categorical/mod.rs
+++ b/src/categorical/mod.rs
@@ -96,7 +96,7 @@ pub(crate) fn binary_data_term(
 ///
 /// A new discrete endpoint family adds **one arm here** and needs no new likelihood
 /// dispatch-site edit: every FOCEI / IOV / SAEM path, the FD-Hessian closure, and IMP reach
-/// it through the single `non_gaussian_subject_nll` seam. It also doubles as the FD-Hessian
+/// it through the single `accumulate_non_gaussian_nll` seam. It also doubles as the FD-Hessian
 /// closure at the FOCEI interaction site: evaluated at a perturbed η it re-scores every
 /// discrete record, so `data_term_hessian_fd` picks up the curvature w.r.t. η.
 pub(crate) fn discrete_subject_nll(

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -80,11 +80,15 @@ pub(crate) fn analytical_ad_unsupported(model: &CompiledModel) -> Option<&'stati
     if model.has_tte() {
         return Some("time-to-event ([event_model]) hazard likelihood");
     }
-    // Binary/categorical (`[binary_model]`, #760): the logit data term has no Dual2
-    // analytic eta-sensitivity (its linear-predictor closure is evaluated numerically),
-    // so - exactly like TTE - it routes to the FD inner gradient. (False without `survival`.)
-    if model.has_binary() {
-        return Some("binary ([binary_model]) logistic likelihood");
+    // Discrete / categorical (`[binary_model]`, #760; ordinal/Poisson/… later): the data term
+    // has no Dual2 analytic eta-sensitivity (its linear-predictor closure is evaluated
+    // numerically), so - exactly like TTE - it routes to the FD inner gradient. Gated on the
+    // family-agnostic `has_discrete()` so a future discrete family routes here automatically
+    // rather than silently falling through to the (sensitivity-free) analytic gradient.
+    // (`has_discrete()` == `has_binary()` today, so this is unchanged for binary models. False
+    // without `survival`.)
+    if model.has_discrete() {
+        return Some("discrete ([binary_model]) likelihood");
     }
     None
 }

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -426,40 +426,21 @@ fn obs_nll_subject_into_iov(
         }
     }
 
-    // TTE term: same convention as obs_nll_subject_into (weight 1.0 to match
-    // the true NLL, since Gaussian obs already contribute at 0.5*(log v + r²/v)).
+    // Non-Gaussian data term at raw-NLL weight (1×) to match the true NLL (Gaussian obs
+    // already contribute at 0.5·(log v + r²/v)): TTE endpoints plus the discrete
+    // (binary/categorical) term. No joint-share on the IOV M-step path, and its analytic TTE
+    // term matches the `tte_data_term` this site inlined.
     #[cfg(feature = "survival")]
     if !subject.obs_records.is_empty() {
-        use crate::survival::tte_data_term;
-        use crate::types::EndpointLikelihood;
-        for (cmt, endpoint) in &model.endpoints {
-            if let EndpointLikelihood::Tte {
-                hazard, recurrence, ..
-            } = endpoint
-            {
-                let records_for_cmt: Vec<crate::types::ObsRecord> = subject
-                    .obs_records
-                    .iter()
-                    .filter(
-                        |r| matches!(r, crate::types::ObsRecord::Event { cmt: c, .. } if c == cmt),
-                    )
-                    .cloned()
-                    .collect();
-                if records_for_cmt.is_empty() {
-                    continue;
-                }
-                total_nll += tte_data_term(
-                    &records_for_cmt,
-                    hazard,
-                    *recurrence,
-                    theta,
-                    eta,
-                    &subject.covariates,
-                );
-            }
-        }
-        // Binary/categorical (#760): raw-NLL weight (1×), matching the TTE term above.
-        total_nll += crate::categorical::discrete_subject_nll(model, subject, theta, eta);
+        crate::stats::likelihood::accumulate_non_gaussian_nll(
+            model,
+            subject,
+            theta,
+            eta,
+            None,
+            1.0,
+            &mut total_nll,
+        );
     }
 
     total_nll

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -459,7 +459,7 @@ fn obs_nll_subject_into_iov(
             }
         }
         // Binary/categorical (#760): raw-NLL weight (1×), matching the TTE term above.
-        total_nll += crate::categorical::binary_subject_nll(model, subject, theta, eta);
+        total_nll += crate::categorical::discrete_subject_nll(model, subject, theta, eta);
     }
 
     total_nll

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3712,6 +3712,148 @@ fn eval_indiv_param_vars(
     vars
 }
 
+/// Shared predictor validation + `[individual_parameters]` restriction for the
+/// `[event_model]` and `[binary_model]` blocks.
+///
+/// Both blocks carry a linear predictor over θ/η/covariates/`[individual_parameters]`
+/// — a hazard parameter expression, or the `logit` log-odds — and both must enforce
+/// the same four invariants on it (previously duplicated verbatim in each block):
+///
+/// 1. reject a **direct** IOV-κ reference (#770): the predictor is evaluated once per
+///    subject with BSV-only η, so a kappa name has no occasion context and would
+///    otherwise fall back to a leniently-read `0.0` covariate, silently dropping it;
+/// 2. restrict the individual-parameter statements to those the predictor references,
+///    transitively (#442) — bounding per-eval work and scoping checks 3–4 to the
+///    parameters the predictor actually depends on;
+/// 3. reject an individual-parameter value that reaches an IOV-κ through η (#442);
+/// 4. reject an individual-parameter value that reads a `[covariate_nn]` output
+///    (#293, `nn`-gated) — it would silently resolve to `0.0` without the forward pass.
+///
+/// Returns the restricted statements (for the predictor closure) and the predictor's
+/// covariate set — the **union** of covariates referenced directly and transitively
+/// through the kept statements, so a time-varying covariate reached only via an
+/// individual parameter cannot slip past the #741 TV-covariate guard silently frozen.
+/// θ/η index collection stays with each caller (it returns those for its own
+/// dead-parameter census). `block` names the block for error messages.
+///
+/// The two blocks previously each carried these four steps verbatim; keeping them here
+/// once means a fix to any #770/#442/#741/#293 invariant lands for both endpoints.
+#[cfg(feature = "survival")]
+fn restrict_and_validate_indiv_stmts(
+    exprs: &[&Expression],
+    indiv_stmts: &[Statement],
+    eta_names: &[String],
+    kappa_names: &[String],
+    block: &str,
+) -> Result<(Vec<Statement>, Vec<String>), String> {
+    // (1) Direct IOV-κ reference — fail loud (#770).
+    for expr in exprs {
+        if let Some(k) = expr_references_kappa(expr, kappa_names) {
+            return Err(format!(
+                "[{block}]: a predictor expression references the inter-occasion (IOV) random \
+                 effect `{k}` directly. The predictor is evaluated once per subject with \
+                 per-subject (BSV) η only, so an IOV kappa has no well-defined value here — write \
+                 it in terms of θ/η, or reference an IOV-free parameter."
+            ));
+        }
+    }
+
+    // (2) Restrict `[individual_parameters]` to what the predictor references, transitively.
+    // Walk declarations in reverse so a needed parameter pulls in the earlier-declared
+    // parameters it depends on. Conditional (`if (...) CL = ...`) parameters are handled by
+    // keying on every assigned name (`assigned_vars_in_order`) and pulling in every referenced
+    // name (`visit_stmt_nodes`, covering RHS, conditions, and both branches).
+    let needed_indiv_stmts: Vec<Statement> = {
+        let mut needed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for expr in exprs {
+            collect_variable_names(expr, &mut needed);
+        }
+        let mut keep: Vec<Statement> = Vec::new();
+        for s in indiv_stmts.iter().rev() {
+            let stmt = std::slice::from_ref(s);
+            if assigned_vars_in_order(stmt)
+                .iter()
+                .any(|n| needed.contains(n))
+            {
+                visit_stmt_nodes(stmt, &mut |e: &Expression| {
+                    if let Expression::Variable(name) = e {
+                        needed.insert(name.clone());
+                    }
+                });
+                keep.push(s.clone());
+            }
+        }
+        keep.reverse();
+        keep
+    };
+
+    // (3) Covariate set: union of covariates referenced directly by the predictor and
+    // transitively through the kept individual-parameter statements (#741).
+    let covariates: Vec<String> = {
+        let mut cov_set = std::collections::HashSet::new();
+        for expr in exprs {
+            collect_covariates(expr, &mut cov_set);
+        }
+        collect_covariates_in_stmts(&needed_indiv_stmts, &mut cov_set);
+        let mut v: Vec<String> = cov_set.into_iter().collect();
+        v.sort();
+        v
+    };
+
+    // (4) An individual-parameter value that depends on an IOV-κ (BSV-only η here) — fail
+    // loud (#442). `eta_names` is BSV-only, so any `Eta(i)` with `i >= n_eta` is the kappa at
+    // position `i - n_eta` in `kappa_names`.
+    {
+        let n_eta = eta_names.len();
+        let mut kappa_hit: Option<String> = None;
+        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
+            if let Expression::Eta(i) = e {
+                if *i >= n_eta && kappa_hit.is_none() {
+                    kappa_hit = Some(
+                        kappa_names
+                            .get(*i - n_eta)
+                            .cloned()
+                            .unwrap_or_else(|| "<kappa>".to_string()),
+                    );
+                }
+            }
+        });
+        if let Some(k) = kappa_hit {
+            return Err(format!(
+                "[{block}]: a predictor expression references an [individual_parameters] value \
+                 that depends on the inter-occasion (IOV) random effect `{k}`. The predictor is \
+                 evaluated with per-subject (BSV) η only — reference an IOV-free parameter, or \
+                 write the predictor in terms of θ/η directly."
+            ));
+        }
+    }
+
+    // (5) An individual-parameter value whose definition reads a `[covariate_nn]` output would
+    // silently resolve to `0.0` (the predictor evaluates these statements without the network
+    // forward pass). Reject it — gated to `nn` like the rest: `Expression::NnOutput` nodes only
+    // exist under the `nn` feature, so the survival coverage build (no `nn`) does not compile
+    // this — a measurement gap, not missed coverage (#293) — and it is unreachable without `nn`.
+    #[cfg(feature = "nn")]
+    {
+        let mut nn_hit = false;
+        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
+            if matches!(e, Expression::NnOutput { .. }) {
+                nn_hit = true;
+            }
+        });
+        if nn_hit {
+            return Err(format!(
+                "[{block}]: a predictor expression references an [individual_parameters] value \
+                 whose definition uses a [covariate_nn] output. Neural-network-driven individual \
+                 parameters are not available to the predictor (it is evaluated without the \
+                 network forward pass) — reference an NN-free parameter instead."
+            ));
+        }
+    }
+
+    Ok((needed_indiv_stmts, covariates))
+}
+
 /// Parse one `[event_model]` (or `[event_model NAME]`) block.
 ///
 /// Returns `(cmt, EndpointLikelihood::Tte { hazard })` ready to insert into
@@ -4027,16 +4169,11 @@ fn parse_event_model_block(
         }
     }
 
-    // Collect covariate/theta/eta references from all expressions BEFORE they are
-    // moved into the param_fn closure.
-    let mut event_model_covariates: Vec<String>;
-    let event_model_thetas: std::collections::HashSet<usize>;
-    let event_model_etas: std::collections::HashSet<usize>;
-    // The hazard's parameter expressions in optimizer-parameter order, bound once
-    // and reused by the three scans below — reference collection, the direct-kappa
-    // reject (#770), and the transitive needed-statement collection (#442) — so a
-    // future family parameter can't be added to one walk and silently forgotten in
-    // another.
+    // The hazard's parameter expressions in optimizer-parameter order. The covariate
+    // union, `[individual_parameters]` restriction, and the direct/via-indiv IOV-κ
+    // (#770/#442) and `[covariate_nn]` (#293) rejects are shared with `[binary_model]`
+    // through `restrict_and_validate_indiv_stmts`; only the θ/η index sets (for the
+    // dead-parameter census) are collected here, since each block returns its own.
     let hazard_param_exprs = [
         &scale_expr,
         &shape_expr,
@@ -4044,153 +4181,22 @@ fn parse_event_model_block(
         &gamma_expr,
         &loghr_expr,
     ];
-    {
-        let mut cov_set = std::collections::HashSet::new();
+    let hazard_exprs: Vec<&Expression> = hazard_param_exprs.into_iter().flatten().collect();
+    let (event_model_thetas, event_model_etas) = {
         let mut theta_set = std::collections::HashSet::new();
         let mut eta_set = std::collections::HashSet::new();
-        for expr in hazard_param_exprs.into_iter().flatten() {
-            collect_covariates(expr, &mut cov_set);
+        for expr in hazard_exprs.iter().copied() {
             collect_theta_eta(expr, &mut theta_set, &mut eta_set);
         }
-        let mut v: Vec<String> = cov_set.into_iter().collect();
-        v.sort();
-        event_model_covariates = v;
-        event_model_thetas = theta_set;
-        event_model_etas = eta_set;
-    }
-
-    // A hazard expression that references an IOV kappa **by name directly**
-    // (e.g. `scale = TVLAMBDA * exp(KAPPA_CL)`) is as ill-defined as one that
-    // reaches a kappa through an [individual_parameters] value (rejected just
-    // below, #442): the hazard is evaluated once per subject, with no occasion
-    // context. The hazard parse scope is BSV-only, so a kappa name here parses as
-    // an unresolved identifier (Variable/Covariate) rather than `Eta(i)` and would
-    // otherwise fall back to a leniently-read 0.0 covariate (see the "read
-    // leniently" note above), silently dropping the IOV term. Reject it fail-loud
-    // instead (#770).
-    for expr in hazard_param_exprs.into_iter().flatten() {
-        if let Some(k) = expr_references_kappa(expr, kappa_names) {
-            return Err(format!(
-                "[event_model]: a hazard expression references the inter-occasion (IOV) \
-                 random effect `{k}` directly. The hazard is evaluated once per subject, with \
-                 no occasion context, so an IOV kappa has no well-defined value here — write \
-                 the hazard in terms of θ/η, or reference an IOV-free parameter."
-            ));
-        }
-    }
-
-    // Restrict the individual-parameter statements the hazard closures evaluate to
-    // just those the hazard references, transitively. This bounds the per-eval work
-    // and scopes the IOV/NN checks below to what the hazard actually depends on (an
-    // unrelated PK parameter that uses an IOV kappa or an NN output must not make a
-    // kappa-free hazard fail). Walking declarations in reverse lets a needed
-    // parameter pull in the (earlier-declared) parameters it depends on. NONMEM-style
-    // `if (...) CL = ...` conditional parameters are handled by keying on every name
-    // the statement assigns (across branches, via `assigned_vars_in_order`) and
-    // pulling in every name it references (RHS, conditions, and both branches, via
-    // `visit_stmt_nodes`).
-    let needed_indiv_stmts: Vec<Statement> = {
-        let mut needed: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for expr in hazard_param_exprs.into_iter().flatten() {
-            collect_variable_names(expr, &mut needed);
-        }
-        let mut keep: Vec<Statement> = Vec::new();
-        for s in indiv_stmts.iter().rev() {
-            let stmt = std::slice::from_ref(s);
-            if assigned_vars_in_order(stmt)
-                .iter()
-                .any(|n| needed.contains(n))
-            {
-                visit_stmt_nodes(stmt, &mut |e: &Expression| {
-                    if let Expression::Variable(name) = e {
-                        needed.insert(name.clone());
-                    }
-                });
-                keep.push(s.clone());
-            }
-        }
-        keep.reverse();
-        keep
+        (theta_set, eta_set)
     };
-
-    // A hazard sub-expression may reference an [individual_parameters] value (PR #442)
-    // whose own definition reads covariates — e.g. `scale = LAMBDA` with
-    // `LAMBDA = TVLAMBDA * exp(TVBETA * CRCL + ETA)`. The `param_fn` evaluates those kept
-    // statements, so the hazard transitively reads `CRCL` at the baseline snapshot. Union
-    // the covariates of the kept statements into the event-model covariate set so (a) they
-    // appear in the covariate table and (b) `hazard_covariates` is complete — otherwise a
-    // *time-varying* covariate reached only through an individual parameter slips past the
-    // #741 guard and is silently frozen (the exact bug #741 exists to reject).
-    {
-        let mut cov_set = std::collections::HashSet::new();
-        collect_covariates_in_stmts(&needed_indiv_stmts, &mut cov_set);
-        for c in cov_set {
-            if !event_model_covariates.contains(&c) {
-                event_model_covariates.push(c);
-            }
-        }
-        event_model_covariates.sort();
-    }
-
-    // The hazard `param_fn` evaluates the kept statements with the BSV-only η it is
-    // handed (kappas are PK/occasion-level, not part of a per-subject hazard), so a
-    // kept statement referencing an IOV kappa would index η out of bounds and abort
-    // the fit (issue #442). Reject it here with a clear error instead. `eta_names` is
-    // BSV-only (it is `model.eta_names`), so any `Eta(i)` with `i >= eta_names.len()`
-    // is the kappa at position `i - n_eta` in `kappa_names`.
-    {
-        let n_eta = eta_names.len();
-        let mut kappa_hit: Option<String> = None;
-        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
-            if let Expression::Eta(i) = e {
-                if *i >= n_eta && kappa_hit.is_none() {
-                    kappa_hit = Some(
-                        kappa_names
-                            .get(*i - n_eta)
-                            .cloned()
-                            .unwrap_or_else(|| "<kappa>".to_string()),
-                    );
-                }
-            }
-        });
-        if let Some(k) = kappa_hit {
-            return Err(format!(
-                "[event_model]: a hazard expression references an [individual_parameters] \
-                 value that depends on the inter-occasion (IOV) random effect `{k}`. The \
-                 hazard is evaluated once per subject, with no occasion context, so an IOV \
-                 parameter has no well-defined value here — reference an IOV-free parameter, \
-                 or write the hazard in terms of θ/η directly."
-            ));
-        }
-    }
-
-    // An `[individual_parameters]` value whose definition reads a `[covariate_nn]`
-    // output would silently resolve to 0.0 in the hazard, because the hazard
-    // `param_fn` evaluates these statements without the network forward pass. Reject
-    // such a reference. `Expression::NnOutput` nodes only exist under the `nn`
-    // feature (they come from `[covariate_nn]` dot-access), so this guard is gated to
-    // it: the survival coverage build (`--features ci,survival`, no `nn`) does not
-    // compile it — a measurement gap, not missed coverage (#293) — and it is
-    // unreachable in any build without `nn`.
-    #[cfg(feature = "nn")]
-    {
-        let mut nn_hit = false;
-        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
-            if matches!(e, Expression::NnOutput { .. }) {
-                nn_hit = true;
-            }
-        });
-        if nn_hit {
-            return Err(
-                "[event_model]: a hazard expression references an [individual_parameters] \
-                 value whose definition uses a [covariate_nn] output. Neural-network-driven \
-                 individual parameters are not available to hazard expressions (the hazard is \
-                 evaluated without the network forward pass) — reference an NN-free parameter \
-                 instead."
-                    .to_string(),
-            );
-        }
-    }
+    let (needed_indiv_stmts, event_model_covariates) = restrict_and_validate_indiv_stmts(
+        &hazard_exprs,
+        indiv_stmts,
+        eta_names,
+        kappa_names,
+        "event_model",
+    )?;
 
     // Build the param_fn closure that evaluates hazard parameters from (θ, η, covariates).
     // Expression nodes hold only indices, so they're safe to move into the closure.
@@ -4355,120 +4361,24 @@ fn parse_binary_model_block(
         }
     }
 
-    // Collect covariate/theta/eta references BEFORE the expression is moved into the closure.
-    let mut lp_covariates: Vec<String>;
-    let lp_thetas: std::collections::HashSet<usize>;
-    let lp_etas: std::collections::HashSet<usize>;
-    {
-        let mut cov_set = std::collections::HashSet::new();
+    // The covariate union, `[individual_parameters]` restriction, and the direct/via-indiv
+    // IOV-κ (#770/#442) and `[covariate_nn]` (#293) rejects are shared with `[event_model]`
+    // through `restrict_and_validate_indiv_stmts`; only the θ/η index sets (for the
+    // dead-parameter census) are collected here, since each block returns its own.
+    let lp_exprs: [&Expression; 1] = [&logit_expr];
+    let (lp_thetas, lp_etas) = {
         let mut theta_set = std::collections::HashSet::new();
         let mut eta_set = std::collections::HashSet::new();
-        collect_covariates(&logit_expr, &mut cov_set);
         collect_theta_eta(&logit_expr, &mut theta_set, &mut eta_set);
-        let mut v: Vec<String> = cov_set.into_iter().collect();
-        v.sort();
-        lp_covariates = v;
-        lp_thetas = theta_set;
-        lp_etas = eta_set;
-    }
-
-    // Reject a direct IOV-kappa reference (#770 analogue): the predictor is evaluated with
-    // BSV-only η, so a kappa name here would silently read 0.0 — fail loud instead.
-    if let Some(k) = expr_references_kappa(&logit_expr, kappa_names) {
-        return Err(format!(
-            "[binary_model]: the logit predictor references the inter-occasion (IOV) random \
-             effect `{k}` directly. The predictor is evaluated with per-subject (BSV) η only, so \
-             an IOV kappa has no well-defined value here — write it in terms of θ/η, or reference \
-             an IOV-free parameter."
-        ));
-    }
-
-    // Restrict the individual-parameter statements the predictor evaluates to just those it
-    // references, transitively (mirrors the hazard path; bounds per-eval work and scopes the
-    // IOV/NN checks below to what the predictor actually depends on).
-    let needed_indiv_stmts: Vec<Statement> = {
-        let mut needed: std::collections::HashSet<String> = std::collections::HashSet::new();
-        collect_variable_names(&logit_expr, &mut needed);
-        let mut keep: Vec<Statement> = Vec::new();
-        for s in indiv_stmts.iter().rev() {
-            let stmt = std::slice::from_ref(s);
-            if assigned_vars_in_order(stmt)
-                .iter()
-                .any(|n| needed.contains(n))
-            {
-                visit_stmt_nodes(stmt, &mut |e: &Expression| {
-                    if let Expression::Variable(name) = e {
-                        needed.insert(name.clone());
-                    }
-                });
-                keep.push(s.clone());
-            }
-        }
-        keep.reverse();
-        keep
+        (theta_set, eta_set)
     };
-
-    // Union covariates reached transitively through `[individual_parameters]` so a
-    // time-varying covariate can't slip past a future TV-covariate guard silently frozen
-    // (the #741 concern, applied to the categorical predictor).
-    {
-        let mut cov_set = std::collections::HashSet::new();
-        collect_covariates_in_stmts(&needed_indiv_stmts, &mut cov_set);
-        for c in cov_set {
-            if !lp_covariates.contains(&c) {
-                lp_covariates.push(c);
-            }
-        }
-        lp_covariates.sort();
-    }
-
-    // Reject an `[individual_parameters]` value that depends on an IOV kappa (BSV-only η here).
-    {
-        let n_eta = eta_names.len();
-        let mut kappa_hit: Option<String> = None;
-        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
-            if let Expression::Eta(i) = e {
-                if *i >= n_eta && kappa_hit.is_none() {
-                    kappa_hit = Some(
-                        kappa_names
-                            .get(*i - n_eta)
-                            .cloned()
-                            .unwrap_or_else(|| "<kappa>".to_string()),
-                    );
-                }
-            }
-        });
-        if let Some(k) = kappa_hit {
-            return Err(format!(
-                "[binary_model]: the logit predictor references an [individual_parameters] value \
-                 that depends on the inter-occasion (IOV) random effect `{k}`. The predictor is \
-                 evaluated with per-subject (BSV) η only — reference an IOV-free parameter, or \
-                 write the predictor in terms of θ/η directly."
-            ));
-        }
-    }
-
-    // An `[individual_parameters]` value that reads a `[covariate_nn]` output would silently
-    // resolve to 0.0 here (the predictor evaluates these statements without the network
-    // forward pass). Reject it — gated to `nn` like the hazard guard (#293 measurement gap,
-    // not missed coverage, in the survival build).
-    #[cfg(feature = "nn")]
-    {
-        let mut nn_hit = false;
-        visit_stmt_nodes(&needed_indiv_stmts, &mut |e: &Expression| {
-            if matches!(e, Expression::NnOutput { .. }) {
-                nn_hit = true;
-            }
-        });
-        if nn_hit {
-            return Err(
-                "[binary_model]: the logit predictor references an [individual_parameters] value \
-                 whose definition uses a [covariate_nn] output. Neural-network-driven individual \
-                 parameters are not available to the predictor — reference an NN-free parameter."
-                    .to_string(),
-            );
-        }
-    }
+    let (needed_indiv_stmts, lp_covariates) = restrict_and_validate_indiv_stmts(
+        &lp_exprs,
+        indiv_stmts,
+        eta_names,
+        kappa_names,
+        "binary_model",
+    )?;
 
     // Build the lp_fn closure over (θ, η, covariates). Expression nodes hold only indices, so
     // they are safe to move; `TIME` resolves via the model-time guard `binary_data_term` sets

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -3746,11 +3746,19 @@ fn restrict_and_validate_indiv_stmts(
     kappa_names: &[String],
     block: &str,
 ) -> Result<(Vec<Statement>, Vec<String>), String> {
+    // Block-appropriate noun for the predictor in error messages — `[event_model]` carries a
+    // hazard, `[binary_model]` the logit — so a user sees the same wording as before the two
+    // blocks shared this helper.
+    let predictor = match block {
+        "event_model" => "a hazard expression",
+        "binary_model" => "the logit predictor",
+        _ => "a predictor expression",
+    };
     // (1) Direct IOV-κ reference — fail loud (#770).
     for expr in exprs {
         if let Some(k) = expr_references_kappa(expr, kappa_names) {
             return Err(format!(
-                "[{block}]: a predictor expression references the inter-occasion (IOV) random \
+                "[{block}]: {predictor} references the inter-occasion (IOV) random \
                  effect `{k}` directly. The predictor is evaluated once per subject with \
                  per-subject (BSV) η only, so an IOV kappa has no well-defined value here — write \
                  it in terms of θ/η, or reference an IOV-free parameter."
@@ -3820,7 +3828,7 @@ fn restrict_and_validate_indiv_stmts(
         });
         if let Some(k) = kappa_hit {
             return Err(format!(
-                "[{block}]: a predictor expression references an [individual_parameters] value \
+                "[{block}]: {predictor} references an [individual_parameters] value \
                  that depends on the inter-occasion (IOV) random effect `{k}`. The predictor is \
                  evaluated with per-subject (BSV) η only — reference an IOV-free parameter, or \
                  write the predictor in terms of θ/η directly."
@@ -3843,7 +3851,7 @@ fn restrict_and_validate_indiv_stmts(
         });
         if nn_hit {
             return Err(format!(
-                "[{block}]: a predictor expression references an [individual_parameters] value \
+                "[{block}]: {predictor} references an [individual_parameters] value \
                  whose definition uses a [covariate_nn] output. Neural-network-driven individual \
                  parameters are not available to the predictor (it is evaluated without the \
                  network forward pass) — reference an NN-free parameter instead."

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -543,7 +543,7 @@ pub fn individual_nll_into_with_schedule(
             }
         }
         // Binary/categorical (#760): same 2× OFV-scale as the TTE term above.
-        data_ll += 2.0 * crate::categorical::binary_subject_nll(model, subject, theta, eta);
+        data_ll += 2.0 * crate::categorical::discrete_subject_nll(model, subject, theta, eta);
     }
 
     let nll = 0.5 * (eta_prior + log_det_omega + data_ll);
@@ -756,7 +756,7 @@ pub(crate) fn obs_nll_subject_from_preds(
             }
         }
         // Binary/categorical (#760): raw-NLL weight (1×), matching the TTE term above.
-        nll += crate::categorical::binary_subject_nll(model, subject, theta, eta);
+        nll += crate::categorical::discrete_subject_nll(model, subject, theta, eta);
     }
 
     nll
@@ -974,7 +974,7 @@ pub fn foce_subject_nll(
         // subject has an empty Gaussian h_matrix; hrh then comes entirely from here.
         if model.has_binary() {
             let bin_fn = |eta_eval: &[f64]| {
-                crate::categorical::binary_subject_nll(model, subject, theta, eta_eval)
+                crate::categorical::discrete_subject_nll(model, subject, theta, eta_eval)
             };
             tte_nll_at_mode += bin_fn(eta_hat.as_slice());
             if n_eta > 0 {
@@ -2459,7 +2459,7 @@ pub fn individual_nll_iov(
             }
         }
         // Binary/categorical (#760): same 2× OFV-scale as the TTE term above.
-        data_ll += 2.0 * crate::categorical::binary_subject_nll(model, subject, theta, eta);
+        data_ll += 2.0 * crate::categorical::discrete_subject_nll(model, subject, theta, eta);
     }
 
     0.5 * (eta_prior + log_det_omega + kappa_prior + (k_occasions as f64) * log_det_iov + data_ll)

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -395,9 +395,14 @@ fn tte_endpoint_nll(
 /// path for multi-endpoint (competing-risks / TTE+binary) subjects.
 ///
 /// `factor` is the site's OFV-scale weight (`2·` on the halved FOCEI/IOV `data_ll`, `1·` on
-/// the raw SAEM / non-interaction NLL). `joint_share` is `None` on every path without the
-/// shared solve — the SAEM and IOV sites, which never carry a joint-PK-TTE endpoint, so their
-/// TTE terms are analytic and `tte_endpoint_nll` equals the `tte_data_term` they inlined.
+/// the raw SAEM / non-interaction NLL). `joint_share` is `None` on every path that does not
+/// build the shared solve, and passing it is faithful to what each inlined:
+/// - the two **IOV** sites (`individual_nll_iov`, `obs_nll_subject_into_iov`) inlined
+///   `tte_data_term`, which equals `tte_endpoint_nll` here because an IOV model's hazard is
+///   always `Analytic` — IOV + joint-PK-TTE is rejected at parse;
+/// - the **SAEM θ-M-step** (`obs_nll_subject_from_preds`) already inlined `tte_endpoint_nll`
+///   and *may* carry an `OdeAccumulated` endpoint (SAEM + joint-PK-TTE is not rejected); the
+///   `_` arm re-solves it via `tte_ode_nll`, exactly as that site did before the fold.
 #[cfg(feature = "survival")]
 pub(crate) fn accumulate_non_gaussian_nll(
     model: &CompiledModel,

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -206,7 +206,7 @@ fn tte_ode_nll_from_curves(
 /// at the TTE event/censor/entry times — so the inner NLL no longer integrates the
 /// same system a second time via `ode_cumhaz_hazard`.
 #[cfg(feature = "survival")]
-struct JointPkTteSolve {
+pub(crate) struct JointPkTteSolve {
     /// Scaled Gaussian predictions — bit-identical to the standalone prediction path.
     preds: Vec<f64>,
     /// Sorted-unique union of every OdeAccumulated endpoint's record times.
@@ -379,6 +379,76 @@ fn tte_endpoint_nll(
     }
 }
 
+/// Accumulate every non-Gaussian endpoint's data-term NLL into `acc`, applying `factor` to
+/// each contribution. This is the single seam the FOCEI, SAEM θ-M-step, and IOV likelihood
+/// paths share: TTE endpoints are scored by [`tte_endpoint_nll`] (an `OdeAccumulated`
+/// joint-PK-TTE hazard reads `H`/`h` off the #570 shared solve when `joint_share` is `Some`);
+/// the discrete families — binary today, ordinal / Poisson / negative-binomial later — by
+/// [`crate::categorical::discrete_subject_nll`]. A new endpoint family is enabled by one arm
+/// in those two callees, touching no dispatch site.
+///
+/// It accumulates **into `acc` per term** — one `factor * term` add per TTE endpoint (in
+/// `model.endpoints` iteration order), then one for the discrete term — rather than returning
+/// a folded sum, so a running `data_ll` that already holds the Gaussian residual term stays
+/// **bit-identical** to the previously-inlined loop. Returning `-> f64` and adding
+/// `factor * sum` once would reassociate the floating-point adds and perturb the FOCEI hot
+/// path for multi-endpoint (competing-risks / TTE+binary) subjects.
+///
+/// `factor` is the site's OFV-scale weight (`2·` on the halved FOCEI/IOV `data_ll`, `1·` on
+/// the raw SAEM / non-interaction NLL). `joint_share` is `None` on every path without the
+/// shared solve — the SAEM and IOV sites, which never carry a joint-PK-TTE endpoint, so their
+/// TTE terms are analytic and `tte_endpoint_nll` equals the `tte_data_term` they inlined.
+#[cfg(feature = "survival")]
+pub(crate) fn accumulate_non_gaussian_nll(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    joint_share: Option<&JointPkTteSolve>,
+    factor: f64,
+    acc: &mut f64,
+) {
+    // Callers gate on `!subject.obs_records.is_empty()`, so an empty subject never reaches
+    // here; both loops below are also natural no-ops on one.
+    // TTE endpoints — one `factor * raw` add each, in endpoints iteration order.
+    for (cmt, endpoint) in &model.endpoints {
+        if let EndpointLikelihood::Tte {
+            hazard, recurrence, ..
+        } = endpoint
+        {
+            let records_for_cmt: Vec<crate::types::ObsRecord> = subject
+                .obs_records
+                .iter()
+                .filter(|r| matches!(r, crate::types::ObsRecord::Event { cmt: c, .. } if c == cmt))
+                .cloned()
+                .collect();
+            if records_for_cmt.is_empty() {
+                continue; // subject has no records for this TTE CMT
+            }
+            let raw = match (joint_share, hazard) {
+                (Some(s), HazardSpec::OdeAccumulated { chz_state }) => tte_ode_nll_from_shared(
+                    model.ode_spec.as_ref().expect("joint share ⟹ ode_spec"),
+                    s,
+                    *chz_state,
+                    &records_for_cmt,
+                ),
+                _ => tte_endpoint_nll(
+                    model,
+                    subject,
+                    hazard,
+                    *recurrence,
+                    &records_for_cmt,
+                    theta,
+                    eta,
+                ),
+            };
+            *acc += factor * raw;
+        }
+    }
+    // Discrete families (binary today; ordinal/Poisson/… later) — one add, matching the TTE terms.
+    *acc += factor * crate::categorical::discrete_subject_nll(model, subject, theta, eta);
+}
+
 /// Hot-path variant that additionally threads through a pre-built
 /// [`pk::event_driven::EventSchedule`]. The FOCE inner-loop obj closure
 /// and Jacobian build the schedule once per `find_ebe` call and reuse
@@ -493,57 +563,20 @@ pub fn individual_nll_into_with_schedule(
         }
     }
 
-    // TTE data term: add −log p(events | η, θ) for each TTE endpoint.
-    // Only compiled and executed when the `survival` feature is enabled and
-    // the subject has non-Gaussian obs_records.
+    // Non-Gaussian data term: −log p for each TTE endpoint plus the discrete
+    // (binary/categorical) endpoints, at the 2× OFV-scale (the whole objective is halved at
+    // the end). #570: an OdeAccumulated endpoint reads `H`/`h` off the shared joint solve.
     #[cfg(feature = "survival")]
     if !subject.obs_records.is_empty() {
-        use crate::types::EndpointLikelihood;
-        // Iterate model.endpoints (typically 1–3 entries) rather than scanning
-        // obs_records for unique CMTs — avoids the HashSet and one pass over records.
-        for (cmt, endpoint) in &model.endpoints {
-            if let EndpointLikelihood::Tte {
-                hazard, recurrence, ..
-            } = endpoint
-            {
-                let records_for_cmt: Vec<crate::types::ObsRecord> = subject
-                    .obs_records
-                    .iter()
-                    .filter(
-                        |r| matches!(r, crate::types::ObsRecord::Event { cmt: c, .. } if c == cmt),
-                    )
-                    .cloned()
-                    .collect();
-                if records_for_cmt.is_empty() {
-                    continue; // subject has no records for this TTE CMT
-                }
-                // tte_endpoint_nll returns a raw NLL; multiply by 2 to match the
-                // Gaussian data_ll convention (everything is halved at the end).
-                // #570: when the shared joint solve is active, an OdeAccumulated
-                // endpoint reads `H`/`h` off it instead of integrating again; every
-                // other case keeps the established per-endpoint dispatch.
-                let raw = match (joint_share.as_ref(), hazard) {
-                    (Some(s), HazardSpec::OdeAccumulated { chz_state }) => tte_ode_nll_from_shared(
-                        model.ode_spec.as_ref().expect("joint share ⟹ ode_spec"),
-                        s,
-                        *chz_state,
-                        &records_for_cmt,
-                    ),
-                    _ => tte_endpoint_nll(
-                        model,
-                        subject,
-                        hazard,
-                        *recurrence,
-                        &records_for_cmt,
-                        theta,
-                        eta,
-                    ),
-                };
-                data_ll += 2.0 * raw;
-            }
-        }
-        // Binary/categorical (#760): same 2× OFV-scale as the TTE term above.
-        data_ll += 2.0 * crate::categorical::discrete_subject_nll(model, subject, theta, eta);
+        accumulate_non_gaussian_nll(
+            model,
+            subject,
+            theta,
+            eta,
+            joint_share.as_ref(),
+            2.0,
+            &mut data_ll,
+        );
     }
 
     let nll = 0.5 * (eta_prior + log_det_omega + data_ll);
@@ -719,44 +752,12 @@ pub(crate) fn obs_nll_subject_from_preds(
         }
     }
 
-    // TTE data term: add −log p(events | η, θ) so the SAEM theta M-step
-    // gradient receives TTE hazard contributions, not just Gaussian residuals.
+    // Non-Gaussian data term at raw-NLL weight (1×) so the SAEM θ M-step gradient receives
+    // the TTE hazard + discrete (binary/categorical) contributions, not just Gaussian
+    // residuals. No joint-share on this path (it re-solves per endpoint).
     #[cfg(feature = "survival")]
     if !subject.obs_records.is_empty() {
-        use crate::types::EndpointLikelihood;
-        for (cmt, endpoint) in &model.endpoints {
-            if let EndpointLikelihood::Tte {
-                hazard, recurrence, ..
-            } = endpoint
-            {
-                // Keep only `ObsRecord::Event` records at this CMT; any `DiscreteState` /
-                // `Count` records (Phase 4.0) are correctly excluded from the TTE data term.
-                // The `..` pattern captures all EventType variants (Exact, RightCensored,
-                // IntervalCensored), so this filter passes every TTE record type.
-                let records_for_cmt: Vec<crate::types::ObsRecord> = subject
-                    .obs_records
-                    .iter()
-                    .filter(
-                        |r| matches!(r, crate::types::ObsRecord::Event { cmt: c, .. } if c == cmt),
-                    )
-                    .cloned()
-                    .collect();
-                if records_for_cmt.is_empty() {
-                    continue;
-                }
-                nll += tte_endpoint_nll(
-                    model,
-                    subject,
-                    hazard,
-                    *recurrence,
-                    &records_for_cmt,
-                    theta,
-                    eta,
-                );
-            }
-        }
-        // Binary/categorical (#760): raw-NLL weight (1×), matching the TTE term above.
-        nll += crate::categorical::discrete_subject_nll(model, subject, theta, eta);
+        accumulate_non_gaussian_nll(model, subject, theta, eta, None, 1.0, &mut nll);
     }
 
     nll
@@ -969,17 +970,18 @@ pub fn foce_subject_nll(
             }
         }
 
-        // Binary/categorical (#760): fold its NLL at the mode and FD Hessian w.r.t. η
-        // into the same accumulators, so log|H̃| includes the logit curvature. A pure-binary
-        // subject has an empty Gaussian h_matrix; hrh then comes entirely from here.
-        if model.has_binary() {
-            let bin_fn = |eta_eval: &[f64]| {
+        // Discrete endpoints (#760: binary; ordinal/Poisson/… later): fold their NLL at the
+        // mode and FD Hessian w.r.t. η into the same accumulators, so log|H̃| includes the
+        // discrete curvature. A pure-discrete subject has an empty Gaussian h_matrix; hrh then
+        // comes entirely from here. `has_discrete()` gates a new family in without a change here.
+        if model.has_discrete() {
+            let discrete_fn = |eta_eval: &[f64]| {
                 crate::categorical::discrete_subject_nll(model, subject, theta, eta_eval)
             };
-            tte_nll_at_mode += bin_fn(eta_hat.as_slice());
+            tte_nll_at_mode += discrete_fn(eta_hat.as_slice());
             if n_eta > 0 {
-                let steps = shi_step_sizes(&bin_fn, eta_hat.as_slice());
-                tte_h += data_term_hessian_fd(&bin_fn, eta_hat.as_slice(), &steps);
+                let steps = shi_step_sizes(&discrete_fn, eta_hat.as_slice());
+                tte_h += data_term_hessian_fd(&discrete_fn, eta_hat.as_slice(), &steps);
             }
         }
 
@@ -2424,42 +2426,14 @@ pub fn individual_nll_iov(
         }
     }
 
-    // TTE data term: same convention as individual_nll_into_with_schedule —
-    // multiply by 2.0 so the final 0.5 factor gives a net weight of 1.0×.
-    // Kappas are PK-only; the hazard param_fn uses BSV eta, not kappas.
+    // Non-Gaussian data term at 2× (the final 0.5 gives net 1.0×): TTE endpoints plus the
+    // discrete (binary/categorical) term. Kappas are PK-only; the hazard param_fn uses BSV η,
+    // not kappas. No joint-share on the IOV path (it never carries a joint-PK-TTE endpoint),
+    // so the TTE term is analytic and `tte_endpoint_nll` matches the `tte_data_term` this
+    // site inlined.
     #[cfg(feature = "survival")]
     if !subject.obs_records.is_empty() {
-        use crate::survival::tte_data_term;
-        use crate::types::EndpointLikelihood;
-        for (cmt, endpoint) in &model.endpoints {
-            if let EndpointLikelihood::Tte {
-                hazard, recurrence, ..
-            } = endpoint
-            {
-                let records_for_cmt: Vec<crate::types::ObsRecord> = subject
-                    .obs_records
-                    .iter()
-                    .filter(
-                        |r| matches!(r, crate::types::ObsRecord::Event { cmt: c, .. } if c == cmt),
-                    )
-                    .cloned()
-                    .collect();
-                if records_for_cmt.is_empty() {
-                    continue;
-                }
-                data_ll += 2.0
-                    * tte_data_term(
-                        &records_for_cmt,
-                        hazard,
-                        *recurrence,
-                        theta,
-                        eta,
-                        &subject.covariates,
-                    );
-            }
-        }
-        // Binary/categorical (#760): same 2× OFV-scale as the TTE term above.
-        data_ll += 2.0 * crate::categorical::discrete_subject_nll(model, subject, theta, eta);
+        accumulate_non_gaussian_nll(model, subject, theta, eta, None, 2.0, &mut data_ll);
     }
 
     0.5 * (eta_prior + log_det_omega + kappa_prior + (k_occasions as f64) * log_det_iov + data_ll)

--- a/src/types.rs
+++ b/src/types.rs
@@ -3365,16 +3365,29 @@ impl CompiledModel {
         c
     }
 
+    /// True if the model carries any **discrete** (non-Gaussian, non-TTE) endpoint — the
+    /// binary / Bernoulli family today; ordinal / Poisson / negative-binomial extend this
+    /// match. This is the family-agnostic gate for the discrete data term and its FD-Hessian
+    /// contribution, so a new discrete family is enabled here and in `discrete_subject_nll`
+    /// without editing a likelihood dispatch site. Equals [`has_binary`](Self::has_binary)
+    /// today.
+    #[cfg(feature = "survival")]
+    pub fn has_discrete(&self) -> bool {
+        self.endpoints
+            .values()
+            .any(|e| matches!(e, EndpointLikelihood::Binary { .. }))
+    }
+
     /// True if the model carries **any non-Gaussian endpoint** (TTE/RTTE or the
     /// Phase-4 categorical/count families). This is the predicate the estimation
     /// machinery gates on when choosing the **FD-Hessian Laplace** inner/outer path
     /// and disabling the analytic outer gradient — those choices are correct for every
     /// non-Gaussian data term, not TTE specifically. Equals [`has_tte`](Self::has_tte)
-    /// exactly when no categorical endpoint is present, so existing TTE behaviour is
+    /// exactly when no discrete endpoint is present, so existing TTE behaviour is
     /// unchanged.
     #[cfg(feature = "survival")]
     pub fn has_non_gaussian(&self) -> bool {
-        self.has_tte() || self.has_binary()
+        self.has_tte() || self.has_discrete()
     }
 
     /// Always false without the `survival` feature - TTE endpoints can't be
@@ -3394,6 +3407,13 @@ impl CompiledModel {
     /// Always false without the `survival` feature - `[binary_model]` can't be parsed.
     #[cfg(not(feature = "survival"))]
     pub fn has_binary(&self) -> bool {
+        false
+    }
+
+    /// Always false without the `survival` feature - no discrete (categorical/count)
+    /// endpoint can be parsed.
+    #[cfg(not(feature = "survival"))]
+    pub fn has_discrete(&self) -> bool {
         false
     }
 


### PR DESCRIPTION
## Why

Follow-up to #807 (`[binary_model]`, #760). Two DRY/altitude items were deferred from
that PR because they touch the shared TTE path and are cleaner as a focused refactor.
Neither is a correctness change — both keep the *next* non-Gaussian endpoint family
(ordinal / Poisson / NB / CTMM / DTMM) a small change instead of a wide one.

Decision (per #808 discussion): do the **full non-Gaussian fold**, not a discrete-only
dispatcher — the roadmap families CTMM/DTMM (#759) are *TTE-shaped* (intensity/transition,
not per-record scalar), so a discrete-only seam would re-open all 5 dispatch sites when
Markov lands. The non-Gaussian union is the seam every future family flows through.

## What changed

Three commits, no behaviour change:

1. **`refactor(parser)`** — extract `restrict_and_validate_indiv_stmts`. `parse_event_model_block`
   and `parse_binary_model_block` carried four near-verbatim predictor-validation blocks
   (transitive `[individual_parameters]` restriction #442, covariate-union #741, direct +
   via-indiv IOV-κ rejects #770/#442, `[covariate_nn]`-output reject #293). Now one helper;
   each block keeps only its own θ/η index collection.

2. **`refactor(likelihood)`** — `binary_subject_nll` → `discrete_subject_nll`, the single
   per-subject dispatcher over discrete (non-Gaussian, non-TTE) families (Binary today;
   ordinal/Poisson/NB are future branches). A new discrete family is one branch here, not a
   new line at every dispatch site.

3. **`refactor(likelihood)`** — `accumulate_non_gaussian_nll`, the single seam summing the
   TTE hazard terms (via `tte_endpoint_nll` + the #570 joint-share) and `discrete_subject_nll`.
   Replaces the four scalar dispatch sites (FOCEI, SAEM θ-M-step, IOV, SAEM IOV-M-step) with
   one call each; the FD-Hessian site keeps its per-endpoint structure but its discrete gate
   is now the family-agnostic `has_discrete()`. A new endpoint family now touches **zero**
   likelihood dispatch sites.

### Bit-identical, by construction and by measurement
- The accumulator adds **one `factor · term` into the caller's `acc` per TTE endpoint, then
  one for the discrete term** — it does *not* return a folded `-> f64` sum. Folding would
  reassociate the floating-point adds (interleaved with the Gaussian `data_ll`) and perturb
  competing-risks / TTE+binary subjects. The per-site OFV-scale factor (`2·` or `1·`) stays
  at the call site.
- Sites d/e (IOV) previously inlined `tte_data_term`; the accumulator routes them through
  `tte_endpoint_nll`, which **is** `tte_data_term(…, &subject.covariates)` for an analytic
  hazard. The only divergent arm (`OdeAccumulated` → real vs the `tte_data_term` sentinel) is
  **unreachable** on the IOV path: IOV + joint-PK-TTE is rejected at parse
  (`hazard_with_iov_errors`).

## Alternatives considered

- **Discrete-only `discrete_subject_nll` dispatcher, leave the 5 TTE loops** — lower risk but
  the wrong shape: CTMM/DTMM are TTE-shaped, so it defers, not eliminates, the 5-site tax.
- **Return `-> f64` and add `factor · sum` once** (the literal #808 sketch) — rejected: not
  bit-identical (float non-associativity across multi-endpoint subjects).

## Breaking changes
- [x] None. New API surface is `pub fn CompiledModel::has_discrete()` (additive; `has_binary`
  and `has_non_gaussian` unchanged — `has_non_gaussian` now routes through `has_discrete`,
  equal today).

## Numerical validation
- [x] Compared against prior ferx commit (pre-fold, commit 2) — **bit-identical** final OFV
  (`outer_maxiter = 8`, all 17 significant digits) on the fixtures that exercise the folded
  sites a/c:

```
fixture           before (commit 2)         after (commit 3)
competing_risks   2.53825380486709491e2  =  2.53825380486709491e2
pktte_joint       6.73641927554185713e1  =  6.73641927554185713e1   (joint-share arm)
binary            2.13595494657298730e2  =  2.13595494657298730e2
```

  competing_risks exercises 2 TTE endpoints (multi-term accumulation order); pktte_joint the
  `OdeAccumulated` + #570 joint-share arm; binary the discrete term. Sites d/e are bit-identical
  by construction (see above). `binary` = 213.5955 also matches the #807 glm/NONMEM anchor.

## Tests
- [x] No new tests needed — pure refactor. Guarded by the existing TTE + binary suites, which
  stay green and (verified) bit-identical: `--features ci,survival` lib (2541 pass, 1 pre-existing
  macOS `run_covariance` failure unrelated), `tte_smoke` (86), `categorical_smoke` (11).

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor, no user-facing change).

## Checklist
- [x] `cargo clippy` clean (no new warnings on the changed code, `--features ci,survival`)
- [x] `cargo fmt` clean

## Reviewer hints
- Commit 3 is where the attention goes; commits 1–2 are mechanical, commit 4 is review fixes.
  The bit-identical claim rests on: (a) the accumulator accumulates per-term into the caller's
  `acc` (never a folded return), and (b) `tte_endpoint_nll ≡ tte_data_term` for analytic
  hazards, with `OdeAccumulated` unreachable on the IOV sites d/e. The OFV table is the check.
- Known accepted tradeoffs (not bugs): the FD-Hessian site (`foce_subject_nll`) keeps its own
  per-endpoint TTE loop (it computes a Hessian with per-endpoint FD step sizes, not a scalar
  sum — folding it would change the numerics); the discrete half *is* centralized there via
  `discrete_subject_nll`. `accumulate_non_gaussian_nll` threads `Option<&JointPkTteSolve>`
  (widened to `pub(crate)`) so the one FOCEI caller keeps the #570 joint-share while the other
  three pass `None` — the alternative (inline the loop at that one caller) re-duplicates it.

## Self-review (xhigh /code-review, 5 finder angles + verify)
Ran an adversarial multi-agent review of the branch before opening. **Zero correctness bugs**;
bit-identical re-confirmed after fixes. Findings resolved in commit 4:
- **Completed the `has_discrete()` migration** — `inner_optimizer.rs`'s analytic-vs-FD inner
  gradient gate still tested `has_binary()`; its reasoning (no Dual2 sensitivity) is
  discrete-general, so a future ordinal/Poisson family would have silently mis-fit. Now
  `has_discrete()`. (`api.rs` E_BINARY_* rejects stay `has_binary()` — binary-specific text.)
- Narrowed an inaccurate `joint_share = None` doc rationale (the SAEM θ-M-step *can* carry a
  joint-PK-TTE endpoint; the `_` arm handles it — only IOV + joint is parse-rejected).
- Restored block-specific error wording ("hazard expression" / "logit predictor") so the
  parser-helper extraction isn't a user-facing reword; fixed a stale doc name.

Refs: #808, #807, #760, `plans/categorical-endpoint-phase4.md`.
