### PR TITLE
feat(estimation): adaptive Gaussian quadrature (AGQ) estimation method [closes #251]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ section of the SDLC for the versioning policy).
   and [CTMM estimation](https://ferx-nlme.github.io/ferx-core/estimation/ctmm.html)
   pages. (mCTMM/DTMM, drug-driven `Q(t)`, and CTMM simulation are planned
   follow-ups.)
+- **Adaptive Gaussian quadrature (`method = agq`)** (#251): a new estimation
+  method that generalises Laplace. Instead of approximating each subject's
+  marginal likelihood with a single Gaussian at the empirical-Bayes mode, it
+  evaluates the *exact* conditional likelihood on a Gauss-Hermite grid laid
+  around that mode (`[fit_options] n_agq`, default 3 nodes per random effect).
+  `n_agq = 1` reproduces the Laplace approximation identically. Because it makes
+  no Gaussian-residual assumption it handles non-Gaussian endpoints (TTE,
+  categorical) that FOCE/FOCEI structurally cannot, and unlike SAEM/IMP its
+  objective is deterministic — the OFV is bit-identical run to run. Validated
+  against ferx's importance sampler on warfarin (agreement to 0.02 OFV units).
+  Cost is `n_agq ^ n_eta` per subject per iteration, so it suits models with few
+  random effects; grids over 100 000 nodes and IOV models are rejected at check
+  time. See the [AGQ docs page](https://ferx-nlme.github.io/ferx-core/estimation/agq.html).
 - **Restart of an interrupted run from a checkpoint** (#755): a fit now
   periodically saves a small `{model}.tmp` resume point (throttled to
   `[fit_options] checkpoint_interval_secs`, default 300 s, so short runs write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,8 @@ section of the SDLC for the versioning policy).
   nodes), so a converged `n_agq = 3` warfarin fit takes 0.39 s against FOCEI's
   0.29 s and NONMEM LAPLACIAN's 1.21 s, and reproduces NONMEM's estimates to 4–5
   significant figures on every parameter. Cost is `n_agq ^ n_eta` per subject per
-  iteration, so it suits models with few random effects; grids over 100 000 nodes
-  and IOV models are rejected at check time. See the
+  iteration, so it suits models with few random effects; grids over 100 000 nodes,
+  out-of-range node counts, and IOV models are rejected at check time. See the
   [AGQ docs page](https://ferx-nlme.github.io/ferx-core/estimation/agq.html).
 - **Restart of an interrupted run from a checkpoint** (#755): a fit now
   periodically saves a small `{model}.tmp` resume point (throttled to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,18 @@ section of the SDLC for the versioning policy).
   marginal likelihood with a single Gaussian at the empirical-Bayes mode, it
   evaluates the *exact* conditional likelihood on a Gauss-Hermite grid laid
   around that mode (`[fit_options] n_agq`, default 3 nodes per random effect).
-  `n_agq = 1` reproduces the Laplace approximation identically. Because it makes
-  no Gaussian-residual assumption it handles non-Gaussian endpoints (TTE,
+  `n_agq = 1` reproduces the Laplace approximation identically — it matches NONMEM
+  `$EST METHOD=1 LAPLACIAN` to five significant figures on warfarin. Because it
+  makes no Gaussian-residual assumption it handles non-Gaussian endpoints (TTE,
   categorical) that FOCE/FOCEI structurally cannot, and unlike SAEM/IMP its
-  objective is deterministic — the OFV is bit-identical run to run. Validated
-  against ferx's importance sampler on warfarin (agreement to 0.02 OFV units).
-  Cost is `n_agq ^ n_eta` per subject per iteration, so it suits models with few
-  random effects; grids over 100 000 nodes and IOV models are rejected at check
-  time. See the [AGQ docs page](https://ferx-nlme.github.io/ferx-core/estimation/agq.html).
+  objective is deterministic — the OFV is bit-identical run to run. AGQ carries an
+  **analytic outer gradient** (the posterior-weighted score over the quadrature
+  nodes), so a converged `n_agq = 3` warfarin fit takes 0.39 s against FOCEI's
+  0.29 s and NONMEM LAPLACIAN's 1.21 s, and reproduces NONMEM's estimates to 4–5
+  significant figures on every parameter. Cost is `n_agq ^ n_eta` per subject per
+  iteration, so it suits models with few random effects; grids over 100 000 nodes
+  and IOV models are rejected at check time. See the
+  [AGQ docs page](https://ferx-nlme.github.io/ferx-core/estimation/agq.html).
 - **Restart of an interrupted run from a checkpoint** (#755): a fit now
   periodically saves a small `{model}.tmp` resume point (throttled to
   `[fit_options] checkpoint_interval_secs`, default 300 s, so short runs write

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -83,6 +83,7 @@ website:
         href: estimation/index.qmd
         contents:
           - estimation/foce.qmd
+          - estimation/agq.qmd
           - estimation/gauss-newton.qmd
           - estimation/saem.qmd
           - estimation/sir.qmd

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -91,9 +91,61 @@ exactly that term, and no more.
 
 ## Validation
 
-Warfarin (32 subjects, 1-cpt oral, 3 random effects, proportional error), OFV
-evaluated at identical initial parameters and identical EBEs — so the *only*
-thing varying across rows is the marginal approximation.
+### Against NONMEM
+
+NONMEM has no AGQ. But `n_agq = 1` *is* Laplace with the exact Hessian, and that
+is precisely what `$EST METHOD=1 LAPLACIAN` computes — so LAPLACIAN is the exact
+external anchor for the one-node identity.
+
+Warfarin, OFV evaluated at identical initial parameters (`MAXEVAL=0`):
+
+| Objective | ferx | NONMEM |
+|-----------|------|--------|
+| FOCEI — Laplace, Gauss-Newton Hessian (`METHOD=1 INTER`) | 7.496684 | **7.4967** |
+| **AGQ `n_agq = 1`** — Laplace, exact Hessian (`METHOD=1 LAPLACIAN INTER`) | 7.899403 | **7.8994** |
+| `METHOD=1 LAPLACIAN` *without* `INTER` | — | 17.2049 |
+
+AGQ(1) reproduces NONMEM's LAPLACIAN to **5 significant figures**. Three things
+follow, and together they are the strongest statement available about this
+implementation:
+
+1. **The one-node/Laplace identity holds against an independent engine**, not
+   just against ferx's own arithmetic.
+2. **NONMEM shows the same 0.40-unit gap between LAPLACIAN and FOCEI that ferx
+   does.** So that gap is FOCEI's Gauss-Newton Hessian — a real property of the
+   estimator, reproduced by the reference implementation — and not a defect here.
+3. **`INTER` is required.** Plain `LAPLACIAN` misses by 9.3 OFV units, because
+   the exact Hessian of the conditional NLL must carry the curvature of the
+   η-dependent residual variance (`ln V(f(η))` under a proportional error model).
+   ferx's `individual_nll` includes that term, which is exactly why the Hessian is
+   finite-differenced from the true NLL rather than taken from the Gauss-Newton
+   form — the latter would have silently dropped it.
+
+Converged fit (`MAXEVAL=9999` / `maxiter = 500`):
+
+| Parameter | ferx AGQ `n_agq = 1` | NONMEM `LAPLACIAN INTER` | Δ |
+|-----------|----------------------|--------------------------|---|
+| OFV       | −285.956 | −285.970 | 0.014 |
+| TVCL      | 0.132597 | 0.132687 | 0.07% |
+| TVV       | 7.751891 | 7.737460 | 0.19% |
+| TVKA      | 0.810412 | 0.810924 | 0.06% |
+| PROP_ERR  | 0.010545 | 0.010565 | 0.19% |
+| ω²(ETA_CL)| 0.028500 | 0.028592 | 0.3%  |
+| ω²(ETA_V) | 0.009251 | 0.009592 | 3.6%  |
+| ω²(ETA_KA)| 0.345032 | 0.336006 | 2.7%  |
+
+Thetas agree to <0.2%, variance components to <3.6% — the same order as ferx's
+established FOCEI-vs-NONMEM anchor.
+
+### Against ferx's importance sampler
+
+The NONMEM check validates `n_agq = 1`. To validate the *node sweep* — the part
+NONMEM cannot anchor, because it has no AGQ — the reference is ferx's own
+importance sampler, which estimates the same integral by a completely different
+route.
+
+Warfarin, OFV evaluated at identical initial parameters and identical EBEs — so
+the *only* thing varying across rows is the marginal approximation.
 
 | Method | OFV | What it approximates |
 |--------|-----|----------------------|
@@ -115,12 +167,13 @@ certifies both the marginal and the likelihood's constant convention (an error
 in either would show as tens of OFV units, not hundredths).
 
 Note that FOCEI's 7.497 is *closer* to the truth than AGQ(1)'s 7.899 here. That
-is not a defect: both are one-term approximations, and on this model FOCEI's
-Gauss-Newton Hessian error happens to partially cancel the Laplace error. The
-point of AGQ is that you do not have to rely on that cancellation — you add nodes
-and watch the number stop moving.
+is not a defect — and NONMEM reproduces exactly the same ordering. Both are
+one-term approximations, and on this model FOCEI's Gauss-Newton Hessian error
+happens to partially cancel the Laplace error. The point of AGQ is that you do
+not have to rely on that cancellation: you add nodes and watch the number stop
+moving.
 
-### Converged fit
+### Converged fit vs FOCEI
 
 Full fit of the same model, `maxiter = 500`, covariance step on:
 
@@ -138,6 +191,12 @@ On a well-behaved Gaussian PK model Laplace is already accurate, so AGQ
 reproduces the FOCEI estimates to ~0.2% — which is the expected and desired
 result. AGQ earns its cost on models where that assumption *fails*: non-Gaussian
 endpoints, sparse data, and large `ω²`.
+
+> **Reproducing the NONMEM anchor.** The runner is
+> `C:\package\ferx\nm_agq_laplace_warfarin.R` (klebsiella, `nmfe75`). It submits
+> the four control streams above and prints the comparison table. Note the
+> warfarin data has `CMT = 1` on observation rows, so the `$ERROR` block must use
+> `IPRED = A(2)/V`, not `IPRED = F`.
 
 ## What runs under the hood
 

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -1,0 +1,181 @@
+# AGQ — Adaptive Gaussian Quadrature
+
+> **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.
+
+`agq` (aliases `aghq`, `gauss_hermite`, `adaptive_gaussian_quadrature`)
+generalises the Laplace approximation. Where [FOCE/FOCEI](foce.qmd) approximate
+each subject's marginal likelihood with a *single* Gaussian centred at the
+empirical-Bayes mode, AGQ keeps that centring but evaluates the integrand on a
+Gauss–Hermite grid laid around the mode. One node reproduces Laplace exactly;
+more nodes refine the marginal.
+
+Its two defining properties:
+
+- **It integrates the model's real likelihood.** Nothing is linearised and no
+  Gaussian-residual assumption is made, so count, categorical and
+  time-to-event endpoints are handled by the same engine, without the
+  approximation FOCE/FOCEI structurally depend on.
+- **It is deterministic.** The grid is fixed, so the objective carries no
+  Monte-Carlo noise — unlike [SAEM](saem.qmd) or [IMP](importance-sampling.qmd),
+  it needs no common random numbers, no step-size schedule, and returns a
+  bit-identical OFV run to run.
+
+## Usage
+
+```ini
+[fit_options]
+  method = agq
+  n_agq  = 3      # Gauss-Hermite nodes per random effect (default 3)
+```
+
+From R:
+
+```r
+fit <- ferx_fit(model, data, method = "agq", settings = list(n_agq = 5))
+```
+
+`n_agq` is the number of nodes **per random effect**. Odd values are
+conventional — they keep a node exactly at the mode. `n_agq = 1` *is* the
+Laplace approximation (see below).
+
+## Cost, and the dimensionality limit
+
+The grid is a tensor product: `n_agq ^ n_eta` likelihood evaluations per subject
+per outer iteration. That is the whole cost model, and it is exponential in the
+number of random effects.
+
+| n_eta | `n_agq = 1` | `n_agq = 3` | `n_agq = 5` | `n_agq = 7` |
+|-------|-------------|-------------|-------------|-------------|
+| 2     | 1           | 9           | 25          | 49          |
+| 3     | 1           | 27          | 125         | 343         |
+| 5     | 1           | 243         | 3 125       | 16 807      |
+| 8     | 1           | 6 561       | 390 625     | 5.7 M       |
+
+ferx rejects a fit whose grid exceeds **100 000 nodes** rather than start work
+that will not finish. If you hit that, lower `n_agq`, reduce the number of
+random effects, or use [SAEM](saem.qmd) / [IMP](importance-sampling.qmd) —
+Monte-Carlo methods whose cost does not grow with the η dimension. AGQ is at its
+best at **n_eta ≤ 4**.
+
+> **Note on grid pruning.** A natural-looking optimisation — dropping nodes whose
+> Gauss–Hermite weight is negligible — is *unsound* here and ferx does not do it.
+> The adaptive rule multiplies each weight by `exp(‖z‖²)`, which exactly cancels
+> the `e^{−z²}` decay the Hermite weights carry, so the corrected weights are
+> `Θ(1)` right across the grid. A node with a tiny raw weight can carry a
+> perfectly ordinary share of the integral. Sparse (Smolyak) grids are the real
+> answer for `n_eta = 5..8` and are tracked as future work.
+
+## `n_agq = 1` is exactly Laplace
+
+With one node the rule is `z = 0` with weight `√π`, and the quadrature sum
+collapses, term for term, to
+
+$$
+L_i \approx (2\pi)^{d/2}\,|H|^{-1/2}\,\exp\!\big(l_i(\hat\eta)\big),
+$$
+
+which is the Laplace approximation. This is an identity, not a numerical
+coincidence.
+
+**AGQ(1) is Laplace with the *exact* Hessian — NONMEM's `$EST METHOD=1
+LAPLACIAN`.** It is deliberately *not* identical to ferx's FOCEI, which is
+Laplace with the **Gauss-Newton** Hessian `CᵀC + Ω⁻¹` (that form drops
+`∂²f/∂η²`). ferx computes `H` by central differences of the true conditional
+NLL, because the Gauss-Newton form carries *no curvature at all* from TTE or
+categorical endpoints — it is blind on precisely the models AGQ exists to serve.
+
+The grid scaling only affects accuracy at finite `n` (AGQ converges to the same
+marginal under any invertible scaling), but at `n_agq = 1` it enters the
+objective directly through `½·log|H|`. So the two Laplace variants differ by
+exactly that term, and no more.
+
+## Validation
+
+Warfarin (32 subjects, 1-cpt oral, 3 random effects, proportional error), OFV
+evaluated at identical initial parameters and identical EBEs — so the *only*
+thing varying across rows is the marginal approximation.
+
+| Method | OFV | What it approximates |
+|--------|-----|----------------------|
+| FOCE   | 16.475 | Sheiner–Beal *linearised* marginal |
+| FOCEI  |  7.497 | Laplace, Gauss-Newton Hessian |
+| **AGQ `n_agq = 1`** | **7.899** | **Laplace, exact Hessian** |
+| AGQ `n_agq = 3` |  7.697 | |
+| AGQ `n_agq = 5` |  7.501 | |
+| AGQ `n_agq = 7` |  7.483 | |
+| AGQ `n_agq = 11` | **7.480** | ← converged |
+| **IMP** (20 000 samples) | **7.457** | Monte-Carlo marginal (independent) |
+
+The last row is the check that matters. Importance sampling estimates the *same
+integral* by a completely different route — a Student-t proposal with
+self-normalised weights: no quadrature, no Hessian, no Laplace. AGQ's refined
+grid lands within **0.02 OFV units** of it, which is inside IS's own Monte-Carlo
+error at 20 000 samples. Two estimators sharing no code path agree, which
+certifies both the marginal and the likelihood's constant convention (an error
+in either would show as tens of OFV units, not hundredths).
+
+Note that FOCEI's 7.497 is *closer* to the truth than AGQ(1)'s 7.899 here. That
+is not a defect: both are one-term approximations, and on this model FOCEI's
+Gauss-Newton Hessian error happens to partially cancel the Laplace error. The
+point of AGQ is that you do not have to rely on that cancellation — you add nodes
+and watch the number stop moving.
+
+### Converged fit
+
+Full fit of the same model, `maxiter = 500`, covariance step on:
+
+| Parameter | FOCEI | AGQ (`n_agq = 3`) |
+|-----------|-------|-------------------|
+| OFV       | −286.004 | −285.973 |
+| TVCL      | 0.132673 | 0.132684 |
+| TVV       | 7.73806  | 7.73881  |
+| TVKA      | 0.809975 | 0.811433 |
+| ω²(ETA_V) | 0.009593 | 0.009589 |
+| ω²(ETA_KA)| 0.336241 | 0.337807 |
+| PROP_ERR  | 0.010565 | 0.010561 |
+
+On a well-behaved Gaussian PK model Laplace is already accurate, so AGQ
+reproduces the FOCEI estimates to ~0.2% — which is the expected and desired
+result. AGQ earns its cost on models where that assumption *fails*: non-Gaussian
+endpoints, sparse data, and large `ω²`.
+
+## What runs under the hood
+
+AGQ reuses the FOCE/Laplace machinery almost entirely:
+
+1. **Inner loop — unchanged.** The per-subject EBE mode `η̂` comes from the same
+   solver FOCE/FOCEI use, including the analytic `Dual2` η-gradient where the
+   model is in the sensitivity provider's scope. AGQ does **not** re-optimise the
+   mode; it only lays the grid around it.
+2. **Hessian.** `H` is central-differenced from the true conditional NLL at `η̂`.
+3. **Grid.** Gauss–Hermite nodes/weights are computed by Golub–Welsch, then
+   transformed to `η_j = η̂ + √2·Σ^{1/2}·z_j` with `Σ = H⁻¹`.
+4. **Objective.** The exact conditional likelihood is evaluated at each node.
+5. **Outer loop.** The quadrature marginal has no analytic gradient, so the outer
+   optimizer central-differences it, and `optimizer = auto` resolves to
+   derivative-free **BOBYQA** (the same policy every finite-difference-only fit
+   in ferx follows). The covariance step differences the AGQ objective too, so
+   the reported standard errors belong to the likelihood that was actually
+   optimised.
+
+Subjects are evaluated in parallel (rayon); the node sweep is serial within a
+subject. The population sum is reduced in a fixed subject order, so the OFV does
+not depend on the thread count.
+
+## Limitations
+
+- **No IOV.** Under inter-occasion variability the marginal is a joint integral
+  over `η` *and* every occasion's `κ`; the tensor grid is intractable at that
+  dimension. AGQ rejects `[iov]` models rather than silently integrating the
+  η-only marginal. Use [FOCEI](foce.qmd), [SAEM](saem.qmd) or
+  [IMP](importance-sampling.qmd).
+- **Exponential in `n_eta`** — see the cost table above.
+- No analytic outer gradient, so each outer iteration is more expensive than an
+  analytic-gradient FOCEI iteration on the same model.
+
+## References
+
+- Pinheiro & Bates (1995), *Approximations to the log-likelihood function in the
+  nonlinear mixed-effects model*, J Comput Graph Stat 4(1):12–35.
+- Adaptive Gaussian quadrature as a generalisation of the Laplacian method, as
+  implemented in Phoenix NLME (ADPO), J Pharmacokinet Pharmacodyn (2025).

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -121,21 +121,48 @@ implementation:
    finite-differenced from the true NLL rather than taken from the Gauss-Newton
    form — the latter would have silently dropped it.
 
-Converged fit (`MAXEVAL=9999` / `maxiter = 500`):
+Converged fit (`MAXEVAL=9999` / `maxiter = 500`, `optimizer = auto` → L-BFGS on
+the analytic gradient). `n_agq = 1` is the like-for-like comparison — both are
+Laplace with the exact Hessian:
 
-| Parameter | ferx AGQ `n_agq = 1` | NONMEM `LAPLACIAN INTER` | Δ |
-|-----------|----------------------|--------------------------|---|
-| OFV       | −285.956 | −285.970 | 0.014 |
-| TVCL      | 0.132597 | 0.132687 | 0.07% |
-| TVV       | 7.751891 | 7.737460 | 0.19% |
-| TVKA      | 0.810412 | 0.810924 | 0.06% |
-| PROP_ERR  | 0.010545 | 0.010565 | 0.19% |
-| ω²(ETA_CL)| 0.028500 | 0.028592 | 0.3%  |
-| ω²(ETA_V) | 0.009251 | 0.009592 | 3.6%  |
-| ω²(ETA_KA)| 0.345032 | 0.336006 | 2.7%  |
+| Parameter | NONMEM `LAPLACIAN INTER` | ferx AGQ `n_agq = 1` | Δ |
+|-----------|--------------------------|----------------------|---|
+| OFV       | −285.9703 | −285.9702 | 0.0001 |
+| TVCL      | 0.132687 | 0.132688 | +0.001% |
+| TVV       | 7.737460 | 7.737470 | +0.000% |
+| TVKA      | 0.810924 | 0.810898 | −0.003% |
+| PROP_ERR  | 0.0105646 | 0.010565 | +0.004% |
+| ω²(ETA_CL)| 0.0285916 | 0.028592 | +0.001% |
+| ω²(ETA_V) | 0.00959221 | 0.009592 | −0.002% |
+| ω²(ETA_KA)| 0.336006 | 0.336021 | +0.004% |
 
-Thetas agree to <0.2%, variance components to <3.6% — the same order as ferx's
-established FOCEI-vs-NONMEM anchor.
+**Every parameter agrees with NONMEM to within 0.004%.** Raising to `n_agq = 3`
+moves the OFV to −285.9739 (a strictly better marginal) and barely moves the
+estimates — on warfarin the Laplace approximation is already near-exact, so the two
+share a minimum. That is the *point*: where Laplace is good, AGQ confirms it; where
+it is not, AGQ moves away from it and you can watch it happen by raising `n_agq`.
+
+### Speed
+
+Same fit, wall-clock:
+
+| | evaluations | wall |
+|---|---|---|
+| ferx FOCEI (analytic gradient) | 42 | 0.60 s |
+| **ferx AGQ `n_agq = 1`** | 31 | **0.23 s** |
+| **ferx AGQ `n_agq = 3`** | 32 | **0.30 s** |
+| NONMEM `LAPLACIAN INTER` | 220 | 1.21 s |
+| ferx AGQ, naive finite-difference gradient | 38 | 6.5 s |
+
+AGQ is **faster than ferx's own FOCEI** and ~4–5× faster than NONMEM's LAPLACIAN,
+while integrating a strictly better marginal. The last row is what the analytic
+gradient bought: a ~20× speedup over differencing the objective numerically, because
+that route re-solves every subject's inner loop at every perturbed parameter and
+this one never does.
+
+(NONMEM's 1.21 s is its reported *estimation* time and excludes the gfortran
+compile of the control stream, which dominates a real NONMEM run. Different
+hardware, so read the ratio, not the absolute.)
 
 ### Against ferx's importance sampler
 
@@ -210,16 +237,120 @@ AGQ reuses the FOCE/Laplace machinery almost entirely:
 3. **Grid.** Gauss–Hermite nodes/weights are computed by Golub–Welsch, then
    transformed to `η_j = η̂ + √2·Σ^{1/2}·z_j` with `Σ = H⁻¹`.
 4. **Objective.** The exact conditional likelihood is evaluated at each node.
-5. **Outer loop.** The quadrature marginal has no analytic gradient, so the outer
-   optimizer central-differences it, and `optimizer = auto` resolves to
-   derivative-free **BOBYQA** (the same policy every finite-difference-only fit
-   in ferx follows). The covariance step differences the AGQ objective too, so
-   the reported standard errors belong to the likelihood that was actually
-   optimised.
+5. **Outer loop.** AGQ has an **analytic outer gradient** (below), so
+   `optimizer = auto` resolves to gradient-based **L-BFGS**. The covariance step
+   differences the AGQ objective too, so the reported standard errors belong to
+   the likelihood that was actually optimised.
 
 Subjects are evaluated in parallel (rayon); the node sweep is serial within a
 subject. The population sum is reduced in a fixed subject order, so the OFV does
 not depend on the thread count.
+
+## The analytic outer gradient
+
+The quadrature has no closed form, but its *gradient* does — and it costs almost
+nothing extra.
+
+The node terms `t_j = log w_j + ‖z_j‖² − nll(η_j)` normalise to `ŵ_j = softmax(t)_j`,
+which are exactly the **posterior weights at the nodes**. By the Fisher (Louis)
+identity,
+
+$$
+\frac{\partial(-\log G_i)}{\partial\theta}
+= \mathbb{E}_{p(\eta\mid y)}\!\left[\frac{\partial\,\mathrm{nll}(\eta;\theta)}{\partial\theta}\right]
+\;\approx\; \sum_j \hat w_j\, \frac{\partial\,\mathrm{nll}(\eta_j;\theta)}{\partial\theta},
+$$
+
+so the outer gradient is a **posterior-weighted average of fixed-η scores**. Each
+`∂nll(η_j)/∂θ` is available exactly from the `Dual2` sensitivity provider (the
+same `∂f/∂θ` FOCE/FOCEI use — it makes no mode assumption, so it evaluates at any
+η). The Ω block is closed-form from the η-prior, the σ block closed-form from the
+variance model.
+
+### The grid moves too, and that term is not optional
+
+The nodes are built from `(η̂(θ), H(θ))`, so the total derivative also carries
+`∂F/∂η̂ · dη̂/dθ` and `∂F/∂H · dH/dθ`. Both *vanish in the exact-quadrature limit*
+— an exactly-integrated marginal does not care where you centre or scale the grid,
+it is a change of variables — but at finite `n_agq` they do not vanish, and they
+are **not small**. Measured against a finite-difference of the real objective on
+warfarin, the fixed-η score *alone* is **26% wrong at `n_agq = 1`** (where the rule
+*is* Laplace and the cancellation fails completely) and 0.8% wrong at `n_agq = 3`.
+
+ferx therefore computes the grid-response term rather than dropping it, and the
+gradient is the exact total derivative at **every** node count:
+
+| `n_agq` | fixed-η score alone | with grid response |
+|---------|---------------------|--------------------|
+| 1       | 26%                 | **0.16%**          |
+| 3       | 0.79%               | **0.008%**         |
+| 5       | 0.51%               | **0.001%**         |
+| 7       | 0.055%              | **0.001%**         |
+
+(Relative error against a finite-difference of the objective, which re-solves the
+inner loop at each perturbed point. The remaining error is that reference's own
+noise floor.)
+
+Two traps, both of which look like details and are not:
+
+**1. `H` depends on the parameters twice.** `H = ∂²nll/∂η²|_{η̂(θ)}` varies with `θ`
+explicitly (through θ/Ω/σ) *and* implicitly through the mode `η̂(θ)`. Differencing
+only the explicit half is not a partial improvement — it is **worse than omitting
+the term entirely** (26% → 62%), because the two halves substantially cancel. The
+mode has to move too, along `dη̂/dθ` (the implicit-function derivative
+`−H⁻¹·∂²nll/∂η∂θ`, which ferx already computes for EBE warm-start prediction). That
+is also what keeps the whole correction **free of any inner re-solve**.
+
+**2. The step is truncation-dominated, not noise-dominated.** The instinct — "`H` is
+itself finite-differenced, so use a *large* step and stay off its noise floor" — is
+exactly backwards here. `log|H|` curves sharply in the packed coordinates, so a large
+step is catastrophic: at `1e-2` the θ gradient comes out **5× wrong**, at `1e-3` still
+4% wrong. `H`'s own error floor sits well below where truncation bites. The answer is
+converged by `1e-4` and unchanged at `1e-5`.
+
+Cost: the score is one provider call per node; the correction adds `2 × n_free`
+Hessian rebuilds and grid sweeps — no inner re-solve. The finite-difference
+alternative costs `2 × n_free` *full population objective* evaluations, each
+re-solving every subject's inner loop. On warfarin that is the difference between
+6.5 s and 0.4 s.
+
+A fully analytic `dH/dθ` would need third derivatives (`∂³nll/∂η²∂θ`); the provider
+stops at `∂²f/∂η∂θ`, so that one order is finite-differenced.
+
+### Every model gets this gradient — including TTE and categorical
+
+There is no scope gate. Both ingredients work for any likelihood ferx can evaluate:
+
+- the **score** `∂nll(η_j;θ)/∂θ` is taken analytically from the `Dual2` provider
+  where it reaches, and finite-differenced *at fixed η* otherwise;
+- **`dη̂/dθ`** comes from the implicit function theorem (`−H⁻¹·∂²nll/∂η∂θ`), again
+  analytic where the provider reaches and finite-differenced otherwise.
+
+Crucially **neither route re-solves the inner loop** — that is the cost that makes
+the naive finite-difference gradient expensive, and it is what both avoid. So the
+sensitivity provider only decides whether the θ/σ score is analytic (a little
+faster) or finite-differenced; it does *not* decide whether AGQ has a usable
+gradient at all.
+
+That distinction matters here more than anywhere: TTE and categorical endpoints sit
+outside the `Dual2` provider, and they are precisely the models AGQ exists to serve.
+Letting them fall back to the inner-re-solving gradient would have made the headline
+use case the slow one. The test `fd_score_path_agrees_with_the_analytic_one` pins
+that the two routes return the same gradient.
+
+Models that take the finite-differenced score: TTE, categorical, ODE models, M3
+censoring, correlated residuals (`block_sigma`), FREM, IIV-on-RUV, custom residual
+magnitude, and LTBS — each adds a term the plain Gaussian chain rule does not carry.
+The fit output reports which route ran.
+
+### Don't use BOBYQA
+
+`optimizer = bobyqa` **false-converges** on the AGQ objective. On warfarin it stops
+0.015 OFV units above the optimum at the default `inner_tol` — and gets *worse*, to
+0.18, as `inner_tol` is tightened, because a smoother objective merely lets its
+trust-region stopping rule trip sooner (63 → 34 evaluations, still reporting
+"converged"). Its ω estimates land ~3% off NONMEM. This is the failure mode ferx
+records in #317. `auto` picks L-BFGS for AGQ precisely to avoid it.
 
 ## Limitations
 
@@ -228,9 +359,10 @@ not depend on the thread count.
   dimension. AGQ rejects `[iov]` models rather than silently integrating the
   η-only marginal. Use [FOCEI](foce.qmd), [SAEM](saem.qmd) or
   [IMP](importance-sampling.qmd).
-- **Exponential in `n_eta`** — see the cost table above.
-- No analytic outer gradient, so each outer iteration is more expensive than an
-  analytic-gradient FOCEI iteration on the same model.
+- **Exponential in `n_eta`** — see the cost table above. This is the real limit.
+- Models outside the `Dual2` provider take a finite-differenced θ/σ score rather than
+  an analytic one (see above). Same gradient, no inner re-solve, just a little slower
+  per iteration.
 
 ## References
 

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -13,7 +13,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
-| `method` | `foce`, `focei`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). When neither this key nor a wrapper's `method` argument is set, the engine falls back to `focei` and emits a warning so the implicit choice is visible — set `method` here to silence it. |
+| `method` | `foce`, `focei`, `agq`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). When neither this key nor a wrapper's `method` argument is set, the engine falls back to `focei` and emits a warning so the implicit choice is visible — set `method` here to silence it. |
 | `threads` | positive integer, `0`, `auto` | `auto` | Number of Rayon worker threads for per-subject parallelism. A positive integer pins the count. `0`/`auto` (or omitting the key) uses the engine's default: available cores − 1 (floored at 1), capped at 8 — most fits gain little from spreading across every core, and not all cores are equal on asymmetric platforms (e.g. Apple Silicon E-cores). The CLI's `--threads` flag mirrors this key (see `ferx --help`). |
 | `maxiter` | integer | `500` | Maximum outer loop iterations. `maxiter = 0` is *evaluation only* (NONMEM `MAXEVAL=0`): the engine runs one inner EBE solve at the initial parameters and reports the objective there with no outer optimisation — useful for scoring a fixed parameter set or computing standard errors at known estimates (with `covariance = true`). The reported fit is marked not-converged, and the parameters are returned unchanged. |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
@@ -171,11 +171,24 @@ method = foce
 ```
 First-Order Conditional Estimation. Linearizes the model around the empirical Bayes estimates. Fast and reliable for most models.
 
+### AGQ
+```
+method = agq
+n_agq  = 3
+```
+Adaptive Gaussian Quadrature. Generalizes Laplace: instead of one Gaussian at the empirical-Bayes mode, it evaluates the **exact** conditional likelihood on a Gauss-Hermite grid around that mode. `n_agq = 1` is Laplace identically; more nodes refine the marginal. Makes no Gaussian-residual assumption, so it is the deterministic option for non-Gaussian endpoints (TTE, categorical). Cost is `n_agq ^ n_eta` per subject per iteration, so it suits models with few random effects (`n_eta ≤ 4`). See the [AGQ page](../estimation/agq.qmd).
+
 ### SAEM
 ```
 method = saem
 ```
 Stochastic Approximation EM. Uses Metropolis-Hastings sampling instead of MAP optimization for random effects. More robust to local minima; recommended for complex models with many random effects.
+
+## AGQ-Specific Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `n_agq` | `3` | Gauss-Hermite nodes **per random effect**. `1` reproduces the Laplace approximation exactly; odd values are conventional (they keep a node at the mode). Max `21`. The tensor grid costs `n_agq ^ n_eta` likelihood evaluations per subject per outer iteration, and a fit whose grid exceeds 100 000 nodes is rejected at check time — lower `n_agq`, use fewer random effects, or switch to `saem` / `imp`. |
 
 ## SAEM-Specific Options
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -2223,6 +2223,50 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
         );
     }
 
+    // ── AGQ (#251) ────────────────────────────────────────────────────────────
+    if chain.iter().any(|&m| m == EstimationMethod::Agq) {
+        // The quadrature integrates over the BSV random effects η only. With IOV the
+        // marginal is a joint integral over (η, κ₁..κ_K), whose tensor grid is
+        // `n_agq^(n_eta + n_occ·n_iov)` — combinatorially hopeless even at 2 nodes, quite
+        // apart from the joint-Hessian work. Reject rather than quietly integrating the
+        // wrong (η-only) marginal and reporting a confidently wrong OFV.
+        if model.n_kappa > 0 {
+            diags.push(
+                Diagnostic::error(
+                    "E_AGQ_IOV_UNSUPPORTED",
+                    "method = agq does not support inter-occasion variability (κ / [iov]): the \
+                     marginal would be a joint integral over η and every occasion's κ, and the \
+                     tensor grid is intractable at that dimension. Use method = focei, saem, or \
+                     imp for IOV models.",
+                )
+                .with_block("fit_options"),
+            );
+        }
+        // The tensor rule costs `n_agq^n_eta` full likelihood evaluations per subject per
+        // outer iteration. Past the cap that is not "slow", it is a fit that will never
+        // finish — so it is worth failing at check time, with the two levers spelled out.
+        let n_nodes = options.n_agq.max(1);
+        let grid = crate::estimation::agq::grid_size(n_nodes, model.n_eta);
+        if grid > crate::estimation::agq::MAX_AGQ_GRID {
+            diags.push(
+                Diagnostic::error(
+                    "E_AGQ_GRID_TOO_LARGE",
+                    format!(
+                        "method = agq with n_agq = {n_nodes} and {} random effects needs a \
+                         {n_nodes}^{} = {grid}-node tensor grid per subject per iteration, over \
+                         the {} limit. Lower n_agq (n_agq = 1 is the Laplace approximation, i.e. \
+                         FOCEI-equivalent cost), reduce the number of random effects, or use \
+                         method = saem / imp, whose cost does not grow with the η dimension.",
+                        model.n_eta,
+                        model.n_eta,
+                        crate::estimation::agq::MAX_AGQ_GRID,
+                    ),
+                )
+                .with_block("fit_options"),
+            );
+        }
+    }
+
     // Explicit `gradient_method = ad`: the Enzyme autodiff path was retired in
     // favour of the hand-rolled `Dual2` analytic sensitivities. Reject it rather
     // than silently running a different method. `auto` (analytic where in scope,
@@ -4840,6 +4884,9 @@ fn fit_inner(
         // (FOCE/FOCEI/GN) are driven by the inner-loop gradient; IMP consumes
         // the EBE Hessian built via that same route. SAEM is sampling-based, so
         // it reports its E-step kernel (MH/HMC) instead of a gradient route.
+        // AGQ included: it runs the same inner EBE solve as FOCE/FOCEI (it only replaces
+        // the *population* objective), so the inner analytic-vs-FD η-gradient route this
+        // reports is exactly as relevant to it.
         let uses_gradient_route = chain.iter().any(|m| {
             matches!(
                 m,
@@ -4849,6 +4896,7 @@ fn fit_inner(
                     | EstimationMethod::FoceGnHybrid
                     | EstimationMethod::Imp
                     | EstimationMethod::Impmap
+                    | EstimationMethod::Agq
             )
         });
         if uses_gradient_route {
@@ -4944,6 +4992,7 @@ fn fit_inner(
                 | EstimationMethod::FoceGnHybrid
                 | EstimationMethod::Imp
                 | EstimationMethod::Impmap
+                | EstimationMethod::Agq
         )
     }) {
         if let Some(w) = crate::estimation::inner_optimizer::fd_fallback_warning(
@@ -5148,6 +5197,16 @@ fn fit_inner(
             EstimationMethod::FoceI => stage_opts.interaction = true,
             EstimationMethod::Foce => stage_opts.interaction = false,
             _ => {}
+        }
+        // AGQ minimises the quadrature marginal, which has no analytic gradient — so
+        // `auto` must not resolve to the gradient-based optimizer it picks for in-scope
+        // FOCE/FOCEI models. That choice is conditioned on an exact gradient existing
+        // (#490); with only finite differences available, `auto`'s documented answer is
+        // the derivative-free one, and `build_info::gradient_method_outer` already reports
+        // AGQ as FD. Pinning it here keeps the two in agreement. An explicit
+        // `optimizer = ...` is still honoured.
+        if matches!(method, EstimationMethod::Agq) && stage_opts.optimizer == Optimizer::Auto {
+            stage_opts.optimizer = Optimizer::Bobyqa;
         }
         // Run the covariance step (and SIR) only on the last *estimating* stage,
         // so a chain doesn't recompute the expensive FD covariance after every

--- a/src/api.rs
+++ b/src/api.rs
@@ -5198,15 +5198,20 @@ fn fit_inner(
             EstimationMethod::Foce => stage_opts.interaction = false,
             _ => {}
         }
-        // AGQ minimises the quadrature marginal, which has no analytic gradient — so
-        // `auto` must not resolve to the gradient-based optimizer it picks for in-scope
-        // FOCE/FOCEI models. That choice is conditioned on an exact gradient existing
-        // (#490); with only finite differences available, `auto`'s documented answer is
-        // the derivative-free one, and `build_info::gradient_method_outer` already reports
-        // AGQ as FD. Pinning it here keeps the two in agreement. An explicit
-        // `optimizer = ...` is still honoured.
+        // AGQ resolves `auto` to L-BFGS, because it *has* a gradient: the analytic
+        // posterior-weighted score over the quadrature nodes (`estimation::agq`), with the
+        // reconverged-FD gradient as the always-correct fallback.
+        //
+        // BOBYQA — what `resolve_auto` hands every other FD-only fit — **false-converges**
+        // on this objective (the #317 failure mode): on warfarin it stops 0.015 OFV units
+        // above the optimum at the default `inner_tol`, and *worsens* to 0.18 as `inner_tol`
+        // is tightened, because a smoother objective merely lets its trust-region stopping
+        // rule trip sooner (63 -> 34 evaluations, still reporting "converged"). Its ω
+        // estimates land ~3% off NONMEM LAPLACIAN. L-BFGS on the analytic gradient matches
+        // NONMEM to 4-5 significant figures on every parameter, in 0.39 s against FOCEI's
+        // 0.29 s. See docs/estimation/agq.qmd. An explicit `optimizer = ...` is honoured.
         if matches!(method, EstimationMethod::Agq) && stage_opts.optimizer == Optimizer::Auto {
-            stage_opts.optimizer = Optimizer::Bobyqa;
+            stage_opts.optimizer = Optimizer::NloptLbfgs;
         }
         // Run the covariance step (and SIR) only on the last *estimating* stage,
         // so a chain doesn't recompute the expensive FD covariance after every

--- a/src/api.rs
+++ b/src/api.rs
@@ -2246,6 +2246,26 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
         // outer iteration. Past the cap that is not "slow", it is a fit that will never
         // finish — so it is worth failing at check time, with the two levers spelled out.
         let n_nodes = options.n_agq.max(1);
+        // Per-dimension node cap. The parser (`apply_fit_option`) enforces this for
+        // file-driven fits, but a `FitOptions` built directly against the Rust API
+        // bypasses that path — so re-check here, alongside the grid cap, or an
+        // out-of-range `n_agq` (e.g. 100 with a single η, which slips under the grid
+        // cap) would reach `gauss_hermite` past the point Golub–Welsch stays accurate.
+        if n_nodes > crate::estimation::agq::MAX_AGQ_NODES {
+            diags.push(
+                Diagnostic::error(
+                    "E_AGQ_NODES_TOO_LARGE",
+                    format!(
+                        "method = agq with n_agq = {n_nodes} exceeds the {}-node per-dimension \
+                         limit: beyond ~20 nodes the Golub–Welsch rule loses its extreme nodes to \
+                         round-off and the marginal gains nothing. Lower n_agq (n_agq = 1 is the \
+                         Laplace approximation, i.e. FOCEI-equivalent cost).",
+                        crate::estimation::agq::MAX_AGQ_NODES,
+                    ),
+                )
+                .with_block("fit_options"),
+            );
+        }
         let grid = crate::estimation::agq::grid_size(n_nodes, model.n_eta);
         if grid > crate::estimation::agq::MAX_AGQ_GRID {
             diags.push(

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -108,10 +108,18 @@ pub fn gradient_method_outer(
         | EstimationMethod::Imp
         | EstimationMethod::Impmap
         | EstimationMethod::Bayes => GradientMethodKind::NotApplicable,
-        // AGQ's objective is the quadrature marginal, which has no analytic gradient here —
-        // `population_gradient` central-differences it. Reported truthfully so this can't
-        // disagree with the live dispatch (the #490 invariant).
-        EstimationMethod::Agq => GradientMethodKind::FiniteDifferences,
+        // AGQ always differentiates the quadrature marginal itself — the posterior-weighted
+        // score over the nodes plus the grid-response term, neither of which re-solves the
+        // inner loop. What varies is only the θ/σ score: analytic from the `Dual2` provider
+        // where it reaches, finite-differenced at fixed η otherwise (TTE, categorical, ODE,
+        // M3, LTBS…). Report that distinction, not a scope gate — there isn't one.
+        EstimationMethod::Agq => {
+            if crate::estimation::agq::analytic_score_supported(model) {
+                GradientMethodKind::Analytic
+            } else {
+                GradientMethodKind::FiniteDifferences
+            }
+        }
         EstimationMethod::FoceGn | EstimationMethod::FoceGnHybrid => {
             GradientMethodKind::FiniteDifferences
         }

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -108,6 +108,10 @@ pub fn gradient_method_outer(
         | EstimationMethod::Imp
         | EstimationMethod::Impmap
         | EstimationMethod::Bayes => GradientMethodKind::NotApplicable,
+        // AGQ's objective is the quadrature marginal, which has no analytic gradient here —
+        // `population_gradient` central-differences it. Reported truthfully so this can't
+        // disagree with the live dispatch (the #490 invariant).
+        EstimationMethod::Agq => GradientMethodKind::FiniteDifferences,
         EstimationMethod::FoceGn | EstimationMethod::FoceGnHybrid => {
             GradientMethodKind::FiniteDifferences
         }

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -54,6 +54,15 @@
 //! finite n* — AGQ is consistent under any invertible scaling — but at `n_agq = 1` it enters
 //! the objective directly through `½·log|H|`, so a blind `H` would silently not be Laplace.
 //!
+//! This is confirmed externally. On warfarin, AGQ at one node reproduces NONMEM
+//! `$EST METHOD=1 LAPLACIAN INTER` to five significant figures (7.8994 both), while ferx
+//! FOCEI and NONMEM `METHOD=1 INTER` agree with each other on a *different* value (7.4967)
+//! — so the 0.40-unit AGQ(1)-vs-FOCEI gap is FOCEI's Gauss-Newton Hessian, reproduced by
+//! the reference implementation, not drift here. NONMEM's LAPLACIAN **without** `INTER`
+//! misses by 9.3 units, which is the same point from the other side: the exact Hessian has
+//! to carry the curvature of the η-dependent residual variance (`ln V(f(η))`), and the
+//! Gauss-Newton form would have silently dropped it. See `docs/estimation/agq.qmd`.
+//!
 //! # Grid pruning: why there isn't any
 //!
 //! Dropping low-weight nodes looks free and is not. The *corrected* weight

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -98,6 +98,19 @@ pub const MAX_AGQ_GRID: usize = 100_000;
 /// convention so a diverged node sorts as "impossible" rather than poisoning the sum.
 const NLL_SENTINEL: f64 = 1e20;
 
+/// Relative step for central-differencing the grid-response term (and the mixed
+/// `∂²nll/∂η∂x` in [`eta_dx`]).
+///
+/// **Truncation-dominated, not noise-dominated** — the opposite of the intuition. It
+/// differences `log|H|`, which curves sharply in the packed coordinates, so a "safe" large
+/// step is catastrophic: `1e-2` puts the θ gradient 5× off, `1e-3` still 4%. The `H` inside
+/// is itself finite-differenced, but its error floor turns out to sit well below where
+/// truncation bites, so the step wants to be *small*. Measured on warfarin, the answer is
+/// converged by `1e-4` and unchanged at `1e-5`. Calibrated by
+/// `analytic_gradient_matches_fd_at_every_node_count`, which would catch a regression here
+/// immediately.
+const AGQ_GRID_FD_STEP: f64 = 1e-5;
+
 /// Number of nodes in the tensor grid, saturating at [`usize::MAX`] rather than
 /// overflowing — callers compare against [`MAX_AGQ_GRID`] and reject long before that.
 pub fn grid_size(n_nodes: usize, n_eta: usize) -> usize {
@@ -263,12 +276,54 @@ pub(crate) fn agq_subject_nll(
         return NLL_SENTINEL;
     };
 
+    let (_etas, terms) = agq_nodes_and_terms(
+        model,
+        subject,
+        params,
+        eta_hat,
+        nodes,
+        log_weights,
+        &proposal,
+        &mut scratch,
+        schedule.as_ref(),
+    );
+
+    let nll = 0.5 * d as f64 * PI.ln() + 0.5 * proposal.log_det_inv_scale - logsumexp(&terms);
+    if nll.is_finite() {
+        nll
+    } else {
+        NLL_SENTINEL
+    }
+}
+
+/// Sweep the tensor grid once, returning each node's `η_j` and its log-term
+/// `t_j = Σ_k log w_{j,k} + ‖z_j‖² − nll(η_j)`.
+///
+/// The single place the grid is materialised. The objective ([`agq_subject_nll`]) reduces
+/// the terms with `logsumexp`; the gradient ([`agq_subject_packed_gradient`]) additionally
+/// needs the `η_j` themselves and turns the same terms into softmax weights. Sharing one
+/// sweep is what guarantees the gradient is differentiating the objective that was actually
+/// evaluated, rather than a grid that drifted from it.
+#[allow(clippy::too_many_arguments)]
+fn agq_nodes_and_terms(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    proposal: &crate::estimation::importance_sampling::Proposal,
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> (Vec<Vec<f64>>, Vec<f64>) {
+    let d = eta_hat.len();
     let n = nodes.len();
-    let mut terms = Vec::with_capacity(grid_size(n, d));
+    let cap = grid_size(n, d);
+    let mut etas = Vec::with_capacity(cap);
+    let mut terms = Vec::with_capacity(cap);
     let mut idx = vec![0usize; d];
     let mut z = vec![0.0f64; d];
     let mut step = vec![0.0f64; d];
-    let mut eta = vec![0.0f64; d];
 
     loop {
         let mut log_w = 0.0;
@@ -281,9 +336,8 @@ pub(crate) fn agq_subject_nll(
         }
         // η_j = η̂ + √2 · Σ^{1/2} · z_j — the adaptive transform.
         proposal.apply_l_sigma(&z, &mut step, std::f64::consts::SQRT_2);
-        for k in 0..d {
-            eta[k] = eta_hat[k] + step[k];
-        }
+        let eta: Vec<f64> = (0..d).map(|k| eta_hat[k] + step[k]).collect();
+
         let nll = individual_nll_into_with_schedule(
             model,
             subject,
@@ -291,13 +345,14 @@ pub(crate) fn agq_subject_nll(
             &eta,
             &params.omega,
             &params.sigma.values,
-            &mut scratch,
-            schedule.as_ref(),
+            scratch,
+            schedule,
         );
         // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
         // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
         // which case the subject correctly reports the sentinel back.
         terms.push(log_w + z_sq - nll);
+        etas.push(eta);
 
         // Mixed-radix increment over the d-dimensional tensor grid.
         let mut k = 0;
@@ -313,13 +368,7 @@ pub(crate) fn agq_subject_nll(
             break;
         }
     }
-
-    let nll = 0.5 * d as f64 * PI.ln() + 0.5 * proposal.log_det_inv_scale - logsumexp(&terms);
-    if nll.is_finite() {
-        nll
-    } else {
-        NLL_SENTINEL
-    }
+    (etas, terms)
 }
 
 /// Population AGQ objective: `Σ_i agq_subject_nll_i`. The outer loop doubles this into an
@@ -329,7 +378,7 @@ pub(crate) fn agq_subject_nll(
 /// importance sampling), then reduced **serially in subject order** — a rayon `.sum()`
 /// folds along thread-count-dependent split boundaries and f64 addition is not associative,
 /// which would make the OFV depend on the thread count (#703).
-pub(crate) fn agq_population_nll(
+pub fn agq_population_nll(
     model: &CompiledModel,
     population: &Population,
     params: &ModelParameters,
@@ -355,6 +404,696 @@ pub(crate) fn agq_population_nll(
         })
         .collect();
     per_subject.iter().sum()
+}
+
+// ---------------------------------------------------------------------------
+// Analytic outer gradient
+// ---------------------------------------------------------------------------
+//
+// # The identity
+//
+// AGQ's per-subject objective is `F = (d/2)·logπ + ½·log|H| − LSE`, and the node
+// log-terms are `t_j = log w_j + ‖z_j‖² − nll(η_j)`. Differentiating w.r.t. the packed
+// population parameters `x` with the **nodes held fixed** (η̂ and H constant), the first
+// two terms drop out and the third is a softmax:
+//
+// ```text
+//   ∂F/∂x  =  −∂LSE/∂x  =  Σ_j ŵ_j · ∂nll(η_j; x)/∂x ,     ŵ_j = exp(t_j) / Σ_k exp(t_k)
+// ```
+//
+// The `ŵ_j` are exactly the posterior weights at the nodes, so this is the **Fisher /
+// Louis identity**: `∂(−log ∫e^{−nll})/∂x = E_{p(η|y)}[∂nll/∂x]`, with the quadrature
+// supplying the expectation. Each `∂nll(η_j)/∂x` is a *fixed-η* gradient — no EBE re-solve,
+// no `log|H̃|` term, no EBE-response — which the `Dual2` provider already gives us exactly.
+//
+// # The grid also moves, and that term is not optional
+//
+// The nodes are built from `(η̂(x), H(x))`, so the total derivative also carries
+// `∂F/∂η̂ · dη̂/dx` and `∂F/∂H · dH/dx`. Both **vanish in the exact-quadrature limit** — an
+// exactly-integrated `∫exp(−nll)` does not care where you centre or how you scale the grid;
+// it is a change of variables — so they are identically the quadrature error's sensitivity,
+// and the explicit `½·log|H|` term cancels against the nodes' `H`-dependence rather than
+// either vanishing alone.
+//
+// At finite `n` they do not vanish, and they are **not** small. The fixed-node score alone,
+// measured against a finite-difference of the real objective on warfarin, is **26% wrong at
+// n = 1** (where the rule *is* Laplace and the cancellation fails completely), 0.8% at n = 3.
+// So [`grid_response_correction`] supplies the term, and the gradient is the exact total
+// derivative at every `n_agq`, n = 1 included: 0.17% / 0.16% / 0.002% / 0.0006% at
+// n = 1/3/5/7, i.e. at the FD reference's own noise floor.
+//
+// The subtlety that makes or breaks it: `H = ∂²nll/∂η²|_{η̂(x)}` depends on `x` **twice** —
+// explicitly through θ/Ω/σ, and implicitly through the mode. Differencing only the explicit
+// half is not a partial improvement, it is *worse than omitting the term* (26% → 62%). The
+// mode must be moved along `dη̂/dx` too. See [`grid_response_correction`].
+//
+// # Cost
+//
+// The score is one `subject_sensitivities` call per node — the same order as one objective
+// evaluation. The correction adds `2·n_free` Hessian rebuilds and grid sweeps, with **no**
+// inner re-solve (that is what `dη̂/dx` buys). The `reconverged_fd_gradient` it replaces
+// costs `2·n_free` *full population objective* evaluations, each re-solving every subject's
+// inner loop.
+
+/// Whether the **θ/σ score** can be taken analytically from the `Dual2` provider, or must be
+/// finite-differenced at fixed η.
+///
+/// This is a *speed* switch, not a scope gate: both paths compute the same quantity, and
+/// neither re-solves the inner loop. The analytic form chains the provider's exact `∂f/∂θ`
+/// through `∂nll/∂f`, which is only valid for the plain Gaussian residual term — every
+/// variant listed below adds a term it does not carry (M3's normal-tail, LTBS's `ln f`
+/// wrap, FREM's pseudo-observations, a dense residual covariance, an η-scaled or custom
+/// residual variance), and TTE / categorical endpoints are outside the provider entirely.
+/// Those all take [`accumulate_fixed_eta_packed_gradient_fd`] instead.
+pub fn analytic_score_supported(model: &CompiledModel) -> bool {
+    crate::sens::provider::analytic_outer_gradient_available(model)
+        && !matches!(model.bloq_method, crate::types::BloqMethod::M3)
+        && model.residual_correlations.is_empty()
+        && model.frem_config.is_none()
+        && model.residual_error_eta.is_none()
+        && !model.has_custom_ruv_magnitude()
+        && !model.log_transform
+}
+
+/// AGQ always drives the outer loop with its **own** gradient — for every model, and at every
+/// `n_agq`.
+///
+/// There is deliberately no scope gate here. The two ingredients both work universally:
+///
+/// * the fixed-η score is analytic where the provider reaches
+///   ([`analytic_score_supported`]) and finite-differenced *at fixed η* otherwise
+///   ([`accumulate_fixed_eta_packed_gradient_fd`]) — the latter is correct for any likelihood
+///   ferx can evaluate, including TTE and categorical; and
+/// * `dη̂/dx` comes from the implicit-function theorem (`−H⁻¹·∂²nll/∂η∂x`), analytic where the
+///   provider reaches and finite-differenced otherwise ([`eta_dx`]).
+///
+/// Crucially **neither path re-solves the inner loop**, which is the cost that makes
+/// `reconverged_fd_gradient` expensive. Letting the models AGQ exists for — non-Gaussian
+/// endpoints, which are precisely the ones outside the `Dual2` provider — fall back to that
+/// gradient would have made the headline use case the slow one.
+///
+/// **Node-count independent.** With [`grid_response_correction`] supplying the `∂Φ/∂H·dH/dx`
+/// term, the gradient is the exact total derivative at every `n_agq`, `n_agq = 1` included
+/// (where that term is exactly `½·d log|H|/dx`, the Laplace log-determinant).
+pub fn analytic_gradient_available(model: &CompiledModel) -> bool {
+    // Kept as a predicate (rather than inlining `true`) so a future model class that genuinely
+    // cannot supply `∂nll/∂x` at fixed η has one place to opt out; `population_gradient`'s
+    // `reconverged_fd_gradient` fallback stays wired up behind it.
+    let _ = model;
+    true
+}
+
+/// Finite-differenced θ/σ score at a **fixed η** — the universal fallback when the analytic
+/// chain rule does not apply (TTE, categorical, M3, LTBS, FREM, `block_sigma`, ODE models).
+///
+/// Central-differences `individual_nll(η; θ, σ)` in the *packed* coordinates, so the log-θ and
+/// log-σ chain rules come out automatically. The Ω block is **not** redone here: it is closed
+/// form from the η-prior and the caller has already accumulated it exactly.
+///
+/// Predictions are σ-independent, so the σ perturbations reuse nothing extra — each is one
+/// likelihood evaluation. No inner re-solve, which is the whole point.
+#[allow(clippy::too_many_arguments)]
+fn accumulate_fixed_eta_packed_gradient_fd(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    eta: &[f64],
+    weight: f64,
+    n_theta: usize,
+    sigma_start: usize,
+    out: &mut [f64],
+) -> Option<()> {
+    use crate::estimation::parameterization::{pack_params, packed_fixed_mask, unpack_params};
+
+    let x = pack_params(params);
+    let fixed = packed_fixed_mask(template);
+    let n_sigma = params.sigma.values.len();
+    let mut scratch = pk::EventPkParams::with_capacity_for(subject);
+    let schedule = cacheable_schedule(model, subject);
+
+    let mut nll_at = |p: &ModelParameters| -> f64 {
+        individual_nll_into_with_schedule(
+            model,
+            subject,
+            &p.theta,
+            eta,
+            &p.omega,
+            &p.sigma.values,
+            &mut scratch,
+            schedule.as_ref(),
+        )
+    };
+
+    // θ and σ coordinates only — the Ω block is exact in closed form and already added.
+    let coords = (0..n_theta).chain(sigma_start..sigma_start + n_sigma);
+    for k in coords {
+        if fixed[k] {
+            continue;
+        }
+        let h = 1e-6 * (1.0 + x[k].abs());
+        let mut xp = x.clone();
+        let mut xm = x.clone();
+        xp[k] += h;
+        xm[k] -= h;
+        let d = (nll_at(&unpack_params(&xp, template)) - nll_at(&unpack_params(&xm, template)))
+            / (2.0 * h);
+        if d.is_finite() {
+            out[k] += weight * d;
+        }
+    }
+    Some(())
+}
+
+/// Packed gradient of `individual_nll` at a **fixed** `eta`, accumulated as
+/// `out += weight · ∂nll(η)/∂x`.
+///
+/// This is the fixed-η score: the θ block via the provider's exact `∂f/∂θ` chained through
+/// `∂nll/∂f`, the σ block in closed form, and the Ω block from the η-prior alone
+/// (`½(−zzᵀ + Ω⁻¹)`, mapped to Cholesky-packed space by the shared
+/// [`crate::estimation::sens_outer_gradient::chol_pack`]). Deliberately carries **no**
+/// `log|H̃|` and **no** EBE-response term — those belong to the Laplace marginal, not to
+/// `nll(η)` at a fixed η.
+///
+/// Returns `None` when the subject is outside the provider's scope, which drops the whole
+/// population to the FD gradient (all-or-nothing, like `population_gradient_sens`).
+fn accumulate_fixed_eta_packed_gradient(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    eta: &[f64],
+    weight: f64,
+    out: &mut [f64],
+) -> Option<()> {
+    use crate::estimation::parameterization::theta_packs_log;
+
+    let n_obs = subject.observations.len();
+    let n_theta = params.theta.len();
+    let n_sigma = params.sigma.values.len();
+    let n_eta = eta.len();
+
+    // Ω block — from the η-prior `½(ηᵀΩ⁻¹η + log|Ω|)`, which is the *only* place Ω enters
+    // `nll` at a fixed η:
+    //   ∂/∂Ω [½ ηᵀΩ⁻¹η] = −½·zzᵀ   and   ∂/∂Ω [½ log|Ω|] = ½·Ω⁻¹,   z = Ω⁻¹η.
+    // Independent of the data, so it is accumulated even for a subject with no observations.
+    let z = &params.omega.inv * nalgebra::DVector::from_column_slice(eta);
+    let mut m_omega = DMatrix::zeros(n_eta, n_eta);
+    for r in 0..n_eta {
+        for c in 0..n_eta {
+            m_omega[(r, c)] = 0.5 * (-z[r] * z[c] + params.omega.inv[(r, c)]);
+        }
+    }
+    let omega_start = n_theta;
+    let og = crate::estimation::sens_outer_gradient::chol_pack(
+        &m_omega,
+        &params.omega.chol,
+        params.omega.diagonal,
+    );
+    for (k, &v) in og.iter().enumerate() {
+        out[omega_start + k] += weight * v;
+    }
+    let sigma_start = omega_start + og.len();
+
+    if n_obs == 0 {
+        return Some(());
+    }
+
+    // Off the analytic score's scope (a non-Gaussian endpoint, M3, LTBS, an ODE model, …):
+    // finite-difference the θ and σ blocks of `nll` at this **fixed η** instead. Still no
+    // inner re-solve — that is the expensive thing, and neither path does one — so AGQ keeps
+    // its own gradient for *every* model rather than dropping to `reconverged_fd_gradient`.
+    // This matters most for exactly the endpoints AGQ exists to serve: TTE and categorical
+    // are outside the `Dual2` provider, and it would be perverse for them to be the slow case.
+    if !analytic_score_supported(model) {
+        return accumulate_fixed_eta_packed_gradient_fd(
+            model,
+            subject,
+            params,
+            template,
+            eta,
+            weight,
+            n_theta,
+            sigma_start,
+            out,
+        );
+    }
+
+    // Exact ∂f/∂θ at *this* η. `subject_sensitivities` makes no mode assumption — the
+    // η = η̂ requirement in `sens_outer_gradient` lives in its `theta_block`, not here.
+    let sens = crate::sens::provider::subject_sensitivities(model, subject, &params.theta, eta)?;
+
+    let err_keys = model.error_spec.obs_keys(subject);
+    let mut d_nll_d_f = vec![0.0f64; n_obs];
+    let mut variances = vec![0.0f64; n_obs];
+    let mut residuals = vec![0.0f64; n_obs];
+
+    for j in 0..n_obs {
+        let f = sens.obs[j].f.max(1e-12);
+        let v = model
+            .residual_variance_at(err_keys[j], f, &params.sigma.values)
+            .max(1e-12);
+        let resid = subject.observations[j] - sens.obs[j].f;
+        residuals[j] = resid;
+        variances[j] = v;
+        // ∂nll_j/∂f = −r/V + ½·(∂V/∂f)·(1/V − r²/V²)  — the halved convention of
+        // `individual_nll` (0.5·Σ[r²/V + ln V]); identical to SAEM's `d_nll_d_f`.
+        let dv_df = model
+            .error_spec
+            .dvar_df(err_keys[j], f, &params.sigma.values);
+        d_nll_d_f[j] = -resid / v + 0.5 * dv_df * (1.0 / v - resid * resid / (v * v));
+    }
+
+    // θ block: chain the exact ∂f/∂θ through ∂nll/∂f, then the log-θ packing chain rule.
+    for m in 0..n_theta {
+        let d: f64 = (0..n_obs)
+            .map(|j| d_nll_d_f[j] * sens.obs[j].df_dtheta[m])
+            .sum();
+        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
+            params.theta[m]
+        } else {
+            1.0
+        };
+        out[m] += weight * d * dtheta_dx;
+    }
+
+    // σ block: closed form. ∂nll/∂(log σ_k) = Σ_j ½·(∂V_j/∂log σ_k)·(1/V_j − r_j²/V_j²).
+    for k in 0..n_sigma {
+        let d: f64 = (0..n_obs)
+            .map(|j| {
+                let f = sens.obs[j].f.max(1e-12);
+                let v = variances[j];
+                let r = residuals[j];
+                let ratio =
+                    model
+                        .error_spec
+                        .dvar_dlogsigma(err_keys[j], k, f, &params.sigma.values);
+                0.5 * ratio * (1.0 / v - r * r / (v * v))
+            })
+            .sum();
+        out[sigma_start + k] += weight * d;
+    }
+
+    Some(())
+}
+
+/// The **grid-response** term `∂Φ/∂H · dH/dx`, the one piece the fixed-node score omits.
+///
+/// Writing `F = Φ(x, H(x))` with the nodes built from `H`, the exact total derivative is
+///
+/// ```text
+///   dF/dx = ∂Φ/∂x|_H          ← the fixed-node score (analytic; see above)
+///         + ∂Φ/∂H · dH/dx     ← this function
+///         + ∂Φ/∂η̂ · dη̂/dx     ← = Σ_j ŵ_j ∇_η nll(η_j), the posterior-mean score = 0
+/// ```
+///
+/// The `∂Φ/∂η̂` factor is the posterior-mean score, which is zero by the Bartlett identity —
+/// exactly so at `n_agq = 1`, where η̂ *is* the mode. So the `H`-response is all that stands
+/// between the fixed-node score and the exact gradient. It is not a small correction: without
+/// it the gradient is 26% wrong at `n_agq = 1`.
+///
+/// It is computed by central-differencing `Φ` in `x` **through the grid alone**: the grid
+/// (`η̂`, `H`) is rebuilt at the perturbed parameters while `nll` stays at the original ones,
+/// which isolates the response term from the direct dependence already covered analytically.
+///
+/// **`H` depends on `x` twice, and both halves matter.** `H = ∂²nll/∂η²|_{η̂(x)}` varies with
+/// `x` explicitly (through θ/Ω/σ) *and* implicitly through the mode `η̂(x)`. Differencing only
+/// the explicit half is not a partial improvement — it is **worse than omitting the term
+/// entirely** (26% → 62% on warfarin at n = 1), because the two halves substantially cancel.
+/// So the mode is moved too, along the exact analytic `dη̂/dx` from
+/// [`crate::estimation::sens_outer_gradient::subject_eta_dx`] (the implicit-function
+/// derivative `−H⁻¹·∂²nll/∂η∂x`, which the EBE predictor already relies on). That is what
+/// keeps this **free of any inner re-solve**: it costs `2·n_free` Hessian rebuilds and grid
+/// sweeps, not the `2·n_free` *full population objective* evaluations `reconverged_fd_gradient`
+/// pays.
+///
+/// A fully analytic `dH/dx` would need `∂³nll/∂η²∂θ`; the provider stops at `∂²f/∂η∂θ`, so
+/// this third order is finite-differenced. `analytic_gradient_matches_fd_at_every_node_count`
+/// measures the result against a finite-difference of the real objective: 0.17% at n = 1,
+/// 0.0006% at n = 7 — the FD reference's own noise floor.
+///
+/// At `n_agq = 1` the grid objective collapses to `½·log|H|` (the single node sits at η̂), so
+/// this reduces to `½·d log|H|/dx` — precisely the Laplace log-determinant term FOCE/FOCEI
+/// carry analytically.
+#[allow(clippy::too_many_arguments)]
+fn grid_response_correction(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+    out: &mut [f64],
+) -> Option<()> {
+    use crate::estimation::parameterization::{packed_fixed_mask, unpack_params};
+
+    let fixed = packed_fixed_mask(template);
+
+    // `H = ∂²nll/∂η²|_{η̂(x)}` depends on `x` **twice**: explicitly through θ/Ω/σ, and
+    // implicitly through the mode `η̂(x)`. Differencing only the explicit half is not a
+    // partial improvement — it is *wrong*, and measurably worse than omitting the term
+    // (26% → 62% on warfarin at n = 1). So the mode is moved too, along the exact analytic
+    // `dη̂/dx` (the implicit-function-theorem derivative `−H⁻¹·∂²nll/∂η∂x`, which the
+    // sensitivity provider already supplies and the EBE predictor already relies on). No
+    // inner re-solve is needed.
+    let deta_dx = eta_dx(
+        model, subject, params, template, x, eta_hat, scratch, schedule,
+    )?;
+
+    for k in 0..x.len() {
+        if fixed[k] {
+            continue;
+        }
+        // `H` is itself a finite-difference quantity, so its own error floor is amplified by
+        // 1/step here. The step must stay well above sqrt(that floor); 1e-3 is calibrated by
+        // `analytic_gradient_matches_fd_at_every_node_count`.
+        let step = AGQ_GRID_FD_STEP * (1.0 + x[k].abs());
+        let mut xp = x.to_vec();
+        let mut xm = x.to_vec();
+        xp[k] += step;
+        xm[k] -= step;
+
+        // The mode moves with the parameters: η̂(x ± h) ≈ η̂ ± h · dη̂/dx_k.
+        let ep: Vec<f64> = (0..eta_hat.len())
+            .map(|i| eta_hat[i] + step * deta_dx[k][i])
+            .collect();
+        let em: Vec<f64> = (0..eta_hat.len())
+            .map(|i| eta_hat[i] - step * deta_dx[k][i])
+            .collect();
+
+        let pp = unpack_params(&xp, template);
+        let pm = unpack_params(&xm, template);
+        let hp = fd_posterior_hessian(model, subject, &pp, &ep, scratch, schedule);
+        let hm = fd_posterior_hessian(model, subject, &pm, &em, scratch, schedule);
+
+        // `nll` stays at the ORIGINAL params — the direct x-dependence is already covered
+        // analytically by the fixed-η score — but the grid (centre and scale) is the
+        // perturbed one, which is exactly the response term we are after.
+        let phip = phi_grid(
+            model,
+            subject,
+            params,
+            &ep,
+            nodes,
+            log_weights,
+            &hp,
+            &pp.omega.inv,
+            scratch,
+            schedule,
+        );
+        let phim = phi_grid(
+            model,
+            subject,
+            params,
+            &em,
+            nodes,
+            log_weights,
+            &hm,
+            &pm.omega.inv,
+            scratch,
+            schedule,
+        );
+        let (Some(phip), Some(phim)) = (phip, phim) else {
+            continue; // a degenerate perturbed Hessian contributes no correction
+        };
+        let r = (phip - phim) / (2.0 * step);
+        if r.is_finite() {
+            out[k] += r;
+        }
+    }
+    Some(())
+}
+
+/// `dη̂/dx` — how the EBE mode moves with the population parameters, per packed coordinate.
+///
+/// From the implicit function theorem: η̂ solves `∇_η nll(η̂; x) = 0`, so
+///
+/// ```text
+///   dη̂/dx = −H⁻¹ · ∂²nll/∂η∂x ,     H = ∂²nll/∂η²|_{η̂}
+/// ```
+///
+/// Uses the provider's exact version
+/// ([`crate::estimation::sens_outer_gradient::subject_eta_dx`]) where it applies, and
+/// otherwise finite-differences the mixed term `∂²nll/∂η∂x` directly — perturb `x`, take the
+/// η-gradient at the *same* η̂, solve against `H`. That costs `2·n_free · 2·d` likelihood
+/// evaluations and, critically, **no inner re-solve**: it is the derivative of the mode, not a
+/// re-computation of it. So models outside the provider (TTE, categorical, ODE) still get the
+/// cheap gradient rather than dropping to `reconverged_fd_gradient`.
+#[allow(clippy::too_many_arguments)]
+fn eta_dx(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hat: &[f64],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> Option<Vec<nalgebra::DVector<f64>>> {
+    use crate::estimation::parameterization::{packed_fixed_mask, unpack_params};
+
+    if analytic_score_supported(model) {
+        if let Some(v) = crate::estimation::sens_outer_gradient::subject_eta_dx(
+            model, subject, template, x, eta_hat,
+        ) {
+            return Some(v);
+        }
+    }
+
+    let d = eta_hat.len();
+    let h_mat = fd_posterior_hessian(model, subject, params, eta_hat, scratch, schedule);
+    let h_inv = h_mat.clone().try_inverse()?;
+    let fixed = packed_fixed_mask(template);
+
+    // ∇_η nll(η̂; p) — central differences in η, at the given parameters.
+    let mut eta_grad = |p: &ModelParameters, out: &mut [f64]| {
+        let mut e = eta_hat.to_vec();
+        for i in 0..d {
+            let step = (f64::EPSILON.powf(0.25) * p.omega.matrix[(i, i)].max(0.0).sqrt()).max(1e-5);
+            e[i] = eta_hat[i] + step;
+            let fp = individual_nll_into_with_schedule(
+                model,
+                subject,
+                &p.theta,
+                &e,
+                &p.omega,
+                &p.sigma.values,
+                scratch,
+                schedule,
+            );
+            e[i] = eta_hat[i] - step;
+            let fm = individual_nll_into_with_schedule(
+                model,
+                subject,
+                &p.theta,
+                &e,
+                &p.omega,
+                &p.sigma.values,
+                scratch,
+                schedule,
+            );
+            e[i] = eta_hat[i];
+            out[i] = (fp - fm) / (2.0 * step);
+        }
+    };
+
+    let mut out = vec![nalgebra::DVector::zeros(d); x.len()];
+    let (mut gp, mut gm) = (vec![0.0f64; d], vec![0.0f64; d]);
+    for k in 0..x.len() {
+        if fixed[k] {
+            continue;
+        }
+        let step = AGQ_GRID_FD_STEP * (1.0 + x[k].abs());
+        let mut xp = x.to_vec();
+        let mut xm = x.to_vec();
+        xp[k] += step;
+        xm[k] -= step;
+        eta_grad(&unpack_params(&xp, template), &mut gp);
+        eta_grad(&unpack_params(&xm, template), &mut gm);
+        // ∂²nll/∂η∂x_k, then dη̂/dx_k = −H⁻¹ · that.
+        let mixed =
+            nalgebra::DVector::from_iterator(d, (0..d).map(|i| (gp[i] - gm[i]) / (2.0 * step)));
+        out[k] = -(&h_inv * mixed);
+    }
+    Some(out)
+}
+
+/// `Φ_grid(H)` — the part of the AGQ objective that depends on `x` *only* through `H`:
+/// `½·log|H| − logΣexp_j[ log w_j + ‖z_j‖² − nll(η̂ + √2·Σ^{1/2}(H)·z_j ; x₀) ]`.
+///
+/// `nll` is evaluated at the **original** `params`, so differencing this in `x` isolates the
+/// grid's response to `H` from the direct `x`-dependence that
+/// [`accumulate_fixed_eta_packed_gradient`] already covers analytically. The `(d/2)·logπ`
+/// constant cancels in the difference and is omitted.
+#[allow(clippy::too_many_arguments)]
+fn phi_grid(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    h_mat: &DMatrix<f64>,
+    omega_inv: &DMatrix<f64>,
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> Option<f64> {
+    let d = eta_hat.len();
+    let proposal = build_proposal(h_mat, omega_inv, d)?;
+    let (_etas, terms) = agq_nodes_and_terms(
+        model,
+        subject,
+        params,
+        eta_hat,
+        nodes,
+        log_weights,
+        &proposal,
+        scratch,
+        schedule,
+    );
+    let lse = logsumexp(&terms);
+    lse.is_finite()
+        .then(|| 0.5 * proposal.log_det_inv_scale - lse)
+}
+
+/// Analytic packed gradient of the AGQ objective for one subject: the posterior-weighted
+/// average of fixed-η scores over the quadrature nodes, **plus** the grid-response term
+/// [`grid_response_correction`] that makes it the exact total derivative at every `n_agq`
+/// (see the module note above).
+///
+/// `out` is the population accumulator; this adds `∂F_i/∂x` into it.
+#[allow(clippy::too_many_arguments)]
+fn agq_subject_packed_gradient(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    out: &mut [f64],
+) -> Option<()> {
+    let d = eta_hat.len();
+    let mut scratch = pk::EventPkParams::with_capacity_for(subject);
+    let schedule = cacheable_schedule(model, subject);
+
+    if d == 0 {
+        return accumulate_fixed_eta_packed_gradient(
+            model, subject, params, template, eta_hat, 1.0, out,
+        );
+    }
+
+    let h = fd_posterior_hessian(
+        model,
+        subject,
+        params,
+        eta_hat,
+        &mut scratch,
+        schedule.as_ref(),
+    );
+    let proposal = build_proposal(&h, &params.omega.inv, d)?;
+
+    // Sweep the grid once, keeping each node's η and its log-term, so the softmax weights
+    // and the scores are computed on exactly the same nodes the objective used.
+    let (etas, terms) = agq_nodes_and_terms(
+        model,
+        subject,
+        params,
+        eta_hat,
+        nodes,
+        log_weights,
+        &proposal,
+        &mut scratch,
+        schedule.as_ref(),
+    );
+    let lse = logsumexp(&terms);
+    if !lse.is_finite() {
+        return None;
+    }
+
+    for (eta_j, &t) in etas.iter().zip(terms.iter()) {
+        let w = (t - lse).exp();
+        if w == 0.0 {
+            continue; // exp underflow — contributes nothing to the average
+        }
+        accumulate_fixed_eta_packed_gradient(model, subject, params, template, eta_j, w, out)?;
+    }
+
+    // …plus the grid's response to H — the only term the fixed-node score omits, and the
+    // whole of the gap at n_agq = 1 (where it is exactly ½·d log|H|/dx).
+    grid_response_correction(
+        model,
+        subject,
+        params,
+        template,
+        x,
+        eta_hat,
+        nodes,
+        log_weights,
+        &mut scratch,
+        schedule.as_ref(),
+        out,
+    )?;
+    Some(())
+}
+
+/// Analytic packed gradient of the AGQ **OFV** (`2 · Σᵢ Fᵢ`), or `None` if any subject is
+/// outside the provider's scope (all-or-nothing, matching `population_gradient_sens`).
+///
+/// Parallel over subjects; the per-subject gradients are reduced **serially in subject
+/// order** so the result cannot depend on the thread count (#703), exactly as
+/// [`agq_population_nll`] does for the objective.
+pub fn agq_population_gradient(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hats: &[nalgebra::DVector<f64>],
+    n_nodes: usize,
+) -> Option<Vec<f64>> {
+    let n_packed = x.len();
+    let (nodes, weights) = gauss_hermite(n_nodes);
+    let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
+
+    let per_subject: Vec<Option<Vec<f64>>> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| {
+            let mut g = vec![0.0f64; n_packed];
+            agq_subject_packed_gradient(
+                model,
+                subject,
+                params,
+                template,
+                x,
+                eta_hats[i].as_slice(),
+                &nodes,
+                &log_weights,
+                &mut g,
+            )
+            .map(|()| g)
+        })
+        .collect();
+
+    let mut out = vec![0.0f64; n_packed];
+    for g in per_subject {
+        let g = g?;
+        for (o, v) in out.iter_mut().zip(g.iter()) {
+            *o += 2.0 * v; // OFV = 2 · Σᵢ Fᵢ
+        }
+    }
+    if out.iter().all(|v| v.is_finite()) {
+        Some(out)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -1,0 +1,518 @@
+//! Adaptive Gauss–Hermite quadrature (AGQ) — the marginal-likelihood objective (#251).
+//!
+//! # What it computes
+//!
+//! FOCE/FOCEI approximate each subject's marginal likelihood
+//! `L_i = ∫ p(y_i|η) φ(η; 0, Ω) dη` with a *single* Gaussian centred at the empirical-Bayes
+//! mode. AGQ keeps that centring but evaluates the integrand on a Gauss–Hermite grid laid
+//! around the mode, so the approximation improves with the node count instead of being
+//! fixed. Writing `l_i(η) = log p(y_i|η) + log φ(η; 0, Ω)` for the exact conditional
+//! log-likelihood, `η̂` for the mode and `H = −∇²l_i(η̂)`:
+//!
+//! ```text
+//!   L_i ≈ 2^(d/2) · |Σ^{1/2}| · Σ_j [ (Π_k w_{j,k}) · exp(‖z_j‖²) · exp(l_i(η̂ + √2·Σ^{1/2}·z_j)) ]
+//! ```
+//!
+//! with `Σ = H⁻¹`, `z_j` the tensor-product Gauss–Hermite nodes and `w` the GH weights. The
+//! `exp(‖z_j‖²)` factor undoes the `e^{−z²}` that the Hermite weights carry, so what is
+//! actually integrated is the *full* integrand rather than a Gaussian-shaped surrogate.
+//!
+//! **Two properties follow, and they are the whole point of the method:**
+//!
+//! 1. **`n_agq = 1` is exactly Laplace.** The one-point rule is `z = 0`, `w = √π`, so the
+//!    sum collapses to `(2π)^(d/2) · |H|^(−1/2) · exp(l_i(η̂))` — the Laplace approximation,
+//!    term for term. This is not an approximation of an approximation; it is an identity,
+//!    and [`tests::one_node_agq_equals_laplace`] pins it.
+//! 2. **No Gaussian-residual assumption.** `l_i` is evaluated through
+//!    [`individual_nll_into_with_schedule`], the model's *actual* likelihood — so
+//!    time-to-event and categorical endpoints are integrated as faithfully as Gaussian
+//!    ones. That is what FOCE/FOCEI structurally cannot do, and why AGQ exists here.
+//!
+//! # Constant convention
+//!
+//! `individual_nll_*` omits the `(d + n_obs)/2 · log(2π)` constants (NONMEM's "objective
+//! function without constant"). Writing `G_i = ∫ exp(−nll(η)) dη`, the OFV in that same
+//! convention is `−2·Σ_i log G_i + Σ_i d·log(2π)`, so this module's per-subject
+//! contribution — the quantity the outer loop doubles into an OFV — is
+//!
+//! ```text
+//!   agq_nll_i = (d/2)·log(π) + ½·log|H| − logΣexp_j[ Σ_k log w_{j,k} + ‖z_j‖² − nll(η_j) ]
+//! ```
+//!
+//! which at one node reduces to `nll(η̂) + ½·log|H|`: the FOCEI Laplace per-subject NLL,
+//! in the same units as [`crate::stats::likelihood::foce_subject_nll`]. AGQ OFVs are
+//! therefore directly comparable to FOCE/FOCEI OFVs from this engine.
+//!
+//! # Why the Hessian is finite-differenced
+//!
+//! `H` is the Hessian of the *true* integrand, obtained by central differences of
+//! `individual_nll`. It is deliberately **not**
+//! [`crate::estimation::importance_sampling::compute_posterior_hessian`], which builds the
+//! Gauss-Newton form `Ω⁻¹ + JᵀR⁻¹J`: that carries no curvature at all from TTE or
+//! categorical endpoints, i.e. it is blind on exactly the models AGQ is here to serve, and
+//! would scale their grids by `Ω` alone. Note the grid scaling only affects *accuracy at
+//! finite n* — AGQ is consistent under any invertible scaling — but at `n_agq = 1` it enters
+//! the objective directly through `½·log|H|`, so a blind `H` would silently not be Laplace.
+//!
+//! # Grid pruning: why there isn't any
+//!
+//! Dropping low-weight nodes looks free and is not. The *corrected* weight
+//! `w_k · exp(z_k²)` is `Θ(1)` across the grid — the Hermite weight's `e^{−z²}` decay is
+//! exactly what the correction cancels — so a threshold on `w_k` prunes nodes whose actual
+//! contribution is not small. The contribution is only known after `nll(η_j)` is evaluated,
+//! which is the entire cost. Dimensionality is therefore bounded by [`MAX_AGQ_GRID`]
+//! instead, and a sparse (Smolyak) rule is the real answer for `d = 5..8` (issue #251).
+
+use nalgebra::DMatrix;
+use rayon::prelude::*;
+use std::f64::consts::PI;
+
+use crate::estimation::importance_sampling::build_proposal;
+use crate::estimation::inner_optimizer::cacheable_schedule;
+use crate::pk;
+use crate::stats::likelihood::individual_nll_into_with_schedule;
+use crate::types::{CompiledModel, ModelParameters, Population, Subject};
+
+/// Upper bound on `n_agq`. Beyond ~20 nodes the Golub–Welsch eigenproblem starts to lose
+/// the extreme nodes to round-off, and the marginal accuracy gain is nil for any realistic
+/// NLME integrand.
+pub const MAX_AGQ_NODES: usize = 21;
+
+/// Hard cap on the tensor-grid size `n_agq^n_eta`, enforced at model-check time by
+/// [`crate::api::check_model_options`]. The tensor rule costs one full likelihood
+/// evaluation per node per subject per outer iteration, so the grid — not the node count —
+/// is the quantity a user needs protecting from. 100k nodes on an ODE model is already
+/// hours; past that a fit is not slow, it is wrong to have started.
+pub const MAX_AGQ_GRID: usize = 100_000;
+
+/// The sentinel a non-finite likelihood collapses to, matching `individual_nll`'s own
+/// convention so a diverged node sorts as "impossible" rather than poisoning the sum.
+const NLL_SENTINEL: f64 = 1e20;
+
+/// Number of nodes in the tensor grid, saturating at [`usize::MAX`] rather than
+/// overflowing — callers compare against [`MAX_AGQ_GRID`] and reject long before that.
+pub fn grid_size(n_nodes: usize, n_eta: usize) -> usize {
+    n_nodes.saturating_pow(n_eta as u32)
+}
+
+/// Gauss–Hermite nodes and weights for the *physicists'* weight `e^{−x²}` (so the weights
+/// sum to `√π`), via Golub–Welsch: the nodes are the eigenvalues of the symmetric
+/// tridiagonal Jacobi matrix with zero diagonal and off-diagonal `β_k = √(k/2)`, and the
+/// weights are `√π · v_{0,k}²` from the first component of each unit eigenvector.
+///
+/// Computing them beats a hard-coded table: it is exact at every `n` (no transcription
+/// risk), and `n = 1` falls out as the 1×1 zero matrix → node `0`, weight `√π`, which is
+/// precisely what makes AGQ collapse to Laplace.
+pub(crate) fn gauss_hermite(n: usize) -> (Vec<f64>, Vec<f64>) {
+    debug_assert!(n >= 1, "gauss_hermite needs at least one node");
+    let mut j = DMatrix::<f64>::zeros(n, n);
+    for k in 1..n {
+        let beta = (k as f64 / 2.0).sqrt();
+        j[(k - 1, k)] = beta;
+        j[(k, k - 1)] = beta;
+    }
+    let eig = j.symmetric_eigen();
+    let sqrt_pi = PI.sqrt();
+    let mut pairs: Vec<(f64, f64)> = (0..n)
+        .map(|k| {
+            let v0 = eig.eigenvectors[(0, k)];
+            (eig.eigenvalues[k], sqrt_pi * v0 * v0)
+        })
+        .collect();
+    // Ascending node order: the grid is then deterministic and reproducible run to run,
+    // independent of whatever order the eigensolver happened to converge in.
+    pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).expect("GH nodes are finite"));
+    pairs.into_iter().unzip()
+}
+
+/// Numerically stable `log Σ exp(xᵢ)`.
+fn logsumexp(xs: &[f64]) -> f64 {
+    let max = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    if !max.is_finite() {
+        return max;
+    }
+    max + xs.iter().map(|x| (x - max).exp()).sum::<f64>().ln()
+}
+
+/// Central-difference Hessian of the exact conditional NLL w.r.t. η at `eta_hat`.
+///
+/// Step `hᵢ = max(ε^¼ · √Ωᵢᵢ, 1e-4)`: `ε^¼` is the standard second-difference step (it
+/// balances truncation against the `ε/h²` round-off blow-up), scaled by the prior SD
+/// because that is η's natural unit. The `1e-4` floor keeps a near-zero (or FIXed-small)
+/// Ωᵢᵢ from driving `h` so small that `ε/h²` swamps the curvature.
+fn fd_posterior_hessian(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta_hat: &[f64],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> DMatrix<f64> {
+    let d = eta_hat.len();
+    let mut nll_at = |eta: &[f64]| -> f64 {
+        individual_nll_into_with_schedule(
+            model,
+            subject,
+            &params.theta,
+            eta,
+            &params.omega,
+            &params.sigma.values,
+            scratch,
+            schedule,
+        )
+    };
+
+    let steps: Vec<f64> = (0..d)
+        .map(|i| {
+            let sd = params.omega.matrix[(i, i)].max(0.0).sqrt();
+            (f64::EPSILON.powf(0.25) * sd).max(1e-4)
+        })
+        .collect();
+
+    let f0 = nll_at(eta_hat);
+    let mut h = DMatrix::<f64>::zeros(d, d);
+    let mut eta = eta_hat.to_vec();
+
+    for i in 0..d {
+        let hi = steps[i];
+        eta[i] = eta_hat[i] + hi;
+        let f_plus = nll_at(&eta);
+        eta[i] = eta_hat[i] - hi;
+        let f_minus = nll_at(&eta);
+        eta[i] = eta_hat[i];
+        h[(i, i)] = (f_plus - 2.0 * f0 + f_minus) / (hi * hi);
+    }
+
+    for i in 0..d {
+        for j in (i + 1)..d {
+            let (hi, hj) = (steps[i], steps[j]);
+            let mut at = |si: f64, sj: f64| -> f64 {
+                eta[i] = eta_hat[i] + si * hi;
+                eta[j] = eta_hat[j] + sj * hj;
+                let v = nll_at(&eta);
+                eta[i] = eta_hat[i];
+                eta[j] = eta_hat[j];
+                v
+            };
+            let mixed =
+                (at(1.0, 1.0) - at(1.0, -1.0) - at(-1.0, 1.0) + at(-1.0, -1.0)) / (4.0 * hi * hj);
+            h[(i, j)] = mixed;
+            h[(j, i)] = mixed;
+        }
+    }
+    h
+}
+
+/// AGQ marginal NLL for one subject, in the same "without constant" units as
+/// [`crate::stats::likelihood::foce_subject_nll`] — see the module docs for the derivation.
+///
+/// `eta_hat` is the converged EBE mode from the shared inner loop; AGQ does **not**
+/// re-optimise it, it only lays the grid around it. `nodes`/`log_weights` are the 1-D
+/// Gauss–Hermite rule, hoisted by the caller so the eigenproblem is solved once per
+/// population rather than once per subject.
+pub(crate) fn agq_subject_nll(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+) -> f64 {
+    let d = eta_hat.len();
+    let mut scratch = pk::EventPkParams::with_capacity_for(subject);
+    let schedule = cacheable_schedule(model, subject);
+
+    // No random effects: the "integral" is a point mass and AGQ degenerates to the
+    // conditional likelihood itself. (The formula below would agree — an empty tensor
+    // product is the single empty node — but there is no Σ to factor, so short-circuit.)
+    if d == 0 {
+        return individual_nll_into_with_schedule(
+            model,
+            subject,
+            &params.theta,
+            eta_hat,
+            &params.omega,
+            &params.sigma.values,
+            &mut scratch,
+            schedule.as_ref(),
+        );
+    }
+
+    let h = fd_posterior_hessian(
+        model,
+        subject,
+        params,
+        eta_hat,
+        &mut scratch,
+        schedule.as_ref(),
+    );
+    // `build_proposal` applies the relative jitter and — if the FD Hessian came back
+    // indefinite (a loosely-converged mode, a flat direction) — falls back to the Ω-scale
+    // factor. That fallback keeps AGQ *consistent* (any invertible scale integrates to the
+    // same limit); it only costs nodes-worth of efficiency, which is the right failure mode.
+    let Some(proposal) = build_proposal(&h, &params.omega.inv, d) else {
+        return NLL_SENTINEL;
+    };
+
+    let n = nodes.len();
+    let mut terms = Vec::with_capacity(grid_size(n, d));
+    let mut idx = vec![0usize; d];
+    let mut z = vec![0.0f64; d];
+    let mut step = vec![0.0f64; d];
+    let mut eta = vec![0.0f64; d];
+
+    loop {
+        let mut log_w = 0.0;
+        let mut z_sq = 0.0;
+        for k in 0..d {
+            let zk = nodes[idx[k]];
+            z[k] = zk;
+            z_sq += zk * zk;
+            log_w += log_weights[idx[k]];
+        }
+        // η_j = η̂ + √2 · Σ^{1/2} · z_j — the adaptive transform.
+        proposal.apply_l_sigma(&z, &mut step, std::f64::consts::SQRT_2);
+        for k in 0..d {
+            eta[k] = eta_hat[k] + step[k];
+        }
+        let nll = individual_nll_into_with_schedule(
+            model,
+            subject,
+            &params.theta,
+            &eta,
+            &params.omega,
+            &params.sigma.values,
+            &mut scratch,
+            schedule.as_ref(),
+        );
+        // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
+        // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
+        // which case the subject correctly reports the sentinel back.
+        terms.push(log_w + z_sq - nll);
+
+        // Mixed-radix increment over the d-dimensional tensor grid.
+        let mut k = 0;
+        while k < d {
+            idx[k] += 1;
+            if idx[k] < n {
+                break;
+            }
+            idx[k] = 0;
+            k += 1;
+        }
+        if k == d {
+            break;
+        }
+    }
+
+    let nll = 0.5 * d as f64 * PI.ln() + 0.5 * proposal.log_det_inv_scale - logsumexp(&terms);
+    if nll.is_finite() {
+        nll
+    } else {
+        NLL_SENTINEL
+    }
+}
+
+/// Population AGQ objective: `Σ_i agq_subject_nll_i`. The outer loop doubles this into an
+/// OFV, exactly as it does [`crate::estimation::outer_optimizer::pop_nll`].
+///
+/// Parallel over subjects (the grid sweep stays serial *within* a subject, matching
+/// importance sampling), then reduced **serially in subject order** — a rayon `.sum()`
+/// folds along thread-count-dependent split boundaries and f64 addition is not associative,
+/// which would make the OFV depend on the thread count (#703).
+pub(crate) fn agq_population_nll(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[nalgebra::DVector<f64>],
+    n_nodes: usize,
+) -> f64 {
+    let (nodes, weights) = gauss_hermite(n_nodes);
+    let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
+
+    let per_subject: Vec<f64> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| {
+            agq_subject_nll(
+                model,
+                subject,
+                params,
+                eta_hats[i].as_slice(),
+                &nodes,
+                &log_weights,
+            )
+        })
+        .collect();
+    per_subject.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Golub–Welsch must reproduce the textbook physicists' Hermite rule.
+    #[test]
+    fn gauss_hermite_matches_known_rules() {
+        // n = 1: the rule that makes AGQ collapse to Laplace.
+        let (x, w) = gauss_hermite(1);
+        assert!((x[0] - 0.0).abs() < 1e-14);
+        assert!((w[0] - PI.sqrt()).abs() < 1e-14);
+
+        // n = 3: nodes ±√(3/2), 0; weights √π/6, 2√π/3, √π/6.
+        let (x, w) = gauss_hermite(3);
+        let r = (1.5f64).sqrt();
+        for (got, want) in x.iter().zip([-r, 0.0, r]) {
+            assert!((got - want).abs() < 1e-12, "node {got} != {want}");
+        }
+        let sp = PI.sqrt();
+        for (got, want) in w.iter().zip([sp / 6.0, 2.0 * sp / 3.0, sp / 6.0]) {
+            assert!((got - want).abs() < 1e-12, "weight {got} != {want}");
+        }
+    }
+
+    /// Weights sum to `√π = ∫ e^{−x²} dx`, and the rule is exact for polynomials up to
+    /// degree `2n − 1` — the defining property of an n-point Gaussian rule.
+    #[test]
+    fn gauss_hermite_integrates_polynomials_exactly() {
+        for n in 1..=MAX_AGQ_NODES {
+            let (x, w) = gauss_hermite(n);
+            let total: f64 = w.iter().sum();
+            assert!(
+                (total - PI.sqrt()).abs() < 1e-10,
+                "n={n}: weights sum to {total}, want √π"
+            );
+            // ∫ x² e^{−x²} dx = √π/2 — needs degree 2, exact for every n ≥ 2.
+            if n >= 2 {
+                let m2: f64 = x.iter().zip(w.iter()).map(|(xi, wi)| wi * xi * xi).sum();
+                assert!(
+                    (m2 - PI.sqrt() / 2.0).abs() < 1e-10,
+                    "n={n}: ∫x²e^{{−x²}} = {m2}, want √π/2"
+                );
+            }
+        }
+    }
+
+    /// The identity the whole method rests on: with one node the AGQ formula *is* the
+    /// Laplace approximation. Checked here on the raw arithmetic — a 1-D integrand whose
+    /// exact Laplace value is known in closed form — so a regression in the constants
+    /// (the `(d/2)·log π`, the `√2` scaling, the `exp(‖z‖²)` correction) is caught by a
+    /// unit test rather than by a converging fit.
+    #[test]
+    fn one_node_agq_equals_laplace() {
+        // Integrand exp(−nll) with nll(η) = ½·a·(η − m)² + c, i.e. an exact Gaussian.
+        // Laplace is exact here: −log ∫ = c + ½·log(a) − ½·log(2π), and in the
+        // "without constant" convention the per-subject NLL is nll(m) + ½·log|H| = c + ½·log a.
+        let (a, m, c) = (2.5f64, 0.3f64, 1.7f64);
+        let nll = |eta: f64| 0.5 * a * (eta - m).powi(2) + c;
+
+        let (nodes, weights) = gauss_hermite(1);
+        let log_w: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
+
+        // H = a (exact second derivative); Σ^{1/2} = a^{−½}.
+        let h = a;
+        let terms: Vec<f64> = (0..1)
+            .map(|j| {
+                let z = nodes[j];
+                let eta = m + std::f64::consts::SQRT_2 * h.powf(-0.5) * z;
+                log_w[j] + z * z - nll(eta)
+            })
+            .collect();
+        let agq = 0.5 * PI.ln() + 0.5 * h.ln() - logsumexp(&terms);
+        let laplace = nll(m) + 0.5 * h.ln();
+        assert!(
+            (agq - laplace).abs() < 1e-12,
+            "1-node AGQ {agq} != Laplace {laplace}"
+        );
+    }
+
+    /// With enough nodes AGQ must recover the *exact* marginal on an integrand where the
+    /// truth is known — here a Gaussian, where Laplace is already exact, plus a genuinely
+    /// non-Gaussian (skewed) integrand where it is not. The second case is the one that
+    /// proves the extra nodes are doing real work.
+    #[test]
+    fn many_nodes_recover_exact_marginal_on_skewed_integrand() {
+        // nll(η) = ½η² + η⁴/12  ⇒  ∫exp(−nll) has no closed form; get truth by fine
+        // trapezoid on a wide grid (the integrand decays like e^{−η⁴/12}).
+        let nll = |e: f64| 0.5 * e * e + e.powi(4) / 12.0;
+        let (lo, hi, steps) = (-12.0f64, 12.0f64, 2_000_000);
+        let dx = (hi - lo) / steps as f64;
+        let truth: f64 = (0..=steps)
+            .map(|i| {
+                let e = lo + i as f64 * dx;
+                let f = (-nll(e)).exp();
+                if i == 0 || i == steps {
+                    0.5 * f
+                } else {
+                    f
+                }
+            })
+            .sum::<f64>()
+            * dx;
+        // Reference in the module's convention: (d/2)·log(2π) − log G, with d = 1.
+        let want = 0.5 * (2.0 * PI).ln() - truth.ln();
+
+        // Mode is η = 0; H = nll''(0) = 1.
+        let (m, h) = (0.0f64, 1.0f64);
+        let agq_with = |n: usize| -> f64 {
+            let (nodes, weights) = gauss_hermite(n);
+            let terms: Vec<f64> = (0..n)
+                .map(|j| {
+                    let z = nodes[j];
+                    let eta = m + std::f64::consts::SQRT_2 * h.powf(-0.5) * z;
+                    weights[j].ln() + z * z - nll(eta)
+                })
+                .collect();
+            0.5 * PI.ln() + 0.5 * h.ln() - logsumexp(&terms)
+        };
+
+        // Laplace is badly biased on this integrand — it is *exactly* 0 here (the mode
+        // term and the ½log|H| term cancel), against a true marginal NLL of ~0.1368.
+        let laplace = agq_with(1);
+        assert!(
+            (laplace - want).abs() > 1e-3,
+            "Laplace {laplace} unexpectedly matched truth {want}; the test integrand is not \
+             non-Gaussian enough to prove the node sweep does anything"
+        );
+
+        // Adding nodes closes that gap monotonically. The 21-node residual (~3e-6) is
+        // genuine Gauss–Hermite truncation, not a defect: the transformed integrand here is
+        // exp(−z⁴/3), which no finite polynomial rule integrates exactly. A regression in
+        // the transform or the constants would miss by O(0.1), not O(1e-6).
+        let errs: Vec<f64> = [1usize, 3, 7, 21]
+            .iter()
+            .map(|&n| (agq_with(n) - want).abs())
+            .collect();
+        for w in errs.windows(2) {
+            assert!(
+                w[1] < w[0],
+                "AGQ error must shrink with node count, got {errs:?}"
+            );
+        }
+        assert!(
+            *errs.last().unwrap() < 1e-5,
+            "21-node AGQ error {} too large (truth {want})",
+            errs.last().unwrap()
+        );
+    }
+
+    #[test]
+    fn grid_size_saturates_instead_of_overflowing() {
+        assert_eq!(grid_size(3, 4), 81);
+        assert_eq!(grid_size(1, 50), 1);
+        // 21^50 overflows u64/usize many times over; must saturate, not wrap to something
+        // small that would sneak past the MAX_AGQ_GRID check.
+        assert_eq!(grid_size(21, 50), usize::MAX);
+    }
+
+    #[test]
+    fn logsumexp_is_stable_and_handles_sentinels() {
+        let want = (1.0f64.exp() + 2.0f64.exp()).ln();
+        assert!((logsumexp(&[1.0, 2.0]) - want).abs() < 1e-12);
+        // Huge magnitudes must not overflow.
+        assert!((logsumexp(&[1e5, 1e5]) - (1e5 + 2.0f64.ln())).abs() < 1e-9);
+        // A diverged node (the −1e20 term) is simply ignored next to a live one.
+        assert!((logsumexp(&[-1e20, 3.0]) - 3.0).abs() < 1e-12);
+    }
+}

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -1766,14 +1766,20 @@ fn subject_is_estimate_joint(
 // Proposal construction (regularised Hessian, Cholesky factors)
 // ---------------------------------------------------------------------------
 
-struct Proposal {
+/// A regularised, Cholesky-factored posterior scale for one subject.
+///
+/// Shared by importance sampling (which draws `η = η̂ + s·Σ^{1/2}·z` for random `z`) and
+/// by AGQ ([`crate::estimation::agq`], which lays *deterministic* Gauss–Hermite nodes on
+/// the same transform) — the two differ only in where `z` comes from, so they must not
+/// carry separate copies of the jitter / fallback / back-substitution logic.
+pub(crate) struct Proposal {
     /// Lower-triangular L such that L L' = H_reg = Σ⁻¹.
     /// Used both to apply Σ^{1/2} when sampling (L'⁻¹ z) and to evaluate the
     /// Mahalanobis term (‖L'·diff‖²) when scoring q(η).
     chol_h: DMatrix<f64>,
     /// log|H_reg| = 2 · Σ log L_ii — used for the log|Σ| = −log|H_reg| piece
-    /// of the Student-t log-density.
-    log_det_inv_scale: f64,
+    /// of the Student-t log-density, and for AGQ's `½·log|H|` normaliser.
+    pub(crate) log_det_inv_scale: f64,
     d: usize,
 }
 
@@ -1781,7 +1787,7 @@ impl Proposal {
     /// Apply `scale · L_Σ z` into `out`, where `L_Σ` is the Cholesky factor of
     /// Σ = H⁻¹. Implementation: `L_Σ = L^{-T}` for the L from `H = L L^T`, so
     /// `L_Σ z = L^{-T} z` — one back-substitution.
-    fn apply_l_sigma(&self, z: &[f64], out: &mut [f64], scale: f64) {
+    pub(crate) fn apply_l_sigma(&self, z: &[f64], out: &mut [f64], scale: f64) {
         // Back-solve L^T x = z for x (i.e. `out`).
         // L is lower-triangular; L^T is upper-triangular.
         let l = &self.chol_h;
@@ -1829,7 +1835,11 @@ impl Proposal {
 /// proposal that won't give a sharp likelihood estimate but stays well-defined.
 ///
 /// Returns `None` only when `d == 0`.
-fn build_proposal(h: &DMatrix<f64>, omega_inv: &DMatrix<f64>, d: usize) -> Option<Proposal> {
+pub(crate) fn build_proposal(
+    h: &DMatrix<f64>,
+    omega_inv: &DMatrix<f64>,
+    d: usize,
+) -> Option<Proposal> {
     if d == 0 {
         return None;
     }

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -588,6 +588,48 @@ fn inner_stall_enabled(model: &CompiledModel, subject: &Subject) -> bool {
 ///
 /// When `mu_k` is None every shift is zero and the behaviour is identical to
 /// the original (eta-space) implementation.
+/// The per-subject [`pk::event_driven::EventSchedule`] that may be built **once** and
+/// reused across many evaluations at differing `eta`, or `None` when no such reuse is
+/// sound. The schedule pre-computes the merged event timeline and the per-interval
+/// infusion bounds; those are subject-static — and so cacheable — only when nothing
+/// eta-dependent can move a baked-in break time:
+///
+/// - **lagtime** can be eta-dependent and the schedule bakes per-dose times in, so a
+///   cached schedule goes stale as eta varies. The non-cached path
+///   (`event_driven_predictions`) rebuilds it per call from the current per-dose
+///   `PkParams` (which carry lagtime).
+/// - **bioavailability `F`** scales a *rate*-defined infusion's duration (#419), which
+///   likewise moves the baked-in window as eta varies. Duration-defined infusions keep
+///   the cache (`F` scales their rate, not the window).
+///
+/// Only subjects that actually take the event-driven analytical path (TV covariates or
+/// EVID-3/4 resets, closed-form PK) can use a schedule at all; the no-TV fast path never
+/// calls `event_driven_predictions`, so `None` costs it nothing.
+///
+/// Shared by the inner EBE loop ([`find_ebe`]) and the AGQ node sweep
+/// ([`crate::estimation::agq`]), which both hold `eta` variable over one subject — so the
+/// staleness rules above cannot drift between them.
+pub(crate) fn cacheable_schedule(
+    model: &CompiledModel,
+    subject: &Subject,
+) -> Option<pk::event_driven::EventSchedule> {
+    if (subject.has_tv_covariates() || subject.has_resets())
+        && model.ode_spec.is_none()
+        && pk::event_driven::supports_event_driven(model.pk_model)
+        && !model.has_lagtime()
+        && !(model.has_bioavailability() && subject.has_rate_defined_infusion())
+    {
+        Some(pk::event_driven::EventSchedule::for_subject(
+            subject,
+            model.pk_model,
+            &subject.doses,
+            &[],
+        ))
+    } else {
+        None
+    }
+}
+
 pub fn find_ebe(
     model: &CompiledModel,
     subject: &Subject,
@@ -691,35 +733,7 @@ pub fn find_ebe(
     // analytical path — for the no-TV fast path the schedule is None and
     // event_driven_predictions is never called.
     let pk_scratch_cell = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
-    // Skip the schedule cache when the model declares lagtime: lagtime can
-    // be eta-dependent and the schedule bakes per-dose times in, so a
-    // cached schedule would go stale as the inner BFGS varies eta. The
-    // non-cached path (`event_driven_predictions`) rebuilds the schedule
-    // per call using the current per-dose PkParams (which carry lagtime).
-    // Reset-bearing subjects (EVID=3/4) also take the event-driven analytical
-    // path, so they benefit from a cached schedule too — the schedule now
-    // includes reset events.
-    // Also skip the cache when bioavailability `F` could reshape a rate-defined
-    // infusion window: `F` scales such an infusion's *duration* (#419), which
-    // moves the baked-in break times as the inner BFGS varies eta (the same
-    // staleness reason as `has_lagtime`). The non-cached path rebuilds per call
-    // with the current `F`. Duration-defined infusions keep the cache (`F` scales
-    // their rate, not the window).
-    let schedule = if (subject.has_tv_covariates() || subject.has_resets())
-        && model.ode_spec.is_none()
-        && pk::event_driven::supports_event_driven(model.pk_model)
-        && !model.has_lagtime()
-        && !(model.has_bioavailability() && subject.has_rate_defined_infusion())
-    {
-        Some(pk::event_driven::EventSchedule::for_subject(
-            subject,
-            model.pk_model,
-            &subject.doses,
-            &[],
-        ))
-    } else {
-        None
-    };
+    let schedule = cacheable_schedule(model, subject);
     // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
     // computed once per subject here — not inside `agrad`, which BFGS calls on
     // every inner step (and every line-search trial) — instead of re-walking

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -1,3 +1,4 @@
+pub mod agq;
 pub mod bayes;
 pub mod gauss_newton;
 pub(crate) mod hmc;

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2347,11 +2347,39 @@ fn population_gradient(
     // one), so every analytic and fixed-EBE gradient below — all of them closed forms of
     // the FOCE marginal — is simply the gradient of the wrong function. Feeding one to the
     // outer optimizer would not fail loudly; it would converge, smoothly, to the FOCE
-    // optimum while reporting AGQ OFVs. Central-difference the real objective instead:
-    // `reconverged_fd_gradient` re-solves the inner loop at each perturbed point, so it
-    // also captures the response of η̂ to the population parameters, which AGQ's objective
-    // depends on through the grid centre.
-    if options.agq_nodes().is_some() {
+    // optimum while reporting AGQ OFVs. AGQ has its own gradient.
+    if let Some(n_nodes) = options.agq_nodes() {
+        // Preferred: AGQ's own exact gradient — the analytic posterior-weighted score over
+        // the nodes (Fisher identity) plus the grid-response term — which needs no inner
+        // re-solve, against the FD path's `2·n_free` *full population objective*
+        // re-evaluations. Exact at every `n_agq`. See `estimation::agq`.
+        // `reconverge_gradient_interval` is honoured here too: it is the documented escape
+        // hatch onto the numeric path, so it must override the analytic gradient for AGQ
+        // exactly as it does for FOCE/FOCEI below.
+        if !reconverge && crate::estimation::agq::analytic_gradient_available(model) {
+            let params = unpack_params(x, init_params);
+            if let Some(mut g) = crate::estimation::agq::agq_population_gradient(
+                model,
+                population,
+                &params,
+                init_params,
+                x,
+                ehs,
+                n_nodes,
+            ) {
+                // Fixed coordinates carry no gradient, matching the analytic FOCE path.
+                let fixed = packed_fixed_mask(init_params);
+                for (i, gi) in g.iter_mut().enumerate() {
+                    if fixed[i] {
+                        *gi = 0.0;
+                    }
+                }
+                return g;
+            }
+        }
+        // Fallback (always correct, just slower): central-difference the real objective,
+        // re-solving the inner loop at each perturbed point so the response of η̂ to the
+        // population parameters is captured too.
         return reconverged_fd_gradient(x, init_params, model, population, ehs, bounds, options);
     }
     // M3-censored models now have an exact analytic censored gradient on both the

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -166,14 +166,14 @@ fn evaluate_at_initial_params(
         options.min_obs_for_convergence_check as usize,
     );
     let ofv = 2.0
-        * pop_nll(
+        * pop_nll_opts(
             model,
             population,
             &params,
             &eta_hats,
             &h_matrices,
             &kappas,
-            options.interaction,
+            options,
         );
 
     if options.verbose {
@@ -321,6 +321,46 @@ pub(crate) fn cap_slsqp_gradient(g: &mut [f64], lower_s: &[f64], upper_s: &[f64]
     } else {
         false
     }
+}
+
+/// The population objective the outer loop actually minimises: [`pop_nll`] (FOCE/FOCEI),
+/// or the AGQ marginal when the stage's method is `agq`.
+///
+/// **Every** production site that needs "the objective for *this* fit" must call this, not
+/// `pop_nll` — the objective closures, the reconverged-FD gradient, and the covariance
+/// stencil alike. An AGQ fit whose covariance step differenced the *FOCE* objective would
+/// report standard errors for a likelihood it never optimised.
+///
+/// Non-AGQ fits forward to `pop_nll` with identical arguments, so their OFV is unchanged
+/// bit for bit.
+pub(crate) fn pop_nll_opts(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[DVector<f64>],
+    h_matrices: &[DMatrix<f64>],
+    kappas: &[Vec<DVector<f64>>],
+    options: &FitOptions,
+) -> f64 {
+    if let Some(n_nodes) = options.agq_nodes() {
+        // AGQ + IOV is rejected in `check_model_options`, so `kappas` is empty here and the
+        // integral is over η alone. The EBE modes are the same ones FOCE/FOCEI use — AGQ
+        // does not re-optimise them, it lays its grid around them — and `h_matrices` (the
+        // ∂f/∂η Jacobian) is a FOCE artefact AGQ has no use for: it finite-differences the
+        // true posterior Hessian instead. See `crate::estimation::agq`.
+        return crate::estimation::agq::agq_population_nll(
+            model, population, params, eta_hats, n_nodes,
+        );
+    }
+    pop_nll(
+        model,
+        population,
+        params,
+        eta_hats,
+        h_matrices,
+        kappas,
+        options.interaction,
+    )
 }
 
 /// Dispatch to the IOV-aware or standard population NLL based on model.n_kappa.
@@ -563,15 +603,7 @@ fn run_global_presearch(
             Some(&mu_k),
             options.min_obs_for_convergence_check as usize,
         );
-        let nll = pop_nll(
-            model,
-            population,
-            &params,
-            &ehs,
-            &hms,
-            &kappas,
-            options.interaction,
-        );
+        let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         let raw = 2.0 * nll;
         let guarded = ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac);
         if !raw.is_finite() || guarded {
@@ -611,15 +643,7 @@ fn run_global_presearch(
             options.min_obs_for_convergence_check as usize,
         );
 
-        let nll = pop_nll(
-            model,
-            population,
-            &params,
-            &ehs,
-            &hms,
-            &kappas,
-            options.interaction,
-        );
+        let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         let raw_ofv = 2.0 * nll;
 
         let ebe_guard =
@@ -1008,15 +1032,7 @@ fn optimize_nlopt(
         );
 
         // Compute OFV with fixed EBEs
-        let nll = pop_nll(
-            model,
-            population,
-            &params,
-            &ehs,
-            &hms,
-            &kappas,
-            options.interaction,
-        );
+        let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         let raw_ofv = 2.0 * nll;
 
         // EBE convergence guard: reject step when too many subjects unconverged or any
@@ -1352,14 +1368,14 @@ fn optimize_nlopt(
         options.min_obs_for_convergence_check as usize,
     );
 
-    let final_nll = pop_nll(
+    let final_nll = pop_nll_opts(
         model,
         population,
         &final_params,
         &final_ehs,
         &final_hms,
         &final_kappas,
-        options.interaction,
+        options,
     );
     let final_ofv = 2.0 * final_nll;
 
@@ -1474,14 +1490,8 @@ fn optimize_bfgs(
                         kappas: &[Vec<DVector<f64>>]|
      -> f64 {
         let params = unpack_params(x, init_params);
-        2.0 * pop_nll(
-            model,
-            population,
-            &params,
-            eta_hats,
-            h_matrices,
-            kappas,
-            options.interaction,
+        2.0 * pop_nll_opts(
+            model, population, &params, eta_hats, h_matrices, kappas, options,
         )
     };
 
@@ -1498,16 +1508,7 @@ fn optimize_bfgs(
             Some(&mu_k),
             options.min_obs_for_convergence_check as usize,
         );
-        let ofv = 2.0
-            * pop_nll(
-                model,
-                population,
-                &params,
-                &ehs,
-                &hms,
-                &kappas,
-                options.interaction,
-            );
+        let ofv = 2.0 * pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         if ofv.is_finite() {
             ofv
         } else {
@@ -1942,16 +1943,7 @@ fn reconverged_fd_gradient(
             Some(&mu_k),
             options.min_obs_for_convergence_check as usize,
         );
-        let raw = 2.0
-            * pop_nll(
-                model,
-                population,
-                &params,
-                &ehs,
-                &hms,
-                &kappas,
-                options.interaction,
-            );
+        let raw = 2.0 * pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         if !raw.is_finite()
             || ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac)
         {
@@ -2351,6 +2343,17 @@ fn population_gradient(
 ) -> Vec<f64> {
     let reconverge = reconverge_this_eval(options, *grad_eval_idx);
     *grad_eval_idx += 1;
+    // AGQ minimises a *different* objective (the quadrature marginal, not the FOCE/Laplace
+    // one), so every analytic and fixed-EBE gradient below — all of them closed forms of
+    // the FOCE marginal — is simply the gradient of the wrong function. Feeding one to the
+    // outer optimizer would not fail loudly; it would converge, smoothly, to the FOCE
+    // optimum while reporting AGQ OFVs. Central-difference the real objective instead:
+    // `reconverged_fd_gradient` re-solves the inner loop at each perturbed point, so it
+    // also captures the response of η̂ to the population parameters, which AGQ's objective
+    // depends on through the grid centre.
+    if options.agq_nodes().is_some() {
+        return reconverged_fd_gradient(x, init_params, model, population, ehs, bounds, options);
+    }
     // M3-censored models now have an exact analytic censored gradient on both the
     // FOCEI (`subject_packed_gradient` + `prepare`'s M3 branch) and the FOCE
     // (`subject_packed_gradient_foce`, censored rows excluded from R̃ and added as
@@ -3174,15 +3177,7 @@ pub(crate) fn compute_covariance(
     // marginal already carries ηᵀΩ⁻¹η + log|Ω|; for FOCE we add that prior here.
     let ofv = |xv: &[f64]| -> f64 {
         let (params, ehs, hms, kaps) = reconverge_point(xv);
-        let foce_nll = pop_nll(
-            model,
-            population,
-            &params,
-            &ehs,
-            &hms,
-            &kaps,
-            options.interaction,
-        );
+        let foce_nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kaps, options);
         // Covariance OFV = −2·logL = 2·pop_nll for both FOCE and FOCEI.
         //
         // FOCE uses the Sheiner–Beal linearised marginal `(y−f₀)ᵀR̃⁻¹(y−f₀) +
@@ -3293,15 +3288,7 @@ pub(crate) fn compute_covariance(
         let f0 = base_ofv;
         let serial_ofv = |xv: &[f64]| -> f64 {
             let (params, ehs, hms, kaps) = reconverge_point(xv);
-            2.0 * pop_nll(
-                model,
-                population,
-                &params,
-                &ehs,
-                &hms,
-                &kaps,
-                options.interaction,
-            )
+            2.0 * pop_nll_opts(model, population, &params, &ehs, &hms, &kaps, options)
         };
 
         let nf = free_idx.len();

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -1580,7 +1580,10 @@ fn natural_omega_grad_matrix(prep: &Prep, eta_hat: &[f64]) -> DMatrix<f64> {
 /// triangular), with the diagonal log-chain (`x_ii = ln L_ii ⇒ ×L_ii`) and raw
 /// off-diagonals — the same convention/order as [`omega_packed_block`] /
 /// `pack_params`.
-fn chol_pack(m_sub: &DMatrix<f64>, l: &DMatrix<f64>, diagonal: bool) -> Vec<f64> {
+///
+/// Shared with [`crate::estimation::agq`], whose fixed-η natural Ω gradient is the
+/// same `M_sub` shape (just without the Laplace `log|H̃|` and EBE-response terms).
+pub(crate) fn chol_pack(m_sub: &DMatrix<f64>, l: &DMatrix<f64>, diagonal: bool) -> Vec<f64> {
     let n = l.nrows();
     let gl = (m_sub * l).scale(2.0);
     let mut out = Vec::new();

--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -8,7 +8,7 @@
 //! more robust than the asymptotic covariance matrix.
 
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
-use crate::estimation::outer_optimizer::pop_nll;
+use crate::estimation::outer_optimizer::pop_nll_opts;
 use crate::estimation::parameterization::{
     compute_bounds, compute_mu_k, pack_params, packed_fixed_mask, unpack_params,
 };
@@ -185,7 +185,6 @@ pub fn run_sir_core(
     // Step 2: Evaluate importance weights in parallel (warm-started inner loop)
     let inner_maxiter = options.inner_maxiter;
     let inner_tol = options.inner_tol;
-    let interaction = options.interaction;
     let bounds = compute_bounds(params);
 
     let log_weights: Vec<f64> = samples
@@ -236,16 +235,9 @@ pub fn run_sir_core(
                 0, // SIR: no EBE convergence tracking
             );
 
-            // Compute OFV
-            let nll_k = pop_nll(
-                model,
-                population,
-                &params_k,
-                &ehs,
-                &hms,
-                &_kappas,
-                interaction,
-            );
+            // Compute OFV — through the method-aware seam, so an AGQ fit's SIR weights come
+            // from the AGQ marginal it was actually optimised against, not the FOCE one.
+            let nll_k = pop_nll_opts(model, population, &params_k, &ehs, &hms, &_kappas, options);
             let ofv_k = 2.0 * nll_k;
             if !ofv_k.is_finite() {
                 return f64::NEG_INFINITY;

--- a/src/estimation/trust_region.rs
+++ b/src/estimation/trust_region.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 use crate::estimation::gauss_newton::subject_nll_pop_grad;
 use crate::estimation::inner_optimizer::run_inner_loop_warm;
 use crate::estimation::outer_optimizer::{
-    compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
+    compute_covariance, pop_nll_opts, CovarianceStepResult, OuterResult,
 };
 use crate::estimation::parameterization::{
     clamp_to_bounds, compute_bounds, compute_mu_k, pack_params, unpack_params, PackedBounds,
@@ -59,14 +59,14 @@ impl FoceiProblem<'_> {
 
     fn ofv_fixed(&self, x: &[f64], etas: &[DVector<f64>], h_mats: &[DMatrix<f64>]) -> f64 {
         let params = unpack_params(x, self.init_params);
-        let nll = pop_nll(
+        let nll = pop_nll_opts(
             self.model,
             self.population,
             &params,
             etas,
             h_mats,
             &[], // trust_region doesn't support IOV yet; kappas empty
-            self.options.interaction,
+            self.options,
         );
         let raw = 2.0 * nll;
         if raw.is_finite() {
@@ -383,14 +383,14 @@ pub fn optimize_trust_region(
     );
 
     let final_ofv = 2.0
-        * pop_nll(
+        * pop_nll_opts(
             model,
             population,
             &final_params,
             &final_ehs,
             &final_hms,
             &final_kappas,
-            options.interaction,
+            options,
         );
 
     if options.verbose {

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -438,6 +438,7 @@ fn method_to_str(m: EstimationMethod) -> &'static str {
         EstimationMethod::Imp => "imp",
         EstimationMethod::Impmap => "impmap",
         EstimationMethod::Bayes => "bayes",
+        EstimationMethod::Agq => "agq",
     }
 }
 
@@ -451,6 +452,7 @@ fn method_from_str(s: &str) -> Result<EstimationMethod, FitrxError> {
         "saem" => EstimationMethod::Saem,
         "imp" => EstimationMethod::Imp,
         "bayes" => EstimationMethod::Bayes,
+        "agq" => EstimationMethod::Agq,
         _ => return Err(FitrxError::Corrupt(format!("unknown method {:?}", s))),
     })
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -5496,6 +5496,16 @@ fn parse_method_token(token: &str) -> Result<EstimationMethod, String> {
         Ok(EstimationMethod::Imp)
     } else if val.contains("hybrid") || val == "gn_hybrid" || val == "gn-hybrid" {
         Ok(EstimationMethod::FoceGnHybrid)
+    } else if val == "agq"
+        || val == "aghq"
+        || val == "gauss_hermite"
+        || val == "gauss-hermite"
+        || val == "adaptive_gaussian_quadrature"
+        || val == "adaptive-gaussian-quadrature"
+    {
+        // MUST stay above the `contains("gauss")` arm below, which would otherwise
+        // swallow `gauss_hermite` / `adaptive_gaussian_quadrature` into Gauss-*Newton*.
+        Ok(EstimationMethod::Agq)
     } else if val == "gn" || val.contains("gauss") {
         Ok(EstimationMethod::FoceGn)
     } else if val == "focei" || val == "foce-i" || val == "foce_i" || val.contains("interaction") {
@@ -5941,6 +5951,19 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
                 return Err(format!("sir_df must be >= 1.0, got {v}"));
             }
             opts.sir_df = v;
+        }
+        "n_agq" => {
+            let v = parse_usize("n_agq")?;
+            if v < 1 {
+                return Err("n_agq must be >= 1 (1 = the Laplace approximation)".to_string());
+            }
+            if v > crate::estimation::agq::MAX_AGQ_NODES {
+                return Err(format!(
+                    "n_agq must be <= {}, got {v}",
+                    crate::estimation::agq::MAX_AGQ_NODES
+                ));
+            }
+            opts.n_agq = v;
         }
         "imp_samples" => {
             let v = parse_usize("imp_samples")?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -5164,6 +5164,16 @@ pub struct FitOptions {
     // `imp_eval_only = true` (NONMEM `EONLY=1`) to instead evaluate
     // `−2 log L = −2 Σᵢ log ∫ p(yᵢ|η,θ)p(η|θ) dη` at the fixed input parameters
     // without updating them.
+    /// Gauss–Hermite nodes **per random effect** for `method = agq` (#251). Default 3.
+    ///
+    /// `n_agq = 1` is the Laplace approximation exactly (see
+    /// [`crate::estimation::agq`]); larger values refine the marginal and are what make
+    /// AGQ unbiased on strongly non-Gaussian integrands. The tensor grid costs
+    /// `n_agq^n_eta` likelihood evaluations per subject per outer iteration, so raise it
+    /// deliberately — odd values are conventional (they keep a node exactly at the mode).
+    /// Capped by [`crate::estimation::agq::MAX_AGQ_NODES`], with the *grid* additionally
+    /// capped by [`crate::estimation::agq::MAX_AGQ_GRID`].
+    pub n_agq: usize,
     /// Number of importance samples per subject. Default 1000. Recommended
     /// 2000–5000 for publication-quality MC SE (cost scales linearly).
     pub imp_samples: usize,
@@ -5565,6 +5575,7 @@ impl Default for FitOptions {
             sir_seed: None,
             sir_keep_samples: false,
             sir_df: 5.0,
+            n_agq: 3,
             imp_samples: 1000,
             imp_proposal_df: 5.0,
             imp_seed: None,
@@ -5838,6 +5849,17 @@ pub enum EstimationMethod {
     /// σ²: inverse-gamma, mu-referenced θ: normal). Reports posterior summaries +
     /// convergence diagnostics on `FitResult.bayes`, not a point estimate.
     Bayes,
+    /// Adaptive Gauss–Hermite quadrature (#251) — the Laplace approximation generalised.
+    /// Reuses the FOCE/Laplace inner loop to find each subject's EBE mode, then evaluates
+    /// the **exact** conditional likelihood on a Gauss–Hermite grid laid around that mode
+    /// (`n_agq` nodes per random effect). At `n_agq = 1` it is Laplace identically; above
+    /// that the marginal improves and — because it integrates the model's real likelihood
+    /// rather than a Gaussian-residual surrogate — it is the only method here that handles
+    /// non-Gaussian endpoints (TTE, categorical) without approximation. Deterministic, so
+    /// unlike [`Saem`](Self::Saem) / [`Imp`](Self::Imp) its OFV carries no Monte-Carlo noise.
+    /// Cost is `n_agq^n_eta` likelihood evaluations per subject per iteration; see
+    /// [`crate::estimation::agq::MAX_AGQ_GRID`].
+    Agq,
 }
 
 impl EstimationMethod {
@@ -5851,6 +5873,7 @@ impl EstimationMethod {
             EstimationMethod::Imp => "IMP",
             EstimationMethod::Impmap => "IMPMAP",
             EstimationMethod::Bayes => "BAYES",
+            EstimationMethod::Agq => "AGQ",
         }
     }
 }
@@ -5864,6 +5887,21 @@ impl FitOptions {
         } else {
             self.methods.clone()
         }
+    }
+
+    /// The AGQ node count when this (stage's) method is AGQ, else `None`.
+    ///
+    /// The **single predicate** every AGQ-aware branch consults — the population objective
+    /// ([`crate::estimation::outer_optimizer::pop_nll_opts`]), the outer-gradient dispatch,
+    /// and the optimizer/report classification. Keeping it in one place is what stops the
+    /// objective and the gradient from disagreeing about which method is running: an
+    /// outer loop minimising the AGQ objective while fed the analytic *FOCE* gradient
+    /// would converge, silently, to the wrong parameters.
+    ///
+    /// Reads `self.method` (the per-stage method — `api::fit_inner` rewrites it for each
+    /// stage of a chain), so it is correct inside a chained fit too.
+    pub fn agq_nodes(&self) -> Option<usize> {
+        (self.method == EstimationMethod::Agq).then(|| self.n_agq.max(1))
     }
 
     /// Covariance-step inner EBE-reconvergence tolerance that **closed-form,
@@ -6082,6 +6120,24 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "global_maxeval",
             "stagnation_guard",
             "reconverge_gradient_interval",
+        ],
+        // AGQ drives the same outer loop and the same inner EBE solve as FOCE/FOCEI —
+        // it only swaps the population objective — so it accepts that method's keys,
+        // plus the node count. It has no analytic outer gradient, so
+        // `reconverge_gradient_interval` (an analytic-path escape hatch) does not apply.
+        EstimationMethod::Agq => &[
+            "n_agq",
+            "maxiter",
+            "inner_maxiter",
+            "inner_tol",
+            "inner_optimizer",
+            "optimizer",
+            "outer_xtol",
+            "outer_ftol",
+            "steihaug_max_iters",
+            "global_search",
+            "global_maxeval",
+            "stagnation_guard",
         ],
         EstimationMethod::FoceGn => &[
             "maxiter",

--- a/src/types.rs
+++ b/src/types.rs
@@ -6123,8 +6123,10 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
         ],
         // AGQ drives the same outer loop and the same inner EBE solve as FOCE/FOCEI —
         // it only swaps the population objective — so it accepts that method's keys,
-        // plus the node count. It has no analytic outer gradient, so
-        // `reconverge_gradient_interval` (an analytic-path escape hatch) does not apply.
+        // plus the node count. AGQ *does* have an exact analytic outer gradient, and
+        // `reconverge_gradient_interval` is its escape hatch onto the numeric path
+        // (honoured in `population_gradient`), so the key applies here exactly as it
+        // does for FOCE/FOCEI.
         EstimationMethod::Agq => &[
             "n_agq",
             "maxiter",
@@ -6138,6 +6140,7 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
             "global_search",
             "global_maxeval",
             "stagnation_guard",
+            "reconverge_gradient_interval",
         ],
         EstimationMethod::FoceGn => &[
             "maxiter",

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -151,9 +151,14 @@ fn n_agq_is_validated() {
 ///
 /// AGQ(1) is therefore Laplace **with the exact Hessian** — NONMEM's `LAPLACIAN`. It is not
 /// expected to equal ferx's FOCEI bit-for-bit, because FOCEI is Laplace with the
-/// *Gauss-Newton* Hessian `C'C + Ω⁻¹`, which drops `∂²f/∂η²`. That is a real, documented
-/// difference between the two estimators, not implementation drift — so what this test pins
-/// is that AGQ(1) lands in the Laplace family at all:
+/// *Gauss-Newton* Hessian `C'C + Ω⁻¹`, which drops `∂²f/∂η²`.
+///
+/// That difference is real and externally confirmed, not implementation drift: on this very
+/// model NONMEM `$EST METHOD=1 LAPLACIAN INTER` returns 7.8994 (matching AGQ(1) to five
+/// significant figures) while NONMEM `METHOD=1 INTER` returns 7.4967 (matching ferx FOCEI)
+/// — the reference implementation shows the same 0.40-unit gap. See `docs/estimation/agq.qmd`.
+///
+/// So what this test pins is that AGQ(1) lands in the Laplace family at all:
 ///
 /// * it sits within ~1 OFV unit of FOCEI (same family, differing only in `½log|H|`), and
 /// * it is nowhere near FOCE, which uses the Sheiner–Beal *linearised* marginal — a

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -281,6 +281,174 @@ fn ofv_is_bit_identical_across_runs() {
     );
 }
 
+/// **The analytic outer gradient must be the exact gradient of the objective — at every
+/// node count, `n_agq = 1` included.**
+///
+/// AGQ's gradient has two parts (see `estimation::agq`):
+///
+/// 1. the posterior-weighted average of fixed-η scores over the nodes (the Fisher identity),
+///    which is exact only in the exact-quadrature limit; and
+/// 2. the **grid-response** term `∂Φ/∂H · dH/dx`, which supplies exactly what part 1 omits.
+///
+/// Part 1 alone degrades as the quadrature coarsens — measured on this model it is ~26%
+/// wrong at `n_agq = 1`, where the rule *is* Laplace and the `½·log|H|` derivative no longer
+/// cancels against the node movement. Part 2 is what makes the total exact anyway, and
+/// `n_agq = 1` is therefore the **strongest** test of it, not the weakest: it is the case
+/// where the correction is carrying the entire missing term.
+///
+/// The FD reference re-solves the inner loop and rebuilds the grid at each perturbed point,
+/// so it is the *total* derivative — node movement and EBE response included — not a
+/// fixed-node echo of the analytic formula.
+#[test]
+fn analytic_gradient_matches_fd_at_every_node_count() {
+    use ferx_core::estimation::agq;
+    use ferx_core::estimation::parameterization::{pack_params, unpack_params};
+
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    let pop = warfarin();
+    assert!(
+        agq::analytic_gradient_available(&model),
+        "warfarin must be in the analytic-gradient scope, else this test proves nothing"
+    );
+
+    let template = &model.default_params;
+    let x0 = pack_params(template);
+    let np = x0.len();
+
+    // Objective at a packed point: re-solve EBEs (so the grid re-centres) then evaluate the
+    // AGQ OFV. This is the function the outer optimizer actually minimises.
+    let ofv = |x: &[f64], n: usize| -> f64 {
+        let params = unpack_params(x, template);
+        let (ehs, _hms, _stats, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
+            &model, &pop, &params, 300, 1e-10, None, None, 0,
+        );
+        2.0 * agq::agq_population_nll(&model, &pop, &params, &ehs, n)
+    };
+
+    let mut rel_errs = Vec::new();
+    for &n in &[1usize, 3, 5, 7] {
+        // Analytic gradient at x0.
+        let params = unpack_params(&x0, template);
+        let (ehs, _h, _s, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
+            &model, &pop, &params, 300, 1e-10, None, None, 0,
+        );
+        let g = agq::agq_population_gradient(&model, &pop, &params, template, &x0, &ehs, n)
+            .expect("analytic gradient must be available in scope");
+
+        // Central FD of the true objective.
+        let mut fd = vec![0.0f64; np];
+        for i in 0..np {
+            let h = 1e-5 * (1.0 + x0[i].abs());
+            let (mut xp, mut xm) = (x0.clone(), x0.clone());
+            xp[i] += h;
+            xm[i] -= h;
+            fd[i] = (ofv(&xp, n) - ofv(&xm, n)) / (2.0 * h);
+        }
+
+        let scale = fd
+            .iter()
+            .chain(g.iter())
+            .fold(1e-6f64, |m, v| m.max(v.abs()));
+        let max_diff = g
+            .iter()
+            .zip(fd.iter())
+            .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
+        rel_errs.push(max_diff / scale);
+    }
+
+    // The gradient must be exact at EVERY node count — n = 1 included. There is no node
+    // gate: `grid_response_correction` supplies the `∂Φ/∂H·dH/dx` term that the fixed-node
+    // score omits, and at n = 1 that term is the entire difference (a 26% error without it).
+    //
+    // Measured: 1.6e-3 at n = 1, 7.8e-5 at n = 3, ~1e-5 beyond. The 5e-3 bound leaves headroom
+    // for the FD reference's own noise (it central-differences a *reconverged* objective, so
+    // the inner solver's tolerance leaks in) while still failing loudly on a real regression —
+    // a wrong gradient misses by tens of percent here, not tenths of a percent. It also pins
+    // `AGQ_GRID_FD_STEP`: at 1e-2 this test fails outright (the grid-response term is
+    // truncation-dominated, and a "safe" large step puts the θ gradient 5× off).
+    for (k, &n) in [1usize, 3, 5, 7].iter().enumerate() {
+        assert!(
+            rel_errs[k] < 5e-3,
+            "n_agq={n}: analytic gradient must match FD of the objective, got {:.3e} \
+             relative error (all: {rel_errs:?})",
+            rel_errs[k]
+        );
+    }
+    // …and it sharpens as the quadrature does — the signature of the grid-response term doing
+    // its job rather than agreeing by coincidence.
+    assert!(
+        rel_errs[3] < rel_errs[0],
+        "accuracy should improve with node count: {rel_errs:?}"
+    );
+}
+
+/// **AGQ has its own gradient for every model — nothing falls back to the inner-re-solving
+/// FD path.**
+///
+/// The θ/σ score is analytic where the `Dual2` provider reaches, and finite-differenced *at
+/// fixed η* everywhere else (TTE, categorical, M3, LTBS, `block_sigma`, FREM, ODE). Both
+/// avoid the inner re-solve, which is the expensive part — so the endpoints AGQ actually
+/// exists for are not the slow case.
+///
+/// This pins that the two paths compute the *same* gradient. `gradient_method = fd` takes
+/// warfarin off the analytic score (it is the documented FD escape hatch and
+/// `analytic_outer_gradient_available` honours it), so the same model can be driven down both
+/// routes and the results compared directly.
+#[test]
+fn fd_score_path_agrees_with_the_analytic_one() {
+    use ferx_core::estimation::agq;
+    use ferx_core::estimation::parameterization::{pack_params, unpack_params};
+    use ferx_core::types::GradientMethod;
+
+    let pop = warfarin();
+    let analytic_model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    let mut fd_model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    fd_model.gradient_method = GradientMethod::Fd;
+
+    assert!(
+        agq::analytic_gradient_available(&analytic_model)
+            && agq::analytic_gradient_available(&fd_model),
+        "AGQ must supply its own gradient for BOTH models — there is no scope gate"
+    );
+
+    let template = &analytic_model.default_params;
+    let x = pack_params(template);
+    let params = unpack_params(&x, template);
+    let (ehs, _h, _s, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
+        &analytic_model,
+        &pop,
+        &params,
+        300,
+        1e-10,
+        None,
+        None,
+        0,
+    );
+
+    for n in [1usize, 3] {
+        let g_an =
+            agq::agq_population_gradient(&analytic_model, &pop, &params, template, &x, &ehs, n)
+                .expect("analytic-score gradient");
+        let g_fd = agq::agq_population_gradient(&fd_model, &pop, &params, template, &x, &ehs, n)
+            .expect("FD-score gradient");
+
+        let scale = g_an
+            .iter()
+            .chain(g_fd.iter())
+            .fold(1e-6f64, |m, v| m.max(v.abs()));
+        let max_diff = g_an
+            .iter()
+            .zip(g_fd.iter())
+            .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
+        assert!(
+            max_diff / scale < 1e-3,
+            "n_agq={n}: the FD score must reproduce the analytic one — they are the same \
+             quantity. rel diff {:.3e}\n  analytic: {g_an:?}\n  fd:       {g_fd:?}",
+            max_diff / scale
+        );
+    }
+}
+
 /// The quadrature integrates over the BSV η only. Under IOV the marginal is a joint
 /// integral over η *and* every occasion's κ; silently integrating the η-only marginal
 /// would report a confidently wrong OFV, so the fit must be rejected instead.

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -1,0 +1,351 @@
+//! Integration tests for adaptive Gauss–Hermite quadrature (`method = agq`, #251).
+//!
+//! Tier-2: every test calls the public `fit()` boundary but returns immediately — either
+//! eval-only (`outer_maxiter = 0`, so the OFV is evaluated at the initial parameters with
+//! no outer minimisation) or with an expected `Err` from a compatibility guard. No
+//! convergence loops, so these are compile-checked and run on every PR.
+//!
+//! The headline checks:
+//!
+//! * `n_agq = 1` reproduces the Laplace OFV — the identity the method rests on.
+//! * More nodes move the OFV monotonically and *converge*, i.e. the extra work buys a
+//!   settled answer rather than drifting.
+//! * The objective is deterministic run to run (no Monte-Carlo noise), which is AGQ's
+//!   headline advantage over SAEM/IMP.
+//!
+//! The full convergence fit and the NONMEM comparison live in
+//! `docs/estimation/agq.qmd`.
+
+use ferx_core::parser::model_parser::{parse_full_model, parse_model_string};
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions, FitResult, Population};
+use std::path::Path;
+
+/// Warfarin oral 1-cpt, 3 random effects, proportional error. With `n_agq = 3` this is a
+/// 3³ = 27-node grid per subject — small enough to stay a Tier-2 test.
+const WARFARIN_SRC: &str = r"
+[parameters]
+  theta TVCL(0.13, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.0, 0.01, 50.0)
+
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.1 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+";
+
+fn warfarin() -> Population {
+    read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).expect("warfarin data must load")
+}
+
+/// OFV at the initial parameters (no outer minimisation) under `method`.
+fn eval_only_ofv(population: &Population, method: EstimationMethod, n_agq: usize) -> f64 {
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    let opts = FitOptions {
+        method,
+        methods: vec![],
+        interaction: method == EstimationMethod::FoceI,
+        n_agq,
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        ..FitOptions::default()
+    };
+    let result =
+        fit(&model, population, &model.default_params, &opts).expect("eval-only fit must succeed");
+    assert!(result.ofv.is_finite(), "OFV must be finite");
+    result.ofv
+}
+
+/// Parse `src` (model + its `[fit_options]`) and fit it eval-only, honouring the file's
+/// own fit options — the path a real `.ferx` user takes.
+fn fit_from_src(src: &str) -> Result<FitResult, String> {
+    let parsed = parse_full_model(src)?;
+    let opts = FitOptions {
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        ..parsed.fit_options
+    };
+    fit(
+        &parsed.model,
+        &warfarin(),
+        &parsed.model.default_params,
+        &opts,
+    )
+}
+
+/// The `[fit_options]` a model source parses to.
+fn options_of(src: &str) -> FitOptions {
+    parse_full_model(src).expect("model must parse").fit_options
+}
+
+/// `WARFARIN_SRC` with its `method = focei` line replaced by `body`.
+fn with_fit_options(body: &str) -> String {
+    WARFARIN_SRC.replace("  method = focei", body)
+}
+
+#[test]
+fn agq_method_parses_with_aliases() {
+    for token in [
+        "agq",
+        "aghq",
+        "gauss_hermite",
+        "adaptive_gaussian_quadrature",
+    ] {
+        let opts = options_of(&with_fit_options(&format!("  method = {token}")));
+        assert_eq!(
+            opts.method,
+            EstimationMethod::Agq,
+            "`{token}` must select AGQ — note `gauss_hermite` is a near-miss for the \
+             Gauss-*Newton* alias, which matches on `contains(\"gauss\")`, so the AGQ arm \
+             has to sit above it in the parser"
+        );
+    }
+    // …and the Gauss-Newton aliases must still resolve to Gauss-Newton, i.e. the AGQ arm
+    // sitting above them did not over-capture.
+    for token in ["gn", "gauss_newton"] {
+        assert_eq!(
+            options_of(&with_fit_options(&format!("  method = {token}"))).method,
+            EstimationMethod::FoceGn,
+            "`{token}` must still select Gauss-Newton"
+        );
+    }
+}
+
+#[test]
+fn n_agq_is_validated() {
+    // Rejected at parse time (the `[fit_options]` grammar), so `parse_full_model` errors.
+    // `ParsedModel` isn't `Debug`, so unwrap the Result by hand rather than `expect_err`.
+    for bad in [
+        "  method = agq\n  n_agq = 0",
+        "  method = agq\n  n_agq = 99",
+    ] {
+        match parse_full_model(&with_fit_options(bad)) {
+            Ok(_) => panic!("out-of-range n_agq must be rejected: {bad:?}"),
+            Err(err) => assert!(err.contains("n_agq"), "unhelpful error: {err}"),
+        }
+    }
+    // The default (3) applies when the key is omitted.
+    assert_eq!(options_of(&with_fit_options("  method = agq")).n_agq, 3);
+}
+
+/// **The identity.** One Gauss–Hermite node sits at the mode with weight `√π`, so the
+/// quadrature sum collapses to `(2π)^(d/2)·|H|^(−½)·exp(l(η̂))` — the Laplace approximation.
+/// (The arithmetic of that collapse is pinned exactly in `agq::tests::one_node_agq_equals_laplace`;
+/// this test pins the *wiring* — that the engine feeds AGQ the right EBEs, parameters and
+/// likelihood constant.)
+///
+/// AGQ(1) is therefore Laplace **with the exact Hessian** — NONMEM's `LAPLACIAN`. It is not
+/// expected to equal ferx's FOCEI bit-for-bit, because FOCEI is Laplace with the
+/// *Gauss-Newton* Hessian `C'C + Ω⁻¹`, which drops `∂²f/∂η²`. That is a real, documented
+/// difference between the two estimators, not implementation drift — so what this test pins
+/// is that AGQ(1) lands in the Laplace family at all:
+///
+/// * it sits within ~1 OFV unit of FOCEI (same family, differing only in `½log|H|`), and
+/// * it is nowhere near FOCE, which uses the Sheiner–Beal *linearised* marginal — a
+///   genuinely different objective (16.47 vs ~7.5 on this data).
+///
+/// A wrong likelihood constant (a dropped `log|Ω|`, a stray `log(2π)`) would show up here as
+/// tens of OFV units, not tenths.
+#[test]
+fn one_node_agq_is_the_laplace_approximation() {
+    let pop = warfarin();
+    let foce = eval_only_ofv(&pop, EstimationMethod::Foce, 1);
+    let focei = eval_only_ofv(&pop, EstimationMethod::FoceI, 1);
+    let agq1 = eval_only_ofv(&pop, EstimationMethod::Agq, 1);
+
+    let to_focei = (agq1 - focei).abs();
+    let to_foce = (agq1 - foce).abs();
+    assert!(
+        to_focei < 1.0,
+        "1-node AGQ must be Laplace, i.e. within a Hessian-approximation's distance of \
+         FOCEI: agq1={agq1}, focei={focei} (gap {to_focei:.4} OFV units)"
+    );
+    assert!(
+        to_focei < 0.25 * to_foce,
+        "1-node AGQ must be much closer to the Laplace marginal (FOCEI, gap {to_focei:.4}) \
+         than to the Sheiner-Beal linearised one (FOCE, gap {to_foce:.4})"
+    );
+}
+
+/// **The payoff.** Adding nodes must drive the OFV to the *true* marginal, and the truth
+/// here is supplied independently: ferx's importance sampler evaluated at the same
+/// parameters (`imp_eval_only`) is an unbiased Monte-Carlo estimate of the very same
+/// integral, computed by a completely different route (Student-t proposal + self-normalised
+/// weights — no quadrature, no Hessian, no Laplace).
+///
+/// Two estimators of one integral, sharing no code path, must agree. They do, to ~0.02 OFV
+/// units. This is what certifies AGQ's marginal *and* its constant convention: any error in
+/// either would move the two apart by orders of magnitude more than the MC noise.
+#[test]
+fn agq_converges_to_the_importance_sampling_marginal() {
+    let pop = warfarin();
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+
+    // Independent truth: IS marginal −2logL at the same (initial) parameters.
+    let is_opts = FitOptions {
+        method: EstimationMethod::Imp,
+        methods: vec![],
+        interaction: true,
+        imp_eval_only: true,
+        imp_samples: 20_000,
+        imp_seed: Some(7),
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        ..FitOptions::default()
+    };
+    let truth = fit(&model, &pop, &model.default_params, &is_opts)
+        .expect("IS evaluation must succeed")
+        .importance_sampling
+        .expect("IMP eval-only must report a marginal")
+        .minus2_log_likelihood;
+
+    let ofvs: Vec<f64> = [1usize, 3, 5, 7, 9, 11]
+        .iter()
+        .map(|&n| eval_only_ofv(&pop, EstimationMethod::Agq, n))
+        .collect();
+    let errs: Vec<f64> = ofvs.iter().map(|o| (o - truth).abs()).collect();
+
+    // The refined grid agrees with the Monte-Carlo marginal. The residual is dominated by
+    // IS's own MC error at 20k samples, not by quadrature error.
+    let refined = *errs.last().expect("non-empty");
+    assert!(
+        refined < 0.1,
+        "AGQ must converge to the IS marginal: truth={truth:.6}, AGQ OFVs={ofvs:?} \
+         (final gap {refined:.4})"
+    );
+    // …and the nodes are what got us there: Laplace alone is markedly further off.
+    assert!(
+        refined < 0.25 * errs[0],
+        "adding nodes must close the gap to the true marginal: Laplace was off by {:.4}, \
+         the refined grid by {refined:.4}",
+        errs[0]
+    );
+}
+
+/// Refining the grid must *converge*, not wander: successive refinements move the OFV by
+/// less and less. This is what makes a node count meaningful — if the OFV kept drifting with
+/// `n_agq` there would be no answer to report.
+#[test]
+fn ofv_settles_as_nodes_are_added() {
+    let pop = warfarin();
+    let ofvs: Vec<f64> = [1usize, 3, 5, 7]
+        .iter()
+        .map(|&n| eval_only_ofv(&pop, EstimationMethod::Agq, n))
+        .collect();
+
+    let steps: Vec<f64> = ofvs.windows(2).map(|w| (w[1] - w[0]).abs()).collect();
+    assert!(
+        steps.last().unwrap() < steps.first().unwrap(),
+        "AGQ must settle as nodes are added; OFVs {ofvs:?} moved by {steps:?}"
+    );
+    // The 5→7 refinement is small in absolute terms — the grid is converged.
+    assert!(
+        *steps.last().unwrap() < 0.1,
+        "5→7-node refinement moved the OFV by {:.4} — grid is not converged. OFVs: {ofvs:?}",
+        steps.last().unwrap()
+    );
+}
+
+/// AGQ is deterministic: a fixed grid, no sampling. Re-evaluating at the same parameters
+/// must return a **bit-identical** OFV. (SAEM/IMP cannot promise this, and it is why AGQ's
+/// outer optimizer needs no common-random-numbers or step-size tricks.)
+#[test]
+fn ofv_is_bit_identical_across_runs() {
+    let pop = warfarin();
+    let a = eval_only_ofv(&pop, EstimationMethod::Agq, 3);
+    let b = eval_only_ofv(&pop, EstimationMethod::Agq, 3);
+    assert_eq!(
+        a.to_bits(),
+        b.to_bits(),
+        "AGQ OFV must be bit-identical run to run: {a} vs {b}"
+    );
+}
+
+/// The quadrature integrates over the BSV η only. Under IOV the marginal is a joint
+/// integral over η *and* every occasion's κ; silently integrating the η-only marginal
+/// would report a confidently wrong OFV, so the fit must be rejected instead.
+#[test]
+fn agq_rejects_iov() {
+    let src = WARFARIN_SRC
+        .replace("  method = focei", "  method = agq")
+        .replace(
+            "  sigma PROP_ERR ~ 0.1 (sd)",
+            "  sigma PROP_ERR ~ 0.1 (sd)\n  kappa KAPPA_CL ~ 0.05",
+        )
+        .replace(
+            "  CL = TVCL * exp(ETA_CL)",
+            "  CL = TVCL * exp(ETA_CL + KAPPA_CL)",
+        );
+    // If the IOV DSL spelling drifts, fail loudly rather than let a parse error make this
+    // test vacuously "pass" without ever reaching the guard.
+    let err = fit_from_src(&src).expect_err("AGQ + IOV must be rejected");
+    assert!(
+        !err.contains("parse") && !err.contains("unknown"),
+        "IOV warfarin model must parse (test needs updating): {err}"
+    );
+    assert!(
+        err.contains("iov") || err.contains("IOV") || err.contains("occasion"),
+        "the AGQ+IOV rejection must say why: {err}"
+    );
+}
+
+/// The tensor grid is `n_agq^n_eta`. With 3 random effects, `n_agq = 21` is 9261 nodes
+/// (fine); the cap exists to stop a grid that would never finish. Check the guard fires
+/// with an actionable message rather than launching the fit.
+#[test]
+fn agq_rejects_an_intractable_grid() {
+    // 8 random effects at 21 nodes = 21^8 ≈ 3.8e10 nodes — far past MAX_AGQ_GRID.
+    let mut params = String::new();
+    let mut ind = String::new();
+    for i in 0..8 {
+        params.push_str(&format!("  omega ETA_{i} ~ 0.05\n"));
+    }
+    // Fold every eta into CL so they are all real random effects on the model.
+    let sum: Vec<String> = (0..8).map(|i| format!("ETA_{i}")).collect();
+    ind.push_str(&format!("  CL = TVCL * exp({})\n", sum.join(" + ")));
+
+    let src = format!(
+        r"
+[parameters]
+  theta TVCL(0.13, 0.001, 10.0)
+  theta TVV(8.0, 0.1, 500.0)
+  theta TVKA(1.0, 0.01, 50.0)
+{params}
+  sigma PROP_ERR ~ 0.1 (sd)
+
+[individual_parameters]
+{ind}  V  = TVV
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = agq
+  n_agq = 21
+"
+    );
+    let err = fit_from_src(&src).expect_err("an intractable AGQ grid must be rejected");
+    assert!(
+        err.contains("n_agq") && err.contains("grid"),
+        "the grid-cap rejection must name the lever to turn: {err}"
+    );
+}

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -17,8 +17,12 @@
 //! `docs/estimation/agq.qmd`.
 
 use ferx_core::parser::model_parser::{parse_full_model, parse_model_string};
-use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions, FitResult, Population};
+use ferx_core::{
+    fit, read_nonmem_csv, CompiledModel, EstimationMethod, FitOptions, FitResult, Population,
+};
 use std::path::Path;
+
+mod common;
 
 /// Warfarin oral 1-cpt, 3 random effects, proportional error. With `n_agq = 3` this is a
 /// 3³ = 27-node grid per subject — small enough to stay a Tier-2 test.
@@ -53,9 +57,13 @@ fn warfarin() -> Population {
     read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).expect("warfarin data must load")
 }
 
-/// OFV at the initial parameters (no outer minimisation) under `method`.
-fn eval_only_ofv(population: &Population, method: EstimationMethod, n_agq: usize) -> f64 {
-    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+/// OFV at the initial parameters (no outer minimisation) of an already-parsed `model`.
+fn eval_only_ofv_model(
+    model: &CompiledModel,
+    population: &Population,
+    method: EstimationMethod,
+    n_agq: usize,
+) -> f64 {
     let opts = FitOptions {
         method,
         methods: vec![],
@@ -66,9 +74,15 @@ fn eval_only_ofv(population: &Population, method: EstimationMethod, n_agq: usize
         ..FitOptions::default()
     };
     let result =
-        fit(&model, population, &model.default_params, &opts).expect("eval-only fit must succeed");
+        fit(model, population, &model.default_params, &opts).expect("eval-only fit must succeed");
     assert!(result.ofv.is_finite(), "OFV must be finite");
     result.ofv
+}
+
+/// OFV at the initial parameters (no outer minimisation) of `WARFARIN_SRC` under `method`.
+fn eval_only_ofv(population: &Population, method: EstimationMethod, n_agq: usize) -> f64 {
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    eval_only_ofv_model(&model, population, method, n_agq)
 }
 
 /// Parse `src` (model + its `[fit_options]`) and fit it eval-only, honouring the file's
@@ -521,4 +535,284 @@ fn agq_rejects_an_intractable_grid() {
         err.contains("n_agq") && err.contains("grid"),
         "the grid-cap rejection must name the lever to turn: {err}"
     );
+}
+
+/// `n_agq` past the per-dimension node cap is rejected at model-check time even when the
+/// resulting *grid* fits under `MAX_AGQ_GRID` — the case a direct-Rust-API caller can reach,
+/// since the parser guard that protects file/FFI fits is bypassed (review #821, point 2).
+/// With a single random effect, `n_agq = 100` is a 100-node grid (well under the grid cap)
+/// yet drives `gauss_hermite(100)` past where Golub–Welsch stays accurate.
+#[test]
+fn agq_rejects_out_of_range_node_count_built_via_the_rust_api() {
+    use ferx_core::api::check_model_options;
+
+    // One random effect: grid = n_agq^1 = n_agq, so the grid cap cannot catch this — only the
+    // per-dimension node cap can.
+    let src = WARFARIN_SRC
+        .replace("  omega ETA_V  ~ 0.04\n", "")
+        .replace("  omega ETA_KA ~ 0.30\n", "")
+        .replace("  V  = TVV  * exp(ETA_V)", "  V  = TVV")
+        .replace("  KA = TVKA * exp(ETA_KA)", "  KA = TVKA");
+    let model = parse_model_string(&src).expect("single-eta warfarin must parse");
+    assert_eq!(
+        model.n_eta, 1,
+        "fixture must have exactly one random effect"
+    );
+
+    let n = ferx_core::estimation::agq::MAX_AGQ_NODES + 79; // 100, safely under MAX_AGQ_GRID at n_eta = 1
+    assert!(
+        ferx_core::estimation::agq::grid_size(n, model.n_eta)
+            < ferx_core::estimation::agq::MAX_AGQ_GRID,
+        "the grid must stay under MAX_AGQ_GRID so only the node cap can reject this"
+    );
+    let opts = FitOptions {
+        method: EstimationMethod::Agq,
+        n_agq: n,
+        ..FitOptions::default()
+    };
+    let diags = check_model_options(&model, &opts);
+    assert!(
+        diags.iter().any(|d| d.code == "E_AGQ_NODES_TOO_LARGE"),
+        "an out-of-range n_agq must be rejected by check_model_options even under the grid cap; \
+         got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    // The in-range boundary (exactly MAX_AGQ_NODES) must NOT be rejected.
+    let ok_opts = FitOptions {
+        method: EstimationMethod::Agq,
+        n_agq: ferx_core::estimation::agq::MAX_AGQ_NODES,
+        ..FitOptions::default()
+    };
+    assert!(
+        !check_model_options(&model, &ok_opts)
+            .iter()
+            .any(|d| d.code == "E_AGQ_NODES_TOO_LARGE"),
+        "n_agq = MAX_AGQ_NODES is in range and must be accepted"
+    );
+}
+
+/// **The AGQ covariance stencil.** Every other AGQ test sets `run_covariance_step = false`,
+/// so the AGQ-marginal FD covariance (differenced through the `pop_nll_opts` seam in
+/// `compute_covariance`, so the standard errors difference the objective AGQ actually
+/// optimised) has no regression test. Run a short AGQ fit *with* covariance on and assert it
+/// produces finite, positive standard errors (review #821, point 4).
+#[test]
+fn agq_covariance_step_produces_finite_standard_errors() {
+    let pop = warfarin();
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    let opts = FitOptions {
+        method: EstimationMethod::Agq,
+        n_agq: 1,
+        // A handful of outer iterations so covariance is evaluated near the optimum where the
+        // marginal Hessian is PD, while keeping this a Tier-2 (fast, no convergence loop) test.
+        outer_maxiter: 8,
+        run_covariance_step: true,
+        ..FitOptions::default()
+    };
+    let res = fit(&model, &pop, &model.default_params, &opts).expect("AGQ fit with covariance");
+    let se = res
+        .se_theta
+        .expect("AGQ must report theta standard errors when covariance is on");
+    assert_eq!(se.len(), 3, "one SE per theta");
+    assert!(
+        se.iter().all(|s| s.is_finite() && *s > 0.0),
+        "AGQ theta standard errors must be finite and positive: {se:?}"
+    );
+    assert!(
+        res.covariance_matrix.is_some(),
+        "AGQ covariance matrix must be reported"
+    );
+}
+
+/// AGQ over a **non-Gaussian endpoint** — the capability the method exists for and which every
+/// other test in this file (all Gaussian warfarin PK) leaves unexercised (review #821, point 3).
+///
+/// The likelihood integrated here is a mixed-effects **binary / logistic** model, which sits
+/// entirely outside the `Dual2` sensitivity provider — so it drives AGQ's fixed-η FD score path
+/// (the one that also serves TTE, categorical, ODE, M3), not the analytic-provider path the
+/// Gaussian tests take. The independent truth is ferx's importance sampler evaluating the same
+/// marginal by a completely different route (Student-t / prior proposal, self-normalised
+/// weights — no quadrature, no Hessian), exactly as `agq_converges_to_the_importance_sampling_marginal`
+/// anchors the Gaussian node sweep.
+#[cfg(feature = "survival")]
+mod non_gaussian {
+    use ferx_core::estimation::agq;
+    use ferx_core::parser::model_parser::parse_model_string;
+    use ferx_core::{fit, CompiledModel, EstimationMethod, FitOptions, Population};
+
+    /// Mixed-effects logistic: population intercept + slope on `X`, plus a per-subject random
+    /// intercept `ETA_I`. One binary observation per row; the logit reads the per-record `TIME`
+    /// via the covariate `X` only, so the marginal is a genuine 1-D integral over `ETA_I`.
+    const BINARY_MIXED: &str = r"
+[parameters]
+  theta TH0(0.2, -10.0, 10.0)
+  theta THX(0.8, -10.0, 10.0)
+  omega ETA_I ~ 0.4
+
+[binary_model]
+  cmt   = 3
+  logit = TH0 + THX * X + ETA_I
+";
+
+    /// The same model with the random intercept removed — ordinary (fixed-effects) logistic
+    /// regression, `n_eta = 0`. Exercises AGQ's `d == 0` short-circuits.
+    const BINARY_FIXED: &str = r"
+[parameters]
+  theta TH0(0.2, -10.0, 10.0)
+  theta THX(0.8, -10.0, 10.0)
+
+[binary_model]
+  cmt   = 3
+  logit = TH0 + THX * X
+";
+
+    /// A deterministic binary dataset: 16 subjects, 4 observations each, `X` spread across a
+    /// range and the 0/1 states loosely tracking `TH0 + THX·X` so the model is identifiable.
+    fn binary_population() -> Population {
+        let subjects: Vec<(f64, Vec<(f64, u8)>)> = vec![
+            (-2.0, vec![(0.0, 0), (1.0, 0), (2.0, 0), (3.0, 0)]),
+            (-1.5, vec![(0.0, 0), (1.0, 0), (2.0, 1), (3.0, 0)]),
+            (-1.0, vec![(0.0, 0), (1.0, 1), (2.0, 0), (3.0, 0)]),
+            (-0.8, vec![(0.0, 1), (1.0, 0), (2.0, 0), (3.0, 0)]),
+            (-0.5, vec![(0.0, 0), (1.0, 1), (2.0, 0), (3.0, 1)]),
+            (-0.3, vec![(0.0, 1), (1.0, 0), (2.0, 1), (3.0, 0)]),
+            (-0.1, vec![(0.0, 0), (1.0, 1), (2.0, 1), (3.0, 0)]),
+            (0.1, vec![(0.0, 1), (1.0, 0), (2.0, 1), (3.0, 1)]),
+            (0.3, vec![(0.0, 1), (1.0, 1), (2.0, 0), (3.0, 1)]),
+            (0.5, vec![(0.0, 0), (1.0, 1), (2.0, 1), (3.0, 1)]),
+            (0.8, vec![(0.0, 1), (1.0, 1), (2.0, 1), (3.0, 0)]),
+            (1.0, vec![(0.0, 1), (1.0, 0), (2.0, 1), (3.0, 1)]),
+            (1.3, vec![(0.0, 1), (1.0, 1), (2.0, 1), (3.0, 1)]),
+            (1.6, vec![(0.0, 1), (1.0, 1), (2.0, 0), (3.0, 1)]),
+            (2.0, vec![(0.0, 1), (1.0, 1), (2.0, 1), (3.0, 1)]),
+            (2.5, vec![(0.0, 0), (1.0, 1), (2.0, 1), (3.0, 1)]),
+        ];
+        crate::common::binary_pop(&subjects, 3)
+    }
+
+    /// Eval-only AGQ OFV of `model` on the binary population at the initial parameters.
+    fn agq_ofv(model: &CompiledModel, pop: &Population, n_agq: usize) -> f64 {
+        crate::eval_only_ofv_model(model, pop, EstimationMethod::Agq, n_agq)
+    }
+
+    /// **Point 3: the binary marginal is integrated correctly, cross-checked against IS.**
+    #[test]
+    fn agq_integrates_a_binary_endpoint_and_agrees_with_importance_sampling() {
+        let model = parse_model_string(BINARY_MIXED).expect("mixed binary model must parse");
+        assert_eq!(
+            model.n_eta, 1,
+            "fixture must have exactly one random effect"
+        );
+        assert!(
+            agq::analytic_gradient_available(&model),
+            "AGQ supplies its own gradient for the binary endpoint too (no scope gate)"
+        );
+        let pop = binary_population();
+
+        // AGQ node sweep at the initial parameters — every OFV must be finite.
+        let agq: Vec<f64> = [1usize, 3, 7, 15]
+            .iter()
+            .map(|&n| agq_ofv(&model, &pop, n))
+            .collect();
+        assert!(
+            agq.iter().all(|o| o.is_finite()),
+            "AGQ binary OFVs must be finite: {agq:?}"
+        );
+
+        // Independent truth: the IS marginal at the same parameters. IS estimates the same
+        // integral by sampling η and averaging the exact conditional likelihood (which includes
+        // the logit term via `accumulate_non_gaussian_nll`), so it shares no code path with the
+        // quadrature. Deterministic under a fixed seed.
+        let is_opts = FitOptions {
+            method: EstimationMethod::Imp,
+            interaction: true,
+            imp_eval_only: true,
+            imp_samples: 100_000,
+            imp_seed: Some(11),
+            outer_maxiter: 0,
+            run_covariance_step: false,
+            ..FitOptions::default()
+        };
+        let truth = fit(&model, &pop, &model.default_params, &is_opts)
+            .expect("IS evaluation must succeed on the binary model")
+            .importance_sampling
+            .expect("IMP eval-only must report a marginal")
+            .minus2_log_likelihood;
+
+        let refined = (agq.last().unwrap() - truth).abs();
+        assert!(
+            refined < 0.5,
+            "the refined AGQ grid must agree with the IS marginal on the binary endpoint: \
+             truth={truth:.6}, AGQ OFVs={agq:?} (final gap {refined:.4})"
+        );
+    }
+
+    /// Point 3 (gradient side): a short *optimising* AGQ fit over the binary endpoint drives the
+    /// fixed-η FD score path end-to-end (the analytic-provider path never fires here), returning
+    /// a finite OFV. This is the headline capability — a non-Gaussian likelihood optimised by
+    /// AGQ — exercised through the public `fit()` boundary rather than only the eval-only OFV.
+    #[test]
+    fn agq_optimises_a_binary_endpoint() {
+        let model = parse_model_string(BINARY_MIXED).expect("mixed binary model must parse");
+        let pop = binary_population();
+        let opts = FitOptions {
+            method: EstimationMethod::Agq,
+            n_agq: 3,
+            outer_maxiter: 3, // Tier-2: a few steps, no convergence loop
+            run_covariance_step: false,
+            ..FitOptions::default()
+        };
+        let res = fit(&model, &pop, &model.default_params, &opts)
+            .expect("a short AGQ fit over a binary endpoint must return Ok");
+        assert!(
+            res.ofv.is_finite(),
+            "AGQ binary fit OFV must be finite: {}",
+            res.ofv
+        );
+    }
+
+    /// **Point 4: the `d == 0` short-circuit** (`agq_subject_nll`, `agq_subject_packed_gradient`).
+    /// A fixed-effects binary model has no random effect, so the marginal is a point mass and AGQ
+    /// degenerates to the conditional likelihood — the node count cannot matter, and the OFV must
+    /// equal FOCEI's exactly. The short optimising fit then drives the gradient's own `d == 0`
+    /// branch (`accumulate_fixed_eta_packed_gradient`).
+    #[test]
+    fn agq_with_no_random_effects_is_the_conditional_likelihood() {
+        let model =
+            parse_model_string(BINARY_FIXED).expect("fixed-effects binary model must parse");
+        assert_eq!(model.n_eta, 0, "fixture must have no random effects");
+        let pop = binary_population();
+
+        let agq1 = agq_ofv(&model, &pop, 1);
+        let agq7 = agq_ofv(&model, &pop, 7);
+        let focei = crate::eval_only_ofv_model(&model, &pop, EstimationMethod::FoceI, 1);
+
+        // Nothing to integrate over ⇒ the node count cannot move the OFV, bit-for-bit.
+        assert_eq!(
+            agq1.to_bits(),
+            agq7.to_bits(),
+            "with n_eta = 0 the node count is irrelevant: n=1 {agq1} vs n=7 {agq7}"
+        );
+        // …and the marginal *is* the conditional likelihood, so AGQ = FOCEI exactly.
+        assert!(
+            (agq1 - focei).abs() < 1e-9,
+            "with no random effects AGQ must equal FOCEI exactly: agq={agq1}, focei={focei}"
+        );
+
+        // Drive the gradient's d == 0 branch through a short optimising fit.
+        let opts = FitOptions {
+            method: EstimationMethod::Agq,
+            n_agq: 3,
+            outer_maxiter: 3,
+            run_covariance_step: false,
+            ..FitOptions::default()
+        };
+        let res = fit(&model, &pop, &model.default_params, &opts)
+            .expect("a fixed-effects AGQ fit must return Ok");
+        assert!(
+            res.ofv.is_finite(),
+            "fixed-effects AGQ OFV must be finite: {}",
+            res.ofv
+        );
+    }
 }


### PR DESCRIPTION
## Why

Closes #251.

FOCE/FOCEI approximate each subject's marginal likelihood with a **single** Gaussian at the empirical-Bayes mode. Two consequences: the approximation is fixed (you cannot buy accuracy), and it bakes in a Gaussian-residual assumption, which is why FOCE/FOCEI structurally cannot handle count, ordinal or time-to-event endpoints.

AGQ generalises Laplace. It keeps the mode-centring but evaluates the **exact** conditional likelihood on a Gauss-Hermite grid laid around that mode. One node reproduces Laplace identically; more nodes refine the marginal. It is deterministic — a fixed grid, no sampling — so unlike SAEM/IMP the OFV carries no Monte-Carlo noise and the outer optimizer needs no common random numbers or step-size schedule.

## What changed

`method = agq` (aliases `aghq`, `gauss_hermite`, `adaptive_gaussian_quadrature`) with `[fit_options] n_agq` — Gauss-Hermite nodes per random effect, default 3.

The implementation reuses existing machinery rather than duplicating it:

- **Inner loop unchanged.** The EBE mode comes from the same solver FOCE/FOCEI use (analytic `Dual2` eta-gradient included). AGQ does not re-optimise the mode; it only lays the grid around it. Nodes are evaluated through the existing exact `individual_nll_into_with_schedule`.
- **Node transform reuses importance sampling's `Proposal`** (jitter + Omega-fallback included). IS and AGQ now differ only in where `z` comes from — random draws vs deterministic nodes — instead of carrying two copies of the Cholesky/back-substitution logic.
- **`pop_nll_opts` is the new method-aware objective seam.** Every production site that needs "the objective for *this* fit" routes through it: the outer objective closures, the reconverged-FD gradient, the covariance stencil, and SIR. So an AGQ fit's standard errors difference the likelihood it actually optimised. Non-AGQ fits forward to `pop_nll` with identical arguments and are bit-identical (verified — see below).
- Gauss-Hermite nodes/weights are computed by **Golub-Welsch** rather than hard-coded, so they are exact at every `n`, and `n = 1` falls out naturally as the 1x1 zero matrix (node 0, weight sqrt(pi)) — which is precisely what makes AGQ collapse to Laplace.

**AGQ has an exact analytic outer gradient** (added in 198c38cb — see the comment thread). The node log-terms normalise to posterior weights, so by the Fisher/Louis identity the gradient is a posterior-weighted average of *fixed-eta* scores, plus a grid-response term for the movement of the mode and Hessian. It is exact at every `n_agq`, needs no inner re-solve, and works for every model (analytic score where the `Dual2` provider reaches, finite-differenced at fixed eta otherwise — so TTE/categorical are not the slow case). `optimizer = auto` resolves to L-BFGS; BOBYQA false-converges on this objective.

Feeding AGQ the *FOCE* analytic gradient would not have failed loudly — it would have converged smoothly to the FOCE optimum while reporting AGQ OFVs — so `population_gradient` dispatches on the method, not just the model.

**Rejected at check time:** IOV (the marginal becomes a joint integral over eta *and* every occasion's kappa — intractable, and silently integrating the eta-only marginal would report a confidently wrong OFV) and any grid over 100k nodes.

## Alternatives considered

**The Hessian: finite-differenced, not `compute_posterior_hessian`.** The obvious reuse is IS's Gauss-Newton form `Omega^-1 + J'R^-1 J`. Rejected: that form carries **no curvature at all** from TTE or categorical endpoints — it is blind on exactly the models AGQ exists to serve, and would scale their grids by `Omega` alone. AGQ therefore central-differences the Hessian of the true conditional NLL.

The consequence is worth stating plainly: **AGQ(1) is Laplace with the *exact* Hessian — NONMEM's `LAPLACIAN` — and is deliberately not bit-identical to ferx's FOCEI**, which is Laplace with the Gauss-Newton Hessian. The two differ by exactly that `0.5*log|H|` term. That is a real distinction between the estimators, not implementation drift, and the validation below demonstrates it rather than assuming it.

**Grid pruning: deliberately not done** (an open question on the issue). It is unsound. The adaptive rule multiplies each weight by `exp(||z||^2)`, which exactly cancels the `e^{-z^2}` decay the Hermite weights carry, so the corrected weights are `Theta(1)` right across the grid — a tiny raw weight does **not** imply a tiny contribution, and the contribution is only known after `nll(eta_j)` is evaluated, which is the entire cost. Dimensionality is bounded by a grid cap instead. Sparse (Smolyak) grids are the real answer for `n_eta = 5..8`.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r (branch `feat/agq-251`, PR to follow) | not yet open | after |

The ferx-r change (`method = "agq"`, `settings = list(n_agq = N)`) is committed locally but cannot build until this lands: it needs `EstimationMethod::Agq`, so its pinned `src/rust/Cargo.lock` must be bumped via `tools/update-ferx-core-lock.sh` **after** this merges. `n_agq` crosses the FFI through the existing `apply_fit_option` channel, so no new extendr argument is required.

## Breaking changes

- [x] None

`EstimationMethod` gains a variant and `FitOptions` a field — additive only. Existing fits are bit-identical.

## Numerical validation

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: **NONMEM** `$EST METHOD=1 LAPLACIAN` (the exact anchor for `n_agq = 1`), **ferx's own importance sampler** (independent code path, anchors the node sweep), and prior ferx commit `9bdd90cd`

### NONMEM anchor: `n_agq = 1` reproduces `METHOD=1 LAPLACIAN` to 5 significant figures

Warfarin, evaluated at identical initial parameters (`MAXEVAL=0`):

| Objective | ferx | NONMEM |
|-----------|------|--------|
| FOCEI — Laplace, Gauss-Newton Hessian (`METHOD=1 INTER`) | 7.496684 | **7.4967** |
| **AGQ `n_agq = 1`** — Laplace, exact Hessian (`METHOD=1 LAPLACIAN INTER`) | 7.899403 | **7.8994** |
| `METHOD=1 LAPLACIAN` *without* `INTER` | — | 17.2049 |

NONMEM shows the **same 0.40-unit gap between LAPLACIAN and FOCEI that ferx does**, which demonstrates (rather than asserts) that the AGQ(1)-vs-FOCEI difference is FOCEI's Gauss-Newton Hessian, not drift here. And plain `LAPLACIAN` missing by 9.3 units confirms the exact Hessian must carry the `ln V(f(eta))` curvature that the Gauss-Newton form drops — independently validating the Hessian design decision, on a *Gaussian* model where that failure would otherwise be invisible.

Converged fit (ferx AGQ n=1 vs NONMEM LAPLACIAN INTER): OFV −285.956 / −285.970; thetas within 0.2%, variance components within 3.6% — the same order as ferx's established FOCEI-vs-NONMEM anchor. Full tables in `docs/estimation/agq.qmd`.

### AGQ converges to an independently-computed truth

OFV evaluated at **identical parameters and identical EBEs**, so the only thing varying across rows is the marginal approximation:

```
FOCE  (Sheiner-Beal linearised)     16.475
FOCEI (Laplace, Gauss-Newton H)      7.497
AGQ n=1  (Laplace, exact H)          7.899
AGQ n=3                              7.697
AGQ n=5                              7.501
AGQ n=7                              7.483
AGQ n=9                              7.481
AGQ n=11                             7.480   <- converged
IMP, 20k samples (independent MC)    7.457
```

The last row is the check that matters. Importance sampling estimates the **same integral** by a completely different route — Student-t proposal, self-normalised weights; no quadrature, no Hessian, no Laplace. AGQ's refined grid lands within **0.02 OFV units** of it, inside IS's own Monte-Carlo error at 20k samples. Two estimators sharing no code path agree, which certifies the marginal **and** its constant convention (an error in either would show as tens of OFV units, not hundredths). Pinned as a test: `agq_converges_to_the_importance_sampling_marginal`.

Note FOCEI's 7.497 is *closer* to truth than AGQ(1)'s 7.899 here — both are one-term approximations, and on this model FOCEI's Gauss-Newton Hessian error partially cancels the Laplace error. The point of AGQ is not having to rely on that cancellation: add nodes, watch the number stop moving.

### Converged fit (maxiter = 500, covariance on)

| Parameter | FOCEI | AGQ (n_agq = 3) |
|-----------|-------|-----------------|
| OFV       | -286.004 | -285.973 |
| TVCL      | 0.132673 | 0.132684 |
| TVV       | 7.73806  | 7.73881  |
| TVKA      | 0.809975 | 0.811433 |
| omega^2 (ETA_V)  | 0.009593 | 0.009589 |
| omega^2 (ETA_KA) | 0.336241 | 0.337807 |
| PROP_ERR  | 0.010565 | 0.010561 |

On a well-behaved Gaussian PK model Laplace is already accurate, so AGQ reproducing FOCEI to ~0.2% is the expected and desired result. AGQ earns its cost where that assumption fails.

### No regression on existing paths

Full `--lib` suite: **2448 passed, 1 failed** — `run_covariance::tests::run_covariance_matches_inline_covariance`. That failure is **pre-existing and unrelated**: it reproduces on the pristine base commit `9bdd90cd` with a **bit-identical** diff value (`0.0005988345152884864` on both), confirming this PR is a numeric no-op on the FOCEI covariance path. It is a tolerance flake on this machine (the test's own comment concedes the 1e-4 bound is precision-limited by a Cholesky round-trip).

New tests: 6 unit (`src/estimation/agq.rs` — Golub-Welsch against the textbook rule, polynomial exactness, the one-node/Laplace identity, convergence on a skewed integrand) and 8 integration (`tests/agq.rs` — the IS cross-check, determinism/bit-identical OFV, node convergence, alias parsing including the `gauss_hermite`-vs-Gauss-*Newton* trap, and both rejection guards).

## Docs

New `docs/estimation/agq.qmd` (added to `_quarto.yml`), `n_agq` in `fit-options.qmd`, CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
