### PR TITLE
test(estimation): IOV run_covariance covariance/SE parity is bit-exact [closes #823]

### DIFF
--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -1450,6 +1450,58 @@ mod tests {
     }
 
     #[test]
+    fn test_unpack_omega_iov_depends_only_on_vector_and_structure() {
+        // The mechanism behind the IOV `run_covariance` bit-exactness (#823):
+        // `unpack_params` rebuilds `omega_iov` from the packed vector and the
+        // template's *structure* (diagonal flag, names, free_mask) alone — the
+        // template's numeric Ω_IOV **values** never leak in. So the inline
+        // covariance step (template = the fit's init params) and the standalone
+        // step (template = `fitted_params_from_result`, carrying the *converged*
+        // Ω_IOV) reconstruct a byte-identical Ω_IOV from the same `packed_estimate`,
+        // even though their templates hold different variances. The diagonal-IOV
+        // branch runs `OmegaMatrix::from_diagonal` (square-then-re-decompose)
+        // rather than the BSV's `from_chol_factor`, so pin every cached field
+        // (`matrix`, `chol`, `inv`, `log_det`) it derives, not just the variance.
+        let t_init = make_iov_template(); // IOV variance 0.01
+
+        // Structurally identical, different values (variance 0.05, and shifted
+        // theta/omega/sigma). `theta_lower` must match `t_init` — it drives the
+        // log-vs-identity packing decision, part of the "structure".
+        let mut t_conv = make_iov_template();
+        t_conv.theta = vec![7.3];
+        t_conv.omega = OmegaMatrix::from_diagonal(&[0.21], vec!["ETA_CL".into()]);
+        t_conv.sigma.values = vec![0.11];
+        t_conv.omega_iov = Some(OmegaMatrix::from_diagonal(&[0.05], vec!["KAPPA_CL".into()]));
+
+        // A packed vector at a converged-ish point (not `pack(t_init)`), so the
+        // unpacked Ω_IOV is a genuine reconstruction, not an identity round-trip.
+        let v = pack_params(&t_conv);
+        assert_eq!(v.len(), packed_len(&t_init));
+
+        let from_init = unpack_params(&v, &t_init);
+        let from_conv = unpack_params(&v, &t_conv);
+
+        let a = from_init.omega_iov.as_ref().unwrap();
+        let b = from_conv.omega_iov.as_ref().unwrap();
+        // Bit-for-bit on every cached field — this is the `1e-12` the fit-level
+        // parity test observes, reduced to its root cause.
+        assert_eq!(
+            a.matrix, b.matrix,
+            "Ω_IOV matrix must not depend on template values"
+        );
+        assert_eq!(
+            a.chol, b.chol,
+            "Ω_IOV chol must not depend on template values"
+        );
+        assert_eq!(a.inv, b.inv, "Ω_IOV inv must not depend on template values");
+        assert_eq!(
+            a.log_det.to_bits(),
+            b.log_det.to_bits(),
+            "Ω_IOV log_det must not depend on template values"
+        );
+    }
+
+    #[test]
     fn test_fixed_kappa_pins_bounds() {
         let mut template = make_iov_template();
         template.kappa_fixed[0] = true;

--- a/src/estimation/run_covariance.rs
+++ b/src/estimation/run_covariance.rs
@@ -358,6 +358,137 @@ mod tests {
         Some(fit)
     }
 
+    /// IOV analogue of `run_covariance_matches_inline_covariance` (#823). The
+    /// reuse path packs/unpacks the `omega_iov` Cholesky block too, and the
+    /// **diagonal-IOV branch of `unpack_params` reconstructs it through
+    /// `OmegaMatrix::from_diagonal` (square-then-re-decompose)** rather than the
+    /// `from_chol_factor` route the BSV `omega` takes — a distinct construction
+    /// with no prior parity coverage.
+    ///
+    /// It is nonetheless **bit-for-bit**: both the inline covariance step
+    /// (`compute_covariance(&x0, …)`) and this standalone step run the entire
+    /// numeric path — the base OFV, every FD-Hessian perturbation, and
+    /// `se_kappa`'s `iov.matrix[(i,i)]` factor — through the *same*
+    /// `unpack_params(x0, template)` on the *same* packed vector
+    /// `fit.packed_estimate`. So the `from_diagonal` construction is applied
+    /// identically on both sides and cannot introduce a divergence; the
+    /// asymmetry the issue flags lives inside `unpack_params`, not between the
+    /// two callers. Observed `max_abs_diff == 0.0`, with `se_kappa` matching to
+    /// the last bit.
+    ///
+    /// `fit_from_files` can't thread `iov_column` from `[fit_options]` (it
+    /// passes `None`), so — like every other IOV test — this drives the direct
+    /// `fit()` API with `read_nonmem_csv(.., Some("OCC"))` and hands both
+    /// `Some(model)` and `Some(pop)` to `run_covariance` (the documented IOV
+    /// workaround; a bare `Some(model)` for an IOV model is an error).
+    #[test]
+    fn run_covariance_matches_inline_covariance_iov() {
+        use crate::api::fit;
+
+        let model = crate::parser::model_parser::parse_full_model_file(std::path::Path::new(
+            "examples/warfarin_iov.ferx",
+        ))
+        .expect("parse warfarin_iov.ferx")
+        .model;
+        assert!(model.n_kappa > 0, "warfarin_iov.ferx must declare kappa");
+        let pop = crate::io::datareader::read_nonmem_csv(
+            std::path::Path::new("data/warfarin_iov.csv"),
+            None,
+            Some("OCC"),
+        )
+        .expect("read warfarin_iov.csv");
+
+        // FOCEI (the IOV case the issue calls for) on the deterministic BOBYQA
+        // outer optimizer, so fit A and fit B converge to the same packed point.
+        let opts = FitOptions {
+            method: crate::types::EstimationMethod::FoceI,
+            interaction: true,
+            ..quick_opts()
+        };
+
+        // Fit A: inline covariance step. Skip (like the non-IOV sibling) if the
+        // FD cov step didn't produce a matrix — the parity assertions need a
+        // non-None reference, and FD conditioning is out of scope here.
+        let fit_a = fit(&model, &pop, &model.default_params, &opts).expect("iov fit A converges");
+        if fit_a.covariance_matrix.is_none() {
+            eprintln!(
+                "[skip] inline IOV covariance step produced no matrix (FD instability); \
+                 skipping run_covariance IOV parity assertions"
+            );
+            return;
+        }
+        // The whole point of the IOV variant: se_kappa must actually be exercised.
+        assert!(
+            fit_a.se_kappa.is_some(),
+            "inline IOV cov step must populate se_kappa"
+        );
+
+        // Fit B: identical settings, no inline covariance step.
+        let fit_b = fit(
+            &model,
+            &pop,
+            &model.default_params,
+            &FitOptions {
+                run_covariance_step: false,
+                ..opts.clone()
+            },
+        )
+        .expect("iov fit B converges");
+        assert!(
+            fit_b.covariance_matrix.is_none(),
+            "fit B should carry no covariance (run_covariance_step = false)"
+        );
+        // The bit-exact reuse relies on the FOCEI fit carrying the packed vector;
+        // guard it so a regression that stops populating it can't silently drop
+        // run_covariance onto the divergent re-decomposition fallback.
+        assert!(
+            fit_b.packed_estimate.is_some(),
+            "an IOV FOCEI fit must carry packed_estimate for run_covariance to reuse"
+        );
+
+        let out = run_covariance(&fit_b, Some(&model), Some(&pop), &opts)
+            .expect("run_covariance succeeds for the IOV model");
+
+        assert_eq!(out.covariance_status, CovarianceStatus::Computed);
+        let cov_ref = fit_a.covariance_matrix.as_ref().unwrap();
+        let cov_new = out
+            .covariance_matrix
+            .as_ref()
+            .expect("run_covariance populated covariance_matrix");
+        assert_eq!(cov_ref.shape(), cov_new.shape());
+        let max_abs_diff = cov_ref
+            .iter()
+            .zip(cov_new.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_abs_diff < 1e-12,
+            "IOV run_covariance matrix diverged from inline cov (max abs diff {max_abs_diff})"
+        );
+
+        // Every SE vector must agree bit-for-bit — se_kappa is the one the IOV
+        // reuse path (`from_diagonal` round-trip) newly covers.
+        let se_eq = |label: &str, a: &Option<Vec<f64>>, b: &Option<Vec<f64>>| {
+            assert_eq!(a.is_some(), b.is_some(), "{label}: presence differs");
+            if let (Some(a), Some(b)) = (a, b) {
+                assert_eq!(a.len(), b.len(), "{label}: length differs");
+                for (x, y) in a.iter().zip(b) {
+                    assert!((x - y).abs() < 1e-12, "{label} diverged: {x} vs {y}");
+                }
+            }
+        };
+        se_eq("se_theta", &fit_a.se_theta, &out.se_theta);
+        se_eq("se_omega", &fit_a.se_omega, &out.se_omega);
+        se_eq("se_sigma", &fit_a.se_sigma, &out.se_sigma);
+        se_eq("se_kappa", &fit_a.se_kappa, &out.se_kappa);
+
+        // Non-covariance fields round-trip unchanged — including omega_iov.
+        assert_eq!(out.theta, fit_b.theta);
+        assert_eq!(out.omega, fit_b.omega);
+        assert_eq!(out.omega_iov, fit_b.omega_iov);
+        assert_eq!(out.ofv, fit_b.ofv);
+    }
+
     #[test]
     fn run_covariance_matches_inline_covariance() {
         // The wrapper must reproduce the inline `fit()` covariance step exactly:


### PR DESCRIPTION
Closes #823.

## Why

Follow-up from #818 (merged `a932f9c9`), which made the standalone `run_covariance` reproduce the inline FD-Hessian covariance step **bit-for-bit** by reusing the optimizer's exact packed vector (`FitResult::packed_estimate`).

The parity test `run_covariance_matches_inline_covariance` only exercised a **non-IOV** model (warfarin). The reuse path also packs/unpacks the `omega_iov` Cholesky block, and the **diagonal-IOV branch of `unpack_params` reconstructs it through `OmegaMatrix::from_diagonal` (square-then-re-decompose)** rather than the `from_chol_factor` route the BSV `omega` takes — a distinct construction with no parity coverage. #823 asked whether that path is bit-exact, and if not, to surface it as an IOV analogue of the #818 fix.

## What changed

Investigated first, then added tests. **The IOV path is already bit-for-bit — a coverage gap, not a defect** (the non-blocking outcome #823 anticipated), so no `from_chol_factor` reuse fix is needed for the IOV block.

Why it can't diverge: both the inline covariance step (`compute_covariance(&x0, init_params)`) and standalone `run_covariance` run the *entire* numeric path — the base OFV, every FD-Hessian perturbation (`unpack_params(xv, template)`), and `se_kappa`'s `iov.matrix[(i,i)]` scale factor — through the **same** `unpack_params` on the **same** packed vector (`final_params = unpack_params(&x0, init_params)`; `packed_estimate = x0`). `unpack_params` reads only the template's *structure* (diagonal flag / names / free_mask / theta_lower), never its Ω values, so the inline template (init params) and the standalone template (`fitted_params_from_result`, carrying the converged Ω) reconstruct a byte-identical Ω_IOV. The `from_diagonal` construction is applied identically on both sides. The flagged asymmetry lives *inside* `unpack_params`, not between the two callers.

Two un-gated `#[cfg(test)]` lib tests added:

- **`run_covariance_matches_inline_covariance_iov`** (`src/estimation/run_covariance.rs`) — the fit-level parity test #823 asks for: FOCEI on `examples/warfarin_iov.ferx`, fit A (inline cov) vs. fit B (cov = false) + `run_covariance`. Asserts the covariance matrix **and all four SE vectors including `se_kappa`** agree to `1e-12`, and that `fit_b.packed_estimate.is_some()` (guards the reuse arm). Observed `max_abs_diff == 0.0`.
- **`test_unpack_omega_iov_depends_only_on_vector_and_structure`** (`src/estimation/parameterization.rs`) — a fast (0.00s) unit test pinning the mechanism: two structurally-identical templates with *different* Ω values, unpacked from the same packed vector, produce a byte-identical Ω_IOV (`matrix` / `chol` / `inv` / `log_det`).

Both stay **un-gated** deliberately: the Codecov `patch` gate runs only on PRs, where slow-tests never run, so gating would leave the `run_covariance` IOV lines uncovered — the same reason the non-IOV sibling is un-gated.

## Alternatives considered

The issue floated a fix "if not bit-exact": reuse the exact IOV factor `L` on the unpack path too (switch the diagonal-IOV branch from `from_diagonal` to `from_chol_factor`). Not applied — parity is already exact, so this would be a gratuitous numeric change to a hot path (`unpack_params` runs every outer iteration) with no benefit and nonzero risk.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change; `ferx-r` fits IOV models via `read_population_for` + `fit()` directly (unaffected).

## Breaking changes
- [x] None

## Numerical validation

Self-consistency parity (standalone `run_covariance` vs. the inline step it mirrors), not a new numerical result — the underlying covariance step is already NONMEM-anchored via #818 and `warfarin_covariance_nonmem`.

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit
- [x] Reference values (IOV FOCEI, `warfarin_iov`):

```
covariance max_abs_diff (standalone vs inline) = 0.0
se_kappa (both paths) = 0.017805628802615464   # identical to the last bit
teeth-check: a 1e-7 perturbation of the standalone kappa center → max_abs_diff ~8e-8 → test fails
```

- [ ] Not applicable

## Performance
- [x] No significant impact expected (test-only; no production code touched)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix (the fit-level test guards the reuse arm — teeth-verified it fails on a perturbed covariance center; the unit test fails if `unpack_params` ever lets template Ω values leak into the IOV reconstruction)
- [ ] No new tests needed

## Example (user-facing features only)
- [x] Not applicable (internal / test-only, no new API surface)

## Docs
- [x] No user-visible change (test-only — no CHANGELOG/docs entry needed)

## Checklist
- [x] `cargo clippy` clean (lib lint — the two changed files add no warnings)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (not touched)
- [x] `Cargo.toml` version bumped if breaking (N/A — not breaking)

## Docs & examples

### ferx-site
- [x] N/A — no new DSL syntax, fit option, example, or data file

### ferx-book
- [x] N/A — no new estimator/DSL feature/fit option

### Example execution
- [x] No example execution step needed (test-only / no user-visible change)

## Reviewer hints

- The substance is the **parity argument** in "What changed": both callers share `unpack_params(x0, template)`, so `from_diagonal` is applied symmetrically → the asymmetry the issue flags can't produce a divergence.
- The fit-level test runs two FOCEI convergence fits (~9s in the lib suite). It's un-gated on purpose (coverage-gate rationale above); the non-IOV sibling in the same module has the same profile.
- `examples/warfarin_iov.ferx` is fit via the **direct `fit()` API** (not `fit_from_files`) — see Open questions.
- The skip guard (return early if the inline FD cov step yields no matrix) mirrors the non-IOV sibling; it does not fire for `warfarin_iov` FOCEI locally, so coverage registers.

## Open questions

While writing this I hit a real sharp edge: **`fit_from_files` can't fit an OCC-column IOV model** — it hardcodes `iov_column = None` (`src/api.rs:3024`) and ignores the file's `[fit_options]`, and it never reads `opts.iov_column` either, so an IOV model whose occasions come from a dataset column fails with "no occasion labels found" with no fix via the API's own options. The CLI (`run_model_with_data_inits`) and `ferx-r` both thread `iov_column` and are unaffected, so blast radius is limited to direct Rust callers of `pub fit_from_files` — but it's discoverable (the `run_sir`/`run_covariance` errors advise "re-fit via `fit_from_files`"). Worth a separate low-priority issue + one-line fix (`opts.iov_column.as_deref()`), plus an `iov_occasion` parity audit. Not filed yet — flagging here for visibility.
