### PR TITLE
feat(estimation): method = laplace, and IOV support for AGQ/Laplace [#251]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,29 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **AGQ and `laplace` now support inter-occasion variability (`[iov]`)** (#251).
+  Under IOV the integral runs over the **stacked** random-effect vector
+  `b = [η, κ₁ … κ_K]`, whose prior is the block-diagonal `Ω ⊕ Ω_iov^⊕K` — which is
+  exactly what ferx's IOV likelihood already scores, so every AGQ formula carries
+  over with `d` the stacked dimension. IOV is a change of *dimension*, not of
+  method. The tensor grid is therefore `n_agq^(n_eta + K·n_kappa)` and grows with
+  the occasion count `K`, so the 100 000-node cap is now enforced against the
+  stacked dimension once the data is read (the error names `K`). **`method =
+  laplace` is always tractable under IOV** — its grid is a single point regardless
+  of `d`. Previously both methods rejected `[iov]` models outright.
+- **`method = laplace` — the Laplace approximation as a first-class estimator** (#251).
+  Alias `laplacian`. This is NONMEM's `$EST METHOD=1 LAPLACIAN`: the Laplace
+  approximation built from the **exact** Hessian of the conditional likelihood.
+  It is *not* the same estimator as `focei`, which builds its Gaussian from the
+  Gauss-Newton Hessian `CᵀC + Ω⁻¹` (dropping `∂²f/∂η²`) and therefore reports a
+  different OFV; `laplace` carries the curvature of the η-dependent residual
+  variance that the Gauss-Newton form discards, which is why it reproduces NONMEM's
+  LAPLACIAN to six significant figures on warfarin. Internally it *is* `agq` with the
+  node count pinned to 1 — same objective, same analytic gradient, same covariance
+  step, bit-identical OFV — so it is the cheapest member of the AGQ family (one node,
+  no grid) and on warfarin converges *faster than FOCEI* (0.23 s vs 0.60 s). `n_agq`
+  is not one of its options; use `method = agq` to vary the node count. See the
+  [AGQ docs page](https://ferx-nlme.github.io/ferx-core/estimation/agq.html).
 - **Exact (analytic) FOCE/FOCEI gradients for lagtime models with IOV, time-varying
   covariates, or `TIME`** (#486): a closed-form model carrying an `ALAG`/`LAGTIME` used to
   fall back to finite differences the moment the subject also had IOV, a time-varying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,6 +449,17 @@ section of the SDLC for the versioning policy).
   every model instead of slipping past the replay. No effect on correct models.
 
 ### Fixed
+- **AGQ / `laplace` fits no longer report "did not converge" while sitting on a settled
+  OFV** (#251). The gradient-based outer optimizer set NLopt's stopping tolerances to
+  `1e-12`, which FOCE/FOCEI can reach (their analytic gradient is exact to ~1e-11) but
+  AGQ cannot: AGQ's gradient is exact yet *finite-difference-limited* (the grid-response
+  term and the posterior Hessian are central differences), so it carries a noise floor.
+  L-BFGS ground on past the point where the objective had settled, until its line search
+  failed on a noise-dominated direction and NLopt returned a bare failure — reporting
+  "not converged" for a result that had been flat to eight significant figures. AGQ now
+  stops on the reachable objective-change criterion (`outer_ftol` / `outer_xtol`), which
+  both fixes the flag and makes the fits **faster** (AGQ+IOV on warfarin: 14.5 s → 8.2 s;
+  Laplace+IOV: 2.2 s → 1.3 s), with identical estimates. FOCE/FOCEI are unchanged.
 - **Wrong analytic gradient for an observation sampled exactly on a moving dose boundary**
   (#486) — a modeled infusion end, or a lagged dose arrival. With a modeled `RATE=-1`/`-2` dose the infusion window end moves with the
   estimated `D{cmt}`/`R{cmt}`. An observation whose time coincided with that end had its

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -65,7 +65,29 @@ best at **n_eta ≤ 4**.
 > perfectly ordinary share of the integral. Sparse (Smolyak) grids are the real
 > answer for `n_eta = 5..8` and are tracked as future work.
 
-## `n_agq = 1` is exactly Laplace
+## `n_agq = 1` is exactly Laplace — and has its own method name
+
+Because the one-node case is a genuinely useful estimator in its own right (it is
+NONMEM's `$EST METHOD=1 LAPLACIAN`), it is exposed directly:
+
+```ini
+[fit_options]
+  method = laplace     # alias: laplacian
+```
+
+`method = laplace` **is** `method = agq` with the node count pinned to 1 — the same
+objective, the same analytic gradient, the same covariance step, routed through the
+same code. The OFVs are bit-identical, and `n_agq` is not one of its options (the
+node count is what *defines* the method). Prefer it when you want a
+NONMEM-`LAPLACIAN`-comparable fit, or a Laplace baseline to raise `n_agq` from.
+
+It is also the cheapest member of the family — one node, no grid — and on warfarin
+it converges *faster than FOCEI* (0.23 s vs 0.60 s), because AGQ's analytic gradient
+needs fewer outer iterations.
+
+> **`laplace` is not `focei`.** Both place a single Gaussian at the empirical-Bayes
+> mode, but they build it from different Hessians — see below. They are different
+> estimators and will report different OFVs.
 
 With one node the rule is `z = 0` with weight `√π`, and the quadrature sum
 collapses, term for term, to
@@ -352,14 +374,44 @@ trust-region stopping rule trip sooner (63 → 34 evaluations, still reporting
 "converged"). Its ω estimates land ~3% off NONMEM. This is the failure mode ferx
 records in #317. `auto` picks L-BFGS for AGQ precisely to avoid it.
 
+## Inter-occasion variability (IOV)
+
+AGQ and `laplace` both support `[iov]`. Under IOV the integral is over the
+**stacked** random-effect vector
+
+$$
+b = [\eta,\ \kappa_1,\ \dots,\ \kappa_K],
+\qquad d = n_\eta + K \cdot n_\kappa
+$$
+
+whose prior is the block-diagonal `Ω_joint = Ω ⊕ Ω_iov ⊕ … ⊕ Ω_iov` (one block per
+occasion). That is not a new model — it is exactly what ferx's IOV likelihood already
+scores, since
+
+```text
+nll_iov = ½·(ηᵀΩ⁻¹η + log|Ω| + Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov| + data)
+        = ½·(bᵀΩ_joint⁻¹b + log|Ω_joint| + data)
+```
+
+So **every formula on this page carries over verbatim** with `d` the stacked
+dimension: the marginal, the `½log|H|` normaliser, the node transform, the
+Fisher-identity gradient. IOV is a change of *dimension*, not of method. The mode is
+the joint `(η̂, κ̂)` one the inner loop already converges.
+
+**The catch is the dimension.** The tensor grid is `n_agq^d`, and `K` — the number
+of occasions — comes from the *data*. Three η, one κ, two occasions gives `d = 5`
+and `3⁵ = 243` nodes (fine); ten occasions gives `d = 13` and `3¹³ ≈ 1.6 M` (not).
+ferx enforces the 100 000-node cap against the stacked dimension once the data is
+read, and the error names the occasion count so the cause is obvious.
+
+> **`method = laplace` is always tractable under IOV.** Its grid is a *single point*
+> no matter how large `d` grows — only the Hessian gets bigger. So Laplace + IOV
+> works at any occasion count, and is the natural choice when the AGQ grid blows up.
+
 ## Limitations
 
-- **No IOV.** Under inter-occasion variability the marginal is a joint integral
-  over `η` *and* every occasion's `κ`; the tensor grid is intractable at that
-  dimension. AGQ rejects `[iov]` models rather than silently integrating the
-  η-only marginal. Use [FOCEI](foce.qmd), [SAEM](saem.qmd) or
-  [IMP](importance-sampling.qmd).
-- **Exponential in `n_eta`** — see the cost table above. This is the real limit.
+- **Exponential in the random-effect dimension** — see the cost table above, and
+  the IOV section below. This is the real limit.
 - Models outside the `Dual2` provider take a finite-differenced θ/σ score rather than
   an analytic one (see above). Same gradient, no inner re-solve, just a little slower
   per iteration.

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -365,6 +365,26 @@ censoring, correlated residuals (`block_sigma`), FREM, IIV-on-RUV, custom residu
 magnitude, and LTBS — each adds a term the plain Gaussian chain rule does not carry.
 The fit output reports which route ran.
 
+### Where AGQ stops
+
+AGQ's gradient is exact but **finite-difference-limited**: the grid-response term
+and the posterior Hessian are both central differences, so it carries a noise floor
+(~1e-4 relative). It therefore cannot drive `|g|` arbitrarily low the way an
+analytic-to-machine-precision gradient can.
+
+So AGQ stops on the **objective-change** criterion (`outer_ftol`, default 1e-6) and
+the step-size criterion (`outer_xtol`), not on a gradient norm. That is where its
+objective actually settles.
+
+This matters more than it sounds. FOCE/FOCEI are given a `1e-12` stop, which they can
+reach; giving the same to AGQ makes it *unreachable*, and an unreachable stop is not
+harmless — the optimizer keeps stepping until the true gradient drops under its own
+noise floor, at which point the search direction is noise, the line search fails, and
+the run is reported as **not converged** despite sitting on an OFV that has been flat
+for a dozen evaluations. Stopping AGQ where it actually settles both fixes that and
+makes it *faster* (on warfarin + IOV: 14.5 s → 8.2 s), because the grinding past the
+plateau was pure waste.
+
 ### Don't use BOBYQA
 
 `optimizer = bobyqa` **false-converges** on the AGQ objective. On warfarin it stops

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -13,7 +13,7 @@ The optional `[fit_options]` block configures the estimation method and optimize
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
-| `method` | `foce`, `focei`, `agq`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). When neither this key nor a wrapper's `method` argument is set, the engine falls back to `focei` and emits a warning so the implicit choice is visible — set `method` here to silence it. |
+| `method` | `foce`, `focei`, `laplace`, `agq`, `saem`, `gn`, `gn_hybrid`, `impmap`, `imp` (only as final chain stage) | `focei` | Estimation method (or single-stage method in a chain). See [chained fits](#chained-fits). When neither this key nor a wrapper's `method` argument is set, the engine falls back to `focei` and emits a warning so the implicit choice is visible — set `method` here to silence it. |
 | `threads` | positive integer, `0`, `auto` | `auto` | Number of Rayon worker threads for per-subject parallelism. A positive integer pins the count. `0`/`auto` (or omitting the key) uses the engine's default: available cores − 1 (floored at 1), capped at 8 — most fits gain little from spreading across every core, and not all cores are equal on asymmetric platforms (e.g. Apple Silicon E-cores). The CLI's `--threads` flag mirrors this key (see `ferx --help`). |
 | `maxiter` | integer | `500` | Maximum outer loop iterations. `maxiter = 0` is *evaluation only* (NONMEM `MAXEVAL=0`): the engine runs one inner EBE solve at the initial parameters and reports the objective there with no outer optimisation — useful for scoring a fixed parameter set or computing standard errors at known estimates (with `covariance = true`). The reported fit is marked not-converged, and the parameters are returned unchanged. |
 | `covariance` | `true`, `false` | `true` | Compute covariance matrix and standard errors |
@@ -170,6 +170,18 @@ FOCE with Interaction. Includes the dependence of the residual error on random e
 method = foce
 ```
 First-Order Conditional Estimation. Linearizes the model around the empirical Bayes estimates. Fast and reliable for most models.
+
+### Laplace
+```
+method = laplace
+```
+The **Laplace approximation with the exact Hessian** — NONMEM `$EST METHOD=1 LAPLACIAN` (alias `laplacian`).
+
+This is *not* the same estimator as `focei`. Both approximate the marginal likelihood with a single Gaussian at the empirical-Bayes mode, but FOCEI builds that Gaussian from the **Gauss-Newton** Hessian `CᵀC + Ω⁻¹` (which drops `∂²f/∂η²`), while `laplace` differentiates the true conditional likelihood. It therefore carries the curvature of the η-dependent residual variance that the Gauss-Newton form discards — which is why it reproduces NONMEM's LAPLACIAN to six significant figures where FOCEI lands on a different value.
+
+Internally it *is* [`agq`](#agq) with the node count pinned to 1 — the one-point Gauss-Hermite rule sits at the mode, and the quadrature sum collapses to the Laplace formula exactly. Same objective, same analytic gradient, same covariance step; `n_agq` is not one of its options. It is the cheapest member of the family (one node, no grid) and on warfarin it is *faster* than FOCEI.
+
+Use it when you want a NONMEM-`LAPLACIAN`-comparable fit, or a Laplace baseline to raise `n_agq` from. See the [AGQ page](../estimation/agq.qmd).
 
 ### AGQ
 ```
@@ -466,7 +478,7 @@ When `optimizer_trace = true`, a CSV is written to `/tmp/ferx_trace_<pid>_<ts>.c
 | Column | Populated by | Description |
 |--------|-------------|-------------|
 | `iter` | all | Iteration number |
-| `method` | all | `foce`, `focei`, `gn`, `gn_hybrid`, `saem` |
+| `method` | all | `foce`, `focei`, `laplace`, `agq`, `gn`, `gn_hybrid`, `saem` |
 | `phase` | gn_hybrid, saem | `focei` (polish) or `explore`/`converge` |
 | `ofv` | all | Objective function value |
 | `wall_ms` | all | Wall time for this iteration (ms) |

--- a/src/api.rs
+++ b/src/api.rs
@@ -2224,28 +2224,35 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
     }
 
     // ── AGQ (#251) ────────────────────────────────────────────────────────────
-    if chain.iter().any(|&m| m == EstimationMethod::Agq) {
-        // The quadrature integrates over the BSV random effects η only. With IOV the
-        // marginal is a joint integral over (η, κ₁..κ_K), whose tensor grid is
-        // `n_agq^(n_eta + n_occ·n_iov)` — combinatorially hopeless even at 2 nodes, quite
-        // apart from the joint-Hessian work. Reject rather than quietly integrating the
-        // wrong (η-only) marginal and reporting a confidently wrong OFV.
-        if model.n_kappa > 0 {
-            diags.push(
-                Diagnostic::error(
-                    "E_AGQ_IOV_UNSUPPORTED",
-                    "method = agq does not support inter-occasion variability (κ / [iov]): the \
-                     marginal would be a joint integral over η and every occasion's κ, and the \
-                     tensor grid is intractable at that dimension. Use method = focei, saem, or \
-                     imp for IOV models.",
-                )
-                .with_block("fit_options"),
-            );
-        }
-        // The tensor rule costs `n_agq^n_eta` full likelihood evaluations per subject per
+    // Laplace routes through the same AGQ objective (one node), so it inherits the same
+    // compatibility guards. Its grid is a single point no matter how many random effects
+    // there are, so the caps below never fire for it — including under IOV.
+    if chain
+        .iter()
+        .any(|&m| matches!(m, EstimationMethod::Agq | EstimationMethod::Laplace))
+    {
+        // IOV is **supported**: AGQ integrates over the stacked (η, κ₁..κ_K), which is exactly
+        // what `individual_nll_iov` already scores. What IOV changes is the *dimension* — and
+        // hence the tensor grid — not the method. The grid cap below is what decides whether a
+        // given IOV model is tractable, and it is checked against the stacked dimension in
+        // `fit_inner` (which, unlike this function, can see the occasion count in the data).
+        //
+        // Name the method the user actually wrote, so a `method = laplace` fit is never told
+        // about "method = agq".
+        let label = if chain.contains(&EstimationMethod::Laplace) {
+            "laplace"
+        } else {
+            "agq"
+        };
+        // The tensor rule costs `n_agq^d` full likelihood evaluations per subject per
         // outer iteration. Past the cap that is not "slow", it is a fit that will never
         // finish — so it is worth failing at check time, with the two levers spelled out.
-        let n_nodes = options.n_agq.max(1);
+        //
+        // Read the node count from `agq_nodes()`, NOT `options.n_agq`: `method = laplace`
+        // pins it to 1 regardless of what `n_agq` holds (the key is not one of its options),
+        // so reading the raw field would let a stray `n_agq = 100` trip these caps on a fit
+        // that only ever builds a single node.
+        let n_nodes = options.agq_nodes().unwrap_or(1);
         // Per-dimension node cap. The parser (`apply_fit_option`) enforces this for
         // file-driven fits, but a `FitOptions` built directly against the Rust API
         // bypasses that path — so re-check here, alongside the grid cap, or an
@@ -2256,7 +2263,7 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 Diagnostic::error(
                     "E_AGQ_NODES_TOO_LARGE",
                     format!(
-                        "method = agq with n_agq = {n_nodes} exceeds the {}-node per-dimension \
+                        "method = {label} with n_agq = {n_nodes} exceeds the {}-node per-dimension \
                          limit: beyond ~20 nodes the Golub–Welsch rule loses its extreme nodes to \
                          round-off and the marginal gains nothing. Lower n_agq (n_agq = 1 is the \
                          Laplace approximation, i.e. FOCEI-equivalent cost).",
@@ -2272,7 +2279,7 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 Diagnostic::error(
                     "E_AGQ_GRID_TOO_LARGE",
                     format!(
-                        "method = agq with n_agq = {n_nodes} and {} random effects needs a \
+                        "method = {label} with n_agq = {n_nodes} and {} random effects needs a \
                          {n_nodes}^{} = {grid}-node tensor grid per subject per iteration, over \
                          the {} limit. Lower n_agq (n_agq = 1 is the Laplace approximation, i.e. \
                          FOCEI-equivalent cost), reduce the number of random effects, or use \
@@ -3420,6 +3427,39 @@ pub fn fit(
         population,
         &options.iov_occasion,
     ))?;
+    // AGQ + IOV: the tensor grid is `n_agq^d` with `d = n_eta + K·n_kappa`, and `K` (the
+    // occasion count) is a property of the *data*, not the model — so this cap cannot be
+    // checked in `check_model_options`, which never sees the population. Check it here, once
+    // the occasions are known, against the worst subject.
+    //
+    // `method = laplace` is a single node regardless of `d`, so it always passes: Laplace +
+    // IOV is tractable at any occasion count.
+    if let Some(n_nodes) = options.agq_nodes() {
+        if model.n_kappa > 0 {
+            let max_occ = population
+                .subjects
+                .iter()
+                .map(|s| crate::stats::likelihood::iov_occasion_groups(s).len())
+                .max()
+                .unwrap_or(0);
+            let d = model.n_eta + max_occ * model.n_kappa;
+            let grid = crate::estimation::agq::grid_size(n_nodes, d);
+            if grid > crate::estimation::agq::MAX_AGQ_GRID {
+                return Err(format!(
+                    "method = agq with n_agq = {n_nodes} needs a {n_nodes}^{d} = {grid}-node \
+                     tensor grid per subject per iteration — over the {} limit. Under IOV the \
+                     integral is over the stacked (η, κ₁..κ_{max_occ}), so the dimension is \
+                     n_eta ({}) + occasions ({max_occ}) × n_kappa ({}) = {d}. Lower n_agq, or \
+                     use method = laplace (one node — always tractable, and the exact-Hessian \
+                     Laplace approximation), or saem / imp, whose cost does not grow with the \
+                     random-effect dimension.",
+                    crate::estimation::agq::MAX_AGQ_GRID,
+                    model.n_eta,
+                    model.n_kappa,
+                ));
+            }
+        }
+    }
     // If any subject has per-event covariate snapshots that don't carry
     // a variation in covariates the model actually references (e.g.
     // DAY / STIME columns in NONMEM-format datasets), clear those
@@ -4933,6 +4973,7 @@ fn fit_inner(
                     | EstimationMethod::Imp
                     | EstimationMethod::Impmap
                     | EstimationMethod::Agq
+                    | EstimationMethod::Laplace
             )
         });
         if uses_gradient_route {
@@ -5029,6 +5070,7 @@ fn fit_inner(
                 | EstimationMethod::Imp
                 | EstimationMethod::Impmap
                 | EstimationMethod::Agq
+                | EstimationMethod::Laplace
         )
     }) {
         if let Some(w) = crate::estimation::inner_optimizer::fd_fallback_warning(
@@ -5246,7 +5288,9 @@ fn fit_inner(
         // estimates land ~3% off NONMEM LAPLACIAN. L-BFGS on the analytic gradient matches
         // NONMEM to 4-5 significant figures on every parameter, in 0.39 s against FOCEI's
         // 0.29 s. See docs/estimation/agq.qmd. An explicit `optimizer = ...` is honoured.
-        if matches!(method, EstimationMethod::Agq) && stage_opts.optimizer == Optimizer::Auto {
+        if matches!(method, EstimationMethod::Agq | EstimationMethod::Laplace)
+            && stage_opts.optimizer == Optimizer::Auto
+        {
             stage_opts.optimizer = Optimizer::NloptLbfgs;
         }
         // Run the covariance step (and SIR) only on the last *estimating* stage,

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -113,8 +113,9 @@ pub fn gradient_method_outer(
         // inner loop. What varies is only the θ/σ score: analytic from the `Dual2` provider
         // where it reaches, finite-differenced at fixed η otherwise (TTE, categorical, ODE,
         // M3, LTBS…). Report that distinction, not a scope gate — there isn't one.
-        EstimationMethod::Agq => {
-            if crate::estimation::agq::analytic_score_supported(model) {
+        // Laplace is AGQ at one node — same objective, same gradient, so same report.
+        EstimationMethod::Agq | EstimationMethod::Laplace => {
+            if crate::estimation::agq::analytic_score_supported_model(model) {
                 GradientMethodKind::Analytic
             } else {
                 GradientMethodKind::FiniteDifferences

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -1055,19 +1055,22 @@ fn eta_dx(
 ) -> Option<Vec<nalgebra::DVector<f64>>> {
     use crate::estimation::parameterization::{packed_fixed_mask, unpack_params};
 
-    // `dη̂/dx` from the provider, non-IOV only.
-    //
-    // Deliberately NOT `subject_eta_dx_iov` for IOV, even though it exists. Both provider
-    // entry points solve `db̂/dx = −H_inner⁻¹ · ∂²nll/∂b∂x` against the *Gauss-Newton* inner
-    // Hessian, whereas AGQ's grid is scaled by the **exact** FD Hessian. Non-IOV that
-    // mismatch is immaterial (it leaves the gradient at 0.16% of FD), but with the stacked
-    // (η, κ) Hessian it is not: it puts the ω gradients ~8% out. The implicit-function finite
-    // difference below uses the same exact `H` the grid does, and brings IOV back in line.
-    // Still no inner re-solve — this is the derivative of the mode, not a recomputation of it.
-    if !stack.is_iov() && analytic_score_supported(model, stack) {
-        if let Some(v) = crate::estimation::sens_outer_gradient::subject_eta_dx(
-            model, subject, template, x, b_hat,
-        ) {
+    // `db̂/dx` from the provider — the stacked (η, κ) entry point under IOV, the η-only one
+    // otherwise. Both are the exact implicit-function derivative `−H_inner⁻¹·∂²nll/∂b∂x`, and
+    // neither re-solves the inner loop: this is the *derivative* of the mode, not a
+    // recomputation of it. The finite difference below is the fallback for models outside the
+    // provider's scope, and uses the same exact `H` the grid is scaled by.
+    if analytic_score_supported(model, stack) {
+        let exact = if stack.is_iov() {
+            crate::estimation::sens_outer_gradient::subject_eta_dx_iov(
+                model, subject, template, x, b_hat,
+            )
+        } else {
+            crate::estimation::sens_outer_gradient::subject_eta_dx(
+                model, subject, template, x, b_hat,
+            )
+        };
+        if let Some(v) = exact {
             return Some(v);
         }
     }

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -156,52 +156,179 @@ fn logsumexp(xs: &[f64]) -> f64 {
     max + xs.iter().map(|x| (x - max).exp()).sum::<f64>().ln()
 }
 
-/// Central-difference Hessian of the exact conditional NLL w.r.t. η at `eta_hat`.
+/// The per-subject **integration variable** and its prior.
 ///
-/// Step `hᵢ = max(ε^¼ · √Ωᵢᵢ, 1e-4)`: `ε^¼` is the standard second-difference step (it
-/// balances truncation against the `ε/h²` round-off blow-up), scaled by the prior SD
-/// because that is η's natural unit. The `1e-4` floor keeps a near-zero (or FIXed-small)
-/// Ωᵢᵢ from driving `h` so small that `ε/h²` swamps the curvature.
-fn fd_posterior_hessian(
-    model: &CompiledModel,
-    subject: &Subject,
-    params: &ModelParameters,
-    eta_hat: &[f64],
-    scratch: &mut pk::EventPkParams,
-    schedule: Option<&pk::event_driven::EventSchedule>,
-) -> DMatrix<f64> {
-    let d = eta_hat.len();
-    let mut nll_at = |eta: &[f64]| -> f64 {
-        individual_nll_into_with_schedule(
+/// AGQ integrates over whatever random effects the subject has. Without IOV that is `b = η`
+/// with prior `Ω`. With IOV it is the **stacked** vector
+///
+/// ```text
+///   b = [η, κ₁, …, κ_K]        (dimension d = n_eta + K·n_kappa)
+/// ```
+///
+/// whose prior is the block-diagonal `Ω_joint = Ω ⊕ Ω_iov ⊕ … ⊕ Ω_iov` (K copies). That is
+/// not a new model — it is exactly what
+/// [`crate::stats::likelihood::individual_nll_iov`] already scores, since
+///
+/// ```text
+///   nll_iov = ½·(ηᵀΩ⁻¹η + log|Ω| + Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov| + data)
+///           = ½·(bᵀΩ_joint⁻¹b + log|Ω_joint| + data)
+/// ```
+///
+/// So **every AGQ formula in this module carries over verbatim** with `d` the stacked
+/// dimension: the marginal, the `(d/2)·logπ + ½log|H|` normaliser, the node transform, the
+/// Fisher-identity gradient. IOV is a change of dimension, not of method.
+///
+/// The cost is that `d` grows with the number of occasions, and the tensor grid is
+/// `n_agq^d` — see [`MAX_AGQ_GRID`]. `method = laplace` (one node) is unaffected: its grid is
+/// a single point no matter how large `d` gets, so Laplace + IOV is always tractable.
+pub(crate) struct Stack {
+    n_eta: usize,
+    n_kappa: usize,
+    /// Occasions for *this* subject (0 when the model or subject has no IOV).
+    n_occ: usize,
+    /// `Ω_joint⁻¹`, the prior precision over `b`. Feeds `build_proposal`'s fallback.
+    omega_joint_inv: DMatrix<f64>,
+    /// `√diag(Ω_joint)` — each coordinate's natural scale, for finite-difference steps.
+    prior_sd: Vec<f64>,
+}
+
+impl Stack {
+    /// Build the stack for a subject with `n_occ` occasions (`0` ⇒ no IOV).
+    fn new(model: &CompiledModel, params: &ModelParameters, n_occ: usize) -> Self {
+        let n_eta = model.n_eta;
+        let n_kappa = if n_occ == 0 { 0 } else { model.n_kappa };
+        let d = n_eta + n_occ * n_kappa;
+
+        let (omega_joint_inv, prior_sd) = match (&params.omega_iov, n_kappa) {
+            (Some(iov), k) if k > 0 => {
+                let inv = crate::estimation::importance_sampling::build_joint_omega_inv(
+                    &params.omega.inv,
+                    &iov.inv,
+                    n_eta,
+                    k,
+                    n_occ,
+                );
+                let mut sd = Vec::with_capacity(d);
+                for i in 0..n_eta {
+                    sd.push(params.omega.matrix[(i, i)].max(0.0).sqrt());
+                }
+                for _ in 0..n_occ {
+                    for i in 0..k {
+                        sd.push(iov.matrix[(i, i)].max(0.0).sqrt());
+                    }
+                }
+                (inv, sd)
+            }
+            _ => {
+                let sd = (0..n_eta)
+                    .map(|i| params.omega.matrix[(i, i)].max(0.0).sqrt())
+                    .collect();
+                (params.omega.inv.clone(), sd)
+            }
+        };
+        Self {
+            n_eta,
+            n_kappa,
+            n_occ,
+            omega_joint_inv,
+            prior_sd,
+        }
+    }
+
+    /// Dimension of the integration variable.
+    fn d(&self) -> usize {
+        self.n_eta + self.n_occ * self.n_kappa
+    }
+
+    fn is_iov(&self) -> bool {
+        self.n_occ > 0 && self.n_kappa > 0
+    }
+
+    /// Split `b` back into `(η, [κ₁ … κ_K])`.
+    fn split<'a>(&self, b: &'a [f64]) -> (&'a [f64], Vec<Vec<f64>>) {
+        let eta = &b[..self.n_eta];
+        let kappas = (0..self.n_occ)
+            .map(|k| {
+                let s = self.n_eta + k * self.n_kappa;
+                b[s..s + self.n_kappa].to_vec()
+            })
+            .collect();
+        (eta, kappas)
+    }
+
+    /// The exact conditional NLL at an arbitrary `b` — the AGQ integrand. Dispatches to the
+    /// IOV-aware likelihood when the subject has occasions; both are the model's *real*
+    /// likelihood, not a surrogate.
+    fn nll_at(
+        &self,
+        model: &CompiledModel,
+        subject: &Subject,
+        params: &ModelParameters,
+        b: &[f64],
+        scratch: &mut pk::EventPkParams,
+        schedule: Option<&pk::event_driven::EventSchedule>,
+    ) -> f64 {
+        if !self.is_iov() {
+            return individual_nll_into_with_schedule(
+                model,
+                subject,
+                &params.theta,
+                b,
+                &params.omega,
+                &params.sigma.values,
+                scratch,
+                schedule,
+            );
+        }
+        let (eta, kappas) = self.split(b);
+        crate::stats::likelihood::individual_nll_iov(
             model,
             subject,
             &params.theta,
             eta,
+            &kappas,
             &params.omega,
+            params.omega_iov.as_ref(),
             &params.sigma.values,
-            scratch,
-            schedule,
         )
-    };
+    }
+}
+
+/// Central-difference Hessian of the exact conditional NLL w.r.t. the integration variable
+/// `b` at `b_hat` (see [`Stack`] — `b = η`, or `[η, κ₁..κ_K]` under IOV).
+///
+/// Step `hᵢ = max(ε^¼ · √Ω_joint,ᵢᵢ, 1e-4)`: `ε^¼` is the standard second-difference step (it
+/// balances truncation against the `ε/h²` round-off blow-up), scaled by the prior SD because
+/// that is each coordinate's natural unit. The `1e-4` floor keeps a near-zero (or FIXed-small)
+/// prior variance from driving `h` so small that `ε/h²` swamps the curvature.
+fn fd_posterior_hessian(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    stack: &Stack,
+    b_hat: &[f64],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> DMatrix<f64> {
+    let d = stack.d();
+    let mut nll_at =
+        |b: &[f64]| -> f64 { stack.nll_at(model, subject, params, b, scratch, schedule) };
 
     let steps: Vec<f64> = (0..d)
-        .map(|i| {
-            let sd = params.omega.matrix[(i, i)].max(0.0).sqrt();
-            (f64::EPSILON.powf(0.25) * sd).max(1e-4)
-        })
+        .map(|i| (f64::EPSILON.powf(0.25) * stack.prior_sd[i]).max(1e-4))
         .collect();
 
-    let f0 = nll_at(eta_hat);
+    let f0 = nll_at(b_hat);
     let mut h = DMatrix::<f64>::zeros(d, d);
-    let mut eta = eta_hat.to_vec();
+    let mut b = b_hat.to_vec();
 
     for i in 0..d {
         let hi = steps[i];
-        eta[i] = eta_hat[i] + hi;
-        let f_plus = nll_at(&eta);
-        eta[i] = eta_hat[i] - hi;
-        let f_minus = nll_at(&eta);
-        eta[i] = eta_hat[i];
+        b[i] = b_hat[i] + hi;
+        let f_plus = nll_at(&b);
+        b[i] = b_hat[i] - hi;
+        let f_minus = nll_at(&b);
+        b[i] = b_hat[i];
         h[(i, i)] = (f_plus - 2.0 * f0 + f_minus) / (hi * hi);
     }
 
@@ -209,11 +336,11 @@ fn fd_posterior_hessian(
         for j in (i + 1)..d {
             let (hi, hj) = (steps[i], steps[j]);
             let mut at = |si: f64, sj: f64| -> f64 {
-                eta[i] = eta_hat[i] + si * hi;
-                eta[j] = eta_hat[j] + sj * hj;
-                let v = nll_at(&eta);
-                eta[i] = eta_hat[i];
-                eta[j] = eta_hat[j];
+                b[i] = b_hat[i] + si * hi;
+                b[j] = b_hat[j] + sj * hj;
+                let v = nll_at(&b);
+                b[i] = b_hat[i];
+                b[j] = b_hat[j];
                 v
             };
             let mixed =
@@ -236,11 +363,12 @@ pub(crate) fn agq_subject_nll(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
-    eta_hat: &[f64],
+    stack: &Stack,
+    b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
 ) -> f64 {
-    let d = eta_hat.len();
+    let d = stack.d();
     let mut scratch = pk::EventPkParams::with_capacity_for(subject);
     let schedule = cacheable_schedule(model, subject);
 
@@ -248,13 +376,11 @@ pub(crate) fn agq_subject_nll(
     // conditional likelihood itself. (The formula below would agree — an empty tensor
     // product is the single empty node — but there is no Σ to factor, so short-circuit.)
     if d == 0 {
-        return individual_nll_into_with_schedule(
+        return stack.nll_at(
             model,
             subject,
-            &params.theta,
-            eta_hat,
-            &params.omega,
-            &params.sigma.values,
+            params,
+            b_hat,
             &mut scratch,
             schedule.as_ref(),
         );
@@ -264,23 +390,26 @@ pub(crate) fn agq_subject_nll(
         model,
         subject,
         params,
-        eta_hat,
+        stack,
+        b_hat,
         &mut scratch,
         schedule.as_ref(),
     );
     // `build_proposal` applies the relative jitter and — if the FD Hessian came back
-    // indefinite (a loosely-converged mode, a flat direction) — falls back to the Ω-scale
-    // factor. That fallback keeps AGQ *consistent* (any invertible scale integrates to the
-    // same limit); it only costs nodes-worth of efficiency, which is the right failure mode.
-    let Some(proposal) = build_proposal(&h, &params.omega.inv, d) else {
+    // indefinite (a loosely-converged mode, a flat direction) — falls back to the prior-scale
+    // factor (`Ω`, or the block-diagonal `Ω_joint` under IOV). That fallback keeps AGQ
+    // *consistent* (any invertible scale integrates to the same limit); it only costs
+    // nodes-worth of efficiency, which is the right failure mode.
+    let Some(proposal) = build_proposal(&h, &stack.omega_joint_inv, d) else {
         return NLL_SENTINEL;
     };
 
-    let (_etas, terms) = agq_nodes_and_terms(
+    let (_bs, terms) = agq_nodes_and_terms(
         model,
         subject,
         params,
-        eta_hat,
+        stack,
+        b_hat,
         nodes,
         log_weights,
         &proposal,
@@ -309,17 +438,18 @@ fn agq_nodes_and_terms(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
-    eta_hat: &[f64],
+    stack: &Stack,
+    b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
     proposal: &crate::estimation::importance_sampling::Proposal,
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> (Vec<Vec<f64>>, Vec<f64>) {
-    let d = eta_hat.len();
+    let d = stack.d();
     let n = nodes.len();
     let cap = grid_size(n, d);
-    let mut etas = Vec::with_capacity(cap);
+    let mut bs = Vec::with_capacity(cap);
     let mut terms = Vec::with_capacity(cap);
     let mut idx = vec![0usize; d];
     let mut z = vec![0.0f64; d];
@@ -334,25 +464,17 @@ fn agq_nodes_and_terms(
             z_sq += zk * zk;
             log_w += log_weights[idx[k]];
         }
-        // η_j = η̂ + √2 · Σ^{1/2} · z_j — the adaptive transform.
+        // b_j = b̂ + √2 · Σ^{1/2} · z_j — the adaptive transform, over the whole stacked
+        // vector (η, and every occasion's κ under IOV).
         proposal.apply_l_sigma(&z, &mut step, std::f64::consts::SQRT_2);
-        let eta: Vec<f64> = (0..d).map(|k| eta_hat[k] + step[k]).collect();
+        let b: Vec<f64> = (0..d).map(|k| b_hat[k] + step[k]).collect();
 
-        let nll = individual_nll_into_with_schedule(
-            model,
-            subject,
-            &params.theta,
-            &eta,
-            &params.omega,
-            &params.sigma.values,
-            scratch,
-            schedule,
-        );
+        let nll = stack.nll_at(model, subject, params, &b, scratch, schedule);
         // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
         // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
         // which case the subject correctly reports the sentinel back.
         terms.push(log_w + z_sq - nll);
-        etas.push(eta);
+        bs.push(b);
 
         // Mixed-radix increment over the d-dimensional tensor grid.
         let mut k = 0;
@@ -368,7 +490,7 @@ fn agq_nodes_and_terms(
             break;
         }
     }
-    (etas, terms)
+    (bs, terms)
 }
 
 /// Population AGQ objective: `Σ_i agq_subject_nll_i`. The outer loop doubles this into an
@@ -383,6 +505,7 @@ pub fn agq_population_nll(
     population: &Population,
     params: &ModelParameters,
     eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
     n_nodes: usize,
 ) -> f64 {
     let (nodes, weights) = gauss_hermite(n_nodes);
@@ -393,17 +516,24 @@ pub fn agq_population_nll(
         .par_iter()
         .enumerate()
         .map(|(i, subject)| {
-            agq_subject_nll(
-                model,
-                subject,
-                params,
-                eta_hats[i].as_slice(),
-                &nodes,
-                &log_weights,
-            )
+            let subj_kappas = kappas.get(i).map(Vec::as_slice).unwrap_or(&[]);
+            let stack = Stack::new(model, params, subj_kappas.len());
+            let b_hat = stack_mode(eta_hats[i].as_slice(), subj_kappas);
+            agq_subject_nll(model, subject, params, &stack, &b_hat, &nodes, &log_weights)
         })
         .collect();
     per_subject.iter().sum()
+}
+
+/// Assemble the stacked mode `b̂ = [η̂, κ̂₁ … κ̂_K]` from what the shared inner loop already
+/// returns. AGQ does not re-optimise either piece — `find_ebe_iov` converges the joint
+/// (η, κ) mode, which is exactly the point the grid is centred on.
+fn stack_mode(eta_hat: &[f64], kappas: &[nalgebra::DVector<f64>]) -> Vec<f64> {
+    let mut b = eta_hat.to_vec();
+    for k in kappas {
+        b.extend_from_slice(k.as_slice());
+    }
+    b
 }
 
 // ---------------------------------------------------------------------------
@@ -465,8 +595,34 @@ pub fn agq_population_nll(
 /// wrap, FREM's pseudo-observations, a dense residual covariance, an η-scaled or custom
 /// residual variance), and TTE / categorical endpoints are outside the provider entirely.
 /// Those all take [`accumulate_fixed_eta_packed_gradient_fd`] instead.
-pub fn analytic_score_supported(model: &CompiledModel) -> bool {
-    crate::sens::provider::analytic_outer_gradient_available(model)
+/// Model-level mirror of [`analytic_score_supported`], for reporting
+/// (`build_info::gradient_method_outer`) which has no per-subject [`Stack`]. Uses the model's
+/// own `n_kappa` to pick the IOV or non-IOV provider scope, which is the same answer every
+/// subject of an IOV model gets.
+pub fn analytic_score_supported_model(model: &CompiledModel) -> bool {
+    let stack = Stack {
+        n_eta: model.n_eta,
+        n_kappa: model.n_kappa,
+        n_occ: usize::from(model.n_kappa > 0),
+        omega_joint_inv: DMatrix::zeros(0, 0),
+        prior_sd: Vec::new(),
+    };
+    analytic_score_supported(model, &stack)
+}
+
+pub fn analytic_score_supported(model: &CompiledModel, stack: &Stack) -> bool {
+    // The provider's scope differs for IOV: `subject_sensitivities_iov` runs the stacked
+    // (θ, η, κ) dual walk, gated by `iov_sens_supported`, while the non-IOV entry point is
+    // gated by `analytic_outer_gradient_available`. `analytic_outer_gradient_available`
+    // already folds in `iov_sens_supported`, but it also carries the `gradient_method = fd`
+    // opt-out and the non-Gaussian/magnitude bails, which apply to both.
+    let provider = if stack.is_iov() {
+        crate::sens::provider::iov_sens_supported(model)
+            && !matches!(model.gradient_method, crate::types::GradientMethod::Fd)
+    } else {
+        crate::sens::provider::analytic_outer_gradient_available(model)
+    };
+    provider
         && !matches!(model.bloq_method, crate::types::BloqMethod::M3)
         && model.residual_correlations.is_empty()
         && model.frem_config.is_none()
@@ -513,12 +669,13 @@ pub fn analytic_gradient_available(model: &CompiledModel) -> bool {
 /// Predictions are σ-independent, so the σ perturbations reuse nothing extra — each is one
 /// likelihood evaluation. No inner re-solve, which is the whole point.
 #[allow(clippy::too_many_arguments)]
-fn accumulate_fixed_eta_packed_gradient_fd(
+fn accumulate_fixed_b_packed_gradient_fd(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
     template: &ModelParameters,
-    eta: &[f64],
+    stack: &Stack,
+    b: &[f64],
     weight: f64,
     n_theta: usize,
     sigma_start: usize,
@@ -533,16 +690,7 @@ fn accumulate_fixed_eta_packed_gradient_fd(
     let schedule = cacheable_schedule(model, subject);
 
     let mut nll_at = |p: &ModelParameters| -> f64 {
-        individual_nll_into_with_schedule(
-            model,
-            subject,
-            &p.theta,
-            eta,
-            &p.omega,
-            &p.sigma.values,
-            &mut scratch,
-            schedule.as_ref(),
-        )
+        stack.nll_at(model, subject, p, b, &mut scratch, schedule.as_ref())
     };
 
     // θ and σ coordinates only — the Ω block is exact in closed form and already added.
@@ -582,22 +730,25 @@ fn accumulate_fixed_eta_packed_gradient(
     subject: &Subject,
     params: &ModelParameters,
     template: &ModelParameters,
+    stack: &Stack,
     eta: &[f64],
     weight: f64,
     out: &mut [f64],
 ) -> Option<()> {
     use crate::estimation::parameterization::theta_packs_log;
 
+    let b = eta; // the integration variable: η, or the stacked [η, κ₁..κ_K] under IOV
     let n_obs = subject.observations.len();
     let n_theta = params.theta.len();
     let n_sigma = params.sigma.values.len();
-    let n_eta = eta.len();
+    let n_eta = stack.n_eta;
+    let (eta_part, kappas) = stack.split(b);
 
-    // Ω block — from the η-prior `½(ηᵀΩ⁻¹η + log|Ω|)`, which is the *only* place Ω enters
-    // `nll` at a fixed η:
+    // ── Ω block ──────────────────────────────────────────────────────────────────────
+    // From the η-prior `½(ηᵀΩ⁻¹η + log|Ω|)`, the only place Ω enters `nll` at a fixed b:
     //   ∂/∂Ω [½ ηᵀΩ⁻¹η] = −½·zzᵀ   and   ∂/∂Ω [½ log|Ω|] = ½·Ω⁻¹,   z = Ω⁻¹η.
-    // Independent of the data, so it is accumulated even for a subject with no observations.
-    let z = &params.omega.inv * nalgebra::DVector::from_column_slice(eta);
+    // Data-independent, so it is accumulated even for a subject with no observations.
+    let z = &params.omega.inv * nalgebra::DVector::from_column_slice(eta_part);
     let mut m_omega = DMatrix::zeros(n_eta, n_eta);
     for r in 0..n_eta {
         for c in 0..n_eta {
@@ -615,23 +766,58 @@ fn accumulate_fixed_eta_packed_gradient(
     }
     let sigma_start = omega_start + og.len();
 
+    // ── Ω_iov block ──────────────────────────────────────────────────────────────────
+    // The κ prior is `½(Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov|)` — the *same* shape as the η
+    // prior, but summed over the K occasions, which share one Ω_iov:
+    //   ∂/∂Ω_iov = ½·(−Σ_k z_k z_kᵀ + K·Ω_iov⁻¹),   z_k = Ω_iov⁻¹κ_k.
+    // Mapped to Cholesky-packed space by the same `chol_pack`. This is the only block that
+    // is genuinely new under IOV; θ and σ are unchanged (see below).
+    let iov_start = sigma_start + n_sigma;
+    if stack.is_iov() {
+        let iov = params
+            .omega_iov
+            .as_ref()
+            .expect("stack.is_iov() ⟹ omega_iov present");
+        let k_occ = kappas.len();
+        let n_iov = stack.n_kappa;
+        let mut m_iov = DMatrix::zeros(n_iov, n_iov);
+        for kap in &kappas {
+            let zk = &iov.inv * nalgebra::DVector::from_column_slice(kap);
+            for r in 0..n_iov {
+                for c in 0..n_iov {
+                    m_iov[(r, c)] -= 0.5 * zk[r] * zk[c];
+                }
+            }
+        }
+        for r in 0..n_iov {
+            for c in 0..n_iov {
+                m_iov[(r, c)] += 0.5 * (k_occ as f64) * iov.inv[(r, c)];
+            }
+        }
+        let ig = crate::estimation::sens_outer_gradient::chol_pack(&m_iov, &iov.chol, iov.diagonal);
+        for (k, &v) in ig.iter().enumerate() {
+            out[iov_start + k] += weight * v;
+        }
+    }
+
     if n_obs == 0 {
         return Some(());
     }
 
     // Off the analytic score's scope (a non-Gaussian endpoint, M3, LTBS, an ODE model, …):
-    // finite-difference the θ and σ blocks of `nll` at this **fixed η** instead. Still no
+    // finite-difference the θ and σ blocks of `nll` at this **fixed b** instead. Still no
     // inner re-solve — that is the expensive thing, and neither path does one — so AGQ keeps
     // its own gradient for *every* model rather than dropping to `reconverged_fd_gradient`.
     // This matters most for exactly the endpoints AGQ exists to serve: TTE and categorical
     // are outside the `Dual2` provider, and it would be perverse for them to be the slow case.
-    if !analytic_score_supported(model) {
-        return accumulate_fixed_eta_packed_gradient_fd(
+    if !analytic_score_supported(model, stack) {
+        return accumulate_fixed_b_packed_gradient_fd(
             model,
             subject,
             params,
             template,
-            eta,
+            stack,
+            b,
             weight,
             n_theta,
             sigma_start,
@@ -639,9 +825,15 @@ fn accumulate_fixed_eta_packed_gradient(
         );
     }
 
-    // Exact ∂f/∂θ at *this* η. `subject_sensitivities` makes no mode assumption — the
-    // η = η̂ requirement in `sens_outer_gradient` lives in its `theta_block`, not here.
-    let sens = crate::sens::provider::subject_sensitivities(model, subject, &params.theta, eta)?;
+    // Exact ∂f/∂θ at *this* b. Neither provider entry point assumes the mode — the η = η̂
+    // requirement in `sens_outer_gradient` lives in its `theta_block`, not here. The IOV
+    // entry point takes the *stacked* (η, κ) vector and returns the same `ObsSens`, so
+    // everything below is identical for both.
+    let sens = if stack.is_iov() {
+        crate::sens::provider::subject_sensitivities_iov(model, subject, &params.theta, b)?
+    } else {
+        crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b)?
+    };
 
     let err_keys = model.error_spec.obs_keys(subject);
     let mut d_nll_d_f = vec![0.0f64; n_obs];
@@ -741,8 +933,9 @@ fn grid_response_correction(
     subject: &Subject,
     params: &ModelParameters,
     template: &ModelParameters,
+    stack: &Stack,
     x: &[f64],
-    eta_hat: &[f64],
+    b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
     scratch: &mut pk::EventPkParams,
@@ -760,8 +953,8 @@ fn grid_response_correction(
     // `dη̂/dx` (the implicit-function-theorem derivative `−H⁻¹·∂²nll/∂η∂x`, which the
     // sensitivity provider already supplies and the EBE predictor already relies on). No
     // inner re-solve is needed.
-    let deta_dx = eta_dx(
-        model, subject, params, template, x, eta_hat, scratch, schedule,
+    let db_dx = eta_dx(
+        model, subject, params, template, stack, x, b_hat, scratch, schedule,
     )?;
 
     for k in 0..x.len() {
@@ -777,18 +970,21 @@ fn grid_response_correction(
         xp[k] += step;
         xm[k] -= step;
 
-        // The mode moves with the parameters: η̂(x ± h) ≈ η̂ ± h · dη̂/dx_k.
-        let ep: Vec<f64> = (0..eta_hat.len())
-            .map(|i| eta_hat[i] + step * deta_dx[k][i])
+        // The mode moves with the parameters: b̂(x ± h) ≈ b̂ ± h · db̂/dx_k.
+        let ep: Vec<f64> = (0..b_hat.len())
+            .map(|i| b_hat[i] + step * db_dx[k][i])
             .collect();
-        let em: Vec<f64> = (0..eta_hat.len())
-            .map(|i| eta_hat[i] - step * deta_dx[k][i])
+        let em: Vec<f64> = (0..b_hat.len())
+            .map(|i| b_hat[i] - step * db_dx[k][i])
             .collect();
 
         let pp = unpack_params(&xp, template);
         let pm = unpack_params(&xm, template);
-        let hp = fd_posterior_hessian(model, subject, &pp, &ep, scratch, schedule);
-        let hm = fd_posterior_hessian(model, subject, &pm, &em, scratch, schedule);
+        // Ω_joint moves with the parameters too, so rebuild the stack at each perturbed point.
+        let sp = Stack::new(model, &pp, stack.n_occ);
+        let sm = Stack::new(model, &pm, stack.n_occ);
+        let hp = fd_posterior_hessian(model, subject, &pp, &sp, &ep, scratch, schedule);
+        let hm = fd_posterior_hessian(model, subject, &pm, &sm, &em, scratch, schedule);
 
         // `nll` stays at the ORIGINAL params — the direct x-dependence is already covered
         // analytically by the fixed-η score — but the grid (centre and scale) is the
@@ -797,11 +993,12 @@ fn grid_response_correction(
             model,
             subject,
             params,
+            stack,
             &ep,
             nodes,
             log_weights,
             &hp,
-            &pp.omega.inv,
+            &sp.omega_joint_inv,
             scratch,
             schedule,
         );
@@ -809,11 +1006,12 @@ fn grid_response_correction(
             model,
             subject,
             params,
+            stack,
             &em,
             nodes,
             log_weights,
             &hm,
-            &pm.omega.inv,
+            &sm.omega_joint_inv,
             scratch,
             schedule,
         );
@@ -849,54 +1047,46 @@ fn eta_dx(
     subject: &Subject,
     params: &ModelParameters,
     template: &ModelParameters,
+    stack: &Stack,
     x: &[f64],
-    eta_hat: &[f64],
+    b_hat: &[f64],
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> Option<Vec<nalgebra::DVector<f64>>> {
     use crate::estimation::parameterization::{packed_fixed_mask, unpack_params};
 
-    if analytic_score_supported(model) {
+    // `dη̂/dx` from the provider, non-IOV only.
+    //
+    // Deliberately NOT `subject_eta_dx_iov` for IOV, even though it exists. Both provider
+    // entry points solve `db̂/dx = −H_inner⁻¹ · ∂²nll/∂b∂x` against the *Gauss-Newton* inner
+    // Hessian, whereas AGQ's grid is scaled by the **exact** FD Hessian. Non-IOV that
+    // mismatch is immaterial (it leaves the gradient at 0.16% of FD), but with the stacked
+    // (η, κ) Hessian it is not: it puts the ω gradients ~8% out. The implicit-function finite
+    // difference below uses the same exact `H` the grid does, and brings IOV back in line.
+    // Still no inner re-solve — this is the derivative of the mode, not a recomputation of it.
+    if !stack.is_iov() && analytic_score_supported(model, stack) {
         if let Some(v) = crate::estimation::sens_outer_gradient::subject_eta_dx(
-            model, subject, template, x, eta_hat,
+            model, subject, template, x, b_hat,
         ) {
             return Some(v);
         }
     }
 
-    let d = eta_hat.len();
-    let h_mat = fd_posterior_hessian(model, subject, params, eta_hat, scratch, schedule);
+    let d = stack.d();
+    let h_mat = fd_posterior_hessian(model, subject, params, stack, b_hat, scratch, schedule);
     let h_inv = h_mat.clone().try_inverse()?;
     let fixed = packed_fixed_mask(template);
 
-    // ∇_η nll(η̂; p) — central differences in η, at the given parameters.
+    // ∇_b nll(b̂; p) — central differences in the stacked variable, at the given parameters.
     let mut eta_grad = |p: &ModelParameters, out: &mut [f64]| {
-        let mut e = eta_hat.to_vec();
+        let mut e = b_hat.to_vec();
         for i in 0..d {
-            let step = (f64::EPSILON.powf(0.25) * p.omega.matrix[(i, i)].max(0.0).sqrt()).max(1e-5);
-            e[i] = eta_hat[i] + step;
-            let fp = individual_nll_into_with_schedule(
-                model,
-                subject,
-                &p.theta,
-                &e,
-                &p.omega,
-                &p.sigma.values,
-                scratch,
-                schedule,
-            );
-            e[i] = eta_hat[i] - step;
-            let fm = individual_nll_into_with_schedule(
-                model,
-                subject,
-                &p.theta,
-                &e,
-                &p.omega,
-                &p.sigma.values,
-                scratch,
-                schedule,
-            );
-            e[i] = eta_hat[i];
+            let step = (f64::EPSILON.powf(0.25) * stack.prior_sd[i]).max(1e-5);
+            e[i] = b_hat[i] + step;
+            let fp = stack.nll_at(model, subject, p, &e, scratch, schedule);
+            e[i] = b_hat[i] - step;
+            let fm = stack.nll_at(model, subject, p, &e, scratch, schedule);
+            e[i] = b_hat[i];
             out[i] = (fp - fm) / (2.0 * step);
         }
     };
@@ -934,7 +1124,8 @@ fn phi_grid(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
-    eta_hat: &[f64],
+    stack: &Stack,
+    b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
     h_mat: &DMatrix<f64>,
@@ -942,13 +1133,14 @@ fn phi_grid(
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> Option<f64> {
-    let d = eta_hat.len();
+    let d = stack.d();
     let proposal = build_proposal(h_mat, omega_inv, d)?;
-    let (_etas, terms) = agq_nodes_and_terms(
+    let (_bs, terms) = agq_nodes_and_terms(
         model,
         subject,
         params,
-        eta_hat,
+        stack,
+        b_hat,
         nodes,
         log_weights,
         &proposal,
@@ -972,19 +1164,20 @@ fn agq_subject_packed_gradient(
     subject: &Subject,
     params: &ModelParameters,
     template: &ModelParameters,
+    stack: &Stack,
     x: &[f64],
-    eta_hat: &[f64],
+    b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
     out: &mut [f64],
 ) -> Option<()> {
-    let d = eta_hat.len();
+    let d = stack.d();
     let mut scratch = pk::EventPkParams::with_capacity_for(subject);
     let schedule = cacheable_schedule(model, subject);
 
     if d == 0 {
         return accumulate_fixed_eta_packed_gradient(
-            model, subject, params, template, eta_hat, 1.0, out,
+            model, subject, params, template, stack, b_hat, 1.0, out,
         );
     }
 
@@ -992,19 +1185,21 @@ fn agq_subject_packed_gradient(
         model,
         subject,
         params,
-        eta_hat,
+        stack,
+        b_hat,
         &mut scratch,
         schedule.as_ref(),
     );
-    let proposal = build_proposal(&h, &params.omega.inv, d)?;
+    let proposal = build_proposal(&h, &stack.omega_joint_inv, d)?;
 
-    // Sweep the grid once, keeping each node's η and its log-term, so the softmax weights
+    // Sweep the grid once, keeping each node's b and its log-term, so the softmax weights
     // and the scores are computed on exactly the same nodes the objective used.
-    let (etas, terms) = agq_nodes_and_terms(
+    let (bs, terms) = agq_nodes_and_terms(
         model,
         subject,
         params,
-        eta_hat,
+        stack,
+        b_hat,
         nodes,
         log_weights,
         &proposal,
@@ -1016,12 +1211,12 @@ fn agq_subject_packed_gradient(
         return None;
     }
 
-    for (eta_j, &t) in etas.iter().zip(terms.iter()) {
+    for (b_j, &t) in bs.iter().zip(terms.iter()) {
         let w = (t - lse).exp();
         if w == 0.0 {
             continue; // exp underflow — contributes nothing to the average
         }
-        accumulate_fixed_eta_packed_gradient(model, subject, params, template, eta_j, w, out)?;
+        accumulate_fixed_eta_packed_gradient(model, subject, params, template, stack, b_j, w, out)?;
     }
 
     // …plus the grid's response to H — the only term the fixed-node score omits, and the
@@ -1031,8 +1226,9 @@ fn agq_subject_packed_gradient(
         subject,
         params,
         template,
+        stack,
         x,
-        eta_hat,
+        b_hat,
         nodes,
         log_weights,
         &mut scratch,
@@ -1055,6 +1251,7 @@ pub fn agq_population_gradient(
     template: &ModelParameters,
     x: &[f64],
     eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
     n_nodes: usize,
 ) -> Option<Vec<f64>> {
     let n_packed = x.len();
@@ -1066,14 +1263,18 @@ pub fn agq_population_gradient(
         .par_iter()
         .enumerate()
         .map(|(i, subject)| {
+            let subj_kappas = kappas.get(i).map(Vec::as_slice).unwrap_or(&[]);
+            let stack = Stack::new(model, params, subj_kappas.len());
+            let b_hat = stack_mode(eta_hats[i].as_slice(), subj_kappas);
             let mut g = vec![0.0f64; n_packed];
             agq_subject_packed_gradient(
                 model,
                 subject,
                 params,
                 template,
+                &stack,
                 x,
-                eta_hats[i].as_slice(),
+                &b_hat,
                 &nodes,
                 &log_weights,
                 &mut g,

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -1590,7 +1590,7 @@ fn compute_joint_posterior_hessian(
 }
 
 /// Build the joint prior precision matrix (block-diagonal: Omega_bsv^{-1} + K copies of Omega_iov^{-1}).
-fn build_joint_omega_inv(
+pub(crate) fn build_joint_omega_inv(
     omega_inv: &DMatrix<f64>,
     omega_iov_inv: &DMatrix<f64>,
     n_eta: usize,

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1267,10 +1267,34 @@ fn optimize_nlopt(
     } else {
         opt.set_maxeval(options.outer_maxiter as u32 * (n as u32 + 1))
             .unwrap();
-        // Use very loose tolerances — FOCE objective is noisy from EBE re-estimation.
-        // Let maxeval be the primary stopping criterion.
-        opt.set_xtol_rel(1e-12).unwrap();
-        opt.set_ftol_rel(1e-12).unwrap();
+        if options.agq_nodes().is_some() {
+            // AGQ's gradient is exact but **finite-difference-limited**: the grid-response
+            // term and the posterior Hessian are both central differences, so the gradient
+            // carries a noise floor (~1e-4 relative). The 1e-12 stops below are therefore
+            // *unreachable* for it — and unreachable stops are not harmless. L-BFGS keeps
+            // stepping until the true gradient drops under that floor, at which point the
+            // search direction is noise, the line search cannot find a decrease, and NLopt
+            // returns a bare `NLOPT_FAILURE`. The fit is fine (the engine restores the
+            // best-seen point) but it is reported as *not converged*, which is a lie about a
+            // result that has been flat to 8 significant figures for 15 evaluations.
+            //
+            // So stop AGQ where its objective actually settles — the same reachable
+            // objective-change / step-size criteria BOBYQA gets — rather than chasing a
+            // gradient norm the gradient cannot deliver. FOCE/FOCEI keep the 1e-12 stops:
+            // their gradient is analytic to ~1e-11 and they *do* reach `XtolReached`.
+            opt.set_xtol_rel(options.outer_xtol).unwrap();
+            let ftol = resolve_outer_ftol(
+                model.has_non_gaussian(),
+                model.is_ode_based(),
+                options.outer_ftol,
+            );
+            opt.set_ftol_rel(ftol).unwrap();
+        } else {
+            // FOCE objective is noisy from EBE re-estimation; let maxeval be the primary
+            // stopping criterion and rely on the analytic gradient to drive |g| down.
+            opt.set_xtol_rel(1e-12).unwrap();
+            opt.set_ftol_rel(1e-12).unwrap();
+        }
     }
 
     if options.verbose {

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -343,13 +343,14 @@ pub(crate) fn pop_nll_opts(
     options: &FitOptions,
 ) -> f64 {
     if let Some(n_nodes) = options.agq_nodes() {
-        // AGQ + IOV is rejected in `check_model_options`, so `kappas` is empty here and the
-        // integral is over η alone. The EBE modes are the same ones FOCE/FOCEI use — AGQ
-        // does not re-optimise them, it lays its grid around them — and `h_matrices` (the
-        // ∂f/∂η Jacobian) is a FOCE artefact AGQ has no use for: it finite-differences the
-        // true posterior Hessian instead. See `crate::estimation::agq`.
+        // AGQ integrates over whatever random effects the subject has: η alone, or the
+        // stacked (η, κ₁..κ_K) under IOV — the joint marginal, not the η-only one. The modes
+        // are the ones the shared inner loop already converged (`find_ebe_iov` returns the
+        // joint mode); AGQ does not re-optimise them, it lays its grid around them.
+        // `h_matrices` (the ∂f/∂η Jacobian) is a FOCE artefact AGQ has no use for — it
+        // finite-differences the true posterior Hessian instead. See `crate::estimation::agq`.
         return crate::estimation::agq::agq_population_nll(
-            model, population, params, eta_hats, n_nodes,
+            model, population, params, eta_hats, kappas, n_nodes,
         );
     }
     pop_nll(
@@ -2365,6 +2366,7 @@ fn population_gradient(
                 init_params,
                 x,
                 ehs,
+                kappas,
                 n_nodes,
             ) {
                 // Fixed coordinates carry no gradient, matching the analytic FOCE path.

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -439,6 +439,7 @@ fn method_to_str(m: EstimationMethod) -> &'static str {
         EstimationMethod::Impmap => "impmap",
         EstimationMethod::Bayes => "bayes",
         EstimationMethod::Agq => "agq",
+        EstimationMethod::Laplace => "laplace",
     }
 }
 
@@ -453,6 +454,7 @@ fn method_from_str(s: &str) -> Result<EstimationMethod, FitrxError> {
         "imp" => EstimationMethod::Imp,
         "bayes" => EstimationMethod::Bayes,
         "agq" => EstimationMethod::Agq,
+        "laplace" => EstimationMethod::Laplace,
         _ => return Err(FitrxError::Corrupt(format!("unknown method {:?}", s))),
     })
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -5658,6 +5658,9 @@ fn parse_method_token(token: &str) -> Result<EstimationMethod, String> {
         Ok(EstimationMethod::Imp)
     } else if val.contains("hybrid") || val == "gn_hybrid" || val == "gn-hybrid" {
         Ok(EstimationMethod::FoceGnHybrid)
+    } else if val == "laplace" || val == "laplacian" {
+        // NONMEM `$EST METHOD=1 LAPLACIAN`. Routes to the AGQ objective with one node.
+        Ok(EstimationMethod::Laplace)
     } else if val == "agq"
         || val == "aghq"
         || val == "gauss_hermite"

--- a/src/types.rs
+++ b/src/types.rs
@@ -5880,6 +5880,22 @@ pub enum EstimationMethod {
     /// Cost is `n_agq^n_eta` likelihood evaluations per subject per iteration; see
     /// [`crate::estimation::agq::MAX_AGQ_GRID`].
     Agq,
+    /// The **Laplace approximation** with the *exact* Hessian — NONMEM `$EST METHOD=1
+    /// LAPLACIAN` (#251).
+    ///
+    /// Identical to [`Agq`](Self::Agq) at one node: the one-point Gauss–Hermite rule sits at
+    /// the mode with weight `√π`, and the quadrature sum collapses, term for term, to
+    /// `(2π)^(d/2)·|H|^(−½)·exp(l(η̂))`. So this variant routes through the AGQ objective with
+    /// the node count pinned to 1 — it is not a separate implementation, and `n_agq` is not
+    /// one of its options.
+    ///
+    /// **Distinct from [`FoceI`](Self::FoceI)**, which is Laplace with the *Gauss-Newton*
+    /// Hessian `CᵀC + Ω⁻¹` (that form drops `∂²f/∂η²`). This one differentiates the true
+    /// conditional NLL, so it carries the curvature of the η-dependent residual variance that
+    /// the Gauss-Newton form discards — which is exactly why it reproduces NONMEM's LAPLACIAN
+    /// (to six significant figures on warfarin) where FOCEI lands on a different value. It is
+    /// also the cheapest member of the AGQ family: one node, no grid.
+    Laplace,
 }
 
 impl EstimationMethod {
@@ -5894,6 +5910,7 @@ impl EstimationMethod {
             EstimationMethod::Impmap => "IMPMAP",
             EstimationMethod::Bayes => "BAYES",
             EstimationMethod::Agq => "AGQ",
+            EstimationMethod::Laplace => "LAPLACE",
         }
     }
 }
@@ -5921,7 +5938,16 @@ impl FitOptions {
     /// Reads `self.method` (the per-stage method — `api::fit_inner` rewrites it for each
     /// stage of a chain), so it is correct inside a chained fit too.
     pub fn agq_nodes(&self) -> Option<usize> {
-        (self.method == EstimationMethod::Agq).then(|| self.n_agq.max(1))
+        match self.method {
+            EstimationMethod::Agq => Some(self.n_agq.max(1)),
+            // Laplace *is* AGQ at one node — not an approximation of it, an identity (the
+            // one-point Gauss-Hermite rule sits at the mode with weight √π, and the sum
+            // collapses to `(2π)^(d/2)·|H|^(−½)·exp(l(η̂))`). So it routes through the same
+            // objective, the same analytic gradient, and the same covariance stencil, with
+            // the node count pinned. `n_agq` is not one of its keys; it cannot be varied.
+            EstimationMethod::Laplace => Some(1),
+            _ => None,
+        }
     }
 
     /// Covariance-step inner EBE-reconvergence tolerance that **closed-form,
@@ -6149,6 +6175,24 @@ pub fn method_specific_keys(m: EstimationMethod) -> &'static [&'static str] {
         // does for FOCE/FOCEI.
         EstimationMethod::Agq => &[
             "n_agq",
+            "maxiter",
+            "inner_maxiter",
+            "inner_tol",
+            "inner_optimizer",
+            "optimizer",
+            "outer_xtol",
+            "outer_ftol",
+            "steihaug_max_iters",
+            "global_search",
+            "global_maxeval",
+            "stagnation_guard",
+            "reconverge_gradient_interval",
+        ],
+        // Laplace is AGQ with the node count pinned to 1, so it takes AGQ's keys **minus
+        // `n_agq`** — that key is not a knob here, and offering it would invite
+        // `method = laplace, n_agq = 5`, which is a contradiction. Users who want to vary the
+        // node count already have `method = agq`.
+        EstimationMethod::Laplace => &[
             "maxiter",
             "inner_maxiter",
             "inner_tol",

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -334,7 +334,7 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
     let ofv = |x: &[f64], n: usize| -> f64 {
         let params = unpack_params(x, template);
         let (ehs, _hms, _stats, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
-            &model, &pop, &params, 300, 1e-10, None, None, 0,
+            &model, &pop, &params, 500, 1e-12, None, None, 0,
         );
         2.0 * agq::agq_population_nll(&model, &pop, &params, &ehs, &[], n)
     };
@@ -344,15 +344,18 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
         // Analytic gradient at x0.
         let params = unpack_params(&x0, template);
         let (ehs, _h, _s, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
-            &model, &pop, &params, 300, 1e-10, None, None, 0,
+            &model, &pop, &params, 500, 1e-12, None, None, 0,
         );
         let g = agq::agq_population_gradient(&model, &pop, &params, template, &x0, &ehs, &[], n)
             .expect("analytic gradient must be available in scope");
 
-        // Central FD of the true objective.
+        // Central FD of the true objective. Step 1e-4, not 1e-5: this references a
+        // **reconverged** objective, so a step below the inner solver's noise floor amplifies
+        // that noise rather than cutting truncation, and the reference — not the gradient —
+        // becomes the inaccurate side. See the IOV twin of this test.
         let mut fd = vec![0.0f64; np];
         for i in 0..np {
-            let h = 1e-5 * (1.0 + x0[i].abs());
+            let h = 1e-4 * (1.0 + x0[i].abs());
             let (mut xp, mut xm) = (x0.clone(), x0.clone());
             xp[i] += h;
             xm[i] -= h;
@@ -374,15 +377,17 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
     // gate: `grid_response_correction` supplies the `∂Φ/∂H·dH/dx` term that the fixed-node
     // score omits, and at n = 1 that term is the entire difference (a 26% error without it).
     //
-    // Measured: 1.6e-3 at n = 1, 7.8e-5 at n = 3, ~1e-5 beyond. The 5e-3 bound leaves headroom
-    // for the FD reference's own noise (it central-differences a *reconverged* objective, so
-    // the inner solver's tolerance leaks in) while still failing loudly on a real regression —
-    // a wrong gradient misses by tens of percent here, not tenths of a percent. It also pins
-    // `AGQ_GRID_FD_STEP`: at 1e-2 this test fails outright (the grid-response term is
-    // truncation-dominated, and a "safe" large step puts the θ gradient 5× off).
+    // Measured: 2.0e-5 at n = 1, 1.5e-6 at n = 3, 2.1e-7 at n = 7 — the gradient is exact to
+    // the reference's own precision. (An earlier revision of this test used a 1e-5 FD step and
+    // read 1.6e-3; that was the *reference's* noise, not the gradient's error — see the step
+    // comment above. Do not "restore" the smaller step.)
+    //
+    // The 1e-4 bound also pins `AGQ_GRID_FD_STEP`: at 1e-2 this test fails outright, because
+    // the grid-response term is truncation-dominated and a "safe" large step puts the θ
+    // gradient 5x off.
     for (k, &n) in [1usize, 3, 5, 7].iter().enumerate() {
         assert!(
-            rel_errs[k] < 5e-3,
+            rel_errs[k] < 1e-4,
             "n_agq={n}: analytic gradient must match FD of the objective, got {:.3e} \
              relative error (all: {rel_errs:?})",
             rel_errs[k]
@@ -1023,10 +1028,14 @@ fn analytic_gradient_matches_fd_under_iov() {
     let np = x0.len();
 
     // Objective at a packed point: re-solve the joint (η, κ) EBEs, then the AGQ OFV.
+    //
+    // The inner solve must be *tightly* converged (1e-12, not the 1e-10 default). This is the
+    // FD reference, and its noise floor is set by how precisely the joint (η, κ) mode is found
+    // — a loosely-solved mode makes the reference, not the gradient, the inaccurate side.
     let ofv = |x: &[f64], n: usize| -> f64 {
         let params = unpack_params(x, template);
         let (ehs, _h, _s, kaps) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
-            model, &pop, &params, 300, 1e-10, None, None, 0,
+            model, &pop, &params, 500, 1e-12, None, None, 0,
         );
         2.0 * agq::agq_population_nll(model, &pop, &params, &ehs, &kaps, n)
     };
@@ -1034,7 +1043,7 @@ fn analytic_gradient_matches_fd_under_iov() {
     for n in [1usize, 3] {
         let params = unpack_params(&x0, template);
         let (ehs, _h, _s, kaps) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
-            model, &pop, &params, 300, 1e-10, None, None, 0,
+            model, &pop, &params, 500, 1e-12, None, None, 0,
         );
         assert!(
             kaps.iter().any(|k| !k.is_empty()),
@@ -1044,9 +1053,15 @@ fn analytic_gradient_matches_fd_under_iov() {
         let g = agq::agq_population_gradient(model, &pop, &params, template, &x0, &ehs, &kaps, n)
             .expect("IOV gradient must be available");
 
+        // FD step 1e-4, NOT the 1e-5 that *looks* more accurate. The reference differences a
+        // **reconverged** objective, so shrinking the step past the inner solver's own noise
+        // floor amplifies that noise instead of reducing truncation. Measured on this model:
+        // 1.4e-3 at h = 1e-5, settling to 2.4e-4 at 1e-4 and staying there through 1e-3 — i.e.
+        // the *reference* was the inaccurate side, not the gradient. Mistaking one for the
+        // other made this gradient look 10x worse than it is; hence this comment.
         let mut fd = vec![0.0f64; np];
         for i in 0..np {
-            let h = 1e-5 * (1.0 + x0[i].abs());
+            let h = 1e-4 * (1.0 + x0[i].abs());
             let (mut xp, mut xm) = (x0.clone(), x0.clone());
             xp[i] += h;
             xm[i] -= h;
@@ -1061,16 +1076,11 @@ fn analytic_gradient_matches_fd_under_iov() {
             .iter()
             .zip(fd.iter())
             .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
-        // 2.5e-2, against 1.6e-3 for the non-IOV case — and honestly so. The FD reference
-        // re-solves the **joint** (η, κ) mode at every perturbed point, and that inner solve is
-        // the noisier half of the comparison (a 5-dimensional mode over 2 occasions of sparse
-        // data). The residual sits on ω_CL / ω_KA — the flat directions — *not* on Ω_iov, whose
-        // block is the genuinely new algebra here and lands at 0.4%. It is comfortably inside
-        // what L-BFGS needs: the IOV fits converge and reproduce FOCEI-IOV's estimates to <1%,
-        // κ included. A wrong Ω_iov block (a dropped `K·Ω_iov⁻¹`, a mis-summed occasion axis)
-        // misses by tens of percent, which this bound still catches.
+        // Measured: 2.4e-4 — the same order as the non-IOV case, not a degraded one. The Ω_iov
+        // block (the genuinely new algebra here) is exact; a wrong one — a dropped
+        // `K·Ω_iov⁻¹`, a mis-summed occasion axis — misses by tens of percent.
         assert!(
-            max_diff / scale < 2.5e-2,
+            max_diff / scale < 1e-3,
             "n_agq={n} (IOV): analytic gradient must match FD of the objective, got {:.3e} \
              relative error\n  analytic: {g:?}\n  fd:       {fd:?}",
             max_diff / scale

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -1087,3 +1087,45 @@ fn analytic_gradient_matches_fd_under_iov() {
         );
     }
 }
+
+/// **AGQ must be able to *declare* convergence, not just reach it.**
+///
+/// AGQ's gradient is exact but **finite-difference-limited** — the grid-response term and the
+/// posterior Hessian are both central differences, so it carries a noise floor around 1e-4
+/// relative. The gradient-optimizer path historically set NLopt's stops to `1e-12`, which is
+/// *unreachable* for such a gradient: L-BFGS keeps stepping until the true gradient drops
+/// under the floor, at which point the search direction is noise, the line search cannot find
+/// a decrease, and NLopt returns a bare `NLOPT_FAILURE`.
+///
+/// The fit was fine (the engine restores the best-seen point) but was reported as **not
+/// converged** — a lie about a result that had been flat to 8 significant figures for a dozen
+/// evaluations, and one paid for with ~40% wasted wall-clock grinding past the plateau.
+///
+/// So AGQ stops on the reachable objective-change criterion instead. This pins that a plain,
+/// well-behaved AGQ fit actually reports `converged`.
+#[test]
+fn agq_reports_convergence_rather_than_grinding_into_nlopt_failure() {
+    let model = parse_model_string(WARFARIN_SRC).expect("model must parse");
+    let pop = warfarin();
+
+    for (method, n) in [
+        (EstimationMethod::Laplace, 1usize),
+        (EstimationMethod::Agq, 3),
+    ] {
+        let opts = FitOptions {
+            method,
+            methods: vec![],
+            n_agq: n,
+            outer_maxiter: 500,
+            run_covariance_step: false,
+            ..FitOptions::default()
+        };
+        let r = fit(&model, &pop, &model.default_params, &opts).expect("fit must succeed");
+        assert!(
+            r.converged,
+            "{method:?} (n_agq={n}) must report convergence, not grind into NLOPT_FAILURE \
+             against an unreachable 1e-12 gradient stop. OFV = {}",
+            r.ofv
+        );
+    }
+}

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -336,7 +336,7 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
         let (ehs, _hms, _stats, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
             &model, &pop, &params, 300, 1e-10, None, None, 0,
         );
-        2.0 * agq::agq_population_nll(&model, &pop, &params, &ehs, n)
+        2.0 * agq::agq_population_nll(&model, &pop, &params, &ehs, &[], n)
     };
 
     let mut rel_errs = Vec::new();
@@ -346,7 +346,7 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
         let (ehs, _h, _s, _k) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
             &model, &pop, &params, 300, 1e-10, None, None, 0,
         );
-        let g = agq::agq_population_gradient(&model, &pop, &params, template, &x0, &ehs, n)
+        let g = agq::agq_population_gradient(&model, &pop, &params, template, &x0, &ehs, &[], n)
             .expect("analytic gradient must be available in scope");
 
         // Central FD of the true objective.
@@ -440,11 +440,20 @@ fn fd_score_path_agrees_with_the_analytic_one() {
     );
 
     for n in [1usize, 3] {
-        let g_an =
-            agq::agq_population_gradient(&analytic_model, &pop, &params, template, &x, &ehs, n)
-                .expect("analytic-score gradient");
-        let g_fd = agq::agq_population_gradient(&fd_model, &pop, &params, template, &x, &ehs, n)
-            .expect("FD-score gradient");
+        let g_an = agq::agq_population_gradient(
+            &analytic_model,
+            &pop,
+            &params,
+            template,
+            &x,
+            &ehs,
+            &[],
+            n,
+        )
+        .expect("analytic-score gradient");
+        let g_fd =
+            agq::agq_population_gradient(&fd_model, &pop, &params, template, &x, &ehs, &[], n)
+                .expect("FD-score gradient");
 
         let scale = g_an
             .iter()
@@ -461,34 +470,6 @@ fn fd_score_path_agrees_with_the_analytic_one() {
             max_diff / scale
         );
     }
-}
-
-/// The quadrature integrates over the BSV η only. Under IOV the marginal is a joint
-/// integral over η *and* every occasion's κ; silently integrating the η-only marginal
-/// would report a confidently wrong OFV, so the fit must be rejected instead.
-#[test]
-fn agq_rejects_iov() {
-    let src = WARFARIN_SRC
-        .replace("  method = focei", "  method = agq")
-        .replace(
-            "  sigma PROP_ERR ~ 0.1 (sd)",
-            "  sigma PROP_ERR ~ 0.1 (sd)\n  kappa KAPPA_CL ~ 0.05",
-        )
-        .replace(
-            "  CL = TVCL * exp(ETA_CL)",
-            "  CL = TVCL * exp(ETA_CL + KAPPA_CL)",
-        );
-    // If the IOV DSL spelling drifts, fail loudly rather than let a parse error make this
-    // test vacuously "pass" without ever reaching the guard.
-    let err = fit_from_src(&src).expect_err("AGQ + IOV must be rejected");
-    assert!(
-        !err.contains("parse") && !err.contains("unknown"),
-        "IOV warfarin model must parse (test needs updating): {err}"
-    );
-    assert!(
-        err.contains("iov") || err.contains("IOV") || err.contains("occasion"),
-        "the AGQ+IOV rejection must say why: {err}"
-    );
 }
 
 /// The tensor grid is `n_agq^n_eta`. With 3 random effects, `n_agq = 21` is 9261 nodes
@@ -813,6 +794,286 @@ mod non_gaussian {
             res.ofv.is_finite(),
             "fixed-effects AGQ OFV must be finite: {}",
             res.ofv
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `method = laplace` — AGQ at one node, exposed as a first-class method (#251)
+// ---------------------------------------------------------------------------
+
+/// **The identity, at the API boundary.** `method = laplace` is not a re-implementation of
+/// Laplace; it is `method = agq` with the node count pinned to 1, routed through the same
+/// objective, the same analytic gradient and the same covariance stencil.
+///
+/// So the OFV must be **bit-identical** — not "close". Anything less means the two are
+/// taking different code paths, which is precisely what this variant exists not to do.
+#[test]
+fn laplace_is_bit_identical_to_agq_with_one_node() {
+    let pop = warfarin();
+    let laplace = eval_only_ofv(&pop, EstimationMethod::Laplace, 1);
+    let agq1 = eval_only_ofv(&pop, EstimationMethod::Agq, 1);
+    assert_eq!(
+        laplace.to_bits(),
+        agq1.to_bits(),
+        "method = laplace must BE agq(n_agq = 1), not merely agree with it: \
+         laplace={laplace}, agq1={agq1}"
+    );
+
+    // And it is genuinely a different estimator from FOCEI — Laplace with the exact Hessian
+    // vs FOCEI's Gauss-Newton one. If these ever coincide, the exact Hessian has been lost.
+    let focei = eval_only_ofv(&pop, EstimationMethod::FoceI, 1);
+    assert!(
+        (laplace - focei).abs() > 1e-6,
+        "LAPLACE (exact Hessian) must not collapse onto FOCEI (Gauss-Newton Hessian): \
+         both {laplace}"
+    );
+}
+
+/// `n_agq` is pinned for Laplace and cannot be varied — the node count is what *defines* the
+/// method. Setting it must not change the answer (and it is not one of the method's keys, so
+/// the engine also warns it is unsupported).
+#[test]
+fn laplace_ignores_n_agq() {
+    let pop = warfarin();
+    let a = eval_only_ofv(&pop, EstimationMethod::Laplace, 1);
+    let b = eval_only_ofv(&pop, EstimationMethod::Laplace, 7);
+    assert_eq!(
+        a.to_bits(),
+        b.to_bits(),
+        "method = laplace must pin the node count to 1 regardless of n_agq: {a} vs {b}"
+    );
+    assert!(
+        !ferx_core::types::method_specific_keys(EstimationMethod::Laplace).contains(&"n_agq"),
+        "`n_agq` must not be an option of method = laplace — it is fixed at 1"
+    );
+}
+
+#[test]
+fn laplace_method_parses() {
+    for token in ["laplace", "LAPLACE", "laplacian"] {
+        let opts = options_of(&with_fit_options(&format!("  method = {token}")));
+        assert_eq!(
+            opts.method,
+            EstimationMethod::Laplace,
+            "`{token}` must select LAPLACE"
+        );
+    }
+    assert_eq!(EstimationMethod::Laplace.label(), "LAPLACE");
+}
+
+// ---------------------------------------------------------------------------
+// IOV — AGQ and Laplace integrate the joint (η, κ) marginal (#251)
+// ---------------------------------------------------------------------------
+
+/// Warfarin with a per-occasion κ on CL. 3 η + 1 κ; the dataset has 2 occasions, so the
+/// stacked integration variable is `b = [η_CL, η_V, η_KA, κ¹, κ²]` — dimension 5.
+const WARFARIN_IOV_SRC: &str = r"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  kappa KAPPA_CL ~ 0.01
+  sigma PROP_ERR ~ 0.2 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = agq
+  iov_column = OCC
+  covariance = false
+";
+
+fn warfarin_iov() -> Population {
+    read_nonmem_csv(Path::new("data/warfarin_iov.csv"), None, Some("OCC"))
+        .expect("warfarin_iov data must load")
+}
+
+/// Eval-only OFV on the IOV model under `method`.
+fn iov_ofv(method: EstimationMethod, n_agq: usize) -> f64 {
+    let parsed = parse_full_model(WARFARIN_IOV_SRC).expect("IOV model must parse");
+    let opts = FitOptions {
+        method,
+        methods: vec![],
+        interaction: method == EstimationMethod::FoceI,
+        n_agq,
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        ..parsed.fit_options
+    };
+    let r = fit(
+        &parsed.model,
+        &warfarin_iov(),
+        &parsed.model.default_params,
+        &opts,
+    )
+    .expect("IOV eval-only fit must succeed");
+    assert!(r.ofv.is_finite(), "IOV OFV must be finite, got {}", r.ofv);
+    r.ofv
+}
+
+/// **AGQ integrates the *joint* (η, κ) marginal under IOV — it does not silently drop κ.**
+///
+/// The integration variable becomes the stacked `b = [η, κ₁ … κ_K]`, whose prior is the
+/// block-diagonal `Ω ⊕ Ω_iov^⊕K`. That is exactly what `individual_nll_iov` already scores,
+/// so every AGQ formula carries over with `d` the stacked dimension.
+///
+/// The check that this is really happening: the κ prior contributes `K·log|Ω_iov|` and the
+/// κ's own quadratic form to the integrand, so an η-only marginal would give a *different*
+/// number. Ω_iov here is 0.01 (a tight prior), so `log|Ω_iov|` is large and negative — an
+/// implementation that ignored κ could not land anywhere near the IOV-aware objective.
+#[test]
+fn agq_and_laplace_integrate_the_joint_iov_marginal() {
+    let laplace = iov_ofv(EstimationMethod::Laplace, 1);
+    let agq1 = iov_ofv(EstimationMethod::Agq, 1);
+    let agq3 = iov_ofv(EstimationMethod::Agq, 3);
+    let focei = iov_ofv(EstimationMethod::FoceI, 1);
+
+    // The identity survives the stacking: laplace IS agq at one node, over the joint vector.
+    assert_eq!(
+        laplace.to_bits(),
+        agq1.to_bits(),
+        "under IOV too, method = laplace must BE agq(n_agq = 1): {laplace} vs {agq1}"
+    );
+
+    // Laplace-family: within a Hessian approximation of FOCEI-IOV, which uses the same joint
+    // mode but the Gauss-Newton curvature. Nowhere near it would mean κ was mishandled.
+    assert!(
+        (agq1 - focei).abs() < 5.0,
+        "AGQ-IOV must be in the same Laplace family as FOCEI-IOV: agq1={agq1}, focei={focei}"
+    );
+
+    // Refining the grid over the *stacked* vector must move the answer (the joint posterior
+    // is not exactly Gaussian) but stay in the same basin.
+    assert!(
+        agq3.is_finite() && (agq3 - agq1).abs() < 5.0,
+        "AGQ-IOV n=3 must refine, not diverge: agq1={agq1}, agq3={agq3}"
+    );
+}
+
+/// The grid is `n_agq^d` with `d = n_eta + K·n_kappa`, and `K` lives in the *data* — so the
+/// cap has to be enforced where the population is visible, not at model-check time. A node
+/// count that is fine without IOV can be intractable with it.
+///
+/// `method = laplace` is exempt by construction: one node, whatever `d` is.
+#[test]
+fn agq_iov_grid_cap_counts_the_stacked_dimension() {
+    // 3 η + 1 κ × 2 occasions = d 5. At n_agq = 21 that is 21^5 ≈ 4.1M nodes — over the cap.
+    let parsed = parse_full_model(WARFARIN_IOV_SRC).expect("parses");
+    let opts = FitOptions {
+        method: EstimationMethod::Agq,
+        n_agq: 21,
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        ..parsed.fit_options.clone()
+    };
+    let err = fit(
+        &parsed.model,
+        &warfarin_iov(),
+        &parsed.model.default_params,
+        &opts,
+    )
+    .expect_err("an intractable IOV grid must be rejected");
+    assert!(
+        err.contains("stacked") || err.contains("occasions"),
+        "the rejection must explain that IOV raised the dimension: {err}"
+    );
+
+    // …and Laplace sails through the same model: one node regardless of the dimension.
+    assert!(
+        iov_ofv(EstimationMethod::Laplace, 1).is_finite(),
+        "method = laplace must always be tractable under IOV — its grid is a single point"
+    );
+}
+
+/// **The analytic gradient must be exact under IOV too.**
+///
+/// Under IOV the θ/σ score comes from the *stacked* sensitivity provider
+/// (`subject_sensitivities_iov`, which walks (θ, η, κ) duals), the Ω block from the η-prior,
+/// and — the only genuinely new piece — the **Ω_iov block** from the κ prior
+/// `½(Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov|)`, whose derivative is
+/// `½(−Σ_k z_k z_kᵀ + K·Ω_iov⁻¹)` summed over the K occasions that *share* one Ω_iov.
+///
+/// That shared-block sum is easy to get wrong (forget the `K·Ω_iov⁻¹`, or sum over the wrong
+/// axis, and the ω_iov gradient is silently off). Differencing the real objective catches it.
+#[test]
+fn analytic_gradient_matches_fd_under_iov() {
+    use ferx_core::estimation::agq;
+    use ferx_core::estimation::parameterization::{pack_params, unpack_params};
+
+    let parsed = parse_full_model(WARFARIN_IOV_SRC).expect("IOV model must parse");
+    let model = &parsed.model;
+    let pop = warfarin_iov();
+    assert!(model.n_kappa > 0, "test model must carry kappa");
+
+    let template = &model.default_params;
+    let x0 = pack_params(template);
+    let np = x0.len();
+
+    // Objective at a packed point: re-solve the joint (η, κ) EBEs, then the AGQ OFV.
+    let ofv = |x: &[f64], n: usize| -> f64 {
+        let params = unpack_params(x, template);
+        let (ehs, _h, _s, kaps) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
+            model, &pop, &params, 300, 1e-10, None, None, 0,
+        );
+        2.0 * agq::agq_population_nll(model, &pop, &params, &ehs, &kaps, n)
+    };
+
+    for n in [1usize, 3] {
+        let params = unpack_params(&x0, template);
+        let (ehs, _h, _s, kaps) = ferx_core::estimation::inner_optimizer::run_inner_loop_warm(
+            model, &pop, &params, 300, 1e-10, None, None, 0,
+        );
+        assert!(
+            kaps.iter().any(|k| !k.is_empty()),
+            "the inner loop must return per-occasion kappas, else this proves nothing"
+        );
+
+        let g = agq::agq_population_gradient(model, &pop, &params, template, &x0, &ehs, &kaps, n)
+            .expect("IOV gradient must be available");
+
+        let mut fd = vec![0.0f64; np];
+        for i in 0..np {
+            let h = 1e-5 * (1.0 + x0[i].abs());
+            let (mut xp, mut xm) = (x0.clone(), x0.clone());
+            xp[i] += h;
+            xm[i] -= h;
+            fd[i] = (ofv(&xp, n) - ofv(&xm, n)) / (2.0 * h);
+        }
+
+        let scale = fd
+            .iter()
+            .chain(g.iter())
+            .fold(1e-6f64, |m, v| m.max(v.abs()));
+        let max_diff = g
+            .iter()
+            .zip(fd.iter())
+            .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
+        // 2.5e-2, against 1.6e-3 for the non-IOV case — and honestly so. The FD reference
+        // re-solves the **joint** (η, κ) mode at every perturbed point, and that inner solve is
+        // the noisier half of the comparison (a 5-dimensional mode over 2 occasions of sparse
+        // data). The residual sits on ω_CL / ω_KA — the flat directions — *not* on Ω_iov, whose
+        // block is the genuinely new algebra here and lands at 0.4%. It is comfortably inside
+        // what L-BFGS needs: the IOV fits converge and reproduce FOCEI-IOV's estimates to <1%,
+        // κ included. A wrong Ω_iov block (a dropped `K·Ω_iov⁻¹`, a mis-summed occasion axis)
+        // misses by tens of percent, which this bound still catches.
+        assert!(
+            max_diff / scale < 2.5e-2,
+            "n_agq={n} (IOV): analytic gradient must match FD of the objective, got {:.3e} \
+             relative error\n  analytic: {g:?}\n  fd:       {fd:?}",
+            max_diff / scale
         );
     }
 }


### PR DESCRIPTION
## Why

Two follow-ups to AGQ (#821, merged), both of which fall out of the same observation: **AGQ is not a family of methods, it is one integral parameterised by (nodes, dimension).**

1. **`method = laplace`.** The one-node case is a genuinely useful estimator — it is NONMEM's `$EST METHOD=1 LAPLACIAN` — but was only reachable by knowing to write `method = agq, n_agq = 1`, which nobody would guess.
2. **IOV.** AGQ and Laplace previously rejected `[iov]` models outright. They no longer need to.

## What changed

### `method = laplace` (alias `laplacian`)

Not sugar over a parser alias — a real `EstimationMethod::Laplace` that routes through the AGQ objective with the node count pinned to 1. Same objective, same analytic gradient, same covariance stencil; the OFV is **bit-identical** to `agq, n_agq = 1` (pinned by `laplace_is_bit_identical_to_agq_with_one_node`). Reported as `LAPLACE` in the fit output and `.fitrx`. `n_agq` is deliberately *not* one of its options — the node count is what defines the method.

**It is not FOCEI.** Both place a single Gaussian at the EBE mode, but FOCEI builds it from the Gauss-Newton Hessian `CᵀC + Ω⁻¹` (dropping `∂²f/∂η²`) while `laplace` differentiates the true conditional NLL. That is why it reproduces NONMEM's LAPLACIAN to **six significant figures** where FOCEI lands on a different value. It is also the cheapest member of the family — one node, no grid — and on warfarin converges **faster than FOCEI** (0.23 s vs 0.60 s).

### IOV

The integral simply runs over the **stacked** random-effect vector

```
b = [η, κ₁ … κ_K],    d = n_eta + K·n_kappa
```

whose prior is the block-diagonal `Ω_joint = Ω ⊕ Ω_iov^⊕K`. That is *exactly* what `individual_nll_iov` already scores:

```
nll_iov = ½(ηᵀΩ⁻¹η + log|Ω| + Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov| + data)
        = ½(bᵀΩ_joint⁻¹b + log|Ω_joint| + data)
```

So **every AGQ formula carries over verbatim** with `d` the stacked dimension — the marginal, the `½log|H|` normaliser, the node transform, the Fisher-identity gradient. **IOV is a change of dimension, not of method.** A `Stack` type carries the per-subject `(n_occ, Ω_joint⁻¹, prior SDs)` and dispatches the integrand; the mode is the joint `(η̂, κ̂)` the inner loop already converges.

**The gradient stays analytic.** θ/σ come from the stacked `subject_sensitivities_iov` (which takes the `(η, κ)` vector and makes no mode assumption — verified: its `f` matches `predict_iov` to 3e-16). The Ω block comes from the η-prior. The one genuinely new piece is the **Ω_iov block** from the κ prior:

```
∂/∂Ω_iov ½(Σ_k κ_kᵀΩ_iov⁻¹κ_k + K·log|Ω_iov|)  =  ½(−Σ_k z_k z_kᵀ + K·Ω_iov⁻¹),   z_k = Ω_iov⁻¹κ_k
```

summed over the K occasions that *share* one `Ω_iov`, mapped through the same `chol_pack`.

`db̂/dx` comes from `subject_eta_dx_iov` — the stacked implicit-function derivative — with the FD version as the fallback for models outside the provider. Neither re-solves the inner loop: this is the *derivative* of the mode, not a recomputation of it.

**Cost.** The grid is `n_agq^d`, and `d` grows with the occasion count — which lives in the *data*. So the 100k-node cap is now enforced against the stacked dimension in `fit_inner` (where the population is visible), not `check_model_options` (where it is not), and the error names `K`. **`method = laplace` is always tractable under IOV**: one node regardless of `d`.

## Validation

`warfarin_iov` — 3 η + 1 κ over 2 occasions, so `d = 5`:

| | OFV | κ²(CL) | converged | wall |
|---|---|---|---|---|
| FOCEI-IOV | 308.83 | 0.035708 | yes | 0.71 s |
| **Laplace-IOV** | 310.67 | 0.035305 | **yes** | **1.28 s** |
| **AGQ(3)-IOV** | 310.24 | 0.035462 | **yes** | **8.15 s** |

κ is genuinely **estimated** (0.01 initial → 0.0355), and all three methods agree to **<1% on every parameter**. AGQ(3) refines Laplace *downward* (310.67 → 310.24) — the same direction the non-IOV sweep moves (7.899 → 7.480). Laplace underestimates the integral; the extra nodes recover it.

## Gradient accuracy

The gradient is exact to the finite-difference reference's own precision, IOV included:

| | `n_agq = 1` | `n_agq = 3` | `n_agq = 7` |
|---|---|---|---|
| non-IOV | 2.0e-5 | 1.5e-6 | 2.1e-7 |
| **IOV** | **2.4e-4** | 2.4e-4 | — |

(Pinned by `analytic_gradient_matches_fd_at_every_node_count` and `analytic_gradient_matches_fd_under_iov`, at 1e-4 / 1e-3.)

> **A note on how these were measured**, because I got it wrong first and it is an easy trap. An earlier revision of this PR reported a "known limitation" — 1.5% error under IOV, 0.16% non-IOV. Both numbers were measuring the **reference**, not the gradient. The FD reference differences a *reconverged* objective (every perturbed point re-solves the inner loop), so it carries the inner solver's noise; shrinking the FD step past that floor amplifies the noise rather than cutting truncation. At `h = 1e-5` the reference is ~1e-3 out; it settles at `1e-4` and stays flat through `1e-3`. When the yardstick is itself numerical, a smaller step is not a more accurate one.
>
> Two consequences once the reference was fixed: `subject_eta_dx_iov` is used after all (an earlier commit disabled it on the strength of a "~8% out" claim measured the same bad way — it is fine, analytic, and cheaper), and **Laplace-IOV now converges** cleanly at 2.18 s.

## An unreachable stopping criterion (fixed here)

AGQ(3)-IOV initially reported `Converged: NO` while sitting on an OFV that had been flat to **eight significant figures for a dozen evaluations**. The fit was correct — the engine restores the best-seen point — but the flag was a lie, and it was paid for in wall-clock.

The gradient-optimizer path sets NLopt's stops to `1e-12`:

```rust
// Use very loose tolerances — FOCE objective is noisy from EBE re-estimation.
opt.set_xtol_rel(1e-12); opt.set_ftol_rel(1e-12);
```

Fine for FOCE/FOCEI, whose analytic gradient is exact to ~1e-11 — they genuinely reach `XtolReached`. **Unreachable for AGQ**, whose gradient is exact but finite-difference-*limited* (the grid-response term and the posterior Hessian are central differences, so it has a ~1e-4 relative noise floor). L-BFGS keeps stepping until the true gradient falls under that floor, at which point the search direction is noise, the line search cannot find a decrease, and NLopt returns a bare `NLOPT_FAILURE`.

**An unreachable stop is not harmless**: the optimizer cannot stop *well*, so it stops *badly*. AGQ now stops where its objective actually settles — the same reachable `outer_ftol` / `outer_xtol` criteria BOBYQA already gets. FOCE/FOCEI keep the 1e-12 stops unchanged.

Every AGQ/Laplace fit now converges **and gets faster** — the grinding past the plateau was pure waste:

| | before | after |
|---|---|---|
| AGQ(3)-IOV | `Failure`, 14.5 s | **`FtolReached`, 8.2 s** |
| Laplace-IOV | `XtolReached`, 2.2 s | **`FtolReached`, 1.3 s** |
| AGQ(3) non-IOV | — | `FtolReached` |
| Laplace non-IOV | — | `FtolReached` |

OFVs and κ are identical throughout — it was already stopping at the right answer.

> **Follow-up, not fixed here:** FOCEI hits the *same* `NLOPT_FAILURE` on non-IOV warfarin (`Converged: NO`). Same root cause — its gradient also has a floor on that model — but touching the FOCE/FOCEI stopping criteria would move long-established numbers and belongs in its own change.

## A vacuous test, fixed

`agq_rejects_iov` asserted `err.contains("occasion")` — which matched an unrelated *"no occasion labels were found"* error from the data reader (warfarin has no OCC column). It never reached the AGQ guard at all. The IOV tests now assert on **diagnostic codes** via `check_model_options`, which needs no data and cannot be short-circuited that way.

## Breaking changes

- [x] None. `EstimationMethod` gains a variant; existing fits are bit-identical.

## Tests

`cargo test --lib`: **2480 passed, 0 failed.** `cargo test --test agq --all-features`: **21 passed**, including:

- `laplace_is_bit_identical_to_agq_with_one_node` — the identity, at the API boundary
- `laplace_ignores_n_agq` — the node count is pinned
- `agq_and_laplace_integrate_the_joint_iov_marginal` — κ is integrated, not dropped
- `analytic_gradient_matches_fd_under_iov` — incl. the Ω_iov block
- `agq_iov_grid_cap_counts_the_stacked_dimension` — and Laplace sails through the same model
- `agq_reports_convergence_rather_than_grinding_into_nlopt_failure` — the stopping criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
