### PR TITLE
fix(api): multi-start returns the best VALID fit, not a diverged sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,6 +450,15 @@ section of the SDLC for the versioning policy).
   Note the deliberate consequence: at *exactly* such a coincidence an analytic gradient and a
   finite-difference gradient legitimately disagree — FD averages across a branch switch the
   model does not make there. That is a property of a kinked model, not a defect.
+- **Multi-start (`n_starts`) no longer returns a diverged run as the "best" fit**
+  (#830): the start selection preferred any `converged` run over an unconverged
+  one *before* comparing OFVs, so a start that diverged — driving the residual
+  covariance indefinite and reporting a ~1e20 sentinel OFV while still flagged
+  `converged` — outranked a valid but unconverged start (including the exact-inits
+  start 0). Multi-start could therefore return a worthless fit with an enormous
+  OFV. Validity (finite, non-sentinel OFV) is now the primary ranking key, so a
+  valid run always wins; converged-vs-OFV ordering is unchanged within a validity
+  class.
 - **`block_sigma` correlated residuals no longer collapse the objective when a
   subject has two samples at the same time** (#827): with a `block_sigma` +
   covariate-selected / per-CMT error model (the free-vs-total assay pattern),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,9 +456,9 @@ section of the SDLC for the versioning policy).
   covariance indefinite and reporting a ~1e20 sentinel OFV while still flagged
   `converged` — outranked a valid but unconverged start (including the exact-inits
   start 0). Multi-start could therefore return a worthless fit with an enormous
-  OFV. Validity (finite, non-sentinel OFV) is now the primary ranking key, so a
-  valid run always wins; converged-vs-OFV ordering is unchanged within a validity
-  class.
+  OFV. Validity (a finite OFV below a divergence-large threshold) is now the
+  primary ranking key, so a valid run always wins; converged-vs-OFV ordering is
+  unchanged within a validity class.
 - **`block_sigma` correlated residuals no longer collapse the objective when a
   subject has two samples at the same time** (#827): with a `block_sigma` +
   covariate-selected / per-CMT error model (the free-vs-total assay pattern),

--- a/src/api.rs
+++ b/src/api.rs
@@ -3241,6 +3241,26 @@ fn perturb_init(
     p
 }
 
+/// Multi-start ranking: should the candidate `(c_ofv, c_conv)` replace the
+/// current best `(b_ofv, b_conv)`?
+///
+/// **Validity is the primary key.** A run whose OFV is non-finite or
+/// sentinel-large (block_sigma `R` gone indefinite, a divergent peripheral
+/// compartment, …) is a failed fit even if it reports `converged = true` — the
+/// inner objective returns the ~1e20 sentinel and the outer optimizer can
+/// "converge" on it. Such a run must never beat a valid but unconverged start
+/// (e.g. the exact-inits start 0), which the old "converged-first" rule allowed,
+/// so multi-start could return a divergence with a huge OFV. Within the same
+/// validity class: prefer converged, then lower OFV.
+fn multistart_prefers(b_ofv: f64, b_conv: bool, c_ofv: f64, c_conv: bool) -> bool {
+    let valid = |o: f64| o.is_finite() && o < 1e14;
+    match (valid(b_ofv), valid(c_ofv)) {
+        (false, true) => true,
+        (true, false) => false,
+        _ => (!b_conv && c_conv) || (b_conv == c_conv && c_ofv < b_ofv),
+    }
+}
+
 /// Main fit entry point: CompiledModel + Population → FitResult.
 ///
 /// When `options.threads` is `Some(n)`, the fit runs inside a scoped rayon
@@ -3598,7 +3618,7 @@ pub fn fit(
         None => par_starts(),
     };
 
-    // Pick best converged result; fall back to best unconverged if none converged.
+    // Pick the best start (see `multistart_prefers` for the ranking).
     let mut best: Option<(usize, FitResult)> = None;
     let mut failed_starts: Vec<String> = Vec::new();
     for (k, res) in results {
@@ -3606,11 +3626,7 @@ pub fn fit(
             Ok(r) => {
                 let better = match &best {
                     None => true,
-                    Some((_, b)) => {
-                        // Prefer converged over unconverged; then lower OFV
-                        (!b.converged && r.converged)
-                            || (b.converged == r.converged && r.ofv < b.ofv)
-                    }
+                    Some((_, b)) => multistart_prefers(b.ofv, b.converged, r.ofv, r.converged),
                 };
                 if better {
                     best = Some((k, r));
@@ -3985,6 +4001,42 @@ fn build_indiv_map(pk: &PkParams, names: &[String], pk_indices: &[usize]) -> Has
         .filter(|(name, _)| !crate::parser::model_parser::is_synthetic_readout_param(name))
         .map(|(name, &idx)| (name.clone(), pk.values[idx]))
         .collect()
+}
+
+#[cfg(test)]
+mod multistart_prefers_tests {
+    use super::multistart_prefers;
+
+    const SENTINEL: f64 = 2.3e16; // block_sigma-indefinite divergence OFV
+
+    #[test]
+    fn valid_unconverged_beats_invalid_converged() {
+        // The regression: a diverged start reporting `converged = true` with a
+        // sentinel OFV must NOT beat the valid, unconverged exact-inits start.
+        assert!(multistart_prefers(SENTINEL, true, 867.0, false));
+        assert!(!multistart_prefers(867.0, false, SENTINEL, true));
+    }
+
+    #[test]
+    fn non_finite_is_invalid() {
+        assert!(multistart_prefers(f64::INFINITY, true, 900.0, false));
+        assert!(multistart_prefers(f64::NAN, true, 900.0, false));
+    }
+
+    #[test]
+    fn among_valid_prefers_converged_then_lower_ofv() {
+        // converged beats unconverged even at a (slightly) higher OFV.
+        assert!(multistart_prefers(730.0, false, 735.0, true));
+        // same convergence: lower OFV wins.
+        assert!(multistart_prefers(740.0, true, 734.0, true));
+        assert!(!multistart_prefers(734.0, true, 740.0, true));
+    }
+
+    #[test]
+    fn both_invalid_prefers_lower() {
+        assert!(multistart_prefers(3e16, false, 2e16, false));
+        assert!(!multistart_prefers(2e16, false, 3e16, false));
+    }
 }
 
 #[cfg(test)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3252,8 +3252,15 @@ fn perturb_init(
 /// (e.g. the exact-inits start 0), which the old "converged-first" rule allowed,
 /// so multi-start could return a divergence with a huge OFV. Within the same
 /// validity class: prefer converged, then lower OFV.
+///
+/// The validity cutoff sits well below the ~1e20 inner-objective sentinel but
+/// far above any legitimate population OFV, so a real fit never trips it; a NaN
+/// OFV is non-finite and therefore also invalid, so it can never block a finite
+/// valid candidate.
 fn multistart_prefers(b_ofv: f64, b_conv: bool, c_ofv: f64, c_conv: bool) -> bool {
-    let valid = |o: f64| o.is_finite() && o < 1e14;
+    /// OFVs at or above this are treated as diverged/invalid (see above).
+    const DIVERGENCE_OFV: f64 = 1e14;
+    let valid = |o: f64| o.is_finite() && o < DIVERGENCE_OFV;
     match (valid(b_ofv), valid(c_ofv)) {
         (false, true) => true,
         (true, false) => false,


### PR DESCRIPTION
## Why
`n_starts` multi-start could return a **diverged** run as the "best" fit. The start selection preferred any `converged` run over an unconverged one *before* comparing OFVs. A start that diverged — driving a `block_sigma` residual covariance indefinite and returning the ~1e20 sentinel OFV, while the outer optimizer still flagged it `converged` — therefore outranked a valid but unconverged start, **including the exact-inits start 0**.

Observed on the fluconazole free/total binding model: `n_starts = 8` returned **OFV 2.3e16** instead of the valid single-start **867** (start 0 alone guarantees a valid result, so the best can never legitimately be worse than that).

## What changed
Extract the ranking into `multistart_prefers(b_ofv, b_conv, c_ofv, c_conv)` with **validity (finite, non-sentinel OFV) as the primary key**:
- a valid run always beats an invalid (sentinel / non-finite) one;
- within the same validity class, prefer `converged`, then lower OFV (unchanged from before).

## Alternatives considered
Tightening the outer optimizer so diverged runs report `converged = false` would also help, but the selection should be robust regardless of how a divergence is flagged — validity-first is the minimal, correct guard.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None (selection returns a *better* — valid — run; a fit that previously returned a sentinel now returns the valid best).

## Numerical validation
- [x] Verified on fluconazole `block_sigma` multi-start:

```
# before: n_starts=8  -> OFV 2.3e16 (a diverged run)
# after : n_starts=8  -> OFV 867.46 (the valid best; == start 0 single-start)
#         n_starts=16 -> 867.46 ; n_starts=16 sig0.5 -> 867.32
```
(The fit still doesn't reach the global basin from these starts — that's a separate open problem — but multi-start no longer returns garbage.)

## Performance
- [x] No impact (selection is O(n_starts), unchanged).

## Tests
- [x] Unit tests added (`multistart_prefers_tests`): valid-unconverged beats invalid-converged (the regression), non-finite is invalid, converged-then-lower-OFV within a validity class, both-invalid prefers lower.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added.
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new warnings in touched code)
- [x] `Dual2` sensitivity path untouched
- [ ] `Cargo.toml` version bump — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fkc1ysrj8QwFm3P2hwF9Em
