### PR TITLE
feat(markov): exact analytic CTMM inner gradient via Van Loan; make the TV-cov walk's derivatives total (#759, #486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Exact (analytic) inner EBE gradient for CTMM (`[markov_model]`) fits** (#759). The
+  transition likelihood `−Σ log P(Δt)[s,s']`, `P = expm(Q·Δt)`, was finite-differenced
+  end-to-end: every EBE step perturbed η, rebuilt `Q`, and redid a matrix exponential per
+  observation gap. The intensities are now replayed over dual numbers with θ and η seeded,
+  giving an exact `∂Q/∂η`, which is chained to `∂P/∂Q` through the Van Loan (1978) Fréchet
+  derivative of the matrix exponential. The generator's row-sum-zero constraint is inherited
+  for free (differentiation is linear, so the derivative of a valid generator is a valid
+  direction). Because only one *entry* of `P` is read per gap, the adjoint form
+  `⟨C, L(A,E)⟩ = ⟨L(Aᵀ,C), E⟩` lets a **single** Fréchet solve per gap serve every parameter
+  at once — so the exact gradient is *cheaper* than the finite differences it replaces, not
+  just more accurate. A drug-driven (time-inhomogeneous) `Q(t)` keeps the FD path: its
+  likelihood is an occupancy ODE, not an `expm`, so the identity does not apply. The FOCEI
+  Laplace `½log|H̃|` term and the outer θ-gradient are still FD.
 - **AGQ and `laplace` now support inter-occasion variability (`[iov]`)** (#251).
   Under IOV the integral runs over the **stacked** random-effect vector
   `b = [η, κ₁ … κ_K]`, whose prior is the block-diagonal `Ω ⊕ Ω_iov^⊕K` — which is

--- a/docs/estimation/ctmm.qmd
+++ b/docs/estimation/ctmm.qmd
@@ -22,10 +22,29 @@ are the declared `transition` intensities and the diagonal is fixed row-sum-zero
 A CTMM's state-occupancy probabilities obey `dP/dt = Qᵀ P`. For a **time-homogeneous**
 generator this has the exact closed-form solution `P(Δt) = expm(Q·Δt)`, so ferx forms the
 transition matrix directly with a matrix exponential (nalgebra's Higham scaling-and-
-squaring Padé) rather than integrating the ODE. The parameter gradients are the exact
-Van Loan (1978) Fréchet derivatives of the exponential — cleaner and exactly
-differentiable, with no ODE solver in the loop. (A genuinely drug-driven, time-varying
-`Q(t)` would need the occupancy ODE and is a planned extension.)
+squaring Padé) rather than integrating the ODE — no ODE solver in the loop, and exactly
+differentiable. A genuinely drug-driven, time-varying `Q(t)` *does* need the occupancy
+ODE, and takes that path instead (see [current scope](#current-scope)).
+
+### The η-gradient is exact
+
+The EBE search differentiates the transition likelihood **analytically** (#759). The
+intensities are replayed over dual numbers with θ and η seeded, giving an exact `∂Q/∂η`;
+that is chained to `∂P/∂Q` through the Van Loan (1978) Fréchet derivative of the matrix
+exponential, `L(A,E) = d/dt expm(A + tE)|₀`. The row-sum-zero constraint
+(`q_jj = −Σ_{k≠j} q_jk`) is inherited for free — differentiation is linear, so the
+derivative of a valid generator is a valid direction.
+
+Only one *entry* of `P` is ever read per observation gap, so ferx uses the adjoint form
+`⟨C, L(A,E)⟩ = ⟨L(Aᵀ,C), E⟩`: a single Fréchet solve per gap serves every parameter at
+once, instead of one solve per (parameter, gap). That makes the exact gradient *cheaper*
+than the finite differences it replaces, not merely more accurate.
+
+Two things are still finite-differenced: the FOCEI Laplace `½log|H̃|` term needs the
+**second** derivative of the data term w.r.t. η (Van Loan gives first derivatives), and
+the **outer** (θ) gradient is still FD for any model with a non-Gaussian endpoint. A
+drug-driven `Q(t)` keeps FD throughout — its likelihood is an occupancy ODE, not an
+`expm`, so the Fréchet identity does not apply.
 
 ferx does **not** use the NONMEM `EVID=3` / occupancy-flag CTMM dataset mechanism: it
 reads ordinary `(ID, TIME, STATE)` rows and conditions on each subject's first observed
@@ -35,7 +54,7 @@ state (see the [data format](../model-file/markov-model.qmd#data-format)).
 
 | Method | CTMM | Notes |
 |--------|:----:|-------|
-| **FOCEI** (Laplace) | ✓ | Default. A finite-difference Hessian of the data term w.r.t. η plus the `½ log\|H̃\|` correction (the transition likelihood has no closed-form analytic η-Hessian, so the inner gradient and outer Laplace are FD, as for TTE / binary). |
+| **FOCEI** (Laplace) | ✓ | Default. The inner EBE gradient is **analytic** (exact `∂Q/∂η` × Van Loan, above); the `½ log\|H̃\|` correction still uses a finite-difference Hessian of the data term w.r.t. η, and the outer θ-gradient is FD, as for TTE / binary. |
 | **SAEM** | ✓ | Preferred for sparse state data — no Laplace approximation. |
 | **IMP** (importance sampling) | ✓ | Unbiased marginal likelihood. |
 | **FOCE** (no interaction) | — | Drops the log-det correction and is biased for a non-Gaussian data term; use `focei`. |
@@ -81,6 +100,12 @@ closed-form `P(Δt)_{00} = (b + a·e^{-(a+b)Δt})/(a+b)` for `Q = [[-a,a],[b,-b]
 
 ## Current scope
 
-The first CTMM slice ships the **fit path** for a time-homogeneous generator (parse →
-datareader routing → FOCEI/SAEM/IMP). Minimal-CTMM (`mctmm`), discrete-time Markov
-(`dtmm`), drug-driven `Q(t)`, and CTMM simulation/prediction are planned follow-ups.
+The **fit path** ships for both a time-homogeneous generator and a **drug-driven** one
+(an intensity may reference an ODE state, e.g.
+`transition s0 -> s1 = exp(LQ01 + SLOPE * (central / V))` — see
+`examples/ctmm_pd_2state.ferx`). The drug-driven case integrates the occupancy ODE
+`dP/dτ = P·Q(τ)` over each gap rather than forming `expm(Q·Δt)`, so it does not get the
+analytic η-gradient above.
+
+Minimal-CTMM (`mctmm`), discrete-time Markov (`dtmm`), and CTMM simulation/prediction are
+planned follow-ups.

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1542,37 +1542,36 @@ pub(crate) fn analytic_inner_grad_supported_model(model: &CompiledModel) -> bool
     if analytic_inner_common_bail(model) {
         return false;
     }
-    // Endpoint-only CTMM (#759): a `[markov_model]` with no `[structural_model]` has no
-    // Gaussian data term and no PK model, so `analytical_supported` rejects it on the
-    // absence of a closed form — yet its inner gradient (prior + the exact CTMM η-term) is
-    // fully analytic. Report that here, because `build_info::gradient_method_inner` reads
-    // this predicate and would otherwise say "fd" while `find_ebe` runs the analytic route.
+    // CTMM (#759): a subject's CTMM term is analytic only when its generator carries a
+    // dual-evaluable program. Without one — a drug-driven `Q(t)`, a `(θ, η)` width past the
+    // dual dispatch cap, an intensity we could not resolve — *every* subject declines at the
+    // survival-record guard in `analytic_inner_grad_supported`, so reporting "analytic" here
+    // would be a pure misreport.
+    //
+    // `analytical_supported` below does **not** catch this, which is the trap: an
+    // endpoint-only model (a `[markov_model]` with no `[structural_model]`) is *still* given
+    // a default `pk_model` and a vacuous `tv_fn` (`model_parser.rs`, `tv_fn = Some(..)` for
+    // any non-ODE model), and its `pk_indices` are empty so the per-slot check passes
+    // trivially — so the closed-form scope check waves it straight through despite there
+    // being no closed form at all.
     #[cfg(feature = "markov")]
-    if endpoint_only_analytic_ctmm(model) {
-        return true;
+    if model.has_ctmm() && !all_ctmm_endpoints_analytic(model) {
+        return false;
     }
     crate::sens::provider::analytical_supported(model)
 }
 
-/// A fit whose *only* data term is a CTMM we can differentiate exactly: no structural PK
-/// model (so no Gaussian observations at all) and every endpoint a time-homogeneous CTMM
-/// with a dual-evaluable generator program. The model-level counterpart of the
-/// `subject.obs_times.is_empty()` branch in [`analytic_inner_grad_supported`].
+/// Every `Ctmm` endpoint on the model carries a dual-evaluable generator program, i.e. its
+/// transition term can be differentiated exactly rather than finite-differenced. The
+/// model-level counterpart of [`ctmm_records_fully_analytic`]'s per-subject check.
 #[cfg(feature = "markov")]
-fn endpoint_only_analytic_ctmm(model: &CompiledModel) -> bool {
+fn all_ctmm_endpoints_analytic(model: &CompiledModel) -> bool {
     use crate::types::EndpointLikelihood;
-    // No `[structural_model]`: neither a closed form (`tv_fn`) nor an `[odes]` block.
-    if model.tv_fn.is_some() || model.ode_spec.is_some() || model.endpoints.is_empty() {
-        return false;
-    }
-    model.endpoints.iter().all(|(_, ep)| {
-        matches!(
-            ep,
-            EndpointLikelihood::Ctmm {
-                generator_program: Some(_),
-                ..
-            }
-        )
+    model.endpoints.iter().all(|(_, ep)| match ep {
+        EndpointLikelihood::Ctmm {
+            generator_program, ..
+        } => generator_program.is_some(),
+        _ => true,
     })
 }
 
@@ -1605,6 +1604,14 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
     // non-Gaussian term, both of which we have exactly, so only the global escape hatches
     // apply. (`analytic_eta_nll_gradient_with_schedule` mirrors this by skipping the
     // provider for such a subject.)
+    //
+    // **Ordering is load-bearing:** this branch is only sound *after* the guard above. A
+    // CTMM subject always carries `DiscreteState` records, so an endpoint-only CTMM whose
+    // generator has no dual-evaluable program (past the axis cap, or an intensity we could
+    // not resolve) is already rejected there — it can never fall through to here and claim
+    // an analytic route the gradient cannot supply. Reaching this line therefore means the
+    // subject's non-Gaussian term is either absent or exactly served, and the only thing
+    // left is the prior. (Pinned by `program_less_endpoint_only_ctmm_stays_fd`.)
     if subject.obs_times.is_empty() {
         return !analytic_inner_common_bail(model);
     }
@@ -3038,6 +3045,46 @@ mod tests {
             assert!(
                 super::super::analytic_inner_grad_supported(&model, &subject()),
                 "a CTMM subject must now take the analytic inner route"
+            );
+        }
+
+        /// An endpoint-only CTMM whose generator has **no** dual-evaluable program — here by
+        /// pushing the `(θ, η)` width past `MAX_CTMM_AXES` — must stay on FD, on *both* the
+        /// model-level predicate `build_info` reports and the per-subject gate `find_ebe`
+        /// runs. The two must agree, or the fit reports a gradient method it does not use.
+        ///
+        /// This pins the ordering inside `analytic_inner_grad_supported`: the survival-record
+        /// guard runs first and rejects a program-less CTMM subject, so it never reaches the
+        /// `obs_times.is_empty()` branch (which would otherwise wave it through on the
+        /// strength of having no Gaussian block). Swap those two and this test fails.
+        #[test]
+        fn program_less_endpoint_only_ctmm_stays_fd() {
+            let n_th = 25; // + 1 η = 26 axes > MAX_CTMM_AXES (24)
+            let mut src = String::from("[parameters]\n");
+            for i in 1..=n_th {
+                src += &format!("  theta T{i}(0.1, -6.0, 3.0)\n");
+            }
+            src += "  omega ETA_Q ~ 0.1\n[markov_model]\n  type   = ctmm\n  cmt    = 5\n  \
+                    states = [awake=0, asleep=1]\n  transition awake  -> asleep = exp(ETA_Q + ";
+            src += &(1..=n_th)
+                .map(|i| format!("T{i}"))
+                .collect::<Vec<_>>()
+                .join(" + ");
+            src += ")\n  transition asleep -> awake  = exp(T1)\n";
+
+            let model = crate::parser::model_parser::parse_model_string(&src).expect("parse");
+            assert_eq!(
+                model.n_theta + model.n_eta,
+                26,
+                "fixture must exceed the cap"
+            );
+            assert!(
+                !super::super::analytic_inner_grad_supported_model(&model),
+                "a CTMM past the dual dispatch cap must report FD"
+            );
+            assert!(
+                !super::super::analytic_inner_grad_supported(&model, &subject()),
+                "…and must actually take FD, not fall through the no-Gaussian-block branch"
             );
         }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1482,6 +1482,50 @@ pub(crate) fn subject_has_survival_records(subject: &Subject) -> bool {
     }
 }
 
+/// Whether **every** non-Gaussian record on this subject is a CTMM state observation that
+/// the analytic path can serve exactly (#759) — i.e. the subject's whole non-Gaussian data
+/// term is `−Σ log P(Δt)[s,s']` on a time-homogeneous generator with a dual-evaluable
+/// program ([`ctmm_subject_eta_grad`](crate::markov::endpoint::ctmm_subject_eta_grad)).
+///
+/// Strict on purpose. The inner gradient is a *sum* of term gradients, so admitting a
+/// subject that also carries a TTE / binary / count record would silently drop that term's
+/// contribution — a wrong gradient, not a slow one. TTE and binary have no analytic η-channel
+/// at all (their `LinearPredictorFn` / `HazardParamFn` are `f64` closures outside `sens/`),
+/// so such a subject keeps FD for the whole objective.
+///
+/// Always `false` without the `markov` feature (there are no CTMM records to serve).
+fn ctmm_records_fully_analytic(model: &CompiledModel, subject: &Subject) -> bool {
+    #[cfg(feature = "markov")]
+    {
+        use crate::types::{EndpointLikelihood, ObsRecord};
+        if !model.has_ctmm() {
+            return false;
+        }
+        // The CMTs whose endpoint is a CTMM we can differentiate exactly. An endpoint with
+        // no `generator_program` — a time-inhomogeneous (drug-driven) generator, whose
+        // likelihood is an occupancy ODE rather than an `expm` — is not one of them.
+        let analytic_cmts: Vec<usize> = model
+            .endpoints
+            .iter()
+            .filter_map(|(cmt, ep)| match ep {
+                EndpointLikelihood::Ctmm {
+                    generator_program, ..
+                } if generator_program.is_some() => Some(*cmt),
+                _ => None,
+            })
+            .collect();
+        subject.obs_records.iter().all(|r| match r {
+            ObsRecord::DiscreteState { cmt, .. } => analytic_cmts.contains(cmt),
+            _ => false,
+        })
+    }
+    #[cfg(not(feature = "markov"))]
+    {
+        let _ = (model, subject);
+        false
+    }
+}
+
 /// Model-level half of [`analytic_inner_grad_supported`]: every gate that does
 /// not depend on the subject. `build_info::gradient_method_inner` reports the
 /// inner route off **this same** predicate, so the reported `gradient_method_inner`
@@ -1498,7 +1542,38 @@ pub(crate) fn analytic_inner_grad_supported_model(model: &CompiledModel) -> bool
     if analytic_inner_common_bail(model) {
         return false;
     }
+    // Endpoint-only CTMM (#759): a `[markov_model]` with no `[structural_model]` has no
+    // Gaussian data term and no PK model, so `analytical_supported` rejects it on the
+    // absence of a closed form — yet its inner gradient (prior + the exact CTMM η-term) is
+    // fully analytic. Report that here, because `build_info::gradient_method_inner` reads
+    // this predicate and would otherwise say "fd" while `find_ebe` runs the analytic route.
+    #[cfg(feature = "markov")]
+    if endpoint_only_analytic_ctmm(model) {
+        return true;
+    }
     crate::sens::provider::analytical_supported(model)
+}
+
+/// A fit whose *only* data term is a CTMM we can differentiate exactly: no structural PK
+/// model (so no Gaussian observations at all) and every endpoint a time-homogeneous CTMM
+/// with a dual-evaluable generator program. The model-level counterpart of the
+/// `subject.obs_times.is_empty()` branch in [`analytic_inner_grad_supported`].
+#[cfg(feature = "markov")]
+fn endpoint_only_analytic_ctmm(model: &CompiledModel) -> bool {
+    use crate::types::EndpointLikelihood;
+    // No `[structural_model]`: neither a closed form (`tv_fn`) nor an `[odes]` block.
+    if model.tv_fn.is_some() || model.ode_spec.is_some() || model.endpoints.is_empty() {
+        return false;
+    }
+    model.endpoints.iter().all(|(_, ep)| {
+        matches!(
+            ep,
+            EndpointLikelihood::Ctmm {
+                generator_program: Some(_),
+                ..
+            }
+        )
+    })
 }
 
 /// Whether the exact analytic η-gradient of the individual NLL
@@ -1512,8 +1587,26 @@ fn analytic_inner_grad_supported(model: &CompiledModel, subject: &Subject) -> bo
     // provider models — the analytical path declines below, and the light ODE walk
     // (`run_subject_eta`) iterates only `subject.obs_times`, so it would silently
     // omit the survival term. Guard both routes up front.
-    if subject_has_survival_records(subject) {
+    //
+    // CTMM is the exception since #759: its transition likelihood *does* have an exact
+    // η-gradient now (`Q` rebuilt over `Dual1` for `∂Q/∂η`, chained through the Van Loan
+    // Fréchet derivative of `expm`), and `analytic_eta_nll_gradient_with_schedule` adds it
+    // to the Gaussian block. `ctmm_records_fully_analytic` is deliberately strict — it
+    // demands that *every* record on the subject be a CTMM state observation the program
+    // can serve, so a subject that also carries a TTE / binary / count record (whose terms
+    // remain FD-only) still declines the whole gradient rather than silently omitting them.
+    if subject_has_survival_records(subject) && !ctmm_records_fully_analytic(model, subject) {
         return false;
+    }
+    // No Gaussian observations ⇒ no Gaussian data term, hence nothing for the PK provider
+    // to serve: an **endpoint-only** fit (a `[markov_model]` with no `[structural_model]`,
+    // which the parser admits) has no PK model at all, and `analytical_supported` below
+    // would reject it on that basis alone. Its inner gradient is the prior plus the
+    // non-Gaussian term, both of which we have exactly, so only the global escape hatches
+    // apply. (`analytic_eta_nll_gradient_with_schedule` mirrors this by skipping the
+    // provider for such a subject.)
+    if subject.obs_times.is_empty() {
+        return !analytic_inner_common_bail(model);
     }
     // ODE models use the light `Dual1` inner provider (#410) with their own
     // per-subject scope ([`ode_inner_grad_supported`]). The global escape hatches
@@ -1740,6 +1833,39 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
     mult: Option<&[Vec<f64>]>,
 ) -> Option<Vec<f64>> {
+    // The inner NLL is `½(η'Ω⁻¹η + log|Ω| + data_gauss + 2·data_nonGaussian)`, so its
+    // η-gradient is a plain **sum** of term gradients. Assemble the non-Gaussian block
+    // first, because it is the one that decides whether this subject can be served at all
+    // (the Gaussian provider's own `None` is handled below, as before).
+    //
+    // CTMM (#759): exact, via `∂Q/∂(θ,η)` over `Dual1` chained through the Van Loan Fréchet
+    // derivative of `expm`. The objective's `2×` on the data term and the outer `½` cancel,
+    // so this enters at 1× — the same scale `ctmm_subject_eta_grad` returns.
+    // TTE / binary / count records have no analytic η-channel and are refused upstream by
+    // `analytic_inner_grad_supported` → `ctmm_records_fully_analytic`, so a subject reaching
+    // here carries no other non-Gaussian term to omit.
+    #[cfg(feature = "markov")]
+    let ctmm_grad: Option<Vec<f64>> = if model.has_ctmm() {
+        Some(crate::markov::endpoint::ctmm_subject_eta_grad(model, subject, theta, eta)?.1)
+    } else {
+        None
+    };
+
+    // No Gaussian observations ⇒ no Gaussian data term and (for an endpoint-only fit) no PK
+    // model for the provider to evaluate. The gradient is prior + non-Gaussian; return it
+    // directly rather than asking a provider that has nothing to compute.
+    if subject.obs_times.is_empty() {
+        let eta_v = nalgebra::DVector::from_column_slice(eta);
+        let mut grad: Vec<f64> = (&omega.inv * &eta_v).as_slice().to_vec();
+        #[cfg(feature = "markov")]
+        if let Some(g) = &ctmm_grad {
+            for (acc, gi) in grad.iter_mut().zip(g.iter()) {
+                *acc += gi;
+            }
+        }
+        return Some(grad);
+    }
+
     // Light first-order provider (value + ∂f/∂η only); the inner gradient never
     // needs the second-order / θ blocks the full `subject_sensitivities` carries.
     let sens = crate::sens::provider::subject_eta_grad_with_schedule(
@@ -1749,11 +1875,24 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
         eta,
         cached_schedule,
     )?;
+    // Fold the non-Gaussian block into whichever Gaussian branch runs below.
+    #[cfg(feature = "markov")]
+    let add_nongaussian = |mut g: Vec<f64>| -> Vec<f64> {
+        if let Some(c) = &ctmm_grad {
+            for (acc, gi) in g.iter_mut().zip(c.iter()) {
+                *acc += gi;
+            }
+        }
+        g
+    };
+    #[cfg(not(feature = "markov"))]
+    let add_nongaussian = |g: Vec<f64>| -> Vec<f64> { g };
     // Correlated residual (`block_sigma`, #627): the per-obs `coef·∂f/∂η` loop below
     // assumes a diagonal R. Route the dense-R generalisation here — it serves both the
     // analytical and the ODE (`Dual1`) inner path, since `sens` carries `∂f/∂η` for both.
     if !model.residual_correlations.is_empty() {
-        return dense_residual_inner_gradient(model, subject, theta, eta, omega, sigma, &sens);
+        return dense_residual_inner_gradient(model, subject, theta, eta, omega, sigma, &sens)
+            .map(add_nongaussian);
     }
     let n_eta = model.n_eta;
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
@@ -1806,7 +1945,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     for (k, g) in grad.iter_mut().enumerate() {
         *g += prior[k];
     }
-    Some(grad)
+    Some(add_nongaussian(grad))
 }
 
 /// Dense-`R` (`block_sigma`, #627) analytic inner η-gradient — the correlated-residual
@@ -2848,6 +2987,104 @@ pub fn run_inner_loop_warm(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    /// An endpoint-only mixed-effects CTMM (#759): no `[structural_model]`, so no Gaussian
+    /// data term and no PK provider — the inner objective is `½(η'Ω⁻¹η + log|Ω|) + D_ctmm(η)`.
+    #[cfg(feature = "markov")]
+    mod ctmm_inner {
+        use crate::types::{ObsRecord, Subject};
+
+        const MIXED_CTMM: &str = r"
+[parameters]
+  theta LQ01(-0.7, -6.0, 3.0)
+  theta LQ10(-1.2, -6.0, 3.0)
+  omega ETA_Q ~ 0.1
+
+[markov_model]
+  type   = ctmm
+  cmt    = 5
+  states = [awake=0, asleep=1]
+  transition awake  -> asleep = exp(LQ01 + ETA_Q)
+  transition asleep -> awake  = exp(LQ10)
+";
+
+        fn subject() -> Subject {
+            Subject {
+                id: "1".into(),
+                obs_records: [(0.0, 0), (1.0, 0), (2.3, 1), (3.1, 1), (5.0, 0)]
+                    .iter()
+                    .map(|&(time, state)| ObsRecord::DiscreteState {
+                        time,
+                        state,
+                        cmt: 5,
+                    })
+                    .collect(),
+                ..Default::default()
+            }
+        }
+
+        /// The route must actually change. Before #759 every subject with `obs_records`
+        /// declined the analytic inner gradient outright, so this predicate was `false` and
+        /// the EBE search finite-differenced the whole objective.
+        #[test]
+        fn endpoint_only_ctmm_reports_and_takes_the_analytic_inner_route() {
+            let model = crate::parser::model_parser::parse_model_string(MIXED_CTMM).unwrap();
+            // Model-level: what `build_info::gradient_method_inner` reports.
+            assert!(
+                super::super::analytic_inner_grad_supported_model(&model),
+                "an endpoint-only CTMM must report an analytic inner gradient"
+            );
+            // Subject-level: what `find_ebe` actually runs.
+            assert!(
+                super::super::analytic_inner_grad_supported(&model, &subject()),
+                "a CTMM subject must now take the analytic inner route"
+            );
+        }
+
+        /// The whole inner gradient — prior + CTMM data term — against a central difference
+        /// of `individual_nll`, the exact objective the EBE search minimizes. This is the
+        /// contract that matters: the two must agree, or BFGS converges on one function
+        /// while descending another.
+        #[test]
+        fn analytic_inner_gradient_matches_fd_of_individual_nll() {
+            let model = crate::parser::model_parser::parse_model_string(MIXED_CTMM).unwrap();
+            let subject = subject();
+            let params = &model.default_params;
+            let theta = &params.theta;
+
+            for &eta0 in &[-0.4_f64, 0.0, 0.55] {
+                let g = super::super::analytic_eta_nll_gradient_with_schedule(
+                    &model,
+                    &subject,
+                    theta,
+                    &[eta0],
+                    &params.omega,
+                    &params.sigma.values,
+                    None,
+                    None,
+                )
+                .expect("endpoint-only CTMM is in analytic scope");
+
+                let nll = |e: f64| {
+                    crate::stats::likelihood::individual_nll(
+                        &model,
+                        &subject,
+                        theta,
+                        &[e],
+                        &params.omega,
+                        &params.sigma.values,
+                    )
+                };
+                let h = 1e-6;
+                let fd = (nll(eta0 + h) - nll(eta0 - h)) / (2.0 * h);
+                assert!(
+                    (g[0] - fd).abs() < 1e-6,
+                    "η = {eta0}: analytic {}, FD {fd}",
+                    g[0]
+                );
+            }
+        }
+    }
 
     /// The M3 censored coefficient `∂/∂f[−logΦ((y−f)/√v)]` must equal a central
     /// finite difference of that data term — across additive (`dv_df = 0`) and

--- a/src/markov/endpoint.rs
+++ b/src/markov/endpoint.rs
@@ -140,6 +140,89 @@ fn ctmm_endpoint_nll(
     }
 }
 
+/// Exact `∂/∂η` of [`ctmm_subject_nll`] — the analytic counterpart of finite-differencing
+/// the whole matrix-exponential likelihood (#759).
+///
+/// `Q` is rebuilt over `Dual1` with θ and η seeded
+/// ([`CtmmGeneratorProgram::eval_generator_duals`]), giving an exact `∂Q/∂(θ,η)`; the η
+/// columns are then chained through the Van Loan Fréchet derivative of `expm` by
+/// [`ctmm_data_term_grad`]. Returns `(value, ∂/∂η)` with the gradient at the **same 1×
+/// scale as the value** — the caller applies the objective's factor.
+///
+/// `None` — caller falls back to FD for this point — when *any* CTMM endpoint on the
+/// subject cannot be served exactly:
+///   * a time-**inhomogeneous** generator (no program: the likelihood is an occupancy ODE,
+///     not an `expm`, so Van Loan does not apply);
+///   * a `(θ, η)` width past the dual dispatch cap, or intensities we could not resolve;
+///   * the degenerate regime — a negative off-diagonal rate, or the `expm`/underflow
+///     guards — where the value is a flat `SUBJECT_SENTINEL_NLL` repellent with no
+///     meaningful derivative.
+///
+/// Only the **η** block is returned today (the inner EBE loop is the consumer). The
+/// program seeds the θ axes too, so an outer θ-gradient is a projection away — see the
+/// non-Gaussian outer-gradient split (#486).
+pub fn ctmm_subject_eta_grad(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<(f64, Vec<f64>)> {
+    let n_eta = model.n_eta;
+    let mut nll = 0.0;
+    let mut grad = vec![0.0_f64; n_eta];
+    if subject.obs_records.is_empty() {
+        return Some((nll, grad));
+    }
+    for (cmt, endpoint) in &model.endpoints {
+        let EndpointLikelihood::Ctmm {
+            n_states,
+            state_codes,
+            generator_program,
+            ..
+        } = endpoint
+        else {
+            continue;
+        };
+        // No program ⇒ inhomogeneous, or not exactly representable. Decline the whole
+        // subject rather than serve a partial gradient.
+        let prog = generator_program.as_ref()?;
+
+        let obs = collect_state_obs(*cmt, state_codes, &subject.obs_records).ok()?;
+        if obs.len() < 2 {
+            continue;
+        }
+        let (q, dq) = prog.eval_generator_duals(theta, eta, &subject.covariates)?;
+        debug_assert_eq!(q.nrows(), *n_states);
+
+        // Same degeneracy guard as the value path (`ctmm_endpoint_nll`): a negative
+        // off-diagonal makes `Q` a non-generator and the value collapses to the flat
+        // sentinel, which has no derivative.
+        for j in 0..q.nrows() {
+            for k in 0..q.ncols() {
+                if j != k && q[(j, k)] < -1e-12 {
+                    return None;
+                }
+            }
+        }
+
+        // Project the (θ, η)-seeded jets onto the η axes: axis `n_theta_axis() + k` is η_k.
+        let eta_axes: Vec<nalgebra::DMatrix<f64>> = (0..n_eta)
+            .map(|k| {
+                dq.get(prog.n_theta_axis() + k)
+                    .cloned()
+                    .unwrap_or_else(|| nalgebra::DMatrix::zeros(*n_states, *n_states))
+            })
+            .collect();
+
+        let (v, g) = crate::markov::ctmm_data_term_grad(&q, &eta_axes, &obs).ok()??;
+        nll += v;
+        for (acc, gi) in grad.iter_mut().zip(g.iter()) {
+            *acc += gi;
+        }
+    }
+    Some((nll, grad))
+}
+
 /// Sum the CTMM-endpoint NLL over every `Ctmm` CMT for one subject, mirroring the
 /// per-endpoint TTE / binary dispatch. Returns `0.0` when the model has no CTMM
 /// endpoint or the subject has no discrete-state records for it.
@@ -467,6 +550,113 @@ mod tests {
             &[disc(0.0, 1, 5), disc(dt, 2, 5)],
         );
         assert!((got - (-p01.ln())).abs() < 1e-12, "got {got}");
+    }
+
+    // ---- analytic η-gradient: dual generator + Van Loan chain (#759) ------------
+
+    /// The mixed-effects CTMM of `tests/markov_smoke.rs`: a per-subject random effect on
+    /// the awake→asleep intensity, no `[structural_model]` (an endpoint-only fit).
+    const MIXED_CTMM: &str = r"
+[parameters]
+  theta LQ01(-0.7, -6.0, 3.0)
+  theta LQ10(-1.2, -6.0, 3.0)
+  omega ETA_Q ~ 0.1
+
+[markov_model]
+  type   = ctmm
+  cmt    = 5
+  states = [awake=0, asleep=1]
+  transition awake  -> asleep = exp(LQ01 + ETA_Q)
+  transition asleep -> awake  = exp(LQ10)
+";
+
+    fn ctmm_subject(states: &[(f64, usize)]) -> Subject {
+        Subject {
+            id: "1".into(),
+            obs_records: states
+                .iter()
+                .map(|&(t, s)| disc(t, s, 5))
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        }
+    }
+
+    /// The load-bearing end-to-end check: the exact η-gradient — `∂Q/∂η` from replaying the
+    /// parsed intensities over `Dual1`, chained through the adjoint Van Loan derivative of
+    /// `expm` — must equal a central finite difference of the *same* subject NLL the fit
+    /// minimizes. This is what pins the whole chain (parser → program → generator jets →
+    /// Fréchet) to the function it claims to differentiate.
+    #[test]
+    fn ctmm_subject_eta_grad_matches_fd() {
+        let model = crate::parser::model_parser::parse_model_string(MIXED_CTMM).expect("parse");
+        assert_eq!(model.n_eta, 1);
+        let subject = ctmm_subject(&[(0.0, 0), (1.0, 0), (2.3, 1), (3.1, 1), (5.0, 0)]);
+        let theta = [-0.7_f64, -1.2];
+
+        // Away from η = 0, so a sign error or a dropped term cannot hide.
+        for &eta0 in &[-0.45_f64, 0.0, 0.6] {
+            let eta = [eta0];
+            let (v, g) = ctmm_subject_eta_grad(&model, &subject, &theta, &eta)
+                .expect("homogeneous CTMM with a dual-evaluable program is analytic");
+            // The gradient path's value must not drift from the value path's.
+            let v_ref = ctmm_subject_nll(&model, &subject, &theta, &eta);
+            assert!((v - v_ref).abs() < 1e-12, "value drift: {v} vs {v_ref}");
+
+            let h = 1e-6;
+            let fd = (ctmm_subject_nll(&model, &subject, &theta, &[eta0 + h])
+                - ctmm_subject_nll(&model, &subject, &theta, &[eta0 - h]))
+                / (2.0 * h);
+            assert!(
+                (g[0] - fd).abs() < 1e-6,
+                "η = {eta0}: analytic {}, FD {fd}",
+                g[0]
+            );
+            // A real gradient, not an accidental zero.
+            assert!(g[0].abs() > 1e-3, "η = {eta0}: gradient suspiciously flat");
+        }
+    }
+
+    /// A time-**inhomogeneous** (drug-driven) generator gets no program — its likelihood is
+    /// an occupancy ODE, not an `expm`, so the Van Loan identity does not apply. It must
+    /// decline to FD rather than silently return the homogeneous answer.
+    #[test]
+    fn inhomogeneous_ctmm_declines_the_analytic_grad() {
+        let src = r"
+[parameters]
+  theta TVCL(1.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta LQ01(-0.7, -6.0, 3.0)
+  theta LQ10(-1.2, -6.0, 3.0)
+  theta SLOPE(0.1, -5.0, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -CL/V * central
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[markov_model]
+  type   = ctmm
+  cmt    = 5
+  states = [s0=0, s1=1]
+  transition s0 -> s1 = exp(LQ01 + SLOPE * (central / V))
+  transition s1 -> s0 = exp(LQ10)
+";
+        let model = crate::parser::model_parser::parse_model_string(src).expect("parse");
+        let subject = ctmm_subject(&[(0.0, 0), (1.0, 1)]);
+        assert!(
+            ctmm_subject_eta_grad(&model, &subject, &model.default_params.theta, &[0.1]).is_none(),
+            "a state-driven generator must decline the expm-based analytic gradient"
+        );
     }
 
     /// A subject with a single observation carries no transition ⇒ 0 contribution.

--- a/src/markov/endpoint.rs
+++ b/src/markov/endpoint.rs
@@ -205,16 +205,18 @@ pub fn ctmm_subject_eta_grad(
             }
         }
 
-        // Project the (θ, η)-seeded jets onto the η axes: axis `n_theta_axis() + k` is η_k.
-        let eta_axes: Vec<nalgebra::DMatrix<f64>> = (0..n_eta)
-            .map(|k| {
-                dq.get(prog.n_theta_axis() + k)
-                    .cloned()
-                    .unwrap_or_else(|| nalgebra::DMatrix::zeros(*n_states, *n_states))
-            })
-            .collect();
-
-        let (v, g) = crate::markov::ctmm_data_term_grad(&q, &eta_axes, &obs).ok()??;
+        // Project the (θ, η)-seeded jets onto the η axes. `dq` is laid out θ₀..θ_{T−1},
+        // η₀..η_{E−1}, so the η block is exactly the tail — borrow it, no clones.
+        //
+        // A length mismatch would mean the program's axis layout disagrees with the model's
+        // η count. Decline (→ FD) rather than zero-fill the missing axes: a zero jet is a
+        // *wrong* gradient reported as analytic, which is the failure mode this whole
+        // change set exists to remove.
+        let n_theta = prog.n_theta_axis();
+        if dq.len() != n_theta + n_eta {
+            return None;
+        }
+        let (v, g) = crate::markov::ctmm_data_term_grad(&q, &dq[n_theta..], &obs).ok()??;
         nll += v;
         for (acc, gi) in grad.iter_mut().zip(g.iter()) {
             *acc += gi;

--- a/src/markov/mod.rs
+++ b/src/markov/mod.rs
@@ -128,6 +128,18 @@ pub enum MarkovError {
         from: usize,
         to: usize,
     },
+
+    /// A generator *derivative* `∂Q/∂p` passed to [`ctmm_data_term_grad`] does not match
+    /// the generator's shape. Checked at runtime, not just in debug: the gradient
+    /// contracts `⟨G, ∂Q/∂p⟩` with a zipped iterator, which on a short `∂Q/∂p` would
+    /// silently *truncate* and return a confidently wrong gradient.
+    #[error("∂Q/∂p at axis {axis} is {rows}×{cols}, but the generator is {n_states}×{n_states}")]
+    DerivativeShapeMismatch {
+        axis: usize,
+        rows: usize,
+        cols: usize,
+        n_states: usize,
+    },
 }
 
 /// Transition-probability matrix `P(Δt) = expm(A)` for `A = Q·Δt`.
@@ -269,10 +281,19 @@ pub fn ctmm_data_term_grad(
     if s < 2 {
         return Err(MarkovError::TooFewStates { n: s });
     }
-    debug_assert!(
-        dq.iter().all(|d| d.shape() == (s, s)),
-        "every ∂Q/∂p must match Q's shape"
-    );
+    // Validated at runtime, not merely debug-asserted: the contraction below zips `G` with
+    // `∂Q/∂p`, so a short derivative matrix would silently truncate and yield a wrong
+    // gradient rather than an error — and this is a `pub` entry point.
+    for (axis, d) in dq.iter().enumerate() {
+        if d.shape() != (s, s) {
+            return Err(MarkovError::DerivativeShapeMismatch {
+                axis,
+                rows: d.nrows(),
+                cols: d.ncols(),
+                n_states: s,
+            });
+        }
+    }
 
     for (i, o) in obs.iter().enumerate() {
         if o.state >= s {
@@ -1034,6 +1055,30 @@ mod tests {
         ];
         assert_eq!(ctmm_data_term(&q, &obs).unwrap(), SENTINEL_NLL);
         assert!(ctmm_data_term_grad(&q, &dq, &obs).unwrap().is_none());
+    }
+
+    /// A misshapen `∂Q/∂p` must be an error, not a truncated contraction. The gradient zips
+    /// `G` with `∂Q/∂p`, so a short derivative would silently drop entries and return a
+    /// confidently wrong gradient — the exact failure mode a `debug_assert!` alone would let
+    /// through in release.
+    #[test]
+    fn data_term_grad_rejects_a_misshapen_derivative() {
+        let q = DMatrix::from_row_slice(2, 2, &[-0.5, 0.5, 0.3, -0.3]);
+        let dq = vec![DMatrix::<f64>::zeros(3, 3)];
+        let obs = vec![
+            StateObs {
+                time: 0.0,
+                state: 0,
+            },
+            StateObs {
+                time: 1.0,
+                state: 1,
+            },
+        ];
+        assert!(matches!(
+            ctmm_data_term_grad(&q, &dq, &obs),
+            Err(MarkovError::DerivativeShapeMismatch { axis: 0, .. })
+        ));
     }
 
     #[test]

--- a/src/markov/mod.rs
+++ b/src/markov/mod.rs
@@ -222,6 +222,144 @@ pub fn generator_rate_direction(s: usize, j: usize, k: usize, dt: f64) -> DMatri
     e
 }
 
+/// Exact gradient of [`ctmm_data_term`] w.r.t. an arbitrary parameter vector, given the
+/// generator `q` and its derivatives `dq[a] = ∂Q/∂p_a` (#759).
+///
+/// This is the analytic replacement for finite-differencing the whole matrix-exponential
+/// likelihood. The chain is
+///
+/// ```text
+///   ∂/∂p_a [ −log P(Δt)[u,v] ]  =  − L(QΔt, (∂Q/∂p_a)·Δt)[u,v] / P(Δt)[u,v]
+/// ```
+///
+/// with `L` the Fréchet derivative ([`matrix_exp_frechet`]). Evaluating that literally
+/// would cost one `2S×2S` `expm` **per axis per gap** — which for a handful of axes is
+/// *slower* than the `S×S` FD it replaces. Instead we use the adjoint identity
+///
+/// ```text
+///   ⟨C, L(A, E)⟩  =  ⟨L(Aᵀ, C), E⟩          (trace inner product)
+/// ```
+///
+/// Only one *entry* `[u,v]` of `P` is ever read, so seeding `C = e_u e_vᵀ` gives a single
+/// matrix `G = L((QΔt)ᵀ, e_u e_vᵀ)` with `∂P[u,v]/∂p_a = ⟨G, (∂Q/∂p_a)·Δt⟩` for **every**
+/// `a`. That is **one** Fréchet solve per observation gap regardless of the parameter count
+/// — cheaper than the FD path (`2·n_axes` `S×S` `expm`s per gap) as soon as there are a few
+/// axes, and it scales to the full `(θ, η)` width for free. `adjoint_frechet_matches_direct`
+/// pins the identity against the direct per-direction form.
+///
+/// `dq[a]` must be a valid generator *direction* (zero row sums). The caller gets that for
+/// free by differentiating the intensities — see `CtmmGeneratorProgram::eval_generator_duals`.
+///
+/// Returns `Ok(None)` where [`ctmm_data_term`] returns [`SENTINEL_NLL`]: at a degenerate
+/// generator the value is a flat repellent constant with no meaningful derivative, so the
+/// caller falls back to FD for that point rather than being handed a zero (or garbage)
+/// gradient. Errors mirror [`ctmm_data_term`] exactly.
+pub fn ctmm_data_term_grad(
+    q: &DMatrix<f64>,
+    dq: &[DMatrix<f64>],
+    obs: &[StateObs],
+) -> Result<Option<(f64, Vec<f64>)>, MarkovError> {
+    if !q.is_square() {
+        return Err(MarkovError::NonSquareGenerator {
+            rows: q.nrows(),
+            cols: q.ncols(),
+        });
+    }
+    let s = q.nrows();
+    if s < 2 {
+        return Err(MarkovError::TooFewStates { n: s });
+    }
+    debug_assert!(
+        dq.iter().all(|d| d.shape() == (s, s)),
+        "every ∂Q/∂p must match Q's shape"
+    );
+
+    for (i, o) in obs.iter().enumerate() {
+        if o.state >= s {
+            return Err(MarkovError::StateOutOfRange {
+                state: o.state,
+                n_states: s,
+            });
+        }
+        if !o.time.is_finite() {
+            return Err(MarkovError::NonFiniteTime {
+                index: i,
+                time: o.time,
+            });
+        }
+    }
+
+    let n_axes = dq.len();
+    let mut grad = vec![0.0_f64; n_axes];
+    if obs.len() < 2 {
+        return Ok(Some((0.0, grad)));
+    }
+
+    let mut nll = 0.0;
+    for (i, pair) in obs.windows(2).enumerate() {
+        let (a, b) = (pair[0], pair[1]);
+        let dt = b.time - a.time;
+
+        if dt < 0.0 {
+            return Err(MarkovError::TimeDecreased {
+                index: i + 1,
+                prev: a.time,
+                next: b.time,
+            });
+        }
+        if dt == 0.0 {
+            if a.state != b.state {
+                return Err(MarkovError::ZeroDtStateChange {
+                    index: i + 1,
+                    time: b.time,
+                    from: a.state,
+                    to: b.state,
+                });
+            }
+            // P(0) = I: the term is identically 0 in both value and derivative.
+            continue;
+        }
+
+        let arg = q * dt;
+        if arg
+            .iter()
+            .any(|x| !x.is_finite() || x.abs() > MAX_EXP_ARG_ABS)
+        {
+            return Ok(None);
+        }
+        let p_mat = matrix_exp(&arg);
+        let p = p_mat[(a.state, b.state)];
+        if !p.is_finite() || p <= 0.0 {
+            return Ok(None);
+        }
+        // Mirror `ctmm_data_term`'s `p.min(1.0)` clamp in the *derivative* too: where the
+        // clamp binds, the implemented value is the constant `ln(1) = 0`, so its exact
+        // derivative is 0 — not `−(∂P/∂p)/p`. Differentiating through a clamp the value
+        // path applies is the classic way an "analytic" gradient stops matching the
+        // function it claims to differentiate.
+        if p > 1.0 {
+            continue;
+        }
+        nll -= p.ln();
+
+        // One adjoint Fréchet solve, reused across every axis (see the doc comment).
+        let mut seed = DMatrix::<f64>::zeros(s, s);
+        seed[(a.state, b.state)] = 1.0;
+        let g = matrix_exp_frechet(&arg.transpose(), &seed);
+        for (ax, dq_a) in dq.iter().enumerate() {
+            // ∂P[u,v]/∂p_a = ⟨G, (∂Q/∂p_a)·Δt⟩; the NLL term is −log P.
+            let dp: f64 = g
+                .iter()
+                .zip(dq_a.iter())
+                .map(|(gi, di)| gi * di)
+                .sum::<f64>()
+                * dt;
+            grad[ax] -= dp / p;
+        }
+    }
+    Ok(Some((nll, grad)))
+}
+
 /// Individual CTMM negative log-likelihood for a **prebuilt** generator `q`:
 /// `−Σ_m log P(Δt_m)[s_m, s_{m+1}]` over consecutive observation pairs.
 ///
@@ -784,6 +922,118 @@ mod tests {
         let qm = DMatrix::from_row_slice(2, 2, &[-(a - ha), a - ha, b, -b]) * dt;
         let grad_fd = (matrix_exp(&qp) - matrix_exp(&qm)) / (2.0 * ha);
         assert!(max_abs_diff(&grad_vl, &grad_fd) < 1e-8);
+    }
+
+    // ---- ctmm_data_term_grad: the adjoint Van Loan chain (#759) -----------------
+
+    /// The identity `ctmm_data_term_grad` is built on: `⟨C, L(A,E)⟩ = ⟨L(Aᵀ,C), E⟩`.
+    ///
+    /// This is what lets one Fréchet solve per observation gap serve *every* parameter
+    /// axis, instead of one solve per (axis, gap). If it ever stopped holding, the
+    /// gradient would be silently wrong — and plausibly so, since it would still have the
+    /// right sparsity and rough magnitude — so pin it directly rather than only through
+    /// the FD comparisons below.
+    #[test]
+    fn adjoint_frechet_matches_direct() {
+        let (a, b, dt) = (0.7, 0.3, 2.0);
+        let q = DMatrix::from_row_slice(2, 2, &[-a, a, b, -b]);
+        let arg = &q * dt;
+        // Direction: raise the 0→1 rate (constrained, row-sum-zero).
+        let e = generator_rate_direction(2, 0, 1, dt);
+        // Direct: the (0,1) entry of L(A, E).
+        let direct = matrix_exp_frechet(&arg, &e)[(0, 1)];
+        // Adjoint: one solve with Aᵀ seeded at the entry we read, contracted with E.
+        let mut seed = DMatrix::<f64>::zeros(2, 2);
+        seed[(0, 1)] = 1.0;
+        let g = matrix_exp_frechet(&arg.transpose(), &seed);
+        let adjoint: f64 = g.iter().zip(e.iter()).map(|(gi, ei)| gi * ei).sum();
+        assert!(
+            (direct - adjoint).abs() < 1e-12,
+            "adjoint Fréchet identity broken: direct {direct}, adjoint {adjoint}"
+        );
+    }
+
+    #[test]
+    fn data_term_grad_matches_fd() {
+        // Q(θ) = [[-e^{t0}, e^{t0}], [e^{t1}, -e^{t1}]] — the shipped 2-state CTMM shape,
+        // parameterized on the log scale so ∂Q/∂θ is not the trivial rate direction.
+        let theta = [(-0.7_f64), -1.2];
+        let build = |t: &[f64; 2]| {
+            let (r01, r10) = (t[0].exp(), t[1].exp());
+            DMatrix::from_row_slice(2, 2, &[-r01, r01, r10, -r10])
+        };
+        // ∂Q/∂θ_0 = r01·(E_01 − E_00); likewise for θ_1.
+        let dq: Vec<DMatrix<f64>> = (0..2)
+            .map(|a| {
+                let r = theta[a].exp();
+                let (j, k) = if a == 0 { (0, 1) } else { (1, 0) };
+                let mut m = DMatrix::<f64>::zeros(2, 2);
+                m[(j, k)] = r;
+                m[(j, j)] = -r;
+                m
+            })
+            .collect();
+        let obs = vec![
+            StateObs {
+                time: 0.0,
+                state: 0,
+            },
+            StateObs {
+                time: 1.3,
+                state: 1,
+            },
+            StateObs {
+                time: 2.1,
+                state: 1,
+            },
+            StateObs {
+                time: 4.0,
+                state: 0,
+            },
+        ];
+        let q = build(&theta);
+        let (v, g) = ctmm_data_term_grad(&q, &dq, &obs)
+            .expect("well-posed generator")
+            .expect("not degenerate");
+        // Value agrees with the plain kernel — the gradient path must not drift from it.
+        assert!((v - ctmm_data_term(&q, &obs).unwrap()).abs() < 1e-14);
+
+        for a in 0..2 {
+            let h = 1e-6;
+            let (mut tp, mut tm) = (theta, theta);
+            tp[a] += h;
+            tm[a] -= h;
+            let fd = (ctmm_data_term(&build(&tp), &obs).unwrap()
+                - ctmm_data_term(&build(&tm), &obs).unwrap())
+                / (2.0 * h);
+            assert!(
+                (g[a] - fd).abs() < 1e-6,
+                "axis {a}: analytic {}, FD {fd}",
+                g[a]
+            );
+        }
+    }
+
+    /// A degenerate generator returns a flat `SENTINEL_NLL` with no meaningful derivative;
+    /// the gradient path must say so (`Ok(None)`) rather than hand back a zero gradient,
+    /// which the optimizer would read as "already at a stationary point".
+    #[test]
+    fn data_term_grad_declines_at_the_degeneracy_sentinel() {
+        let big = MAX_EXP_ARG_ABS;
+        let q = DMatrix::from_row_slice(2, 2, &[-big, big, big, -big]);
+        let dq = vec![DMatrix::<f64>::zeros(2, 2)];
+        let obs = vec![
+            StateObs {
+                time: 0.0,
+                state: 0,
+            },
+            StateObs {
+                time: 10.0,
+                state: 1,
+            },
+        ];
+        assert_eq!(ctmm_data_term(&q, &obs).unwrap(), SENTINEL_NLL);
+        assert!(ctmm_data_term_grad(&q, &dq, &obs).unwrap().is_none());
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -5024,6 +5024,30 @@ fn parse_markov_model_block(
     // injected into the variable map so `eval_expression` resolves it. On the homogeneous
     // path `generator_states` is empty and `state` is ignored.
     let n_states = states.len();
+
+    // Snapshot a resolved, **dual-evaluable** form of the intensities before they move into
+    // the f64 closure below — the CTMM analogue of `IndivParamProgram` (#759). This is what
+    // lets `markov::endpoint` produce an exact `∂Q/∂(θ,η)` (and, chained through the Van Loan
+    // Fréchet derivative of `expm`, an exact likelihood gradient) instead of finite-
+    // differencing the whole matrix-exponential likelihood.
+    //
+    // Built only for the **time-homogeneous** endpoint: an intensity that reads an ODE state
+    // makes `Q` a functional of the PK trajectory, whose derivative needs the state's own
+    // sensitivities (and whose likelihood is an occupancy ODE, not an `expm` — so Van Loan
+    // does not apply). Those keep the FD path, so the program is `None` there.
+    let generator_program = if generator_states.is_empty() {
+        build_ctmm_generator_program(
+            &transitions,
+            &needed_indiv_stmts,
+            &generator_covariates,
+            n_states,
+            theta_names.len(),
+            eta_names.len(),
+        )
+    } else {
+        None
+    };
+
     let indiv = needed_indiv_stmts;
     let gen_states = generator_states.clone();
     let generator_fn: crate::types::GeneratorFn = Box::new(
@@ -5060,6 +5084,7 @@ fn parse_markov_model_block(
             n_states,
             state_codes,
             generator_fn,
+            generator_program,
             generator_covariates: generator_covariates.clone(),
             generator_states,
         },
@@ -13919,6 +13944,245 @@ fn compute_cov_static_mask(stmts: &[Statement], n_vars: usize) -> Vec<bool> {
         }
     }
     dyn_vars.iter().map(|&d| !d).collect()
+}
+
+/// Widest `(θ, η)` axis count the CTMM generator's dual dispatch specializes.
+/// Above this, [`CtmmGeneratorProgram::eval_generator_duals`] returns `None` and the
+/// endpoint keeps its finite-difference gradient — a fallback, never a wrong answer.
+#[cfg(feature = "markov")]
+pub(crate) const MAX_CTMM_AXES: usize = 24;
+
+/// Compiled, **dual-evaluable** `[markov_model]` transition intensities — the CTMM
+/// analogue of [`IndivParamProgram`] (#759).
+///
+/// The f64 [`GeneratorFn`](crate::types::GeneratorFn) tree-walks `Expression`s and can
+/// only ever produce `Q` itself, which is why the CTMM likelihood has been finite-
+/// differenced end-to-end (perturb η, rebuild `Q`, redo an `expm` per observation gap).
+/// This snapshot carries the same intensities in *resolved* form — the shared
+/// `Bytecode` the rest of the analytic-sensitivity path uses — so they can be replayed
+/// over `Dual1<M>` with θ and η seeded, yielding an exact `∂Q/∂(θ,η)`.
+///
+/// Chained through the Van Loan Fréchet derivative of `expm`
+/// ([`markov::matrix_exp_frechet`](crate::markov::matrix_exp_frechet)) this gives the exact
+/// likelihood gradient. Note `∂Q/∂p` inherits the generator's **row-sum-zero constraint**
+/// for free: every intensity is added at its off-diagonal entry and subtracted from the
+/// diagonal, and differentiation is linear, so the derivative of a valid generator is a
+/// valid *direction*. That is the constraint `generator_rate_direction` hand-builds for the
+/// one-rate-at-a-time case, and the reason a naive "one gradient per `Q` entry" API is wrong
+/// (see the `markov` module docs).
+///
+/// Time-**inhomogeneous** endpoints (an intensity reading an ODE state) get no program:
+/// their likelihood is an occupancy ODE, not an `expm`, so Van Loan does not apply.
+#[cfg(feature = "markov")]
+#[derive(Debug, Clone)]
+pub struct CtmmGeneratorProgram {
+    /// Resolved `[individual_parameters]` statements the intensities read, in
+    /// dependency order (already restricted to the transitively-referenced subset).
+    stmts: Vec<Statement>,
+    /// Var-slot count the statements above write into.
+    n_vars: usize,
+    /// `(from, to, intensity)` — one compiled off-diagonal rate per `transition` line.
+    rates: Vec<(usize, usize, Bytecode)>,
+    n_states: usize,
+    /// Covariate names in the generator's own (sorted) order, for the cov slice.
+    cov_names: Vec<String>,
+    n_theta: usize,
+    /// BSV η count. IOV kappas are rejected in an intensity at parse, so this is the
+    /// full η width the intensities can read.
+    n_eta: usize,
+}
+
+#[cfg(feature = "markov")]
+impl CtmmGeneratorProgram {
+    /// Dual width needed to seed every `(θ, η)` axis: `n_theta + n_eta`.
+    pub(crate) fn n_axes(&self) -> usize {
+        self.n_theta + self.n_eta
+    }
+    pub(crate) fn n_theta_axis(&self) -> usize {
+        self.n_theta
+    }
+
+    /// `Q` and `∂Q/∂(θ, η)` at a covariate snapshot, evaluated over `Dual1<M>` with
+    /// θ_m on axis `m` and η_k on axis `n_theta + k` (the same axis convention
+    /// [`IndivParamProgram::eval_param_duals`] uses).
+    ///
+    /// Returns `(q, dq)` where `q` is the `S×S` generator and `dq[a]` is `∂Q/∂(axis a)`,
+    /// length `n_axes()`. Both are built by placing each intensity — value and jet — at
+    /// its off-diagonal entry and subtracting it from the diagonal, so each `dq[a]` has
+    /// zero row sums by construction.
+    ///
+    /// `None` above the dispatch cap ([`MAX_CTMM_AXES`]): the endpoint then keeps its FD
+    /// gradient rather than a wrong one.
+    pub(crate) fn eval_generator_duals(
+        &self,
+        theta: &[f64],
+        eta: &[f64],
+        covariates: &HashMap<String, f64>,
+    ) -> Option<(nalgebra::DMatrix<f64>, Vec<nalgebra::DMatrix<f64>>)> {
+        macro_rules! disp {
+            ($($m:literal),+) => {
+                match self.n_axes() {
+                    $($m => Some(self.eval_generator_duals_n::<$m>(theta, eta, covariates)),)+
+                    _ => None,
+                }
+            };
+        }
+        disp!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+    }
+
+    fn eval_generator_duals_n<const M: usize>(
+        &self,
+        theta: &[f64],
+        eta: &[f64],
+        covariates: &HashMap<String, f64>,
+    ) -> (nalgebra::DMatrix<f64>, Vec<nalgebra::DMatrix<f64>>) {
+        use crate::sens::dual1::Dual1;
+        debug_assert_eq!(M, self.n_axes());
+        let theta_d: Vec<Dual1<M>> = theta
+            .iter()
+            .enumerate()
+            .map(|(m, &v)| {
+                if m < M {
+                    Dual1::var(v, m)
+                } else {
+                    // A θ the intensities cannot reference anyway (the program is sized by
+                    // the model's declared θ count, so this is unreachable in practice).
+                    Dual1::constant(v)
+                }
+            })
+            .collect();
+        let eta_d: Vec<Dual1<M>> = eta
+            .iter()
+            .enumerate()
+            .map(|(k, &v)| {
+                let dim = self.n_theta + k;
+                if dim < M {
+                    Dual1::var(v, dim)
+                } else {
+                    // IOV kappas are appended past the BSV η block and are rejected in an
+                    // intensity at parse, so they are correctly seeded as constants here.
+                    Dual1::constant(v)
+                }
+            })
+            .collect();
+        let cov_vec: Vec<f64> = self
+            .cov_names
+            .iter()
+            .map(|n| covariates.get(n).copied().unwrap_or(0.0))
+            .collect();
+
+        let mut vars = vec![Dual1::<M>::constant(0.0); self.n_vars];
+        let mut stack: Vec<Dual1<M>> = Vec::new();
+        eval_statements_g::<Dual1<M>>(
+            &self.stmts,
+            &theta_d,
+            &eta_d,
+            &cov_vec,
+            &mut vars,
+            None,
+            &mut stack,
+            &[],
+        );
+
+        let s = self.n_states;
+        let n_axes = self.n_axes();
+        let mut q = nalgebra::DMatrix::<f64>::zeros(s, s);
+        let mut dq = vec![nalgebra::DMatrix::<f64>::zeros(s, s); n_axes];
+        let empty_nn: Vec<Vec<f64>> = Vec::new();
+        for (j, k, bc) in &self.rates {
+            let rate = eval_bytecode_g::<Dual1<M>>(
+                bc, &theta_d, &eta_d, &cov_vec, &vars, &empty_nn, &mut stack,
+            );
+            q[(*j, *k)] += rate.value;
+            q[(*j, *j)] -= rate.value;
+            for (a, dq_a) in dq.iter_mut().enumerate().take(n_axes) {
+                let g = rate.grad[a];
+                dq_a[(*j, *k)] += g;
+                dq_a[(*j, *j)] -= g;
+            }
+        }
+        (q, dq)
+    }
+}
+
+/// Resolve + compile a `[markov_model]`'s intensities into a [`CtmmGeneratorProgram`].
+/// `None` when the program cannot be represented exactly, in which case the endpoint keeps
+/// its FD gradient: an intensity or an `[individual_parameters]` value that reads an
+/// identifier we cannot bind (which would silently lower to a constant `0.0` push and thus
+/// a silently-wrong derivative), or a `(θ, η)` width past the dual dispatch cap.
+#[cfg(feature = "markov")]
+fn build_ctmm_generator_program(
+    transitions: &[(usize, usize, Expression)],
+    needed_indiv_stmts: &[Statement],
+    generator_covariates: &[String],
+    n_states: usize,
+    n_theta: usize,
+    n_eta: usize,
+) -> Option<CtmmGeneratorProgram> {
+    if n_theta + n_eta == 0 || n_theta + n_eta > MAX_CTMM_AXES {
+        return None;
+    }
+
+    // Var slots for the `[individual_parameters]` values the intensities read, in the
+    // order they are assigned (so a later value may read an earlier one).
+    let var_names = assigned_vars_in_order(needed_indiv_stmts);
+    let var_idx: HashMap<String, usize> = var_names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.clone(), i))
+        .collect();
+    let n_vars = var_names.len();
+    let cov_idx: HashMap<String, usize> = generator_covariates
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.clone(), i))
+        .collect();
+
+    // An unresolved `Variable`/`Covariate` leaf lowers to a constant `0.0` in
+    // `compile_bytecode` (its documented fall-through). That is survivable for a *value*
+    // path that never sees one, but here it would hand back a confidently wrong gradient,
+    // so refuse the program instead and let FD serve the endpoint.
+    let resolvable = |e: &Expression| -> bool {
+        let mut ok = true;
+        visit_expr_nodes(e, &mut |node: &Expression| match node {
+            Expression::Variable(name) => ok &= var_idx.contains_key(name),
+            Expression::Covariate(name) => ok &= cov_idx.contains_key(name),
+            _ => {}
+        });
+        ok
+    };
+    if !transitions.iter().all(|(_, _, e)| resolvable(e)) {
+        return None;
+    }
+    let mut indiv_ok = true;
+    visit_stmt_nodes(needed_indiv_stmts, &mut |e: &Expression| {
+        indiv_ok &= resolvable(e);
+    });
+    if !indiv_ok {
+        return None;
+    }
+
+    let mut stmts: Vec<Statement> = needed_indiv_stmts.to_vec();
+    resolve_variable_indices(&mut stmts, &var_idx, &cov_idx, None);
+
+    let rates: Vec<(usize, usize, Bytecode)> = transitions
+        .iter()
+        .map(|(j, k, expr)| {
+            let mut e = expr.clone();
+            resolve_expr_indices(&mut e, &var_idx, &cov_idx);
+            (*j, *k, compile_bytecode(&e))
+        })
+        .collect();
+
+    Some(CtmmGeneratorProgram {
+        stmts,
+        n_vars,
+        rates,
+        n_states,
+        cov_names: generator_covariates.to_vec(),
+        n_theta,
+        n_eta,
+    })
 }
 
 /// Compiled `[individual_parameters]` block + var layout, exposed so the

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -9533,11 +9533,12 @@ mod tests {
     }
 
     /// A model whose individual-parameter program carries more than `MAX_ODE_AXES`
-    /// (16) axes must make `param_derivatives_at_cov` return `None` gracefully (its
-    /// dispatch only specializes `1..=16`, hitting the `_ => None` arm) rather than
+    /// axes must make `param_derivatives_at_cov` return `None` gracefully (its dispatch
+    /// only specializes `1..=MAX_ODE_AXES`, hitting the `_ => None` arm) rather than
     /// panic — the seeders propagate that `None` via `?`, so the caller falls back to
-    /// FD. (The gate caps `n_theta + n_eta ≤ 16`, so this `_ => None` is otherwise
-    /// reachable only through intermediate-axis inflation — see #455.) (#451 re-review #10)
+    /// FD. (The gate caps `n_theta + n_eta ≤ MAX_ODE_AXES`, so this `_ => None` is
+    /// otherwise reachable only through intermediate-axis inflation — see #455.)
+    /// (#451 re-review #10)
     #[test]
     fn param_derivatives_at_cov_declines_over_max_axes_gracefully() {
         // 16 thetas + 1 eta = 17 axes (> MAX_ODE_AXES). All thetas feed CL so the
@@ -9573,6 +9574,25 @@ mod tests {
             pd.is_none(),
             "> MAX_ODE_AXES axes must decline to FD, not panic"
         );
+
+        // The decline is a property of the **program's axis count**, never of the covariate
+        // snapshot: `param_derivatives_at_cov` reads `cov` only to *evaluate* the program, and
+        // decides `Some`/`None` before that, on `prog.n_axes()` alone. `run_obs_grad_tvcov`
+        // relies on exactly this — it hoists one `ParamDerivs` per event behind a single `?`,
+        // which is only equivalent to the old per-consumer checks because a program that
+        // resolves at one event's covariates resolves at all of them. If a future change ever
+        // made the decline cov-dependent, the hoist would silently serve the *first* event's
+        // answer to every other event, so pin the invariant here rather than in a comment.
+        for cov in [
+            HashMap::new(),
+            HashMap::from([("WT".to_string(), 70.0)]),
+            HashMap::from([("WT".to_string(), 1.0e6), ("AGE".to_string(), -3.0)]),
+        ] {
+            assert!(
+                param_derivatives_at_cov(prog, &model, &cov, &theta, &[0.1]).is_none(),
+                "the > MAX_ODE_AXES decline must not depend on the covariate snapshot"
+            );
+        }
     }
 
     // ---- #430 slice 1: built-in inverse-Gaussian absorption forcing over Dual2 ----

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -560,6 +560,12 @@ const _: () = assert!(
 /// analytic **outer** gradient while the inner declined via `?` — an analytic outer against a
 /// fixed-EBE FD inner, exactly the split `subject_eta_grad_tvcov_with_schedule` forbids
 /// (#449 re-review #2). Raise the two together, never this one alone.
+///
+/// That decline is now the *only* consequence of a cap divergence: `run_obs_grad_tvcov` hoists
+/// the program derivatives, so every consumer inside it is total and a miss can no longer be
+/// papered over with a zero jet (it used to be, in the modeled-dose slot dual and the readout's
+/// high slots — a wrong gradient reported as analytic). The assert still stands, because an
+/// inner-FD / outer-analytic *scope split* remains wrong on its own.
 const MAX_TVCOV_AXES: usize = 24;
 
 const _: () = assert!(
@@ -3154,13 +3160,42 @@ fn run_obs_grad_tvcov<const N: usize>(
     // the `Dual1` η-derivative walk (gated on `uses_time`, like the f64 closure;
     // #486 / #610).
     let uses_time = crate::parser::model_parser::compiled_model_uses_time_builtin(model);
-    let mk = |time: f64,
-              cov: &std::collections::HashMap<String, f64>|
-     -> Option<PkDual<Dual1<N>>> {
+
+    // Per-event program derivatives (`∂p/∂η`), evaluated **once per event** and shared by every
+    // consumer below: the event `PkDual`s, the modeled-dose / lagtime slot duals, and the Form-C
+    // readout's high slots.
+    //
+    // `param_derivatives_at_cov` declines (`None`) purely on the *program's* axis count —
+    // `n_theta + n_eta` above the `disp!` cap (#449 review #1) — which is a property of `prog`,
+    // never of `cov` (`ode_provider::param_derivatives_at_cov`). Its `None` is therefore uniform
+    // across a subject's events, so hoisting it collapses the decline into the single `?` below
+    // that drops the whole subject to FD. The consumers then take a `&ParamDerivs` and are
+    // *total*: there is no longer a site that can substitute a **zero jet** for a missing
+    // derivative and report the result as analytic. Two such fallbacks used to exist (the
+    // modeled-dose slot dual and the readout's high slots); both were unreachable only by
+    // coincidence, and a `MAX_TVCOV_AXES > MAX_ODE_AXES` cap divergence would have made them a
+    // silently-wrong gradient rather than an FD fallback (#822 follow-up).
+    let pd_at = |time: f64,
+                 cov: &std::collections::HashMap<String, f64>|
+     -> Option<crate::sens::ode_provider::ParamDerivs> {
         let _time_guard = crate::parser::model_parser::ModelTimeGuard::enter_if(uses_time, time);
-        // `None` above the param-derivative dispatch cap (n_axes > MAX_ODE_AXES): decline
-        // so the inner loop falls back to FD rather than panicking (#449 review #1).
-        let pd = param_derivatives_at_cov(prog, model, cov, theta, eta)?;
+        param_derivatives_at_cov(prog, model, cov, theta, eta)
+    };
+    let pd_dose: Vec<crate::sens::ode_provider::ParamDerivs> = (0..subject.doses.len())
+        .map(|k| pd_at(subject.doses[k].time, subject.dose_cov(k)))
+        .collect::<Option<Vec<_>>>()?;
+    let pd_obs: Vec<crate::sens::ode_provider::ParamDerivs> = (0..subject.obs_times.len())
+        .map(|j| pd_at(subject.obs_times[j], subject.obs_cov(j)))
+        .collect::<Option<Vec<_>>>()?;
+    let pd_pk_only: Vec<crate::sens::ode_provider::ParamDerivs> = (0..subject.pk_only_times.len())
+        .map(|m| pd_at(subject.pk_only_times[m], subject.pk_only_cov(m)))
+        .collect::<Option<Vec<_>>>()?;
+
+    let mk = |pd: &crate::sens::ode_provider::ParamDerivs,
+              time: f64,
+              cov: &std::collections::HashMap<String, f64>|
+     -> PkDual<Dual1<N>> {
+        let _time_guard = crate::parser::model_parser::ModelTimeGuard::enter_if(uses_time, time);
         let pk = (model.pk_param_fn)(theta, eta, cov, time);
         let seed_row = |i: usize, val: f64| -> Dual1<N> {
             let mut grad = [0.0; N];
@@ -3175,7 +3210,7 @@ fn run_obs_grad_tvcov<const N: usize>(
                 None => Dual1::<N>::constant(val),
             }
         };
-        Some(PkDual {
+        PkDual {
             cl: dv(PK_IDX_CL, pk.cl()),
             v: dv(PK_IDX_V, pk.v()),
             q: dv(PK_IDX_Q, pk.q()),
@@ -3184,18 +3219,24 @@ fn run_obs_grad_tvcov<const N: usize>(
             q3: dv(PK_IDX_Q3, pk.q3()),
             v3: dv(PK_IDX_V3, pk.v3()),
             f: dv(PK_IDX_F, pk.f_bio()),
-        })
+        }
     };
 
     let pk_at_dose: Vec<PkDual<Dual1<N>>> = (0..subject.doses.len())
-        .map(|k| mk(subject.doses[k].time, subject.dose_cov(k)))
-        .collect::<Option<Vec<_>>>()?;
+        .map(|k| mk(&pd_dose[k], subject.doses[k].time, subject.dose_cov(k)))
+        .collect();
     let pk_at_obs: Vec<PkDual<Dual1<N>>> = (0..subject.obs_times.len())
-        .map(|j| mk(subject.obs_times[j], subject.obs_cov(j)))
-        .collect::<Option<Vec<_>>>()?;
+        .map(|j| mk(&pd_obs[j], subject.obs_times[j], subject.obs_cov(j)))
+        .collect();
     let pk_at_pk_only: Vec<PkDual<Dual1<N>>> = (0..subject.pk_only_times.len())
-        .map(|m| mk(subject.pk_only_times[m], subject.pk_only_cov(m)))
-        .collect::<Option<Vec<_>>>()?;
+        .map(|m| {
+            mk(
+                &pd_pk_only[m],
+                subject.pk_only_times[m],
+                subject.pk_only_cov(m),
+            )
+        })
+        .collect();
 
     // Modeled-`RATE=-1/-2` doses (#486): resolve to concrete rate/duration and build
     // the per-dose duals (dual rate + moving infusion-end boundary). A modeled dose's
@@ -3222,15 +3263,11 @@ fn run_obs_grad_tvcov<const N: usize>(
     if !moving_bounds_separable(model, subject, &eff_doses, &dose_lagtimes) {
         return None;
     }
+    // Reads the dose's already-computed `∂p/∂η` — no program re-evaluation, and no `None` arm
+    // to swallow (see the `pd_dose` hoist above).
     let slot_dual = |k: usize, slot: usize| -> Dual1<N> {
-        let cov = subject.dose_cov(k);
-        let _guard =
-            crate::parser::model_parser::ModelTimeGuard::enter_if(uses_time, subject.doses[k].time);
         let val = dose_pk[k].values.get(slot).copied().unwrap_or(0.0);
-        match param_derivatives_at_cov(prog, model, cov, theta, eta) {
-            Some(pd) => pk_slot_dual_inner::<N>(slot, val, &pd.dp_deta, slots, n_eta),
-            None => Dual1::constant(val),
-        }
+        pk_slot_dual_inner::<N>(slot, val, &pd_dose[k].dp_deta, slots, n_eta)
     };
     let dose_inf_dual = modeled_dose_inf_duals::<Dual1<N>>(model, subject, &slot_dual);
     let dose_lag_dual = dose_lag_duals::<Dual1<N>>(model, subject, &slot_dual);
@@ -3264,11 +3301,9 @@ fn run_obs_grad_tvcov<const N: usize>(
 
     // Analytic Form C readout (#650): per-observation dual eval scratch (Dual1).
     // Readout params past the eight structural slots — the inner (`Dual1`, η-only) mirror of
-    // `run_obs_tvcov`'s `ro_extra` (#486). `ro_slots` is hoisted the same way as the outer's,
-    // so a readout with nothing to differentiate above `PK_IDX_V3` skips the per-observation
-    // `param_derivatives_at_cov` pass instead of paying it every inner BFGS step and
-    // discarding the result (#822 review #2 — the outer already had this guard, #822 review
-    // #8, but the inner's copy of the same prologue was missing it).
+    // `run_obs_tvcov`'s `ro_extra` (#486). `ro_slots` is empty when the readout differentiates
+    // nothing above `PK_IDX_V3`, in which case the per-observation seeding below is a no-op;
+    // the derivatives it seeds from are `pd_obs[j]`, already computed once for the walk.
     let ro_slots: Vec<usize> = if readout.is_some() {
         (PK_IDX_V3 + 1..N_PK)
             .filter(|&s| slot_row[s].is_some())
@@ -3283,23 +3318,16 @@ fn run_obs_grad_tvcov<const N: usize>(
                 let t = subject.obs_times[j];
                 let _guard = crate::parser::model_parser::ModelTimeGuard::enter_if(uses_time, t);
                 let pk = (model.pk_param_fn)(theta, eta, cov, t);
-                let extras = if ro_slots.is_empty() {
-                    Vec::new()
-                } else {
-                    match param_derivatives_at_cov(prog, model, cov, theta, eta) {
-                        Some(pd) => ro_slots
-                            .iter()
-                            .map(|&s| {
-                                let val = pk.values.get(s).copied().unwrap_or(0.0);
-                                (
-                                    s,
-                                    pk_slot_dual_inner::<N>(s, val, &pd.dp_deta, slots, n_eta),
-                                )
-                            })
-                            .collect(),
-                        None => Vec::new(),
-                    }
-                };
+                let extras: Vec<(usize, Dual1<N>)> = ro_slots
+                    .iter()
+                    .map(|&s| {
+                        let val = pk.values.get(s).copied().unwrap_or(0.0);
+                        (
+                            s,
+                            pk_slot_dual_inner::<N>(s, val, &pd_obs[j].dp_deta, slots, n_eta),
+                        )
+                    })
+                    .collect();
                 (pk, extras)
             })
             .collect()

--- a/src/types.rs
+++ b/src/types.rs
@@ -2851,6 +2851,17 @@ pub enum EndpointLikelihood {
         state_codes: Vec<usize>,
         /// Builds the generator `Q(θ,η,cov,state)` — see [`GeneratorFn`].
         generator_fn: GeneratorFn,
+        /// Resolved, dual-evaluable form of the same intensities, for the **analytic**
+        /// gradient: it yields `∂Q/∂(θ,η)` exactly, which the endpoint chains through the
+        /// Van Loan Fréchet derivative of `expm` instead of finite-differencing the whole
+        /// matrix-exponential likelihood (#759).
+        ///
+        /// `None` — and the endpoint keeps its FD gradient — when the intensities are
+        /// time-**inhomogeneous** (an intensity reads an ODE state, so `Q` is a functional
+        /// of the PK trajectory and the likelihood is an occupancy ODE rather than an
+        /// `expm`), or when the program cannot be represented exactly (see
+        /// `build_ctmm_generator_program`).
+        generator_program: Option<crate::parser::model_parser::CtmmGeneratorProgram>,
         /// Covariate names referenced by any transition intensity (including any
         /// reached transitively through `[individual_parameters]`). Evaluated at a
         /// baseline snapshot, so a covariate listed here that is time-varying in

--- a/tests/markov_smoke.rs
+++ b/tests/markov_smoke.rs
@@ -115,6 +115,48 @@ mod ctmm_smoke {
         assert!(res.ofv.is_finite(), "OFV must be finite, got {}", res.ofv);
     }
 
+    /// The analytic inner EBE gradient (#759 — exact `∂Q/∂η` chained through the Van Loan
+    /// Fréchet derivative of `expm`) must land the *fit* in the same place the finite-
+    /// difference inner gradient does. They optimize the same objective, so the OFV and the
+    /// estimates must agree to well inside the FD gradient's own noise; a sign error, a
+    /// dropped prior, or a factor-of-2 in the wiring would move the EBEs and show up here
+    /// even though the term-level gradient tests pass.
+    #[test]
+    fn ctmm_analytic_inner_gradient_matches_the_fd_route() {
+        let subjects: Vec<(f64, Vec<(f64, u8)>)> = vec![
+            (0.0, vec![(0.0, 0), (1.0, 0), (2.0, 1), (3.5, 1)]),
+            (0.0, vec![(0.0, 1), (1.0, 0), (2.0, 0), (3.5, 1)]),
+            (0.0, vec![(0.0, 0), (1.0, 1), (2.0, 1), (3.5, 0)]),
+            (0.0, vec![(0.0, 1), (1.0, 1), (2.0, 0), (3.5, 0)]),
+            (0.0, vec![(0.0, 0), (1.0, 0), (2.0, 0), (3.5, 1)]),
+            (0.0, vec![(0.0, 1), (1.0, 0), (2.0, 1), (3.5, 1)]),
+        ];
+        let pop = common::binary_pop(&subjects, 5);
+
+        let analytic = parse_model_string(MIXED_MODEL).unwrap();
+        // `gradient = fd` trips `analytic_inner_common_bail`, restoring the pre-#759 route:
+        // the EBE search finite-differences the whole objective.
+        let fd = parse_model_string(&format!("{MIXED_MODEL}\n[fit_options]\n  gradient = fd\n"))
+            .unwrap();
+
+        let opts = FitOptions {
+            outer_maxiter: 12,
+            ..Default::default()
+        };
+        let ra = fit(&analytic, &pop, &analytic.default_params, &opts).expect("analytic fit");
+        let rf = fit(&fd, &pop, &fd.default_params, &opts).expect("fd fit");
+
+        assert!(
+            (ra.ofv - rf.ofv).abs() < 1e-4,
+            "analytic-inner OFV {} vs FD-inner OFV {}",
+            ra.ofv,
+            rf.ofv
+        );
+        for (i, (a, f)) in ra.theta.iter().zip(rf.theta.iter()).enumerate() {
+            assert!((a - f).abs() < 1e-3, "theta[{i}]: analytic {a} vs FD {f}");
+        }
+    }
+
     /// SAEM runs a short CTMM fit and returns a finite OFV — exercises the SAEM dispatch
     /// site the FOCEI tests do not reach.
     #[test]


### PR DESCRIPTION
## Why

Two items off the post-#822 audit of #486 — plus a correction to a claim I got wrong in that audit.

**1. A latent silent-zero-jet in the inner TV-cov walk (#486).** `run_obs_grad_tvcov` read `∂p/∂η` from `param_derivatives_at_cov` at three places. One propagated a miss with `?` (subject falls back to FD — correct). The other two — the modeled-dose/lagtime slot dual and the Form-C readout's high slots — substituted `Dual1::constant(val)` / an empty extras vector. That is a **silent zero jet**: a wrong gradient, still reported as analytic, rather than an FD decline. Both were unreachable, but *only by coincidence*: the `MAX_TVCOV_AXES <= MAX_ODE_AXES` static assert added by #822 is the sole thing keeping the dispatch from declining for an admitted model — and before #822 those caps were 24 and 16, i.e. already diverged.

**2. The exact CTMM gradient existed and had zero callers (#759).** `matrix_exp_frechet` (Van Loan) + `generator_rate_direction` have been in `markov/mod.rs` since the endpoint landed, referenced only by their own tests. Meanwhile the transition likelihood `−Σ log P(Δt)[s,s']`, `P = expm(Q·Δt)`, was finite-differenced end-to-end: every EBE step perturbed η, rebuilt `Q` through the f64 generator closure, and redid a matrix exponential per observation gap. `markov/endpoint.rs` said so outright ("the FD path differentiates through `generator_fn`") while `docs/estimation/ctmm.qmd` claimed the opposite ("the parameter gradients are the exact Van Loan (1978) Fréchet derivatives"). The docs were aspirational.

## What changed

### 1. Make the derivatives *total* rather than patch the fallbacks

`param_derivatives_at_cov` declines on the **program's axis count alone** — it never inspects `cov`. So its `None` is uniform across a subject's events, and the right fix isn't `return None` at each site; it's to hoist one `ParamDerivs` per event behind a single `?` and hand the consumers a `&ParamDerivs`. They become total, and the illegal state is no longer representable. Side effect: drops the redundant per-dose and per-observation re-evaluation of the program (`mk` had already computed the very same derivatives at the very same covariates).

The load-bearing invariant — that the decline is covariate-independent — is pinned as a test, not a comment, since the hoist would silently serve the first event's answer to every event if it ever stopped holding.

### 2. Wire Van Loan into the CTMM inner gradient

`CtmmGeneratorProgram` is the CTMM analogue of `IndivParamProgram`: the transition intensities, resolved and compiled to the same `Bytecode` the rest of the analytic-sensitivity path uses, so they can be replayed over `Dual1` with **θ and η seeded**. That gives an exact `∂Q/∂(θ,η)`. The generator's row-sum-zero constraint is inherited for free — every intensity is added off-diagonal and subtracted from the diagonal, and differentiation is linear, so the derivative of a valid generator is a valid *direction*. (That is exactly the constraint `generator_rate_direction` hand-builds for the one-rate-at-a-time case, and the reason the module docs warn that a per-`Q`-entry gradient API is wrong.)

**The chain uses the adjoint Fréchet form, and this is the part worth reviewing.** Evaluating `∂P/∂p = L(QΔt, (∂Q/∂p)·Δt)` literally costs one `2S×2S` `expm` **per (axis, gap)** — which for a handful of axes is *slower* than the `S×S` FD it replaces. Van Loan is not automatically a win. But only one *entry* of `P` is ever read per gap, so the adjoint identity

```
⟨C, L(A, E)⟩  =  ⟨L(Aᵀ, C), E⟩
```

seeded with `C = e_u e_vᵀ` makes a **single** Fréchet solve serve every axis at once. The exact gradient is then *cheaper* than the finite differences, not merely more accurate — and it scales to the full (θ, η) width for free, which is what a non-Gaussian outer-gradient split would need.

**Consumer side, the inner gradient stops being all-or-nothing.** It is a *sum* of term gradients, so `analytic_eta_nll_gradient_with_schedule` adds the CTMM term to the Gaussian block, and `analytic_inner_grad_supported` admits a subject whose non-Gaussian records are entirely CTMM-with-a-program. It stays deliberately strict: a subject *also* carrying a TTE / binary / count record still declines the whole gradient, because those terms have no analytic η-channel and silently omitting one is a wrong gradient, not a slow one. An **endpoint-only** fit (a `[markov_model]` with no `[structural_model]`, which the parser admits) has no Gaussian block and no PK model at all, so it gets its own branch — prior + CTMM — rather than being rejected for the absence of a closed form it never had. The model-level predicate `build_info` reports off is updated in lockstep, so the reported gradient method cannot drift from the route actually taken.

## Alternatives considered

- **FD on `Q` only**, instead of a dual generator. `Q` is small and smooth, and an FD difference of two valid generators automatically keeps row sums at zero, so this would have been far less code. Rejected because the machinery for an *exact* jet already exists: `eval_statements_g` / `eval_bytecode_g` are generic over `PkNum` and take `theta: &[T]`, `eta: &[T]` — their doc says θ/η are "lifted as constants," but that is only how today's caller uses them, not what the signature allows. With an exact channel a program away, an FD one would have been a choice to be approximately right.
- **One Fréchet solve per axis** (the obvious reading of the module docs). Rejected on cost — see above; it is *slower* than the FD it replaces.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

`EndpointLikelihood::Ctmm` gains a `generator_program` field, but the variant is not constructed outside the parser.

## Numerical validation

The CTMM gradient is pinned at five levels, each against the function it actually claims to differentiate:

1. **The adjoint identity itself** (`adjoint_frechet_matches_direct`) — against the direct per-direction `matrix_exp_frechet`. Pinned separately because a broken adjoint would still produce a gradient with the right sparsity and rough magnitude; it would fail *plausibly*.
2. **The kernel** (`data_term_grad_matches_fd`) — `ctmm_data_term_grad` vs a central difference of `ctmm_data_term`, on a log-scale-parameterized 2-state generator (so `∂Q/∂θ` is not the trivial rate direction). Also asserts the gradient path's *value* does not drift from the value path's.
3. **End-to-end through the parser** (`ctmm_subject_eta_grad_matches_fd`) — the exact η-gradient vs a central difference of the subject NLL, at η ∈ {−0.45, 0, 0.6}, plus an assertion that the gradient is not an accidental zero.
4. **The consumer** (`analytic_inner_gradient_matches_fd_of_individual_nll`) — the *whole* inner gradient (prior + CTMM) vs FD of `individual_nll`, the exact objective `find_ebe` minimizes.
5. **The fit** (`ctmm_analytic_inner_gradient_matches_the_fd_route`) — a mixed-effects CTMM fit on the analytic inner route vs the same fit with `gradient = fd`. OFV agrees to `1e-4`, θ to `1e-3`. This is the one that catches a sign error or a factor-of-2 in the wiring that the term-level tests would pass.

Also pinned: a drug-driven (time-inhomogeneous) generator **declines** the analytic path (`inhomogeneous_ctmm_declines_the_analytic_grad`), and a degenerate generator returns `Ok(None)` rather than a zero gradient the optimizer would read as "already stationary".

The existing NONMEM anchor (`markov_nonmem.rs`, fixed-effects `n_eta = 0`) is untouched by construction — that model has no inner loop, so this PR cannot move it.

```
Suite                             Result
cargo test --lib                  2480 passed, 0 failed
cargo test --lib -F markov        2643 passed, 0 failed
--test markov_smoke -F markov       27 passed, 0 failed
```

## Performance

- [x] Faster — for the CTMM inner gradient. FD costs `2·n_eta` full objective evaluations per BFGS step (each an `expm` per gap); the adjoint form costs **one** `2S×2S` Fréchet solve per gap, total, regardless of the parameter count. For a joint PK + CTMM subject the win is larger: the pre-#759 route finite-differenced the *entire joint objective*, so it paid `2·n_eta` **PK solves** just to get the CTMM term's η-gradient.
- The hoist in item 1 also removes a redundant per-dose / per-observation program re-evaluation on the inner hot path.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

## Example (user-facing features only)
- [x] Not applicable — no new DSL surface. The same models fit; the inner gradient is now exact. `examples/ctmm_2state.ferx` and the mixed-effects model in `tests/markov_smoke.rs` cover it.

## What this does NOT do

Worth being explicit, because the #486 issue text (mine) overstated what was left:

- **The outer θ-gradient is still FD.** `analytic_outer_gradient_available`'s `!model.has_non_gaussian()` clause blocks CTMM exactly as it blocks TTE/binary, so a CTMM model still resolves `auto` → BOBYQA. The program seeds the θ axes, so the θ-gradient is a projection away — but it has no consumer until that gate is split.
- **The FOCEI Laplace `½log|H̃|` term is still FD.** Van Loan gives first derivatives; that term needs the second.
- **The non-Gaussian outer split is not the block-sum I wrote into #486.** The *data* term is separable, but `log|H̃_gauss + H_nonGauss|` is not, and the EBE minimizes the joint objective — so the Almquist assembly's `H̃`, `h_inner`, `M` and `g_eta` would be **wrong**, not merely incomplete, if the non-Gaussian term were ignored. A correct split additionally needs `∂H_ng/∂η`, a third derivative that exists nowhere in the codebase. I will correct #486 accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
