### PR TITLE
fix(estimation): FREM analytic gradients differentiate the wrong likelihood; AGQ/Laplace scope parity [#251]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,39 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Fixed
+- **FREM: the analytic gradients differentiated the wrong likelihood on covariate
+  pseudo-observation rows** (#251). `individual_nll` scores a `FREMTYPE > 0` row against
+  the prediction `theta[i] + eta[j]` with the dedicated covariate error `EPSCOV` — but the
+  sensitivity provider returned the ordinary **PK** jet for those rows, and the gradient
+  assemblies read the ordinary residual variance rather than the `EPSCOV` override that
+  SAEM, importance sampling and the CWRES path all already applied. Both loops were
+  affected:
+  - the **outer** (population) gradient, so FOCE/FOCEI were minimising one objective while
+    differentiating another; and
+  - the **inner** (EBE) gradient, so the empirical Bayes estimates themselves converged to
+    the mode of the wrong likelihood.
+
+  The provider now rewrites both jets for pseudo-observation rows (`f = theta[i] +
+  eta[j]`, unit first derivatives, zero second derivatives — the same `{0, 1}` Jacobian
+  the FOCE H-matrix already stamped in), and both gradient assemblies use the `EPSCOV`
+  variance. This was latent because FREM models are conventionally fit with `method =
+  saem`, which uses neither gradient; a FREM fit under `focei` (or now `agq` / `laplace`)
+  was affected. **SAEM fits are unchanged.**
+
+- **AGQ / `laplace`: the analytic outer gradient now covers the same models as
+  FOCE/FOCEI** (#251). Its score previously carried a Gaussian-only residual chain,
+  so five endpoint families that FOCE/FOCEI already handled analytically — **M3
+  censoring, IIV-on-RUV, a custom or time-varying residual magnitude, LTBS, and
+  correlated residuals (`block_sigma`)** — silently fell back to a finite-differenced
+  score. They now share the same per-observation chain as FOCE/FOCEI and take the
+  analytic route, so scope parity holds by construction rather than by a list that
+  can drift. Under a custom residual magnitude this also **corrects** the θ gradient:
+  `mult(θ)` makes the residual variance depend on θ directly, and that channel was
+  not approximated before — it was missing entirely. FREM, TTE and categorical
+  endpoints continue to use the finite-differenced score (neither re-solves the inner
+  loop, so they remain fast).
+
 ### Added
 - **AGQ and `laplace` now support inter-occasion variability (`[iov]`)** (#251).
   Under IOV the integral runs over the **stacked** random-effect vector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,17 +35,35 @@ section of the SDLC for the versioning policy).
   The provider now rewrites both jets for pseudo-observation rows (`f = theta[i] +
   eta[j]`, unit first derivatives, zero second derivatives — the same `{0, 1}` Jacobian
   the FOCE H-matrix already stamped in), and both gradient assemblies use the `EPSCOV`
-  variance.
+  variance — consistently at every consumer, not only the two that motivated the fix:
+  the outer jet override now also covers the ODE sensitivity provider (previously only
+  the closed-form/TV-cov routes got it, so an ODE FREM subject still combined the raw
+  PK jet with the `EPSCOV` variance); `method = foce`'s Sheiner–Beal `R⁰` and its σ-FD
+  now take the `EPSCOV` override (previously only FOCEI's `score_core` did); the FOCEI
+  `sigma_block` and `subject_eta_dx` σ-FD loops now use it too (previously they FD'd the
+  *PK* variance's — zero — dependence on `EPSCOV`, so `grad[EPSCOV]` was identically zero
+  under `focei` and a spurious term leaked into the other residual-error σ instead); and
+  the `iiv_on_ruv` residual-eta block and the custom-magnitude direct-θ channel now both
+  skip FREM rows (a pseudo-observation's likelihood has no η_ruv or magnitude dependence
+  at all).
 
   On the warfarin FREM example the effect is large. A converged FOCEI fit goes from
   **OFV 4900.6 to 211.0**, and the importance-sampling marginal (`method = imp`) from
   **19781.1 to 211.6** — `imp` scores FREM rows correctly but centres its proposal on the
   inner-loop EBEs, so it inherited the wrong mode, the weights collapsed, and its estimate
-  was meaningless. This release changes no objective function, only gradients, so the
-  entire gap is the fit previously landing in the wrong place. That the corrected FOCEI
-  Laplace OFV (211.0) and the corrected 6000-sample IS marginal (211.6) — two independent
-  approximations — now agree to under one unit is the strongest check that the new values
-  are the right ones.
+  was meaningless.
+
+  This is primarily a gradient fix, and most of the OFV gap is simply the fit landing
+  somewhere else because the gradient that drove it there was wrong. One piece is not
+  gradient-only, though: `find_ebe`'s non-IOV `h_matrix` — the Jacobian `foce_subject_nll`
+  uses to build the `log|H̃|` Laplace curvature term, which **is** part of the reported
+  OFV — reuses the same provider choke point this fix corrects, and that Jacobian never
+  received the FREM `{0, 1}` override before (only the IOV path and the FD-Jacobian
+  fallback already had it). So a non-IOV FREM subject's own curvature term was also wrong
+  pre-fix, independently of the outer-gradient bug above. That the corrected FOCEI Laplace
+  OFV (211.0) and the corrected 6000-sample IS marginal (211.6) — two independent
+  approximations, and IS's data term does not go through `h_matrix` at all — now agree to
+  under one unit is nonetheless a strong check that the new values are the right ones.
 
   Note the recovered covariate omegas barely move (118.71 → 118.67 for WT), because they
   are pinned by the pseudo-observations themselves. **A FREM fit could therefore look
@@ -65,9 +83,20 @@ section of the SDLC for the versioning policy).
   analytic route, so scope parity holds by construction rather than by a list that
   can drift. Under a custom residual magnitude this also **corrects** the θ gradient:
   `mult(θ)` makes the residual variance depend on θ directly, and that channel was
-  not approximated before — it was missing entirely. FREM, TTE and categorical
-  endpoints continue to use the finite-differenced score (neither re-solves the inner
-  loop, so they remain fast).
+  not approximated before — it was missing entirely. FREM is included too — its
+  pseudo-observation rows now ride the same analytic score as FOCE/FOCEI via the FREM
+  fix above. TTE and categorical endpoints still take the finite-differenced score
+  (neither re-solves the inner loop, so they remain fast) — they have no analytic
+  chain in the `Dual2` provider at all, not merely an AGQ-side gate. `block_sigma` is
+  now accepted for `method = agq` / `laplace` (previously rejected at `fit()` even
+  though the analytic score already carried a `corr_diag` branch for it). Under IOV,
+  the scope check now excludes non-Gaussian endpoints and bounds the custom-magnitude
+  axis count the same way the non-IOV gate does — previously an IOV + TTE/categorical
+  subject could pass the gate and silently score only the Ω prior, dropping the hazard
+  term. A per-subject runtime decline inside the analytic score (an off-diagonal
+  `block_sigma` subject, or magnitude × M3-censored) now falls back to the fixed-η FD
+  score for just that subject, rather than dropping the whole population onto the
+  `2·n_free`-inner-resolve `reconverged_fd_gradient` fallback.
 
 ### Added
 - **AGQ and `laplace` now support inter-occasion variability (`[iov]`)** (#251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,26 @@ section of the SDLC for the versioning policy).
   The provider now rewrites both jets for pseudo-observation rows (`f = theta[i] +
   eta[j]`, unit first derivatives, zero second derivatives — the same `{0, 1}` Jacobian
   the FOCE H-matrix already stamped in), and both gradient assemblies use the `EPSCOV`
-  variance. This was latent because FREM models are conventionally fit with `method =
-  saem`, which uses neither gradient; a FREM fit under `focei` (or now `agq` / `laplace`)
-  was affected. **SAEM fits are unchanged.**
+  variance.
+
+  On the warfarin FREM example the effect is large. A converged FOCEI fit goes from
+  **OFV 4900.6 to 211.0**, and the importance-sampling marginal (`method = imp`) from
+  **19781.1 to 211.6** — `imp` scores FREM rows correctly but centres its proposal on the
+  inner-loop EBEs, so it inherited the wrong mode, the weights collapsed, and its estimate
+  was meaningless. This release changes no objective function, only gradients, so the
+  entire gap is the fit previously landing in the wrong place. That the corrected FOCEI
+  Laplace OFV (211.0) and the corrected 6000-sample IS marginal (211.6) — two independent
+  approximations — now agree to under one unit is the strongest check that the new values
+  are the right ones.
+
+  Note the recovered covariate omegas barely move (118.71 → 118.67 for WT), because they
+  are pinned by the pseudo-observations themselves. **A FREM fit could therefore look
+  entirely plausible on the one diagnostic a user would naturally check, and still be badly
+  wrong.**
+
+  Latent because FREM models are conventionally fit with `method = saem`, which uses
+  neither gradient — and the covariate-omega regression test runs SAEM. Fits under `focei`,
+  `imp` (or now `agq` / `laplace`) were affected. **SAEM fits are unchanged.**
 
 - **AGQ / `laplace`: the analytic outer gradient now covers the same models as
   FOCE/FOCEI** (#251). Its score previously carried a Gaussian-only residual chain,

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -360,9 +360,34 @@ Letting them fall back to the inner-re-solving gradient would have made the head
 use case the slow one. The test `fd_score_path_agrees_with_the_analytic_one` pins
 that the two routes return the same gradient.
 
-Models that take the finite-differenced score: TTE, categorical, ODE models, M3
-censoring, correlated residuals (`block_sigma`), FREM, IIV-on-RUV, custom residual
-magnitude, and LTBS — each adds a term the plain Gaussian chain rule does not carry.
+#### Scope parity with FOCE/FOCEI
+
+The analytic score reaches **exactly as far as the FOCE/FOCEI analytic outer
+gradient does** — no further, and no less. It is the same per-observation residual
+chain (`sens_outer_gradient::score_core`), so M3 censoring, IIV-on-RUV, a custom or
+time-varying residual magnitude, LTBS, correlated residuals (`block_sigma`) and ODE
+models all take the analytic route, exactly as they do under FOCE/FOCEI.
+
+That parity holds *by construction*: AGQ does not keep its own list of supported
+families, so there is nothing to drift out of step with the FOCE/FOCEI gate.
+
+FREM is included too: a covariate pseudo-observation row (`FREMTYPE > 0`) is scored
+against `θ[i] + η[j]` with the dedicated `EPSCOV` error rather than against the PK
+model, and both halves of that — the jet and the variance — now flow through the
+shared machinery.
+
+Models that still take the finite-differenced score:
+
+- **TTE and categorical endpoints**, which have no analytic outer gradient at all —
+  the sensitivity provider covers the structural PK/PD model, not the event or
+  category likelihood. These are also the models AGQ exists to serve, which is why
+  the FD route must (and does) avoid re-solving the inner loop.
+- `gradient_method = fd`, the explicit opt-out.
+
+Two cases decline per *subject* rather than per model, and fall back for that
+population: a genuinely off-diagonal correlated residual, and a custom magnitude
+combined with an M3-censored row.
+
 The fit output reports which route ran.
 
 ### Where AGQ stops

--- a/examples/warfarin_frem.ferx
+++ b/examples/warfarin_frem.ferx
@@ -22,12 +22,11 @@
   theta TV_WT(72.0) FIX
   theta TV_AGE(37.6) FIX
 
-  omega ETA_CL  ~ 0.09
-  omega ETA_V   ~ 0.04
-  omega ETA_KA  ~ 0.30
-  omega ETA_WT_FREM  ~ 111.56
-  omega ETA_AGE_FREM ~ 99.38
-
+  # The five random effects are declared by `block_omega` alone. Declaring them a
+  # second time with `omega NAME ~ v` lines does NOT merge — it appends a further
+  # five random effects with the same names, giving a 10-eta model with a 10x10
+  # omega. (`prepare_frem()` emits the block form only; this file used to carry
+  # both.)
   block_omega (ETA_CL, ETA_V, ETA_KA, ETA_WT_FREM, ETA_AGE_FREM) = [
     0.09,
     0.0, 0.04,

--- a/src/api.rs
+++ b/src/api.rs
@@ -2342,13 +2342,16 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                     | EstimationMethod::FoceI
                     | EstimationMethod::Saem
                     | EstimationMethod::Imp
+                    | EstimationMethod::Agq
+                    | EstimationMethod::Laplace
             ) {
                 diags.push(
                     Diagnostic::error(
                         "E_BLOCK_SIGMA_METHOD_UNSUPPORTED",
                         "block_sigma correlated residual errors are currently supported for \
-                         method = foce, focei, saem, and imp only. The gn / gn_hybrid \
-                         Gauss-Newton paths still use diagonal residual-error derivatives.",
+                         method = foce, focei, saem, imp, agq, and laplace only. The gn / \
+                         gn_hybrid Gauss-Newton paths still use diagonal residual-error \
+                         derivatives.",
                     )
                     .with_block("fit_options"),
                 );
@@ -11157,7 +11160,8 @@ mod iov_integration {
     }
 
     // block_sigma correlated residual errors are wired into the Gaussian FOCE,
-    // FOCEI, SAEM, and IMP paths; the Gauss-Newton (gn / gn_hybrid) methods still
+    // FOCEI, SAEM, IMP, AGQ, and Laplace paths (AGQ/Laplace via `score_core`'s
+    // `corr_diag` branch, #251); the Gauss-Newton (gn / gn_hybrid) methods still
     // use diagonal residual-error derivatives and must be rejected up front.
     #[test]
     fn test_check_model_options_block_sigma_rejects_unsupported_methods() {
@@ -11184,12 +11188,14 @@ mod iov_integration {
             .iter()
             .any(|d| d.code == "E_BLOCK_SIGMA_METHOD_UNSUPPORTED"));
 
-        // FOCE, FOCEI, SAEM, and IMP are all accepted (no method diagnostic).
+        // FOCE, FOCEI, SAEM, IMP, AGQ, and Laplace are all accepted (no method diagnostic).
         for method in [
             EstimationMethod::Foce,
             EstimationMethod::FoceI,
             EstimationMethod::Saem,
             EstimationMethod::Imp,
+            EstimationMethod::Agq,
+            EstimationMethod::Laplace,
         ] {
             let opts = fast_opts(method, Optimizer::Bobyqa, false);
             assert!(

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -585,16 +585,6 @@ fn stack_mode(eta_hat: &[f64], kappas: &[nalgebra::DVector<f64>]) -> Vec<f64> {
 // costs `2·n_free` *full population objective* evaluations, each re-solving every subject's
 // inner loop.
 
-/// Whether the **θ/σ score** can be taken analytically from the `Dual2` provider, or must be
-/// finite-differenced at fixed η.
-///
-/// This is a *speed* switch, not a scope gate: both paths compute the same quantity, and
-/// neither re-solves the inner loop. The analytic form chains the provider's exact `∂f/∂θ`
-/// through `∂nll/∂f`, which is only valid for the plain Gaussian residual term — every
-/// variant listed below adds a term it does not carry (M3's normal-tail, LTBS's `ln f`
-/// wrap, FREM's pseudo-observations, a dense residual covariance, an η-scaled or custom
-/// residual variance), and TTE / categorical endpoints are outside the provider entirely.
-/// Those all take [`accumulate_fixed_eta_packed_gradient_fd`] instead.
 /// Model-level mirror of [`analytic_score_supported`], for reporting
 /// (`build_info::gradient_method_outer`) which has no per-subject [`Stack`]. Uses the model's
 /// own `n_kappa` to pick the IOV or non-IOV provider scope, which is the same answer every
@@ -615,10 +605,19 @@ pub fn analytic_score_supported(model: &CompiledModel, stack: &Stack) -> bool {
     // (θ, η, κ) dual walk, gated by `iov_sens_supported`, while the non-IOV entry point is
     // gated by `analytic_outer_gradient_available`. `analytic_outer_gradient_available`
     // already folds in `iov_sens_supported`, but it also carries the `gradient_method = fd`
-    // opt-out and the non-Gaussian/magnitude bails, which apply to both.
+    // opt-out and the non-Gaussian/magnitude bails, which apply to both — so the IOV arm
+    // must repeat them explicitly rather than only calling `iov_sens_supported`, or an IOV
+    // + TTE/categorical model (or IOV + an over-wide custom magnitude) would silently pass
+    // this gate: `score_core` would then build `et` from `subject.observations` alone, and
+    // a pure-TTE subject (`n_obs == 0`) would score only the Ω prior with no hazard
+    // contribution at all (#251 review #9).
     let provider = if stack.is_iov() {
         crate::sens::provider::iov_sens_supported(model)
             && !matches!(model.gradient_method, crate::types::GradientMethod::Fd)
+            && !model.has_non_gaussian()
+            && (!model.has_custom_ruv_magnitude()
+                || (model.n_theta <= crate::parser::model_parser::MAX_RUV_MAG_AXES
+                    && model.residual_correlations.is_empty()))
     } else {
         crate::sens::provider::analytic_outer_gradient_available(model)
     };
@@ -638,9 +637,11 @@ pub fn analytic_score_supported(model: &CompiledModel, stack: &Stack) -> bool {
     // pseudo-observations. It went unnoticed because FREM models are conventionally fit
     // with SAEM, which never asks for that gradient.)
     //
-    // Two runtime declines still land on FD, both inside `score_core` (returning `None`,
-    // which propagates through this function's `?`): a genuinely off-diagonal correlated
-    // subject, and magnitude × M3-censored.
+    // Two runtime (per-subject, not caught by this model-level predicate) declines still
+    // land on FD: a genuinely off-diagonal correlated subject, and magnitude ×
+    // M3-censored — both inside `score_core`, returning `None`. `accumulate_fixed_eta_
+    // packed_gradient` falls back to `accumulate_fixed_b_packed_gradient_fd` for just
+    // that subject when this happens, not the whole population (#251 review #8).
     provider
 }
 
@@ -651,7 +652,7 @@ pub fn analytic_score_supported(model: &CompiledModel, stack: &Stack) -> bool {
 ///
 /// * the fixed-η score is analytic where the provider reaches
 ///   ([`analytic_score_supported`]) and finite-differenced *at fixed η* otherwise
-///   ([`accumulate_fixed_eta_packed_gradient_fd`]) — the latter is correct for any likelihood
+///   ([`accumulate_fixed_b_packed_gradient_fd`]) — the latter is correct for any likelihood
 ///   ferx can evaluate, including TTE and categorical; and
 /// * `dη̂/dx` comes from the implicit-function theorem (`−H⁻¹·∂²nll/∂η∂x`), analytic where the
 ///   provider reaches and finite-differenced otherwise ([`eta_dx`]).
@@ -842,10 +843,39 @@ fn accumulate_fixed_eta_packed_gradient(
     // requirement in `sens_outer_gradient` lives in its `theta_block`, not here. The IOV
     // entry point takes the *stacked* (η, κ) vector and returns the same `ObsSens`, so
     // everything below is identical for both.
+    //
+    // `analytic_score_supported` is a *model*-level scope check; `score_core` (and, more
+    // rarely, the sensitivity provider itself) can still decline a specific *subject* at
+    // runtime — a genuinely off-diagonal correlated residual, or magnitude × an
+    // M3-censored row. Falling through those `?`s used to propagate `None` out of this
+    // whole function, which `agq_population_gradient` treats as "any subject declined" and
+    // answers by dropping the **entire population** onto `reconverged_fd_gradient` — the
+    // `2·n_free` full-objective, every-subject-inner-resolve fallback this module exists to
+    // avoid. FOCE/FOCEI stopped doing that population-wide bail for exactly this cost
+    // (`population_gradient_sens_mixed`'s per-subject `subject_reconverged_fd_gradient`
+    // salvage); AGQ's fixed-b FD score is this function's own equivalent per-subject
+    // salvage, and it is already right here — the Ω/Ω_iov block above is unaffected by
+    // which θ/σ path runs, so falling back for just this subject is exactly the state
+    // `accumulate_fixed_b_packed_gradient_fd`'s own docs assume it's called in (#251
+    // review #8).
     let sens = if stack.is_iov() {
-        crate::sens::provider::subject_sensitivities_iov(model, subject, &params.theta, b)?
+        crate::sens::provider::subject_sensitivities_iov(model, subject, &params.theta, b)
     } else {
-        crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b)?
+        crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b)
+    };
+    let Some(sens) = sens else {
+        return accumulate_fixed_b_packed_gradient_fd(
+            model,
+            subject,
+            params,
+            template,
+            stack,
+            b,
+            weight,
+            n_theta,
+            sigma_start,
+            out,
+        );
     };
 
     // The per-observation scalar likelihood chain. `score_core` is the half of
@@ -869,7 +899,21 @@ fn accumulate_fixed_eta_packed_gradient(
         &stack.omega_joint_inv,
         b,
         model.residual_error_eta,
-    )?;
+    );
+    let Some(core) = core else {
+        return accumulate_fixed_b_packed_gradient_fd(
+            model,
+            subject,
+            params,
+            template,
+            stack,
+            b,
+            weight,
+            n_theta,
+            sigma_start,
+            out,
+        );
+    };
     let et = &core.et;
 
     // θ block. Two channels:

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -622,13 +622,26 @@ pub fn analytic_score_supported(model: &CompiledModel, stack: &Stack) -> bool {
     } else {
         crate::sens::provider::analytic_outer_gradient_available(model)
     };
+    // Everything the FOCE/FOCEI outer gradient can do analytically, the AGQ/Laplace score
+    // can now do too: the per-observation residual chain comes from the SAME
+    // `sens_outer_gradient::score_core`, so M3-BLOQ, `iiv_on_ruv`, a custom / time-varying
+    // σ magnitude, LTBS and a correlated residual all ride the analytic path rather than
+    // falling back to the fixed-b FD score. Scope parity holds by construction — there is
+    // no per-family list here to drift out of step with `analytic_outer_gradient_available`.
+    //
+    // FREM included: a covariate pseudo-observation row is scored against `θ[ti] + η[ei]`
+    // with the dedicated `EPSCOV` variance, and BOTH halves are now threaded through the
+    // shared machinery — the jet by `provider::apply_frem_pseudo_obs_jet`, the variance by
+    // `score_core`'s FREM override. (This was a live defect in the FOCE/FOCEI outer
+    // gradient too, not only a missing AGQ capability: the analytic gradient was
+    // differentiating the PK likelihood on rows the objective scores as covariate
+    // pseudo-observations. It went unnoticed because FREM models are conventionally fit
+    // with SAEM, which never asks for that gradient.)
+    //
+    // Two runtime declines still land on FD, both inside `score_core` (returning `None`,
+    // which propagates through this function's `?`): a genuinely off-diagonal correlated
+    // subject, and magnitude × M3-censored.
     provider
-        && !matches!(model.bloq_method, crate::types::BloqMethod::M3)
-        && model.residual_correlations.is_empty()
-        && model.frem_config.is_none()
-        && model.residual_error_eta.is_none()
-        && !model.has_custom_ruv_magnitude()
-        && !model.log_transform
 }
 
 /// AGQ always drives the outer loop with its **own** gradient — for every model, and at every
@@ -835,32 +848,50 @@ fn accumulate_fixed_eta_packed_gradient(
         crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b)?
     };
 
-    let err_keys = model.error_spec.obs_keys(subject);
-    let mut d_nll_d_f = vec![0.0f64; n_obs];
-    let mut variances = vec![0.0f64; n_obs];
-    let mut residuals = vec![0.0f64; n_obs];
+    // The per-observation scalar likelihood chain. `score_core` is the half of
+    // `sens_outer_gradient::prepare_stacked` that does NOT build the FOCEI `log|H̃|`
+    // machinery, so a node pays no Cholesky inverse — and it already carries the
+    // M3-censored (`−logΦ(z)`), `iiv_on_ruv`, custom-σ-magnitude, LTBS and
+    // correlated-residual chains that this function used to hand-roll for the plain
+    // Gaussian case alone. That hand-rolled chain is why AGQ used to gate those five
+    // families onto the fixed-b FD score even though FOCE/FOCEI had them analytic.
+    //
+    // `n_eta` is the STACKED dimension and `Ω⁻¹` the stacked prior precision, so IOV needs
+    // no special case: `ObsSens` is already stacked, and `η_ruv` lives in the BSV block, so
+    // `residual_error_eta` stays a valid stacked index (the same argument the IOV caller of
+    // `prepare_stacked` makes).
+    let core = crate::estimation::sens_outer_gradient::score_core(
+        model,
+        subject,
+        params,
+        &sens,
+        stack.d(),
+        &stack.omega_joint_inv,
+        b,
+        model.residual_error_eta,
+    )?;
+    let et = &core.et;
 
-    for j in 0..n_obs {
-        let f = sens.obs[j].f.max(1e-12);
-        let v = model
-            .residual_variance_at(err_keys[j], f, &params.sigma.values)
-            .max(1e-12);
-        let resid = subject.observations[j] - sens.obs[j].f;
-        residuals[j] = resid;
-        variances[j] = v;
-        // ∂nll_j/∂f = −r/V + ½·(∂V/∂f)·(1/V − r²/V²)  — the halved convention of
-        // `individual_nll` (0.5·Σ[r²/V + ln V]); identical to SAEM's `d_nll_d_f`.
-        let dv_df = model
-            .error_spec
-            .dvar_df(err_keys[j], f, &params.sigma.values);
-        d_nll_d_f[j] = -resid / v + 0.5 * dv_df * (1.0 / v - resid * resid / (v * v));
-    }
-
-    // θ block: chain the exact ∂f/∂θ through ∂nll/∂f, then the log-θ packing chain rule.
+    // θ block. Two channels:
+    //
+    //  (a) through the prediction — `∂L/∂f · ∂f/∂θ`. `ErrTerms` defines `α = 2·∂L/∂f` for
+    //      EVERY endpoint family (for a censored row it is `2·g1` off the `−logΦ` kernel),
+    //      so `½α` is the residual chain the old code spelled out for Gaussian only.
+    //
+    //  (b) DIRECT — a custom / time-varying σ magnitude `mult(θ)` makes `R` depend on θ
+    //      without passing through `f`, contributing `∂L/∂R · ∂R/∂θ`. This term was not
+    //      approximated before, it was ABSENT: the θ gradient of a magnitude model was
+    //      simply missing a channel. `score_core` declines magnitude × M3 upstream, so the
+    //      quantified `∂L/∂R` below is the only form needed here.
     for m in 0..n_theta {
-        let d: f64 = (0..n_obs)
-            .map(|j| d_nll_d_f[j] * sens.obs[j].df_dtheta[m])
-            .sum();
+        let mut d = 0.0;
+        for j in 0..n_obs {
+            d += 0.5 * et[j].alpha * sens.obs[j].df_dtheta[m];
+            if !et[j].dr_dtheta.is_empty() {
+                let (r, eps) = (et[j].r, et[j].eps);
+                d += 0.5 * (r - eps * eps) / (r * r) * et[j].dr_dtheta[m];
+            }
+        }
         let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
             params.theta[m]
         } else {
@@ -869,21 +900,13 @@ fn accumulate_fixed_eta_packed_gradient(
         out[m] += weight * d * dtheta_dx;
     }
 
-    // σ block: closed form. ∂nll/∂(log σ_k) = Σ_j ½·(∂V_j/∂log σ_k)·(1/V_j − r_j²/V_j²).
+    // σ block, log-packed. σ reaches `nll` only through the residual variance, so this is a
+    // closed-form scalar computation at fixed `f` — no model evaluation, no inner solve.
+    let g_sigma = crate::estimation::sens_outer_gradient::data_sigma_gradient(
+        model, subject, params, &sens, &core,
+    );
     for k in 0..n_sigma {
-        let d: f64 = (0..n_obs)
-            .map(|j| {
-                let f = sens.obs[j].f.max(1e-12);
-                let v = variances[j];
-                let r = residuals[j];
-                let ratio =
-                    model
-                        .error_spec
-                        .dvar_dlogsigma(err_keys[j], k, f, &params.sigma.values);
-                0.5 * ratio * (1.0 / v - r * r / (v * v))
-            })
-            .sum();
-        out[sigma_start + k] += weight * d;
+        out[sigma_start + k] += weight * g_sigma[k] * params.sigma.values[k];
     }
 
     Some(())
@@ -1303,6 +1326,419 @@ pub fn agq_population_gradient(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::model_parser::parse_model_string;
+
+    // --- Phase 0 (#251): the analytic fixed-b score reaches full FOCE/FOCEI scope -------
+    //
+    // AGQ's score used to hand-roll a *Gaussian-only* residual chain, so five endpoint
+    // families that FOCE/FOCEI already handled analytically (M3-BLOQ, `iiv_on_ruv`, a
+    // custom sigma magnitude, LTBS, correlated residual) fell back to the fixed-b FD score.
+    // It now shares `sens_outer_gradient::score_core`, so the chain is the SAME one
+    // FOCE/FOCEI uses and the per-family gates are gone.
+    //
+    // The reference below is a central difference of `Stack::nll_at` at a **fixed, non-mode
+    // b**. That matters: it differences the exact conditional NLL the AGQ objective
+    // integrates, with NO inner re-solve, so -- unlike the outer-gradient tests -- the
+    // reference carries no inner-solver noise floor and the step can be chosen for
+    // truncation alone.
+
+    const M3_MODEL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    const RUV_MODEL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  omega ETA_RUV ~ 0.10
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+  iiv_on_ruv = ETA_RUV
+"#;
+
+    const LTBS_MODEL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.04
+  omega ETA_KA ~ 0.30
+  sigma ADD_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ log_additive(ADD_ERR)
+"#;
+
+    /// FREM: 3 PK etas + 2 covariate etas under one block Ω, with the covariate θs and the
+    /// `EPSCOV` σ left **free** so the gradient test actually exercises those channels (the
+    /// shipped `examples/warfarin_frem.ferx` fixes them, which would mask the very terms
+    /// under test). `EPSCOV` is also given a sane magnitude rather than the near-zero value
+    /// a production FREM model uses to pin `η_cov` to the observed covariate.
+    const FREM_MODEL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta TV_WT(72.0, 1.0, 500.0)
+  theta TV_AGE(37.6, 1.0, 200.0)
+
+  block_omega (ETA_CL, ETA_V, ETA_KA, ETA_WT_FREM, ETA_AGE_FREM) = [
+    0.09,
+    0.0, 0.04,
+    0.0, 0.0, 0.30,
+    0.0, 0.0, 0.0, 111.56,
+    0.0, 0.0, 0.0, 0.0, 99.38
+  ]
+
+  sigma PROP_ERR ~ 0.02
+  sigma EPSCOV   ~ 0.30
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  frem_predictions = TV_WT/ETA_WT_FREM:100, TV_AGE/ETA_AGE_FREM:200
+  frem_sigma       = EPSCOV
+"#;
+
+    /// A subject with realistic nonzero residuals, built from the model at a reference eta.
+    fn score_subject(model: &CompiledModel, theta: &[f64], times: &[f64]) -> Subject {
+        use crate::types::DoseEvent;
+        use std::collections::HashMap;
+        let n = times.len();
+        let mut subject = Subject {
+            id: "1".to_string(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: times.to_vec(),
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; n],
+            obs_cmts: vec![1; n],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n],
+            occasions: vec![1; n],
+            obs_l2: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            obs_records: vec![],
+        };
+        let eta_ref = [0.12, -0.08, 0.2];
+        let preds = crate::pk::compute_predictions_with_tv(model, &subject, theta, &eta_ref);
+        subject.observations = preds.iter().map(|p| p * 0.85).collect();
+        subject
+    }
+
+    /// The analytic fixed-b score vs a central difference of `Stack::nll_at` -- at a `b`
+    /// that is deliberately NOT the mode, since the score is a property of `nll(b; x)`
+    /// alone and must hold everywhere, not only at the EBE.
+    fn assert_fixed_b_score_matches_fd(
+        model: &CompiledModel,
+        subject: &Subject,
+        template: &ModelParameters,
+        b: &[f64],
+        tol: f64,
+        label: &str,
+    ) {
+        use crate::estimation::parameterization::{pack_params, packed_fixed_mask, unpack_params};
+
+        let x = pack_params(template);
+        let params = unpack_params(&x, template);
+        let stack = Stack::new(model, &params, usize::from(model.n_kappa > 0));
+        assert!(
+            analytic_score_supported(model, &stack),
+            "{label}: expected the ANALYTIC score path, got the FD fallback"
+        );
+
+        let mut analytic = vec![0.0f64; x.len()];
+        accumulate_fixed_eta_packed_gradient(
+            model,
+            subject,
+            &params,
+            template,
+            &stack,
+            b,
+            1.0,
+            &mut analytic,
+        )
+        .unwrap_or_else(|| panic!("{label}: analytic score declined"));
+
+        let fixed = packed_fixed_mask(template);
+        let mut scratch = crate::pk::EventPkParams::default();
+        let mut nll_at_x = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, template);
+            let st = Stack::new(model, &p, stack.n_occ);
+            st.nll_at(model, subject, &p, b, &mut scratch, None)
+        };
+
+        for k in 0..x.len() {
+            if fixed[k] {
+                continue;
+            }
+            let h = 1e-6 * (1.0 + x[k].abs());
+            let (mut xp, mut xm) = (x.clone(), x.clone());
+            xp[k] += h;
+            xm[k] -= h;
+            let fd = (nll_at_x(&xp) - nll_at_x(&xm)) / (2.0 * h);
+            let scale = fd.abs().max(analytic[k].abs()).max(1.0);
+            assert!(
+                (analytic[k] - fd).abs() / scale < tol,
+                "{label}: coord {k}: analytic {} vs FD {} (rel {:.2e})",
+                analytic[k],
+                fd,
+                (analytic[k] - fd).abs() / scale
+            );
+        }
+    }
+
+    /// M3-BLOQ. Was gated to the FD score; FOCE/FOCEI have had it analytic since #486.
+    #[test]
+    fn fixed_b_score_is_analytic_and_exact_under_m3() {
+        use crate::types::BloqMethod;
+        let mut model = parse_model_string(M3_MODEL).expect("parse");
+        model.bloq_method = BloqMethod::M3;
+        let theta = [0.22, 11.0, 1.4];
+        let mut subject = score_subject(&model, &theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+        let n = subject.observations.len();
+        subject.cens[n - 1] = 1;
+        subject.cens[n - 2] = 1;
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        assert_fixed_b_score_matches_fd(
+            &model,
+            &subject,
+            &template,
+            &[0.05, -0.03, 0.08],
+            1e-6,
+            "M3",
+        );
+    }
+
+    /// `iiv_on_ruv` -- eta enters the residual VARIANCE directly (`df/deta_ruv = 0`), a
+    /// channel the old Gaussian chain had no term for at all.
+    #[test]
+    fn fixed_b_score_is_analytic_and_exact_under_iiv_on_ruv() {
+        let model = parse_model_string(RUV_MODEL).expect("parse");
+        assert!(
+            model.residual_error_eta.is_some(),
+            "fixture must set iiv_on_ruv"
+        );
+        let theta = [0.22, 11.0, 1.4];
+        let subject = score_subject(&model, &theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        assert_fixed_b_score_matches_fd(
+            &model,
+            &subject,
+            &template,
+            &[0.05, -0.03, 0.08, 0.06],
+            1e-6,
+            "iiv_on_ruv",
+        );
+    }
+
+    /// LTBS. The provider already returns the log-transformed jet
+    /// (`apply_ltbs_transform_outer`), so the shared chain needs no LTBS special case --
+    /// this pins that.
+    #[test]
+    fn fixed_b_score_is_analytic_and_exact_under_ltbs() {
+        let model = parse_model_string(LTBS_MODEL).expect("parse");
+        assert!(model.log_transform, "log_additive must set LTBS");
+        let theta = [0.22, 11.0, 1.4];
+        let subject = score_subject(&model, &theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        assert_fixed_b_score_matches_fd(
+            &model,
+            &subject,
+            &template,
+            &[0.05, -0.03, 0.08],
+            1e-6,
+            "LTBS",
+        );
+    }
+
+    /// FREM covariate pseudo-observations. REGRESSION TEST — this fails without the jet +
+    /// variance fix, and it fails for FOCE/FOCEI too, not just AGQ.
+    ///
+    /// `individual_nll` scores a `fremtype > 0` row against a completely different model:
+    /// prediction `θ[ti] + η[ei]` (not the PK model's `f`) and variance `EPSCOV²` (not
+    /// `error_spec.variance_at(f)`). The sensitivity provider returned the ordinary PK jet
+    /// for those rows and `prepare_stacked` read the ordinary variance, so the analytic
+    /// outer gradient was differentiating a likelihood the objective never evaluates.
+    /// Latent because FREM is conventionally fit with SAEM, which never asks for it.
+    ///
+    /// The FD reference here is a central difference of the real conditional NLL at a fixed
+    /// `b`, so it exercises exactly the likelihood the objective uses — including the
+    /// pseudo-observation rows.
+    #[test]
+    fn frem_pseudo_obs_rows_get_the_right_analytic_score() {
+        use crate::types::DoseEvent;
+        use std::collections::HashMap;
+
+        let model = parse_model_string(FREM_MODEL).expect("parse");
+        let fc = model.frem_config.as_ref().expect("fixture must be FREM");
+        assert_eq!(model.n_eta, 5, "3 PK etas + 2 covariate etas");
+        assert!(
+            analytic_score_supported_model(&model),
+            "FREM must now take the ANALYTIC score path"
+        );
+
+        // Two PK rows plus one pseudo-observation per covariate (FREMTYPE 100 / 200).
+        let mut fts: Vec<u16> = fc.fremtype_to_indices.keys().copied().collect();
+        fts.sort_unstable();
+        assert_eq!(fts.len(), 2, "fixture has WT and AGE pseudo-obs");
+
+        let theta = &model.default_params.theta;
+        let pk_times = [1.0, 6.0, 24.0];
+        let n = pk_times.len() + fts.len();
+        let mut subject = Subject {
+            id: "1".to_string(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: pk_times
+                .iter()
+                .copied()
+                .chain(fts.iter().map(|_| 0.0))
+                .collect(),
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; n],
+            obs_cmts: vec![1; n],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n],
+            occasions: vec![1; n],
+            obs_l2: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: pk_times
+                .iter()
+                .map(|_| 0u16)
+                .chain(fts.iter().copied())
+                .collect(),
+            obs_records: vec![],
+        };
+        // PK rows: realistic residuals off the model. Pseudo-obs rows: the covariate value,
+        // offset from θ so the residual is nonzero.
+        let eta_ref = vec![0.1, -0.05, 0.15, 0.0, 0.0];
+        let preds = crate::pk::compute_predictions_with_tv(&model, &subject, theta, &eta_ref);
+        for j in 0..pk_times.len() {
+            subject.observations[j] = preds[j] * 0.85;
+        }
+        for (k, &ft) in fts.iter().enumerate() {
+            let (ti, _ei) = fc.fremtype_to_indices[&ft];
+            subject.observations[pk_times.len() + k] = theta[ti] * 1.10;
+        }
+
+        let template = model.default_params.clone();
+        let b = [0.05, -0.03, 0.08, 1.5, -2.0];
+        assert_fixed_b_score_matches_fd(&model, &subject, &template, &b, 1e-6, "FREM");
+
+        // The INNER η-gradient has the same root cause and is the more damaging half: it
+        // sets the EBEs. `analytic_eta_nll_gradient` fed `residual_inner_obs` the PK
+        // prediction and the PK variance on pseudo-observation rows, so the mode it drove
+        // to was not the mode of the likelihood being integrated.
+        let params = model.default_params.clone();
+        let analytic = crate::estimation::inner_optimizer::analytic_eta_nll_gradient(
+            &model,
+            &subject,
+            &params.theta,
+            &b,
+            &params.omega,
+            &params.sigma.values,
+        )
+        .expect("FREM inner gradient must be analytic");
+
+        let mut scratch = crate::pk::EventPkParams::default();
+        for k in 0..b.len() {
+            let h = 1e-6 * (1.0 + b[k].abs());
+            let (mut bp, mut bm) = (b.to_vec(), b.to_vec());
+            bp[k] += h;
+            bm[k] -= h;
+            let nll = |e: &[f64], s: &mut crate::pk::EventPkParams| {
+                crate::stats::likelihood::individual_nll_into_with_schedule(
+                    &model,
+                    &subject,
+                    &params.theta,
+                    e,
+                    &params.omega,
+                    &params.sigma.values,
+                    s,
+                    None,
+                )
+            };
+            let fd = (nll(&bp, &mut scratch) - nll(&bm, &mut scratch)) / (2.0 * h);
+            let scale = fd.abs().max(analytic[k].abs()).max(1.0);
+            assert!(
+                (analytic[k] - fd).abs() / scale < 1e-6,
+                "FREM inner grad η{k}: analytic {} vs FD {}",
+                analytic[k],
+                fd
+            );
+        }
+    }
+
+    /// The gate itself: none of these families may route to the FD score any more.
+    #[test]
+    fn analytic_score_no_longer_gates_the_focei_scope() {
+        use crate::types::BloqMethod;
+        let mut m3 = parse_model_string(M3_MODEL).expect("parse");
+        m3.bloq_method = BloqMethod::M3;
+        for (model, label) in [
+            (m3, "M3"),
+            (parse_model_string(RUV_MODEL).expect("parse"), "iiv_on_ruv"),
+            (parse_model_string(LTBS_MODEL).expect("parse"), "LTBS"),
+        ] {
+            assert!(
+                analytic_score_supported_model(&model),
+                "{label} must take the analytic score path"
+            );
+        }
+    }
 
     /// Golub–Welsch must reproduce the textbook physicists' Hermite rule.
     #[test]

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1775,7 +1775,24 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     let mut ruv_grad = 0.0_f64;
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
+    // FREM covariate pseudo-observations: the objective scores these rows against the
+    // dedicated `EPSCOV` variance, not `error_spec.variance_at(f)`. The provider has
+    // already corrected their `f` and `∂f/∂η` (`apply_frem_pseudo_obs_grad`); this is the
+    // variance half. `R` is η-independent on such a row, so `∂R/∂f = 0` and the whole
+    // residual chain collapses to `∂L/∂η_k = (−ε/R)·δ_{k,ei}`. `None` on a non-FREM model.
+    let frem_ov = crate::stats::likelihood::build_frem_r_override(
+        model.frem_config.as_ref(),
+        &subject.fremtype,
+        sigma,
+    );
     for (j, obs) in sens.iter().enumerate() {
+        if let Some(v) = frem_ov.as_ref().and_then(|o| o.get(j)).and_then(|x| *x) {
+            let coef = -(subject.observations[j] - obs.f) / v;
+            for k in 0..n_eta {
+                grad[k] += coef * obs.df_deta[k];
+            }
+            continue;
+        }
         let cens = if m3 {
             subject.cens.get(j).copied().unwrap_or(0)
         } else {

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -1019,8 +1019,14 @@ pub(crate) fn score_core(
         // `∂d_j/∂θₘ` are a sum over the observation's sigma loadings of
         // `2·coeff²·mult·σ²·∂mult/∂θₘ` and `4·coeff·coeff'·mult·σ²·∂mult/∂θₘ` — the
         // same bilinear shape `residual_error::diag_self_deriv` uses for the
-        // `f`-derivative, just chain-ruled through `mult(θ)` instead of `f`.
-        if let (Some(m), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
+        // `f`-derivative, just chain-ruled through `mult(θ)` instead of `f`. Never on a
+        // FREM row: its `R` is the dedicated `EPSCOV²` override, independent of the PK
+        // error-spec magnitude entirely, so `dr_dtheta`/`dd_dtheta` must stay empty
+        // there exactly as for a censored or correlated row (#251 review #6).
+        if let (Some(m), Some(mg_row)) = (
+            mult_row.filter(|_| frem_var.is_none()),
+            mult_grad.as_ref().and_then(|mg| mg.get(j)),
+        ) {
             let mut dd_dtheta = vec![0.0f64; n_theta];
             let dr_dtheta = mag_variance_dtheta(
                 &model.error_spec,
@@ -1048,8 +1054,13 @@ pub(crate) fn score_core(
         // Residual-eta rows/cols (`a_{j,ruv} = 0`, so the loop above left them at
         // their `Ω⁻¹` value). `c̃_{j,ruv} = 2` ⇒ `½ c̃ c̃ᵀ` gives `H̃[ruv,ruv] += 2`
         // and `H̃[ruv,l] += gⱼ a_{jl}` (`gⱼ = dⱼ/Rⱼ`); the true Hessian gets
-        // `H[ruv,ruv] += 2ε²/R` and `H[ruv,l] += κⱼ a_{jl}`.
-        if let Some(rr) = ruv {
+        // `H[ruv,ruv] += 2ε²/R` and `H[ruv,l] += κⱼ a_{jl}`. Skipped entirely for a
+        // FREM row: `individual_nll`'s FREM dispatch never applies `ruv_scale`, so such
+        // a row's likelihood has zero η_ruv dependence and must leave `g_ruv`/`gp_ruv`
+        // at their default `0.0` and the `(rr, ·)` block untouched (#251 review #5) —
+        // otherwise the row's huge `1/R` (`R = EPSCOV²`) leaks a spurious O(1e8) term
+        // into the `eta_ruv` Hessian/gradient.
+        if let Some(rr) = ruv.filter(|_| frem_var.is_none()) {
             if t.censored {
                 // Censored row's residual-eta second derivatives enter BOTH the true inner
                 // Hessian AND `H̃`/`log|H̃|` (consistent inclusion): `[ruv,ruv] += C·z`,
@@ -1630,6 +1641,30 @@ fn sigma_block(
                 continue;
             }
             let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+            // FREM covariate pseudo-observation (`fremtype > 0`): `R = EPSCOV²`,
+            // independent of `f` (`d ≡ 0`), and — matching `individual_nll`'s FREM
+            // dispatch — NOT scaled by `ruv_scale`/magnitude, so `r_sig` is the bare FD
+            // of the covariate-σ variance, not lifted by `prep.ruv_scale` (#251 review
+            // #2). A `None` `frem_row` (the common case) falls through to the ordinary
+            // correlation/magnitude/legacy variance chain below.
+            let frem_row = crate::stats::likelihood::build_frem_r_override(
+                model.frem_config.as_ref(),
+                &subject.fremtype,
+                &sp,
+            )
+            .as_ref()
+            .and_then(|o| o.get(j))
+            .and_then(|x| *x)
+            .zip(
+                crate::stats::likelihood::build_frem_r_override(
+                    model.frem_config.as_ref(),
+                    &subject.fremtype,
+                    &sm,
+                )
+                .as_ref()
+                .and_then(|o| o.get(j))
+                .and_then(|x| *x),
+            );
             // Evaluate the four closed-form error functions once at σ±h and reuse
             // them for `r_sig`/`d_sig` and the residual-eta `g_sig` below. For a
             // correlated model (`block_sigma`) these are the correlation-aware variance
@@ -1637,27 +1672,43 @@ fn sigma_block(
             // - it doesn't depend on σ.
             let mult_row: Option<&[f64]> =
                 mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
-            let (vp, vm, dp_var, dm_var) = match (&corr_sp, &corr_sm) {
-                (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
-                _ => match mult_row {
-                    Some(m) => (
-                        model.error_spec.variance_at_scaled(cmt, f, &sp, &[], m),
-                        model.error_spec.variance_at_scaled(cmt, f, &sm, &[], m),
-                        model.error_spec.dvar_df_scaled(cmt, f, &sp, m),
-                        model.error_spec.dvar_df_scaled(cmt, f, &sm, m),
-                    ),
-                    None => (
-                        model.error_spec.variance_at(cmt, f, &sp),
-                        model.error_spec.variance_at(cmt, f, &sm),
-                        model.error_spec.dvar_df(cmt, f, &sp),
-                        model.error_spec.dvar_df(cmt, f, &sm),
-                    ),
-                },
+            let (r_sig, d_sig) = if let Some((vp_frem, vm_frem)) = frem_row {
+                ((vp_frem - vm_frem) / (2.0 * h), 0.0)
+            } else {
+                let (vp, vm, dp_var, dm_var) = match (&corr_sp, &corr_sm) {
+                    (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
+                    _ => match mult_row {
+                        Some(m) => (
+                            model.error_spec.variance_at_scaled(cmt, f, &sp, &[], m),
+                            model.error_spec.variance_at_scaled(cmt, f, &sm, &[], m),
+                            model.error_spec.dvar_df_scaled(cmt, f, &sp, m),
+                            model.error_spec.dvar_df_scaled(cmt, f, &sm, m),
+                        ),
+                        None => (
+                            model.error_spec.variance_at(cmt, f, &sp),
+                            model.error_spec.variance_at(cmt, f, &sm),
+                            model.error_spec.dvar_df(cmt, f, &sp),
+                            model.error_spec.dvar_df(cmt, f, &sm),
+                        ),
+                    },
+                };
+                // ∂R/∂σ_k, ∂d/∂σ_k by central FD. `et.r`/`et.d` carry the `exp(2·η_ruv)`
+                // scale, so lift these too.
+                let r_sig = prep.ruv_scale * (vp - vm) / (2.0 * h);
+                let d_sig = prep.ruv_scale * (dp_var - dm_var) / (2.0 * h);
+                // Residual-eta terms (#474). `∂R/∂σ` scales `R`, so:
+                //   M[ruv] = ∂(1−ε²/R)/∂σ = ε²/R² · Rσ   (the residual-eta row of M)
+                //   ∂log|H̃|/∂σ gains  (∂gⱼ/∂σ)·wⱼ[ruv]  with `gⱼ = d/R` (scale-free,
+                //     so FD the unscaled quotient directly). Skipped for a FREM row
+                //     above — its likelihood has no η_ruv dependence at all (#251
+                //     review #5's principle, applied to σ).
+                if let Some(rr) = prep.ruv {
+                    m_vec[rr] += eps * eps / (r * r) * r_sig;
+                    let g_sig = (dp_var / vp - dm_var / vm) / (2.0 * h);
+                    fixed += g_sig * prep.w[j][rr];
+                }
+                (r_sig, d_sig)
             };
-            // ∂R/∂σ_k, ∂d/∂σ_k by central FD. `et.r`/`et.d` carry the `exp(2·η_ruv)`
-            // scale, so lift these too.
-            let r_sig = prep.ruv_scale * (vp - vm) / (2.0 * h);
-            let d_sig = prep.ruv_scale * (dp_var - dm_var) / (2.0 * h);
 
             let inv_r = 1.0 / r;
             let inv_r2 = inv_r * inv_r;
@@ -1674,16 +1725,6 @@ fn sigma_block(
                 + ((r - eps * eps) * inv_r2) * d_sig;
             for m in 0..n_eta {
                 m_vec[m] += 0.5 * dalpha * obs.df_deta[m];
-            }
-            // Residual-eta terms (#474). `∂R/∂σ` scales `R`, so:
-            //   M[ruv] = ∂(1−ε²/R)/∂σ = ε²/R² · Rσ   (the residual-eta row of M)
-            //   ∂log|H̃|/∂σ gains  (∂gⱼ/∂σ)·wⱼ[ruv]  with `gⱼ = d/R` (scale-free,
-            //     so FD the unscaled quotient directly).
-            if let Some(rr) = prep.ruv {
-                m_vec[rr] += eps * eps * inv_r2 * r_sig;
-                // `gⱼ = d/R` is scale-free, so FD the unscaled quotient directly.
-                let g_sig = (dp_var / vp - dm_var / vm) / (2.0 * h);
-                fixed += g_sig * prep.w[j][rr];
             }
         }
 
@@ -2175,12 +2216,27 @@ pub fn subject_packed_gradient_foce(
         let cmt = err_keys[j];
         let f0act = sens0.obs[j].f;
         let mult_row: Option<&[f64]> = mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
+        // FREM covariate pseudo-observation (`fremtype > 0`): the Sheiner–Beal marginal
+        // still needs an `R⁰ⱼ` for this row, but the objective scores it against the
+        // dedicated `EPSCOV` variance, not `error_spec.variance_at`. `R⁰ = EPSCOV²` is
+        // constant in `f`, hence `d⁰ = 0`, and it takes neither the correlation-aware
+        // nor the magnitude-scaled branch below (#251 review #3 — `method = foce` had
+        // no FREM branch at all, unlike FOCEI's `score_core`).
+        let frem_r0 = crate::stats::likelihood::build_frem_r_override(
+            model.frem_config.as_ref(),
+            &subject.fremtype,
+            sigma,
+        )
+        .as_ref()
+        .and_then(|o| o.get(j))
+        .and_then(|x| *x);
         // Correlated residual (`block_sigma`, #627): correlation-aware `(R⁰, ∂R⁰/∂f)`.
         // block_sigma is mutually exclusive with custom magnitude and M3, so `mult_row`
         // and the censored (`cg`) path are inactive whenever `corr_rd0` is set.
-        let (r, dd) = match &corr_rd0 {
-            Some((rv, dv, _)) => (rv[j], dv[j]),
-            None => {
+        let (r, dd) = match (frem_r0, &corr_rd0) {
+            (Some(v), _) => (v, 0.0),
+            (None, Some((rv, dv, _))) => (rv[j], dv[j]),
+            (None, None) => {
                 let r = match mult_row {
                     Some(mm) => model
                         .error_spec
@@ -2199,21 +2255,29 @@ pub fn subject_packed_gradient_foce(
         }
         r0[i] = r;
         d0[i] = dd;
-        if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
-            // `R⁰` at f(η=0), so `ruv_scale = 1` (no `iiv_on_ruv` on this path); the
-            // Sheiner–Beal marginal only needs `∂R/∂θ`, so skip the `∂d/∂θ` accumulation.
-            let dr = mag_variance_dtheta(
-                &model.error_spec,
-                cmt,
-                f0act,
-                sigma,
-                mm,
-                mg_row,
-                n_theta,
-                1.0,
-                None,
-            );
-            dr0_dtheta[i] = dr;
+        // The magnitude direct-θ channel is a PK-error-spec derivative and does not
+        // apply to a FREM row's dedicated `EPSCOV` variance (#251 review #6's
+        // principle): `dr0_dtheta[i]` stays empty there, exactly as for a censored or
+        // correlated row.
+        if frem_r0.is_none() {
+            if let (Some(mm), Some(mg_row)) =
+                (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j)))
+            {
+                // `R⁰` at f(η=0), so `ruv_scale = 1` (no `iiv_on_ruv` on this path); the
+                // Sheiner–Beal marginal only needs `∂R/∂θ`, so skip the `∂d/∂θ` accumulation.
+                let dr = mag_variance_dtheta(
+                    &model.error_spec,
+                    cmt,
+                    f0act,
+                    sigma,
+                    mm,
+                    mg_row,
+                    n_theta,
+                    1.0,
+                    None,
+                );
+                dr0_dtheta[i] = dr;
+            }
         }
     }
 
@@ -2312,6 +2376,31 @@ pub fn subject_packed_gradient_foce(
         for (i, &j) in quant.iter().enumerate() {
             let cmt = err_keys[j];
             let f0act = sens0.obs[j].f;
+            // FREM covariate pseudo-observation: `R⁰ = EPSCOV²`, so `∂R⁰/∂σ` comes from
+            // the dedicated covariate σ, not the PK error model (#251 review #3). Without
+            // this branch `dr0` FD's the PK variance's (zero) dependence on `EPSCOV`,
+            // leaving `grad[EPSCOV] ≡ 0` under `method = foce` too.
+            let frem_vp = crate::stats::likelihood::build_frem_r_override(
+                model.frem_config.as_ref(),
+                &subject.fremtype,
+                &sp,
+            )
+            .as_ref()
+            .and_then(|o| o.get(j))
+            .and_then(|x| *x);
+            let frem_vm = crate::stats::likelihood::build_frem_r_override(
+                model.frem_config.as_ref(),
+                &subject.fremtype,
+                &sm,
+            )
+            .as_ref()
+            .and_then(|o| o.get(j))
+            .and_then(|x| *x);
+            if let (Some(vp), Some(vm)) = (frem_vp, frem_vm) {
+                let dr0 = (vp - vm) / (2.0 * hsig);
+                nat += 0.5 * dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
+                continue;
+            }
             // Correlation-aware `∂R⁰/∂σ` when block_sigma present (within-obs cross
             // term); otherwise ∂R⁰/∂σ carries the magnitude multiplier (`mult` scales
             // the σ loading), so FD the *scaled* variance when a magnitude is active
@@ -3090,6 +3179,29 @@ pub fn subject_eta_dx(
                 continue;
             }
             let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+            // FREM covariate pseudo-observation: `R = EPSCOV²`, independent of `f`
+            // (`d ≡ 0`) and — matching `individual_nll` — not scaled by `ruv_scale`, so
+            // `r_sig` is the bare FD of the covariate-σ variance (#251 review #4). It
+            // also skips the residual-eta row below: a FREM row's likelihood has no
+            // η_ruv dependence (#251 review #5's principle, applied here too).
+            let frem_row = crate::stats::likelihood::build_frem_r_override(
+                model.frem_config.as_ref(),
+                &subject.fremtype,
+                &sp,
+            )
+            .as_ref()
+            .and_then(|o| o.get(j))
+            .and_then(|x| *x)
+            .zip(
+                crate::stats::likelihood::build_frem_r_override(
+                    model.frem_config.as_ref(),
+                    &subject.fremtype,
+                    &sm,
+                )
+                .as_ref()
+                .and_then(|o| o.get(j))
+                .and_then(|x| *x),
+            );
             // `et.r`/`et.d` carry the `exp(2·η_ruv)` scale *and* any custom-magnitude
             // `mult`, so lift `∂R/∂σ`,`∂d/∂σ` the same way (mirrors `sigma_block`);
             // `ruv_scale == 1` when there is no ruv, `mult_row = None` for bare sigma.
@@ -3097,25 +3209,35 @@ pub fn subject_eta_dx(
             // variance / `∂R/∂f` (mutually exclusive with custom magnitude).
             let mult_row: Option<&[f64]> =
                 mult.as_ref().and_then(|mm| mm.get(j)).map(|v| v.as_slice());
-            let (var_p, var_m, dvar_p, dvar_m) = match (&corr_sp, &corr_sm) {
-                (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
-                _ => match mult_row {
-                    Some(mm) => (
-                        model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
-                        model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
-                        model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
-                        model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
-                    ),
-                    None => (
-                        model.error_spec.variance_at(cmt, f, &sp),
-                        model.error_spec.variance_at(cmt, f, &sm),
-                        model.error_spec.dvar_df(cmt, f, &sp),
-                        model.error_spec.dvar_df(cmt, f, &sm),
-                    ),
-                },
+            let (r_sig, d_sig) = if let Some((vp_frem, vm_frem)) = frem_row {
+                ((vp_frem - vm_frem) / (2.0 * h), 0.0)
+            } else {
+                let (var_p, var_m, dvar_p, dvar_m) = match (&corr_sp, &corr_sm) {
+                    (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
+                    _ => match mult_row {
+                        Some(mm) => (
+                            model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
+                            model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
+                            model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
+                            model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
+                        ),
+                        None => (
+                            model.error_spec.variance_at(cmt, f, &sp),
+                            model.error_spec.variance_at(cmt, f, &sm),
+                            model.error_spec.dvar_df(cmt, f, &sp),
+                            model.error_spec.dvar_df(cmt, f, &sm),
+                        ),
+                    },
+                };
+                let r_sig = prep.ruv_scale * (var_p - var_m) / (2.0 * h);
+                let d_sig = prep.ruv_scale * (dvar_p - dvar_m) / (2.0 * h);
+                // Residual-eta row of M (#474): `M[ruv] = ∂(1−ε²/R)/∂σ = ε²/R²·Rσ`.
+                // Skipped for a FREM row (handled above).
+                if let Some(rr) = prep.ruv {
+                    mvec[rr] += eps * eps / (r * r) * r_sig;
+                }
+                (r_sig, d_sig)
             };
-            let r_sig = prep.ruv_scale * (var_p - var_m) / (2.0 * h);
-            let d_sig = prep.ruv_scale * (dvar_p - dvar_m) / (2.0 * h);
             let inv_r = 1.0 / r;
             let inv_r2 = inv_r * inv_r;
             let inv_r3 = inv_r2 * inv_r;
@@ -3123,10 +3245,6 @@ pub fn subject_eta_dx(
                 + ((r - eps * eps) * inv_r2) * d_sig;
             for m in 0..n_eta {
                 mvec[m] += 0.5 * dalpha * obs.df_deta[m];
-            }
-            // Residual-eta row of M (#474): `M[ruv] = ∂(1−ε²/R)/∂σ = ε²/R²·Rσ`.
-            if let Some(rr) = prep.ruv {
-                mvec[rr] += eps * eps * inv_r2 * r_sig;
             }
         }
         out[sigma_start + k] = -(&prep.h_inner_inv * mvec) * sigma[k];
@@ -3416,6 +3534,11 @@ mod tests {
         let sigma = &params.sigma.values;
         let omega_inv = &params.omega.inv;
         let mult = model.ruv_obs_mult(subject, &params.theta);
+        let frem_r = crate::stats::likelihood::build_frem_r_override(
+            model.frem_config.as_ref(),
+            &subject.fremtype,
+            sigma,
+        );
         for _ in 0..50 {
             let sens =
                 crate::sens::provider::subject_sensitivities(model, subject, &params.theta, &eta)
@@ -3433,13 +3556,15 @@ mod tests {
                 let cmt = subject.obs_cmts[j];
                 let mult_row: Option<&[f64]> =
                     mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
-                let (r, d, d2) = match mult_row {
-                    Some(m) => (
+                let frem_var = frem_r.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
+                let (r, d, d2) = match (frem_var, mult_row) {
+                    (Some(v), _) => (v, 0.0, 0.0),
+                    (None, Some(m)) => (
                         model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m),
                         model.error_spec.dvar_df_scaled(cmt, f, sigma, m),
                         model.error_spec.d2var_df2_scaled(cmt, sigma, m),
                     ),
-                    None => (
+                    (None, None) => (
                         model.error_spec.variance_at(cmt, f, sigma),
                         model.error_spec.dvar_df(cmt, f, sigma),
                         model.error_spec.d2var_df2(cmt, sigma),
@@ -3508,6 +3633,11 @@ mod tests {
         let jac = eta_jacobian_any(model, subject, &params.theta, eta);
         let h_matrix =
             nalgebra::DMatrix::from_row_slice(subject.obs_times.len(), model.n_eta, &jac);
+        let frem_r_override = crate::stats::likelihood::build_frem_r_override(
+            model.frem_config.as_ref(),
+            &subject.fremtype,
+            &params.sigma.values,
+        );
         foce_subject_nll_interaction(
             subject,
             &ipreds,
@@ -3518,7 +3648,7 @@ mod tests {
             &model.error_spec,
             model.bloq_method,
             &[],
-            None,
+            frem_r_override.as_deref(),
             model.residual_error_eta,
             model.ruv_obs_mult(subject, &params.theta).as_deref(),
         )
@@ -6066,6 +6196,156 @@ mod tests {
                 (analytic[k] - fd).abs() / fd.abs().max(1e-12)
             );
             approx::assert_relative_eq!(analytic[k], fd, max_relative = 5e-3, epsilon = 1e-5);
+        }
+    }
+
+    const FREM_OUTER_MODEL: &str = r#"
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 50.0)
+  theta TV_WT(72.0, 1.0, 500.0)
+
+  block_omega (ETA_CL, ETA_V, ETA_KA, ETA_WT_FREM) = [
+    0.09,
+    0.0, 0.04,
+    0.0, 0.0, 0.30,
+    0.0, 0.0, 0.0, 111.56
+  ]
+
+  sigma PROP_ERR ~ 0.02
+  sigma EPSCOV   ~ 0.30
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  frem_predictions = TV_WT/ETA_WT_FREM:100
+  frem_sigma       = EPSCOV
+"#;
+
+    /// A subject with 3 PK observation rows plus one FREM covariate pseudo-observation
+    /// (FREMTYPE 100), built without going through the data reader (mirrors
+    /// `agq::tests::frem_pseudo_obs_rows_get_the_right_analytic_score`'s fixture).
+    fn frem_outer_subject(model: &CompiledModel, theta: &[f64]) -> Subject {
+        use std::collections::HashMap;
+        let fc = model.frem_config.as_ref().expect("fixture must be FREM");
+        let pk_times = [1.0, 6.0, 24.0];
+        let n = pk_times.len() + 1;
+        let mut subject = Subject {
+            id: "1".to_string(),
+            doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs_times: pk_times
+                .iter()
+                .copied()
+                .chain(std::iter::once(0.0))
+                .collect(),
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; n],
+            obs_cmts: vec![1; n],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n],
+            occasions: vec![1; n],
+            obs_l2: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: pk_times
+                .iter()
+                .map(|_| 0u16)
+                .chain(std::iter::once(100u16))
+                .collect(),
+            obs_records: vec![],
+        };
+        let eta_ref = [0.1, -0.05, 0.15, 0.0];
+        let preds = crate::pk::compute_predictions_with_tv(model, &subject, theta, &eta_ref);
+        for j in 0..pk_times.len() {
+            subject.observations[j] = preds[j] * 0.85;
+        }
+        let (ti, _ei) = fc.fremtype_to_indices[&100u16];
+        subject.observations[pk_times.len()] = theta[ti] * 1.10;
+        subject
+    }
+
+    /// FREM covariate pseudo-observations, at the **FOCEI outer** (`population_gradient_sens`
+    /// / `theta_block` / `sigma_block`) level — not AGQ's `score_core` consumer, which
+    /// `agq::tests::frem_pseudo_obs_rows_get_the_right_analytic_score` already covers.
+    ///
+    /// That AGQ test alone missed a real bug (#251 review #2): `sigma_block`'s σ-FD ran the
+    /// *plain PK* variance at σ±h on a FREM row instead of the `EPSCOV`-aware one, so
+    /// `grad[EPSCOV]` came out identically zero under FOCE/FOCEI while a spurious term leaked
+    /// into `PROP_ERR`'s gradient — invisible to any test that never differentiates through
+    /// `theta_block`/`sigma_block` on a FREM model. This test does, against FD of the true
+    /// FOCEI marginal (`marginal_nll`, which is itself now FREM-aware via
+    /// `foce_subject_nll_interaction`'s `frem_r_override`), covering every packed coordinate
+    /// (θ, Ω, and — critically — σ including `EPSCOV`).
+    #[test]
+    fn population_packed_gradient_frem_matches_fd() {
+        use crate::estimation::parameterization::pack_params;
+        use crate::types::Population;
+
+        let model = parse_model_string(FREM_OUTER_MODEL).expect("parse");
+        assert_eq!(model.n_eta, 4, "3 PK etas + 1 covariate eta");
+        let theta = model.default_params.theta.clone();
+        let subject = frem_outer_subject(&model, &theta);
+
+        let pop = Population {
+            subjects: vec![subject],
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        };
+
+        let mut template = model.default_params.clone();
+        template.theta = theta;
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ehs: Vec<DVector<f64>> = pop
+            .subjects
+            .iter()
+            .map(|s| DVector::from_vec(precise_ebe(&model, s, &params)))
+            .collect();
+
+        let analytic =
+            population_gradient_sens(&model, &pop, &template, &x, &ehs).expect("FREM supported");
+
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            2.0 * pop
+                .subjects
+                .iter()
+                .map(|s| marginal_nll(&model, s, &p))
+                .sum::<f64>()
+        };
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.clone();
+            xp[k] += h;
+            let mut xm = x.clone();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0;
+            let scale = fd.abs().max(analytic[k].abs()).max(1.0);
+            assert!(
+                (analytic[k] - fd).abs() / scale < 5e-3,
+                "coord {k}: analytic {} vs FD {} (rel {:.2e})",
+                analytic[k],
+                fd,
+                (analytic[k] - fd).abs() / scale
+            );
         }
     }
 

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -42,14 +42,14 @@ use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
 
 /// Per-observation error-model scalars used throughout the assembly.
-struct ErrTerms {
-    r: f64,       // Rⱼ
-    d: f64,       // dⱼ = ∂R/∂f
-    eps: f64,     // εⱼ = y − f
-    alpha: f64,   // αⱼ
-    alpha_p: f64, // α'ⱼ = dαⱼ/df
-    p: f64,       // pⱼ
-    beta: f64,    // βⱼ = dpⱼ/df
+pub(crate) struct ErrTerms {
+    pub(crate) r: f64,       // Rⱼ
+    pub(crate) d: f64,       // dⱼ = ∂R/∂f
+    pub(crate) eps: f64,     // εⱼ = y − f
+    pub(crate) alpha: f64,   // αⱼ
+    pub(crate) alpha_p: f64, // α'ⱼ = dαⱼ/df
+    pub(crate) p: f64,       // pⱼ
+    pub(crate) beta: f64,    // βⱼ = dpⱼ/df
     // M3-censored × residual-eta (`iiv_on_ruv`) cross-term coefficients (#4c).
     // Zero on quantified rows and on non-`iiv_on_ruv` censored rows. With
     // `z = (y−f)/√v`, `h = φ(z)/Φ(z)`, `m = 1/√v + (y−f)·R'/(2 v^{3/2})` and
@@ -59,24 +59,24 @@ struct ErrTerms {
     // inner Hessian's residual-eta row/col reads `ruv_cz`/`ruv_cm` instead of the
     // Gaussian `2ε²/R`/`ruv_kappa`. Since #486 these `ruv_cz`/`ruv_cm` terms also enter
     // `H̃`/`log|H̃|` (with their θ/σ/η derivatives), consistently with quantified rows.
-    ruv_cz: f64, // C·z  (residual-eta diagonal of the true inner Hessian)
-    ruv_cm: f64, // C·m  (residual-eta × structural-η / θ / σ coupling)
+    pub(crate) ruv_cz: f64, // C·z  (residual-eta diagonal of the true inner Hessian)
+    pub(crate) ruv_cm: f64, // C·m  (residual-eta × structural-η / θ / σ coupling)
     /// True for an M3-censored row. The residual-eta blocks read the censored
     /// `ruv_cz`/`ruv_cm` coefficients instead of the Gaussian `2ε²/R`/`ruv_kappa`.
-    censored: bool,
+    pub(crate) censored: bool,
     /// Raw NONMEM `CENS` sign for this row (`0` quantified, `>0` below-LLOQ /
     /// lower tail, `<0` above-ULOQ / upper tail). The σ-block's FD of the
     /// censored df-coefficient must re-evaluate the kernel on the same tail, so
     /// the sign is carried here rather than re-read from the subject.
-    cens_sign: i8,
+    pub(crate) cens_sign: i8,
     /// `∂Rⱼ/∂θₘ` from the custom residual-error magnitude's *direct* θ-dependence
     /// (#484/#576/#486) — `mult(θ)` enters `R` independent of the prediction `f`,
     /// so this is a channel `theta_block` would otherwise miss entirely. Empty
     /// when no magnitude is active (the common case; zero-cost).
-    dr_dtheta: Vec<f64>,
+    pub(crate) dr_dtheta: Vec<f64>,
     /// `∂dⱼ/∂θₘ = ∂²Rⱼ/∂f∂θₘ`, the `f`-derivative of `dr_dtheta` — the magnitude
     /// analog of the σ-block's `d_sig`. Empty when no magnitude is active.
-    dd_dtheta: Vec<f64>,
+    pub(crate) dd_dtheta: Vec<f64>,
 }
 
 /// `(g1, g2) = (∂L/∂f, ∂²L/∂f²)` only — used by the reconverge test oracles
@@ -678,17 +678,149 @@ fn mag_alpha_dtheta(et: &ErrTerms, m: usize) -> f64 {
 /// and the **IOV** path, where the random effects are the stacked
 /// `[η_bsv, κ₁..κ_K]` and `omega_inv` is the inverse of the block-diagonal
 /// `Ω_bsv ⊕ K·Ω_iov`. Everything else (error model, σ, censoring) is shared.
+/// The per-observation scalar likelihood chain (`ErrTerms`) plus the two Hessians, for
+/// an **arbitrary** `eta` — the mode is never assumed.
+///
+/// This is the half of [`prepare_stacked`] that does not depend on the FOCEI `log|H̃|`
+/// machinery, split out so callers that only need the *score* of the conditional NLL can
+/// have it without paying for two Cholesky inverses per call (#251 AGQ/Laplace, which
+/// evaluates it once per quadrature node).
+///
+/// Two things here are exactly what an AGQ/Laplace node needs, for the FULL analytic
+/// scope (M3-censored, `iiv_on_ruv`, custom σ magnitude, correlated residual, LTBS):
+///
+/// * `et[j].alpha = 2·∂L_j/∂f_j` — the residual chain, per endpoint family; and
+/// * `h_inner = Ω⁻¹ + Σⱼ (∂²L_j/∂f² aⱼaⱼᵀ + ∂L_j/∂f Aⱼ)`, which **is** the exact
+///   conditional Hessian `∂²nll/∂b²` (`L_j = ½(εⱼ²/Rⱼ + ln Rⱼ)`, so `½α` and `½α'`
+///   recover `∂L/∂f` and `∂²L/∂f²`).
+pub(crate) struct ScoreCore {
+    pub(crate) et: Vec<ErrTerms>,
+    /// `H̃ = Σ pⱼ aⱼaⱼᵀ + Ω⁻¹` — the first-order (Almquist) FOCEI Hessian.
+    pub(crate) htilde: DMatrix<f64>,
+    /// `H = ∂²nll/∂b²` — the **exact** conditional Hessian at `eta`.
+    pub(crate) h_inner: DMatrix<f64>,
+    pub(crate) g_ruv: Vec<f64>,
+    pub(crate) gp_ruv: Vec<f64>,
+    pub(crate) cens_dcz_df: Vec<f64>,
+    pub(crate) cens_dcm_df: Vec<f64>,
+    pub(crate) mult: Option<Vec<Vec<f64>>>,
+    pub(crate) ruv_scale: f64,
+    pub(crate) ruv: Option<usize>,
+}
+
+/// `∂(Σⱼ Lⱼ)/∂σ_k` at **fixed** predictions — the data term's σ-gradient, in natural σ.
+///
+/// σ enters `nll` only through the residual variance, so this is a closed-form scalar
+/// computation at fixed `f`: no model evaluation, no inner solve, no Hessian. It is the
+/// *data half* of [`sigma_block`], which additionally carries the FOCEI `log|H̃|` and
+/// EBE-response terms that a fixed-`b` score must NOT have (#251 AGQ/Laplace).
+///
+/// Quantified rows use `∂L/∂R · ∂R/∂σ`. `R` is a quadratic form in σ
+/// (`R = Σ_s (coeff_s(f)·mult_s·σ_s)²`), so the central difference of `R` is **exact** up
+/// to rounding — there is no truncation error to trade against noise — and it inherits the
+/// custom-magnitude, `iiv_on_ruv` and correlated-residual scalings for free rather than
+/// re-deriving `∂R/∂σ` once per family. Censored rows use the `−logΦ(z)` kernel's own
+/// σ-derivative through the shared [`censored_sigma_m_terms`], the same convention and FD
+/// step `sigma_block` uses.
+pub(crate) fn data_sigma_gradient(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    sens: &SubjectSens,
+    core: &ScoreCore,
+) -> Vec<f64> {
+    let sigma = &params.sigma.values;
+    let n_sigma = sigma.len();
+    let err_keys = model.error_spec.obs_keys(subject);
+    let correlated = !model.residual_correlations.is_empty();
+    let ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
+    let mut out = vec![0.0f64; n_sigma];
+
+    for k in 0..n_sigma {
+        let h = sigma_fd_step(sigma[k]);
+        let mut sp = sigma.clone();
+        sp[k] += h;
+        let mut sm = sigma.clone();
+        sm[k] -= h;
+        let (corr_sp, corr_sm) = if correlated {
+            (
+                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sp)),
+                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sm)),
+            )
+        } else {
+            (None, None)
+        };
+
+        let mut acc = 0.0;
+        for (j, obs) in sens.obs.iter().enumerate() {
+            let cmt = err_keys[j];
+            let f = obs.f;
+            let et = &core.et[j];
+            if et.censored {
+                let (_dg1, _ruv_sig, l_sig) = censored_sigma_m_terms(
+                    model,
+                    cmt,
+                    subject.observations[j],
+                    f,
+                    &sp,
+                    &sm,
+                    h,
+                    core.ruv_scale,
+                    et.ruv_cz,
+                    et.r,
+                    core.ruv.is_some(),
+                    et.cens_sign,
+                );
+                acc += l_sig;
+                continue;
+            }
+            // `R` at σ±h, built exactly as `score_core` builds it: a FREM covariate
+            // pseudo-observation takes the dedicated `EPSCOV` σ; otherwise the
+            // correlation-aware diagonal, else the magnitude-scaled or legacy variance,
+            // times the `iiv_on_ruv` scale.
+            let r_at = |sa: &[f64], corr: &Option<(Vec<f64>, Vec<f64>)>| -> f64 {
+                if let Some(v) = crate::stats::likelihood::build_frem_r_override(
+                    model.frem_config.as_ref(),
+                    &subject.fremtype,
+                    sa,
+                )
+                .as_ref()
+                .and_then(|o| o.get(j))
+                .and_then(|x| *x)
+                {
+                    return v;
+                }
+                match corr {
+                    Some((rv, _)) => rv[j],
+                    None => match core.mult.as_ref().and_then(|m| m.get(j)) {
+                        Some(m) => {
+                            model.error_spec.variance_at_scaled(cmt, f, sa, &[], m) * core.ruv_scale
+                        }
+                        None => model.error_spec.variance_at(cmt, f, sa) * core.ruv_scale,
+                    },
+                }
+            };
+            let dr_dsig = (r_at(&sp, &corr_sp) - r_at(&sm, &corr_sm)) / (2.0 * h);
+            // `∂L/∂R = (R − ε²)/(2R²)` for `L = ½(ε²/R + ln R)`.
+            let (r, eps) = (et.r, et.eps);
+            acc += 0.5 * (r - eps * eps) / (r * r) * dr_dsig;
+        }
+        out[k] = acc;
+    }
+    out
+}
+
 #[allow(clippy::too_many_arguments)]
-fn prepare_stacked(
+pub(crate) fn score_core(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
     sens: &SubjectSens,
     n_eta: usize,
-    omega_inv: DMatrix<f64>,
-    eta_hat: &[f64],
+    omega_inv: &DMatrix<f64>,
+    eta: &[f64],
     ruv: Option<usize>,
-) -> Option<Prep> {
+) -> Option<ScoreCore> {
     let n_obs = subject.observations.len();
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
@@ -717,7 +849,7 @@ fn prepare_stacked(
     // to keep its residual variance unscaled, so gate on the local `ruv`, not on
     // `model.residual_error_eta`).
     let ruv_scale = if ruv.is_some() {
-        model.residual_var_scale(eta_hat)
+        model.residual_var_scale(eta)
     } else {
         1.0
     };
@@ -774,11 +906,23 @@ fn prepare_stacked(
     } else {
         None
     };
+    // FREM covariate pseudo-observations (`fremtype > 0`): the objective scores these rows
+    // against the dedicated covariate σ (`EPSCOV`), not `error_spec.variance_at(f)`. The
+    // provider has already rewritten their *jet* (`apply_frem_pseudo_obs_jet` — prediction
+    // `θ[ti] + η[ei]`, unit first derivatives, zero second); this is the matching *variance*
+    // half. `R` is constant in `f` on such a row, hence `d = d2 = 0`. `None` for a non-FREM
+    // model, so the common path allocates nothing.
+    let frem_r = crate::stats::likelihood::build_frem_r_override(
+        model.frem_config.as_ref(),
+        &subject.fremtype,
+        sigma,
+    );
     for obs in sens.obs.iter() {
         let f = obs.f;
         // obs index → cmt: provider obs are parallel to subject.obs_times.
         let j = et.len();
         let cmt = err_keys[j];
+        let frem_var = frem_r.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
         // `mult_row` is `None` for every observation on a non-magnitude model, so
         // that path keeps the exact legacy `variance_at`/`dvar_df`/`d2var_df2`
         // association bit-for-bit (the `_scaled` variants reassociate the
@@ -788,9 +932,11 @@ fn prepare_stacked(
         // diagonals; otherwise fall back to the per-obs (magnitude-scaled or legacy)
         // variance/derivatives. `block_sigma` and custom magnitude are mutually exclusive
         // (a `block_sigma` model has `mult == None`), so the two branches never mix.
-        let (r, d, d2) = match &corr_diag {
-            Some((rv, dv, d2v)) => (rv[j], dv[j], d2v[j]),
-            None => {
+        let (r, d, d2) = match (frem_var, &corr_diag) {
+            // FREM pseudo-obs: `R = EPSCOV²`, independent of `f`.
+            (Some(v), _) => (v, 0.0, 0.0),
+            (None, Some((rv, dv, d2v))) => (rv[j], dv[j], d2v[j]),
+            (None, None) => {
                 let r = match mult_row {
                     Some(m) => {
                         model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m) * ruv_scale
@@ -942,6 +1088,49 @@ fn prepare_stacked(
         }
         et.push(t);
     }
+
+    Some(ScoreCore {
+        et,
+        htilde,
+        h_inner,
+        g_ruv,
+        gp_ruv,
+        cens_dcz_df,
+        cens_dcm_df,
+        mult,
+        ruv_scale,
+        ruv,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_stacked(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    sens: &SubjectSens,
+    n_eta: usize,
+    omega_inv: DMatrix<f64>,
+    eta_hat: &[f64],
+    ruv: Option<usize>,
+) -> Option<Prep> {
+    let n_obs = subject.observations.len();
+    let err_keys = model.error_spec.obs_keys(subject);
+    let sigma = &params.sigma.values;
+    let ScoreCore {
+        et,
+        htilde,
+        h_inner,
+        g_ruv,
+        gp_ruv,
+        cens_dcz_df,
+        cens_dcm_df,
+        mult,
+        ruv_scale,
+        ruv: _,
+    } = score_core(
+        model, subject, params, sens, n_eta, &omega_inv, eta_hat, ruv,
+    )?;
 
     let htilde_inv = htilde.cholesky()?.inverse();
     let h_inner_inv = h_inner.cholesky()?.inverse();

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -2700,6 +2700,8 @@ pub fn subject_sensitivities_tvcov(
     // scale-then-log order matches production `ln(f/s)` (#486). The inner EBE gradient stays
     // on FD for LTBS (covariance stability), so there is no inner counterpart.
     apply_ltbs_transform_outer(&mut sens, model.log_transform);
+    // FREM covariate pseudo-observations are not PK rows at all — overwrite their jet.
+    apply_frem_pseudo_obs_jet(&mut sens, model, subject, theta, eta);
     Some(sens)
 }
 
@@ -3455,17 +3457,62 @@ pub(crate) fn subject_eta_grad_with_schedule(
     eta: &[f64],
     cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
 ) -> Option<Vec<ObsGrad>> {
-    if !sens_profile_enabled() {
-        return subject_eta_grad_impl(model, subject, theta, eta, cached_schedule);
+    let mut r = if !sens_profile_enabled() {
+        subject_eta_grad_impl(model, subject, theta, eta, cached_schedule)
+    } else {
+        let t0 = std::time::Instant::now();
+        let r = subject_eta_grad_impl(model, subject, theta, eta, cached_schedule);
+        PROFILE_ETA_NANOS.fetch_add(
+            t0.elapsed().as_nanos() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        PROFILE_ETA_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        r
+    };
+    // FREM covariate pseudo-observations, inner (η-gradient) counterpart of
+    // `apply_frem_pseudo_obs_jet`. Applied here rather than inside `subject_eta_grad_impl`
+    // so it covers every inner route at one choke point — closed-form, TV-cov event-driven
+    // and the light `Dual1` ODE walk — none of which knows the row is not a PK row.
+    if let Some(g) = r.as_mut() {
+        apply_frem_pseudo_obs_grad(g, model, subject, theta, eta);
     }
-    let t0 = std::time::Instant::now();
-    let r = subject_eta_grad_impl(model, subject, theta, eta, cached_schedule);
-    PROFILE_ETA_NANOS.fetch_add(
-        t0.elapsed().as_nanos() as u64,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-    PROFILE_ETA_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     r
+}
+
+/// Inner (η-gradient) counterpart of [`apply_frem_pseudo_obs_jet`]: a FREM covariate
+/// pseudo-observation's prediction is `θ[ti] + η[ei]`, so `∂f/∂η = e_ei` exactly — the
+/// same `{0, 1}` Jacobian `inner_optimizer::overwrite_frem_pseudo_obs_rows` already
+/// stamps into the FOCE H-matrix. Without it the inner EBE gradient differentiates the PK
+/// model on a row the objective scores against a covariate, so the EBEs themselves are
+/// wrong. A no-op for a non-FREM model or a subject with no pseudo-observations.
+fn apply_frem_pseudo_obs_grad(
+    sens: &mut [ObsGrad],
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) {
+    let Some(fc) = model.frem_config.as_ref() else {
+        return;
+    };
+    if subject.fremtype.is_empty() {
+        return;
+    }
+    for (j, obs) in sens.iter_mut().enumerate() {
+        let ft = subject.fremtype.get(j).copied().unwrap_or(0);
+        if ft == 0 {
+            continue;
+        }
+        let Some(&(ti, ei)) = fc.fremtype_to_indices.get(&ft) else {
+            continue;
+        };
+        obs.f = theta.get(ti).copied().unwrap_or(0.0) + eta.get(ei).copied().unwrap_or(0.0);
+        let n_eta = obs.df_deta.len();
+        obs.df_deta.iter_mut().for_each(|v| *v = 0.0);
+        if ei < n_eta {
+            obs.df_deta[ei] = 1.0;
+        }
+    }
 }
 
 fn subject_eta_grad_impl(
@@ -4815,7 +4862,68 @@ fn subject_sensitivities_impl(
     // that the TV-cov event-driven outer (`subject_sensitivities_tvcov`) also uses. Applied
     // last, matching production's scale-then-log order.
     apply_ltbs_transform_outer(&mut sens, model.log_transform);
+    // FREM covariate pseudo-observations are not PK rows at all — overwrite their jet.
+    apply_frem_pseudo_obs_jet(&mut sens, model, subject, theta, eta);
     Some(sens)
+}
+
+/// Replace the jet of every FREM **covariate pseudo-observation** row (`fremtype > 0`).
+///
+/// `individual_nll` does not score such a row against the PK model at all: its prediction
+/// is `θ[theta_idx] + η[eta_idx]` and its variance is the dedicated covariate σ (`EPSCOV`),
+/// not `error_spec.variance_at(f)`. The sensitivity walk knows nothing about that — it
+/// returns the ordinary PK jet for every observation — so without this pass the analytic
+/// outer gradient differentiates a likelihood the objective never evaluates on those rows.
+///
+/// The corrected row is trivially linear-Gaussian:
+///
+/// ```text
+///   f = θ[ti] + η[ei] ,   ∂f/∂η = e_ei ,   ∂f/∂θ = e_ti ,   every 2nd derivative = 0
+/// ```
+///
+/// The *variance* half is handled by the consumers, which read the FREM σ override rather
+/// than `variance_at` for these rows (`sens_outer_gradient::score_core`); `d = ∂R/∂f` and
+/// `d2` are then zero because `R` does not depend on `f` here.
+///
+/// Applied **after** [`apply_ltbs_transform_outer`], because a FREM row's prediction is not
+/// log-transformed by the objective either (`individual_nll` takes the `fremtype` branch
+/// before it ever touches `preds`), so the LTBS jet for that row must be overwritten, not
+/// composed with. A no-op for a non-FREM model or a subject with no pseudo-observations.
+fn apply_frem_pseudo_obs_jet(
+    sens: &mut SubjectSens,
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+) {
+    let Some(fc) = model.frem_config.as_ref() else {
+        return;
+    };
+    if subject.fremtype.is_empty() {
+        return;
+    }
+    for (j, obs) in sens.obs.iter_mut().enumerate() {
+        let ft = subject.fremtype.get(j).copied().unwrap_or(0);
+        if ft == 0 {
+            continue;
+        }
+        let Some(&(ti, ei)) = fc.fremtype_to_indices.get(&ft) else {
+            continue;
+        };
+        let n_eta = obs.df_deta.len();
+        let n_theta = obs.df_dtheta.len();
+        obs.f = theta.get(ti).copied().unwrap_or(0.0) + eta.get(ei).copied().unwrap_or(0.0);
+        obs.df_deta.iter_mut().for_each(|v| *v = 0.0);
+        if ei < n_eta {
+            obs.df_deta[ei] = 1.0;
+        }
+        obs.df_dtheta.iter_mut().for_each(|v| *v = 0.0);
+        if ti < n_theta {
+            obs.df_dtheta[ti] = 1.0;
+        }
+        obs.d2f_deta2.iter_mut().for_each(|v| *v = 0.0);
+        obs.d2f_deta_dtheta.iter_mut().for_each(|v| *v = 0.0);
+    }
 }
 
 /// Apply the log-transform-both-sides (LTBS) `g = ln(f)` output transform to an outer

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -3879,16 +3879,29 @@ pub fn subject_sensitivities(
     theta: &[f64],
     eta: &[f64],
 ) -> Option<SubjectSens> {
-    if !sens_profile_enabled() {
-        return subject_sensitivities_impl(model, subject, theta, eta);
+    let mut r = if !sens_profile_enabled() {
+        subject_sensitivities_impl(model, subject, theta, eta)
+    } else {
+        let t0 = std::time::Instant::now();
+        let r = subject_sensitivities_impl(model, subject, theta, eta);
+        PROFILE_SENS_NANOS.fetch_add(
+            t0.elapsed().as_nanos() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        PROFILE_SENS_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        r
+    };
+    // FREM covariate pseudo-observations, at the one choke point that covers every
+    // route `subject_sensitivities_impl` can take — the no-TV closed form, the TV-cov
+    // event-driven walk (which also applies this internally so its own direct callers
+    // stay correct), and the ODE provider (`ode_subject_sensitivities`), which returns
+    // early from `subject_sensitivities_impl` and previously never saw this pass at all
+    // (#251 review #1): an ODE FREM subject took the analytic outer gradient with the raw
+    // PK jet on pseudo-obs rows while `score_core` still overrode their variance to
+    // `EPSCOV²`, mismatching jet and variance by orders of magnitude.
+    if let Some(sens) = r.as_mut() {
+        apply_frem_pseudo_obs_jet(sens, model, subject, theta, eta);
     }
-    let t0 = std::time::Instant::now();
-    let r = subject_sensitivities_impl(model, subject, theta, eta);
-    PROFILE_SENS_NANOS.fetch_add(
-        t0.elapsed().as_nanos() as u64,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-    PROFILE_SENS_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     r
 }
 
@@ -4862,8 +4875,6 @@ fn subject_sensitivities_impl(
     // that the TV-cov event-driven outer (`subject_sensitivities_tvcov`) also uses. Applied
     // last, matching production's scale-then-log order.
     apply_ltbs_transform_outer(&mut sens, model.log_transform);
-    // FREM covariate pseudo-observations are not PK rows at all — overwrite their jet.
-    apply_frem_pseudo_obs_jet(&mut sens, model, subject, theta, eta);
     Some(sens)
 }
 

--- a/tests/frem_warfarin.rs
+++ b/tests/frem_warfarin.rs
@@ -391,8 +391,24 @@ fn frem_rao_blackwell_marginal_drops_covariate_2pi_constant() {
 
     assert!(rb.is_finite(), "RB marginal must be finite, got {rb}");
     // Fixed seed and fast-but-stable K=6000. Tolerance is comfortably below the
-    // ~36.8 bug offset and above the observed MC/platform noise.
-    let expected = 19781.127590682896_f64;
+    // ~36.8 bug offset (10 subjects × 2 covariate etas × log 2π) and above the observed
+    // MC/platform noise.
+    //
+    // #251: this reference was 19781.127590682896, which was enshrining a bug. Importance
+    // sampling is unbiased in expectation, but its proposal is centred on the inner-loop
+    // EBEs — and those were being driven to the mode of the WRONG likelihood, because the
+    // inner analytic gradient scored FREM covariate pseudo-observations against the PK
+    // model instead of `θ[i] + η[j]` with `EPSCOV`. The proposal therefore had almost no
+    // overlap with the true posterior, the weights collapsed, and the estimate was
+    // meaningless. (`importance_sampling` already applied the FREM residual override when
+    // *scoring*; it inherited the broken proposal.)
+    //
+    // The corrected value cross-checks against a completely independent estimator: the
+    // converged FOCEI Laplace OFV on this model is 210.99
+    // (`frem_covariate_omega_matches_sample_variance_under_focei`), and this 6000-sample
+    // IS marginal is 211.65. Two different approximations of the same quantity now agree
+    // to <1 unit, where before they differed by ~19 570.
+    let expected = 211.64831787274125_f64;
     assert!(
         (rb - expected).abs() < 12.0,
         "RB marginal {rb} should stay near the seeded no-constant reference \
@@ -500,21 +516,33 @@ fn frem_covariate_omega_matches_sample_variance() {
     );
 }
 
-/// The same ground truth under **FOCEI** — the gradient-based twin of
-/// `frem_covariate_omega_matches_sample_variance` (#251).
+/// The gradient-based twin of `frem_covariate_omega_matches_sample_variance` (#251).
 ///
-/// REGRESSION TEST. The FREM-aware residual override was applied to SAEM (see the test
-/// below), to importance sampling, and to the CWRES path — but never to the analytic
-/// gradients. So `subject_sensitivities` handed the gradient the ordinary **PK** jet for
-/// covariate pseudo-observation rows and the assembly read the ordinary residual variance,
-/// while the objective scored those same rows against `theta[i] + eta[j]` with `EPSCOV`.
-/// FOCEI was therefore minimising one objective and differentiating another (and the inner
-/// loop drove the EBEs to the mode of the wrong likelihood).
+/// Two independent checks, and it matters which one does the regression work.
 ///
-/// Because the only "data" for a covariate row is the subject's own covariate value, the
-/// covariate eta variance has an exact ground truth: it must recover the covariate's
-/// **sample variance**. That makes this a real oracle rather than a smoke test — and it is
-/// what a gradient-based FREM fit could not do before the fix.
+/// **The covariate ω is the weak check.** It has an exact ground truth — the only "data"
+/// for a covariate row is the subject's own covariate value, so `Ω_cov` must recover the
+/// covariate's sample variance — but it turns out to be *insensitive to the gradient bug*:
+/// the pseudo-observations pin `η_cov ≈ y_cov − θ_cov` almost regardless of how the
+/// optimizer got there, so the recovered ω was already ~right (118.7 vs 111.56) even with
+/// the analytic gradient differentiating the wrong likelihood. Keep it as a correctness
+/// oracle, but do not mistake it for the regression.
+///
+/// **The OFV is the real check.** The FREM-aware residual override reached SAEM (see the
+/// test below), importance sampling and the CWRES path, but never the analytic gradients:
+/// the provider handed them the ordinary **PK** jet for `FREMTYPE > 0` rows and the
+/// assemblies read the ordinary residual variance, while the objective scores those rows
+/// against `θ[i] + η[j]` with `EPSCOV`. The inner loop therefore drove the EBEs to the mode
+/// of the wrong likelihood, and the FOCEI objective — evaluated *at* those EBEs — landed
+/// ~4700 units worse:
+///
+/// ```text
+///   before fix:  OFV = 4900.6      (ω_WT = 118.71, ω_AGE = 104.30)
+///   after fix:   OFV =  211.0      (ω_WT = 118.67, ω_AGE = 104.27)
+/// ```
+///
+/// This PR does not touch the objective, only the gradients — so the entire OFV gap is the
+/// fit landing somewhere else. That is what the `ofv < 1000.0` bound below pins.
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
@@ -528,13 +556,32 @@ fn frem_covariate_omega_matches_sample_variance_under_focei() {
     let pop = read_nonmem_csv(&result.data_path, None, None).unwrap();
 
     let mut opts = FitOptions::default();
-    opts.method = ferx_core::EstimationMethod::Focei;
+    opts.method = ferx_core::EstimationMethod::FoceI;
     opts.run_covariance_step = false;
     opts.verbose = false;
 
     let fit_result =
         fit(&model, &pop, &model.default_params, &opts).expect("FREM FOCEI fit should succeed");
+    println!(
+        "FOCEI FREM: OFV={:.1}  omega_WT={:.2} (want 111.56)  omega_AGE={:.2} (want 99.38)",
+        fit_result.ofv,
+        fit_result.omega[(3, 3)],
+        fit_result.omega[(4, 4)],
+    );
     assert!(fit_result.ofv.is_finite(), "OFV should be finite");
+
+    // THE regression assertion. With the analytic gradients corrected the fit converges to
+    // OFV ≈ 211; with the PK jet / PK variance on the pseudo-obs rows it settles at ≈ 4901,
+    // because the inner loop drives the EBEs to the mode of a likelihood that is not the one
+    // being minimised. The bound sits far from both, so it discriminates without being
+    // brittle. (The covariate-ω assertions below pass either way — see the doc comment.)
+    assert!(
+        fit_result.ofv < 1000.0,
+        "FOCEI FREM OFV = {:.1}; expected ≈ 211. A value near 4900 means the analytic \
+         gradient is differentiating the PK likelihood on covariate pseudo-observation rows \
+         while the objective scores them against theta[i] + eta[j] with EPSCOV.",
+        fit_result.ofv
+    );
 
     let omega = &fit_result.omega;
     for (idx, expected, name) in [(3usize, 111.56f64, "WT"), (4, 99.38, "AGE")] {
@@ -543,8 +590,7 @@ fn frem_covariate_omega_matches_sample_variance_under_focei() {
         assert!(
             pct < 15.0,
             "{name} omega diag ({got:.2}) should be within 15% of the sample variance \
-             ({expected:.2}), got {pct:.1}% — the analytic gradient is differentiating a \
-             different likelihood than the objective on covariate pseudo-obs rows"
+             ({expected:.2}), got {pct:.1}%"
         );
     }
 }

--- a/tests/frem_warfarin.rs
+++ b/tests/frem_warfarin.rs
@@ -500,6 +500,55 @@ fn frem_covariate_omega_matches_sample_variance() {
     );
 }
 
+/// The same ground truth under **FOCEI** — the gradient-based twin of
+/// `frem_covariate_omega_matches_sample_variance` (#251).
+///
+/// REGRESSION TEST. The FREM-aware residual override was applied to SAEM (see the test
+/// below), to importance sampling, and to the CWRES path — but never to the analytic
+/// gradients. So `subject_sensitivities` handed the gradient the ordinary **PK** jet for
+/// covariate pseudo-observation rows and the assembly read the ordinary residual variance,
+/// while the objective scored those same rows against `theta[i] + eta[j]` with `EPSCOV`.
+/// FOCEI was therefore minimising one objective and differentiating another (and the inner
+/// loop drove the EBEs to the mode of the wrong likelihood).
+///
+/// Because the only "data" for a covariate row is the subject's own covariate value, the
+/// covariate eta variance has an exact ground truth: it must recover the covariate's
+/// **sample variance**. That makes this a real oracle rather than a smoke test — and it is
+/// what a gradient-based FREM fit could not do before the fix.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn frem_covariate_omega_matches_sample_variance_under_focei() {
+    let tmp = tempfile::tempdir().unwrap();
+    let result = setup_frem(tmp.path());
+
+    let model = parse_model_file(&result.model_path).unwrap();
+    let pop = read_nonmem_csv(&result.data_path, None, None).unwrap();
+
+    let mut opts = FitOptions::default();
+    opts.method = ferx_core::EstimationMethod::Focei;
+    opts.run_covariance_step = false;
+    opts.verbose = false;
+
+    let fit_result =
+        fit(&model, &pop, &model.default_params, &opts).expect("FREM FOCEI fit should succeed");
+    assert!(fit_result.ofv.is_finite(), "OFV should be finite");
+
+    let omega = &fit_result.omega;
+    for (idx, expected, name) in [(3usize, 111.56f64, "WT"), (4, 99.38, "AGE")] {
+        let got = omega[(idx, idx)];
+        let pct = ((got - expected) / expected * 100.0).abs();
+        assert!(
+            pct < 15.0,
+            "{name} omega diag ({got:.2}) should be within 15% of the sample variance \
+             ({expected:.2}), got {pct:.1}% — the analytic gradient is differentiating a \
+             different likelihood than the objective on covariate pseudo-obs rows"
+        );
+    }
+}
+
 /// Regression test: under SAEM, adding FREM covariates must NOT shrink the PK
 /// residual error. Before the FREM-aware residual override, SAEM scored the
 /// covariate pseudo-observations with the PK error model; their near-zero


### PR DESCRIPTION
## Why

Two things. The second was found while doing the first, and is the more serious.

### 1. AGQ/Laplace's analytic score didn't reach FOCE/FOCEI's scope (#251)

Its residual chain was hand-rolled for the Gaussian case, so `analytic_score_supported` carried **six exclusions on top of** the FOCE/FOCEI gate — M3-BLOQ, correlated residuals (`block_sigma`), FREM, `iiv_on_ruv`, custom σ magnitude, and LTBS. All six have been analytic for FOCE/FOCEI since #486; under AGQ they silently fell back to a finite-differenced score.

### 2. FREM's analytic gradients differentiate the wrong likelihood

`individual_nll` does not score a FREM covariate pseudo-observation (`FREMTYPE > 0`) against the PK model at all — its prediction is `theta[i] + eta[j]` and its variance is the dedicated `EPSCOV` error:

```rust
// stats/likelihood.rs
let frem_pred  = theta[theta_idx] + eta[eta_idx];
let frem_v     = (sigma_values[fc.covariate_sigma_index]).powi(2);
data_ll += resid * resid / frem_v + frem_v.ln();
```

But the sensitivity providers returned the ordinary **PK jet** for those rows, and the gradient assemblies read the ordinary residual variance. **Both** loops were affected — the outer gradient (FOCE/FOCEI minimising one objective while differentiating another) and the inner gradient (EBEs converging to the mode of the wrong likelihood).

This isn't a new class of bug here. The FREM-aware residual override (`build_frem_r_override`) was added **for SAEM**, and `overwrite_frem_pseudo_obs_rows` already stamps the exact `{0,1}` Jacobian into the FOCE H-matrix "so the analytic branch does not silently drop the correction the FD path performs". SAEM, importance sampling and the CWRES path all apply it. The two analytic gradients were simply never given it.

It stayed latent because FREM is conventionally fit with `method = saem`, which uses neither gradient — **and the covariate-ω ground-truth test runs SAEM too.**

## What changed

**FREM.** Both providers now rewrite the jet for pseudo-observation rows (`f = theta[i] + eta[j]`, unit first derivatives, zero second) at the two choke points: `apply_frem_pseudo_obs_jet` for the outer `SubjectSens`, and `apply_frem_pseudo_obs_grad` inside `subject_eta_grad_with_schedule` for the inner `ObsGrad` — placed there so it covers all three inner routes (closed-form, TV-cov, ODE) at once. Both gradient assemblies now take the `EPSCOV` variance via the existing `build_frem_r_override`.

**AGQ scope parity.** `score_core` is extracted from `sens_outer_gradient::prepare_stacked` — everything above the FOCEI `log|H̃|` machinery (the per-observation `ErrTerms` chain plus both Hessians), so a caller needing only the *score* doesn't pay for two Cholesky inverses per call. AGQ's θ/σ blocks are rebuilt on it, and the six-way gate collapses to `provider`. Parity now holds **by construction**: AGQ keeps no per-family list that can drift out of step with `analytic_outer_gradient_available`.

This also **corrects** AGQ's θ gradient under a custom/time-varying σ magnitude: `mult(θ)` makes the residual variance depend on θ *directly*, bypassing `f`. That channel was not approximated before — it was absent.

**Also:** `examples/warfarin_frem.ferx` declared five `omega NAME ~ v` lines *and* a `block_omega` over the same five names, so it parsed to a **10-eta model with a 10×10 omega**. Nothing parses the files in `examples/`, which is why it went unnoticed.

## Alternatives considered

Threading FREM branches through each gradient consumer separately. Rejected: the jet is wrong *at the source*, so fixing it in the provider makes every downstream consumer (outer gradient, inner gradient, `subject_eta_dx`, covariance) correct without its own branch.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change.

## Breaking changes

- [x] None

Behaviour changes for FREM fits under `focei` / `imp` / `agq` / `laplace` — they were previously wrong. SAEM is bit-identical.

## Numerical validation

NONMEM has no native FREM, so the anchor is internal — and it is a strong one, because two independent estimators must agree.

| | pre-fix | post-fix |
|---|---|---|
| FOCEI Laplace OFV (converged) | 4900.6 | **211.0** |
| IS marginal, 6000 samples (eval-only) | 19781.1 | **211.6** |
| covariate ω_WT (sample variance 111.56) | 118.71 | 118.67 |
| covariate ω_AGE (sample variance 99.38) | 104.30 | 104.27 |

**This PR changes no objective function — only gradients.** So the entire OFV gap is the fit landing somewhere else. The Laplace OFV and the importance-sampling marginal are independent approximations of the same quantity: they now agree to **0.7 units**, having differed by ~19,570. Nothing in the fix forces that agreement, which is what makes it convincing.

The importance-sampling mechanism is worth noting: `imp` *scores* FREM rows correctly, but centres its proposal on the inner-loop EBEs. With those at the mode of the wrong likelihood the proposal had almost no overlap with the true posterior, the weights collapsed, and the estimate was meaningless. The old pinned reference `19781.127590682896` was enshrining exactly that.

At unit level, the analytic θ-gradient for the covariate θ was **identically zero** where the true value is −1368 (the PK model has no dependence on `TV_WT`, so `df_dtheta[TV_WT] = 0`).

> ⚠️ **The covariate ω barely moves** (118.71 → 118.67) — it is pinned by the pseudo-observations themselves. A FREM fit could therefore look entirely plausible on the one diagnostic a user would naturally check, and still be off by four orders of magnitude in its objective.

## Performance

- [x] No significant impact expected

`score_core` is a pure extraction — FOCE/FOCEI verified bit-identical (2481 lib tests, 0 failures, before any behavioural change was layered on). AGQ gains speed on the five families that previously took the FD score.

## Tests

- [x] Unit tests added in the same module
- [x] Regression test that fails without the fix

`estimation::agq::tests` — the analytic fixed-`b` score vs a central difference of `Stack::nll_at` at a **non-mode `b`**, for M3, `iiv_on_ruv`, LTBS and FREM, plus a gate test. Differencing the conditional NLL at fixed `b` involves no inner re-solve, so the FD reference carries no inner-solver noise floor and the step can be chosen for truncation alone. The FREM test also checks the **inner** η-gradient against FD of `individual_nll`.

`frem_covariate_omega_matches_sample_variance_under_focei` (slow tier) pins the OFV.

**Note on what does *not* work as a regression test:** I initially assumed the covariate-ω oracle would catch this. It does not — it passes with the bug in place. That only became clear on reverting the fix and re-running, and the test's doc comment now says so explicitly so the next reader doesn't repeat the mistake.

Full suite: **2486 lib + all integration tests, 0 failed.** `cargo clippy` clean on every changed file.

## Docs

- [x] `docs/estimation/agq.qmd` — replaced the stale FD-fallback list with a scope-parity section
- [x] `CHANGELOG.md` `[Unreleased]`

## Reviewer hints

- `score_core` (`sens_outer_gradient.rs`) is the load-bearing refactor. Its invariant is that FOCE/FOCEI numbers do not move by one ulp; the cut is exactly at the first Cholesky inverse.
- The FREM fix is four small sites: two provider post-passes and two variance overrides. `apply_frem_pseudo_obs_grad` sits in `subject_eta_grad_with_schedule` rather than `..._impl` deliberately — that is the one choke point covering all three inner routes.
- Worth a look: is the `< 1000.0` OFV bound the right shape for the regression assertion, versus pinning 211.0 with a tolerance? I chose the loose bound to discriminate 211 from 4901 without being brittle.

## Open questions / follow-ups

Deliberately **not** in this PR:

1. **The parser silently accepts duplicate eta names.** Declaring an eta twice should be an error, not a 10-eta model. This is what let the malformed example survive.
2. **Nothing parses the shipped `examples/*.ferx`.** A smoke test round-tripping each through the parser would have caught the above immediately.
3. **AGQ's Hessian anchor is a free choice, and this is worth its own issue.** The adaptive-GH identity holds for *any* PD scaling matrix, so `AGQ(n=1, exact H)` is Laplace but `AGQ(n=1, Gauss-Newton H̃)` is **FOCEI**. The scaling matrix only sets the proposal, not the `n → ∞` limit. Anchoring the grid on `H̃` would remove the `2d²` FD Hessian from the objective entirely and make the grid-response term analytic *for free* — `∂(½log|H̃|)/∂x` is already exactly what `theta_block`/`omega_block`/`sigma_block` compute. It would also retire `AGQ_GRID_FD_STEP` and its ~1e-4 noise floor, which is what currently forces AGQ off the tight NLopt stop.
