### PR TITLE
refactor: consolidate duplicated code into shared helpers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1493,6 +1493,20 @@ pub(crate) fn assert_modeled_doses_supported(model: &CompiledModel, population: 
     }
 }
 
+/// Shared check→`panic!` wrapper for the non-`fit` entry points (`predict()`/
+/// `simulate()`): if the sibling `check_*` produced a message, fail loudly with
+/// the common template naming `what` the engine received. `fit()` surfaces the
+/// same conditions as an `Err` instead of panicking. Callers holding a
+/// `Result`-returning check pass `first_error(&check).err()`.
+fn panic_if_unsupported(result: Option<String>, what: &str) {
+    if let Some(msg) = result {
+        panic!(
+            "predict()/simulate() received {what}: {msg}\n\
+             (fit() reports this as an error rather than panicking.)"
+        );
+    }
+}
+
 /// Features the analytic closed-form absorption models — transit (`one_cpt_transit`,
 /// `two_cpt_transit`, #386) and inverse-Gaussian (`one_cpt_ig`, `two_cpt_ig`, #790) —
 /// do not support: the exponential-tilting closed form is a constant-parameter
@@ -1917,13 +1931,10 @@ pub(crate) fn check_survival_tv_covariates(
 /// loudly rather than return a subtly wrong result.
 #[cfg(feature = "survival")]
 pub(crate) fn assert_survival_tv_covariates(model: &CompiledModel, population: &Population) {
-    if let Some(msg) = check_survival_tv_covariates(model, population) {
-        panic!(
-            "predict()/simulate() received a survival model / data combination with a \
-             time-varying covariate on a hazard: {msg}\n(fit() reports this as an error rather \
-             than panicking.)"
-        );
-    }
+    panic_if_unsupported(
+        check_survival_tv_covariates(model, population),
+        "a survival model / data combination with a time-varying covariate on a hazard",
+    );
 }
 
 /// Reject an analytic Form C readout (`[scaling] y = <expr>`, #650) that reads
@@ -1966,13 +1977,10 @@ pub(crate) fn assert_absorption_closed_form_support(
     model: &CompiledModel,
     population: &Population,
 ) {
-    if let Some(msg) = check_absorption_closed_form_support(model, population) {
-        panic!(
-            "predict()/simulate() received a model/data combination the analytic absorption \
-             closed form cannot honour: {msg}\n(fit() reports this as an error rather than \
-             panicking.)"
-        );
-    }
+    panic_if_unsupported(
+        check_absorption_closed_form_support(model, population),
+        "a model/data combination the analytic absorption closed form cannot honour",
+    );
 }
 
 /// Reject a transit closed form with **no ODE twin** whose η = 0 typical parameters
@@ -2043,25 +2051,20 @@ pub(crate) fn assert_absorption_flip_flop_no_twin(
     population: &Population,
     theta: &[f64],
 ) {
-    if let Some(msg) = check_absorption_flip_flop_no_twin(model, population, theta) {
-        panic!(
-            "predict()/simulate() received a model/data combination the absorption closed form \
-             cannot honour: {msg}\n(fit() reports this as an error rather than panicking.)"
-        );
-    }
+    panic_if_unsupported(
+        check_absorption_flip_flop_no_twin(model, population, theta),
+        "a model/data combination the absorption closed form cannot honour",
+    );
 }
 
 /// Panic on a depot-referencing analytic Form C readout + reset subject, for the
 /// `Vec`-returning `predict()`/`simulate()` paths (mirrors
 /// [`assert_absorption_closed_form_support`]). `fit()` returns this as an `Err`.
 pub(crate) fn assert_analytic_readout_support(model: &CompiledModel, population: &Population) {
-    if let Some(msg) = check_analytic_readout_support(model, population) {
-        panic!(
-            "predict()/simulate() received a model/data combination the analytic Form C \
-             readout cannot honour: {msg}\n(fit() reports this as an error rather than \
-             panicking.)"
-        );
-    }
+    panic_if_unsupported(
+        check_analytic_readout_support(model, population),
+        "a model/data combination the analytic Form C readout cannot honour",
+    );
 }
 
 /// Panic on a malformed built-in **absorption input-rate** model/data combination —
@@ -2076,13 +2079,10 @@ pub(crate) fn assert_analytic_readout_support(model: &CompiledModel, population:
 /// [`check_absorption_dosing`] for the *value* / domain checks that need data. A
 /// no-op for any model with no built-in input-rate forcing (the common case).
 pub(crate) fn assert_absorption_dosing_supported(model: &CompiledModel, population: &Population) {
-    if let Err(msg) = first_error(&check_absorption_dosing(model, population)) {
-        panic!(
-            "predict()/simulate() received a model/data combination the built-in absorption \
-             input-rate machinery cannot honour: {msg}\n(fit() reports this as an error rather \
-             than panicking.)"
-        );
-    }
+    panic_if_unsupported(
+        first_error(&check_absorption_dosing(model, population)).err(),
+        "a model/data combination the built-in absorption input-rate machinery cannot honour",
+    );
 }
 
 /// Model + estimation-option *compatibility* checks that don't depend on data:
@@ -6941,42 +6941,72 @@ fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'stat
     hits
 }
 
-/// Build the human message + native structured entry (with `details`) for
-/// theta estimates pinned to an optimizer bound, or `None` when none are.
-fn boundary_estimate_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
-    let hits = boundary_estimates(params);
+/// Construct a fit-end [`WarningEntry`] with the invariant fields every native
+/// emitter shares (`severity: Warning`, `source_method: None`), varying only
+/// `category`, `message`, and `details`.
+fn warning_entry(
+    category: WarningCode,
+    message: String,
+    details: Option<serde_json::Value>,
+) -> WarningEntry {
+    WarningEntry {
+        severity: WarningSeverity::Warning,
+        category,
+        message,
+        source_method: None,
+        details,
+    }
+}
+
+/// Shared scaffold for the list-style fit-end warnings: given a set of `hits`,
+/// return `None` when empty, otherwise join a human `list` string (`line` per
+/// hit), format the message (`msg` over the joined list), build the structured
+/// `details`, and wrap it in a [`WarningEntry`] as `Some((message, entry))`.
+fn list_warning<H>(
+    hits: Vec<H>,
+    category: WarningCode,
+    line: impl Fn(&H) -> String,
+    msg: impl Fn(&str) -> String,
+    details: impl Fn(&[H]) -> serde_json::Value,
+) -> Option<(String, WarningEntry)> {
     if hits.is_empty() {
         return None;
     }
-    let list = hits
-        .iter()
-        .map(|(name, est, _bound, side)| format!("{name} ({est:.4} at {side} bound)"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let msg = format!(
-        "Parameter estimate(s) pinned to an optimizer bound: {list}. This often \
-         indicates non-identifiability or a too-tight bound; inspect the affected \
-         parameter(s) and consider relaxing the bound or simplifying the model."
-    );
-    let params_json: Vec<serde_json::Value> = hits
-        .iter()
-        .map(|(name, est, bound, side)| {
-            serde_json::json!({
-                "parameter": name,
-                "estimate": est,
-                "bound": bound,
-                "side": side,
-            })
-        })
-        .collect();
-    let entry = WarningEntry {
-        severity: WarningSeverity::Warning,
-        category: WarningCode::BoundaryEstimate,
-        message: msg.clone(),
-        source_method: None,
-        details: Some(serde_json::json!({ "parameters": params_json })),
-    };
+    let list = hits.iter().map(|h| line(h)).collect::<Vec<_>>().join(", ");
+    let msg = msg(&list);
+    let entry = warning_entry(category, msg.clone(), Some(details(&hits)));
     Some((msg, entry))
+}
+
+/// Build the human message + native structured entry (with `details`) for
+/// theta estimates pinned to an optimizer bound, or `None` when none are.
+fn boundary_estimate_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
+    list_warning(
+        boundary_estimates(params),
+        WarningCode::BoundaryEstimate,
+        |(name, est, _bound, side)| format!("{name} ({est:.4} at {side} bound)"),
+        |list| {
+            format!(
+                "Parameter estimate(s) pinned to an optimizer bound: {list}. This often \
+                 indicates non-identifiability or a too-tight bound; inspect the affected \
+                 parameter(s) and consider relaxing the bound or simplifying the model."
+            )
+        },
+        |hits| {
+            let params_json: Vec<serde_json::Value> = hits
+                .iter()
+                .map(|(name, est, bound, side)| {
+                    serde_json::json!({
+                        "parameter": name,
+                        "estimate": est,
+                        "bound": bound,
+                        "side": side,
+                    })
+                })
+                .collect();
+            serde_json::json!({ "parameters": params_json })
+        },
+    )
 }
 
 /// Relative-standard-error threshold (percent) above which a free THETA is
@@ -7022,45 +7052,38 @@ fn inflated_rse_warning(
     se_theta: &Option<Vec<f64>>,
     params: &ModelParameters,
 ) -> Option<(String, WarningEntry)> {
-    let hits = inflated_rse_thetas(se_theta, params);
-    if hits.is_empty() {
-        return None;
-    }
-    let list = hits
-        .iter()
+    list_warning(
+        inflated_rse_thetas(se_theta, params),
+        WarningCode::InflatedRse,
         // One decimal so a borderline value (e.g. 50.4%) is not displayed as
         // "50%" — which would read as below the threshold it just tripped.
-        .map(|(name, _est, _se, rse)| format!("{name} ({rse:.1}%)"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let msg = format!(
-        "High relative standard error (RSE > {:.0}%): {list}. These parameter(s) \
-         are imprecisely estimated — often a sign of over-parameterization or \
-         data that do not inform them; consider simplifying the model.",
-        RSE_WARN_THRESHOLD_PCT
-    );
-    let params_json: Vec<serde_json::Value> = hits
-        .iter()
-        .map(|(name, est, se, rse)| {
+        |(name, _est, _se, rse)| format!("{name} ({rse:.1}%)"),
+        |list| {
+            format!(
+                "High relative standard error (RSE > {:.0}%): {list}. These parameter(s) \
+                 are imprecisely estimated — often a sign of over-parameterization or \
+                 data that do not inform them; consider simplifying the model.",
+                RSE_WARN_THRESHOLD_PCT
+            )
+        },
+        |hits| {
+            let params_json: Vec<serde_json::Value> = hits
+                .iter()
+                .map(|(name, est, se, rse)| {
+                    serde_json::json!({
+                        "parameter": name,
+                        "estimate": est,
+                        "se": se,
+                        "rse_pct": rse,
+                    })
+                })
+                .collect();
             serde_json::json!({
-                "parameter": name,
-                "estimate": est,
-                "se": se,
-                "rse_pct": rse,
+                "threshold_pct": RSE_WARN_THRESHOLD_PCT,
+                "parameters": params_json,
             })
-        })
-        .collect();
-    let entry = WarningEntry {
-        severity: WarningSeverity::Warning,
-        category: WarningCode::InflatedRse,
-        message: msg.clone(),
-        source_method: None,
-        details: Some(serde_json::json!({
-            "threshold_pct": RSE_WARN_THRESHOLD_PCT,
-            "parameters": params_json,
-        })),
-    };
-    Some((msg, entry))
+        },
+    )
 }
 
 /// Absolute correlation above which a parameter pair is flagged as
@@ -7109,37 +7132,30 @@ fn high_correlation_pairs(
 /// Build the human message + native structured entry (with `details`) for
 /// highly correlated THETA pairs in the fit's covariance matrix, or `None`.
 fn high_correlation_warning(result: &FitResult) -> Option<(String, WarningEntry)> {
-    let pairs = high_correlation_pairs(result.covariance_matrix.as_ref(), &result.theta_names);
-    if pairs.is_empty() {
-        return None;
-    }
-    let list = pairs
-        .iter()
-        .map(|(a, b, r)| format!("{a} ~ {b} ({r:.2})"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let msg = format!(
-        "Highly correlated parameter pair(s) (|r| >= {CORRELATION_WARN_THRESHOLD:.2}): \
-         {list}. Highly correlated estimates indicate over-parameterization or \
-         non-identifiability; consider fixing or removing one of each pair."
-    );
-    let pairs_json: Vec<serde_json::Value> = pairs
-        .iter()
-        .map(
-            |(a, b, r)| serde_json::json!({ "parameter_a": a, "parameter_b": b, "correlation": r }),
-        )
-        .collect();
-    let entry = WarningEntry {
-        severity: WarningSeverity::Warning,
-        category: WarningCode::HighCorrelation,
-        message: msg.clone(),
-        source_method: None,
-        details: Some(serde_json::json!({
-            "threshold": CORRELATION_WARN_THRESHOLD,
-            "pairs": pairs_json,
-        })),
-    };
-    Some((msg, entry))
+    list_warning(
+        high_correlation_pairs(result.covariance_matrix.as_ref(), &result.theta_names),
+        WarningCode::HighCorrelation,
+        |(a, b, r)| format!("{a} ~ {b} ({r:.2})"),
+        |list| {
+            format!(
+                "Highly correlated parameter pair(s) (|r| >= {CORRELATION_WARN_THRESHOLD:.2}): \
+                 {list}. Highly correlated estimates indicate over-parameterization or \
+                 non-identifiability; consider fixing or removing one of each pair."
+            )
+        },
+        |pairs| {
+            let pairs_json: Vec<serde_json::Value> = pairs
+                .iter()
+                .map(|(a, b, r)| {
+                    serde_json::json!({ "parameter_a": a, "parameter_b": b, "correlation": r })
+                })
+                .collect();
+            serde_json::json!({
+                "threshold": CORRELATION_WARN_THRESHOLD,
+                "pairs": pairs_json,
+            })
+        },
+    )
 }
 
 /// Build the human message + native structured entry for a **twin-less** transit /
@@ -7217,17 +7233,15 @@ fn absorption_flip_flop_ebe_warning(
         ode_fn,
         params
     );
-    let entry = WarningEntry {
-        severity: WarningSeverity::Warning,
-        category: WarningCode::FlipFlop,
-        message: msg.clone(),
-        source_method: None,
-        details: Some(serde_json::json!({
+    let entry = warning_entry(
+        WarningCode::FlipFlop,
+        msg.clone(),
+        Some(serde_json::json!({
             "phase": "ebe",
             "model": model.pk_model.canonical_name(),
             "subjects": crossers,
         })),
-    };
+    );
     Some((msg, entry))
 }
 

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -39,6 +39,7 @@ use crate::estimation::outer_optimizer::{
     compute_covariance, pop_nll, CovarianceStepResult, OuterResult,
 };
 use crate::estimation::parameterization::{compute_mu_k, pack_params, theta_packs_log};
+use crate::estimation::saem::{floor_omega_diagonal, get_mu_ref_pairs};
 use crate::pk::EventPkParams;
 use crate::stats::likelihood::obs_nll_subject_into;
 use crate::types::*;
@@ -47,19 +48,6 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rand_distr::{Distribution, StandardNormal};
 use rayon::prelude::*;
-
-/// Floor the free Ω diagonal to keep the proposal/prior positive-definite.
-/// Mirrors SAEM's `floor_omega_diagonal`: FIX-ed diagonals are left untouched.
-fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
-    for i in 0..omega_mat.nrows() {
-        if omega_fixed.get(i).copied().unwrap_or(false) {
-            continue;
-        }
-        if omega_mat[(i, i)] < floor {
-            omega_mat[(i, i)] = floor;
-        }
-    }
-}
 
 /// Positive-definite floor for free Ω diagonals (matches the SAEM constant).
 const OMEGA_DIAG_FLOOR: f64 = 1e-6;
@@ -157,30 +145,6 @@ fn covariance_to_proposal_hessian(
         Some(ch) => ch.inverse(),
         None => DMatrix::zeros(n, n),
     }
-}
-
-/// Log-transformed mu-referencing pairs `(theta_idx, eta_idx)`. For these the
-/// typical value satisfies `log(P_i) = log(θ) + η_i`, so the EM M-step shifts
-/// `log(θ) += mean(η)` in closed form — without it θ and the η mean are
-/// confounded and the variance Ω absorbs the misfit instead. Mirrors SAEM's
-/// `get_mu_ref_pairs`.
-fn mu_ref_log_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
-    let mut pairs = Vec::new();
-    for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
-        if let Some(mu_ref) = model.mu_refs.get(eta_name) {
-            if !mu_ref.log_transformed {
-                continue;
-            }
-            if let Some(theta_idx) = model
-                .theta_names
-                .iter()
-                .position(|n| n == &mu_ref.theta_name)
-            {
-                pairs.push((theta_idx, eta_idx));
-            }
-        }
-    }
-    pairs
 }
 
 /// Names of non-fixed thetas that have **no associated ETA** (are not the target
@@ -585,7 +549,7 @@ fn run_mcem(
         ));
     }
 
-    let mu_ref_pairs = mu_ref_log_pairs(model);
+    let mu_ref_pairs = get_mu_ref_pairs(model);
     // A log-mu-referenced typical value is updated only through the closed-form
     // `log θ += mean(η)` shift. When its paired η carries negligible IIV (a tiny,
     // often `FIX`ed ω — e.g. a structural parameter given a dummy random effect

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -432,11 +432,10 @@ pub fn run_importance_sampling(
                                 defensive_alpha,
                             ) {
                                 let ess_fraction = rb.ess_fraction;
-                                let var_log_marginal = if ess_fraction > 0.0 {
-                                    (1.0 / ess_fraction - 1.0) / (k_samples as f64)
-                                } else {
-                                    1.0
-                                };
+                                let var_log_marginal = var_log_marginal_from_ess_fraction(
+                                    ess_fraction,
+                                    k_samples as f64,
+                                );
                                 return SubjectIsOutput {
                                     log_marginal: rb.log_marginal,
                                     var_log_marginal,
@@ -594,9 +593,7 @@ fn subject_is_estimate(
     let half_d = 0.5 * d as f64;
     let iscale_log_adj = -(d as f64) * iscale.ln();
     let inv_iscale_sq = 1.0 / (iscale * iscale);
-    let log_t_const = ln_gamma(0.5 * (nu + d as f64))
-        - ln_gamma(0.5 * nu)
-        - half_d * (nu * std::f64::consts::PI).ln()
+    let log_t_const = student_t_gamma_ratio(nu, d) - half_d * (nu * std::f64::consts::PI).ln()
         + 0.5 * proposal.log_det_inv_scale
         + iscale_log_adj;
     let log_p_eta_const = -half_d * TWO_PI.ln() - 0.5 * log_det_omega;
@@ -670,29 +667,13 @@ fn subject_is_estimate(
     // logsumexp + ESS.
     let (lse, weights_norm) = logsumexp_with_normalised(&log_w);
     let log_marginal = lse - (k_samples as f64).ln();
-    let ess = if weights_norm.is_empty() {
-        0.0
-    } else {
-        let sum_sq: f64 = weights_norm.iter().map(|w| w * w).sum();
-        if sum_sq > 0.0 {
-            1.0 / sum_sq
-        } else {
-            0.0
-        }
-    };
+    let ess = ess_from_weights(&weights_norm);
     let ess_fraction = ess / (k_samples as f64);
 
     // Asymptotic variance of log p̂(yᵢ) for a self-normalised IS estimator:
     //   Var(log p̂) ≈ (K · Σ wₖ² − 1) / K = (1/ESS_fraction − 1) / K
     // (Geweke 1989; equivalent to the standard "1/ESS − 1/K" relation.)
-    let var_log_marginal = if ess_fraction > 0.0 {
-        (1.0 / ess_fraction - 1.0) / (k_samples as f64)
-    } else {
-        // Degenerate — treat the per-subject estimate as having undefined SE.
-        // Inflate by a finite-but-large number so the overall MC SE flags it
-        // without producing a NaN that contaminates the sum.
-        1.0
-    };
+    let var_log_marginal = var_log_marginal_from_ess_fraction(ess_fraction, k_samples as f64);
 
     SubjectIsOutput {
         log_marginal,
@@ -965,9 +946,7 @@ pub(crate) fn subject_is_draws_frem_rb(
     let log_q_const = if mvn {
         -half_np * TWO_PI.ln() + 0.5 * proposal.log_det_inv_scale + iscale_log_adj
     } else {
-        ln_gamma(0.5 * (nu + np as f64)) - ln_gamma(0.5 * nu)
-            + 0.5 * proposal.log_det_inv_scale
-            + iscale_log_adj
+        student_t_gamma_ratio(nu, np) + 0.5 * proposal.log_det_inv_scale + iscale_log_adj
             - half_np * (nu * std::f64::consts::PI).ln()
     };
 
@@ -1064,14 +1043,7 @@ pub(crate) fn subject_is_draws_frem_rb(
 
     let (lse, weights) = logsumexp_with_normalised(&log_w);
     let log_marginal = lse - (k_samples as f64).ln() + log_p_d;
-    let ess = {
-        let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
-        if sum_sq > 0.0 {
-            1.0 / sum_sq
-        } else {
-            0.0
-        }
-    };
+    let ess = ess_from_weights(&weights);
     let ess_fraction = ess / (k_samples as f64);
 
     // Reconstruct full-η weighted moments. η_p moments from the samples; η_c = d
@@ -1208,9 +1180,7 @@ pub(crate) fn subject_is_draws(
     let log_q_const = if mvn {
         -half_d * TWO_PI.ln() + 0.5 * proposal.log_det_inv_scale + iscale_log_adj
     } else {
-        ln_gamma(0.5 * (nu + d as f64)) - ln_gamma(0.5 * nu)
-            + 0.5 * proposal.log_det_inv_scale
-            + iscale_log_adj
+        student_t_gamma_ratio(nu, d) + 0.5 * proposal.log_det_inv_scale + iscale_log_adj
             - half_d * (nu * std::f64::consts::PI).ln()
     };
 
@@ -1297,14 +1267,7 @@ pub(crate) fn subject_is_draws(
 
     let (lse, weights) = logsumexp_with_normalised(&log_w);
     let log_marginal = lse - (k_samples as f64).ln();
-    let ess = {
-        let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
-        if sum_sq > 0.0 {
-            1.0 / sum_sq
-        } else {
-            0.0
-        }
-    };
+    let ess = ess_from_weights(&weights);
     let ess_fraction = ess / (k_samples as f64);
 
     // Weighted first and second moments Σₖ w̃ₖ ηₖ and Σₖ w̃ₖ ηₖ ηₖᵀ.
@@ -1658,9 +1621,7 @@ fn subject_is_estimate_joint(
     let chi_sq = ChiSquared::new(nu).expect("ChiSquared requires nu > 0; checked by caller");
 
     let half_d = 0.5 * n_b as f64;
-    let log_t_const = ln_gamma(0.5 * (nu + n_b as f64))
-        - ln_gamma(0.5 * nu)
-        - half_d * (nu * std::f64::consts::PI).ln()
+    let log_t_const = student_t_gamma_ratio(nu, n_b) - half_d * (nu * std::f64::consts::PI).ln()
         + 0.5 * proposal.log_det_inv_scale;
     let log_p_joint_const = -half_d * TWO_PI.ln() - 0.5 * log_det_omega_joint;
 
@@ -1737,23 +1698,10 @@ fn subject_is_estimate_joint(
     // logsumexp + ESS
     let (lse, weights_norm) = logsumexp_with_normalised(&log_w);
     let log_marginal = lse - (k_samples as f64).ln();
-    let ess = if weights_norm.is_empty() {
-        0.0
-    } else {
-        let sum_sq: f64 = weights_norm.iter().map(|w| w * w).sum();
-        if sum_sq > 0.0 {
-            1.0 / sum_sq
-        } else {
-            0.0
-        }
-    };
+    let ess = ess_from_weights(&weights_norm);
     let ess_fraction = ess / (k_samples as f64);
 
-    let var_log_marginal = if ess_fraction > 0.0 {
-        (1.0 / ess_fraction - 1.0) / (k_samples as f64)
-    } else {
-        1.0
-    };
+    let var_log_marginal = var_log_marginal_from_ess_fraction(ess_fraction, k_samples as f64);
 
     SubjectIsOutput {
         log_marginal,
@@ -1971,6 +1919,45 @@ impl DefensiveMixture {
 // ---------------------------------------------------------------------------
 // Numerical helpers
 // ---------------------------------------------------------------------------
+
+/// Student-t proposal log-normaliser Γ-ratio: `ln Γ((ν+d)/2) − ln Γ(ν/2)`.
+///
+/// This is the leftmost sub-expression of every Student-t log-q constant in
+/// this module (`subject_is_estimate`, `subject_is_draws`,
+/// `subject_is_draws_frem_rb`, `subject_is_estimate_joint`). Only the Γ-ratio
+/// is shared: the surrounding `−½d·ln(νπ)`, `½·log|Σ⁻¹|` and `−d·ln(iscale)`
+/// terms are summed in site-specific orders, so folding them in here would
+/// reorder the floating-point reduction. Callers append those terms in their
+/// own order, keeping each constant bit-identical to the pre-refactor code.
+#[inline]
+fn student_t_gamma_ratio(nu: f64, d: usize) -> f64 {
+    ln_gamma(0.5 * (nu + d as f64)) - ln_gamma(0.5 * nu)
+}
+
+/// Effective sample size `1 / Σ w̃ₖ²` from normalised weights. Returns `0.0`
+/// when the weights are empty or all-zero (matches the prior inline guards).
+#[inline]
+fn ess_from_weights(weights: &[f64]) -> f64 {
+    let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
+    if sum_sq > 0.0 {
+        1.0 / sum_sq
+    } else {
+        0.0
+    }
+}
+
+/// Asymptotic variance of `log p̂(yᵢ)` for a self-normalised IS estimator:
+/// `(1/ESS_fraction − 1) / K` (Geweke 1989). For the degenerate
+/// `ess_fraction == 0` case it returns a finite-but-large `1.0` so the overall
+/// MC SE flags the subject without producing a NaN that contaminates the sum.
+#[inline]
+fn var_log_marginal_from_ess_fraction(ess_fraction: f64, k: f64) -> f64 {
+    if ess_fraction > 0.0 {
+        (1.0 / ess_fraction - 1.0) / k
+    } else {
+        1.0
+    }
+}
 
 /// Stable `log(eᵃ + eᵇ)` for the two-component defensive-mixture denominator.
 fn logsumexp2(a: f64, b: f64) -> f64 {

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2954,19 +2954,7 @@ fn compute_jacobian_fd(
     // ∂Y/∂η_j = 1 if j == m, 0 otherwise. The FD values for these rows
     // are noisy (esp. cross-terms that should be exactly 0) and corrupt
     // the posterior Hessian used by the IS proposal.
-    if let Some(ref fc) = model.frem_config {
-        if !subject.fremtype.is_empty() {
-            for (i, &ft) in subject.fremtype.iter().enumerate() {
-                if ft > 0 {
-                    if let Some(&(_theta_idx, eta_idx)) = fc.fremtype_to_indices.get(&ft) {
-                        for j in 0..n_eta {
-                            h[(i, j)] = if j == eta_idx { 1.0 } else { 0.0 };
-                        }
-                    }
-                }
-            }
-        }
-    }
+    overwrite_frem_pseudo_obs_rows(&mut h, model, subject, n_eta);
 
     h
 }

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -64,7 +64,10 @@ const OMEGA_SA_MAX_STEP: f64 = 0.1;
 /// Raise every *free* diagonal entry of the BSV Ω that has fallen below `floor`
 /// up to `floor`. FIX-ed diagonals (`omega_fixed[i] == true`) are left untouched
 /// — they carry the user's declared variance and must not be perturbed.
-fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
+///
+/// Shared source of truth for the SAEM and IMPMAP estimators (`impmap.rs` calls
+/// this instead of carrying its own byte-identical copy).
+pub(crate) fn floor_omega_diagonal(omega_mat: &mut DMatrix<f64>, omega_fixed: &[bool], floor: f64) {
     for i in 0..omega_mat.nrows() {
         let fixed = omega_fixed.get(i).copied().unwrap_or(false);
         if !fixed && omega_mat[(i, i)] < floor {
@@ -1123,7 +1126,7 @@ fn combined_additive_sigma_at_floor(model: &CompiledModel, params: &ModelParamet
 /// `log_transformed = false`) require the extra factor of `theta` from the
 /// log-space chain rule and are deliberately excluded — they fall through to
 /// the regular NLopt M-step.
-fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
+pub(crate) fn get_mu_ref_pairs(model: &CompiledModel) -> Vec<(usize, usize)> {
     let mut pairs = Vec::new();
     for (eta_idx, eta_name) in model.eta_names.iter().enumerate() {
         if let Some(mu_ref) = model.mu_refs.get(eta_name) {

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -1268,17 +1268,7 @@ fn omega_block(prep: &Prep, params: &ModelParameters, eta_hat: &[f64]) -> Vec<f6
     let u = &prep.h_inner_inv * DVector::from_column_slice(&prep.g_eta);
     let v = &prep.omega_inv * u;
 
-    let entries: Vec<(usize, usize)> = if params.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for c in 0..n_eta {
-            for r in c..n_eta {
-                e.push((r, c));
-            }
-        }
-        e
-    };
+    let entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, params.omega.diagonal);
 
     entries
         .iter()
@@ -1522,17 +1512,7 @@ fn omega_packed_block(prep: &Prep, params: &ModelParameters, eta_hat: &[f64]) ->
     let g_mat = &prep.omega_inv * &prep.htilde_inv * &prep.omega_inv;
     let s = &prep.omega_inv * (&prep.h_inner_inv * DVector::from_column_slice(&prep.g_eta));
 
-    let entries: Vec<(usize, usize)> = if params.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for c in 0..n_eta {
-            for r in c..n_eta {
-                e.push((r, c));
-            }
-        }
-        e
-    };
+    let entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, params.omega.diagonal);
 
     entries
         .iter()
@@ -1666,11 +1646,7 @@ pub fn subject_packed_gradient_iov(
     // θ (log/identity chain).
     let g_theta = theta_block(&prep, &sens, n_theta);
     for m in 0..n_theta {
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         g[m] = g_theta[m] * dtheta_dx;
     }
 
@@ -1736,11 +1712,7 @@ pub fn subject_packed_gradient(
     // θ: ∂F/∂x = ∂F/∂θ · ∂θ/∂x, ∂θ/∂x = θ (log) or 1 (identity).
     let g_theta = theta_block(&prep, &sens, n_theta);
     for m in 0..n_theta {
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         g[m] = g_theta[m] * dtheta_dx;
     }
 
@@ -1762,6 +1734,43 @@ pub fn subject_packed_gradient(
     Some(g)
 }
 
+/// Shared all-or-nothing population sum `d(OFV)/dx = 2·Σᵢ per_subject(i)` in
+/// packed space, short-circuiting to `None` if any subject is unsupported and
+/// zeroing fixed coordinates. The per-subject closure is the only difference
+/// between the FOCEI ([`population_gradient_sens`]) and FOCE
+/// ([`population_gradient_sens_foce`]) forms.
+///
+/// Subject-parallel (the FD path this replaces was already subject-parallel;
+/// PR #381 review #7). `collect::<Option<_>>` short-circuits to `None` if any
+/// subject is out of analytic scope, and preserves subject order so the
+/// accumulation below is bit-reproducible across runs.
+fn population_sum(
+    population: &Population,
+    template: &ModelParameters,
+    n: usize,
+    per_subject: impl Fn(usize, &Subject) -> Option<Vec<f64>> + Sync,
+) -> Option<Vec<f64>> {
+    let grads: Vec<Vec<f64>> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| per_subject(i, subject))
+        .collect::<Option<Vec<_>>>()?;
+    let mut grad = vec![0.0f64; n];
+    for gi in &grads {
+        for k in 0..n {
+            grad[k] += 2.0 * gi[k];
+        }
+    }
+    let fixed = packed_fixed_mask(template);
+    for k in 0..n {
+        if fixed[k] {
+            grad[k] = 0.0;
+        }
+    }
+    Some(grad)
+}
+
 /// The exact analytic population gradient `d(OFV)/dx = 2·Σᵢ dFᵢ/dx` in packed
 /// space, or **`None` if any single subject is unsupported** (all-or-nothing).
 /// Fixed coordinates are zeroed. `eta_hats[i]` must be subject `i`'s EBE at `x`.
@@ -1781,32 +1790,9 @@ pub fn population_gradient_sens(
     x: &[f64],
     eta_hats: &[DVector<f64>],
 ) -> Option<Vec<f64>> {
-    let n = x.len();
-    // Per-subject gradients in parallel (the FD path this replaces was already
-    // subject-parallel; PR #381 review #7). `collect::<Option<_>>` short-circuits
-    // to `None` if any subject is out of analytic scope, and preserves subject
-    // order so the accumulation below is bit-reproducible across runs.
-    let per_subject: Vec<Vec<f64>> = population
-        .subjects
-        .par_iter()
-        .enumerate()
-        .map(|(i, subject)| {
-            subject_packed_gradient(model, subject, template, x, eta_hats[i].as_slice())
-        })
-        .collect::<Option<Vec<_>>>()?;
-    let mut grad = vec![0.0f64; n];
-    for gi in &per_subject {
-        for k in 0..n {
-            grad[k] += 2.0 * gi[k];
-        }
-    }
-    let fixed = packed_fixed_mask(template);
-    for k in 0..n {
-        if fixed[k] {
-            grad[k] = 0.0;
-        }
-    }
-    Some(grad)
+    population_sum(population, template, x.len(), |i, subject| {
+        subject_packed_gradient(model, subject, template, x, eta_hats[i].as_slice())
+    })
 }
 
 /// Per-subject analytic packed gradients `dᵢ = d(nllᵢ)/dx` (FOCEI when
@@ -2074,11 +2060,7 @@ pub fn subject_packed_gradient_foce(
         let tr = (&rtilde_inv * &emojt).trace();
         let uemu = u.dot(&(&emojt * &u));
         let nat = u.dot(&qm) + tr - uemu + 0.5 * dvar + cg.theta[m];
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         fixed[m] = nat * dtheta_dx;
     }
 
@@ -2088,17 +2070,7 @@ pub fn subject_packed_gradient_foce(
     let l = &params.omega.chol;
     let jl = &jmat * l;
     let cjl = cg.prep_jl(l); // (Jⱼ L) per censored row, once
-    let entries: Vec<(usize, usize)> = if params.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for col in 0..n_eta {
-            for r in col..n_eta {
-                e.push((r, col));
-            }
-        }
-        e
-    };
+    let entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, params.omega.diagonal);
     let omega_start = n_theta;
     for (ko, &(row, col)) in entries.iter().enumerate() {
         let jr = jmat.column(row);
@@ -2204,29 +2176,9 @@ pub fn population_gradient_sens_foce(
     x: &[f64],
     eta_hats: &[DVector<f64>],
 ) -> Option<Vec<f64>> {
-    let n = x.len();
-    // Subject-parallel; see `population_gradient_sens` (PR #381 review #7).
-    let per_subject: Vec<Vec<f64>> = population
-        .subjects
-        .par_iter()
-        .enumerate()
-        .map(|(i, subject)| {
-            subject_packed_gradient_foce(model, subject, template, x, eta_hats[i].as_slice())
-        })
-        .collect::<Option<Vec<_>>>()?;
-    let mut grad = vec![0.0f64; n];
-    for gi in &per_subject {
-        for k in 0..n {
-            grad[k] += 2.0 * gi[k];
-        }
-    }
-    let fixed = packed_fixed_mask(template);
-    for k in 0..n {
-        if fixed[k] {
-            grad[k] = 0.0;
-        }
-    }
-    Some(grad)
+    population_sum(population, template, x.len(), |i, subject| {
+        subject_packed_gradient_foce(model, subject, template, x, eta_hats[i].as_slice())
+    })
 }
 
 /// Lower-triangle packed-entry list for an Ω of dimension `n` (diagonal: `(i,i)`;
@@ -2242,6 +2194,17 @@ fn lower_tri_entries(n: usize, diagonal: bool) -> Vec<(usize, usize)> {
             }
         }
         e
+    }
+}
+
+/// θ→packed chain rule `∂θ/∂x`: `θ` when the parameter packs in log-space,
+/// else `1.0`. Shared by every θ-loop of the packed-gradient / eta-dx functions.
+#[inline]
+fn theta_dx_chain(template: &ModelParameters, theta: &[f64], m: usize) -> f64 {
+    if theta_packs_log(template.theta_lower[m]) {
+        theta[m]
+    } else {
+        1.0
     }
 }
 
@@ -2333,11 +2296,7 @@ pub fn subject_eta_dx_iov(
 
     // θ coords.
     for m in 0..n_theta {
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         let mut mvec = mixed_eta_theta(&sens.obs, &prep.et, n_st, prep.n_obs, m, prep.ruv);
         for (j, et) in prep.et.iter().enumerate() {
             let dalpha = mag_alpha_dtheta(et, m);
@@ -2646,11 +2605,7 @@ pub fn subject_packed_gradient_foce_iov(
         let tr = (&rtilde_inv * &emojt).trace();
         let uemu = u.dot(&(&emojt * &u));
         let nat = u.dot(&qm) + tr - uemu + 0.5 * dvar + cg.theta[m];
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         fixed[m] = nat * dtheta_dx;
     }
 
@@ -2783,11 +2738,7 @@ pub fn subject_eta_dx(
 
     // θ coords: dη̂/dx = −H⁻¹ (∂²l/∂η∂θ · ∂θ/∂x).
     for m in 0..n_theta {
-        let dtheta_dx = if theta_packs_log(template.theta_lower[m]) {
-            params.theta[m]
-        } else {
-            1.0
-        };
+        let dtheta_dx = theta_dx_chain(template, &params.theta, m);
         let mut mvec = mixed_eta_theta(&sens.obs, &prep.et, n_eta, prep.n_obs, m, prep.ruv);
         // Custom / time-varying σ magnitude (#576/#486): `mult(θ)` makes the inner
         // variance depend on θ directly, adding `½ ∂α/∂θ · a` to `∂²l/∂η∂θ` — the
@@ -2816,17 +2767,7 @@ pub fn subject_eta_dx(
     // Ω coords: M_L = −Ω⁻¹(e_row·(v·z) + v·z_row), v = L[:,col]; ×L_kk for diag-log.
     let z = &prep.omega_inv * DVector::from_column_slice(eta_hat);
     let l = &params.omega.chol;
-    let entries: Vec<(usize, usize)> = if params.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for c in 0..n_eta {
-            for r in c..n_eta {
-                e.push((r, c));
-            }
-        }
-        e
-    };
+    let entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, params.omega.diagonal);
     let omega_start = n_theta;
     for (ko, &(row, col)) in entries.iter().enumerate() {
         let v = DVector::from_iterator(n_eta, (0..n_eta).map(|r| l[(r, col)]));
@@ -3096,6 +3037,59 @@ mod tests {
         p.theta = theta.to_vec();
         p.omega = OmegaMatrix::from_diagonal(vars, model.eta_names.clone());
         p
+    }
+
+    /// The byte-identical no-covariate `Population` wrapper used across the FD
+    /// comparison tests (empty covariates/inputs, `DV` column, no exclusions).
+    fn pop_of(subjects: Vec<Subject>) -> Population {
+        Population {
+            subjects,
+            covariate_names: vec![],
+            dv_column: "DV".into(),
+            input_columns: vec![],
+            exclusions: None,
+            warnings: vec![],
+        }
+    }
+
+    /// Per-coordinate Richardson-FD gradient check shared by the packed-gradient
+    /// comparison tests. For each coordinate `k`, forms the Richardson combination
+    /// of two central differences of `ofv` (steps `h` and `h/2`, with
+    /// `h = 1e-4·(1+|x[k]|)`) and asserts `analytic[k]` matches it to the caller's
+    /// `max_relative` / `epsilon`. Moves the harness arithmetic verbatim — each
+    /// test supplies only its own `ofv` closure and tolerances.
+    fn assert_grad_matches_richardson_fd(
+        x: &[f64],
+        analytic: &[f64],
+        ofv: impl Fn(&[f64]) -> f64,
+        max_relative: f64,
+        epsilon: f64,
+    ) {
+        let fd_at = |k: usize, h: f64| -> f64 {
+            let mut xp = x.to_vec();
+            xp[k] += h;
+            let mut xm = x.to_vec();
+            xm[k] -= h;
+            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
+        };
+        for k in 0..x.len() {
+            let h = 1e-4 * (1.0 + x[k].abs());
+            let f1 = fd_at(k, h);
+            let f2 = fd_at(k, h / 2.0);
+            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
+            eprintln!(
+                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
+                analytic[k],
+                fd,
+                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
+            );
+            approx::assert_relative_eq!(
+                analytic[k],
+                fd,
+                max_relative = max_relative,
+                epsilon = epsilon
+            );
+        }
     }
 
     const WARFARIN: &str = r#"
@@ -3379,18 +3373,10 @@ mod tests {
     /// packed gradient must match the reconverged-FD of ferx's FOCE OFV.
     fn run_packed_check_foce(model: &CompiledModel, theta: &[f64]) {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let s1 = subject_with_obs(model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = subject_with_obs(model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0, 72.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -3413,26 +3399,7 @@ mod tests {
                 .map(|s| marginal_nll_foce(model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
     }
 
     #[test]
@@ -3754,18 +3721,10 @@ mod tests {
     /// independently NONMEM-validated (#413).
     fn run_ruv_packed_check(model: &CompiledModel, theta: &[f64]) {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let s1 = ruv_subject(model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = ruv_subject(model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0, 72.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -3792,26 +3751,7 @@ mod tests {
                 })
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
     }
 
     #[test]
@@ -3931,7 +3871,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_block_sigma_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model = parse_model_string(BLOCK_SIGMA_1CPT).expect("parse block_sigma");
         assert!(
@@ -3945,14 +3884,7 @@ mod tests {
         let theta = &[1.1, 11.0];
         let s1 = dense_subject(&model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = dense_subject(&model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -3978,26 +3910,7 @@ mod tests {
                 })
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
     }
 
     /// FOCE (non-interaction) analog of `population_packed_gradient_block_sigma_matches_fd`.
@@ -4007,7 +3920,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_block_sigma_foce_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let src = BLOCK_SIGMA_1CPT.replace("method = focei", "method = foce");
         let model = parse_model_string(&src).expect("parse block_sigma foce");
@@ -4016,14 +3928,7 @@ mod tests {
         let theta = &[1.1, 11.0];
         let s1 = dense_subject(&model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = dense_subject(&model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -4049,20 +3954,7 @@ mod tests {
                 })
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
     }
 
     /// Covariate-selected (`if/else`) `block_sigma` fixture: each row's residual
@@ -4101,7 +3993,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_selected_block_sigma_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model =
             parse_model_string(SELECTED_BLOCK_SIGMA_1CPT).expect("parse selected block_sigma");
@@ -4159,20 +4050,7 @@ mod tests {
                 })
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
     }
 
     /// `block_sigma` + η-dependent `ExpressionScale` `obs_scale` (#627 × #486): the analytic
@@ -4182,7 +4060,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_block_sigma_expression_scale_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let src = BLOCK_SIGMA_1CPT.replace(
             "[structural_model]",
@@ -4200,14 +4077,7 @@ mod tests {
         let theta = &[1.1, 11.0];
         let s1 = dense_subject(&model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = dense_subject(&model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -4233,20 +4103,7 @@ mod tests {
                 })
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 2e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
     }
 
     /// Closed-form `iiv_on_ruv` + **M3 BLOQ** (#4c): the analytic FOCEI packed
@@ -4258,7 +4115,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_iiv_on_ruv_m3_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let mut model = parse_model_string(WARFARIN_RUV).expect("parse");
         model.bloq_method = crate::types::BloqMethod::M3;
@@ -4280,17 +4136,10 @@ mod tests {
             }
             s
         };
-        let pop = Population {
-            subjects: vec![
-                mk(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]),
-                mk(&[0.25, 1.5, 3.0, 6.0, 12.0, 36.0, 72.0]),
-            ],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![
+            mk(&[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]),
+            mk(&[0.25, 1.5, 3.0, 6.0, 12.0, 36.0, 72.0]),
+        ]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.clone();
@@ -4507,7 +4356,6 @@ mod tests {
     #[test]
     fn iiv_on_ruv_m3_2cpt_combined_packed_gradient_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
         let mut model = parse_model_string(RUV_2CPT_COMBINED).expect("parse 2cpt ruv combined");
         model.bloq_method = crate::types::BloqMethod::M3;
         assert_eq!(model.residual_error_eta, Some(2));
@@ -4524,17 +4372,10 @@ mod tests {
             }
             s
         };
-        let pop = Population {
-            subjects: vec![
-                mk(&[0.5, 2.0, 6.0, 12.0, 24.0, 48.0]),
-                mk(&[1.0, 3.0, 8.0, 16.0, 36.0, 72.0]),
-            ],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![
+            mk(&[0.5, 2.0, 6.0, 12.0, 24.0, 48.0]),
+            mk(&[1.0, 3.0, 8.0, 16.0, 36.0, 72.0]),
+        ]);
         let mut template = model.default_params.clone();
         template.theta = theta.clone();
         let x = pack_params(&template);
@@ -4701,18 +4542,10 @@ mod tests {
 
     fn run_population_packed_gradient_check(model: &CompiledModel, theta: &[f64]) {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let s1 = subject_with_obs(model, theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s2 = subject_with_obs(model, theta, &[0.25, 1.5, 3.0, 6.0, 12.0, 36.0, 72.0]);
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -4736,26 +4569,7 @@ mod tests {
                 .map(|s| marginal_nll(model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
     }
 
     #[test]
@@ -4938,7 +4752,7 @@ mod tests {
     #[test]
     fn population_packed_gradient_ode_ss_reset_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::{DoseEvent, Population};
+        use crate::types::DoseEvent;
 
         let model = parse_model_string(ONECPT_IV_ODE_SS_RESET).expect("parse ODE SS+reset");
         assert!(model.is_ode_based(), "must be on the ODE path");
@@ -4987,14 +4801,7 @@ mod tests {
         let preds = crate::pk::compute_predictions_with_tv(&model, &s, &theta, &eta_ref);
         s.observations = preds.iter().map(|p| p * 0.85).collect();
 
-        let pop = Population {
-            subjects: vec![s],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s]);
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
         let x = pack_params(&template);
@@ -5040,7 +4847,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_reset_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model = parse_model_string(ONECPT_IV_RESET).expect("parse");
         let theta = [0.22, 11.0];
@@ -5049,14 +4855,7 @@ mod tests {
         // One reset subject + one ordinary subject, so the population mixes both.
         let s_reset = reset_subject_outer(&model, &theta, &eta_ref, "reset");
         let s_plain = subject_with_obs(&model, &theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
-        let pop = Population {
-            subjects: vec![s_reset, s_plain],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s_reset, s_plain]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5091,26 +4890,7 @@ mod tests {
                     })
                     .sum::<f64>()
             };
-            let fd_at = |k: usize, h: f64| -> f64 {
-                let mut xp = x.clone();
-                xp[k] += h;
-                let mut xm = x.clone();
-                xm[k] -= h;
-                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-            };
-            for k in 0..x.len() {
-                let h = 1e-4 * (1.0 + x[k].abs());
-                let f1 = fd_at(k, h);
-                let f2 = fd_at(k, h / 2.0);
-                let fd = (4.0 * f2 - f1) / 3.0;
-                eprintln!(
-                    "interaction={interaction} x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                    analytic[k],
-                    fd,
-                    (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-                );
-                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-            }
+            assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
         }
     }
 
@@ -5126,7 +4906,6 @@ mod tests {
     #[test]
     fn ss_reset_subject_is_analytic_and_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model = parse_model_string(ONECPT_IV_RESET).expect("parse");
         let theta = [0.22, 11.0];
@@ -5143,14 +4922,7 @@ mod tests {
             "SS+reset subject must be served analytically by the event walk (#486)"
         );
 
-        let pop = Population {
-            subjects: vec![s_ss_reset, s_plain],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s_ss_reset, s_plain]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5184,20 +4956,7 @@ mod tests {
                     })
                     .sum::<f64>()
             };
-            let fd_at = |k: usize, h: f64| -> f64 {
-                let mut xp = x.clone();
-                xp[k] += h;
-                let mut xm = x.clone();
-                xm[k] -= h;
-                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-            };
-            for k in 0..x.len() {
-                let h = 1e-4 * (1.0 + x[k].abs());
-                let f1 = fd_at(k, h);
-                let f2 = fd_at(k, h / 2.0);
-                let fd = (4.0 * f2 - f1) / 3.0;
-                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-            }
+            assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
         }
     }
 
@@ -5240,7 +4999,7 @@ mod tests {
     fn mixed_gradient_with_out_of_scope_subject_matches_fd() {
         use crate::estimation::outer_optimizer::population_gradient_sens_mixed;
         use crate::estimation::parameterization::{compute_bounds, pack_params};
-        use crate::types::{FitOptions, Population};
+        use crate::types::FitOptions;
 
         // The out-of-scope subject used to be SS+reset; since #486 the event walk serves that
         // combination analytically (see `ss_reset_subject_is_analytic_and_matches_fd`), so this
@@ -5253,14 +5012,7 @@ mod tests {
         // In-scope plain (bolus) subject + an out-of-scope rate-defined-infusion subject.
         let s_plain = subject_with_obs(&model, &theta, &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]);
         let s_oos = reset_subject_outer(&model, &theta, &eta_ref, "rate_inf_f");
-        let pop = Population {
-            subjects: vec![s_plain, s_oos],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s_plain, s_oos]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5341,20 +5093,7 @@ mod tests {
                 .map(|s| subj_marginal(s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            approx::assert_relative_eq!(mixed[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &mixed, ofv, 3e-3, 1e-5);
     }
 
     // 1-cpt oral with allometric WT-on-CL — the canonical time-varying covariate.
@@ -5446,7 +5185,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_tvcov_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model = parse_model_string(ONECPT_ORAL_TVCOV_OUTER).expect("parse tvcov");
         let theta = [0.22, 11.0, 1.4, 0.7];
@@ -5533,26 +5271,7 @@ mod tests {
                     })
                     .sum::<f64>()
             };
-            let fd_at = |k: usize, h: f64| -> f64 {
-                let mut xp = x.clone();
-                xp[k] += h;
-                let mut xm = x.clone();
-                xm[k] -= h;
-                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-            };
-            for k in 0..x.len() {
-                let h = 1e-4 * (1.0 + x[k].abs());
-                let f1 = fd_at(k, h);
-                let f2 = fd_at(k, h / 2.0);
-                let fd = (4.0 * f2 - f1) / 3.0;
-                eprintln!(
-                    "interaction={interaction} x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                    analytic[k],
-                    fd,
-                    (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-                );
-                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-            }
+            assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
         }
     }
 
@@ -5586,7 +5305,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_init_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
 
         let model = parse_model_string(ONECPT_ORAL_INIT_OUTER).expect("parse init outer");
         assert_eq!(model.analytical_init.len(), 1);
@@ -5625,17 +5343,10 @@ mod tests {
             s.observations = preds.iter().map(|p| p * 0.85).collect();
             s
         };
-        let pop = Population {
-            subjects: vec![
-                make("init_a", &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]),
-                make("init_b", &[1.0, 3.0, 6.0, 12.0]),
-            ],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![
+            make("init_a", &[0.5, 1.0, 2.0, 4.0, 8.0, 24.0]),
+            make("init_b", &[1.0, 3.0, 6.0, 12.0]),
+        ]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5669,20 +5380,7 @@ mod tests {
                     })
                     .sum::<f64>()
             };
-            let fd_at = |k: usize, h: f64| -> f64 {
-                let mut xp = x.clone();
-                xp[k] += h;
-                let mut xm = x.clone();
-                xm[k] -= h;
-                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-            };
-            for k in 0..x.len() {
-                let h = 1e-4 * (1.0 + x[k].abs());
-                let f1 = fd_at(k, h);
-                let f2 = fd_at(k, h / 2.0);
-                let fd = (4.0 * f2 - f1) / 3.0;
-                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-            }
+            assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
         }
     }
 
@@ -5717,7 +5415,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_lagtime_matches_fd() {
         use crate::estimation::parameterization::{pack_params, unpack_params};
-        use crate::types::Population;
         use std::collections::HashMap;
 
         let model = parse_model_string(WARFARIN_LAG).expect("parse lag");
@@ -5752,17 +5449,10 @@ mod tests {
             s.observations = preds.iter().map(|p| p * 0.85).collect();
             s
         };
-        let pop = Population {
-            subjects: vec![
-                build(&[1.0, 2.0, 4.0, 8.0, 24.0]),
-                build(&[1.5, 3.0, 6.0, 12.0, 36.0]),
-            ],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![
+            build(&[1.0, 2.0, 4.0, 8.0, 24.0]),
+            build(&[1.5, 3.0, 6.0, 12.0, 36.0]),
+        ]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5784,20 +5474,7 @@ mod tests {
                 .map(|s| marginal_nll(&model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
     }
 
     /// The analytic FOCEI **M3** packed gradient (censored rows enter `prepare`'s
@@ -5808,7 +5485,7 @@ mod tests {
     #[test]
     fn population_packed_gradient_m3_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::{BloqMethod, Population};
+        use crate::types::BloqMethod;
 
         let mut model = parse_model_string(WARFARIN).expect("parse");
         model.bloq_method = BloqMethod::M3;
@@ -5826,14 +5503,7 @@ mod tests {
         }
         assert!(s1.cens.iter().any(|&c| c != 0) && s2.cens.iter().any(|&c| c != 0));
 
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5858,26 +5528,7 @@ mod tests {
                 .map(|s| marginal_nll(&model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 5e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 5e-3, 1e-5);
     }
 
     // 1-cpt oral **user-ODE** model with M3 BLOQ, tight tolerances. ODE counterpart
@@ -5920,7 +5571,7 @@ mod tests {
     #[test]
     fn population_packed_gradient_ode_m3_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::{BloqMethod, Population};
+        use crate::types::BloqMethod;
 
         let model = parse_model_string(ONECPT_ODE_M3_OUTER).expect("parse ODE M3");
         assert!(matches!(model.bloq_method, BloqMethod::M3), "must be M3");
@@ -5936,14 +5587,7 @@ mod tests {
         }
         assert!(s1.cens.iter().any(|&c| c != 0) && s2.cens.iter().any(|&c| c != 0));
 
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -5966,26 +5610,7 @@ mod tests {
                 .map(|s| marginal_nll(&model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 5e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 5e-3, 1e-5);
     }
 
     /// Non-IOV 1-cpt oral **user-ODE** model with M3 BLOQ **and** `iiv_on_ruv`
@@ -6033,7 +5658,7 @@ mod tests {
     #[test]
     fn population_packed_gradient_ode_m3_iiv_on_ruv_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::{BloqMethod, Population};
+        use crate::types::BloqMethod;
 
         let model = parse_model_string(ONECPT_ODE_M3_RUV_OUTER).expect("parse ODE M3 + iiv_on_ruv");
         assert!(matches!(model.bloq_method, BloqMethod::M3), "must be M3");
@@ -6056,14 +5681,7 @@ mod tests {
             }
             assert!(s1.cens.iter().any(|&c| c != 0) && s2.cens.iter().any(|&c| c != 0));
 
-            let pop = Population {
-                subjects: vec![s1, s2],
-                covariate_names: vec![],
-                dv_column: "DV".into(),
-                input_columns: vec![],
-                exclusions: None,
-                warnings: vec![],
-            };
+            let pop = pop_of(vec![s1, s2]);
 
             let mut template = model.default_params.clone();
             template.theta = theta.to_vec();
@@ -6091,26 +5709,7 @@ mod tests {
                     })
                     .sum::<f64>()
             };
-            let fd_at = |k: usize, h: f64| -> f64 {
-                let mut xp = x.clone();
-                xp[k] += h;
-                let mut xm = x.clone();
-                xm[k] -= h;
-                (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-            };
-            for k in 0..x.len() {
-                let h = 1e-4 * (1.0 + x[k].abs());
-                let f1 = fd_at(k, h);
-                let f2 = fd_at(k, h / 2.0);
-                let fd = (4.0 * f2 - f1) / 3.0; // Richardson
-                eprintln!(
-                    "ode m3+ruv (right={right}) x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                    analytic[k],
-                    fd,
-                    (analytic[k] - fd).abs() / fd.abs().max(1e-9)
-                );
-                approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 2e-5);
-            }
+            assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 2e-5);
         }
     }
 
@@ -6121,7 +5720,7 @@ mod tests {
     #[test]
     fn population_packed_gradient_m3_foce_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::{BloqMethod, Population};
+        use crate::types::BloqMethod;
 
         let mut model = parse_model_string(WARFARIN).expect("parse");
         model.bloq_method = BloqMethod::M3;
@@ -6135,14 +5734,7 @@ mod tests {
             s.cens[n - 2] = 1;
         }
 
-        let pop = Population {
-            subjects: vec![s1, s2],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![s1, s2]);
 
         let mut template = model.default_params.clone();
         template.theta = theta.to_vec();
@@ -6165,26 +5757,7 @@ mod tests {
                 .map(|s| marginal_nll_foce(&model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            eprintln!(
-                "x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 5e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 5e-3, 1e-5);
     }
 
     #[test]
@@ -6247,7 +5820,6 @@ mod tests {
     #[test]
     fn population_packed_gradient_foce_init_infusion_matches_fd() {
         use crate::estimation::parameterization::pack_params;
-        use crate::types::Population;
         let model = parse_model_string(IV_INIT_INFUSION).expect("parse init+infusion");
         let theta = vec![1.0, 20.0, 300.0];
         // Two subjects, each dosed by a finite IV infusion (rate 25 → 4 h window) on top of the
@@ -6261,17 +5833,10 @@ mod tests {
             s.observations = preds.iter().map(|p| p * 0.85).collect();
             s
         };
-        let pop = Population {
-            subjects: vec![
-                mk(&[1.0, 2.0, 4.0, 6.0, 10.0]),
-                mk(&[0.5, 3.0, 5.0, 8.0, 24.0]),
-            ],
-            covariate_names: vec![],
-            dv_column: "DV".into(),
-            input_columns: vec![],
-            exclusions: None,
-            warnings: vec![],
-        };
+        let pop = pop_of(vec![
+            mk(&[1.0, 2.0, 4.0, 6.0, 10.0]),
+            mk(&[0.5, 3.0, 5.0, 8.0, 24.0]),
+        ]);
         let mut template = model.default_params.clone();
         template.theta = theta.clone();
         let x = pack_params(&template);
@@ -6291,20 +5856,7 @@ mod tests {
                 .map(|s| marginal_nll_foce(&model, s, &p))
                 .sum::<f64>()
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0;
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
     }
 
     // --- Eq. 48 EBE warm-start predictor: is it correct & better than plain warm? ---
@@ -8617,26 +8169,7 @@ mod tests {
             let p = unpack_params(xv, &template);
             marginal_nll_foce(model, subject, &p)
         };
-        let fd_at = |k: usize, h: f64| -> f64 {
-            let mut xp = x.clone();
-            xp[k] += h;
-            let mut xm = x.clone();
-            xm[k] -= h;
-            (ofv(&xp) - ofv(&xm)) / (2.0 * h)
-        };
-        for k in 0..x.len() {
-            let h = 1e-4 * (1.0 + x[k].abs());
-            let f1 = fd_at(k, h);
-            let f2 = fd_at(k, h / 2.0);
-            let fd = (4.0 * f2 - f1) / 3.0; // Richardson
-            eprintln!(
-                "foce magnitude x[{k}]: analytic={:.8}  fd={:.8}  rel={:.2e}",
-                analytic[k],
-                fd,
-                (analytic[k] - fd).abs() / fd.abs().max(1e-12)
-            );
-            approx::assert_relative_eq!(analytic[k], fd, max_relative = 3e-3, epsilon = 1e-5);
-        }
+        assert_grad_matches_richardson_fd(&x, &analytic, ofv, 3e-3, 1e-5);
     }
 
     #[test]

--- a/src/io/checkpoint.rs
+++ b/src/io/checkpoint.rs
@@ -32,49 +32,10 @@ use std::time::Instant;
 /// [`load`] rejects a checkpoint whose version this build doesn't understand.
 pub const SCHEMA_VERSION: u32 = 1;
 
-// ─── NaN-safe f64 serde (JSON has no NaN/±Inf) ───────────────────────────────
-// Mirrors the approach in `io/fitrx.rs`: non-finite serialises to `null` and
-// `null` deserialises back to NaN, so the round-trip never fails on a value
-// that is legitimately NaN early in a fit (e.g. the OFV before the first eval).
-
-mod nan_safe_f64 {
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
-        if v.is_finite() {
-            s.serialize_f64(*v)
-        } else {
-            s.serialize_none()
-        }
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
-        Ok(Option::<f64>::deserialize(d)?.unwrap_or(f64::NAN))
-    }
-}
-
-mod nan_safe_vec {
-    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(v: &Vec<f64>, s: S) -> Result<S::Ok, S::Error> {
-        let mut seq = s.serialize_seq(Some(v.len()))?;
-        for x in v {
-            if x.is_finite() {
-                seq.serialize_element(x)?;
-            } else {
-                seq.serialize_element(&Option::<f64>::None)?;
-            }
-        }
-        seq.end()
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<f64>, D::Error> {
-        Ok(Vec::<Option<f64>>::deserialize(d)?
-            .into_iter()
-            .map(|o| o.unwrap_or(f64::NAN))
-            .collect())
-    }
-}
+// NaN-safe f64 serde (JSON has no NaN/±Inf) lives in the shared
+// `crate::io::serde_nan` module: non-finite serialises to `null` and `null`
+// deserialises back to NaN, so the round-trip never fails on a value that is
+// legitimately NaN early in a fit (e.g. the OFV before the first eval).
 
 /// The on-disk checkpoint payload (serialised as pretty JSON).
 ///
@@ -95,7 +56,7 @@ pub struct Checkpoint {
     /// Index into `method_chain` of the stage that was running when saved.
     pub stage_idx: usize,
     /// Packed unconstrained parameter vector (see struct docs).
-    #[serde(with = "nan_safe_vec")]
+    #[serde(with = "crate::io::serde_nan::vec")]
     pub packed: Vec<f64>,
     /// Optimizer coordinate names in packed order; length- and name-checked on
     /// resume so a structurally different model can never be resumed by mistake.
@@ -103,7 +64,7 @@ pub struct Checkpoint {
     /// Iteration / eval counter within the running stage at save time.
     pub iter: usize,
     /// Best OFV seen so far (informational; shown in the resume banner).
-    #[serde(with = "nan_safe_f64")]
+    #[serde(with = "crate::io::serde_nan::scalar")]
     pub ofv: f64,
     /// Unix seconds at save (informational).
     pub unix_time: u64,

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -198,6 +198,33 @@ pub fn read_nonmem_csv_with_covariates(
     read_nonmem_csv_with_covariates_mapped(path, decls, extra_columns, iov_column, &[])
 }
 
+/// Build the covariate-column read set: declared names first (so the covariate
+/// table's column order matches the declaration), then each `extra` column not
+/// already present. Dedup is case-sensitive, matching the declared spelling.
+fn declared_union(decls: &[CovariateDecl], extra: &[String]) -> Vec<String> {
+    let mut union: Vec<String> = decls.iter().map(|d| d.name.clone()).collect();
+    for c in extra {
+        if !union.iter().any(|n| n == c) {
+            union.push(c.clone());
+        }
+    }
+    union
+}
+
+/// Ensure every covariate column referenced by a `[data_selection]` filter is
+/// present in `cols`, so a filter on an otherwise-unread column still fires.
+/// Case-insensitive dedup: referenced names are lowercased, declared names may
+/// not be. No-op when `filter` is `None`.
+fn augment_with_filter(cols: &mut Vec<String>, filter: Option<&SelectionFilter>) {
+    if let Some(f) = filter {
+        for c in f.referenced_covariate_columns() {
+            if !cols.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
+                cols.push(c);
+            }
+        }
+    }
+}
+
 /// Like [`read_nonmem_csv_with_covariates`] but with a `[data]` column
 /// remapping (#730). See [`read_nonmem_csv_mapped`].
 pub(crate) fn read_nonmem_csv_with_covariates_mapped(
@@ -209,12 +236,7 @@ pub(crate) fn read_nonmem_csv_with_covariates_mapped(
 ) -> Result<(Population, CovariateTable), String> {
     // Population reads the union of declared + referenced-but-undeclared columns,
     // declared first so the table's column order matches the declaration.
-    let mut union: Vec<String> = decls.iter().map(|d| d.name.clone()).collect();
-    for c in extra_columns {
-        if !union.iter().any(|n| n == c) {
-            union.push(c.clone());
-        }
-    }
+    let union = declared_union(decls, extra_columns);
     let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
     let (pop, table) = read_nonmem_csv_impl(
         path,
@@ -258,11 +280,7 @@ pub(crate) fn read_nonmem_csv_filtered_mapped(
     // augmentation is needed.) Symmetric with the `[covariates]` reader.
     let augmented: Option<Vec<String>> = covariate_columns.map(|cols| {
         let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
-        for c in filter.referenced_covariate_columns() {
-            if !v.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
-                v.push(c);
-            }
-        }
+        augment_with_filter(&mut v, Some(filter));
         v
     });
     let cols_ref: Option<Vec<&str>> = augmented
@@ -308,23 +326,14 @@ pub(crate) fn read_nonmem_csv_with_covariates_filtered_mapped(
     filter: &SelectionFilter,
     column_map: &[(String, String)],
 ) -> Result<(Population, CovariateTable), String> {
-    let mut union: Vec<String> = decls.iter().map(|d| d.name.clone()).collect();
-    for c in extra_columns {
-        if !union.iter().any(|n| n == c) {
-            union.push(c.clone());
-        }
-    }
+    let mut union = declared_union(decls, extra_columns);
     // Ensure any covariate column referenced by an ignore/accept clause is read
     // into each subject's covariate map, even if the model never declared it.
     // Without this, a filter on an undeclared column would silently never fire
     // on the declared-`[covariates]` read path (`union` would lack the column,
     // so it would be absent from `locf_state`). Case-insensitive dedup: the
     // referenced names are lowercased, declared names may not be.
-    for c in filter.referenced_covariate_columns() {
-        if !union.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
-            union.push(c);
-        }
-    }
+    augment_with_filter(&mut union, Some(filter));
     let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
     let (pop, table) = read_nonmem_csv_impl(
         path,
@@ -527,13 +536,7 @@ pub(crate) fn read_nonmem_csv_filtered_tte(
 ) -> Result<Population, String> {
     let augmented: Option<Vec<String>> = covariate_columns.map(|cols| {
         let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
-        if let Some(f) = filter {
-            for c in f.referenced_covariate_columns() {
-                if !v.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
-                    v.push(c);
-                }
-            }
-        }
+        augment_with_filter(&mut v, filter);
         v
     });
     let cols_ref: Option<Vec<&str>> = augmented
@@ -563,19 +566,8 @@ pub(crate) fn read_nonmem_csv_with_covariates_tte(
     discrete_cmts: &HashSet<usize>,
     column_map: &[(String, String)],
 ) -> Result<(Population, CovariateTable), String> {
-    let mut union: Vec<String> = decls.iter().map(|d| d.name.clone()).collect();
-    for c in extra_columns {
-        if !union.iter().any(|n| n == c) {
-            union.push(c.clone());
-        }
-    }
-    if let Some(f) = filter {
-        for c in f.referenced_covariate_columns() {
-            if !union.iter().any(|n| n.eq_ignore_ascii_case(&c)) {
-                union.push(c);
-            }
-        }
-    }
+    let mut union = declared_union(decls, extra_columns);
+    augment_with_filter(&mut union, filter);
     let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
     let (pop, table) = read_nonmem_csv_impl(
         path,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -27,106 +27,9 @@ use zip::{ZipArchive, ZipWriter};
 
 pub const FORMAT_VERSION: &str = "1";
 
-// ---------------------------------------------------------------------------
-// Serde helpers for non-finite floats
-// ---------------------------------------------------------------------------
-//
-// JSON has no representation for NaN/±Inf. `serde_json` writes them as
-// `null` on serialize, which is correct per the spec but means the default
-// `Deserialize` for `f64` then fails when reading the value back. These
-// helpers make the round-trip lossless: non-finite serializes to `null`,
-// and `null` deserializes back to `NaN`. Use via `#[serde(with = "...")]`
-// on fields that may legitimately carry NaN (shrinkage, cov_condition_number
-// when the Hessian is singular, etc.).
-
-mod f64_nan_as_null {
-    use serde::{de::Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(value: &f64, ser: S) -> Result<S::Ok, S::Error> {
-        if value.is_finite() {
-            ser.serialize_f64(*value)
-        } else {
-            ser.serialize_none()
-        }
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<f64, D::Error> {
-        let opt: Option<f64> = Option::deserialize(de)?;
-        Ok(opt.unwrap_or(f64::NAN))
-    }
-}
-
-mod vec_f64_nan_as_null {
-    use serde::{de::Deserialize, ser::SerializeSeq, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(value: &Vec<f64>, ser: S) -> Result<S::Ok, S::Error> {
-        let mut seq = ser.serialize_seq(Some(value.len()))?;
-        for v in value {
-            if v.is_finite() {
-                seq.serialize_element(v)?;
-            } else {
-                seq.serialize_element(&Option::<f64>::None)?;
-            }
-        }
-        seq.end()
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<f64>, D::Error> {
-        let opts: Vec<Option<f64>> = Vec::deserialize(de)?;
-        Ok(opts.into_iter().map(|o| o.unwrap_or(f64::NAN)).collect())
-    }
-}
-
-mod vec_vec_f64_nan_as_null {
-    use serde::{de::Deserialize, ser::SerializeSeq, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(value: &Vec<Vec<f64>>, ser: S) -> Result<S::Ok, S::Error> {
-        let mut outer = ser.serialize_seq(Some(value.len()))?;
-        for inner in value {
-            // Delegate each inner Vec<f64> to the same NaN-as-null logic.
-            struct NanSafeSlice<'a>(&'a [f64]);
-            impl serde::Serialize for NanSafeSlice<'_> {
-                fn serialize<S2: Serializer>(&self, s: S2) -> Result<S2::Ok, S2::Error> {
-                    use serde::ser::SerializeSeq as _;
-                    let mut seq = s.serialize_seq(Some(self.0.len()))?;
-                    for v in self.0 {
-                        if v.is_finite() {
-                            seq.serialize_element(v)?;
-                        } else {
-                            seq.serialize_element(&Option::<f64>::None)?;
-                        }
-                    }
-                    seq.end()
-                }
-            }
-            outer.serialize_element(&NanSafeSlice(inner))?;
-        }
-        outer.end()
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<Vec<f64>>, D::Error> {
-        let outer: Vec<Vec<Option<f64>>> = Vec::deserialize(de)?;
-        Ok(outer
-            .into_iter()
-            .map(|inner| inner.into_iter().map(|o| o.unwrap_or(f64::NAN)).collect())
-            .collect())
-    }
-}
-
-mod opt_f64_nan_as_null {
-    use serde::{de::Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(value: &Option<f64>, ser: S) -> Result<S::Ok, S::Error> {
-        match value {
-            Some(v) if v.is_finite() => ser.serialize_some(v),
-            _ => ser.serialize_none(),
-        }
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Option<f64>, D::Error> {
-        Option::<f64>::deserialize(de)
-    }
-}
+// Serde helpers for non-finite floats (non-finite -> JSON `null`, `null` ->
+// `NaN`) live in the shared `crate::io::serde_nan` module; fields reference them
+// via `#[serde(with = "crate::io::serde_nan::{scalar,vec,vec_vec,opt}")]`.
 
 /// Errors from `.fitrx` save/load.
 #[derive(Debug, thiserror::Error)]
@@ -216,15 +119,15 @@ struct FitWire {
     omega: OmegaWire,
     sigma: SigmaWire,
     error_model: String,
-    #[serde(with = "f64_nan_as_null")]
+    #[serde(with = "crate::io::serde_nan::scalar")]
     shrinkage_eps: f64,
-    #[serde(default = "default_nan", with = "f64_nan_as_null")]
+    #[serde(default = "default_nan", with = "crate::io::serde_nan::scalar")]
     iwres_lag1_r: f64,
-    #[serde(default = "default_nan", with = "f64_nan_as_null")]
+    #[serde(default = "default_nan", with = "crate::io::serde_nan::scalar")]
     dw_statistic: f64,
     covariance_matrix: Option<MatrixWire>,
     cov_eigenvalues: Option<Vec<f64>>,
-    #[serde(with = "opt_f64_nan_as_null")]
+    #[serde(with = "crate::io::serde_nan::opt")]
     cov_condition_number: Option<f64>,
 
     sir: Option<SirWire>,
@@ -311,7 +214,7 @@ struct OmegaWire {
     fixed: Vec<bool>,
     log_transformed: Vec<bool>,
     param_corr: Option<MatrixWire>,
-    #[serde(with = "vec_f64_nan_as_null")]
+    #[serde(with = "crate::io::serde_nan::vec")]
     shrinkage: Vec<f64>,
     /// Per-eta SD-init flag (see `FitResult.omega_init_as_sd`). Optional /
     /// defaulted so .fitrx files written before issue #5 still load — older
@@ -349,11 +252,11 @@ struct IovWire {
     kappa_names: Vec<String>,
     kappa_fixed: Vec<bool>,
     se_kappa: Option<Vec<f64>>,
-    #[serde(with = "vec_f64_nan_as_null")]
+    #[serde(with = "crate::io::serde_nan::vec")]
     shrinkage_kappa: Vec<f64>,
     /// Per-occasion kappa shrinkage: `[occ_idx][kappa_idx]`.
     /// Defaulted for backward compatibility with older .fitrx files.
-    #[serde(default, with = "vec_vec_f64_nan_as_null")]
+    #[serde(default, with = "crate::io::serde_nan::vec_vec")]
     shrinkage_kappa_by_occ: Vec<Vec<f64>>,
     omega_iov: MatrixWire,
     omega_iov_param_corr: Option<MatrixWire>,
@@ -379,7 +282,7 @@ struct EtaParamInfoWire {
 struct MatrixWire {
     rows: usize,
     cols: usize,
-    #[serde(with = "vec_f64_nan_as_null")]
+    #[serde(with = "crate::io::serde_nan::vec")]
     data: Vec<f64>,
 }
 
@@ -428,142 +331,102 @@ fn default_one() -> usize {
     1
 }
 
-fn method_to_str(m: EstimationMethod) -> &'static str {
-    match m {
-        EstimationMethod::Foce => "foce",
-        EstimationMethod::FoceI => "focei",
-        EstimationMethod::FoceGn => "foce_gn",
-        EstimationMethod::FoceGnHybrid => "foce_gn_hybrid",
-        EstimationMethod::Saem => "saem",
-        EstimationMethod::Imp => "imp",
-        EstimationMethod::Impmap => "impmap",
-        EstimationMethod::Bayes => "bayes",
-        EstimationMethod::Agq => "agq",
-        EstimationMethod::Laplace => "laplace",
-    }
-}
-
-fn method_from_str(s: &str) -> Result<EstimationMethod, FitrxError> {
-    Ok(match s {
-        "foce" => EstimationMethod::Foce,
-        "focei" => EstimationMethod::FoceI,
-        "impmap" => EstimationMethod::Impmap,
-        "foce_gn" => EstimationMethod::FoceGn,
-        "foce_gn_hybrid" => EstimationMethod::FoceGnHybrid,
-        "saem" => EstimationMethod::Saem,
-        "imp" => EstimationMethod::Imp,
-        "bayes" => EstimationMethod::Bayes,
-        "agq" => EstimationMethod::Agq,
-        "laplace" => EstimationMethod::Laplace,
-        _ => return Err(FitrxError::Corrupt(format!("unknown method {:?}", s))),
-    })
-}
-
-fn error_model_to_str(m: ErrorModel) -> &'static str {
-    match m {
-        ErrorModel::Additive => "additive",
-        ErrorModel::Proportional => "proportional",
-        ErrorModel::Combined => "combined",
-    }
-}
-
-fn error_model_from_str(s: &str) -> Result<ErrorModel, FitrxError> {
-    Ok(match s {
-        "additive" => ErrorModel::Additive,
-        "proportional" => ErrorModel::Proportional,
-        "combined" => ErrorModel::Combined,
-        _ => return Err(FitrxError::Corrupt(format!("unknown error_model {:?}", s))),
-    })
-}
-
-fn covariance_status_to_str(s: &CovarianceStatus) -> &'static str {
-    match s {
-        CovarianceStatus::NotRequested => "not_requested",
-        CovarianceStatus::Computed => "computed",
-        CovarianceStatus::Failed => "failed",
-        CovarianceStatus::SirFallback => "sir_fallback",
-    }
-}
-
-fn covariance_status_from_str(s: &str) -> Result<CovarianceStatus, FitrxError> {
-    Ok(match s {
-        "not_requested" => CovarianceStatus::NotRequested,
-        "computed" => CovarianceStatus::Computed,
-        "failed" => CovarianceStatus::Failed,
-        "sir_fallback" => CovarianceStatus::SirFallback,
-        _ => {
-            return Err(FitrxError::Corrupt(format!(
-                "unknown covariance_status {:?}",
-                s
-            )))
+/// Generate the `<enum> <-> &str` wire-format mapping pair for one enum.
+///
+/// Emits `$to_fn(v) -> &'static str` and `$from_fn(&str) -> Result<$enum, _>`
+/// from a single variant/literal table, so the two can never drift apart. The
+/// string literals are the on-disk `.fitrx` wire format, so they must stay
+/// byte-identical; the `$to_arg` type lets a mapping take its enum by reference
+/// (e.g. `&CovarianceStatus`) while `$from_fn` always returns it by value.
+macro_rules! str_enum_map {
+    (
+        $enum:ident, $label:literal,
+        $to_fn:ident($to_arg:ty), $from_fn:ident,
+        { $($variant:ident => $lit:literal),+ $(,)? }
+    ) => {
+        fn $to_fn(v: $to_arg) -> &'static str {
+            match v {
+                $($enum::$variant => $lit,)+
+            }
         }
-    })
-}
 
-fn theta_transform_to_str(t: ThetaTransform) -> &'static str {
-    match t {
-        ThetaTransform::Identity => "identity",
-        ThetaTransform::Log => "log",
-        ThetaTransform::Logit => "logit",
-        ThetaTransform::LogitProbability => "logit_probability",
-    }
-}
-
-fn theta_transform_from_str(s: &str) -> Result<ThetaTransform, FitrxError> {
-    Ok(match s {
-        "identity" => ThetaTransform::Identity,
-        "log" => ThetaTransform::Log,
-        "logit" => ThetaTransform::Logit,
-        "logit_probability" => ThetaTransform::LogitProbability,
-        _ => {
-            return Err(FitrxError::Corrupt(format!(
-                "unknown theta_transform {:?}",
-                s
-            )))
+        fn $from_fn(s: &str) -> Result<$enum, FitrxError> {
+            Ok(match s {
+                $($lit => $enum::$variant,)+
+                _ => {
+                    return Err(FitrxError::Corrupt(format!(
+                        concat!("unknown ", $label, " {:?}"),
+                        s
+                    )))
+                }
+            })
         }
-    })
+    };
 }
 
-fn sigma_type_to_str(t: SigmaType) -> &'static str {
-    match t {
-        SigmaType::Proportional => "proportional",
-        SigmaType::Additive => "additive",
+str_enum_map!(EstimationMethod, "method", method_to_str(EstimationMethod), method_from_str, {
+    Foce => "foce",
+    FoceI => "focei",
+    FoceGn => "foce_gn",
+    FoceGnHybrid => "foce_gn_hybrid",
+    Saem => "saem",
+    Imp => "imp",
+    Impmap => "impmap",
+    Bayes => "bayes",
+    Agq => "agq",
+    Laplace => "laplace",
+});
+
+str_enum_map!(ErrorModel, "error_model", error_model_to_str(ErrorModel), error_model_from_str, {
+    Additive => "additive",
+    Proportional => "proportional",
+    Combined => "combined",
+});
+
+str_enum_map!(
+    CovarianceStatus,
+    "covariance_status",
+    covariance_status_to_str(&CovarianceStatus),
+    covariance_status_from_str,
+    {
+        NotRequested => "not_requested",
+        Computed => "computed",
+        Failed => "failed",
+        SirFallback => "sir_fallback",
     }
-}
+);
 
-fn sigma_type_from_str(s: &str) -> Result<SigmaType, FitrxError> {
-    Ok(match s {
-        "proportional" => SigmaType::Proportional,
-        "additive" => SigmaType::Additive,
-        _ => return Err(FitrxError::Corrupt(format!("unknown sigma_type {:?}", s))),
-    })
-}
-
-fn eta_param_type_to_str(t: EtaParamType) -> &'static str {
-    match t {
-        EtaParamType::LogNormal => "log_normal",
-        EtaParamType::Additive => "additive",
-        EtaParamType::Logit => "logit",
-        EtaParamType::LogitProbability => "logit_probability",
-        EtaParamType::Custom => "custom",
+str_enum_map!(
+    ThetaTransform,
+    "theta_transform",
+    theta_transform_to_str(ThetaTransform),
+    theta_transform_from_str,
+    {
+        Identity => "identity",
+        Log => "log",
+        Logit => "logit",
+        LogitProbability => "logit_probability",
     }
-}
+);
 
-fn eta_param_type_from_str(s: &str) -> Result<EtaParamType, FitrxError> {
-    Ok(match s {
-        "log_normal" => EtaParamType::LogNormal,
-        "additive" => EtaParamType::Additive,
-        "logit" => EtaParamType::Logit,
-        "logit_probability" => EtaParamType::LogitProbability,
-        "custom" => EtaParamType::Custom,
-        _ => {
-            return Err(FitrxError::Corrupt(format!(
-                "unknown eta_param_type {:?}",
-                s
-            )))
-        }
-    })
-}
+str_enum_map!(SigmaType, "sigma_type", sigma_type_to_str(SigmaType), sigma_type_from_str, {
+    Proportional => "proportional",
+    Additive => "additive",
+});
+
+str_enum_map!(
+    EtaParamType,
+    "eta_param_type",
+    eta_param_type_to_str(EtaParamType),
+    eta_param_type_from_str,
+    {
+        LogNormal => "log_normal",
+        Additive => "additive",
+        Logit => "logit",
+        LogitProbability => "logit_probability",
+        Custom => "custom",
+    }
+);
 
 // ---------------------------------------------------------------------------
 // Save
@@ -957,11 +820,9 @@ fn write_predictions_csv<W: Write>(
 }
 
 fn fmt_f64(v: f64) -> String {
-    if v.is_nan() {
-        String::new()
-    } else {
-        format!("{:.6}", v)
-    }
+    // Shared CSV float formatter (NaN → empty, else 6 dp). See
+    // `io::output::fmt_num` for the single source of truth.
+    crate::io::output::fmt_num(v)
 }
 
 fn csv_escape(s: &str) -> String {
@@ -1082,30 +943,6 @@ pub fn load_fit(path: &Path) -> Result<LoadedFit, FitrxError> {
     })
 }
 
-fn read_json<T: serde::de::DeserializeOwned, R: Read + std::io::Seek>(
-    archive: &mut ZipArchive<R>,
-    name: &str,
-) -> Result<T, FitrxError> {
-    let mut file = archive
-        .by_name(name)
-        .map_err(|_| FitrxError::Corrupt(format!("missing entry {}", name)))?;
-    let mut buf = String::new();
-    file.read_to_string(&mut buf)?;
-    Ok(serde_json::from_str(&buf)?)
-}
-
-fn read_text<R: Read + std::io::Seek>(
-    archive: &mut ZipArchive<R>,
-    name: &str,
-) -> Result<String, FitrxError> {
-    let mut file = archive
-        .by_name(name)
-        .map_err(|_| FitrxError::Corrupt(format!("missing entry {}", name)))?;
-    let mut buf = String::new();
-    file.read_to_string(&mut buf)?;
-    Ok(buf)
-}
-
 fn read_bytes<R: Read + std::io::Seek>(
     archive: &mut ZipArchive<R>,
     name: &str,
@@ -1116,6 +953,23 @@ fn read_bytes<R: Read + std::io::Seek>(
     let mut buf = Vec::new();
     file.read_to_end(&mut buf)?;
     Ok(buf)
+}
+
+fn read_text<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+    name: &str,
+) -> Result<String, FitrxError> {
+    let buf = read_bytes(archive, name)?;
+    String::from_utf8(buf)
+        .map_err(|e| FitrxError::Corrupt(format!("invalid UTF-8 in entry {}: {}", name, e)))
+}
+
+fn read_json<T: serde::de::DeserializeOwned, R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+    name: &str,
+) -> Result<T, FitrxError> {
+    let buf = read_bytes(archive, name)?;
+    Ok(serde_json::from_slice(&buf)?)
 }
 
 fn parse_subjects(
@@ -2655,7 +2509,7 @@ mod tests {
         assert!(loaded.fit.shrinkage_eta[0].is_nan());
         assert_eq!(loaded.fit.shrinkage_eta[1], 0.15);
         // cov_condition_number was +Inf; round-trips as None (null) under the
-        // current opt_f64_nan_as_null adapter. Either NaN or None is fine —
+        // current serde_nan::opt adapter. Either NaN or None is fine —
         // both mean "could not be computed reliably" downstream.
         assert!(loaded
             .fit

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,3 +4,4 @@ pub mod filter_expr;
 pub mod fitrx;
 pub mod hash;
 pub mod output;
+mod serde_nan;

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -4,6 +4,46 @@ fn fixed_label(name: &str) -> String {
     format!("{} [FIX]", name)
 }
 
+/// Relative standard error as a percent: `|se / est| · 100`, or `NaN` when the
+/// estimate is ~0 (guards the divide-by-zero for a parameter pinned at 0).
+fn rse_pct(est: f64, se: f64) -> f64 {
+    if est.abs() > 1e-12 {
+        (se / est.abs()) * 100.0
+    } else {
+        f64::NAN
+    }
+}
+
+/// Coefficient of variation as a percent from a variance: `sqrt(var) · 100`, or
+/// `0` for a non-positive variance.
+fn cv_pct(var: f64) -> f64 {
+    if var > 0.0 {
+        var.sqrt() * 100.0
+    } else {
+        0.0
+    }
+}
+
+/// Parameter correlation for the off-diagonal `(i, j)`: prefer the precomputed
+/// `param_corr` matrix entry when present, else fall back to
+/// `cov / (sqrt(var_i) · sqrt(var_j))` (0 when either variance is non-positive).
+fn param_corr_fallback(
+    m: Option<&nalgebra::DMatrix<f64>>,
+    cov: f64,
+    var_i: f64,
+    var_j: f64,
+    i: usize,
+    j: usize,
+) -> f64 {
+    m.map(|m| m[(i, j)]).unwrap_or_else(|| {
+        if var_i > 0.0 && var_j > 0.0 {
+            cov / (var_i.sqrt() * var_j.sqrt())
+        } else {
+            0.0
+        }
+    })
+}
+
 /// Summary statistics over an NN's flat weight vector for the compact
 /// `neural_networks:` section in the fit YAML / CLI output. Empty input
 /// yields all zeros (defensive — shouldn't happen in practice because
@@ -94,11 +134,7 @@ pub fn print_results(result: &FitResult) {
             match &result.se_theta {
                 Some(se) => {
                     let se_val = se[i];
-                    let rse = if est.abs() > 1e-12 {
-                        (se_val / est.abs()) * 100.0
-                    } else {
-                        f64::NAN
-                    };
+                    let rse = rse_pct(est, se_val);
                     (format!("{:.6}", se_val), format!("{:.1}", rse))
                 }
                 None => ("N/A".to_string(), "N/A".to_string()),
@@ -163,7 +199,7 @@ pub fn print_results(result: &FitResult) {
             }
         };
         if show_cv {
-            let cv = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+            let cv = cv_pct(var);
             eprintln!(
                 "  {:<20} = {:.6}  (CV% = {:.1})  SE = {}",
                 label, var, cv, se_str
@@ -182,19 +218,14 @@ pub fn print_results(result: &FitResult) {
                 }
                 let name_i = result.eta_names.get(i).map(|s| s.as_str()).unwrap_or("ETA");
                 let name_j = result.eta_names.get(j).map(|s| s.as_str()).unwrap_or("ETA");
-                let param_corr = result
-                    .omega_param_corr
-                    .as_ref()
-                    .map(|m| m[(i, j)])
-                    .unwrap_or_else(|| {
-                        let var_i = result.omega[(i, i)];
-                        let var_j = result.omega[(j, j)];
-                        if var_i > 0.0 && var_j > 0.0 {
-                            cov / (var_i.sqrt() * var_j.sqrt())
-                        } else {
-                            0.0
-                        }
-                    });
+                let param_corr = param_corr_fallback(
+                    result.omega_param_corr.as_ref(),
+                    cov,
+                    result.omega[(i, i)],
+                    result.omega[(j, j)],
+                    i,
+                    j,
+                );
                 let se_cov = crate::types::omega_se_at(&result.se_omega, n_eta, i, j);
                 let se_str = match se_cov {
                     Some(s) => format!("  SE = {:.6}", s),
@@ -278,7 +309,7 @@ pub fn print_results(result: &FitResult) {
                 }
             };
             if show_cv {
-                let cv = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+                let cv = cv_pct(var);
                 eprintln!(
                     "  {:<20} = {:.6}  (CV% = {:.1})  SE = {}",
                     label, var, cv, se_str
@@ -307,19 +338,14 @@ pub fn print_results(result: &FitResult) {
                         .get(j)
                         .map(|s| s.as_str())
                         .unwrap_or("KAPPA");
-                    let param_corr = result
-                        .omega_iov_param_corr
-                        .as_ref()
-                        .map(|m| m[(i, j)])
-                        .unwrap_or_else(|| {
-                            let var_i = iov[(i, i)];
-                            let var_j = iov[(j, j)];
-                            if var_i > 0.0 && var_j > 0.0 {
-                                cov / (var_i.sqrt() * var_j.sqrt())
-                            } else {
-                                0.0
-                            }
-                        });
+                    let param_corr = param_corr_fallback(
+                        result.omega_iov_param_corr.as_ref(),
+                        cov,
+                        iov[(i, i)],
+                        iov[(j, j)],
+                        i,
+                        j,
+                    );
                     eprintln!(
                         "  {} × {} = {:.6}  (param corr = {:.4})",
                         name_i, name_j, cov, param_corr,
@@ -602,11 +628,7 @@ pub fn format_summary(result: &FitResult) -> String {
             match &result.se_theta {
                 Some(se) => {
                     let se_val = se[i];
-                    let rse = if est.abs() > 1e-12 {
-                        (se_val / est.abs()) * 100.0
-                    } else {
-                        f64::NAN
-                    };
+                    let rse = rse_pct(est, se_val);
                     (format!("{:.6}", se_val), format!("{:.1}", rse))
                 }
                 None => ("N/A".to_string(), "N/A".to_string()),
@@ -641,7 +663,7 @@ pub fn format_summary(result: &FitResult) -> String {
                 }
             };
             if show_cv {
-                let cv = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+                let cv = cv_pct(var);
                 let _ = writeln!(
                     out,
                     "  {:<16} = {:.6}  (CV% = {:.1})  SE = {}",
@@ -662,19 +684,14 @@ pub fn format_summary(result: &FitResult) -> String {
                     }
                     let ni = result.eta_names.get(i).map(|s| s.as_str()).unwrap_or("ETA");
                     let nj = result.eta_names.get(j).map(|s| s.as_str()).unwrap_or("ETA");
-                    let corr = result
-                        .omega_param_corr
-                        .as_ref()
-                        .map(|m| m[(i, j)])
-                        .unwrap_or_else(|| {
-                            let vi = result.omega[(i, i)];
-                            let vj = result.omega[(j, j)];
-                            if vi > 0.0 && vj > 0.0 {
-                                cov / (vi.sqrt() * vj.sqrt())
-                            } else {
-                                0.0
-                            }
-                        });
+                    let corr = param_corr_fallback(
+                        result.omega_param_corr.as_ref(),
+                        cov,
+                        result.omega[(i, i)],
+                        result.omega[(j, j)],
+                        i,
+                        j,
+                    );
                     let _ = writeln!(out, "  corr({}, {}) = {:.4}", ni, nj, corr);
                 }
             }
@@ -1412,7 +1429,12 @@ pub fn write_conddist_outputs(result: &FitResult, model_name: &str) -> Vec<Strin
 }
 
 /// Format a numeric cell for CSV output: NaN → empty (missing), else 6 dp.
-fn fmt_num(v: f64) -> String {
+///
+/// Shared with `io::fitrx` (via its `fmt_f64` wrapper) so bundle CSVs and sdtab
+/// covariate/conddist CSVs format floats identically. NOTE: `write_sdtab_csv`
+/// deliberately does *not* use this — it blanks on `!is_finite()` (also ±Inf),
+/// a documented divergence.
+pub(crate) fn fmt_num(v: f64) -> String {
     if v.is_nan() {
         String::new()
     } else {
@@ -1628,13 +1650,7 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         let est = result.theta[i];
         let is_fixed = result.theta_fixed.get(i).copied().unwrap_or(false);
         let se = result.se_theta.as_ref().map(|v| v[i]);
-        let rse = se.map(|s| {
-            if est.abs() > 1e-12 {
-                (s / est.abs()) * 100.0
-            } else {
-                f64::NAN
-            }
-        });
+        let rse = se.map(|s| rse_pct(est, s));
         writeln!(f, "  {}:", name).map_err(|e| e.to_string())?;
         writeln!(f, "    estimate: {:.6}", est).map_err(|e| e.to_string())?;
         if is_fixed {
@@ -1699,7 +1715,7 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
     writeln!(f, "\nomega:").map_err(|e| e.to_string())?;
     for i in 0..n_eta {
         let var = result.omega[(i, i)];
-        let cv_pct = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+        let cv_pct = cv_pct(var);
         let is_fixed = result.omega_fixed.get(i).copied().unwrap_or(false);
         let se = crate::types::omega_se_at(&result.se_omega, n_eta, i, i);
         let key = result
@@ -1735,19 +1751,14 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                     .get(j)
                     .cloned()
                     .unwrap_or_else(|| format!("eta_{}", j + 1));
-                let param_corr = result
-                    .omega_param_corr
-                    .as_ref()
-                    .map(|m| m[(i, j)])
-                    .unwrap_or_else(|| {
-                        let var_i = result.omega[(i, i)];
-                        let var_j = result.omega[(j, j)];
-                        if var_i > 0.0 && var_j > 0.0 {
-                            cov / (var_i.sqrt() * var_j.sqrt())
-                        } else {
-                            0.0
-                        }
-                    });
+                let param_corr = param_corr_fallback(
+                    result.omega_param_corr.as_ref(),
+                    cov,
+                    result.omega[(i, i)],
+                    result.omega[(j, j)],
+                    i,
+                    j,
+                );
                 let se_cov = crate::types::omega_se_at(&result.se_omega, n_eta, i, j);
                 writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
                 writeln!(f, "    covariance: {:.6}", cov).map_err(|e| e.to_string())?;
@@ -1810,7 +1821,7 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         let n_kappa = iov.nrows();
         for i in 0..n_kappa {
             let var = iov[(i, i)];
-            let cv_pct = if var > 0.0 { var.sqrt() * 100.0 } else { 0.0 };
+            let cv_pct = cv_pct(var);
             let is_fixed = result.kappa_fixed.get(i).copied().unwrap_or(false);
             let se = result.se_kappa.as_ref().and_then(|v| v.get(i).copied());
             let name = result
@@ -1850,19 +1861,14 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                     .get(j)
                     .cloned()
                     .unwrap_or_else(|| format!("kappa_{}", j + 1));
-                let param_corr = result
-                    .omega_iov_param_corr
-                    .as_ref()
-                    .map(|m| m[(i, j)])
-                    .unwrap_or_else(|| {
-                        let var_i = iov[(i, i)];
-                        let var_j = iov[(j, j)];
-                        if var_i > 0.0 && var_j > 0.0 {
-                            cov / (var_i.sqrt() * var_j.sqrt())
-                        } else {
-                            0.0
-                        }
-                    });
+                let param_corr = param_corr_fallback(
+                    result.omega_iov_param_corr.as_ref(),
+                    cov,
+                    iov[(i, i)],
+                    iov[(j, j)],
+                    i,
+                    j,
+                );
                 writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
                 writeln!(f, "    covariance: {:.6}", cov).map_err(|e| e.to_string())?;
                 writeln!(f, "    correlation: {:.6}", param_corr).map_err(|e| e.to_string())?;
@@ -2078,11 +2084,7 @@ pub fn parameter_table(result: &FitResult) -> String {
         let (se_str, rse_str) = match &result.se_theta {
             Some(se) => {
                 let se_val = se[i];
-                let rse = if est.abs() > 1e-12 {
-                    (se_val / est.abs()) * 100.0
-                } else {
-                    f64::NAN
-                };
+                let rse = rse_pct(est, se_val);
                 (format!("{:.6}", se_val), format!("{:.1}", rse))
             }
             None => ("---".to_string(), "---".to_string()),

--- a/src/io/serde_nan.rs
+++ b/src/io/serde_nan.rs
@@ -1,0 +1,114 @@
+//! Shared NaN-as-`null` serde adapters for JSON bundles (`.fitrx`, checkpoints).
+//!
+//! JSON has no representation for NaN/±Inf. `serde_json` writes them as `null`
+//! on serialize, which is correct per the spec but means the default
+//! `Deserialize` for `f64` then fails when reading the value back. These modules
+//! make the round-trip lossless: non-finite serializes to `null`, and `null`
+//! deserializes back to `NaN`. Use via `#[serde(with = "...")]` on fields that
+//! may legitimately carry NaN (shrinkage, `cov_condition_number` when the
+//! Hessian is singular, the OFV before the first eval, etc.):
+//!
+//! - `crate::io::serde_nan::scalar`  for `f64`
+//! - `crate::io::serde_nan::vec`     for `Vec<f64>`
+//! - `crate::io::serde_nan::vec_vec` for `Vec<Vec<f64>>`
+//! - `crate::io::serde_nan::opt`     for `Option<f64>`
+
+use serde::{Serialize, Serializer};
+
+/// A single `f64` that serializes as itself when finite, else as JSON `null`.
+/// The one place the scalar element rule lives; the sequence serializers reuse
+/// it so there is no second copy of the finite check.
+struct NanNull(f64);
+
+impl Serialize for NanNull {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        if self.0.is_finite() {
+            ser.serialize_f64(self.0)
+        } else {
+            ser.serialize_none()
+        }
+    }
+}
+
+/// A slice of `f64` serialized as a sequence of [`NanNull`] elements. Reused by
+/// both `vec` and `vec_vec` so the inner element writer exists exactly once.
+struct NanNullSlice<'a>(&'a [f64]);
+
+impl Serialize for NanNullSlice<'_> {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        let mut seq = ser.serialize_seq(Some(self.0.len()))?;
+        for v in self.0 {
+            seq.serialize_element(&NanNull(*v))?;
+        }
+        seq.end()
+    }
+}
+
+/// `f64` field: non-finite -> `null`, `null` -> `NaN`.
+pub mod scalar {
+    use super::NanNull;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &f64, ser: S) -> Result<S::Ok, S::Error> {
+        NanNull(*value).serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<f64, D::Error> {
+        let opt: Option<f64> = Option::deserialize(de)?;
+        Ok(opt.unwrap_or(f64::NAN))
+    }
+}
+
+/// `Vec<f64>` field: each non-finite element -> `null`, `null` -> `NaN`.
+pub mod vec {
+    use super::NanNullSlice;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Vec<f64>, ser: S) -> Result<S::Ok, S::Error> {
+        NanNullSlice(value.as_slice()).serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<f64>, D::Error> {
+        let opts: Vec<Option<f64>> = Vec::deserialize(de)?;
+        Ok(opts.into_iter().map(|o| o.unwrap_or(f64::NAN)).collect())
+    }
+}
+
+/// `Vec<Vec<f64>>` field: each non-finite element -> `null`, `null` -> `NaN`.
+pub mod vec_vec {
+    use super::NanNullSlice;
+    use serde::{de::Deserialize, ser::SerializeSeq, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Vec<Vec<f64>>, ser: S) -> Result<S::Ok, S::Error> {
+        let mut outer = ser.serialize_seq(Some(value.len()))?;
+        for inner in value {
+            outer.serialize_element(&NanNullSlice(inner.as_slice()))?;
+        }
+        outer.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<Vec<f64>>, D::Error> {
+        let outer: Vec<Vec<Option<f64>>> = Vec::deserialize(de)?;
+        Ok(outer
+            .into_iter()
+            .map(|inner| inner.into_iter().map(|o| o.unwrap_or(f64::NAN)).collect())
+            .collect())
+    }
+}
+
+/// `Option<f64>` field: `Some(non-finite)` and `None` both -> `null`.
+pub mod opt {
+    use serde::{de::Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Option<f64>, ser: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) if v.is_finite() => ser.serialize_some(v),
+            _ => ser.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Option<f64>, D::Error> {
+        Option::<f64>::deserialize(de)
+    }
+}

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -989,6 +989,140 @@ fn read_observable(
         .eval(u, pk_params_flat, theta, eta, covariates, obs_cmt)
 }
 
+/// Record `read_observable` into `predictions[obs_idx]` for every observation
+/// sharing a break/save time — the state-independent obs-recording idiom copied
+/// across the dense drivers. `pk`/`eta` are the (constant) snapshot for these
+/// observations; the per-observation TV/IOV variants (which pick `pk`/`eta` per
+/// `obs_idx`) stay inline. When `states` is `Some`, the compartment state `u` is
+/// cloned into `states[obs_idx]` too (the `_with_states` driver).
+#[inline]
+fn record_observations(
+    ode: &OdeSpec,
+    obs_idxs: &[usize],
+    u: &[f64],
+    pk: &[f64],
+    theta: &[f64],
+    eta: &[f64],
+    subject: &Subject,
+    predictions: &mut [f64],
+    mut states: Option<&mut [Vec<f64>]>,
+) {
+    for &obs_idx in obs_idxs {
+        let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
+        predictions[obs_idx] =
+            read_observable(ode, u, pk, theta, eta, subject.obs_cov(obs_idx), cmt);
+        if let Some(states) = states.as_deref_mut() {
+            states[obs_idx] = u.to_vec();
+        }
+    }
+}
+
+/// Clamp negative predictions to zero (ODE solver overshoot guard) — the shared
+/// epilogue of the dense drivers. NaN is intentionally NOT clamped (it survives
+/// `< 0.0` per IEEE 754) so it propagates to a NaN OFV.
+#[inline]
+fn clamp_negative_predictions(predictions: &mut [f64]) {
+    for p in predictions.iter_mut() {
+        if *p < 0.0 {
+            *p = 0.0;
+        }
+    }
+}
+
+/// TAD anchor for `ext_params[MAX_PK_PARAMS + 1]`: the last effective dose time at
+/// or before `t_start`, SS-aware (`rem_euclid` wraps the elapsed time back into
+/// `[0, II)` so TAD stays within one dosing interval). Returns NaN when no
+/// effective prior dose exists, so the ODE RHS injects NaN for TAD (matching the
+/// sdtab convention) rather than `+∞`.
+#[inline]
+fn tad_anchor(subject: &Subject, dose_lagtimes: &[f64], t_start: f64) -> f64 {
+    let last_dose_eff = subject
+        .doses
+        .iter()
+        .enumerate()
+        .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
+        .map(|(i, d)| {
+            let lag = dose_lagtimes[i];
+            if d.ss && d.ii > 0.0 {
+                let elapsed = t_start - (d.time + lag);
+                t_start - elapsed.rem_euclid(d.ii)
+            } else {
+                d.time + lag
+            }
+        })
+        .fold(f64::NEG_INFINITY, f64::max);
+    if last_dose_eff.is_finite() {
+        last_dose_eff
+    } else {
+        f64::NAN
+    }
+}
+
+/// Per dose-compartment lagtime / bioavailability vectors (`Fn`/`ALAGn`; issue
+/// #369, with fallback to the bare `lagtime`/`F` slots). Uniform on the no-TV
+/// dense path, where every dose reads the same `pk_params_flat`.
+#[inline]
+fn subject_dose_attrs(
+    subject: &Subject,
+    ode: &OdeSpec,
+    pk_params_flat: &[f64],
+) -> (Vec<f64>, Vec<f64>) {
+    let dose_lagtimes: Vec<f64> = subject
+        .doses
+        .iter()
+        .map(|d| ode.dose_attr_map.lagtime(d.cmt, pk_params_flat))
+        .collect();
+    let dose_f_bio: Vec<f64> = subject
+        .doses
+        .iter()
+        .map(|d| ode.dose_attr_map.f_bio(d.cmt, pk_params_flat))
+        .collect();
+    (dose_lagtimes, dose_f_bio)
+}
+
+/// Earliest dose record time, or `+∞` when the subject has no doses.
+#[inline]
+fn earliest_dose_time(subject: &Subject) -> f64 {
+    subject
+        .doses
+        .iter()
+        .map(|d| d.time)
+        .fold(f64::INFINITY, f64::min)
+}
+
+/// Seed the extended-parameter array for the ODE RHS: slots `0..MAX_PK_PARAMS`
+/// hold the PK snapshot; slot `MAX_PK_PARAMS` carries the TAFD anchor (the first
+/// dose time, NaN when there are no doses so the RHS injects NaN rather than `-∞`);
+/// slot `MAX_PK_PARAMS + 1` (TAD) is left NaN for the per-segment update.
+#[inline]
+fn seed_ext_params(
+    pk_params_flat: &[f64],
+    first_dose_time: f64,
+) -> [f64; crate::types::MAX_PK_PARAMS + 2] {
+    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
+    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
+    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
+    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
+        first_dose_time
+    } else {
+        f64::NAN
+    };
+    ext_params
+}
+
+/// Map each time (by bit pattern) to *all* its indices. Multiple observations can
+/// share a time (e.g. simultaneous PK/PD samples on different CMTs), so each time
+/// maps to every index — recording only one would leave the others at their
+/// initial NaN.
+#[inline]
+fn build_obs_index_map(times: &[f64]) -> HashMap<u64, Vec<usize>> {
+    let mut map: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, &t) in times.iter().enumerate() {
+        map.entry(t.to_bits()).or_default().push(i);
+    }
+    map
+}
+
 /// ODE specification for a model
 pub struct OdeSpec {
     /// RHS function: (u, pk_params_flat, t, du) — writes derivatives into du
@@ -1165,30 +1299,7 @@ fn integrate_segment(
 
     // Update TAD anchor (slot MAX_PK_PARAMS+1): last effective dose time
     // before this segment, SS-aware (gives TAD = t - last_dose_eff).
-    {
-        let last_dose_eff = subject
-            .doses
-            .iter()
-            .enumerate()
-            .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
-            .map(|(i, d)| {
-                let lag = dose_lagtimes[i];
-                if d.ss && d.ii > 0.0 {
-                    let elapsed = t_start - (d.time + lag);
-                    t_start - elapsed.rem_euclid(d.ii)
-                } else {
-                    d.time + lag
-                }
-            })
-            .fold(f64::NEG_INFINITY, f64::max);
-        // Store NaN when no effective prior dose exists so the ODE RHS injects
-        // NaN for TAD (consistent with sdtab) rather than +∞ (t - NEG_INFINITY).
-        ext_params[crate::types::MAX_PK_PARAMS + 1] = if last_dose_eff.is_finite() {
-            last_dose_eff
-        } else {
-            f64::NAN
-        };
-    }
+    ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor(subject, dose_lagtimes, t_start);
 
     // Integrate. If any infusions are active in this segment, wrap
     // the user RHS so it adds `+rate` to each infusion's compartment.
@@ -1239,18 +1350,17 @@ fn integrate_segment(
     // Extract predictions and update state
     for pt in &sol {
         if let Some(obs_idxs) = obs_map.get(&pt.t.to_bits()) {
-            for &obs_idx in obs_idxs {
-                let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
-                predictions[obs_idx] = read_observable(
-                    ode,
-                    &pt.u,
-                    pk_params_flat,
-                    theta,
-                    eta,
-                    subject.obs_cov(obs_idx),
-                    cmt,
-                );
-            }
+            record_observations(
+                ode,
+                obs_idxs,
+                &pt.u,
+                pk_params_flat,
+                theta,
+                eta,
+                subject,
+                predictions,
+                None,
+            );
         }
     }
 
@@ -1431,43 +1541,18 @@ fn ode_predictions_with_extra_breaks_and_stats(
     // models behave identically. Resolved **per dose compartment** so a model
     // with `Fn`/`ALAGn` (issue #369) applies the right value to each route; the
     // common bare-`F`/`lagtime` model gets a uniform vector.
-    let dose_lagtimes: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.lagtime(d.cmt, pk_params_flat))
-        .collect();
-    let dose_f_bio: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.f_bio(d.cmt, pk_params_flat))
-        .collect();
+    let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
     // Extended params: slots 0..MAX_PK_PARAMS hold the PK parameters; slots
     // MAX_PK_PARAMS and MAX_PK_PARAMS+1 carry TAFD/TAD anchors for the ODE RHS.
-    let first_dose_time = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
-    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
-    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
-    // Store NaN when there are no doses so the ODE RHS injects NaN for TAFD
-    // (consistent with the sdtab convention) rather than -∞ (INFINITY - t).
-    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
-        first_dose_time
-    } else {
-        f64::NAN
-    };
+    let first_dose_time = earliest_dose_time(subject);
+    let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Build obs_time → indices map. Multiple observations can share a time
     // (e.g. simultaneous PK/PD samples on different CMTs), so each time maps to
     // *all* its observation indices — recording only one would leave the others
     // at their initial NaN.
-    let mut obs_map: HashMap<u64, Vec<usize>> = HashMap::new();
-    for (i, &t) in subject.obs_times.iter().enumerate() {
-        obs_map.entry(t.to_bits()).or_default().push(i);
-    }
+    let obs_map = build_obs_index_map(&subject.obs_times);
 
     // Break timeline at lagtime-shifted dose times — and, for infusions,
     // at lagtime-shifted infusion-end times too, so each segment is
@@ -1574,18 +1659,17 @@ fn ode_predictions_with_extra_breaks_and_stats(
 
         // Record observations exactly at t_start (after dose)
         if let Some(obs_idxs) = obs_map.get(&t_start.to_bits()) {
-            for &obs_idx in obs_idxs {
-                let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
-                predictions[obs_idx] = read_observable(
-                    ode,
-                    &u,
-                    pk_params_flat,
-                    theta,
-                    eta,
-                    subject.obs_cov(obs_idx),
-                    cmt,
-                );
-            }
+            record_observations(
+                ode,
+                obs_idxs,
+                &u,
+                pk_params_flat,
+                theta,
+                eta,
+                subject,
+                &mut predictions,
+                None,
+            );
         }
 
         // #570: a soft (CHZ) time coinciding with this segment's *left* boundary is
@@ -1662,11 +1746,7 @@ fn ode_predictions_with_extra_breaks_and_stats(
     // This is also what surfaces a missing `OdeReadout::PerCmt` entry as
     // a loud failure rather than a silent zero. (Pre-Phase-2 the clamp
     // included NaN; Copilot's review of #84 caught the inconsistency.)
-    for p in &mut predictions {
-        if *p < 0.0 {
-            *p = 0.0;
-        }
-    }
+    clamp_negative_predictions(&mut predictions);
 
     (predictions, chz_states)
 }
@@ -2630,11 +2710,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
     }
 
     // Clamp negative predictions to zero, matching the static predictor.
-    for p in &mut predictions {
-        if *p < 0.0 {
-            *p = 0.0;
-        }
-    }
+    clamp_negative_predictions(&mut predictions);
 
     Ok(AdaptiveRun {
         predictions,
@@ -2854,12 +2930,10 @@ fn adaptive_frozen_replay_tv(
     // Injected doses carry no lag (a nonzero lag is rejected at injection).
     let dose_lagtimes = vec![0.0; subject.doses.len()];
 
+    // NB: PK slots are left NaN here (unlike `seed_ext_params`) — the replay
+    // overwrites them per-segment from each event's own snapshot before integrating.
     let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let first_dose_time = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
+    let first_dose_time = earliest_dose_time(subject);
     ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
         first_dose_time
     } else {
@@ -2994,11 +3068,7 @@ fn adaptive_frozen_replay_tv(
         }
     }
 
-    for p in &mut predictions {
-        if *p < 0.0 {
-            *p = 0.0;
-        }
-    }
+    clamp_negative_predictions(&mut predictions);
     predictions
 }
 
@@ -3669,35 +3739,12 @@ pub fn ode_predictions_with_states(
     // Per dose-compartment bioavailability / lag (`Fn`/`ALAGn`; issue #369),
     // falling back to the bare `PK_IDX_F`/`PK_IDX_LAGTIME` slots. Uniform on
     // this no-TV path, where every dose reads the same `pk_params_flat`.
-    let dose_lagtimes: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.lagtime(d.cmt, pk_params_flat))
-        .collect();
-    let dose_f_bio: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.f_bio(d.cmt, pk_params_flat))
-        .collect();
+    let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
-    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
-    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
-    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
-        first_dose_time
-    } else {
-        f64::NAN
-    };
+    let first_dose_time = earliest_dose_time(subject);
+    let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
-    let mut obs_map: HashMap<u64, Vec<usize>> = HashMap::new();
-    for (i, &t) in subject.obs_times.iter().enumerate() {
-        obs_map.entry(t.to_bits()).or_default().push(i);
-    }
+    let obs_map = build_obs_index_map(&subject.obs_times);
 
     let t_last = subject.obs_times.iter().cloned().fold(0.0f64, f64::max);
     let mut break_times: Vec<f64> = vec![subject_integration_start(subject)];
@@ -3775,19 +3822,17 @@ pub fn ode_predictions_with_states(
 
         // Handle obs at t_start (after dose).
         if let Some(obs_idxs) = obs_map.get(&t_start.to_bits()) {
-            for &obs_idx in obs_idxs {
-                let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
-                predictions[obs_idx] = read_observable(
-                    ode,
-                    &u,
-                    pk_params_flat,
-                    theta,
-                    eta,
-                    subject.obs_cov(obs_idx),
-                    cmt,
-                );
-                states[obs_idx] = u.clone();
-            }
+            record_observations(
+                ode,
+                obs_idxs,
+                &u,
+                pk_params_flat,
+                theta,
+                eta,
+                subject,
+                &mut predictions,
+                Some(states.as_mut_slice()),
+            );
         }
 
         // #731: integrate the open interval `(t_start, t_end]` to the next break, if
@@ -3823,28 +3868,7 @@ pub fn ode_predictions_with_states(
         // TAD anchor: last effective dose time before this segment, SS-aware.
         // For SS doses, rem_euclid maps the elapsed time back into [0, II) so
         // TAD stays within one dosing interval — matching ode_predictions.
-        ext_params[crate::types::MAX_PK_PARAMS + 1] = {
-            let last_dose_eff = subject
-                .doses
-                .iter()
-                .enumerate()
-                .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
-                .map(|(i, d)| {
-                    let lag = dose_lagtimes[i];
-                    if d.ss && d.ii > 0.0 {
-                        let elapsed = t_start - (d.time + lag);
-                        t_start - elapsed.rem_euclid(d.ii)
-                    } else {
-                        d.time + lag
-                    }
-                })
-                .fold(f64::NEG_INFINITY, f64::max);
-            if last_dose_eff.is_finite() {
-                last_dose_eff
-            } else {
-                f64::NAN
-            }
-        };
+        ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor(subject, &dose_lagtimes, t_start);
 
         active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
         // Resolve each active infusion to (cmt_idx, F·rate, t_start, t_end) for
@@ -3877,19 +3901,17 @@ pub fn ode_predictions_with_states(
 
         for pt in &sol {
             if let Some(obs_idxs) = obs_map.get(&pt.t.to_bits()) {
-                for &obs_idx in obs_idxs {
-                    let cmt = subject.obs_cmts.get(obs_idx).copied().unwrap_or(0);
-                    predictions[obs_idx] = read_observable(
-                        ode,
-                        &pt.u,
-                        pk_params_flat,
-                        theta,
-                        eta,
-                        subject.obs_cov(obs_idx),
-                        cmt,
-                    );
-                    states[obs_idx] = pt.u.clone();
-                }
+                record_observations(
+                    ode,
+                    obs_idxs,
+                    &pt.u,
+                    pk_params_flat,
+                    theta,
+                    eta,
+                    subject,
+                    &mut predictions,
+                    Some(states.as_mut_slice()),
+                );
             }
         }
 
@@ -3898,11 +3920,7 @@ pub fn ode_predictions_with_states(
         }
     }
 
-    for p in &mut predictions {
-        if *p < 0.0 {
-            *p = 0.0;
-        }
-    }
+    clamp_negative_predictions(&mut predictions);
 
     (predictions, states)
 }
@@ -4099,28 +4117,7 @@ fn apply_segment_boundary(
 
     // TAD anchor: SS-aware, matching ode_predictions (rem_euclid wraps the elapsed
     // time back into [0, II)).
-    ext_params[crate::types::MAX_PK_PARAMS + 1] = {
-        let last_dose_eff = subject
-            .doses
-            .iter()
-            .enumerate()
-            .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
-            .map(|(i, d)| {
-                let lag = dose_lagtimes[i];
-                if d.ss && d.ii > 0.0 {
-                    let elapsed = t_start - (d.time + lag);
-                    t_start - elapsed.rem_euclid(d.ii)
-                } else {
-                    d.time + lag
-                }
-            })
-            .fold(f64::NEG_INFINITY, f64::max);
-        if last_dose_eff.is_finite() {
-            last_dose_eff
-        } else {
-            f64::NAN
-        }
-    };
+    ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor(subject, dose_lagtimes, t_start);
 
     active_infusions.retain(|(_, _, e)| *e > t_start + 1e-12);
     // Resolve to (cmt_idx, F·rate, t_start, t_end) for the seam's time-gated
@@ -4187,36 +4184,13 @@ pub fn ode_dense_solve_states(
     // Per dose-compartment bioavailability / lag (`Fn`/`ALAGn`; issue #369),
     // falling back to the bare `PK_IDX_F`/`PK_IDX_LAGTIME` slots. Uniform on
     // this no-TV path, where every dose reads the same `pk_params_flat`.
-    let dose_lagtimes: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.lagtime(d.cmt, pk_params_flat))
-        .collect();
-    let dose_f_bio: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.f_bio(d.cmt, pk_params_flat))
-        .collect();
+    let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
-    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
-    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
-    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
-        first_dose_time
-    } else {
-        f64::NAN
-    };
+    let first_dose_time = earliest_dose_time(subject);
+    let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Build saveat → index map for fast lookup.
-    let mut saveat_map: HashMap<u64, Vec<usize>> = HashMap::new();
-    for (i, &t) in saveat.iter().enumerate() {
-        saveat_map.entry(t.to_bits()).or_default().push(i);
-    }
+    let saveat_map = build_obs_index_map(saveat);
 
     let t_last = saveat.iter().cloned().fold(0.0f64, f64::max);
     // Zero-order absorption windows for this subject (#504): a single PK snapshot,
@@ -4430,30 +4404,10 @@ pub(crate) fn ode_solve_until_chz_threshold(
     let resolved = resolve_subject_doses(subject, &ode.dose_attr_map, pk_params_flat);
     let subject: &Subject = &resolved;
 
-    let dose_lagtimes: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.lagtime(d.cmt, pk_params_flat))
-        .collect();
-    let dose_f_bio: Vec<f64> = subject
-        .doses
-        .iter()
-        .map(|d| ode.dose_attr_map.f_bio(d.cmt, pk_params_flat))
-        .collect();
+    let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min);
-    let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
-    ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
-    ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
-        first_dose_time
-    } else {
-        f64::NAN
-    };
+    let first_dose_time = earliest_dose_time(subject);
+    let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Zero-order windows, reused for the break points and the per-segment injection
     // (same as the dense path). The terminal break is the horizon; doses scheduled

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -5979,6 +5979,50 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
             .parse::<f64>()
             .map_err(|_| format!("fit option `{name}`: expected number, got `{value}`"))
     };
+    // Parse an f64 that must be strictly positive and finite.
+    let parse_pos_finite = |name: &str| -> Result<f64, String> {
+        let v = parse_f64(name)?;
+        if v <= 0.0 || !v.is_finite() {
+            return Err(format!("{name} must be a positive finite value, got {v}"));
+        }
+        Ok(v)
+    };
+    // Parse an f64 with an inclusive lower bound (`v >= min`). `min` is rendered
+    // with Debug so integral bounds keep their trailing `.0` (e.g. `>= 1.0`).
+    let parse_f64_min = |name: &str, min: f64| -> Result<f64, String> {
+        let v = parse_f64(name)?;
+        if v < min {
+            return Err(format!("{name} must be >= {min:?}, got {v}"));
+        }
+        Ok(v)
+    };
+    // Parse an f64 constrained to the closed unit interval [0.0, 1.0].
+    let parse_unit_interval = |name: &str| -> Result<f64, String> {
+        let v = parse_f64(name)?;
+        if !(0.0..=1.0).contains(&v) {
+            return Err(format!("{name} must be in [0.0, 1.0], got {v}"));
+        }
+        Ok(v)
+    };
+    // Parse a Student-t proposal df: `normal`/`mvn` select a multivariate-normal
+    // proposal (∞ df), otherwise a finite df `>= 1.0`. `strip_quotes` mirrors the
+    // impmap site, which tolerates a quoted `"normal"` token.
+    let parse_proposal_df = |name: &str, strip_quotes: bool| -> Result<f64, String> {
+        let tok = if strip_quotes {
+            value.trim_matches(|c| c == '"' || c == '\'')
+        } else {
+            value
+        };
+        if tok.eq_ignore_ascii_case("normal") || tok.eq_ignore_ascii_case("mvn") {
+            Ok(f64::INFINITY)
+        } else {
+            let v = parse_f64(name)?;
+            if v < 1.0 {
+                return Err(format!("{name} must be >= 1.0 or `normal`, got {v}"));
+            }
+            Ok(v)
+        }
+    };
 
     // Dispatch first, then record the key on success so we can later warn
     // when a key is set that the selected method does not consume. Malformed
@@ -5989,42 +6033,10 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "inner_tol" => opts.inner_tol = parse_f64("inner_tol")?,
         "inner_restarts" => opts.inner_restarts = parse_usize("inner_restarts")?,
         "cov_inner_tol" => opts.cov_inner_tol = Some(parse_f64("cov_inner_tol")?),
-        "outer_xtol" => {
-            let v = parse_f64("outer_xtol")?;
-            if v <= 0.0 || !v.is_finite() {
-                return Err(format!(
-                    "outer_xtol must be a positive finite value, got {v}"
-                ));
-            }
-            opts.outer_xtol = v;
-        }
-        "outer_ftol" => {
-            let v = parse_f64("outer_ftol")?;
-            if v <= 0.0 || !v.is_finite() {
-                return Err(format!(
-                    "outer_ftol must be a positive finite value, got {v}"
-                ));
-            }
-            opts.outer_ftol = Some(v);
-        }
-        "ode_reltol" => {
-            let v = parse_f64("ode_reltol")?;
-            if v <= 0.0 || !v.is_finite() {
-                return Err(format!(
-                    "ode_reltol must be a positive finite value, got {v}"
-                ));
-            }
-            opts.ode_reltol = v;
-        }
-        "ode_abstol" => {
-            let v = parse_f64("ode_abstol")?;
-            if v <= 0.0 || !v.is_finite() {
-                return Err(format!(
-                    "ode_abstol must be a positive finite value, got {v}"
-                ));
-            }
-            opts.ode_abstol = v;
-        }
+        "outer_xtol" => opts.outer_xtol = parse_pos_finite("outer_xtol")?,
+        "outer_ftol" => opts.outer_ftol = Some(parse_pos_finite("outer_ftol")?),
+        "ode_reltol" => opts.ode_reltol = parse_pos_finite("ode_reltol")?,
+        "ode_abstol" => opts.ode_abstol = parse_pos_finite("ode_abstol")?,
         "ode_max_steps" => {
             let v = parse_usize("ode_max_steps")?;
             if v == 0 {
@@ -6058,16 +6070,7 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
                 }
             };
         }
-        "fd_hessian_step" => {
-            let v = parse_f64("fd_hessian_step")?;
-            if v <= 0.0 || !v.is_finite() {
-                return Err(format!(
-                    "fd_hessian_step must be a positive finite value, got {}",
-                    v
-                ));
-            }
-            opts.fd_hessian_step = v;
-        }
+        "fd_hessian_step" => opts.fd_hessian_step = parse_pos_finite("fd_hessian_step")?,
         "verbose" => opts.verbose = parse_bool("verbose")?,
         "optimizer" => {
             opts.optimizer = match value.to_lowercase().as_str() {
@@ -6136,13 +6139,7 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "sir_resamples" => opts.sir_resamples = parse_usize("sir_resamples")?,
         "sir_seed" => opts.sir_seed = parse_u64_opt("sir_seed")?,
         "sir_keep_samples" => opts.sir_keep_samples = parse_bool("sir_keep_samples")?,
-        "sir_df" => {
-            let v = parse_f64("sir_df")?;
-            if v < 1.0 {
-                return Err(format!("sir_df must be >= 1.0, got {v}"));
-            }
-            opts.sir_df = v;
-        }
+        "sir_df" => opts.sir_df = parse_f64_min("sir_df", 1.0)?,
         "n_agq" => {
             let v = parse_usize("n_agq")?;
             if v < 1 {
@@ -6163,29 +6160,10 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
             }
             opts.imp_samples = v;
         }
-        "imp_proposal_df" => {
-            let tok = value.trim();
-            if tok.eq_ignore_ascii_case("normal") || tok.eq_ignore_ascii_case("mvn") {
-                opts.imp_proposal_df = f64::INFINITY;
-            } else {
-                let v = parse_f64("imp_proposal_df")?;
-                if v < 1.0 {
-                    return Err(format!(
-                        "imp_proposal_df must be >= 1.0 or `normal`, got {v}"
-                    ));
-                }
-                opts.imp_proposal_df = v;
-            }
-        }
+        "imp_proposal_df" => opts.imp_proposal_df = parse_proposal_df("imp_proposal_df", false)?,
         "imp_seed" => opts.imp_seed = parse_u64_opt("imp_seed")?,
         "imp_low_ess_threshold" => {
-            let v = parse_f64("imp_low_ess_threshold")?;
-            if !(0.0..=1.0).contains(&v) {
-                return Err(format!(
-                    "imp_low_ess_threshold must be in [0.0, 1.0], got {v}"
-                ));
-            }
-            opts.imp_low_ess_threshold = v;
+            opts.imp_low_ess_threshold = parse_unit_interval("imp_low_ess_threshold")?
         }
         "imp_iterations" => {
             let v = parse_usize("imp_iterations")?;
@@ -6210,32 +6188,16 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
             }
             opts.impmap_samples = v;
         }
+        // `normal` / `mvn` (or a very large df) select a multivariate-normal
+        // proposal — NONMEM's IMPMAP default. A finite value gives Student-t.
+        // `strip_quotes = true` tolerates a quoted `"normal"` token.
         "impmap_proposal_df" => {
-            // `normal` / `mvn` (or a very large df) select a multivariate-normal
-            // proposal — NONMEM's IMPMAP default. A finite value gives Student-t.
-            let tok = value.trim().trim_matches(|c| c == '"' || c == '\'');
-            if tok.eq_ignore_ascii_case("normal") || tok.eq_ignore_ascii_case("mvn") {
-                opts.impmap_proposal_df = f64::INFINITY;
-            } else {
-                let v = parse_f64("impmap_proposal_df")?;
-                if v < 1.0 {
-                    return Err(format!(
-                        "impmap_proposal_df must be >= 1.0 or `normal`, got {v}"
-                    ));
-                }
-                opts.impmap_proposal_df = v;
-            }
+            opts.impmap_proposal_df = parse_proposal_df("impmap_proposal_df", true)?
         }
         "impmap_seed" => opts.impmap_seed = parse_u64_opt("impmap_seed")?,
         "impmap_averaging" => opts.impmap_averaging = parse_usize("impmap_averaging")?,
         "impmap_low_ess_threshold" => {
-            let v = parse_f64("impmap_low_ess_threshold")?;
-            if !(0.0..=1.0).contains(&v) {
-                return Err(format!(
-                    "impmap_low_ess_threshold must be in [0.0, 1.0], got {v}"
-                ));
-            }
-            opts.impmap_low_ess_threshold = v;
+            opts.impmap_low_ess_threshold = parse_unit_interval("impmap_low_ess_threshold")?
         }
         "impmap_trace" => opts.impmap_trace = parse_bool("impmap_trace")?,
         "impmap_mceta" => opts.impmap_mceta = parse_usize("impmap_mceta")?,

--- a/src/sens/dual1.rs
+++ b/src/sens/dual1.rs
@@ -38,27 +38,29 @@ impl<const N: usize> Dual1<N> {
         Dual1 { value, grad }
     }
 
+    /// Unary chain rule: given the output `value` and the scalar first derivative
+    /// `d1 = ∂u/∂x`, scale the incoming gradient `src = x'` by it (`u' = d1·x'`).
+    /// Factors out the `grad[i] = d1 * self.grad[i]` scale-loop shared verbatim by
+    /// every unary transcendental op.
+    #[inline]
+    fn chain1(value: f64, d1: f64, src: &[f64; N]) -> Self {
+        let mut grad = [0.0; N];
+        for i in 0..N {
+            grad[i] = d1 * src[i];
+        }
+        Dual1 { value, grad }
+    }
+
     /// `exp(self)`: `u = e^x`, `u' = u·x'`.
     pub fn exp(self) -> Self {
         let v = self.value.exp();
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = v * self.grad[i];
-        }
-        Dual1 { value: v, grad }
+        Dual1::chain1(v, v, &self.grad)
     }
 
     /// `ln(self)`: `u' = x'/x`.
     pub fn ln(self) -> Self {
         let inv = 1.0 / self.value;
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = self.grad[i] * inv;
-        }
-        Dual1 {
-            value: self.value.ln(),
-            grad,
-        }
+        Dual1::chain1(self.value.ln(), inv, &self.grad)
     }
 
     /// `ln Γ(self)`: `u' = ψ(x)·x'`, where ψ is the digamma function. The
@@ -66,14 +68,7 @@ impl<const N: usize> Dual1<N> {
     /// analytic ODE sensitivity path (#430).
     pub fn ln_gamma(self) -> Self {
         let d1 = crate::stats::special::digamma(self.value);
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = d1 * self.grad[i];
-        }
-        Dual1 {
-            value: crate::stats::special::ln_gamma(self.value),
-            grad,
-        }
+        Dual1::chain1(crate::stats::special::ln_gamma(self.value), d1, &self.grad)
     }
 
     /// `sqrt(self)`: `u' = x'/(2√x)`.
@@ -95,21 +90,13 @@ impl<const N: usize> Dual1<N> {
         }
         let v = self.value.sqrt();
         let inv2u = 0.5 / v;
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = inv2u * self.grad[i];
-        }
-        Dual1 { value: v, grad }
+        Dual1::chain1(v, inv2u, &self.grad)
     }
 
     /// `cos(self)`: `u' = −sin(x)·x'`.
     pub fn cos(self) -> Self {
         let (s, c) = self.value.sin_cos();
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = -s * self.grad[i];
-        }
-        Dual1 { value: c, grad }
+        Dual1::chain1(c, -s, &self.grad)
     }
 
     /// `acos(self)`: `u' = g₁·x'`, `g₁ = −1/√(1−x²)`. Same `|x|→1` self-defence as
@@ -127,14 +114,7 @@ impl<const N: usize> Dual1<N> {
             }
         };
         let g1 = -1.0 / one_minus.sqrt();
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = g1 * self.grad[i];
-        }
-        Dual1 {
-            value: v_clamped.acos(),
-            grad,
-        }
+        Dual1::chain1(v_clamped.acos(), g1, &self.grad)
     }
 
     /// `self^e`. Constant exponent uses the power rule `c₁ = n·aⁿ⁻¹` (exact for any
@@ -149,11 +129,7 @@ impl<const N: usize> Dual1<N> {
                 return Dual1::constant(an);
             }
             let c1 = n * a.powf(n - 1.0);
-            let mut grad = [0.0; N];
-            for i in 0..N {
-                grad[i] = c1 * self.grad[i];
-            }
-            return Dual1 { value: an, grad };
+            return Dual1::chain1(an, c1, &self.grad);
         }
         (e * self.ln()).exp()
     }
@@ -171,36 +147,21 @@ impl<const N: usize> Dual1<N> {
     pub fn inv_logit(self) -> Self {
         let u = 1.0 / (1.0 + (-self.value).exp());
         let d = u * (1.0 - u);
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = d * self.grad[i];
-        }
-        Dual1 { value: u, grad }
+        Dual1::chain1(u, d, &self.grad)
     }
 
     /// `logit(self) = ln(x/(1−x))`: `u' = x'/(x(1−x))`.
     pub fn logit(self) -> Self {
         let x = self.value;
         let d = 1.0 / (x * (1.0 - x));
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = d * self.grad[i];
-        }
-        Dual1 {
-            value: (x / (1.0 - x)).ln(),
-            grad,
-        }
+        Dual1::chain1((x / (1.0 - x)).ln(), d, &self.grad)
     }
 
     /// `1/self`: `u' = −x'/x²`.
     pub fn recip(self) -> Self {
         let inv = 1.0 / self.value;
         let inv2 = inv * inv;
-        let mut grad = [0.0; N];
-        for i in 0..N {
-            grad[i] = -self.grad[i] * inv2;
-        }
-        Dual1 { value: inv, grad }
+        Dual1::chain1(inv, -inv2, &self.grad)
     }
 }
 

--- a/src/sens/num.rs
+++ b/src/sens/num.rs
@@ -114,139 +114,88 @@ impl PkNum for f64 {
     }
 }
 
-impl<const N: usize> PkNum for Dual1<N> {
-    const SECOND_ORDER: bool = false;
-    #[inline]
-    fn from_f64(x: f64) -> Self {
-        Dual1::constant(x)
-    }
-    #[inline]
-    fn var(x: f64, dim: usize) -> Self {
-        Dual1::var(x, dim)
-    }
-    #[inline]
-    fn val(self) -> f64 {
-        self.value
-    }
-    #[inline]
-    fn exp(self) -> Self {
-        Dual1::exp(self)
-    }
-    #[inline]
-    fn ln(self) -> Self {
-        Dual1::ln(self)
-    }
-    #[inline]
-    fn sqrt(self) -> Self {
-        Dual1::sqrt(self)
-    }
-    #[inline]
-    fn pow(self, e: Self) -> Self {
-        Dual1::powd(self, e)
-    }
-    #[inline]
-    fn abs(self) -> Self {
-        Dual1::abs(self)
-    }
-    #[inline]
-    fn inv_logit(self) -> Self {
-        Dual1::inv_logit(self)
-    }
-    #[inline]
-    fn logit(self) -> Self {
-        Dual1::logit(self)
-    }
-    #[inline]
-    fn cos(self) -> Self {
-        Dual1::cos(self)
-    }
-    #[inline]
-    fn acos(self) -> Self {
-        Dual1::acos(self)
-    }
-    #[inline]
-    fn guard_floor(self, lo: f64) -> Self {
-        // `!(value >= lo)` (not `value < lo`) so a `NaN` value floors too, matching
-        // `f64::max(lo)` on the scalar path (`NaN.max(lo) == lo`) — otherwise a
-        // transient `NaN` would give a finite f64 prediction but a `NaN` dual
-        // gradient (the clamped region is flat, so the floored jet is zero) (#430).
-        if !(self.value >= lo) {
-            Dual1::constant(lo)
-        } else {
-            self
+/// Generate the `PkNum` impl for a dual type whose every method is a one-line
+/// delegation to the inherent method of the same name. `Dual1<N>` and
+/// `DualMixed<NA, N>` differ only in their const-generic list, the
+/// `SECOND_ORDER` flag, and (implicitly) which inherent method the delegator
+/// resolves to — everything else is identical, including the `guard_floor`
+/// NaN-flooring body. The scalar `f64` impl stays hand-written (its bodies are
+/// inline formulas, not delegation).
+macro_rules! impl_pknum_delegate {
+    ($ty:ident<$(const $c:ident: usize),+>, second_order = $so:expr) => {
+        impl<$(const $c: usize),+> PkNum for $ty<$($c),+> {
+            const SECOND_ORDER: bool = $so;
+            #[inline]
+            fn from_f64(x: f64) -> Self {
+                $ty::constant(x)
+            }
+            #[inline]
+            fn var(x: f64, dim: usize) -> Self {
+                $ty::var(x, dim)
+            }
+            #[inline]
+            fn val(self) -> f64 {
+                self.value
+            }
+            #[inline]
+            fn exp(self) -> Self {
+                $ty::exp(self)
+            }
+            #[inline]
+            fn ln(self) -> Self {
+                $ty::ln(self)
+            }
+            #[inline]
+            fn sqrt(self) -> Self {
+                $ty::sqrt(self)
+            }
+            #[inline]
+            fn pow(self, e: Self) -> Self {
+                $ty::powd(self, e)
+            }
+            #[inline]
+            fn abs(self) -> Self {
+                $ty::abs(self)
+            }
+            #[inline]
+            fn inv_logit(self) -> Self {
+                $ty::inv_logit(self)
+            }
+            #[inline]
+            fn logit(self) -> Self {
+                $ty::logit(self)
+            }
+            #[inline]
+            fn cos(self) -> Self {
+                $ty::cos(self)
+            }
+            #[inline]
+            fn acos(self) -> Self {
+                $ty::acos(self)
+            }
+            #[inline]
+            fn guard_floor(self, lo: f64) -> Self {
+                // `!(value >= lo)` (not `value < lo`) so a `NaN` value floors too,
+                // matching `f64::max(lo)` on the scalar path (`NaN.max(lo) == lo`) —
+                // otherwise a transient `NaN` would give a finite f64 prediction but a
+                // `NaN` dual gradient (the clamped region is flat, so the floored jet
+                // is zero) (#430).
+                if !(self.value >= lo) {
+                    $ty::constant(lo)
+                } else {
+                    self
+                }
+            }
+            #[inline]
+            fn ln_gamma(self) -> Self {
+                $ty::ln_gamma(self)
+            }
         }
-    }
-    #[inline]
-    fn ln_gamma(self) -> Self {
-        Dual1::ln_gamma(self)
-    }
+    };
 }
 
-impl<const NA: usize, const N: usize> PkNum for DualMixed<NA, N> {
-    const SECOND_ORDER: bool = true;
-    #[inline]
-    fn from_f64(x: f64) -> Self {
-        DualMixed::constant(x)
-    }
-    #[inline]
-    fn var(x: f64, dim: usize) -> Self {
-        DualMixed::var(x, dim)
-    }
-    #[inline]
-    fn val(self) -> f64 {
-        self.value
-    }
-    #[inline]
-    fn exp(self) -> Self {
-        DualMixed::exp(self)
-    }
-    #[inline]
-    fn ln(self) -> Self {
-        DualMixed::ln(self)
-    }
-    #[inline]
-    fn sqrt(self) -> Self {
-        DualMixed::sqrt(self)
-    }
-    #[inline]
-    fn pow(self, e: Self) -> Self {
-        DualMixed::powd(self, e)
-    }
-    #[inline]
-    fn abs(self) -> Self {
-        DualMixed::abs(self)
-    }
-    #[inline]
-    fn inv_logit(self) -> Self {
-        DualMixed::inv_logit(self)
-    }
-    #[inline]
-    fn logit(self) -> Self {
-        DualMixed::logit(self)
-    }
-    #[inline]
-    fn cos(self) -> Self {
-        DualMixed::cos(self)
-    }
-    #[inline]
-    fn acos(self) -> Self {
-        DualMixed::acos(self)
-    }
-    #[inline]
-    fn guard_floor(self, lo: f64) -> Self {
-        // `!(value >= lo)` floors `NaN` too, matching `f64::max(lo)` — see the
-        // `Dual1` impl above (#430).
-        if !(self.value >= lo) {
-            DualMixed::constant(lo)
-        } else {
-            self
-        }
-    }
-    #[inline]
-    fn ln_gamma(self) -> Self {
-        DualMixed::ln_gamma(self)
-    }
-}
+impl_pknum_delegate!(Dual1<const N: usize>, second_order = false);
+impl_pknum_delegate!(DualMixed<const NA: usize, const N: usize>, second_order = true);
 
 #[cfg(test)]
 mod tests {

--- a/src/sens/one_cpt_explicit.rs
+++ b/src/sens/one_cpt_explicit.rs
@@ -27,6 +27,35 @@ use super::dual2::Dual2;
 use super::jet::Jet;
 use super::one_cpt::{one_cpt_infusion_ss_g, one_cpt_oral_g, one_cpt_oral_ss_g};
 
+/// Seed a generic dual PK kernel and collapse it to a `(value, grad, hess)`
+/// tuple — the `_explicit` fallback boilerplate written once.
+///
+/// `$f` is the generic `*_g` kernel, `$n` its `Dual2` width. `[$pre…]` are the
+/// leading arguments forwarded verbatim (raw scalars plus `Dual2::constant(t)`
+/// and any `ii`); `[$var…]` are the parameter values seeded as successive
+/// `Dual2::var` axes `0, 1, 2, …` in the order written. Expansion forwards the
+/// same seeds as the hand-written fallbacks, so it is bit-identical.
+///
+/// Shared across the three `*_cpt_explicit` modules via `pub(crate) use`.
+macro_rules! dual2_tuple {
+    ($f:ident, $n:literal, [$($pre:expr),* $(,)?], [$($var:expr),* $(,)?]) => {
+        dual2_tuple!(@seed $f, $n, [$($pre,)*], 0usize, [$($var,)*])
+    };
+    (@seed $f:ident, $n:literal, [$($acc:expr,)*], $idx:expr, [$head:expr, $($rest:expr,)*]) => {
+        dual2_tuple!(
+            @seed $f, $n,
+            [$($acc,)* $crate::sens::dual2::Dual2::var($head, $idx),],
+            $idx + 1usize,
+            [$($rest,)*]
+        )
+    };
+    (@seed $f:ident, $n:literal, [$($acc:expr,)*], $idx:expr, []) => {{
+        let d = $f::<Dual2<$n>>($($acc),*);
+        (d.value, d.grad, d.hess)
+    }};
+}
+pub(crate) use dual2_tuple;
+
 /// Chain a prefactor `A(CL,V)` and a shape `G(k)` (given as value/`G'`/`G''`,
 /// `k = CL/V`) into `(f, ∂f/∂[CL,V], ∂²f/∂[CL,V]²)` for `f = A·G(k)`. `A` is
 /// supplied by its own partials `(a, a_CL, a_V, a_CLCL, a_CLV, a_VV)`; the
@@ -131,15 +160,12 @@ pub fn oral_explicit(
     let k = cl / v;
     if (ka - k).abs() < 1e-6 {
         // L'Hôpital limit — rare; let the dual path handle it exactly.
-        let d = one_cpt_oral_g::<Dual2<4>>(
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v, 1),
-            Dual2::var(ka, 2),
-            Dual2::var(f_bio, 3),
+        return dual2_tuple!(
+            one_cpt_oral_g,
+            4,
+            [amt, Dual2::constant(t)],
+            [cl, v, ka, f_bio]
         );
-        return (d.value, d.grad, d.hess);
     }
 
     // Non-SS Bateman: S = e^{−kt} − e^{−ka·t}; ∂S/∂k∂ka = 0 (separates).
@@ -241,16 +267,12 @@ pub fn oral_ss_explicit(
     }
     let k = cl / v;
     let fallback = || {
-        let d = one_cpt_oral_ss_g::<Dual2<4>>(
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v, 1),
-            Dual2::var(ka, 2),
-            Dual2::var(f_bio, 3),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            one_cpt_oral_ss_g,
+            4,
+            [amt, Dual2::constant(t), ii],
+            [cl, v, ka, f_bio]
+        )
     };
     if (ka - k).abs() < 1e-6 {
         return fallback();
@@ -380,16 +402,12 @@ pub fn infusion_ss_explicit(
         // Overlapping SS infusion: delegate to the generic dual kernel, which
         // superposes the past pulse train (#379). Rare enough not to warrant a
         // hand-written explicit variant.
-        let d = one_cpt_infusion_ss_g::<Dual2<2>>(
-            rate,
-            dur,
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v, 1),
+        return dual2_tuple!(
+            one_cpt_infusion_ss_g,
+            2,
+            [rate, dur, amt, Dual2::constant(t), ii],
+            [cl, v]
         );
-        return (d.value, d.grad, d.hess);
     }
     let k = cl / v;
     let kj = Jet::<1>::var(k, 0);

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -547,6 +547,22 @@ const _: () = assert!(
     "dispatch_init_impulse! enumerates 1..=24; update it when MAX_SCALE_AXES changes",
 );
 
+/// Monomorphize a `const`-generic dispatcher on a runtime dimension: expand
+/// `$dim` against the literal table `$($n),+`, binding the matched literal as a
+/// block-local `const $N: usize` for `$body` to use as its const-generic
+/// argument, with a `_ => None` fallback. Written once and shared by the seven
+/// `run_*::<N>` dispatch ladders below (formerly a per-function `macro_rules!
+/// disp` re-declared at each site). The generated `match` arms are the same
+/// tokens as the hand-written ladders, so the dispatch is bit-identical.
+macro_rules! const_dispatch {
+    ($dim:expr; $($n:literal),+ $(,)?; |$N:ident| $body:expr $(,)?) => {
+        match $dim {
+            $($n => { const $N: usize = $n; $body })+
+            _ => None,
+        }
+    };
+}
+
 /// Maximum `(θ, η)` axis count (`n_theta + n_eta`) for the TV-cov event-driven dual
 /// walk. The outer `run_obs_tvcov` (`m_dim`) and inner `run_obs_grad_tvcov` (`n_eta
 /// ≤ m_dim`) dispatch tables both enumerate `1..=MAX_TVCOV_AXES`, and
@@ -808,6 +824,58 @@ fn lognormal_param_derivatives(
     }
 }
 
+/// Resolve the exact `(∂p/∂(θ,η)` full [`ParamDerivs`], `slots)` pair for a subject:
+/// evaluate the compiled `[individual_parameters]` program over `Dual2` seeded on
+/// `(θ, η)` when it covers the required PK slots, else fall back to the closed-form
+/// log-normal chain (`pk·sel` / `tv_theta_jacobian`) whose rows follow
+/// `pk_indices` order. Returns `None` — the caller falls back to FD — only when the
+/// program path is unavailable AND some PK-param η is not `LogNormal` (the
+/// log-normal chain would then be wrong). Hoisted from the two byte-identical outer
+/// call sites (`apply_tvcov_init_outer`, `subject_sensitivities`) — see F4.
+fn resolve_param_derivs(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    pk: &crate::types::PkParams,
+) -> Option<(crate::sens::ode_provider::ParamDerivs, Vec<usize>)> {
+    match model
+        .indiv_param_partials
+        .indiv_param_program
+        .as_ref()
+        .filter(|prog| prog_covers_required_pk_slots(model, prog))
+        .and_then(|prog| {
+            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
+                .map(|pd| (pd, prog.pk_slots()))
+        }) {
+        Some(v) => Some(v),
+        None => {
+            if !model
+                .eta_param_info
+                .iter()
+                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
+            {
+                return None;
+            }
+            let pd = lognormal_param_derivatives(model, subject, theta, pk);
+            Some((pd, model.pk_indices.clone()))
+        }
+    }
+}
+
+/// PK slot → differentiated-row index of a `pd`/`dp_deta` whose rows follow `slots`
+/// order: `out[slots[i]] = Some(i)` for every in-range slot, `None` otherwise.
+/// Hoisted from the five identical `[None; N_PK]` build loops (F4).
+fn seed_dim_from_slots(slots: &[usize]) -> [Option<usize>; N_PK] {
+    let mut seed_dim: [Option<usize>; N_PK] = [None; N_PK];
+    for (i, &slot) in slots.iter().enumerate() {
+        if slot < N_PK {
+            seed_dim[slot] = Some(i);
+        }
+    }
+    seed_dim
+}
+
 // ─── IOV (inter-occasion variability) analytic sensitivities ──────────
 //
 // IOV makes the PK parameters switch mid-decay at occasion boundaries (NONMEM
@@ -862,17 +930,13 @@ pub(crate) fn iov_combined_derivs_dyn(
     theta: &[f64],
     combined: &[f64],
 ) -> Option<CombinedDerivs> {
-    macro_rules! disp {
-        ($($m:literal),+) => {
-            match n_theta + n_eff {
-                $($m => Some(iov_combined_derivs::<$m>(
-                    prog, n_theta, n_eff, n_rows, cov, theta, combined,
-                )),)+
-                _ => None,
-            }
-        };
-    }
-    disp!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+    const_dispatch!(
+        n_theta + n_eff;
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24;
+        |M| Some(iov_combined_derivs::<M>(
+            prog, n_theta, n_eff, n_rows, cov, theta, combined,
+        ))
+    )
 }
 
 /// Evaluate the compiled `[individual_parameters]` program over `Dual2<MP>` seeded
@@ -1153,21 +1217,15 @@ pub fn subject_sensitivities_iov(
     // the *unknowns* (n_eta + K·n_kappa + n_theta), not the PK axes, so it stays
     // narrow for many occasions whenever n_kappa < n_diff (the usual κ-on-CL case).
     let m_dim = s.n_theta + s.n_stacked;
-    macro_rules! disp {
-        ($($m:literal),+) => {
-            match m_dim {
-                $($m => run_obs_iov::<$m>(
-                    model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
-                    &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_eff, s.n_stacked,
-                    s.n_theta, s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
-                    readout, s.readout_obs.as_ref(),
-                ),)+
-                _ => None,
-            }
-        };
-    }
-    let mut sens = disp!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    let mut sens = const_dispatch!(
+        m_dim;
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24;
+        |M| run_obs_iov::<M>(
+            model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
+            &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_eff, s.n_stacked,
+            s.n_theta, s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
+            readout, s.readout_obs.as_ref(),
+        )
     )?;
     // LTBS (#486): apply the `ln(f)` jet LAST — after the in-walk scale quotient / Form C
     // readout / init impulse — so the outer θ/Ω/σ gradient matches production's scale-then-log
@@ -1289,12 +1347,7 @@ fn build_iov_sources(
     let slots = prog.pk_slots_ref();
     let n_diff = slots.len();
     // PK slot → differentiated-row index (for seeding the dual axis).
-    let mut slot_row: [Option<usize>; N_PK] = [None; N_PK];
-    for (i, &sl) in slots.iter().enumerate() {
-        if sl < N_PK {
-            slot_row[sl] = Some(i);
-        }
-    }
+    let slot_row = seed_dim_from_slots(slots);
 
     // Combined derivatives at `(theta, combined)` evaluated at covariate map `cov`
     // and event time `time`, dispatching the program-eval width `MP = n_theta +
@@ -1512,20 +1565,16 @@ fn subject_eta_grad_iov_analytical(
         .and_then(|ar| ar.program.as_ref());
     let s = build_iov_sources(model, subject, theta, stacked_eta)?;
     let n_dim = s.n_stacked;
-    macro_rules! disp {
-        ($($n:literal),+) => {
-            match n_dim {
-                $($n => run_obs_iov_eta::<$n>(
-                    model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
-                    &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_stacked,
-                    s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
-                    readout, s.readout_obs.as_ref(),
-                ),)+
-                _ => None,
-            }
-        };
-    }
-    disp!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+    const_dispatch!(
+        n_dim;
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24;
+        |N| run_obs_iov_eta::<N>(
+            model, subject, theta, stacked_eta, &s.sources, &s.dose_src, &s.obs_src,
+            &s.pkonly_src, &s.slot_row, s.n_eta, s.n_kappa, s.n_stacked,
+            s.scale_groups.as_deref(), s.bsv_amount.as_ref(),
+            readout, s.readout_obs.as_ref(),
+        )
+    )
 }
 
 /// The dual-width-`M` inner of [`subject_sensitivities_iov`] (`M = n_theta +
@@ -2511,28 +2560,7 @@ fn apply_tvcov_init_outer(
     let n_theta = model.n_theta;
     let n_eta = model.n_eta;
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
-    let (pd, slots): (crate::sens::ode_provider::ParamDerivs, Vec<usize>) = match model
-        .indiv_param_partials
-        .indiv_param_program
-        .as_ref()
-        .filter(|prog| prog_covers_required_pk_slots(model, prog))
-        .and_then(|prog| {
-            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
-                .map(|pd| (pd, prog.pk_slots()))
-        }) {
-        Some(v) => v,
-        None => {
-            if !model
-                .eta_param_info
-                .iter()
-                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
-            {
-                return None;
-            }
-            let pd = lognormal_param_derivatives(model, subject, theta, &pk);
-            (pd, model.pk_indices.clone())
-        }
-    };
+    let (pd, slots) = resolve_param_derivs(model, subject, theta, eta, &pk)?;
     dispatch_init_impulse!(
         n_theta + n_eta,
         apply_analytical_init_outer,
@@ -2566,28 +2594,11 @@ fn apply_tvcov_init_inner(
     }
     let n_eta = model.n_eta;
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
-    let (dp_deta, slots): (Vec<Vec<f64>>, Vec<usize>) = match model
-        .indiv_param_partials
-        .indiv_param_program
-        .as_ref()
-        .filter(|prog| prog_covers_required_pk_slots(model, prog))
-        .and_then(|prog| {
-            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
-                .map(|pd| (pd.dp_deta, prog.pk_slots()))
-        }) {
-        Some(v) => v,
-        None => {
-            if !model
-                .eta_param_info
-                .iter()
-                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
-            {
-                return None;
-            }
-            let pd = lognormal_param_derivatives(model, subject, theta, &pk);
-            (pd.dp_deta, model.pk_indices.clone())
-        }
-    };
+    // Full `ParamDerivs` via the shared resolver, then project the η-block (the inner
+    // init impulse consumes `∂p/∂η` only) — bit-identical to the former inline
+    // `param_derivatives_from_prog(...).map(|pd| pd.dp_deta)` + log-normal fallback (F4).
+    let (pd, slots) = resolve_param_derivs(model, subject, theta, eta, &pk)?;
+    let dp_deta = pd.dp_deta;
     dispatch_init_impulse!(
         n_eta,
         apply_analytical_init_inner,
@@ -2657,12 +2668,7 @@ pub fn subject_sensitivities_tvcov(
     let slots = prog.pk_slots_ref();
     // PK slot → differentiated-row index of `pd_from_program` (for seeding the
     // dual axis). `pd` rows follow `pk_slots()` order, so row `i` ↔ slot `slots[i]`.
-    let mut slot_row: [Option<usize>; N_PK] = [None; N_PK];
-    for (i, &s) in slots.iter().enumerate() {
-        if s < N_PK {
-            slot_row[s] = Some(i);
-        }
-    }
+    let slot_row = seed_dim_from_slots(slots);
 
     // Analytic Form C readout program (#650); `readout_tvcov_supported` (checked at
     // the gate) guarantees it fits the eight structural `PkDual` slots here.
@@ -2670,18 +2676,12 @@ pub fn subject_sensitivities_tvcov(
         .analytic_readout
         .as_ref()
         .and_then(|ar| ar.program.as_ref());
-    macro_rules! disp {
-        ($($m:literal),+) => {
-            match m_dim {
-                $($m => run_obs_tvcov::<$m>(
-                    model, subject, theta, eta, prog, &slot_row, n_eta, n_theta, readout,
-                ),)+
-                _ => None,
-            }
-        };
-    }
-    let mut sens = disp!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    let mut sens = const_dispatch!(
+        m_dim;
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24;
+        |M| run_obs_tvcov::<M>(
+            model, subject, theta, eta, prog, &slot_row, n_eta, n_theta, readout,
+        )
     )?;
 
     // Analytic `[initial_conditions]` impulse (#486): layer `A₀·kernel(t, pk)` and its exact
@@ -3081,31 +3081,20 @@ pub(crate) fn subject_eta_grad_tvcov_with_schedule(
         .as_ref()
         .expect("tvcov_analytical_supported guarantees the program");
     let slots = prog.pk_slots_ref();
-    let mut slot_row: [Option<usize>; N_PK] = [None; N_PK];
-    for (i, &s) in slots.iter().enumerate() {
-        if s < N_PK {
-            slot_row[s] = Some(i);
-        }
-    }
+    let slot_row = seed_dim_from_slots(slots);
 
     let readout = model
         .analytic_readout
         .as_ref()
         .and_then(|ar| ar.program.as_ref());
-    macro_rules! disp {
-        ($($n:literal),+) => {
-            match n_eta {
-                $($n => run_obs_grad_tvcov::<$n>(model, subject, theta, eta, prog, &slot_row, n_eta, cached_schedule, readout),)+
-                _ => None,
-            }
-        };
-    }
     // Match the outer `run_obs_tvcov` cap (`m_dim = n_theta + n_eta` over `1..=24`):
     // since `n_eta ≤ m_dim`, bounding the gate at 24 (below) makes both dispatch
     // tables resolve, so the inner and outer analytic scope stay matched rather than
     // splitting to a fixed-EBE FD inner (#449 re-review #2).
-    let mut out = disp!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    let mut out = const_dispatch!(
+        n_eta;
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24;
+        |N| run_obs_grad_tvcov::<N>(model, subject, theta, eta, prog, &slot_row, n_eta, cached_schedule, readout)
     )?;
 
     // Analytic `[initial_conditions]` impulse (#486): η-gradient only, layered BEFORE scaling —
@@ -3612,12 +3601,7 @@ fn subject_eta_grad_impl(
             (pd.dp_deta, model.pk_indices.clone())
         }
     };
-    let mut seed_dim: [Option<usize>; N_PK] = [None; N_PK];
-    for (i, &slot) in slots.iter().enumerate() {
-        if slot < N_PK {
-            seed_dim[slot] = Some(i);
-        }
-    }
+    let seed_dim = seed_dim_from_slots(&slots);
 
     // Analytic Form C readout program (#650); the gate guarantees it is dual-
     // evaluable and depot-free, so the inner `run_obs_grad` serves it exactly.
@@ -3625,18 +3609,14 @@ fn subject_eta_grad_impl(
         .analytic_readout
         .as_ref()
         .and_then(|ar| ar.program.as_ref());
-    macro_rules! disp {
-        ($($n:literal),+) => {
-            match slots.len() {
-                $($n => Some(run_obs_grad::<$n>(
-                    &seed_dim, &pk, oral, two_cpt, three_cpt, transit, two_cpt_transit, ig,
-                    two_cpt_ig, subject, &dp_deta, n_eta, readout,
-                )),)+
-                _ => None,
-            }
-        };
-    }
-    let mut out = disp!(1, 2, 3, 4, 5, 6, 7, 8, 9)?;
+    let mut out = const_dispatch!(
+        slots.len();
+        1, 2, 3, 4, 5, 6, 7, 8, 9;
+        |N| Some(run_obs_grad::<N>(
+            &seed_dim, &pk, oral, two_cpt, three_cpt, transit, two_cpt_transit, ig,
+            two_cpt_ig, subject, &dp_deta, n_eta, readout,
+        ))
+    )?;
     // Analytic `[initial_conditions]` impulse (#524): η-gradient only, layered on
     // BEFORE scaling — same insertion order as the f64 `pk::add_analytical_init`.
     // The inner path runs on `Dual1<n_eta>`, so it dispatches on `n_eta` (≤ the
@@ -4695,46 +4675,14 @@ fn subject_sensitivities_impl(
     // `tv_theta_jacobian` θ chain (`ρ`) — whose rows ARE in `pk_indices` order —
     // when the program path is unavailable (NN-weight θ / IOV kappa axis mismatch,
     // or a literal-const PK slot the program omits).
-    let (pd, slots): (crate::sens::ode_provider::ParamDerivs, Vec<usize>) = match model
-        .indiv_param_partials
-        .indiv_param_program
-        .as_ref()
-        .filter(|prog| prog_covers_required_pk_slots(model, prog))
-        .and_then(|prog| {
-            crate::sens::ode_provider::param_derivatives_from_prog(prog, model, subject, theta, eta)
-                .map(|pd| (pd, prog.pk_slots()))
-        }) {
-        Some((pd, slots)) => (pd, slots),
-        None => {
-            // The closed-form fallback assumes `∂p/∂η = pk·sel` (log-normal). It is
-            // only valid when every PK-param eta is LogNormal; for additive / logit
-            // / custom etas the exact `∂p/∂η` must come from the program chain
-            // above, and if that is unavailable (NN-weight θ or IOV kappa axis
-            // mismatch) we fall back to FD rather than mis-apply the log-normal
-            // chain (which would be off by a factor of `pk` vs `1`). PR #381 #4.
-            if !model
-                .eta_param_info
-                .iter()
-                .all(|e| e.param_type == crate::types::EtaParamType::LogNormal)
-            {
-                return None;
-            }
-            let pd = lognormal_param_derivatives(model, subject, theta, &pk);
-            (pd, model.pk_indices.clone())
-        }
-    };
+    let (pd, slots) = resolve_param_derivs(model, subject, theta, eta, &pk)?;
 
     // Right-size the dual width to the number of differentiated PK parameters
     // (issue #367): seed only those on a compact `0..N`, so a 2-cpt IV model runs
     // `Dual2<4>` (4× fewer Hessian entries per op than the former fixed `Dual2<8>`),
     // 3-cpt `Dual2<6>`, etc. `seed_dim[s]` is the compact dual axis for PK slot `s`
     // (`None` = constant, not differentiated); `pd` row `i` ↔ compact axis `i`.
-    let mut seed_dim: [Option<usize>; N_PK] = [None; N_PK];
-    for (i, &slot) in slots.iter().enumerate() {
-        if slot < N_PK {
-            seed_dim[slot] = Some(i);
-        }
-    }
+    let seed_dim = seed_dim_from_slots(&slots);
 
     // Explicit-kernel fast path (the default): pick the model class, then take it
     // only if a hand-written kernel covers every dose (else the whole subject uses
@@ -4776,20 +4724,16 @@ fn subject_sensitivities_impl(
         .analytic_readout
         .as_ref()
         .and_then(|ar| ar.program.as_ref());
-    macro_rules! disp {
-        ($($n:literal),+) => {
-            match slots.len() {
-                $($n => Some(SubjectSens {
-                    obs: run_obs::<$n>(
-                        &seed_dim, &pk, oral, two_cpt, three_cpt, transit, two_cpt_transit, ig,
-                        two_cpt_ig, explicit_kind, subject, &pd, n_eta, n_theta, readout,
-                    ),
-                }),)+
-                _ => None,
-            }
-        };
-    }
-    let mut sens = disp!(1, 2, 3, 4, 5, 6, 7, 8, 9)?;
+    let mut sens = const_dispatch!(
+        slots.len();
+        1, 2, 3, 4, 5, 6, 7, 8, 9;
+        |N| Some(SubjectSens {
+            obs: run_obs::<N>(
+                &seed_dim, &pk, oral, two_cpt, three_cpt, transit, two_cpt_transit, ig,
+                two_cpt_ig, explicit_kind, subject, &pd, n_eta, n_theta, readout,
+            ),
+        })
+    )?;
     // Analytic `[initial_conditions]` impulse (#524): layer `A₀ · kernel(t, pk)`
     // and its exact `(θ, η)` jet onto every observation BEFORE scaling — the same
     // insertion order as the f64 `pk::add_analytical_init`. Dispatched on the

--- a/src/sens/three_cpt_explicit.rs
+++ b/src/sens/three_cpt_explicit.rs
@@ -31,6 +31,7 @@
 
 use super::dual2::Dual2;
 use super::jet::{over_v1, Jet};
+use super::one_cpt_explicit::dual2_tuple;
 use super::three_cpt::{
     three_cpt_infusion_g, three_cpt_infusion_ss_g, three_cpt_iv_bolus_g, three_cpt_iv_bolus_ss_g,
     three_cpt_oral_g, three_cpt_oral_ss_g,
@@ -174,17 +175,12 @@ pub fn iv_bolus_explicit(
     v3: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = three_cpt_iv_bolus_g::<Dual2<6>>(
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_iv_bolus_g,
+            6,
+            [amt, Dual2::constant(t)],
+            [cl, v1, q2, v2, q3, v3]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || v3 <= 0.0 || cl <= 0.0 || q2 < 0.0 || q3 < 0.0 {
         return (0.0, [0.0; 6], [[0.0; 6]; 6]);
@@ -239,19 +235,12 @@ pub fn infusion_explicit(
     v3: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = three_cpt_infusion_g::<Dual2<6>>(
-            rate,
-            dur,
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_infusion_g,
+            6,
+            [rate, dur, amt, Dual2::constant(t)],
+            [cl, v1, q2, v2, q3, v3]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || v3 <= 0.0 || cl <= 0.0 || q2 < 0.0 || q3 < 0.0 {
         return (0.0, [0.0; 6], [[0.0; 6]; 6]);
@@ -330,19 +319,12 @@ pub fn oral_explicit(
     f_bio: f64,
 ) -> (f64, [f64; 8], [[f64; 8]; 8]) {
     let fallback = || {
-        let d = three_cpt_oral_g::<Dual2<8>>(
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-            Dual2::var(ka, 6),
-            Dual2::var(f_bio, 7),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_oral_g,
+            8,
+            [amt, Dual2::constant(t)],
+            [cl, v1, q2, v2, q3, v3, ka, f_bio]
+        )
     };
     if t < 0.0
         || v1 <= 0.0
@@ -410,18 +392,12 @@ pub fn iv_bolus_ss_explicit(
     v3: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = three_cpt_iv_bolus_ss_g::<Dual2<6>>(
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_iv_bolus_ss_g,
+            6,
+            [amt, Dual2::constant(t), ii],
+            [cl, v1, q2, v2, q3, v3]
+        )
     };
     if t < 0.0
         || v1 <= 0.0
@@ -482,20 +458,12 @@ pub fn oral_ss_explicit(
     f_bio: f64,
 ) -> (f64, [f64; 8], [[f64; 8]; 8]) {
     let fallback = || {
-        let d = three_cpt_oral_ss_g::<Dual2<8>>(
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-            Dual2::var(ka, 6),
-            Dual2::var(f_bio, 7),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_oral_ss_g,
+            8,
+            [amt, Dual2::constant(t), ii],
+            [cl, v1, q2, v2, q3, v3, ka, f_bio]
+        )
     };
     if t < 0.0
         || v1 <= 0.0
@@ -573,20 +541,12 @@ pub fn infusion_ss_explicit(
     v3: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = three_cpt_infusion_ss_g::<Dual2<6>>(
-            rate,
-            dur,
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q2, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(q3, 4),
-            Dual2::var(v3, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            three_cpt_infusion_ss_g,
+            6,
+            [rate, dur, amt, Dual2::constant(t), ii],
+            [cl, v1, q2, v2, q3, v3]
+        )
     };
     if t < 0.0
         || v1 <= 0.0

--- a/src/sens/two_cpt_explicit.rs
+++ b/src/sens/two_cpt_explicit.rs
@@ -21,6 +21,7 @@
 
 use super::dual2::Dual2;
 use super::jet::{over_v1, Jet};
+use super::one_cpt_explicit::dual2_tuple;
 use super::two_cpt::{
     two_cpt_infusion_g, two_cpt_infusion_ss_g, two_cpt_iv_bolus_g, two_cpt_iv_bolus_ss_g,
     two_cpt_oral_g, two_cpt_oral_ss_g,
@@ -101,15 +102,12 @@ pub fn iv_bolus_explicit(
     v2: f64,
 ) -> (f64, [f64; 4], [[f64; 4]; 4]) {
     let fallback = || {
-        let d = two_cpt_iv_bolus_g::<Dual2<4>>(
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_iv_bolus_g,
+            4,
+            [amt, Dual2::constant(t)],
+            [cl, v1, q, v2]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 {
         return (0.0, [0.0; 4], [[0.0; 4]; 4]);
@@ -148,17 +146,12 @@ pub fn infusion_explicit(
     v2: f64,
 ) -> (f64, [f64; 4], [[f64; 4]; 4]) {
     let fallback = || {
-        let d = two_cpt_infusion_g::<Dual2<4>>(
-            rate,
-            dur,
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_infusion_g,
+            4,
+            [rate, dur, amt, Dual2::constant(t)],
+            [cl, v1, q, v2]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 {
         return (0.0, [0.0; 4], [[0.0; 4]; 4]);
@@ -221,17 +214,12 @@ pub fn oral_explicit(
     f_bio: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = two_cpt_oral_g::<Dual2<6>>(
-            amt,
-            Dual2::constant(t),
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(ka, 4),
-            Dual2::var(f_bio, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_oral_g,
+            6,
+            [amt, Dual2::constant(t)],
+            [cl, v1, q, v2, ka, f_bio]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 || ka <= 0.0 {
         return (0.0, [0.0; 6], [[0.0; 6]; 6]);
@@ -283,16 +271,12 @@ pub fn iv_bolus_ss_explicit(
     v2: f64,
 ) -> (f64, [f64; 4], [[f64; 4]; 4]) {
     let fallback = || {
-        let d = two_cpt_iv_bolus_ss_g::<Dual2<4>>(
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_iv_bolus_ss_g,
+            4,
+            [amt, Dual2::constant(t), ii],
+            [cl, v1, q, v2]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 || ii <= 0.0 {
         return (0.0, [0.0; 4], [[0.0; 4]; 4]);
@@ -332,18 +316,12 @@ pub fn oral_ss_explicit(
     f_bio: f64,
 ) -> (f64, [f64; 6], [[f64; 6]; 6]) {
     let fallback = || {
-        let d = two_cpt_oral_ss_g::<Dual2<6>>(
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-            Dual2::var(ka, 4),
-            Dual2::var(f_bio, 5),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_oral_ss_g,
+            6,
+            [amt, Dual2::constant(t), ii],
+            [cl, v1, q, v2, ka, f_bio]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 || ka <= 0.0 || ii <= 0.0 {
         return (0.0, [0.0; 6], [[0.0; 6]; 6]);
@@ -399,18 +377,12 @@ pub fn infusion_ss_explicit(
     v2: f64,
 ) -> (f64, [f64; 4], [[f64; 4]; 4]) {
     let fallback = || {
-        let d = two_cpt_infusion_ss_g::<Dual2<4>>(
-            rate,
-            dur,
-            amt,
-            Dual2::constant(t),
-            ii,
-            Dual2::var(cl, 0),
-            Dual2::var(v1, 1),
-            Dual2::var(q, 2),
-            Dual2::var(v2, 3),
-        );
-        (d.value, d.grad, d.hess)
+        dual2_tuple!(
+            two_cpt_infusion_ss_g,
+            4,
+            [rate, dur, amt, Dual2::constant(t), ii],
+            [cl, v1, q, v2]
+        )
     };
     if t < 0.0 || v1 <= 0.0 || v2 <= 0.0 || cl <= 0.0 || q < 0.0 || ii <= 0.0 {
         return (0.0, [0.0; 4], [[0.0; 4]; 4]);

--- a/src/stats/convergence.rs
+++ b/src/stats/convergence.rs
@@ -156,54 +156,12 @@ pub fn effective_sample_size(chains: &[Vec<f64>]) -> f64 {
     ess.min((m * n) as f64)
 }
 
-/// Inverse standard-normal CDF (probit), Acklam's rational approximation
-/// (|error| < ~1.2e-9 over (0,1)). `p` is clamped to the open interval.
+/// Inverse standard-normal CDF (probit). Delegates to the shared Acklam
+/// approximation ([`crate::stats::special::normal_inv_cdf`]); the explicit clamp
+/// to `[1e-12, 1 − 1e-12]` reproduces this module's historical open-interval edge
+/// behavior (the shared copy returns `±inf` at `p ≤ 0` / `p ≥ 1`).
 fn inv_normal_cdf(p: f64) -> f64 {
-    const A: [f64; 6] = [
-        -3.969683028665376e+01,
-        2.209460984245205e+02,
-        -2.759285104469687e+02,
-        1.383577518672690e+02,
-        -3.066479806614716e+01,
-        2.506628277459239e+00,
-    ];
-    const B: [f64; 5] = [
-        -5.447609879822406e+01,
-        1.615858368580409e+02,
-        -1.556989798598866e+02,
-        6.680131188771972e+01,
-        -1.328068155288572e+01,
-    ];
-    const C: [f64; 6] = [
-        -7.784894002430293e-03,
-        -3.223964580411365e-01,
-        -2.400758277161838e+00,
-        -2.549732539343734e+00,
-        4.374664141464968e+00,
-        2.938163982698783e+00,
-    ];
-    const D: [f64; 4] = [
-        7.784695709041462e-03,
-        3.224671290700398e-01,
-        2.445134137142996e+00,
-        3.754408661907416e+00,
-    ];
-    let p = p.clamp(1e-12, 1.0 - 1e-12);
-    let plow = 0.02425;
-    if p < plow {
-        let q = (-2.0 * p.ln()).sqrt();
-        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
-            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
-    } else if p <= 1.0 - plow {
-        let q = p - 0.5;
-        let r = q * q;
-        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
-            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
-    } else {
-        let q = (-2.0 * (1.0 - p).ln()).sqrt();
-        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
-            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
-    }
+    crate::stats::special::normal_inv_cdf(p.clamp(1e-12, 1.0 - 1e-12))
 }
 
 /// Rank-normalize draws pooled across chains, preserving per-chain order

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -1,5 +1,4 @@
 use crate::pk;
-use crate::stats::residual_error::compute_r_matrix_with_correlations;
 use crate::stats::special::log_normal_cdf;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -604,7 +603,8 @@ pub fn individual_nll_into_with_schedule(
 
 /// Dense correlated-residual (block_sigma) Gaussian data term for one subject.
 ///
-/// Builds the residual covariance `R` from [`compute_r_matrix_with_correlations`],
+/// Builds the residual covariance `R` from
+/// [`compute_r_matrix_with_correlations`](crate::stats::residual_error::compute_r_matrix_with_correlations),
 /// scales it by `ruv_scale`, adds the per-observation EKF process-noise `p_obs`
 /// to the diagonal (`&[]` on the SAEM / non-SDE paths), then returns the
 /// un-halved quadratic form plus log-determinant `rᵀ R⁻¹ r + log|R|`. Returns
@@ -627,31 +627,15 @@ fn dense_residual_data_term(
 ) -> Option<f64> {
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
-    let mut r = match ruv_mult {
-        Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
-            &model.error_spec,
-            preds,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            &model.residual_correlations,
-            mult,
-        ),
-        None => compute_r_matrix_with_correlations(
-            &model.error_spec,
-            preds,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            &model.residual_correlations,
-        ),
-    };
+    let mut r = crate::stats::residual_error::r_matrix_maybe_scaled(
+        &model.error_spec,
+        preds,
+        err_keys.as_ref(),
+        subject,
+        sigma_values,
+        &model.residual_correlations,
+        ruv_mult,
+    );
     if ruv_scale != 1.0 {
         r *= ruv_scale;
     }
@@ -839,17 +823,7 @@ fn ekf_p_obs(
 
 /// Log-determinant of Omega via Cholesky: log|Omega| = 2 * sum(log(L_ii))
 fn omega_log_det(omega: &OmegaMatrix) -> f64 {
-    let n = omega.chol.nrows();
-    let mut ld = 0.0;
-    for i in 0..n {
-        let lii = omega.chol[(i, i)];
-        if lii > 0.0 {
-            ld += lii.ln();
-        } else {
-            return 1e20;
-        }
-    }
-    2.0 * ld
+    chol_log_det(&omega.chol)
 }
 
 /// FOCE per-subject negative log-likelihood.
@@ -1231,31 +1205,15 @@ pub fn foce_subject_nll_standard(
     // override must come last so it survives the r_pred_override re-evaluation
     // of R.
     let r_eval: &[f64] = r_pred_override.unwrap_or(&f0);
-    let mut r_matrix = match ruv_mult {
-        Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
-            error_spec,
-            r_eval,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            residual_correlations,
-            mult,
-        ),
-        None => compute_r_matrix_with_correlations(
-            error_spec,
-            r_eval,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            residual_correlations,
-        ),
-    };
+    let mut r_matrix = crate::stats::residual_error::r_matrix_maybe_scaled(
+        error_spec,
+        r_eval,
+        err_keys.as_ref(),
+        subject,
+        sigma_values,
+        residual_correlations,
+        ruv_mult,
+    );
     for (j, v) in p_obs.iter().enumerate() {
         if j < r_matrix.nrows() {
             r_matrix[(j, j)] += *v;
@@ -1442,7 +1400,8 @@ pub fn foce_subject_nll_interaction(
 ///
 /// The diagonal interaction path forms `R` one observation at a time and so
 /// silently drops the `block_sigma` off-diagonals. This path instead carries the
-/// full residual covariance `R` (from [`compute_r_matrix_with_correlations`],
+/// full residual covariance `R` (from
+/// [`compute_r_matrix_with_correlations`](crate::stats::residual_error::compute_r_matrix_with_correlations),
 /// the same matrix the FOCE non-interaction and SAEM paths use), giving the
 /// Almquist 2015 first-order conditional Hessian
 ///
@@ -1487,31 +1446,15 @@ pub fn foce_subject_nll_interaction_dense(
 
     // Dense R at η̂ (+ SDE process noise on the diagonal), assembled exactly as
     // the data term and FOCE-standard path assemble it.
-    let mut r = match ruv_mult {
-        Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
-            error_spec,
-            ipreds,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            correlations,
-            mult,
-        ),
-        None => compute_r_matrix_with_correlations(
-            error_spec,
-            ipreds,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            correlations,
-        ),
-    };
+    let mut r = crate::stats::residual_error::r_matrix_maybe_scaled(
+        error_spec,
+        ipreds,
+        err_keys.as_ref(),
+        subject,
+        sigma_values,
+        correlations,
+        ruv_mult,
+    );
     for (j, v) in p_obs.iter().enumerate() {
         if j < r.nrows() {
             r[(j, j)] += *v;
@@ -2233,31 +2176,15 @@ pub fn compute_cwres(
         .collect();
 
     // R_tilde
-    let mut r_matrix = match ruv_mult {
-        Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
-            error_spec,
-            &f0,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            residual_correlations,
-            mult,
-        ),
-        None => compute_r_matrix_with_correlations(
-            error_spec,
-            &f0,
-            err_keys.as_ref(),
-            &subject.obs_times,
-            &subject.obs_raw_times,
-            &subject.occasions,
-            &subject.obs_l2,
-            sigma_values,
-            residual_correlations,
-        ),
-    };
+    let mut r_matrix = crate::stats::residual_error::r_matrix_maybe_scaled(
+        error_spec,
+        &f0,
+        err_keys.as_ref(),
+        subject,
+        sigma_values,
+        residual_correlations,
+        ruv_mult,
+    );
     if let Some(overrides) = frem_r_override {
         apply_frem_r_matrix_overrides(&mut r_matrix, overrides);
     }

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -1,4 +1,4 @@
-use crate::types::{ErrorModel, ErrorSpec, ResidualCorrelation, SubjectResult};
+use crate::types::{ErrorModel, ErrorSpec, ResidualCorrelation, Subject, SubjectResult};
 use nalgebra::DMatrix;
 
 const MIN_VARIANCE: f64 = 1e-12;
@@ -391,6 +391,50 @@ pub fn compute_r_matrix_with_correlations_scaled(
     );
     fill_cross_covariances(&mut r, &pairs);
     r
+}
+
+/// Dense residual covariance `R`, dispatching on the optional per-observation
+/// custom-magnitude multiplier: `Some(mult)` routes through the `_scaled`
+/// association ([`compute_r_matrix_with_correlations_scaled`]) and `None` through
+/// the bare ([`compute_r_matrix_with_correlations`]) diagonal form. The two are
+/// equal in exact arithmetic but differ by ~1 ULP under IEEE-754 reassociation,
+/// so the split is preserved (not merged). `obs_times`/`obs_raw_times`/
+/// `occasions`/`obs_l2` are pulled off `subject`. Folds the identical `match`
+/// that the FOCE/FOCEI/data-term/CWRES paths each carried.
+pub(crate) fn r_matrix_maybe_scaled(
+    error_spec: &ErrorSpec,
+    preds: &[f64],
+    err_keys: &[usize],
+    subject: &Subject,
+    sigma_values: &[f64],
+    correlations: &[ResidualCorrelation],
+    ruv_mult: Option<&[Vec<f64>]>,
+) -> DMatrix<f64> {
+    match ruv_mult {
+        Some(mult) => compute_r_matrix_with_correlations_scaled(
+            error_spec,
+            preds,
+            err_keys,
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            &subject.obs_l2,
+            sigma_values,
+            correlations,
+            mult,
+        ),
+        None => compute_r_matrix_with_correlations(
+            error_spec,
+            preds,
+            err_keys,
+            &subject.obs_times,
+            &subject.obs_raw_times,
+            &subject.occasions,
+            &subject.obs_l2,
+            sigma_values,
+            correlations,
+        ),
+    }
 }
 
 /// `∂R/∂f_m` matrices of the dense residual covariance built by


### PR DESCRIPTION
## Why

Large stretches of the codebase were hand-rolled: copy-pasted functions, near-identical
match/dispatch blocks, repeated boilerplate idioms, and duplicated test scaffolding. This
PR consolidates the clearly-safe cases into shared helpers/macros/generics to shrink the
codebase and give each pattern a single source of truth (several had already drifted between
copies). No behavioural change is intended — this is internal cleanup only.

## What changed

Verbatim, **bit-identical** extractions only — no floating-point reassociation, no RNG
draw-order changes, no `.fitrx` wire-format changes. Net **~ -960 LOC** across 23 files
(+1464 / -2402). Landed in two verified batches (each `cargo check --tests` + `cargo test
--lib` green, 0 new warnings). Highlights:

- **estimation/sens_outer_gradient**: Richardson-FD comparison harness collapsed into one
  test helper (~20 sites, tolerances passed through unchanged); `pop_of` for 19 identical
  `Population` literals; reuse of the existing `lower_tri_entries`, plus `theta_dx_chain`
  and a shared `population_sum`.
- **stats**: `r_matrix_maybe_scaled` folds the `Some/None` R-matrix dispatch (4 sites);
  `omega_log_det` delegates to `chol_log_det`; the Acklam probit is de-duplicated
  (`convergence` now calls `stats::special::normal_inv_cdf`).
- **sens**: `impl_pknum_delegate!` macro for the `Dual1`/`DualMixed` `PkNum` impls;
  `chain1` unary chain-rule helper; `dual2_tuple!` collapsing ~15 `*_explicit` fallback
  sites; provider `const_dispatch!` (7 copies → 1) and a shared `ParamDerivs` resolver.
- **io**: `str_enum_map!` for the six `.fitrx` enum↔str pairs; a shared `serde_nan` module
  replacing six NaN-as-null serde copies; `declared_union`/`augment_with_filter`, single-
  source CSV float formatter, and folded zip-entry readers.
- **ode/predictions**: per-subject prologue extraction (5 drivers) + `record_observations`
  / `tad_anchor` / `clamp_negative_predictions` idiom helpers.
- **parser**: shared `apply_fit_option` validation closures (message strings preserved
  verbatim).
- **api**: `panic_if_unsupported`, `list_warning`, and `warning_entry` builders.
- **estimation (saem/impmap/IS)**: mu-ref pairs, omega-diagonal floor, and importance-
  sampling scalar helpers single-sourced.

Divergent sites were deliberately left inline where folding them would change behaviour or a
message string (e.g. the `assert_modeled_doses_supported` panic tail, the `param_eta_deriv`
inner resolver, the usize/half-open validation guards, adaptive per-observation obs-record).

## Alternatives considered

A larger, higher-risk set was catalogued but intentionally deferred: parser hot-path
evaluator-twin unification, the `run_obs`/`run_obs_grad` superpose merge, the
`ode_predictions_with_states` clone (has a latent EVID-3/4 behaviour difference), pk
closed-form merges, and a cross-cutting `linalg`/`mathutil` module. These need per-item
bit-identity tests and closer review; this PR stops at the "obviously safe" tier.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#— | not needed | — |

No `pub` API surface changed (helpers are private / `pub(crate)`), so ferx-r is unaffected.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (refactor only — all changes are verbatim bit-identical extractions,
  covered by the existing Tier-1 suite)

## Performance
- [x] No significant impact expected (macros/generics monomorphise to the same code; hot
  f64 paths were left untouched)

## Tests
- [x] No new tests needed — behaviour is unchanged and the existing 2486 lib tests
  (including the wire-format round-trips, `conc_g_all_dose_kinds_*`, PkNum coverage, and
  the FD-comparison oracles) all pass unmodified.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor)

## Docs
- [x] No user-visible change; `CHANGELOG.md` entry N/A (internal refactor per repo policy)

## Checklist
- [x] `cargo fmt` clean (pre-commit hook passed)
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay
  differentiable — the `sens` changes only factor out seeding/dispatch boilerplate; the
  generic kernels are untouched.
- [x] No `Cargo.toml` version bump needed (non-breaking)

## Reviewer hints

Focus on the four sites that carry the most subtlety:
- `sens/one_cpt_explicit.rs` `dual2_tuple!` — confirm the seeded `Dual2::var` axis indices
  match the former hand-written order at each of the ~15 call sites.
- `io/serde_nan.rs` + `io/fitrx.rs` `str_enum_map!` — confirm the on-disk literals and the
  NaN↔null mapping are byte-identical (round-trip tests cover this).
- `stats/residual_error.rs` `r_matrix_maybe_scaled` — confirm the `_scaled`-vs-bare split is
  preserved per call site.
- `estimation/importance_sampling.rs` — the Student-t log-normaliser was split so only the
  leftmost Γ-ratio sub-expression is shared, preserving each site's reduction order.

Everything else is mechanical control-flow/boilerplate extraction.

## Open questions

None — happy to split this into per-subsystem commits if that eases review.
