### PR TITLE
refactor: consolidate deeper duplicated logic into shared helpers (round 2)

### DIFF
--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -673,6 +673,66 @@ fn mag_alpha_dtheta(et: &ErrTerms, m: usize) -> f64 {
         + ((r - eps * eps) * inv_r2) * d_th
 }
 
+/// Residual variance `R` and its `f`-derivative `d = ∂R/∂f` for one observation,
+/// dispatching on whether a custom σ-magnitude is active (`mult_row = Some`): the
+/// scaled closed forms when it is, the legacy ones when it is not (`None` keeps
+/// the exact `variance_at`/`dvar_df` association bit-for-bit — the `_scaled`
+/// variants reassociate the `f`-dependent term by ~1 ULP). Callers apply
+/// `ruv_scale` (and any FD combination) at the call site so float association is
+/// unchanged. Diagonal-`R` only (`block_sigma` correlations force FD upstream).
+#[inline]
+fn variance_rd(
+    es: &crate::types::ErrorSpec,
+    cmt: usize,
+    f: f64,
+    sigma: &[f64],
+    mult_row: Option<&[f64]>,
+) -> (f64, f64) {
+    match mult_row {
+        Some(m) => (
+            es.variance_at_scaled(cmt, f, sigma, &[], m),
+            es.dvar_df_scaled(cmt, f, sigma, m),
+        ),
+        None => (es.variance_at(cmt, f, sigma), es.dvar_df(cmt, f, sigma)),
+    }
+}
+
+/// [`variance_rd`] plus the second `f`-derivative `d2 = ∂²R/∂f²`.
+#[inline]
+fn variance_rd2(
+    es: &crate::types::ErrorSpec,
+    cmt: usize,
+    f: f64,
+    sigma: &[f64],
+    mult_row: Option<&[f64]>,
+) -> (f64, f64, f64) {
+    match mult_row {
+        Some(m) => (
+            es.variance_at_scaled(cmt, f, sigma, &[], m),
+            es.dvar_df_scaled(cmt, f, sigma, m),
+            es.d2var_df2_scaled(cmt, sigma, m),
+        ),
+        None => (
+            es.variance_at(cmt, f, sigma),
+            es.dvar_df(cmt, f, sigma),
+            es.d2var_df2(cmt, sigma),
+        ),
+    }
+}
+
+/// The σ-EBE-response data-term coefficient derivative for one observation:
+/// `∂α/∂σ = [2ε/R² + d(2ε²−R)/R³]·Rσ + [(R−ε²)/R²]·dσ`, given `(r, d, eps)` and the
+/// σ-FD slopes `r_sig = ∂R/∂σ`, `d_sig = ∂d/∂σ`. The σ mirror of [`mag_alpha_dtheta`],
+/// shared by the three σ-blocks (`sigma_block`, `subject_eta_dx{,_iov}`).
+#[inline]
+fn dalpha_dsigma(r: f64, d: f64, eps: f64, r_sig: f64, d_sig: f64) -> f64 {
+    let inv_r = 1.0 / r;
+    let inv_r2 = inv_r * inv_r;
+    let inv_r3 = inv_r2 * inv_r;
+    (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_sig
+        + ((r - eps * eps) * inv_r2) * d_sig
+}
+
 /// [`prepare`] generalized over the random-effect dimension and prior precision,
 /// so it serves both the non-IOV path (`n_eta = model.n_eta`, `Ω⁻¹ = params.omega.inv`)
 /// and the **IOV** path, where the random effects are the stacked
@@ -937,21 +997,8 @@ pub(crate) fn score_core(
             (Some(v), _) => (v, 0.0, 0.0),
             (None, Some((rv, dv, d2v))) => (rv[j], dv[j], d2v[j]),
             (None, None) => {
-                let r = match mult_row {
-                    Some(m) => {
-                        model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m) * ruv_scale
-                    }
-                    None => model.error_spec.variance_at(cmt, f, sigma) * ruv_scale,
-                };
-                let d = match mult_row {
-                    Some(m) => model.error_spec.dvar_df_scaled(cmt, f, sigma, m) * ruv_scale,
-                    None => model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale,
-                };
-                let d2 = match mult_row {
-                    Some(m) => model.error_spec.d2var_df2_scaled(cmt, sigma, m) * ruv_scale,
-                    None => model.error_spec.d2var_df2(cmt, sigma) * ruv_scale,
-                };
-                (r, d, d2)
+                let (r, d, d2) = variance_rd2(&model.error_spec, cmt, f, sigma, mult_row);
+                (r * ruv_scale, d * ruv_scale, d2 * ruv_scale)
             }
         };
         if !(r.is_finite() && r > 0.0) {
@@ -1667,20 +1714,11 @@ fn sigma_block(
             } else {
                 let (vp, vm, dp_var, dm_var) = match (&corr_sp, &corr_sm) {
                     (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
-                    _ => match mult_row {
-                        Some(m) => (
-                            model.error_spec.variance_at_scaled(cmt, f, &sp, &[], m),
-                            model.error_spec.variance_at_scaled(cmt, f, &sm, &[], m),
-                            model.error_spec.dvar_df_scaled(cmt, f, &sp, m),
-                            model.error_spec.dvar_df_scaled(cmt, f, &sm, m),
-                        ),
-                        None => (
-                            model.error_spec.variance_at(cmt, f, &sp),
-                            model.error_spec.variance_at(cmt, f, &sm),
-                            model.error_spec.dvar_df(cmt, f, &sp),
-                            model.error_spec.dvar_df(cmt, f, &sm),
-                        ),
-                    },
+                    _ => {
+                        let (vp, dp_var) = variance_rd(&model.error_spec, cmt, f, &sp, mult_row);
+                        let (vm, dm_var) = variance_rd(&model.error_spec, cmt, f, &sm, mult_row);
+                        (vp, vm, dp_var, dm_var)
+                    }
                 };
                 // ∂R/∂σ_k, ∂d/∂σ_k by central FD. `et.r`/`et.d` carry the `exp(2·η_ruv)`
                 // scale, so lift these too.
@@ -1711,8 +1749,7 @@ fn sigma_block(
             fixed += 0.5 * dp * prep.q[j];
 
             // ∂α/∂σ = [2ε/R² + d(2ε²−R)/R³] Rσ + [(R−ε²)/R²] dσ
-            let dalpha = (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_sig
-                + ((r - eps * eps) * inv_r2) * d_sig;
+            let dalpha = dalpha_dsigma(r, d, eps, r_sig, d_sig);
             for m in 0..n_eta {
                 m_vec[m] += 0.5 * dalpha * obs.df_deta[m];
             }
@@ -2222,19 +2259,7 @@ pub fn subject_packed_gradient_foce(
         let (r, dd) = match (frem_r0, &corr_rd0) {
             (Some(v), _) => (v, 0.0),
             (None, Some((rv, dv, _))) => (rv[j], dv[j]),
-            (None, None) => {
-                let r = match mult_row {
-                    Some(mm) => model
-                        .error_spec
-                        .variance_at_scaled(cmt, f0act, sigma, &[], mm),
-                    None => model.error_spec.variance_at(cmt, f0act, sigma),
-                };
-                let d = match mult_row {
-                    Some(mm) => model.error_spec.dvar_df_scaled(cmt, f0act, sigma, mm),
-                    None => model.error_spec.dvar_df(cmt, f0act, sigma),
-                };
-                (r, d)
-            }
+            (None, None) => variance_rd(&model.error_spec, cmt, f0act, sigma, mult_row),
         };
         if !(r.is_finite() && r > 0.0) {
             return None;
@@ -2661,27 +2686,11 @@ pub fn subject_eta_dx_iov(
             // Magnitude-scaled `∂R/∂σ`,`∂d/∂σ` (consistent with the scaled `et.r`/`et.d`).
             let mult_row: Option<&[f64]> =
                 mult.as_ref().and_then(|mm| mm.get(j)).map(|v| v.as_slice());
-            let (var_p, var_m, dvar_p, dvar_m) = match mult_row {
-                Some(mm) => (
-                    model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
-                    model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
-                    model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
-                    model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
-                ),
-                None => (
-                    model.error_spec.variance_at(cmt, f, &sp),
-                    model.error_spec.variance_at(cmt, f, &sm),
-                    model.error_spec.dvar_df(cmt, f, &sp),
-                    model.error_spec.dvar_df(cmt, f, &sm),
-                ),
-            };
+            let (var_p, dvar_p) = variance_rd(&model.error_spec, cmt, f, &sp, mult_row);
+            let (var_m, dvar_m) = variance_rd(&model.error_spec, cmt, f, &sm, mult_row);
             let r_sig = (var_p - var_m) / (2.0 * h);
             let d_sig = (dvar_p - dvar_m) / (2.0 * h);
-            let inv_r = 1.0 / r;
-            let inv_r2 = inv_r * inv_r;
-            let inv_r3 = inv_r2 * inv_r;
-            let dalpha = (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_sig
-                + ((r - eps * eps) * inv_r2) * d_sig;
+            let dalpha = dalpha_dsigma(r, d, eps, r_sig, d_sig);
             for m in 0..n_st {
                 mvec[m] += 0.5 * dalpha * obs.df_deta[m];
             }
@@ -2799,20 +2808,12 @@ pub fn subject_packed_gradient_foce_iov(
         let cmt = err_keys[j];
         let f0act = sens0.obs[j].f;
         let mult_row: Option<&[f64]> = mult.as_ref().and_then(|m| m.get(j)).map(|v| v.as_slice());
-        let r = match mult_row {
-            Some(mm) => model
-                .error_spec
-                .variance_at_scaled(cmt, f0act, sigma, &[], mm),
-            None => model.error_spec.variance_at(cmt, f0act, sigma),
-        };
+        let (r, d) = variance_rd(&model.error_spec, cmt, f0act, sigma, mult_row);
         if !(r.is_finite() && r > 0.0) {
             return None;
         }
         r0[i] = r;
-        d0[i] = match mult_row {
-            Some(mm) => model.error_spec.dvar_df_scaled(cmt, f0act, sigma, mm),
-            None => model.error_spec.dvar_df(cmt, f0act, sigma),
-        };
+        d0[i] = d;
         if let (Some(mm), Some(mg_row)) = (mult_row, mult_grad.as_ref().and_then(|mg| mg.get(j))) {
             // Sheiner–Beal marginal only needs `∂R/∂θ` → skip the `∂d/∂θ` accumulation.
             let dr = mag_variance_dtheta(
@@ -3155,20 +3156,11 @@ pub fn subject_eta_dx(
             } else {
                 let (var_p, var_m, dvar_p, dvar_m) = match (&corr_sp, &corr_sm) {
                     (Some((rvp, dvp)), Some((rvm, dvm))) => (rvp[j], rvm[j], dvp[j], dvm[j]),
-                    _ => match mult_row {
-                        Some(mm) => (
-                            model.error_spec.variance_at_scaled(cmt, f, &sp, &[], mm),
-                            model.error_spec.variance_at_scaled(cmt, f, &sm, &[], mm),
-                            model.error_spec.dvar_df_scaled(cmt, f, &sp, mm),
-                            model.error_spec.dvar_df_scaled(cmt, f, &sm, mm),
-                        ),
-                        None => (
-                            model.error_spec.variance_at(cmt, f, &sp),
-                            model.error_spec.variance_at(cmt, f, &sm),
-                            model.error_spec.dvar_df(cmt, f, &sp),
-                            model.error_spec.dvar_df(cmt, f, &sm),
-                        ),
-                    },
+                    _ => {
+                        let (var_p, dvar_p) = variance_rd(&model.error_spec, cmt, f, &sp, mult_row);
+                        let (var_m, dvar_m) = variance_rd(&model.error_spec, cmt, f, &sm, mult_row);
+                        (var_p, var_m, dvar_p, dvar_m)
+                    }
                 };
                 let r_sig = prep.ruv_scale * (var_p - var_m) / (2.0 * h);
                 let d_sig = prep.ruv_scale * (dvar_p - dvar_m) / (2.0 * h);
@@ -3179,11 +3171,7 @@ pub fn subject_eta_dx(
                 }
                 (r_sig, d_sig)
             };
-            let inv_r = 1.0 / r;
-            let inv_r2 = inv_r * inv_r;
-            let inv_r3 = inv_r2 * inv_r;
-            let dalpha = (2.0 * eps * inv_r2 + d * (2.0 * eps * eps - r) * inv_r3) * r_sig
-                + ((r - eps * eps) * inv_r2) * d_sig;
+            let dalpha = dalpha_dsigma(r, d, eps, r_sig, d_sig);
             for m in 0..n_eta {
                 mvec[m] += 0.5 * dalpha * obs.df_deta[m];
             }

--- a/src/markov/endpoint.rs
+++ b/src/markov/endpoint.rs
@@ -124,12 +124,8 @@ fn ctmm_endpoint_nll(
     // the optimizer toward the unphysical region. Treat it as the degenerate case and
     // repel, exactly as the kernel does for an underflowed transition. The tiny
     // tolerance absorbs floating round-off on a rate that is physically zero.
-    for j in 0..q.nrows() {
-        for k in 0..q.ncols() {
-            if j != k && q[(j, k)] < -1e-12 {
-                return SUBJECT_SENTINEL_NLL;
-            }
-        }
+    if super::has_negative_offdiagonal(&q) {
+        return SUBJECT_SENTINEL_NLL;
     }
     match ctmm_data_term(&q, &obs) {
         Ok(nll) => nll,
@@ -197,12 +193,8 @@ pub fn ctmm_subject_eta_grad(
         // Same degeneracy guard as the value path (`ctmm_endpoint_nll`): a negative
         // off-diagonal makes `Q` a non-generator and the value collapses to the flat
         // sentinel, which has no derivative.
-        for j in 0..q.nrows() {
-            for k in 0..q.ncols() {
-                if j != k && q[(j, k)] < -1e-12 {
-                    return None;
-                }
-            }
+        if super::has_negative_offdiagonal(&q) {
+            return None;
         }
 
         // Project the (θ, η)-seeded jets onto the η axes. `dq` is laid out θ₀..θ_{T−1},

--- a/src/markov/mod.rs
+++ b/src/markov/mod.rs
@@ -234,6 +234,151 @@ pub fn generator_rate_direction(s: usize, j: usize, k: usize, dt: f64) -> DMatri
     e
 }
 
+/// Structural validation of the generator itself: square with at least two states.
+/// Returns the state count `s`. A failure is a parameter-independent [`MarkovError`]
+/// (fail loud), not the degenerate sentinel.
+fn validate_generator(q: &DMatrix<f64>) -> Result<usize, MarkovError> {
+    if !q.is_square() {
+        return Err(MarkovError::NonSquareGenerator {
+            rows: q.nrows(),
+            cols: q.ncols(),
+        });
+    }
+    let s = q.nrows();
+    if s < 2 {
+        return Err(MarkovError::TooFewStates { n: s });
+    }
+    Ok(s)
+}
+
+/// Validate every observation's state index (`< s`) and finite time up front, so a
+/// malformed record fails loud regardless of where it sits (not only if the loop
+/// reaches it).
+fn validate_obs(obs: &[StateObs], s: usize) -> Result<(), MarkovError> {
+    for (i, o) in obs.iter().enumerate() {
+        if o.state >= s {
+            return Err(MarkovError::StateOutOfRange {
+                state: o.state,
+                n_states: s,
+            });
+        }
+        if !o.time.is_finite() {
+            return Err(MarkovError::NonFiniteTime {
+                index: i,
+                time: o.time,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Shared structural / data validation preamble for the value kernel
+/// ([`ctmm_data_term`]): the generator is square with ≥2 states, and every
+/// observation is in range with a finite time. Returns the state count `s`.
+/// [`ctmm_data_term_grad`] composes [`validate_generator`] and [`validate_obs`]
+/// directly so its `∂Q/∂p` shape check stays interposed between them, exactly as
+/// before.
+fn validate_generator_and_obs(q: &DMatrix<f64>, obs: &[StateObs]) -> Result<usize, MarkovError> {
+    let s = validate_generator(q)?;
+    validate_obs(obs, s)?;
+    Ok(s)
+}
+
+/// Outcome of one consecutive-observation gap, shared by the value and gradient
+/// kernels so the per-gap dt guards, the `expm`-argument finiteness / magnitude
+/// guard, the matrix exponential, and the `P ≤ 0` degeneracy handling live in one
+/// place. The two callers diverge only *after* a valid [`GapOutcome::Prob`].
+enum GapOutcome {
+    /// A zero-length gap between identical states (`P(0) = I`): contributes nothing.
+    Skip,
+    /// A parameter-driven degeneracy (non-finite / enormous argument, or a
+    /// non-positive observed transition probability): the caller returns its own
+    /// sentinel ([`SENTINEL_NLL`]) / `Ok(None)`.
+    Degenerate,
+    /// A valid transition probability `p = P(Δt)[from, to]` over the gap, carrying
+    /// the scaled argument `arg = Q·Δt` and `dt` (both needed by the gradient's
+    /// adjoint Fréchet solve).
+    Prob { p: f64, arg: DMatrix<f64>, dt: f64 },
+}
+
+/// Score one consecutive-observation gap `(a → b)` at zero-based window index `i`.
+///
+/// Fails loud on a structural gap error (times decrease, or a zero-length gap
+/// between *different* states); otherwise classifies the gap as [`GapOutcome`].
+/// The `expm` argument is guarded for both non-finiteness and magnitude before it
+/// reaches nalgebra (a non-finite entry can panic its internal LU solve; a
+/// finite-but-enormous one hangs its scaling-and-squaring loop) — see
+/// [`MAX_EXP_ARG_ABS`].
+fn gap_transition(
+    q: &DMatrix<f64>,
+    a: StateObs,
+    b: StateObs,
+    i: usize,
+) -> Result<GapOutcome, MarkovError> {
+    let dt = b.time - a.time;
+
+    if dt < 0.0 {
+        return Err(MarkovError::TimeDecreased {
+            index: i + 1,
+            prev: a.time,
+            next: b.time,
+        });
+    }
+    if dt == 0.0 {
+        if a.state != b.state {
+            return Err(MarkovError::ZeroDtStateChange {
+                index: i + 1,
+                time: b.time,
+                from: a.state,
+                to: b.state,
+            });
+        }
+        // Δt = 0, same state: P(0) = I ⇒ log P[s,s] = log 1 = 0.
+        return Ok(GapOutcome::Skip);
+    }
+
+    let arg = q * dt;
+    if arg
+        .iter()
+        .any(|x| !x.is_finite() || x.abs() > MAX_EXP_ARG_ABS)
+    {
+        return Ok(GapOutcome::Degenerate);
+    }
+    let p_mat = matrix_exp(&arg);
+    let p = p_mat[(a.state, b.state)];
+    // Underflow / non-positive probability for an *observed* transition:
+    // this is the degenerate case, not a hard error — repel the optimizer.
+    if !p.is_finite() || p <= 0.0 {
+        return Ok(GapOutcome::Degenerate);
+    }
+    Ok(GapOutcome::Prob { p, arg, dt })
+}
+
+/// Whether any off-diagonal entry of a generator is (past round-off) negative.
+///
+/// A transition intensity is an unconstrained user expression, so a covariate /
+/// parameter regime (or a diverged η) can drive an off-diagonal rate negative,
+/// which makes `Q` a non-generator (`expm(Q·Δt)` is no longer stochastic and an
+/// observed transition can score `P > 1`). Callers treat that as the degenerate
+/// case and repel the optimizer with their own sentinel / `None`. The `1e-12`
+/// tolerance absorbs floating round-off on a rate that is physically zero.
+///
+/// Used by the two homogeneous endpoint sites in `markov/endpoint.rs`
+/// (`ctmm_endpoint_nll`, `ctmm_subject_eta_grad`). The inhomogeneous per-sub-node
+/// guard stays inline there because it shares a single pass with the
+/// finite/`MAX_EXP_ARG_ABS` magnitude check.
+#[inline]
+pub(crate) fn has_negative_offdiagonal(q: &DMatrix<f64>) -> bool {
+    for j in 0..q.nrows() {
+        for k in 0..q.ncols() {
+            if j != k && q[(j, k)] < -1e-12 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Exact gradient of [`ctmm_data_term`] w.r.t. an arbitrary parameter vector, given the
 /// generator `q` and its derivatives `dq[a] = ∂Q/∂p_a` (#759).
 ///
@@ -271,19 +416,11 @@ pub fn ctmm_data_term_grad(
     dq: &[DMatrix<f64>],
     obs: &[StateObs],
 ) -> Result<Option<(f64, Vec<f64>)>, MarkovError> {
-    if !q.is_square() {
-        return Err(MarkovError::NonSquareGenerator {
-            rows: q.nrows(),
-            cols: q.ncols(),
-        });
-    }
-    let s = q.nrows();
-    if s < 2 {
-        return Err(MarkovError::TooFewStates { n: s });
-    }
+    let s = validate_generator(q)?;
     // Validated at runtime, not merely debug-asserted: the contraction below zips `G` with
     // `∂Q/∂p`, so a short derivative matrix would silently truncate and yield a wrong
-    // gradient rather than an error — and this is a `pub` entry point.
+    // gradient rather than an error — and this is a `pub` entry point. Checked between the
+    // generator and observation validation to preserve the original error precedence.
     for (axis, d) in dq.iter().enumerate() {
         if d.shape() != (s, s) {
             return Err(MarkovError::DerivativeShapeMismatch {
@@ -294,21 +431,7 @@ pub fn ctmm_data_term_grad(
             });
         }
     }
-
-    for (i, o) in obs.iter().enumerate() {
-        if o.state >= s {
-            return Err(MarkovError::StateOutOfRange {
-                state: o.state,
-                n_states: s,
-            });
-        }
-        if !o.time.is_finite() {
-            return Err(MarkovError::NonFiniteTime {
-                index: i,
-                time: o.time,
-            });
-        }
-    }
+    validate_obs(obs, s)?;
 
     let n_axes = dq.len();
     let mut grad = vec![0.0_f64; n_axes];
@@ -319,40 +442,12 @@ pub fn ctmm_data_term_grad(
     let mut nll = 0.0;
     for (i, pair) in obs.windows(2).enumerate() {
         let (a, b) = (pair[0], pair[1]);
-        let dt = b.time - a.time;
-
-        if dt < 0.0 {
-            return Err(MarkovError::TimeDecreased {
-                index: i + 1,
-                prev: a.time,
-                next: b.time,
-            });
-        }
-        if dt == 0.0 {
-            if a.state != b.state {
-                return Err(MarkovError::ZeroDtStateChange {
-                    index: i + 1,
-                    time: b.time,
-                    from: a.state,
-                    to: b.state,
-                });
-            }
+        let (p, arg, dt) = match gap_transition(q, a, b, i)? {
             // P(0) = I: the term is identically 0 in both value and derivative.
-            continue;
-        }
-
-        let arg = q * dt;
-        if arg
-            .iter()
-            .any(|x| !x.is_finite() || x.abs() > MAX_EXP_ARG_ABS)
-        {
-            return Ok(None);
-        }
-        let p_mat = matrix_exp(&arg);
-        let p = p_mat[(a.state, b.state)];
-        if !p.is_finite() || p <= 0.0 {
-            return Ok(None);
-        }
+            GapOutcome::Skip => continue,
+            GapOutcome::Degenerate => return Ok(None),
+            GapOutcome::Prob { p, arg, dt } => (p, arg, dt),
+        };
         // Mirror `ctmm_data_term`'s `p.min(1.0)` clamp in the *derivative* too: where the
         // clamp binds, the implemented value is the constant `ln(1) = 0`, so its exact
         // derivative is 0 — not `−(∂P/∂p)/p`. Differentiating through a clamp the value
@@ -404,33 +499,7 @@ pub fn ctmm_data_term_grad(
 /// `≥ 0`, rows summing to `0`) is the model builder's responsibility and is not
 /// re-checked per-evaluation here.
 pub fn ctmm_data_term(q: &DMatrix<f64>, obs: &[StateObs]) -> Result<f64, MarkovError> {
-    if !q.is_square() {
-        return Err(MarkovError::NonSquareGenerator {
-            rows: q.nrows(),
-            cols: q.ncols(),
-        });
-    }
-    let s = q.nrows();
-    if s < 2 {
-        return Err(MarkovError::TooFewStates { n: s });
-    }
-
-    // Validate every state index and every time up front, so a malformed record
-    // fails loud regardless of where it sits (not only if the loop reaches it).
-    for (i, o) in obs.iter().enumerate() {
-        if o.state >= s {
-            return Err(MarkovError::StateOutOfRange {
-                state: o.state,
-                n_states: s,
-            });
-        }
-        if !o.time.is_finite() {
-            return Err(MarkovError::NonFiniteTime {
-                index: i,
-                time: o.time,
-            });
-        }
-    }
+    validate_generator_and_obs(q, obs)?;
 
     if obs.len() < 2 {
         return Ok(0.0);
@@ -439,52 +508,14 @@ pub fn ctmm_data_term(q: &DMatrix<f64>, obs: &[StateObs]) -> Result<f64, MarkovE
     let mut nll = 0.0;
     for (i, pair) in obs.windows(2).enumerate() {
         let (a, b) = (pair[0], pair[1]);
-        let dt = b.time - a.time;
-
-        if dt < 0.0 {
-            return Err(MarkovError::TimeDecreased {
-                index: i + 1,
-                prev: a.time,
-                next: b.time,
-            });
-        }
-        if dt == 0.0 {
-            if a.state != b.state {
-                return Err(MarkovError::ZeroDtStateChange {
-                    index: i + 1,
-                    time: b.time,
-                    from: a.state,
-                    to: b.state,
-                });
-            }
+        let p = match gap_transition(q, a, b, i)? {
             // Δt = 0, same state: P(0) = I ⇒ log P[s,s] = log 1 = 0.
-            continue;
-        }
-
-        // Guard the exponential's argument before it reaches nalgebra's `expm`.
-        // Two failure modes, both from a rate that diverged during optimization:
-        //   • a non-finite entry (∞/NaN, e.g. an infinite rate from a bad η) —
-        //     `expm`'s internal LU solve `.unwrap()` can *panic* on it; and
-        //   • a finite-but-enormous entry (|q·dt| ≳ 1e38) — `expm` forms internal
-        //     matrix powers that overflow to ∞, driving its scaling count to
-        //     `u64::MAX` so it *hangs* in an unbounded squaring loop.
-        // A hang survives neither the post-`expm` finiteness check nor
-        // `catch_unwind`, so both are rejected here up front. Either is the
-        // degenerate case (repel the optimizer), not a crash or a frozen fit.
-        let arg = q * dt;
-        if arg
-            .iter()
-            .any(|x| !x.is_finite() || x.abs() > MAX_EXP_ARG_ABS)
-        {
-            return Ok(SENTINEL_NLL);
-        }
-        let p_mat = matrix_exp(&arg);
-        let p = p_mat[(a.state, b.state)];
-        // Underflow / non-positive probability for an *observed* transition:
-        // this is the degenerate case, not a hard error — repel the optimizer.
-        if !p.is_finite() || p <= 0.0 {
-            return Ok(SENTINEL_NLL);
-        }
+            GapOutcome::Skip => continue,
+            // Underflow / non-positive probability, or a non-finite / enormous
+            // `expm` argument from a diverged rate — repel the optimizer.
+            GapOutcome::Degenerate => return Ok(SENTINEL_NLL),
+            GapOutcome::Prob { p, .. } => p,
+        };
         // A valid generator gives P ∈ [0, 1]; clamp to 1 so floating round-off on
         // a near-certain transition (p = 1 + ε) contributes ~0 rather than a
         // spurious *negative* NLL, and a malformed generator (a P entry > 1)

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -12363,12 +12363,84 @@ fn check_unused_parameters(
     warnings
 }
 
-fn eval_expression(
+// ─── Shared expression / condition evaluators ───────────────────────────────
+//
+// `eval_expression`/`eval_condition` (HashMap-keyed name lookup) and
+// `eval_expression_indexed`/`eval_condition_indexed` (slice-index lookup) were
+// byte-for-byte identical in every arithmetic/unary/power/conditional/literal
+// arm; they differed ONLY in how the four "environment" variants
+// (`Variable`/`Covariate` vs `VariableIdx`/`CovariateIdx`) resolve a name to an
+// `f64`. That name resolution is factored into the `EvalEnv` trait, with a
+// HashMap impl (`MapEnv`) and a slice impl (`SliceEnv`), so the arithmetic lives
+// once in the generic `eval_expr`/`eval_cond`. Monomorphization keeps both call
+// sites zero-cost. Every arithmetic/guard arm is copied verbatim from the
+// originals (the `Div` 1e-30 guard, the unary fn set, the `NnOutput` cache
+// lookup).
+
+/// Name resolution for the four environment expression variants
+/// (`Variable`/`Covariate`/`VariableIdx`/`CovariateIdx`). The generic
+/// evaluator routes exactly those variants here; every other arm is handled
+/// generically.
+trait EvalEnv {
+    fn resolve(&self, expr: &Expression) -> f64;
+}
+
+/// HashMap-keyed environment (the unindexed evaluator).
+struct MapEnv<'a> {
+    covariates: &'a HashMap<String, f64>,
+    vars: &'a HashMap<String, f64>,
+}
+
+impl EvalEnv for MapEnv<'_> {
+    #[inline]
+    fn resolve(&self, expr: &Expression) -> f64 {
+        match expr {
+            Expression::Covariate(name) => self.covariates.get(name).copied().unwrap_or(0.0),
+            Expression::Variable(name) => {
+                if name.eq_ignore_ascii_case("MACHEPS") {
+                    f64::EPSILON
+                } else {
+                    self.vars.get(name).copied().unwrap_or(0.0)
+                }
+            }
+            _ => {
+                debug_assert!(
+                    false,
+                    "indexed expression reached unindexed eval_expression"
+                );
+                0.0
+            }
+        }
+    }
+}
+
+/// Slice-indexed environment (the resolved, hot indexed evaluator).
+struct SliceEnv<'a> {
+    covariates: &'a [f64],
+    vars: &'a [f64],
+}
+
+impl EvalEnv for SliceEnv<'_> {
+    #[inline]
+    fn resolve(&self, expr: &Expression) -> f64 {
+        match expr {
+            Expression::VariableIdx(i) => self.vars.get(*i).copied().unwrap_or(0.0),
+            Expression::CovariateIdx(i) => self.covariates.get(*i).copied().unwrap_or(0.0),
+            _ => {
+                debug_assert!(false, "unresolved name reached eval_expression_indexed");
+                0.0
+            }
+        }
+    }
+}
+
+/// Generic expression evaluator. All arithmetic/unary/power/conditional/literal
+/// arms are shared; the environment variants delegate to `env.resolve`.
+fn eval_expr<E: EvalEnv>(
     expr: &Expression,
     theta: &[f64],
     eta: &[f64],
-    covariates: &HashMap<String, f64>,
-    vars: &HashMap<String, f64>,
+    env: &E,
     nn_outputs: &[Vec<f64>],
 ) -> f64 {
     match expr {
@@ -12376,24 +12448,13 @@ fn eval_expression(
         Expression::Theta(i) => theta[*i],
         Expression::Eta(i) => eta[*i],
         Expression::Time => current_model_time(),
-        Expression::Covariate(name) => covariates.get(name).copied().unwrap_or(0.0),
-        Expression::Variable(name) => {
-            if name.eq_ignore_ascii_case("MACHEPS") {
-                f64::EPSILON
-            } else {
-                vars.get(name).copied().unwrap_or(0.0)
-            }
-        }
-        Expression::VariableIdx(_) | Expression::CovariateIdx(_) => {
-            debug_assert!(
-                false,
-                "indexed expression reached unindexed eval_expression"
-            );
-            0.0
-        }
+        Expression::Variable(_)
+        | Expression::Covariate(_)
+        | Expression::VariableIdx(_)
+        | Expression::CovariateIdx(_) => env.resolve(expr),
         Expression::BinOp(lhs, op, rhs) => {
-            let l = eval_expression(lhs, theta, eta, covariates, vars, nn_outputs);
-            let r = eval_expression(rhs, theta, eta, covariates, vars, nn_outputs);
+            let l = eval_expr(lhs, theta, eta, env, nn_outputs);
+            let r = eval_expr(rhs, theta, eta, env, nn_outputs);
             match op {
                 BinOp::Add => l + r,
                 BinOp::Sub => l - r,
@@ -12409,7 +12470,7 @@ fn eval_expression(
             }
         }
         Expression::UnaryFn(name, arg) => {
-            let v = eval_expression(arg, theta, eta, covariates, vars, nn_outputs);
+            let v = eval_expr(arg, theta, eta, env, nn_outputs);
             match name.as_str() {
                 "exp" => v.exp(),
                 "log" | "ln" => v.max(1e-30).ln(),
@@ -12435,23 +12496,23 @@ fn eval_expression(
             }
         }
         Expression::Power(base, exp) => {
-            let b = eval_expression(base, theta, eta, covariates, vars, nn_outputs);
-            let e = eval_expression(exp, theta, eta, covariates, vars, nn_outputs);
+            let b = eval_expr(base, theta, eta, env, nn_outputs);
+            let e = eval_expr(exp, theta, eta, env, nn_outputs);
             b.powf(e)
         }
         Expression::Conditional(cond, t, e) => {
-            if eval_condition(cond, theta, eta, covariates, vars, nn_outputs) {
-                eval_expression(t, theta, eta, covariates, vars, nn_outputs)
+            if eval_cond(cond, theta, eta, env, nn_outputs) {
+                eval_expr(t, theta, eta, env, nn_outputs)
             } else {
-                eval_expression(e, theta, eta, covariates, vars, nn_outputs)
+                eval_expr(e, theta, eta, env, nn_outputs)
             }
         }
         Expression::NnOutput { nn_idx, output_idx } => {
-            // Same per-call cache as the indexed evaluator. Callers
-            // populate `nn_outputs` from `NamedMlpMapper::forward_raw`
-            // (see the `tv_fn` closure for the eta=0 path). Out-of-bounds
-            // indices return 0.0 with a debug-assert so a logic bug
-            // surfaces in tests but doesn't crash release builds.
+            // Per-call cache populated once per forward via
+            // `NamedMlpMapper::forward_raw`. Multiple references to outputs of
+            // the same NN therefore share a single forward pass. Out-of-bounds
+            // indices return 0.0 with a debug-assert so a logic bug surfaces in
+            // tests but doesn't crash release builds.
             nn_outputs
                 .get(*nn_idx)
                 .and_then(|v| v.get(*output_idx))
@@ -12459,7 +12520,7 @@ fn eval_expression(
                 .unwrap_or_else(|| {
                     debug_assert!(
                         false,
-                        "NnOutput nn_idx={nn_idx} output_idx={output_idx} out of bounds in unindexed eval"
+                        "NnOutput nn_idx={nn_idx} output_idx={output_idx} out of bounds"
                     );
                     0.0
                 })
@@ -12467,18 +12528,18 @@ fn eval_expression(
     }
 }
 
-fn eval_condition(
+/// Generic condition evaluator (shared by the HashMap and slice entry points).
+fn eval_cond<E: EvalEnv>(
     cond: &Condition,
     theta: &[f64],
     eta: &[f64],
-    covariates: &HashMap<String, f64>,
-    vars: &HashMap<String, f64>,
+    env: &E,
     nn_outputs: &[Vec<f64>],
 ) -> bool {
     match cond {
         Condition::Compare(l, op, r) => {
-            let lv = eval_expression(l, theta, eta, covariates, vars, nn_outputs);
-            let rv = eval_expression(r, theta, eta, covariates, vars, nn_outputs);
+            let lv = eval_expr(l, theta, eta, env, nn_outputs);
+            let rv = eval_expr(r, theta, eta, env, nn_outputs);
             match op {
                 CmpOp::Lt => lv < rv,
                 CmpOp::Le => lv <= rv,
@@ -12489,15 +12550,39 @@ fn eval_condition(
             }
         }
         Condition::And(l, r) => {
-            eval_condition(l, theta, eta, covariates, vars, nn_outputs)
-                && eval_condition(r, theta, eta, covariates, vars, nn_outputs)
+            eval_cond(l, theta, eta, env, nn_outputs) && eval_cond(r, theta, eta, env, nn_outputs)
         }
         Condition::Or(l, r) => {
-            eval_condition(l, theta, eta, covariates, vars, nn_outputs)
-                || eval_condition(r, theta, eta, covariates, vars, nn_outputs)
+            eval_cond(l, theta, eta, env, nn_outputs) || eval_cond(r, theta, eta, env, nn_outputs)
         }
-        Condition::Not(c) => !eval_condition(c, theta, eta, covariates, vars, nn_outputs),
+        Condition::Not(c) => !eval_cond(c, theta, eta, env, nn_outputs),
     }
+}
+
+#[inline]
+fn eval_expression(
+    expr: &Expression,
+    theta: &[f64],
+    eta: &[f64],
+    covariates: &HashMap<String, f64>,
+    vars: &HashMap<String, f64>,
+    nn_outputs: &[Vec<f64>],
+) -> f64 {
+    let env = MapEnv { covariates, vars };
+    eval_expr(expr, theta, eta, &env, nn_outputs)
+}
+
+#[inline]
+fn eval_condition(
+    cond: &Condition,
+    theta: &[f64],
+    eta: &[f64],
+    covariates: &HashMap<String, f64>,
+    vars: &HashMap<String, f64>,
+    nn_outputs: &[Vec<f64>],
+) -> bool {
+    let env = MapEnv { covariates, vars };
+    eval_cond(cond, theta, eta, &env, nn_outputs)
 }
 
 // ─── Bytecode interpreter ───────────────────────────────────────────────────
@@ -13342,6 +13427,7 @@ fn eval_bytecode_g<T: crate::sens::num::PkNum>(
 /// + probe in the `pk_param_fn` closure. Falls back to 0.0 for the
 /// HashMap-keyed variants (Variable/Covariate) since callers running
 /// the indexed path have already resolved every name.
+#[inline]
 fn eval_expression_indexed(
     expr: &Expression,
     theta: &[f64],
@@ -13350,91 +13436,11 @@ fn eval_expression_indexed(
     vars: &[f64],
     nn_outputs: &[Vec<f64>],
 ) -> f64 {
-    match expr {
-        Expression::Literal(v) => *v,
-        Expression::Theta(i) => theta[*i],
-        Expression::Eta(i) => eta[*i],
-        Expression::Time => current_model_time(),
-        Expression::VariableIdx(i) => vars.get(*i).copied().unwrap_or(0.0),
-        Expression::CovariateIdx(i) => covariates.get(*i).copied().unwrap_or(0.0),
-        Expression::Covariate(_) | Expression::Variable(_) => {
-            debug_assert!(false, "unresolved name reached eval_expression_indexed");
-            0.0
-        }
-        Expression::BinOp(lhs, op, rhs) => {
-            let l = eval_expression_indexed(lhs, theta, eta, covariates, vars, nn_outputs);
-            let r = eval_expression_indexed(rhs, theta, eta, covariates, vars, nn_outputs);
-            match op {
-                BinOp::Add => l + r,
-                BinOp::Sub => l - r,
-                BinOp::Mul => l * r,
-                BinOp::Div => {
-                    if r.abs() < 1e-30 {
-                        0.0
-                    } else {
-                        l / r
-                    }
-                }
-                BinOp::Mod => l.rem_euclid(r),
-            }
-        }
-        Expression::UnaryFn(name, arg) => {
-            let v = eval_expression_indexed(arg, theta, eta, covariates, vars, nn_outputs);
-            match name.as_str() {
-                "exp" => v.exp(),
-                "log" | "ln" => v.max(1e-30).ln(),
-                "sqrt" => v.max(0.0).sqrt(),
-                "abs" => v.abs(),
-                "floor" => v.floor(),
-                "ceil" => v.ceil(),
-                "round" => v.round(),
-                "inv_logit" | "expit" => {
-                    if v >= 0.0 {
-                        1.0 / (1.0 + (-v).exp())
-                    } else {
-                        let e = v.exp();
-                        e / (1.0 + e)
-                    }
-                }
-                "logit" => {
-                    let clamped = v.clamp(1e-15, 1.0 - 1e-15);
-                    (clamped / (1.0 - clamped)).ln()
-                }
-                _ => v,
-            }
-        }
-        Expression::Power(base, exp) => {
-            let b = eval_expression_indexed(base, theta, eta, covariates, vars, nn_outputs);
-            let e = eval_expression_indexed(exp, theta, eta, covariates, vars, nn_outputs);
-            b.powf(e)
-        }
-        Expression::Conditional(cond, t, e) => {
-            if eval_condition_indexed(cond, theta, eta, covariates, vars, nn_outputs) {
-                eval_expression_indexed(t, theta, eta, covariates, vars, nn_outputs)
-            } else {
-                eval_expression_indexed(e, theta, eta, covariates, vars, nn_outputs)
-            }
-        }
-        Expression::NnOutput { nn_idx, output_idx } => {
-            // Reads from the per-call cache that `build_pk_param_fn`
-            // populates once per forward via `NamedMlpMapper::forward_raw`.
-            // Multiple references to outputs of the same NN therefore share
-            // a single forward pass.
-            nn_outputs
-                .get(*nn_idx)
-                .and_then(|v| v.get(*output_idx))
-                .copied()
-                .unwrap_or_else(|| {
-                    debug_assert!(
-                        false,
-                        "NnOutput nn_idx={nn_idx} output_idx={output_idx} out of bounds"
-                    );
-                    0.0
-                })
-        }
-    }
+    let env = SliceEnv { covariates, vars };
+    eval_expr(expr, theta, eta, &env, nn_outputs)
 }
 
+#[inline]
 fn eval_condition_indexed(
     cond: &Condition,
     theta: &[f64],
@@ -13443,29 +13449,8 @@ fn eval_condition_indexed(
     vars: &[f64],
     nn_outputs: &[Vec<f64>],
 ) -> bool {
-    match cond {
-        Condition::Compare(l, op, r) => {
-            let lv = eval_expression_indexed(l, theta, eta, covariates, vars, nn_outputs);
-            let rv = eval_expression_indexed(r, theta, eta, covariates, vars, nn_outputs);
-            match op {
-                CmpOp::Lt => lv < rv,
-                CmpOp::Le => lv <= rv,
-                CmpOp::Gt => lv > rv,
-                CmpOp::Ge => lv >= rv,
-                CmpOp::Eq => lv == rv,
-                CmpOp::Ne => lv != rv,
-            }
-        }
-        Condition::And(l, r) => {
-            eval_condition_indexed(l, theta, eta, covariates, vars, nn_outputs)
-                && eval_condition_indexed(r, theta, eta, covariates, vars, nn_outputs)
-        }
-        Condition::Or(l, r) => {
-            eval_condition_indexed(l, theta, eta, covariates, vars, nn_outputs)
-                || eval_condition_indexed(r, theta, eta, covariates, vars, nn_outputs)
-        }
-        Condition::Not(c) => !eval_condition_indexed(c, theta, eta, covariates, vars, nn_outputs),
-    }
+    let env = SliceEnv { covariates, vars };
+    eval_cond(cond, theta, eta, &env, nn_outputs)
 }
 
 /// Inner statement evaluator threaded with a caller-owned bytecode stack.

--- a/src/pk/three_compartment.rs
+++ b/src/pk/three_compartment.rs
@@ -224,119 +224,81 @@ pub(crate) fn three_cpt_iv_peripherals(
     let c2_scalar = q2 / (v1 * v2); // k12/v2
     let c3_scalar = q3 / (v1 * v3); // k13/v3
     let d = dose.amt;
+    let is_ss = dose.ss && dose.ii > 0.0;
 
-    if dose.ss && dose.ii > 0.0 {
-        let ii = dose.ii;
-        if dose.is_infusion() {
-            let dur = dose.duration;
-            if dur <= 0.0 {
-                // Treat as bolus SS
-                let c2 = c2_scalar
-                    * d
-                    * (-(alpha - k31) / (ab * ag) * (-alpha * tau).exp() * ss_coeff_3(alpha, ii)
-                        + (beta - k31) / (ab * bg) * (-beta * tau).exp() * ss_coeff_3(beta, ii)
-                        - (gamma - k31) / (ag * bg) * (-gamma * tau).exp() * ss_coeff_3(gamma, ii));
-                let c3 = c3_scalar
-                    * d
-                    * (-(alpha - k21) / (ab * ag) * (-alpha * tau).exp() * ss_coeff_3(alpha, ii)
-                        + (beta - k21) / (ab * bg) * (-beta * tau).exp() * ss_coeff_3(beta, ii)
-                        - (gamma - k21) / (ag * bg) * (-gamma * tau).exp() * ss_coeff_3(gamma, ii));
-                return [c2, c3];
-            }
-            if dur > dose.ii {
-                return [0.0; 2];
-            }
-            // Helper for infusion SS peripheral (after-infusion formula with SS coeff)
-            let infusion_periph_ss = |c_scalar: f64, k_far: f64| -> f64 {
-                let r = dose.rate;
-                // After-infusion peripheral formula with SS geometric series:
-                // coeff_X = rate · c_scalar · (X_eigenvalue_residue) / (product · eigenvalue)
-                let coeff_a = -r * c_scalar * (alpha - k_far) / (ab * ag * alpha);
-                let coeff_b = r * c_scalar * (beta - k_far) / (ab * bg * beta);
-                let coeff_g = -r * c_scalar * (gamma - k_far) / (ag * bg * gamma);
-                if tau <= dur {
-                    let cur = coeff_a * (1.0 - (-alpha * tau).exp())
-                        + coeff_b * (1.0 - (-beta * tau).exp())
-                        + coeff_g * (1.0 - (-gamma * tau).exp());
-                    let past = coeff_a
-                        * (1.0 - (-alpha * dur).exp())
-                        * (-alpha * (tau - dur)).exp()
-                        * (-alpha * dose.ii).exp()
-                        * ss_coeff_3(alpha, ii)
-                        + coeff_b
-                            * (1.0 - (-beta * dur).exp())
-                            * (-beta * (tau - dur)).exp()
-                            * (-beta * dose.ii).exp()
-                            * ss_coeff_3(beta, ii)
-                        + coeff_g
-                            * (1.0 - (-gamma * dur).exp())
-                            * (-gamma * (tau - dur)).exp()
-                            * (-gamma * dose.ii).exp()
-                            * ss_coeff_3(gamma, ii);
-                    cur + past
-                } else {
-                    let dt = tau - dur;
-                    coeff_a
-                        * (1.0 - (-alpha * dur).exp())
-                        * (-alpha * dt).exp()
-                        * ss_coeff_3(alpha, ii)
-                        + coeff_b
-                            * (1.0 - (-beta * dur).exp())
-                            * (-beta * dt).exp()
-                            * ss_coeff_3(beta, ii)
-                        + coeff_g
-                            * (1.0 - (-gamma * dur).exp())
-                            * (-gamma * dt).exp()
-                            * ss_coeff_3(gamma, ii)
-                }
-            };
-            [
-                infusion_periph_ss(c2_scalar, k31),
-                infusion_periph_ss(c3_scalar, k21),
-            ]
+    // Per-eigenvalue steady-state geometric factor, folded conditionally exactly as
+    // `three_cpt_oral_peripherals` does: 1/(1−e^{−λ·II}) at SS, else 1. Kept as a
+    // *separate* trailing factor (not multiplied into e^{−λτ}), so the residue
+    // arithmetic is bit-identical to the four hand-written copies this collapses —
+    // `x * 1.0` is the identity, so the non-SS path is unchanged, and the SS path
+    // keeps the original `((coeff · e^{−λτ}) · ss_coeff_3)` association.
+    let term = |lambda: f64| -> f64 {
+        if is_ss {
+            ss_coeff_3(lambda, dose.ii)
         } else {
-            // Bolus SS
-            let c2 = c2_scalar
-                * d
-                * (-(alpha - k31) / (ab * ag) * (-alpha * tau).exp() * ss_coeff_3(alpha, ii)
-                    + (beta - k31) / (ab * bg) * (-beta * tau).exp() * ss_coeff_3(beta, ii)
-                    - (gamma - k31) / (ag * bg) * (-gamma * tau).exp() * ss_coeff_3(gamma, ii));
-            let c3 = c3_scalar
-                * d
-                * (-(alpha - k21) / (ab * ag) * (-alpha * tau).exp() * ss_coeff_3(alpha, ii)
-                    + (beta - k21) / (ab * bg) * (-beta * tau).exp() * ss_coeff_3(beta, ii)
-                    - (gamma - k21) / (ag * bg) * (-gamma * tau).exp() * ss_coeff_3(gamma, ii));
-            [c2, c3]
+            1.0
         }
-    } else if dose.is_infusion() {
+    };
+
+    // Bolus tri-exponential residue — the single closed form for single-dose,
+    // SS, and degenerate (`dur ≤ 0`) infusion. C_periph1 uses (c2_scalar, k31);
+    // C_periph2 swaps k31↔k21 and q2/v2 → q3/v3 (i.e. c3_scalar, k21).
+    let periph_bolus = |c_scalar: f64, k_far: f64| -> f64 {
+        c_scalar
+            * d
+            * (-(alpha - k_far) / (ab * ag) * (-alpha * tau).exp() * term(alpha)
+                + (beta - k_far) / (ab * bg) * (-beta * tau).exp() * term(beta)
+                - (gamma - k_far) / (ag * bg) * (-gamma * tau).exp() * term(gamma))
+    };
+
+    if dose.is_infusion() {
         let dur = dose.duration;
         if dur <= 0.0 {
-            let c2 = c2_scalar
-                * d
-                * (-(alpha - k31) / (ab * ag) * (-alpha * tau).exp()
-                    + (beta - k31) / (ab * bg) * (-beta * tau).exp()
-                    - (gamma - k31) / (ag * bg) * (-gamma * tau).exp());
-            let c3 = c3_scalar
-                * d
-                * (-(alpha - k21) / (ab * ag) * (-alpha * tau).exp()
-                    + (beta - k21) / (ab * bg) * (-beta * tau).exp()
-                    - (gamma - k21) / (ag * bg) * (-gamma * tau).exp());
-            return [c2, c3];
+            // Degenerate infusion → treat as bolus (SS folds through `term`).
+            return [periph_bolus(c2_scalar, k31), periph_bolus(c3_scalar, k21)];
         }
+        if is_ss && dur > dose.ii {
+            return [0.0; 2];
+        }
+        // After-infusion peripheral formula. During the infusion window the SS case
+        // additionally superposes the past-pulse train (each pulse carrying its own
+        // `ss_coeff_3` geometric factor); after the window every term picks up the
+        // conditional `term(λ)` factor (1 for non-SS).
         let infusion_periph = |c_scalar: f64, k_far: f64| -> f64 {
             let r = dose.rate;
+            // coeff_X = rate · c_scalar · (X_eigenvalue_residue) / (product · eigenvalue)
             let coeff_a = -r * c_scalar * (alpha - k_far) / (ab * ag * alpha);
             let coeff_b = r * c_scalar * (beta - k_far) / (ab * bg * beta);
             let coeff_g = -r * c_scalar * (gamma - k_far) / (ag * bg * gamma);
             if tau <= dur {
-                coeff_a * (1.0 - (-alpha * tau).exp())
+                let cur = coeff_a * (1.0 - (-alpha * tau).exp())
                     + coeff_b * (1.0 - (-beta * tau).exp())
-                    + coeff_g * (1.0 - (-gamma * tau).exp())
+                    + coeff_g * (1.0 - (-gamma * tau).exp());
+                if is_ss {
+                    let past = coeff_a
+                        * (1.0 - (-alpha * dur).exp())
+                        * (-alpha * (tau - dur)).exp()
+                        * (-alpha * dose.ii).exp()
+                        * ss_coeff_3(alpha, dose.ii)
+                        + coeff_b
+                            * (1.0 - (-beta * dur).exp())
+                            * (-beta * (tau - dur)).exp()
+                            * (-beta * dose.ii).exp()
+                            * ss_coeff_3(beta, dose.ii)
+                        + coeff_g
+                            * (1.0 - (-gamma * dur).exp())
+                            * (-gamma * (tau - dur)).exp()
+                            * (-gamma * dose.ii).exp()
+                            * ss_coeff_3(gamma, dose.ii);
+                    cur + past
+                } else {
+                    cur
+                }
             } else {
                 let dt = tau - dur;
-                coeff_a * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp()
-                    + coeff_b * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp()
-                    + coeff_g * (1.0 - (-gamma * dur).exp()) * (-gamma * dt).exp()
+                coeff_a * (1.0 - (-alpha * dur).exp()) * (-alpha * dt).exp() * term(alpha)
+                    + coeff_b * (1.0 - (-beta * dur).exp()) * (-beta * dt).exp() * term(beta)
+                    + coeff_g * (1.0 - (-gamma * dur).exp()) * (-gamma * dt).exp() * term(gamma)
             }
         };
         [
@@ -344,18 +306,7 @@ pub(crate) fn three_cpt_iv_peripherals(
             infusion_periph(c3_scalar, k21),
         ]
     } else {
-        // Single-dose bolus
-        let c2 = c2_scalar
-            * d
-            * (-(alpha - k31) / (ab * ag) * (-alpha * tau).exp()
-                + (beta - k31) / (ab * bg) * (-beta * tau).exp()
-                - (gamma - k31) / (ag * bg) * (-gamma * tau).exp());
-        let c3 = c3_scalar
-            * d
-            * (-(alpha - k21) / (ab * ag) * (-alpha * tau).exp()
-                + (beta - k21) / (ab * bg) * (-beta * tau).exp()
-                - (gamma - k21) / (ag * bg) * (-gamma * tau).exp());
-        [c2, c3]
+        [periph_bolus(c2_scalar, k31), periph_bolus(c3_scalar, k21)]
     }
 }
 

--- a/src/pk/two_compartment.rs
+++ b/src/pk/two_compartment.rs
@@ -1,4 +1,6 @@
-use crate::pk::analytical_absorption::{convolve_2cpt_peripheral, IgAbsorption, TransitAbsorption};
+use crate::pk::analytical_absorption::{
+    convolve_2cpt_peripheral, IgAbsorption, TiltedAbsorption, TransitAbsorption,
+};
 use crate::pk::one_compartment::{one_cpt_ig_depot, one_cpt_transit_depot};
 use crate::sens::two_cpt::{
     ig_2cpt_domain_ok, transit_2cpt_domain_ok, two_cpt_ig_g, two_cpt_infusion_g,
@@ -75,6 +77,48 @@ pub fn two_cpt_transit_f(
     two_cpt_transit_g::<f64>(dose.amt, t, cl, v1, q, v2, n, mtt, f_bio)
 }
 
+/// Shared depot-side wrapper for a tilted-absorption 2-cpt model: return the
+/// 1-cpt depot delegate's value when the disposition-domain guard holds, else 0.
+/// `domain_ok` is the model's `*_2cpt_domain_ok(...)` result (evaluated eagerly,
+/// as in each original); `f` builds the disposition-independent 1-cpt depot mass.
+#[inline]
+fn guard_then<T>(domain_ok: Option<T>, f: impl FnOnce() -> f64) -> f64 {
+    if domain_ok.is_some() {
+        f()
+    } else {
+        0.0
+    }
+}
+
+/// Peripheral-compartment concentration `A2/V2` for a single tilted-absorption
+/// 2-cpt bolus at elapsed time `tau`, generic over the [`TiltedAbsorption`] kernel
+/// `abs` and its model's `domain_ok` guard. Shared body of
+/// [`two_cpt_transit_peripheral`] / [`two_cpt_ig_peripheral`]: the absorption
+/// density convolved with the peripheral IV-bolus impulse response
+/// ([`convolve_2cpt_peripheral`]) with `k12 = q/v1` and `(f_bio·amt)/v2`. Returns 0
+/// for `tau < 0`, infusion doses, or when the disposition-domain guard collapses
+/// (confluent `α = β` / flip-flop) — mirrors the central guards.
+#[allow(clippy::too_many_arguments)]
+fn two_cpt_absorption_peripheral<A: TiltedAbsorption<f64>>(
+    abs: &A,
+    domain_ok: Option<(f64, f64, f64)>,
+    dose: &DoseEvent,
+    tau: f64,
+    q: f64,
+    v1: f64,
+    v2: f64,
+    f_bio: f64,
+) -> f64 {
+    if tau < 0.0 || dose.is_infusion() {
+        return 0.0;
+    }
+    let Some((alpha, beta, _k21)) = domain_ok else {
+        return 0.0;
+    };
+    let k12 = q / v1;
+    convolve_2cpt_peripheral(abs, tau, alpha, beta, k12, (f_bio * dose.amt) / v2)
+}
+
 /// Unabsorbed amount still in the transit chain for a single bolus at elapsed time
 /// `tau`: `F·Dose·(1 − P(n+1, KTR·tau))`, `KTR = (n+1)/mtt`. The lumped depot-side
 /// state of the analytic 2-cpt transit model. The unabsorbed-chain mass is
@@ -96,10 +140,9 @@ pub(crate) fn two_cpt_transit_depot(
     mtt: f64,
     f_bio: f64,
 ) -> f64 {
-    if transit_2cpt_domain_ok(cl, v1, q, v2, n, mtt).is_none() {
-        return 0.0;
-    }
-    one_cpt_transit_depot(dose, tau, n, mtt, f_bio)
+    guard_then(transit_2cpt_domain_ok(cl, v1, q, v2, n, mtt), || {
+        one_cpt_transit_depot(dose, tau, n, mtt, f_bio)
+    })
 }
 
 /// Peripheral-compartment concentration `A2/V2` for a single 2-cpt transit bolus at
@@ -120,16 +163,17 @@ pub(crate) fn two_cpt_transit_peripheral(
     mtt: f64,
     f_bio: f64,
 ) -> f64 {
-    if tau < 0.0 || dose.is_infusion() {
-        return 0.0;
-    }
     // Same shared disposition-domain guard as the central path (#634 finding 7).
-    let Some((alpha, beta, _k21)) = transit_2cpt_domain_ok(cl, v1, q, v2, n, mtt) else {
-        return 0.0;
-    };
-    let abs = TransitAbsorption { n, mtt };
-    let k12 = q / v1;
-    convolve_2cpt_peripheral(&abs, tau, alpha, beta, k12, (f_bio * dose.amt) / v2)
+    two_cpt_absorption_peripheral(
+        &TransitAbsorption { n, mtt },
+        transit_2cpt_domain_ok(cl, v1, q, v2, n, mtt),
+        dose,
+        tau,
+        q,
+        v1,
+        v2,
+        f_bio,
+    )
 }
 
 /// 2-cpt inverse-Gaussian absorption central concentration (#790). `F` is baked into
@@ -170,10 +214,9 @@ pub(crate) fn two_cpt_ig_depot(
     cv2: f64,
     f_bio: f64,
 ) -> f64 {
-    if ig_2cpt_domain_ok(cl, v1, q, v2, mat, cv2).is_none() {
-        return 0.0;
-    }
-    one_cpt_ig_depot(dose, tau, mat, cv2, f_bio)
+    guard_then(ig_2cpt_domain_ok(cl, v1, q, v2, mat, cv2), || {
+        one_cpt_ig_depot(dose, tau, mat, cv2, f_bio)
+    })
 }
 
 /// Peripheral-compartment concentration `A2/V2` for a single 2-cpt IG bolus at elapsed
@@ -194,18 +237,19 @@ pub(crate) fn two_cpt_ig_peripheral(
     cv2: f64,
     f_bio: f64,
 ) -> f64 {
-    if tau < 0.0 || dose.is_infusion() {
-        return 0.0;
-    }
-    let Some((alpha, beta, _k21)) = ig_2cpt_domain_ok(cl, v1, q, v2, mat, cv2) else {
-        return 0.0;
-    };
-    let abs = IgAbsorption {
-        mat,
-        lambda: mat / cv2,
-    };
-    let k12 = q / v1;
-    convolve_2cpt_peripheral(&abs, tau, alpha, beta, k12, (f_bio * dose.amt) / v2)
+    two_cpt_absorption_peripheral(
+        &IgAbsorption {
+            mat,
+            lambda: mat / cv2,
+        },
+        ig_2cpt_domain_ok(cl, v1, q, v2, mat, cv2),
+        dose,
+        tau,
+        q,
+        v1,
+        v2,
+        f_bio,
+    )
 }
 
 /// Predict concentration from a single dose at elapsed time t using 2-cmt model.

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -65,60 +65,65 @@ pub struct SubjectSens {
     pub obs: Vec<ObsSens>,
 }
 
-/// Constant `ScalarScale` output divisor `f_scaled = f/k` on the **full** `(θ, η)` jet:
-/// every derivative is linear in `f` and `k` is constant (`∂k/∂η = ∂k/∂θ = 0`), so value,
-/// gradient, and both Hessian blocks divide by the same `k`. Matches `pk::apply_scaling`
-/// (`pred /= s`). No-op at `k == 1.0` (identity scale — skip the per-observation multiply,
-/// as the ODE and closed-form twins do). Shared by the closed-form, TV-cov, and IOV outer
-/// walks so the field set stays in sync across paths (#486).
-#[inline]
-fn scale_obs_sens_full(obs: &mut [ObsSens], k: f64) {
-    if k == 1.0 {
-        return;
+/// Shared accessor letting the constant-`ScalarScale` divide run once over both the
+/// outer full-jet ([`ObsSens`]) and the inner η-grad ([`ObsGrad`]) observation types.
+/// `for_each_scaled_axis` visits every derivative the scale multiplies by `1/k`, in the
+/// same order the two hand-written copies did: the outer visits `∂f/∂η`, `∂²f/∂η²`,
+/// `∂f/∂θ`, `∂²f/∂η∂θ`; the inner only `∂f/∂η` (that width carries no θ / Hessian block).
+trait ScalableObs {
+    fn scale_f_mut(&mut self) -> &mut f64;
+    fn for_each_scaled_axis(&mut self, f: impl FnMut(&mut f64));
+}
+
+impl ScalableObs for ObsSens {
+    #[inline]
+    fn scale_f_mut(&mut self) -> &mut f64 {
+        &mut self.f
     }
-    // Match `pk::apply_scaling` / `ScalingSpec::build_obs_scale_array`: a non-positive or
-    // non-finite scale is invalid and NaN-outs the prediction (loud-failure semantics).
-    // Multiplying by a NaN reciprocal NaNs out the whole jet (value + every derivative),
-    // keeping the analytic path in lock-step with the production predictor the FD oracle
-    // differentiates — rather than emitting an `inf`/sign-flipped jet for `k <= 0`.
-    let inv = if k.is_finite() && k > 0.0 {
-        1.0 / k
-    } else {
-        f64::NAN
-    };
-    for o in obs.iter_mut() {
-        o.f *= inv;
-        for v in o
-            .df_deta
+    #[inline]
+    fn for_each_scaled_axis(&mut self, f: impl FnMut(&mut f64)) {
+        self.df_deta
             .iter_mut()
-            .chain(o.d2f_deta2.iter_mut())
-            .chain(o.df_dtheta.iter_mut())
-            .chain(o.d2f_deta_dtheta.iter_mut())
-        {
-            *v *= inv;
-        }
+            .chain(self.d2f_deta2.iter_mut())
+            .chain(self.df_dtheta.iter_mut())
+            .chain(self.d2f_deta_dtheta.iter_mut())
+            .for_each(f);
     }
 }
 
-/// Constant `ScalarScale` divisor on the **η-only** first-order jet (inner EBE walks):
-/// `f` and each `∂f/∂η` divide by the η-independent `k`; there is no θ / Hessian block to
-/// scale here (these walks emit [`ObsGrad`], not [`ObsSens`]). The grad-only counterpart of
-/// [`scale_obs_sens_full`]; same `k == 1.0` no-op and same `pk::apply_scaling` parity (#486).
+impl ScalableObs for ObsGrad {
+    #[inline]
+    fn scale_f_mut(&mut self) -> &mut f64 {
+        &mut self.f
+    }
+    #[inline]
+    fn for_each_scaled_axis(&mut self, f: impl FnMut(&mut f64)) {
+        self.df_deta.iter_mut().for_each(f);
+    }
+}
+
+/// Divide a subject's jet by a constant `ScalarScale` output divisor `k` (`f_scaled = f/k`)
+/// in place, on either observation width. Every derivative is linear in `f` and `k` is
+/// constant (`∂k/∂η = ∂k/∂θ = 0`), so value, gradient, and (for the outer width) both
+/// Hessian blocks divide by the same `k`. Matches `pk::apply_scaling` (`pred /= s`); no-op
+/// at `k == 1.0`. Per `pk::apply_scaling` / `ScalingSpec::build_obs_scale_array`, a
+/// non-positive or non-finite scale is invalid and NaN-outs the whole jet (loud-failure
+/// semantics) rather than emitting an `inf`/sign-flipped jet, keeping the analytic path in
+/// lock-step with the production predictor the FD oracle differentiates. Shared by the
+/// closed-form, TV-cov, and IOV outer/inner walks so the field set stays in sync (#486).
 #[inline]
-fn scale_obs_sens_grad(obs: &mut [ObsGrad], k: f64) {
+fn scale_obs_sens<J: ScalableObs>(obs: &mut [J], k: f64) {
     if k == 1.0 {
         return;
     }
-    // Invalid (`k <= 0` / non-finite) scale NaN-outs the jet, matching `pk::apply_scaling`
-    // (see `scale_obs_sens_full`).
     let inv = if k.is_finite() && k > 0.0 {
         1.0 / k
     } else {
         f64::NAN
     };
     for o in obs.iter_mut() {
-        o.f *= inv;
-        o.df_deta.iter_mut().for_each(|x| *x *= inv);
+        *o.scale_f_mut() *= inv;
+        o.for_each_scaled_axis(|v| *v *= inv);
     }
 }
 
@@ -216,6 +221,159 @@ fn lagged_elapsed<T: PkNum>(dose: &DoseEvent, t_obs: f64, lag_val: f64, lag_d: T
     } else {
         None
     }
+}
+
+/// The seven PK-class booleans that select which closed-form concentration kernel a dose
+/// superposition dispatches to. Bundled into one `Copy` argument so [`superpose_doses`]
+/// takes it in place of seven flags, and the outer ([`run_obs`]) and inner
+/// ([`run_obs_grad`]) walkers build it from the same field set.
+#[derive(Clone, Copy)]
+struct PkClassFlags {
+    oral: bool,
+    two_cpt: bool,
+    three_cpt: bool,
+    transit: bool,
+    two_cpt_transit: bool,
+    ig: bool,
+    two_cpt_ig: bool,
+}
+
+/// The 14 PK-parameter duals a dose superposition reads, seeded once from `seed_dim`
+/// (which slot maps to which compact dual axis; `None` = constant). Generic over the
+/// seeded number type so the outer walker instantiates it at `Dual2<N>` (full `(θ,η)`
+/// jet + Hessian) and the inner at `Dual1<N>` (η-gradient only) from identical code.
+/// `lag_val` is kept alongside `lag_d` so the lagged-arrival reset test can branch on the
+/// plain value without a borrow.
+struct SeededPkDuals<T: PkNum> {
+    cl_d: T,
+    v1_d: T,
+    q_d: T,
+    v2_d: T,
+    ka_d: T,
+    f_d: T,
+    q3_d: T,
+    v3_d: T,
+    lag_d: T,
+    lag_val: f64,
+    n_d: T,
+    mtt_d: T,
+    mat_d: T,
+    cv2_d: T,
+}
+
+impl<T: PkNum> SeededPkDuals<T> {
+    /// Seed each PK slot as an independent dual axis (`seed_dim[slot] = Some(k)`) or a
+    /// constant (`None`), reading the values off `pk`. Mirrors the per-slot `dv` closure
+    /// the two walkers previously inlined verbatim.
+    fn seed(seed_dim: &[Option<usize>; N_PK], pk: &crate::types::PkParams) -> Self {
+        let dv = |slot: usize, value: f64| -> T {
+            match seed_dim[slot] {
+                Some(k) => T::var(value, k),
+                None => T::from_f64(value),
+            }
+        };
+        let lag_val = pk.lagtime();
+        Self {
+            cl_d: dv(PK_IDX_CL, pk.cl()),
+            v1_d: dv(PK_IDX_V, pk.v()),
+            q_d: dv(PK_IDX_Q, pk.q()),
+            v2_d: dv(PK_IDX_V2, pk.v2()),
+            ka_d: dv(PK_IDX_KA, pk.ka()),
+            f_d: dv(PK_IDX_F, pk.f_bio()),
+            q3_d: dv(PK_IDX_Q3, pk.q3()),
+            v3_d: dv(PK_IDX_V3, pk.v3()),
+            lag_d: dv(PK_IDX_LAGTIME, lag_val),
+            lag_val,
+            n_d: dv(PK_IDX_N, pk.n_transit()),
+            mtt_d: dv(PK_IDX_MTT, pk.mtt()),
+            mat_d: dv(PK_IDX_MAT, pk.mat()),
+            cv2_d: dv(PK_IDX_CV2, pk.cv2()),
+        }
+    }
+}
+
+/// Seed the full `N_PK`-slot PK-parameter dual array the analytic Form-C readout reads
+/// (indexed by PK slot, so `eval_output_g` can pull `V`, binding constants, … via its
+/// `indiv_to_pk` plan). Same per-slot var/constant seeding as [`SeededPkDuals::seed`],
+/// over every slot. Generic so the outer/inner walkers build it at `Dual2<N>`/`Dual1<N>`.
+fn ro_pk_dual_array<T: PkNum>(
+    seed_dim: &[Option<usize>; N_PK],
+    pk: &crate::types::PkParams,
+) -> [T; N_PK] {
+    std::array::from_fn(|s| {
+        let val = pk.values.get(s).copied().unwrap_or(0.0);
+        match seed_dim[s] {
+            Some(k) => T::var(val, k),
+            None => T::from_f64(val),
+        }
+    })
+}
+
+/// The reset segment floor at `t_obs`: the most recent EVID=3/4 reset at or before this
+/// observation (`−∞` when the subject has no resets). Doses before it were zeroed out of
+/// the compartments, so the superposition excludes them — mirroring the event-driven
+/// walker's `event_reset_floor`.
+#[inline]
+fn reset_floor_at(subject: &Subject, t_obs: f64) -> f64 {
+    subject
+        .reset_times
+        .iter()
+        .copied()
+        .filter(|&r| r <= t_obs)
+        .fold(f64::NEG_INFINITY, f64::max)
+}
+
+/// Superpose one observation's dose contributions through the closed-form PK kernel the
+/// `flags` select: `f = Σ conc(dose, elapsed)`, restricted to the current reset segment
+/// (`dose.time + lag < reset_floor` excludes washed-out doses, keyed on the *lagged
+/// arrival* — a dose recorded before a reset but arriving after it via lagtime still
+/// contributes, exactly as the event-driven walk applies it, PR #381 #2). `elapsed`
+/// carries the lagtime shift and the SS pre-arrival tail wrap ([`lagged_elapsed`]).
+/// Generic over the seeded dual type, so the `Dual2` outer ([`run_obs`]) and `Dual1`
+/// inner ([`run_obs_grad`]) walkers share the byte-identical dispatch ladder.
+#[inline]
+fn superpose_doses<T: PkNum>(
+    d: &SeededPkDuals<T>,
+    flags: PkClassFlags,
+    subject: &Subject,
+    t_obs: f64,
+    reset_floor: f64,
+) -> T {
+    let mut fd = T::from_f64(0.0);
+    for dose in &subject.doses {
+        if dose.time + d.lag_val < reset_floor {
+            continue;
+        }
+        let Some(elapsed) = lagged_elapsed(dose, t_obs, d.lag_val, d.lag_d) else {
+            continue;
+        };
+        let c = if flags.transit {
+            one_cpt_transit_conc_g(dose, elapsed, d.cl_d, d.v1_d, d.n_d, d.mtt_d, d.f_d)
+        } else if flags.two_cpt_transit {
+            two_cpt_transit_conc_g(
+                dose, elapsed, d.cl_d, d.v1_d, d.q_d, d.v2_d, d.n_d, d.mtt_d, d.f_d,
+            )
+        } else if flags.ig {
+            one_cpt_ig_conc_g(dose, elapsed, d.cl_d, d.v1_d, d.mat_d, d.cv2_d, d.f_d)
+        } else if flags.two_cpt_ig {
+            two_cpt_ig_conc_g(
+                dose, elapsed, d.cl_d, d.v1_d, d.q_d, d.v2_d, d.mat_d, d.cv2_d, d.f_d,
+            )
+        } else if flags.three_cpt {
+            three_cpt_conc_g(
+                dose, elapsed, d.cl_d, d.v1_d, d.q_d, d.v2_d, d.q3_d, d.v3_d, d.ka_d, d.f_d,
+                flags.oral,
+            )
+        } else if flags.two_cpt {
+            two_cpt_conc_g(
+                dose, elapsed, d.cl_d, d.v1_d, d.q_d, d.v2_d, d.ka_d, d.f_d, flags.oral,
+            )
+        } else {
+            one_cpt_conc_g(dose, elapsed, d.cl_d, d.v1_d, d.ka_d, d.f_d, flags.oral)
+        };
+        fd = fd + c;
+    }
+    fd
 }
 
 /// Master switch for the user-ODE sensitivity path (issue #367, Option A). The
@@ -410,6 +568,48 @@ fn eval_readout_jet<T: crate::sens::num::PkNum>(
     ro_state.resize(n_states, T::from_f64(0.0));
     ro_state[central_slot] = conc * params[PK_IDX_V];
     prog.eval_output_g::<T>(ro_state, params, cov, ro_vars, ro_stack)
+}
+
+/// Apply the analytic Form-C readout (#650) to one observation's (already clamped)
+/// concentration jet: replace `conc` with `y = <expr>` over the seeded dual (central
+/// amount = conc × V), under this observation's `ModelTimeGuard` so a `TIME`-referencing
+/// readout resolves `Op::PushTime` to `t_obs` (matching production's
+/// `apply_analytic_readout` guard; a no-op for a `TIME`-free readout). Returns `conc`
+/// unchanged with no readout, touching the covariate/time snapshots only on the readout
+/// path. Generic over the dual width, so the `Dual2` outer ([`run_obs`]) and `Dual1` inner
+/// ([`run_obs_grad`]) walkers share the guard/eval wiring (#637); the resulting `∂y/∂pk`
+/// (and `∂²y/∂pk²` on the outer width) then rides the same `pd`/`dp_deta` chain.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn apply_readout_jet<T: PkNum>(
+    conc: T,
+    readout: Option<&crate::parser::model_parser::OdeOutputProgram>,
+    ro_pk_duals: Option<&[T; N_PK]>,
+    subject: &Subject,
+    obs_i: usize,
+    ro_state: &mut Vec<T>,
+    ro_vars: &mut Vec<T>,
+    ro_stack: &mut Vec<T>,
+) -> T {
+    if let (Some(prog), Some(pkd)) = (readout, ro_pk_duals) {
+        // A `TIME`-referencing readout resolves `Op::PushTime` from the model-time
+        // thread-local; enter this observation's time to match production's
+        // `apply_analytic_readout` guard (no-op for a `TIME`-free readout).
+        let _time_guard = crate::parser::model_parser::ModelTimeGuard::enter(
+            subject.obs_times.get(obs_i).copied().unwrap_or(0.0),
+        );
+        eval_readout_jet::<T>(
+            prog,
+            conc,
+            pkd,
+            subject.obs_cov(obs_i),
+            ro_state,
+            ro_vars,
+            ro_stack,
+        )
+    } else {
+        conc
+    }
 }
 
 /// κ = 0 (BSV-only) readout-parameter snapshots for the analytic IOV walk (#655).
@@ -1926,7 +2126,7 @@ fn run_obs_iov<const M: usize>(
     // entry (value, gradient, Hessian) divides by the same `k` — the IOV twin of the non-IOV
     // `f_scaled = f/k` and production `apply_scaling` (#486 IOV-scope parity).
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_full(&mut obs_out, k);
+        scale_obs_sens(&mut obs_out, k);
     }
 
     Some(SubjectSens { obs: obs_out })
@@ -2199,7 +2399,7 @@ fn run_obs_iov_eta<const N: usize>(
     // Constant `ScalarScale` output divisor `f/k` (first-order): `f` and each `∂f/∂stacked-η`
     // divide by `k` (#486 IOV-scope parity — the inner twin of the `run_obs_iov` step).
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_grad(&mut out, k);
+        scale_obs_sens(&mut out, k);
     }
 
     Some(out)
@@ -2693,7 +2893,7 @@ pub fn subject_sensitivities_tvcov(
     // linear in `f` and `k` is constant, so the whole jet divides by `k` — matches
     // `pk::apply_scaling` (`pred /= s`) on the production TV-cov path.
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_full(&mut sens.obs, k);
+        scale_obs_sens(&mut sens.obs, k);
     }
     // η-dependent `ExpressionScale` divisor `s(θ, η)`: apply the subject-static quotient
     // `scaled_f = f/s` on the walked jet — the SAME shared quotient the dose-superposition
@@ -3108,7 +3308,7 @@ pub(crate) fn subject_eta_grad_tvcov_with_schedule(
     // matching the outer TV-cov path and `pk::apply_scaling`. (LTBS keeps the FD inner —
     // gated upstream; `ExpressionScale` is applied below.)
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_grad(&mut out, k);
+        scale_obs_sens(&mut out, k);
     }
     // η-dependent `ExpressionScale` divisor: the η-only quotient — the light counterpart
     // of the outer path, matching the static inner path (#486). Subject-static scale from
@@ -3689,7 +3889,7 @@ fn subject_eta_grad_impl(
     // linear in `f` so it divides by the same `k` (η-independent). Matches
     // `pk::apply_scaling` (`pred /= s`). Other scaling variants are gated out.
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_grad(&mut out, k);
+        scale_obs_sens(&mut out, k);
     }
     // η-dependent `ExpressionScale` output divisor `s(θ, η)`: `f_scaled = f/s`, with the
     // η-only quotient rule `∂(f/s)/∂η_k = (∂f/∂η_k)/s − f·(∂s/∂η_k)/s²`. The light
@@ -3740,95 +3940,28 @@ fn run_obs_grad<const N: usize>(
     n_eta: usize,
     readout: Option<&crate::parser::model_parser::OdeOutputProgram>,
 ) -> Vec<ObsGrad> {
-    let (cl, v1, q, v2, ka, f_bio, q3, v3) = (
-        pk.cl(),
-        pk.v(),
-        pk.q(),
-        pk.v2(),
-        pk.ka(),
-        pk.f_bio(),
-        pk.q3(),
-        pk.v3(),
-    );
-    let dv = |slot: usize, value: f64| -> Dual1<N> {
-        match seed_dim[slot] {
-            Some(k) => Dual1::<N>::var(value, k),
-            None => Dual1::<N>::constant(value),
-        }
+    let seeded = SeededPkDuals::<Dual1<N>>::seed(seed_dim, pk);
+    let flags = PkClassFlags {
+        oral,
+        two_cpt,
+        three_cpt,
+        transit,
+        two_cpt_transit,
+        ig,
+        two_cpt_ig,
     };
-    let cl_d = dv(PK_IDX_CL, cl);
-    let v1_d = dv(PK_IDX_V, v1);
-    let q_d = dv(PK_IDX_Q, q);
-    let v2_d = dv(PK_IDX_V2, v2);
-    let ka_d = dv(PK_IDX_KA, ka);
-    let f_d = dv(PK_IDX_F, f_bio);
-    let q3_d = dv(PK_IDX_Q3, q3);
-    let v3_d = dv(PK_IDX_V3, v3);
-    // Lagtime enters each dose's concentration through the elapsed-time argument
-    // (`elapsed = (t_obs − dose.time) − lagtime`), so seed it as its own dual axis.
-    let lag_val = pk.lagtime();
-    let lag_d = dv(PK_IDX_LAGTIME, lag_val);
-    // Transit `n`/`mtt` (#386) and IG `mat`/`cv2` (#790), seeded like the other
-    // structural params.
-    let n_d = dv(PK_IDX_N, pk.n_transit());
-    let mtt_d = dv(PK_IDX_MTT, pk.mtt());
-    let mat_d = dv(PK_IDX_MAT, pk.mat());
-    let cv2_d = dv(PK_IDX_CV2, pk.cv2());
 
     // Analytic Form C readout (#650): PK-slot dual vector + scratch, built once
     // (subject-static). Mirrors the outer `run_obs`, on `Dual1<N>` (η-grad only).
-    let ro_pk_duals: Option<[Dual1<N>; N_PK]> = readout.map(|_| {
-        std::array::from_fn(|s| {
-            let val = pk.values.get(s).copied().unwrap_or(0.0);
-            match seed_dim[s] {
-                Some(k) => Dual1::<N>::var(val, k),
-                None => Dual1::<N>::constant(val),
-            }
-        })
-    });
+    let ro_pk_duals: Option<[Dual1<N>; N_PK]> =
+        readout.map(|_| ro_pk_dual_array::<Dual1<N>>(seed_dim, pk));
     let mut ro_state: Vec<Dual1<N>> = Vec::new();
     let mut ro_vars: Vec<Dual1<N>> = Vec::new();
     let mut ro_stack: Vec<Dual1<N>> = Vec::new();
     let mut out = Vec::with_capacity(subject.obs_times.len());
     for (obs_i, &t_obs) in subject.obs_times.iter().enumerate() {
-        let reset_floor = subject
-            .reset_times
-            .iter()
-            .copied()
-            .filter(|&r| r <= t_obs)
-            .fold(f64::NEG_INFINITY, f64::max);
-
-        let mut fd = Dual1::<N>::constant(0.0);
-        for dose in &subject.doses {
-            // Exclude doses washed out by a reset — keyed on the *lagged arrival*
-            // `dose.time + lag`, not the record time: a dose recorded before a
-            // reset but arriving after it (via lagtime) contributes to the new
-            // segment, exactly as the event-driven walk applies it (PR #381 #2).
-            if dose.time + lag_val < reset_floor {
-                continue;
-            }
-            let Some(elapsed) = lagged_elapsed(dose, t_obs, lag_val, lag_d) else {
-                continue;
-            };
-            let c = if transit {
-                one_cpt_transit_conc_g(dose, elapsed, cl_d, v1_d, n_d, mtt_d, f_d)
-            } else if two_cpt_transit {
-                two_cpt_transit_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, n_d, mtt_d, f_d)
-            } else if ig {
-                one_cpt_ig_conc_g(dose, elapsed, cl_d, v1_d, mat_d, cv2_d, f_d)
-            } else if two_cpt_ig {
-                two_cpt_ig_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, mat_d, cv2_d, f_d)
-            } else if three_cpt {
-                three_cpt_conc_g(
-                    dose, elapsed, cl_d, v1_d, q_d, v2_d, q3_d, v3_d, ka_d, f_d, oral,
-                )
-            } else if two_cpt {
-                two_cpt_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, ka_d, f_d, oral)
-            } else {
-                one_cpt_conc_g(dose, elapsed, cl_d, v1_d, ka_d, f_d, oral)
-            };
-            fd = fd + c;
-        }
+        let reset_floor = reset_floor_at(subject, t_obs);
+        let fd = superpose_doses(&seeded, flags, subject, t_obs, reset_floor);
 
         // Mirror production's `conc.max(0.0)`: a negative closed-form value clamps
         // to 0, so its η-gradient is 0 there too (consistency with the objective).
@@ -3839,32 +3972,23 @@ fn run_obs_grad<const N: usize>(
         };
 
         // Analytic Form C readout (#650): replace the central concentration with
-        // `y = <expr>` over `Dual1<N>` (central amount = conc × V), mirroring the
-        // outer `run_obs`. Its `∂y/∂pk` then rides the `dp_deta` chain below.
-        let (fval, g) = if let (Some(prog), Some(pkd)) = (readout, ro_pk_duals.as_ref()) {
-            let conc = Dual1::<N> {
-                value: fval,
-                grad: g,
-            };
-            // A `TIME`-referencing readout resolves `Op::PushTime` from the model-time
-            // thread-local; enter this observation's time to match production's
-            // `apply_analytic_readout` guard (no-op for a `TIME`-free readout).
-            let _time_guard = crate::parser::model_parser::ModelTimeGuard::enter(
-                subject.obs_times.get(obs_i).copied().unwrap_or(0.0),
-            );
-            let y = eval_readout_jet::<Dual1<N>>(
-                prog,
-                conc,
-                pkd,
-                subject.obs_cov(obs_i),
-                &mut ro_state,
-                &mut ro_vars,
-                &mut ro_stack,
-            );
-            (y.value, y.grad)
-        } else {
-            (fval, g)
+        // `y = <expr>` over `Dual1<N>` (central amount = conc × V), mirroring the outer
+        // `run_obs`. Its `∂y/∂pk` then rides the `dp_deta` chain below.
+        let conc = Dual1::<N> {
+            value: fval,
+            grad: g,
         };
+        let y = apply_readout_jet(
+            conc,
+            readout,
+            ro_pk_duals.as_ref(),
+            subject,
+            obs_i,
+            &mut ro_state,
+            &mut ro_vars,
+            &mut ro_stack,
+        );
+        let (fval, g) = (y.value, y.grad);
 
         let mut df_deta = vec![0.0; n_eta];
         for i in 0..N {
@@ -4820,7 +4944,7 @@ fn subject_sensitivities_impl(
     // linear in `f` and `k` is constant (`∂k/∂η = ∂k/∂θ = 0`), so the whole jet
     // divides by `k`. Matches `pk::apply_scaling` (`pred /= s`).
     if let ScalingSpec::ScalarScale(k) = model.scaling {
-        scale_obs_sens_full(&mut sens.obs, k);
+        scale_obs_sens(&mut sens.obs, k);
     }
     // ExpressionScale: divide by a per-subject scale `s(θ, η)` whose own jet is
     // computed exactly from the differentiable scale program; quotient-combine
@@ -5032,18 +5156,20 @@ fn run_obs<const N: usize>(
         pk.q3(),
         pk.v3(),
     );
+    let flags = PkClassFlags {
+        oral,
+        two_cpt,
+        three_cpt,
+        transit,
+        two_cpt_transit,
+        ig,
+        two_cpt_ig,
+    };
     // Analytic Form C readout (#650): the PK-parameter dual vector (indexed by PK
     // slot, so `eval_output_g` can pull `V`, binding constants, … via its
     // `indiv_to_pk` plan) and reusable scratch. Subject-static, so built once.
-    let ro_pk_duals: Option<[Dual2<N>; N_PK]> = readout.map(|_| {
-        std::array::from_fn(|s| {
-            let val = pk.values.get(s).copied().unwrap_or(0.0);
-            match seed_dim[s] {
-                Some(k) => Dual2::<N>::var(val, k),
-                None => Dual2::<N>::constant(val),
-            }
-        })
-    });
+    let ro_pk_duals: Option<[Dual2<N>; N_PK]> =
+        readout.map(|_| ro_pk_dual_array::<Dual2<N>>(seed_dim, pk));
     let mut ro_state: Vec<Dual2<N>> = Vec::new();
     let mut ro_vars: Vec<Dual2<N>> = Vec::new();
     let mut ro_stack: Vec<Dual2<N>> = Vec::new();
@@ -5055,12 +5181,7 @@ fn run_obs<const N: usize>(
         // superposition below — mirroring the event-driven walker's
         // `event_reset_floor`. A reset+dose record (EVID=4) sits exactly at the
         // floor and is kept (`dose.time >= reset_floor`).
-        let reset_floor = subject
-            .reset_times
-            .iter()
-            .copied()
-            .filter(|&r| r <= t_obs)
-            .fold(f64::NEG_INFINITY, f64::max);
+        let reset_floor = reset_floor_at(subject, t_obs);
 
         // `(f, ∂f/∂pk, ∂²f/∂pk²)` in the compact `0..N` layout — from the explicit
         // kernels when applicable, else the generic `Dual2<N>` path.
@@ -5080,64 +5201,11 @@ fn run_obs<const N: usize>(
             }
             (val, gv, hv)
         } else {
-            // Seed only the differentiated PK params as `Dual2<N>` on their compact
-            // axes; everything else is a constant. `dv(slot, value)` does the lookup.
-            let dv = |slot: usize, value: f64| -> Dual2<N> {
-                match seed_dim[slot] {
-                    Some(k) => Dual2::<N>::var(value, k),
-                    None => Dual2::<N>::constant(value),
-                }
-            };
-            let cl_d = dv(PK_IDX_CL, cl);
-            let v1_d = dv(PK_IDX_V, v1);
-            let q_d = dv(PK_IDX_Q, q);
-            let v2_d = dv(PK_IDX_V2, v2);
-            let ka_d = dv(PK_IDX_KA, ka);
-            let f_d = dv(PK_IDX_F, f_bio);
-            let q3_d = dv(PK_IDX_Q3, q3);
-            let v3_d = dv(PK_IDX_V3, v3);
-            // Lagtime enters each dose's concentration through the elapsed-time
-            // argument; seed it as its own dual axis (`∂elapsed/∂lagtime = −1`).
-            let lag_val = pk.lagtime();
-            let lag_d = dv(PK_IDX_LAGTIME, lag_val);
-            // Transit `n`/`mtt` (#386) and IG `mat`/`cv2` (#790), seeded like the
-            // other structural params.
-            let n_d = dv(PK_IDX_N, pk.n_transit());
-            let mtt_d = dv(PK_IDX_MTT, pk.mtt());
-            let mat_d = dv(PK_IDX_MAT, pk.mat());
-            let cv2_d = dv(PK_IDX_CV2, pk.cv2());
-
-            // Superpose dose contributions: f = Σ conc(dose, elapsed), restricted
-            // to the current reset segment (`dose.time >= reset_floor`); `elapsed`
+            // Seed only the differentiated PK params as `Dual2<N>` and superpose the
+            // dose contributions restricted to the current reset segment; `elapsed`
             // carries the lagtime shift and the SS pre-arrival tail wrap.
-            let mut fd = Dual2::<N>::constant(0.0);
-            for dose in &subject.doses {
-                // Lagged-arrival reset exclusion — see the value path above (#2).
-                if dose.time + lag_val < reset_floor {
-                    continue;
-                }
-                let Some(elapsed) = lagged_elapsed(dose, t_obs, lag_val, lag_d) else {
-                    continue;
-                };
-                let c = if transit {
-                    one_cpt_transit_conc_g(dose, elapsed, cl_d, v1_d, n_d, mtt_d, f_d)
-                } else if two_cpt_transit {
-                    two_cpt_transit_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, n_d, mtt_d, f_d)
-                } else if ig {
-                    one_cpt_ig_conc_g(dose, elapsed, cl_d, v1_d, mat_d, cv2_d, f_d)
-                } else if two_cpt_ig {
-                    two_cpt_ig_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, mat_d, cv2_d, f_d)
-                } else if three_cpt {
-                    three_cpt_conc_g(
-                        dose, elapsed, cl_d, v1_d, q_d, v2_d, q3_d, v3_d, ka_d, f_d, oral,
-                    )
-                } else if two_cpt {
-                    two_cpt_conc_g(dose, elapsed, cl_d, v1_d, q_d, v2_d, ka_d, f_d, oral)
-                } else {
-                    one_cpt_conc_g(dose, elapsed, cl_d, v1_d, ka_d, f_d, oral)
-                };
-                fd = fd + c;
-            }
+            let seeded = SeededPkDuals::<Dual2<N>>::seed(seed_dim, pk);
+            let fd = superpose_doses(&seeded, flags, subject, t_obs, reset_floor);
             (fd.value, fd.grad, fd.hess)
         };
 
@@ -5153,37 +5221,28 @@ fn run_obs<const N: usize>(
             (fval, g, h)
         };
 
-        // Analytic Form C readout (#650): replace the central concentration jet
-        // with `y = <expr>` over `Dual2<N>`. The central compartment **amount** is
-        // `concentration × V` (so a `central / V` readout recovers the
-        // concentration and an additive term layers on); the readout's `∂y/∂pk` /
-        // `∂²y/∂pk²` then ride the same `pd` chain to `(θ, η)` below. Covariates
-        // come from the per-observation snapshot (a per-row `FREE`-style flag).
-        let (fval, g, h) = if let (Some(prog), Some(pkd)) = (readout, ro_pk_duals.as_ref()) {
-            let conc = Dual2::<N> {
-                value: fval,
-                grad: g,
-                hess: h,
-            };
-            // A `TIME`-referencing readout resolves `Op::PushTime` from the model-time
-            // thread-local; enter this observation's time to match production's
-            // `apply_analytic_readout` guard (no-op for a `TIME`-free readout).
-            let _time_guard = crate::parser::model_parser::ModelTimeGuard::enter(
-                subject.obs_times.get(obs_i).copied().unwrap_or(0.0),
-            );
-            let y = eval_readout_jet::<Dual2<N>>(
-                prog,
-                conc,
-                pkd,
-                subject.obs_cov(obs_i),
-                &mut ro_state,
-                &mut ro_vars,
-                &mut ro_stack,
-            );
-            (y.value, y.grad, y.hess)
-        } else {
-            (fval, g, h)
+        // Analytic Form C readout (#650): replace the central concentration jet with
+        // `y = <expr>` over `Dual2<N>`. The central compartment **amount** is
+        // `concentration × V` (so a `central / V` readout recovers the concentration and
+        // an additive term layers on); the readout's `∂y/∂pk` / `∂²y/∂pk²` then ride the
+        // same `pd` chain to `(θ, η)` below. Covariates come from the per-observation
+        // snapshot (a per-row `FREE`-style flag).
+        let conc = Dual2::<N> {
+            value: fval,
+            grad: g,
+            hess: h,
         };
+        let y = apply_readout_jet(
+            conc,
+            readout,
+            ro_pk_duals.as_ref(),
+            subject,
+            obs_i,
+            &mut ro_state,
+            &mut ro_vars,
+            &mut ro_stack,
+        );
+        let (fval, g, h) = (y.value, y.grad, y.hess);
 
         let mut df_deta = vec![0.0; n_eta];
         let mut d2f_deta2 = vec![0.0; n_eta * n_eta];

--- a/src/suggest_start/nca.rs
+++ b/src/suggest_start/nca.rs
@@ -22,6 +22,20 @@ pub struct SubjectNca {
     pub mrt: Option<f64>,
 }
 
+/// One linear-up / log-down trapezoid segment of width `dt`: the linear rule
+/// `0.5·(y0 + y1)·dt` when the segment is rising (`y1 >= y0`) or either endpoint
+/// is non-positive, else the log-down (log-mean) rule `(y0 − y1)/(ln y0 − ln y1)·dt`.
+/// Shared by the AUC, AUMC and Wagner-Nelson cumulative-AUC accumulators so the
+/// segment rule lives in one place.
+#[inline]
+fn logdown_trapezoid(y0: f64, y1: f64, dt: f64) -> f64 {
+    if y1 >= y0 || y0 <= 0.0 || y1 <= 0.0 {
+        0.5 * (y0 + y1) * dt
+    } else {
+        (y0 - y1) / (y0.ln() - y1.ln()) * dt
+    }
+}
+
 /// Compute linear-up / log-down trapezoidal AUC for dose-normalised
 /// concentrations on the first-dose interval [t0, t_end).
 ///
@@ -48,12 +62,7 @@ pub fn auc_trapezoid(times: &[f64], concs: &[f64]) -> Option<(f64, f64, f64)> {
             continue;
         }
         // Linear-up / log-down: linear when c1 >= c0, log-down otherwise.
-        let trap = if c1 >= c0 || c0 <= 0.0 || c1 <= 0.0 {
-            0.5 * (c0 + c1) * dt
-        } else {
-            (c0 - c1) / (c0.ln() - c1.ln()) * dt
-        };
-        auc += trap;
+        auc += logdown_trapezoid(c0, c1, dt);
     }
 
     let &(t_last, c_last) = pairs.last().unwrap();
@@ -82,12 +91,7 @@ pub fn aumc_trapezoid(times: &[f64], concs: &[f64]) -> Option<(f64, f64, f64)> {
         if dt <= 0.0 {
             continue;
         }
-        let trap = if tc1 >= tc0 || tc0 <= 0.0 || tc1 <= 0.0 {
-            0.5 * (tc0 + tc1) * dt
-        } else {
-            (tc0 - tc1) / (tc0.ln() - tc1.ln()) * dt
-        };
-        aumc += trap;
+        aumc += logdown_trapezoid(tc0, tc1, dt);
     }
 
     let &(t_last, tc_last) = pairs.last().unwrap();
@@ -233,12 +237,7 @@ pub fn wagner_nelson_ka(times: &[f64], concs: &[f64], cl_f: f64, v_f: f64) -> Op
         let (t0, c0) = pairs[i - 1];
         let (t1, c1) = pairs[i];
         let dt = t1 - t0;
-        let trap = if c1 >= c0 || c0 <= 0.0 || c1 <= 0.0 {
-            0.5 * (c0 + c1) * dt
-        } else {
-            (c0 - c1) / (c0.ln() - c1.ln()) * dt
-        };
-        cum_auc[i] = cum_auc[i - 1] + trap;
+        cum_auc[i] = cum_auc[i - 1] + logdown_trapezoid(c0, c1, dt);
     }
 
     let c_last = pairs.last().unwrap().1;

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -187,23 +187,11 @@ pub fn tte_nll_from_curves(
         let h_entry = entry_lower_limit(*entry_time, &cumhaz_at);
 
         match event_type {
-            EventType::RightCensored => {
-                let h_t = cumhaz_at(*time);
-                if monotone_violation(h_t, h_entry) {
-                    return 1e20;
+            EventType::RightCensored | EventType::Exact => {
+                match score_event(event_type, *time, h_entry, &cumhaz_at, &hazard_at, tol) {
+                    Some((contrib, _)) => nll += contrib,
+                    None => return 1e20,
                 }
-                nll += h_t - h_entry;
-            }
-            EventType::Exact => {
-                let h_val = hazard_at(*time);
-                if h_val <= 0.0 {
-                    return 1e20;
-                }
-                let h_t = cumhaz_at(*time);
-                if monotone_violation(h_t, h_entry) {
-                    return 1e20;
-                }
-                nll += h_t - h_entry - h_val.ln();
             }
             EventType::IntervalCensored { left, right } => {
                 let h_l = cumhaz_at(*left);
@@ -267,6 +255,56 @@ fn entry_lower_limit(entry_time: f64, cumhaz_at: impl Fn(f64) -> f64) -> f64 {
     }
 }
 
+/// Shared `RightCensored` / `Exact` scoring for one TTE event record, given the
+/// hazard-clock argument `arg` (absolute time or a reset gap) and the lower
+/// cumulative-hazard limit `h_lo` to subtract:
+///   RightCensored: `H(arg) − h_lo`
+///   Exact:         `H(arg) − h_lo − log h(arg)`
+///
+/// Returns `(contribution, H(arg))` where `contribution` is the record's NLL term
+/// and `H(arg) = cumhaz_at(arg)` (used by the clock-forward path to telescope
+/// `h_lo`), or `None` when the record is numerically ill-defined — a non-positive
+/// hazard at an exact event, or a non-monotone cumulative hazard past the
+/// [`MonoTol`] round-off band — which each caller folds into its `1e20` sentinel.
+///
+/// The three survival loops ([`tte_nll_from_curves`], [`rtte_forward_nll_from_curves`],
+/// [`rtte_reset_nll_from_curves`]) share these two arms verbatim and differ only in
+/// their lower-limit bookkeeping, which stays inline in each. `IntervalCensored` is
+/// **not** scored here — single-event TTE handles it inline and the RTTE paths reject
+/// it — so that arm is unreachable (folded to `None` for exhaustiveness).
+#[inline]
+fn score_event(
+    event_type: &EventType,
+    arg: f64,
+    h_lo: f64,
+    cumhaz_at: impl Fn(f64) -> f64,
+    hazard_at: impl Fn(f64) -> f64,
+    tol: MonoTol,
+) -> Option<(f64, f64)> {
+    match event_type {
+        EventType::RightCensored => {
+            let h_a = cumhaz_at(arg);
+            if cumhaz_monotone_violation(h_a, h_lo, tol) {
+                return None;
+            }
+            Some((h_a - h_lo, h_a))
+        }
+        EventType::Exact => {
+            let h_val = hazard_at(arg);
+            if h_val <= 0.0 {
+                return None;
+            }
+            let h_a = cumhaz_at(arg);
+            if cumhaz_monotone_violation(h_a, h_lo, tol) {
+                return None;
+            }
+            Some(((h_a - h_lo) - h_val.ln(), h_a))
+        }
+        // Handled inline by the single-event path; rejected by the RTTE paths.
+        EventType::IntervalCensored { .. } => None,
+    }
+}
+
 /// Clock-forward (Andersen–Gill) **recurrent-event** (RTTE) negative log-likelihood
 /// from cumulative-hazard / hazard curves:
 ///
@@ -326,25 +364,14 @@ pub fn rtte_forward_nll_from_curves(
         }
 
         match event_type {
-            EventType::RightCensored => {
-                let h_t = cumhaz_at(*time);
-                if cumhaz_monotone_violation(h_t, h_lo, tol) {
-                    return 1e20;
+            EventType::RightCensored | EventType::Exact => {
+                match score_event(event_type, *time, h_lo, &cumhaz_at, &hazard_at, tol) {
+                    Some((contrib, h_t)) => {
+                        nll += contrib;
+                        h_lo = h_t;
+                    }
+                    None => return 1e20,
                 }
-                nll += h_t - h_lo;
-                h_lo = h_t;
-            }
-            EventType::Exact => {
-                let h_val = hazard_at(*time);
-                if h_val <= 0.0 {
-                    return 1e20;
-                }
-                let h_t = cumhaz_at(*time);
-                if cumhaz_monotone_violation(h_t, h_lo, tol) {
-                    return 1e20;
-                }
-                nll += (h_t - h_lo) - h_val.ln();
-                h_lo = h_t;
             }
             // RTTE + interval censoring is unsupported (rejected at the fit boundary by
             // `api::check_rtte_records`, since DV-driven censoring is invisible to the
@@ -447,23 +474,11 @@ pub fn rtte_reset_nll_from_curves(
         }
 
         match event_type {
-            EventType::RightCensored => {
-                let h_arg = cumhaz_at(arg);
-                if cumhaz_monotone_violation(h_arg, h_lo, tol) {
-                    return 1e20;
+            EventType::RightCensored | EventType::Exact => {
+                match score_event(event_type, arg, h_lo, &cumhaz_at, &hazard_at, tol) {
+                    Some((contrib, _)) => nll += contrib,
+                    None => return 1e20,
                 }
-                nll += h_arg - h_lo;
-            }
-            EventType::Exact => {
-                let h_val = hazard_at(arg);
-                if h_val <= 0.0 {
-                    return 1e20;
-                }
-                let h_arg = cumhaz_at(arg);
-                if cumhaz_monotone_violation(h_arg, h_lo, tol) {
-                    return 1e20;
-                }
-                nll += (h_arg - h_lo) - h_val.ln();
             }
             // RTTE + interval censoring is unsupported (rejected at parse); sentinel.
             EventType::IntervalCensored { .. } => return 1e20,


### PR DESCRIPTION
## Why

Follow-up to #845. That PR removed the shallow, obviously-safe duplication (~-960 LOC).
This second pass targets the **deeper, wider** duplication that remained — copy-pasted
orchestration and near-identical function twins that the code itself flags as "edit both
together" / "kept in sync by parity tests". The goal here is single-source-of-truth for
correctness-critical blocks (drift safety), not raw line count.

## What changed

Verbatim, **bit-identical** extractions only — no floating-point reassociation, no RNG
draw-order changes, no wire-format changes. Validated by the full Tier-1 suite (**2492 lib
tests, 0 failures**) with no new compiler warnings.

This round is roughly **LOC-neutral** (9 files, +904 / -840, net +64): the shared-helper
scaffolding (generic signatures, small state structs, doc comments) offsets the deduped
bodies because the remaining duplication is wide-but-shallow. The win is that each of these
correctness-critical patterns now has one source instead of 2–7 hand-kept-in-sync copies.

- **parser**: `eval_expression`/`eval_condition` (HashMap name resolution) and their
  `_indexed` slice twins unified behind an `EvalEnv` trait + one generic walker; the four
  public entry points remain thin wrappers so all callers are unchanged. (The `eval_bytecode`
  f64-vs-generic split is deliberately left — it uses an `unsafe` unchecked stack for perf.)
- **sens/provider**: `run_obs` (Dual2) and `run_obs_grad` (Dual1) now share one generic
  per-observation orchestration (`PkClassFlags`, `SeededPkDuals`, `superpose_doses`, the
  Form-C readout apply); each caller keeps only its own grad-vs-Hessian chain. `scale_obs_sens`
  unified behind a `ScalableObs` trait. The Hessian-carrying init/expr-scale pairs were left
  inline (High risk, excluded).
- **estimation/sens_outer_gradient**: `variance_rd`/`variance_rd2` fold the residual-variance
  `Some/None` dispatch (6 sites; `* ruv_scale` stays at the call site to preserve association);
  `dalpha_dsigma` scalar helper (mirrors the existing `mag_alpha_dtheta`).
- **pk**: the 3-cpt IV peripheral tri-exponential residue collapsed to one `term(λ)` closure
  (the SS factor is kept as a **separate trailing multiply** to preserve the original
  left-association exactly); 2-cpt transit/IG peripheral made generic over `TiltedAbsorption`.
- **survival**: `score_event` shares the `RightCensored`/`Exact` scoring arms across the three
  TTE/RTTE NLL loops; per-function lower-limit bookkeeping stays inline.
- **markov**: `validate_generator_and_obs` + a per-gap transition helper shared by
  `ctmm_data_term` value/grad (error precedence preserved bit-for-bit); the negative-off-
  diagonal guard folded into `has_negative_offdiagonal` (2 of 3 sites — the inhomogeneous
  per-sub-node guard stays inline because it shares one pass with the magnitude check).
- **suggest_start/nca**: shared log-down trapezoid helper (3 → 1).

## Alternatives considered

The genuinely High-risk merges remain deferred: the `eval_bytecode` unsafe-stack twin, the
Hessian-carrying `apply_analytical_init`/`apply_tvcov_init` provider pairs, the full σ-EBE-
response loop, and the `precise_ebe*` FD-oracle skeleton. A cross-cutting `linalg`/`mathutil`
module (`chol_log_det`, `robust_cholesky`, `safe_ln`) is also still open — low LOC and some
sentinel-semantics nuance, so it wasn't worth bundling here.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#— | not needed | — |

No `pub` API surface changed (helpers are private / `pub(crate)`).

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (refactor only — verbatim bit-identical extractions, covered by the
  existing Tier-1 suite; the provider/pk/markov/survival changes are guarded by the
  `check_*_vs_fd`, pk `*_matches_dual`, ctmm value/grad/degenerate, and survival closed-form
  unit tests, all passing unchanged).

## Performance
- [x] No significant impact expected — generics/traits monomorphise to the same code; the hot
  `_indexed` eval path stays `#[inline]`, and the site-3 markov guard was left inline
  specifically to avoid a second O(n²) pass.

## Tests
- [x] No new tests needed — behaviour unchanged; the existing 2492 lib tests all pass.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor)

## Docs
- [x] No user-visible change; `CHANGELOG.md` entry N/A (internal refactor).

## Checklist
- [x] `cargo fmt` clean (pre-commit hook passed)
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay
  differentiable — provider/pk helpers are generic over `T: PkNum` / `TiltedAbsorption`;
  no generic kernel arithmetic was changed.
- [x] No `Cargo.toml` version bump needed (non-breaking)

## Reviewer hints

The two sites with the most float-association subtlety:
- `pk/three_compartment.rs` — confirm `term(λ)` returns the SS coefficient as a **separate
  trailing factor** (`(coeff·e^{−λτ})·ss_coeff` unchanged), not folded into the exponential.
- `estimation/sens_outer_gradient.rs` — `variance_rd` callers still apply `* ruv_scale`
  themselves; the two-σ sites reorder only independent side-effect-free `ErrorSpec` calls.

The `parser` `EvalEnv` unification and the `sens/provider` `superpose_doses` extraction are
the largest diffs but are mechanical arm-for-arm moves; the `check_*_vs_fd` and
`bytecode_g_matches_f64` tests pin them.

## Open questions

None — this closes the "obviously/moderately safe" tier. The remaining duplication is the
High-risk tail listed under Alternatives; happy to take those on individually with dedicated
bit-identity tests if wanted.
