### PR TITLE
refactor(pk,stats): modularization audit + safe-tier extractions (pk::topology, stats::util)

### DIFF
--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -1998,14 +1998,4 @@ mod tests {
         // small that would sneak past the MAX_AGQ_GRID check.
         assert_eq!(grid_size(21, 50), usize::MAX);
     }
-
-    #[test]
-    fn logsumexp_is_stable_and_handles_sentinels() {
-        let want = (1.0f64.exp() + 2.0f64.exp()).ln();
-        assert!((logsumexp(&[1.0, 2.0]) - want).abs() < 1e-12);
-        // Huge magnitudes must not overflow.
-        assert!((logsumexp(&[1e5, 1e5]) - (1e5 + 2.0f64.ln())).abs() < 1e-9);
-        // A diverged node (the −1e20 term) is simply ignored next to a live one.
-        assert!((logsumexp(&[-1e20, 3.0]) - 3.0).abs() < 1e-12);
-    }
 }

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -80,6 +80,7 @@ use crate::estimation::importance_sampling::build_proposal;
 use crate::estimation::inner_optimizer::cacheable_schedule;
 use crate::pk;
 use crate::stats::likelihood::individual_nll_into_with_schedule;
+use crate::stats::util::log_sum_exp as logsumexp;
 use crate::types::{CompiledModel, HessianAnchor, ModelParameters, Population, Subject};
 
 /// Upper bound on `n_agq`. Beyond ~20 nodes the Golub–Welsch eigenproblem starts to lose
@@ -145,15 +146,6 @@ pub(crate) fn gauss_hermite(n: usize) -> (Vec<f64>, Vec<f64>) {
     // independent of whatever order the eigensolver happened to converge in.
     pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).expect("GH nodes are finite"));
     pairs.into_iter().unzip()
-}
-
-/// Numerically stable `log Σ exp(xᵢ)`.
-fn logsumexp(xs: &[f64]) -> f64 {
-    let max = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-    if !max.is_finite() {
-        return max;
-    }
-    max + xs.iter().map(|x| (x - max).exp()).sum::<f64>().ln()
 }
 
 /// The per-subject **integration variable** and its prior.

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -27,6 +27,10 @@ use crate::pk::{compute_predictions_with_tv_into, predict_iov, EventPkParams};
 use crate::stats::likelihood::{iov_occasion_groups, m3_logcdf, obs_nll_subject_into};
 use crate::stats::residual_error::compute_r_diag;
 use crate::stats::special::ln_gamma;
+use crate::stats::util::{
+    ess_from_weights, log_sum_exp2 as logsumexp2,
+    log_sum_exp_normalised as logsumexp_with_normalised,
+};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use rand::rngs::StdRng;
@@ -42,65 +46,14 @@ const TWO_PI: f64 = std::f64::consts::TAU;
 // Inverse normal CDF (Acklam rational approximation)
 // ---------------------------------------------------------------------------
 
-/// Inverse normal CDF (probit function): given u ∈ (0, 1), returns z such that
-/// Φ(z) = u. Uses the Acklam rational approximation with full f64 precision
-/// (~1.15e-9 relative error over the entire range).
-///
-/// Used to transform uniform Sobol quasi-random points to N(0,1) draws.
+/// Inverse normal CDF (probit) for Sobol quasi-random N(0,1) draws. Clamps u to
+/// the historical open interval [1e-15, 1-1e-15] (the shared copy returns ±inf at
+/// the raw boundary), then delegates to the canonical Acklam implementation in
+/// [`crate::stats::special::normal_inv_cdf`]. Because the clamped u is always in
+/// (0,1), that function's `p<=0`/`p>=1` ±inf guards never fire, so the output is
+/// bit-identical to the prior inline copy for every input this wrapper receives.
 fn inv_normal_cdf(u: f64) -> f64 {
-    let u = u.clamp(1e-15, 1.0 - 1e-15);
-
-    // Acklam (2003) rational approximation coefficients
-    const A: [f64; 6] = [
-        -3.969683028665376e+01,
-        2.209460984245205e+02,
-        -2.759285104469687e+02,
-        1.383577518672690e+02,
-        -3.066479806614716e+01,
-        2.506628277459239e+00,
-    ];
-    const B: [f64; 5] = [
-        -5.447609879822406e+01,
-        1.615858368580409e+02,
-        -1.556989798598866e+02,
-        6.680131188771972e+01,
-        -1.328068155288572e+01,
-    ];
-    const C: [f64; 6] = [
-        -7.784894002430293e-03,
-        -3.223964580411365e-01,
-        -2.400758277161838e+00,
-        -2.549732539343734e+00,
-        4.374664141464968e+00,
-        2.938163982698783e+00,
-    ];
-    const D: [f64; 4] = [
-        7.784695709041462e-03,
-        3.224671290700398e-01,
-        2.445134137142996e+00,
-        3.754408661907416e+00,
-    ];
-
-    const P_LOW: f64 = 0.02425;
-    const P_HIGH: f64 = 1.0 - P_LOW;
-
-    if u < P_LOW {
-        // Lower tail
-        let q = (-2.0 * u.ln()).sqrt();
-        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
-            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
-    } else if u <= P_HIGH {
-        // Central region
-        let q = u - 0.5;
-        let r = q * q;
-        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
-            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
-    } else {
-        // Upper tail (symmetry)
-        let q = (-2.0 * (1.0 - u).ln()).sqrt();
-        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
-            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
-    }
+    crate::stats::special::normal_inv_cdf(u.clamp(1e-15, 1.0 - 1e-15))
 }
 
 /// Generate `k_samples` quasi-random N(0,1) vectors of dimension `d` using
@@ -1934,18 +1887,6 @@ fn student_t_gamma_ratio(nu: f64, d: usize) -> f64 {
     ln_gamma(0.5 * (nu + d as f64)) - ln_gamma(0.5 * nu)
 }
 
-/// Effective sample size `1 / Σ w̃ₖ²` from normalised weights. Returns `0.0`
-/// when the weights are empty or all-zero (matches the prior inline guards).
-#[inline]
-fn ess_from_weights(weights: &[f64]) -> f64 {
-    let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
-    if sum_sq > 0.0 {
-        1.0 / sum_sq
-    } else {
-        0.0
-    }
-}
-
 /// Asymptotic variance of `log p̂(yᵢ)` for a self-normalised IS estimator:
 /// `(1/ESS_fraction − 1) / K` (Geweke 1989). For the degenerate
 /// `ess_fraction == 0` case it returns a finite-but-large `1.0` so the overall
@@ -1957,64 +1898,6 @@ fn var_log_marginal_from_ess_fraction(ess_fraction: f64, k: f64) -> f64 {
     } else {
         1.0
     }
-}
-
-/// Stable `log(eᵃ + eᵇ)` for the two-component defensive-mixture denominator.
-fn logsumexp2(a: f64, b: f64) -> f64 {
-    let m = a.max(b);
-    if m == f64::NEG_INFINITY {
-        return f64::NEG_INFINITY;
-    }
-    m + ((a - m).exp() + (b - m).exp()).ln()
-}
-
-/// Numerically stable `log Σ exp(xᵢ)` plus the normalised weights `wᵢ`.
-fn logsumexp_with_normalised(xs: &[f64]) -> (f64, Vec<f64>) {
-    if xs.is_empty() {
-        return (f64::NEG_INFINITY, Vec::new());
-    }
-
-    let n_pos_inf = xs
-        .iter()
-        .filter(|x| x.is_infinite() && x.is_sign_positive())
-        .count();
-    if n_pos_inf > 0 {
-        let w = 1.0 / n_pos_inf as f64;
-        let weights = xs
-            .iter()
-            .map(|x| {
-                if x.is_infinite() && x.is_sign_positive() {
-                    w
-                } else {
-                    0.0
-                }
-            })
-            .collect();
-        return (f64::INFINITY, weights);
-    }
-
-    let m = xs
-        .iter()
-        .copied()
-        .filter(|x| x.is_finite())
-        .fold(f64::NEG_INFINITY, f64::max);
-    if !m.is_finite() {
-        return (f64::NEG_INFINITY, vec![0.0; xs.len()]);
-    }
-    let mut sum = 0.0;
-    let mut shifted: Vec<f64> = Vec::with_capacity(xs.len());
-    for &x in xs {
-        let s = if x.is_finite() { (x - m).exp() } else { 0.0 };
-        shifted.push(s);
-        sum += s;
-    }
-    let lse = m + sum.ln();
-    let weights: Vec<f64> = if sum > 0.0 {
-        shifted.iter().map(|&s| s / sum).collect()
-    } else {
-        vec![0.0; xs.len()]
-    };
-    (lse, weights)
 }
 
 /// Sheiner–Beal posterior-Hessian approximation at η̂.

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1917,6 +1917,8 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     // directly rather than asking a provider that has nothing to compute.
     if subject.obs_times.is_empty() {
         let eta_v = nalgebra::DVector::from_column_slice(eta);
+        // `mut` is only exercised by the markov CTMM fold below.
+        #[cfg_attr(not(feature = "markov"), allow(unused_mut))]
         let mut grad: Vec<f64> = (&omega.inv * &eta_v).as_slice().to_vec();
         #[cfg(feature = "markov")]
         if let Some(g) = &ctmm_grad {

--- a/src/estimation/run_sir.rs
+++ b/src/estimation/run_sir.rs
@@ -483,7 +483,6 @@ mod tests {
         // wrapper uses them as-is — no hash verification. Tampering with
         // the on-disk files (so the recorded hashes no longer match)
         // must NOT trigger a hash mismatch error in this branch.
-        use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let (model_path, data_path) = copy_example_to_tempdir(dir.path());
 

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -8023,7 +8023,7 @@ mod tests {
         let occasions = vec![1u32, 1, 1, 2, 2, 2];
         let obs_wts = [70.0, 72.0, 78.0, 88.0, 90.0, 95.0];
         let n = obs_times.len();
-        let mut wt_map = |w: f64| {
+        let wt_map = |w: f64| {
             let mut m = std::collections::HashMap::new();
             m.insert("WT".to_string(), w);
             m

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -3257,6 +3257,9 @@ mod tests {
                         .map(|r| match r {
                             ObsRecord::DiscreteState { time, .. }
                             | ObsRecord::Count { time, .. } => *time,
+                            // Reachable only when non-default endpoint features add
+                            // more `ObsRecord` variants; unreachable under default features.
+                            #[allow(unreachable_patterns)]
                             other => panic!("{set_name}/{missing}: unexpected record {other:?}"),
                         })
                         .collect();

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -29,6 +29,7 @@
 //! Infusion into an oral peripheral compartment still panics — a rare
 //! clinical setup tracked as a follow-up.
 
+use crate::pk::topology::Channel;
 use crate::types::{DoseEvent, PkModel, PkParams, Subject};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
@@ -297,32 +298,13 @@ fn compute_propagation_bounds(
 /// Caller-side dispatch (in `pk::compute_predictions`) uses this to fall
 /// back to the existing superposition path for unsupported models.
 pub fn supports_event_driven(pk_model: PkModel) -> bool {
-    matches!(
-        pk_model,
-        PkModel::OneCptIv
-            | PkModel::OneCptOral
-            | PkModel::TwoCptIv
-            | PkModel::TwoCptOral
-            | PkModel::ThreeCptIv
-            | PkModel::ThreeCptOral
-    )
+    pk_model.topology().event_walk_supported
 }
 
 /// State-vector dimension and central-compartment slot index for a given
 /// pk_model. Central is where the observation read-out reads from.
 fn state_layout(pk_model: PkModel) -> (usize, usize) {
-    match pk_model {
-        PkModel::OneCptIv => (1, 0),
-        PkModel::OneCptOral => (2, 1),    // [depot, central]
-        PkModel::OneCptTransit => (2, 1), // [depot (lumped transit), central]
-        PkModel::OneCptIg => (2, 1),      // [depot (unabsorbed IG mass), central]
-        PkModel::TwoCptIv => (2, 0),
-        PkModel::TwoCptOral => (3, 1),    // [depot, central, periph]
-        PkModel::TwoCptTransit => (3, 1), // [depot (lumped transit), central, periph]
-        PkModel::TwoCptIg => (3, 1),      // [depot (unabsorbed IG mass), central, periph]
-        PkModel::ThreeCptIv => (3, 0),
-        PkModel::ThreeCptOral => (4, 1), // [depot, central, periph1, periph2]
-    }
+    pk_model.topology().state_layout()
 }
 
 /// Number of cycles to expand for SS equilibration in the event-driven
@@ -872,20 +854,12 @@ fn propagate_with_bounds(
             }
             if d.rate > 0.0 && d.duration > 0.0 && t_start <= mid && t_end >= mid {
                 let r = d.rate;
-                match (pk_model, d.cmt) {
-                    (PkModel::OneCptIv, 1) => rate_central += r,
-                    (PkModel::OneCptOral, 1) => rate_depot += r,
-                    (PkModel::OneCptOral, 2) => rate_central += r,
-                    (PkModel::TwoCptIv, 1) => rate_central += r,
-                    (PkModel::TwoCptIv, 2) => rate_periph1 += r,
-                    (PkModel::TwoCptOral, 1) => rate_depot += r,
-                    (PkModel::TwoCptOral, 2) => rate_central += r,
-                    (PkModel::ThreeCptIv, 1) => rate_central += r,
-                    (PkModel::ThreeCptIv, 2) => rate_periph1 += r,
-                    (PkModel::ThreeCptIv, 3) => rate_periph2 += r,
-                    (PkModel::ThreeCptOral, 1) => rate_depot += r,
-                    (PkModel::ThreeCptOral, 2) => rate_central += r,
-                    _ => panic!(
+                match pk_model.topology().dose_channel(d.cmt) {
+                    Some(Channel::Central) => rate_central += r,
+                    Some(Channel::Periph1) => rate_periph1 += r,
+                    Some(Channel::Periph2) => rate_periph2 += r,
+                    Some(Channel::Depot) => rate_depot += r,
+                    None => panic!(
                         "event-driven PK: infusion into compartment {} not supported \
                          for model {:?}. Supported: central for all models; depot (cmt 1) \
                          for oral models; periph1/2 for 2- and 3-cpt IV models. Oral \

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -4,6 +4,7 @@ pub mod event_driven;
 pub mod ode_template;
 pub mod one_compartment;
 pub mod three_compartment;
+pub(crate) mod topology;
 pub mod two_compartment;
 
 use crate::types::{CompiledModel, DoseEvent, PkModel, PkParams, ScalingSpec, Subject};
@@ -1658,18 +1659,7 @@ pub fn analytical_state_at_times(
          return empty states for analytical+reset subjects instead"
     );
     let lagtime = pk_params.lagtime();
-    let n_states = match pk_model {
-        PkModel::OneCptIv => 1,
-        PkModel::OneCptOral => 2,
-        PkModel::OneCptTransit => 2,
-        PkModel::OneCptIg => 2,
-        PkModel::TwoCptIv => 2,
-        PkModel::TwoCptOral => 3,
-        PkModel::TwoCptTransit => 3,
-        PkModel::TwoCptIg => 3,
-        PkModel::ThreeCptIv => 3,
-        PkModel::ThreeCptOral => 4,
-    };
+    let n_states = pk_model.topology().n_states;
     times
         .iter()
         .map(|&t| {

--- a/src/pk/topology.rs
+++ b/src/pk/topology.rs
@@ -1,0 +1,280 @@
+//! Single per-`PkModel` compartment-topology descriptor.
+//!
+//! Consolidates the per-model lookup tables that previously re-encoded the same
+//! compartment geometry independently in `event_driven::state_layout`,
+//! `propagate::state_layout_g`, `pk/mod::analytical_state_at_times` (inline
+//! `n_states`), `types::analytical_compartment_names`,
+//! `types::infusable_compartments`, `supports_event_driven` / `walk_supports`,
+//! and the two `match (pk_model, d.cmt)` rate-routing blocks in
+//! `propagate_with_bounds` / `active_rates_g`.
+//!
+//! Every symbol here is an integer / name / boolean lookup feeding vec sizing,
+//! an index read, rate-channel selection, or a supported/unsupported branch. No
+//! f64 arithmetic lives here, so consolidation is provably numerically inert.
+
+use crate::types::PkModel;
+
+/// Which internal rate accumulator a 1-based dose compartment routes into for
+/// the closed-form event walk. Returned by [`PkTopology::dose_channel`]; callers
+/// map each arm onto their own `rate_*` accumulator and decide the `None` policy
+/// (event_driven panics on an unsupported infusion cmt; active_rates_g skips).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Channel {
+    Central,
+    Periph1,
+    Periph2,
+    Depot,
+}
+
+/// Compartment geometry for one `PkModel`. `'static` throughout so callers keep
+/// their existing `&'static` return signatures.
+pub(crate) struct PkTopology {
+    /// State-vector dimension. Invariant: `== compartment_names.len()`
+    /// (asserted by `topology_fields_are_internally_consistent`).
+    pub n_states: usize,
+    /// Index of `"central"` within `compartment_names` (the read-out slot).
+    /// Stored (not derived) for a literal transcription; the test above pins it
+    /// to `compartment_names.iter().position(|n| *n == "central")`.
+    pub central_slot: usize,
+    /// Ordered analytical compartment names (the state-vector layout).
+    pub compartment_names: &'static [&'static str],
+    /// Rate channel for each 1-based dose compartment; index = `cmt - 1`.
+    /// `None` / out-of-range = not an infusable compartment for this model.
+    pub channels: &'static [Option<Channel>],
+    /// 1-based compartments a modeled infusion (`D{cmt}`/`R{cmt}`) may target.
+    /// Invariant: `== {i+1 | channels[i] == Some(_)}` (asserted by the
+    /// consistency test).
+    pub infusable: &'static [usize],
+    /// Absorption model (dose enters an input/depot cmt), incl. transit/IG.
+    pub is_oral: bool,
+    /// Has an event-driven closed-form walk implementation (the six
+    /// non-transit/IG analytical models).
+    pub event_walk_supported: bool,
+}
+
+impl PkModel {
+    /// The compartment topology for this model. `'static` table lookup.
+    pub(crate) fn topology(self) -> &'static PkTopology {
+        match self {
+            PkModel::OneCptIv => &ONE_CPT_IV,
+            PkModel::OneCptOral => &ONE_CPT_ORAL,
+            PkModel::OneCptTransit => &ONE_CPT_TRANSIT,
+            PkModel::OneCptIg => &ONE_CPT_IG,
+            PkModel::TwoCptIv => &TWO_CPT_IV,
+            PkModel::TwoCptOral => &TWO_CPT_ORAL,
+            PkModel::TwoCptTransit => &TWO_CPT_TRANSIT,
+            PkModel::TwoCptIg => &TWO_CPT_IG,
+            PkModel::ThreeCptIv => &THREE_CPT_IV,
+            PkModel::ThreeCptOral => &THREE_CPT_ORAL,
+        }
+    }
+}
+
+impl PkTopology {
+    /// `(n_states, central_slot)` — the tuple the two `state_layout*` facades return.
+    #[inline]
+    pub(crate) fn state_layout(&self) -> (usize, usize) {
+        (self.n_states, self.central_slot)
+    }
+
+    /// Rate channel for a 1-based dose compartment. `None` = not infusable for
+    /// this model (caller decides panic vs skip). Preserves the old
+    /// `match (pk_model, d.cmt) { .. , _ => .. }` fall-through: any cmt not
+    /// explicitly mapped (incl. cmt 0 and peripherals of oral models) yields
+    /// `None`, exactly the arms the old `_` caught.
+    #[inline]
+    pub(crate) fn dose_channel(&self, cmt_1based: usize) -> Option<Channel> {
+        cmt_1based
+            .checked_sub(1)
+            .and_then(|i| self.channels.get(i).copied().flatten())
+    }
+
+    /// 1-based compartments a modeled infusion may target.
+    #[inline]
+    pub(crate) fn infusable_compartments(&self) -> &'static [usize] {
+        self.infusable
+    }
+}
+
+use Channel::{Central, Depot, Periph1, Periph2};
+
+static ONE_CPT_IV: PkTopology = PkTopology {
+    n_states: 1,
+    central_slot: 0,
+    compartment_names: &["central"],
+    channels: &[Some(Central)],
+    infusable: &[1],
+    is_oral: false,
+    event_walk_supported: true,
+};
+static ONE_CPT_ORAL: PkTopology = PkTopology {
+    n_states: 2,
+    central_slot: 1,
+    compartment_names: &["depot", "central"],
+    channels: &[Some(Depot), Some(Central)],
+    infusable: &[1, 2],
+    is_oral: true,
+    event_walk_supported: true,
+};
+static ONE_CPT_TRANSIT: PkTopology = PkTopology {
+    n_states: 2,
+    central_slot: 1,
+    compartment_names: &["depot", "central"],
+    channels: &[],
+    infusable: &[],
+    is_oral: true,
+    event_walk_supported: false,
+};
+static ONE_CPT_IG: PkTopology = PkTopology {
+    n_states: 2,
+    central_slot: 1,
+    compartment_names: &["depot", "central"],
+    channels: &[],
+    infusable: &[],
+    is_oral: true,
+    event_walk_supported: false,
+};
+static TWO_CPT_IV: PkTopology = PkTopology {
+    n_states: 2,
+    central_slot: 0,
+    compartment_names: &["central", "peripheral"],
+    channels: &[Some(Central), Some(Periph1)],
+    infusable: &[1, 2],
+    is_oral: false,
+    event_walk_supported: true,
+};
+static TWO_CPT_ORAL: PkTopology = PkTopology {
+    n_states: 3,
+    central_slot: 1,
+    compartment_names: &["depot", "central", "peripheral"],
+    channels: &[Some(Depot), Some(Central)],
+    infusable: &[1, 2],
+    is_oral: true,
+    event_walk_supported: true,
+};
+static TWO_CPT_TRANSIT: PkTopology = PkTopology {
+    n_states: 3,
+    central_slot: 1,
+    compartment_names: &["depot", "central", "peripheral"],
+    channels: &[],
+    infusable: &[],
+    is_oral: true,
+    event_walk_supported: false,
+};
+static TWO_CPT_IG: PkTopology = PkTopology {
+    n_states: 3,
+    central_slot: 1,
+    compartment_names: &["depot", "central", "peripheral"],
+    channels: &[],
+    infusable: &[],
+    is_oral: true,
+    event_walk_supported: false,
+};
+static THREE_CPT_IV: PkTopology = PkTopology {
+    n_states: 3,
+    central_slot: 0,
+    compartment_names: &["central", "peripheral1", "peripheral2"],
+    channels: &[Some(Central), Some(Periph1), Some(Periph2)],
+    infusable: &[1, 2, 3],
+    is_oral: false,
+    event_walk_supported: true,
+};
+static THREE_CPT_ORAL: PkTopology = PkTopology {
+    n_states: 4,
+    central_slot: 1,
+    compartment_names: &["depot", "central", "peripheral1", "peripheral2"],
+    channels: &[Some(Depot), Some(Central)],
+    infusable: &[1, 2],
+    is_oral: true,
+    event_walk_supported: true,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [PkModel; 10] = [
+        PkModel::OneCptIv,
+        PkModel::OneCptOral,
+        PkModel::OneCptTransit,
+        PkModel::OneCptIg,
+        PkModel::TwoCptIv,
+        PkModel::TwoCptOral,
+        PkModel::TwoCptTransit,
+        PkModel::TwoCptIg,
+        PkModel::ThreeCptIv,
+        PkModel::ThreeCptOral,
+    ];
+
+    /// The three stored-but-derivable fields must agree with their canonical
+    /// derivation for every variant. This is the drift guard that lets the
+    /// descriptor be a flat literal.
+    #[test]
+    fn topology_fields_are_internally_consistent() {
+        for m in ALL {
+            let t = m.topology();
+            assert_eq!(t.n_states, t.compartment_names.len(), "{m:?} n_states");
+            assert_eq!(
+                t.central_slot,
+                t.compartment_names
+                    .iter()
+                    .position(|n| *n == "central")
+                    .unwrap(),
+                "{m:?} central_slot"
+            );
+            let derived: Vec<usize> = t
+                .channels
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| c.map(|_| i + 1))
+                .collect();
+            assert_eq!(t.infusable, derived.as_slice(), "{m:?} infusable");
+        }
+    }
+
+    /// Pin the six event-walk-supported models (== old supports_event_driven).
+    #[test]
+    fn event_walk_supported_matches_the_six_analytical_models() {
+        for m in ALL {
+            let expect = matches!(
+                m,
+                PkModel::OneCptIv
+                    | PkModel::OneCptOral
+                    | PkModel::TwoCptIv
+                    | PkModel::TwoCptOral
+                    | PkModel::ThreeCptIv
+                    | PkModel::ThreeCptOral
+            );
+            assert_eq!(m.topology().event_walk_supported, expect, "{m:?}");
+        }
+    }
+
+    /// dose_channel reproduces the old 12-arm (pk_model, cmt) routing table,
+    /// and returns None for every arm the old `_` caught (cmt 0, oral periph).
+    #[test]
+    fn dose_channel_reproduces_routing_table() {
+        use PkModel::*;
+        let cases = [
+            (OneCptIv, 1, Some(Channel::Central)),
+            (OneCptOral, 1, Some(Channel::Depot)),
+            (OneCptOral, 2, Some(Channel::Central)),
+            (TwoCptIv, 1, Some(Channel::Central)),
+            (TwoCptIv, 2, Some(Channel::Periph1)),
+            (TwoCptOral, 1, Some(Channel::Depot)),
+            (TwoCptOral, 2, Some(Channel::Central)),
+            (ThreeCptIv, 1, Some(Channel::Central)),
+            (ThreeCptIv, 2, Some(Channel::Periph1)),
+            (ThreeCptIv, 3, Some(Channel::Periph2)),
+            (ThreeCptOral, 1, Some(Channel::Depot)),
+            (ThreeCptOral, 2, Some(Channel::Central)),
+            // old `_` arms -> None
+            (OneCptIv, 0, None),
+            (OneCptIv, 2, None),
+            (TwoCptOral, 3, None),
+            (ThreeCptOral, 3, None),
+        ];
+        for (m, cmt, want) in cases {
+            assert_eq!(m.topology().dose_channel(cmt), want, "{m:?} cmt {cmt}");
+        }
+    }
+}

--- a/src/pk/topology.rs
+++ b/src/pk/topology.rs
@@ -45,8 +45,6 @@ pub(crate) struct PkTopology {
     /// Invariant: `== {i+1 | channels[i] == Some(_)}` (asserted by the
     /// consistency test).
     pub infusable: &'static [usize],
-    /// Absorption model (dose enters an input/depot cmt), incl. transit/IG.
-    pub is_oral: bool,
     /// Has an event-driven closed-form walk implementation (the six
     /// non-transit/IG analytical models).
     pub event_walk_supported: bool,
@@ -104,7 +102,6 @@ static ONE_CPT_IV: PkTopology = PkTopology {
     compartment_names: &["central"],
     channels: &[Some(Central)],
     infusable: &[1],
-    is_oral: false,
     event_walk_supported: true,
 };
 static ONE_CPT_ORAL: PkTopology = PkTopology {
@@ -113,25 +110,29 @@ static ONE_CPT_ORAL: PkTopology = PkTopology {
     compartment_names: &["depot", "central"],
     channels: &[Some(Depot), Some(Central)],
     infusable: &[1, 2],
-    is_oral: true,
     event_walk_supported: true,
 };
+// Transit models a bolus absorbed through the Gamma transit chain; modeled-duration
+// infusions are unsupported in v1, so a `D{cmt}` on a transit model is rejected at parse
+// (#386) — hence `infusable: &[]`. There is no event walk, so `channels: &[]` too. Do NOT
+// populate these to "fix an oversight": routing would accept a `D1` that #386 rejects.
 static ONE_CPT_TRANSIT: PkTopology = PkTopology {
     n_states: 2,
     central_slot: 1,
     compartment_names: &["depot", "central"],
     channels: &[],
     infusable: &[],
-    is_oral: true,
     event_walk_supported: false,
 };
+// Inverse-Gaussian, like transit: absorbs an instantaneous bolus through the IG
+// absorption-time density; modeled-duration infusions are unsupported, so a `D{cmt}` on an
+// IG model is rejected at parse (#790) — hence `infusable: &[]` and no walk (`channels: &[]`).
 static ONE_CPT_IG: PkTopology = PkTopology {
     n_states: 2,
     central_slot: 1,
     compartment_names: &["depot", "central"],
     channels: &[],
     infusable: &[],
-    is_oral: true,
     event_walk_supported: false,
 };
 static TWO_CPT_IV: PkTopology = PkTopology {
@@ -140,7 +141,6 @@ static TWO_CPT_IV: PkTopology = PkTopology {
     compartment_names: &["central", "peripheral"],
     channels: &[Some(Central), Some(Periph1)],
     infusable: &[1, 2],
-    is_oral: false,
     event_walk_supported: true,
 };
 static TWO_CPT_ORAL: PkTopology = PkTopology {
@@ -149,25 +149,25 @@ static TWO_CPT_ORAL: PkTopology = PkTopology {
     compartment_names: &["depot", "central", "peripheral"],
     channels: &[Some(Depot), Some(Central)],
     infusable: &[1, 2],
-    is_oral: true,
     event_walk_supported: true,
 };
+// 2-cpt transit: same as the 1-cpt transit — modeled-duration infusion rejected at parse
+// (#386), no event walk. `channels`/`infusable` intentionally empty.
 static TWO_CPT_TRANSIT: PkTopology = PkTopology {
     n_states: 3,
     central_slot: 1,
     compartment_names: &["depot", "central", "peripheral"],
     channels: &[],
     infusable: &[],
-    is_oral: true,
     event_walk_supported: false,
 };
+// 2-cpt inverse-Gaussian: same as the 1-cpt IG (#790). `channels`/`infusable` empty.
 static TWO_CPT_IG: PkTopology = PkTopology {
     n_states: 3,
     central_slot: 1,
     compartment_names: &["depot", "central", "peripheral"],
     channels: &[],
     infusable: &[],
-    is_oral: true,
     event_walk_supported: false,
 };
 static THREE_CPT_IV: PkTopology = PkTopology {
@@ -176,7 +176,6 @@ static THREE_CPT_IV: PkTopology = PkTopology {
     compartment_names: &["central", "peripheral1", "peripheral2"],
     channels: &[Some(Central), Some(Periph1), Some(Periph2)],
     infusable: &[1, 2, 3],
-    is_oral: false,
     event_walk_supported: true,
 };
 static THREE_CPT_ORAL: PkTopology = PkTopology {
@@ -185,7 +184,6 @@ static THREE_CPT_ORAL: PkTopology = PkTopology {
     compartment_names: &["depot", "central", "peripheral1", "peripheral2"],
     channels: &[Some(Depot), Some(Central)],
     infusable: &[1, 2],
-    is_oral: true,
     event_walk_supported: true,
 };
 
@@ -206,9 +204,17 @@ mod tests {
         PkModel::ThreeCptOral,
     ];
 
-    /// The three stored-but-derivable fields must agree with their canonical
-    /// derivation for every variant. This is the drift guard that lets the
-    /// descriptor be a flat literal.
+    /// Drift guard for the stored-but-derivable geometry fields.
+    ///
+    /// `n_states`/`central_slot` are pinned to their canonical derivation from
+    /// `compartment_names`. For `infusable` vs `channels` we assert only the
+    /// genuinely-invariant DIRECTION — every routable compartment must be a
+    /// parse-accepted infusion target (`channels[i].is_some() ⇒ infusable ∋ i+1`) —
+    /// NOT full equality. The two fields answer different questions (`infusable` is
+    /// the parse-time gate for `D{cmt}`/`R{cmt}`; `channels` is the walk's rate-accumulator
+    /// routing), and enforcing equality would force a future PR that legitimately accepts an
+    /// infusion into a no-walk model to invent a fake routing arm. So `infusable` may be a
+    /// superset of the channel set; it may not contain a compartment the walk can't route.
     #[test]
     fn topology_fields_are_internally_consistent() {
         for m in ALL {
@@ -222,13 +228,16 @@ mod tests {
                     .unwrap(),
                 "{m:?} central_slot"
             );
-            let derived: Vec<usize> = t
-                .channels
-                .iter()
-                .enumerate()
-                .filter_map(|(i, c)| c.map(|_| i + 1))
-                .collect();
-            assert_eq!(t.infusable, derived.as_slice(), "{m:?} infusable");
+            for (i, c) in t.channels.iter().enumerate() {
+                if c.is_some() {
+                    assert!(
+                        t.infusable.contains(&(i + 1)),
+                        "{m:?}: cmt {} is routable (channels[{i}]=Some) but not in infusable {:?}",
+                        i + 1,
+                        t.infusable
+                    );
+                }
+            }
         }
     }
 

--- a/src/sens/one_cpt.rs
+++ b/src/sens/one_cpt.rs
@@ -584,7 +584,7 @@ mod tests {
         let d2 = time_it("Dual2<2> (minimal width)", &|t| {
             iv_bolus_width::<2>(amt, t, cl, v)
         });
-        let d4 = time_it("Dual2<4>", &|t| iv_bolus_width::<4>(amt, t, cl, v));
+        let _d4 = time_it("Dual2<4>", &|t| iv_bolus_width::<4>(amt, t, cl, v));
         let d8 = time_it("Dual2<8> (provider width)", &|t| {
             iv_bolus_width::<8>(amt, t, cl, v)
         });

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -19,6 +19,7 @@
 
 use super::num::PkNum;
 use crate::pk::event_driven::{Event, EventKind, EventSchedule};
+use crate::pk::topology::Channel;
 use crate::types::{DoseEvent, PkModel, Subject};
 
 /// 1-cpt IV/central propagator: evolve `state[0]` (central amount) over `dt` with
@@ -707,18 +708,7 @@ const SS_EQUILIBRATION_CYCLES: usize = 50;
 /// included for the forthcoming extension; the walk currently propagates 1-/2-cpt.
 #[inline]
 fn state_layout_g(pk_model: PkModel) -> (usize, usize) {
-    match pk_model {
-        PkModel::OneCptIv => (1, 0),
-        PkModel::OneCptOral => (2, 1),
-        PkModel::OneCptTransit => (2, 1),
-        PkModel::OneCptIg => (2, 1),
-        PkModel::TwoCptIv => (2, 0),
-        PkModel::TwoCptOral => (3, 1),
-        PkModel::TwoCptTransit => (3, 1),
-        PkModel::TwoCptIg => (3, 1),
-        PkModel::ThreeCptIv => (3, 0),
-        PkModel::ThreeCptOral => (4, 1),
-    }
+    pk_model.topology().state_layout()
 }
 
 /// True when the generic walk implements this model — all six analytical 1-/2-/3-
@@ -726,15 +716,7 @@ fn state_layout_g(pk_model: PkModel) -> (usize, usize) {
 /// defensive backstop.
 #[inline]
 fn walk_supports(pk_model: PkModel) -> bool {
-    matches!(
-        pk_model,
-        PkModel::OneCptIv
-            | PkModel::OneCptOral
-            | PkModel::TwoCptIv
-            | PkModel::TwoCptOral
-            | PkModel::ThreeCptIv
-            | PkModel::ThreeCptOral
-    )
+    pk_model.topology().event_walk_supported
 }
 
 #[inline]
@@ -911,20 +893,12 @@ fn active_rates_g<T: PkNum>(
                 Some((rate_bare, _)) => pk.f * rate_bare,
                 None => pk.f * T::from_f64(d.rate),
             };
-            match (pk_model, d.cmt) {
-                (PkModel::OneCptIv, 1) => rate_central = rate_central + r,
-                (PkModel::OneCptOral, 1) => rate_depot = rate_depot + r,
-                (PkModel::OneCptOral, 2) => rate_central = rate_central + r,
-                (PkModel::TwoCptIv, 1) => rate_central = rate_central + r,
-                (PkModel::TwoCptIv, 2) => rate_periph1 = rate_periph1 + r,
-                (PkModel::TwoCptOral, 1) => rate_depot = rate_depot + r,
-                (PkModel::TwoCptOral, 2) => rate_central = rate_central + r,
-                (PkModel::ThreeCptIv, 1) => rate_central = rate_central + r,
-                (PkModel::ThreeCptIv, 2) => rate_periph1 = rate_periph1 + r,
-                (PkModel::ThreeCptIv, 3) => rate_periph2 = rate_periph2 + r,
-                (PkModel::ThreeCptOral, 1) => rate_depot = rate_depot + r,
-                (PkModel::ThreeCptOral, 2) => rate_central = rate_central + r,
-                _ => {}
+            match pk_model.topology().dose_channel(d.cmt) {
+                Some(Channel::Central) => rate_central = rate_central + r,
+                Some(Channel::Periph1) => rate_periph1 = rate_periph1 + r,
+                Some(Channel::Periph2) => rate_periph2 = rate_periph2 + r,
+                Some(Channel::Depot) => rate_depot = rate_depot + r,
+                None => {}
             }
         }
     }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -3,4 +3,4 @@ pub mod likelihood;
 pub mod npde;
 pub mod residual_error;
 pub mod special;
-pub mod util;
+pub(crate) mod util;

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -3,3 +3,4 @@ pub mod likelihood;
 pub mod npde;
 pub mod residual_error;
 pub mod special;
+pub mod util;

--- a/src/stats/util.rs
+++ b/src/stats/util.rs
@@ -1,0 +1,176 @@
+//! Shared f64-only aggregate numerics (log-sum-exp family, effective sample size).
+//!
+//! These are the *sample-combinator* helpers used by the marginal-likelihood
+//! estimators (AGQ, importance sampling). They are deliberately separate from
+//! [`crate::stats::special`], which is scoped to *differentiable* special
+//! functions on the Dual2 gradient path; everything here is plain `f64` and off
+//! any sensitivity path.
+//!
+//! There are intentionally TWO logsumexp functions with DIFFERENT edge-case
+//! contracts — do not collapse them into one:
+//!   * [`log_sum_exp`]         — simple: folds ALL elements into max/sum; NaN
+//!                               propagates; returns `max` when `max` is not finite.
+//!   * [`log_sum_exp_normalised`] — FILTERS non-finite before max/sum (NaN ignored),
+//!                               has a dedicated +inf-splitting branch, and returns
+//!                               the normalised weights alongside the lse.
+
+/// Numerically stable `log Σ exp(xᵢ)` (simple contract, moved verbatim from
+/// `agq::logsumexp`). All elements enter the fold, so a `NaN` propagates and a
+/// `-inf` is ignored via `f64::max`; returns `max` when `max` is not finite.
+pub(crate) fn log_sum_exp(xs: &[f64]) -> f64 {
+    let max = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    if !max.is_finite() {
+        return max;
+    }
+    max + xs.iter().map(|x| (x - max).exp()).sum::<f64>().ln()
+}
+
+/// Stable `log(eᵃ + eᵇ)` for a two-component mixture denominator (moved verbatim
+/// from `importance::logsumexp2`). `NEG_INFINITY`-safe.
+pub(crate) fn log_sum_exp2(a: f64, b: f64) -> f64 {
+    let m = a.max(b);
+    if m == f64::NEG_INFINITY {
+        return f64::NEG_INFINITY;
+    }
+    m + ((a - m).exp() + (b - m).exp()).ln()
+}
+
+/// Numerically stable `log Σ exp(xᵢ)` plus the normalised weights `wᵢ` (moved
+/// verbatim from `importance::logsumexp_with_normalised`). Filters non-finite
+/// entries out of the max/sum (so a `NaN` log-weight is ignored, not propagated),
+/// splits mass equally across any `+inf` entries, and returns `(NEG_INFINITY, [])`
+/// on empty input.
+pub(crate) fn log_sum_exp_normalised(xs: &[f64]) -> (f64, Vec<f64>) {
+    if xs.is_empty() {
+        return (f64::NEG_INFINITY, Vec::new());
+    }
+
+    let n_pos_inf = xs
+        .iter()
+        .filter(|x| x.is_infinite() && x.is_sign_positive())
+        .count();
+    if n_pos_inf > 0 {
+        let w = 1.0 / n_pos_inf as f64;
+        let weights = xs
+            .iter()
+            .map(|x| {
+                if x.is_infinite() && x.is_sign_positive() {
+                    w
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        return (f64::INFINITY, weights);
+    }
+
+    let m = xs
+        .iter()
+        .copied()
+        .filter(|x| x.is_finite())
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !m.is_finite() {
+        return (f64::NEG_INFINITY, vec![0.0; xs.len()]);
+    }
+    let mut sum = 0.0;
+    let mut shifted: Vec<f64> = Vec::with_capacity(xs.len());
+    for &x in xs {
+        let s = if x.is_finite() { (x - m).exp() } else { 0.0 };
+        shifted.push(s);
+        sum += s;
+    }
+    let lse = m + sum.ln();
+    let weights: Vec<f64> = if sum > 0.0 {
+        shifted.iter().map(|&s| s / sum).collect()
+    } else {
+        vec![0.0; xs.len()]
+    };
+    (lse, weights)
+}
+
+/// Kish effective sample size `1 / Σ w̃ₖ²` from normalised weights (moved verbatim
+/// from `importance::ess_from_weights`). Returns `0.0` when weights are empty or
+/// all-zero. NOTE: this is the IS-weight ESS — NOT the Geyer autocorrelation
+/// chain-ESS in `crate::stats::convergence::effective_sample_size`; the two are
+/// different statistics and must never be conflated.
+#[inline]
+pub(crate) fn ess_from_weights(weights: &[f64]) -> f64 {
+    let sum_sq: f64 = weights.iter().map(|w| w * w).sum();
+    if sum_sq > 0.0 {
+        1.0 / sum_sq
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_sum_exp_is_stable_and_handles_sentinels() {
+        let want = (1.0f64.exp() + 2.0f64.exp()).ln();
+        assert!((log_sum_exp(&[1.0, 2.0]) - want).abs() < 1e-12);
+        assert!((log_sum_exp(&[1e5, 1e5]) - (1e5 + 2.0f64.ln())).abs() < 1e-9);
+        assert!((log_sum_exp(&[-1e20, 3.0]) - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn log_sum_exp2_matches_direct_and_handles_neginf() {
+        let a = -1.3_f64;
+        let b = 2.7_f64;
+        let want = (a.exp() + b.exp()).ln();
+        assert!((log_sum_exp2(a, b) - want).abs() < 1e-12);
+        assert!((log_sum_exp2(f64::NEG_INFINITY, 5.0) - 5.0).abs() < 1e-12);
+        assert!((log_sum_exp2(5.0, f64::NEG_INFINITY) - 5.0).abs() < 1e-12);
+        assert_eq!(
+            log_sum_exp2(f64::NEG_INFINITY, f64::NEG_INFINITY),
+            f64::NEG_INFINITY
+        );
+        assert!(
+            (log_sum_exp2(1000.0, 1001.0) - (1001.0 + (1.0 + (-1.0_f64).exp()).ln())).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn log_sum_exp_normalised_extreme_spread_and_shift_invariance() {
+        let (lse, w) = log_sum_exp_normalised(&[1000.0, 1001.0]);
+        assert!((lse - (1001.0 + (1.0 + (-1.0_f64).exp()).ln())).abs() < 1e-10);
+        assert!(((w.iter().sum::<f64>()) - 1.0).abs() < 1e-12);
+        assert!((w[1] / w[0] - 1.0_f64.exp()).abs() < 1e-10);
+        let xs = vec![0.1, -0.5, 2.3, -1.2, 0.8];
+        let (_, w1) = log_sum_exp_normalised(&xs);
+        let (_, w2) = log_sum_exp_normalised(&xs.iter().map(|x| x + 17.4).collect::<Vec<_>>());
+        for (a, b) in w1.iter().zip(w2.iter()) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn log_sum_exp_normalised_edge_cases() {
+        let (lse, w) = log_sum_exp_normalised(&[]);
+        assert_eq!(lse, f64::NEG_INFINITY);
+        assert!(w.is_empty());
+        let (lse, w) = log_sum_exp_normalised(&[f64::NEG_INFINITY; 3]);
+        assert_eq!(lse, f64::NEG_INFINITY);
+        assert_eq!(w, vec![0.0, 0.0, 0.0]);
+        let (lse, w) = log_sum_exp_normalised(&[f64::NAN, 2.0, 3.0, f64::NEG_INFINITY]);
+        assert!((lse - (3.0 + (1.0 + (-1.0_f64).exp()).ln())).abs() < 1e-10);
+        assert_eq!(w[0], 0.0);
+        assert!(w[1] > 0.0);
+        assert!(w[2] > w[1]);
+        assert_eq!(w[3], 0.0);
+        let (lse, w) = log_sum_exp_normalised(&[1.0, f64::INFINITY, f64::NAN, f64::INFINITY]);
+        assert_eq!(lse, f64::INFINITY);
+        assert_eq!(w, vec![0.0, 0.5, 0.0, 0.5]);
+    }
+
+    #[test]
+    fn ess_from_weights_kish_and_zero_guard() {
+        let k = 100usize;
+        let w = vec![1.0 / k as f64; k];
+        assert!((ess_from_weights(&w) - k as f64).abs() < 1e-10);
+        assert_eq!(ess_from_weights(&[0.0, 0.0, 0.0]), 0.0);
+        assert_eq!(ess_from_weights(&[]), 0.0);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1428,29 +1428,7 @@ impl PkModel {
     /// this set is rejected at parse time rather than silently mis-routed (no-TV
     /// path) or panicking (event-driven path).
     pub(crate) fn infusable_compartments(&self) -> &'static [usize] {
-        match self {
-            PkModel::OneCptIv => &[1],
-            // Oral: cmt 1 = depot (zero-order-into-depot, #400), cmt 2 = central
-            // (depot-bypassing infusion).
-            PkModel::OneCptOral => &[1, 2],
-            // Transit models a bolus absorbed through the Gamma transit chain;
-            // modeled-duration infusions are unsupported in v1, so a `D{cmt}` on a
-            // transit model is rejected at parse (#386).
-            PkModel::OneCptTransit => &[],
-            // Inverse-Gaussian, like transit: absorbs an instantaneous bolus through
-            // the IG absorption-time density; modeled-duration infusions are
-            // unsupported, so a `D{cmt}` on an IG model is rejected at parse (#790).
-            PkModel::OneCptIg => &[],
-            PkModel::TwoCptIv => &[1, 2],
-            PkModel::TwoCptOral => &[1, 2],
-            // Like the 1-cpt transit: modeled-duration infusions unsupported in v1,
-            // so a `D{cmt}` on a 2-cpt transit model is rejected at parse (#386).
-            PkModel::TwoCptTransit => &[],
-            // Inverse-Gaussian 2-cpt: same as the 1-cpt IG (#790).
-            PkModel::TwoCptIg => &[],
-            PkModel::ThreeCptIv => &[1, 2, 3],
-            PkModel::ThreeCptOral => &[1, 2],
-        }
+        self.topology().infusable_compartments()
     }
 
     /// Resolve a `[structural_model]` model name (canonical or long-form alias,
@@ -3863,30 +3841,19 @@ impl CompiledModel {
             "analytical_compartment_names called on an ODE model — use ode_spec.state_names instead"
         );
         use std::sync::OnceLock;
-        macro_rules! names {
-            ($lock:ident, $($name:expr),+) => {{
-                static $lock: OnceLock<Vec<String>> = OnceLock::new();
-                $lock.get_or_init(|| vec![$($name.to_string()),+]).as_slice()
-            }};
-        }
-        match self.pk_model {
-            PkModel::OneCptIv => names!(ONE_CMT_IV, "central"),
-            PkModel::OneCptOral => names!(ONE_CMT_ORAL, "depot", "central"),
-            PkModel::OneCptTransit => names!(ONE_CMT_TRANSIT, "depot", "central"),
-            PkModel::OneCptIg => names!(ONE_CMT_IG, "depot", "central"),
-            PkModel::TwoCptIv => names!(TWO_CMT_IV, "central", "peripheral"),
-            PkModel::TwoCptOral => names!(TWO_CMT_ORAL, "depot", "central", "peripheral"),
-            PkModel::TwoCptTransit => names!(TWO_CMT_TRANSIT, "depot", "central", "peripheral"),
-            PkModel::TwoCptIg => names!(TWO_CMT_IG, "depot", "central", "peripheral"),
-            PkModel::ThreeCptIv => names!(THREE_CMT_IV, "central", "peripheral1", "peripheral2"),
-            PkModel::ThreeCptOral => names!(
-                THREE_CMT_ORAL,
-                "depot",
-                "central",
-                "peripheral1",
-                "peripheral2"
-            ),
-        }
+        // Discriminant-indexed cache: the compartment name literals are the
+        // single source of truth in `pk::topology`; here we lazily materialise
+        // the owned `Vec<String>` the public `&'static [String]` API returns.
+        static NAMES: [OnceLock<Vec<String>>; 10] = [const { OnceLock::new() }; 10];
+        let topo = self.pk_model.topology();
+        NAMES[self.pk_model as usize]
+            .get_or_init(|| {
+                topo.compartment_names
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .as_slice()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3841,19 +3841,38 @@ impl CompiledModel {
             "analytical_compartment_names called on an ODE model — use ode_spec.state_names instead"
         );
         use std::sync::OnceLock;
-        // Discriminant-indexed cache: the compartment name literals are the
-        // single source of truth in `pk::topology`; here we lazily materialise
-        // the owned `Vec<String>` the public `&'static [String]` API returns.
-        static NAMES: [OnceLock<Vec<String>>; 10] = [const { OnceLock::new() }; 10];
-        let topo = self.pk_model.topology();
-        NAMES[self.pk_model as usize]
-            .get_or_init(|| {
-                topo.compartment_names
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect()
-            })
-            .as_slice()
+        // Exhaustive `match` on `pk_model` so adding an 11th `PkModel` variant is a
+        // COMPILE error here (a missing arm), not a runtime index-out-of-bounds on a
+        // fixed-size array. Each arm lazily materialises its own owned `Vec<String>`
+        // from the compartment-name literals in `pk::topology` — the single source of
+        // truth — that the public `&'static [String]` API returns.
+        macro_rules! cached_names {
+            ($lock:ident) => {{
+                static $lock: OnceLock<Vec<String>> = OnceLock::new();
+                $lock
+                    .get_or_init(|| {
+                        self.pk_model
+                            .topology()
+                            .compartment_names
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect()
+                    })
+                    .as_slice()
+            }};
+        }
+        match self.pk_model {
+            PkModel::OneCptIv => cached_names!(ONE_CPT_IV),
+            PkModel::OneCptOral => cached_names!(ONE_CPT_ORAL),
+            PkModel::OneCptTransit => cached_names!(ONE_CPT_TRANSIT),
+            PkModel::OneCptIg => cached_names!(ONE_CPT_IG),
+            PkModel::TwoCptIv => cached_names!(TWO_CPT_IV),
+            PkModel::TwoCptOral => cached_names!(TWO_CPT_ORAL),
+            PkModel::TwoCptTransit => cached_names!(TWO_CPT_TRANSIT),
+            PkModel::TwoCptIg => cached_names!(TWO_CPT_IG),
+            PkModel::ThreeCptIv => cached_names!(THREE_CPT_IV),
+            PkModel::ThreeCptOral => cached_names!(THREE_CPT_ORAL),
+        }
     }
 }
 


### PR DESCRIPTION
## Why
`ferx-core` has grown organically to ~199k LOC. A structured internal audit identified
where the codebase re-encodes the same logic in several places, hurting maintainability
(a change means editing N sites in lockstep). This PR lands the audit's two **safest,
provably behavior-preserving** extractions. (The audit write-up is kept internal — not
in this PR.)

Key context: much apparent "duplication" in this crate is deliberate bit-equality
lockstep that must *not* be collapsed (e.g. the two PK event-walk skeletons — the f64
walk memoizes the eigensolve). So these two changes target single-source-of-truth, not
raw line deletion.

## What changed
Two independent, numerically-inert refactors:

1. **`stats::util` numeric dedup** (`16595427`) — extracted the f64 sample-combinator
   numerics (`log_sum_exp`, `log_sum_exp2`, `log_sum_exp_normalised`, `ess_from_weights`)
   into a new `src/stats/util.rs`, moved **verbatim** from their single sources in
   `agq.rs` / `importance_sampling.rs` (imported back via aliases → no call site changed).
   Also deleted a 55-LOC copy of the Acklam probit in `importance_sampling::inv_normal_cdf`,
   which now delegates to the canonical `stats::special::normal_inv_cdf` behind a thin
   `[1e-15, 1-1e-15]` clamp wrapper. The 22 coefficients + `P_LOW` are byte-identical and
   the clamp keeps `u ∈ (0,1)` so the `±inf` guards never fire → bit-identical output.

2. **`pk::topology` descriptor** (`e1172e2a`) — collapsed **8** independently
   hand-maintained per-`PkModel` lookup tables (`state_layout` ×2, `supports_event_driven`
   /`walk_supports`, the inline `n_states` match, `analytical_compartment_names`,
   `infusable_compartments`, and the two 12-arm `match (pk_model, d.cmt)` rate-routing
   tables) into a single `PkModel::topology() -> &'static PkTopology`. Originals kept as
   thin facades with unchanged signatures. The panic-vs-silent-skip asymmetry between the
   two rate-routing matches is preserved via `dose_channel() -> Option<Channel>` (each
   caller keeps its own `None` arm). Rate-accumulation loops are untouched → dose-sum order
   byte-for-byte unchanged.

### Note on LOC
This PR is net **+237 LOC of code** (`src/`), not a reduction — expected for these two:
they replace terse scattered tables with one explicit descriptor + new mandatory tests
(the repo gates ≥90% patch coverage). The payoff is drift-elimination (add a `PkModel` =
1 edit, not 8 in lockstep) and one home for the shared numerics. Genuine LOC reducers
(covariance-module extraction −190, inline-test relocation) are separate follow-up PRs.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API changed (`normal_inv_cdf` was already `pub`; new helpers are `pub(crate)`;
`pk::topology` is `pub(crate)`).

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable — pure code motion / bit-identical delegation / numerically-inert
  lookup consolidation. No f64 arithmetic is reordered.

Verified against the crate's own FD-gradient + bit-equality unit tests:
```
cargo test --profile ci-test --lib  →  2505 passed; 0 failed; 18 ignored
```
(2502 baseline + 3 new `pk::topology` drift-guard tests; the numerics change added the
`stats::util` test module and left every existing `agq`/`importance_sampling` test green.)

## Performance
- [x] No significant impact expected (static `&'static` table lookups replace inline matches).

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes) — `stats::util`
  branch-coverage tests; `pk::topology` field-consistency + routing-table + support drift guards.

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor, no user-facing change)
- [x] No user-visible change

## Checklist
- [x] `rustfmt` clean (changed files formatted)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — `pk::topology`
  consolidation only touches integer/name/bool lookups; the generic `active_rates_g<T:PkNum>`
  routing now goes through `dose_channel()` but the `T`-valued rate arithmetic is unchanged.
- [ ] `cargo clippy` clean (not re-run in this env; no clippy-relevant constructs introduced)

## Reviewer hints
- The whole correctness argument for `pk::topology` is that the descriptor tables transcribe
  the *exact* prior per-model values — cross-checked against source for all 10 variants, and
  pinned by the new drift-guard tests. Focus review there.
- `stats::util` bodies are verbatim moves; the only semantic change is `inv_normal_cdf` now
  delegating (bit-identical for all reachable inputs, argued above).

## Open questions
- None.
