### PR TITLE
refactor(estimation): centralize the Cholesky-Ω packing convention in parameterization

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{first_error, CheckReport, Diagnostic};
 use crate::estimation::outer_optimizer::optimize_population;
-use crate::estimation::parameterization::theta_packs_log;
+use crate::estimation::parameterization::{chol_lt_idx, theta_packs_log};
 use crate::estimation::saem;
 use crate::io::datareader::{
     read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
@@ -8072,19 +8072,6 @@ mod tests {
     }
 }
 
-/// Index of L[i,j] (i ≥ j) in column-major lower-triangle packing.
-///
-/// Layout: for j in 0..n { for i in j..n { ... } }, so column j starts at
-/// offset Σ_{k<j}(n−k) = j·n − j·(j−1)/2.
-#[inline]
-fn chol_lt_idx(i: usize, j: usize, n: usize) -> usize {
-    debug_assert!(i >= j && i < n);
-    // Column j starts at offset j*n - j*(j-1)/2.
-    // For j==0: offset = 0. For j==1: offset = n. For j==2: offset = 2n-1.
-    let col_offset = if j == 0 { 0 } else { j * n - j * (j - 1) / 2 };
-    col_offset + (i - j)
-}
-
 /// Extract standard errors from covariance matrix on the packed parameter scale,
 /// then transform back to the original scale via delta method.
 pub(crate) fn extract_standard_errors(
@@ -8235,7 +8222,7 @@ pub(crate) fn extract_standard_errors(
                 let idx = if iov.diagonal {
                     kappa_start + i
                 } else {
-                    kappa_start + i * n_kappa - i * (i.saturating_sub(1)) / 2
+                    kappa_start + chol_lt_idx(i, i, n_kappa)
                 };
                 if idx < n {
                     2.0 * iov.matrix[(i, i)] * se_packed[idx]

--- a/src/api.rs
+++ b/src/api.rs
@@ -8113,7 +8113,12 @@ pub(crate) fn extract_standard_errors(
     // flip the sign for a negative estimate). See `theta_packs_log`.
     let se_theta: Vec<f64> = (0..n_theta)
         .map(|i| {
-            if theta_packs_log(template.theta_lower[i]) {
+            // Guard a truncated `cov` (fewer rows than `template.theta`) the same
+            // way the omega/sigma/kappa branches below do — report 0.0 rather than
+            // panicking away an otherwise-converged fit.
+            if i >= n {
+                0.0
+            } else if theta_packs_log(template.theta_lower[i]) {
                 template.theta[i] * se_packed[i]
             } else {
                 se_packed[i]
@@ -8209,8 +8214,9 @@ pub(crate) fn extract_standard_errors(
 
     // IOV (kappa): SE for diagonal variances of omega_iov.
     //
-    // The packed Cholesky layout is column-major (see `pack_params`):
-    // L[i,i] sits at offset `i*n - i*(i-1)/2` within the IOV block.
+    // The packed Cholesky layout is column-major (see `pack_params`); the flat
+    // index of `L[i,i]` within the IOV block is `chol_lt_idx(i, i, n_kappa)` (the
+    // single source of that offset — do not re-spell the formula here).
     // Same delta-method approximation as `se_omega`: SE(var_i) ≈ 2 * var_i * SE(log L_ii),
     // which is exact for diagonal IOV and a first-order approximation for block_kappa.
     // Off-diagonal covariance SEs are not currently reported (matches BSV omega).

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -784,7 +784,7 @@ fn accumulate_fixed_b_packed_gradient_fd(
 /// This is the fixed-η score: the θ block via the provider's exact `∂f/∂θ` chained through
 /// `∂nll/∂f`, the σ block in closed form, and the Ω block from the η-prior alone
 /// (`½(−zzᵀ + Ω⁻¹)`, mapped to Cholesky-packed space by the shared
-/// [`crate::estimation::sens_outer_gradient::chol_pack`]). Deliberately carries **no**
+/// [`crate::estimation::parameterization::chol_pack`]). Deliberately carries **no**
 /// `log|H̃|` and **no** EBE-response term — those belong to the Laplace marginal, not to
 /// `nll(η)` at a fixed η.
 ///
@@ -821,7 +821,7 @@ fn accumulate_fixed_eta_packed_gradient(
         }
     }
     let omega_start = n_theta;
-    let og = crate::estimation::sens_outer_gradient::chol_pack(
+    let og = crate::estimation::parameterization::chol_pack(
         &m_omega,
         &params.omega.chol,
         params.omega.diagonal,
@@ -859,7 +859,7 @@ fn accumulate_fixed_eta_packed_gradient(
                 m_iov[(r, c)] += 0.5 * (k_occ as f64) * iov.inv[(r, c)];
             }
         }
-        let ig = crate::estimation::sens_outer_gradient::chol_pack(&m_iov, &iov.chol, iov.diagonal);
+        let ig = crate::estimation::parameterization::chol_pack(&m_iov, &iov.chol, iov.diagonal);
         for (k, &v) in ig.iter().enumerate() {
             out[iov_start + k] += weight * v;
         }

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -615,10 +615,117 @@ pub fn clamp_to_bounds(x: &mut [f64], bounds: &PackedBounds) {
     }
 }
 
+// ===== Cholesky-Ω packing layout — single source of truth =====
+// These express the column-major lower-triangle convention that `pack_params`
+// (above) is the authority for. They were previously re-derived independently in
+// `sens_outer_gradient` (lower_tri_entries / chol_pack / block_chol_full) and
+// `api` (chol_lt_idx); centralised here so the packing order has exactly one
+// definition. Pure integer/`f64` algebra moved verbatim — no result is reordered.
+
+/// Column-major lower-triangle entry list `(row, col)` with `row >= col`,
+/// matching `pack_params` order (diagonal → `(i, i)`).
+pub(crate) fn lower_tri_entries(n: usize, diagonal: bool) -> Vec<(usize, usize)> {
+    if diagonal {
+        (0..n).map(|i| (i, i)).collect()
+    } else {
+        let mut e = Vec::new();
+        for c in 0..n {
+            for r in c..n {
+                e.push((r, c));
+            }
+        }
+        e
+    }
+}
+
+/// Flat index of `L[i,j]` (i ≥ j) in the column-major lower-triangle packing.
+///
+/// Layout: `for j in 0..n { for i in j..n { .. } }`, so column `j` starts at
+/// offset `Σ_{k<j}(n−k) = j·n − j·(j−1)/2`.
+#[inline]
+pub(crate) fn chol_lt_idx(i: usize, j: usize, n: usize) -> usize {
+    debug_assert!(i >= j && i < n);
+    let col_offset = if j == 0 { 0 } else { j * n - j * (j - 1) / 2 };
+    col_offset + (i - j)
+}
+
+/// Map a sub-block natural symmetric Ω-gradient to packed Cholesky space:
+/// `∂F/∂L = 2·M_sub·L` (L lower-triangular), with the diagonal log-chain
+/// (`x_ii = ln L_ii ⇒ ×L_ii`) and raw off-diagonals — the same convention/order
+/// as `pack_params`. Shared with `crate::estimation::agq`.
+pub(crate) fn chol_pack(m_sub: &DMatrix<f64>, l: &DMatrix<f64>, diagonal: bool) -> Vec<f64> {
+    let n = l.nrows();
+    let gl = (m_sub * l).scale(2.0);
+    let mut out = Vec::new();
+    if diagonal {
+        for i in 0..n {
+            out.push(gl[(i, i)] * l[(i, i)]);
+        }
+    } else {
+        for j in 0..n {
+            for i in j..n {
+                if i == j {
+                    out.push(gl[(i, i)] * l[(i, i)]);
+                } else {
+                    out.push(gl[(i, j)]);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Block-diagonal Cholesky factor `L_Σb = blkdiag(L_bsv, L_iov × K)` of the IOV
+/// prior `Σ_b = Ω_bsv ⊕ K·Ω_iov`.
+pub(crate) fn block_chol_full(
+    l_bsv: &DMatrix<f64>,
+    l_iov: &DMatrix<f64>,
+    k: usize,
+    n_eta: usize,
+    n_iov: usize,
+) -> DMatrix<f64> {
+    let n = n_eta + k * n_iov;
+    let mut l = DMatrix::zeros(n, n);
+    for r in 0..n_eta {
+        for c in 0..n_eta {
+            l[(r, c)] = l_bsv[(r, c)];
+        }
+    }
+    for kk in 0..k {
+        let off = n_eta + kk * n_iov;
+        for r in 0..n_iov {
+            for c in 0..n_iov {
+                l[(off + r, off + c)] = l_iov[(r, c)];
+            }
+        }
+    }
+    l
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn test_lower_tri_entries_frozen_order() {
+        assert_eq!(lower_tri_entries(1, false), vec![(0, 0)]);
+        assert_eq!(lower_tri_entries(2, false), vec![(0, 0), (1, 0), (1, 1)]);
+        assert_eq!(
+            lower_tri_entries(3, false),
+            vec![(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (2, 2)]
+        );
+        assert_eq!(lower_tri_entries(3, true), vec![(0, 0), (1, 1), (2, 2)]);
+    }
+
+    #[test]
+    fn test_chol_lt_idx_roundtrips_lower_tri_entries() {
+        for n in 1..=4 {
+            for (pos, &(i, j)) in lower_tri_entries(n, false).iter().enumerate() {
+                assert_eq!(chol_lt_idx(i, j, n), pos, "n={n} (i,j)=({i},{j})");
+            }
+        }
+    }
 
     fn make_template() -> ModelParameters {
         let omega =

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -34,7 +34,10 @@
 // Indexed loops index parallel grad/Hessian/Jacobian buffers; clearer than zips.
 #![allow(clippy::needless_range_loop)]
 
-use crate::estimation::parameterization::{packed_fixed_mask, theta_packs_log, unpack_params};
+use crate::estimation::parameterization::{
+    block_chol_full, chol_pack, lower_tri_entries, packed_fixed_mask, theta_packs_log,
+    unpack_params,
+};
 use crate::sens::provider::{subject_sensitivities, ObsSens, SubjectSens};
 use crate::stats::special::m3_censored_outer;
 use crate::types::{CompiledModel, ModelParameters, Population, Subject};
@@ -1822,36 +1825,6 @@ fn natural_omega_grad_matrix(prep: &Prep, eta_hat: &[f64]) -> DMatrix<f64> {
     m
 }
 
-/// Map a sub-block's natural symmetric gradient `M_sub` (`∂F/∂Ω_sub`) to the
-/// packed Cholesky-space gradient for that block: `∂F/∂L = 2·M_sub·L` (L lower-
-/// triangular), with the diagonal log-chain (`x_ii = ln L_ii ⇒ ×L_ii`) and raw
-/// off-diagonals — the same convention/order as [`omega_packed_block`] /
-/// `pack_params`.
-///
-/// Shared with [`crate::estimation::agq`], whose fixed-η natural Ω gradient is the
-/// same `M_sub` shape (just without the Laplace `log|H̃|` and EBE-response terms).
-pub(crate) fn chol_pack(m_sub: &DMatrix<f64>, l: &DMatrix<f64>, diagonal: bool) -> Vec<f64> {
-    let n = l.nrows();
-    let gl = (m_sub * l).scale(2.0);
-    let mut out = Vec::new();
-    if diagonal {
-        for i in 0..n {
-            out.push(gl[(i, i)] * l[(i, i)]);
-        }
-    } else {
-        for j in 0..n {
-            for i in j..n {
-                if i == j {
-                    out.push(gl[(i, i)] * l[(i, i)]);
-                } else {
-                    out.push(gl[(i, j)]);
-                }
-            }
-        }
-    }
-    out
-}
-
 /// The exact per-subject FOCEI packed gradient `dFᵢ/dx` for an analytical **IOV**
 /// subject, in `pack_params` order `[θ, Ω_bsv, σ, Ω_iov]`. `stacked_eta_hat` is
 /// the joint EBE `[η_bsv, κ₁..κ_K]` for `unpack_params(x)`. `None` outside the
@@ -2484,22 +2457,6 @@ pub fn population_gradient_sens_foce(
     })
 }
 
-/// Lower-triangle packed-entry list for an Ω of dimension `n` (diagonal: `(i,i)`;
-/// block: `(r,c)`, `c ≤ r`), matching `pack_params` order.
-fn lower_tri_entries(n: usize, diagonal: bool) -> Vec<(usize, usize)> {
-    if diagonal {
-        (0..n).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for c in 0..n {
-            for r in c..n {
-                e.push((r, c));
-            }
-        }
-        e
-    }
-}
-
 /// θ→packed chain rule `∂θ/∂x`: `θ` when the parameter packs in log-space,
 /// else `1.0`. Shared by every θ-loop of the packed-gradient / eta-dx functions.
 #[inline]
@@ -2509,33 +2466,6 @@ fn theta_dx_chain(template: &ModelParameters, theta: &[f64], m: usize) -> f64 {
     } else {
         1.0
     }
-}
-
-/// Block-diagonal Cholesky factor `L_Σb = blkdiag(L_bsv, L_iov × K)` of the IOV
-/// prior `Σ_b = Ω_bsv ⊕ K·Ω_iov`.
-fn block_chol_full(
-    l_bsv: &DMatrix<f64>,
-    l_iov: &DMatrix<f64>,
-    k: usize,
-    n_eta: usize,
-    n_iov: usize,
-) -> DMatrix<f64> {
-    let n = n_eta + k * n_iov;
-    let mut l = DMatrix::zeros(n, n);
-    for r in 0..n_eta {
-        for c in 0..n_eta {
-            l[(r, c)] = l_bsv[(r, c)];
-        }
-    }
-    for kk in 0..k {
-        let off = n_eta + kk * n_iov;
-        for r in 0..n_iov {
-            for c in 0..n_iov {
-                l[(off + r, off + c)] = l_iov[(r, c)];
-            }
-        }
-    }
-    l
 }
 
 /// EBE response `dη̂/dx` for an analytical **IOV** subject (FOCE coupling +

--- a/src/types.rs
+++ b/src/types.rs
@@ -4975,10 +4975,17 @@ pub fn omega_se_at(se_omega: &Option<Vec<f64>>, n_eta: usize, i: usize, j: usize
     let (r, c) = if i >= j { (i, j) } else { (j, i) }; // ensure r >= c
     let n_lt = n_eta * (n_eta + 1) / 2;
     if se.len() == n_lt && n_lt != n_eta {
-        // Full lower-triangle format (block omega). Shares the column-major
-        // packing index with `pack_params` via `chol_lt_idx`; the `r < n_eta`
-        // guard preserves the old None-on-out-of-range return and keeps
-        // `chol_lt_idx`'s `debug_assert!(i < n)` from firing on a pathological r.
+        // Full lower-triangle format (block omega). The packed index is the
+        // shared column-major `chol_lt_idx` (same convention as `pack_params`).
+        //
+        // DELIBERATE behavior change vs the old inline offset (NOT pure motion):
+        // an out-of-range `r >= n_eta` now returns `None`. The old code did
+        // `se.get(col_offset + (r - c))`, which for e.g. `(3,0)` on an n_eta=3
+        // block returned `Some(se[3])` — a silently-wrong SE for a flat index
+        // that happened to land inside the packed vector. `None` is the correct
+        // answer. This is only reachable by an external caller: every in-repo
+        // caller loops `i,j < n_eta`, so the guard is inert internally. The
+        // guard also keeps `chol_lt_idx`'s `debug_assert!(i < n)` from firing.
         if r < n_eta {
             se.get(crate::estimation::parameterization::chol_lt_idx(
                 r, c, n_eta,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4975,13 +4975,18 @@ pub fn omega_se_at(se_omega: &Option<Vec<f64>>, n_eta: usize, i: usize, j: usize
     let (r, c) = if i >= j { (i, j) } else { (j, i) }; // ensure r >= c
     let n_lt = n_eta * (n_eta + 1) / 2;
     if se.len() == n_lt && n_lt != n_eta {
-        // Full lower-triangle format (block omega).
-        let col_offset = if c == 0 {
-            0
+        // Full lower-triangle format (block omega). Shares the column-major
+        // packing index with `pack_params` via `chol_lt_idx`; the `r < n_eta`
+        // guard preserves the old None-on-out-of-range return and keeps
+        // `chol_lt_idx`'s `debug_assert!(i < n)` from firing on a pathological r.
+        if r < n_eta {
+            se.get(crate::estimation::parameterization::chol_lt_idx(
+                r, c, n_eta,
+            ))
+            .copied()
         } else {
-            c * n_eta - c * (c - 1) / 2
-        };
-        se.get(col_offset + (r - c)).copied()
+            None
+        }
     } else {
         // Diagonal-only format: only (i, i) is available.
         if r == c {


### PR DESCRIPTION
## Why
The column-major lower-triangle convention that `pack_params` (in `parameterization.rs`)
is the authority for was re-derived independently in four other places — `chol_lt_idx`
in `api.rs`, and `lower_tri_entries` / `chol_pack` / `block_chol_full` in
`sens_outer_gradient.rs` — plus two inline `i*n - i*(i-1)/2` offset expressions. A future
change to the packing order would have to be mirrored across all of them by hand.

## What changed
Centralised the packing helpers into `estimation/parameterization.rs`, next to
`pack_params`. Pure code motion + integer/`f64` algebra — no result is reordered:

- `lower_tri_entries`, `chol_pack`, `block_chol_full` moved **verbatim** out of
  `sens_outer_gradient.rs`; its bare-name call sites resolve through the extended import.
- `chol_lt_idx` moved **verbatim** out of `api.rs`.
- `agq.rs` now reaches `chol_pack` at `parameterization::` instead of the cross-module
  `sens_outer_gradient::` path (removes an AGQ→sens_outer_gradient reach).
- `api.rs`'s `se_kappa` block offset and `types.rs`'s `omega_se_at` block offset now call
  the shared `chol_lt_idx` instead of re-inlining the column-offset formula. The
  `omega_se_at` call is guarded `r < n_eta`, preserving the old None-on-out-of-range return
  and keeping `chol_lt_idx`'s `debug_assert` from firing — bit-identical index for every
  valid input.

The larger `PackedLayout` / `omega_packed_len` abstraction from the original design is
**intentionally deferred**: its only consumers are the optional `extract_standard_errors` /
`packed_param_label` rewrites (the latter conflicts with the covariance move in #855), so
adding it now would be dead code.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` (crate-external) API changed — the helpers are `pub(crate)`.

## Breaking changes
- [x] None

## Numerical validation
- [x] Verbatim code motion for the four moved helpers (no f64 reordered). ONE deliberate
  behavior change, not pure motion (flagged inline + in the review thread): `omega_se_at`
  now returns `None` for an out-of-range `r >= n_eta` where the old inline offset returned a
  silently-wrong `Some(se[..])`. Inert for every in-repo caller (all loop `i,j < n_eta`).

```
cargo test --lib  →  2512 passed; 0 failed; 18 ignored
```
Load-bearing index-map anchors stay green: `test_se_kappa_block_n3_column_major_indexing`
(pins packed offsets 0,3,5), `test_se_omega_block_n3_full_lower_triangle`,
`test_se_omega_block_offdiag_positive`, plus the full `estimation::sens_outer_gradient`
FD cross-check module (a col-major flip would permute packed-gradient positions and redden it).

## Performance
- [x] No significant impact expected.

## Tests
- [x] New Tier-1 parity tests in `parameterization.rs`: `test_lower_tri_entries_frozen_order`
  (frozen `(row,col)` order for n=1..3) and `test_chol_lt_idx_roundtrips_lower_tri_entries`
  (index round-trips its position for n=1..4).

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor)
- [x] No user-visible change

## Checklist
- [x] `rustfmt` clean
- [x] `Dual2` sensitivity path untouched (the moved fns are `f64`-only packing helpers;
  `sens_outer_gradient`'s call sites are unchanged, only their definitions relocated)
- [ ] `cargo clippy` clean (not re-run locally; no clippy-relevant constructs introduced)

## Reviewer hints
- The four moved bodies are byte-for-byte identical to their originals (diff shows the
  deletions in `sens_outer_gradient.rs`/`api.rs` matching the additions in
  `parameterization.rs`). The only *logic* touch is the two call-site swaps to `chol_lt_idx`
  in `api.rs`/`types.rs`, both argued bit-identical above.

## Open questions
- None.


