### PR TITLE
refactor(dosing): extract a neutral crate::dosing module out of ode/predictions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ FitResult → io/output.rs → sdtab CSV + fit YAML
 | `pk/` | Analytical 1-cpt and 2-cpt PK solutions (IV, oral, infusion) with superposition |
 | `ode/solver.rs` | Dormand-Prince RK45 adaptive ODE solver |
 | `ode/predictions.rs` | ODE-based predictions with dose event handling |
+| `dosing.rs` | Neutral dose-resolution (`resolve_subject_doses`, #324) + SS-equilibration policy (`SS_EQUILIBRATION_CYCLES`, `SsStopTracker`) — the single home shared by pk/ode/sens |
 | `estimation/gauss_newton.rs` | Gauss-Newton (BHHH) optimizer with LM damping; pure GN and GN+FOCEI hybrid |
 | `estimation/trust_region.rs` | Newton trust-region outer optimizer (argmin + Steihaug CG); FD gradient & Hessian with fixed EBEs |
 | `estimation/parameterization.rs` | Pack/unpack optimizer vector (log-theta, Cholesky-omega, log-sigma) |

--- a/docs/model-file/steady-state.qmd
+++ b/docs/model-file/steady-state.qmd
@@ -177,9 +177,9 @@ slow PK (`λ·II = 0.1`, ~14 half-lives total over the 50 cycles),
 bound is conservative and (b) skipping the convergence check keeps
 the hot path branch-free.
 
-If you need tighter accuracy for an unusually slow PK, the constant
-lives at `SS_EQUILIBRATION_CYCLES` in `src/ode/predictions.rs` and
-`EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES` in `src/pk/event_driven.rs`.
+If you need tighter accuracy for an unusually slow PK, the constant has a single
+definition: `SS_EQUILIBRATION_CYCLES` in `src/dosing.rs` (the analytical
+event-driven and ODE paths both use it).
 
 ### Cost comparison
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -178,7 +178,7 @@ pub(crate) fn model_preds(
         // to a concrete duration/rate before the analytical closed form — mirrors
         // the ODE `resolve_subject_doses` step inside `compute_predictions_ode`.
         // Borrowed (no allocation) for the all-`Fixed` common case.
-        let resolved = crate::ode::resolve_subject_doses(
+        let resolved = crate::dosing::resolve_subject_doses(
             subject,
             model.active_dose_attr_map(),
             &pk_params.values,

--- a/src/dosing.rs
+++ b/src/dosing.rs
@@ -2,9 +2,10 @@
 //!
 //! These were extracted from `ode/predictions.rs` so that `pk/`, `sens/`, and
 //! `api` no longer depend *upward* on `ode/` merely to resolve modeled-`RATE`
-//! doses or to share the SS-equilibration convergence tracker. Pure code motion:
-//! `ode::predictions` re-exports every symbol below, so all historical
-//! `crate::ode::{resolve_subject_doses, predictions::*}` paths keep resolving.
+//! doses or to share the SS-equilibration convergence tracker. Pure code motion.
+//! `ode::predictions` *privately* imports the symbols it still uses (it does NOT
+//! re-export them as `crate::ode::…`, so the upward dependency stays removed);
+//! every other consumer reaches these through `crate::dosing::…`.
 //!
 //! - Dose resolution (`resolve_subject_doses{,_with}`): the #324 single source of
 //!   truth for turning modeled-`RATE` (`RATE=-2` → modeled duration `D{cmt}`)
@@ -89,17 +90,6 @@ pub(crate) const SS_EQUILIBRATION_CYCLES: usize = 50;
 /// PK. Fast disposition (`λ·II ≈ 2`) converges in ~14 cycles; slow PK (`λ·II ≈ 0.1`) never
 /// trips it and runs the full [`SS_EQUILIBRATION_CYCLES`] — identical to the old behaviour.
 pub(crate) const SS_EQUILIBRATION_TOL: f64 = 1e-12;
-
-/// Relative floor for truncating the steady-state **input-rate periodic sum** (#719). An
-/// `SS=1` dose into a built-in absorption compartment stands for an infinite past pulse
-/// train, so its appearance rate at time `t` is `Σ_{j≥0} R_in(tad + j·II)` — the tail of
-/// every prior pulse still arriving (see [`add_prepared_input_rate_forcing`]). The absorption
-/// density is eventually monotone-decreasing, so once a term falls below this fraction of the
-/// running sum the remaining tail is spent and the sum stops (hard-capped at
-/// [`SS_EQUILIBRATION_CYCLES`] so a pathologically slow absorption — mode ≫ II — still
-/// terminates, matching the trough's own cycle budget). Conservative (`1e-10`): the dropped
-/// tail is far below the provider-vs-production parity tolerance.
-pub(crate) const SS_TAIL_REL_FLOOR: f64 = 1e-10;
 
 /// Whether the SS-equilibration trough has converged between two successive cycles. Shared
 /// by the f64 predictor, the event-driven f64 loop, and the dual gradient path so every path
@@ -196,14 +186,16 @@ pub(crate) fn last_ss_equilibration_cycles() -> usize {
 /// test sharing the harness thread.
 #[cfg(test)]
 pub(crate) fn with_full_ss_equilibration<R>(f: impl FnOnce() -> R) -> R {
-    struct Reset;
+    // Re-entrant: the guard restores the PRIOR value, not an unconditional `false`, so a
+    // nested call leaves the outer body running with full equilibration still forced.
+    struct Reset(bool);
     impl Drop for Reset {
         fn drop(&mut self) {
-            FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(false));
+            FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(self.0));
         }
     }
-    FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(true));
-    let _reset = Reset;
+    let prev = FORCE_FULL_SS_EQUILIBRATION.with(|c| c.replace(true));
+    let _reset = Reset(prev);
     f()
 }
 

--- a/src/dosing.rs
+++ b/src/dosing.rs
@@ -1,0 +1,213 @@
+//! Neutral dose-resolution + steady-state-equilibration primitives.
+//!
+//! These were extracted from `ode/predictions.rs` so that `pk/`, `sens/`, and
+//! `api` no longer depend *upward* on `ode/` merely to resolve modeled-`RATE`
+//! doses or to share the SS-equilibration convergence tracker. Pure code motion:
+//! `ode::predictions` re-exports every symbol below, so all historical
+//! `crate::ode::{resolve_subject_doses, predictions::*}` paths keep resolving.
+//!
+//! - Dose resolution (`resolve_subject_doses{,_with}`): the #324 single source of
+//!   truth for turning modeled-`RATE` (`RATE=-2` → modeled duration `D{cmt}`)
+//!   doses into concrete `Fixed` doses.
+//! - SS equilibration (`SS_EQUILIBRATION_CYCLES`, `SS_EQUILIBRATION_TOL`,
+//!   `ss_cycle_converged`, `SsStopTracker`, and the test-only cycle recorder):
+//!   the shared convergence policy the analytical, ODE, and sensitivity SS loops
+//!   all reuse so their troughs can't drift apart.
+
+use crate::types::Subject;
+use std::borrow::Cow;
+
+/// Resolve any modeled-`RATE` doses (#324, e.g. `RATE=-2` → modeled duration
+/// `D{cmt}`) in `subject` to concrete (`Fixed`) doses. `pk_for_dose(k)` supplies
+/// the per-dose `PkParams::values` slice used to evaluate dose `k`'s modeled
+/// parameter — pass a constant closure for the no-TV-covariate paths (see
+/// [`resolve_subject_doses`]) or `|k| &pk_at_dose[k].values` for the per-dose
+/// event-driven path. Returns the subject **borrowed** (no allocation) when every
+/// dose is already `Fixed` (the common case — see [`Subject::all_doses_fixed`]),
+/// and an owned copy with resolved `doses` otherwise.
+///
+/// Single source of truth: every ODE entrypoint funnels its subject through this
+/// (or the thin [`resolve_subject_doses`] wrapper) before building the dose
+/// timeline, so the integrator and SS helpers only ever see a concrete
+/// `rate`/`duration` and a coded `RATE=-2` cannot reach them unresolved.
+///
+/// The owned branch clones the whole `Subject`, not just `doses`, because the
+/// downstream machinery ([`crate::pk::event_driven::EventSchedule::for_subject`],
+/// the SS pre-equilibration, the break-time timeline) consumes a unified
+/// `&Subject` and reads `obs_times` / `pk_only_times` / `reset_times` alongside
+/// the resolved `doses`. Cloning only `doses` would force every one of those deep
+/// helpers to take the resolved doses as a separate argument — the
+/// "thread the resolved doses through every helper" design that was deliberately
+/// rejected in favour of resolving once at the entrypoint. The clone is paid
+/// only on the (uncommon) modeled-`RATE` path; the all-`Fixed` path is borrowed.
+pub(crate) fn resolve_subject_doses_with<'a>(
+    subject: &'a Subject,
+    attr_map: &crate::types::DoseAttrMap,
+    pk_for_dose: impl Fn(usize) -> &'a [f64],
+) -> Cow<'a, Subject> {
+    // Fast path: with no compartment-indexed attribute there can be no modeled
+    // dose to resolve, so skip the per-dose `all_doses_fixed()` scan entirely —
+    // the overwhelmingly common case (no `D{cmt}`). A modeled dose cannot reach
+    // here with an empty map: it would have been rejected by the data gate first.
+    if attr_map.is_empty() || subject.all_doses_fixed() {
+        return Cow::Borrowed(subject);
+    }
+    let mut owned = subject.clone();
+    for (k, d) in owned.doses.iter_mut().enumerate() {
+        *d = d.resolve_rate(attr_map, pk_for_dose(k));
+    }
+    Cow::Owned(owned)
+}
+
+/// Resolve modeled-`RATE` doses using `params` for **every** dose — the
+/// no-time-varying-covariate ODE paths, where the PK snapshot is constant across
+/// doses. The event-driven / TV-covariate path calls
+/// [`resolve_subject_doses_with`] directly with a per-dose closure. See
+/// [`resolve_subject_doses_with`].
+pub(crate) fn resolve_subject_doses<'a>(
+    subject: &'a Subject,
+    attr_map: &crate::types::DoseAttrMap,
+    params: &'a [f64],
+) -> Cow<'a, Subject> {
+    resolve_subject_doses_with(subject, attr_map, |_| params)
+}
+/// Number of dosing cycles to simulate when pre-equilibrating an SS=1
+/// dose. With a typical t₁/₂/II ratio under 2 (the common clinical range)
+/// this is comfortably past saturation — each additional cycle adds
+/// `exp(-k·II)` of the prior decay, so by N=50 the truncation tail is
+/// well below 1e-6 for any reasonable PK. The analytic-sensitivity SS
+/// equilibration (`sens::ode_provider::equilibrate_ss_state_g`) reuses this
+/// same constant so its trough can't drift from this f64 predictor (#473 review #11).
+pub(crate) const SS_EQUILIBRATION_CYCLES: usize = 50;
+
+/// Relative-`L∞` tolerance for the steady-state equilibration **early stop** (#519). The
+/// `(apply dose; integrate II)` cycle is a geometric contraction with ratio `≈ exp(−λ·II)`;
+/// once the cycle-to-cycle state change falls below this *relative* threshold, every
+/// remaining cycle would move the trough by less still, so the truncation is already at f64
+/// precision and we stop. Conservative (`1e-12`): the dropped tail is far below the
+/// `provider`-vs-production parity tolerance, so the value is unchanged for any realistic
+/// PK. Fast disposition (`λ·II ≈ 2`) converges in ~14 cycles; slow PK (`λ·II ≈ 0.1`) never
+/// trips it and runs the full [`SS_EQUILIBRATION_CYCLES`] — identical to the old behaviour.
+pub(crate) const SS_EQUILIBRATION_TOL: f64 = 1e-12;
+
+/// Relative floor for truncating the steady-state **input-rate periodic sum** (#719). An
+/// `SS=1` dose into a built-in absorption compartment stands for an infinite past pulse
+/// train, so its appearance rate at time `t` is `Σ_{j≥0} R_in(tad + j·II)` — the tail of
+/// every prior pulse still arriving (see [`add_prepared_input_rate_forcing`]). The absorption
+/// density is eventually monotone-decreasing, so once a term falls below this fraction of the
+/// running sum the remaining tail is spent and the sum stops (hard-capped at
+/// [`SS_EQUILIBRATION_CYCLES`] so a pathologically slow absorption — mode ≫ II — still
+/// terminates, matching the trough's own cycle budget). Conservative (`1e-10`): the dropped
+/// tail is far below the provider-vs-production parity tolerance.
+pub(crate) const SS_TAIL_REL_FLOOR: f64 = 1e-10;
+
+/// Whether the SS-equilibration trough has converged between two successive cycles. Shared
+/// by the f64 predictor, the event-driven f64 loop, and the dual gradient path so every path
+/// truncates on the *same* criterion — the dual feeds the value parts (`PkNum::val`) of its
+/// state (#519), which keeps its stop cycle identical to the f64 path's, so the truncated
+/// gradient is the exact derivative of the truncated value (see [`crate::sens::propagate::ss_dual_cycle_should_stop`]).
+///
+/// **Mixed `atol`/`rtol` test on the per-cycle *increment*** (#532 review #1): a compartment
+/// is converged when its movement since the previous cycle is below `tol·|cur| + tol·max_mag`
+/// — negligible both relative to itself and relative to the dominant compartment. Testing the
+/// *increment* (not the magnitude) is what makes this safe in a scale-separated model: a small
+/// compartment still in transit (effect-site / metabolite many orders below central) keeps the
+/// loop running until it too stops moving, rather than being declared converged merely for
+/// being small. The `tol·max_mag` term is the absolute floor that lets a genuinely-settled
+/// near-zero compartment — where the pure relative test is ill-conditioned — pass; without it
+/// the loop could never stop. Because the stop only fires once every compartment's increment
+/// is below f64-relative precision, the value has reached its fixed point and the elided cycles
+/// do not move it — predictions are unchanged to f64 precision, and gradients match a full
+/// budget to `< 1e-6` (see `ode_provider_ss_early_stop_matches_full_budget`).
+///
+/// A **non-finite** (`NaN`/`Inf`) compartment means the integration blew up: never report
+/// convergence — don't early-exit and silently return a poisoned state; run the full cycle
+/// budget exactly as the pre-#519 code did so the failure surfaces identically (#532 review
+/// #4). Required because `f64::max` would otherwise *drop* a `NaN` and mask it.
+pub(crate) fn ss_cycle_converged(cur: &[f64], prev: &[f64], tol: f64) -> bool {
+    // Test-only escape hatch: force every path to run the full cycle budget so a test can
+    // compare the early-stopped result against the fully-equilibrated one (#532 review #4).
+    #[cfg(test)]
+    if FORCE_FULL_SS_EQUILIBRATION.with(|c| c.get()) {
+        return false;
+    }
+    if cur.iter().any(|x| !x.is_finite()) {
+        return false;
+    }
+    let max_mag = cur.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
+    let atol = tol * max_mag;
+    cur.iter()
+        .zip(prev)
+        .all(|(&a, &b)| (a - b).abs() <= tol * a.abs() + atol)
+}
+
+/// Rolling prev-state tracker for the f64 SS-equilibration early stop. Owns the previous
+/// cycle's state so the f64 predictor and the event-driven f64 loop share one scaffold instead
+/// of each re-implementing the `cycle > 0` + `copy_from_slice` dance — a later tweak missed in
+/// one site would reintroduce cross-path trough drift (#532 review #6). The dual paths use the
+/// generic [`crate::sens::propagate::ss_dual_cycle_should_stop`], which applies the same
+/// [`ss_cycle_converged`] criterion to the value parts of the dual state.
+#[derive(Default)]
+pub(crate) struct SsStopTracker {
+    prev: Vec<f64>,
+}
+
+impl SsStopTracker {
+    /// Record `cur` and report whether the trough has converged (from cycle 1 on). Returns
+    /// `true` to break the equilibration loop.
+    pub(crate) fn should_stop(&mut self, cycle: usize, cur: &[f64]) -> bool {
+        if cycle > 0 && ss_cycle_converged(cur, &self.prev, SS_EQUILIBRATION_TOL) {
+            return true;
+        }
+        self.prev.clear();
+        self.prev.extend_from_slice(cur);
+        false
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Cycles the most recent SS-equilibration call ran — a **test-only** observation of the
+    /// #519 early stop, so a test can assert it fired for fast PK and ran the full budget for
+    /// slow PK (#532 review #5/#6 — otherwise the stop logic ships unverified, since the loose
+    /// end-value tolerances absorb a too-early exit). Set by the f64 predictor, the dual ODE /
+    /// closed-form loops, and the event-driven loop.
+    static LAST_SS_EQUILIBRATION_CYCLES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+
+    /// When set, [`ss_cycle_converged`] always reports "not converged" so every path runs the
+    /// full cycle budget — lets a test pin that early-stop is value-preserving vs full
+    /// equilibration (#532 review #4).
+    static FORCE_FULL_SS_EQUILIBRATION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn record_ss_equilibration_cycles(n: usize) {
+    LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.set(n));
+}
+
+/// Cycles the most recent SS-equilibration call ran (test observation; see above).
+#[cfg(test)]
+pub(crate) fn last_ss_equilibration_cycles() -> usize {
+    LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get())
+}
+
+/// Run `f` with every SS-equilibration path forced to the full cycle budget (#532 review #4).
+/// The reset rides a drop guard so a panic in `f` cannot leave the flag set and poison a later
+/// test sharing the harness thread.
+#[cfg(test)]
+pub(crate) fn with_full_ss_equilibration<R>(f: impl FnOnce() -> R) -> R {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(false));
+        }
+    }
+    FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(true));
+    let _reset = Reset;
+    f()
+}
+
+/// No-op in non-test builds (zero cost on the hot path).
+#[cfg(not(test))]
+#[inline(always)]
+pub(crate) fn record_ss_equilibration_cycles(_n: usize) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cancel;
 #[cfg(feature = "survival")]
 pub mod categorical;
 pub mod diagnostics;
+pub(crate) mod dosing;
 pub mod environment;
 pub mod estimation;
 pub mod frem;

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -19,7 +19,6 @@ use crate::sim::adaptive::{
 #[cfg(test)]
 use crate::sim::adaptive::MonitorSpec;
 use crate::types::{DoseEvent, PkParams, Subject};
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Epsilon used to decide whether an infusion fully spans a segment.
@@ -46,60 +45,14 @@ pub(crate) fn is_real_infusion(d: &DoseEvent) -> bool {
     d.is_infusion() && d.duration > 0.0 && d.duration.is_finite()
 }
 
-/// Resolve any modeled-`RATE` doses (#324, e.g. `RATE=-2` → modeled duration
-/// `D{cmt}`) in `subject` to concrete (`Fixed`) doses. `pk_for_dose(k)` supplies
-/// the per-dose `PkParams::values` slice used to evaluate dose `k`'s modeled
-/// parameter — pass a constant closure for the no-TV-covariate paths (see
-/// [`resolve_subject_doses`]) or `|k| &pk_at_dose[k].values` for the per-dose
-/// event-driven path. Returns the subject **borrowed** (no allocation) when every
-/// dose is already `Fixed` (the common case — see [`Subject::all_doses_fixed`]),
-/// and an owned copy with resolved `doses` otherwise.
-///
-/// Single source of truth: every ODE entrypoint funnels its subject through this
-/// (or the thin [`resolve_subject_doses`] wrapper) before building the dose
-/// timeline, so the integrator and SS helpers only ever see a concrete
-/// `rate`/`duration` and a coded `RATE=-2` cannot reach them unresolved.
-///
-/// The owned branch clones the whole `Subject`, not just `doses`, because the
-/// downstream machinery ([`crate::pk::event_driven::EventSchedule::for_subject`],
-/// the SS pre-equilibration, the break-time timeline) consumes a unified
-/// `&Subject` and reads `obs_times` / `pk_only_times` / `reset_times` alongside
-/// the resolved `doses`. Cloning only `doses` would force every one of those deep
-/// helpers to take the resolved doses as a separate argument — the
-/// "thread the resolved doses through every helper" design that was deliberately
-/// rejected in favour of resolving once at the entrypoint. The clone is paid
-/// only on the (uncommon) modeled-`RATE` path; the all-`Fixed` path is borrowed.
-pub(crate) fn resolve_subject_doses_with<'a>(
-    subject: &'a Subject,
-    attr_map: &crate::types::DoseAttrMap,
-    pk_for_dose: impl Fn(usize) -> &'a [f64],
-) -> Cow<'a, Subject> {
-    // Fast path: with no compartment-indexed attribute there can be no modeled
-    // dose to resolve, so skip the per-dose `all_doses_fixed()` scan entirely —
-    // the overwhelmingly common case (no `D{cmt}`). A modeled dose cannot reach
-    // here with an empty map: it would have been rejected by the data gate first.
-    if attr_map.is_empty() || subject.all_doses_fixed() {
-        return Cow::Borrowed(subject);
-    }
-    let mut owned = subject.clone();
-    for (k, d) in owned.doses.iter_mut().enumerate() {
-        *d = d.resolve_rate(attr_map, pk_for_dose(k));
-    }
-    Cow::Owned(owned)
-}
-
-/// Resolve modeled-`RATE` doses using `params` for **every** dose — the
-/// no-time-varying-covariate ODE paths, where the PK snapshot is constant across
-/// doses. The event-driven / TV-covariate path calls
-/// [`resolve_subject_doses_with`] directly with a per-dose closure. See
-/// [`resolve_subject_doses_with`].
-pub(crate) fn resolve_subject_doses<'a>(
-    subject: &'a Subject,
-    attr_map: &crate::types::DoseAttrMap,
-    params: &'a [f64],
-) -> Cow<'a, Subject> {
-    resolve_subject_doses_with(subject, attr_map, |_| params)
-}
+// Dose resolution + SS-equilibration primitives moved to `crate::dosing` (a
+// neutral leaf module) so pk/sens/api don't depend upward on ode/. Re-exported
+// here (permanent) so the ode-internal callers + `crate::ode::*` paths still resolve.
+pub(crate) use crate::dosing::{
+    record_ss_equilibration_cycles, resolve_subject_doses, resolve_subject_doses_with,
+    ss_cycle_converged, SsStopTracker, SS_EQUILIBRATION_CYCLES, SS_EQUILIBRATION_TOL,
+    SS_TAIL_REL_FLOOR,
+};
 
 /// The time at which a subject's integration begins: the earliest event on the
 /// subject's timeline (first dose, observation, PK-only sample, or reset).
@@ -131,147 +84,6 @@ pub(crate) fn subject_integration_start(subject: &Subject) -> f64 {
         0.0
     }
 }
-
-/// Number of dosing cycles to simulate when pre-equilibrating an SS=1
-/// dose. With a typical t₁/₂/II ratio under 2 (the common clinical range)
-/// this is comfortably past saturation — each additional cycle adds
-/// `exp(-k·II)` of the prior decay, so by N=50 the truncation tail is
-/// well below 1e-6 for any reasonable PK. The analytic-sensitivity SS
-/// equilibration (`sens::ode_provider::equilibrate_ss_state_g`) reuses this
-/// same constant so its trough can't drift from this f64 predictor (#473 review #11).
-pub(crate) const SS_EQUILIBRATION_CYCLES: usize = 50;
-
-/// Relative-`L∞` tolerance for the steady-state equilibration **early stop** (#519). The
-/// `(apply dose; integrate II)` cycle is a geometric contraction with ratio `≈ exp(−λ·II)`;
-/// once the cycle-to-cycle state change falls below this *relative* threshold, every
-/// remaining cycle would move the trough by less still, so the truncation is already at f64
-/// precision and we stop. Conservative (`1e-12`): the dropped tail is far below the
-/// `provider`-vs-production parity tolerance, so the value is unchanged for any realistic
-/// PK. Fast disposition (`λ·II ≈ 2`) converges in ~14 cycles; slow PK (`λ·II ≈ 0.1`) never
-/// trips it and runs the full [`SS_EQUILIBRATION_CYCLES`] — identical to the old behaviour.
-pub(crate) const SS_EQUILIBRATION_TOL: f64 = 1e-12;
-
-/// Relative floor for truncating the steady-state **input-rate periodic sum** (#719). An
-/// `SS=1` dose into a built-in absorption compartment stands for an infinite past pulse
-/// train, so its appearance rate at time `t` is `Σ_{j≥0} R_in(tad + j·II)` — the tail of
-/// every prior pulse still arriving (see [`add_prepared_input_rate_forcing`]). The absorption
-/// density is eventually monotone-decreasing, so once a term falls below this fraction of the
-/// running sum the remaining tail is spent and the sum stops (hard-capped at
-/// [`SS_EQUILIBRATION_CYCLES`] so a pathologically slow absorption — mode ≫ II — still
-/// terminates, matching the trough's own cycle budget). Conservative (`1e-10`): the dropped
-/// tail is far below the provider-vs-production parity tolerance.
-pub(crate) const SS_TAIL_REL_FLOOR: f64 = 1e-10;
-
-/// Whether the SS-equilibration trough has converged between two successive cycles. Shared
-/// by the f64 predictor, the event-driven f64 loop, and the dual gradient path so every path
-/// truncates on the *same* criterion — the dual feeds the value parts (`PkNum::val`) of its
-/// state (#519), which keeps its stop cycle identical to the f64 path's, so the truncated
-/// gradient is the exact derivative of the truncated value (see [`crate::sens::propagate::ss_dual_cycle_should_stop`]).
-///
-/// **Mixed `atol`/`rtol` test on the per-cycle *increment*** (#532 review #1): a compartment
-/// is converged when its movement since the previous cycle is below `tol·|cur| + tol·max_mag`
-/// — negligible both relative to itself and relative to the dominant compartment. Testing the
-/// *increment* (not the magnitude) is what makes this safe in a scale-separated model: a small
-/// compartment still in transit (effect-site / metabolite many orders below central) keeps the
-/// loop running until it too stops moving, rather than being declared converged merely for
-/// being small. The `tol·max_mag` term is the absolute floor that lets a genuinely-settled
-/// near-zero compartment — where the pure relative test is ill-conditioned — pass; without it
-/// the loop could never stop. Because the stop only fires once every compartment's increment
-/// is below f64-relative precision, the value has reached its fixed point and the elided cycles
-/// do not move it — predictions are unchanged to f64 precision, and gradients match a full
-/// budget to `< 1e-6` (see `ode_provider_ss_early_stop_matches_full_budget`).
-///
-/// A **non-finite** (`NaN`/`Inf`) compartment means the integration blew up: never report
-/// convergence — don't early-exit and silently return a poisoned state; run the full cycle
-/// budget exactly as the pre-#519 code did so the failure surfaces identically (#532 review
-/// #4). Required because `f64::max` would otherwise *drop* a `NaN` and mask it.
-pub(crate) fn ss_cycle_converged(cur: &[f64], prev: &[f64], tol: f64) -> bool {
-    // Test-only escape hatch: force every path to run the full cycle budget so a test can
-    // compare the early-stopped result against the fully-equilibrated one (#532 review #4).
-    #[cfg(test)]
-    if FORCE_FULL_SS_EQUILIBRATION.with(|c| c.get()) {
-        return false;
-    }
-    if cur.iter().any(|x| !x.is_finite()) {
-        return false;
-    }
-    let max_mag = cur.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
-    let atol = tol * max_mag;
-    cur.iter()
-        .zip(prev)
-        .all(|(&a, &b)| (a - b).abs() <= tol * a.abs() + atol)
-}
-
-/// Rolling prev-state tracker for the f64 SS-equilibration early stop. Owns the previous
-/// cycle's state so the f64 predictor and the event-driven f64 loop share one scaffold instead
-/// of each re-implementing the `cycle > 0` + `copy_from_slice` dance — a later tweak missed in
-/// one site would reintroduce cross-path trough drift (#532 review #6). The dual paths use the
-/// generic [`crate::sens::propagate::ss_dual_cycle_should_stop`], which applies the same
-/// [`ss_cycle_converged`] criterion to the value parts of the dual state.
-#[derive(Default)]
-pub(crate) struct SsStopTracker {
-    prev: Vec<f64>,
-}
-
-impl SsStopTracker {
-    /// Record `cur` and report whether the trough has converged (from cycle 1 on). Returns
-    /// `true` to break the equilibration loop.
-    pub(crate) fn should_stop(&mut self, cycle: usize, cur: &[f64]) -> bool {
-        if cycle > 0 && ss_cycle_converged(cur, &self.prev, SS_EQUILIBRATION_TOL) {
-            return true;
-        }
-        self.prev.clear();
-        self.prev.extend_from_slice(cur);
-        false
-    }
-}
-
-#[cfg(test)]
-thread_local! {
-    /// Cycles the most recent SS-equilibration call ran — a **test-only** observation of the
-    /// #519 early stop, so a test can assert it fired for fast PK and ran the full budget for
-    /// slow PK (#532 review #5/#6 — otherwise the stop logic ships unverified, since the loose
-    /// end-value tolerances absorb a too-early exit). Set by the f64 predictor, the dual ODE /
-    /// closed-form loops, and the event-driven loop.
-    static LAST_SS_EQUILIBRATION_CYCLES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-
-    /// When set, [`ss_cycle_converged`] always reports "not converged" so every path runs the
-    /// full cycle budget — lets a test pin that early-stop is value-preserving vs full
-    /// equilibration (#532 review #4).
-    static FORCE_FULL_SS_EQUILIBRATION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-}
-
-#[cfg(test)]
-pub(crate) fn record_ss_equilibration_cycles(n: usize) {
-    LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.set(n));
-}
-
-/// Cycles the most recent SS-equilibration call ran (test observation; see above).
-#[cfg(test)]
-pub(crate) fn last_ss_equilibration_cycles() -> usize {
-    LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get())
-}
-
-/// Run `f` with every SS-equilibration path forced to the full cycle budget (#532 review #4).
-/// The reset rides a drop guard so a panic in `f` cannot leave the flag set and poison a later
-/// test sharing the harness thread.
-#[cfg(test)]
-pub(crate) fn with_full_ss_equilibration<R>(f: impl FnOnce() -> R) -> R {
-    struct Reset;
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(false));
-        }
-    }
-    FORCE_FULL_SS_EQUILIBRATION.with(|c| c.set(true));
-    let _reset = Reset;
-    f()
-}
-
-/// No-op in non-test builds (zero cost on the hot path).
-#[cfg(not(test))]
-#[inline(always)]
-pub(crate) fn record_ss_equilibration_cycles(_n: usize) {}
 
 /// Closed-form periodic steady-state trough for an `SS=1` dose into a built-in absorption
 /// input-rate compartment on a **linear** disposition (#719).
@@ -9883,7 +9695,7 @@ mod tests {
         // so the early stop fires well inside SS_EQUILIBRATION_CYCLES.
         let fast = pk_one(20.0, 10.0);
         let _ = equilibrate_ss_state(&ode, &fast.values, &dose, &ode.solver_opts);
-        let fast_cycles = LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get());
+        let fast_cycles = crate::dosing::last_ss_equilibration_cycles();
         assert!(
             (2..SS_EQUILIBRATION_CYCLES).contains(&fast_cycles),
             "fast PK should early-stop inside the budget, ran {fast_cycles}"
@@ -9894,7 +9706,7 @@ mod tests {
         // pre-existing slow-PK truncation, tracked separately — #532 review #12).
         let slow = pk_one(0.05, 100.0);
         let _ = equilibrate_ss_state(&ode, &slow.values, &dose, &ode.solver_opts);
-        let slow_cycles = LAST_SS_EQUILIBRATION_CYCLES.with(|c| c.get());
+        let slow_cycles = crate::dosing::last_ss_equilibration_cycles();
         assert_eq!(
             slow_cycles, SS_EQUILIBRATION_CYCLES,
             "slow PK should run the full budget, ran {slow_cycles}"

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -45,14 +45,30 @@ pub(crate) fn is_real_infusion(d: &DoseEvent) -> bool {
     d.is_infusion() && d.duration > 0.0 && d.duration.is_finite()
 }
 
-// Dose resolution + SS-equilibration primitives moved to `crate::dosing` (a
-// neutral leaf module) so pk/sens/api don't depend upward on ode/. Re-exported
-// here (permanent) so the ode-internal callers + `crate::ode::*` paths still resolve.
-pub(crate) use crate::dosing::{
+// Dose resolution + SS-equilibration primitives moved to `crate::dosing` (a neutral
+// leaf module) so pk/sens/api don't depend upward on ode/. A PRIVATE import (NOT a
+// `pub(crate) use` re-export) so these do not leak back out as `crate::ode::…` — the
+// upward dependency this move removed stays removed. The ode-internal resolve callers
+// + `equilibrate_ss_state` use the bare names; the `#[cfg(test)] mod tests` picks them
+// up via `use super::*`. Test-only symbols (`ss_cycle_converged`, `SS_EQUILIBRATION_TOL`,
+// `last_ss_equilibration_cycles`, `with_full_ss_equilibration`) are referenced directly
+// as `crate::dosing::…` by the tests, so they are not imported here.
+use crate::dosing::{
     record_ss_equilibration_cycles, resolve_subject_doses, resolve_subject_doses_with,
-    ss_cycle_converged, SsStopTracker, SS_EQUILIBRATION_CYCLES, SS_EQUILIBRATION_TOL,
-    SS_TAIL_REL_FLOOR,
+    SsStopTracker, SS_EQUILIBRATION_CYCLES,
 };
+
+/// Relative floor for truncating the steady-state **input-rate periodic sum** (#719). An
+/// `SS=1` dose into a built-in absorption compartment stands for an infinite past pulse
+/// train, so its appearance rate at time `t` is `Σ_{j≥0} R_in(tad + j·II)` — the tail of
+/// every prior pulse still arriving (see [`add_prepared_input_rate_forcing`]). The absorption
+/// density is eventually monotone-decreasing, so once a term falls below this fraction of the
+/// running sum the remaining tail is spent and the sum stops (hard-capped at
+/// [`crate::dosing::SS_EQUILIBRATION_CYCLES`] so a pathologically slow absorption — mode ≫ II
+/// — still terminates, matching the trough's own cycle budget). Conservative (`1e-10`): the
+/// dropped tail is far below the provider-vs-production parity tolerance. (Kept in
+/// `ode/predictions` — its only consumers — rather than in the neutral `dosing` module.)
+const SS_TAIL_REL_FLOOR: f64 = 1e-10;
 
 /// The time at which a subject's integration begins: the earliest event on the
 /// subject's timeline (first dose, observation, PK-only sample, or reset).
@@ -9621,6 +9637,9 @@ mod tests {
 
     #[test]
     fn ss_cycle_converged_is_mixed_atol_rtol_on_increment() {
+        // Referenced directly from `crate::dosing` (test-only here — not re-exported by
+        // the private facade above).
+        use crate::dosing::{ss_cycle_converged, SS_EQUILIBRATION_TOL};
         // Increment below tol: a 1e-13 move on a magnitude-100 state is ≪ tol·(|a| + max) →
         // converged.
         assert!(ss_cycle_converged(

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -307,12 +307,6 @@ fn state_layout(pk_model: PkModel) -> (usize, usize) {
     pk_model.topology().state_layout()
 }
 
-/// Number of cycles to expand for SS equilibration in the event-driven
-/// analytical path. Matches the ODE-side default in `ode/predictions.rs`
-/// for consistency. 50 cycles puts `exp(-50·k·II)` well below 1e-9 of
-/// the SS amount for any realistic PK.
-const EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES: usize = 50;
-
 /// Pre-equilibrate the event-driven analytical state to its SS value for
 /// an SS=1 dose. Same scheme as `ode/predictions.rs::equilibrate_ss_state`:
 /// reset state, then loop N cycles of (apply dose; propagate one II).
@@ -369,9 +363,9 @@ fn equilibrate_ss_state_event_driven(
     let mut eigen = crate::sens::propagate::EigenCacheG::default();
     // Shared early stop (#519, #532 review #6/#11): same mixed atol/rtol criterion and scaffold
     // (`SsStopTracker`) as the ODE f64 path.
-    let mut tracker = crate::ode::predictions::SsStopTracker::default();
+    let mut tracker = crate::dosing::SsStopTracker::default();
     let mut cycles_run = 0usize;
-    for cycle in 0..EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES {
+    for cycle in 0..crate::dosing::SS_EQUILIBRATION_CYCLES {
         if !is_inf {
             // Bolus pulse: instantaneous amount jump (with F).
             state[cmt_idx] += pk.bioavailable_amount(dose.amt);
@@ -391,7 +385,7 @@ fn equilibrate_ss_state_event_driven(
             break;
         }
     }
-    crate::ode::predictions::record_ss_equilibration_cycles(cycles_run);
+    crate::dosing::record_ss_equilibration_cycles(cycles_run);
 
     state
 }

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -940,7 +940,7 @@ pub fn predict_iov(
         // reads the analytical model's `dose_attr_map`.) Borrowed no-op when every
         // dose is already `Fixed`.
         let resolved =
-            crate::ode::resolve_subject_doses_with(subject, model.active_dose_attr_map(), |k| {
+            crate::dosing::resolve_subject_doses_with(subject, model.active_dose_attr_map(), |k| {
                 &dose_params[k].values
             });
         event_driven::event_driven_predictions(
@@ -1802,7 +1802,7 @@ pub fn compute_predictions_with_states(
             // Reached only when !uses_time (guarded above), so t=0 is exact.
             let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
             // Resolve modeled-`RATE` doses (#394) before the superposition states.
-            let resolved = crate::ode::resolve_subject_doses(
+            let resolved = crate::dosing::resolve_subject_doses(
                 subject,
                 model.active_dose_attr_map(),
                 &pk.values,
@@ -2071,7 +2071,7 @@ pub fn compute_predictions_with_tv_into_with_schedule(
         // event-driven walker builds its infusion bounds. Borrowed (no allocation)
         // for the all-`Fixed` common case.
         let resolved =
-            crate::ode::resolve_subject_doses_with(subject, model.active_dose_attr_map(), |k| {
+            crate::dosing::resolve_subject_doses_with(subject, model.active_dose_attr_map(), |k| {
                 &scratch.dose[k].values
             });
         // A cached `EventSchedule` was built from the *unresolved* subject, whose
@@ -2109,7 +2109,7 @@ pub fn compute_predictions_with_tv_into_with_schedule(
         let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
         // Resolve any modeled-`RATE` doses (#394) before the closed-form math.
         let resolved =
-            crate::ode::resolve_subject_doses(subject, model.active_dose_attr_map(), &pk.values);
+            crate::dosing::resolve_subject_doses(subject, model.active_dose_attr_map(), &pk.values);
         compute_predictions(model.pk_model, &resolved, &pk)
     };
 

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -3487,7 +3487,7 @@ fn pk_snapshot_equal<T: crate::sens::num::PkNum>(a: &[T], b: &[T]) -> bool {
 /// `equilibrate_ss_state`. NONMEM SS=1 loads the compartments with the steady-state
 /// amounts of an infinite-past pulse train of interval `II`. There is no closed form for
 /// a general ODE, so production expands the train as a **finite**
-/// [`crate::ode::predictions::SS_EQUILIBRATION_CYCLES`] loop of `(apply dose; integrate II)`
+/// [`crate::dosing::SS_EQUILIBRATION_CYCLES`] loop of `(apply dose; integrate II)`
 /// from a zero state, returning the pre-pulse trough (the shared const keeps this trough
 /// from drifting from the f64 predictor). Because the loop is finite and explicit, running
 /// it over the dual type `T` propagates `∂(SS state)/∂(θ,η)` directly — no implicit
@@ -3561,7 +3561,7 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
         let mut prev = vec![0.0_f64; n_states];
         let mut cur = vec![0.0_f64; n_states];
         let mut cycles_run = 0usize;
-        for cycle in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
+        for cycle in 0..crate::dosing::SS_EQUILIBRATION_CYCLES {
             let rhs_active = |us: &[T], ps: &[T], t: f64, du: &mut [T]| {
                 bare_rhs(us, ps, t, du);
                 if cmt_idx < du.len() {
@@ -3604,7 +3604,7 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
                 break;
             }
         }
-        crate::ode::predictions::record_ss_equilibration_cycles(cycles_run);
+        crate::dosing::record_ss_equilibration_cycles(cycles_run);
         return u;
     }
     // Bolus SS: each cycle applies the pulse `F·amt`, then decays over one interval.
@@ -3613,7 +3613,7 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
     let mut prev = vec![0.0_f64; n_states];
     let mut cur = vec![0.0_f64; n_states];
     let mut cycles_run = 0usize;
-    for cycle in 0..crate::ode::predictions::SS_EQUILIBRATION_CYCLES {
+    for cycle in 0..crate::dosing::SS_EQUILIBRATION_CYCLES {
         u[cmt_idx] = u[cmt_idx] + f_bio * amt;
         let sol = solve_ode_g(&bare_rhs, &u, (0.0, dose.ii), params, &saveat, opts);
         if let Some(last) = sol.last() {
@@ -3624,7 +3624,7 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
             break;
         }
     }
-    crate::ode::predictions::record_ss_equilibration_cycles(cycles_run);
+    crate::dosing::record_ss_equilibration_cycles(cycles_run);
     u
 }
 
@@ -7663,16 +7663,16 @@ mod tests {
         let eta = [0.1, 0.05];
 
         let early = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
-        let early_cycles = crate::ode::predictions::last_ss_equilibration_cycles();
-        let full = crate::ode::predictions::with_full_ss_equilibration(|| {
+        let early_cycles = crate::dosing::last_ss_equilibration_cycles();
+        let full = crate::dosing::with_full_ss_equilibration(|| {
             ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported")
         });
-        let full_cycles = crate::ode::predictions::last_ss_equilibration_cycles();
+        let full_cycles = crate::dosing::last_ss_equilibration_cycles();
 
         // The dual stop must actually fire on this model, or the comparison is vacuous (#532 #5).
         assert_eq!(
             full_cycles,
-            crate::ode::predictions::SS_EQUILIBRATION_CYCLES,
+            crate::dosing::SS_EQUILIBRATION_CYCLES,
             "forced-full must run the whole budget"
         );
         assert!(
@@ -7880,15 +7880,15 @@ mod tests {
         let eta = [0.1, 0.05];
 
         let early = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
-        let early_cycles = crate::ode::predictions::last_ss_equilibration_cycles();
-        let full = crate::ode::predictions::with_full_ss_equilibration(|| {
+        let early_cycles = crate::dosing::last_ss_equilibration_cycles();
+        let full = crate::dosing::with_full_ss_equilibration(|| {
             ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported")
         });
-        let full_cycles = crate::ode::predictions::last_ss_equilibration_cycles();
+        let full_cycles = crate::dosing::last_ss_equilibration_cycles();
 
         assert_eq!(
             full_cycles,
-            crate::ode::predictions::SS_EQUILIBRATION_CYCLES,
+            crate::dosing::SS_EQUILIBRATION_CYCLES,
             "forced-full must run the whole budget"
         );
         assert!(

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -699,10 +699,6 @@ impl<T: PkNum> OneCptPk<T> {
     }
 }
 
-/// Cycles to expand for SS equilibration — mirrors
-/// `event_driven::EVENT_DRIVEN_SS_EQUILIBRATION_CYCLES` (kept private there).
-const SS_EQUILIBRATION_CYCLES: usize = 50;
-
 /// State-vector dimension and central-compartment read-out slot for a `pk_model`.
 /// Mirrors `event_driven::state_layout` (kept private there). 3-cpt rows are
 /// included for the forthcoming extension; the walk currently propagates 1-/2-cpt.
@@ -1053,7 +1049,7 @@ fn obs_boundary_correction<T: PkNum>(
 
 /// Shared early-stop driver for the **dual** SS-equilibration loops (#519; #532 review #9/#10):
 /// refresh `cur` from the value parts (`PkNum::val`) of the dual state `u`, decide the stop on
-/// the *same* [`crate::ode::predictions::ss_cycle_converged`] criterion the f64 predictor uses
+/// the *same* [`crate::dosing::ss_cycle_converged`] criterion the f64 predictor uses
 /// (from cycle 1 on), and roll `cur`→`prev` by swap — no per-cycle `O(n_states)` copy. Returns
 /// `true` to break. Used by both `equilibrate_ss_g` (here) and `equilibrate_ss_state_g` (the
 /// ODE provider) so the dual convergence logic lives in **one** place.
@@ -1082,11 +1078,7 @@ pub(crate) fn ss_dual_cycle_should_stop<T: PkNum>(
         *c = x.val();
     }
     if cycle > 0
-        && crate::ode::predictions::ss_cycle_converged(
-            cur,
-            prev,
-            crate::ode::predictions::SS_EQUILIBRATION_TOL,
-        )
+        && crate::dosing::ss_cycle_converged(cur, prev, crate::dosing::SS_EQUILIBRATION_TOL)
     {
         return true;
     }
@@ -1142,7 +1134,7 @@ fn equilibrate_ss_g<T: PkNum>(
     let mut prev = vec![0.0_f64; n_states];
     let mut cur = vec![0.0_f64; n_states];
     let mut cycles_run = 0usize;
-    for cycle in 0..SS_EQUILIBRATION_CYCLES {
+    for cycle in 0..crate::dosing::SS_EQUILIBRATION_CYCLES {
         if !is_inf {
             state[cmt_idx] = state[cmt_idx] + pk.f * T::from_f64(dose.amt);
         }
@@ -1165,7 +1157,7 @@ fn equilibrate_ss_g<T: PkNum>(
             break;
         }
     }
-    crate::ode::predictions::record_ss_equilibration_cycles(cycles_run);
+    crate::dosing::record_ss_equilibration_cycles(cycles_run);
     state
 }
 


### PR DESCRIPTION
## Why
`resolve_subject_doses{,_with}` (the #324 single source of truth for turning modeled-`RATE`
doses into concrete `Fixed` doses) and the SS-equilibration primitives lived *inside*
`ode/predictions.rs`. That forced `pk/`, `sens/`, and `api` to depend **upward** on `ode/`
merely to resolve doses or to share the steady-state convergence policy — a dependency
inversion (the analytical/event-driven PK paths reaching into the ODE predictor). Two
`const … = 50` cycle-count shadows had also drifted into `pk/event_driven.rs` and
`sens/propagate.rs` alongside the canonical one.

## What changed
Moved the dose-resolution + SS-equilibration primitives **verbatim** into a new neutral
leaf module `crate::dosing`:

- `resolve_subject_doses`, `resolve_subject_doses_with`
- `SS_EQUILIBRATION_CYCLES`, `SS_EQUILIBRATION_TOL`, `SS_TAIL_REL_FLOOR`, `ss_cycle_converged`,
  `SsStopTracker`, `record_ss_equilibration_cycles`, and the test-only
  `last_ss_equilibration_cycles` / `with_full_ss_equilibration`.

`ode::predictions` re-exports all of them (`pub(crate) use crate::dosing::{..}`), so its 7
internal resolve callers + `equilibrate_ss_state` compile unchanged and every historical
`crate::ode::{resolve_subject_doses, predictions::*}` path still resolves. The ~30 external
call sites in `pk/{mod,event_driven}`, `sens/{propagate,ode_provider}`, and `api` are
repointed to `crate::dosing::…`, and the two duplicate `= 50` shadows are collapsed onto the
canonical `crate::dosing::SS_EQUILIBRATION_CYCLES` (50 == 50).

Net effect: `pk/` and `sens/` no longer reach up into `ode/` for dose resolution, and the SS
cycle count has exactly one definition.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` (crate-external) API changed — every moved symbol is `pub(crate)`; `crate::dosing`
itself is `pub(crate) mod`.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable — pure code motion. No f64 arithmetic is reordered; the two collapsed
  const shadows were both literally `50`.

```
cargo test --lib  →  2516 passed; 0 failed; 18 ignored
```
The dose/SS behaviour anchors stay green: `ss_cycle_converged_is_mixed_atol_rtol_on_increment`
(resolves `ss_cycle_converged` through the facade), `ss_equilibration_early_stop_fires_for_fast_pk`
(reads the moved thread-local via the `last_ss_equilibration_cycles()` accessor), and the
analytical/ODE resolve-dose paths.

## Performance
- [x] No significant impact expected (module boundary only; the `= 50` constants are unchanged).

## Tests
- [x] Existing dose/SS unit tests pass unchanged; the `ss_cycle_converged` test now co-locates
  conceptually with its code (kept in `predictions` via the facade to minimise churn).

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor)
- [x] No user-visible change

## Checklist
- [x] `rustfmt` clean
- [x] `Dual2` sensitivity path untouched — the moved `ss_cycle_converged` / `SsStopTracker` are
  the same `f64` SS-convergence helpers the sensitivity SS loops already called (now via
  `crate::dosing::` instead of `crate::ode::predictions::`); no generic/`PkNum` code moved.
- [ ] `cargo clippy` clean (not re-run locally)

## Reviewer hints
- The move is verbatim; the substantive surface is (a) the `ode::predictions` facade re-export
  (keeps internal callers + `crate::ode::*` paths resolving), and (b) the two collapsed const
  shadows — confirm `50 == 50`.
- Known unrelated pre-existing warning inherited from main (`run_covariance.rs:265`, an unused
  `mut` from #855) is **not** in this diff; I'll clean it separately.

## Open questions
- None.
