### PR TITLE
fix(estimation): drop unused mut on run_covariance's new_warnings

### DIFF
--- a/src/estimation/run_covariance.rs
+++ b/src/estimation/run_covariance.rs
@@ -262,7 +262,7 @@ pub fn run_covariance(
     let CovStepOutcome {
         matrix: covariance_matrix,
         wall_time_secs: covariance_wall_time_secs,
-        warnings: mut new_warnings,
+        warnings: new_warnings,
         sir_fallback_proposal: _,
     } = run_covariance_step_inner(
         &x_hat,


### PR DESCRIPTION
## Why
An `unused_mut` warning slipped into main via #855: run_covariance's `CovStepOutcome` destructure binds `warnings: mut new_warnings`, but the binding is only read (`out.warnings.extend(new_warnings)`), never mutated.

## What changed
One token: `warnings: mut new_warnings` → `warnings: new_warnings`.

## Numerical validation
- [x] Not applicable — removing `mut` on a never-mutated binding is compile-checked behaviour-preserving (a genuinely-mutated binding would fail to compile).

## Breaking changes
- [x] None

## Docs
- [x] No user-visible change (internal warning cleanup)