### PR TITLE
refactor(estimation): express the packing convention via one lower_tri_iter (closes #858 review #3)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{first_error, CheckReport, Diagnostic};
 use crate::estimation::outer_optimizer::optimize_population;
-use crate::estimation::parameterization::{chol_lt_idx, theta_packs_log};
+use crate::estimation::parameterization::{chol_lt_idx, lower_tri_iter, theta_packs_log};
 use crate::estimation::saem;
 use crate::io::datareader::{
     read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
@@ -8155,41 +8155,39 @@ pub(crate) fn extract_standard_errors(
         let cov_omega = cov.view((omega_start, omega_start), (n_lt, n_lt));
 
         let mut se_vec = Vec::with_capacity(n_lt);
-        // Column-major lower-triangle: for j in 0..n, for i in j..n
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                // Build gradient of omega_{ij} w.r.t. packed omega params.
-                // omega_{ij} = Σ_{k=0}^{j} L_{ik} * L_{jk}
-                let mut grad = vec![0.0f64; n_lt];
-                for k in 0..=j {
-                    let idx_ik = chol_lt_idx(i, k, n_eta);
-                    let idx_jk = chol_lt_idx(j, k, n_eta);
-                    // Chain rule: ∂L_{ab}/∂x_{ab} = L_{ab} if a==b (log), else 1.
-                    let chain_ik = if i == k { l[(i, k)] } else { 1.0 };
-                    let chain_jk = if j == k { l[(j, k)] } else { 1.0 };
-                    grad[idx_ik] += l[(j, k)] * chain_ik;
-                    if i != j {
-                        grad[idx_jk] += l[(i, k)] * chain_jk;
-                    } else {
-                        // i == j: both terms contribute to the same index
-                        grad[idx_ik] += l[(i, k)] * chain_ik;
-                    }
+        // Column-major lower-triangle order — single source: `lower_tri_iter`.
+        for (i, j) in lower_tri_iter(n_eta, false) {
+            // Build gradient of omega_{ij} w.r.t. packed omega params.
+            // omega_{ij} = Σ_{k=0}^{j} L_{ik} * L_{jk}
+            let mut grad = vec![0.0f64; n_lt];
+            for k in 0..=j {
+                let idx_ik = chol_lt_idx(i, k, n_eta);
+                let idx_jk = chol_lt_idx(j, k, n_eta);
+                // Chain rule: ∂L_{ab}/∂x_{ab} = L_{ab} if a==b (log), else 1.
+                let chain_ik = if i == k { l[(i, k)] } else { 1.0 };
+                let chain_jk = if j == k { l[(j, k)] } else { 1.0 };
+                grad[idx_ik] += l[(j, k)] * chain_ik;
+                if i != j {
+                    grad[idx_jk] += l[(i, k)] * chain_jk;
+                } else {
+                    // i == j: both terms contribute to the same index
+                    grad[idx_ik] += l[(i, k)] * chain_ik;
                 }
-                // SE²(omega_{ij}) = g^T * C_omega * g
-                let mut var = 0.0;
-                for a in 0..n_lt {
-                    if grad[a] == 0.0 {
+            }
+            // SE²(omega_{ij}) = g^T * C_omega * g
+            let mut var = 0.0;
+            for a in 0..n_lt {
+                if grad[a] == 0.0 {
+                    continue;
+                }
+                for b in 0..n_lt {
+                    if grad[b] == 0.0 {
                         continue;
                     }
-                    for b in 0..n_lt {
-                        if grad[b] == 0.0 {
-                            continue;
-                        }
-                        var += grad[a] * cov_omega[(a, b)] * grad[b];
-                    }
+                    var += grad[a] * cov_omega[(a, b)] * grad[b];
                 }
-                se_vec.push(if var > 0.0 { var.sqrt() } else { 0.0 });
             }
+            se_vec.push(if var > 0.0 { var.sqrt() } else { 0.0 });
         }
         se_vec
     };

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -71,28 +71,12 @@ pub(crate) fn packed_param_label(packed_idx: usize, template: &ModelParameters) 
         format!("theta[{}]", name)
     } else if packed_idx < n_theta + n_omega {
         let omega_idx = packed_idx - n_theta;
-        let (row, col) = if template.omega.diagonal {
-            (omega_idx, omega_idx)
-        } else {
-            let mut cnt = 0usize;
-            let mut found = false;
-            let mut res = (0, 0);
-            'search: for c in 0..n_eta {
-                for r in c..n_eta {
-                    if cnt == omega_idx {
-                        res = (r, c);
-                        found = true;
-                        break 'search;
-                    }
-                    cnt += 1;
-                }
-            }
-            debug_assert!(
-                found,
-                "unreachable: omega_idx={omega_idx} >= n_omega={n_omega}"
-            );
-            res
-        };
+        // Decode a packed Ω index back to (row, col) via the centralized packing
+        // order (single source: `lower_tri_entries`; `omega_idx < n_omega` here, so
+        // the index is always in range). Cold path (labelling), so the Vec is fine.
+        let (row, col) =
+            crate::estimation::parameterization::lower_tri_entries(n_eta, template.omega.diagonal)
+                [omega_idx];
         let nr = template
             .omega
             .eta_names

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -895,17 +895,8 @@ fn subject_nll_pop_grad_analytical(
 
     // ── Omega packed parameters ────────────────────────────────────────────
     let omega_start = n_theta;
-    let omega_entries: Vec<(usize, usize)> = if template.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut v = Vec::new();
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                v.push((i, j));
-            }
-        }
-        v
-    };
+    // Single source: same column-major lower-tri order as `pack_params`.
+    let omega_entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, template.omega.diagonal);
     let free_mask = &template.omega.free_mask;
 
     for (ko, &(row, col)) in omega_entries.iter().enumerate() {
@@ -1339,17 +1330,8 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
     let g_mat: DMatrix<f64> = &omega.inv * &htilde_inv * &omega.inv;
 
     let omega_start = n_theta;
-    let omega_entries: Vec<(usize, usize)> = if template.omega.diagonal {
-        (0..n_eta).map(|i| (i, i)).collect()
-    } else {
-        let mut v = Vec::new();
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                v.push((i, j));
-            }
-        }
-        v
-    };
+    // Single source: same column-major lower-tri order as `pack_params`.
+    let omega_entries: Vec<(usize, usize)> = lower_tri_entries(n_eta, template.omega.diagonal);
     let l_omega = &omega.chol;
     let free_mask = &template.omega.free_mask;
 

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -52,22 +52,15 @@ pub fn pack_params(params: &ModelParameters) -> Vec<f64> {
         }
     }
 
-    // Omega Cholesky factor: diagonal as log, off-diagonal as-is
+    // Omega Cholesky factor: diagonal as log, off-diagonal as-is. `lower_tri_iter`
+    // yields only `(i,i)` when `diagonal`, so this one loop covers both cases.
     let l = &params.omega.chol;
     let n_eta = l.nrows();
-    if params.omega.diagonal {
-        for i in 0..n_eta {
-            v.push(l[(i, i)].max(1e-10).ln());
-        }
-    } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                if i == j {
-                    v.push(l[(i, j)].max(1e-10).ln());
-                } else {
-                    v.push(l[(i, j)]);
-                }
-            }
+    for (i, j) in lower_tri_iter(n_eta, params.omega.diagonal) {
+        if i == j {
+            v.push(l[(i, j)].max(1e-10).ln());
+        } else {
+            v.push(l[(i, j)]);
         }
     }
 
@@ -79,20 +72,11 @@ pub fn pack_params(params: &ModelParameters) -> Vec<f64> {
     // IOV omega: diagonal elements as log; off-diagonal as-is (mirrors BSV omega).
     if let Some(ref iov) = params.omega_iov {
         let l = &iov.chol;
-        let n = iov.dim();
-        if iov.diagonal {
-            for i in 0..n {
-                v.push(l[(i, i)].max(1e-10).ln());
-            }
-        } else {
-            for j in 0..n {
-                for i in j..n {
-                    if i == j {
-                        v.push(l[(i, j)].max(1e-10).ln());
-                    } else {
-                        v.push(l[(i, j)]);
-                    }
-                }
+        for (i, j) in lower_tri_iter(iov.dim(), iov.diagonal) {
+            if i == j {
+                v.push(l[(i, j)].max(1e-10).ln());
+            } else {
+                v.push(l[(i, j)]);
             }
         }
     }
@@ -120,24 +104,12 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
         })
         .collect();
 
-    // Omega Cholesky
+    // Omega Cholesky. `lower_tri_iter` yields only `(i,i)` when `diagonal`, so this
+    // one loop covers both cases (same packed order as `pack_params`).
     let mut l = DMatrix::zeros(n_eta, n_eta);
-    if template.omega.diagonal {
-        for i in 0..n_eta {
-            l[(i, i)] = v[idx].exp();
-            idx += 1;
-        }
-    } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                if i == j {
-                    l[(i, j)] = v[idx].exp();
-                } else {
-                    l[(i, j)] = v[idx];
-                }
-                idx += 1;
-            }
-        }
+    for (i, j) in lower_tri_iter(n_eta, template.omega.diagonal) {
+        l[(i, j)] = if i == j { v[idx].exp() } else { v[idx] };
+        idx += 1;
     }
     let omega = OmegaMatrix::from_chol_factor(
         l,
@@ -175,15 +147,9 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
             ))
         } else {
             let mut l = DMatrix::zeros(n_iov, n_iov);
-            for j in 0..n_iov {
-                for i in j..n_iov {
-                    if i == j {
-                        l[(i, j)] = v[idx].exp();
-                    } else {
-                        l[(i, j)] = v[idx];
-                    }
-                    idx += 1;
-                }
+            for (i, j) in lower_tri_iter(n_iov, false) {
+                l[(i, j)] = if i == j { v[idx].exp() } else { v[idx] };
+                idx += 1;
             }
             Some(OmegaMatrix::from_chol_factor(
                 l,
@@ -230,18 +196,12 @@ pub fn packed_fixed_mask(template: &ModelParameters) -> Vec<bool> {
 
     let n_eta = template.omega.dim();
     let omega_fixed: &[bool] = &template.omega_fixed;
-    if template.omega.diagonal {
-        for i in 0..n_eta {
-            mask.push(omega_fixed.get(i).copied().unwrap_or(false));
-        }
-    } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                let fi = omega_fixed.get(i).copied().unwrap_or(false);
-                let fj = omega_fixed.get(j).copied().unwrap_or(false);
-                mask.push(fi || fj);
-            }
-        }
+    // `lower_tri_iter` yields only `(i,i)` when diagonal, where `fi || fj`
+    // reduces to `omega_fixed[i]` — the same value the diagonal branch pushed.
+    for (i, j) in lower_tri_iter(n_eta, template.omega.diagonal) {
+        let fi = omega_fixed.get(i).copied().unwrap_or(false);
+        let fj = omega_fixed.get(j).copied().unwrap_or(false);
+        mask.push(fi || fj);
     }
 
     for &f in &template.sigma_fixed {
@@ -250,20 +210,11 @@ pub fn packed_fixed_mask(template: &ModelParameters) -> Vec<bool> {
 
     // IOV: mirrors BSV omega mask logic, checking the diagonal flag.
     if let Some(ref iov) = template.omega_iov {
-        let n = iov.dim();
         let kf = &template.kappa_fixed;
-        if iov.diagonal {
-            for i in 0..n {
-                mask.push(kf.get(i).copied().unwrap_or(false));
-            }
-        } else {
-            for j in 0..n {
-                for i in j..n {
-                    let fi = kf.get(i).copied().unwrap_or(false);
-                    let fj = kf.get(j).copied().unwrap_or(false);
-                    mask.push(fi || fj);
-                }
-            }
+        for (i, j) in lower_tri_iter(iov.dim(), iov.diagonal) {
+            let fi = kf.get(i).copied().unwrap_or(false);
+            let fj = kf.get(j).copied().unwrap_or(false);
+            mask.push(fi || fj);
         }
     }
 
@@ -288,15 +239,12 @@ pub fn omega_structural_zero_mask(template: &ModelParameters) -> Vec<bool> {
         if om.diagonal {
             return; // diagonal Ω has no off-diagonal entries to mark
         }
-        let n = om.dim();
         let mut p = start;
-        for j in 0..n {
-            for i in j..n {
-                if i != j && !om.free_mask[(i, j)] {
-                    mask[p] = true;
-                }
-                p += 1;
+        for (i, j) in lower_tri_iter(om.dim(), false) {
+            if i != j && !om.free_mask[(i, j)] {
+                mask[p] = true;
             }
+            p += 1;
         }
     };
 
@@ -370,22 +318,15 @@ pub fn compute_bounds(template: &ModelParameters) -> PackedBounds {
     // whose covariate omega diagonals can reach 15 000+.  With 6.0 the cap
     // is exp(6) ≈ 403, max variance ≈ 162 000 — sufficient for practical
     // FREM covariate variances while still preventing runaway.
-    if template.omega.diagonal {
-        for _ in 0..n_eta {
-            lower.push(-6.0); // exp(-6) ≈ 0.0025
-            upper.push(6.0); // exp(6) ≈ 403
-        }
-    } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                if i == j {
-                    lower.push(-6.0);
-                    upper.push(6.0);
-                } else {
-                    lower.push(-10.0);
-                    upper.push(10.0);
-                }
-            }
+    // `lower_tri_iter` yields only `(i,i)` when diagonal, so the `i == j` arm
+    // (`[-6, 6]`) covers the diagonal case; off-diagonals get `[-10, 10]`.
+    for (i, j) in lower_tri_iter(n_eta, template.omega.diagonal) {
+        if i == j {
+            lower.push(-6.0); // exp(-6) ≈ 0.0025 .. exp(6) ≈ 403
+            upper.push(6.0);
+        } else {
+            lower.push(-10.0);
+            upper.push(10.0);
         }
     }
 
@@ -397,23 +338,13 @@ pub fn compute_bounds(template: &ModelParameters) -> PackedBounds {
 
     // IOV bounds: diagonal same as BSV diagonal; off-diagonal same as BSV off-diagonal.
     if let Some(ref iov) = template.omega_iov {
-        let n = iov.dim();
-        if iov.diagonal {
-            for _ in 0..n {
+        for (i, j) in lower_tri_iter(iov.dim(), iov.diagonal) {
+            if i == j {
                 lower.push(-6.0);
                 upper.push(6.0);
-            }
-        } else {
-            for j in 0..n {
-                for i in j..n {
-                    if i == j {
-                        lower.push(-6.0);
-                        upper.push(6.0);
-                    } else {
-                        lower.push(-10.0);
-                        upper.push(10.0);
-                    }
-                }
+            } else {
+                lower.push(-10.0);
+                upper.push(10.0);
             }
         }
     }
@@ -470,24 +401,17 @@ fn named_or(v: &[String], i: usize, fallback: impl FnOnce() -> String) -> String
 fn push_omega_names(names: &mut Vec<String>, om: &OmegaMatrix) {
     let n = om.dim();
     let diag_name = |i: usize| named_or(&om.eta_names, i, || format!("OMEGA({},{})", i + 1, i + 1));
-    if om.diagonal {
-        for i in 0..n {
+    // Column-major lower triangle — mirrors `pack_params`. `lower_tri_iter` yields
+    // only `(i,i)` when diagonal, so the `i == j` arm covers the diagonal case.
+    for (i, j) in lower_tri_iter(n, om.diagonal) {
+        if i == j {
             names.push(diag_name(i));
-        }
-    } else {
-        // Column-major lower triangle — mirrors `pack_params`.
-        for j in 0..n {
-            for i in j..n {
-                if i == j {
-                    names.push(diag_name(i));
-                } else {
-                    let ni = om.eta_names.get(i).filter(|s| !s.is_empty());
-                    let nj = om.eta_names.get(j).filter(|s| !s.is_empty());
-                    match (ni, nj) {
-                        (Some(a), Some(b)) => names.push(format!("{}~{}", a, b)),
-                        _ => names.push(format!("OMEGA({},{})", i + 1, j + 1)),
-                    }
-                }
+        } else {
+            let ni = om.eta_names.get(i).filter(|s| !s.is_empty());
+            let nj = om.eta_names.get(j).filter(|s| !s.is_empty());
+            match (ni, nj) {
+                (Some(a), Some(b)) => names.push(format!("{}~{}", a, b)),
+                _ => names.push(format!("OMEGA({},{})", i + 1, j + 1)),
             }
         }
     }
@@ -528,17 +452,8 @@ pub fn coordinate_values_raw(
 }
 
 fn push_omega_vals(v: &mut Vec<f64>, m: &DMatrix<f64>, diagonal: bool) {
-    let n = m.nrows();
-    if diagonal {
-        for i in 0..n {
-            v.push(m[(i, i)]);
-        }
-    } else {
-        for j in 0..n {
-            for i in j..n {
-                v.push(m[(i, j)]);
-            }
-        }
+    for (i, j) in lower_tri_iter(m.nrows(), diagonal) {
+        v.push(m[(i, j)]);
     }
 }
 
@@ -625,17 +540,21 @@ pub fn clamp_to_bounds(x: &mut [f64], bounds: &PackedBounds) {
 /// Column-major lower-triangle entry list `(row, col)` with `row >= col`,
 /// matching `pack_params` order (diagonal → `(i, i)`).
 pub(crate) fn lower_tri_entries(n: usize, diagonal: bool) -> Vec<(usize, usize)> {
-    if diagonal {
-        (0..n).map(|i| (i, i)).collect()
-    } else {
-        let mut e = Vec::new();
-        for c in 0..n {
-            for r in c..n {
-                e.push((r, c));
-            }
-        }
-        e
-    }
+    lower_tri_iter(n, diagonal).collect()
+}
+
+/// Non-allocating iterator over the column-major lower-triangle entries `(row, col)`
+/// (`row >= col`), in `pack_params` order. `diagonal` restricts each column to its
+/// single `(c, c)` entry. This is the single source of the `for j in 0..n { for i
+/// in j..n }` packing convention: `pack_params`/`unpack_params` and the mask/bounds
+/// walkers all iterate through it, so a change to the packing order is a one-place
+/// edit. Returns an iterator (not a `Vec`) so the hot `pack`/`unpack` paths allocate
+/// nothing.
+pub(crate) fn lower_tri_iter(n: usize, diagonal: bool) -> impl Iterator<Item = (usize, usize)> {
+    (0..n).flat_map(move |c| {
+        let end = if diagonal { c + 1 } else { n };
+        (c..end).map(move |r| (r, c))
+    })
 }
 
 /// Flat index of `L[i,j]` (i ≥ j) in the column-major lower-triangle packing.
@@ -656,23 +575,17 @@ pub(crate) fn chol_lt_idx(i: usize, j: usize, n: usize) -> usize {
 pub(crate) fn chol_pack(m_sub: &DMatrix<f64>, l: &DMatrix<f64>, diagonal: bool) -> Vec<f64> {
     let n = l.nrows();
     let gl = (m_sub * l).scale(2.0);
-    let mut out = Vec::new();
-    if diagonal {
-        for i in 0..n {
-            out.push(gl[(i, i)] * l[(i, i)]);
-        }
-    } else {
-        for j in 0..n {
-            for i in j..n {
-                if i == j {
-                    out.push(gl[(i, i)] * l[(i, i)]);
-                } else {
-                    out.push(gl[(i, j)]);
-                }
+    // `lower_tri_iter` yields only `(i,i)` when diagonal, where the `i == j` arm
+    // (diagonal log-chain `×L_ii`) applies; off-diagonals are raw.
+    lower_tri_iter(n, diagonal)
+        .map(|(i, j)| {
+            if i == j {
+                gl[(i, j)] * l[(i, j)]
+            } else {
+                gl[(i, j)]
             }
-        }
-    }
-    out
+        })
+        .collect()
 }
 
 /// Block-diagonal Cholesky factor `L_Σb = blkdiag(L_bsv, L_iov × K)` of the IOV

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1530,16 +1530,15 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
             names.push(format!("log_chol_{name}"));
         }
     } else {
-        for j in 0..n_eta {
-            for i in j..n_eta {
-                if i == j {
-                    names.push(format!("log_chol_{}", result.eta_names[i]));
-                } else {
-                    names.push(format!(
-                        "chol_{}_{}",
-                        result.eta_names[i], result.eta_names[j]
-                    ));
-                }
+        // Block lower-triangle order — single source: `lower_tri_iter`.
+        for (i, j) in crate::estimation::parameterization::lower_tri_iter(n_eta, false) {
+            if i == j {
+                names.push(format!("log_chol_{}", result.eta_names[i]));
+            } else {
+                names.push(format!(
+                    "chol_{}_{}",
+                    result.eta_names[i], result.eta_names[j]
+                ));
             }
         }
     }
@@ -1552,16 +1551,14 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
                 names.push(format!("log_chol_{name}"));
             }
         } else {
-            for j in 0..n_kappa {
-                for i in j..n_kappa {
-                    if i == j {
-                        names.push(format!("log_chol_{}", result.kappa_names[i]));
-                    } else {
-                        names.push(format!(
-                            "chol_{}_{}",
-                            result.kappa_names[i], result.kappa_names[j]
-                        ));
-                    }
+            for (i, j) in crate::estimation::parameterization::lower_tri_iter(n_kappa, false) {
+                if i == j {
+                    names.push(format!("log_chol_{}", result.kappa_names[i]));
+                } else {
+                    names.push(format!(
+                        "chol_{}_{}",
+                        result.kappa_names[i], result.kappa_names[j]
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Why
Follow-up to #858, closing that PR's review finding #3. #858 centralised the Cholesky-Ω
packing *helpers* into `parameterization.rs`, but the designated authority — `pack_params`
itself — and its sibling walkers still hand-rolled the identical `for j in 0..n { for i in
j..n }` column-major loop. The convention still had ~8 copies, so a change to the packing
order needed as many hand edits.

## What changed
Added a **non-allocating** iterator:

```rust
pub(crate) fn lower_tri_iter(n: usize, diagonal: bool) -> impl Iterator<Item = (usize, usize)>
```

(column-major lower triangle, `pack_params` order; yields only `(i,i)` when `diagonal`), and
made `lower_tri_entries` delegate to it (`.collect()`). Then routed **all eight** hand-rolled
walkers through it: `pack_params`, `unpack_params`, `packed_fixed_mask`,
`omega_structural_zero_mask`, `compute_bounds`, `push_omega_names`, `push_omega_vals`, and
`chol_pack`. The packing order now has exactly **one** definition.

Each function's separate diagonal + block branches collapse into a single loop: because
`lower_tri_iter(n, diagonal)` restricts each column to `(c,c)` under `diagonal`, an
`if i == j` body reproduces the old diagonal branch exactly. The hot `pack`/`unpack` paths
**iterate** — no per-call `Vec` allocation (the reason the `Vec`-returning `lower_tri_entries`
couldn't go there directly).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` (crate-external) API changed.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable — this reorders nothing. `lower_tri_iter` yields the identical
  `(row, col)` sequence the manual loops produced, so the packed vector and every value are
  bit-identical.

```
cargo test --lib  →  2518 passed; 0 failed; 18 ignored
```
The order-sensitive anchors stay green: `test_compute_covariance_reconverged_matches_scalar_fd_with_factor_two`
(FD gradient — a packed-order flip would redden it), `test_coordinate_values_*`,
`test_packed_len_*`, and the full `estimation::sens_outer_gradient` FD cross-check module.

## Performance
- [x] No significant impact expected — the hot `pack`/`unpack` paths iterate with no allocation
  (that was the design constraint that kept `lower_tri_entries` out of them).

## Tests
- [x] Covered by the existing pack/unpack round-trip, `packed_len`, `coordinate_values`, and
  FD-gradient tests — any change to the packed order reddens them. The `lower_tri_entries`
  frozen-order / `chol_lt_idx` round-trip tests from #858 also pin the iterator (via the
  `.collect()` delegation).

## Docs
- [x] `CHANGELOG.md` — N/A (internal refactor)
- [x] No user-visible change

## Checklist
- [x] `rustfmt` clean
- [x] `Dual2` sensitivity path untouched (all converted loops are `f64`/index packing walkers)
- [ ] `cargo clippy` clean (not re-run locally)

## Reviewer hints
- The substantive review is the `lower_tri_iter` definition + confirming the diagonal-branch
  collapse is exact (`diagonal ⇒ only (i,i) ⇒ the i==j arm`). Everything else is mechanical
  loop replacement, guarded by the order-sensitive tests above.

## Open questions
- None.
