### PR TITLE
fix(estimation): gate #855's test-only covariance re-export + SymmetricEigen behind cfg(test)

### DIFF
--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -2,14 +2,21 @@ use crate::estimation::inner_optimizer::{find_ebe, run_inner_loop_warm, InnerLoo
 use crate::estimation::parameterization::{compute_mu_k, *};
 use crate::stats::likelihood::{foce_population_nll, foce_population_nll_iov};
 use crate::types::*;
-use nalgebra::{DMatrix, DVector, SymmetricEigen};
+use nalgebra::{DMatrix, DVector};
+// `SymmetricEigen` is used only by this module's `#[cfg(test)]` code (the non-PD
+// fallback tests); gate the import so a non-test build doesn't flag it unused.
+#[cfg(test)]
+use nalgebra::SymmetricEigen;
 use rayon::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-// The covariance/SE subsystem moved to `estimation::covariance` (refactor T4).
-// Re-export the two symbols other estimators/tests import via the historical
-// `outer_optimizer::{compute_covariance, CovarianceStepResult}` paths.
+// The covariance/SE subsystem moved to `estimation::covariance` (refactor T4). The
+// re-export exists only so this module's `#[cfg(test)] mod tests` can reach
+// `compute_covariance` / `CovarianceStepResult` via `super::*`; no non-test code uses
+// the historical `outer_optimizer::{..}` path, so gate it to avoid an unused-import
+// warning in a non-test build.
+#[cfg(test)]
 pub(crate) use crate::estimation::covariance::{compute_covariance, CovarianceStepResult};
 
 /// Result of outer optimization


### PR DESCRIPTION
## Why
After #855 moved the covariance subsystem out of `outer_optimizer`, its `pub(crate) use {compute_covariance, CovarianceStepResult}` re-export and its `SymmetricEigen` import are used **only** by this module's `#[cfg(test)]` code — so a non-test `cargo build --lib` emitted two `unused_imports` warnings (surfaced during the #861 review). Clippy doesn't `-D warnings` today, so this wasn't red, but it's a permanent warning on every build.

## What changed
Gated both behind `#[cfg(test)]`. The test module still reaches them via `super::*`; a non-test build no longer sees them.

## Numerical validation
- [x] Not applicable — import visibility only, no code path changed.

## Tests
- [x] `cargo build --lib` (non-test): no warnings. `cargo test --lib`: 2518 passed, 0 failed.

## Breaking changes
- [x] None

## Docs
- [x] No user-visible change (internal warning cleanup)