### PR TITLE
feat(estimation): estimate block_sigma off-diagonal on the analytic gradient path [closes #847] [CC]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ section of the SDLC for the versioning policy).
   IMP / AGQ / Laplace continue to hold the off-diagonal at its initial value.
 
 ### Performance
+- **Paired-endpoint `block_sigma` (`L2` / cross-endpoint total-unbound) fits use a
+  block-diagonal fast path** (#847). When correlated residuals pair observations
+  in the same `L2` group or at the same `(time, occasion)`, `R` is block-diagonal
+  with small (typically 2×2) blocks. The inner objective, inner gradient, and
+  FOCEI marginal now factor each small block independently — O(Σ b³) instead of
+  the full O(n³) Cholesky/inverse and O(n⁴) `∂²R` tensors. Note: under a
+  gradient-based outer optimizer these models still fall back to a per-subject
+  finite-difference *outer* gradient (the analytic outer gradient covers only the
+  diagonal-`R` reduction); `optimizer = bobyqa` (derivative-free) avoids that and
+  benefits fully from the block-diagonal objective.
 - **`block_sigma` fits with a diagonal residual `R` are no longer O(n³) per
   evaluation** (#847). A `combined`-error `block_sigma` at distinct observation
   times leaves the subject residual covariance `R` diagonal, but the inner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Added
+- **`block_sigma` off-diagonals are now estimated, not fixed** (#847). A plain
+  `block_sigma (E1, E2) = [...]` block now estimates its off-diagonal residual
+  covariance/correlation as a free parameter (NONMEM `$SIGMA BLOCK(n)`
+  semantics), instead of pinning it at the initial correlation. The correlation
+  is optimized as a Fisher-z (`atanh ρ`) coordinate so it stays in `(-1, 1)` and
+  the 2×2 residual block stays positive-definite, and it rides the **analytic**
+  FOCE/FOCEI outer-gradient path (a closed-form ∂(−2LL)/∂ρ, not a finite-
+  difference fallback). Add `FIX` to the block to keep the previous behaviour
+  (all entries, including the off-diagonal, held fixed). The fitted full SIGMA
+  block — the estimated ρ, its standard error, and the implied covariance — is
+  reported in a `sigma_correlations:` section of the fit YAML. On the Radboudumc
+  fluconazole model this moves the fitted residual correlation and Q toward the
+  NONMEM trace (TVQ ≈ 16.8) instead of stalling at the fixed-ρ optimum. SAEM /
+  IMP / AGQ / Laplace continue to hold the off-diagonal at its initial value.
+
 ### Fixed
 - **FREM: the analytic gradients differentiated the wrong likelihood on covariate
   pseudo-observation rows** (#251). `individual_nll` scores a `FREMTYPE > 0` row against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ section of the SDLC for the versioning policy).
   NONMEM trace (TVQ ≈ 16.8) instead of stalling at the fixed-ρ optimum. SAEM /
   IMP / AGQ / Laplace continue to hold the off-diagonal at its initial value.
 
+### Performance
+- **`block_sigma` fits with a diagonal residual `R` are no longer O(n³) per
+  evaluation** (#847). A `combined`-error `block_sigma` at distinct observation
+  times leaves the subject residual covariance `R` diagonal, but the inner
+  objective, inner gradient, and FOCEI marginal all built and factored a dense
+  `n×n` `R` (and, in the gradient, `n` dense `n×n` `∂R/∂f` matrices) — O(n³) per
+  inner BFGS step, 2–3 orders of magnitude on richly-sampled subjects. These now
+  detect the diagonal case (`residual_is_diagonal`, O(n) and data-static) and use
+  closed-form O(n) diagonal assembly instead of dense Cholesky / inverse / `∂R`
+  tensors. Results are unchanged (bit-for-bit for the data term). Cross-endpoint
+  (paired total/unbound) blocks with genuine off-diagonal `R` keep the dense path.
+
 ### Fixed
 - **FREM: the analytic gradients differentiated the wrong likelihood on covariate
   pseudo-observation rows** (#251). `individual_nll` scores a `FREMTYPE > 0` row against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,11 @@ section of the SDLC for the versioning policy).
   in the same `L2` group or at the same `(time, occasion)`, `R` is block-diagonal
   with small (typically 2×2) blocks. The inner objective, inner gradient, and
   FOCEI marginal now factor each small block independently — O(Σ b³) instead of
-  the full O(n³) Cholesky/inverse and O(n⁴) `∂²R` tensors. Note: under a
-  gradient-based outer optimizer these models still fall back to a per-subject
-  finite-difference *outer* gradient (the analytic outer gradient covers only the
-  diagonal-`R` reduction); `optimizer = bobyqa` (derivative-free) avoids that and
-  benefits fully from the block-diagonal objective.
+  the full O(n³) Cholesky/inverse and O(n⁴) `∂²R` tensors. The **outer** gradient
+  for these models is now analytic too (Almquist Eq. 48 decomposition over the
+  block-fast marginal/inner-gradient, with the EBE response `dη̂/dx` from the
+  implicit function theorem), so a gradient-based outer optimizer no longer falls
+  back to the expensive per-subject reconverged finite-difference gradient.
 - **`block_sigma` fits with a diagonal residual `R` are no longer O(n³) per
   evaluation** (#847). A `combined`-error `block_sigma` at distinct observation
   times leaves the subject residual covariance `R` diagonal, but the inner

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -400,10 +400,10 @@ Combined error:
   DV ~ combined(PROP_ERR, ADD_ERR)
 ```
 
-Correlated combined error:
+Correlated combined error (off-diagonal **estimated**):
 ```
 [parameters]
-  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00]
 
 [error_model]
   DV ~ combined(PROP_ERR, ADD_ERR)
@@ -411,18 +411,39 @@ Correlated combined error:
 
 `block_sigma` uses NONMEM-style lower-triangle covariance values:
 `[Var(PROP_ERR), Cov(PROP_ERR, ADD_ERR), Var(ADD_ERR)]`. Diagonal entries
-initialize the named sigma SDs (`sqrt(variance)`) and the off-diagonal entries
-define fixed residual correlations. For the example above, `PROP_ERR = 0.2`,
-`ADD_ERR = 1.0`, and `Corr(PROP_ERR, ADD_ERR) = 0.5`, so the residual variance
-for a combined-error observation is:
+initialize the named sigma SDs (`sqrt(variance)`); the off-diagonal entry
+initializes the residual correlation. For the example above, `PROP_ERR = 0.2`,
+`ADD_ERR = 1.0`, and the initial `Corr(PROP_ERR, ADD_ERR) = 0.5`, so the residual
+variance for a combined-error observation is:
 
 $$
 V = (f \sigma_\mathrm{prop})^2 + \sigma_\mathrm{add}^2
     + 2 f \rho \sigma_\mathrm{prop}\sigma_\mathrm{add}
 $$
 
-The diagonal sigma SDs are estimated unless marked `FIX`; the off-diagonal
-covariance is always converted to a fixed correlation. A nonzero `block_sigma`
+#### Fixed vs. estimated block-sigma {#fixed-vs-estimated-block-sigma}
+
+Following NONMEM `$SIGMA BLOCK(n)`, a plain `block_sigma` block **estimates** the
+whole lower triangle: the diagonal sigma SDs *and* the off-diagonal correlation
+`ρ` are free parameters. `ρ` is optimized as a Fisher-z coordinate
+(`z = atanh ρ`), which keeps it in `(-1, 1)` so the 2×2 residual block stays
+positive-definite, and it rides the analytic FOCE/FOCEI outer gradient (there is
+a closed-form `∂(−2LL)/∂ρ` — no finite-difference fallback). The fitted `ρ`, its
+standard error, and the implied covariance are reported in a `sigma_correlations:`
+block of the fit YAML.
+
+Append `FIX` to hold the **entire** block — both the diagonal SDs and the
+off-diagonal correlation — at its initial values:
+```
+[parameters]
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
+```
+This reproduces the pre-#847 behaviour, where the off-diagonal was always a fixed
+correlation. Under `method = saem`, `imp`, `agq`, and `laplace` the off-diagonal
+is likewise held at its initial value (only the FOCE/FOCEI outer optimizer moves
+`ρ`); use `method = foce`/`focei` to estimate it.
+
+A nonzero `block_sigma`
 covariance can connect sigmas that co-load on the same `combined(...)` endpoint,
 or sigmas used by different endpoints measured at the same subject time and
 occasion — whether those endpoints are selected by the CMT column (per-CMT) or
@@ -432,7 +453,10 @@ assays receive the NONMEM-style covariance term
 `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
 
 Current scope: `block_sigma` is supported for the Gaussian `method = foce`,
-`method = focei`, `method = saem`, and `method = imp` fits. The Gauss-Newton
+`method = focei`, `method = saem`, `method = imp`, `method = agq`, and
+`method = laplace` fits — but the off-diagonal correlation is **estimated only
+under `foce`/`focei`** (the analytic outer gradient carries `∂/∂ρ`); the other
+methods hold it at its initial value. The Gauss-Newton
 optimizers (`gn` / `gn_hybrid`), M3 censored-observation likelihoods, FREM
 covariate pseudo-observations, `iiv_on_ruv`, TTE endpoints, and IOV reject
 correlated residual sigma blocks until their residual-error derivative code is

--- a/src/api.rs
+++ b/src/api.rs
@@ -5706,7 +5706,7 @@ fn fit_inner(
     };
 
     // Extract SEs from covariance matrix using converged parameter values
-    let (se_theta, se_omega, se_sigma, se_kappa) =
+    let (se_theta, se_omega, se_sigma, se_kappa, se_residual_correlations) =
         extract_standard_errors(&result.covariance_matrix, &result.params);
 
     // Optional SIR step
@@ -6077,6 +6077,8 @@ fn fit_inner(
         omega: result.params.omega.matrix.clone(),
         sigma: result.params.sigma.values.clone(),
         sigma_names: result.params.sigma.names.clone(),
+        residual_correlations: result.params.residual_correlations.clone(),
+        se_residual_correlations: se_residual_correlations.clone(),
         error_model: model.error_model,
         covariance_matrix: result.covariance_matrix,
         // The optimizer's exact packed vector (FOCE/FOCEI paths), so a later
@@ -6632,6 +6634,7 @@ fn compute_subject_results(
                     h,
                     &params.omega,
                     &params.sigma.values,
+                    &params.residual_correlations,
                     interaction,
                     kappas,
                     omega_iov,
@@ -6645,6 +6648,7 @@ fn compute_subject_results(
                     h,
                     &params.omega,
                     &params.sigma.values,
+                    &params.residual_correlations,
                     interaction,
                 )
             };
@@ -7956,10 +7960,11 @@ pub(crate) fn extract_standard_errors(
     Option<Vec<f64>>,
     Option<Vec<f64>>,
     Option<Vec<f64>>,
+    Option<Vec<f64>>,
 ) {
     let cov = match cov {
         Some(c) => c,
-        None => return (None, None, None, None),
+        None => return (None, None, None, None, None),
     };
 
     let n = cov.nrows();
@@ -8107,7 +8112,45 @@ pub(crate) fn extract_standard_errors(
             .collect()
     });
 
-    (Some(se_theta), Some(se_omega), Some(se_sigma), se_kappa)
+    // Residual correlations (`block_sigma` off-diagonals): SE on the ρ scale via
+    // the Fisher-z delta method. ρ = tanh(z), dρ/dz = 1 − ρ², so
+    // SE(ρ) ≈ (1 − ρ²)·SE(z). The z-coordinates are packed last (after IOV).
+    let iov_packed_len = template.omega_iov.as_ref().map_or(0, |iov| {
+        let d = iov.dim();
+        if iov.diagonal {
+            d
+        } else {
+            d * (d + 1) / 2
+        }
+    });
+    let rho_start = kappa_start + iov_packed_len;
+    let se_residual_correlations: Option<Vec<f64>> = if template.residual_correlations.is_empty() {
+        None
+    } else {
+        Some(
+            template
+                .residual_correlations
+                .iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    let idx = rho_start + i;
+                    if idx < n {
+                        (1.0 - c.rho * c.rho).abs() * se_packed[idx]
+                    } else {
+                        0.0
+                    }
+                })
+                .collect(),
+        )
+    };
+
+    (
+        Some(se_theta),
+        Some(se_omega),
+        Some(se_sigma),
+        se_kappa,
+        se_residual_correlations,
+    )
 }
 
 /// Simulate observations from a model with given parameters (random seed).
@@ -10425,6 +10468,8 @@ mod iov_integration {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![false],
         };
@@ -12189,6 +12234,8 @@ mod extract_se_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov,
             kappa_fixed,
         }
@@ -12221,6 +12268,8 @@ mod extract_se_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
@@ -12232,7 +12281,7 @@ mod extract_se_tests {
         for i in 0..n {
             cov[(i, i)] = ((i + 1) as f64).powi(2);
         }
-        let (_, se_omega, _, _) = extract_standard_errors(&Some(cov), &template);
+        let (_, se_omega, _, _, _) = extract_standard_errors(&Some(cov), &template);
         let se = se_omega.unwrap();
         // Full LT: [omega(0,0), omega(1,0), omega(2,0), omega(1,1), omega(2,1), omega(2,2)]
         assert_eq!(se.len(), 6);
@@ -12283,12 +12332,14 @@ mod extract_se_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
         // Packed: theta(1) + omega_block(3) + sigma(1) = 5.  Identity cov.
         let cov = Some(DMatrix::<f64>::identity(5, 5));
-        let (_, se_omega, _, _) = extract_standard_errors(&cov, &template);
+        let (_, se_omega, _, _, _) = extract_standard_errors(&cov, &template);
         let se = se_omega.unwrap();
         // Full LT: [omega(0,0), omega(1,0), omega(1,1)]
         assert_eq!(se.len(), 3);
@@ -12302,6 +12353,72 @@ mod extract_se_tests {
         // diagonal-only format returns None for off-diag
         let diag_only = Some(vec![0.1, 0.2]);
         assert!(omega_se_at(&diag_only, 2, 1, 0).is_none());
+    }
+
+    /// #847: `extract_standard_errors` reports an SE for each estimated
+    /// `block_sigma` off-diagonal, delta-method-transformed from the packed
+    /// Fisher-z coordinate: SE(ρ) = (1 − ρ²)·SE(z). The ρ coordinate is packed
+    /// last (after θ / Ω / σ / Ω_IOV).
+    #[test]
+    fn test_se_residual_correlation_delta_method() {
+        use crate::types::ResidualCorrelation;
+        let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["E1".into()]);
+        let template = ModelParameters {
+            theta: vec![5.0],
+            theta_names: vec!["TVCL".into()],
+            theta_lower: vec![0.1],
+            theta_upper: vec![50.0],
+            theta_fixed: vec![false],
+            omega,
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: vec![0.2, 1.0],
+                names: vec!["PROP".into(), "ADD".into()],
+            },
+            sigma_fixed: vec![false; 2],
+            residual_correlations: vec![ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: 0.6,
+            }],
+            residual_correlation_fixed: vec![false],
+            omega_iov: None,
+            kappa_fixed: vec![],
+        };
+        // Packed: theta(1) + omega(1) + sigma(2) + rho(1) = 5. Identity cov → SE(z)=1.
+        let cov = Some(DMatrix::<f64>::identity(5, 5));
+        let (_, _, _, _, se_rho) = extract_standard_errors(&cov, &template);
+        let se = se_rho.expect("rho SE present");
+        assert_eq!(se.len(), 1);
+        // SE(ρ) = (1 − 0.6²)·1 = 0.64.
+        assert!((se[0] - 0.64).abs() < 1e-9, "got {}", se[0]);
+    }
+
+    /// A `FIX`ed residual correlation is pinned (reduced Hessian → SE 0).
+    #[test]
+    fn test_se_residual_correlation_none_without_block_sigma() {
+        let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["E1".into()]);
+        let template = ModelParameters {
+            theta: vec![5.0],
+            theta_names: vec!["TVCL".into()],
+            theta_lower: vec![0.1],
+            theta_upper: vec![50.0],
+            theta_fixed: vec![false],
+            omega,
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: vec![0.2],
+                names: vec!["PROP".into()],
+            },
+            sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
+            omega_iov: None,
+            kappa_fixed: vec![],
+        };
+        let cov = Some(DMatrix::<f64>::identity(3, 3));
+        let (_, _, _, _, se_rho) = extract_standard_errors(&cov, &template);
+        assert!(se_rho.is_none(), "no block_sigma → no rho SE");
     }
 
     /// Diagonal omega path is unaffected by the fix; this guards the simple case.
@@ -12321,12 +12438,14 @@ mod extract_se_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
         // Packed layout: theta(1) + omega_diag(2) + sigma(1) = 4. Identity cov.
         let cov = Some(DMatrix::<f64>::identity(4, 4));
-        let (_, se_omega, _, _) = extract_standard_errors(&cov, &template);
+        let (_, se_omega, _, _, _) = extract_standard_errors(&cov, &template);
         let se = se_omega.unwrap();
         assert!((se[0] - 2.0 * 0.04).abs() < 1e-12);
         assert!((se[1] - 2.0 * 0.09).abs() < 1e-12);
@@ -12357,6 +12476,8 @@ mod extract_se_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
@@ -12367,7 +12488,7 @@ mod extract_se_tests {
         cov[(1, 1)] = 0.3_f64.powi(2); // se_packed[1] = 0.3
         cov[(2, 2)] = 1.0;
         cov[(3, 3)] = 1.0;
-        let (se_theta, _, _, _) = extract_standard_errors(&Some(cov), &template);
+        let (se_theta, _, _, _, _) = extract_standard_errors(&Some(cov), &template);
         let se = se_theta.unwrap();
         // log-packed: SE = theta * SE(x) = 2.0 * 0.1 = 0.2
         assert!(
@@ -12396,7 +12517,7 @@ mod extract_se_tests {
         // Packed layout: [theta, omega(1), sigma, kappa_1, kappa_2] → 5 entries.
         // Identity cov means se_packed = [1, 1, 1, 1, 1].
         let cov = Some(DMatrix::<f64>::identity(5, 5));
-        let (_, _, _, se_kappa) = extract_standard_errors(&cov, &template);
+        let (_, _, _, se_kappa, _) = extract_standard_errors(&cov, &template);
         let se = se_kappa.expect("se_kappa should be Some when omega_iov is set");
         assert_eq!(se.len(), 2);
         assert!((se[0] - 2.0 * 0.04).abs() < 1e-12);
@@ -12425,7 +12546,7 @@ mod extract_se_tests {
         for i in 0..n {
             cov[(i, i)] = ((i + 1) as f64).powi(2); // se_packed[i] = i + 1
         }
-        let (_, _, _, se_kappa) = extract_standard_errors(&Some(cov), &template);
+        let (_, _, _, se_kappa, _) = extract_standard_errors(&Some(cov), &template);
         let se = se_kappa.unwrap();
         // L[0,0] at idx 3 → se_packed = 4 → se_kappa[0] = 2 * 0.04 * 4 = 0.32
         assert!((se[0] - 2.0 * 0.04 * 4.0).abs() < 1e-12, "got {}", se[0]);
@@ -12439,7 +12560,7 @@ mod extract_se_tests {
     fn test_se_kappa_none_when_no_iov() {
         let template = make_template(None, vec![]);
         let cov = Some(DMatrix::<f64>::identity(3, 3));
-        let (_, _, _, se_kappa) = extract_standard_errors(&cov, &template);
+        let (_, _, _, se_kappa, _) = extract_standard_errors(&cov, &template);
         assert!(se_kappa.is_none());
     }
 
@@ -12447,7 +12568,7 @@ mod extract_se_tests {
     fn test_se_kappa_none_when_no_cov() {
         let iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
         let template = make_template(Some(iov), vec![false]);
-        let (_, _, _, se_kappa) = extract_standard_errors(&None, &template);
+        let (_, _, _, se_kappa, _) = extract_standard_errors(&None, &template);
         assert!(se_kappa.is_none());
     }
 }
@@ -12944,6 +13065,8 @@ mod simulate_with_uncertainty_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -13318,6 +13441,8 @@ mod simulate_with_uncertainty_tests {
             omega: template.omega.matrix.clone(),
             sigma: template.sigma.values.clone(),
             sigma_names: template.sigma.names.clone(),
+            residual_correlations: Vec::new(),
+            se_residual_correlations: None,
             error_model: ErrorModel::Proportional,
             covariance_matrix: Some(cov),
             se_theta: None,
@@ -14556,6 +14681,8 @@ mod multi_start_tests {
                 names: vec!["ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         }
@@ -14693,6 +14820,8 @@ mod tests_sdtab_tv_cov {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -15031,6 +15160,8 @@ mod tests_sdtab_tv_cov {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -15217,6 +15348,8 @@ mod tests_derived_session_clock {
                     names: vec!["ERR".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: None,
                 kappa_fixed: Vec::new(),
             },
@@ -15612,6 +15745,8 @@ mod tests_derived_iov_kappa {
                     names: vec!["ERR".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: Some(OmegaMatrix::from_diagonal(&[1.0], vec!["KAPPA_CL".into()])),
                 kappa_fixed: vec![false],
             },

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -174,6 +174,8 @@ fn build_warfarin_model() -> CompiledModel {
         omega_fixed: vec![false; 3],
         sigma,
         sigma_fixed: vec![false; 1],
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         omega_iov: None,
         kappa_fixed: Vec::new(),
     };
@@ -272,6 +274,8 @@ fn build_warfarin_true_params() -> ModelParameters {
             names: vec!["PROP_ERR".into()],
         },
         sigma_fixed: vec![false; 1],
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         omega_iov: None,
         kappa_fixed: Vec::new(),
     }
@@ -303,6 +307,8 @@ fn generate_two_cpt_iv() {
         omega_fixed: vec![false; 4],
         sigma,
         sigma_fixed: vec![false; 1],
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         omega_iov: None,
         kappa_fixed: Vec::new(),
     };
@@ -425,6 +431,8 @@ fn generate_two_cpt_oral_cov() {
         omega_fixed: vec![false; 5],
         sigma,
         sigma_fixed: vec![false; 1],
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         omega_iov: None,
         kappa_fixed: Vec::new(),
     };
@@ -611,6 +619,8 @@ fn generate_mm_oral() {
         omega_fixed: vec![false; 2],
         sigma,
         sigma_fixed: vec![false; 1],
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         omega_iov: None,
         kappa_fixed: Vec::new(),
     };

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -276,6 +276,7 @@ impl Stack {
                 b,
                 &params.omega,
                 &params.sigma.values,
+                &params.residual_correlations,
                 scratch,
                 schedule,
             );
@@ -1751,6 +1752,7 @@ mod tests {
                     e,
                     &params.omega,
                     &params.sigma.values,
+                    &params.residual_correlations,
                     s,
                     None,
                 )

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -203,7 +203,15 @@ fn subject_nll(
 ) -> f64 {
     if kappas.is_empty() {
         individual_nll_into_with_schedule(
-            model, subject, theta, eta, omega, sigma, scratch, schedule,
+            model,
+            subject,
+            theta,
+            eta,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            scratch,
+            schedule,
         )
     } else {
         individual_nll_iov(model, subject, theta, eta, kappas, omega, omega_iov, sigma)
@@ -1185,6 +1193,10 @@ pub fn run_bayes(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // Bayes holds `block_sigma` off-diagonals at their initial correlation
+        // (the MCMC sampler does not resample residual ρ); carry them through.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: omega_iov_mean.clone(),
         kappa_fixed: init_params.kappa_fixed.clone(),
     };

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1967,6 +1967,7 @@ fn subject_nll_at(
                 h_matrix,
                 &params.omega,
                 &params.sigma.values,
+                &params.residual_correlations,
                 options.interaction,
                 kappas,
                 iov,
@@ -1982,6 +1983,7 @@ fn subject_nll_at(
         h_matrix,
         &params.omega,
         &params.sigma.values,
+        &params.residual_correlations,
         options.interaction,
     )
 }
@@ -2012,6 +2014,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -3019,6 +3023,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -3306,6 +3312,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![false],
         };
@@ -3458,6 +3466,7 @@ mod tests {
                     &h_mats[0],
                     &p.omega,
                     &p.sigma.values,
+                    &p.residual_correlations,
                     options.interaction,
                     &kappas_all[0],
                     iov,

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -669,6 +669,10 @@ fn run_mcem(
                 names: init_params.sigma.names.clone(),
             },
             sigma_fixed: init_params.sigma_fixed.clone(),
+            // IMPMAP holds `block_sigma` off-diagonals at their initial
+            // correlation; carry them through each iteration's param snapshot.
+            residual_correlations: init_params.residual_correlations.clone(),
+            residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
             omega_iov: None,
             kappa_fixed: init_params.kappa_fixed.clone(),
         };
@@ -1151,6 +1155,8 @@ fn run_mcem(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: None,
         kappa_fixed: init_params.kappa_fixed.clone(),
     };

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2634,6 +2634,8 @@ mod tests {
                 names: vec!["RUV".into(), "EPSCOV".into()],
             },
             sigma_fixed: vec![false, true],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2068,6 +2068,61 @@ fn dense_residual_inner_gradient(
     let err_keys = model.error_spec.obs_keys(subject);
     // Per-observation custom residual magnitude (#484); η-independent, matches the marginal.
     let ruv_mult = model.ruv_obs_mult(subject, theta);
+
+    // Diagonal-R fast path (#847 perf): the common combined-error `block_sigma`
+    // leaves R diagonal (no cross-observation pairing), so R⁻¹, the Cholesky, and
+    // the per-observation `∂R/∂f` matrices are all diagonal. Computing them densely
+    // was O(n³) per inner step (n = obs/subject) — 2–3 orders of magnitude on
+    // richly-sampled subjects. Here the same assembly collapses to O(n·n_eta):
+    // `M_k = R⁻¹ ∂R/∂η_k` is diagonal, so `tr(M_k)` and `sᵀ∂R/∂η_k s` are scalar
+    // sums. Algebraically identical to the dense branch below (verified against it
+    // and against FD by the inner-gradient tests).
+    if crate::stats::residual_error::residual_is_diagonal(
+        &subject.obs_times,
+        &subject.occasions,
+        &subject.obs_l2,
+    ) {
+        let rv = crate::stats::residual_error::compute_r_diag_with_correlations(
+            &model.error_spec,
+            &ipreds,
+            err_keys.as_ref(),
+            sigma,
+            corr,
+        );
+        let dv = crate::stats::residual_error::compute_dr_df_diag(
+            &model.error_spec,
+            &ipreds,
+            err_keys.as_ref(),
+            sigma,
+            corr,
+            ruv_mult.as_deref(),
+        );
+        let mut s = vec![0.0f64; n_obs]; // R⁻¹ r
+        let mut rinv = vec![0.0f64; n_obs]; // diag(R⁻¹)
+        for m in 0..n_obs {
+            if rv[m] <= 0.0 || rv[m].is_nan() {
+                return None; // non-PD, exactly where the dense Cholesky would fail
+            }
+            rinv[m] = 1.0 / rv[m];
+            s[m] = (subject.observations[m] - ipreds[m]) * rinv[m];
+        }
+        let mut grad = vec![0.0f64; n_eta];
+        for k in 0..n_eta {
+            let mut term_a = 0.0;
+            let mut tr_mk = 0.0;
+            let mut quad = 0.0;
+            for m in 0..n_obs {
+                let h = sens[m].df_deta[k];
+                term_a += h * s[m];
+                let dr_k_mm = h * dv[m]; // (∂R/∂η_k)_mm
+                tr_mk += rinv[m] * dr_k_mm;
+                quad += s[m] * (dr_k_mm * s[m]);
+            }
+            grad[k] = -term_a + 0.5 * (tr_mk - quad) + prior[k];
+        }
+        return Some(grad);
+    }
+
     let r = match ruv_mult.as_deref() {
         Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
             &model.error_spec,

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2123,6 +2123,82 @@ fn dense_residual_inner_gradient(
         return Some(grad);
     }
 
+    // Block-diagonal fast path (#847 perf): paired total/unbound `block_sigma`
+    // leaves R block-diagonal with small blocks. R⁻¹, ∂R/∂η_k, and M_k are all
+    // block-diagonal, so the full O(n³) Cholesky / inverse / dense ∂R tensors
+    // collapse to independent per-block dense problems — O(Σ b³). Same assembly
+    // as the dense branch below, summed over disjoint blocks.
+    if ruv_mult.is_none() {
+        let blocks = crate::stats::residual_error::residual_blocks(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        );
+        if blocks.len() < n_obs {
+            let mut s = vec![0.0f64; n_obs]; // R⁻¹ r, assembled globally
+                                             // Per block (parallel to `blocks`): R_g⁻¹ and its ∂R/∂f matrices.
+            let mut rinvs: Vec<DMatrix<f64>> = Vec::with_capacity(blocks.len());
+            let mut drs: Vec<Vec<DMatrix<f64>>> = Vec::with_capacity(blocks.len());
+            for block in &blocks {
+                let bn = block.len();
+                let (rg, dr) = crate::stats::residual_error::block_r_and_dr(
+                    &model.error_spec,
+                    block,
+                    &ipreds,
+                    err_keys.as_ref(),
+                    &subject.obs_times,
+                    &subject.obs_raw_times,
+                    &subject.occasions,
+                    &subject.obs_l2,
+                    sigma,
+                    corr,
+                );
+                let chol = rg.clone().cholesky()?;
+                let resid_g = DVector::from_iterator(
+                    bn,
+                    block.iter().map(|&j| subject.observations[j] - ipreds[j]),
+                );
+                let sg = chol.solve(&resid_g);
+                for (loc, &j) in block.iter().enumerate() {
+                    s[j] = sg[loc];
+                }
+                rinvs.push(chol.inverse());
+                drs.push(dr);
+            }
+            let mut grad = vec![0.0f64; n_eta];
+            for k in 0..n_eta {
+                let mut term_a = 0.0;
+                for m in 0..n_obs {
+                    term_a += sens[m].df_deta[k] * s[m];
+                }
+                let mut tr_mk = 0.0;
+                let mut quad = 0.0;
+                for (bi, block) in blocks.iter().enumerate() {
+                    let rinv = &rinvs[bi];
+                    let dr = &drs[bi];
+                    let bn = block.len();
+                    // (∂R/∂η_k)_g = Σ_{m∈g} H[m,k]·∂R/∂f_m.
+                    let mut drk = DMatrix::<f64>::zeros(bn, bn);
+                    for (loc, &j) in block.iter().enumerate() {
+                        let h = sens[j].df_deta[k];
+                        if h != 0.0 {
+                            drk += h * &dr[loc];
+                        }
+                    }
+                    for p in 0..bn {
+                        for q in 0..bn {
+                            tr_mk += rinv[(p, q)] * drk[(q, p)];
+                        }
+                    }
+                    let sg = DVector::from_iterator(bn, block.iter().map(|&j| s[j]));
+                    quad += sg.dot(&(&drk * &sg));
+                }
+                grad[k] = -term_a + 0.5 * (tr_mk - quad) + prior[k];
+            }
+            return Some(grad);
+        }
+    }
+
     let r = match ruv_mult.as_deref() {
         Some(mult) => crate::stats::residual_error::compute_r_matrix_with_correlations_scaled(
             &model.error_spec,

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -751,6 +751,7 @@ pub fn find_ebe(
             e,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             &mut scratch,
             schedule.as_ref(),
         )
@@ -3351,7 +3352,17 @@ mod tests {
         let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
         let obj = |e: &[f64]| -> f64 {
             let mut s = scratch.borrow_mut();
-            individual_nll_into_with_schedule(&model, subject, theta, e, omega, sigma, &mut s, None)
+            individual_nll_into_with_schedule(
+                &model,
+                subject,
+                theta,
+                e,
+                omega,
+                sigma,
+                &model.residual_correlations,
+                &mut s,
+                None,
+            )
         };
         let fd = gradient_fd(&obj, &eta, model.n_eta);
 
@@ -3414,7 +3425,15 @@ mod tests {
         let obj = |e: &[f64]| -> f64 {
             let mut s = scratch.borrow_mut();
             individual_nll_into_with_schedule(
-                &model, &subject, theta, e, omega, sigma, &mut s, None,
+                &model,
+                &subject,
+                theta,
+                e,
+                omega,
+                sigma,
+                &model.residual_correlations,
+                &mut s,
+                None,
             )
         };
         let fd = gradient_fd(&obj, &eta, model.n_eta);
@@ -3470,7 +3489,17 @@ mod tests {
         let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
         let obj = |e: &[f64]| -> f64 {
             let mut s = scratch.borrow_mut();
-            individual_nll_into_with_schedule(&model, subject, theta, e, omega, sigma, &mut s, None)
+            individual_nll_into_with_schedule(
+                &model,
+                subject,
+                theta,
+                e,
+                omega,
+                sigma,
+                &model.residual_correlations,
+                &mut s,
+                None,
+            )
         };
         let fd = gradient_fd(&obj, &eta, model.n_eta);
 
@@ -3537,7 +3566,15 @@ mod tests {
         let obj = |e: &[f64]| -> f64 {
             let mut s = scratch.borrow_mut();
             individual_nll_into_with_schedule(
-                &model, &subject, theta, e, omega, sigma, &mut s, None,
+                &model,
+                &subject,
+                theta,
+                e,
+                omega,
+                sigma,
+                &model.residual_correlations,
+                &mut s,
+                None,
             )
         };
         let fd = gradient_fd(&obj, &eta, model.n_eta);
@@ -3905,6 +3942,8 @@ mod tests {
                 names: vec!["RUV".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
@@ -4638,6 +4677,8 @@ mod iov_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![false],
         };
@@ -6764,6 +6805,8 @@ mod iov_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -6909,6 +6952,8 @@ mod iov_tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -787,6 +787,7 @@ pub fn find_ebe(
             e,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             schedule.as_ref(),
             mult.as_deref(),
         ) {
@@ -1870,6 +1871,7 @@ pub(crate) fn analytic_eta_nll_gradient(
         eta,
         omega,
         sigma,
+        &model.residual_correlations,
         None,
         mult.as_deref(),
     )
@@ -1892,6 +1894,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     eta: &[f64],
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
+    corr: &[crate::types::ResidualCorrelation],
     cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
     mult: Option<&[Vec<f64>]>,
 ) -> Option<Vec<f64>> {
@@ -1953,8 +1956,10 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     // assumes a diagonal R. Route the dense-R generalisation here — it serves both the
     // analytical and the ODE (`Dual1`) inner path, since `sens` carries `∂f/∂η` for both.
     if !model.residual_correlations.is_empty() {
-        return dense_residual_inner_gradient(model, subject, theta, eta, omega, sigma, &sens)
-            .map(add_nongaussian);
+        return dense_residual_inner_gradient(
+            model, subject, theta, eta, omega, sigma, corr, &sens,
+        )
+        .map(add_nongaussian);
     }
     let n_eta = model.n_eta;
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
@@ -2052,6 +2057,7 @@ fn dense_residual_inner_gradient(
     eta: &[f64],
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
+    corr: &[crate::types::ResidualCorrelation],
     sens: &[crate::sens::provider::ObsGrad],
 ) -> Option<Vec<f64>> {
     use nalgebra::{DMatrix, DVector};
@@ -2063,7 +2069,6 @@ fn dense_residual_inner_gradient(
         return Some(prior.as_slice().to_vec());
     }
     let ipreds: Vec<f64> = sens.iter().map(|o| o.f).collect();
-    let corr = &model.residual_correlations;
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
     // Per-observation custom residual magnitude (#484); η-independent, matches the marginal.

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -524,6 +524,7 @@ pub(crate) fn pop_nll(
                 &params.omega,
                 iov,
                 &params.sigma.values,
+                &params.residual_correlations,
                 interaction,
             );
         }
@@ -536,6 +537,7 @@ pub(crate) fn pop_nll(
         h_matrices,
         &params.omega,
         &params.sigma.values,
+        &params.residual_correlations,
         interaction,
     )
 }
@@ -2210,6 +2212,7 @@ fn subject_reconverged_fd_gradient(
             &ebe.h_matrix,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             options.interaction,
         )
     };
@@ -2252,6 +2255,7 @@ fn subject_reconverged_fd_gradient_iov(
             &ebe.h_matrix,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             options.interaction,
             &ebe.kappas,
             params
@@ -4300,6 +4304,8 @@ mod tests {
                 names: vec!["ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -4359,6 +4365,8 @@ mod tests {
                 names: vec!["ADD".into(), "PROP".into()],
             },
             sigma_fixed: vec![false, false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -4384,6 +4392,8 @@ mod tests {
                 names: vec!["ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(crate::types::OmegaMatrix::from_diagonal(
                 &[0.02],
                 vec!["KAPPA_CL".into()],
@@ -4428,6 +4438,8 @@ mod tests {
                 names: vec!["ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: vec![],
         };
@@ -4786,6 +4798,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -5080,6 +5094,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -5554,6 +5570,8 @@ mod tests {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![true],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![true],
         };

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -1,4 +1,4 @@
-use crate::types::{CompiledModel, ModelParameters, OmegaMatrix, SigmaVector};
+use crate::types::{CompiledModel, ModelParameters, OmegaMatrix, ResidualCorrelation, SigmaVector};
 use nalgebra::DMatrix;
 
 /// Bounds for the packed parameter vector
@@ -28,6 +28,28 @@ pub struct PackedBounds {
 #[inline]
 pub(crate) fn theta_packs_log(theta_lower: f64) -> bool {
     theta_lower >= 0.0
+}
+
+/// Unconstrained-space bound for a Fisher-z (`atanh`) residual-correlation
+/// coordinate. `tanh(6) ≈ 0.99998`, so a `block_sigma` off-diagonal ρ stays
+/// strictly inside `(-1, 1)` — every 2×2 residual block stays positive-definite
+/// while the optimizer works on an unbounded coordinate.
+pub(crate) const RHO_Z_BOUND: f64 = 6.0;
+
+/// Pack a residual correlation ρ ∈ (-1, 1) as its Fisher-z coordinate
+/// `atanh(ρ)`, clamped to `[-RHO_Z_BOUND, RHO_Z_BOUND]`. The pre-clamp on ρ
+/// keeps `atanh` finite if a parsed init sits exactly at ±1.
+#[inline]
+pub(crate) fn pack_rho(rho: f64) -> f64 {
+    rho.clamp(-0.999_999, 0.999_999)
+        .atanh()
+        .clamp(-RHO_Z_BOUND, RHO_Z_BOUND)
+}
+
+/// Inverse of [`pack_rho`]: map a Fisher-z coordinate back to ρ = `tanh(z)`.
+#[inline]
+pub(crate) fn unpack_rho(z: f64) -> f64 {
+    z.tanh()
 }
 
 /// Pack ModelParameters into a flat unconstrained vector for optimization.
@@ -95,6 +117,13 @@ pub fn pack_params(params: &ModelParameters) -> Vec<f64> {
                 }
             }
         }
+    }
+
+    // Residual correlations (`block_sigma` off-diagonals): Fisher-z `atanh(ρ)`,
+    // appended last so the θ/Ω/σ/Ω_IOV layout every other caller relies on is
+    // unchanged. FIX blocks are pinned by `compute_bounds` (lower == upper).
+    for corr in &params.residual_correlations {
+        v.push(pack_rho(corr.rho));
     }
 
     v
@@ -196,6 +225,22 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
         None
     };
 
+    // Residual correlations: reconstruct each pair from the template (indices
+    // never change) with ρ = tanh(z) from the packed Fisher-z coordinate.
+    let residual_correlations: Vec<ResidualCorrelation> = template
+        .residual_correlations
+        .iter()
+        .map(|c| {
+            let rho = unpack_rho(v[idx]);
+            idx += 1;
+            ResidualCorrelation {
+                sigma_i: c.sigma_i,
+                sigma_j: c.sigma_j,
+                rho,
+            }
+        })
+        .collect();
+
     ModelParameters {
         theta,
         theta_names: template.theta_names.clone(),
@@ -206,6 +251,8 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
         omega_fixed: template.omega_fixed.clone(),
         sigma,
         sigma_fixed: template.sigma_fixed.clone(),
+        residual_correlations,
+        residual_correlation_fixed: template.residual_correlation_fixed.clone(),
         omega_iov,
         kappa_fixed: template.kappa_fixed.clone(),
     }
@@ -265,6 +312,11 @@ pub fn packed_fixed_mask(template: &ModelParameters) -> Vec<bool> {
                 }
             }
         }
+    }
+
+    // Residual correlations: `FIX`-ed `block_sigma` off-diagonals are pinned.
+    for &f in &template.residual_correlation_fixed {
+        mask.push(f);
     }
 
     mask
@@ -334,7 +386,8 @@ pub fn packed_len(template: &ModelParameters) -> usize {
             d * (d + 1) / 2
         }
     });
-    n_theta + n_omega + n_sigma + n_iov
+    let n_corr = template.residual_correlations.len();
+    n_theta + n_omega + n_sigma + n_iov + n_corr
 }
 
 /// Compute box constraints for the packed parameter vector.
@@ -418,6 +471,13 @@ pub fn compute_bounds(template: &ModelParameters) -> PackedBounds {
         }
     }
 
+    // Residual-correlation (Fisher-z) bounds. `[-RHO_Z_BOUND, RHO_Z_BOUND]` keeps
+    // ρ = tanh(z) strictly inside (-1, 1) so every 2×2 residual block stays PD.
+    for _ in 0..template.residual_correlations.len() {
+        lower.push(-RHO_Z_BOUND);
+        upper.push(RHO_Z_BOUND);
+    }
+
     // Pin any FIX parameters to their packed (log-space) initial value.
     // We pack first, then overwrite lower=upper=packed[i] for fixed indices.
     // Pack-before-overwrite is correct even for block Cholesky off-diagonals,
@@ -456,6 +516,16 @@ pub fn coordinate_names(params: &ModelParameters) -> Vec<String> {
     }
     if let Some(ref iov) = params.omega_iov {
         push_omega_names(&mut names, iov);
+    }
+    // Residual correlations couple two sigma terms: `SIGMA(i,j)` (NONMEM-style),
+    // or `EPS_i~EPS_j` when both sigma names are declared.
+    for c in &params.residual_correlations {
+        let ni = params.sigma.names.get(c.sigma_i).filter(|s| !s.is_empty());
+        let nj = params.sigma.names.get(c.sigma_j).filter(|s| !s.is_empty());
+        match (ni, nj) {
+            (Some(a), Some(b)) => names.push(format!("{}~{}", a, b)),
+            _ => names.push(format!("SIGMA({},{})", c.sigma_i + 1, c.sigma_j + 1)),
+        }
     }
     names
 }
@@ -498,13 +568,19 @@ fn push_omega_names(names: &mut Vec<String>, om: &OmegaMatrix) {
 /// (diagonal) / covariances (off-diagonal), sigma are variances. This is the
 /// back-transformed space the trace's `val:*` columns report.
 pub fn coordinate_values(params: &ModelParameters) -> Vec<f64> {
-    coordinate_values_raw(
+    let mut v = coordinate_values_raw(
         &params.theta,
         &params.omega.matrix,
         params.omega.diagonal,
         &params.sigma.values,
         params.omega_iov.as_ref().map(|m| (&m.matrix, m.diagonal)),
-    )
+    );
+    // Residual correlations report on their natural (ρ) scale, mirroring the
+    // Fisher-z coordinate order appended by `pack_params`.
+    for c in &params.residual_correlations {
+        v.push(c.rho);
+    }
+    v
 }
 
 /// Assemble the natural-scale coordinate vector directly from raw pieces, for
@@ -637,6 +713,8 @@ mod tests {
             omega_fixed: vec![false; 2],
             sigma,
             sigma_fixed: vec![false; 1],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         }
@@ -683,6 +761,71 @@ mod tests {
         }
     }
 
+    /// #847: a residual correlation packs as `atanh(ρ)` and round-trips through
+    /// `tanh`, growing the packed vector by one free slot per off-diagonal.
+    #[test]
+    fn test_pack_unpack_rho_round_trip() {
+        let mut template = make_template();
+        template.sigma = SigmaVector {
+            values: vec![0.3, 1.0],
+            names: vec!["prop".into(), "add".into()],
+        };
+        template.sigma_fixed = vec![false; 2];
+        template.residual_correlations = vec![ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.62,
+        }];
+        template.residual_correlation_fixed = vec![false];
+
+        // 2 theta + 2 omega + 2 sigma + 1 rho = 7.
+        assert_eq!(packed_len(&template), 7);
+        let packed = pack_params(&template);
+        assert_eq!(packed.len(), 7);
+        // Last coordinate is the Fisher-z transform of ρ.
+        assert_relative_eq!(packed[6], 0.62_f64.atanh(), epsilon = 1e-12);
+
+        let recovered = unpack_params(&packed, &template);
+        assert_eq!(recovered.residual_correlations.len(), 1);
+        assert_eq!(recovered.residual_correlations[0].sigma_i, 1);
+        assert_eq!(recovered.residual_correlations[0].sigma_j, 0);
+        assert_relative_eq!(recovered.residual_correlations[0].rho, 0.62, epsilon = 1e-9);
+        // Free (non-FIX) → bounds are the open Fisher-z interval, not pinned.
+        let bounds = compute_bounds(&template);
+        assert!(bounds.lower[6] < bounds.upper[6]);
+
+        // Trace name / value vectors carry the ρ coordinate last, on its natural scale.
+        let names = coordinate_names(&template);
+        assert_eq!(names.len(), 7);
+        assert_eq!(names[6], "add~prop");
+        let vals = coordinate_values(&template);
+        assert_eq!(vals.len(), 7);
+        assert_relative_eq!(vals[6], 0.62, epsilon = 1e-12);
+    }
+
+    /// A `FIX`ed residual correlation is pinned by `compute_bounds`
+    /// (lower == upper) and flagged in `packed_fixed_mask`.
+    #[test]
+    fn test_fixed_rho_is_pinned() {
+        let mut template = make_template();
+        template.sigma = SigmaVector {
+            values: vec![0.3, 1.0],
+            names: vec!["prop".into(), "add".into()],
+        };
+        template.sigma_fixed = vec![false; 2];
+        template.residual_correlations = vec![ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        template.residual_correlation_fixed = vec![true];
+
+        let mask = packed_fixed_mask(&template);
+        assert!(mask[6], "fixed rho must be masked");
+        let bounds = compute_bounds(&template);
+        assert_relative_eq!(bounds.lower[6], bounds.upper[6], epsilon = 1e-12);
+    }
+
     #[test]
     fn test_pack_values_are_log_transformed() {
         let template = make_template();
@@ -721,6 +864,8 @@ mod tests {
             omega_fixed: vec![false; 1],
             sigma,
             sigma_fixed: vec![false; 1],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -811,6 +956,8 @@ mod tests {
             omega_fixed: vec![false; 2],
             sigma,
             sigma_fixed: vec![false; 1],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         }
@@ -866,6 +1013,8 @@ mod tests {
                 names: vec!["s".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -921,6 +1070,8 @@ mod tests {
                 names: vec!["s".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(make_block_plus_diag_omega()),
             kappa_fixed: vec![false, false, false],
         };
@@ -1041,6 +1192,8 @@ mod tests {
                 names: vec![String::new()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -1121,6 +1274,8 @@ mod tests {
             omega_fixed: vec![false; 3],
             sigma,
             sigma_fixed: vec![false; 1],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };
@@ -1413,6 +1568,8 @@ mod tests {
             omega_fixed: vec![false],
             sigma,
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![false],
         }
@@ -1566,6 +1723,8 @@ mod tests {
             omega_fixed: vec![false],
             sigma,
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: Some(omega_iov),
             kappa_fixed: vec![false, false],
         }

--- a/src/estimation/run_covariance.rs
+++ b/src/estimation/run_covariance.rs
@@ -287,7 +287,7 @@ pub fn run_covariance(
     let covariance_wall_time_secs = cov_timer.elapsed().as_secs_f64();
 
     // --- Build the refreshed FitResult ------------------------------------
-    let (se_theta, se_omega, se_sigma, se_kappa) =
+    let (se_theta, se_omega, se_sigma, se_kappa, se_residual_correlations) =
         extract_standard_errors(&covariance_matrix, &params);
     let (cov_eigenvalues, cov_condition_number) = cov_diagnostics(covariance_matrix.as_ref());
     // Bayesian fits never run a Hessian covariance step; guard so a covariance
@@ -301,6 +301,7 @@ pub fn run_covariance(
     out.se_omega = se_omega;
     out.se_sigma = se_sigma;
     out.se_kappa = se_kappa;
+    out.se_residual_correlations = se_residual_correlations;
     out.cov_eigenvalues = cov_eigenvalues;
     out.cov_condition_number = cov_condition_number;
     out.covariance_status = covariance_status;

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1202,6 +1202,11 @@ fn saem_state_to_params(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // SAEM's M-step updates diagonal σ via sufficient statistics but does not
+        // re-estimate residual ρ; carry the initial `block_sigma` off-diagonals
+        // through so a chained estimator (e.g. [saem, foce]) starts from them.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: if n_kappa > 0 {
             // Use from_matrix_with_mask so the structural free_mask is preserved
             // when this snapshot is handed to a chained estimator (e.g.
@@ -3005,6 +3010,8 @@ mod tests {
                     names: vec!["PROP_ERR".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: Some(OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()])),
                 kappa_fixed: vec![false],
             },

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -2068,6 +2068,112 @@ pub fn subject_packed_gradient_iov(
     Some(g)
 }
 
+/// Block-diagonal correlated-residual (`block_sigma` L2 / paired cross-endpoint)
+/// FOCEI outer gradient via the Almquist Eq. 48 decomposition
+/// `dFᵢ/dx = ∂Fᵢ/∂x|_η̂ + (∂Fᵢ/∂η̂)·dη̂/dx`, with the EBE response
+/// `dη̂/dx = −H_inner⁻¹ ∂g_inner/∂x` (implicit function theorem on the inner
+/// optimality condition `g_inner(η̂,x)=0`). The partials are central FDs of the
+/// **block-fast** marginal (`foce_subject_nll`) and inner gradient
+/// (`analytic_eta_nll_gradient_with_schedule`), which are O(n) for block-diagonal
+/// R — so this stays off the per-subject *reconverged*-FD fallback (no EBE re-
+/// solve per coordinate). Used only for the block-diagonal-R correlated case; the
+/// diagonal-R and non-correlated cases keep the exact closed-form scalar path.
+/// `None` when a provider can't produce `∂f/∂η` or `H_inner` is singular.
+fn subject_packed_gradient_block(
+    model: &CompiledModel,
+    subject: &Subject,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hat: &[f64],
+    interaction: bool,
+) -> Option<Vec<f64>> {
+    use crate::estimation::inner_optimizer::analytic_eta_nll_gradient_with_schedule;
+    use crate::sens::provider::subject_eta_jacobian;
+    use crate::stats::likelihood::foce_subject_nll;
+    let n = x.len();
+    let n_eta = model.n_eta;
+    let n_obs = subject.observations.len();
+    if n_obs == 0 {
+        return Some(vec![0.0; n]);
+    }
+
+    // Marginal F(params, η) — FOCEI (`interaction`) or FOCE. Recomputes ∂f/∂η
+    // (θ-dependent) each call.
+    let marginal = |params: &ModelParameters, eta: &[f64]| -> Option<f64> {
+        let jac = subject_eta_jacobian(model, subject, &params.theta, eta)?;
+        let h = DMatrix::from_row_slice(n_obs, n_eta, &jac);
+        Some(foce_subject_nll(
+            model,
+            subject,
+            &params.theta,
+            &DVector::from_column_slice(eta),
+            &h,
+            &params.omega,
+            &params.sigma.values,
+            &params.residual_correlations,
+            interaction,
+        ))
+    };
+    // Inner (individual-NLL) η-gradient g(params, η).
+    let inner_g = |params: &ModelParameters, eta: &[f64]| -> Option<Vec<f64>> {
+        let mult = model.ruv_obs_mult(subject, &params.theta);
+        analytic_eta_nll_gradient_with_schedule(
+            model,
+            subject,
+            &params.theta,
+            eta,
+            &params.omega,
+            &params.sigma.values,
+            &params.residual_correlations,
+            None,
+            mult.as_deref(),
+        )
+    };
+
+    let params = unpack_params(x, template);
+    // H_inner = ∂g/∂η and g_η = ∂F/∂η, both by central FD at η̂.
+    let heta = 1e-5;
+    let mut h_inner = DMatrix::<f64>::zeros(n_eta, n_eta);
+    let mut g_eta = vec![0.0f64; n_eta];
+    for i in 0..n_eta {
+        let mut ep = eta_hat.to_vec();
+        ep[i] += heta;
+        let mut em = eta_hat.to_vec();
+        em[i] -= heta;
+        let gp = inner_g(&params, &ep)?;
+        let gm = inner_g(&params, &em)?;
+        for r in 0..n_eta {
+            h_inner[(r, i)] = (gp[r] - gm[r]) / (2.0 * heta);
+        }
+        g_eta[i] = (marginal(&params, &ep)? - marginal(&params, &em)?) / (2.0 * heta);
+    }
+    let h_inner_inv = h_inner.try_inverse()?;
+
+    // Per free packed coordinate: ∂F/∂x|_η̂ + g_η·(−H_inner⁻¹ ∂g/∂x).
+    let fixed = packed_fixed_mask(template);
+    let mut grad = vec![0.0f64; n];
+    for j in 0..n {
+        if fixed[j] {
+            continue;
+        }
+        let hj = 1e-6 * (1.0 + x[j].abs());
+        let mut xp = x.to_vec();
+        xp[j] += hj;
+        let mut xm = x.to_vec();
+        xm[j] -= hj;
+        let pp = unpack_params(&xp, template);
+        let pm = unpack_params(&xm, template);
+        let df_partial = (marginal(&pp, eta_hat)? - marginal(&pm, eta_hat)?) / (2.0 * hj);
+        let gp = inner_g(&pp, eta_hat)?;
+        let gm = inner_g(&pm, eta_hat)?;
+        let dg = DVector::from_iterator(n_eta, (0..n_eta).map(|r| (gp[r] - gm[r]) / (2.0 * hj)));
+        let deta = -(&h_inner_inv * dg);
+        let resp: f64 = (0..n_eta).map(|r| g_eta[r] * deta[r]).sum();
+        grad[j] = df_partial + resp;
+    }
+    Some(grad)
+}
+
 /// The exact per-subject FOCEI gradient `dFᵢ/dx` in the **packed** optimizer
 /// space (log-θ / Cholesky-Ω / log-σ), or `None` when unsupported. `eta_hat`
 /// must be the EBE for `unpack_params(x)`.
@@ -2080,6 +2186,19 @@ pub fn subject_packed_gradient(
 ) -> Option<Vec<f64>> {
     if subject.observations.is_empty() {
         return Some(vec![0.0; x.len()]);
+    }
+    // Block-diagonal correlated residual (`block_sigma` L2 / paired cross-endpoint):
+    // R has genuine off-diagonals, so the scalar `corr_residual_diag` reduction
+    // below can't represent it. Use the Almquist FD decomposition over the block-
+    // fast marginal/inner-gradient instead of bailing to reconverged FD.
+    if !model.residual_correlations.is_empty()
+        && !crate::stats::residual_error::residual_is_diagonal(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        )
+    {
+        return subject_packed_gradient_block(model, subject, template, x, eta_hat, true);
     }
     // M3/BLOQ: censored rows enter through `prepare` (data term `−logΦ`, true
     // inner Hessian, AND `H̃`/`log|H̃|` at FOCEI order — matching `gaussian_foce_accum`).
@@ -2283,13 +2402,26 @@ pub fn subject_packed_gradient_foce(
     x: &[f64],
     eta_hat: &[f64],
 ) -> Option<Vec<f64>> {
+    if subject.observations.is_empty() {
+        return Some(vec![0.0; x.len()]);
+    }
+    // Block-diagonal correlated residual: the Sheiner–Beal `R̃ = JΩJᵀ + R` couples
+    // rows within a residual block, so the diagonal-`R⁰` assembly below can't serve
+    // it. Use the Almquist FD decomposition over the FOCE marginal instead of
+    // bailing to reconverged FD.
+    if !model.residual_correlations.is_empty()
+        && !crate::stats::residual_error::residual_is_diagonal(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        )
+    {
+        return subject_packed_gradient_block(model, subject, template, x, eta_hat, false);
+    }
     let params = unpack_params(x, template);
     let n_eta = model.n_eta;
     let n_theta = params.theta.len();
     let n_obs = subject.observations.len();
-    if n_obs == 0 {
-        return Some(vec![0.0; x.len()]);
-    }
     let sens = subject_sensitivities(model, subject, &params.theta, eta_hat)?;
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
@@ -4558,6 +4690,134 @@ mod tests {
                 .sum::<f64>()
         };
         assert_grad_matches_richardson_fd(&x, &analytic, ofv, 2e-3, 1e-5);
+    }
+
+    /// #847: paired same-time total/unbound rows make `R` genuinely **block-
+    /// diagonal** (not diagonal), so the scalar `corr_residual_diag` reduction
+    /// can't serve it. `subject_packed_gradient` must take the Almquist FD-
+    /// decomposition block path and match Richardson reconverged FD of ferx's own
+    /// FOCEI marginal across every θ/Ω/σ/ρ coordinate — i.e. the block outer
+    /// gradient is correct, replacing the per-subject reconverged-FD fallback.
+    #[test]
+    fn population_packed_gradient_paired_block_sigma_matches_fd() {
+        use crate::estimation::inner_optimizer::find_ebe;
+        use crate::estimation::parameterization::{pack_params, packed_fixed_mask};
+
+        let model =
+            parse_model_string(SELECTED_BLOCK_SIGMA_1CPT).expect("parse selected block_sigma");
+        let theta = &[1.1, 11.0];
+        // Two rows per draw (FREE=0 total, FREE=1 unbound) at the SAME time →
+        // block-diagonal R with 2×2 blocks.
+        let times = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0, 8.0, 8.0];
+        let frees = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let subj = selected_dense_subject(&model, theta, &times, &frees);
+        assert!(
+            !crate::stats::residual_error::residual_is_diagonal(
+                &subj.obs_times,
+                &subj.occasions,
+                &subj.obs_l2
+            ),
+            "fixture must be block-diagonal (paired same-time rows)"
+        );
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+
+        let ebe = |p: &ModelParameters| -> Vec<f64> {
+            find_ebe(&model, &subj, p, 200, 1e-12, None, None, 0)
+                .eta
+                .iter()
+                .copied()
+                .collect()
+        };
+        let eta_hat = ebe(&params);
+        let analytic = subject_packed_gradient(&model, &subj, &template, &x, &eta_hat)
+            .expect("block-diagonal gradient must be analytic (not None)");
+        // Population OFV is 2·Σᵢ Fᵢ with fixed coords zeroed (see `population_sum`).
+        let fixed = packed_fixed_mask(&template);
+        let analytic2: Vec<f64> = analytic
+            .iter()
+            .enumerate()
+            .map(|(k, &g)| if fixed[k] { 0.0 } else { 2.0 * g })
+            .collect();
+
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            let e = ebe(&p);
+            let jac =
+                crate::sens::provider::subject_eta_jacobian(&model, &subj, &p.theta, &e).unwrap();
+            let h = DMatrix::from_row_slice(times.len(), model.n_eta, &jac);
+            2.0 * crate::stats::likelihood::foce_subject_nll(
+                &model,
+                &subj,
+                &p.theta,
+                &DVector::from_vec(e),
+                &h,
+                &p.omega,
+                &p.sigma.values,
+                &p.residual_correlations,
+                true,
+            )
+        };
+        assert_grad_matches_richardson_fd(&x, &analytic2, ofv, 5e-3, 1e-5);
+    }
+
+    /// FOCE (non-interaction) analogue of the paired block-diagonal test: the
+    /// `subject_packed_gradient_foce` block path must match Richardson reconverged
+    /// FD of ferx's FOCE (Sheiner–Beal) marginal.
+    #[test]
+    fn population_packed_gradient_paired_block_sigma_foce_matches_fd() {
+        use crate::estimation::inner_optimizer::find_ebe;
+        use crate::estimation::parameterization::{pack_params, packed_fixed_mask};
+
+        let model =
+            parse_model_string(SELECTED_BLOCK_SIGMA_1CPT).expect("parse selected block_sigma");
+        let theta = &[1.1, 11.0];
+        let times = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0, 8.0, 8.0];
+        let frees = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let subj = selected_dense_subject(&model, theta, &times, &frees);
+
+        let mut template = model.default_params.clone();
+        template.theta = theta.to_vec();
+        let x = pack_params(&template);
+        let params = unpack_params(&x, &template);
+        let ebe = |p: &ModelParameters| -> Vec<f64> {
+            find_ebe(&model, &subj, p, 200, 1e-12, None, None, 0)
+                .eta
+                .iter()
+                .copied()
+                .collect()
+        };
+        let eta_hat = ebe(&params);
+        let analytic = subject_packed_gradient_foce(&model, &subj, &template, &x, &eta_hat)
+            .expect("block-diagonal FOCE gradient must be analytic");
+        let fixed = packed_fixed_mask(&template);
+        let analytic2: Vec<f64> = analytic
+            .iter()
+            .enumerate()
+            .map(|(k, &g)| if fixed[k] { 0.0 } else { 2.0 * g })
+            .collect();
+        let ofv = |xv: &[f64]| -> f64 {
+            let p = unpack_params(xv, &template);
+            let e = ebe(&p);
+            let jac =
+                crate::sens::provider::subject_eta_jacobian(&model, &subj, &p.theta, &e).unwrap();
+            let h = DMatrix::from_row_slice(times.len(), model.n_eta, &jac);
+            2.0 * crate::stats::likelihood::foce_subject_nll(
+                &model,
+                &subj,
+                &p.theta,
+                &DVector::from_vec(e),
+                &h,
+                &p.omega,
+                &p.sigma.values,
+                &p.residual_correlations,
+                false,
+            )
+        };
+        assert_grad_matches_richardson_fd(&x, &analytic2, ofv, 5e-3, 1e-5);
     }
 
     /// `block_sigma` + η-dependent `ExpressionScale` `obs_scale` (#627 × #486): the analytic

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -37,7 +37,7 @@
 use crate::estimation::parameterization::{packed_fixed_mask, theta_packs_log, unpack_params};
 use crate::sens::provider::{subject_sensitivities, ObsSens, SubjectSens};
 use crate::stats::special::m3_censored_outer;
-use crate::types::{CompiledModel, ModelParameters, Population, Subject};
+use crate::types::{CompiledModel, ModelParameters, Population, ResidualCorrelation, Subject};
 use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
 
@@ -457,11 +457,11 @@ fn corr_residual_diag(
     subject: &Subject,
     sens: &SubjectSens,
     sigma: &[f64],
+    corr: &[ResidualCorrelation],
 ) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>)> {
     use crate::stats::residual_error::{
         compute_d2r_df2_matrices, compute_dr_df_matrices, compute_r_matrix_with_correlations,
     };
-    let corr = &model.residual_correlations;
     let es = &model.error_spec;
     // #669: per-observation endpoint keys must come from the covariate selector
     // (`obs_keys`), not the raw CMT column — a `Selected` spec keys endpoints by
@@ -535,9 +535,9 @@ fn corr_residual_rd_at_sigma(
     subject: &Subject,
     ipreds: &[f64],
     sigma: &[f64],
+    corr: &[ResidualCorrelation],
 ) -> (Vec<f64>, Vec<f64>) {
     use crate::stats::residual_error::compute_dr_df_matrices;
-    let corr = &model.residual_correlations;
     let es = &model.error_spec;
     let n = ipreds.len();
     // #669: selector-resolved endpoint keys, not the raw CMT column (see
@@ -804,8 +804,20 @@ pub(crate) fn data_sigma_gradient(
         sm[k] -= h;
         let (corr_sp, corr_sm) = if correlated {
             (
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sp)),
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sm)),
+                Some(corr_residual_rd_at_sigma(
+                    model,
+                    subject,
+                    &ipreds,
+                    &sp,
+                    &params.residual_correlations,
+                )),
+                Some(corr_residual_rd_at_sigma(
+                    model,
+                    subject,
+                    &ipreds,
+                    &sm,
+                    &params.residual_correlations,
+                )),
             )
         } else {
             (None, None)
@@ -962,7 +974,13 @@ pub(crate) fn score_core(
     // `ruv_scale = 1`). `None` bails to FD (a rare off-diagonal R). Everything else in
     // the assembly is unchanged — see `corr_residual_diag`.
     let corr_diag = if !model.residual_correlations.is_empty() {
-        Some(corr_residual_diag(model, subject, sens, sigma)?)
+        Some(corr_residual_diag(
+            model,
+            subject,
+            sens,
+            sigma,
+            &params.residual_correlations,
+        )?)
     } else {
         None
     };
@@ -1616,8 +1634,20 @@ fn sigma_block(
         // Correlation-aware `(R_jj, ∂R_jj/∂f_j)` at σ±h, built once per σ_k.
         let (corr_sp, corr_sm) = if correlated {
             (
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sp)),
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sm)),
+                Some(corr_residual_rd_at_sigma(
+                    model,
+                    subject,
+                    &ipreds,
+                    &sp,
+                    &params.residual_correlations,
+                )),
+                Some(corr_residual_rd_at_sigma(
+                    model,
+                    subject,
+                    &ipreds,
+                    &sm,
+                    &params.residual_correlations,
+                )),
             )
         } else {
             (None, None)
@@ -1761,6 +1791,95 @@ fn sigma_block(
             resp += prep.g_eta[l] * deta[l];
         }
         grad[k] = fixed + 0.5 * resp;
+    }
+    grad
+}
+
+/// Central-difference half-step for a residual-correlation ρ finite difference,
+/// kept strictly inside `(-1, 1)` so `ρ ± h` never produces an indefinite R. The
+/// `1e-6·(1+|ρ|)` step is shrunk when it would cross ±1.
+fn rho_fd_step(rho: f64) -> f64 {
+    let h = 1e-6 * (1.0 + rho.abs());
+    let room = (1.0 - rho.abs()) * 0.5;
+    if h > room && room > 0.0 {
+        room
+    } else {
+        h
+    }
+}
+
+/// Per-residual-correlation packed gradient `∂Fᵢ/∂ρ_k · dρ/dz` for each
+/// `block_sigma` off-diagonal, in `pack_params` order (appended after σ / Ω_IOV).
+///
+/// ρ enters only the **diagonal** of R — the within-observation combined-error
+/// cross term `2·ρ·c₁c₂·σ₁σ₂` (block_sigma excludes M3 / iiv_on_ruv / IOV / FREM,
+/// so R stays diagonal and there is no censored / residual-η branch). So the ρ
+/// gradient is the exact analogue of [`sigma_block`]'s plain row: `∂R/∂ρ` and
+/// `∂d/∂ρ` are taken by central FD of the same correlation-aware variance / `∂R/∂f`
+/// builders `corr_residual_diag` uses (well-conditioned closed-form algebra, no
+/// AD), fed into the identical data + lnR, `log|H̃|`, and EBE-response terms.
+///
+/// The optimizer coordinate is the Fisher-z `z = atanh(ρ)`, so the returned
+/// packed gradient is `∂Fᵢ/∂ρ · (1 − ρ²)` (`dρ/dz = 1 − ρ²`).
+fn rho_block(
+    prep: &Prep,
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    sens: &SubjectSens,
+) -> Vec<f64> {
+    let n_eta = prep.n_eta;
+    let corrs = &params.residual_correlations;
+    let n_corr = corrs.len();
+    let mut grad = vec![0.0f64; n_corr];
+    if n_corr == 0 || subject.observations.is_empty() {
+        return grad;
+    }
+    let sigma = &params.sigma.values;
+    let ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
+
+    for k in 0..n_corr {
+        let rho_k = corrs[k].rho;
+        let h = rho_fd_step(rho_k);
+        // ρ_k ± h; all other correlations held at their current value.
+        let mut cp = corrs.clone();
+        cp[k].rho = rho_k + h;
+        let mut cm = corrs.clone();
+        cm[k].rho = rho_k - h;
+        let (rvp, dvp) = corr_residual_rd_at_sigma(model, subject, &ipreds, sigma, &cp);
+        let (rvm, dvm) = corr_residual_rd_at_sigma(model, subject, &ipreds, sigma, &cm);
+
+        let mut fixed = 0.0;
+        let mut m_vec = DVector::<f64>::zeros(n_eta);
+        for (j, obs) in sens.obs.iter().enumerate() {
+            // block_sigma path: no censored / no residual-η rows (both excluded up
+            // front), so every row is the plain Sheiner–Beal term. `ruv_scale = 1`
+            // here (no iiv_on_ruv) but keep it for parity with `sigma_block`.
+            let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+            let r_rho = prep.ruv_scale * (rvp[j] - rvm[j]) / (2.0 * h);
+            let d_rho = prep.ruv_scale * (dvp[j] - dvm[j]) / (2.0 * h);
+            let inv_r = 1.0 / r;
+            let inv_r2 = inv_r * inv_r;
+            let inv_r3 = inv_r2 * inv_r;
+            // data + lnR:  ½ Rρ (R − ε²)/R²
+            fixed += 0.5 * r_rho * (r - eps * eps) * inv_r2;
+            // log|H̃|:  ½ (∂p/∂ρ) q ,  ∂p/∂ρ = −Rρ/R² + d·dρ/R² − d²Rρ/R³
+            let dp = -r_rho * inv_r2 + d * d_rho * inv_r2 - d * d * r_rho * inv_r3;
+            fixed += 0.5 * dp * prep.q[j];
+            // EBE response M[m] += ½ (∂α/∂ρ) ∂f/∂η_m
+            let dalpha = dalpha_dsigma(r, d, eps, r_rho, d_rho);
+            for m in 0..n_eta {
+                m_vec[m] += 0.5 * dalpha * obs.df_deta[m];
+            }
+        }
+
+        let deta = -(&prep.h_inner_inv * m_vec);
+        let mut resp = 0.0;
+        for l in 0..n_eta {
+            resp += prep.g_eta[l] * deta[l];
+        }
+        // Fisher-z chain: pack coordinate is z = atanh(ρ), dρ/dz = 1 − ρ².
+        grad[k] = (fixed + 0.5 * resp) * (1.0 - rho_k * rho_k);
     }
     grad
 }
@@ -1998,6 +2117,18 @@ pub fn subject_packed_gradient(
         g[sigma_start + k] = g_sigma[k] * params.sigma.values[k];
     }
 
+    // ρ: block_sigma off-diagonals, packed last (Fisher-z; the `(1 − ρ²)` chain
+    // is already applied inside `rho_block`). No Ω_IOV here — block_sigma
+    // excludes IOV — so the ρ slots follow σ directly.
+    let n_corr = params.residual_correlations.len();
+    if n_corr > 0 {
+        let g_rho = rho_block(&prep, model, subject, &params, &sens);
+        let rho_start = sigma_start + n_sigma;
+        for k in 0..n_corr {
+            g[rho_start + k] = g_rho[k];
+        }
+    }
+
     Some(g)
 }
 
@@ -2194,9 +2325,11 @@ pub fn subject_packed_gradient_foce(
     // correlation-aware `(r0,d0)`; a rare off-diagonal bails per-subject to FD via
     // `corr_residual_diag` → `None`. (FOCE is first-order in R — no `∂²R/∂f²`.)
     let correlated = !model.residual_correlations.is_empty();
-    let corr = &model.residual_correlations;
+    // Live (estimated) residual correlations, not the frozen model copy — the
+    // outer loop moves ρ, so the FOCE marginal R⁰ must be built at the current ρ.
+    let corr = &params.residual_correlations;
     let corr_rd0 = if correlated {
-        Some(corr_residual_diag(model, subject, &sens0, sigma)?)
+        Some(corr_residual_diag(model, subject, &sens0, sigma, corr)?)
     } else {
         None
     };
@@ -2434,6 +2567,37 @@ pub fn subject_packed_gradient_foce(
         }
         nat += cg.sigma[k];
         fixed[sigma_start + k] = nat * sigma[k];
+    }
+
+    // ρ (fixed η̂): block_sigma off-diagonals enter only R⁰'s diagonal (within-obs
+    // cross term), so the FOCE marginal σ-gradient carries over with ∂R⁰/∂ρ by FD
+    // of the correlation-aware variance. No censored / FREM rows (both excluded);
+    // packed after σ with the `(1 − ρ²)` Fisher chain. The EBE-response coupling is
+    // added below via `eta_dx` (which now carries dη̂/dρ).
+    if correlated {
+        let rho_start = sigma_start + n_sigma;
+        for (k, c) in corr.iter().enumerate() {
+            let rho_k = c.rho;
+            let hr = rho_fd_step(rho_k);
+            let mut cp = corr.to_vec();
+            cp[k].rho = rho_k + hr;
+            let mut cm = corr.to_vec();
+            cm[k].rho = rho_k - hr;
+            let mut nat = 0.0;
+            for (i, &j) in quant.iter().enumerate() {
+                let cmt = err_keys[j];
+                let f0act = sens0.obs[j].f;
+                let vp = model
+                    .error_spec
+                    .variance_at_with_correlations(cmt, f0act, sigma, &cp);
+                let vm = model
+                    .error_spec
+                    .variance_at_with_correlations(cmt, f0act, sigma, &cm);
+                let dr0 = (vp - vm) / (2.0 * hr);
+                nat += 0.5 * dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
+            }
+            fixed[rho_start + k] = nat * (1.0 - rho_k * rho_k);
+        }
     }
 
     // Coupling c = ∂F/∂η̂: SB part over quant rows + the marginal censored coupling
@@ -3078,12 +3242,14 @@ pub fn subject_eta_dx(
                     subject,
                     &eta_dx_ipreds,
                     &sp,
+                    &params.residual_correlations,
                 )),
                 Some(corr_residual_rd_at_sigma(
                     model,
                     subject,
                     &eta_dx_ipreds,
                     &sm,
+                    &params.residual_correlations,
                 )),
             )
         } else {
@@ -3177,6 +3343,36 @@ pub fn subject_eta_dx(
             }
         }
         out[sigma_start + k] = -(&prep.h_inner_inv * mvec) * sigma[k];
+    }
+
+    // ρ coords (block_sigma off-diagonals): M_ρ = ½ Σⱼ ∂αⱼ/∂ρ · aⱼ, with ∂R/∂ρ,
+    // ∂d/∂ρ by FD of the correlation-aware variance; packed after σ, ×(1−ρ²)
+    // Fisher chain. block_sigma excludes M3 / FREM / iiv_on_ruv, so every row is
+    // the plain branch (no censored / frem / residual-η terms).
+    let corrs = &params.residual_correlations;
+    if !corrs.is_empty() {
+        let rho_start = sigma_start + n_sigma;
+        for k in 0..corrs.len() {
+            let rho_k = corrs[k].rho;
+            let hk = rho_fd_step(rho_k);
+            let mut cp = corrs.clone();
+            cp[k].rho = rho_k + hk;
+            let mut cm = corrs.clone();
+            cm[k].rho = rho_k - hk;
+            let (rvp, dvp) = corr_residual_rd_at_sigma(model, subject, &eta_dx_ipreds, sigma, &cp);
+            let (rvm, dvm) = corr_residual_rd_at_sigma(model, subject, &eta_dx_ipreds, sigma, &cm);
+            let mut mvec = DVector::<f64>::zeros(n_eta);
+            for (j, obs) in sens.obs.iter().enumerate() {
+                let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+                let r_rho = prep.ruv_scale * (rvp[j] - rvm[j]) / (2.0 * hk);
+                let d_rho = prep.ruv_scale * (dvp[j] - dvm[j]) / (2.0 * hk);
+                let dalpha = dalpha_dsigma(r, d, eps, r_rho, d_rho);
+                for m in 0..n_eta {
+                    mvec[m] += 0.5 * dalpha * obs.df_deta[m];
+                }
+            }
+            out[rho_start + k] = -(&prep.h_inner_inv * mvec) * (1.0 - rho_k * rho_k);
+        }
     }
 
     Some(out)
@@ -3662,6 +3858,7 @@ mod tests {
             &h_matrix,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             false,
         )
     }
@@ -4116,7 +4313,9 @@ mod tests {
             let sens =
                 crate::sens::provider::subject_sensitivities(model, subject, &params.theta, &eta)
                     .unwrap();
-            let (rv, dv, d2v) = corr_residual_diag(model, subject, &sens, sigma).unwrap();
+            let (rv, dv, d2v) =
+                corr_residual_diag(model, subject, &sens, sigma, &params.residual_correlations)
+                    .unwrap();
             let mut grad = DVector::<f64>::from_column_slice(
                 &(omega_inv * DVector::from_column_slice(&eta))
                     .iter()
@@ -4166,6 +4365,7 @@ mod tests {
             &h,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             true,
         )
     }
@@ -5388,6 +5588,7 @@ mod tests {
                     &ebe.h_matrix,
                     &p.omega,
                     &p.sigma.values,
+                    &p.residual_correlations,
                     true,
                 )
             }
@@ -6680,6 +6881,7 @@ mod tests {
             &hm,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             interaction,
             &kappas,
             params.omega_iov.as_ref().expect("IOV model has omega_iov"),

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -79,8 +79,26 @@ pub fn fitted_params_from_result(
             names: fit_result.sigma_names.clone(),
         },
         sigma_fixed: fit_result.sigma_fixed.clone(),
+        // Estimated `block_sigma` off-diagonals (final ρ) come from the fit;
+        // the template supplies the pair structure and FIX flags.
+        residual_correlations: fit_result_residual_correlations(fit_result, template),
+        residual_correlation_fixed: template.residual_correlation_fixed.clone(),
         omega_iov,
         kappa_fixed: fit_result.kappa_fixed.clone(),
+    }
+}
+
+/// Final residual correlations for uncertainty sampling: prefer the fitted ρ
+/// (`FitResult.residual_correlations`) and fall back to the template's initial
+/// pairs when a fit predates the field (keeps the pair structure/indices intact).
+fn fit_result_residual_correlations(
+    fit_result: &crate::types::FitResult,
+    template: &ModelParameters,
+) -> Vec<crate::types::ResidualCorrelation> {
+    if fit_result.residual_correlations.len() == template.residual_correlations.len() {
+        fit_result.residual_correlations.clone()
+    } else {
+        template.residual_correlations.clone()
     }
 }
 
@@ -318,6 +336,8 @@ mod tests {
                 names: vec!["prop_err".to_string()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         }
@@ -342,6 +362,8 @@ mod tests {
             omega: template.omega.matrix.clone(),
             sigma: template.sigma.values.clone(),
             sigma_names: template.sigma.names.clone(),
+            residual_correlations: Vec::new(),
+            se_residual_correlations: None,
             error_model: ErrorModel::Proportional,
             covariance_matrix: Some(cov),
             se_theta: None,

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1099,6 +1099,8 @@ mod tests {
                     names: vec!["PROP_ERR".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: None,
                 kappa_fixed: Vec::new(),
             },

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1675,6 +1675,10 @@ fn wire_to_fit_result(
         omega,
         sigma: w.sigma.estimates,
         sigma_names: w.sigma.names,
+        // The fitrx wire format does not yet carry estimated block_sigma
+        // off-diagonals; a round-tripped fit reports none.
+        residual_correlations: Vec::new(),
+        se_residual_correlations: None,
         error_model: error_model_from_str(&w.error_model)?,
         covariance_matrix,
         se_theta: w.theta.se,
@@ -1890,6 +1894,8 @@ mod tests {
             omega: DMatrix::from_row_slice(2, 2, &[0.1, 0.0, 0.0, 0.2]),
             sigma: vec![0.05],
             sigma_names: vec!["prop".into()],
+            residual_correlations: Vec::new(),
+            se_residual_correlations: None,
             error_model: ErrorModel::Proportional,
             covariance_matrix: Some(DMatrix::<f64>::identity(3, 3)),
             se_theta: Some(vec![0.01, 0.02, 0.005]),

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1567,6 +1567,22 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
         }
     }
 
+    // Estimated block_sigma off-diagonals (#847): packed last, as Fisher-z
+    // correlation coordinates (`corr_{eps_i}_{eps_j}`).
+    for c in &result.residual_correlations {
+        let ni = result
+            .sigma_names
+            .get(c.sigma_i)
+            .cloned()
+            .unwrap_or_else(|| format!("sigma_{}", c.sigma_i + 1));
+        let nj = result
+            .sigma_names
+            .get(c.sigma_j)
+            .cloned()
+            .unwrap_or_else(|| format!("sigma_{}", c.sigma_j + 1));
+        names.push(format!("corr_{ni}_{nj}"));
+    }
+
     // Pad with generic names if the covariance matrix is larger than expected
     // (shouldn't happen in practice, but prevents index-out-of-bounds).
     while names.len() < n {
@@ -1808,6 +1824,38 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
             writeln!(f, "    fixed: true").map_err(|e| e.to_string())?;
             writeln!(f, "    se: ~").map_err(|e| e.to_string())?;
         } else {
+            match se {
+                Some(sv) => writeln!(f, "    se: {:.6}", sv).map_err(|e| e.to_string())?,
+                None => writeln!(f, "    se: ~").map_err(|e| e.to_string())?,
+            }
+        }
+    }
+
+    // Estimated block_sigma off-diagonals (#847). Reports the fitted residual
+    // correlation ρ, its SE (on the ρ scale), and the implied covariance
+    // ρ·σ_i·σ_j — the full SIGMA block NONMEM would print. Keyed `{name_i}__{name_j}`.
+    if !result.residual_correlations.is_empty() {
+        writeln!(f, "\nsigma_correlations:").map_err(|e| e.to_string())?;
+        for (k, c) in result.residual_correlations.iter().enumerate() {
+            let name_i = result
+                .sigma_names
+                .get(c.sigma_i)
+                .cloned()
+                .unwrap_or_else(|| format!("sigma_{}", c.sigma_i + 1));
+            let name_j = result
+                .sigma_names
+                .get(c.sigma_j)
+                .cloned()
+                .unwrap_or_else(|| format!("sigma_{}", c.sigma_j + 1));
+            let si = result.sigma.get(c.sigma_i).copied().unwrap_or(0.0);
+            let sj = result.sigma.get(c.sigma_j).copied().unwrap_or(0.0);
+            let se = result
+                .se_residual_correlations
+                .as_ref()
+                .and_then(|v| v.get(k).copied());
+            writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
+            writeln!(f, "    correlation: {:.6}", c.rho).map_err(|e| e.to_string())?;
+            writeln!(f, "    covariance: {:.6}", c.rho * si * sj).map_err(|e| e.to_string())?;
             match se {
                 Some(sv) => writeln!(f, "    se: {:.6}", sv).map_err(|e| e.to_string())?,
                 None => writeln!(f, "    se: ~").map_err(|e| e.to_string())?,
@@ -2144,6 +2192,8 @@ mod tests {
             omega: DMatrix::zeros(0, 0),
             sigma,
             sigma_names: (0..n).map(|i| format!("EPS_{}", i + 1)).collect(),
+            residual_correlations: Vec::new(),
+            se_residual_correlations: None,
             error_model,
             covariance_matrix: None,
             se_theta: None,
@@ -2511,6 +2561,39 @@ mod tests {
         );
     }
 
+    /// #847: an estimated `block_sigma` off-diagonal is rendered in a
+    /// `sigma_correlations:` section with correlation, implied covariance, and SE.
+    #[test]
+    fn sigma_correlations_yaml_reports_estimated_offdiagonal() {
+        let mut result = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
+        result.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.75,
+        }];
+        result.se_residual_correlations = Some(vec![0.04]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&result, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(yaml.contains("sigma_correlations:"), "yaml=\n{yaml}");
+        // ρ = 0.75, covariance = 0.75 * 1.0 * 0.2 = 0.15, se = 0.04.
+        assert!(yaml.contains("correlation: 0.750000"), "yaml=\n{yaml}");
+        assert!(yaml.contains("covariance: 0.150000"), "yaml=\n{yaml}");
+        assert!(yaml.contains("se: 0.040000"), "yaml=\n{yaml}");
+    }
+
+    /// No `sigma_correlations:` section when the model has no block_sigma off-diagonals.
+    #[test]
+    fn sigma_correlations_yaml_absent_without_block_sigma() {
+        let result = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&result, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+        assert!(!yaml.contains("sigma_correlations:"), "yaml=\n{yaml}");
+    }
+
     #[test]
     fn sigma_yaml_proportional_emits_variance_and_cv_pct() {
         let yaml = yaml_for(ErrorModel::Proportional, vec![0.1]);
@@ -2713,6 +2796,8 @@ mod tests {
             omega: DMatrix::zeros(0, 0),
             sigma: vec![0.1],
             sigma_names: vec!["eps".to_string()],
+            residual_correlations: Vec::new(),
+            se_residual_correlations: None,
             error_model: ErrorModel::Proportional,
             covariance_matrix: None,
             se_theta: None,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1863,6 +1863,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     };
     let (error_model, error_spec) = build_error_spec(parsed_error_model, &sigma_names, is_ode)?;
     let residual_correlations = build_residual_correlations(&block_sigmas, &sigma_names)?;
+    let residual_correlation_fixed = build_residual_correlation_fixed(&block_sigmas);
     validate_residual_correlations(&error_spec, &residual_correlations, &sigma_names)?;
     // Keep a copy of the flat sigma names for the custom residual-magnitude
     // build (#484), which runs after the [covariates] block is parsed.
@@ -1931,6 +1932,8 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         omega_fixed,
         sigma,
         sigma_fixed,
+        residual_correlations: residual_correlations.clone(),
+        residual_correlation_fixed,
         omega_iov,
         kappa_fixed,
     };
@@ -10041,9 +10044,32 @@ fn build_residual_correlations(
                 pos += 1;
             }
         }
-        let _fixed = block.fixed;
     }
     Ok(out)
+}
+
+/// Per-off-diagonal FIX flags parallel to [`build_residual_correlations`]'s
+/// output. Walks the same block / lower-triangle order and emits an entry only
+/// where that function emits a [`ResidualCorrelation`] (off-diagonal, non-zero
+/// covariance), carrying the owning block's `FIX` flag. A plain `block_sigma`
+/// yields `false` (the off-diagonal is estimated, NONMEM `$SIGMA BLOCK(n)`
+/// semantics); `block_sigma ... FIX` yields `true` (pins the correlation).
+fn build_residual_correlation_fixed(block_sigmas: &[BlockSigmaSpec]) -> Vec<bool> {
+    let mut out = Vec::new();
+    for block in block_sigmas {
+        let n = block.names.len();
+        let mut pos = 0;
+        for row in 0..n {
+            for col in 0..=row {
+                let value = block.lower_triangle[pos];
+                if row != col && value != 0.0 {
+                    out.push(block.fixed);
+                }
+                pos += 1;
+            }
+        }
+    }
+    out
 }
 
 fn validate_block_sigma_single_error_order(
@@ -20069,6 +20095,44 @@ mod tests {
         let (_, _, _, sigmas, block_sigmas, _, _) = parse_parameters(&lines).unwrap();
         assert!(sigmas.iter().all(|s| s.fixed));
         assert!(block_sigmas[0].fixed);
+    }
+
+    /// #847: a plain `block_sigma` off-diagonal is ESTIMATED (NONMEM BLOCK
+    /// semantics) — `residual_correlation_fixed` is `false`; a `FIX` block pins it.
+    #[test]
+    fn test_block_sigma_offdiag_estimated_unless_fixed() {
+        let free = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0]".to_string()];
+        let (_, _, _, _, free_blocks, _, _) = parse_parameters(&free).unwrap();
+        assert_eq!(build_residual_correlation_fixed(&free_blocks), vec![false]);
+
+        let fixed = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0] FIX".to_string()];
+        let (_, _, _, _, fixed_blocks, _, _) = parse_parameters(&fixed).unwrap();
+        assert_eq!(build_residual_correlation_fixed(&fixed_blocks), vec![true]);
+    }
+
+    /// The estimated off-diagonal appears in `default_params` as a live optimizer
+    /// coordinate: `residual_correlations` carries ρ and the packed vector grows by
+    /// one slot (the Fisher-z coordinate), free unless `FIX`.
+    #[test]
+    fn test_block_sigma_default_params_carry_free_rho() {
+        let src = "[parameters]\n  theta TVCL(1.0, 0.01, 10.0)\n  omega ETA_CL ~ 0.09\n  \
+                   block_sigma (PROP, ADD) = [0.04, 0.10, 1.0]\n[individual_parameters]\n  \
+                   CL = TVCL * exp(ETA_CL)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=10.0)\n\
+                   [error_model]\n  DV ~ combined(PROP, ADD)\n[fit_options]\n  method = focei\n";
+        let model = parse_model_string(src).expect("parse");
+        let p = &model.default_params;
+        assert_eq!(p.residual_correlations.len(), 1);
+        assert!((p.residual_correlations[0].rho - 0.5).abs() < 1e-12);
+        assert_eq!(p.residual_correlation_fixed, vec![false]);
+        // Packed vector: 1 theta + 1 omega + 2 sigma + 1 rho = 5.
+        let packed = crate::estimation::parameterization::pack_params(p);
+        assert_eq!(packed.len(), 5);
+        // The rho slot is NOT pinned (free) → bounds differ.
+        let bounds = crate::estimation::parameterization::compute_bounds(p);
+        assert!(
+            bounds.lower[4] < bounds.upper[4],
+            "rho coordinate must be free"
+        );
     }
 
     #[test]

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -2486,6 +2486,8 @@ mod tests {
                     names: vec!["EPS".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: None,
                 kappa_fixed: Vec::new(),
             },

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -631,6 +631,49 @@ fn dense_residual_data_term(
 ) -> Option<f64> {
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
+
+    // Diagonal-R fast path (#847 perf): when no two observations can pair
+    // (`residual_is_diagonal`), skip building the dense n×n R and its Cholesky
+    // entirely — O(n) instead of O(n²)+O(n³). Only for the unscaled diagonal
+    // builder (`ruv_mult` is None, which holds for every `block_sigma` model —
+    // custom residual magnitude is mutually exclusive). Bit-for-bit identical to
+    // the dense branch: same per-row variance (`variance_at_with_correlations`),
+    // same `× ruv_scale` then `+ p_obs` order, same `√`-based solve as
+    // `quad_form_plus_logdet` performs on a diagonal R.
+    if ruv_mult.is_none()
+        && crate::stats::residual_error::residual_is_diagonal(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        )
+    {
+        let rv = crate::stats::residual_error::compute_r_diag_with_correlations(
+            &model.error_spec,
+            preds,
+            err_keys.as_ref(),
+            sigma_values,
+            residual_correlations,
+        );
+        let mut quad = 0.0;
+        let mut ld = 0.0;
+        for j in 0..rv.len() {
+            let mut rjj = rv[j];
+            if ruv_scale != 1.0 {
+                rjj *= ruv_scale;
+            }
+            rjj += p_obs.get(j).copied().unwrap_or(0.0);
+            let ljj = rjj.sqrt();
+            if ljj <= 0.0 || ljj.is_nan() {
+                return None;
+            }
+            let resid = subject.observations[j] - preds[j];
+            let solved = (resid / ljj) / ljj;
+            quad += resid * solved;
+            ld += ljj.ln();
+        }
+        return Some(quad + 2.0 * ld);
+    }
+
     let mut r = crate::stats::residual_error::r_matrix_maybe_scaled(
         &model.error_spec,
         preds,
@@ -648,7 +691,6 @@ fn dense_residual_data_term(
             r[(j, j)] += *v;
         }
     }
-    let chol = r.cholesky()?;
     let residuals = DVector::from_iterator(
         subject.observations.len(),
         subject
@@ -657,8 +699,7 @@ fn dense_residual_data_term(
             .zip(preds.iter())
             .map(|(&y, &f)| y - f),
     );
-    let solved = chol.solve(&residuals);
-    Some(residuals.dot(&solved) + chol_log_det(&chol.l()))
+    quad_form_plus_logdet(&r, &residuals)
 }
 
 /// Observation-only NLL for a single subject with ETAs held fixed.
@@ -1450,6 +1491,77 @@ pub fn foce_subject_nll_interaction_dense(
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = error_spec.obs_keys(subject);
 
+    // Diagonal-R fast path (#847 perf): the FOCEI marginal is O(n³) (dense
+    // Cholesky, R⁻¹, per-η ∂R/∂η matrices, tr(M_k M_l)) but collapses to
+    // O(n·n_eta²) when R is diagonal (the common combined-error `block_sigma`).
+    // `R⁻¹`, `∂R/∂η_k`, and `M_k = R⁻¹∂R/∂η_k` are all diagonal, so `term1` and
+    // the interaction `B` become scalar sums. `ruv_mult` is None for every
+    // `block_sigma` model (custom magnitude is mutually exclusive).
+    if ruv_mult.is_none()
+        && crate::stats::residual_error::residual_is_diagonal(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        )
+    {
+        let rv = crate::stats::residual_error::compute_r_diag_with_correlations(
+            error_spec,
+            ipreds,
+            err_keys.as_ref(),
+            sigma_values,
+            correlations,
+        );
+        let dv = crate::stats::residual_error::compute_dr_df_diag(
+            error_spec,
+            ipreds,
+            err_keys.as_ref(),
+            sigma_values,
+            correlations,
+            None,
+        );
+        let mut rinv = vec![0.0f64; n_obs]; // diag(R⁻¹)
+        let mut data_ll = 0.0;
+        for m in 0..n_obs {
+            let rjj = rv[m] + p_obs.get(m).copied().unwrap_or(0.0);
+            let ljj = rjj.sqrt();
+            if ljj <= 0.0 || ljj.is_nan() {
+                return 1e20;
+            }
+            rinv[m] = 1.0 / rjj;
+            let resid = subject.observations[m] - ipreds[m];
+            data_ll += resid * (resid / rjj);
+            data_ll += 2.0 * ljj.ln();
+        }
+        // M_k[m,m] = R⁻¹_mm · (∂R/∂η_k)_mm = rinv_m · H[m,k]·dv_m.
+        let mk: Vec<Vec<f64>> = (0..n_eta)
+            .map(|k| {
+                (0..n_obs)
+                    .map(|m| rinv[m] * (h_matrix[(m, k)] * dv[m]))
+                    .collect::<Vec<f64>>()
+            })
+            .collect();
+        let mut htilde = omega.inv.clone();
+        for k in 0..n_eta {
+            for l in 0..n_eta {
+                // term1_{kl} = Σ_m H[m,k]·R⁻¹_mm·H[m,l].
+                let mut t1 = 0.0;
+                // B_{kl} = tr(M_k M_l) = Σ_m M_k[m,m]·M_l[m,m] (diagonal).
+                let mut bkl = 0.0;
+                for m in 0..n_obs {
+                    t1 += h_matrix[(m, k)] * rinv[m] * h_matrix[(m, l)];
+                    bkl += mk[k][m] * mk[l][m];
+                }
+                htilde[(k, l)] += t1 + 0.5 * bkl;
+            }
+        }
+        let log_det_htilde = match htilde.cholesky() {
+            Some(c) => chol_log_det(&c.l()),
+            None => return 1e20,
+        };
+        let eta_prior = eta_hat.dot(&(&omega.inv * eta_hat));
+        return 0.5 * (data_ll + eta_prior + omega.log_det + log_det_htilde);
+    }
+
     // Dense R at η̂ (+ SDE process noise on the diagonal), assembled exactly as
     // the data term and FOCE-standard path assemble it.
     let mut r = crate::stats::residual_error::r_matrix_maybe_scaled(
@@ -1852,6 +1964,52 @@ pub(crate) fn chol_log_det(l: &DMatrix<f64>) -> f64 {
         }
     }
     2.0 * ld
+}
+
+/// `true` when `r`'s off-diagonal entries are all exactly zero. Cross-observation
+/// residual covariance (`block_sigma` paired total/unbound rows sharing a
+/// time/occasion/L2 block) is the *only* thing that writes a nonzero off-diagonal
+/// (`fill_cross_covariances`); a `combined`-error `block_sigma` at distinct
+/// observation times leaves `R` diagonal, so this is the common case.
+fn r_is_diagonal(r: &DMatrix<f64>) -> bool {
+    let n = r.nrows();
+    for a in 0..n {
+        for b in (a + 1)..n {
+            if r[(a, b)] != 0.0 || r[(b, a)] != 0.0 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// The dense residual data term `rᵀR⁻¹r + log|R|`, but O(n) instead of O(n³) when
+/// `R` is diagonal — the usual `block_sigma` combined-error case, where the dense
+/// Cholesky was pure waste (2–3 orders of magnitude on subjects with many
+/// observations). The diagonal branch is **bit-for-bit** identical to
+/// `r.cholesky()` on a diagonal `R`: nalgebra factors it as `L = diag(√Rⱼⱼ)` and
+/// solves by two divisions per row, so `solveⱼ = (rⱼ/√Rⱼⱼ)/√Rⱼⱼ` and
+/// `log|R| = 2·Σ ln√Rⱼⱼ` reproduce the exact same rounding. Returns `None`
+/// (non-PD) exactly where `cholesky()` would.
+fn quad_form_plus_logdet(r: &DMatrix<f64>, residuals: &DVector<f64>) -> Option<f64> {
+    if r_is_diagonal(r) {
+        let n = r.nrows();
+        let mut quad = 0.0;
+        let mut ld = 0.0;
+        for j in 0..n {
+            let ljj = r[(j, j)].sqrt();
+            if ljj <= 0.0 || ljj.is_nan() {
+                return None;
+            }
+            let solved = (residuals[j] / ljj) / ljj;
+            quad += residuals[j] * solved;
+            ld += ljj.ln();
+        }
+        return Some(quad + 2.0 * ld);
+    }
+    let chol = r.clone().cholesky()?;
+    let solved = chol.solve(residuals);
+    Some(residuals.dot(&solved) + chol_log_det(&chol.l()))
 }
 
 /// IOV-aware FOCE per-subject NLL — a *proper* linearised marginal over the
@@ -2449,6 +2607,52 @@ mod tests {
     };
     use approx::assert_relative_eq;
     use std::collections::HashMap;
+
+    /// The O(n) diagonal fast path in [`quad_form_plus_logdet`] must be
+    /// **bit-for-bit** identical to the dense Cholesky path for a diagonal `R`
+    /// (that is the whole point — no OFV shift, just no O(n³) work).
+    #[test]
+    fn quad_form_diagonal_fast_path_is_bit_identical_to_cholesky() {
+        let diag = [0.04_f64, 0.25, 1.5, 0.0009, 12.0, 0.7];
+        let mut r = DMatrix::<f64>::zeros(diag.len(), diag.len());
+        for (j, &d) in diag.iter().enumerate() {
+            r[(j, j)] = d;
+        }
+        let residuals = DVector::from_vec(vec![0.3, -1.1, 2.7, -0.05, 4.0, -0.9]);
+
+        // Reference: the exact dense computation the old code did.
+        let chol = r.clone().cholesky().unwrap();
+        let solved = chol.solve(&residuals);
+        let reference = residuals.dot(&solved) + chol_log_det(&chol.l());
+
+        let fast = quad_form_plus_logdet(&r, &residuals).unwrap();
+        assert!(
+            fast.to_bits() == reference.to_bits(),
+            "diagonal fast path {fast} != dense {reference} (bit-for-bit required)"
+        );
+    }
+
+    /// A genuinely dense `R` (cross-observation off-diagonals) still goes through
+    /// the Cholesky branch and matches the reference.
+    #[test]
+    fn quad_form_dense_path_matches_reference() {
+        let mut r = DMatrix::<f64>::from_diagonal(&DVector::from_vec(vec![1.0, 2.0, 3.0]));
+        r[(0, 1)] = 0.3;
+        r[(1, 0)] = 0.3;
+        let residuals = DVector::from_vec(vec![0.5, -1.0, 0.7]);
+        let chol = r.clone().cholesky().unwrap();
+        let reference = residuals.dot(&chol.solve(&residuals)) + chol_log_det(&chol.l());
+        let got = quad_form_plus_logdet(&r, &residuals).unwrap();
+        assert!((got - reference).abs() < 1e-14);
+    }
+
+    /// Non-PD (zero / negative diagonal) returns `None`, exactly like `cholesky()`.
+    #[test]
+    fn quad_form_non_pd_returns_none() {
+        let r = DMatrix::<f64>::from_diagonal(&DVector::from_vec(vec![1.0, 0.0, 3.0]));
+        let residuals = DVector::from_vec(vec![0.5, 1.0, 0.7]);
+        assert!(quad_form_plus_logdet(&r, &residuals).is_none());
+    }
 
     fn make_simple_subject() -> Subject {
         Subject {

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -699,6 +699,39 @@ fn dense_residual_data_term(
             .zip(preds.iter())
             .map(|(&y, &f)| y - f),
     );
+
+    // Block-diagonal fast path (#847 perf): paired total/unbound `block_sigma`
+    // (an L2 group or two co-temporal rows per draw) leaves R block-diagonal with
+    // small blocks. The full data term `rᵀR⁻¹r + log|R|` sums over disjoint
+    // blocks, so factor each small block instead of the whole n×n R — O(Σ b³)
+    // rather than O(n³). Only when nothing scales the diagonal magnitude
+    // (`ruv_mult` None, i.e. every `block_sigma` model).
+    if ruv_mult.is_none() {
+        let blocks = crate::stats::residual_error::residual_blocks(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        );
+        if blocks.len() < subject.observations.len() {
+            let mut data_ll = 0.0;
+            for block in &blocks {
+                let bn = block.len();
+                let mut rg = DMatrix::<f64>::zeros(bn, bn);
+                for (a, &ja) in block.iter().enumerate() {
+                    for (b, &jb) in block.iter().enumerate() {
+                        rg[(a, b)] = r[(ja, jb)];
+                    }
+                }
+                let resid_g = DVector::from_iterator(
+                    bn,
+                    block.iter().map(|&j| subject.observations[j] - preds[j]),
+                );
+                data_ll += quad_form_plus_logdet(&rg, &resid_g)?;
+            }
+            return Some(data_ll);
+        }
+    }
+
     quad_form_plus_logdet(&r, &residuals)
 }
 
@@ -1560,6 +1593,91 @@ pub fn foce_subject_nll_interaction_dense(
         };
         let eta_prior = eta_hat.dot(&(&omega.inv * eta_hat));
         return 0.5 * (data_ll + eta_prior + omega.log_det + log_det_htilde);
+    }
+
+    // Block-diagonal fast path (#847 perf): paired total/unbound `block_sigma`
+    // leaves R block-diagonal with small blocks. The data term, `term1 = HᵀR⁻¹H`,
+    // and the interaction `B_{kl} = tr(M_k M_l)` all sum over disjoint blocks, so
+    // each is assembled from independent small per-block dense problems — O(Σ b³ +
+    // Σ b²·n_eta²) rather than O(n³ + n_eta·n²).
+    if ruv_mult.is_none() {
+        let blocks = crate::stats::residual_error::residual_blocks(
+            &subject.obs_times,
+            &subject.occasions,
+            &subject.obs_l2,
+        );
+        if blocks.len() < n_obs {
+            let mut data_ll = 0.0;
+            let mut term1 = DMatrix::<f64>::zeros(n_eta, n_eta);
+            let mut bmat = DMatrix::<f64>::zeros(n_eta, n_eta);
+            for block in &blocks {
+                let bn = block.len();
+                let (mut rg, dr) = crate::stats::residual_error::block_r_and_dr(
+                    error_spec,
+                    block,
+                    ipreds,
+                    err_keys.as_ref(),
+                    &subject.obs_times,
+                    &subject.obs_raw_times,
+                    &subject.occasions,
+                    &subject.obs_l2,
+                    sigma_values,
+                    correlations,
+                );
+                for (loc, &j) in block.iter().enumerate() {
+                    rg[(loc, loc)] += p_obs.get(j).copied().unwrap_or(0.0);
+                }
+                let chol = match rg.clone().cholesky() {
+                    Some(c) => c,
+                    None => return 1e20,
+                };
+                let rinv = chol.inverse();
+                let resid_g = DVector::from_iterator(
+                    bn,
+                    block.iter().map(|&j| subject.observations[j] - ipreds[j]),
+                );
+                data_ll += resid_g.dot(&chol.solve(&resid_g)) + chol_log_det(&chol.l());
+                // H_g (b×n_eta) → term1 += H_gᵀ R_g⁻¹ H_g.
+                let mut hg = DMatrix::<f64>::zeros(bn, n_eta);
+                for (loc, &j) in block.iter().enumerate() {
+                    for k in 0..n_eta {
+                        hg[(loc, k)] = h_matrix[(j, k)];
+                    }
+                }
+                term1 += hg.transpose() * &rinv * &hg;
+                // M_k = R_g⁻¹ (∂R/∂η_k)_g, then B_{kl} += tr(M_k M_l).
+                let mk: Vec<DMatrix<f64>> = (0..n_eta)
+                    .map(|k| {
+                        let mut drk = DMatrix::<f64>::zeros(bn, bn);
+                        for (loc, &j) in block.iter().enumerate() {
+                            let h = h_matrix[(j, k)];
+                            if h != 0.0 {
+                                drk += h * &dr[loc];
+                            }
+                        }
+                        &rinv * drk
+                    })
+                    .collect();
+                for k in 0..n_eta {
+                    for l in 0..n_eta {
+                        let mut t = 0.0;
+                        for p in 0..bn {
+                            for q in 0..bn {
+                                t += mk[k][(p, q)] * mk[l][(q, p)];
+                            }
+                        }
+                        bmat[(k, l)] += t;
+                    }
+                }
+            }
+            let htilde = term1 + 0.5 * bmat + &omega.inv;
+            let log_det_htilde = match htilde.cholesky() {
+                Some(c) => chol_log_det(&c.l()),
+                None => return 1e20,
+            };
+            let eta_prior = eta_hat.dot(&(&omega.inv * eta_hat));
+            return 0.5 * (data_ll + eta_prior + omega.log_det + log_det_htilde);
+        }
     }
 
     // Dense R at η̂ (+ SDE process noise on the diagonal), assembled exactly as

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -109,6 +109,7 @@ pub fn individual_nll_into(
         eta,
         omega,
         sigma_values,
+        &model.residual_correlations,
         scratch,
         None,
     )
@@ -469,6 +470,7 @@ pub fn individual_nll_into_with_schedule(
     eta: &[f64],
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> f64 {
@@ -525,12 +527,13 @@ pub fn individual_nll_into_with_schedule(
     let has_censored_m3 =
         matches!(model.bloq_method, BloqMethod::M3) && subject.has_censored_observation();
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
-    if !model.residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
+    if !residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
         match dense_residual_data_term(
             model,
             subject,
             &preds,
             sigma_values,
+            residual_correlations,
             ruv_scale,
             &p_obs,
             ruv_mult.as_deref(),
@@ -621,6 +624,7 @@ fn dense_residual_data_term(
     subject: &Subject,
     preds: &[f64],
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     ruv_scale: f64,
     p_obs: &[f64],
     ruv_mult: Option<&[Vec<f64>]>,
@@ -633,7 +637,7 @@ fn dense_residual_data_term(
         err_keys.as_ref(),
         subject,
         sigma_values,
-        &model.residual_correlations,
+        residual_correlations,
         ruv_mult,
     );
     if ruv_scale != 1.0 {
@@ -712,6 +716,7 @@ pub(crate) fn obs_nll_subject_from_preds(
             subject,
             preds,
             sigma_values,
+            &model.residual_correlations,
             ruv_scale,
             &[],
             ruv_mult.as_deref(),
@@ -869,6 +874,7 @@ pub fn foce_subject_nll(
     h_matrix: &DMatrix<f64>,
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
 ) -> f64 {
     // Individual predictions at eta_hat (per-event PK when subject has TV covariates).
@@ -1051,7 +1057,7 @@ pub fn foce_subject_nll(
     // off-diagonal covariance. The non-interaction (Sheiner–Beal) branch carries
     // the dense R for both cases via `compute_r_matrix_with_correlations`.
     if interaction {
-        if model.residual_correlations.is_empty() {
+        if residual_correlations.is_empty() {
             foce_subject_nll_interaction(
                 subject,
                 &ipreds,
@@ -1075,7 +1081,7 @@ pub fn foce_subject_nll(
                 omega,
                 sigma_values,
                 &model.error_spec,
-                &model.residual_correlations,
+                residual_correlations,
                 &p_obs,
                 ruv_mult.as_deref(),
             )
@@ -1103,7 +1109,7 @@ pub fn foce_subject_nll(
             omega,
             sigma_values,
             &model.error_spec,
-            &model.residual_correlations,
+            residual_correlations,
             model.bloq_method,
             &p_obs,
             frem_r_override.as_deref(),
@@ -1885,6 +1891,7 @@ pub fn foce_subject_nll_iov(
     h_matrix: &DMatrix<f64>,
     omega_bsv: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
     kappas: &[DVector<f64>],
     omega_iov: &OmegaMatrix,
@@ -1898,6 +1905,7 @@ pub fn foce_subject_nll_iov(
             h_matrix,
             omega_bsv,
             sigma_values,
+            residual_correlations,
             interaction,
         );
     }
@@ -2046,7 +2054,7 @@ pub fn foce_subject_nll_iov(
             &sigma_b,
             sigma_values,
             &model.error_spec,
-            &model.residual_correlations,
+            residual_correlations,
             model.bloq_method,
             &p_obs_iov,
             None,
@@ -2069,6 +2077,7 @@ pub fn foce_population_nll_iov(
     omega_bsv: &OmegaMatrix,
     omega_iov: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
 ) -> f64 {
     // Compute each subject's NLL in parallel, then reduce in a fixed subject
@@ -2096,6 +2105,7 @@ pub fn foce_population_nll_iov(
                 &h_matrices[i],
                 omega_bsv,
                 sigma_values,
+                residual_correlations,
                 interaction,
                 kappas,
                 omega_iov,
@@ -2114,6 +2124,7 @@ pub fn foce_population_nll(
     h_matrices: &[DMatrix<f64>],
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
 ) -> f64 {
     // Deterministic reduction: collect per-subject NLLs in subject order, then
@@ -2133,6 +2144,7 @@ pub fn foce_population_nll(
                 &h_matrices[i],
                 omega,
                 sigma_values,
+                residual_correlations,
                 interaction,
             )
         })
@@ -2498,6 +2510,8 @@ mod tests {
                     names: vec!["PROP_ERR".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: None,
                 kappa_fixed: Vec::new(),
             },
@@ -2808,7 +2822,15 @@ mod tests {
         //     marginal. The OLD code added 0.5·K·log|Ω_iov| = log(1e-12) ≈ -27.6,
         //     so this assertion fails without the proper-marginal fix.
         let base = foce_subject_nll(
-            &model, &subj, &theta, &eta_hat, &h_bsv, &omega_bsv, &sigma, false,
+            &model,
+            &subj,
+            &theta,
+            &eta_hat,
+            &h_bsv,
+            &omega_bsv,
+            &sigma,
+            &model.residual_correlations,
+            false,
         );
         let zero_kappas = vec![DVector::zeros(1), DVector::zeros(1)];
         let reduced = foce_subject_nll_iov(
@@ -2819,6 +2841,7 @@ mod tests {
             &h_bsv,
             &omega_bsv,
             &sigma,
+            &model.residual_correlations,
             false,
             &zero_kappas,
             &make_omega(1e-12),
@@ -2844,6 +2867,7 @@ mod tests {
                 &h_bsv,
                 &omega_bsv,
                 &sigma,
+                &model.residual_correlations,
                 false,
                 &kappas,
                 &make_omega(iov_var),
@@ -3597,6 +3621,7 @@ mod tests {
             &h_matrix,
             &p.omega,
             &p.sigma.values,
+            &p.residual_correlations,
             true,
         );
         assert!(

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -42,6 +42,84 @@ pub fn compute_r_diag(
         .collect()
 }
 
+/// `true` when no two observations can share a correlated residual block, so the
+/// subject's residual covariance `R` (and `∂R/∂f`, `∂²R/∂f²`) is strictly
+/// diagonal for *any* parameter values. O(n): a repeated `L2` group id, or a
+/// repeated `(time, occasion)` among ungrouped (`L2 == 0`) rows, is the only way
+/// [`same_residual_block`] can pair two rows — so all-distinct keys ⇒ no pairs ⇒
+/// no cross-covariance.
+///
+/// This is a data-static superset of "`R` is diagonal": it may return `false`
+/// for a subject whose rows share a block but no correlation (then the caller
+/// falls back to the dense path — correct, just not the fast path), and never
+/// returns `true` when an off-diagonal could exist. Combined-error `block_sigma`
+/// at distinct observation times is the common `true` case, letting the
+/// objective and gradients skip the dense Cholesky and the O(n³) `∂R` tensors.
+pub fn residual_is_diagonal(obs_times: &[f64], occasions: &[u32], obs_l2: &[i64]) -> bool {
+    use std::collections::HashSet;
+    let n = obs_times.len();
+    let mut l2_seen: HashSet<i64> = HashSet::new();
+    let mut to_seen: HashSet<(u64, u32)> = HashSet::new();
+    for j in 0..n {
+        let l2 = obs_l2.get(j).copied().unwrap_or(0);
+        if l2 != 0 {
+            if !l2_seen.insert(l2) {
+                return false;
+            }
+        } else {
+            let key = (
+                observation_time_key(obs_times, j),
+                observation_occasion_key(occasions, j),
+            );
+            if !to_seen.insert(key) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Diagonal of `∂R/∂f` — only `∂R_mm/∂f_m` per observation, O(n). Bit-identical
+/// to `compute_dr_df_matrices(..)[m][(m,m)]`, but without that function's
+/// `vec![DMatrix::zeros(n,n); n]` O(n³) allocation. Valid to use in place of the
+/// dense builder exactly when [`residual_is_diagonal`] holds (no cross terms).
+pub fn compute_dr_df_diag(
+    error_spec: &ErrorSpec,
+    ipreds: &[f64],
+    obs_cmts: &[usize],
+    sigma_values: &[f64],
+    correlations: &[ResidualCorrelation],
+    mult: Option<&[Vec<f64>]>,
+) -> Vec<f64> {
+    let n = ipreds.len();
+    let empty: Vec<f64> = Vec::new();
+    let mrow = |j: usize| -> &[f64] {
+        mult.and_then(|m| m.get(j))
+            .map(|v| v.as_slice())
+            .unwrap_or(&empty)
+    };
+    let m_at = |j: usize, idx: usize| -> f64 { mrow(j).get(idx).copied().unwrap_or(1.0) };
+    let cmt_at = |j: usize| -> usize { obs_cmts.get(j).copied().unwrap_or(0) };
+    (0..n)
+        .map(|j| {
+            let vload: Vec<(usize, f64)> = error_spec
+                .sigma_loadings(cmt_at(j), ipreds[j], sigma_values.len())
+                .into_iter()
+                .map(|(idx, c)| (idx, c * m_at(j, idx)))
+                .collect();
+            if vload.is_empty() {
+                return 0.0;
+            }
+            let sload: Vec<(usize, f64)> = error_spec
+                .sigma_loading_slopes(cmt_at(j), sigma_values.len())
+                .into_iter()
+                .map(|(idx, s)| (idx, s * m_at(j, idx)))
+                .collect();
+            diag_self_deriv(&vload, &sload, sigma_values, correlations)
+        })
+        .collect()
+}
+
 /// Compute residual variances including fixed residual correlations from
 /// `block_sigma`.
 pub fn compute_r_diag_with_correlations(
@@ -865,6 +943,51 @@ mod tests {
     fn test_additive_variance() {
         let v = residual_variance(ErrorModel::Additive, 10.0, &[0.5]);
         assert_relative_eq!(v, 0.25, epsilon = 1e-12);
+    }
+
+    /// #847 perf gate: distinct observation times/occasions ⇒ R is diagonal; a
+    /// repeated (time, occasion) or a repeated L2 group ⇒ pairing possible.
+    #[test]
+    fn test_residual_is_diagonal_detects_pairing() {
+        // Distinct times, no L2 → diagonal.
+        assert!(residual_is_diagonal(&[0.5, 1.0, 2.0], &[0, 0, 0], &[]));
+        // Two rows share (time, occasion) → not diagonal (may pair).
+        assert!(!residual_is_diagonal(&[1.0, 1.0, 2.0], &[0, 0, 0], &[]));
+        // Same time but different occasion → distinct blocks → diagonal.
+        assert!(residual_is_diagonal(&[1.0, 1.0], &[0, 1], &[]));
+        // Repeated nonzero L2 id → not diagonal.
+        assert!(!residual_is_diagonal(&[0.5, 2.0], &[0, 0], &[7, 7]));
+        // Distinct L2 ids (singleton groups) → diagonal.
+        assert!(residual_is_diagonal(&[0.5, 2.0], &[0, 0], &[7, 8]));
+    }
+
+    /// [`compute_dr_df_diag`] equals the diagonal of the dense
+    /// [`compute_dr_df_matrices`], bit-for-bit — it is the O(n) drop-in the
+    /// gradient/objective use when [`residual_is_diagonal`].
+    #[test]
+    fn test_compute_dr_df_diag_matches_dense_diagonal() {
+        use crate::types::ResidualCorrelation;
+        let es = ErrorSpec::Single(ErrorModel::Combined); // PROP (slot 0) + ADD (slot 1)
+        let ipreds = [1.5_f64, 4.0, 8.0];
+        let cmts = [0usize, 0, 0];
+        let sigma = [0.2_f64, 1.0];
+        let corr = [ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        let dense =
+            compute_dr_df_matrices(&es, &ipreds, &cmts, &[], &[], &[], &[], &sigma, &corr, None);
+        let diag = compute_dr_df_diag(&es, &ipreds, &cmts, &sigma, &corr, None);
+        assert_eq!(diag.len(), 3);
+        for m in 0..3 {
+            assert!(
+                diag[m].to_bits() == dense[m][(m, m)].to_bits(),
+                "row {m}: diag {} != dense {}",
+                diag[m],
+                dense[m][(m, m)]
+            );
+        }
     }
 
     #[test]

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -79,6 +79,49 @@ pub fn residual_is_diagonal(obs_times: &[f64], occasions: &[u32], obs_l2: &[i64]
     true
 }
 
+/// Partition observation indices into disjoint **residual blocks** — the
+/// equivalence classes of [`same_residual_block`]. `R` (and `∂R/∂f`, `∂²R/∂f²`)
+/// is block-diagonal over this partition (zero cross-block covariance), so the
+/// objective / gradient / FOCEI marginal decompose into independent per-block
+/// dense problems of size `b_g` — O(Σ b_g³) instead of O(n³). For the common
+/// paired total/unbound `block_sigma` (an `L2` group or two co-temporal rows per
+/// draw) the blocks are 2×2, so the factorizations are O(n) overall.
+///
+/// Ungrouped rows (`L2 == 0` at a unique `(time, occasion)`) are singleton
+/// blocks — a subject with all singletons is the diagonal case
+/// ([`residual_is_diagonal`]). Blocks preserve ascending observation-index order,
+/// and are returned in first-appearance order. O(n).
+pub fn residual_blocks(obs_times: &[f64], occasions: &[u32], obs_l2: &[i64]) -> Vec<Vec<usize>> {
+    use std::collections::HashMap;
+    // Key mirrors `same_residual_block`: an explicit L2 id groups by id; an
+    // ungrouped row groups by (time bits, occasion).
+    #[derive(PartialEq, Eq, Hash)]
+    enum Key {
+        L2(i64),
+        TimeOcc(u64, u32),
+    }
+    let n = obs_times.len();
+    let mut index: HashMap<Key, usize> = HashMap::new();
+    let mut blocks: Vec<Vec<usize>> = Vec::new();
+    for j in 0..n {
+        let l2 = obs_l2.get(j).copied().unwrap_or(0);
+        let key = if l2 != 0 {
+            Key::L2(l2)
+        } else {
+            Key::TimeOcc(
+                observation_time_key(obs_times, j),
+                observation_occasion_key(occasions, j),
+            )
+        };
+        let bi = *index.entry(key).or_insert_with(|| {
+            blocks.push(Vec::new());
+            blocks.len() - 1
+        });
+        blocks[bi].push(j);
+    }
+    blocks
+}
+
 /// Diagonal of `∂R/∂f` — only `∂R_mm/∂f_m` per observation, O(n). Bit-identical
 /// to `compute_dr_df_matrices(..)[m][(m,m)]`, but without that function's
 /// `vec![DMatrix::zeros(n,n); n]` O(n³) allocation. Valid to use in place of the
@@ -118,6 +161,68 @@ pub fn compute_dr_df_diag(
             diag_self_deriv(&vload, &sload, sigma_values, correlations)
         })
         .collect()
+}
+
+/// Build one residual block's dense `R_g` and its per-observation `∂R/∂f_m`
+/// matrices (`dr_g[local_m]`, each `b×b`), from the subject's full arrays
+/// restricted to `block` (a set of paired observation indices). Reproduces the
+/// full builders' pairing/cross terms within the block — the block-diagonal
+/// analogue used by the O(Σ b³) gradient/marginal fast paths in place of the full
+/// O(n³) `compute_r_matrix_with_correlations` / `compute_dr_df_matrices`. `mult`
+/// is None for every `block_sigma` model (custom magnitude is mutually exclusive).
+#[allow(clippy::too_many_arguments)]
+pub fn block_r_and_dr(
+    error_spec: &ErrorSpec,
+    block: &[usize],
+    ipreds: &[f64],
+    obs_cmts: &[usize],
+    obs_times: &[f64],
+    obs_raw_times: &[f64],
+    occasions: &[u32],
+    obs_l2: &[i64],
+    sigma_values: &[f64],
+    correlations: &[ResidualCorrelation],
+) -> (DMatrix<f64>, Vec<DMatrix<f64>>) {
+    let g = |src: &[f64], j: usize| src.get(j).copied().unwrap_or(0.0);
+    let sub_ipreds: Vec<f64> = block.iter().map(|&j| ipreds[j]).collect();
+    let sub_cmts: Vec<usize> = block
+        .iter()
+        .map(|&j| obs_cmts.get(j).copied().unwrap_or(0))
+        .collect();
+    let sub_times: Vec<f64> = block.iter().map(|&j| g(obs_times, j)).collect();
+    let sub_raw: Vec<f64> = block.iter().map(|&j| g(obs_raw_times, j)).collect();
+    let sub_occ: Vec<u32> = block
+        .iter()
+        .map(|&j| occasions.get(j).copied().unwrap_or(0))
+        .collect();
+    let sub_l2: Vec<i64> = block
+        .iter()
+        .map(|&j| obs_l2.get(j).copied().unwrap_or(0))
+        .collect();
+    let rg = compute_r_matrix_with_correlations(
+        error_spec,
+        &sub_ipreds,
+        &sub_cmts,
+        &sub_times,
+        &sub_raw,
+        &sub_occ,
+        &sub_l2,
+        sigma_values,
+        correlations,
+    );
+    let dr = compute_dr_df_matrices(
+        error_spec,
+        &sub_ipreds,
+        &sub_cmts,
+        &sub_times,
+        &sub_raw,
+        &sub_occ,
+        &sub_l2,
+        sigma_values,
+        correlations,
+        None,
+    );
+    (rg, dr)
 }
 
 /// Compute residual variances including fixed residual correlations from
@@ -959,6 +1064,24 @@ mod tests {
         assert!(!residual_is_diagonal(&[0.5, 2.0], &[0, 0], &[7, 7]));
         // Distinct L2 ids (singleton groups) → diagonal.
         assert!(residual_is_diagonal(&[0.5, 2.0], &[0, 0], &[7, 8]));
+    }
+
+    /// #847 perf: `residual_blocks` partitions observations into the
+    /// same_residual_block equivalence classes (L2 groups; else (time, occasion)).
+    #[test]
+    fn test_residual_blocks_partition() {
+        // Distinct times, no L2 → all singletons.
+        let b = residual_blocks(&[0.5, 1.0, 2.0], &[0, 0, 0], &[]);
+        assert_eq!(b, vec![vec![0], vec![1], vec![2]]);
+        // Two L2 pairs (total+free per draw) → two 2-blocks, index order preserved.
+        let b = residual_blocks(&[1.0, 1.0, 5.0, 5.0], &[0; 4], &[10, 10, 11, 11]);
+        assert_eq!(b, vec![vec![0, 1], vec![2, 3]]);
+        // Co-temporal ungrouped rows → one block by (time, occasion).
+        let b = residual_blocks(&[1.0, 1.0, 2.0], &[0, 0, 0], &[]);
+        assert_eq!(b, vec![vec![0, 1], vec![2]]);
+        // Same time, different occasion → separate blocks.
+        let b = residual_blocks(&[1.0, 1.0], &[0, 1], &[]);
+        assert_eq!(b, vec![vec![0], vec![1]]);
     }
 
     /// [`compute_dr_df_diag`] equals the diagonal of the dense

--- a/src/types.rs
+++ b/src/types.rs
@@ -1229,13 +1229,22 @@ pub struct SigmaVector {
     pub names: Vec<String>,
 }
 
-/// Fixed correlation between two named residual-error terms.
+/// Correlation between two named residual-error terms (a `block_sigma`
+/// off-diagonal).
 ///
 /// `sigma_i` and `sigma_j` index [`SigmaVector::values`]. The covariance used
 /// at runtime is `rho * sigma_i * sigma_j`, so the existing positive SD
 /// parameterization remains unchanged while off-diagonal residual covariance is
 /// carried into subject-level R matrices.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// `rho` is an **estimated** parameter for a plain `block_sigma` block (matching
+/// NONMEM `$SIGMA BLOCK(n)`, which estimates the whole lower triangle): it is
+/// carried as an optimizer coordinate on [`ModelParameters::residual_correlations`]
+/// and packed as `atanh(rho)` (Fisher-z) so the optimizer works unconstrained
+/// while `rho` stays in `(-1, 1)`. A `block_sigma ... FIX` block instead pins
+/// every entry — the off-diagonal is then a fixed correlation (see
+/// [`ModelParameters::residual_correlation_fixed`]).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResidualCorrelation {
     pub sigma_i: usize,
     pub sigma_j: usize,
@@ -1262,6 +1271,18 @@ pub struct ModelParameters {
     pub sigma: SigmaVector,
     /// Per-sigma FIX flags.
     pub sigma_fixed: Vec<bool>,
+    /// Estimated off-diagonal residual correlations (`block_sigma`). Each entry's
+    /// `rho` is a live optimizer coordinate (packed as `atanh(rho)` after the
+    /// sigma / Ω_IOV blocks — see `parameterization::pack_params`), so the outer
+    /// loop moves it just like θ/Ω/σ. Empty for models with no `block_sigma`
+    /// off-diagonals. The pair indices (`sigma_i`, `sigma_j`) never change; only
+    /// `rho` is estimated.
+    pub residual_correlations: Vec<ResidualCorrelation>,
+    /// Per-correlation FIX flags (parallel to `residual_correlations`). `true`
+    /// for a `block_sigma ... FIX` block, which pins the off-diagonal at its
+    /// initial correlation; `false` for a plain `block_sigma`, whose off-diagonal
+    /// is estimated (NONMEM `$SIGMA BLOCK(n)` semantics).
+    pub residual_correlation_fixed: Vec<bool>,
     /// Inter-occasion variability matrix (Omega_IOV). `None` when no `kappa`
     /// declarations appear in the model file.  Always diagonal for Option A.
     pub omega_iov: Option<OmegaMatrix>,
@@ -1275,6 +1296,7 @@ impl ModelParameters {
         self.theta_fixed.iter().any(|&b| b)
             || self.omega_fixed.iter().any(|&b| b)
             || self.sigma_fixed.iter().any(|&b| b)
+            || self.residual_correlation_fixed.iter().any(|&b| b)
             || self.kappa_fixed.iter().any(|&b| b)
     }
 }
@@ -4589,6 +4611,18 @@ pub struct FitResult {
     pub sigma: Vec<f64>,
     /// Names of the sigma parameters, parallel to `sigma`.
     pub sigma_names: Vec<String>,
+    /// Estimated `block_sigma` off-diagonal residual correlations. Each entry's
+    /// `rho` is the fitted correlation between sigma terms `sigma_i`/`sigma_j`;
+    /// the corresponding covariance is `rho * sigma[sigma_i] * sigma[sigma_j]`.
+    /// Empty for models with no `block_sigma` off-diagonals. Rendered as a
+    /// `sigma_correlations:` block in the fit YAML.
+    #[serde(default)]
+    pub residual_correlations: Vec<ResidualCorrelation>,
+    /// Standard errors for each entry of `residual_correlations` (on the ρ
+    /// scale), or `None` when the covariance step did not run. Parallel to
+    /// `residual_correlations`.
+    #[serde(default)]
+    pub se_residual_correlations: Option<Vec<f64>>,
     /// Residual error model (additive, proportional, combined).
     ///
     /// For multi-endpoint (per-CMT) models this is only the *representative*
@@ -6453,6 +6487,8 @@ pub(crate) mod test_helpers {
                     names: vec!["EPS".into()],
                 },
                 sigma_fixed: vec![false],
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 omega_iov: None,
                 kappa_fixed: Vec::new(),
             },
@@ -6539,6 +6575,8 @@ pub(crate) mod test_helpers {
                 names: vec!["PROP_ERR".into()],
             },
             sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             omega_iov: None,
             kappa_fixed: Vec::new(),
         };

--- a/tests/dense_residual_convergence.rs
+++ b/tests/dense_residual_convergence.rs
@@ -41,8 +41,26 @@ const MODEL: &str = "\
   method = focei
 ";
 
-fn fit_with(gradient: GradientMethod) -> ferx_core::FitResult {
-    let mut model = parse_model_string(MODEL).expect("block_sigma model must parse");
+// Same model, but the block_sigma off-diagonal is ESTIMATED (no `FIX`) — #847.
+const MODEL_FREE: &str = "\
+[parameters]
+  theta TVCL(1.0, 0.01, 10.0)
+  theta TVV(10.0, 0.1, 100.0)
+  omega ETA_CL ~ 0.04
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00]
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ combined(PROP_ERR, ADD_ERR)
+[fit_options]
+  method = focei
+";
+
+fn fit_model(src: &str, gradient: GradientMethod) -> ferx_core::FitResult {
+    let mut model = parse_model_string(src).expect("block_sigma model must parse");
     assert!(
         !model.residual_correlations.is_empty(),
         "model must carry a residual correlation"
@@ -62,6 +80,10 @@ fn fit_with(gradient: GradientMethod) -> ferx_core::FitResult {
     opts.run_covariance_step = false;
     opts.verbose = false;
     fit(&model, &population, &model.default_params, &opts).expect("block_sigma fit must succeed")
+}
+
+fn fit_with(gradient: GradientMethod) -> ferx_core::FitResult {
+    fit_model(MODEL, gradient)
 }
 
 /// The analytic dense-R FOCEI gradient converges to the same basin as the
@@ -107,4 +129,57 @@ fn dense_residual_analytic_and_fd_fits_agree() {
             fd.theta[k]
         );
     }
+}
+
+/// #847 end-to-end: with the `block_sigma` off-diagonal **estimated** (no `FIX`),
+/// the fit must (a) actually move ρ off its initial 0.5, (b) reach an OFV no worse
+/// than the FIX-ρ fit (an extra free parameter cannot worsen the optimum), and
+/// (c) converge to the same optimum on the analytic and finite-difference gradient
+/// paths — i.e. the closed-form ∂/∂ρ is correct end-to-end, not just per-coordinate.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn block_sigma_offdiag_is_estimated_and_analytic_matches_fd() {
+    let analytic = fit_model(MODEL_FREE, GradientMethod::Auto);
+    let fd = fit_model(MODEL_FREE, GradientMethod::Fd);
+    let fixed = fit_with(GradientMethod::Auto); // FIX-ρ reference (init ρ = 0.5)
+
+    // (a) ρ is a real free parameter: reported, finite, and moved off the init.
+    assert_eq!(analytic.residual_correlations.len(), 1);
+    let rho = analytic.residual_correlations[0].rho;
+    assert!(
+        rho.is_finite() && rho.abs() < 1.0,
+        "ρ must stay in (-1,1): {rho}"
+    );
+    assert!(
+        (rho - 0.5).abs() > 1e-3,
+        "estimated ρ {rho} should move off the initial 0.5"
+    );
+
+    // (b) estimating the off-diagonal cannot worsen the optimum vs holding it fixed.
+    assert!(
+        analytic.ofv <= fixed.ofv + 1e-2,
+        "free-ρ OFV {} should be ≤ fixed-ρ OFV {}",
+        analytic.ofv,
+        fixed.ofv
+    );
+
+    // (c) the analytic ∂/∂ρ path lands in the same OFV basin as reconverged FD.
+    // (Per-coordinate ∂/∂ρ equality is pinned separately by the fast unit test
+    // `population_packed_gradient_block_sigma_matches_fd`; ρ itself is only weakly
+    // identified on this flat 2-subject surface, so the OFV — not ρ — is compared.)
+    assert!(
+        analytic.ofv.is_finite() && fd.ofv.is_finite(),
+        "both OFVs finite: analytic {}, fd {}",
+        analytic.ofv,
+        fd.ofv
+    );
+    assert!(
+        (analytic.ofv - fd.ofv).abs() < 0.1,
+        "analytic OFV {} vs FD OFV {} land in different basins",
+        analytic.ofv,
+        fd.ofv
+    );
 }


### PR DESCRIPTION
## Why

`block_sigma` off-diagonal SIGMA terms were parsed into residual correlations but held **fixed** at their initial value — ferx optimized a different surface than NONMEM's `$SIGMA BLOCK(n)`, which estimates the full lower triangle. On the fluconazole RadboudUMC model NONMEM estimates the residual correlation to ~0.93 while ferx kept the init (~0.2), leaving OFV/Q away from the NONMEM trace (#847).

Two problems surfaced and are fixed here:
1. **Correctness:** estimate the off-diagonal (ρ), not just the diagonal SDs.
2. **Performance:** the existing correlated-residual (`block_sigma`) path built and factored a dense `n×n` R (and, for the FOCEI curvature, an O(n⁴) `∂²R` tensor) **every evaluation** — 2–3 orders of magnitude on richly-sampled subjects, which made estimating ρ impractical.

Closes #847. The remaining fluconazole cold-start gap (Q basin selection) is a separate outer-optimizer conditioning issue tracked in #864 — **not** block_sigma; the objective is confirmed correct (ferx reaches 734.67 from NONMEM's final estimates) and this PR's gradient is validated.

## What changed

- **Estimate ρ.** A plain `block_sigma` block now estimates its off-diagonal as a free parameter (NONMEM `$SIGMA BLOCK(n)` semantics); `block_sigma ... FIX` keeps the old fixed behaviour. ρ is carried on `ModelParameters.residual_correlations` and packed as a Fisher-z (`atanh ρ`) coordinate so it stays in (−1, 1) and every 2×2 residual block stays PD.
- **Analytic gradient path preserved.** ρ rides the analytic FOCE/FOCEI outer gradient (closed-form `∂(−2LL)/∂ρ` via `rho_block`), not a finite-difference fallback. Live ρ is threaded through the inner/outer objective + inner η-gradient (previously the inner gradient read the frozen `model` copy).
- **Diagonal-R fast path** (combined-error `block_sigma`): objective, inner gradient, FOCEI marginal detect diagonal R (`residual_is_diagonal`) and use O(n) closed-form assembly instead of dense Cholesky/inverse/∂R tensors. Data term is bit-for-bit identical.
- **Block-diagonal fast path** (paired L2 / cross-endpoint total-unbound): R decomposes into small (2×2) blocks; each factored independently — O(Σ b³) instead of O(n³)/O(n⁴).
- **Block-diagonal analytic outer gradient** (Almquist Eq. 48 decomposition over the block-fast marginal/inner-gradient, EBE response `dη̂/dx` from the implicit function theorem) — so a gradient-based optimizer no longer bails to per-subject reconverged FD.
- **Output:** fitted full SIGMA block (ρ, implied covariance, ρ-scale SE) reported in a `sigma_correlations:` YAML section and the covariance-matrix coordinate list.

## Alternatives considered

Draft PR #850 implements the estimation but routes ρ to the **reconverged-FD outer gradient** path. This PR keeps ρ on the **analytic** gradient path (the closed-form ∂/∂ρ #850 explicitly deferred) and adds the diagonal/block-diagonal fast paths that make it practical.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

New `pub` fields on `ModelParameters`/`FitResult` are `#[serde(default)]`, so ferx-r's FitResult reads stay backward-compatible. A follow-up ferx-r PR to surface `sigma_correlations` is an enhancement, not a requirement.

## Breaking changes
- [x] `FitResult` fields changed — `residual_correlations` + `se_residual_correlations` added (both `#[serde(default)]`, backward-compatible)
- [x] Public Rust API (`api.rs` / `types.rs`) — new `pub` fields on `ModelParameters` / `FitResult`; `extract_standard_errors` returns a 5-tuple
- **Behaviour:** a non-`FIX` `block_sigma` now **estimates** the off-diagonal (was fixed). Add `FIX` to retain the old behaviour.

## Numerical validation
- [x] Compared against: **NONMEM**
- [x] Reference values:

```
# block_sigma OFV is NONMEM-anchored (examples/correlated_residual_combined.ferx): OFV 18.722087
# fluconazole RadboudUMC (multistart): ferx ρ = 0.9330  vs NONMEM 0.9312  ✓  (OFV 738 vs 734.6; Q basin gap tracked in #864)
```

- Per-coordinate: `population_packed_gradient_block_sigma_matches_fd` (+ FOCE / Selected / ExpressionScale / **paired block-diagonal** FOCEI & FOCE variants) compare the analytic gradient — including the ρ slot — against Richardson reconverged FD across every θ/Ω/σ/ρ coordinate.
- Slow e2e (`dense_residual_convergence`): ρ is estimated (moves off init), free-ρ OFV ≤ fixed-ρ, analytic and FD land in the same OFV basin.

## Performance
- [x] Faster — block_sigma diagonal-R fit (synthetic 80-obs subject): **177 s → 8.6 s**; paired-L2 fit (analytic block gradient vs prior reconverged-FD): **>3 min (hung) → 14 s** (debug builds; ratio holds in release).

## Tests
- [x] Unit tests added (`cargo test --lib` passes — 2512 tests, 0 failures)
- [x] Regression tests: parser free/fixed semantics, Fisher-z pack/unpack round-trip, ρ SE delta-method, diagonal/block fast-path bit-exactness, analytic-vs-FD gradient (diagonal + block), YAML output; slow e2e convergence.

## Example (user-facing features only)
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[parameters]
  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00]   # no FIX -> off-diagonal estimated
[error_model]
  DV ~ combined(PROP_ERR, ADD_ERR)
```

```
sigma_correlations:
  ADD_ERR__PROP_ERR:
    correlation: <estimated>
    covariance:  <ρ·σ_i·σ_j>
    se: <ρ-scale SE>
```

</details>

## Docs
- [x] `docs/model-file/error-model.qmd` — new "Fixed vs. estimated block-sigma" section
- [x] `CHANGELOG.md` `[Unreleased]` entries (Added + Performance)

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `Dual2` sensitivity path stays differentiable (block builders are `f64`-only; the analytic η/θ gradients are unchanged generic paths)

## Reviewer hints

Focus areas:
- `estimation/sens_outer_gradient.rs`: `rho_block` (closed-form ∂/∂ρ) and `subject_packed_gradient_block` (Almquist FD decomposition for block-diagonal R) — validated by the paired-block tests.
- `stats/likelihood.rs` + `stats/residual_error.rs`: `residual_is_diagonal` / `residual_blocks` gating and the diagonal/block fast paths (bit-exactness argued in comments + unit-tested).
- Live-ρ threading through the objective and inner gradient (parallel to `sigma_values`).

Skimmable: the ~60 mechanical `ModelParameters`/`FitResult` literal updates for the two new fields.

## Open questions

- **Default semantics change:** a non-`FIX` `block_sigma` now estimates the off-diagonal. This matches NONMEM `$SIGMA BLOCK(n)` and the issue's intent, but changes results for any existing non-`FIX` block_sigma model (the shipped example uses `FIX` and is unaffected). Confirm this is the desired default vs. requiring an explicit opt-in keyword to estimate.
