### PR TITLE
chore(audit): strengthen topology infusable guard + dedup SIR's Kish ESS

### DIFF
--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -276,9 +276,10 @@ pub fn run_sir_core(
     let sum_w: f64 = weights.iter().sum();
     let normalized_weights: Vec<f64> = weights.iter().map(|w| w / sum_w).collect();
 
-    // Effective sample size
-    let sum_w2: f64 = normalized_weights.iter().map(|w| w * w).sum();
-    let ess = if sum_w2 > 0.0 { 1.0 / sum_w2 } else { 0.0 };
+    // Effective sample size — shared Kish ESS (`1/Σw̃²` with zero-guard). SIR's
+    // log-sum-exp normalisation above stays local (its `Err`-on-all-invalid +
+    // no-non-finite-filter contract differs from `stats::util::log_sum_exp_normalised`).
+    let ess = crate::stats::util::ess_from_weights(&normalized_weights);
 
     if options.verbose {
         eprintln!("  SIR: effective sample size = {:.1}", ess);

--- a/src/pk/topology.rs
+++ b/src/pk/topology.rs
@@ -228,15 +228,29 @@ mod tests {
                     .unwrap(),
                 "{m:?} central_slot"
             );
-            for (i, c) in t.channels.iter().enumerate() {
-                if c.is_some() {
-                    assert!(
-                        t.infusable.contains(&(i + 1)),
-                        "{m:?}: cmt {} is routable (channels[{i}]=Some) but not in infusable {:?}",
-                        i + 1,
-                        t.infusable
-                    );
-                }
+            let channel_set: Vec<usize> = t
+                .channels
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| c.map(|_| i + 1))
+                .collect();
+            // Every routable compartment must be a parse-accepted infusion target.
+            for &cmt in &channel_set {
+                assert!(
+                    t.infusable.contains(&cmt),
+                    "{m:?}: cmt {cmt} is routable but not in infusable {:?}",
+                    t.infusable
+                );
+            }
+            // For a WALK-SUPPORTED model `infusable` must EQUAL the channel set: an
+            // extra entry would let the parser accept a `D{cmt}` that `dose_channel`
+            // can't route, panicking the event walk at fit time. (A no-walk transit/IG
+            // model may legitimately keep `infusable` a superset — direction-only above.)
+            if t.event_walk_supported {
+                assert_eq!(
+                    t.infusable, channel_set,
+                    "{m:?}: walk-supported model's infusable must equal its channel set"
+                );
             }
         }
     }


### PR DESCRIPTION
Deep-audit follow-ups (adversarial audit found **0 correctness bugs** across the modularization series; these are drift-risk / cleanup).

## What changed
- **`pk/topology.rs`** — the #853 review weakened `topology_fields_are_internally_consistent` to a one-directional check, leaving `infusable`'s upper bound unpinned. For a **walk-supported** model an extra `infusable` entry would let the parser accept a `D{cmt}` that `dose_channel` can't route, panicking the event walk at fit time. Re-assert **equality** (`infusable == channel set`) for `event_walk_supported` models; no-walk transit/IG models keep the direction-only (superset-allowed) check.
- **`estimation/sir.rs`** — route SIR's effective-sample-size to the shared `stats::util::ess_from_weights` (byte-identical `1/Σw̃²` with zero-guard). SIR's log-sum-exp normalisation stays local — its `Err`-on-all-invalid + no-non-finite-filter contract genuinely differs from `stats::util::log_sum_exp_normalised`.

## Numerical validation
- [x] `topology` change is test-only (tightens a guard; all 10 current tables already satisfy equality). SIR ESS is a byte-identical helper swap.
- [x] `cargo test --lib` => 2518 passed, 0 failed, no warnings.

## Breaking changes
- [x] None

## Docs
- [x] No user-visible change