### PR TITLE
fix(build_info): match the live IOV inner-gradient gate (require omega_iov)

### DIFF
--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -74,6 +74,11 @@ pub fn gradient_method_inner(_build: &BuildInfo, model: &CompiledModel) -> Gradi
     // so the IOV branch must be reported explicitly (#466 review round 4 #1).
     let analytic = crate::estimation::inner_optimizer::analytic_inner_grad_supported_model(model)
         || (crate::sens::provider::iov_sens_supported(model)
+            // Match the live IOV inner gate (`analytic_iov_inner`, inner_optimizer.rs):
+            // it also requires `omega_iov.is_some()`. `iov_sens_supported` can be true
+            // structurally for a non-IOV model, so without this the report would claim
+            // "Analytic" where the model actually has no IOV inner gradient at all.
+            && model.default_params.omega_iov.is_some()
             && !crate::estimation::inner_optimizer::analytic_inner_common_bail(model));
     if analytic {
         GradientMethodKind::Analytic


### PR DESCRIPTION
## Why
The deep audit flagged `build_info::gradient_method_inner` as reconstructing the IOV inner-gradient scope by hand and diverging from the live gate. Its IOV disjunct is `iov_sens_supported(model) && !analytic_inner_common_bail(model)`, but the live gate `analytic_iov_inner` (`inner_optimizer.rs`) additionally requires `omega_iov.is_some()`. `iov_sens_supported` can be `true` structurally for a **non-IOV** model (`find_ebe_iov` gates `iov_sens_supported` and `omega_iov.is_none()` separately), so the report could claim **Analytic** for a model that has no IOV inner gradient at all.

## What changed
Added `model.default_params.omega_iov.is_some()` to the disjunct so the reported gradient method matches the live per-model dispatch.

## Numerical validation
- [x] **Reporting-only** — `build_info` feeds the diagnostics/summary output; it does not affect the fit or any numeric result. `cargo build --lib` compiles clean.

## Breaking changes
- [x] None

## Docs
- [x] No user-visible change (corrects a diagnostic label)