### PR TITLE
refactor(estimation): single-source the Ω packed-length formula via omega_packed_len

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,8 @@
 use crate::diagnostics::{first_error, CheckReport, Diagnostic};
 use crate::estimation::outer_optimizer::optimize_population;
-use crate::estimation::parameterization::{chol_lt_idx, lower_tri_iter, theta_packs_log};
+use crate::estimation::parameterization::{
+    chol_lt_idx, lower_tri_iter, omega_packed_len, theta_packs_log,
+};
 use crate::estimation::saem;
 use crate::io::datareader::{
     read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
@@ -8197,7 +8199,7 @@ pub(crate) fn extract_standard_errors(
             })
             .collect()
     } else {
-        let n_lt = n_eta * (n_eta + 1) / 2;
+        let n_lt = omega_packed_len(n_eta, false);
         let l = &template.omega.chol;
 
         // Extract omega sub-block of the full covariance matrix.
@@ -8242,12 +8244,7 @@ pub(crate) fn extract_standard_errors(
     };
 
     // Sigma: SE via delta method (log-transformed)
-    let sigma_start = omega_start
-        + if template.omega.diagonal {
-            n_eta
-        } else {
-            n_eta * (n_eta + 1) / 2
-        };
+    let sigma_start = omega_start + omega_packed_len(n_eta, template.omega.diagonal);
     let se_sigma: Vec<f64> = (0..n_sigma)
         .map(|i| {
             let idx = sigma_start + i;

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -47,20 +47,12 @@ pub(crate) enum CovarianceStepResult {
 pub(crate) fn packed_param_label(packed_idx: usize, template: &ModelParameters) -> String {
     let n_theta = template.theta.len();
     let n_eta = template.omega.dim();
-    let n_omega = if template.omega.diagonal {
-        n_eta
-    } else {
-        n_eta * (n_eta + 1) / 2
-    };
+    let n_omega = omega_packed_len(n_eta, template.omega.diagonal);
     let n_sigma = template.sigma.values.len();
-    let n_iov = template.omega_iov.as_ref().map_or(0, |m| {
-        let d = m.dim();
-        if m.diagonal {
-            d
-        } else {
-            d * (d + 1) / 2
-        }
-    });
+    let n_iov = template
+        .omega_iov
+        .as_ref()
+        .map_or(0, |m| omega_packed_len(m.dim(), m.diagonal));
 
     if packed_idx < n_theta {
         let name = template

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -251,12 +251,7 @@ pub fn omega_structural_zero_mask(template: &ModelParameters) -> Vec<bool> {
     mark(&mut mask, &template.omega, n_theta);
 
     if let Some(ref iov) = template.omega_iov {
-        let n_eta = template.omega.dim();
-        let n_omega = if template.omega.diagonal {
-            n_eta
-        } else {
-            n_eta * (n_eta + 1) / 2
-        };
+        let n_omega = omega_packed_len(template.omega.dim(), template.omega.diagonal);
         let iov_start = n_theta + n_omega + template.sigma.values.len();
         mark(&mut mask, iov, iov_start);
     }
@@ -267,21 +262,12 @@ pub fn omega_structural_zero_mask(template: &ModelParameters) -> Vec<bool> {
 /// Compute the number of packed parameters
 pub fn packed_len(template: &ModelParameters) -> usize {
     let n_theta = template.theta.len();
-    let n_eta = template.omega.dim();
-    let n_omega = if template.omega.diagonal {
-        n_eta
-    } else {
-        n_eta * (n_eta + 1) / 2
-    };
+    let n_omega = omega_packed_len(template.omega.dim(), template.omega.diagonal);
     let n_sigma = template.sigma.values.len();
-    let n_iov = template.omega_iov.as_ref().map_or(0, |m| {
-        let d = m.dim();
-        if m.diagonal {
-            d
-        } else {
-            d * (d + 1) / 2
-        }
-    });
+    let n_iov = template
+        .omega_iov
+        .as_ref()
+        .map_or(0, |m| omega_packed_len(m.dim(), m.diagonal));
     n_theta + n_omega + n_sigma + n_iov
 }
 
@@ -555,6 +541,19 @@ pub(crate) fn lower_tri_iter(n: usize, diagonal: bool) -> impl Iterator<Item = (
         let end = if diagonal { c + 1 } else { n };
         (c..end).map(move |r| (r, c))
     })
+}
+
+/// Number of packed entries for an Ω / Ω_iov of dimension `n`: `n` if `diagonal`
+/// (variances only), else the full lower-triangle `n*(n+1)/2`. Single source of the
+/// triangular-length formula that was re-derived at ~10 sites (api/covariance/output/
+/// types/parameterization). Equals `lower_tri_iter(n, diagonal).count()`, without allocating.
+#[inline]
+pub(crate) fn omega_packed_len(n: usize, diagonal: bool) -> usize {
+    if diagonal {
+        n
+    } else {
+        n * (n + 1) / 2
+    }
 }
 
 /// Flat index of `L[i,j]` (i ≥ j) in the column-major lower-triangle packing.

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1490,13 +1490,10 @@ fn packed_param_names(result: &FitResult, n: usize) -> Vec<String> {
     let n_kappa = result.kappa_names.len();
 
     let n_omega_diag = n_eta;
-    let n_omega_full = n_eta * (n_eta + 1) / 2;
+    let n_omega_full = crate::estimation::parameterization::omega_packed_len(n_eta, false);
     let n_kappa_diag = n_kappa;
-    let n_kappa_full = if n_kappa > 0 {
-        n_kappa * (n_kappa + 1) / 2
-    } else {
-        0
-    };
+    // `omega_packed_len(0, false) == 0`, so this covers the no-IOV case too.
+    let n_kappa_full = crate::estimation::parameterization::omega_packed_len(n_kappa, false);
     let n_remaining = n.saturating_sub(n_theta + n_sigma);
 
     // Try all four diagonal/block combinations; take the first match.

--- a/src/types.rs
+++ b/src/types.rs
@@ -5003,7 +5003,7 @@ impl FitResult {
 pub fn omega_se_at(se_omega: &Option<Vec<f64>>, n_eta: usize, i: usize, j: usize) -> Option<f64> {
     let se = se_omega.as_ref()?;
     let (r, c) = if i >= j { (i, j) } else { (j, i) }; // ensure r >= c
-    let n_lt = n_eta * (n_eta + 1) / 2;
+    let n_lt = crate::estimation::parameterization::omega_packed_len(n_eta, false);
     if se.len() == n_lt && n_lt != n_eta {
         // Full lower-triangle format (block omega). The packed index is the
         // shared column-major `chol_lt_idx` (same convention as `pack_params`).


### PR DESCRIPTION
## Why
The deep audit flagged the triangular packed-length formula (`diagonal ? n : n*(n+1)/2`) as re-derived at ~8 sites — the deferred `PackedLayout` drift concern. A change to the packing scheme would need editing all of them independently.

## What changed
Added `omega_packed_len(n, diagonal)` to `parameterization.rs` (beside `lower_tri_iter`/`chol_lt_idx`) as the single source, and routed:
- `packed_len`, `omega_structural_zero_mask` (parameterization)
- `packed_param_label` (covariance)
- `extract_standard_errors` (`n_lt`, `sigma_start`) (api)
- `omega_se_at` (types)
- `packed_param_names` (`n_omega_full`/`n_kappa_full`) (output) — `omega_packed_len(0,false)==0` folds the no-IOV case

`impmap::lower_triangle` is intentionally left: it flattens a generic matrix in **row-major** order, not the col-major Ω packing convention. The additive block offsets (`omega_start`/`sigma_start`/`kappa_start`) are trivial and low-drift, so a full `PackedLayout` struct was judged not worth the churn.

## Numerical validation
- [x] Pure formula centralization — identical value at every site. `cargo test --lib` => 2518 passed, 0 failed; `test_packed_len_*` and the SE index-map tests green.

## Breaking changes
- [x] None

## Docs
- [x] No user-visible change