### PR TITLE
fix(frem): preserve modeled RATE sentinel in FREM dataset writer

### DIFF
--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -12,7 +12,7 @@
 //! 3. [`generate_frem_model`] — write a new `.ferx` model file with extended parameters
 //! 4. Fit the resulting FREM model normally
 
-use crate::types::{CompiledModel, Population};
+use crate::types::{CompiledModel, Population, RateMode};
 use nalgebra::DMatrix;
 use regex::Regex;
 use std::collections::HashMap;
@@ -323,7 +323,17 @@ pub fn transform_dataset_for_frem(
                 "1".to_string(), // EVID
                 format!("{}", dose.amt),
                 format!("{}", dose.cmt),
-                format!("{}", dose.rate),
+                // Reconstruct the RATE column from the dose's rate mode. NONMEM
+                // overloads RATE with negative sentinels for modeled infusions:
+                // RATE=-2 (ModeledDuration, D{cmt}) and RATE=-1 (ModeledRate,
+                // R{cmt}). `dose.rate` holds 0.0 for those, so writing it raw
+                // silently drops the sentinel and turns a modeled zero-order
+                // absorption into an instantaneous bolus (see FREM MAT drift).
+                match dose.rate_mode {
+                    RateMode::ModeledDuration => "-2".to_string(),
+                    RateMode::ModeledRate => "-1".to_string(),
+                    RateMode::Fixed => format!("{}", dose.rate),
+                },
                 "1".to_string(), // MDV
                 if dose.ii > 0.0 {
                     format!("{}", dose.ii)
@@ -1178,6 +1188,72 @@ mod tests {
         assert_eq!(lines[3].split(',').nth(ft_col).unwrap(), "200");
         // Lines 5-7 = PK obs for subject 1 → FREMTYPE=0
         assert_eq!(lines[4].split(',').nth(ft_col).unwrap(), "0");
+    }
+
+    #[test]
+    fn test_transform_dataset_preserves_modeled_rate_sentinel() {
+        // Regression: the FREM dataset writer must reconstruct the RATE column
+        // from `rate_mode`, not from `dose.rate` (which is 0.0 for a modeled
+        // infusion). Dropping the -2/-1 sentinel turns a modeled zero-order
+        // absorption into an instantaneous bolus, so structural absorption
+        // parameters (e.g. MAT) drift when the FREM model is re-fit.
+        let mut pop = make_test_population();
+        // Subject 1: RATE=-2 (ModeledDuration, D{cmt}).
+        pop.subjects[0].doses = vec![DoseEvent::modeled(
+            0.0,
+            100.0,
+            1,
+            false,
+            0.0,
+            RateMode::ModeledDuration,
+        )];
+        // Subject 2: RATE=-1 (ModeledRate, R{cmt}).
+        pop.subjects[1].doses = vec![DoseEvent::modeled(
+            0.0,
+            100.0,
+            1,
+            false,
+            0.0,
+            RateMode::ModeledRate,
+        )];
+        let model = make_test_model();
+        let covs = vec!["WT".to_string(), "AGE".to_string()];
+        let (csv, _) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
+
+        let lines: Vec<&str> = csv.lines().collect();
+        let header = lines[0];
+        let rate_col = header.split(',').position(|h| h == "RATE").unwrap();
+        let evid_col = header.split(',').position(|h| h == "EVID").unwrap();
+
+        // Collect the RATE value on every dose row (EVID=1), in file order.
+        let dose_rates: Vec<&str> = lines[1..]
+            .iter()
+            .filter(|l| l.split(',').nth(evid_col) == Some("1"))
+            .map(|l| l.split(',').nth(rate_col).unwrap())
+            .collect();
+        assert_eq!(dose_rates, vec!["-2", "-1"]);
+    }
+
+    #[test]
+    fn test_transform_dataset_preserves_fixed_positive_rate() {
+        // A literal RATE>0 infusion must round-trip its numeric rate unchanged.
+        let mut pop = make_test_population();
+        pop.subjects[0].doses = vec![DoseEvent::new(0.0, 100.0, 1, 25.0, false, 0.0)];
+        let model = make_test_model();
+        let covs = vec!["WT".to_string(), "AGE".to_string()];
+        let (csv, _) = transform_dataset_for_frem(&pop, &model, &covs, &[], None).unwrap();
+
+        let lines: Vec<&str> = csv.lines().collect();
+        let header = lines[0];
+        let rate_col = header.split(',').position(|h| h == "RATE").unwrap();
+        let evid_col = header.split(',').position(|h| h == "EVID").unwrap();
+        // Subject 1's dose row is the first EVID=1 line.
+        let rate = lines[1..]
+            .iter()
+            .find(|l| l.split(',').nth(evid_col) == Some("1"))
+            .map(|l| l.split(',').nth(rate_col).unwrap())
+            .unwrap();
+        assert_eq!(rate.parse::<f64>().unwrap(), 25.0);
     }
 
     #[test]


### PR DESCRIPTION
## Why
`ferx_model_to_frem()` produced a FREM dataset in which structural absorption parameters silently drifted on re-fit, violating the FREM invariant that base parameters are preserved.

User report: fitting `run2_base_block.ferx` gives `TVMAT ~= 2.6`. Converting the same model to FREM and fitting gives `TVMAT ~= 4.6`. Other thetas move slightly; MAT nearly doubles. Reproduces under both IMP and IMPMAP.

Root cause: the base model uses NONMEM modeled zero-order absorption - dose rows carry `RATE=-2` and the model splits mean absorption time as `D1 = MAT*(1-FRD1)` (zero-order duration) and `KA = 1/(MAT*FRD1)` (first-order). The FREM dataset writer emitted the RATE column as the raw `dose.rate` field, which is `0.0` for a modeled infusion (the `-2`/`-1` sentinel lives in the separate `rate_mode` field). So every `RATE=-2` dose became `RATE=0` - an instantaneous bolus. The zero-order absorption phase vanished, and the fit re-estimated MAT upward to fake the lost absorption delay. Because it corrupts the data, it is method-independent.

Verified on the reprex: regenerated FREM data now carries `RATE=-2` on all 1785 dose rows (was `0`); `SS`/`II` were already correct.

## What changed
FREM dataset writer (`src/frem/mod.rs`) now reconstructs the RATE column from `rate_mode`:
- `RateMode::ModeledDuration` -> `-2`
- `RateMode::ModeledRate` -> `-1`
- `RateMode::Fixed` -> literal `dose.rate`

## Alternatives considered
None reasonable - the sentinel must be reconstructed from `rate_mode`; `dose.rate` alone cannot represent a modeled infusion.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#--- | not needed | after (bump `src/rust/Cargo.lock` pin once this merges) |

No R-side code change; ferx-r picks up the fix via the pinned ferx-core commit.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable at the estimation level, but data-level fix verified: FREM dataset RATE column round-trips `-2` for all modeled-duration dose rows.

```
# before (FREM dose rows): RATE=0    x1785   -> instantaneous bolus, TVMAT ~= 4.6
# after  (FREM dose rows): RATE=-2   x1785   -> modeled zero-order duration preserved, TVMAT ~= 2.6 (base)
```

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib frem` passes, 44/44)
- [x] Regression test added that fails without this fix (`test_transform_dataset_preserves_modeled_rate_sentinel`, plus `test_transform_dataset_preserves_fixed_positive_rate`)

## Docs
- [x] No user-visible API change

## Checklist
- [x] `cargo clippy` clean (no new warnings introduced)

## Reviewer hints
Single-line behavioural change at the RATE-column emit in `transform_dataset_for_frem`; the rest is the two regression tests. `dose.rate` is `0.0` for any modeled infusion - the mode is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
