### PR TITLE
refactor(stats): route likelihood's residual dispatch through residual_rd

### DIFF
--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -1,4 +1,5 @@
 use crate::pk;
+use crate::stats::residual_error::{residual_rd, residual_rd2};
 use crate::stats::special::log_normal_cdf;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -1684,14 +1685,16 @@ fn gaussian_foce_accum(
         // residual-eta c̃ column only on ordinary PK rows.
         let frem_ov = frem_r_override.and_then(|o| o.get(j)).and_then(|v| *v);
         let is_pk_row = frem_ov.is_none();
-        let v_resid = if let Some(v) = frem_ov {
-            v
-        } else {
-            match mult_row(j) {
-                Some(m) => {
-                    error_spec.variance_at_scaled(err_keys[j], f, sigma_values, &[], m) * ruv_scale
-                }
-                None => error_spec.variance_at(err_keys[j], f, sigma_values) * ruv_scale,
+        // `residual_rd` returns the bare `(R, ∂R/∂f)` pair and leaves `ruv_scale`
+        // to the caller, so both carry the factor: scaling `R` by `exp(2·η_ruv)`
+        // multiplies `∂R/∂f` by the same amount, and the two cancel in `c_scale`
+        // below. FREM covariate rows take their variance from the override and
+        // contribute `∂R/∂f = 0` (additive near-zero sigma).
+        let (v_resid, dvar_df) = match frem_ov {
+            Some(v) => (v, 0.0),
+            None => {
+                let (rv, dv) = residual_rd(error_spec, err_keys[j], f, sigma_values, mult_row(j));
+                (rv * ruv_scale, dv * ruv_scale)
             }
         };
         let v = v_resid + p_obs.get(j).copied().unwrap_or(0.0);
@@ -1702,18 +1705,9 @@ fn gaussian_foce_accum(
         data_ll += r * r / v + v.ln();
 
         // a_j = row j of H (∂f_j/∂η); c̃_{j,k} = (∂R_j/∂η_k)/R_j.
-        // For a PK eta: (∂R/∂f)·a / R; scaling R by exp(2η_ruv) multiplies both
-        // ∂R/∂f and R, so the factor cancels — hence scale dvar_df too.
+        // For a PK eta: (∂R/∂f)·a / R.
         // For the residual eta: ∂R/∂η_ruv = 2·R, so the column is the constant 2.
         let aj = h_matrix.row(j);
-        let dvar_df = if is_pk_row {
-            match mult_row(j) {
-                Some(m) => error_spec.dvar_df_scaled(err_keys[j], f, sigma_values, m) * ruv_scale,
-                None => error_spec.dvar_df(err_keys[j], f, sigma_values) * ruv_scale,
-            }
-        } else {
-            0.0 // FREM rows: additive near-zero sigma, ∂R/∂f = 0
-        };
         let c_scale = dvar_df / v;
         let inv_v = 1.0 / v;
         let c_ruv = |k: usize| -> f64 {
@@ -1746,18 +1740,8 @@ fn gaussian_foce_accum(
         // `v_resid`/`d`/`d2` all carry the same proportional-loading (`m²`) and
         // `exp(2·η_ruv)` scaling, so the censored curvature is built from mutually
         // consistent derivatives of one `v(f)`.
-        let (v_resid, d, d2) = match mult_row(j) {
-            Some(m) => (
-                error_spec.variance_at_scaled(cmt, f, sigma_values, &[], m) * ruv_scale,
-                error_spec.dvar_df_scaled(cmt, f, sigma_values, m) * ruv_scale,
-                error_spec.d2var_df2_scaled(cmt, sigma_values, m) * ruv_scale,
-            ),
-            None => (
-                error_spec.variance_at(cmt, f, sigma_values) * ruv_scale,
-                error_spec.dvar_df(cmt, f, sigma_values) * ruv_scale,
-                error_spec.d2var_df2(cmt, sigma_values) * ruv_scale,
-            ),
-        };
+        let (rv, dv, d2v) = residual_rd2(error_spec, cmt, f, sigma_values, mult_row(j));
+        let (v_resid, d, d2) = (rv * ruv_scale, dv * ruv_scale, d2v * ruv_scale);
         // Inflate by the EKF process-noise term exactly as the quantified rows do
         // (line above), so a censored row's `v` — in both the data term and `H̃` —
         // matches its subject's Gaussian rows under an SDE model. `p_obs` is


### PR DESCRIPTION
> **Stacked on #885** (base it there; retarget to `main` once #885 merges). This PR consumes `residual_rd`/`residual_rd2`, which #885 introduces.

## Why

#885 made `stats/residual_error.rs` the single owner of the residual-variance math and promoted `residual_rd`/`residual_rd2` as the canonical scalar `(r, d[, d2])` accessors. The FOCEI Gaussian accumulator (`gaussian_foce_accum`) still hand-rolled the same `Some(mult) -> _scaled / None -> legacy` dispatch in three places. This routes them through the shared accessors, finishing the single-owner work.

This is the deferred "Step 3" from #885's plan, split out deliberately: it is the **only** part of that work that touches an association-sensitive hot path (the FOCEI objective), so it gets its own PR and its own scrutiny rather than riding along with pure code motion.

## What changed

−16 LOC across three dispatch sites in `gaussian_foce_accum`:

1. **Quantified rows.** `v_resid` and `dvar_df` were two halves of one `residual_rd` call for the same `(j, f, sigma)` — split across the loop body, each calling `mult_row(j)` separately, each re-doing the `Some/None` match. They collapse into a single `match frem_ov`:

   ```rust
   let (v_resid, dvar_df) = match frem_ov {
       Some(v) => (v, 0.0),
       None => {
           let (rv, dv) = residual_rd(error_spec, err_keys[j], f, sigma_values, mult_row(j));
           (rv * ruv_scale, dv * ruv_scale)
       }
   };
   ```

   This also makes the FREM contract explicit in one place instead of two: a covariate pseudo-observation takes its variance from the override and contributes `∂R/∂f = 0` — exactly what the old `is_pk_row` guard did, since `is_pk_row == frem_ov.is_none()`.

2. **Censored rows.** The `(v_resid, d, d2)` triple is a verbatim `residual_rd2`.

Net effect per quantified row: **one** dispatch and **one** `mult_row(j)` call instead of two.

## Why this is behavior-preserving

**Equivalence is exact by construction, not by testing.** `residual_rd`'s arms *are* the inline arms:

| | inline (before) | `residual_rd` (after) |
|---|---|---|
| `None` | `variance_at(cmt,f,σ)` / `dvar_df(cmt,f,σ)` | identical |
| `Some(m)` | `variance_at_scaled(cmt,f,σ,&[],m)` / `dvar_df_scaled(cmt,f,σ,m)` | identical |

…and each result is multiplied by `ruv_scale` at the same point as before.

**`ruv_scale` is deliberately NOT pushed into the accessors.** This is the association trap the accessors exist to respect: `likelihood.rs` scales the variance directly (`r = v·ruv_scale`), while `sens_outer_gradient.rs` scales an FD *difference* (`ruv_scale·(vp−vm)/2h`). Those are different associations, so the accessor returns bare `(r,d[,d2])` and every caller scales at its own call site — unchanged here.

`mult_row` is a pure closure (`|j| ruv_mult.map(|m| m[j].as_slice())`), so calling it once instead of twice is not observable.

**The one behavioral difference**, stated plainly: `dvar_df` is now computed *before* the `v.is_finite() && v > 0.0` early return, where it was previously computed after. That costs one unused multiply on a path that discards the subject anyway, and cannot change any returned value.

## What is deliberately NOT deduped

**`CompiledModel::residual_variance_at_scaled` (types.rs) is the same *shape* but not the same *glue*, and merging it would be a bug.**

The original plan listed it as a fourth copy of this dispatch. It isn't: it passes `&self.residual_correlations`, and its `None` arm routes to `variance_at_with_correlations`. `residual_rd` is **diagonal-`R` only by contract** (`&[]` correlations — `block_sigma` correlations force FD upstream). Folding it into `residual_rd` would silently **drop the residual correlations**, producing a wrong variance on every `block_sigma` model. Left alone.

## Alternatives considered

- **Use `residual_rd` at both sites separately, taking `.0` at one and `.1` at the other.** Rejected: `residual_rd` computes both halves, so that would double the work rather than halve it.
- **Keep the two sites split to preserve the lazy `dvar_df`.** Rejected: merging is the entire point, and the "cost" is one multiply on an error path.
- **Also dedupe `CompiledModel::residual_variance_at_scaled`.** Rejected as an active bug — see above.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] **None** — internal to `gaussian_foce_accum`

## Numerical validation
- [x] Compared against prior ferx commit — **`cargo test --lib`: 2570 passed, 0 failed, 18 ignored**, identical to the #885 baseline.
- [x] **300 FD-parity / bit-equality tests exercised, none moved.** This is the gate the change was required to clear: the plan's instruction was to abandon the step if any pin moved. No pin moved.
- [x] The equivalence argument above is exact by construction (identical functions, identical `ruv_scale` placement), so the tests corroborate rather than carry the claim.

## Performance
- [x] Marginally **faster** — one dispatch and one `mult_row(j)` per quantified row instead of two, in the FOCEI inner objective. Not benchmarked; the win is small and the change was made for single-ownership, not speed.

## Tests
- [x] No new tests needed (**why: no behavior change — this is a dispatch-glue substitution whose arms are identical to the code they replace. `gaussian_foce_accum` is already covered by the FOCEI/AGQ FD-parity and OFV suites, 300 of which ran green; test count unchanged at 2570**).

## Example (user-facing features only)
- [x] Not applicable (internal refactor)

## Docs
- [x] `CHANGELOG.md` N/A — internal refactor, no user-facing change
- [x] No user-visible change

## Checklist
- [x] `cargo clippy --no-default-features --features ci,markov` — `likelihood.rs` unchanged at 17 pre-existing hits, **none at the edited lines**; crate-wide count unchanged (279 → 279 vs the #885 base)
- [x] `cargo fmt --check` clean
- [x] `Dual2` path unaffected — no `*_g<T: PkNum>` function touched; this is f64 scalar dispatch
- [x] `Cargo.toml` version bump not needed (non-breaking)

## Docs & examples
- [x] No example execution step needed (internal refactor / no user-visible change)

## Reviewer hints

**Where to focus — the FREM merge (site 1).** It is the only structural change. Verify that `is_pk_row == frem_ov.is_none()` (it's defined that way one line above), so `match frem_ov { Some(v) => (v, 0.0), None => dispatch }` reproduces the old pair exactly:
- old `v_resid`: `if let Some(v) = frem_ov { v } else { dispatch * ruv_scale }`
- old `dvar_df`: `if is_pk_row { dispatch * ruv_scale } else { 0.0 }`

Also confirm `is_pk_row` is still live — it is, at the `c_ruv` closure, for the residual-eta column.

**What's subtle:** `ruv_scale` placement (must stay caller-side) and the `&[]` correlations contract that makes `CompiledModel::residual_variance_at_scaled` un-mergeable. Both are covered above.

**Skimmable:** site 2 (censored rows) is a mechanical `residual_rd2` substitution.

## Open questions

- Hoisting `dvar_df` above the `is_finite` early return is the one semantic wrinkle. I judged one unused multiply on a subject-rejection path to be a non-issue versus halving the dispatch on the hot path — but if you'd rather keep it lazy, say so and I'll restructure.
- Worth running the slow-tests suite (`--features slow-tests`) on this before merge? The Tier-1 FD-parity tests all pass, and the argument is exact by construction, so I did not — but this is the FOCEI objective, and it's your call whether that warrants the extra convergence coverage.
