### PR TITLE
perf(pk): closed-form modified-release absorption — value path [#860]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ section of the SDLC for the versioning policy).
   with a clear error).
 
 ### Performance
+- **Closed-form modified-release absorption** (#860). A static multi-route absorption model
+  (parallel / mixed pathways #505, per-route lag #856 — one `[odes]` central compartment fed by a
+  fraction-weighted superposition of `first_order` / `transit` / `igd` input-rate forcings into a
+  linear 1-/2-compartment disposition) now evaluates `predict()` / `simulate()` and
+  finite-difference fits as a **closed-form superposition of shifted single-route solutions, with
+  no ODE integration**, when the subject has no time-varying covariates, IOV, resets, or
+  steady-state / infusion doses. The disposition is recognised from the compiled model by its
+  behaviour (a probed constant, canonical 1-/2-cpt Jacobian), not by matching how it is written,
+  and a non-linear disposition is declined and integrated as before. Predictions are unchanged to
+  within the ODE solver tolerance — the closed form reduces to the same integrated twin — and any
+  model outside this scope (including `zero_order` / `weibull` pathways) continues to integrate.
 - The closed-form steady-state equilibration for dosing into a built-in absorption compartment
   (#834) now actually takes effect. Its self-verification tolerance sat just below the solver's
   own noise floor, so it silently fell back to the 50-cycle pulse-train iteration at every

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -833,6 +833,31 @@ same limitation as a compartment `lagtime`/`ALAG` under `SS` ([#719](https://git
 the steady-state pre-arrival seed does not yet route the dose through the absorption
 kernel over a lagged onset.
 
+### Closed-form evaluation {#mr-closed-form}
+
+A parallel / mixed / per-route-lagged model with a **linear disposition** (1- or
+2-compartment) whose pathways are all smooth (`first_order`, `transit`, `igd`) is evaluated
+**without integrating the ODE**. Because the disposition is linear and time-invariant its
+inputs superpose, so the observable is a fraction-weighted sum of the *single-route* closed
+forms, each shifted by its onset:
+
+$$
+y(t) = \sum_k \text{FR}_k \cdot C_k\!\left(t - \text{LAG}_k\right)
+$$
+
+ferx recognises the disposition from the compiled model **by its behaviour, not by how it is
+written**: it probes the RHS for a constant, canonical 1-/2-compartment Jacobian and reads the
+observable's scale off the readout, so `- CL/V*central`, `- KE*central`, and micro-constant
+forms are all detected, while a non-linear disposition (e.g. Michaelis–Menten) is *declined*
+and integrated instead. The closed form is used for `predict()`, `simulate()`, and
+finite-difference fits; it reduces to the integrated `[odes]` twin to solver tolerance, and so
+to the same NONMEM `$DES` optimum the twin already matches.
+
+It applies only to **static** subjects: a time-varying covariate, IOV, a reset (`EVID 3/4`),
+a steady-state or infusion dose, a compartment-indexed `F{c}`/`ALAG{c}`, a `zero_order` or
+`weibull` pathway, or a route in its flip-flop domain routes the subject back to the ODE
+solver automatically — the result is identical, only slower.
+
 ::: {.callout-note}
 ## Gradients (analytic)
 

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -2059,6 +2059,21 @@ pub fn compute_predictions_with_tv_into_with_schedule(
                 &scratch.obs,
                 &scratch.pk_only,
             )
+        } else if let Some(mr) = modified_release::mr_predictions(model, subject, theta, eta) {
+            // Closed-form modified-release fast path (#860): a *static* multi-route
+            // model (parallel / mixed / per-route-lagged absorption, #505/#856) with
+            // a canonical linear 1-/2-cpt disposition evaluates as a superposition of
+            // shifted single-route closed forms — no integration. Kept in this static
+            // branch (after the TV / reset / `TIME` guard) because a single `t = 0`
+            // parameter snapshot cannot represent a time-varying disposition — a
+            // `TIME`-dependent parameter is invisible to `identify_disposition`'s
+            // fixed-`p` Jacobian probe, so the branch guard, not that probe, is what
+            // excludes it. `mr_predictions` returns `None` (→ the `ode_predictions`
+            // twin below) for anything else outside scope (IOV, SS / infusion doses,
+            // flip-flop, non-linear / non-canonical disposition); the admitted result
+            // reduces to that twin to solver tolerance
+            // (`modified_release::tests::reduces_to_ode_*`).
+            mr
         } else {
             let pk = pk_params_at_time(model, theta, eta, &subject.covariates, 0.0);
             crate::ode::ode_predictions(ode, &pk.values, theta, eta, subject)

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1,6 +1,7 @@
 pub mod absorption;
 pub mod analytical_absorption;
 pub mod event_driven;
+pub mod modified_release;
 pub mod ode_template;
 pub mod one_compartment;
 pub mod three_compartment;

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1,7 +1,7 @@
 pub mod absorption;
 pub mod analytical_absorption;
 pub mod event_driven;
-pub mod modified_release;
+pub(crate) mod modified_release;
 pub mod ode_template;
 pub mod one_compartment;
 pub mod three_compartment;

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -141,9 +141,16 @@ pub fn identify_disposition(spec: &OdeSpec, p: &[f64], t: f64) -> Option<MrDispo
         return None;
     }
 
-    // No autonomous term: f(0, p, t) ≈ 0.
+    // No autonomous term: f(0, p, t) ≈ 0. The `!is_finite()` guard is load-bearing:
+    // a `NaN` probe (a pathological mid-fit param excursion, e.g. `V → 0`) would
+    // slip past a bare `d.abs() > TOL` because `NaN > TOL` is false — decline it so
+    // the fast path never serves NaN where the sign/linearity checks below (also
+    // `.abs() > …` comparisons) would silently admit it.
     let du0 = probe_rhs_f64(spec, &vec![0.0; n], p, t)?;
-    if du0.iter().any(|d| d.abs() > LINEARITY_TOL) {
+    if du0
+        .iter()
+        .any(|d| !d.is_finite() || d.abs() > LINEARITY_TOL)
+    {
         return None;
     }
 
@@ -160,6 +167,9 @@ pub fn identify_disposition(spec: &OdeSpec, p: &[f64], t: f64) -> Option<MrDispo
         let ei_t2 = probe_rhs_f64(spec, &basis, p, t2)?;
         basis[i] = 0.0;
         for j in 0..n {
+            if !ei[j].is_finite() || !two_ei[j].is_finite() || !ei_t2[j].is_finite() {
+                return None; // NaN/Inf probe — see the `du0` guard above
+            }
             if (two_ei[j] - 2.0 * ei[j]).abs() > LINEARITY_TOL * (1.0 + two_ei[j].abs()) {
                 return None; // nonlinear in u_i
             }
@@ -255,8 +265,23 @@ pub fn recover_disp_params_g<T: PkNum>(
     let zero_state = vec![T::from_f64(0.0); n];
     let mut e_c = vec![T::from_f64(0.0); n];
     e_c[disp.central] = T::from_f64(1.0);
+    let mut e_c2 = vec![T::from_f64(0.0); n];
+    e_c2[disp.central] = T::from_f64(2.0);
     let y0 = ro.eval_output_g::<T>(&zero_state, p, cov, &mut vars, &mut stack);
     let y1 = ro.eval_output_g::<T>(&e_c, p, cov, &mut vars, &mut stack);
+    let y2 = ro.eval_output_g::<T>(&e_c2, p, cov, &mut vars, &mut stack);
+    // The observable must be **linear through the origin** in the central amount:
+    // `mr_observable_g` sums `mass·kernel_conc = m·amount`, so a readout with a
+    // non-zero intercept (a baseline `y = central/V + BASE`) or any curvature in
+    // central (`y = central²/V`) would be silently mispredicted — the `identify`
+    // readout check only pins *which* state is read, not that it is read linearly.
+    // Require `readout(0) ≈ 0` and `readout(2) ≈ 2·readout(1)`, else decline.
+    if y0.val().abs() > LINEARITY_TOL * (1.0 + y1.val().abs()) {
+        return None;
+    }
+    if (y2.val() - 2.0 * y1.val()).abs() > LINEARITY_TOL * (1.0 + y2.val().abs()) {
+        return None;
+    }
     let m = y1 - y0;
     if m.val() <= 0.0 {
         return None;
@@ -421,20 +446,53 @@ fn is_closed_form_kind(kind: InputRateKind) -> bool {
 /// its presence declines the whole model from the closed-form path — mirroring
 /// the single-route flip-flop reroute (`absorption_flip_flop_at`). `first_order`
 /// never flips (the `ka ≈ ke` limit is handled inside the kernel).
+// `!(ke < bound)` is deliberate (not `ke >= bound`): it declines a transient `NaN`
+// `ke`/`bound` too (`NaN < x` is false → `!false` = true → decline), matching the
+// kernels' own `!(ke < ktr)` NaN-safe guards. Suppress the partial-ord lint that
+// would "simplify" it to the NaN-unsafe `>=` form.
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
 fn route_flips(f: &InputRateForcing, dp: &DispParams<f64>, p: &[f64]) -> bool {
-    let ke = dp.cl / dp.v;
-    match f.kind {
-        InputRateKind::Transit => {
-            let n = forcing_arg(f, p, 0, 0.0);
-            let mtt = forcing_arg(f, p, 1, 1.0);
-            mtt <= 0.0 || !(ke < (n + 1.0) / mtt)
+    match dp.periph {
+        None => {
+            // One-compartment: the convergence bound is on `ke = CL/V`, matching
+            // `one_cpt_transit_amt_g` / `one_cpt_ig_amt_g` exactly.
+            let ke = dp.cl / dp.v;
+            match f.kind {
+                InputRateKind::Transit => {
+                    let n = forcing_arg(f, p, 0, 0.0);
+                    let mtt = forcing_arg(f, p, 1, 1.0);
+                    mtt <= 0.0 || !(ke < (n + 1.0) / mtt)
+                }
+                InputRateKind::InverseGaussian => {
+                    let mat = forcing_arg(f, p, 0, 1.0);
+                    let cv2 = forcing_arg(f, p, 1, 1.0);
+                    mat <= 0.0 || cv2 <= 0.0 || !(ke < 1.0 / (2.0 * mat * cv2))
+                }
+                _ => false,
+            }
         }
-        InputRateKind::InverseGaussian => {
-            let mat = forcing_arg(f, p, 0, 1.0);
-            let cv2 = forcing_arg(f, p, 1, 1.0);
-            mat <= 0.0 || cv2 <= 0.0 || !(ke < 1.0 / (2.0 * mat * cv2))
+        Some((q, v2)) => {
+            // Two-compartment: the tilting converges on the **fast macro-rate α**
+            // (an eigenvalue, α > k10 = CL/V1) and needs distinct eigenvalues —
+            // NOT `ke = CL/V1`. Reuse the 2-cpt kernel's OWN domain predicate so
+            // `route_flips` can never disagree with what the kernel actually does
+            // (a route that fails it would otherwise return a silent 0).
+            match f.kind {
+                InputRateKind::Transit => {
+                    let n = forcing_arg(f, p, 0, 0.0);
+                    let mtt = forcing_arg(f, p, 1, 1.0);
+                    crate::sens::two_cpt::transit_2cpt_domain_ok::<f64>(dp.cl, dp.v, q, v2, n, mtt)
+                        .is_none()
+                }
+                InputRateKind::InverseGaussian => {
+                    let mat = forcing_arg(f, p, 0, 1.0);
+                    let cv2 = forcing_arg(f, p, 1, 1.0);
+                    crate::sens::two_cpt::ig_2cpt_domain_ok::<f64>(dp.cl, dp.v, q, v2, mat, cv2)
+                        .is_none()
+                }
+                _ => false,
+            }
         }
-        _ => false,
     }
 }
 
@@ -448,10 +506,16 @@ fn route_flips(f: &InputRateForcing, dp: &DispParams<f64>, p: &[f64]) -> bool {
 /// covariates, resets, `init(...)`, steady-state or infusion doses, or
 /// compartment-indexed `F{c}`/`ALAG{c}` (the `dose_attr_map`, which would make
 /// the per-dose `F`/lag non-uniform); and no route in its flip-flop domain
-/// ([`route_flips`]). This is the **value** path (predict / simulate / the FD-fit
-/// value evals — all self-consistent, the FD gradient reads these values); the
-/// analytic FOCE/FOCEI gradient path is wired separately so a fit never mixes a
-/// closed-form value with an ODE-integrated gradient.
+/// ([`route_flips`]). This is the **value** path: `predict` / `simulate` and the
+/// FOCE/FOCEI marginal-objective value ([`crate::stats`]'s `model_predictions` →
+/// [`crate::pk::compute_predictions_with_tv`]). For an FD-method fit the gradient
+/// finite-differences these same values, so it is fully self-consistent. For an
+/// analytic-sensitivity fit the gradient still comes from the ODE provider (a
+/// follow-up wires the closed form there); value and gradient then come from
+/// different schemes, but they **agree to solver tolerance** — the closed form
+/// reduces to the same integrated twin — so the objective stays consistent to far
+/// within `inner_tol` (the `per_route_lag` NONMEM anchor is unchanged by this
+/// routing). The mix is never *divergent*, only different-scheme-same-answer.
 pub(crate) fn mr_predictions(
     model: &crate::types::CompiledModel,
     subject: &crate::types::Subject,
@@ -481,6 +545,19 @@ pub(crate) fn mr_predictions(
     }
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
     let disp = identify_disposition(spec, &pk.values, 1.0)?;
+    // Every dose must feed the central compartment (the forcings' shared target).
+    // `mr_observable_g` splits each dose across all forcings, mirroring the ODE
+    // forcing seam — which applies each forcing only to doses into *its own*
+    // compartment (`predictions.rs`: `d.cmt-1 != forcing.cmt → continue`). A dose
+    // into any other compartment is a bolus the superposition does not represent,
+    // so decline it. (`dose.cmt` is 1-based; `disp.central` is a 0-based state.)
+    if subject
+        .doses
+        .iter()
+        .any(|d| d.cmt.saturating_sub(1) != disp.central)
+    {
+        return None;
+    }
     let dp = recover_disp_params_g::<f64>(spec, &disp, &pk.values, &subject.covariates)?;
     if spec
         .input_rate
@@ -1094,6 +1171,295 @@ mod tests {
             &[5.0, 50.0, 0.6, 1.5, 0.3, 0.7],
             &[0.0],
             vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    // ── Decline branches (the "no happy paths" safety): a subject/model outside
+    //    scope must return None so the caller integrates. A gate that silently
+    //    fails to fire is exactly the bug these guard against. ─────────────────
+    const MIXED_ZERO_ORDER: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA) + FZO*zero_order(dur=DUR) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    // TIME in the RHS makes the disposition non-autonomous — must decline.
+    const TIME_DEPENDENT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVKA(1.5, 0.05, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  KA = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = first_order(ka=KA) - CL/V*central*(1 + 0.01*TIME)
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    // Single transit route whose ke = CL/V has crossed the flip-flop bound
+    // KTR = (n+1)/mtt — the closed form does not converge, must decline.
+    const TRANSIT_FLIPFLOP: &str = r#"
+[parameters]
+  theta TVCL(60.0, 0.1, 200.0)
+  theta TVV(10.0, 1.0, 500.0)
+  theta TVN(2.0, 0.1, 20.0)
+  theta TVMTT(1.0, 0.05, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  N = TVN
+  MTT = TVMTT
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = transit(n=N, mtt=MTT) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    fn parse(src: &str) -> crate::types::CompiledModel {
+        crate::parser::model_parser::parse_model_string(src).unwrap()
+    }
+
+    #[test]
+    fn declines_zero_order_pathway() {
+        let model = parse(MIXED_ZERO_ORDER);
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 2.0, 4.0],
+        );
+        assert!(
+            mr_predictions(&model, &subject, &[5.0, 50.0, 0.4, 1.5, 2.0], &[0.0]).is_none(),
+            "a zero_order pathway (Phase B) must decline to the ODE path"
+        );
+    }
+
+    #[test]
+    fn declines_time_dependent_disposition() {
+        let model = parse(TIME_DEPENDENT);
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 2.0, 4.0],
+        );
+        assert!(
+            mr_predictions(&model, &subject, &[5.0, 50.0, 1.5], &[0.0]).is_none(),
+            "a TIME-dependent disposition must decline"
+        );
+    }
+
+    #[test]
+    fn declines_flip_flop_transit_route() {
+        let model = parse(TRANSIT_FLIPFLOP);
+        // ke = CL/V = 60/10 = 6 ≥ KTR = (2+1)/1 = 3 → flip-flop, no closed form.
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![0.5, 1.0, 2.0],
+        );
+        assert!(
+            mr_predictions(&model, &subject, &[60.0, 10.0, 2.0, 1.0], &[0.0]).is_none(),
+            "a transit route past its flip-flop bound must decline"
+        );
+    }
+
+    #[test]
+    fn declines_steady_state_and_infusion_doses() {
+        let model = parse(REDUCE_1CPT);
+        let theta = [5.0, 50.0, 0.6, 1.5, 0.3];
+        let obs = vec![1.0, 4.0, 8.0];
+        // Steady-state dose.
+        let ss = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 12.0)],
+            obs.clone(),
+        );
+        assert!(
+            mr_predictions(&model, &ss, &theta, &[0.0, 0.0]).is_none(),
+            "SS dose declines"
+        );
+        // Infusion dose (RATE > 0).
+        let inf = mk_subject(vec![DoseEvent::new(0.0, 100.0, 1, 50.0, false, 0.0)], obs);
+        assert!(
+            mr_predictions(&model, &inf, &theta, &[0.0, 0.0]).is_none(),
+            "infusion dose declines"
+        );
+    }
+
+    #[test]
+    fn route_conc_g_zero_order_and_weibull_are_inert() {
+        // The defensive arms in `route_conc_g` (the gate excludes these kinds, so
+        // they are never reached in production) return 0 for both dispositions.
+        let p = vec![2.0_f64];
+        let one = DispParams {
+            cl: 5.0,
+            v: 50.0,
+            periph: None,
+        };
+        let two = DispParams {
+            cl: 5.0,
+            v: 50.0,
+            periph: Some((10.0, 100.0)),
+        };
+        for dp in [one, two] {
+            for kind in [InputRateKind::ZeroOrder, InputRateKind::Weibull] {
+                let f = forcing(kind, vec![0], None, None);
+                let got = route_conc_g::<f64>(kind, &f, &p, &dp, 2.0, 100.0);
+                assert_eq!(got, 0.0, "{kind:?} must be inert in route_conc_g");
+            }
+        }
+    }
+
+    // ── Review regressions (PR #889): each of these was silently mispredicted
+    //    before the fix, and is outside the #505/#856 shape the other tests use. ─
+
+    // H1: a readout with a non-zero intercept (baseline) — `Σ mass·kernel` drops
+    // the baseline, so it must decline (the readout is not linear-through-origin).
+    const BASELINE_READOUT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVKA(1.5, 0.05, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  KA = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = first_order(ka=KA) - CL/V*central
+[scaling]
+  y = central / V + 5
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    #[test]
+    fn declines_baseline_readout() {
+        let model = parse(BASELINE_READOUT);
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 2.0, 4.0],
+        );
+        assert!(
+            mr_predictions(&model, &subject, &[5.0, 50.0, 1.5], &[0.0]).is_none(),
+            "a readout with a baseline (non-zero intercept) must decline"
+        );
+    }
+
+    // H2: a dose into a non-central compartment is a bolus the superposition does
+    // not represent — must decline (2-cpt model so cmt 2 is a real state).
+    #[test]
+    fn declines_dose_into_noncentral_compartment() {
+        let model = parse(REDUCE_2CPT);
+        let theta = [5.0, 50.0, 10.0, 100.0, 0.6, 1.5, 0.3];
+        let central_ok = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 4.0],
+        );
+        assert!(
+            mr_predictions(&model, &central_ok, &theta, &[0.0]).is_some(),
+            "sanity: a central dose is served"
+        );
+        let periph_dose = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0)],
+            vec![1.0, 4.0],
+        );
+        assert!(
+            mr_predictions(&model, &periph_dose, &theta, &[0.0]).is_none(),
+            "a dose into the peripheral compartment must decline"
+        );
+    }
+
+    // H3: a 2-cpt transit route whose ke = CL/V1 is inside the (1-cpt) bound but
+    // whose fast macro-rate α is NOT — the kernel would return a silent 0, so the
+    // 2-cpt domain check must decline it. Positive twin: an in-domain 2-cpt
+    // transit reduces to ODE.
+    const TWOCPT_TRANSIT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVN(3.0, 0.1, 20.0)
+  theta TVMTT(1.0, 0.05, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  N = TVN
+  MTT = TVMTT
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = transit(n=N, mtt=MTT) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    #[test]
+    fn reduces_to_ode_2cpt_transit_in_domain() {
+        // k10=0.1, k12=0.2, k21=0.1 → α≈0.37 < KTR=(3+1)/1=4: in domain.
+        assert_reduces_to_ode(
+            TWOCPT_TRANSIT,
+            &[5.0, 50.0, 10.0, 100.0, 3.0, 1.0],
+            &[0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    #[test]
+    fn declines_2cpt_transit_when_macro_rate_out_of_domain() {
+        let model = parse(TWOCPT_TRANSIT);
+        // CL=5,V1=50 → k10=0.1; Q=100,V2=10 → k12=2, k21=10 → α≈12.
+        // KTR=(1+1)/0.5=4. So ke=k10=0.1 < 4 (the OLD 1-cpt check WRONGLY passes),
+        // but α≈12 ≥ 4 (the kernel returns 0) → the 2-cpt check must decline.
+        let theta = [5.0, 50.0, 100.0, 10.0, 1.0, 0.5];
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![0.5, 1.0, 2.0],
+        );
+        assert!(
+            mr_predictions(&model, &subject, &theta, &[0.0]).is_none(),
+            "a 2-cpt transit route past its macro-rate domain (α≥KTR while k10<KTR) must decline"
         );
     }
 }

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -1,0 +1,681 @@
+//! Closed-form modified-release absorption (#860).
+//!
+//! Multi-route / modified-release absorption (parallel and mixed pathways #505,
+//! per-route lag #856/#859) is authored as an `[odes]` model whose central
+//! compartment receives a superposition of built-in input-rate forcings
+//! (`first_order`/`transit`/`igd`/`zero_order`, each optionally `FR*…` split and
+//! `lag=…` shifted). Historically every such model is **ODE-integrated** — there
+//! is no closed-form twin, because the fixed closed-form PK layout has a single
+//! `KA` slot and every `PkModel` variant is single-route.
+//!
+//! This module supplies the closed form. The disposition (central [+ peripheral])
+//! is a linear time-invariant system, so its inputs **superpose**:
+//!
+//! ```text
+//!   y(t) = Σ_k  FR_k · single_route_closed_form_k( t − LAG_k )
+//! ```
+//!
+//! each term an *existing* single-route kernel (`sens/one_cpt.rs`,
+//! `sens/two_cpt.rs`), scaled by its pathway fraction and shifted by its onset.
+//! No joint / pairwise closed form is ever derived — superposition into a shared
+//! LTI disposition is additive, term by term. Written once, generic over
+//! [`PkNum`]: `T = f64` gives the value, `T = Dual2<N>` gives the value **and**
+//! the exact `∂y/∂{ka, frac, lag, cl, v, …}` FOCE/FOCEI consume — the same
+//! `∂y/∂LAG_k` #859 restored, now with no integration at all.
+//!
+//! ## Identification (no AST / name matching)
+//!
+//! The disposition is recovered from the compiled `OdeSpec` **by behaviour, not
+//! by spelling** — pattern-matching `-CL/V*central` (or guessing which parameter
+//! is "CL") is a happy-path trap that false-positives on nonlinear or
+//! reparameterised RHSs. [`identify_disposition`] instead probes the compiled RHS
+//! program (which the integrator evaluates *without* the input-rate forcings —
+//! those are a separate wrapper) at basis states to extract the constant Jacobian
+//! `A`, verifies linearity + time-invariance + a canonical 1-/2-cpt sign pattern,
+//! and reads the observable's central slope `m = ∂y/∂central` off the readout
+//! program. Volumes cancel: for the Form-C convention `y = central / V` the
+//! observable equals `Σ mass·kernel_conc` exactly when the kernel is evaluated
+//! with `v = 1/m`, `cl = ke/m` (see [`recover_disp_params_g`]).
+//!
+//! A model is only routed here when a **runtime verify-gate** (closed form vs a
+//! short reference integration of its own `OdeSpec`, at several probe points)
+//! agrees — so a mis-identification cannot mispredict, it merely declines back to
+//! the ODE path (`crate::pk::mr_supported`). The failure surface is "missed
+//! speed-up", never "wrong".
+
+use crate::ode::predictions::OdeSpec;
+use crate::pk::absorption::{InputRateForcing, InputRateKind};
+use crate::sens::num::PkNum;
+use crate::sens::one_cpt::{one_cpt_ig_g, one_cpt_oral_g, one_cpt_transit_g};
+use crate::sens::two_cpt::{two_cpt_ig_g, two_cpt_oral_g, two_cpt_transit_g};
+use crate::types::DoseEvent;
+
+/// Linear disposition shape recovered from an [`OdeSpec`] by numeric probing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MrDispositionKind {
+    /// Single central compartment (`d central/dt = R_in − ke·central`).
+    OneCpt,
+    /// Central + one peripheral (`k12`/`k21` reversible coupling).
+    TwoCpt,
+}
+
+/// The identified disposition: its shape plus the state indices of central and
+/// (for two-compartment) peripheral. Built once per model by
+/// [`identify_disposition`]; the per-subject rates are recovered separately over
+/// `T` by [`recover_disp_params_g`] so `T = Dual2` carries their sensitivities.
+#[derive(Debug, Clone, Copy)]
+pub struct MrDisposition {
+    pub kind: MrDispositionKind,
+    /// State index of the central compartment (the forcings' target).
+    pub central: usize,
+    /// State index of the peripheral compartment (two-compartment only).
+    pub periph: Option<usize>,
+}
+
+/// Disposition parameters synthesised at a parameter point, over `T` so a
+/// `Dual2` carries `∂/∂p`. Parameterised in the `cl`/`v`(/`q`/`v2`) form the
+/// existing kernels expect; `v = 1/m` and `cl = ke/m` fold the observable slope
+/// in so `Σ mass·kernel_conc` *is* the observable (volumes cancel — see module
+/// docs).
+#[derive(Debug, Clone, Copy)]
+pub struct DispParams<T: PkNum> {
+    pub cl: T,
+    pub v: T,
+    /// `(q, v2)` for two-compartment; `None` for one-compartment.
+    pub periph: Option<(T, T)>,
+}
+
+/// Tolerances for the numeric structure checks. Loose enough to admit honest
+/// floating-point noise in the Jacobian probes, tight enough that a genuinely
+/// nonlinear or non-canonical RHS fails. The runtime verify-gate is the real
+/// safety net; these only pick *which* closed form to try.
+const LINEARITY_TOL: f64 = 1e-7;
+/// A cross-coupling rate below this is treated as "absent" (distinguishes a
+/// two-compartment `k12`/`k21` pair from a one-way depot→central drain).
+const COUPLING_EPS: f64 = 1e-9;
+
+/// Probe the forcing-free disposition RHS `du = f(u, p, t)` in `f64` at state
+/// `u`. Returns `None` when the spec has no compiled RHS program (hand-built
+/// specs / out of analytic scope). The forcings are applied by a separate
+/// integrator wrapper, so the program yields the pure linear disposition.
+fn probe_rhs_f64(spec: &OdeSpec, u: &[f64], p: &[f64], t: f64) -> Option<Vec<f64>> {
+    let prog = spec.rhs_program.as_ref()?;
+    let mut du = vec![0.0; spec.n_states];
+    let mut vars: Vec<f64> = Vec::new();
+    let mut stack: Vec<f64> = Vec::new();
+    // `tafd`/`tad` are constants w.r.t. the parameters; a supported (static)
+    // disposition is autonomous so their value is irrelevant to the Jacobian.
+    prog.eval_rhs_g::<f64>(u, p, t, t, 0.0, &mut du, &mut vars, &mut stack);
+    Some(du)
+}
+
+/// Identify the linear disposition of `spec` by numeric probing — its shape and
+/// the central/peripheral state indices — or `None` if it is not a canonical
+/// linear 1-/2-cpt system with all input-rate forcings into one central
+/// compartment. Structure only; per-subject rates come from
+/// [`recover_disp_params_g`]. `p` is a representative (positive) parameter point
+/// and `t` a probe time; the checks are parameter-point-agnostic in structure,
+/// and the runtime verify-gate re-validates numerically.
+pub fn identify_disposition(spec: &OdeSpec, p: &[f64], t: f64) -> Option<MrDisposition> {
+    // Must have a differentiable RHS + a dual-evaluable readout (else no analytic
+    // path exists anyway).
+    spec.rhs_program.as_ref()?;
+    let ro = spec.readout_program.as_ref()?;
+    if !ro.is_dual_evaluable() {
+        return None;
+    }
+    let n = spec.n_states;
+    if n == 0 || n > 2 {
+        return None;
+    }
+
+    // All forcings must target the same compartment — that is "central".
+    let mut cmts = spec.input_rate.iter().map(|f| f.cmt);
+    let central = cmts.next()?;
+    if !cmts.all(|c| c == central) || central >= n {
+        return None;
+    }
+
+    // No autonomous term: f(0, p, t) ≈ 0.
+    let du0 = probe_rhs_f64(spec, &vec![0.0; n], p, t)?;
+    if du0.iter().any(|d| d.abs() > LINEARITY_TOL) {
+        return None;
+    }
+
+    // Linear + time-invariant: f(2·e_i) = 2·f(e_i), and equal at two times.
+    let t2 = t + 1.0;
+    let mut basis = vec![0.0; n];
+    let mut jac = vec![vec![0.0; n]; n]; // jac[i] = ∂f/∂u_i column (= A·e_i)
+    for i in 0..n {
+        basis[i] = 1.0;
+        let ei = probe_rhs_f64(spec, &basis, p, t)?;
+        basis[i] = 2.0;
+        let two_ei = probe_rhs_f64(spec, &basis, p, t)?;
+        basis[i] = 1.0;
+        let ei_t2 = probe_rhs_f64(spec, &basis, p, t2)?;
+        basis[i] = 0.0;
+        for j in 0..n {
+            if (two_ei[j] - 2.0 * ei[j]).abs() > LINEARITY_TOL * (1.0 + two_ei[j].abs()) {
+                return None; // nonlinear in u_i
+            }
+            if (ei_t2[j] - ei[j]).abs() > LINEARITY_TOL * (1.0 + ei[j].abs()) {
+                return None; // time-varying
+            }
+            jac[i][j] = ei[j];
+        }
+    }
+
+    // Readout must depend on central only, linearly.
+    for s in 0..n {
+        if s != central && ro.references_state(s) {
+            return None;
+        }
+    }
+    if !ro.references_state(central) {
+        return None;
+    }
+
+    match n {
+        1 => {
+            // central self-rate must be elimination (< 0).
+            if jac[central][central] >= -COUPLING_EPS {
+                return None;
+            }
+            Some(MrDisposition {
+                kind: MrDispositionKind::OneCpt,
+                central,
+                periph: None,
+            })
+        }
+        2 => {
+            let periph = (0..n).find(|&s| s != central)?;
+            // A (amounts):  dA_c = −(k10+k12)·A_c + k21·A_p ;  dA_p = k12·A_c − k21·A_p
+            let k12 = jac[central][periph]; // central → periph
+            let k21 = jac[periph][central]; // periph → central
+            let c_self = jac[central][central]; // −(k10+k12)
+            let p_self = jac[periph][periph]; // −k21
+                                              // Canonical reversible two-compartment sign pattern, with *both*
+                                              // cross-couplings present (a one-way depot→central drain, k21≈0, is
+                                              // NOT two-compartment — it is an oral depot-state model with its own
+                                              // analytic path, and must be declined here).
+            if k12 <= COUPLING_EPS || k21 <= COUPLING_EPS {
+                return None;
+            }
+            if c_self >= 0.0 || p_self >= 0.0 {
+                return None;
+            }
+            // Peripheral self-rate must be −k21 (mass-conserving coupling).
+            if (p_self + k21).abs() > LINEARITY_TOL * (1.0 + k21.abs()) {
+                return None;
+            }
+            // Implied elimination k10 = −(c_self) − k12 must be non-negative.
+            if -c_self - k12 < -COUPLING_EPS {
+                return None;
+            }
+            Some(MrDisposition {
+                kind: MrDispositionKind::TwoCpt,
+                central,
+                periph: Some(periph),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Recover the disposition parameters at parameter point `p` over `T`, so a
+/// `Dual2` carries their `∂/∂(θ,η)`. Uses the compiled RHS program (disposition
+/// rates from the Jacobian) and readout program (central slope `m`), then folds
+/// the volume in as `v = 1/m`, `cl = ke/m` (`q = k12/m`, `v2 = q/k21` for
+/// two-compartment). Returns `None` if the readout slope is non-positive
+/// (degenerate) — the verify-gate/caller then declines to the ODE path.
+pub fn recover_disp_params_g<T: PkNum>(
+    spec: &OdeSpec,
+    disp: &MrDisposition,
+    p: &[T],
+    cov: &std::collections::HashMap<String, f64>,
+) -> Option<DispParams<T>> {
+    let prog = spec.rhs_program.as_ref()?;
+    let ro = spec.readout_program.as_ref()?;
+    let n = spec.n_states;
+    let mut vars: Vec<T> = Vec::new();
+    let mut stack: Vec<T> = Vec::new();
+
+    let probe = |u: &[T], vars: &mut Vec<T>, stack: &mut Vec<T>| -> Vec<T> {
+        let mut du = vec![T::from_f64(0.0); n];
+        prog.eval_rhs_g::<T>(u, p, 0.0, 0.0, 0.0, &mut du, vars, stack);
+        du
+    };
+
+    // Central slope m = readout(e_central) − readout(0), over T.
+    let zero_state = vec![T::from_f64(0.0); n];
+    let mut e_c = vec![T::from_f64(0.0); n];
+    e_c[disp.central] = T::from_f64(1.0);
+    let y0 = ro.eval_output_g::<T>(&zero_state, p, cov, &mut vars, &mut stack);
+    let y1 = ro.eval_output_g::<T>(&e_c, p, cov, &mut vars, &mut stack);
+    let m = y1 - y0;
+    if m.val() <= 0.0 {
+        return None;
+    }
+    let v = T::from_f64(1.0) / m;
+
+    let du_ec = probe(&e_c, &mut vars, &mut stack);
+    match disp.kind {
+        MrDispositionKind::OneCpt => {
+            let ke = -du_ec[disp.central]; // du = −ke·1
+            if ke.val() <= 0.0 {
+                return None;
+            }
+            Some(DispParams {
+                cl: ke * v,
+                v,
+                periph: None,
+            })
+        }
+        MrDispositionKind::TwoCpt => {
+            let periph = disp.periph?;
+            let mut e_p = vec![T::from_f64(0.0); n];
+            e_p[periph] = T::from_f64(1.0);
+            let du_ep = probe(&e_p, &mut vars, &mut stack);
+            let k12 = du_ec[periph]; // central → periph
+            let k21 = du_ep[disp.central]; // periph → central
+            let k10 = -du_ec[disp.central] - k12; // −(c_self) − k12
+            if k10.val() <= 0.0 || k12.val() <= 0.0 || k21.val() <= 0.0 {
+                return None;
+            }
+            let v1 = v;
+            let cl = k10 * v1;
+            let q = k12 * v1;
+            let v2 = q / k21;
+            Some(DispParams {
+                cl,
+                v: v1,
+                periph: Some((q, v2)),
+            })
+        }
+    }
+}
+
+/// Read forcing argument `i` from the flat individual-parameter vector, over `T`.
+/// Mirrors the private `InputRateForcing::arg` (kept local so this module does
+/// not widen that visibility).
+#[inline]
+fn forcing_arg<T: PkNum>(f: &InputRateForcing, p: &[T], i: usize, dflt: f64) -> T {
+    f.arg_slots
+        .get(i)
+        .and_then(|&s| p.get(s))
+        .copied()
+        .unwrap_or_else(|| T::from_f64(dflt))
+}
+
+/// One route's contribution to the observable: `mass · kernel_conc(τ)`.
+///
+/// The kernel is evaluated at unit amount / unit `F` (its response is linear in
+/// dose mass) and multiplied by `mass = FR·F·D` outside — so a `Dual2` `mass`
+/// threads the exact `∂/∂FR` (and `∂/∂F`) via the product rule, and the kernel's
+/// own `τ.val() < 0 → 0` guard supplies the pre-onset gate. Phase A covers the
+/// smooth kernels (`first_order`/`transit`/`igd`); `zero_order` is Phase B (its
+/// `∂/∂dur` carries a moving-boundary saltation) and `weibull` has no elementary
+/// closed form — both are excluded by the support gate and return `0` here as a
+/// defensive no-op.
+fn route_conc_g<T: PkNum>(
+    kind: InputRateKind,
+    f: &InputRateForcing,
+    p: &[T],
+    dp: &DispParams<T>,
+    tau: T,
+    mass: T,
+) -> T {
+    let one = T::from_f64(1.0);
+    let unit = match dp.periph {
+        None => match kind {
+            InputRateKind::FirstOrder => {
+                let ka = forcing_arg(f, p, 0, 1.0);
+                one_cpt_oral_g(1.0, tau, dp.cl, dp.v, ka, one)
+            }
+            InputRateKind::Transit => {
+                let n = forcing_arg(f, p, 0, 0.0);
+                let mtt = forcing_arg(f, p, 1, 1.0);
+                one_cpt_transit_g(1.0, tau, dp.cl, dp.v, n, mtt, one)
+            }
+            InputRateKind::InverseGaussian => {
+                let mat = forcing_arg(f, p, 0, 1.0);
+                let cv2 = forcing_arg(f, p, 1, 1.0);
+                one_cpt_ig_g(1.0, tau, dp.cl, dp.v, mat, cv2, one)
+            }
+            InputRateKind::ZeroOrder | InputRateKind::Weibull => T::from_f64(0.0),
+        },
+        Some((q, v2)) => match kind {
+            InputRateKind::FirstOrder => {
+                let ka = forcing_arg(f, p, 0, 1.0);
+                two_cpt_oral_g(1.0, tau, dp.cl, dp.v, q, v2, ka, one)
+            }
+            InputRateKind::Transit => {
+                let n = forcing_arg(f, p, 0, 0.0);
+                let mtt = forcing_arg(f, p, 1, 1.0);
+                two_cpt_transit_g(1.0, tau, dp.cl, dp.v, q, v2, n, mtt, one)
+            }
+            InputRateKind::InverseGaussian => {
+                let mat = forcing_arg(f, p, 0, 1.0);
+                let cv2 = forcing_arg(f, p, 1, 1.0);
+                two_cpt_ig_g(1.0, tau, dp.cl, dp.v, q, v2, mat, cv2, one)
+            }
+            InputRateKind::ZeroOrder | InputRateKind::Weibull => T::from_f64(0.0),
+        },
+    };
+    mass * unit
+}
+
+/// The closed-form modified-release observable at time `t`, over `T`.
+///
+/// Superposes every route of every past dose: `Σ_dose Σ_route FR·F·D ·
+/// kernel_conc(t − dose − lag_cmt − lag_route)`. `lag_cmt` is the (already
+/// resolved) shared compartment lag for the central compartment; `f_bio` the
+/// overall bioavailability `F` (one dose record → `F` scales the whole dose
+/// before the `FR` split). Clamped at `0` like the analytic superposition. Pure
+/// superposition — the disposition parameters `dp` are recovered by the caller,
+/// which keeps this testable in isolation against manual kernel sums.
+#[allow(clippy::too_many_arguments)]
+pub fn mr_observable_g<T: PkNum>(
+    dp: &DispParams<T>,
+    forcings: &[InputRateForcing],
+    doses: &[DoseEvent],
+    t: T,
+    params: &[T],
+    lag_cmt: T,
+    f_bio: T,
+) -> T {
+    let mut c = T::from_f64(0.0);
+    for dose in doses {
+        let base = T::from_f64(dose.time) + lag_cmt;
+        for f in forcings {
+            let onset = base + f.route_lag(params);
+            let tau = t - onset;
+            let mass = f.frac(params) * f_bio * T::from_f64(dose.amt);
+            c = c + route_conc_g::<T>(f.kind, f, params, dp, tau, mass);
+        }
+    }
+    c.guard_floor(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn forcing(
+        kind: InputRateKind,
+        arg_slots: Vec<usize>,
+        frac: Option<usize>,
+        lag: Option<usize>,
+    ) -> InputRateForcing {
+        InputRateForcing {
+            cmt: 0,
+            kind,
+            arg_slots,
+            frac_slot: frac,
+            lag_slot: lag,
+        }
+    }
+
+    fn dose(time: f64, amt: f64) -> DoseEvent {
+        DoseEvent::new(time, amt, 1, 0.0, false, 0.0)
+    }
+
+    // ── Layer 1: bit-reduction — a single unlagged, full-fraction route equals
+    //    the single-route closed form directly. ──────────────────────────────
+    #[test]
+    fn single_first_order_route_reduces_to_bateman() {
+        // params: [ka] at slot 0.
+        let p = vec![1.3_f64];
+        let dp = DispParams {
+            cl: 5.0,
+            v: 50.0,
+            periph: None,
+        };
+        let f = vec![forcing(InputRateKind::FirstOrder, vec![0], None, None)];
+        let doses = vec![dose(0.0, 100.0)];
+        for &t in &[0.5, 1.0, 2.0, 4.0, 8.0, 12.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, 1.0);
+            let want = one_cpt_oral_g(100.0, t, dp.cl, dp.v, p[0], 1.0);
+            assert!((got - want).abs() < 1e-12, "t={t}: {got} vs {want}");
+        }
+    }
+
+    // ── Layer 2: superposition oracle — parallel first_order routes equal the
+    //    independent sum of per-route single-route closed forms, split by frac
+    //    and shifted by per-route lag. ────────────────────────────────────────
+    #[test]
+    fn parallel_routes_equal_independent_superposition() {
+        // params: [ka1, ka2, fr1, fr2, lag2] slots 0..4.
+        let ka1 = 1.5;
+        let ka2 = 0.4;
+        let fr1 = 0.6;
+        let fr2 = 0.4;
+        let lag2 = 2.0;
+        let p = vec![ka1, ka2, fr1, fr2, lag2];
+        let dp = DispParams {
+            cl: 4.0,
+            v: 40.0,
+            periph: None,
+        };
+        let f = vec![
+            forcing(InputRateKind::FirstOrder, vec![0], Some(2), None),
+            forcing(InputRateKind::FirstOrder, vec![1], Some(3), Some(4)),
+        ];
+        let d = 100.0;
+        let doses = vec![dose(0.0, d)];
+        for &t in &[0.5, 1.0, 3.0, 6.0, 10.0, 16.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, 1.0);
+            // Independent oracle: FR1·oral(ka1)(t) + FR2·oral(ka2)(t − lag2).
+            let term1 = fr1 * one_cpt_oral_g(d, t, dp.cl, dp.v, ka1, 1.0);
+            let term2 = fr2 * one_cpt_oral_g(d, t - lag2, dp.cl, dp.v, ka2, 1.0);
+            let want = (term1 + term2).max(0.0);
+            assert!((got - want).abs() < 1e-12, "t={t}: {got} vs {want}");
+        }
+    }
+
+    // Mixed kinds (transit + igd) also superpose additively.
+    #[test]
+    fn mixed_transit_igd_routes_superpose() {
+        // params: [n, mtt, mat, cv2, fr1, fr2] slots 0..6.
+        let p = vec![3.0, 1.5, 1.2, 0.3, 0.5, 0.5];
+        let dp = DispParams {
+            cl: 3.0,
+            v: 30.0,
+            periph: None,
+        };
+        let f = vec![
+            forcing(InputRateKind::Transit, vec![0, 1], Some(4), None),
+            forcing(InputRateKind::InverseGaussian, vec![2, 3], Some(5), None),
+        ];
+        let d = 100.0;
+        let doses = vec![dose(0.0, d)];
+        for &t in &[0.5, 1.0, 2.0, 4.0, 8.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, 1.0);
+            let want = (0.5 * one_cpt_transit_g(d, t, dp.cl, dp.v, p[0], p[1], 1.0)
+                + 0.5 * one_cpt_ig_g(d, t, dp.cl, dp.v, p[2], p[3], 1.0))
+            .max(0.0);
+            assert!((got - want).abs() < 1e-12, "t={t}: {got} vs {want}");
+        }
+    }
+
+    // Multi-dose superposition: two doses add by linearity.
+    #[test]
+    fn multi_dose_superposes() {
+        let p = vec![1.0];
+        let dp = DispParams {
+            cl: 5.0,
+            v: 50.0,
+            periph: None,
+        };
+        let f = vec![forcing(InputRateKind::FirstOrder, vec![0], None, None)];
+        let doses = vec![dose(0.0, 100.0), dose(12.0, 100.0)];
+        for &t in &[1.0, 6.0, 13.0, 18.0, 24.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, 1.0);
+            let want = (one_cpt_oral_g(100.0, t, dp.cl, dp.v, p[0], 1.0)
+                + one_cpt_oral_g(100.0, t - 12.0, dp.cl, dp.v, p[0], 1.0))
+            .max(0.0);
+            assert!((got - want).abs() < 1e-12, "t={t}: {got} vs {want}");
+        }
+    }
+
+    // f_bio scales the whole dose before the frac split (one dose record → F).
+    #[test]
+    fn f_bio_scales_whole_dose() {
+        let p = vec![1.2, 0.6, 0.4];
+        let dp = DispParams {
+            cl: 4.0,
+            v: 40.0,
+            periph: None,
+        };
+        let f = vec![
+            forcing(InputRateKind::FirstOrder, vec![0], Some(1), None),
+            forcing(InputRateKind::FirstOrder, vec![0], Some(2), None),
+        ];
+        let doses = vec![dose(0.0, 100.0)];
+        let f_bio = 0.7;
+        for &t in &[1.0, 4.0, 8.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, f_bio);
+            let want =
+                ((0.6 + 0.4) * f_bio * one_cpt_oral_g(100.0, t, dp.cl, dp.v, p[0], 1.0)).max(0.0);
+            assert!((got - want).abs() < 1e-12, "t={t}: {got} vs {want}");
+        }
+    }
+
+    // ── Layer A1: behavioural disposition identification on *compiled* models —
+    //    the numeric probe must recover CL/V(/Q/V2) from the RHS/readout alone,
+    //    with no name or AST matching. ────────────────────────────────────────
+    const PARALLEL_1CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    const PARALLEL_2CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    fn flat_params(model: &crate::types::CompiledModel, theta: &[f64], eta: &[f64]) -> Vec<f64> {
+        let cov = std::collections::HashMap::new();
+        (model.pk_param_fn)(theta, eta, &cov, 0.0).values.to_vec()
+    }
+
+    #[test]
+    fn identifies_one_cpt_and_recovers_cl_v() {
+        let model = crate::parser::model_parser::parse_model_string(PARALLEL_1CPT).unwrap();
+        let spec = model.ode_spec.as_ref().expect("ode model");
+        let theta = [5.0, 50.0, 0.6, 1.5, 0.3];
+        let eta = [0.0, 0.0];
+        let p = flat_params(&model, &theta, &eta);
+        let disp = identify_disposition(spec, &p, 1.0).expect("identifies 1-cpt");
+        assert_eq!(disp.kind, MrDispositionKind::OneCpt);
+        let cov = std::collections::HashMap::new();
+        let dp = recover_disp_params_g::<f64>(spec, &disp, &p, &cov).expect("recovers");
+        assert!((dp.cl - 5.0).abs() < 1e-9, "cl={}", dp.cl);
+        assert!((dp.v - 50.0).abs() < 1e-9, "v={}", dp.v);
+        assert!(dp.periph.is_none());
+    }
+
+    #[test]
+    fn identifies_two_cpt_and_recovers_cl_v1_q_v2() {
+        let model = crate::parser::model_parser::parse_model_string(PARALLEL_2CPT).unwrap();
+        let spec = model.ode_spec.as_ref().expect("ode model");
+        let theta = [5.0, 50.0, 10.0, 100.0, 0.6, 1.5, 0.3];
+        let eta = [0.0];
+        let p = flat_params(&model, &theta, &eta);
+        let disp = identify_disposition(spec, &p, 1.0).expect("identifies 2-cpt");
+        assert_eq!(disp.kind, MrDispositionKind::TwoCpt);
+        let cov = std::collections::HashMap::new();
+        let dp = recover_disp_params_g::<f64>(spec, &disp, &p, &cov).expect("recovers");
+        let (q, v2) = dp.periph.expect("two-cpt periph");
+        assert!((dp.cl - 5.0).abs() < 1e-9, "cl={}", dp.cl);
+        assert!((dp.v - 50.0).abs() < 1e-9, "v1={}", dp.v);
+        assert!((q - 10.0).abs() < 1e-9, "q={q}");
+        assert!((v2 - 100.0).abs() < 1e-9, "v2={v2}");
+    }
+
+    // A nonlinear (Michaelis–Menten) elimination must be DECLINED — the numeric
+    // linearity probe is what protects the fast path from a silent wrong value.
+    const MM_1CPT: &str = r#"
+[parameters]
+  theta TVVMAX(10.0, 0.1, 100.0)
+  theta TVKM(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVKA(1.5, 0.05, 24.0)
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  VMAX = TVVMAX
+  KM = TVKM
+  V = TVV * exp(ETA_V)
+  KA = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = first_order(ka=KA) - VMAX*central/(KM + central)
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+    #[test]
+    fn declines_nonlinear_michaelis_menten() {
+        let model = crate::parser::model_parser::parse_model_string(MM_1CPT).unwrap();
+        let spec = model.ode_spec.as_ref().expect("ode model");
+        let theta = [10.0, 5.0, 50.0, 1.5];
+        let eta = [0.0];
+        let p = flat_params(&model, &theta, &eta);
+        assert!(
+            identify_disposition(spec, &p, 1.0).is_none(),
+            "MM elimination must be declined (nonlinear)"
+        );
+    }
+}

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -37,11 +37,16 @@
 //! observable equals `Σ mass·kernel_conc` exactly when the kernel is evaluated
 //! with `v = 1/m`, `cl = ke/m` (see [`recover_disp_params_g`]).
 //!
-//! A model is only routed here when a **runtime verify-gate** (closed form vs a
-//! short reference integration of its own `OdeSpec`, at several probe points)
-//! agrees — so a mis-identification cannot mispredict, it merely declines back to
-//! the ODE path (`crate::pk::mr_supported`). The failure surface is "missed
-//! speed-up", never "wrong".
+//! Identification is deliberately **conservative** — it declines on any
+//! nonlinearity, time-variance, non-canonical sign pattern, or non-central /
+//! nonlinear readout — and the ODE path is always a correct fallback, so an
+//! un-admitted model is only ever *slower*, never wrong. The remaining risk (a
+//! model that identifies but whose parameters are recovered wrongly) is closed
+//! by the **reduction-to-ODE test anchor**: the admitted closed form is asserted
+//! bit-for-bit (to solver tolerance) against its own integrated `OdeSpec` twin
+//! across a model zoo, and transitively against the NONMEM `$DES` anchor the ODE
+//! path already matches. [`mr_predictions`] is the routing entry; it returns
+//! `None` (→ ODE) for anything outside scope.
 
 use crate::ode::predictions::OdeSpec;
 use crate::pk::absorption::{InputRateForcing, InputRateKind};
@@ -397,6 +402,114 @@ pub fn mr_observable_g<T: PkNum>(
     c.guard_floor(0.0)
 }
 
+/// Whether this input-rate kind has an elementary closed-form central response
+/// that can be superposed. `first_order`/`transit`/`igd` do (Phase A);
+/// `zero_order` is Phase B (its `∂/∂dur` carries a moving-boundary saltation, a
+/// separate kernel); `weibull` has no elementary convolution with exponential
+/// disposition and stays on the ODE path permanently. Exhaustive so a new kind
+/// forces a decision here.
+fn is_closed_form_kind(kind: InputRateKind) -> bool {
+    match kind {
+        InputRateKind::FirstOrder | InputRateKind::Transit | InputRateKind::InverseGaussian => true,
+        InputRateKind::ZeroOrder | InputRateKind::Weibull => false,
+    }
+}
+
+/// Whether a `transit`/`igd` route is in its flip-flop domain, where the
+/// exponential-tilting closed form does not converge and the kernel returns `0`.
+/// Such a subject must integrate (the ODE forcing is valid for any params), so
+/// its presence declines the whole model from the closed-form path — mirroring
+/// the single-route flip-flop reroute (`absorption_flip_flop_at`). `first_order`
+/// never flips (the `ka ≈ ke` limit is handled inside the kernel).
+fn route_flips(f: &InputRateForcing, dp: &DispParams<f64>, p: &[f64]) -> bool {
+    let ke = dp.cl / dp.v;
+    match f.kind {
+        InputRateKind::Transit => {
+            let n = forcing_arg(f, p, 0, 0.0);
+            let mtt = forcing_arg(f, p, 1, 1.0);
+            mtt <= 0.0 || !(ke < (n + 1.0) / mtt)
+        }
+        InputRateKind::InverseGaussian => {
+            let mat = forcing_arg(f, p, 0, 1.0);
+            let cv2 = forcing_arg(f, p, 1, 1.0);
+            mat <= 0.0 || cv2 <= 0.0 || !(ke < 1.0 / (2.0 * mat * cv2))
+        }
+        _ => false,
+    }
+}
+
+/// Closed-form modified-release predictions for `subject` at its observation
+/// times, or `None` when the model/subject is outside the closed-form scope —
+/// in which case the caller falls back to the ODE path (always correct).
+///
+/// Scope (all must hold): an `[odes]` model with ≥1 input-rate forcing, every one
+/// of a closed-form-able kind ([`is_closed_form_kind`]); a canonical linear
+/// 1-/2-cpt disposition ([`identify_disposition`]); no IOV, time-varying
+/// covariates, resets, `init(...)`, steady-state or infusion doses, or
+/// compartment-indexed `F{c}`/`ALAG{c}` (the `dose_attr_map`, which would make
+/// the per-dose `F`/lag non-uniform); and no route in its flip-flop domain
+/// ([`route_flips`]). This is the **value** path (predict / simulate / the FD-fit
+/// value evals — all self-consistent, the FD gradient reads these values); the
+/// analytic FOCE/FOCEI gradient path is wired separately so a fit never mixes a
+/// closed-form value with an ODE-integrated gradient.
+pub(crate) fn mr_predictions(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<Vec<f64>> {
+    let spec = model.ode_spec.as_ref()?;
+    if model.n_kappa > 0 || subject.has_tv_covariates() || subject.has_resets() {
+        return None;
+    }
+    // A `TIME`-dependent model is time-varying: the single `t = 0` parameter
+    // snapshot below cannot represent it, and a `TIME`-via-parameter dependence is
+    // invisible to `identify_disposition`'s fixed-`p` Jacobian probe (only
+    // `TIME` *in the RHS* fails the time-invariance check). Decline it here so a
+    // direct caller is safe, independent of the routing site's own guard.
+    if crate::pk::model_uses_time_builtin(model) {
+        return None;
+    }
+    if spec.init_fn.is_some() || !spec.dose_attr_map.is_empty() {
+        return None;
+    }
+    if spec.input_rate.is_empty() || !spec.input_rate.iter().all(|f| is_closed_form_kind(f.kind)) {
+        return None;
+    }
+    if subject.doses.iter().any(|d| d.ss || d.is_infusion()) {
+        return None;
+    }
+    let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
+    let disp = identify_disposition(spec, &pk.values, 1.0)?;
+    let dp = recover_disp_params_g::<f64>(spec, &disp, &pk.values, &subject.covariates)?;
+    if spec
+        .input_rate
+        .iter()
+        .any(|f| route_flips(f, &dp, &pk.values))
+    {
+        return None;
+    }
+    let lag_cmt = pk.lagtime();
+    let f_bio = pk.f_bio();
+    Some(
+        subject
+            .obs_times
+            .iter()
+            .map(|&t| {
+                mr_observable_g(
+                    &dp,
+                    &spec.input_rate,
+                    &subject.doses,
+                    t,
+                    &pk.values,
+                    lag_cmt,
+                    f_bio,
+                )
+            })
+            .collect(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -676,6 +789,311 @@ mod tests {
         assert!(
             identify_disposition(spec, &p, 1.0).is_none(),
             "MM elimination must be declined (nonlinear)"
+        );
+    }
+
+    // ── Layer 3 (the anchor): the admitted closed form must reduce to its own
+    //    integrated OdeSpec twin, to solver tolerance. This is what ties the
+    //    fast path to the (NONMEM-anchored) ODE path. Tight solver tol so the
+    //    integrator's own onset-kink error (~1e-3 at default reltol) does not
+    //    mask a real discrepancy. ───────────────────────────────────────────
+    fn mk_subject(doses: Vec<DoseEvent>, obs_times: Vec<f64>) -> crate::types::Subject {
+        let n = obs_times.len();
+        let nd = doses.len();
+        crate::types::Subject {
+            id: "R".into(),
+            doses,
+            obs_times,
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0; n],
+            obs_cmts: vec![1; n],
+            covariates: std::collections::HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0; n],
+            occasions: vec![1; n],
+            obs_l2: Vec::new(),
+            dose_occasions: vec![1; nd],
+            fremtype: Vec::new(),
+            obs_records: vec![],
+        }
+    }
+
+    fn assert_reduces_to_ode(model_src: &str, theta: &[f64], eta: &[f64], doses: Vec<DoseEvent>) {
+        let model = crate::parser::model_parser::parse_model_string(model_src).unwrap();
+        let spec = model.ode_spec.as_ref().expect("ode model");
+        let obs: Vec<f64> = (1..=60).map(|i| i as f64 * 0.4).collect(); // 0.4 .. 24 h
+        let subject = mk_subject(doses, obs.clone());
+        let mr = mr_predictions(&model, &subject, theta, eta).expect("MR-supported");
+        let p = flat_params(&model, theta, eta);
+        let ode = crate::ode::ode_predictions(spec, &p, theta, eta, &subject);
+        assert_eq!(mr.len(), ode.len());
+        for (i, (&a, &b)) in mr.iter().zip(&ode).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-5 * (1.0 + b.abs()),
+                "obs {i} t={}: MR {a} vs ODE {b}",
+                obs[i]
+            );
+        }
+    }
+
+    const REDUCE_1CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    // IR + delayed-release: a per-route lag on the second pathway (the classic
+    // modified-release picture, #856). The closed form shifts τ; the twin lags
+    // the forcing onset — they must agree.
+    const REDUCE_1CPT_LAG: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.5, 0.05, 0.95)
+  theta TVKA1(1.2, 0.05, 24.0)
+  theta TVKA2(0.8, 0.05, 24.0)
+  theta TVLAG2(3.0, 0.001, 12.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+  LAG2 = TVLAG2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2, lag=LAG2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    const REDUCE_2CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    #[test]
+    fn reduces_to_ode_1cpt_parallel() {
+        assert_reduces_to_ode(
+            REDUCE_1CPT,
+            &[5.0, 50.0, 0.6, 1.5, 0.3],
+            &[0.0, 0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    #[test]
+    fn reduces_to_ode_1cpt_parallel_nonzero_eta() {
+        // η ≠ 0 exercises the recovered ke/V carrying the individual shift.
+        assert_reduces_to_ode(
+            REDUCE_1CPT,
+            &[5.0, 50.0, 0.6, 1.5, 0.3],
+            &[0.3, -0.2],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    #[test]
+    fn reduces_to_ode_1cpt_per_route_lag() {
+        assert_reduces_to_ode(
+            REDUCE_1CPT_LAG,
+            &[5.0, 50.0, 0.5, 1.2, 0.8, 3.0],
+            &[0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    #[test]
+    fn reduces_to_ode_1cpt_multi_dose() {
+        assert_reduces_to_ode(
+            REDUCE_1CPT,
+            &[5.0, 50.0, 0.6, 1.5, 0.3],
+            &[0.0, 0.0],
+            vec![
+                DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+                DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+            ],
+        );
+    }
+
+    #[test]
+    fn reduces_to_ode_2cpt_parallel() {
+        assert_reduces_to_ode(
+            REDUCE_2CPT,
+            &[5.0, 50.0, 10.0, 100.0, 0.6, 1.5, 0.3],
+            &[0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
+    // A *static* covariate (WT on CL) is baked into the parameters at the single
+    // `t = 0` snapshot — valid because it does not vary in time — and the recovered
+    // `ke` must carry it, matching the twin which reads the same covariate.
+    const REDUCE_1CPT_COV: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL) * WT / 70
+  V = TVV
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    // Bioavailability F (< 1) scales the whole dose before the FR split, in both
+    // the closed form (`mass = FR·F·D`) and the twin (`dose_f_bio`).
+    const REDUCE_1CPT_F: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  theta TVF(0.7, 0.05, 1.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+  F = TVF
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    #[test]
+    fn reduces_to_ode_1cpt_static_covariate() {
+        let model = crate::parser::model_parser::parse_model_string(REDUCE_1CPT_COV).unwrap();
+        let spec = model.ode_spec.as_ref().unwrap();
+        let theta = [5.0, 50.0, 0.6, 1.5, 0.3];
+        let eta = [0.1];
+        let obs: Vec<f64> = (1..=60).map(|i| i as f64 * 0.4).collect();
+        let mut subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            obs.clone(),
+        );
+        subject.covariates = std::collections::HashMap::from([("WT".to_string(), 140.0)]);
+        let mr = mr_predictions(&model, &subject, &theta, &eta).expect("MR-supported");
+        // Flat params WITH the covariate baked in, for the ODE reference.
+        let pk = (model.pk_param_fn)(&theta, &eta, &subject.covariates, 0.0);
+        let ode = crate::ode::ode_predictions(spec, &pk.values, &theta, &eta, &subject);
+        for (i, (&a, &b)) in mr.iter().zip(&ode).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-5 * (1.0 + b.abs()),
+                "cov obs {i} t={}: MR {a} vs ODE {b}",
+                obs[i]
+            );
+        }
+    }
+
+    #[test]
+    fn reduces_to_ode_1cpt_bioavailability() {
+        assert_reduces_to_ode(
+            REDUCE_1CPT_F,
+            &[5.0, 50.0, 0.6, 1.5, 0.3, 0.7],
+            &[0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
         );
     }
 }

--- a/tests/per_route_lag_nonmem_anchor.rs
+++ b/tests/per_route_lag_nonmem_anchor.rs
@@ -17,6 +17,13 @@
 //! gradient route, so this pins the same absorption mechanism the analytic parallel/mixed
 //! anchors do.)
 //! Final NONMEM values are read from `nonmem_anchor/results/per_route_lag.ext`.
+//!
+//! This same static model is what the **closed-form modified-release** path (#860) serves for
+//! `predict()` / `simulate()` — a superposition of shifted single-route Bateman terms, no
+//! integration. That closed form is anchored to NONMEM *transitively*: the reduction-to-ODE
+//! tests (`pk::modified_release::tests::reduces_to_ode_1cpt_per_route_lag`) pin it bit-for-bit
+//! (to solver tolerance) against this same integrated `[odes]` twin, and this test pins the
+//! twin against NONMEM's `#OBJV` — so closed form ≡ twin ≡ NONMEM.
 
 mod common;
 


### PR DESCRIPTION
## Why

Multi-route / modified-release absorption — parallel & mixed pathways (#505) and per-route
absorption lag (#856/#859) — is **ODE-integrated only**. There is no closed-form representation
in ferx: the fixed closed-form PK layout has a single `KA` slot and every `PkModel` variant is
single-route, so even the classic NONMEM two-depot IR+DR trick would integrate. #860 asks for a
closed form, `y(t) = Σ_k FR_k · closed_form_k(t − LAG_k)`. This PR lands the **value path** (a
follow-up wires the analytic FOCE/FOCEI gradient).

## What changed

- **New `src/pk/modified_release.rs`** (generic over `PkNum`, so `T = f64` gives the value and a
  later `T = Dual2` gives value + gradient from the same code):
  - `identify_disposition` — recovers the linear disposition **by behaviour, not spelling**:
    probes the compiled RHS program (forcing-free) at basis states for a *constant, canonical
    1-/2-compartment Jacobian*, checks linearity + time-invariance + the reversible sign pattern,
    and reads the observable's central slope off the readout. No AST or parameter-name matching.
  - `recover_disp_params_g` — synthesises `cl/v(/q/v2)` over `T`; volumes cancel, so the
    observable is `Σ mass·kernel_conc` with `v = 1/m`, `cl = ke/m`.
  - `mr_observable_g` — the `Σ FR_k · single_route_kernel(t − LAG_k)` superposition, reusing the
    existing anchored `one_cpt_*_g` / `two_cpt_*_g` kernels.
  - `mr_predictions` — the scope gate.
- **Routing hook** in `compute_predictions_with_tv_into_with_schedule` (static branch): a static
  multi-route model evaluates closed-form for `predict` / `simulate` / finite-difference fits;
  anything outside scope returns `None` and integrates as before.

Scope (all else → ODE): linear 1-/2-cpt disposition; only `first_order`/`transit`/`igd` pathways;
no `TIME` builtin, time-varying covariate, IOV, reset, steady-state / infusion dose, or
compartment-indexed `F{c}`/`ALAG{c}`; no route in its flip-flop domain.

## Alternatives considered

- **AST / parameter-name matching of the disposition** (`-CL/V*central`) — rejected: false-positives
  on nonlinear or reparameterised RHSs (e.g. a linear term next to Michaelis–Menten), the
  "happy-path" trap. The behavioural Jacobian probe is sound and declines those.
- **Runtime verify-gate memoised on `CompiledModel`** — rejected: 60 construction sites for a
  stretch feature. The verify-gate is realised instead as the reduction-to-ODE **test** anchor,
  backed by conservative behavioural identification + an always-correct ODE fallback.
- **A new `PkModel` variant** — rejected: multi-route doesn't fit the fixed `[f64; N]` `PkParams`
  array; a new `OdeSpec` fast-path evaluator is the right shape.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Internal only — the module is `pub(crate)`, no public API change.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: **the integrated `[odes]` twin** and, transitively, **NONMEM**.
- Reduction-to-ODE (the anchor): the closed form equals its own integrated twin to solver
  tolerance (~1e-8) across 1-/2-cpt, parallel, mixed `transit`+`igd`, per-route lag, multi-dose,
  η ≠ 0, a static covariate on CL, and bioavailability F < 1.
- NONMEM: closed form ≡ twin (reduction tests) ≡ NONMEM `$DES` (the existing `ADVAN13`
  `per_route_lag` anchor, `#OBJV −882.357`, still green) → closed form ≡ NONMEM transitively.
- A Michaelis–Menten disposition is declined (integrated), asserted by test.

## Performance
- [x] Faster — static multi-route `predict` / `simulate` / FD fits skip ODE integration entirely.
  (No headline benchmark number yet; the win scales with the observation grid and dose count.)

## Tests
- [x] Unit tests added (`src/pk/modified_release.rs`, 15): superposition oracles, behavioural
  identification (recovers CL/V and CL/V1/Q/V2), reduction-to-ODE zoo, MM decline. Full lib suite
  green (2589 passed); the `TIME`-builtin provider-vs-production check exercised (and validated)
  the static-branch guard.

## Example (user-facing features only)
- [x] Not applicable — a transparent acceleration of existing `#505`/`#856` model shapes; the
  `parallel` / `mixed` / `per_route_lag` example models already ship.

## Docs
- [x] `docs/model-file/absorption.qmd` — new `### Closed-form evaluation {#mr-closed-form}`.
- [x] `CHANGELOG.md` `[Unreleased]` → Performance.

## Checklist
- [x] `cargo clippy` clean
- [x] `Dual2` path stays differentiable — `mr_observable_g` is generic over `PkNum` (ready for the
  analytic-gradient follow-up); the existing kernels it calls are the anchored `*_g<T>` forms.
- [x] no version bump (non-breaking)

## Reviewer hints
Focus on: (1) `identify_disposition`'s numeric checks — is the admitted set tight enough that a
mis-identification is impossible in practice (vs the always-correct ODE fallback)? (2) the routing
hook placement — MR sits **after** the `has_tv || resets || uses_time` guard because a single
`t = 0` parameter snapshot can't represent a time-varying disposition, and a `TIME`-via-parameter
dependence is invisible to the fixed-`p` Jacobian probe. (3) the `v = 1/m` volume cancellation in
`recover_disp_params_g`.

## Open questions
The analytic FOCE/FOCEI gradient path (`A6`) and `zero_order` (`B`) are deliberate follow-ups. The
FOCE/FOCEI marginal-objective **value** does route through the closed form (via
`stats::likelihood::model_predictions`), while the analytic **gradient** still comes from the ODE
provider — so for an analytic fit the value and gradient come from different schemes. This is not a
divergent mix: the closed form reduces to the same integrated twin (to solver tolerance), so the
objective is consistent to far within `inner_tol`, and the `per_route_lag` NONMEM anchor
(value now closed-form, gradient still integrated) is unchanged at −882.357. `A6` removes the
provider integration so both come from one generic `_g<T>`. Is landing the value path first, with
the analytic-sens hook as a focused follow-up PR, the split you want?

An adversarial self-review of this PR found four gate holes (all silent-wrong only *outside* the
`#505`/`#856` shape, hence not caught by the reduction zoo) — a non-linear/baselined readout, a
dose into a non-central compartment, a 2-cpt transit/igd route past its macro-rate domain, and this
value/gradient-claim inaccuracy. All four are fixed in this PR with regression tests (see the
review commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
