### PR TITLE
fix(stats): restore two commits stranded by the #885 / #887 merge ordering

### DIFF
--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -1,4 +1,5 @@
 use crate::pk;
+use crate::stats::residual_error::{residual_rd, residual_rd2};
 use crate::stats::special::log_normal_cdf;
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -1684,14 +1685,16 @@ fn gaussian_foce_accum(
         // residual-eta c̃ column only on ordinary PK rows.
         let frem_ov = frem_r_override.and_then(|o| o.get(j)).and_then(|v| *v);
         let is_pk_row = frem_ov.is_none();
-        let v_resid = if let Some(v) = frem_ov {
-            v
-        } else {
-            match mult_row(j) {
-                Some(m) => {
-                    error_spec.variance_at_scaled(err_keys[j], f, sigma_values, &[], m) * ruv_scale
-                }
-                None => error_spec.variance_at(err_keys[j], f, sigma_values) * ruv_scale,
+        // `residual_rd` returns the bare `(R, ∂R/∂f)` pair and leaves `ruv_scale`
+        // to the caller, so both carry the factor: scaling `R` by `exp(2·η_ruv)`
+        // multiplies `∂R/∂f` by the same amount, and the two cancel in `c_scale`
+        // below. FREM covariate rows take their variance from the override and
+        // contribute `∂R/∂f = 0` (additive near-zero sigma).
+        let (v_resid, dvar_df) = match frem_ov {
+            Some(v) => (v, 0.0),
+            None => {
+                let (rv, dv) = residual_rd(error_spec, err_keys[j], f, sigma_values, mult_row(j));
+                (rv * ruv_scale, dv * ruv_scale)
             }
         };
         let v = v_resid + p_obs.get(j).copied().unwrap_or(0.0);
@@ -1702,18 +1705,9 @@ fn gaussian_foce_accum(
         data_ll += r * r / v + v.ln();
 
         // a_j = row j of H (∂f_j/∂η); c̃_{j,k} = (∂R_j/∂η_k)/R_j.
-        // For a PK eta: (∂R/∂f)·a / R; scaling R by exp(2η_ruv) multiplies both
-        // ∂R/∂f and R, so the factor cancels — hence scale dvar_df too.
+        // For a PK eta: (∂R/∂f)·a / R.
         // For the residual eta: ∂R/∂η_ruv = 2·R, so the column is the constant 2.
         let aj = h_matrix.row(j);
-        let dvar_df = if is_pk_row {
-            match mult_row(j) {
-                Some(m) => error_spec.dvar_df_scaled(err_keys[j], f, sigma_values, m) * ruv_scale,
-                None => error_spec.dvar_df(err_keys[j], f, sigma_values) * ruv_scale,
-            }
-        } else {
-            0.0 // FREM rows: additive near-zero sigma, ∂R/∂f = 0
-        };
         let c_scale = dvar_df / v;
         let inv_v = 1.0 / v;
         let c_ruv = |k: usize| -> f64 {
@@ -1746,18 +1740,8 @@ fn gaussian_foce_accum(
         // `v_resid`/`d`/`d2` all carry the same proportional-loading (`m²`) and
         // `exp(2·η_ruv)` scaling, so the censored curvature is built from mutually
         // consistent derivatives of one `v(f)`.
-        let (v_resid, d, d2) = match mult_row(j) {
-            Some(m) => (
-                error_spec.variance_at_scaled(cmt, f, sigma_values, &[], m) * ruv_scale,
-                error_spec.dvar_df_scaled(cmt, f, sigma_values, m) * ruv_scale,
-                error_spec.d2var_df2_scaled(cmt, sigma_values, m) * ruv_scale,
-            ),
-            None => (
-                error_spec.variance_at(cmt, f, sigma_values) * ruv_scale,
-                error_spec.dvar_df(cmt, f, sigma_values) * ruv_scale,
-                error_spec.d2var_df2(cmt, sigma_values) * ruv_scale,
-            ),
-        };
+        let (rv, dv, d2v) = residual_rd2(error_spec, cmt, f, sigma_values, mult_row(j));
+        let (v_resid, d, d2) = (rv * ruv_scale, dv * ruv_scale, d2v * ruv_scale);
         // Inflate by the EKF process-noise term exactly as the quantified rows do
         // (line above), so a censored row's `v` — in both the data term and `H̃` —
         // matches its subject's Gaussian rows under an SDE model. `p_obs` is

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -240,7 +240,7 @@ impl ErrorSpec {
             };
             v += 2.0 * ci * cj * corr.rho * si * sj;
         }
-        v.max(1e-12)
+        v.max(MIN_VARIANCE)
     }
 
     /// `SigmaType` for each entry of the flat global sigma vector, as a `Vec`


### PR DESCRIPTION
## Why

**Two commits are on `main`-adjacent branches but not on `main`, because of merge ordering. This PR carries them across. No new work — every line here has already been written, verified, and reviewed.**

What happened:

1. **#885 merged to `main` at 10:52** at its 3-commit head (`2955b9e2`, `90a1f4e5`, `588eaf51`). Its 4th commit — `639def82`, the `MIN_VARIANCE` fix — was pushed after the merge and so never reached `main`.
2. **#887 merged at 11:07 into `refactor/residual-error-single-owner`**, which was its stacked base. But that branch had already merged and closed 15 minutes earlier, so #887's content went into a dead branch. **Despite GitHub reporting #887 as "merged", none of its code is on `main`.**

Verified with `git merge-base --is-ancestor`:

| commit | change | in `main`? |
|---|---|---|
| `2955b9e2` | residual_error single-owner move | yes |
| `90a1f4e5` | `needless_range_loop` fix | yes |
| `588eaf51` | RuvMagnitude doc-link fix | yes |
| `639def82` | **`MIN_VARIANCE` floor** | **NO — stranded** |
| `cd758d47` | **#887: likelihood → `residual_rd`** | **NO — stranded** |

This is the same failure mode as #879 → #881: a PR merged at an earlier head than its final one.

## What changed

The two stranded commits, rebased onto current `main`. Both applied cleanly (`639def82`'s parent `588eaf51` is already on `main`, so there is no gap).

1. **`refactor(stats): floor variance_at_scaled on MIN_VARIANCE, not a bare 1e-12`** — `residual_error.rs`, 1 line. Provably inert: `const MIN_VARIANCE: f64 = 1e-12`, so the constant, the clamp, and the result are identical. The literal was *necessary* while `variance_at_scaled` lived in `types.rs` (where `MIN_VARIANCE` is out of scope); #885's move made the dedup possible. Surfaced by the #887 review.
2. **`refactor(stats): route likelihood's residual dispatch through residual_rd`** — `likelihood.rs`, −16 LOC. This is #887 verbatim. Its full rationale is in that PR; briefly: `gaussian_foce_accum` hand-rolled the same `Some(mult) -> _scaled / None -> legacy` dispatch that `residual_rd`/`residual_rd2` express, in three places. `ruv_scale` stays caller-side (the association trap), and `CompiledModel::residual_variance_at_scaled` is deliberately not deduped (it carries real correlations; `residual_rd` is diagonal-only).

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] **None**

## Numerical validation
- [x] **`cargo test --lib`: 2570 passed, 0 failed, 18 ignored** — verified on this exact content before the merge-ordering mishap, including **300 FD-parity / bit-equality tests, none moved**.
- [x] `MIN_VARIANCE` is provably inert (identical constant → identical clamp → bit-identical result).
- [x] The `likelihood.rs` substitution is exact by construction: `residual_rd`'s arms *are* the inline arms (`None` → `variance_at`/`dvar_df` legacy association; `Some` → `variance_at_scaled(..., &[], m)`/`dvar_df_scaled`), each multiplied by `ruv_scale` at the same point as before.
- [x] Both float-association traps preserved: `variance_at` is not collapsed into `variance_at_scaled`; `ruv_scale` is not folded into the accessor.

## Performance
- [x] No significant impact expected — marginally faster (one dispatch and one `mult_row(j)` per quantified row instead of two).

## Tests
- [x] No new tests needed (**why: no behavior change — a provably-inert constant substitution plus a dispatch-glue substitution whose arms are identical to the code they replace. Already covered by the FOCEI/AGQ FD-parity and OFV suites; test count unchanged at 2570**).

## Example (user-facing features only)
- [x] Not applicable (internal refactor)

## Docs
- [x] `CHANGELOG.md` N/A — internal refactor, no user-facing change
- [x] No user-visible change

## Checklist
- [x] `cargo clippy --no-default-features --features ci,markov` — no new diagnostics; `likelihood.rs` unchanged at its 17 pre-existing hits, none at the edited lines
- [x] `cargo fmt --check` clean
- [x] `Dual2` path unaffected — no `*_g<T: PkNum>` function touched
- [x] `Cargo.toml` version bump not needed (non-breaking)

## Docs & examples
- [x] No example execution step needed (internal refactor / no user-visible change)

## Reviewer hints

**Both commits were already reviewed and came back clean** — the `likelihood.rs` change got a dedicated adversarial review whose verdict was *"exactly equivalent to the code it replaces — bit-for-bit on every returned value, for every `(frem_ov, mult_row, cmt, sigma)` combination."* That review independently confirmed the one thing worth re-checking: hoisting `dvar_df` above the `v.is_finite()` early return cannot panic, because every lookup on the derivative path is total (`map.get(&cmt)?`, `else { return 0.0 }`, `mult.get(slot).unwrap_or(1.0)`).

So the useful thing to verify here is **not** the code — it is that this PR carries exactly the two stranded commits and nothing else:

```bash
git log --oneline origin/main..fix/restore-stranded-885-887   # expect exactly 2
git diff origin/main...fix/restore-stranded-885-887 --stat     # expect only likelihood.rs + residual_error.rs
```

**Housekeeping:** `refactor/residual-error-single-owner` and `refactor/likelihood-residual-rd` are now dead and safe to delete once this lands. #886 has been retargeted from the dead base onto `main` and no longer carries `MIN_VARIANCE` (this PR owns it), so the two are disjoint and can merge in either order.

## Open questions

- Should #887 be reopened and retargeted to `main` instead of superseded by this PR? I chose a fresh PR because #887 is already marked MERGED and its base branch is gone — reopening would be more confusing than a clean carry-across. Happy to do it the other way.
- Worth a repo convention to avoid the recurrence? This is the second time (after #879 → #881) that a PR merged at an earlier head than its final one. A stacked PR whose base merges first is the sharp edge here — merging #887 silently targeted a dead branch rather than failing.
