### PR TITLE
perf(pk): analytic-gradient + zero_order closed-form modified-release [closes #860]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,20 @@ section of the SDLC for the versioning policy).
   behaviour (a probed constant, canonical 1-/2-cpt Jacobian), not by matching how it is written,
   and a non-linear disposition is declined and integrated as before. Predictions are unchanged to
   within the ODE solver tolerance — the closed form reduces to the same integrated twin — and any
-  model outside this scope (including `zero_order` / `weibull` pathways) continues to integrate.
+  model outside this scope (including `weibull` pathways) continues to integrate.
+- **Closed-form modified-release absorption now covers `zero_order` routes** (#860 Phase B). A
+  `zero_order(dur=...)` pathway in a static multi-route model no longer falls back to ODE
+  integration for `predict()` / `simulate()` / finite-difference fits — the box-car input rate has
+  its own closed-form convolution against the linear 1-/2-cpt disposition, superposed exactly like
+  the other pathway kinds. Predictions are unchanged to within solver tolerance.
+- **Closed-form modified-release absorption now accelerates the analytic FOCE/FOCEI gradient
+  too** (#860 Phase A6). Fitting a static multi-route model with the default analytic-sensitivity
+  method now skips the ODE integration for both the value AND the gradient — previously only the
+  value took the closed-form fast path, and the gradient still integrated. The disposition-recovery
+  and superposition formulas are evaluated once, generically, over dual numbers instead of plain
+  doubles, so there is no separate hand-derived gradient to drift out of sync. Gradients are
+  unchanged to within solver tolerance — verified directly against the ODE-integrated analytic
+  provider, not only against finite differences.
 - The closed-form steady-state equilibration for dosing into a built-in absorption compartment
   (#834) now actually takes effect. Its self-verification tolerance sat just below the solver's
   own noise floor, so it silently fell back to the 50-cycle pulse-train iteration at every

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -836,8 +836,8 @@ kernel over a lagged onset.
 ### Closed-form evaluation {#mr-closed-form}
 
 A parallel / mixed / per-route-lagged model with a **linear disposition** (1- or
-2-compartment) whose pathways are all smooth (`first_order`, `transit`, `igd`) is evaluated
-**without integrating the ODE**. Because the disposition is linear and time-invariant its
+2-compartment) whose pathways are all `first_order`, `zero_order`, `transit`, or `igd` is
+evaluated **without integrating the ODE**. Because the disposition is linear and time-invariant its
 inputs superpose, so the observable is a fraction-weighted sum of the *single-route* closed
 forms, each shifted by its onset:
 
@@ -851,12 +851,16 @@ observable's scale off the readout, so `- CL/V*central`, `- KE*central`, and mic
 forms are all detected, while a non-linear disposition (e.g. Michaelis–Menten) is *declined*
 and integrated instead. The closed form is used for `predict()`, `simulate()`, and
 finite-difference fits; it reduces to the integrated `[odes]` twin to solver tolerance, and so
-to the same NONMEM `$DES` optimum the twin already matches.
+to the same NONMEM `$DES` optimum the twin already matches. An **analytic-sensitivity**
+(default) FOCE/FOCEI fit on the same static subjects also skips the ODE integration for its
+gradient — the disposition-recovery and superposition formulas are evaluated once over dual
+numbers instead of over plain doubles, giving the exact `∂/∂(θ,η)` jet with no separate
+integration pass.
 
 It applies only to **static** subjects: a time-varying covariate, IOV, a reset (`EVID 3/4`),
-a steady-state or infusion dose, a compartment-indexed `F{c}`/`ALAG{c}`, a `zero_order` or
-`weibull` pathway, or a route in its flip-flop domain routes the subject back to the ODE
-solver automatically — the result is identical, only slower.
+a steady-state or infusion dose, a compartment-indexed `F{c}`/`ALAG{c}`, a `weibull` pathway,
+or a route in its flip-flop domain routes the subject back to the ODE solver automatically —
+the result is identical, only slower.
 
 ::: {.callout-note}
 ## Gradients (analytic)

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -51,8 +51,8 @@
 use crate::ode::predictions::OdeSpec;
 use crate::pk::absorption::{InputRateForcing, InputRateKind};
 use crate::sens::num::PkNum;
-use crate::sens::one_cpt::{one_cpt_ig_g, one_cpt_oral_g, one_cpt_transit_g};
-use crate::sens::two_cpt::{two_cpt_ig_g, two_cpt_oral_g, two_cpt_transit_g};
+use crate::sens::one_cpt::{one_cpt_ig_g, one_cpt_oral_g, one_cpt_transit_g, one_cpt_zero_order_g};
+use crate::sens::two_cpt::{two_cpt_ig_g, two_cpt_oral_g, two_cpt_transit_g, two_cpt_zero_order_g};
 use crate::types::DoseEvent;
 
 /// Linear disposition shape recovered from an [`OdeSpec`] by numeric probing.
@@ -342,11 +342,12 @@ fn forcing_arg<T: PkNum>(f: &InputRateForcing, p: &[T], i: usize, dflt: f64) -> 
 /// The kernel is evaluated at unit amount / unit `F` (its response is linear in
 /// dose mass) and multiplied by `mass = FR·F·D` outside — so a `Dual2` `mass`
 /// threads the exact `∂/∂FR` (and `∂/∂F`) via the product rule, and the kernel's
-/// own `τ.val() < 0 → 0` guard supplies the pre-onset gate. Phase A covers the
-/// smooth kernels (`first_order`/`transit`/`igd`); `zero_order` is Phase B (its
-/// `∂/∂dur` carries a moving-boundary saltation) and `weibull` has no elementary
-/// closed form — both are excluded by the support gate and return `0` here as a
-/// defensive no-op.
+/// own `τ.val() < 0 → 0` guard supplies the pre-onset gate. Covers the smooth
+/// kernels (`first_order`/`transit`/`igd`) and the box-car `zero_order` kernel
+/// (`∂/∂dur` exact on whichever side of the `t == dur` boundary is selected,
+/// see [`crate::sens::one_cpt::one_cpt_zero_order_g`]); `weibull` has no
+/// elementary closed form and is excluded by the support gate, returning `0`
+/// here as a defensive no-op.
 fn route_conc_g<T: PkNum>(
     kind: InputRateKind,
     f: &InputRateForcing,
@@ -372,7 +373,11 @@ fn route_conc_g<T: PkNum>(
                 let cv2 = forcing_arg(f, p, 1, 1.0);
                 one_cpt_ig_g(1.0, tau, dp.cl, dp.v, mat, cv2, one)
             }
-            InputRateKind::ZeroOrder | InputRateKind::Weibull => T::from_f64(0.0),
+            InputRateKind::ZeroOrder => {
+                let dur = forcing_arg(f, p, 0, 1.0);
+                one_cpt_zero_order_g(1.0, tau, dp.cl, dp.v, dur, one)
+            }
+            InputRateKind::Weibull => T::from_f64(0.0),
         },
         Some((q, v2)) => match kind {
             InputRateKind::FirstOrder => {
@@ -389,7 +394,11 @@ fn route_conc_g<T: PkNum>(
                 let cv2 = forcing_arg(f, p, 1, 1.0);
                 two_cpt_ig_g(1.0, tau, dp.cl, dp.v, q, v2, mat, cv2, one)
             }
-            InputRateKind::ZeroOrder | InputRateKind::Weibull => T::from_f64(0.0),
+            InputRateKind::ZeroOrder => {
+                let dur = forcing_arg(f, p, 0, 1.0);
+                two_cpt_zero_order_g(1.0, tau, dp.cl, dp.v, q, v2, dur, one)
+            }
+            InputRateKind::Weibull => T::from_f64(0.0),
         },
     };
     mass * unit
@@ -428,15 +437,17 @@ pub fn mr_observable_g<T: PkNum>(
 }
 
 /// Whether this input-rate kind has an elementary closed-form central response
-/// that can be superposed. `first_order`/`transit`/`igd` do (Phase A);
-/// `zero_order` is Phase B (its `∂/∂dur` carries a moving-boundary saltation, a
-/// separate kernel); `weibull` has no elementary convolution with exponential
-/// disposition and stays on the ODE path permanently. Exhaustive so a new kind
-/// forces a decision here.
-fn is_closed_form_kind(kind: InputRateKind) -> bool {
+/// that can be superposed. `first_order`/`transit`/`igd` (smooth kernels) and
+/// `zero_order` (box-car convolution, #860 Phase B) do; `weibull` has no
+/// elementary convolution with an exponential disposition and stays on the ODE
+/// path permanently. Exhaustive so a new kind forces a decision here.
+pub(crate) fn is_closed_form_kind(kind: InputRateKind) -> bool {
     match kind {
-        InputRateKind::FirstOrder | InputRateKind::Transit | InputRateKind::InverseGaussian => true,
-        InputRateKind::ZeroOrder | InputRateKind::Weibull => false,
+        InputRateKind::FirstOrder
+        | InputRateKind::Transit
+        | InputRateKind::InverseGaussian
+        | InputRateKind::ZeroOrder => true,
+        InputRateKind::Weibull => false,
     }
 }
 
@@ -496,9 +507,23 @@ fn route_flips(f: &InputRateForcing, dp: &DispParams<f64>, p: &[f64]) -> bool {
     }
 }
 
-/// Closed-form modified-release predictions for `subject` at its observation
-/// times, or `None` when the model/subject is outside the closed-form scope —
-/// in which case the caller falls back to the ODE path (always correct).
+/// Everything the closed-form MR path needs once a subject is admitted: the
+/// compiled ODE spec, the identified disposition, its recovered `f64` rates
+/// (used for the `route_flips` domain check both the value and gradient path
+/// share), and the `f64` PK-parameter snapshot at `(θ, η, t=0)`.
+pub(crate) struct MrScope<'a> {
+    pub spec: &'a OdeSpec,
+    pub disp: MrDisposition,
+    pub dp: DispParams<f64>,
+    pub pk: crate::types::PkParams,
+}
+
+/// The single closed-form MR scope gate, shared by the value path
+/// ([`mr_predictions`]) and the gradient path (`mr_subject_sensitivities` /
+/// `mr_subject_eta_grad`) so the two can never admit a different set of
+/// subjects — a value/gradient scope drift is exactly the silent-wrong class
+/// the reduction-to-ODE tests guard against, and it can only be prevented by
+/// having one gate, not two independently-maintained copies.
 ///
 /// Scope (all must hold): an `[odes]` model with ≥1 input-rate forcing, every one
 /// of a closed-form-able kind ([`is_closed_form_kind`]); a canonical linear
@@ -506,22 +531,14 @@ fn route_flips(f: &InputRateForcing, dp: &DispParams<f64>, p: &[f64]) -> bool {
 /// covariates, resets, `init(...)`, steady-state or infusion doses, or
 /// compartment-indexed `F{c}`/`ALAG{c}` (the `dose_attr_map`, which would make
 /// the per-dose `F`/lag non-uniform); and no route in its flip-flop domain
-/// ([`route_flips`]). This is the **value** path: `predict` / `simulate` and the
-/// FOCE/FOCEI marginal-objective value ([`crate::stats`]'s `model_predictions` →
-/// [`crate::pk::compute_predictions_with_tv`]). For an FD-method fit the gradient
-/// finite-differences these same values, so it is fully self-consistent. For an
-/// analytic-sensitivity fit the gradient still comes from the ODE provider (a
-/// follow-up wires the closed form there); value and gradient then come from
-/// different schemes, but they **agree to solver tolerance** — the closed form
-/// reduces to the same integrated twin — so the objective stays consistent to far
-/// within `inner_tol` (the `per_route_lag` NONMEM anchor is unchanged by this
-/// routing). The mix is never *divergent*, only different-scheme-same-answer.
-pub(crate) fn mr_predictions(
-    model: &crate::types::CompiledModel,
+/// ([`route_flips`]). Returns `None` when out of scope, in which case the
+/// caller falls back to the ODE path (always correct).
+pub(crate) fn mr_scope<'a>(
+    model: &'a crate::types::CompiledModel,
     subject: &crate::types::Subject,
     theta: &[f64],
     eta: &[f64],
-) -> Option<Vec<f64>> {
+) -> Option<MrScope<'a>> {
     let spec = model.ode_spec.as_ref()?;
     if model.n_kappa > 0 || subject.has_tv_covariates() || subject.has_resets() {
         return None;
@@ -535,6 +552,23 @@ pub(crate) fn mr_predictions(
         return None;
     }
     if spec.init_fn.is_some() || !spec.dose_attr_map.is_empty() {
+        return None;
+    }
+    // An SDE (`[diffusion]` block on one or more states): `identify_disposition`'s
+    // Jacobian probe reads only `rhs_program` (the drift), so it is structurally blind
+    // to a diffusion term on an otherwise-canonical-linear state and would admit it.
+    // For the *value* this is harmless (the SDE mean prediction IS the drift solution —
+    // `likelihood::model_predictions` returns the drift, EKF noise enters only the
+    // variance `p_obs`), so the closed form would give the correct mean. For the
+    // *gradient* it is not: the analytic jet of the drift omits `∂p_obs/∂θ`, which the
+    // FD gradient of the full OFV carries — so an SDE must take FD, exactly as
+    // `ode_analytical_supported` enforces (`!diffusion_var.is_empty() → false`). Higher
+    // gates (`sens_supported` / `analytic_inner_grad_supported_model`) already route SDE
+    // to FD before either provider is reached, so this is the same defensive re-check
+    // `ode_subject_sensitivities` keeps (fail loudly to FD, never a silent wrong jet;
+    // the #637 layering principle) — placed in the shared gate so value and gradient
+    // stay on one scope.
+    if !spec.diffusion_var.is_empty() {
         return None;
     }
     if spec.input_rate.is_empty() || !spec.input_rate.iter().all(|f| is_closed_form_kind(f.kind)) {
@@ -566,25 +600,264 @@ pub(crate) fn mr_predictions(
     {
         return None;
     }
-    let lag_cmt = pk.lagtime();
-    let f_bio = pk.f_bio();
+    Some(MrScope { spec, disp, dp, pk })
+}
+
+/// Closed-form modified-release predictions for `subject` at its observation
+/// times, or `None` when out of scope ([`mr_scope`]). This is the **value**
+/// path: `predict` / `simulate` and the FOCE/FOCEI marginal-objective value
+/// ([`crate::stats`]'s `model_predictions` →
+/// [`crate::pk::compute_predictions_with_tv`]). For an FD-method fit the
+/// gradient finite-differences these same values, so it is fully
+/// self-consistent. For an analytic-sensitivity fit the gradient comes from
+/// [`mr_subject_sensitivities`]/[`mr_subject_eta_grad`] when in scope
+/// (identical `mr_scope`, so never a different subject set), else the ODE
+/// provider — either way value and gradient **agree to solver tolerance** (the
+/// closed form reduces to the same integrated twin), so the objective stays
+/// consistent to far within `inner_tol`.
+pub(crate) fn mr_predictions(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<Vec<f64>> {
+    let s = mr_scope(model, subject, theta, eta)?;
+    let lag_cmt = s.pk.lagtime();
+    let f_bio = s.pk.f_bio();
     Some(
         subject
             .obs_times
             .iter()
             .map(|&t| {
                 mr_observable_g(
-                    &dp,
-                    &spec.input_rate,
+                    &s.dp,
+                    &s.spec.input_rate,
                     &subject.doses,
                     t,
-                    &pk.values,
+                    &s.pk.values,
                     lag_cmt,
                     f_bio,
                 )
             })
             .collect(),
     )
+}
+
+/// Analytic-provider axis-count guard shared by [`mr_subject_sensitivities`] and
+/// [`mr_subject_eta_grad`]: the compiled individual-parameter program's `(θ,η)`
+/// axis counts must match the model's exactly (a mismatch is an NN-θ / IOV-κ
+/// desugaring this fast path does not carry) — mirrors
+/// [`crate::sens::ode_provider::ode_analytical_supported`]'s identical check.
+/// Declining here (→ `None` → the ODE provider, which re-checks the same
+/// invariant) is cheap insurance against a silently-wrong jet; it is not a new
+/// "is this subject analytic" report, since `ode_analytical_supported` already
+/// requires this for the model to be reported analytic at all.
+fn mr_prog_axes_match(
+    prog: &crate::parser::model_parser::IndivParamProgram,
+    n_theta: usize,
+    n_eta: usize,
+) -> bool {
+    prog.n_theta_axis() == n_theta
+        && prog.n_eta_axis() == n_eta
+        && prog.n_axes() <= crate::sens::ode_provider::MAX_ODE_AXES
+}
+
+/// Closed-form analytic FOCE/FOCEI outer sensitivities for a modified-release
+/// subject (#860 Phase A6) — the fast-path alternative to
+/// [`crate::sens::ode_provider::ode_subject_sensitivities`] for the same
+/// (already-analytic, per `ode_analytical_supported`) subjects `mr_scope`
+/// additionally admits. `mr_observable_g` is evaluated at `T = Dual2<M>`
+/// seeded directly on `(θ, η)` via
+/// [`crate::sens::ode_provider::seed_pk_dual2`] — the same seeding the TV-cov
+/// event-driven walk (`run_subject_tvcov`) uses — so no ODE integration and no
+/// separate outer chain-rule step: composing `mr_observable_g`'s arithmetic
+/// over an already-`(θ,η)`-seeded `Dual2` *is* the chain rule. `None` when
+/// `mr_scope` declines, or the axis-count guard fails — either way the caller
+/// falls back to `ode_subject_sensitivities`.
+pub(crate) fn mr_subject_sensitivities(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<crate::sens::provider::SubjectSens> {
+    let s = mr_scope(model, subject, theta, eta)?;
+    let prog = s.spec.indiv_param_program.as_ref()?;
+    if !mr_prog_axes_match(prog, model.n_theta, model.n_eta)
+        || !crate::sens::ode_provider::ode_scaling_supported(model)
+    {
+        return None;
+    }
+    macro_rules! dispatch {
+        ($($m:literal),+) => {
+            match model.n_theta + model.n_eta {
+                $($m => mr_sens_dual::<$m>(model, subject, &s, prog, theta, eta),)+
+                _ => None,
+            }
+        };
+    }
+    let mut sens = dispatch!(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    )?;
+    crate::sens::provider::apply_event_walk_expression_scale_outer(
+        &mut sens, model, subject, prog, theta, eta,
+    )?;
+    Some(sens)
+}
+
+/// `Dual2<M>`-width monomorphisation of [`mr_subject_sensitivities`]. Seeds the
+/// PK-slot duals, recovers the disposition params over the same duals (so
+/// `v = 1/m`, `cl = ke/m`, and the 2-cpt `v2 = q/k21` division all carry exact
+/// `(θ,η)` sensitivities), evaluates `mr_observable_g` per observation, then
+/// unpacks the jet into [`crate::sens::provider::ObsSens`] — the identical
+/// field layout `run_subject_tvcov` uses (axes `0..n_theta` = θ,
+/// `n_theta..M` = η).
+fn mr_sens_dual<const M: usize>(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    s: &MrScope,
+    prog: &crate::parser::model_parser::IndivParamProgram,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<crate::sens::provider::SubjectSens> {
+    use crate::sens::dual2::Dual2;
+    let n_theta = model.n_theta;
+    let n_eta = model.n_eta;
+    let p: Vec<Dual2<M>> = crate::sens::ode_provider::seed_pk_dual2::<M>(
+        model,
+        prog,
+        theta,
+        eta,
+        &subject.covariates,
+        0.0,
+    );
+    let dp = recover_disp_params_g::<Dual2<M>>(s.spec, &s.disp, &p, &subject.covariates)?;
+    let lag_cmt = p[crate::types::PK_IDX_LAGTIME];
+    let f_bio = p[crate::types::PK_IDX_F];
+    let mut out = Vec::with_capacity(subject.obs_times.len());
+    for &t in &subject.obs_times {
+        let fd = mr_observable_g::<Dual2<M>>(
+            &dp,
+            &s.spec.input_rate,
+            &subject.doses,
+            Dual2::constant(t),
+            &p,
+            lag_cmt,
+            f_bio,
+        );
+        // `ScalarScale`/LTBS output transform, mirroring the ODE provider's
+        // `resolve_obs_readout` → `apply_output_transform` (same per-observation
+        // site, basis-agnostic over which space the dual's axes represent — see
+        // that function's doc). `ExpressionScale` is handled separately, after
+        // the whole `SubjectSens` is assembled, by `apply_event_walk_expression_scale_outer`.
+        let fd = crate::sens::ode_provider::apply_output_transform(model, fd);
+        let g = &fd.grad;
+        let h = &fd.hess;
+        let mut df_deta = vec![0.0; n_eta];
+        let mut df_dtheta = vec![0.0; n_theta];
+        let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
+        let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
+        for k in 0..n_eta {
+            df_deta[k] = g[n_theta + k];
+            for l in 0..n_eta {
+                d2f_deta2[k * n_eta + l] = h[n_theta + k][n_theta + l];
+            }
+            for m in 0..n_theta {
+                d2f_deta_dtheta[k * n_theta + m] = h[n_theta + k][m];
+            }
+        }
+        for m in 0..n_theta {
+            df_dtheta[m] = g[m];
+        }
+        out.push(crate::sens::provider::ObsSens {
+            f: fd.value,
+            df_deta,
+            d2f_deta2,
+            df_dtheta,
+            d2f_deta_dtheta,
+        });
+    }
+    Some(crate::sens::provider::SubjectSens { obs: out })
+}
+
+/// Closed-form light **inner** η-gradient for a modified-release subject (#860
+/// Phase A6) — the fast-path alternative to
+/// [`crate::sens::ode_provider::ode_subject_eta_grad`], mirroring
+/// [`mr_subject_sensitivities`] at `Dual1<N>` (`N = n_eta`) width via
+/// [`crate::sens::ode_provider::seed_pk_dual1`]. Per the shared per-subject
+/// scope contract ([`crate::sens::ode_provider::ode_subject_supported`]'s doc),
+/// this and [`mr_subject_sensitivities`] must serve exactly the same subjects —
+/// both share `mr_scope` and `mr_prog_axes_match`, so that holds structurally.
+pub(crate) fn mr_subject_eta_grad(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<Vec<crate::sens::provider::ObsGrad>> {
+    let s = mr_scope(model, subject, theta, eta)?;
+    let prog = s.spec.indiv_param_program.as_ref()?;
+    if !mr_prog_axes_match(prog, model.n_theta, model.n_eta)
+        || !crate::sens::ode_provider::ode_scaling_supported(model)
+    {
+        return None;
+    }
+    macro_rules! dispatch {
+        ($($n:literal),+) => {
+            match model.n_eta {
+                $($n => mr_eta_grad_dual::<$n>(model, subject, &s, prog, theta, eta),)+
+                _ => None,
+            }
+        };
+    }
+    let mut out = dispatch!(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    )?;
+    crate::sens::provider::apply_event_walk_expression_scale_inner(
+        &mut out, model, subject, prog, theta, eta,
+    )?;
+    Some(out)
+}
+
+/// `Dual1<N>`-width monomorphisation of [`mr_subject_eta_grad`].
+fn mr_eta_grad_dual<const N: usize>(
+    model: &crate::types::CompiledModel,
+    subject: &crate::types::Subject,
+    s: &MrScope,
+    prog: &crate::parser::model_parser::IndivParamProgram,
+    theta: &[f64],
+    eta: &[f64],
+) -> Option<Vec<crate::sens::provider::ObsGrad>> {
+    use crate::sens::dual1::Dual1;
+    let p: Vec<Dual1<N>> = crate::sens::ode_provider::seed_pk_dual1::<N>(
+        model,
+        prog,
+        theta,
+        eta,
+        &subject.covariates,
+        0.0,
+    )?;
+    let dp = recover_disp_params_g::<Dual1<N>>(s.spec, &s.disp, &p, &subject.covariates)?;
+    let lag_cmt = p[crate::types::PK_IDX_LAGTIME];
+    let f_bio = p[crate::types::PK_IDX_F];
+    let mut out = Vec::with_capacity(subject.obs_times.len());
+    for &t in &subject.obs_times {
+        let fd = mr_observable_g::<Dual1<N>>(
+            &dp,
+            &s.spec.input_rate,
+            &subject.doses,
+            Dual1::constant(t),
+            &p,
+            lag_cmt,
+            f_bio,
+        );
+        // See the matching comment in `mr_sens_dual`: `ScalarScale`/LTBS via the
+        // same shared, basis-agnostic `apply_output_transform`.
+        let fd = crate::sens::ode_provider::apply_output_transform(model, fd);
+        out.push(crate::sens::provider::ObsGrad {
+            f: fd.value,
+            df_deta: fd.grad.to_vec(),
+        });
+    }
+    Some(out)
 }
 
 #[cfg(test)]
@@ -1072,6 +1345,54 @@ mod tests {
         );
     }
 
+    // #860 Phase B, 2-cpt: a zero_order route mixed with first_order into a
+    // two-compartment disposition — exercises `two_cpt_zero_order_g`'s macro-rate
+    // (α/β) form, not just the 1-cpt kernel.
+    const MIXED_ZERO_ORDER_2CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA) + FZO*zero_order(dur=DUR) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+    #[test]
+    fn reduces_to_ode_2cpt_zero_order_mixed() {
+        assert_reduces_to_ode(
+            MIXED_ZERO_ORDER_2CPT,
+            &[5.0, 50.0, 10.0, 100.0, 0.4, 1.5, 2.0],
+            &[0.0],
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        );
+    }
+
     // A *static* covariate (WT on CL) is baked into the parameters at the single
     // `t = 0` snapshot — valid because it does not vary in time — and the recovered
     // `ke` must carry it, matching the twin which reads the same covariate.
@@ -1255,15 +1576,14 @@ mod tests {
     }
 
     #[test]
-    fn declines_zero_order_pathway() {
-        let model = parse(MIXED_ZERO_ORDER);
-        let subject = mk_subject(
+    fn admits_zero_order_pathway_and_reduces_to_ode() {
+        // #860 Phase B: a mixed first_order + zero_order model no longer declines —
+        // it must both admit the closed form AND reduce to the ODE twin.
+        assert_reduces_to_ode(
+            MIXED_ZERO_ORDER,
+            &[5.0, 50.0, 0.4, 1.5, 2.0],
+            &[0.0],
             vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
-            vec![1.0, 2.0, 4.0],
-        );
-        assert!(
-            mr_predictions(&model, &subject, &[5.0, 50.0, 0.4, 1.5, 2.0], &[0.0]).is_none(),
-            "a zero_order pathway (Phase B) must decline to the ODE path"
         );
     }
 
@@ -1277,6 +1597,50 @@ mod tests {
         assert!(
             mr_predictions(&model, &subject, &[5.0, 50.0, 1.5], &[0.0]).is_none(),
             "a TIME-dependent disposition must decline"
+        );
+    }
+
+    #[test]
+    fn declines_sde_diffusion() {
+        // A parsed SDE model always uses an `ObsCmt` readout (Form-C `y = <expr>`
+        // is rejected on SDE at parse), and `ObsCmt` has no `readout_program`, so
+        // `identify_disposition` already declines it at its `readout_program.as_ref()?`
+        // — the `diffusion_var` guard can't be reached through the normal parse path
+        // *today*. It is forward-defensive: were `ObsCmt` (or a future readout) ever
+        // made MR-identifiable, an SDE's linear *drift* would identify and the guard
+        // is the only thing keeping the stochastic model off the deterministic closed
+        // form. Exercise it directly by injecting a diffusion term into a model
+        // `mr_scope` otherwise admits, proving the guard is load-bearing.
+        let mut model = parse(REDUCE_1CPT);
+        let subject = mk_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 2.0, 4.0],
+        );
+        let theta = [5.0, 50.0, 0.6, 1.5, 0.3];
+        let eta = [0.0, 0.0];
+        // Baseline: this model IS admitted (sanity — else the test proves nothing).
+        assert!(
+            mr_scope(&model, &subject, &theta, &eta).is_some(),
+            "REDUCE_1CPT must be MR-admitted before the diffusion injection"
+        );
+        // Inject a state diffusion term without touching the (still canonical-linear)
+        // drift RHS the disposition probe reads. The guard keys on `diffusion_var`,
+        // exactly as the ODE provider's `ode_analytical_supported` does (both read
+        // `diffusion_var`, not `is_sde()`'s `diffusion_theta_start`), so setting this
+        // one field is what exercises the guard.
+        let spec = model.ode_spec.as_mut().unwrap();
+        spec.diffusion_var = vec![0.01; spec.n_states];
+        assert!(
+            mr_scope(&model, &subject, &theta, &eta).is_none(),
+            "an SDE (diffusion term) must decline the closed-form MR scope"
+        );
+        assert!(
+            mr_predictions(&model, &subject, &theta, &eta).is_none(),
+            "an SDE must decline the MR value path"
+        );
+        assert!(
+            mr_subject_sensitivities(&model, &subject, &theta, &eta).is_none(),
+            "an SDE must decline the MR analytic-gradient path"
         );
     }
 
@@ -1317,9 +1681,9 @@ mod tests {
     }
 
     #[test]
-    fn route_conc_g_zero_order_and_weibull_are_inert() {
-        // The defensive arms in `route_conc_g` (the gate excludes these kinds, so
-        // they are never reached in production) return 0 for both dispositions.
+    fn route_conc_g_weibull_is_inert() {
+        // The defensive arm in `route_conc_g` (the gate excludes this kind, so it
+        // is never reached in production) returns 0 for both dispositions.
         let p = vec![2.0_f64];
         let one = DispParams {
             cl: 5.0,
@@ -1332,11 +1696,92 @@ mod tests {
             periph: Some((10.0, 100.0)),
         };
         for dp in [one, two] {
-            for kind in [InputRateKind::ZeroOrder, InputRateKind::Weibull] {
-                let f = forcing(kind, vec![0], None, None);
-                let got = route_conc_g::<f64>(kind, &f, &p, &dp, 2.0, 100.0);
-                assert_eq!(got, 0.0, "{kind:?} must be inert in route_conc_g");
-            }
+            let f = forcing(InputRateKind::Weibull, vec![0], None, None);
+            let got = route_conc_g::<f64>(InputRateKind::Weibull, &f, &p, &dp, 2.0, 100.0);
+            assert_eq!(got, 0.0, "Weibull must be inert in route_conc_g");
+        }
+    }
+
+    // ── #860 Phase B: zero_order box-car kernel. ──────────────────────────────
+
+    #[test]
+    fn single_zero_order_route_matches_infusion_kernel() {
+        // A single, unlagged, full-fraction zero_order route must match the
+        // fixed-duration infusion kernel exactly (same box-car-into-1cpt physics,
+        // `dur` generic here vs `f64` there) — the bit-reduction anchor for the
+        // new kernel, mirroring `single_first_order_route_reduces_to_bateman`.
+        let dur = 2.5_f64;
+        let p = vec![dur];
+        let dp = DispParams {
+            cl: 5.0,
+            v: 50.0,
+            periph: None,
+        };
+        let f = vec![forcing(InputRateKind::ZeroOrder, vec![0], None, None)];
+        let doses = vec![dose(0.0, 100.0)];
+        let rate = 100.0 / dur;
+        for &t in &[0.5, 1.0, dur, 2.0 * dur, 8.0] {
+            let got = mr_observable_g(&dp, &f, &doses, t, &p, 0.0, 1.0);
+            let want = crate::sens::one_cpt::one_cpt_infusion_g(rate, dur, 100.0, t, dp.cl, dp.v);
+            assert!((got - want).abs() < 1e-9, "t={t}: {got} vs {want}");
+        }
+    }
+
+    #[test]
+    fn zero_order_dual2_matches_fd_near_dur_boundary() {
+        // The real risk in #860 Phase B: `∂/∂dur` near the moving t == dur
+        // boundary. Central-FD the f64 kernel against the analytic Dual2 kernel
+        // at observation times straddling `dur` (just below/just above), 1-cpt
+        // and 2-cpt. `t == dur` exactly is deliberately excluded: there, central
+        // FD perturbs `dur` past the *fixed* `t`, so the finite difference mixes
+        // the during- and after-window branches (a genuine secant across a kink,
+        // not a one-sided derivative) — no analytic one-sided derivative can
+        // match it, and no real observation time lands there exactly.
+        use crate::sens::dual2::Dual2;
+        let h = 1e-5;
+        let cl = 5.0_f64;
+        let v = 50.0_f64;
+        let q = 3.0_f64;
+        let v2 = 80.0_f64;
+        let dur0 = 3.0_f64;
+        for &t in &[1.0, 2.999, 3.001, 6.0] {
+            // 1-cpt.
+            let plus = one_cpt_zero_order_g(1.0, t, cl, v, dur0 + h, 1.0);
+            let minus = one_cpt_zero_order_g(1.0, t, cl, v, dur0 - h, 1.0);
+            let fd = (plus - minus) / (2.0 * h);
+            let dur_d = Dual2::<1>::var(dur0, 0);
+            let got = one_cpt_zero_order_g(
+                1.0,
+                Dual2::<1>::constant(t),
+                Dual2::constant(cl),
+                Dual2::constant(v),
+                dur_d,
+                Dual2::constant(1.0),
+            );
+            assert!(
+                (got.grad[0] - fd).abs() < 1e-4 * (1.0 + fd.abs()),
+                "1cpt t={t}: analytic {} vs FD {fd}",
+                got.grad[0]
+            );
+            // 2-cpt.
+            let plus2 = two_cpt_zero_order_g(1.0, t, cl, v, q, v2, dur0 + h, 1.0);
+            let minus2 = two_cpt_zero_order_g(1.0, t, cl, v, q, v2, dur0 - h, 1.0);
+            let fd2 = (plus2 - minus2) / (2.0 * h);
+            let got2 = two_cpt_zero_order_g(
+                1.0,
+                Dual2::<1>::constant(t),
+                Dual2::constant(cl),
+                Dual2::constant(v),
+                Dual2::constant(q),
+                Dual2::constant(v2),
+                dur_d,
+                Dual2::constant(1.0),
+            );
+            assert!(
+                (got2.grad[0] - fd2).abs() < 1e-4 * (1.0 + fd2.abs()),
+                "2cpt t={t}: analytic {} vs FD {fd2}",
+                got2.grad[0]
+            );
         }
     }
 

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -65,9 +65,14 @@ pub enum MrDispositionKind {
 }
 
 /// The identified disposition: its shape plus the state indices of central and
-/// (for two-compartment) peripheral. Built once per model by
-/// [`identify_disposition`]; the per-subject rates are recovered separately over
-/// `T` by [`recover_disp_params_g`] so `T = Dual2` carries their sensitivities.
+/// (for two-compartment) peripheral. Produced by [`identify_disposition`] from
+/// the immutable [`OdeSpec`] structure, so it is **model-invariant** (independent
+/// of subject, `θ`, `η`). It is currently recovered afresh on each [`mr_scope`]
+/// call rather than cached on the model — a memoisation opportunity, since the
+/// numeric Jacobian probing repeats every value / gradient evaluation (tracked as
+/// a follow-up; the fast path still avoids all ODE integration, so the probing is
+/// a second-order cost). The per-subject rates are recovered separately over `T`
+/// by [`recover_disp_params_g`] so `T = Dual2` carries their sensitivities.
 #[derive(Debug, Clone, Copy)]
 pub struct MrDisposition {
     pub kind: MrDispositionKind,
@@ -750,31 +755,10 @@ fn mr_sens_dual<const M: usize>(
         // that function's doc). `ExpressionScale` is handled separately, after
         // the whole `SubjectSens` is assembled, by `apply_event_walk_expression_scale_outer`.
         let fd = crate::sens::ode_provider::apply_output_transform(model, fd);
-        let g = &fd.grad;
-        let h = &fd.hess;
-        let mut df_deta = vec![0.0; n_eta];
-        let mut df_dtheta = vec![0.0; n_theta];
-        let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
-        let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
-        for k in 0..n_eta {
-            df_deta[k] = g[n_theta + k];
-            for l in 0..n_eta {
-                d2f_deta2[k * n_eta + l] = h[n_theta + k][n_theta + l];
-            }
-            for m in 0..n_theta {
-                d2f_deta_dtheta[k * n_theta + m] = h[n_theta + k][m];
-            }
-        }
-        for m in 0..n_theta {
-            df_dtheta[m] = g[m];
-        }
-        out.push(crate::sens::provider::ObsSens {
-            f: fd.value,
-            df_deta,
-            d2f_deta2,
-            df_dtheta,
-            d2f_deta_dtheta,
-        });
+        // Shared jet→ObsSens scatter (identical axis layout in every provider).
+        out.push(crate::sens::provider::obs_sens_from_dual2::<M>(
+            &fd, n_theta, n_eta,
+        ));
     }
     Some(crate::sens::provider::SubjectSens { obs: out })
 }

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -248,6 +248,28 @@ fn expression_scale_axes_admissible(
         && (1..=MAX_ODE_AXES).contains(&p.n_axes())
 }
 
+/// The model-level scaling allowlist [`ode_analytical_supported`] requires: `None`
+/// and a constant `ScalarScale` divisor are always analytic (handled per-observation
+/// by [`apply_output_transform`]); an `ExpressionScale` divisor is analytic only when
+/// [`expression_scale_axes_admissible`] (which also excludes it under LTBS); anything
+/// else (e.g. `PerCmt`) declines. Allowlist, not denylist, so a future scaling variant
+/// can only *narrow* the analytic scope, never silently admit an unhandled one.
+///
+/// Factored out (not just inlined in `ode_analytical_supported`) so
+/// `pk::modified_release`'s closed-form MR gradient fast path (#860 Phase A6) — which
+/// additionally applies [`apply_output_transform`] itself, since it does not go through
+/// `run_subject`'s per-observation loop — can require the identical scaling scope
+/// without a second, driftable copy of this match.
+pub(crate) fn ode_scaling_supported(model: &CompiledModel) -> bool {
+    match &model.scaling {
+        ScalingSpec::None | ScalingSpec::ScalarScale(_) => true,
+        ScalingSpec::ExpressionScale { deriv: Some(p), .. } => {
+            expression_scale_axes_admissible(p, model)
+        }
+        _ => false,
+    }
+}
+
 /// True when [`ode_subject_sensitivities`] can serve this model: an ODE model
 /// with a compiled RHS program, single `ObsCmt` readout, no built-in absorption,
 /// no `init(...)`, no IOV/SDE, no output transform, and an individual-parameter
@@ -348,11 +370,8 @@ pub fn ode_analytical_supported(model: &CompiledModel) -> bool {
     // LTBS keeps the FD fallback). Both compose with a Form-C readout (`y = state/V`), the
     // other supported route. Allowlist (not denylist) so a future scaling variant can only
     // *narrow* the analytic scope, never silently admit an unhandled one.
-    match &model.scaling {
-        ScalingSpec::None | ScalingSpec::ScalarScale(_) => {}
-        ScalingSpec::ExpressionScale { deriv: Some(p), .. }
-            if expression_scale_axes_admissible(p, model) => {}
-        _ => return false,
+    if !ode_scaling_supported(model) {
+        return false;
     }
     // (ODE models have no `tv_fn` — typical values come from `pk_param_fn` at
     // η = 0 instead; see `run_subject`.)
@@ -1664,7 +1683,15 @@ fn init_taylor_seed_at<T: crate::sens::num::PkNum>(
 /// `pk::apply_scaling` (`pred /= k`) and `pk::apply_log_transform`
 /// (`p = max(p, LTBS_FLOOR).ln()`; below the floor the value is clamped to a
 /// constant, so the jet vanishes).
-fn apply_output_transform<T: crate::sens::num::PkNum>(model: &CompiledModel, p: T) -> T {
+///
+/// Basis-agnostic: it only divides/logs the dual `p` as a whole, so it works
+/// identically whether `p`'s axes are PK-parameter space (the static walk,
+/// chained to `(θ,η)` afterward) or already `(θ,η)`-space (the TV-cov walk's
+/// `seed_pk_dual2` convention) — already proven by [`resolve_obs_readout`]
+/// calling it from both. `pub(crate)`: also reused by
+/// `pk::modified_release::mr_sens_dual`/`mr_eta_grad_dual` (#860 Phase A6),
+/// whose `mr_observable_g::<Dual2<M>>` result is `(θ,η)`-seeded the same way.
+pub(crate) fn apply_output_transform<T: crate::sens::num::PkNum>(model: &CompiledModel, p: T) -> T {
     // A NaN readout (e.g. a per-CMT map miss — rejected upstream by fit-time
     // `validate_per_cmt_scaling`, so unreachable in a real fit) must stay NaN as a
     // visible tripwire: neither the `ScalarScale` divisor nor the LTBS floor below
@@ -2131,7 +2158,12 @@ fn run_subject_eta<const N: usize>(
 /// individual parameter `i` carries `∂p/∂θ_m` on axis `m` and `∂p/∂η_k` on axis
 /// `n_theta+k` (plus the η-η / η-θ 2nd-order blocks); every other slot is a
 /// constant. The returned `Vec` is indexed by PK slot (what the ODE RHS reads).
-fn seed_pk_dual2<const M: usize>(
+///
+/// `pub(crate)`: also reused by the closed-form MR gradient path
+/// (`pk::modified_release::mr_subject_sensitivities`, #860 Phase A6), which
+/// needs the identical `(θ,η)`-seeded PK-slot duals `mr_observable_g::<Dual2<M>>`
+/// consumes — not a second copy of this seeding logic.
+pub(crate) fn seed_pk_dual2<const M: usize>(
     model: &CompiledModel,
     prog: &crate::parser::model_parser::IndivParamProgram,
     theta: &[f64],
@@ -3219,7 +3251,10 @@ pub(crate) fn param_derivatives_at_cov(
 /// Per-event flat PK-slot duals seeded on **η only** (`Dual1<N>`, `N = n_eta`) at a
 /// covariate snapshot — the light-inner counterpart of [`seed_pk_dual2`]. Slot for
 /// individual parameter `i` carries `∂p/∂η_k` on axis `k`; other slots are constant.
-fn seed_pk_dual1<const N: usize>(
+///
+/// `pub(crate)`: also reused by `pk::modified_release::mr_subject_eta_grad`
+/// (#860 Phase A6), the closed-form counterpart of `ode_subject_eta_grad`.
+pub(crate) fn seed_pk_dual1<const N: usize>(
     model: &CompiledModel,
     prog: &crate::parser::model_parser::IndivParamProgram,
     theta: &[f64],

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -2452,31 +2452,9 @@ fn run_subject_tvcov<const M: usize>(
 
     let mut out = Vec::with_capacity(preds.len());
     for fd in &preds {
-        let g = &fd.grad;
-        let h = &fd.hess;
-        let mut df_deta = vec![0.0; n_eta];
-        let mut df_dtheta = vec![0.0; n_theta];
-        let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
-        let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
-        for k in 0..n_eta {
-            df_deta[k] = g[n_theta + k];
-            for l in 0..n_eta {
-                d2f_deta2[k * n_eta + l] = h[n_theta + k][n_theta + l];
-            }
-            for m in 0..n_theta {
-                d2f_deta_dtheta[k * n_theta + m] = h[n_theta + k][m];
-            }
-        }
-        for m in 0..n_theta {
-            df_dtheta[m] = g[m];
-        }
-        out.push(ObsSens {
-            f: fd.value,
-            df_deta,
-            d2f_deta2,
-            df_dtheta,
-            d2f_deta_dtheta,
-        });
+        out.push(crate::sens::provider::obs_sens_from_dual2::<M>(
+            fd, n_theta, n_eta,
+        ));
     }
     let mut sens = SubjectSens { obs: out };
     // η-dependent `ExpressionScale` divisor: apply the subject-static quotient on the

--- a/src/sens/one_cpt.rs
+++ b/src/sens/one_cpt.rs
@@ -143,6 +143,34 @@ pub fn one_cpt_infusion_g<T: PkNum>(rate: f64, dur: f64, amt: f64, t: T, cl: T, 
     }
 }
 
+/// 1-cpt zero-order (box-car) absorption of duration `dur` — the closed-form
+/// modified-release counterpart of [`one_cpt_infusion_g`] with `dur` (and hence
+/// the rate `mass/dur`) itself generic over [`PkNum`], so a `Dual2` carries
+/// `∂C/∂dur` (#860 Phase B). `amt`/`f_bio` follow the same convention as the
+/// other MR-superposable kernels (`route_conc_g` calls with unit `amt = 1.0`
+/// and folds the dose mass in via `f_bio` externally). The value formula is
+/// identical to `one_cpt_infusion_g`'s (same box-car-into-1cpt convolution);
+/// only the domain of `dur` differs (a fitted individual parameter here, not
+/// dose data), so this is not a duplicate derivation. The branch on
+/// `t.val() <= dur.val()` picks one side's smooth formula at the boundary
+/// (like every other `.val()`-branching kernel in this module) — the resulting
+/// `∂/∂dur` jet is exact on whichever side is selected; real observation times
+/// essentially never land exactly on `dur`.
+pub fn one_cpt_zero_order_g<T: PkNum>(amt: f64, t: T, cl: T, v: T, dur: T, f_bio: T) -> T {
+    if t.val() < 0.0 || v.val() <= 0.0 || cl.val() <= 0.0 || dur.val() <= 0.0 {
+        return T::from_f64(0.0);
+    }
+    let k = cl / v;
+    let d = f_bio * T::from_f64(amt);
+    let r_cl = d / (dur * cl);
+    let one = T::from_f64(1.0);
+    if t.val() <= dur.val() {
+        r_cl * (one - (-(k * t)).exp())
+    } else {
+        r_cl * (one - (-(k * dur)).exp()) * (-(k * (t - dur))).exp()
+    }
+}
+
 /// 1-cpt IV bolus at steady state (interval `ii`).
 pub fn one_cpt_iv_bolus_ss_g<T: PkNum>(amt: f64, t: T, ii: f64, cl: T, v: T) -> T {
     if t.val() < 0.0 || v.val() <= 0.0 || cl.val() <= 0.0 || ii <= 0.0 {

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -3748,6 +3748,17 @@ fn subject_eta_grad_impl(
     // scope the outer provider uses, so inner and outer stay on the same route.
     if model.ode_spec.is_some() {
         if ODE_SENS_ENABLED {
+            // Closed-form modified-release fast path (#860 Phase A6): a *static*
+            // multi-route subject `mr_scope` admits skips the ODE integration
+            // entirely (same "analytic" report as `ode_subject_eta_grad` below —
+            // `ode_analytical_supported` already covers this model — just a
+            // faster computation of the identical jet). `None` falls through to
+            // the ODE provider unchanged.
+            if let Some(g) =
+                crate::pk::modified_release::mr_subject_eta_grad(model, subject, theta, eta)
+            {
+                return Some(g);
+            }
             return crate::sens::ode_provider::ode_subject_eta_grad(model, subject, theta, eta);
         }
         return None;
@@ -4782,6 +4793,19 @@ fn subject_sensitivities_impl(
     // `ODE_SENS_ENABLED` master switch stays as a single kill-switch for the path.
     if model.ode_spec.is_some() {
         if ODE_SENS_ENABLED {
+            // Closed-form modified-release fast path (#860 Phase A6): try the
+            // no-integration superposition first for the *static* subjects
+            // `mr_scope` admits — a pure speed swap inside the branch
+            // `ode_analytical_supported` already reports "analytic" for, not a
+            // new supported/declined predicate (so `sens_supported` /
+            // `analytic_outer_gradient_available` need no change). `None` (out
+            // of `mr_scope`'s narrower static scope, or an axis-count mismatch)
+            // falls through to the ODE provider unchanged.
+            if let Some(sens) =
+                crate::pk::modified_release::mr_subject_sensitivities(model, subject, theta, eta)
+            {
+                return Some(sens);
+            }
             return crate::sens::ode_provider::ode_subject_sensitivities(
                 model, subject, theta, eta,
             );

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -65,6 +65,49 @@ pub struct SubjectSens {
     pub obs: Vec<ObsSens>,
 }
 
+/// Scatter one observation's `(θ,η)`-seeded `Dual2<M>` jet into an [`ObsSens`],
+/// with the canonical axis layout every provider uses: θ on dual axes
+/// `0..n_theta`, η on `n_theta..M` (`M = n_theta + n_eta`). The second-order
+/// blocks kept are the η-η Hessian and the η-θ cross block (the only ones the
+/// FOCEI outer gradient consumes). The dual must already carry any output
+/// transform (`apply_output_transform` / readout) — this only reshapes.
+///
+/// Single home for a loop that was written verbatim in three places
+/// (`run_subject_tvcov`, `subject_sensitivities_tvcov`, and the closed-form MR
+/// `mr_sens_dual`, #860); a drift in the axis convention here would otherwise be
+/// silently wrong in whichever copy was missed.
+pub(crate) fn obs_sens_from_dual2<const M: usize>(
+    fd: &Dual2<M>,
+    n_theta: usize,
+    n_eta: usize,
+) -> ObsSens {
+    let g = &fd.grad;
+    let h = &fd.hess;
+    let mut df_deta = vec![0.0; n_eta];
+    let mut df_dtheta = vec![0.0; n_theta];
+    let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
+    let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
+    for k in 0..n_eta {
+        df_deta[k] = g[n_theta + k];
+        for l in 0..n_eta {
+            d2f_deta2[k * n_eta + l] = h[n_theta + k][n_theta + l];
+        }
+        for m in 0..n_theta {
+            d2f_deta_dtheta[k * n_theta + m] = h[n_theta + k][m];
+        }
+    }
+    for m in 0..n_theta {
+        df_dtheta[m] = g[m];
+    }
+    ObsSens {
+        f: fd.value,
+        df_deta,
+        d2f_deta2,
+        df_dtheta,
+        d2f_deta_dtheta,
+    }
+}
+
 /// Shared accessor letting the constant-`ScalarScale` divide run once over both the
 /// outer full-jet ([`ObsSens`]) and the inner η-grad ([`ObsGrad`]) observation types.
 /// `for_each_scaled_axis` visits every derivative the scale multiplies by `1/k`, in the
@@ -3188,30 +3231,7 @@ fn run_obs_tvcov<const M: usize>(
         } else {
             c_clamped
         };
-        let c = &c;
-        let mut df_deta = vec![0.0; n_eta];
-        let mut df_dtheta = vec![0.0; n_theta];
-        let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
-        let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
-        for k in 0..n_eta {
-            df_deta[k] = c.grad[n_theta + k];
-            for l in 0..n_eta {
-                d2f_deta2[k * n_eta + l] = c.hess[n_theta + k][n_theta + l];
-            }
-            for m in 0..n_theta {
-                d2f_deta_dtheta[k * n_theta + m] = c.hess[n_theta + k][m];
-            }
-        }
-        for m in 0..n_theta {
-            df_dtheta[m] = c.grad[m];
-        }
-        obs_out.push(ObsSens {
-            f: c.value,
-            df_deta,
-            d2f_deta2,
-            df_dtheta,
-            d2f_deta_dtheta,
-        });
+        obs_out.push(obs_sens_from_dual2::<M>(&c, n_theta, n_eta));
     }
     Some(SubjectSens { obs: obs_out })
 }

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -2876,6 +2876,334 @@ fn provider_matches_fd_of_production_predictor() {
     check_full_provider_vs_fd(&model, &subject, &[0.2, 10.0, 1.5], &[0.15, -0.10, 0.25]);
 }
 
+// ── #860 Phase A6: closed-form MR analytic gradient ──────────────────────────
+//
+// `subject_sensitivities`/`subject_eta_grad` now try the no-integration MR
+// superposition before the ODE provider for the static subjects `mr_scope`
+// admits. Each test below both (a) confirms the fast path actually fired —
+// `mr_subject_sensitivities` returning `Some` directly — so a scope regression
+// that silently falls back to the (still-correct, just slower) ODE provider
+// would be caught, and (b) exercises the full FD-parity / cross-provider
+// agreement check through the same public entry points production uses.
+
+const MR_MIXED_1CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  theta TVLAG(1.0, 0.001, 6.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.04
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+  LAG = TVLAG
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA, lag=LAG) + FZO*zero_order(dur=DUR) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+const MR_PARALLEL_2CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVFR1(0.6, 0.05, 0.95)
+  theta TVKA1(1.5, 0.05, 24.0)
+  theta TVKA2(0.3, 0.01, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q = TVQ
+  V2 = TVV2
+  FR1 = TVFR1
+  FR2 = 1 - TVFR1
+  KA1 = TVKA1
+  KA2 = TVKA2
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = FR1*first_order(ka=KA1) + FR2*first_order(ka=KA2) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+/// 1-cpt mixed `first_order` (per-route-lagged) + `zero_order`: the closed-form
+/// outer/inner MR gradient must match central FD of the production predictor,
+/// via the SAME public `subject_sensitivities` entry point production uses —
+/// and must actually take the MR fast path, not silently fall back to ODE.
+#[test]
+fn mr_1cpt_mixed_provider_matches_fd_and_takes_fast_path() {
+    let model = parse_model_string(MR_MIXED_1CPT).expect("parse");
+    // Deliberately avoids exact coincidence with TVDUR (2.0) / TVLAG (1.0) —
+    // at t == dur or t == lag exactly, central-FD-of-θ perturbs the boundary
+    // past a *fixed* observation time, mixing two branches (a secant across a
+    // kink, not a one-sided derivative); see the kernel-level
+    // `zero_order_dual2_matches_fd_near_dur_boundary` test for the isolated
+    // case. No real observation time lands exactly on a fitted dur/lag either.
+    let subject = oral_subject(&[0.5, 1.3, 2.7, 3.6, 4.4, 8.2, 12.0]);
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0, 1.0];
+    let eta = [0.1, -0.05];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_some(),
+        "expected the MR closed-form fast path to admit this static 1-cpt mixed subject"
+    );
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
+/// 2-cpt parallel `first_order` routes: exercises the macro-rate (`α`/`β`) and
+/// `v2 = q/k21` division inside `recover_disp_params_g` under `Dual2` — the
+/// riskiest single spot for the outer chain (a reciprocal/quotient under a
+/// second-order dual) — via the same public entry point.
+#[test]
+fn mr_2cpt_parallel_provider_matches_fd_and_takes_fast_path() {
+    let model = parse_model_string(MR_PARALLEL_2CPT).expect("parse");
+    let subject = oral_subject(&[0.5, 1.0, 2.0, 4.0, 8.0, 16.0]);
+    let theta = [5.0, 50.0, 10.0, 100.0, 0.6, 1.5, 0.3];
+    let eta = [0.1];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_some(),
+        "expected the MR closed-form fast path to admit this static 2-cpt parallel subject"
+    );
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
+/// The MR closed-form jet and the ODE-integrated jet are two different schemes
+/// computing the same "analytic" gradient for the same subject
+/// (`ode_analytical_supported` already reports this model analytic;
+/// `mr_scope` is a narrower, faster alternative for it) — they must agree to
+/// solver tolerance, directly, not just both agreeing with FD (FD's own
+/// tolerance is far looser than solver `ode_reltol`/`ode_abstol`, so this is
+/// the tighter regression guard against the two scopes silently drifting apart).
+#[test]
+fn mr_subject_sensitivities_matches_ode_provider_directly() {
+    let model = parse_model_string(MR_MIXED_1CPT).expect("parse");
+    let subject = oral_subject(&[0.5, 1.0, 2.0, 3.0, 4.0, 8.0, 12.0]);
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0, 1.0];
+    let eta = [0.1, -0.05];
+    let mr = crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+        .expect("MR fast path admits this subject");
+    let ode = crate::sens::ode_provider::ode_subject_sensitivities(&model, &subject, &theta, &eta)
+        .expect("ODE provider also serves this subject analytically");
+    assert_eq!(mr.obs.len(), ode.obs.len());
+    for (j, (a, b)) in mr.obs.iter().zip(&ode.obs).enumerate() {
+        approx::assert_relative_eq!(a.f, b.f, max_relative = 1e-6, epsilon = 1e-9);
+        for k in 0..a.df_deta.len() {
+            approx::assert_relative_eq!(
+                a.df_deta[k],
+                b.df_deta[k],
+                max_relative = 1e-4,
+                epsilon = 1e-8
+            );
+        }
+        for m in 0..a.df_dtheta.len() {
+            approx::assert_relative_eq!(
+                a.df_dtheta[m],
+                b.df_dtheta[m],
+                max_relative = 1e-4,
+                epsilon = 1e-8
+            );
+        }
+        for idx in 0..a.d2f_deta2.len() {
+            approx::assert_relative_eq!(
+                a.d2f_deta2[idx],
+                b.d2f_deta2[idx],
+                max_relative = 1e-3,
+                epsilon = 1e-6
+            );
+        }
+        for idx in 0..a.d2f_deta_dtheta.len() {
+            approx::assert_relative_eq!(
+                a.d2f_deta_dtheta[idx],
+                b.d2f_deta_dtheta[idx],
+                max_relative = 1e-3,
+                epsilon = 1e-6
+            );
+        }
+        let _ = j;
+    }
+}
+
+/// Inner light `Dual1` η-gradient counterpart: `mr_subject_eta_grad` must match
+/// `ode_subject_eta_grad` too — the shared per-subject scope contract requires
+/// inner and outer to serve exactly the same subjects, so their `f`/`df_deta`
+/// values (which both must ALSO match the outer path's) are checked directly
+/// against the ODE inner provider.
+#[test]
+fn mr_subject_eta_grad_matches_ode_provider_directly() {
+    let model = parse_model_string(MR_MIXED_1CPT).expect("parse");
+    let subject = oral_subject(&[0.5, 1.0, 2.0, 3.0, 4.0, 8.0, 12.0]);
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0, 1.0];
+    let eta = [0.1, -0.05];
+    let mr = crate::pk::modified_release::mr_subject_eta_grad(&model, &subject, &theta, &eta)
+        .expect("MR fast path admits this subject");
+    let ode = crate::sens::ode_provider::ode_subject_eta_grad(&model, &subject, &theta, &eta)
+        .expect("ODE provider also serves this subject analytically");
+    assert_eq!(mr.len(), ode.len());
+    for (a, b) in mr.iter().zip(&ode) {
+        approx::assert_relative_eq!(a.f, b.f, max_relative = 1e-6, epsilon = 1e-9);
+        for k in 0..a.df_deta.len() {
+            approx::assert_relative_eq!(
+                a.df_deta[k],
+                b.df_deta[k],
+                max_relative = 1e-4,
+                epsilon = 1e-8
+            );
+        }
+    }
+}
+
+// Regression: an ODE model may compose a Form-C `y = <expr>` readout WITH a
+// separate `obs_scale = <const>` divisor on top (the parser explicitly allows
+// this for ODE models — "ODE keeps its historical behaviour" — unlike
+// analytical models, where it is rejected). `ode_subject_sensitivities`
+// applies that divisor per observation via `apply_output_transform`, inside
+// `resolve_obs_readout` — a site `mr_scope` does not go through at all. An
+// earlier version of the MR fast path had no equivalent step, so it silently
+// returned the *unscaled* jet for any `ScalarScale`-composed MR model instead
+// of either applying the divisor or declining to the ODE provider.
+const MR_MIXED_1CPT_SCALAR_SCALE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  theta TVLAG(1.0, 0.001, 6.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.04
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+  LAG = TVLAG
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA, lag=LAG) + FZO*zero_order(dur=DUR) - CL/V*central
+[scaling]
+  y = central / V
+  obs_scale = 2.5
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+#[test]
+fn mr_subject_sensitivities_with_scalar_scale_matches_ode_provider() {
+    let model = parse_model_string(MR_MIXED_1CPT_SCALAR_SCALE).expect("parse");
+    let subject = oral_subject(&[0.5, 1.3, 2.7, 3.6, 4.4, 8.2, 12.0]);
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0, 1.0];
+    let eta = [0.1, -0.05];
+    let mr = crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+        .expect("MR fast path must admit a ScalarScale-composed model, not silently misfire");
+    let ode = crate::sens::ode_provider::ode_subject_sensitivities(&model, &subject, &theta, &eta)
+        .expect("ODE provider also serves this subject analytically");
+    assert_eq!(mr.obs.len(), ode.obs.len());
+    for (a, b) in mr.obs.iter().zip(&ode.obs) {
+        approx::assert_relative_eq!(a.f, b.f, max_relative = 1e-6, epsilon = 1e-9);
+        for k in 0..a.df_deta.len() {
+            approx::assert_relative_eq!(
+                a.df_deta[k],
+                b.df_deta[k],
+                max_relative = 1e-4,
+                epsilon = 1e-8
+            );
+        }
+        for m in 0..a.df_dtheta.len() {
+            approx::assert_relative_eq!(
+                a.df_dtheta[m],
+                b.df_dtheta[m],
+                max_relative = 1e-4,
+                epsilon = 1e-8
+            );
+        }
+    }
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
+// Regression: `PerCmt` scaling is the one `ScalingSpec` variant
+// `ode_analytical_supported` declines outright (routes to FD) — `mr_scope`
+// must decline it too via the same `ode_scaling_supported` gate, not silently
+// admit it with a plain (wrong, unscaled-per-CMT) jet.
+#[test]
+fn mr_subject_sensitivities_declines_percmt_scaling() {
+    const MR_PERCMT_SCALE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA) + FZO*zero_order(dur=DUR) - CL/V*central
+[scaling]
+  y = central / V
+  obs_scale[CMT=1] = 2.5
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let model = parse_model_string(MR_PERCMT_SCALE).expect("parse");
+    let subject = oral_subject(&[0.5, 1.3, 2.7]);
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0];
+    let eta = [0.1];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_none(),
+        "PerCmt scaling must decline the MR fast path, matching ode_scaling_supported"
+    );
+    assert!(
+        crate::pk::modified_release::mr_subject_eta_grad(&model, &subject, &theta, &eta).is_none(),
+        "PerCmt scaling must decline the MR inner fast path too"
+    );
+}
+
 // ── analytic Form C readout (#650) exact sensitivities ───────────────────
 
 /// A nonlinear analytic Form C readout — a saturable protein-binding total

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -2996,6 +2996,143 @@ fn mr_2cpt_parallel_provider_matches_fd_and_takes_fast_path() {
     check_full_provider_vs_fd(&model, &subject, &theta, &eta);
 }
 
+// A 2-cpt disposition fed by a mixed first_order + zero_order absorption. This
+// is the ONLY full-provider FD check that exercises `two_cpt_zero_order_g`'s
+// gradient w.r.t. the disposition params (CL/V1/Q/V2) — the macro-rate (α/β)
+// and `v2 = q/k21` quotient under `Dual2` the parallel-2cpt test (all
+// first_order) never touches. IIV on both CL and V1 so ∂/∂η and ∂²/∂η∂θ of the
+// box-car kernel are checked, not just ∂/∂θ.
+const MR_ZERO_ORDER_2CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 5.0, 500.0)
+  theta TVQ(10.0, 0.1, 100.0)
+  theta TVV2(100.0, 5.0, 1000.0)
+  theta TVFZO(0.4, 0.05, 0.95)
+  theta TVKA(1.5, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V1 ~ 0.04
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q = TVQ
+  V2 = TVV2
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA) + FZO*zero_order(dur=DUR) - CL/V1*central - Q/V1*central + Q/V2*periph
+  d/dt(periph) = Q/V1*central - Q/V2*periph
+[scaling]
+  y = central / V1
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+#[test]
+fn mr_2cpt_zero_order_provider_matches_fd_and_takes_fast_path() {
+    let model = parse_model_string(MR_ZERO_ORDER_2CPT).expect("parse");
+    // Obs times off the TVDUR=2.0 boundary (see the 1-cpt mixed test's rationale).
+    let subject = oral_subject(&[0.5, 1.3, 2.7, 4.0, 8.0, 16.0]);
+    let theta = [5.0, 50.0, 10.0, 100.0, 0.4, 1.5, 2.0];
+    let eta = [0.1, -0.05];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_some(),
+        "expected the MR fast path to admit this static 2-cpt zero_order subject"
+    );
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
+// A per-route `lag=` on the zero_order route: the box-car onset is a MOVING
+// boundary at `t = dose + lag`, so the kernel has two `t`-dependent boundaries
+// (onset at τ=0 and window-end at τ=dur), and ∂/∂lag threads a compound
+// saltation. No other MR test lags the zero_order route (MR_MIXED_1CPT lags the
+// first_order route). Exercises ∂/∂lag of `one_cpt_zero_order_g` end-to-end.
+const MR_ZERO_ORDER_LAGGED_1CPT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVFZO(0.5, 0.05, 0.95)
+  theta TVKA(1.2, 0.05, 24.0)
+  theta TVDUR(2.0, 0.1, 12.0)
+  theta TVLAGZO(1.5, 0.001, 6.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V ~ 0.04
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  FZO = TVFZO
+  FZO1 = 1 - TVFZO
+  KA = TVKA
+  DUR = TVDUR
+  LAGZO = TVLAGZO
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = FZO1*first_order(ka=KA) + FZO*zero_order(dur=DUR, lag=LAGZO) - CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+#[test]
+fn mr_1cpt_lagged_zero_order_provider_matches_fd_and_takes_fast_path() {
+    let model = parse_model_string(MR_ZERO_ORDER_LAGGED_1CPT).expect("parse");
+    // Obs times off both moving boundaries: the window is [LAGZO, LAGZO+DUR] =
+    // [1.5, 3.5]; avoid t == 1.5 (onset) and t == 3.5 (window-end).
+    let subject = oral_subject(&[0.5, 1.1, 2.3, 3.1, 4.2, 8.0, 12.0]);
+    let theta = [5.0, 50.0, 0.5, 1.2, 2.0, 1.5];
+    let eta = [0.1, -0.05];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_some(),
+        "expected the MR fast path to admit this static lagged-zero_order subject"
+    );
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
+// Multi-dose with OVERLAPPING zero_order windows: `mr_observable_g` selects the
+// `t <= dur` box-car branch independently per dose in its superposition loop, so
+// the derivative-discontinuous branch is the one place a per-dose superposition
+// bug hides. Two doses at 0 and 1.5 with DUR=2.0 → windows [0,2] and [1.5,3.5]
+// overlap in [1.5,2.0]; obs times are placed so some see dose-A post-window while
+// dose-B is mid-window (and t=1.8 sees BOTH mid-window). Off every dur/lag edge.
+#[test]
+fn mr_1cpt_zero_order_multidose_overlapping_matches_fd() {
+    let model = parse_model_string(MR_MIXED_1CPT).expect("parse");
+    let mut subject = oral_subject(&[0.7, 1.8, 2.6, 3.2, 5.0, 9.0]);
+    // MR_MIXED_1CPT lags the first_order route (LAG=1.0) and has DUR=2.0 on the
+    // zero_order route; second dose at 1.5 overlaps the first's zero_order window.
+    subject.doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(1.5, 100.0, 1, 0.0, false, 0.0),
+    ];
+    let theta = [5.0, 50.0, 0.4, 1.5, 2.0, 1.0];
+    let eta = [0.1, -0.05];
+    assert!(
+        crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
+            .is_some(),
+        "expected the MR fast path to admit this multi-dose zero_order subject"
+    );
+    check_full_provider_vs_fd(&model, &subject, &theta, &eta);
+}
+
 /// The MR closed-form jet and the ODE-integrated jet are two different schemes
 /// computing the same "analytic" gradient for the same subject
 /// (`ode_analytical_supported` already reports this model analytic;
@@ -3158,9 +3295,16 @@ fn mr_subject_sensitivities_with_scalar_scale_matches_ode_provider() {
 }
 
 // Regression: `PerCmt` scaling is the one `ScalingSpec` variant
-// `ode_analytical_supported` declines outright (routes to FD) — `mr_scope`
-// must decline it too via the same `ode_scaling_supported` gate, not silently
-// admit it with a plain (wrong, unscaled-per-CMT) jet.
+// `ode_analytical_supported` declines outright (routes to FD) — the MR GRADIENT
+// paths must decline it too via the same `ode_scaling_supported` gate, not
+// silently admit it with a plain (wrong, unscaled-per-CMT) jet. The VALUE path
+// (`mr_predictions` / `mr_scope`) deliberately does NOT gate on scaling: it
+// returns the raw closed-form concentration, and the caller
+// (`compute_predictions_with_tv`) applies the per-CMT scale afterward — so the
+// value stays fast while the gradient falls to FD of that same scaled value.
+// This test pins that intentional value-admits / gradient-declines asymmetry so
+// it can't silently flip to "value declines" (a perf loss) or "gradient admits"
+// (a correctness bug — an unscaled jet).
 #[test]
 fn mr_subject_sensitivities_declines_percmt_scaling() {
     const MR_PERCMT_SCALE: &str = r#"
@@ -3193,10 +3337,16 @@ fn mr_subject_sensitivities_declines_percmt_scaling() {
     let subject = oral_subject(&[0.5, 1.3, 2.7]);
     let theta = [5.0, 50.0, 0.4, 1.5, 2.0];
     let eta = [0.1];
+    // Value path admits (the raw closed form; the per-CMT scale is a caller step).
+    assert!(
+        crate::pk::modified_release::mr_predictions(&model, &subject, &theta, &eta).is_some(),
+        "PerCmt scaling must NOT decline the MR value path — scaling is applied by the caller"
+    );
+    // Both gradient paths decline (→ ODE provider → FD of the scaled value).
     assert!(
         crate::pk::modified_release::mr_subject_sensitivities(&model, &subject, &theta, &eta)
             .is_none(),
-        "PerCmt scaling must decline the MR fast path, matching ode_scaling_supported"
+        "PerCmt scaling must decline the MR outer gradient, matching ode_scaling_supported"
     );
     assert!(
         crate::pk::modified_release::mr_subject_eta_grad(&model, &subject, &theta, &eta).is_none(),

--- a/src/sens/two_cpt.rs
+++ b/src/sens/two_cpt.rs
@@ -140,6 +140,46 @@ pub fn two_cpt_infusion_g<T: PkNum>(
     }
 }
 
+/// 2-cpt zero-order (box-car) absorption of duration `dur` — the closed-form
+/// modified-release counterpart of [`two_cpt_infusion_g`] with `dur` (and the
+/// rate `mass/dur`) generic over [`PkNum`], carrying `∂C/∂dur` (#860 Phase B).
+/// Same value formula as `two_cpt_infusion_g`, same `.val()`-branch convention
+/// at the `t == dur` boundary as every other kernel here; see
+/// [`one_cpt_zero_order_g`] for the rationale (only the domain of `dur` differs
+/// from the fixed-duration infusion kernel).
+#[allow(clippy::too_many_arguments)]
+pub fn two_cpt_zero_order_g<T: PkNum>(
+    amt: f64,
+    t: T,
+    cl: T,
+    v1: T,
+    q: T,
+    v2: T,
+    dur: T,
+    f_bio: T,
+) -> T {
+    if t.val() < 0.0 || v1.val() <= 0.0 || cl.val() <= 0.0 || dur.val() <= 0.0 {
+        return T::from_f64(0.0);
+    }
+    let (alpha, beta, k21) = macro_rates_g(cl, v1, q, v2);
+    let diff = alpha - beta;
+    if diff.val().abs() < 1e-12 || alpha.val().abs() < 1e-12 || beta.val().abs() < 1e-12 {
+        return T::from_f64(0.0);
+    }
+    let d = f_bio * T::from_f64(amt);
+    let r_v1 = d / (dur * v1);
+    let a_coeff = r_v1 * (alpha - k21) / (diff * alpha);
+    let b_coeff = r_v1 * (k21 - beta) / (diff * beta);
+    let one = T::from_f64(1.0);
+    if t.val() <= dur.val() {
+        a_coeff * (one - (-(alpha * t)).exp()) + b_coeff * (one - (-(beta * t)).exp())
+    } else {
+        let dt = t - dur;
+        a_coeff * (one - (-(alpha * dur)).exp()) * (-(alpha * dt)).exp()
+            + b_coeff * (one - (-(beta * dur)).exp()) * (-(beta * dt)).exp()
+    }
+}
+
 /// 2-cpt oral (first-order absorption), with `ka ≈ α`/`ka ≈ β` L'Hôpital limits.
 pub fn two_cpt_oral_g<T: PkNum>(amt: f64, t: T, cl: T, v1: T, q: T, v2: T, ka: T, f_bio: T) -> T {
     two_cpt_oral_amt_g(T::from_f64(amt), t, cl, v1, q, v2, ka, f_bio)


### PR DESCRIPTION
## Why

[#889](https://github.com/FeRx-NLME/ferx-core/pull/889) landed the **value-path** closed form
for modified-release / multi-route absorption ([#860](https://github.com/FeRx-NLME/ferx-core/issues/860)):
a static multi-route `[odes]` model with a canonical linear 1-/2-cpt disposition predicts as a
fraction-weighted superposition of shifted single-route closed forms instead of integrating the
ODE. Its "Open questions" section named two deliberate follow-ups, both landed here:

- **A6** — the FOCE/FOCEI **gradient** for these models still came from the ODE provider's
  Dual2-seeded RK45 integration, even though the value was closed-form. An analytic-default
  (non-FD) fit therefore only got half the speedup.
- **B** — a `zero_order(dur=…)` route declined the closed form outright, dropping the whole
  model back to ODE integration for value **and** gradient.

## What changed

**B — `zero_order` box-car kernel.** New generic `one_cpt_zero_order_g` / `two_cpt_zero_order_g`
(`sens/one_cpt.rs`, `sens/two_cpt.rs`) — the box-car-into-1/2-cpt convolution, `dur` generic over
`PkNum` so a `Dual2` carries `∂C/∂dur`. Same value formula as the fixed-duration infusion kernel;
only the domain of `dur` differs (a fitted parameter, not dose data). Wired into `route_conc_g` and
admitted by `is_closed_form_kind`, so a `zero_order` route now superposes in closed form.

**A6 — analytic FOCE/FOCEI gradient.** New `mr_subject_sensitivities` (outer, `Dual2<M>`) and
`mr_subject_eta_grad` (inner, `Dual1<N>`) in `pk/modified_release.rs` evaluate the existing generic
`mr_observable_g` over PK-slot duals seeded directly on `(θ, η)` — reusing the ODE provider's own
`seed_pk_dual2` / `seed_pk_dual1` — so composing the superposition's arithmetic over an
already-seeded dual **is** the chain rule; no ODE integration, no separate hand-derived gradient.
Wired into `sens/provider.rs`'s `subject_sensitivities` / `subject_eta_grad` as a fast-path *try*
ahead of the ODE provider: a pure computation swap inside the branch `ode_analytical_supported`
already reports analytic for, so `sens_supported` / `analytic_outer_gradient_available` /
`analytic_inner_grad_supported_model` are untouched (no report/reality drift, the #637 class).

**Shared scope gate.** The value path (`mr_predictions`) and both gradient paths now go through one
`mr_scope` — value and gradient can never admit a different subject set. An adversarial self-review
of A6 surfaced three holes, each *outside* the reduction-to-ODE test shape (so CI-green would not
have caught them), all fixed by routing through the ODE provider's own shared predicate rather than
a second copy, plus a regression test:
- missing `ScalarScale` / LTBS output transform → now applies the shared `apply_output_transform`;
- `PerCmt` scaling silently admitted → now declines via the shared `ode_scaling_supported`;
- an SDE (`[diffusion]`) drift is linear so the disposition probe is blind to it → explicit
  `diffusion_var` decline, mirroring `ode_analytical_supported`.

## Alternatives considered

- **A new analytic-scope predicate for MR gradients** — rejected. MR models are already reported
  analytic by `ode_analytical_supported`; A6 only changes *which computation* runs once a subject
  is inside that branch. Adding a predicate would risk the report-says-analytic / every-subject-FDs
  drift the codebase repeatedly guards against.
- **Second scope check for the gradient path** — rejected in favour of the shared `mr_scope`; two
  independently-maintained gates that disagree is exactly the silent value/gradient divergence the
  reduction tests exist to catch.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Internal only — every new symbol is `pub(crate)`, no public Rust API change.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: the **ODE-integrated analytic provider** (directly, tighter than FD) and
  **NONMEM** (transitively, via the unchanged `$DES` anchor).
- The closed-form outer jet matches `ode_subject_sensitivities` to solver tolerance and central FD
  of `compute_predictions_with_tv`, for 1-cpt (mixed `first_order`-lagged + `zero_order`) and 2-cpt
  (parallel `first_order`) — the 2-cpt case exercises the `v = 1/m` reciprocal and `v2 = q/k21`
  quotient under `Dual2`. Inner `Dual1` η-gradient matches `ode_subject_eta_grad`.
- `zero_order` reduces to its integrated `[odes]` twin (1-cpt and 2-cpt), and its `∂/∂dur` matches
  central FD near the moving `t = dur` boundary.
- `per_route_lag` NONMEM `ADVAN13 $DES` anchor (`#OBJV −882.357`) unchanged — value was already
  closed-form; the gradient-scheme change does not move the optimum.

## Performance
- [x] Faster — an analytic-default FOCE/FOCEI fit on a static multi-route model now skips the ODE
  integration for the **gradient** as well as the value (A6); a `zero_order` route now takes the
  closed-form value/gradient path at all instead of integrating (B). No headline benchmark number;
  the win scales with observation grid × dose count.

## Tests
- [x] Unit tests added (`cargo test --lib` passes, 2625): `zero_order` bit-reduction to the
  infusion kernel, boundary `∂/∂dur` Dual2-vs-FD, `zero_order` reduction-to-ODE (1-/2-cpt); MR outer
  and inner analytic-vs-FD and analytic-vs-ODE-provider parity; `ScalarScale` composition parity,
  `PerCmt` decline, SDE decline.
- [x] Regression tests that fail without the fixes (the three self-review holes).

## Example (user-facing features only)
- [x] Not applicable — a transparent acceleration of existing `#505` / `#856` / `#860` model shapes;
  the `parallel` / `mixed` / `per_route_lag` example models already ship.

## Docs
- [x] `docs/model-file/absorption.qmd` — `zero_order` added to the closed-form set; note that the
  analytic-sensitivity gradient is now closed-form too.
- [x] `CHANGELOG.md` `[Unreleased]` → Performance (two entries: A6, B).

## Checklist
- [x] `cargo clippy` clean
- [x] `Dual2` path stays differentiable — the new kernels and gradient functions are generic
  `*_g<T: PkNum>`, exercised at `T = Dual2` / `Dual1` by the parity tests.
- [x] no version bump (non-breaking)

## Reviewer hints
Focus on: (1) the shared `mr_scope` — is any admit/decline condition present in the value path but
missing from what the gradient path needs, or vice versa? (2) `apply_output_transform` reuse — it is
basis-agnostic (PK-space vs `(θ,η)`-space dual), relied on here for the `(θ,η)`-seeded MR jet;
(3) the three self-review fixes and their tests. The `zero_order` kernels are value-identical to the
already-anchored infusion kernels, so the risk there is only the `∂/∂dur` boundary convention
(tested).

## Open questions
After A6 + B, the closed form covers every `first_order` / `transit` / `igd` / `zero_order` pathway
combination by superposition; `weibull` has no elementary closed form and stays on the ODE path by
design. I've marked this `closes #860` on that basis — shout if you'd rather keep it open for
anything I've missed.
