### PR TITLE
feat(estimation): SAEM reports OFV before covariance step [closes #893]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ section of the SDLC for the versioning policy).
   Predictions are unchanged.
 
 ### Changed
+- **SAEM prints its final OFV before the covariance step** (#893). In a verbose run
+  (the CLI default), the `SAEM completed. Final OFV = …` line is now emitted *before*
+  the covariance matrix is computed rather than after, so you can judge the fit and
+  interrupt (Ctrl-C) before paying for the — often expensive — covariance step when the
+  OFV already rules the run out.
 - **`method = agq` removed; adaptive quadrature is now an *argument*, not a method**
   (#251). Adaptive Gauss–Hermite quadrature is not a separate estimator — it is the
   single-point method (Laplace / FOCEI) evaluated on more nodes. So the **method name now

--- a/docs/estimation/saem.qmd
+++ b/docs/estimation/saem.qmd
@@ -340,7 +340,14 @@ SAEM: 10 subjects, 3 ETAs, 400 total iter (150 explore + 250 converge)
   SAEM iter  400/400 [converge] γ=0.004  condNLL=38.096
 SAEM iterations complete. Computing final EBEs and OFV...
 SAEM completed. Final OFV = ...
+Running covariance step...
 ```
+
+The `Final OFV = ...` line is printed **before** the covariance step starts (#893).
+SAEM only learns its OFV at the very end (the final FOCE approximation), and the
+covariance matrix is often the most expensive part of the run — so seeing the OFV
+first lets you interrupt (Ctrl-C) when the OFV already rules the run out, instead of
+waiting for a covariance matrix you won't use.
 
 ### Why `γ` (gamma) is shown
 

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1224,6 +1224,16 @@ fn saem_state_to_params(
 // Main SAEM loop
 // ---------------------------------------------------------------------------
 
+/// Progress line printed once SAEM's final OFV is known, *before* the covariance
+/// step runs (#893). SAEM learns its OFV only at the very end (the final FOCE
+/// approximation), and the covariance step is often the most expensive part of
+/// the run, so reporting the OFV first lets a CLI user interrupt (Ctrl-C) on a
+/// bad OFV before paying for the covariance matrix. Kept as a pure function so
+/// the message is unit-testable.
+fn saem_final_ofv_report(ofv: f64) -> String {
+    format!("SAEM completed. Final OFV = {:.4}", ofv)
+}
+
 pub fn run_saem(
     model: &CompiledModel,
     population: &Population,
@@ -2241,6 +2251,15 @@ pub fn run_saem(
             options.interaction,
         );
 
+    // ---- Report OFV *before* the covariance step (#893) ----
+    // SAEM only learns its OFV here (the final FOCE approximation); the covariance
+    // step that follows can be the most expensive part of the run. Print the OFV
+    // first so a CLI user can judge the fit and interrupt (Ctrl-C) before paying
+    // for the covariance matrix when the OFV already rules the run out.
+    if verbose {
+        eprintln!("{}", saem_final_ofv_report(ofv));
+    }
+
     // ---- Covariance step ----
     let packed = pack_params(&final_params);
     let out = crate::estimation::covariance::run_covariance_step(
@@ -2261,10 +2280,6 @@ pub fn run_saem(
         sir_fallback_proposal,
     } = out;
     warnings.extend(cov_warnings);
-
-    if verbose {
-        eprintln!("SAEM completed. Final OFV = {:.4}", ofv);
-    }
 
     let saem_mu_ref_m_step_evals_saved = if use_closed_form_mstep {
         Some(mstep_grad_step_evals_saved)
@@ -2335,6 +2350,20 @@ mod tests {
     use super::*;
     use crate::types::test_helpers::analytical_model;
     use crate::types::{GradientMethod, MuRef};
+
+    #[test]
+    fn saem_final_ofv_report_formats_ofv_to_four_decimals() {
+        // #893: the pre-covariance progress line reports the OFV to 4 dp so a
+        // CLI user can judge the fit before the covariance step runs.
+        assert_eq!(
+            saem_final_ofv_report(1234.56789),
+            "SAEM completed. Final OFV = 1234.5679"
+        );
+        assert_eq!(
+            saem_final_ofv_report(-42.0),
+            "SAEM completed. Final OFV = -42.0000"
+        );
+    }
 
     #[test]
     fn fold_nll_grad_sums_nll_and_grad_elementwise_in_input_order() {


### PR DESCRIPTION
## Why

Closes #893. In an SAEM run the OFV is only known at the very end (the final
FOCE approximation), and the covariance step that follows is often the most
expensive part of the run. Previously the `SAEM completed. Final OFV = ...`
line was printed *after* `run_covariance_step` returned, so from the CLI a user
paid for the full covariance matrix before ever seeing the OFV — even when a
bad OFV already ruled the fit out.

## What changed

Moved the OFV report to **before** the covariance step in `run_saem`. Verbose
is on by default for CLI runs, so the sequence is now:

```
SAEM iterations complete. Computing final EBEs and OFV...
SAEM completed. Final OFV = -286.0038
Running covariance step...
```

The user can now judge the OFV and interrupt (Ctrl-C) before the covariance
matrix is computed. No numerical behaviour changes — this is purely the
ordering of two stderr progress lines. Extracted the message into a pure
`saem_final_ofv_report(ofv)` helper so the format is unit-testable.

## Alternatives considered

Wiring a Ctrl-C signal handler into the CLI that sets the cooperative
`CancelFlag` (so covariance aborts gracefully and the fit still returns without
SEs). The covariance step already honours the cancel flag, but the CLI has no
signal handler. Left out of scope: the issue asks to *show* the OFV first; the
"cancel" is Ctrl-C, and a bad-OFV run is discarded anyway. Can follow up if
graceful cancel (keeping the fit) is wanted.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (progress-line ordering only; OFV value and all estimates unchanged)

Verified end-to-end via `ferx examples/warfarin_saem.ferx --data data/warfarin.csv`:
`Final OFV = -286.0038` now prints on the line before `Running covariance step...`.

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test added (`saem_final_ofv_report_formats_ofv_to_four_decimals`, `cargo test --lib` passes)

## Docs
- [x] `docs/estimation/saem.qmd` updated (output sequence + note on the new ordering)
- [x] `CHANGELOG.md` `[Unreleased]` entry added under Changed

## Checklist
- [x] `cargo clippy` clean (no new warnings from this change)

## Reviewer hints

The whole change is the ~10-line reorder in `src/estimation/saem.rs` around the
`// ---- Covariance step ----` block, plus the extracted helper and its test.
