### PR TITLE
feat(pk): dose any compartment on the analytical engine; superposition and event-driven paths agree [closes #375]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,25 @@ section of the SDLC for the versioning policy).
   is forgiving of a loose mode).
 
 ### Fixed
+- **An infusion into a compartment the analytical model cannot deliver into is now an error,
+  not a crash** (#375). A positive `RATE` into a compartment outside the model's infusable set
+  — most commonly an oral model's peripheral (`CMT=3` on `two_cpt_oral`) — used to abort the
+  process from deep inside the event-driven prediction walk whenever the subject also had a
+  time-varying covariate, an `EVID=3/4` reset, or IOV. Nothing validated a *fixed* `RATE`
+  against the model's topology: the data reader has no model, and the parse-time check only
+  fires for a declared `D{cmt}`/`R{cmt}`. Such doses are now rejected up front, naming the
+  subject, time, and the compartments the model *can* infuse — `fit()` returns an error, and
+  `predict()`/`simulate()` fail with the same message, matching every other dose precondition.
+  An out-of-range dose compartment (`CMT` past the end of the model's compartment list) is
+  rejected the same way. This also removes a silent disagreement between the three analytical
+  paths on the same dataset: the dose-superposition path used to route the infusion into the
+  central compartment regardless of `CMT`, and the gradient (sensitivity) walk used to drop it
+  entirely — so a fit could have differentiated a different dosing history than it predicted.
+  Two behaviour changes worth noting: an infusion with `CMT=0` is now rejected (there is no
+  "default compartment" for an infusion — it previously mis-routed to central or panicked,
+  depending on the path), while a **bolus** with `CMT=0` is unchanged, since both analytical
+  paths already agree it means NONMEM's default dose compartment. Boluses into an existing but
+  non-infusable compartment (e.g. a peripheral) are unaffected.
 - **Analytic FOCEI sensitivities for IIV on an absorption lag feeding a `first_order` forcing**
   (#880). Fixes to the rate-on onset of a built-in `first_order` (Bateman) input-rate forcing
   whose arrival is a moving boundary — a compartment lagtime (`ALAG1`/`LAGTIME`) **or** a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,37 @@ section of the SDLC for the versioning policy).
   negligible cost near the optimum. FOCE/FOCEI are unchanged (their Gauss-Newton `log|H̃|`
   is forgiving of a loose mode).
 
+### Added
+- **Infusion into an oral model's peripheral compartment on the analytical engine** (#375).
+  `two_cpt_oral` (`CMT=3`) and `three_cpt_oral` (`CMT=3`/`CMT=4`) previously rejected a
+  positive `RATE` — and, before that, crashed on one — because the oral closed-form
+  propagators had no peripheral forcing term where the IV ones did. They need no new closed
+  form: nothing flows back into the depot, so a rate into a peripheral drives exactly the
+  central/peripheral sub-system the IV model has, and the oral propagator superposes that
+  same forced response onto its own homogeneous evolution. Combined with the bolus change
+  below, **every compartment of every analytical model now accepts both a bolus and an
+  infusion**, alone or together. Validated against NONMEM 7.6.0 `ADVAN4`/`ADVAN12` and —
+  more tightly than NONMEM can express, since its own forced response carries ~2e-6 here —
+  against a `1e-12` integration of the same system written out as explicit `[odes]`, which
+  agrees to ~1e-11 (`tests/oral_peripheral_infusion.rs`), including a peripheral infusion
+  overlapping an oral depot dose.
+
 ### Fixed
+- **A dose into a non-default compartment is now computed in that compartment on the
+  analytical engine** (#375). The closed-form dose-superposition path never read the dose's
+  `CMT`: it chose the formula from the *model*, so it placed every bolus in compartment 1
+  (the depot of an oral model, central of an IV one) and every infusion into central,
+  whatever the data said. A bolus into an IV model's peripheral, or into an oral model's
+  central compartment (an IV loading dose against an oral maintenance model), was therefore
+  computed in the wrong compartment — silently, with a finite OFV and no warning, and
+  disagreeing with NONMEM by up to two orders of magnitude on a 3-compartment model. Which
+  answer you got depended only on whether the subject happened to carry a time-varying
+  covariate, an `EVID=3/4` reset, or IOV, since those route to the event-driven walk, which
+  places doses correctly. Such doses now route to that walk on every dataset, so both paths
+  agree and both match NONMEM. Validated against NONMEM 7.6.0 `ADVAN1/2/3/4/11/12`
+  (`tests/nonmem_dose_compartment_anchor.rs`). Per-compartment amounts in
+  sdtab / `[derived]` are reported as `NaN` for these subjects rather than wrong, with the
+  existing warning extended to explain why; predictions are exact.
 - **A steady-state dose with `CMT=0` no longer loses its accumulation on the analytical
   event-driven path** (#375). `CMT=0` is NONMEM's "default dose compartment", and every dose
   site resolves it to the model's first compartment — except the event-driven walk's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,14 +109,42 @@ section of the SDLC for the versioning policy).
   form: nothing flows back into the depot, so a rate into a peripheral drives exactly the
   central/peripheral sub-system the IV model has, and the oral propagator superposes that
   same forced response onto its own homogeneous evolution. Combined with the bolus change
-  below, **every compartment of every analytical model now accepts both a bolus and an
-  infusion**, alone or together. Validated against NONMEM 7.6.0 `ADVAN4`/`ADVAN12` and —
+  below, **every compartment of the six analytical disposition models now accepts both a
+  bolus and an infusion**, alone or together. (The transit and inverse-Gaussian absorption
+  models are unchanged — they are dosed through the depot, `CMT=1`, only.) Validated
+  against NONMEM 7.6.0 `ADVAN4`/`ADVAN12` and —
   more tightly than NONMEM can express, since its own forced response carries ~2e-6 here —
   against a `1e-12` integration of the same system written out as explicit `[odes]`, which
   agrees to ~1e-11 (`tests/oral_peripheral_infusion.rs`), including a peripheral infusion
   overlapping an oral depot dose.
 
 ### Fixed
+- **An analytic `[scaling]` readout that references the oral `depot` is rejected when the
+  data dose a non-default compartment, instead of silently corrupting the objective**
+  (#375). The depot amount behind a Form C readout is reconstructed by dose superposition,
+  which never reads the dose's `CMT` — so a bolus written `CMT=2` on a `one_cpt_oral` model
+  was reconstructed as if it had been absorbed through the depot, adding a phantom depot
+  amount to `PRED` and therefore to the OFV. Measured on `y = (central + depot)/V`: OFV
+  188.37 where an explicit `[odes]` twin of the same model gives 1761.47 (the same model
+  with the dose at `CMT=1` agrees with the twin exactly). This joins the existing
+  reset-based rejection in `check_analytic_readout_support`, with the same remedy —
+  reference only `central`, or use an `ode(...)` model.
+- **A `[derived]` integral over `compartments[i]` no longer returns a wrong finite value
+  for a subject dosing a non-default compartment** (#375). The per-observation compartment
+  columns correctly degrade to `NaN` for those subjects, and the emitted warning says so —
+  but the separate dense-grid reconstruction used by `integral(...)` still used the older,
+  narrower predicate and fell through to the compartment-blind superposition helper. In the
+  same sdtab row, `compartments[1]` read `NaN` while `integral(compartments[1], 0→24)` read
+  19.17 against a true 31.13. Both paths now use the same predicate.
+- **A zero-amount dose with an out-of-range `CMT` is rejected instead of aborting the
+  process** (#375). The dose-compartment check skipped `AMT=0` rows entirely, on the
+  reasoning that a zero bolus is a no-op — but both prediction walks bound-check the
+  compartment *before* the amount is read, so such a row still panicked. It is reachable
+  from ordinary NONMEM data: an `EVID=4` reset row written with `AMT=0` and a stale `CMT`.
+  `ferx check` reported the dataset clean and `fit()` then aborted. The range rule now
+  applies to every dose regardless of amount; the zero-amount exemption is kept only for the
+  infusion routing rule, where `duration = AMT/RATE = 0` genuinely means nothing is
+  delivered.
 - **A dose into a non-default compartment is now computed in that compartment on the
   analytical engine** (#375). The closed-form dose-superposition path never read the dose's
   `CMT`: it chose the formula from the *model*, so it placed every bolus in compartment 1
@@ -140,13 +168,15 @@ section of the SDLC for the versioning policy).
   *single-dose* curve instead of the accumulated steady state whenever the subject took that
   path (a time-varying covariate, an `EVID=3/4` reset, or IOV), while the same dataset without
   those features returned the correct steady state from the superposition path — a silent
-  ~43 % under-prediction on a one-compartment example, with no warning. Both the value walk and
+  ~30 % under-prediction on a one-compartment example, with no warning. Both the value walk and
   the gradient walk now equilibrate the default compartment like any other, matching the
   closed form `(D/V)·e^{−kt}/(1−e^{−k·II})`. Predictions change only for `SS` doses written
-  with `CMT=0`; every other dataset is bit-identical.
+  with `CMT=0`. Note the ODE engine still bails on `SS` with `CMT=0`, so an analytical model
+  and its explicit `[odes]` twin currently disagree on that combination.
 - **An infusion into a compartment the analytical model cannot deliver into is now an error,
   not a crash** (#375). A positive `RATE` into a compartment outside the model's infusable set
-  — most commonly an oral model's peripheral (`CMT=3` on `two_cpt_oral`) — used to abort the
+  — an oral model's peripheral (`CMT=3` on `two_cpt_oral`), which the `Added` entry above now
+  makes work, or a `CMT` the model does not have at all — used to abort the
   process from deep inside the event-driven prediction walk whenever the subject also had a
   time-varying covariate, an `EVID=3/4` reset, or IOV. Nothing validated a *fixed* `RATE`
   against the model's topology: the data reader has no model, and the parse-time check only
@@ -158,11 +188,13 @@ section of the SDLC for the versioning policy).
   paths on the same dataset: the dose-superposition path used to route the infusion into the
   central compartment regardless of `CMT`, and the gradient (sensitivity) walk used to drop it
   entirely — so a fit could have differentiated a different dosing history than it predicted.
-  Two behaviour changes worth noting: an infusion with `CMT=0` is now rejected (there is no
-  "default compartment" for an infusion — it previously mis-routed to central or panicked,
-  depending on the path), while a **bolus** with `CMT=0` is unchanged, since both analytical
-  paths already agree it means NONMEM's default dose compartment. Boluses into an existing but
-  non-infusable compartment (e.g. a peripheral) are unaffected.
+  One behaviour change worth calling out: an infusion with `CMT=0` is now **rejected**. On an
+  IV model that previously fitted, since superposition delivers into central, which is what
+  `CMT=0` means — so this is a deliberate tightening, not a bug fix: `CMT=0` is NONMEM's
+  *default dose compartment*, well defined for a bolus but not for a zero-order input, and
+  leaving it implicit hid which compartment was being infused. Write the compartment
+  explicitly. A **bolus** with `CMT=0` is unchanged (every path agrees it means compartment 1),
+  as is `SS` with `CMT=0` after the fix above.
 - **Analytic FOCEI sensitivities for IIV on an absorption lag feeding a `first_order` forcing**
   (#880). Fixes to the rate-on onset of a built-in `first_order` (Bateman) input-rate forcing
   whose arrival is a moving boundary — a compartment lagtime (`ALAG1`/`LAGTIME`) **or** a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@ section of the SDLC for the versioning policy).
   is forgiving of a loose mode).
 
 ### Fixed
+- **A steady-state dose with `CMT=0` no longer loses its accumulation on the analytical
+  event-driven path** (#375). `CMT=0` is NONMEM's "default dose compartment", and every dose
+  site resolves it to the model's first compartment — except the event-driven walk's
+  steady-state equilibration, which bailed out early on `CMT=0` and returned an unequilibrated
+  (all-zero) starting state. An `SS=1` dose written with `CMT=0` therefore produced the
+  *single-dose* curve instead of the accumulated steady state whenever the subject took that
+  path (a time-varying covariate, an `EVID=3/4` reset, or IOV), while the same dataset without
+  those features returned the correct steady state from the superposition path — a silent
+  ~43 % under-prediction on a one-compartment example, with no warning. Both the value walk and
+  the gradient walk now equilibrate the default compartment like any other, matching the
+  closed form `(D/V)·e^{−kt}/(1−e^{−k·II})`. Predictions change only for `SS` doses written
+  with `CMT=0`; every other dataset is bit-identical.
 - **An infusion into a compartment the analytical model cannot deliver into is now an error,
   not a crash** (#375). A positive `RATE` into a compartment outside the model's infusable set
   — most commonly an oral model's peripheral (`CMT=3` on `two_cpt_oral`) — used to abort the

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -137,7 +137,9 @@ The analytic `Dual2` gradient path is event-driven for all analytical models; ti
 Infusion routing on the event-driven path:
 
 - **IV models**: central infusion (cmt=1) for all 1/2/3-cpt; **peripheral infusion** for 2-cpt (cmt=2) and 3-cpt (cmt=2 → periph1, cmt=3 → periph2). Steady-state amounts per channel are computed by linear superposition over the channels.
-- **Oral models**: central infusion (cmt=2) is supported; peripheral infusion is rare clinically and still panics with a clear message (tracked as a follow-up).
+- **Oral models**: depot infusion (cmt=1, a zero-order release then first-order `KA` absorption), central infusion (cmt=2, depot-bypassing), and — since #375 — **peripheral infusion** (cmt=3 on `two_cpt_oral`; cmt=3 → periph1, cmt=4 → periph2 on `three_cpt_oral`). The oral propagators reuse the IV forced response: nothing flows back into the depot, so a rate into a peripheral drives exactly the central/peripheral sub-system the IV model has.
+
+Every compartment of the six analytical disposition models is therefore infusable. What is still rejected is `CMT=0` on an infusion (NONMEM's *default dose compartment* is defined for a bolus, not for a zero-order input — name the compartment explicitly) and any `CMT` past the end of the model's state vector. Transit and inverse-Gaussian absorption models are dosed through the depot (`CMT=1`) only.
 
 ## Event Types (EVID)
 
@@ -322,8 +324,9 @@ is a depot-bypassing infusion straight into central. Both stay on the closed-for
 analytical engine — no `ode(...)` block needed. (Compartment amounts in
 `sdtab`/`[derived]` are not available for analytical depot-zero-order subjects;
 the predictions themselves are exact — use an `ode(...)` model if you need the
-per-compartment amounts.) Infusion into an oral **peripheral** compartment is
-still unsupported and needs an `ode(...)` model.
+per-compartment amounts.) `D3` on a `two_cpt_oral` model (and `D3`/`D4` on
+`three_cpt_oral`) infuses a **peripheral** compartment, also on the closed-form
+engine since #375.
 
 `RATE = -1` makes the infusion **rate** a model parameter: declare an individual
 parameter `R{cmt}` (`R1` for a dose into compartment 1, etc.) and ferx infuses

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -373,10 +373,11 @@ misread the coded forms as a bolus (#324).
 ### Which compartments can an analytical model be infused into?
 
 On the analytical `pk(...)` engine the closed forms can deliver a zero-order
-input into the **central** compartment of every model, the **oral depot**
-(`CMT=1`, a zero-order release followed by first-order `ka` absorption), and the
-**peripheral** compartment(s) of the 2- and 3-compartment IV models. An oral
-model's peripherals have no closed form and are not infusable.
+input into **any compartment the model has**: the **central** compartment of
+every model, the **oral depot** (`CMT=1`, a zero-order release followed by
+first-order `ka` absorption), and the **peripheral** compartment(s) of both the
+IV and the oral models. A **bolus** likewise targets any compartment the model
+has.
 
 An infusion into any other compartment is rejected up front with
 `E_DOSE_CMT_NOT_INFUSABLE`, naming the subject, time, and the compartments the

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -370,6 +370,26 @@ Both codes are *parameter*-driven; neither reads a separate `DURATION` data colu
 Any other negative or non-finite `RATE` is rejected — earlier versions silently
 misread the coded forms as a bolus (#324).
 
+### Which compartments can an analytical model be infused into?
+
+On the analytical `pk(...)` engine the closed forms can deliver a zero-order
+input into the **central** compartment of every model, the **oral depot**
+(`CMT=1`, a zero-order release followed by first-order `ka` absorption), and the
+**peripheral** compartment(s) of the 2- and 3-compartment IV models. An oral
+model's peripherals have no closed form and are not infusable.
+
+An infusion into any other compartment is rejected up front with
+`E_DOSE_CMT_NOT_INFUSABLE`, naming the subject, time, and the compartments the
+model *can* infuse; a dose whose `CMT` is past the end of the model's
+compartment list is rejected with `E_DOSE_CMT_OUT_OF_RANGE` (#375). `fit()`
+returns the error; `predict()` / `simulate()` fail with the same message. Use an
+`ode(...)` model if you need a zero-order input into a compartment the closed
+forms cannot reach — ODE models address any compartment their `[odes]` block
+declares, so neither check applies to them.
+
+Note that this is about *infusions* only. A **bolus** may target any
+compartment the model actually has, infusable or not.
+
 For bioavailability `F ≠ 1`, ferx reshapes an infusion the NONMEM way (#419): a
 *rate-defined* infusion (`RATE>0` data and `RATE=-1` → `R{cmt}`) holds the rate and
 scales the **duration** to `F·AMT/RATE`, while a *duration-defined* infusion

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -372,24 +372,32 @@ misread the coded forms as a bolus (#324).
 
 ### Which compartments can an analytical model be infused into?
 
-On the analytical `pk(...)` engine the closed forms can deliver a zero-order
-input into **any compartment the model has**: the **central** compartment of
-every model, the **oral depot** (`CMT=1`, a zero-order release followed by
-first-order `ka` absorption), and the **peripheral** compartment(s) of both the
-IV and the oral models. A **bolus** likewise targets any compartment the model
-has.
+On the six analytical **disposition** models — `one_cpt_iv`, `one_cpt_oral`,
+`two_cpt_iv`, `two_cpt_oral`, `three_cpt_iv`, `three_cpt_oral` — the closed
+forms deliver a zero-order input into **any compartment the model has**: the
+**central** compartment of every model, the **oral depot** (`CMT=1`, a
+zero-order release followed by first-order `ka` absorption), and the
+**peripheral** compartment(s) of both the IV and the oral models. A **bolus**
+likewise targets any compartment those models have.
 
-An infusion into any other compartment is rejected up front with
-`E_DOSE_CMT_NOT_INFUSABLE`, naming the subject, time, and the compartments the
-model *can* infuse; a dose whose `CMT` is past the end of the model's
-compartment list is rejected with `E_DOSE_CMT_OUT_OF_RANGE` (#375). `fit()`
-returns the error; `predict()` / `simulate()` fail with the same message. Use an
-`ode(...)` model if you need a zero-order input into a compartment the closed
-forms cannot reach — ODE models address any compartment their `[odes]` block
+Two cases are still rejected, both up front, naming the subject and time:
+
+- `CMT=0` on an **infusion** → `E_DOSE_CMT_NOT_INFUSABLE`. `CMT=0` is NONMEM's
+  *default dose compartment*, which is defined for a bolus (and treated as
+  compartment 1 throughout ferx, including under `SS`) but has no meaning for a
+  zero-order input. Name the target compartment explicitly.
+- A `CMT` past the end of the model's compartment list, for **either** dose kind
+  → `E_DOSE_CMT_OUT_OF_RANGE` (#375).
+
+`fit()` returns the error; `predict()` / `simulate()` fail with the same message.
+
+The **transit** and **inverse-Gaussian** absorption models are the exception:
+they are dosed through the depot (`CMT=1`) only, for either dose kind, because
+the closed form routes every dose through the absorption process regardless of
+compartment while their ODE twin would bolus it into a disposition compartment —
+so the two paths would disagree. Use an `ode(...)` model to dose those
+compartments directly; ODE models address any compartment their `[odes]` block
 declares, so neither check applies to them.
-
-Note that this is about *infusions* only. A **bolus** may target any
-compartment the model actually has, infusable or not.
 
 For bioavailability `F ≠ 1`, ferx reshapes an infusion the NONMEM way (#419): a
 *rate-defined* infusion (`RATE>0` data and `RATE=-1` → `R{cmt}`) holds the rate and

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -317,10 +317,12 @@ absorption** model: drug is released into the depot at a constant rate over the
 modeled duration, then absorbed first-order into central via `KA`. This stays on
 the closed-form engine — no `ode(...)` block needed. (Per-compartment amounts in
 `sdtab`/`[derived]` are not available for those subjects — the predictions are
-exact; use an `ode(...)` model if you need the compartment amounts.) Infusing
-into an oral **peripheral** compartment is still not modelled by the closed forms,
-so a `D{periph}` (or any other non-infusable compartment) is **rejected at parse
-time** — use an `ode(...)` model.
+exact; use an `ode(...)` model if you need the compartment amounts.) Since #375
+the closed forms also infuse an oral **peripheral** compartment, so `D3` on
+`two_cpt_oral` (and `D3`/`D4` on `three_cpt_oral`) is accepted. A `D{cmt}` naming
+a compartment the model does not have — or any `D{cmt}` on a transit /
+inverse-Gaussian absorption model — is still **rejected at parse time**; use an
+`ode(...)` model for those.
 
 > One subtlety: when a subject has any modeled-`RATE` dose (`RATE=-2` or `-1`) on
 > an **analytical** model, that subject's inner-loop gradient falls back to finite

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -337,6 +337,10 @@ where
     // the model is an analytic absorption closed form, which this ODE-only path rejects
     // up front — but is wired for parity and #702 base-regimen support.)
     first_error(&check_modeled_dose_rates(model, population))?;
+    // Parity-only today, like `check_absorption_closed_form_support` above: this
+    // path is ODE-only and `check_dose_compartments` is a no-op for ODE models.
+    // Wired so the chokepoint keeps one uniform contract if an analytical model
+    // ever reaches it (#375).
     first_error(&check_dose_compartments(model, population))?;
     if let Some(msg) = check_absorption_closed_form_support(model, population) {
         return Err(msg);

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -337,6 +337,7 @@ where
     // the model is an analytic absorption closed form, which this ODE-only path rejects
     // up front — but is wired for parity and #702 base-regimen support.)
     first_error(&check_modeled_dose_rates(model, population))?;
+    first_error(&check_dose_compartments(model, population))?;
     if let Some(msg) = check_absorption_closed_form_support(model, population) {
         return Err(msg);
     }

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1600,24 +1600,27 @@ fn fit_inner(
                     .to_string(),
             );
         }
-        // Analytical oral model with a zero-order input into the depot (#400):
-        // the superposition state helper models an oral infusion as a depot
-        // bypass, so it cannot express a depot zero-order input. ipred is exact
-        // (event-driven path), but per-obs compartment states return empty (→ NaN)
-        // rather than report silently-wrong amounts.
+        // Analytical model with a dose into a compartment the superposition state
+        // helper cannot express — a zero-order input into the oral depot (#400),
+        // or any bolus outside compartment 1 / infusion outside central (#375).
+        // ipred is exact (those subjects reroute to the event-driven walk), but
+        // per-obs compartment states return empty (→ NaN) rather than report
+        // silently-wrong amounts.
         if model.ode_spec.is_none()
             && population
                 .subjects
                 .iter()
-                .any(|s| crate::pk::has_oral_depot_infusion(model.pk_model, s))
+                .any(|s| crate::pk::dose_needs_event_walk(model.pk_model, s))
         {
             warnings.push(
-                "W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL: analytical oral model \
-                 with a zero-order input into the depot (RATE=-2 D1 / infusion into \
-                 compartment 1) — compartment states are not available for those \
-                 subjects (predictions are exact); [derived] expressions that \
+                "W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL: analytical model with a \
+                 dose the closed-form superposition cannot place — a zero-order input \
+                 into the oral depot (RATE=-2 D1 / infusion into compartment 1), or a \
+                 bolus into a compartment other than 1, or an infusion into a \
+                 non-central compartment — compartment states are not available for \
+                 those subjects (predictions are exact); [derived] expressions that \
                  reference compartments[i] evaluate to NaN for them. Use an ODE model \
-                 if depot/central compartment amounts are required."
+                 if per-compartment amounts are required."
                     .to_string(),
             );
         }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -14,10 +14,10 @@ mod validation;
 pub(crate) use validation::{
     apply_iov_occasion_rule, assert_absorption_closed_form_support,
     assert_absorption_dosing_supported, assert_absorption_flip_flop_no_twin,
-    assert_analytic_readout_support, assert_modeled_doses_supported,
-    check_absorption_closed_form_support, check_absorption_dosing,
+    assert_analytic_readout_support, assert_dose_compartments_supported,
+    assert_modeled_doses_supported, check_absorption_closed_form_support, check_absorption_dosing,
     check_absorption_flip_flop_no_twin, check_analytic_readout_support, check_covariates,
-    check_modeled_dose_rates,
+    check_dose_compartments, check_modeled_dose_rates,
 };
 #[cfg(feature = "survival")]
 pub(crate) use validation::{
@@ -160,6 +160,10 @@ mod build_indiv_map_tests;
 #[cfg(test)]
 #[path = "tests/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "tests/dose_compartment_tests.rs"]
+mod dose_compartment_tests;
 
 // ======================================================================
 // Adaptive (state-reactive / feedback) dosing — epic #391, beta.

--- a/src/api/output_columns.rs
+++ b/src/api/output_columns.rs
@@ -640,14 +640,23 @@ pub(crate) fn compute_extra_output_columns(
                                 // so every grid point evaluates to NaN, consistent with
                                 // W_DERIVED_CMT_TV_ANALYTICAL warning.
                                 vec![]
-                            } else if crate::pk::has_oral_depot_infusion(model.pk_model, subject) {
-                                // Analytical oral model + zero-order input into the depot
-                                // (#400): the superposition state helper models an oral
-                                // infusion as a depot bypass and cannot express a depot
-                                // zero-order input, so it would return silently-wrong finite
-                                // amounts. Return empty so every grid point evaluates to NaN,
-                                // matching the per-obs path in compute_predictions_with_states
-                                // and the W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL warning.
+                            } else if crate::pk::dose_needs_event_walk(model.pk_model, subject) {
+                                // Analytical model + a dose the superposition state helper
+                                // cannot place: a zero-order input into the oral depot
+                                // (#400), any bolus outside compartment 1, or any infusion
+                                // outside central (#375). `single_dose_states` never reads
+                                // `dose.cmt` — it picks the closed form from the *model* —
+                                // so it would return silently-wrong finite amounts (measured
+                                // 38% low on a `two_cpt_iv` peripheral-bolus AUC against a
+                                // 1e-12 ODE twin). Return empty so every grid point evaluates
+                                // to NaN, matching the per-obs path in
+                                // compute_predictions_with_states and the
+                                // W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL warning, which
+                                // promises exactly that. Must stay the *same* predicate as
+                                // the per-obs path: when this branch used the narrower
+                                // `has_oral_depot_infusion` the two disagreed, and a
+                                // `[derived]` grid integral returned a confident wrong number
+                                // while the adjacent per-obs column was NaN.
                                 vec![]
                             } else {
                                 // Time-independent params: one snapshot (t=0) is exact

--- a/src/api/predict.rs
+++ b/src/api/predict.rs
@@ -50,6 +50,10 @@ pub fn predict(
     // model-aware dose precondition so a modeled-`RATE` dose can't reach the
     // predictor unresolved (silent-wrong analytical / `.expect` panic). #324.
     assert_modeled_doses_supported(model, population);
+    // …and that every dose names a compartment the analytical engine can route
+    // it into, so an unroutable infusion errors here with subject/time context
+    // instead of panicking deep inside the event-driven walk (#375).
+    assert_dose_compartments_supported(model, population);
     assert_absorption_closed_form_support(model, population);
     assert_absorption_flip_flop_no_twin(model, population, &params.theta);
     // A time-varying covariate on a survival hazard would be silently frozen — panic

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -400,6 +400,7 @@ pub fn simulate_with_options_diag(
     // integrates the whole warm-EBE pass first and fails only at the chokepoint,
     // with a confusable "EBE did not converge" instead of the real cause.
     assert_modeled_doses_supported(model, population);
+    assert_dose_compartments_supported(model, population);
     assert_absorption_closed_form_support(model, population);
     assert_absorption_flip_flop_no_twin(model, population, &params.theta);
     // A time-varying covariate on a survival hazard would be silently frozen — panic
@@ -788,8 +789,10 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     // Single chokepoint for every `simulate*` variant (both `simulate_inner` and
     // the propensity path funnel through here). Guard the modeled-`RATE` dose
     // precondition once per call, as `predict()` does — `simulate()` runs no
-    // data-check otherwise. #324.
+    // data-check otherwise. #324. The dose-compartment routing guard (#375) rides
+    // the same chokepoint.
     assert_modeled_doses_supported(model, population);
+    assert_dose_compartments_supported(model, population);
     assert_absorption_closed_form_support(model, population);
     assert_absorption_flip_flop_no_twin(model, population, &params.theta);
     // A time-varying covariate on a survival hazard would be silently frozen — panic

--- a/src/api/tests/dose_compartment_tests.rs
+++ b/src/api/tests/dose_compartment_tests.rs
@@ -1,0 +1,312 @@
+//! Unit tests for [`check_dose_compartments`] (#375) — the up-front guard that
+//! every dose names a compartment the analytical engine can actually deliver it
+//! into.
+//!
+//! Before this check the three analytical paths disagreed on an unroutable dose:
+//! the dose-superposition path silently routed the infusion into central, the
+//! event-driven walk `panic!`ed from inside the prediction loop, and the `sens`
+//! gradient walk silently dropped it. These tests pin the rejection (so the
+//! panic is unreachable from user data) and, just as importantly, the positive
+//! controls — the compartments that *are* routable must stay accepted.
+use super::check_dose_compartments;
+use crate::types::test_helpers::{analytical_model, ode_model};
+use crate::types::{CompiledModel, DoseEvent, GradientMethod, PkModel, Population, Subject};
+use std::collections::HashMap;
+
+/// A one-subject population carrying exactly the doses under test.
+fn population_with_doses(doses: Vec<DoseEvent>) -> Population {
+    Population {
+        subjects: vec![Subject {
+            id: "1".into(),
+            doses,
+            obs_times: vec![1.0],
+            obs_raw_times: Vec::new(),
+            observations: vec![0.0],
+            obs_cmts: vec![1],
+            covariates: HashMap::new(),
+            dose_covariates: Vec::new(),
+            obs_covariates: Vec::new(),
+            pk_only_times: Vec::new(),
+            pk_only_covariates: Vec::new(),
+            reset_times: Vec::new(),
+            cens: vec![0],
+            occasions: Vec::new(),
+            obs_l2: Vec::new(),
+            dose_occasions: Vec::new(),
+            fremtype: Vec::new(),
+            obs_records: vec![],
+        }],
+        covariate_names: Vec::new(),
+        dv_column: "DV".into(),
+        input_columns: Vec::new(),
+        exclusions: None,
+        warnings: Vec::new(),
+    }
+}
+
+fn model_with(pk_model: PkModel) -> CompiledModel {
+    let mut model = analytical_model(GradientMethod::Fd);
+    model.pk_model = pk_model;
+    model
+}
+
+/// `RATE>0` into compartment `cmt`.
+fn infusion(cmt: usize) -> DoseEvent {
+    DoseEvent::new(0.0, 100.0, cmt, 10.0, false, 0.0)
+}
+
+/// A plain bolus into compartment `cmt`.
+fn bolus(cmt: usize) -> DoseEvent {
+    DoseEvent::new(0.0, 100.0, cmt, 0.0, false, 0.0)
+}
+
+fn codes(model: &CompiledModel, population: &Population) -> Vec<String> {
+    check_dose_compartments(model, population)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ── the reported case: infusion into a compartment the walk cannot route ──
+
+/// The #375 repro: `two_cpt_oral` has no closed form for an infusion into its
+/// peripheral, and the event-driven walk used to `panic!` on it.
+#[test]
+fn infusion_into_oral_peripheral_is_rejected() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![infusion(3)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+}
+
+/// Same class, one compartment further out.
+#[test]
+fn infusion_into_three_cpt_oral_peripheral_is_rejected() {
+    let model = model_with(PkModel::ThreeCptOral);
+    let population = population_with_doses(vec![infusion(3)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+}
+
+/// `one_cpt_iv` has a single compartment, so cmt 2 is neither infusable nor in
+/// range. The infusion rule owns it (it is reported once, not twice).
+#[test]
+fn infusion_beyond_the_state_count_is_rejected_once() {
+    let model = model_with(PkModel::OneCptIv);
+    let population = population_with_doses(vec![infusion(2)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+}
+
+/// An infusion has no "default compartment" fallback — `dose_channel(0)` is
+/// `None`, so the walk panicked on `CMT=0` too. Rejected rather than silently
+/// treated as central (which is what the superposition path did).
+#[test]
+fn infusion_into_cmt_zero_is_rejected() {
+    let model = model_with(PkModel::OneCptIv);
+    let population = population_with_doses(vec![infusion(0)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+}
+
+/// The message must carry the subject/time context the deep-in-the-walk panic
+/// never had, and name the compartments that *are* infusable.
+#[test]
+fn rejection_message_names_the_subject_time_and_infusable_set() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![infusion(3)]);
+    let diags = check_dose_compartments(&model, &population);
+    let msg = &diags[0].message;
+    assert!(msg.contains("subject 1"), "{msg}");
+    assert!(msg.contains("compartment 3"), "{msg}");
+    assert!(msg.contains("two_cpt_oral"), "{msg}");
+    assert!(msg.contains("[1, 2]"), "{msg}");
+    assert_eq!(diags[0].block.as_deref(), Some("structural_model"));
+}
+
+// ── positive controls: everything the closed forms genuinely route ──
+
+/// Zero-order release into the oral depot is supported since #400 — this check
+/// must not regress it.
+#[test]
+fn infusion_into_oral_depot_is_accepted() {
+    for pk_model in [
+        PkModel::OneCptOral,
+        PkModel::TwoCptOral,
+        PkModel::ThreeCptOral,
+    ] {
+        let model = model_with(pk_model);
+        let population = population_with_doses(vec![infusion(1)]);
+        assert!(
+            codes(&model, &population).is_empty(),
+            "{pk_model:?} depot infusion should be accepted"
+        );
+    }
+}
+
+/// Central is infusable for every model; the IV models also take their
+/// peripheral(s).
+#[test]
+fn infusion_into_central_and_iv_peripherals_is_accepted() {
+    let cases = [
+        (PkModel::OneCptIv, 1),
+        (PkModel::OneCptOral, 2),
+        (PkModel::TwoCptIv, 1),
+        (PkModel::TwoCptIv, 2),
+        (PkModel::ThreeCptIv, 2),
+        (PkModel::ThreeCptIv, 3),
+        (PkModel::TwoCptOral, 2),
+        (PkModel::ThreeCptOral, 2),
+    ];
+    for (pk_model, cmt) in cases {
+        let model = model_with(pk_model);
+        let population = population_with_doses(vec![infusion(cmt)]);
+        assert!(
+            codes(&model, &population).is_empty(),
+            "{pk_model:?} cmt {cmt} infusion should be accepted"
+        );
+    }
+}
+
+/// A bolus into a compartment that exists is fine even when that compartment is
+/// not *infusable* — the walk adds the amount to the state directly. Rejecting
+/// these would break `two_cpt_oral` peripheral boluses the walk handles today.
+#[test]
+fn bolus_into_a_non_infusable_but_existing_compartment_is_accepted() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![bolus(3)]);
+    assert!(codes(&model, &population).is_empty());
+}
+
+/// `CMT=0` on a bolus is NONMEM's "default dose compartment", and both
+/// analytical paths already agree on it (the walk via `saturating_sub(1)`, the
+/// superposition path by ignoring `cmt`). Not a silent mis-route, so not
+/// rejected.
+#[test]
+fn bolus_into_cmt_zero_is_accepted() {
+    let model = model_with(PkModel::OneCptIv);
+    let population = population_with_doses(vec![bolus(0)]);
+    assert!(codes(&model, &population).is_empty());
+}
+
+// ── the out-of-range bolus ──
+
+/// The sibling panic: a bolus past the end of the state vector.
+#[test]
+fn bolus_beyond_the_state_count_is_rejected() {
+    let model = model_with(PkModel::OneCptIv);
+    let population = population_with_doses(vec![bolus(2)]);
+    let diags = check_dose_compartments(&model, &population);
+    assert_eq!(
+        diags.iter().map(|d| d.code.as_str()).collect::<Vec<_>>(),
+        vec!["E_DOSE_CMT_OUT_OF_RANGE"]
+    );
+    let msg = &diags[0].message;
+    assert!(msg.contains("only 1 compartment(s)"), "{msg}");
+    assert!(msg.contains("central"), "{msg}");
+}
+
+/// The boundary: `cmt == n_states` is the last valid compartment.
+#[test]
+fn bolus_into_the_last_compartment_is_accepted() {
+    let model = model_with(PkModel::TwoCptOral); // depot, central, peripheral
+    let population = population_with_doses(vec![bolus(3)]);
+    assert!(codes(&model, &population).is_empty());
+    let population = population_with_doses(vec![bolus(4)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_OUT_OF_RANGE"]);
+}
+
+// ── scope: which engines and models this check owns ──
+
+/// ODE models index the state vector directly and honour any compartment the
+/// `[odes]` block declares — this analytical-routing check must not fire.
+#[test]
+fn ode_models_are_exempt() {
+    let model = ode_model(GradientMethod::Fd);
+    let population = population_with_doses(vec![infusion(9), bolus(9)]);
+    assert!(codes(&model, &population).is_empty());
+}
+
+/// Transit/IG never take the event-driven walk, so its routing table does not
+/// apply to them: an infusion reroutes the subject to the model's ODE twin
+/// (`effective_for`, #719 gap 2), which addresses compartments directly.
+/// Rejecting here would break a **supported** model — only the SS+infusion
+/// combination is rejected, and `check_absorption_closed_form_support` owns
+/// that.
+#[test]
+fn transit_and_ig_infusions_are_not_rejected_by_the_routing_check() {
+    for pk_model in [
+        PkModel::OneCptTransit,
+        PkModel::TwoCptTransit,
+        PkModel::OneCptIg,
+        PkModel::TwoCptIg,
+    ] {
+        let model = model_with(pk_model);
+        let population = population_with_doses(vec![infusion(1)]);
+        assert!(
+            codes(&model, &population).is_empty(),
+            "{pk_model:?} infusion should defer to the absorption check"
+        );
+    }
+}
+
+/// …but their *bolus* range check still applies (they are 2-state models).
+#[test]
+fn transit_bolus_range_is_still_checked() {
+    let model = model_with(PkModel::OneCptTransit);
+    let population = population_with_doses(vec![bolus(3)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_OUT_OF_RANGE"]);
+}
+
+// ── reporting shape ──
+
+/// Many offending rows give one actionable error per cause, matching
+/// `check_modeled_dose_rates`.
+#[test]
+fn errors_are_deduped_per_kind_and_compartment() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![
+        infusion(3),
+        infusion(3),
+        infusion(3),
+        bolus(9),
+        bolus(9),
+    ]);
+    assert_eq!(
+        codes(&model, &population),
+        vec!["E_DOSE_CMT_NOT_INFUSABLE", "E_DOSE_CMT_OUT_OF_RANGE"]
+    );
+}
+
+/// An infusion and a bolus into the same bad compartment are independent
+/// causes — reporting only one would hide the other after the user fixes it.
+#[test]
+fn infusion_and_bolus_into_the_same_compartment_report_separately() {
+    let model = model_with(PkModel::OneCptIv);
+    let population = population_with_doses(vec![infusion(2), bolus(2)]);
+    assert_eq!(
+        codes(&model, &population),
+        vec!["E_DOSE_CMT_NOT_INFUSABLE", "E_DOSE_CMT_OUT_OF_RANGE"]
+    );
+}
+
+/// The common dataset — every dose routable — costs one scan and reports
+/// nothing.
+#[test]
+fn a_clean_population_reports_nothing() {
+    let model = model_with(PkModel::OneCptOral);
+    let population = population_with_doses(vec![bolus(1), infusion(2)]);
+    assert!(codes(&model, &population).is_empty());
+}
+
+// ── wiring ──
+
+/// `fit()` reaches this through `check_model_data`, so the new codes must be in
+/// that aggregate rather than only reachable directly.
+#[test]
+fn check_model_data_surfaces_the_new_error() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![infusion(3)]);
+    let diags = crate::api::check_model_data(&model, &population);
+    assert!(
+        diags.iter().any(|d| d.code == "E_DOSE_CMT_NOT_INFUSABLE"),
+        "check_model_data should carry the dose-compartment diagnostic: {diags:?}"
+    );
+    assert!(crate::diagnostics::first_error(&diags).is_err());
+}

--- a/src/api/tests/dose_compartment_tests.rs
+++ b/src/api/tests/dose_compartment_tests.rs
@@ -87,12 +87,32 @@ fn infusion_into_three_cpt_oral_peripheral_is_rejected() {
 }
 
 /// `one_cpt_iv` has a single compartment, so cmt 2 is neither infusable nor in
-/// range. The infusion rule owns it (it is reported once, not twice).
+/// range. The **range** rule owns it — "the model has only 1 compartment" is a
+/// more useful message than "that compartment is not infusable" — and it is
+/// reported once, not twice.
 #[test]
-fn infusion_beyond_the_state_count_is_rejected_once() {
+fn infusion_beyond_the_state_count_is_rejected_once_as_out_of_range() {
     let model = model_with(PkModel::OneCptIv);
     let population = population_with_doses(vec![infusion(2)]);
-    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_OUT_OF_RANGE"]);
+}
+
+/// The range rule must apply to infusions on transit/IG too. They skip the
+/// *routing* rule (an infusion reroutes them to their ODE twin, #719 gap 2), but
+/// they are still 2-/3-state models: without a range check an out-of-range
+/// infusion passes validation and is then silently dropped by the twin's bounds
+/// check — the silent-drop failure this whole check exists to remove.
+#[test]
+fn out_of_range_infusion_on_transit_is_still_rejected() {
+    for pk_model in [PkModel::OneCptTransit, PkModel::OneCptIg] {
+        let model = model_with(pk_model);
+        let population = population_with_doses(vec![infusion(9)]);
+        assert_eq!(
+            codes(&model, &population),
+            vec!["E_DOSE_CMT_OUT_OF_RANGE"],
+            "{pk_model:?} out-of-range infusion"
+        );
+    }
 }
 
 /// An infusion has no "default compartment" fallback — `dose_channel(0)` is
@@ -276,14 +296,24 @@ fn errors_are_deduped_per_kind_and_compartment() {
 
 /// An infusion and a bolus into the same bad compartment are independent
 /// causes — reporting only one would hide the other after the user fixes it.
+/// Both are out of range on `one_cpt_iv`, so both take the range rule.
 #[test]
 fn infusion_and_bolus_into_the_same_compartment_report_separately() {
     let model = model_with(PkModel::OneCptIv);
     let population = population_with_doses(vec![infusion(2), bolus(2)]);
     assert_eq!(
         codes(&model, &population),
-        vec!["E_DOSE_CMT_NOT_INFUSABLE", "E_DOSE_CMT_OUT_OF_RANGE"]
+        vec!["E_DOSE_CMT_OUT_OF_RANGE", "E_DOSE_CMT_OUT_OF_RANGE"]
     );
+}
+
+/// …and where the two rules genuinely differ: on `two_cpt_oral` cmt 3 exists
+/// (so a bolus is fine) but is not infusable, so only the infusion is reported.
+#[test]
+fn the_two_rules_are_distinguished_on_an_in_range_non_infusable_compartment() {
+    let model = model_with(PkModel::TwoCptOral);
+    let population = population_with_doses(vec![infusion(3), bolus(3)]);
+    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
 }
 
 /// The common dataset — every dose routable — costs one scan and reports

--- a/src/api/tests/dose_compartment_tests.rs
+++ b/src/api/tests/dose_compartment_tests.rs
@@ -69,21 +69,51 @@ fn codes(model: &CompiledModel, population: &Population) -> Vec<String> {
 
 // ── the reported case: infusion into a compartment the walk cannot route ──
 
-/// The #375 repro: `two_cpt_oral` has no closed form for an infusion into its
-/// peripheral, and the event-driven walk used to `panic!` on it.
+/// The #375 repro — an infusion into an oral model's peripheral. It used to
+/// `panic!` from inside the event-driven walk, then (mid-#375) was rejected, and
+/// is now **supported**: the oral propagators gained the peripheral forcing term
+/// by reusing the IV forced response. Validated against NONMEM `ADVAN4`/`ADVAN12`
+/// and, exactly, against an ODE twin (`tests/oral_peripheral_infusion.rs`).
 #[test]
-fn infusion_into_oral_peripheral_is_rejected() {
-    let model = model_with(PkModel::TwoCptOral);
-    let population = population_with_doses(vec![infusion(3)]);
-    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+fn infusion_into_oral_peripheral_is_supported() {
+    for (pk_model, cmt) in [
+        (PkModel::TwoCptOral, 3),
+        (PkModel::ThreeCptOral, 3),
+        (PkModel::ThreeCptOral, 4),
+    ] {
+        let model = model_with(pk_model);
+        let population = population_with_doses(vec![infusion(cmt)]);
+        assert!(
+            codes(&model, &population).is_empty(),
+            "{pk_model:?} cmt {cmt} infusion should be supported"
+        );
+    }
 }
 
-/// Same class, one compartment further out.
+/// With every in-range compartment of every walk-supported model now infusable,
+/// `E_DOSE_CMT_NOT_INFUSABLE` narrows to exactly one case: `CMT=0`, which has no
+/// rate channel because an infusion has no "default compartment" fallback. Pinned
+/// so the code isn't quietly dead.
 #[test]
-fn infusion_into_three_cpt_oral_peripheral_is_rejected() {
-    let model = model_with(PkModel::ThreeCptOral);
-    let population = population_with_doses(vec![infusion(3)]);
-    assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
+fn every_in_range_compartment_is_infusable_on_walk_models() {
+    for pk_model in [
+        PkModel::OneCptIv,
+        PkModel::OneCptOral,
+        PkModel::TwoCptIv,
+        PkModel::TwoCptOral,
+        PkModel::ThreeCptIv,
+        PkModel::ThreeCptOral,
+    ] {
+        let n = pk_model.topology().state_layout().0;
+        for cmt in 1..=n {
+            let model = model_with(pk_model);
+            let population = population_with_doses(vec![infusion(cmt)]);
+            assert!(
+                codes(&model, &population).is_empty(),
+                "{pk_model:?} cmt {cmt} infusion should be supported"
+            );
+        }
+    }
 }
 
 /// `one_cpt_iv` has a single compartment, so cmt 2 is neither infusable nor in
@@ -130,13 +160,13 @@ fn infusion_into_cmt_zero_is_rejected() {
 #[test]
 fn rejection_message_names_the_subject_time_and_infusable_set() {
     let model = model_with(PkModel::TwoCptOral);
-    let population = population_with_doses(vec![infusion(3)]);
+    let population = population_with_doses(vec![infusion(0)]);
     let diags = check_dose_compartments(&model, &population);
     let msg = &diags[0].message;
     assert!(msg.contains("subject 1"), "{msg}");
-    assert!(msg.contains("compartment 3"), "{msg}");
+    assert!(msg.contains("compartment 0"), "{msg}");
     assert!(msg.contains("two_cpt_oral"), "{msg}");
-    assert!(msg.contains("[1, 2]"), "{msg}");
+    assert!(msg.contains("[1, 2, 3]"), "{msg}");
     assert_eq!(diags[0].block.as_deref(), Some("structural_model"));
 }
 
@@ -282,9 +312,9 @@ fn transit_bolus_range_is_still_checked() {
 fn errors_are_deduped_per_kind_and_compartment() {
     let model = model_with(PkModel::TwoCptOral);
     let population = population_with_doses(vec![
-        infusion(3),
-        infusion(3),
-        infusion(3),
+        infusion(0),
+        infusion(0),
+        infusion(0),
         bolus(9),
         bolus(9),
     ]);
@@ -307,12 +337,13 @@ fn infusion_and_bolus_into_the_same_compartment_report_separately() {
     );
 }
 
-/// …and where the two rules genuinely differ: on `two_cpt_oral` cmt 3 exists
-/// (so a bolus is fine) but is not infusable, so only the infusion is reported.
+/// …and where the two rules genuinely differ: `CMT=0` is the default dose
+/// compartment for a **bolus** (accepted) but has no rate channel for an
+/// **infusion** (rejected), so only the infusion is reported.
 #[test]
-fn the_two_rules_are_distinguished_on_an_in_range_non_infusable_compartment() {
+fn the_two_rules_are_distinguished_on_cmt_zero() {
     let model = model_with(PkModel::TwoCptOral);
-    let population = population_with_doses(vec![infusion(3), bolus(3)]);
+    let population = population_with_doses(vec![infusion(0), bolus(0)]);
     assert_eq!(codes(&model, &population), vec!["E_DOSE_CMT_NOT_INFUSABLE"]);
 }
 
@@ -325,6 +356,22 @@ fn a_clean_population_reports_nothing() {
     assert!(codes(&model, &population).is_empty());
 }
 
+/// A zero-amount dose is a no-op on every path — the walk's bolus branch adds
+/// `F·0` and its infusion branch needs `duration > 0`, which `AMT=0` never has.
+/// `is_infusion()` still reports `true` for it (it is `rate > 0 || !is_fixed()`,
+/// broader than the walk's predicate), so without an explicit skip the check
+/// would reject a dataset that previously ran fine and delivered nothing.
+#[test]
+fn a_zero_amount_dose_is_not_rejected() {
+    let model = model_with(PkModel::TwoCptOral);
+    let mut inf = infusion(3); // cmt 3 is not infusable
+    inf.amt = 0.0;
+    let mut bol = bolus(9); // cmt 9 is out of range
+    bol.amt = 0.0;
+    assert!(codes(&model, &population_with_doses(vec![inf])).is_empty());
+    assert!(codes(&model, &population_with_doses(vec![bol])).is_empty());
+}
+
 // ── wiring ──
 
 /// `fit()` reaches this through `check_model_data`, so the new codes must be in
@@ -332,7 +379,7 @@ fn a_clean_population_reports_nothing() {
 #[test]
 fn check_model_data_surfaces_the_new_error() {
     let model = model_with(PkModel::TwoCptOral);
-    let population = population_with_doses(vec![infusion(3)]);
+    let population = population_with_doses(vec![infusion(0)]);
     let diags = crate::api::check_model_data(&model, &population);
     assert!(
         diags.iter().any(|d| d.code == "E_DOSE_CMT_NOT_INFUSABLE"),

--- a/src/api/tests/dose_compartment_tests.rs
+++ b/src/api/tests/dose_compartment_tests.rs
@@ -362,14 +362,27 @@ fn a_clean_population_reports_nothing() {
 /// broader than the walk's predicate), so without an explicit skip the check
 /// would reject a dataset that previously ran fine and delivered nothing.
 #[test]
-fn a_zero_amount_dose_is_not_rejected() {
+fn a_zero_amount_dose_is_exempt_from_the_routing_rule_but_not_the_range_rule() {
     let model = model_with(PkModel::TwoCptOral);
-    let mut inf = infusion(3); // cmt 3 is not infusable
+    // Exempt: an in-range zero-amount infusion delivers nothing on any path
+    // (`duration = AMT/RATE = 0`, and the walk's infusion branch needs
+    // `duration > 0`), so failing a whole fit over an inert row would be
+    // stricter than the bug being fixed.
+    let mut inf = infusion(0); // cmt 0 has no channel for an infusion
     inf.amt = 0.0;
-    let mut bol = bolus(9); // cmt 9 is out of range
-    bol.amt = 0.0;
     assert!(codes(&model, &population_with_doses(vec![inf])).is_empty());
-    assert!(codes(&model, &population_with_doses(vec![bol])).is_empty());
+
+    // NOT exempt: both walks bound-check the compartment *before* the amount is
+    // read (`if cmt_idx < n_states { … } else { panic! }`), so a zero-amount
+    // dose with an out-of-range CMT reaches the panic exactly like a real one —
+    // and since #375 routes any `cmt != 1` bolus to the walk, it gets there.
+    // Exempting it here made `ferx check` bless the dataset and `fit()` abort.
+    let mut bol = bolus(9); // cmt 9 is past the end of the 3-state model
+    bol.amt = 0.0;
+    assert_eq!(
+        codes(&model, &population_with_doses(vec![bol])),
+        vec!["E_DOSE_CMT_OUT_OF_RANGE"],
+    );
 }
 
 // ── wiring ──

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -614,6 +614,49 @@ pub(crate) fn check_modeled_dose_rates(
     diags
 }
 
+/// Whether **anything in this dataset** asks the analytical PK predictor for a
+/// value — any Gaussian observation, or any `EVID=2` PK-only request.
+///
+/// This exists for one narrow case: a pure-TTE / pure-discrete model still needs
+/// a `[structural_model]` line, and the idiom is a **placeholder** `one_cpt_iv`
+/// with dummy `CL`/`V` (the parser supplies exactly that when the block is
+/// absent, `model_parser.rs`). Validating dose compartments against that
+/// placeholder's 1-compartment topology would reject a working model over dose
+/// records no PK code ever reads.
+///
+/// Deliberately a **population**-level predicate, not a per-subject one. "This
+/// subject has no Gaussian observation" does **not** imply the PK path is
+/// skipped for it: the event-driven walk is driven by the subject's event
+/// schedule (doses and `EVID=2` times), and the FOCE/FOCEI sensitivity provider
+/// runs per subject regardless. A per-subject exemption would let a TTE-only
+/// subject *of a joint PK-TTE model* carry an unroutable infusion straight back
+/// into the panics this check exists to prevent — a routine pattern (an early
+/// dropout, or a TTE-only arm, that still has dose records).
+///
+/// Non-Gaussian endpoints are registered per CMT in `CompiledModel::endpoints`,
+/// so an observation CMT absent from that map is Gaussian. Without the
+/// `survival` feature no non-Gaussian endpoint can be parsed, so every
+/// observation is Gaussian by construction and this is always `true`.
+fn population_uses_analytical_pk(model: &CompiledModel, population: &Population) -> bool {
+    #[cfg(feature = "survival")]
+    {
+        if model.endpoints.is_empty() {
+            return true;
+        }
+        population.subjects.iter().any(|s| {
+            !s.pk_only_times.is_empty()
+                || s.obs_cmts
+                    .iter()
+                    .any(|cmt| !model.endpoints.contains_key(cmt))
+        })
+    }
+    #[cfg(not(feature = "survival"))]
+    {
+        let _ = (model, population);
+        true
+    }
+}
+
 /// Every dose must name a compartment the **analytical** engine can actually
 /// deliver it into (#375). The datareader cannot make this call — it has no
 /// model — and the parse-time infusable check
@@ -623,8 +666,21 @@ pub(crate) fn check_modeled_dose_rates(
 /// predictors unvalidated. The three analytical paths then disagreed on it:
 /// the dose-superposition path never reads `dose.cmt` and silently routed the
 /// infusion into central, the event-driven walk `panic!`ed, and the `sens`
-/// gradient walk silently dropped the infusion. Rejecting up front is what
-/// makes all three agree, and keeps the prediction hot path panic-free.
+/// gradient walk silently dropped the infusion. Rejecting up front removes that
+/// disagreement **for the doses it rejects**, and keeps the prediction hot path
+/// panic-free.
+///
+/// It does **not** make the three paths agree in general, and this check should
+/// not be read as claiming that. The superposition path never reads `dose.cmt`
+/// at all: it dispatches on the *model*, so it computes every accepted dose as
+/// going into that model's default route (the depot for an oral model, central
+/// for an IV one). For every compartment other than that default the two paths
+/// therefore still disagree — an IV-peripheral infusion and any non-default
+/// bolus among them, by orders of magnitude on the 2-/3-compartment models.
+/// Those doses are *accepted* here because the event-driven walk computes them
+/// correctly and rejecting them would break working models; the fix is to route
+/// them to that walk (as `has_oral_depot_infusion` already does for depot
+/// infusions), which is tracked separately.
 ///
 /// Two rules, both 1-based like NONMEM's `CMT`:
 ///   - **Infusion** (`RATE>0`, or a resolved modeled rate/duration): the
@@ -644,7 +700,13 @@ pub(crate) fn check_modeled_dose_rates(
 ///     silent mis-route.
 ///
 /// ODE models are exempt: `ode/predictions.rs` indexes the state vector
-/// directly and honours any compartment the `[odes]` block declares.
+/// directly, so every compartment the `[odes]` block **declares** is
+/// addressable and none of this analytical routing applies. Note this is an
+/// exemption, not a clean bill of health — an ODE dose whose `CMT` is past the
+/// end of the declared state vector is still silently dropped by that engine's
+/// `if cmt_idx < n { … }` guards. Closing that is a separate change (it needs
+/// the ODE state count, not a `PkModel` topology) and is tracked separately;
+/// this check deliberately does not half-do it.
 ///
 /// Reported once per `(kind, compartment)` so a dataset with many offending
 /// rows yields one actionable error per cause, matching
@@ -665,6 +727,12 @@ pub(crate) fn check_dose_compartments(
     // De-dup by (is_infusion, compartment): an infusion and a bolus into the
     // same bad compartment are independent causes and are reported separately.
     let mut reported: std::collections::HashSet<(bool, usize)> = std::collections::HashSet::new();
+    // Nothing in this dataset asks the analytical predictor for a value — the
+    // `pk` line is a pure-TTE / pure-discrete model's placeholder. See
+    // `population_uses_analytical_pk` for why this is a population-level test.
+    if !population_uses_analytical_pk(model, population) {
+        return diags;
+    }
     for subject in &population.subjects {
         for dose in &subject.doses {
             let is_infusion = dose.is_infusion();
@@ -672,7 +740,25 @@ pub(crate) fn check_dose_compartments(
                 continue;
             }
             let cmt = dose.cmt;
-            if is_infusion {
+            // Range first, and for **both** dose kinds. Transit/IG skip the
+            // routing rule below but are still 2-/3-state models, so without this
+            // an out-of-range infusion on them would pass validation and then be
+            // silently dropped by the ODE twin's bounds check — the exact
+            // silent-drop failure this check exists to remove.
+            if cmt > n_states {
+                diags.push(
+                    Diagnostic::error(
+                        "E_DOSE_CMT_OUT_OF_RANGE",
+                        format!(
+                            "subject {}, time {}: dose into compartment {cmt}, but the \
+                             analytical `{name}` model has only {n_states} compartment(s) \
+                             (CMT is 1-based: {:?}).",
+                            subject.id, dose.time, topology.compartment_names,
+                        ),
+                    )
+                    .with_block("structural_model"),
+                );
+            } else if is_infusion {
                 // Transit/IG (`event_walk_supported == false`) never take the
                 // walk this routing table belongs to — an infusion reroutes them
                 // to their ODE twin (#719 gap 2), which addresses compartments
@@ -700,19 +786,6 @@ pub(crate) fn check_dose_compartments(
                         .with_block("structural_model"),
                     );
                 }
-            } else if cmt > n_states {
-                diags.push(
-                    Diagnostic::error(
-                        "E_DOSE_CMT_OUT_OF_RANGE",
-                        format!(
-                            "subject {}, time {}: dose into compartment {cmt}, but the \
-                             analytical `{name}` model has only {n_states} compartment(s) \
-                             (CMT is 1-based: {:?}).",
-                            subject.id, dose.time, topology.compartment_names,
-                        ),
-                    )
-                    .with_block("structural_model"),
-                );
             }
         }
     }

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -132,6 +132,7 @@ pub fn check_model_data_rule(
     diags.extend(check_iov_occasions(model, population, iov_rule));
     diags.extend(check_absorption_dosing(model, population));
     diags.extend(check_modeled_dose_rates(model, population));
+    diags.extend(check_dose_compartments(model, population));
     diags.extend(validate_output_columns(model, population));
     diags
 }
@@ -611,6 +612,125 @@ pub(crate) fn check_modeled_dose_rates(
         }
     }
     diags
+}
+
+/// Every dose must name a compartment the **analytical** engine can actually
+/// deliver it into (#375). The datareader cannot make this call — it has no
+/// model — and the parse-time infusable check
+/// (`model_parser`, [`PkModel::infusable_compartments`]) only fires for a
+/// *declared* `D{cmt}`/`R{cmt}`, so an explicit positive `RATE` (or an
+/// out-of-range bolus `CMT`) read straight from the dataset reached the
+/// predictors unvalidated. The three analytical paths then disagreed on it:
+/// the dose-superposition path never reads `dose.cmt` and silently routed the
+/// infusion into central, the event-driven walk `panic!`ed, and the `sens`
+/// gradient walk silently dropped the infusion. Rejecting up front is what
+/// makes all three agree, and keeps the prediction hot path panic-free.
+///
+/// Two rules, both 1-based like NONMEM's `CMT`:
+///   - **Infusion** (`RATE>0`, or a resolved modeled rate/duration): the
+///     compartment must be in [`PkModel::infusable_compartments`] — central for
+///     every model, the oral depot since #400, and the peripheral(s) of the
+///     2-/3-cpt IV models. Oral peripherals have no closed form and are
+///     rejected rather than mis-routed. Checked only for the six event-walk
+///     models: `dose_channel` *is* the walk's routing table, and a transit/IG
+///     subject never takes that walk — an infusion reroutes it to the model's
+///     ODE twin (`CompiledModel::effective_for`, #719 gap 2), which addresses
+///     compartments directly. Applying this table to them would reject a
+///     supported model.
+///   - **Bolus**: `cmt` must not exceed the model's state count. `CMT=0` is
+///     left alone — both analytical paths already treat it as NONMEM's
+///     "default dose compartment" (the walk via `saturating_sub(1)`, the
+///     superposition path by ignoring `cmt`), so it is consistent, not a
+///     silent mis-route.
+///
+/// ODE models are exempt: `ode/predictions.rs` indexes the state vector
+/// directly and honours any compartment the `[odes]` block declares.
+///
+/// Reported once per `(kind, compartment)` so a dataset with many offending
+/// rows yields one actionable error per cause, matching
+/// [`check_modeled_dose_rates`].
+pub(crate) fn check_dose_compartments(
+    model: &CompiledModel,
+    population: &Population,
+) -> Vec<Diagnostic> {
+    // ODE engine: any declared compartment is addressable, nothing to check.
+    if model.ode_spec.is_some() {
+        return Vec::new();
+    }
+    let pk_model = model.pk_model;
+    let topology = pk_model.topology();
+    let (n_states, _) = topology.state_layout();
+    let name = pk_model.canonical_name();
+    let mut diags = Vec::new();
+    // De-dup by (is_infusion, compartment): an infusion and a bolus into the
+    // same bad compartment are independent causes and are reported separately.
+    let mut reported: std::collections::HashSet<(bool, usize)> = std::collections::HashSet::new();
+    for subject in &population.subjects {
+        for dose in &subject.doses {
+            let is_infusion = dose.is_infusion();
+            if !reported.insert((is_infusion, dose.cmt)) {
+                continue;
+            }
+            let cmt = dose.cmt;
+            if is_infusion {
+                // Transit/IG (`event_walk_supported == false`) never take the
+                // walk this routing table belongs to — an infusion reroutes them
+                // to their ODE twin (#719 gap 2), which addresses compartments
+                // directly. Rejecting here would break a supported model.
+                if !topology.event_walk_supported {
+                    continue;
+                }
+                // For a walk-supported model `infusable` *equals* the walk's
+                // routing table (pinned by `topology_fields_are_internally_consistent`),
+                // so this is exactly the set `dose_channel` can route.
+                if !pk_model.infusable_compartments().contains(&cmt) {
+                    diags.push(
+                        Diagnostic::error(
+                            "E_DOSE_CMT_NOT_INFUSABLE",
+                            format!(
+                                "subject {}, time {}: infusion into compartment {cmt}, \
+                                 but the analytical `{name}` model can only infuse into \
+                                 compartment(s) {:?}. An infusion into another compartment \
+                                 (e.g. an oral peripheral) needs an `ode(...)` model.",
+                                subject.id,
+                                dose.time,
+                                pk_model.infusable_compartments(),
+                            ),
+                        )
+                        .with_block("structural_model"),
+                    );
+                }
+            } else if cmt > n_states {
+                diags.push(
+                    Diagnostic::error(
+                        "E_DOSE_CMT_OUT_OF_RANGE",
+                        format!(
+                            "subject {}, time {}: dose into compartment {cmt}, but the \
+                             analytical `{name}` model has only {n_states} compartment(s) \
+                             (CMT is 1-based: {:?}).",
+                            subject.id, dose.time, topology.compartment_names,
+                        ),
+                    )
+                    .with_block("structural_model"),
+                );
+            }
+        }
+    }
+    diags
+}
+
+/// Precondition shared by [`predict`] and the `simulate*` family: every dose
+/// must name a compartment the analytical engine can deliver it into (#375) —
+/// the `predict()`/`simulate()` twin of [`check_dose_compartments`], which
+/// `fit()` reaches through [`check_model_data`]. Without it these entry points
+/// reach the event-driven walk's routing `match` with an unroutable
+/// compartment, which used to `panic!` from deep inside the prediction loop
+/// with no subject/time context.
+pub(crate) fn assert_dose_compartments_supported(model: &CompiledModel, population: &Population) {
+    panic_if_unsupported(
+        first_error(&check_dose_compartments(model, population)).err(),
+        "a dose into a compartment the model cannot deliver into",
+    );
 }
 
 /// Precondition shared by [`predict`] and the `simulate*` family: every

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -670,36 +670,39 @@ fn population_uses_analytical_pk(model: &CompiledModel, population: &Population)
 /// disagreement **for the doses it rejects**, and keeps the prediction hot path
 /// panic-free.
 ///
-/// It does **not** make the three paths agree in general, and this check should
-/// not be read as claiming that. The superposition path never reads `dose.cmt`
-/// at all: it dispatches on the *model*, so it computes every accepted dose as
-/// going into that model's default route (the depot for an oral model, central
-/// for an IV one). For every compartment other than that default the two paths
-/// therefore still disagree — an IV-peripheral infusion and any non-default
-/// bolus among them, by orders of magnitude on the 2-/3-compartment models.
-/// Those doses are *accepted* here because the event-driven walk computes them
-/// correctly and rejecting them would break working models; the fix is to route
-/// them to that walk (as `has_oral_depot_infusion` already does for depot
-/// infusions), which is tracked separately.
+/// This check alone does **not** make the paths agree — it only removes the
+/// doses that have no target at all. Agreement for the doses it *accepts* comes
+/// from [`crate::pk::dose_needs_event_walk`], which reroutes every dose the
+/// superposition dispatch cannot place (it never reads `dose.cmt`, so it would
+/// compute the dose as going into the model's default route — the depot for an
+/// oral model, central for an IV one) to the event-driven walk, which places it
+/// correctly and is NONMEM-anchored. The two are complements and must be read
+/// together: this one rejects the unroutable, that one routes the rest.
 ///
 /// Two rules, both 1-based like NONMEM's `CMT`:
-///   - **Infusion** (`RATE>0`, or a resolved modeled rate/duration): the
-///     compartment must be in [`PkModel::infusable_compartments`] — central for
-///     every model, the oral depot since #400, and the peripheral(s) of the
-///     2-/3-cpt IV models, and — since #375 — the oral models' peripheral(s)
-///     too (the oral propagators reuse the IV forced response; nothing flows
-///     back into the depot). What remains rejected is a compartment with no
-///     rate channel at all. Checked only for the six event-walk
-///     models: `dose_channel` *is* the walk's routing table, and a transit/IG
-///     subject never takes that walk — an infusion reroutes it to the model's
-///     ODE twin (`CompiledModel::effective_for`, #719 gap 2), which addresses
+///   - **Range — every dose, whatever its amount.** `cmt` must not exceed the
+///     model's state count. This is deliberately *not* skipped for `AMT=0`:
+///     both walks bound-check the compartment before the amount is read, so an
+///     inert row with an out-of-range `CMT` panics exactly like a real dose.
+///     `CMT=0` is left alone — every path treats it as NONMEM's "default dose
+///     compartment" (the walk via `saturating_sub(1)`, `dose_needs_event_walk`
+///     by mapping it to 1, the superposition path by ignoring `cmt`), so it is
+///     consistent, not a silent mis-route.
+///   - **Routing — infusions that actually deliver.** The compartment must be
+///     in [`PkModel::infusable_compartments`] — central for every model, the
+///     oral depot since #400, the peripheral(s) of the 2-/3-cpt IV models, and
+///     — since #375 — the oral models' peripheral(s) too (the oral propagators
+///     reuse the IV forced response; nothing flows back into the depot). That
+///     makes the set `1..=n_states` for all six walk-supported models, so with
+///     the range rule claimed first the only value this rule can still reject
+///     is `CMT=0`, which has no meaning for a zero-order input. A zero-amount
+///     infusion is exempt (`duration = AMT/RATE = 0`, so no path opens a rate
+///     window). Checked only for the six event-walk models: `dose_channel` *is*
+///     the walk's routing table, and a transit/IG subject never takes that walk
+///     — an infusion reroutes it to the model's ODE twin
+///     (`CompiledModel::effective_for`, #719 gap 2), which addresses
 ///     compartments directly. Applying this table to them would reject a
 ///     supported model.
-///   - **Bolus**: `cmt` must not exceed the model's state count. `CMT=0` is
-///     left alone — both analytical paths already treat it as NONMEM's
-///     "default dose compartment" (the walk via `saturating_sub(1)`, the
-///     superposition path by ignoring `cmt`), so it is consistent, not a
-///     silent mis-route.
 ///
 /// ODE models are exempt: `ode/predictions.rs` indexes the state vector
 /// directly, so every compartment the `[odes]` block **declares** is
@@ -707,8 +710,8 @@ fn population_uses_analytical_pk(model: &CompiledModel, population: &Population)
 /// exemption, not a clean bill of health — an ODE dose whose `CMT` is past the
 /// end of the declared state vector is still silently dropped by that engine's
 /// `if cmt_idx < n { … }` guards. Closing that is a separate change (it needs
-/// the ODE state count, not a `PkModel` topology) and is tracked separately;
-/// this check deliberately does not half-do it.
+/// the ODE state count, not a `PkModel` topology) and is tracked as #899; this
+/// check deliberately does not half-do it.
 ///
 /// Reported once per `(kind, compartment)` so a dataset with many offending
 /// rows yields one actionable error per cause, matching
@@ -737,68 +740,84 @@ pub(crate) fn check_dose_compartments(
     }
     for subject in &population.subjects {
         for dose in &subject.doses {
-            // A zero-amount dose delivers nothing on any path and never reaches
-            // the routing `match` this check guards: the walk's bolus branch adds
-            // `F·0`, and its infusion branch requires `duration > 0`, which an
-            // `AMT=0` infusion never has (`duration = AMT/RATE = 0`). Such a row
-            // is a no-op, not a mis-routed dose — rejecting a whole fit over it
-            // would be stricter than the failure being fixed. (`is_infusion()` is
-            // `rate > 0 || !is_fixed()`, which is deliberately broader than the
-            // walk's `rate > 0 && duration > 0`; this is where the two reconcile.)
-            if dose.amt == 0.0 {
-                continue;
-            }
             let is_infusion = dose.is_infusion();
-            if !reported.insert((is_infusion, dose.cmt)) {
-                continue;
-            }
             let cmt = dose.cmt;
-            // Range first, and for **both** dose kinds. Transit/IG skip the
-            // routing rule below but are still 2-/3-state models, so without this
-            // an out-of-range infusion on them would pass validation and then be
-            // silently dropped by the ODE twin's bounds check — the exact
-            // silent-drop failure this check exists to remove.
+            // **Range rule — every dose, whatever its amount.** Both walks
+            // bound-check the compartment *before* the amount is read
+            // (`event_driven::…impl`'s `if cmt_idx < n_states { … } else { panic! }`
+            // and its `sens::propagate` twin), so an `AMT=0` row with an
+            // out-of-range `CMT` reaches the panic exactly like a real dose —
+            // and since #375 routes any `cmt != 1` bolus to the walk, it now
+            // gets there. Exempting zero-amount doses here (as an earlier
+            // revision did, on the incorrect premise that the bolus branch just
+            // "adds `F·0`") re-opened that panic for a NONMEM-idiomatic
+            // `EVID=4, AMT=0` reset row carrying a stale `CMT`.
+            //
+            // Transit/IG skip the routing rule below but are still 2-/3-state
+            // models, so this also stops an out-of-range infusion on them from
+            // passing validation and being silently dropped by the ODE twin's
+            // bounds check.
             if cmt > n_states {
-                diags.push(
-                    Diagnostic::error(
-                        "E_DOSE_CMT_OUT_OF_RANGE",
-                        format!(
-                            "subject {}, time {}: dose into compartment {cmt}, but the \
-                             analytical `{name}` model has only {n_states} compartment(s) \
-                             (CMT is 1-based: {:?}).",
-                            subject.id, dose.time, topology.compartment_names,
-                        ),
-                    )
-                    .with_block("structural_model"),
-                );
-            } else if is_infusion {
-                // Transit/IG (`event_walk_supported == false`) never take the
-                // walk this routing table belongs to — an infusion reroutes them
-                // to their ODE twin (#719 gap 2), which addresses compartments
-                // directly. Rejecting here would break a supported model.
-                if !topology.event_walk_supported {
-                    continue;
-                }
-                // For a walk-supported model `infusable` *equals* the walk's
-                // routing table (pinned by `topology_fields_are_internally_consistent`),
-                // so this is exactly the set `dose_channel` can route.
-                if !pk_model.infusable_compartments().contains(&cmt) {
+                if reported.insert((is_infusion, cmt)) {
                     diags.push(
                         Diagnostic::error(
-                            "E_DOSE_CMT_NOT_INFUSABLE",
+                            "E_DOSE_CMT_OUT_OF_RANGE",
                             format!(
-                                "subject {}, time {}: infusion into compartment {cmt}, \
-                                 but the analytical `{name}` model can only infuse into \
-                                 compartment(s) {:?}. An infusion into another compartment \
-                                 (e.g. an oral peripheral) needs an `ode(...)` model.",
-                                subject.id,
-                                dose.time,
-                                pk_model.infusable_compartments(),
+                                "subject {}, time {}: dose into compartment {cmt}, but the \
+                                 analytical `{name}` model has only {n_states} compartment(s) \
+                                 (CMT is 1-based: {:?}).",
+                                subject.id, dose.time, topology.compartment_names,
                             ),
                         )
                         .with_block("structural_model"),
                     );
                 }
+                continue;
+            }
+            // **Routing rule — infusions that actually deliver.** Unlike the
+            // range rule, the zero-amount exemption is sound here: an `AMT=0`
+            // infusion has `duration = AMT/RATE = 0`, and the walk's infusion
+            // branch requires `duration > 0`, so no path ever opens a rate
+            // window for it. Rejecting a whole fit over an inert row would be
+            // stricter than the failure being fixed. (`is_infusion()` is
+            // `rate > 0 || !is_fixed()`, deliberately broader than the walk's
+            // `rate > 0 && duration > 0`; this is where the two reconcile.)
+            if !is_infusion || dose.amt == 0.0 {
+                continue;
+            }
+            // Transit/IG (`event_walk_supported == false`) never take the walk
+            // this routing table belongs to — an infusion reroutes them to their
+            // ODE twin (#719 gap 2), which addresses compartments directly.
+            // Rejecting here would break a supported model.
+            if !topology.event_walk_supported {
+                continue;
+            }
+            // For a walk-supported model `infusable` *equals* the walk's routing
+            // table (pinned by `topology_fields_are_internally_consistent`), so
+            // this is exactly the set `dose_channel` can route. Since #375 that
+            // set is `1..=n_states` for all six of them, and `cmt > n_states` is
+            // already claimed above — so the only value that reaches this arm is
+            // `CMT=0`, which has no meaning for an infusion (see the message).
+            if !pk_model.infusable_compartments().contains(&cmt)
+                && reported.insert((is_infusion, cmt))
+            {
+                diags.push(
+                    Diagnostic::error(
+                        "E_DOSE_CMT_NOT_INFUSABLE",
+                        format!(
+                            "subject {}, time {}: infusion into compartment {cmt}, but the \
+                             analytical `{name}` model can only infuse into compartment(s) \
+                             {:?}. `CMT=0` is NONMEM's *default dose compartment*, which is \
+                             defined for a bolus but not for a zero-order input — name the \
+                             target compartment explicitly (1-based: {:?}).",
+                            subject.id,
+                            dose.time,
+                            pk_model.infusable_compartments(),
+                            topology.compartment_names,
+                        ),
+                    )
+                    .with_block("structural_model"),
+                );
             }
         }
     }
@@ -1326,13 +1345,32 @@ pub(crate) fn assert_survival_tv_covariates(model: &CompiledModel, population: &
 }
 
 /// Reject an analytic Form C readout (`[scaling] y = <expr>`, #650) that reads
-/// the oral **depot** amount on a subject carrying an EVID=3/4 reset.
+/// the oral **depot** amount on a subject whose dose history dose superposition
+/// cannot reconstruct — an EVID=3/4 reset, or a dose the superposition state
+/// helper cannot place (#375).
 ///
-/// The depot amount is reconstructed by dose superposition (`apply_analytic_readout`),
-/// which is invalid across a reset — the closed form cannot restart the accumulation,
-/// so the readout would silently see a zero depot after the reset and mis-predict.
+/// `apply_analytic_readout` reconstructs the depot amount with
+/// [`crate::pk::analytical_state_at_times`], and both failure modes make that
+/// reconstruction wrong in a way that reaches `PRED` — and therefore the **OFV**,
+/// not just a diagnostic column:
+///
+///  - a **reset** zeroes the compartments mid-record, which is not a sum of
+///    independent dose responses, so the readout would see a zero depot after
+///    the reset;
+///  - a **non-default dose compartment** is invisible to `single_dose_states`,
+///    which never reads `dose.cmt` and places every bolus in compartment 1 and
+///    every infusion in central. A bolus written `CMT=2` on a `one_cpt_oral`
+///    model is therefore reconstructed as if it had been absorbed through the
+///    depot, adding a phantom depot amount. Measured on
+///    `[scaling] y = (central + depot)/V`: OFV 188.37 against an ODE twin's
+///    1761.47, where the same model with the dose at `CMT=1` agrees with the
+///    twin exactly.
+///
+/// The `ipred` path itself is correct for these subjects (it reroutes to the
+/// event-driven walk, `dose_needs_event_walk`), but that walk has no states
+/// variant for the readout to read, so there is nothing to fall back to.
 /// Rather than return a subtly wrong `PRED`/OFV, fail loudly and point at an ODE
-/// model (which integrates the depot state across resets). A `central`-only readout
+/// model (which integrates the depot state directly). A `central`-only readout
 /// is unaffected. Returns `None` for the common no-readout / IV / central-only case.
 pub(crate) fn check_analytic_readout_support(
     model: &CompiledModel,
@@ -1351,6 +1389,20 @@ pub(crate) fn check_analytic_readout_support(
                  across a reset. Reference only the `central` amount, or use an ODE model \
                  (`ode(states=[depot, central])`) which integrates the depot across resets. \
                  See issue #650.",
+                subject.id
+            ));
+        }
+        if crate::pk::dose_needs_event_walk(model.pk_model, subject) {
+            return Some(format!(
+                "[scaling] y: an analytic Form C readout that references the oral `depot` \
+                 amount is not supported on a subject dosing a non-default compartment \
+                 (subject {}): the depot amount is reconstructed by dose superposition, \
+                 which places every bolus in compartment 1 and every infusion in central \
+                 regardless of `CMT`, so a dose elsewhere would contribute a phantom depot \
+                 amount to `PRED` (and to the objective). Reference only the `central` \
+                 amount, dose the default compartment, or use an ODE model \
+                 (`ode(states=[depot, central])`) which addresses compartments directly. \
+                 See issue #375.",
                 subject.id
             ));
         }

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -686,8 +686,10 @@ fn population_uses_analytical_pk(model: &CompiledModel, population: &Population)
 ///   - **Infusion** (`RATE>0`, or a resolved modeled rate/duration): the
 ///     compartment must be in [`PkModel::infusable_compartments`] — central for
 ///     every model, the oral depot since #400, and the peripheral(s) of the
-///     2-/3-cpt IV models. Oral peripherals have no closed form and are
-///     rejected rather than mis-routed. Checked only for the six event-walk
+///     2-/3-cpt IV models, and — since #375 — the oral models' peripheral(s)
+///     too (the oral propagators reuse the IV forced response; nothing flows
+///     back into the depot). What remains rejected is a compartment with no
+///     rate channel at all. Checked only for the six event-walk
 ///     models: `dose_channel` *is* the walk's routing table, and a transit/IG
 ///     subject never takes that walk — an infusion reroutes it to the model's
 ///     ODE twin (`CompiledModel::effective_for`, #719 gap 2), which addresses
@@ -735,6 +737,17 @@ pub(crate) fn check_dose_compartments(
     }
     for subject in &population.subjects {
         for dose in &subject.doses {
+            // A zero-amount dose delivers nothing on any path and never reaches
+            // the routing `match` this check guards: the walk's bolus branch adds
+            // `F·0`, and its infusion branch requires `duration > 0`, which an
+            // `AMT=0` infusion never has (`duration = AMT/RATE = 0`). Such a row
+            // is a no-op, not a mis-routed dose — rejecting a whole fit over it
+            // would be stricter than the failure being fixed. (`is_infusion()` is
+            // `rate > 0 || !is_fixed()`, which is deliberately broader than the
+            // walk's `rate > 0 && duration > 0`; this is where the two reconcile.)
+            if dose.amt == 0.0 {
+                continue;
+            }
             let is_infusion = dose.is_infusion();
             if !reported.insert((is_infusion, dose.cmt)) {
                 continue;

--- a/src/estimation/run_covariance.rs
+++ b/src/estimation/run_covariance.rs
@@ -167,6 +167,14 @@ pub fn run_covariance(
         }
     };
 
+    // This entry point re-runs the inner loop (EBEs → the prediction walk), so
+    // it needs the same dose-compartment precondition `fit()` enforces (#375) —
+    // otherwise a caller-supplied population with an unroutable dose aborts the
+    // process from inside the walk, from a `Result`-returning API. Matches the
+    // `Result` form used at the adaptive chokepoint rather than the
+    // `predict()`/`simulate()` panic.
+    crate::diagnostics::first_error(&crate::api::check_dose_compartments(model_ref, pop_ref))?;
+
     // --- Sanity-check dimensions ------------------------------------------
     if model_ref.n_eta != fit.omega.nrows() {
         return Err(format!(

--- a/src/estimation/run_sir.rs
+++ b/src/estimation/run_sir.rs
@@ -160,6 +160,11 @@ pub fn run_sir(
         }
     };
 
+    // Re-runs the inner loop (EBEs → the prediction walk), so it needs the same
+    // dose-compartment precondition `fit()` enforces (#375) — a `Result`-returning
+    // API must not abort the process from inside the walk. Mirrors `run_covariance`.
+    crate::diagnostics::first_error(&crate::api::check_dose_compartments(model_ref, pop_ref))?;
+
     // --- Sanity-check dimensions ------------------------------------------
     if model_ref.n_eta != fit.omega.nrows() {
         return Err(format!(

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1635,15 +1635,17 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
                 }
             };
             // Reject a `D{cmt}`/`R{cmt}` whose compartment the analytical engine
-            // cannot infuse into — the central compartment for every model, plus
-            // the peripheral compartment(s) of the 2-/3-cpt IV models, but NOT an
-            // oral depot or oral peripheral (see `PkModel::infusable_compartments`).
-            // A looser bound (e.g. raw compartment count) would let a coded `RATE`
-            // into an oral depot pass parse + the data gate, then either silently
-            // route into central (no-TV superposition) or panic in the
-            // event-driven walker — the silent/abrupt failure class this feature
-            // exists to prevent. Caught here at parse time with an actionable
-            // message.
+            // cannot infuse into (see `PkModel::infusable_compartments`): every
+            // compartment of the six walk-supported models is infusable — central
+            // for all, the oral depot since #400, the oral peripherals since #375
+            // — so what this actually catches is a `D{cmt}` past the end of the
+            // state vector, and any `D{cmt}` at all on a transit/IG model (whose
+            // `infusable` is empty). A looser bound (e.g. raw compartment count)
+            // would let such a coded `RATE` pass parse + the data gate, then
+            // either silently route into central (no-TV superposition) or panic in
+            // the event-driven walker — the silent/abrupt failure class this
+            // feature exists to prevent. Caught here at parse time with an
+            // actionable message.
             let infusable = pk_model.infusable_compartments();
             if !infusable.contains(&cmt) {
                 let supported = infusable
@@ -1655,17 +1657,18 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
                     "[individual_parameters]: `{name}` is a modeled infusion {kind} \
                      (RATE={rate_code}) for compartment {cmt}, but the analytical `{}` model \
                      can only infuse into compartment(s) {:?} ({supported}). A zero-order \
-                     input into another compartment (e.g. an oral depot) needs an \
-                     `ode(...)` model.",
+                     input into a compartment the closed form does not have — or into any \
+                     compartment of a transit / inverse-Gaussian absorption model — needs \
+                     an `ode(...)` model.",
                     pk_model.canonical_name(),
                     infusable,
                 ));
             }
-            // `infusable_compartments()` has ≤ 3 entries and at most one `D` and
-            // one `R` per compartment, so at most 6 distinct modeled-dose
-            // parameters are routed — comfortably inside the 9..16 (7-slot) spare
-            // region. A debug assertion documents that invariant without a
-            // permanently-dead user-facing error arm.
+            // `infusable_compartments()` has ≤ 4 entries (`three_cpt_oral`, since
+            // #375) and at most one `D` and one `R` per compartment, so at most 8
+            // distinct modeled-dose parameters are routed — comfortably inside
+            // `MAX_PK_PARAMS`. A debug assertion documents that invariant without
+            // a permanently-dead user-facing error arm.
             debug_assert!(
                 next_slot < crate::types::MAX_PK_PARAMS,
                 "modeled-dose slot {next_slot} exceeds MAX_PK_PARAMS; \

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -12310,11 +12310,13 @@ fn analytical_modeled_duration_into_oral_depot_parses() {
 }
 
 #[test]
-fn analytical_modeled_duration_into_oral_peripheral_is_rejected() {
-    // `D3` on a `two_cpt_oral` model targets a PERIPHERAL (cmt 3), which the
-    // analytical oral closed forms still cannot infuse into (infusable =
-    // {1 depot, 2 central}). It must be a loud parse error pointing at
-    // `ode(...)` — not silently routed or a runtime panic (#400).
+fn analytical_modeled_duration_into_oral_peripheral_parses() {
+    // `D3` on a `two_cpt_oral` model targets a PERIPHERAL (cmt 3). Since #375 the
+    // analytical oral closed forms CAN infuse a peripheral — the oral propagators
+    // reuse the 2-cpt IV forced response, since nothing flows back into the depot
+    // — so `infusable = {1 depot, 2 central, 3 peripheral}` and this must parse.
+    // (It was a loud parse error before #375, when the oral propagators had no
+    // peripheral forcing term; see #400 for the depot case.)
     let src = r#"
 [parameters]
   theta TVCL(5.0, 0.1, 100.0)
@@ -12340,12 +12342,43 @@ fn analytical_modeled_duration_into_oral_peripheral_is_rejected() {
 [error_model]
   DV ~ proportional(PROP)
 "#;
+    parse_full_model(src).expect("D3 (oral peripheral) is infusable since #375");
+}
+
+/// …but a `D{cmt}` past the end of the state vector is still a loud parse error.
+#[test]
+fn analytical_modeled_duration_beyond_oral_state_count_is_rejected() {
+    let src = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV1(50.0, 1.0, 500.0)
+  theta TVQ(5.0, 0.1, 100.0)
+  theta TVV2(80.0, 1.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  theta TVD4(5.0, 0.1, 24.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP ~ 0.04 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+  D4 = TVD4
+
+[structural_model]
+  pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
     let err = parse_full_model(src)
         .err()
-        .expect("D3 (oral peripheral) on an analytical oral model must error");
+        .expect("D4 on a 3-state oral model must error");
     assert!(
-        err.contains("compartment 3") && err.contains("D3") && err.contains("ode("),
-        "error must name the compartment, the param, and point to ode(...): {err}"
+        err.contains("compartment 4") && err.contains("D4"),
+        "error should name the offending slot: {err}"
     );
 }
 

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -878,9 +878,8 @@ fn propagate_with_bounds(
                     None => panic!(
                         "event-driven PK: infusion into compartment {} not supported \
                          for model {:?}. Supported: central for all models; depot (cmt 1) \
-                         for oral models; periph1/2 for 2- and 3-cpt IV models. Oral \
-                         peripheral infusion is unsupported — should have been rejected \
-                         by `check_dose_compartments`.",
+                         and peripheral(s) for oral models; periph1/2 for 2- and 3-cpt IV \
+                         models — should have been rejected by `check_dose_compartments`.",
                         d.cmt, pk_model
                     ),
                 }
@@ -932,6 +931,7 @@ fn propagate_with_bounds(
                         &e,
                         pk.ka(),
                         rate_central,
+                        rate_periph1,
                         rate_depot,
                     );
                 }
@@ -958,6 +958,8 @@ fn propagate_with_bounds(
                         &e,
                         pk.ka(),
                         rate_central,
+                        rate_periph1,
+                        rate_periph2,
                         rate_depot,
                     );
                 }

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -701,9 +701,16 @@ fn event_driven_predictions_with_schedule_impl(
                     if cmt_idx < n_states {
                         state[cmt_idx] += pk_now.bioavailable_amount(d.amt);
                     } else {
+                        // Unreachable from a validated call: `check_dose_compartments`
+                        // (#375) rejects `cmt > n_states` up front — as an `Err` from
+                        // `fit()`, as a panic naming the subject/time from
+                        // `predict()`/`simulate()`. Kept as a defensive guard so an
+                        // internal caller that skips validation still fails loudly
+                        // instead of dropping the dose.
                         panic!(
                             "event-driven PK: dose into compartment {} but model has \
-                             {} states (cmt is 1-based)",
+                             {} states (cmt is 1-based) — should have been rejected by \
+                             `check_dose_compartments`",
                             d.cmt, n_states
                         );
                     }
@@ -853,11 +860,18 @@ fn propagate_with_bounds(
                     Some(Channel::Periph1) => rate_periph1 += r,
                     Some(Channel::Periph2) => rate_periph2 += r,
                     Some(Channel::Depot) => rate_depot += r,
+                    // Unreachable from a validated call: `check_dose_compartments`
+                    // (#375) rejects an infusion outside `infusable_compartments()`
+                    // up front, with the subject/time context this deep-in-the-walk
+                    // panic could never carry. Kept as a defensive guard, and
+                    // mirrored by `sens::propagate::active_rates_g` so the value
+                    // and gradient walks agree on what is unroutable.
                     None => panic!(
                         "event-driven PK: infusion into compartment {} not supported \
                          for model {:?}. Supported: central for all models; depot (cmt 1) \
                          for oral models; periph1/2 for 2- and 3-cpt IV models. Oral \
-                         peripheral infusion is a tracked follow-up.",
+                         peripheral infusion is unsupported — should have been rejected \
+                         by `check_dose_compartments`.",
                         d.cmt, pk_model
                     ),
                 }
@@ -1042,6 +1056,44 @@ mod tests {
         use crate::types::RateMode;
         let modeled = DoseEvent::modeled(0.0, 100.0, 1, false, 0.0, RateMode::ModeledDuration);
         let subject = make_subject(vec![modeled], vec![1.0]);
+        let pk = pk_one(5.0, 50.0);
+        let _ = event_driven_predictions(
+            PkModel::OneCptIv,
+            &subject,
+            std::slice::from_ref(&pk),
+            std::slice::from_ref(&pk),
+            &[],
+        );
+    }
+
+    /// #375: the walk's routing `match` is the guard `check_dose_compartments`
+    /// makes unreachable from a validated call. Direct call (bypassing the
+    /// entry-point gates) confirms the predictor still fails loudly rather than
+    /// silently dropping the infusion, and pins the message the sens walk
+    /// mirrors.
+    #[test]
+    #[should_panic(expected = "infusion into compartment 2 not supported")]
+    fn event_driven_predictions_panics_on_an_unroutable_infusion() {
+        // `one_cpt_iv` has a single compartment, so cmt 2 has no rate channel.
+        let infusion = DoseEvent::new(0.0, 100.0, 2, 20.0, false, 0.0);
+        let subject = make_subject(vec![infusion], vec![1.0]);
+        let pk = pk_one(5.0, 50.0);
+        let _ = event_driven_predictions(
+            PkModel::OneCptIv,
+            &subject,
+            std::slice::from_ref(&pk),
+            std::slice::from_ref(&pk),
+            &[],
+        );
+    }
+
+    /// #375's sibling: a bolus past the end of the state vector. Same contract —
+    /// rejected up front, defensive panic if an internal caller skips validation.
+    #[test]
+    #[should_panic(expected = "should have been rejected by `check_dose_compartments`")]
+    fn event_driven_predictions_panics_on_an_out_of_range_bolus() {
+        let bolus = DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0);
+        let subject = make_subject(vec![bolus], vec![1.0]);
         let pk = pk_one(5.0, 50.0);
         let _ = event_driven_predictions(
             PkModel::OneCptIv,

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -323,9 +323,18 @@ fn equilibrate_ss_state_event_driven(
     let (n_states, _) = state_layout(pk_model);
     let mut state = vec![0.0_f64; n_states];
 
-    if dose.ii <= 0.0 || dose.cmt == 0 {
+    if dose.ii <= 0.0 {
         return state;
     }
+    // `CMT=0` is NONMEM's "default dose compartment", and every other dose site
+    // on this walk resolves it that way via `saturating_sub(1)` → state 0 (the
+    // depot for an oral model, central for an IV one), matching the
+    // superposition path, which ignores `cmt` entirely. This branch used to bail
+    // to an all-zero state on `cmt == 0` instead, silently dropping the
+    // steady-state accumulation of an `SS=1` dose — the walk returned the
+    // single-dose curve while superposition returned the correct
+    // `(D/V)·e^{-kt}/(1−e^{-k·II})` (#375). Fall through so the default
+    // compartment equilibrates like any other.
     let cmt_idx = dose.cmt.saturating_sub(1);
     if cmt_idx >= n_states {
         return state;
@@ -1064,6 +1073,47 @@ mod tests {
             std::slice::from_ref(&pk),
             &[],
         );
+    }
+
+    /// #375: `CMT=0` is NONMEM's default dose compartment, and
+    /// `check_dose_compartments` permits it on a **bolus** precisely because
+    /// both analytical paths agree on it. `equilibrate_ss_state_event_driven`
+    /// used to break that agreement for `SS=1`: it bailed to an all-zero state
+    /// on `cmt == 0`, so the walk returned the single-dose curve while the
+    /// superposition path returned the accumulated steady state.
+    ///
+    /// Anchored on the closed form rather than on the other path, so this pins
+    /// the right answer and not merely agreement:
+    /// `C_ss(t) = (D/V)·e^{−kt} / (1 − e^{−k·II})`.
+    #[test]
+    fn ss_dose_into_cmt_zero_equilibrates_like_the_default_compartment() {
+        let (cl, v, amt, ii) = (5.0, 50.0, 100.0, 12.0);
+        let obs_times = vec![1.0, 4.0, 8.0];
+        let pk = pk_one(cl, v);
+        let run = |cmt: usize| -> Vec<f64> {
+            let dose = DoseEvent::new(0.0, amt, cmt, 0.0, true, ii);
+            let subject = make_subject(vec![dose], obs_times.clone());
+            event_driven_predictions(
+                PkModel::OneCptIv,
+                &subject,
+                std::slice::from_ref(&pk),
+                &vec![pk; obs_times.len()],
+                &[],
+            )
+        };
+        let k = cl / v;
+        let expected: Vec<f64> = obs_times
+            .iter()
+            .map(|t| (amt / v) * (-k * t).exp() / (1.0 - (-k * ii).exp()))
+            .collect();
+        for (label, got) in [("cmt 0", run(0)), ("cmt 1", run(1))] {
+            for (j, (&g, &e)) in got.iter().zip(&expected).enumerate() {
+                assert!(
+                    (g - e).abs() < 1e-9,
+                    "{label} obs {j}: walk {g} vs closed-form steady state {e}"
+                );
+            }
+        }
     }
 
     /// #375: the walk's routing `match` is the guard `check_dose_compartments`

--- a/src/pk/event_driven.rs
+++ b/src/pk/event_driven.rs
@@ -26,8 +26,14 @@
 //!     depot-bypassing infusion) AND into the **depot** (cmt 1, #400) —
 //!     a zero-order release into the depot, then first-order `ka`
 //!     absorption into central.
-//! Infusion into an oral peripheral compartment still panics — a rare
-//! clinical setup tracked as a follow-up.
+//!   - Oral models, since #375: into the **peripheral** compartment(s) too
+//!     (cmt 3 on `two_cpt_oral`, cmt 3/4 on `three_cpt_oral`). Nothing flows
+//!     back into the depot, so a rate into a peripheral drives exactly the
+//!     central/peripheral sub-system the IV model has, and the oral propagator
+//!     superposes that same IV forced response onto its homogeneous evolution.
+//! Every compartment of the six walk-supported models is therefore infusable;
+//! what remains rejected is `CMT=0` (no default compartment for a zero-order
+//! input) and anything past the end of the state vector.
 
 use crate::pk::topology::Channel;
 use crate::types::{DoseEvent, PkModel, PkParams, Subject};

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1889,27 +1889,6 @@ pub fn compute_predictions(pk_model: PkModel, subject: &Subject, pk_params: &PkP
         .collect()
 }
 
-/// Whether `subject` has a zero-order infusion into the **depot** (cmt 1) of an
-/// oral model (#400) — a dose into compartment 1 of `one_cpt_oral` /
-/// `two_cpt_oral` / `three_cpt_oral` that [`DoseEvent::is_infusion`] reports as
-/// an infusion (an explicit positive `RATE`, or a still-modeled `RATE=-2` `D1`).
-///
-/// Such doses have no closed form in the superposition path (which models the
-/// oral depot as bolus-only), so the dispatcher routes them through the
-/// event-driven propagator instead, and their per-compartment states degrade to
-/// NaN. IV models and oral **central** infusions (cmt 2, handled by the
-/// depot-bypass IV formula) return `false`.
-///
-/// Uses `is_infusion()` rather than `rate > 0` so the predicate gives the same
-/// answer on the **raw** subject (modeled `RATE=-2` doses still read `rate == 0`)
-/// and the **resolved** subject (where it reduces to `rate > 0`). This is the
-/// single source of truth shared by the prediction dispatch, the compartment-
-/// state degradation, and the `W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL`
-/// warning — so the three can never disagree about which subjects are affected.
-pub(crate) fn has_oral_depot_infusion(pk_model: PkModel, subject: &Subject) -> bool {
-    pk_model.is_oral() && subject.doses.iter().any(|d| d.cmt == 1 && d.is_infusion())
-}
-
 /// True when any dose targets a compartment the **dose-superposition** dispatch
 /// cannot express, so the subject must be served by the event-driven walk.
 ///
@@ -1924,8 +1903,8 @@ pub(crate) fn has_oral_depot_infusion(pk_model: PkModel, subject: &Subject) -> b
 /// - an **infusion** takes the IV infusion form, which delivers into
 ///   **central** — compartment 2 for an oral model (the documented depot-bypass,
 ///   #350), compartment 1 for an IV model. Any other target is wrong: the oral
-///   **depot** (#400, previously the only case handled, by
-///   [`has_oral_depot_infusion`]) and every **peripheral**.
+///   **depot** (#400, previously the only case handled, by the since-removed
+///   `has_oral_depot_infusion`) and every **peripheral**.
 ///
 /// `CMT=0` is NONMEM's default dose compartment and resolves to compartment 1,
 /// so it is treated as such here.
@@ -1938,10 +1917,18 @@ pub(crate) fn has_oral_depot_infusion(pk_model: PkModel, subject: &Subject) -> b
 /// disagrees with NONMEM by up to two orders of magnitude. Rerouting is
 /// therefore a correction, not a preference (#375).
 ///
-/// Subsumes [`has_oral_depot_infusion`] (an oral depot infusion is an infusion
-/// whose compartment is not central); that predicate is kept for the
-/// compartment-state degradation and its warning, which are about a different
-/// question.
+/// **Single source of truth.** This is the *only* predicate deciding which
+/// subjects superposition cannot serve, and every consumer must use it: the
+/// prediction dispatch (`compute_predictions`), the compartment-state
+/// degradation (`compute_predictions_with_states`), the dense `[derived]` grid
+/// states (`api::output_columns`), the analytic Form-C readout gate
+/// (`check_analytic_readout_support`), the `sens` gradient router
+/// (`provider::subject_routes_to_event_walk`), and the
+/// `W_DERIVED_CMT_ORAL_DEPOT_INFUSION_ANALYTICAL` warning. It replaced the
+/// narrower `has_oral_depot_infusion` (which handled only the #400 depot case);
+/// leaving one consumer on the old predicate is exactly how a `[derived]` grid
+/// integral came to report a confident wrong number while the adjacent per-obs
+/// column was NaN.
 pub(crate) fn dose_needs_event_walk(pk_model: PkModel, subject: &Subject) -> bool {
     // Transit/IG cannot be state-propagated, so there is no walk to route to.
     // They reject non-depot doses up front instead (`check_absorption_dosing` /

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1808,15 +1808,18 @@ pub fn compute_predictions_with_states(
                 model.active_dose_attr_map(),
                 &pk.values,
             );
-            if has_oral_depot_infusion(model.pk_model, &resolved) {
-                // The superposition state helper (`single_dose_states`) models an
-                // oral infusion as a depot-bypassing input into central, so it
-                // cannot express a zero-order input into the **depot** (#400) —
-                // it would report silently-wrong compartment amounts. The
-                // event-driven path (used for `ipred` above) has no states
-                // variant yet, so return outer-empty → NaN compartments, matching
-                // the reset/TV-analytical convention. ipred stays correct;
-                // sdtab/`[derived]` compartment amounts degrade to NaN.
+            if dose_needs_event_walk(model.pk_model, &resolved) {
+                // `single_dose_states` shares `single_dose_concentration`'s
+                // cmt-blindness: it models an oral infusion as a depot-bypassing
+                // input into central (so it cannot express a zero-order input
+                // into the **depot**, #400) and every bolus as going into
+                // compartment 1 — so for any dose outside those it would report
+                // silently-wrong compartment amounts. `ipred` above is correct
+                // either way (it reroutes to the event-driven walk), but that
+                // path has no states variant yet, so return outer-empty → NaN
+                // compartments, matching the reset/TV-analytical convention.
+                // sdtab/`[derived]` compartment amounts degrade to NaN rather
+                // than being wrong (#375).
                 vec![]
             } else {
                 predict_all_states(model.pk_model, &resolved, &pk)
@@ -1861,7 +1864,11 @@ pub fn compute_predictions(pk_model: PkModel, subject: &Subject, pk_params: &PkP
     // have no depot-infusion form, so a `D{depot}` infusion would be silently
     // mishandled. The event-driven propagator implements the depot zero-order
     // forced response, so route depot-infusion subjects there too.
-    if (subject.has_resets() || has_oral_depot_infusion(pk_model, subject))
+    // `dose_needs_event_walk` subsumes the depot-infusion case above and extends
+    // it to every dose whose compartment superposition cannot express — any
+    // bolus outside compartment 1, and any infusion outside central. NONMEM
+    // agrees with the walk on all of them (#375).
+    if (subject.has_resets() || dose_needs_event_walk(pk_model, subject))
         && event_driven::supports_event_driven(pk_model)
     {
         let pk_dose = vec![*pk_params; subject.doses.len()];
@@ -1901,6 +1908,57 @@ pub fn compute_predictions(pk_model: PkModel, subject: &Subject, pk_params: &PkP
 /// warning — so the three can never disagree about which subjects are affected.
 pub(crate) fn has_oral_depot_infusion(pk_model: PkModel, subject: &Subject) -> bool {
     pk_model.is_oral() && subject.doses.iter().any(|d| d.cmt == 1 && d.is_infusion())
+}
+
+/// True when any dose targets a compartment the **dose-superposition** dispatch
+/// cannot express, so the subject must be served by the event-driven walk.
+///
+/// [`single_dose_concentration`] never reads `dose.cmt`. It branches only on
+/// `is_infusion()` and then picks the closed form from the *model*, which fixes
+/// where the dose lands:
+///
+/// - a **bolus** takes the model's own form — an oral model absorbs it through
+///   the depot, an IV model injects it into central. Either way that is
+///   compartment **1**, so any bolus into compartment ≥ 2 is computed in the
+///   wrong compartment.
+/// - an **infusion** takes the IV infusion form, which delivers into
+///   **central** — compartment 2 for an oral model (the documented depot-bypass,
+///   #350), compartment 1 for an IV model. Any other target is wrong: the oral
+///   **depot** (#400, previously the only case handled, by
+///   [`has_oral_depot_infusion`]) and every **peripheral**.
+///
+/// `CMT=0` is NONMEM's default dose compartment and resolves to compartment 1,
+/// so it is treated as such here.
+///
+/// The event-driven walk applies each dose to its actual compartment and is
+/// **NONMEM-anchored for exactly these cases** — `ADVAN2` central bolus,
+/// `ADVAN3`/`ADVAN4` peripheral bolus, `ADVAN11` peripheral-2 bolus, `ADVAN12`
+/// central bolus, and an `ADVAN3` peripheral infusion all match to <1e-8
+/// relative (`tests/nonmem_dose_compartment_anchor.rs`), while superposition
+/// disagrees with NONMEM by up to two orders of magnitude. Rerouting is
+/// therefore a correction, not a preference (#375).
+///
+/// Subsumes [`has_oral_depot_infusion`] (an oral depot infusion is an infusion
+/// whose compartment is not central); that predicate is kept for the
+/// compartment-state degradation and its warning, which are about a different
+/// question.
+pub(crate) fn dose_needs_event_walk(pk_model: PkModel, subject: &Subject) -> bool {
+    // Transit/IG cannot be state-propagated, so there is no walk to route to.
+    // They reject non-depot doses up front instead (`check_absorption_dosing` /
+    // `check_absorption_closed_form_support`).
+    if !event_driven::supports_event_driven(pk_model) {
+        return false;
+    }
+    let central_cmt = if pk_model.is_oral() { 2 } else { 1 };
+    subject.doses.iter().any(|d| {
+        // `CMT=0` == the default dose compartment == 1.
+        let cmt = if d.cmt == 0 { 1 } else { d.cmt };
+        if d.is_infusion() {
+            cmt != central_cmt
+        } else {
+            cmt != 1
+        }
+    })
 }
 
 /// Compute predictions using ODE integration.

--- a/src/pk/topology.rs
+++ b/src/pk/topology.rs
@@ -17,7 +17,10 @@ use crate::types::PkModel;
 /// Which internal rate accumulator a 1-based dose compartment routes into for
 /// the closed-form event walk. Returned by [`PkTopology::dose_channel`]; callers
 /// map each arm onto their own `rate_*` accumulator and decide the `None` policy
-/// (event_driven panics on an unsupported infusion cmt; active_rates_g skips).
+/// — since #375 both walks `panic!` on it (silently dropping an infusion from
+/// the *gradient* only would make FOCE differentiate a different dosing history
+/// than it predicted), and `check_dose_compartments` makes that unreachable from
+/// a validated call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Channel {
     Central,
@@ -76,10 +79,14 @@ impl PkTopology {
     }
 
     /// Rate channel for a 1-based dose compartment. `None` = not infusable for
-    /// this model (caller decides panic vs skip). Preserves the old
+    /// this model; every caller panics on it (see [`Channel`]). Preserves the old
     /// `match (pk_model, d.cmt) { .. , _ => .. }` fall-through: any cmt not
-    /// explicitly mapped (incl. cmt 0 and peripherals of oral models) yields
-    /// `None`, exactly the arms the old `_` caught.
+    /// explicitly mapped yields `None`, exactly the arms the old `_` caught.
+    /// Since #375 the oral peripherals map to `Some(Periph1)`/`Some(Periph2)`,
+    /// so for the six walk-supported models the only in-range `None` is `cmt 0`
+    /// (`checked_sub(1)`), NONMEM's default dose compartment — which has no
+    /// meaning for a zero-order input and is rejected by
+    /// `check_dose_compartments`.
     #[inline]
     pub(crate) fn dose_channel(&self, cmt_1based: usize) -> Option<Channel> {
         cmt_1based

--- a/src/pk/topology.rs
+++ b/src/pk/topology.rs
@@ -147,8 +147,12 @@ static TWO_CPT_ORAL: PkTopology = PkTopology {
     n_states: 3,
     central_slot: 1,
     compartment_names: &["depot", "central", "peripheral"],
-    channels: &[Some(Depot), Some(Central)],
-    infusable: &[1, 2],
+    // The oral peripheral is infusable since #375: the depot takes no inflow from
+    // the disposition sub-system, so a rate into the peripheral drives exactly the
+    // central/peripheral pair the 2-cpt IV model has, and the oral propagator
+    // reuses that IV forced response.
+    channels: &[Some(Depot), Some(Central), Some(Periph1)],
+    infusable: &[1, 2, 3],
     event_walk_supported: true,
 };
 // 2-cpt transit: same as the 1-cpt transit — modeled-duration infusion rejected at parse
@@ -182,8 +186,10 @@ static THREE_CPT_ORAL: PkTopology = PkTopology {
     n_states: 4,
     central_slot: 1,
     compartment_names: &["depot", "central", "peripheral1", "peripheral2"],
-    channels: &[Some(Depot), Some(Central)],
-    infusable: &[1, 2],
+    // Both oral peripherals are infusable since #375 — same reduction to the
+    // 3-cpt IV forced response as `TWO_CPT_ORAL`.
+    channels: &[Some(Depot), Some(Central), Some(Periph1), Some(Periph2)],
+    infusable: &[1, 2, 3, 4],
     event_walk_supported: true,
 };
 
@@ -285,16 +291,25 @@ mod tests {
             (TwoCptIv, 2, Some(Channel::Periph1)),
             (TwoCptOral, 1, Some(Channel::Depot)),
             (TwoCptOral, 2, Some(Channel::Central)),
+            // Oral peripherals gained a rate channel in #375 — the oral
+            // propagators reuse the IV forced response, so an infusion into them
+            // is routable rather than rejected.
+            (TwoCptOral, 3, Some(Channel::Periph1)),
             (ThreeCptIv, 1, Some(Channel::Central)),
             (ThreeCptIv, 2, Some(Channel::Periph1)),
             (ThreeCptIv, 3, Some(Channel::Periph2)),
             (ThreeCptOral, 1, Some(Channel::Depot)),
             (ThreeCptOral, 2, Some(Channel::Central)),
-            // old `_` arms -> None
+            (ThreeCptOral, 3, Some(Channel::Periph1)),
+            (ThreeCptOral, 4, Some(Channel::Periph2)),
+            // Still unroutable: cmt 0 (an infusion has no default compartment)
+            // and anything past the end of the state vector.
             (OneCptIv, 0, None),
             (OneCptIv, 2, None),
-            (TwoCptOral, 3, None),
-            (ThreeCptOral, 3, None),
+            (TwoCptOral, 0, None),
+            (TwoCptOral, 4, None),
+            (ThreeCptOral, 0, None),
+            (ThreeCptOral, 5, None),
         ];
         for (m, cmt, want) in cases {
             assert_eq!(m.topology().dose_channel(cmt), want, "{m:?} cmt {cmt}");

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -224,6 +224,7 @@ pub fn propagate_two_cpt_oral_core_g<T: PkNum>(
     e: &TwoCptEigen<T>,
     ka: T,
     rate_central: T,
+    rate_periph1: T,
     rate_depot: T,
 ) {
     let (alpha, beta, k10, k12, k21) = (e.alpha, e.beta, e.k10, e.k12, e.k21);
@@ -273,13 +274,22 @@ pub fn propagate_two_cpt_oral_core_g<T: PkNum>(
     state[1] = h_c_dt + cap_a * e_ka;
     state[2] = h_p_dt + cap_b * e_ka;
 
-    // Constant infusion into central (depot bypass): forced response of the 2-cpt
-    // IV propagator from a zero initial state. `rate_central` is structurally 0 or
-    // positive (never crossing during differentiation), so the `.val()` guard is
-    // derivative-safe and just skips the no-infusion intervals.
-    if rate_central.val() > 0.0 {
+    // Constant infusion into central (depot bypass) and/or into the **peripheral**
+    // (#375): forced response of the 2-cpt IV propagator from a zero initial state.
+    //
+    // Both reduce to the same delegation because the depot is decoupled from the
+    // disposition sub-system in the inflow direction — nothing flows *back* into
+    // the depot — so a rate into central or peripheral drives exactly the
+    // central/peripheral pair an IV model has, and the system is linear, so the
+    // forced response superposes onto the homogeneous evolution above. The oral
+    // peripheral therefore needs no new closed form: it *is* the IV one.
+    //
+    // `rate_*` are structurally 0 or positive (never crossing during
+    // differentiation), so the `.val()` guards are derivative-safe and just skip
+    // the no-infusion intervals.
+    if rate_central.val() > 0.0 || rate_periph1.val() > 0.0 {
         let mut inflow = [T::from_f64(0.0), T::from_f64(0.0)];
-        propagate_two_cpt_core_g(&mut inflow, dt, e, rate_central, T::from_f64(0.0));
+        propagate_two_cpt_core_g(&mut inflow, dt, e, rate_central, rate_periph1);
         state[1] = state[1] + inflow[0];
         state[2] = state[2] + inflow[1];
     }
@@ -299,7 +309,15 @@ pub fn propagate_two_cpt_oral_core_g<T: PkNum>(
         };
         let d_ss = rate_depot / ka;
         let mut xss = [d_ss, c_ss, p_ss];
-        propagate_two_cpt_oral_core_g(&mut xss, dt, e, ka, T::from_f64(0.0), T::from_f64(0.0));
+        propagate_two_cpt_oral_core_g(
+            &mut xss,
+            dt,
+            e,
+            ka,
+            T::from_f64(0.0),
+            T::from_f64(0.0),
+            T::from_f64(0.0),
+        );
         state[0] = state[0] + (d_ss - xss[0]);
         state[1] = state[1] + (c_ss - xss[1]);
         state[2] = state[2] + (p_ss - xss[2]);
@@ -317,13 +335,14 @@ pub fn propagate_two_cpt_oral_g<T: PkNum>(
     v2: T,
     ka: T,
     rate_central: T,
+    rate_periph1: T,
     rate_depot: T,
 ) {
     if ka.val() <= 0.0 {
         return;
     }
     if let Some(e) = two_cpt_eigen_g(cl, v1, q, v2) {
-        propagate_two_cpt_oral_core_g(state, dt, &e, ka, rate_central, rate_depot);
+        propagate_two_cpt_oral_core_g(state, dt, &e, ka, rate_central, rate_periph1, rate_depot);
     }
 }
 
@@ -501,6 +520,8 @@ pub fn propagate_three_cpt_oral_core_g<T: PkNum>(
     e: &ThreeCptEigen<T>,
     ka: T,
     rate_central: T,
+    rate_periph1: T,
+    rate_periph2: T,
     rate_depot: T,
 ) {
     let (alpha, beta, gamma, k10, k12, k13, k21, k31) =
@@ -536,19 +557,16 @@ pub fn propagate_three_cpt_oral_core_g<T: PkNum>(
     state[2] = p1a + p1b + p1g + cap_b * e_ka;
     state[3] = p2a + p2b + p2g + cap_c * e_ka;
 
-    // Constant infusion into central (depot bypass): forced response of the 3-cpt
-    // IV propagator from a zero initial state. `.val()` guard is derivative-safe
-    // (`rate_central` is structurally 0 or positive).
-    if rate_central.val() > 0.0 {
+    // Constant infusion into central (depot bypass) and/or into either
+    // **peripheral** (#375): forced response of the 3-cpt IV propagator from a
+    // zero initial state. The depot takes no inflow from the disposition
+    // sub-system, so a rate into central or a peripheral drives exactly the
+    // three-state system an IV model has — the oral peripherals reuse the IV
+    // closed form rather than needing a new one. `.val()` guards are
+    // derivative-safe (each rate is structurally 0 or positive).
+    if rate_central.val() > 0.0 || rate_periph1.val() > 0.0 || rate_periph2.val() > 0.0 {
         let mut inflow = [T::from_f64(0.0), T::from_f64(0.0), T::from_f64(0.0)];
-        propagate_three_cpt_core_g(
-            &mut inflow,
-            dt,
-            e,
-            rate_central,
-            T::from_f64(0.0),
-            T::from_f64(0.0),
-        );
+        propagate_three_cpt_core_g(&mut inflow, dt, e, rate_central, rate_periph1, rate_periph2);
         state[1] = state[1] + inflow[0];
         state[2] = state[2] + inflow[1];
         state[3] = state[3] + inflow[2];
@@ -571,7 +589,16 @@ pub fn propagate_three_cpt_oral_core_g<T: PkNum>(
         };
         let d_ss = rate_depot / ka;
         let mut xss = [d_ss, c_ss, p1_ss, p2_ss];
-        propagate_three_cpt_oral_core_g(&mut xss, dt, e, ka, T::from_f64(0.0), T::from_f64(0.0));
+        propagate_three_cpt_oral_core_g(
+            &mut xss,
+            dt,
+            e,
+            ka,
+            T::from_f64(0.0),
+            T::from_f64(0.0),
+            T::from_f64(0.0),
+            T::from_f64(0.0),
+        );
         state[0] = state[0] + (d_ss - xss[0]);
         state[1] = state[1] + (c_ss - xss[1]);
         state[2] = state[2] + (p1_ss - xss[2]);
@@ -592,13 +619,24 @@ pub fn propagate_three_cpt_oral_g<T: PkNum>(
     v3: T,
     ka: T,
     rate_central: T,
+    rate_periph1: T,
+    rate_periph2: T,
     rate_depot: T,
 ) {
     if ka.val() <= 0.0 {
         return;
     }
     if let Some(e) = three_cpt_eigen_g(cl, v1, q2, v2, q3, v3) {
-        propagate_three_cpt_oral_core_g(state, dt, &e, ka, rate_central, rate_depot);
+        propagate_three_cpt_oral_core_g(
+            state,
+            dt,
+            &e,
+            ka,
+            rate_central,
+            rate_periph1,
+            rate_periph2,
+            rate_depot,
+        );
     }
 }
 
@@ -962,6 +1000,7 @@ fn apply_step_g<T: PkNum>(
                 pk.v2,
                 pk.ka,
                 rate_central,
+                rate_periph1,
                 rate_depot,
             ),
             PkModel::ThreeCptIv => propagate_three_cpt_g(
@@ -988,6 +1027,8 @@ fn apply_step_g<T: PkNum>(
                 pk.v3,
                 pk.ka,
                 rate_central,
+                rate_periph1,
+                rate_periph2,
                 rate_depot,
             ),
         }

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -894,7 +894,18 @@ fn active_rates_g<T: PkNum>(
                 Some(Channel::Periph1) => rate_periph1 = rate_periph1 + r,
                 Some(Channel::Periph2) => rate_periph2 = rate_periph2 + r,
                 Some(Channel::Depot) => rate_depot = rate_depot + r,
-                None => {}
+                // Unreachable from a validated call — `check_dose_compartments`
+                // (#375) rejects an unroutable infusion before any prediction. The
+                // old silent `{}` was worse than the value walk's `panic!` twin in
+                // `pk::event_driven::propagate_with_bounds`: it dropped the
+                // infusion from the *gradient* only, so FOCE/FOCEI would have
+                // differentiated a different dosing history than it predicted.
+                // Fail the same way the value walk does instead.
+                None => panic!(
+                    "sens PK walk: infusion into compartment {} not supported for model \
+                     {:?} — should have been rejected by `check_dose_compartments`",
+                    d.cmt, pk_model
+                ),
             }
         }
     }
@@ -1541,6 +1552,38 @@ mod tests {
             ka: p.ka(),
             f: p.f_bio(),
         }
+    }
+
+    /// #375: `active_rates_g` used to answer an unroutable infusion with a silent
+    /// `None => {}`, dropping the dose from the **gradient** while the production
+    /// value walk (`pk::event_driven::propagate_with_bounds`) panicked on the same
+    /// input — so had the value path been made lenient, FOCE/FOCEI would have
+    /// differentiated a different dosing history than it predicted. Both walks now
+    /// fail the same way; `check_dose_compartments` makes this unreachable from a
+    /// validated call, and this test is the direct-call proof that the guard is
+    /// still there.
+    #[test]
+    #[should_panic(expected = "infusion into compartment 2 not supported")]
+    fn sens_walk_panics_on_an_unroutable_infusion_like_the_value_walk() {
+        // `one_cpt_iv` has a single compartment, so cmt 2 has no rate channel.
+        let dose = DoseEvent::new(0.0, 100.0, 2, 20.0, false, 0.0);
+        let subject = make_subject(vec![dose], vec![1.0, 4.0]);
+        let pk = pk_full(5.0, 50.0, 1.0);
+        let schedule = EventSchedule::for_subject(
+            &subject,
+            PkModel::OneCptIv,
+            &subject.doses,
+            &[pk.lagtime()],
+        );
+        let pk_g = one_cpt_pk_f64(&pk);
+        let _ = event_driven_sens_one_cpt_g::<f64>(
+            false,
+            &subject,
+            &schedule,
+            &[pk_g],
+            &vec![pk_g; 2],
+            &[],
+        );
     }
 
     /// The `f64` instantiation of the full event walk must reproduce the

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -1110,9 +1110,14 @@ fn equilibrate_ss_g<T: PkNum>(
 ) -> Vec<T> {
     let (n_states, _) = state_layout_g(pk_model);
     let mut state = vec![T::from_f64(0.0); n_states];
-    if dose.ii <= 0.0 || dose.cmt == 0 {
+    if dose.ii <= 0.0 {
         return state;
     }
+    // `CMT=0` = NONMEM's default dose compartment — resolved by
+    // `saturating_sub(1)` like every other dose site. Mirrors the value walk's
+    // `equilibrate_ss_state_event_driven`, whose identical `cmt == 0` bail
+    // silently dropped an `SS=1` dose's accumulation (#375); the gradient must
+    // equilibrate the same state the value does.
     let cmt_idx = dose.cmt.saturating_sub(1);
     if cmt_idx >= n_states {
         return state;
@@ -1286,6 +1291,18 @@ pub fn event_driven_sens_with_doses_g<T: PkNum>(
                     let cmt_idx = d.cmt.saturating_sub(1);
                     if cmt_idx < n_states {
                         state[cmt_idx] = state[cmt_idx] + pk_now.f * T::from_f64(d.amt);
+                    } else {
+                        // Unreachable from a validated call — `check_dose_compartments`
+                        // (#375) rejects `cmt > n_states` up front. Kept as a defensive
+                        // guard that matches the value walk's twin in
+                        // `pk::event_driven`: silently dropping the dose here would
+                        // differentiate a different dosing history than was predicted.
+                        panic!(
+                            "sens PK walk: dose into compartment {} but model has {} states \
+                             (cmt is 1-based) — should have been rejected by \
+                             `check_dose_compartments`",
+                            d.cmt, n_states
+                        );
                     }
                 }
             }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -4779,6 +4779,12 @@ pub(crate) fn subject_routes_to_event_walk(model: &CompiledModel, subject: &Subj
     }
     subject.has_tv_covariates()
         || subject_has_oral_infusion(model, subject)
+        // A dose the superposition dispatch cannot place — any bolus outside
+        // compartment 1, any infusion outside central (#375). Production reroutes
+        // exactly these subjects to the walk (`pk::compute_predictions*`), so the
+        // gradient must follow or FOCE/FOCEI would differentiate a different
+        // dosing history than it predicted. Same single source of truth.
+        || crate::pk::dose_needs_event_walk(model.pk_model, subject)
         || crate::parser::model_parser::compiled_model_uses_time_builtin(model)
         // A modeled-`RATE=-1/-2` dose (`R{cmt}`/`D{cmt}`) resolves its rate/window
         // from PK params, so the infusion *end* is a moving boundary — the

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -2730,6 +2730,111 @@ fn oral_infusion_provider_matches_fd_of_production() {
     }
 }
 
+/// #375 gradient oracle: an infusion into an **oral model's peripheral**
+/// (`two_cpt_oral` cmt 3, `three_cpt_oral` cmt 3/4) is a brand-new forcing term
+/// on the analytic sensitivity path — `propagate_{two,three}_cpt_oral_core_g`
+/// delegate it to the IV core. The value path is pinned against an ODE twin
+/// (`tests/oral_peripheral_infusion.rs`), but the **`Dual2` gradient** has no
+/// second copy of the formula to disagree with it, so it must be asserted
+/// against central FD of the `T = f64` production predictor (CLAUDE.md's
+/// `Dual2`-vs-FD rule).
+///
+/// Cases exercise, in order: peripheral alone; peripheral **overlapping an
+/// absorbing depot dose** (the reduction is only valid if the depot's
+/// contribution is counted exactly once); **central + peripheral simultaneously
+/// active** (the combined-rate steady state in the IV core); and both 3-cpt
+/// peripherals.
+#[test]
+fn oral_peripheral_infusion_provider_matches_fd_of_production() {
+    let times = [1.0, 3.0, 5.0, 7.0, 10.0, 24.0];
+    let two_theta = vec![10.0, 50.0, 15.0, 100.0, 1.0];
+    let three_theta = vec![5.0, 10.0, 2.0, 20.0, 1.5, 30.0, 1.5];
+    let eta = vec![0.1, -0.05, 0.08];
+    let cases: Vec<(&str, CompiledModel, Subject, Vec<f64>)> = vec![
+        // 2-cpt oral: infusion into the peripheral (cmt 3) only. amt 1000 at
+        // rate 125 → an 8 h window, so obs straddle it.
+        (
+            "2cpt periph only",
+            parse_model_string(TWOCPT_ORAL).expect("parse 2cpt oral"),
+            subject_with_dose(DoseEvent::new(0.0, 1000.0, 3, 125.0, false, 0.0), &times),
+            two_theta.clone(),
+        ),
+        // …plus an oral depot bolus landing *inside* the infusion window, so the
+        // depot's Bateman term and the peripheral forced response superpose.
+        (
+            "2cpt periph + depot bolus mid-window",
+            parse_model_string(TWOCPT_ORAL).expect("parse 2cpt oral"),
+            subject_with_doses_and_resets(
+                vec![
+                    DoseEvent::new(0.0, 1000.0, 3, 125.0, false, 0.0),
+                    DoseEvent::new(2.0, 500.0, 1, 0.0, false, 0.0),
+                ],
+                &times,
+                Vec::new(),
+            ),
+            two_theta.clone(),
+        ),
+        // Central AND peripheral infusion simultaneously active (the `||` guard's
+        // combined branch: one must not clobber the other).
+        (
+            "2cpt central + periph simultaneous",
+            parse_model_string(TWOCPT_ORAL).expect("parse 2cpt oral"),
+            subject_with_doses_and_resets(
+                vec![
+                    DoseEvent::new(0.0, 1000.0, 3, 125.0, false, 0.0),
+                    DoseEvent::new(1.0, 600.0, 2, 100.0, false, 0.0),
+                ],
+                &times,
+                Vec::new(),
+            ),
+            two_theta.clone(),
+        ),
+        // 3-cpt oral, peripheral-1 (cmt 3) + a depot bolus.
+        (
+            "3cpt periph1 + depot bolus",
+            parse_model_string(THREECPT_ORAL).expect("parse 3cpt oral"),
+            subject_with_doses_and_resets(
+                vec![
+                    DoseEvent::new(0.0, 1000.0, 3, 125.0, false, 0.0),
+                    DoseEvent::new(2.0, 500.0, 1, 0.0, false, 0.0),
+                ],
+                &times,
+                Vec::new(),
+            ),
+            three_theta.clone(),
+        ),
+        // 3-cpt oral, peripheral-2 (cmt 4) — the `rate_periph2` channel.
+        (
+            "3cpt periph2 + depot bolus",
+            parse_model_string(THREECPT_ORAL).expect("parse 3cpt oral"),
+            subject_with_doses_and_resets(
+                vec![
+                    DoseEvent::new(0.0, 1000.0, 4, 125.0, false, 0.0),
+                    DoseEvent::new(2.0, 500.0, 1, 0.0, false, 0.0),
+                ],
+                &times,
+                Vec::new(),
+            ),
+            three_theta.clone(),
+        ),
+    ];
+    for (label, m, s, theta) in &cases {
+        assert!(
+            crate::pk::dose_needs_event_walk(m.pk_model, s),
+            "[{label}] fixture must route to the event walk"
+        );
+        assert!(
+            subject_routes_to_event_walk(m, s),
+            "[{label}] the gradient must follow production onto the walk"
+        );
+        assert!(
+            subject_sensitivities(m, s, theta, &eta).is_some(),
+            "[{label}] must be served analytically, not by FD"
+        );
+        check_full_provider_vs_fd(m, s, theta, &eta);
+    }
+}
+
 /// Two infusion occasions on a 3-cpt IV model separated by an EVID=4 reset:
 /// occasion-2 observations must rebuild from zero (no occasion-1 carryover).
 /// The provider's reset-segment superposition must reproduce the production

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -2831,7 +2831,15 @@ fn oral_peripheral_infusion_provider_matches_fd_of_production() {
             subject_sensitivities(m, s, theta, &eta).is_some(),
             "[{label}] must be served analytically, not by FD"
         );
-        check_full_provider_vs_fd(m, s, theta, &eta);
+        // `1e-3` rather than the harness default `1e-4`: on these cases the
+        // mixed `∂²f/∂η∂θ` FD is roundoff-dominated at `1e-4` and clears the
+        // (unchanged) `3e-3` bound by only 1.4%, which last-bit libm differences
+        // flip between platforms. The FD converges to the analytic value as the
+        // step is refined toward its optimum, so this is a better-conditioned
+        // reference, not a looser test — it tightens the observed agreement from
+        // ~3e-3 to 1.5e-4. See `check_full_provider_vs_fd_with_step` for the
+        // step-refinement study.
+        check_full_provider_vs_fd_with_step(m, s, theta, &eta, 1e-3);
     }
 }
 
@@ -2884,6 +2892,39 @@ fn provider_1cpt_reset_midinfusion_matches_production() {
 /// applies the matching `g = ln(f)` jet transform, so the same FD check covers
 /// the log-scale value, gradient, and Hessian.
 fn check_full_provider_vs_fd(model: &CompiledModel, subject: &Subject, theta: &[f64], eta: &[f64]) {
+    check_full_provider_vs_fd_with_step(model, subject, theta, eta, 1e-4);
+}
+
+/// As [`check_full_provider_vs_fd`], with the **second-derivative** FD step as a
+/// parameter (the first-derivative steps stay at `1e-6`).
+///
+/// The second-derivative blocks use 4-point central differences, whose total
+/// error is `O(h²)` truncation plus `O(ε/h²)` roundoff — a U-curve with a
+/// problem-dependent optimum. The default `1e-4` sits comfortably inside the
+/// `3e-3` bound for the models this harness was written against, but it is *not*
+/// universally well-conditioned: on the 3-cpt oral peripheral-infusion cases the
+/// mixed `∂²f/∂η∂θ` entries are roundoff-dominated there. Measured worst
+/// assert-margin (1.0 == the assert fails) over every entry of both
+/// second-derivative blocks, `3cpt periph1 + depot bolus`:
+///
+/// | h        | 1e-2 | 3e-3  | 1e-3      | 3e-4  | 1e-4      | 3e-5 | 1e-5 |
+/// |----------|------|-------|-----------|-------|-----------|------|------|
+/// | margin   | 4.25 | 0.386 | **0.049** | 0.151 | **0.986** | 6.16 | 69.9 |
+///
+/// At `1e-4` that case clears the assert by 1.4% — close enough that last-bit
+/// `exp`/`ln` differences between platforms flip it (it passed on macOS and
+/// failed on the Linux CI runners). The FD converges *to* the analytic value as
+/// `h` is refined toward the optimum — the analytic kernel is the accurate party
+/// — so the fix is a better-conditioned reference, not a looser bound: at `1e-3`
+/// the same entry agrees to `1.5e-4` relative, a 20× margin under the unchanged
+/// `3e-3` tolerance.
+fn check_full_provider_vs_fd_with_step(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    heh: f64,
+) {
     let n_eta = model.n_eta;
     let n_theta = theta.len();
 
@@ -2895,7 +2936,6 @@ fn check_full_provider_vs_fd(model: &CompiledModel, subject: &Subject, theta: &[
     };
     let he = 1e-6; // first-derivative step
     let ht = 1e-6;
-    let heh = 1e-4; // second-derivative step (4-point central is roundoff-prone)
 
     for (j, obs) in sens.obs.iter().enumerate() {
         // value

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -75,6 +75,7 @@ pub fn inits_from_nca(
     // dose precondition here too — same loud-not-silent contract as
     // `predict()`/`simulate()` (#324). No-op for the common all-`Fixed` dataset.
     crate::api::assert_modeled_doses_supported(model, population);
+    crate::api::assert_dose_compartments_supported(model, population);
     match method {
         NcaInit::Nca => nca_only(model, population),
         NcaInit::Sweep => nca_with_sweep(model, population),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1419,10 +1419,13 @@ impl PkModel {
     /// the **central** compartment for every model, plus the **peripheral**
     /// compartment(s) for the 2-/3-cpt IV models, and — since #400 — the oral
     /// **depot** (cmt 1), a zero-order release into the depot followed by
-    /// first-order `ka` absorption into central. Notably this still EXCLUDES oral
-    /// peripherals, which the closed forms cannot infuse into. A `D{cmt}` outside
-    /// this set is rejected at parse time rather than silently mis-routed (no-TV
-    /// path) or panicking (event-driven path).
+    /// first-order `ka` absorption into central, and — since #375 — the oral
+    /// models' **peripheral**(s) too (the oral propagators reuse the IV forced
+    /// response; nothing flows back into the depot). That makes the set
+    /// `1..=n_states` for all six walk-supported models; transit/IG stay `&[]`
+    /// (they have no walk, and reroute an infusion to their ODE twin). A
+    /// `D{cmt}` outside this set is rejected at parse time rather than silently
+    /// mis-routed (no-TV path) or panicking (event-driven path).
     pub(crate) fn infusable_compartments(&self) -> &'static [usize] {
         self.topology().infusable_compartments()
     }

--- a/tests/derived_output.rs
+++ b/tests/derived_output.rs
@@ -496,3 +496,75 @@ fn integral_window_zero_is_rejected_at_parse() {
         "error should cite window= and positive, got: {err}"
     )
 }
+
+/// Regression (#375): a `[derived]` **grid integral** over `compartments[i]` must
+/// degrade to `NaN` for a subject dosing a non-default compartment, exactly like
+/// the per-observation `compartments[i]` column next to it.
+///
+/// The two are computed by different code paths — the per-obs column by
+/// `compute_predictions_with_states`, the integral by a dense-grid reconstruction
+/// in `api::output_columns` — and they must consult the *same* predicate for
+/// "superposition cannot place this dose". When the grid path still used the older,
+/// narrower `has_oral_depot_infusion`, it fell through to the compartment-blind
+/// `analytical_state_at_times`: in the same sdtab row `compartments[1]` read `NaN`
+/// while `integral(compartments[1], 0→24)` read 19.17 against a true 31.13 (a
+/// `1e-12` `[odes]` twin of the same system) — a confident wrong number beside a
+/// column that correctly admitted it had none.
+#[test]
+fn derived_grid_integral_over_compartments_is_nan_for_a_rerouted_subject() {
+    const MODEL: &str = "
+[parameters]
+  theta CL(5.0, 0.1, 50.0)
+  theta V1(30.0, 3.0, 300.0)
+  theta Q(2.0, 0.1, 20.0)
+  theta V2(50.0, 5.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP   ~ 0.01
+
+[individual_parameters]
+  CL = CL * exp(ETA_CL)
+  V1 = V1
+  Q  = Q
+  V2 = V2
+
+[structural_model]
+  pk two_cpt_iv(cl=CL, v1=V1, q=Q, v2=V2)
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[derived]
+  C_P   = compartments[1]
+  AUC_P = integral(compartments[1], from=0, to=24)
+
+[fit_options]
+  method   = focei
+  maxiter  = 2
+  gradient = fd
+";
+    let model = parse_model_string(MODEL).expect("model must parse");
+    // Bolus into CMT=2 — the peripheral. Superposition cannot place it, so the
+    // subject reroutes to the event-driven walk and has no compartment states.
+    let mut pop = one_dose_population();
+    pop.subjects[0].doses = vec![DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0)];
+
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    let result = fit(&model, &pop, &model.default_params, &opts).expect("short fit must not error");
+
+    for sr in &result.subjects {
+        for name in &["C_P", "AUC_P"] {
+            let col = sr
+                .extra_columns
+                .iter()
+                .find(|(n, _)| n == name)
+                .unwrap_or_else(|| panic!("extra column '{name}' missing"));
+            assert!(
+                col.1.iter().all(|v| v.is_nan()),
+                "'{name}' must be NaN for a subject dosing a non-default compartment \
+                 (superposition cannot reconstruct its states), got {:?}",
+                col.1
+            );
+        }
+    }
+}

--- a/tests/dose_compartment_routing.rs
+++ b/tests/dose_compartment_routing.rs
@@ -166,9 +166,114 @@ fn central_and_depot_infusions_still_predict_on_the_event_driven_walk() {
     }
 }
 
+// ── pure-TTE subjects: the PK model is a placeholder, do not validate against it ──
+
+/// A pure-TTE model still needs a `[structural_model]` line, and the idiom is a
+/// **dummy** `one_cpt_iv` with throwaway CL/V (see `tests/tte_smoke.rs`; the
+/// parser supplies exactly that when the block is absent). That placeholder has
+/// one compartment, so validating a TTE dataset's dose records against it would
+/// reject a working model over a dose the PK engine never reads — the subject
+/// has no Gaussian observation, so the analytical predictor is never invoked.
+#[cfg(feature = "survival")]
+const TTE_ONLY: &str = r#"
+[parameters]
+  theta TVLAMBDA(0.05, 0.001, 5.0)
+  theta DUMMY_CL(1.0, 0.01, 100.0)
+  theta DUMMY_V(10.0, 0.1, 1000.0)
+  omega ETA_LAMBDA ~ 0.0
+  sigma SIGMA_DV ~ 0.1
+
+[individual_parameters]
+  LAMBDA = TVLAMBDA * exp(ETA_LAMBDA)
+  CL     = DUMMY_CL
+  V      = DUMMY_V
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ additive(SIGMA_DV)
+
+[event_model]
+  cmt    = 2
+  family = exponential
+  scale  = LAMBDA
+"#;
+
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_subject_is_not_validated_against_the_placeholder_pk_model() {
+    let model = model_of(TTE_ONLY);
+    assert_eq!(
+        format!("{:?}", model.pk_model),
+        "OneCptIv",
+        "fixture must exercise the 1-compartment placeholder"
+    );
+    // A dose row into CMT=2 — out of range for `one_cpt_iv`, but this subject's
+    // only observation is the TTE event at CMT=2, so no PK prediction happens.
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().all(|d| !d.is_error()),
+        "a pure-TTE subject must not be rejected over its dose compartment: {diags:?}"
+    );
+}
+
+/// …but a subject that *does* carry a Gaussian observation is still checked,
+/// even on a model that also has a TTE endpoint. Guards against the exemption
+/// being too broad and silently disabling the fix for joint PK-TTE models.
+#[cfg(feature = "survival")]
+#[test]
+fn a_gaussian_observation_on_a_tte_model_is_still_validated() {
+    let model = model_of(TTE_ONLY);
+    // Same model; this subject has a Gaussian PK observation at CMT=1 as well as
+    // the TTE record at CMT=2, so the analytical predictor does run for it.
+    let pop =
+        pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,3,4.2,0,.,1,0\n1,5,1,0,.,2,0\n");
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_DOSE_CMT_OUT_OF_RANGE"),
+        "a subject with Gaussian observations must still be validated: {diags:?}"
+    );
+}
+
+/// The exemption above must be **population**-level, not per-subject. In a joint
+/// PK-TTE dataset a subject can legitimately carry dose records and a TTE record
+/// but no PK sample (an early dropout, or a TTE-only arm) — and the PK path
+/// still runs for it, because the event-driven walk is driven by the event
+/// schedule and the FOCE/FOCEI sensitivity provider runs per subject regardless.
+/// A per-subject exemption let exactly this subject carry an unroutable dose
+/// straight back into the panics, which is strictly worse than the bug #375
+/// reports. Subject 1 supplies the PK samples; subject 2 is the dangerous one.
+#[cfg(feature = "survival")]
+#[test]
+fn a_tte_only_subject_of_a_pk_tte_dataset_is_still_validated() {
+    let model = model_of(TTE_ONLY);
+    let pop = pop_of(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n\
+         1,0,.,1,100,1,0,1\n\
+         1,3,4.2,0,.,1,.,0\n\
+         1,9,0,0,.,2,.,0\n\
+         2,0,.,1,100,2,20,1\n\
+         2,5,1,0,.,2,.,0\n",
+    );
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_DOSE_CMT_OUT_OF_RANGE"),
+        "the TTE-only subject's out-of-range dose must still be caught: {diags:?}"
+    );
+}
+
 /// A bolus into the same peripheral compartment is *not* rejected — the walk
 /// adds the amount to the state directly. Guards against the check being
 /// over-broad and breaking a legitimate dosing pattern.
+///
+/// The assertion is deliberately weak (finite, not a specific value): which
+/// analytical path serves this subject decides the *answer*, because the
+/// superposition path ignores `dose.cmt` and would compute this as a depot dose.
+/// This test pins "not rejected", NOT "correct" — the value disagreement is a
+/// separate, pre-existing defect tracked outside this PR, and asserting a number
+/// here would bless whichever path happens to run.
 #[test]
 fn a_bolus_into_the_peripheral_is_still_accepted() {
     let model = model_of(TWO_CPT_ORAL);

--- a/tests/dose_compartment_routing.rs
+++ b/tests/dose_compartment_routing.rs
@@ -1,20 +1,25 @@
-//! Tier-2 integration tests for #375 — an infusion into a compartment the
-//! analytical closed forms cannot deliver into must be **rejected up front**,
-//! not `panic!`ed on from inside the event-driven prediction walk.
+//! Tier-2 integration tests for #375 at the public boundary.
 //!
-//! The reported failure was reachable from ordinary NONMEM-format data: a
-//! positive `RATE` into `CMT=3` of a `two_cpt_oral` model, on a subject that
-//! also carries a time-varying covariate (which is what routes the subject to
-//! the event-driven walk in the first place). Nothing validated a *fixed*
-//! positive `RATE` against the model's topology — the datareader has no model,
-//! and the parse-time infusable check only fires for a declared `D{cmt}`/
-//! `R{cmt}` — so the walk's routing `match` was the first thing to see it and
-//! it aborted the process.
+//! The reported failure was a positive `RATE` into `CMT=3` of a `two_cpt_oral`
+//! model — an oral **peripheral** — on a subject that also carried a
+//! time-varying covariate (which is what routes it to the event-driven walk).
+//! Nothing validated a *fixed* positive `RATE` against the model's topology (the
+//! datareader has no model, and the parse-time check only fires for a declared
+//! `D{cmt}`/`R{cmt}`), so the walk's routing `match` was the first thing to see
+//! it and it aborted the process.
 //!
-//! These tests pin the public-boundary contract: `fit()` returns `Err`,
-//! `predict()`/`simulate()` panic with the actionable diagnostic (the existing
-//! convention for entry points that run no data-check), and the routable
-//! compartments still predict.
+//! **That exact case is now supported**, not merely rejected: the oral
+//! propagators gained the peripheral forcing term (see
+//! `tests/oral_peripheral_infusion.rs` for its exact ODE-twin oracle and
+//! `tests/nonmem_dose_compartment_anchor.rs` for the NONMEM anchor), so the
+//! headline test below asserts it *predicts* rather than that it errors.
+//!
+//! What remains rejected is a dose with no routable target at all — an infusion
+//! into `CMT=0` (an infusion has no "default compartment" fallback) or any dose
+//! past the end of the model's compartment list. These tests pin that contract:
+//! `fit()` returns `Err`, `predict()`/`simulate()` panic with the actionable
+//! diagnostic (the existing convention for entry points that run no data-check),
+//! and every routable compartment predicts.
 //!
 //! All return immediately (a `check_model_data` pass, a `predict()` at fixed
 //! parameters, or a `fit()` that errors before iterating), so they need no
@@ -73,10 +78,16 @@ fn pop_of(csv: &str) -> Population {
 
 const OBS_ROWS: &str = "1,1,5.0,0,.,2,.,0,70\n1,4,4.0,0,.,2,.,0,72\n1,8,3.0,0,.,2,.,0,74\n";
 
-/// `RATE>0` into CMT=3 — the oral **peripheral**, which no closed form can
-/// infuse into. This is the #375 repro.
+/// `RATE>0` into CMT=3 — the oral **peripheral**. This is the original #375
+/// repro, which used to panic and is now supported.
 fn peripheral_infusion_csv() -> String {
     format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,3,20,1,70\n{OBS_ROWS}")
+}
+
+/// `RATE>0` into CMT=0 — no default compartment exists for an infusion, so this
+/// is unroutable on every analytical path and is the surviving reject case.
+fn unroutable_infusion_csv() -> String {
+    format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,0,20,1,70\n{OBS_ROWS}")
 }
 
 /// The same dataset dosing into CMT=2 (central) — routable, must still work.
@@ -92,25 +103,44 @@ fn depot_infusion_csv() -> String {
 // ── fit(): a recoverable error, not a crash ──
 
 #[test]
-fn fit_rejects_an_infusion_into_an_oral_peripheral() {
+fn fit_rejects_an_unroutable_infusion() {
     let model = model_of(TWO_CPT_ORAL);
-    let pop = pop_of(&peripheral_infusion_csv());
+    let pop = pop_of(&unroutable_infusion_csv());
     let err = fit(&model, &pop, &model.default_params, &FitOptions::default())
         .expect_err("an unroutable infusion must be an Err, not a panic");
     assert!(
-        err.contains("compartment 3") && err.contains("two_cpt_oral"),
+        err.contains("compartment 0") && err.contains("two_cpt_oral"),
         "error should name the offending compartment and model: {err}"
     );
     assert!(
-        err.contains("[1, 2]"),
+        err.contains("[1, 2, 3]"),
         "error should name the infusable compartments: {err}"
+    );
+}
+
+/// The original #375 repro now **predicts** instead of aborting: an infusion into
+/// the oral peripheral is supported, and both analytical paths serve it.
+#[test]
+fn fit_accepts_the_original_repro_now_that_oral_peripheral_infusion_is_supported() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&peripheral_infusion_csv());
+    assert!(
+        check_model_data(&model, &pop).iter().all(|d| !d.is_error()),
+        "oral peripheral infusion is supported since #375"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert_eq!(preds.len(), 3);
+    assert!(
+        preds.iter().all(|p| p.pred.is_finite() && p.pred > 0.0),
+        "got {:?}",
+        preds.iter().map(|p| p.pred).collect::<Vec<_>>()
     );
 }
 
 #[test]
 fn check_model_data_reports_the_unroutable_infusion() {
     let model = model_of(TWO_CPT_ORAL);
-    let pop = pop_of(&peripheral_infusion_csv());
+    let pop = pop_of(&unroutable_infusion_csv());
     let diags = check_model_data(&model, &pop);
     let d = diags
         .iter()
@@ -130,7 +160,7 @@ fn predict_panics_before_reaching_the_event_driven_walk() {
     // Previously this panicked from `propagate_with_bounds`'s routing `match`
     // with no subject/time context; now the entry-point guard intercepts it.
     let model = model_of(TWO_CPT_ORAL);
-    let pop = pop_of(&peripheral_infusion_csv());
+    let pop = pop_of(&unroutable_infusion_csv());
     let _ = predict(&model, &pop, &model.default_params);
 }
 
@@ -138,7 +168,7 @@ fn predict_panics_before_reaching_the_event_driven_walk() {
 #[should_panic(expected = "a dose into a compartment the model cannot deliver into")]
 fn simulate_panics_before_reaching_the_event_driven_walk() {
     let model = model_of(TWO_CPT_ORAL);
-    let pop = pop_of(&peripheral_infusion_csv());
+    let pop = pop_of(&unroutable_infusion_csv());
     let _ = simulate(&model, &pop, &model.default_params, 1);
 }
 
@@ -265,17 +295,16 @@ fn a_tte_only_subject_of_a_pk_tte_dataset_is_still_validated() {
 }
 
 /// A bolus into the same peripheral compartment is *not* rejected — the walk
-/// adds the amount to the state directly. Guards against the check being
-/// over-broad and breaking a legitimate dosing pattern.
+/// adds the amount to the state directly, and since #375 the dispatcher routes
+/// such a dose there instead of letting the cmt-blind superposition form compute
+/// it as a depot dose.
 ///
-/// The assertion is deliberately weak (finite, not a specific value): which
-/// analytical path serves this subject decides the *answer*, because the
-/// superposition path ignores `dose.cmt` and would compute this as a depot dose.
-/// This test pins "not rejected", NOT "correct" — the value disagreement is a
-/// separate, pre-existing defect tracked outside this PR, and asserting a number
-/// here would bless whichever path happens to run.
+/// Asserts the **value**, not merely "not rejected": `two_cpt_oral` with a bolus
+/// into CMT=3 is NONMEM `ADVAN4` CMT=3, anchored in
+/// `tests/nonmem_dose_compartment_anchor.rs`. Before the reroute this returned
+/// the depot-dose curve (1.1536 at t=1) — ~17x the correct 0.068.
 #[test]
-fn a_bolus_into_the_peripheral_is_still_accepted() {
+fn a_bolus_into_the_peripheral_is_computed_in_the_peripheral() {
     let model = model_of(TWO_CPT_ORAL);
     let pop = pop_of(&format!(
         "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,3,0,1,70\n{OBS_ROWS}"
@@ -284,6 +313,21 @@ fn a_bolus_into_the_peripheral_is_still_accepted() {
         check_model_data(&model, &pop).iter().all(|d| !d.is_error()),
         "a peripheral bolus must stay accepted"
     );
-    let preds = predict(&model, &pop, &model.default_params);
-    assert!(preds.iter().all(|p| p.pred.is_finite()));
+    let preds: Vec<f64> = predict(&model, &pop, &model.default_params)
+        .into_iter()
+        .map(|p| p.pred)
+        .collect();
+    // The TV covariate in TWO_CPT_ORAL scales CL, so these are not the bare
+    // NONMEM numbers; what matters is that the dose landed in the peripheral —
+    // a peripheral bolus rises from ~0 as it redistributes, where a depot dose
+    // would start high. Guard the qualitative shape plus the first-point
+    // magnitude, which differ by an order of magnitude between the two.
+    assert!(
+        preds[0] < 0.2,
+        "a peripheral bolus should start low (depot-dose bug gave ~1.15): {preds:?}"
+    );
+    assert!(
+        preds[1] > preds[0],
+        "a peripheral bolus redistributes into central, so it should rise: {preds:?}"
+    );
 }

--- a/tests/dose_compartment_routing.rs
+++ b/tests/dose_compartment_routing.rs
@@ -196,6 +196,55 @@ fn central_and_depot_infusions_still_predict_on_the_event_driven_walk() {
     }
 }
 
+/// Regression (#375): a **zero-amount** dose with an out-of-range `CMT` must be
+/// rejected, not accepted-then-panicked.
+///
+/// An earlier revision skipped every `AMT=0` dose in `check_dose_compartments`,
+/// reasoning that a zero bolus "delivers nothing on any path". That is true of the
+/// *addition* but not of the guard around it: both walks evaluate
+/// `if cmt_idx < n_states { state[cmt_idx] += … } else { panic!(…) }`, so control
+/// never reaches the `F·0`. Combined with `dose_needs_event_walk` routing any
+/// `cmt != 1` bolus to the walk, such a row made `ferx check` report the dataset
+/// clean and `fit()` abort the process — the exact failure #375 exists to remove.
+/// Reachable from ordinary NONMEM data as an `EVID=4` reset row with a stale `CMT`.
+#[test]
+fn a_zero_amount_out_of_range_dose_is_rejected_not_panicked() {
+    let model = model_of(TWO_CPT_ORAL); // depot, central, peripheral → 3 states
+    let pop = pop_of(&format!(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n\
+         1,0,.,1,100,1,0,1,70\n\
+         1,0,.,1,0,9,0,1,70\n{OBS_ROWS}"
+    ));
+    let diags = check_model_data(&model, &pop);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.is_error() && d.code == "E_DOSE_CMT_OUT_OF_RANGE"),
+        "a zero-amount dose into compartment 9 of a 3-state model must be rejected \
+         by the range rule, which applies regardless of amount; got {diags:?}"
+    );
+}
+
+/// …while a zero-amount dose into an **in-range** compartment stays accepted: the
+/// range rule is the only one that ignores the amount. A zero-amount *infusion*
+/// has `duration = AMT/RATE = 0`, so no path ever opens a rate window for it and
+/// rejecting a whole fit over an inert row would be stricter than the bug fixed.
+#[test]
+fn a_zero_amount_in_range_dose_is_still_accepted() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&format!(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n\
+         1,0,.,1,100,1,0,1,70\n\
+         1,0,.,1,0,3,20,1,70\n{OBS_ROWS}"
+    ));
+    assert!(
+        check_model_data(&model, &pop).iter().all(|d| !d.is_error()),
+        "an inert AMT=0 row into an existing compartment must not fail the fit"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert_eq!(preds.len(), 3);
+}
+
 // ── pure-TTE subjects: the PK model is a placeholder, do not validate against it ──
 
 /// A pure-TTE model still needs a `[structural_model]` line, and the idiom is a
@@ -330,4 +379,74 @@ fn a_bolus_into_the_peripheral_is_computed_in_the_peripheral() {
         preds[1] > preds[0],
         "a peripheral bolus redistributes into central, so it should rise: {preds:?}"
     );
+}
+
+// ── analytic Form C readout: the depot is reconstructed by superposition ─────
+
+/// Regression (#375): an analytic `[scaling]` readout that references the oral
+/// `depot` must be **rejected** on a subject dosing a non-default compartment,
+/// not silently fed a phantom depot amount.
+///
+/// `apply_analytic_readout` reconstructs the depot with
+/// `analytical_state_at_times` → `single_dose_states`, which never reads
+/// `dose.cmt`: it places every bolus in compartment 1 and every infusion in
+/// central. A bolus written `CMT=2` on a `one_cpt_oral` model was therefore
+/// reconstructed as if absorbed through the depot, adding a phantom amount to
+/// `PRED` — and so to the **objective**, not just a diagnostic column. Measured
+/// on `y = (central + depot)/V`: OFV 188.37 where an explicit `[odes]` twin of
+/// the same model gives 1761.47; with the dose at `CMT=1` the two agree exactly.
+///
+/// The `ipred` path is correct for these subjects (it reroutes to the
+/// event-driven walk), but that walk has no states variant the readout could
+/// read, so there is nothing to fall back to — hence reject rather than degrade.
+#[test]
+fn depot_readout_with_a_non_default_dose_compartment_is_rejected() {
+    const READOUT: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 3.0, 300.0)
+  theta TVKA(1.0, 0.05, 20.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[scaling]
+  y = (central + depot) / V
+
+[error_model]
+  DV ~ proportional(PROP)
+
+[fit_options]
+  maxiter = 0
+"#;
+    let model = model_of(READOUT);
+    let obs = "1,0.25,3.1,0,.,2,.,0,70\n1,1,2.2,0,.,2,.,0,70\n1,4,1.5,0,.,2,.,0,70\n";
+
+    // Dose into CMT=2 (central) — not the depot the readout reconstructs.
+    // The readout gate lives on the `fit()`/`predict()` boundary (alongside the
+    // pre-existing reset rejection), not in `check_model_data`.
+    let bad = pop_of(&format!(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,2,0,1,70\n{obs}"
+    ));
+    let err = fit(&model, &bad, &model.default_params, &FitOptions::default())
+        .expect_err("a depot readout with a CMT=2 bolus must be an Err, not a mis-prediction");
+    assert!(
+        err.contains("phantom depot"),
+        "the error should explain the phantom depot amount: {err}"
+    );
+
+    // Control: the same model dosing the depot is unaffected. `maxiter = 0` makes
+    // this an evaluation-only run, so the test still returns immediately (Tier 2).
+    let good = pop_of(&format!(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,1,0,1,70\n{obs}"
+    ));
+    fit(&model, &good, &model.default_params, &FitOptions::default())
+        .expect("a depot readout dosing the depot must stay accepted");
 }

--- a/tests/dose_compartment_routing.rs
+++ b/tests/dose_compartment_routing.rs
@@ -1,0 +1,184 @@
+//! Tier-2 integration tests for #375 — an infusion into a compartment the
+//! analytical closed forms cannot deliver into must be **rejected up front**,
+//! not `panic!`ed on from inside the event-driven prediction walk.
+//!
+//! The reported failure was reachable from ordinary NONMEM-format data: a
+//! positive `RATE` into `CMT=3` of a `two_cpt_oral` model, on a subject that
+//! also carries a time-varying covariate (which is what routes the subject to
+//! the event-driven walk in the first place). Nothing validated a *fixed*
+//! positive `RATE` against the model's topology — the datareader has no model,
+//! and the parse-time infusable check only fires for a declared `D{cmt}`/
+//! `R{cmt}` — so the walk's routing `match` was the first thing to see it and
+//! it aborted the process.
+//!
+//! These tests pin the public-boundary contract: `fit()` returns `Err`,
+//! `predict()`/`simulate()` panic with the actionable diagnostic (the existing
+//! convention for entry points that run no data-check), and the routable
+//! compartments still predict.
+//!
+//! All return immediately (a `check_model_data` pass, a `predict()` at fixed
+//! parameters, or a `fit()` that errors before iterating), so they need no
+//! `slow-tests` gate.
+
+use ferx_core::api::check_model_data;
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{
+    fit, predict, read_nonmem_csv, simulate, CompiledModel, FitOptions, Population, Severity,
+};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// Two-compartment oral model with a time-varying covariate on CL, so every
+/// subject is routed to the event-driven walk (`has_tv_covariates`) — the path
+/// that used to panic. `WT` is the TV covariate.
+const TWO_CPT_ORAL: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * (WT / 70) * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[structural_model]
+  pk two_cpt_oral(cl=CL, v=V, q=Q, v2=V2, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+fn write_csv(contents: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("temp file");
+    write!(f, "{contents}").expect("write csv");
+    f.flush().expect("flush");
+    f
+}
+
+fn model_of(src: &str) -> CompiledModel {
+    parse_full_model(src).expect("model parses").model
+}
+
+fn pop_of(csv: &str) -> Population {
+    let f = write_csv(csv);
+    read_nonmem_csv(f.path(), None, None).expect("dataset loads")
+}
+
+const OBS_ROWS: &str = "1,1,5.0,0,.,2,.,0,70\n1,4,4.0,0,.,2,.,0,72\n1,8,3.0,0,.,2,.,0,74\n";
+
+/// `RATE>0` into CMT=3 — the oral **peripheral**, which no closed form can
+/// infuse into. This is the #375 repro.
+fn peripheral_infusion_csv() -> String {
+    format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,3,20,1,70\n{OBS_ROWS}")
+}
+
+/// The same dataset dosing into CMT=2 (central) — routable, must still work.
+fn central_infusion_csv() -> String {
+    format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,2,20,1,70\n{OBS_ROWS}")
+}
+
+/// …and into CMT=1 (the oral depot), routable since #400.
+fn depot_infusion_csv() -> String {
+    format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,1,20,1,70\n{OBS_ROWS}")
+}
+
+// ── fit(): a recoverable error, not a crash ──
+
+#[test]
+fn fit_rejects_an_infusion_into_an_oral_peripheral() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&peripheral_infusion_csv());
+    let err = fit(&model, &pop, &model.default_params, &FitOptions::default())
+        .expect_err("an unroutable infusion must be an Err, not a panic");
+    assert!(
+        err.contains("compartment 3") && err.contains("two_cpt_oral"),
+        "error should name the offending compartment and model: {err}"
+    );
+    assert!(
+        err.contains("[1, 2]"),
+        "error should name the infusable compartments: {err}"
+    );
+}
+
+#[test]
+fn check_model_data_reports_the_unroutable_infusion() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&peripheral_infusion_csv());
+    let diags = check_model_data(&model, &pop);
+    let d = diags
+        .iter()
+        .find(|d| d.code == "E_DOSE_CMT_NOT_INFUSABLE")
+        .unwrap_or_else(|| panic!("expected E_DOSE_CMT_NOT_INFUSABLE, got {diags:?}"));
+    assert_eq!(d.severity, Severity::Error);
+    // The subject/time context the deep-in-the-walk panic could never carry.
+    assert!(d.message.contains("subject 1"), "{}", d.message);
+    assert!(d.message.contains("time 0"), "{}", d.message);
+}
+
+// ── predict()/simulate(): the existing loud-not-silent convention ──
+
+#[test]
+#[should_panic(expected = "a dose into a compartment the model cannot deliver into")]
+fn predict_panics_before_reaching_the_event_driven_walk() {
+    // Previously this panicked from `propagate_with_bounds`'s routing `match`
+    // with no subject/time context; now the entry-point guard intercepts it.
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&peripheral_infusion_csv());
+    let _ = predict(&model, &pop, &model.default_params);
+}
+
+#[test]
+#[should_panic(expected = "a dose into a compartment the model cannot deliver into")]
+fn simulate_panics_before_reaching_the_event_driven_walk() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&peripheral_infusion_csv());
+    let _ = simulate(&model, &pop, &model.default_params, 1);
+}
+
+// ── positive controls: the routable compartments still predict ──
+
+#[test]
+fn central_and_depot_infusions_still_predict_on_the_event_driven_walk() {
+    let model = model_of(TWO_CPT_ORAL);
+    for (label, csv) in [
+        ("central", central_infusion_csv()),
+        ("depot", depot_infusion_csv()),
+    ] {
+        let pop = pop_of(&csv);
+        assert!(
+            check_model_data(&model, &pop).iter().all(|d| !d.is_error()),
+            "{label} infusion must stay accepted"
+        );
+        let preds = predict(&model, &pop, &model.default_params);
+        assert_eq!(preds.len(), 3, "{label}: one row per observation");
+        assert!(
+            preds.iter().all(|p| p.pred.is_finite() && p.pred > 0.0),
+            "{label}: predictions should be finite and positive, got {:?}",
+            preds.iter().map(|p| p.pred).collect::<Vec<_>>()
+        );
+    }
+}
+
+/// A bolus into the same peripheral compartment is *not* rejected — the walk
+/// adds the amount to the state directly. Guards against the check being
+/// over-broad and breaking a legitimate dosing pattern.
+#[test]
+fn a_bolus_into_the_peripheral_is_still_accepted() {
+    let model = model_of(TWO_CPT_ORAL);
+    let pop = pop_of(&format!(
+        "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,WT\n1,0,.,1,100,3,0,1,70\n{OBS_ROWS}"
+    ));
+    assert!(
+        check_model_data(&model, &pop).iter().all(|d| !d.is_error()),
+        "a peripheral bolus must stay accepted"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert!(preds.iter().all(|p| p.pred.is_finite()));
+}

--- a/tests/nonmem_dose_compartment_anchor.rs
+++ b/tests/nonmem_dose_compartment_anchor.rs
@@ -1,0 +1,241 @@
+//! NONMEM anchor for dose-compartment handling on the analytical engine (#375).
+//!
+//! Reference values are `PRED` from **NONMEM 7.6.0**, printed at full precision
+//! (`$TABLE ... FORMAT=,1PE17.10`), `$ESTIMATION MAXEVAL=0`
+//! (evaluation at fixed THETA, `$OMEGA 0 FIX`), one subject, a 100 mg dose at
+//! t = 0 and observations at t = 1, 4, 8 h. Parameters throughout:
+//! `CL = 5, V/V1 = 50, Q = 3, V2 = 80, Q3 = 1, V3 = 120, KA = 1`.
+//!
+//! The control streams are one `$PROBLEM` per case, `ADVAN{1,2,3,4,11,12}` with
+//! `TRANS2`/`TRANS4`, differing only in the dose record's `CMT` (and `SS`/`II`
+//! or `RATE` where noted). They were run with `nmfe76`; the numbers below are
+//! transcribed from each run's `$TABLE` output.
+//!
+//! Two things are pinned here.
+//!
+//! 1. **`SS=1` with `CMT=0`.** NONMEM produces *identical* `PRED` for `CMT=0`
+//!    and `CMT=1` — confirming `CMT=0` means "the default dose compartment" and
+//!    that it must equilibrate like any other. ferx's event-driven walk used to
+//!    bail out of steady-state equilibration on `CMT=0` and return the
+//!    single-dose curve (#375).
+//! 2. **Dosing into a non-default compartment.** For every model, NONMEM agrees
+//!    with ferx's **event-driven walk**. It disagrees sharply with the
+//!    dose-superposition path, which never reads `dose.cmt` and computes every
+//!    dose as going into the model's default route — by up to two orders of
+//!    magnitude. These cases are therefore asserted against the walk; the
+//!    superposition path's disagreement is a separate, pre-existing defect
+//!    (tracked separately) and is deliberately *not* asserted here.
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{predict, read_nonmem_csv, CompiledModel, Population};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn pop_of(csv: &str) -> Population {
+    let mut f = NamedTempFile::new().expect("temp file");
+    write!(f, "{csv}").expect("write");
+    f.flush().expect("flush");
+    read_nonmem_csv(f.path(), None, None).expect("dataset loads")
+}
+
+fn model_src(structural: &str, params: &str, indiv: &str) -> String {
+    format!(
+        r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+{params}
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+{indiv}
+
+[structural_model]
+  {structural}
+
+[error_model]
+  DV ~ proportional(PROP)
+"#
+    )
+}
+
+/// Predictions on the **event-driven walk**. The walk is selected by adding a
+/// `WT` column that varies across rows; the model never references `WT`, so no
+/// parameter value differs from the plain dataset — only the code path does.
+fn walk_preds(src: &str, dose_cmt: usize, obs_cmt: usize, rate: f64, ss: u8, ii: f64) -> Vec<f64> {
+    let model: CompiledModel = parse_full_model(src).expect("model parses").model;
+    let dose = format!("1,0,.,1,100,{dose_cmt},{rate},1,{ss},{ii},70");
+    let obs: String = [(1, 80), (4, 90), (8, 100)]
+        .iter()
+        .map(|(t, w)| format!("1,{t},5.0,0,.,{obs_cmt},.,0,0,0,{w}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let csv = format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II,WT\n{dose}\n{obs}\n");
+    predict(&model, &pop_of(&csv), &model.default_params)
+        .into_iter()
+        .map(|p| p.pred)
+        .collect()
+}
+
+/// The control streams print `PRED` with `FORMAT=,1PE17.10` (11 significant
+/// figures), so this is a strict anchor, not a loose one: at the default 5-figure
+/// `$TABLE` precision several of these cases sit right at the printing resolution
+/// and a slack tolerance would hide a real difference rather than reveal one.
+fn assert_matches_nonmem(got: &[f64], nonmem: &[f64], case: &str) {
+    assert_close(got, nonmem, 1e-9, case)
+}
+
+/// 3-compartment closed forms obtain their eigenvalues by solving a **cubic**;
+/// ferx and NONMEM use different root-finders, so the last couple of digits
+/// legitimately differ there. Still a strict anchor — 1e-8 relative on an
+/// 11-significant-figure reference — just not one that pretends two independent
+/// cubic solves agree to the ULP.
+fn assert_matches_nonmem_3cpt(got: &[f64], nonmem: &[f64], case: &str) {
+    assert_close(got, nonmem, 1e-8, case)
+}
+
+fn assert_close(got: &[f64], nonmem: &[f64], tol: f64, case: &str) {
+    assert_eq!(got.len(), nonmem.len(), "{case}: row count");
+    for (j, (&g, &n)) in got.iter().zip(nonmem).enumerate() {
+        let rel = (g - n).abs() / n.abs().max(1e-12);
+        assert!(
+            rel < tol,
+            "{case} obs {j}: ferx {g:.8} vs NONMEM {n:.8} (rel {rel:.2e})"
+        );
+    }
+}
+
+fn one_cpt_iv() -> String {
+    model_src("pk one_cpt_iv(cl=CL, v=V)", "", "")
+}
+fn one_cpt_oral() -> String {
+    model_src(
+        "pk one_cpt_oral(cl=CL, v=V, ka=KA)",
+        "  theta TVKA(1.0, 0.01, 10.0)",
+        "  KA = TVKA",
+    )
+}
+fn two_cpt_iv() -> String {
+    model_src(
+        "pk two_cpt_iv(cl=CL, v=V, q=Q, v2=V2)",
+        "  theta TVQ(3.0, 0.1, 50.0)\n  theta TVV2(80.0, 5.0, 500.0)",
+        "  Q  = TVQ\n  V2 = TVV2",
+    )
+}
+fn two_cpt_oral() -> String {
+    model_src(
+        "pk two_cpt_oral(cl=CL, v=V, q=Q, v2=V2, ka=KA)",
+        "  theta TVKA(1.0, 0.01, 10.0)\n  theta TVQ(3.0, 0.1, 50.0)\n  theta TVV2(80.0, 5.0, 500.0)",
+        "  KA = TVKA\n  Q  = TVQ\n  V2 = TVV2",
+    )
+}
+const THREE_P: &str = "  theta TVQ(3.0, 0.1, 50.0)\n  theta TVV2(80.0, 5.0, 500.0)\n  \
+                       theta TVQ3(1.0, 0.1, 50.0)\n  theta TVV3(120.0, 5.0, 900.0)";
+const THREE_I: &str = "  Q  = TVQ\n  V2 = TVV2\n  Q3 = TVQ3\n  V3 = TVV3";
+fn three_cpt_iv() -> String {
+    model_src(
+        "pk three_cpt_iv(cl=CL, v=V, q=Q, v2=V2, q3=Q3, v3=V3)",
+        THREE_P,
+        THREE_I,
+    )
+}
+fn three_cpt_oral() -> String {
+    model_src(
+        "pk three_cpt_oral(cl=CL, v=V, q=Q, v2=V2, q3=Q3, v3=V3, ka=KA)",
+        &format!("  theta TVKA(1.0, 0.01, 10.0)\n{THREE_P}"),
+        &format!("  KA = TVKA\n{THREE_I}"),
+    )
+}
+
+// ── 1. SS=1 with CMT=0 (ADVAN1, SS=1, II=12) ─────────────────────────────────
+
+/// NONMEM `ADVAN1 TRANS2`, `SS=1 II=12`, dose `CMT=0` and `CMT=1`. Both runs
+/// print the same `PRED`, which is also the closed form
+/// `(D/V)·e^{−kt}/(1−e^{−k·II})`. Before #375 the walk returned the *single
+/// dose* curve for `CMT=0` (1.8097 / 1.3406 / 0.8987) — ~30 % low here.
+#[test]
+fn ss_dose_cmt_zero_and_one_match_nonmem() {
+    const NONMEM_SS: [f64; 3] = [2.5896677831, 1.9184730793, 1.2859909628];
+    for cmt in [0usize, 1] {
+        let got = walk_preds(&one_cpt_iv(), cmt, 1, 0.0, 1, 12.0);
+        assert_matches_nonmem(&got, &NONMEM_SS, &format!("ADVAN1 SS=1 CMT={cmt}"));
+    }
+}
+
+// ── 2. bolus into a non-default compartment, per model ───────────────────────
+
+/// `ADVAN2` (1-cpt oral), bolus into `CMT=2` — the central compartment, i.e. an
+/// IV dose written against an oral model. Superposition computes 1.19324 here
+/// (it treats it as a depot dose); NONMEM and the walk agree on 1.8097.
+#[test]
+fn one_cpt_oral_bolus_into_central_matches_nonmem() {
+    let got = walk_preds(&one_cpt_oral(), 2, 2, 0.0, 0, 0.0);
+    assert_matches_nonmem(
+        &got,
+        &[1.8096748361, 1.3406400921, 0.89865792823],
+        "ADVAN2 bolus CMT=2",
+    );
+}
+
+/// `ADVAN3` (2-cpt IV), bolus into `CMT=2` — the peripheral compartment.
+#[test]
+fn two_cpt_iv_bolus_into_peripheral_matches_nonmem() {
+    let got = walk_preds(&two_cpt_iv(), 2, 1, 0.0, 0, 0.0);
+    assert_matches_nonmem(
+        &got,
+        &[0.068015673681, 0.20535408329, 0.29007691882],
+        "ADVAN3 bolus CMT=2",
+    );
+}
+
+/// `ADVAN4` (2-cpt oral), bolus into `CMT=3` — the peripheral compartment.
+#[test]
+fn two_cpt_oral_bolus_into_peripheral_matches_nonmem() {
+    let got = walk_preds(&two_cpt_oral(), 3, 2, 0.0, 0, 0.0);
+    assert_matches_nonmem(
+        &got,
+        &[0.068015673681, 0.20535408329, 0.29007691882],
+        "ADVAN4 bolus CMT=3",
+    );
+}
+
+/// `ADVAN11` (3-cpt IV), bolus into `CMT=3` — the second peripheral.
+#[test]
+fn three_cpt_iv_bolus_into_peripheral2_matches_nonmem() {
+    let got = walk_preds(&three_cpt_iv(), 3, 1, 0.0, 0, 0.0);
+    assert_matches_nonmem_3cpt(
+        &got,
+        &[0.015193556553, 0.046937359706, 0.069431483504],
+        "ADVAN11 bolus CMT=3",
+    );
+}
+
+/// `ADVAN12` (3-cpt oral), bolus into `CMT=2` — the central compartment.
+#[test]
+fn three_cpt_oral_bolus_into_central_matches_nonmem() {
+    let got = walk_preds(&three_cpt_oral(), 2, 2, 0.0, 0, 0.0);
+    assert_matches_nonmem(
+        &got,
+        &[1.6726602861, 0.99662213471, 0.53066189083],
+        "ADVAN12 bolus CMT=2",
+    );
+}
+
+// ── 3. infusion into an IV peripheral (accepted by check_dose_compartments) ──
+
+/// `ADVAN3` with `RATE=20` into `CMT=2`. This compartment *is* in
+/// `infusable_compartments()`, so `check_dose_compartments` accepts it — this
+/// anchor confirms the walk then computes it the way NONMEM does, i.e. that
+/// accepting it is correct and not merely permissive.
+#[test]
+fn two_cpt_iv_infusion_into_peripheral_matches_nonmem() {
+    let got = walk_preds(&two_cpt_iv(), 2, 1, 20.0, 0, 0.0);
+    assert_matches_nonmem(
+        &got,
+        &[0.0070275296315, 0.09332945504, 0.24115537856],
+        "ADVAN3 infusion CMT=2",
+    );
+}

--- a/tests/nonmem_dose_compartment_anchor.rs
+++ b/tests/nonmem_dose_compartment_anchor.rs
@@ -22,9 +22,11 @@
 //!    with ferx's **event-driven walk**. It disagrees sharply with the
 //!    dose-superposition path, which never reads `dose.cmt` and computes every
 //!    dose as going into the model's default route — by up to two orders of
-//!    magnitude. These cases are therefore asserted against the walk; the
-//!    superposition path's disagreement is a separate, pre-existing defect
-//!    (tracked separately) and is deliberately *not* asserted here.
+//!    magnitude — because it never reads `dose.cmt` and computes every dose as
+//!    going into the model's default route. Since #375 such a dose reroutes to
+//!    the walk, so **every case here asserts both paths** — each against NONMEM,
+//!    and against each other. That three-way agreement is the acceptance
+//!    criterion; before the fix the `[default dispatch]` arm failed.
 
 use ferx_core::parser::model_parser::parse_full_model;
 use ferx_core::{predict, read_nonmem_csv, CompiledModel, Population};
@@ -74,7 +76,29 @@ fn walk_preds(src: &str, dose_cmt: usize, obs_cmt: usize, rate: f64, ss: u8, ii:
         .collect::<Vec<_>>()
         .join("\n");
     let csv = format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II,WT\n{dose}\n{obs}\n");
-    predict(&model, &pop_of(&csv), &model.default_params)
+    preds_of(&model, &csv)
+}
+
+/// Predictions on the **plain** dataset — no time-varying covariate, so the
+/// dispatcher's default route. Historically this was the dose-superposition
+/// path, which ignores `dose.cmt`; since #375 a dose the superposition form
+/// cannot place reroutes to the same walk, so this must now agree with
+/// `walk_preds` *and* with NONMEM. That agreement is the point of asserting
+/// both.
+fn plain_preds(src: &str, dose_cmt: usize, obs_cmt: usize, rate: f64, ss: u8, ii: f64) -> Vec<f64> {
+    let model: CompiledModel = parse_full_model(src).expect("model parses").model;
+    let dose = format!("1,0,.,1,100,{dose_cmt},{rate},1,{ss},{ii}");
+    let obs: String = [1, 4, 8]
+        .iter()
+        .map(|t| format!("1,{t},5.0,0,.,{obs_cmt},.,0,0,0"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let csv = format!("ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II\n{dose}\n{obs}\n");
+    preds_of(&model, &csv)
+}
+
+fn preds_of(model: &CompiledModel, csv: &str) -> Vec<f64> {
+    predict(model, &pop_of(csv), &model.default_params)
         .into_iter()
         .map(|p| p.pred)
         .collect()
@@ -87,6 +111,51 @@ fn walk_preds(src: &str, dose_cmt: usize, obs_cmt: usize, rate: f64, ss: u8, ii:
 fn assert_matches_nonmem(got: &[f64], nonmem: &[f64], case: &str) {
     assert_close(got, nonmem, 1e-9, case)
 }
+
+/// Assert **both** analytical paths reproduce NONMEM for the same dose row: the
+/// event-driven walk, and the plain dispatcher route. Before #375 the second one
+/// was dose superposition, which ignores `dose.cmt` and disagreed with NONMEM by
+/// up to two orders of magnitude; the two paths agreeing *and* both landing on
+/// NONMEM is the acceptance criterion.
+fn assert_both_paths_match(
+    src: &str,
+    dose_cmt: usize,
+    obs_cmt: usize,
+    rate: f64,
+    ss: u8,
+    ii: f64,
+    nonmem: &[f64],
+    tol: f64,
+    case: &str,
+) {
+    let walk = walk_preds(src, dose_cmt, obs_cmt, rate, ss, ii);
+    let plain = plain_preds(src, dose_cmt, obs_cmt, rate, ss, ii);
+    assert_close(&walk, nonmem, tol, &format!("{case} [event-driven walk]"));
+    assert_close(&plain, nonmem, tol, &format!("{case} [default dispatch]"));
+    assert_close(&plain, &walk, tol, &format!("{case} [paths agree]"));
+}
+
+/// 3-compartment **infusion** cases. NONMEM's own `ADVAN11`/`ADVAN12` forced
+/// response carries ~2e-6 relative error here, and it is NONMEM that is off, not
+/// ferx: the closed form was cross-checked against a 1e-12 RK45 solve of the
+/// *same* ODE system (`d/dt` written out explicitly, `ode_reltol = 1e-12`) and
+/// the two ferx paths agree to **1.8e-12**, while both differ from NONMEM by the
+/// same 2.15e-6. The bolus cases on the identical eigenvalues agree with NONMEM
+/// to <1e-8, so this is specific to its infusion forced response. The tolerance
+/// is therefore set by the *reference's* accuracy, not ferx's — and
+/// `three_cpt_oral_peripheral_infusion_matches_the_ode_twin` pins the exact
+/// oracle so this looser bound cannot hide a regression.
+fn assert_matches_nonmem_3cpt_infusion(got: &[f64], nonmem: &[f64], case: &str) {
+    assert_close(got, nonmem, NONMEM_3CPT_INFUSION_TOL, case)
+}
+
+/// Bound set by **NONMEM's** accuracy on these cases, not ferx's: the measured
+/// gap is 2.1e-6 on `ADVAN11 CMT=2` and 1.1e-5 on the smallest-magnitude case
+/// (`ADVAN12 CMT=4`, PRED ~1.6e-3). ferx's own agreement with an independent
+/// 1e-12 integration of the same system is ~1e-11 — see
+/// `tests/oral_peripheral_infusion.rs`, which is the tight oracle. This anchor's
+/// job is cross-tool corroboration; that file's job is precision.
+const NONMEM_3CPT_INFUSION_TOL: f64 = 3e-5;
 
 /// 3-compartment closed forms obtain their eigenvalues by solving a **cubic**;
 /// ferx and NONMEM use different root-finders, so the last couple of digits
@@ -160,8 +229,17 @@ fn three_cpt_oral() -> String {
 fn ss_dose_cmt_zero_and_one_match_nonmem() {
     const NONMEM_SS: [f64; 3] = [2.5896677831, 1.9184730793, 1.2859909628];
     for cmt in [0usize, 1] {
-        let got = walk_preds(&one_cpt_iv(), cmt, 1, 0.0, 1, 12.0);
-        assert_matches_nonmem(&got, &NONMEM_SS, &format!("ADVAN1 SS=1 CMT={cmt}"));
+        assert_both_paths_match(
+            &one_cpt_iv(),
+            cmt,
+            1,
+            0.0,
+            1,
+            12.0,
+            &NONMEM_SS,
+            1e-9,
+            &format!("ADVAN1 SS=1 CMT={cmt}"),
+        );
     }
 }
 
@@ -172,10 +250,15 @@ fn ss_dose_cmt_zero_and_one_match_nonmem() {
 /// (it treats it as a depot dose); NONMEM and the walk agree on 1.8097.
 #[test]
 fn one_cpt_oral_bolus_into_central_matches_nonmem() {
-    let got = walk_preds(&one_cpt_oral(), 2, 2, 0.0, 0, 0.0);
-    assert_matches_nonmem(
-        &got,
+    assert_both_paths_match(
+        &one_cpt_oral(),
+        2,
+        2,
+        0.0,
+        0,
+        0.0,
         &[1.8096748361, 1.3406400921, 0.89865792823],
+        1e-9,
         "ADVAN2 bolus CMT=2",
     );
 }
@@ -183,10 +266,15 @@ fn one_cpt_oral_bolus_into_central_matches_nonmem() {
 /// `ADVAN3` (2-cpt IV), bolus into `CMT=2` — the peripheral compartment.
 #[test]
 fn two_cpt_iv_bolus_into_peripheral_matches_nonmem() {
-    let got = walk_preds(&two_cpt_iv(), 2, 1, 0.0, 0, 0.0);
-    assert_matches_nonmem(
-        &got,
+    assert_both_paths_match(
+        &two_cpt_iv(),
+        2,
+        1,
+        0.0,
+        0,
+        0.0,
         &[0.068015673681, 0.20535408329, 0.29007691882],
+        1e-9,
         "ADVAN3 bolus CMT=2",
     );
 }
@@ -194,10 +282,15 @@ fn two_cpt_iv_bolus_into_peripheral_matches_nonmem() {
 /// `ADVAN4` (2-cpt oral), bolus into `CMT=3` — the peripheral compartment.
 #[test]
 fn two_cpt_oral_bolus_into_peripheral_matches_nonmem() {
-    let got = walk_preds(&two_cpt_oral(), 3, 2, 0.0, 0, 0.0);
-    assert_matches_nonmem(
-        &got,
+    assert_both_paths_match(
+        &two_cpt_oral(),
+        3,
+        2,
+        0.0,
+        0,
+        0.0,
         &[0.068015673681, 0.20535408329, 0.29007691882],
+        1e-9,
         "ADVAN4 bolus CMT=3",
     );
 }
@@ -205,10 +298,15 @@ fn two_cpt_oral_bolus_into_peripheral_matches_nonmem() {
 /// `ADVAN11` (3-cpt IV), bolus into `CMT=3` — the second peripheral.
 #[test]
 fn three_cpt_iv_bolus_into_peripheral2_matches_nonmem() {
-    let got = walk_preds(&three_cpt_iv(), 3, 1, 0.0, 0, 0.0);
-    assert_matches_nonmem_3cpt(
-        &got,
+    assert_both_paths_match(
+        &three_cpt_iv(),
+        3,
+        1,
+        0.0,
+        0,
+        0.0,
         &[0.015193556553, 0.046937359706, 0.069431483504],
+        1e-8,
         "ADVAN11 bolus CMT=3",
     );
 }
@@ -216,10 +314,15 @@ fn three_cpt_iv_bolus_into_peripheral2_matches_nonmem() {
 /// `ADVAN12` (3-cpt oral), bolus into `CMT=2` — the central compartment.
 #[test]
 fn three_cpt_oral_bolus_into_central_matches_nonmem() {
-    let got = walk_preds(&three_cpt_oral(), 2, 2, 0.0, 0, 0.0);
-    assert_matches_nonmem(
-        &got,
+    assert_both_paths_match(
+        &three_cpt_oral(),
+        2,
+        2,
+        0.0,
+        0,
+        0.0,
         &[1.6726602861, 0.99662213471, 0.53066189083],
+        1e-8,
         "ADVAN12 bolus CMT=2",
     );
 }
@@ -232,10 +335,105 @@ fn three_cpt_oral_bolus_into_central_matches_nonmem() {
 /// accepting it is correct and not merely permissive.
 #[test]
 fn two_cpt_iv_infusion_into_peripheral_matches_nonmem() {
-    let got = walk_preds(&two_cpt_iv(), 2, 1, 20.0, 0, 0.0);
-    assert_matches_nonmem(
-        &got,
+    assert_both_paths_match(
+        &two_cpt_iv(),
+        2,
+        1,
+        20.0,
+        0,
+        0.0,
         &[0.0070275296315, 0.09332945504, 0.24115537856],
+        1e-9,
         "ADVAN3 infusion CMT=2",
+    );
+}
+
+// ── 4. infusion into an ORAL model's peripheral (#375) ───────────────────────
+
+/// `ADVAN4` (2-cpt oral) with `RATE=20` into `CMT=3` — the **peripheral** of an
+/// oral model. Previously rejected: the oral propagators had no peripheral-rate
+/// forcing term where the IV ones did.
+///
+/// The closed form needed is the IV one. Nothing flows back into the depot, so a
+/// rate into the peripheral drives exactly the central/peripheral pair a 2-cpt IV
+/// model has, and the oral propagator superposes that forced response onto its
+/// homogeneous evolution. NONMEM confirms the reduction exactly: this run prints
+/// the *same* `PRED` as `ADVAN3` with an infusion into `CMT=2`
+/// (`two_cpt_iv_infusion_into_peripheral_matches_nonmem`), because the depot is
+/// empty throughout.
+#[test]
+fn two_cpt_oral_infusion_into_peripheral_matches_nonmem() {
+    assert_both_paths_match(
+        &two_cpt_oral(),
+        3,
+        2,
+        20.0,
+        0,
+        0.0,
+        &[0.0070275296315, 0.09332945504, 0.24115537856],
+        1e-9,
+        "ADVAN4 infusion CMT=3",
+    );
+}
+
+/// `ADVAN12` (3-cpt oral), infusion into the **first** peripheral (`CMT=3`).
+#[test]
+fn three_cpt_oral_infusion_into_peripheral1_matches_nonmem() {
+    assert_both_paths_match(
+        &three_cpt_oral(),
+        3,
+        2,
+        20.0,
+        0,
+        0.0,
+        &[0.0069821063874, 0.091126295438, 0.2297334849],
+        NONMEM_3CPT_INFUSION_TOL,
+        "ADVAN12 infusion CMT=3",
+    );
+}
+
+/// `ADVAN12` (3-cpt oral), infusion into the **second** peripheral (`CMT=4`).
+#[test]
+fn three_cpt_oral_infusion_into_peripheral2_matches_nonmem() {
+    assert_both_paths_match(
+        &three_cpt_oral(),
+        4,
+        2,
+        20.0,
+        0,
+        0.0,
+        &[0.0015668828542, 0.021085941254, 0.056167606771],
+        NONMEM_3CPT_INFUSION_TOL,
+        "ADVAN12 infusion CMT=4",
+    );
+}
+
+/// 3-cpt **IV** peripheral infusions — the same forced response the oral cases
+/// above delegate to. Anchored separately so a discrepancy is attributed to the
+/// right place (the shared `propagate_three_cpt_core_g`), not to the oral wiring.
+/// NONMEM prints identical `PRED` for these and their `ADVAN12` twins.
+#[test]
+fn three_cpt_iv_infusion_into_peripherals_matches_nonmem() {
+    assert_both_paths_match(
+        &three_cpt_iv(),
+        2,
+        1,
+        20.0,
+        0,
+        0.0,
+        &[0.0069821063874, 0.091126295438, 0.2297334849],
+        NONMEM_3CPT_INFUSION_TOL,
+        "ADVAN11 infusion CMT=2",
+    );
+    assert_both_paths_match(
+        &three_cpt_iv(),
+        3,
+        1,
+        20.0,
+        0,
+        0.0,
+        &[0.0015668828542, 0.021085941254, 0.056167606771],
+        NONMEM_3CPT_INFUSION_TOL,
+        "ADVAN11 infusion CMT=3",
     );
 }

--- a/tests/oral_peripheral_infusion.rs
+++ b/tests/oral_peripheral_infusion.rs
@@ -246,3 +246,58 @@ fn three_cpt_peripheral_infusion_overlapping_oral_dose_matches_the_ode_twin() {
         "three_cpt_oral peripheral infusion + overlapping depot dose",
     );
 }
+
+/// A **central AND peripheral infusion simultaneously active**. The oral
+/// propagator makes one delegated call carrying both rates, so the IV core's
+/// combined steady state (`A_c = (R_c+R_p)/k10`,
+/// `A_p = (k12·R_c + (k10+k12)·R_p)/(k21·k10)`) is what decides whether one
+/// clobbers the other. Every other test drives exactly one channel, so this is
+/// the only one that can see a clobber.
+#[test]
+fn simultaneous_central_and_peripheral_infusion_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n\
+               1,0,.,1,100,3,20,1\n\
+               1,1,.,1,120,2,30,1\n\
+               1,2,4.5,0,.,2,.,0\n1,4,4.0,0,.,2,.,0\n1,6,3.5,0,.,2,.,0\n\
+               1,8,3.0,0,.,2,.,0\n1,12,2.0,0,.,2,.,0\n";
+    assert_agree(
+        &preds(TWO_CPT_ORAL_CF, csv),
+        &preds(TWO_CPT_ORAL_ODE, csv),
+        1e-9,
+        "two_cpt_oral central + peripheral infusion overlapping",
+    );
+}
+
+/// **Steady state** into an oral peripheral (`SS=1`, `II=24`, window 5 h). The
+/// walk's `equilibrate_ss_state_event_driven` runs the synthetic pulse through
+/// the same routing table, so the peripheral channel has to survive the
+/// equilibration loop as well as the ordinary walk.
+#[test]
+fn ss_peripheral_infusion_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II\n\
+               1,0,.,1,100,3,20,1,1,24\n\
+               1,1,5.0,0,.,2,.,0,.,.\n1,4,4.0,0,.,2,.,0,.,.\n\
+               1,8,3.0,0,.,2,.,0,.,.\n1,20,2.0,0,.,2,.,0,.,.\n";
+    assert_agree(
+        &preds(TWO_CPT_ORAL_CF, csv),
+        &preds(TWO_CPT_ORAL_ODE, csv),
+        1e-6,
+        "two_cpt_oral SS peripheral infusion",
+    );
+}
+
+/// Steady-state **bolus** into an oral peripheral — the other half of the SS
+/// routing (`state[cmt_idx] += F·amt` inside the equilibration loop).
+#[test]
+fn ss_peripheral_bolus_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV,SS,II\n\
+               1,0,.,1,100,3,.,1,1,24\n\
+               1,1,5.0,0,.,2,.,0,.,.\n1,4,4.0,0,.,2,.,0,.,.\n\
+               1,8,3.0,0,.,2,.,0,.,.\n1,20,2.0,0,.,2,.,0,.,.\n";
+    assert_agree(
+        &preds(TWO_CPT_ORAL_CF, csv),
+        &preds(TWO_CPT_ORAL_ODE, csv),
+        1e-6,
+        "two_cpt_oral SS peripheral bolus",
+    );
+}

--- a/tests/oral_peripheral_infusion.rs
+++ b/tests/oral_peripheral_infusion.rs
@@ -1,0 +1,248 @@
+//! Exact oracle for **infusion into an oral model's peripheral compartment**
+//! (#375) — the closed form versus a tight-tolerance RK45 solve of the *same*
+//! ODE system.
+//!
+//! This is the primary correctness test for that feature, and it is deliberately
+//! independent of NONMEM: NONMEM's `ADVAN11`/`ADVAN12` forced response carries
+//! ~2e-6 relative error on these cases (see
+//! `tests/nonmem_dose_compartment_anchor.rs`, where that is measured), so it
+//! cannot pin the closed form tighter than that. Writing the same system out as
+//! explicit `[odes]` and integrating it to `ode_reltol = 1e-12` can, and does —
+//! to ~1e-11.
+//!
+//! Why the oral peripheral needs no new closed form: nothing flows back into the
+//! depot, so a constant rate into a peripheral drives exactly the
+//! central/peripheral sub-system that the IV model has. The oral propagator
+//! superposes that IV forced response onto its own homogeneous evolution. These
+//! tests are what verify that reduction rather than assuming it.
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{predict, read_nonmem_csv, Population};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn pop_of(csv: &str) -> Population {
+    let mut f = NamedTempFile::new().expect("temp file");
+    write!(f, "{csv}").expect("write");
+    f.flush().expect("flush");
+    read_nonmem_csv(f.path(), None, None).expect("dataset loads")
+}
+
+fn preds(src: &str, csv: &str) -> Vec<f64> {
+    let m = parse_full_model(src).expect("model parses").model;
+    predict(&m, &pop_of(csv), &m.default_params)
+        .into_iter()
+        .map(|p| p.pred)
+        .collect()
+}
+
+const TWO_CPT_ORAL_CF: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[structural_model]
+  pk two_cpt_oral(cl=CL, v=V, q=Q, v2=V2, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+const TWO_CPT_ORAL_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[structural_model]
+  ode(states=[depot, central, periph])
+
+[odes]
+  d/dt(depot)   = -KA*depot
+  d/dt(central) = KA*depot - (CL/V)*central - (Q/V)*central + (Q/V2)*periph
+  d/dt(periph)  = (Q/V)*central - (Q/V2)*periph
+
+[scaling]
+  y = central / V
+
+[fit_options]
+  ode_reltol = 1e-12
+  ode_abstol = 1e-14
+  ode_max_steps = 10000000
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+const THREE_CPT_ORAL_CF: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVQ3(1.0, 0.1, 50.0)
+  theta TVV3(120.0, 5.0, 900.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  Q3 = TVQ3
+  V3 = TVV3
+  KA = TVKA
+
+[structural_model]
+  pk three_cpt_oral(cl=CL, v=V, q=Q, v2=V2, q3=Q3, v3=V3, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+const THREE_CPT_ORAL_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVQ3(1.0, 0.1, 50.0)
+  theta TVV3(120.0, 5.0, 900.0)
+  theta TVKA(1.0, 0.01, 10.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  Q3 = TVQ3
+  V3 = TVV3
+  KA = TVKA
+
+[structural_model]
+  ode(states=[depot, central, periph1, periph2])
+
+[odes]
+  d/dt(depot)   = -KA*depot
+  d/dt(central) = KA*depot - (CL/V)*central - (Q/V)*central + (Q/V2)*periph1 - (Q3/V)*central + (Q3/V3)*periph2
+  d/dt(periph1) = (Q/V)*central - (Q/V2)*periph1
+  d/dt(periph2) = (Q3/V)*central - (Q3/V3)*periph2
+
+[scaling]
+  y = central / V
+
+[fit_options]
+  ode_reltol = 1e-12
+  ode_abstol = 1e-14
+  ode_max_steps = 10000000
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+fn assert_agree(cf: &[f64], ode: &[f64], tol: f64, case: &str) {
+    assert_eq!(cf.len(), ode.len(), "{case}: row count");
+    assert!(
+        ode.iter().all(|x| x.is_finite() && *x > 0.0),
+        "{case}: ODE reference must be non-trivial, got {ode:?}"
+    );
+    for (j, (&c, &o)) in cf.iter().zip(ode).enumerate() {
+        let rel = (c - o).abs() / o.abs();
+        assert!(
+            rel < tol,
+            "{case} obs {j}: closed form {c:.14} vs ODE {o:.14} (rel {rel:.2e})"
+        );
+    }
+}
+
+/// `two_cpt_oral`, infusion into CMT=3 (the peripheral), observed in central.
+#[test]
+fn two_cpt_oral_peripheral_infusion_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n1,0,.,1,100,3,20,1\n\
+               1,1,5.0,0,.,2,.,0\n1,4,4.0,0,.,2,.,0\n1,8,3.0,0,.,2,.,0\n1,12,2.0,0,.,2,.,0\n";
+    assert_agree(
+        &preds(TWO_CPT_ORAL_CF, csv),
+        &preds(TWO_CPT_ORAL_ODE, csv),
+        1e-9,
+        "two_cpt_oral infusion CMT=3",
+    );
+}
+
+/// `three_cpt_oral`, infusion into each peripheral in turn.
+#[test]
+fn three_cpt_oral_peripheral_infusion_matches_the_ode_twin() {
+    for cmt in [3usize, 4] {
+        let csv = format!(
+            "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n1,0,.,1,100,{cmt},20,1\n\
+             1,1,5.0,0,.,2,.,0\n1,4,4.0,0,.,2,.,0\n1,8,3.0,0,.,2,.,0\n1,12,2.0,0,.,2,.,0\n"
+        );
+        assert_agree(
+            &preds(THREE_CPT_ORAL_CF, &csv),
+            &preds(THREE_CPT_ORAL_ODE, &csv),
+            1e-9,
+            &format!("three_cpt_oral infusion CMT={cmt}"),
+        );
+    }
+}
+
+/// The interesting combination: a peripheral infusion **and** an oral depot dose
+/// on the same subject, so the depot's homogeneous evolution and the peripheral
+/// forced response superpose. A reduction that only held with an empty depot
+/// would pass the tests above and fail here.
+#[test]
+fn peripheral_infusion_plus_oral_dose_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n\
+               1,0,.,1,100,3,20,1\n\
+               1,2,.,1,200,1,0,1\n\
+               1,1,5.0,0,.,2,.,0\n1,4,4.0,0,.,2,.,0\n1,8,3.0,0,.,2,.,0\n1,12,2.0,0,.,2,.,0\n";
+    assert_agree(
+        &preds(TWO_CPT_ORAL_CF, csv),
+        &preds(TWO_CPT_ORAL_ODE, csv),
+        1e-9,
+        "two_cpt_oral peripheral infusion + depot dose",
+    );
+}
+
+/// …and the 3-cpt version, with a depot dose landing *during* the infusion
+/// window so both forcings are simultaneously active.
+#[test]
+fn three_cpt_peripheral_infusion_overlapping_oral_dose_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n\
+               1,0,.,1,100,3,20,1\n\
+               1,2,.,1,200,1,0,1\n\
+               1,1,5.0,0,.,2,.,0\n1,3,4.5,0,.,2,.,0\n1,4,4.0,0,.,2,.,0\n\
+               1,8,3.0,0,.,2,.,0\n1,12,2.0,0,.,2,.,0\n";
+    assert_agree(
+        &preds(THREE_CPT_ORAL_CF, csv),
+        &preds(THREE_CPT_ORAL_ODE, csv),
+        1e-9,
+        "three_cpt_oral peripheral infusion + overlapping depot dose",
+    );
+}


### PR DESCRIPTION
## Why

`#375` reported that an infusion into a compartment the analytical closed forms cannot deliver
into `panic!`s from inside the event-driven prediction walk. It was reachable from ordinary
NONMEM-format data — a positive `RATE` into `CMT=3` of a `two_cpt_oral` model, on a subject that
also has a time-varying covariate, an `EVID=3/4` reset, or IOV.

Fixing it surfaced two larger problems underneath, both silent:

**The three analytical paths disagreed on the same dose.**

| path | unroutable infusion | out-of-range bolus |
|---|---|---|
| dose superposition | ignores `cmt`, computes it as central | ignores `cmt`, silent |
| event-driven walk | `panic!` | `panic!` |
| `sens` gradient walk | `None => {}` — silently dropped | silently dropped |

The gradient one is the sharp edge: FOCE/FOCEI would have differentiated a *different dosing
history* than it predicted.

**Superposition never read `dose.cmt` at all.** `single_dose_concentration` branches only on
`is_infusion()` and picks the closed form from the *model*, so it placed every bolus in
compartment 1 and every infusion into central, whatever the data said. Which answer you got
depended only on whether the subject happened to carry a TV covariate / reset / IOV, since those
route to the walk, which places doses correctly. NONMEM confirms the walk and contradicts
superposition — by up to two orders of magnitude:

| case | NONMEM | walk | superposition (before) |
|---|---|---|---|
| `three_cpt_iv` bolus → periph-2 | 0.015194 | **0.015194** | 1.67266 |
| `two_cpt_iv` bolus → periph | 0.068016 | **0.068016** | 1.706286 |
| `one_cpt_oral` bolus → central | 1.8097 | **1.809675** | 1.19324 |

## What changed

**1. Reject what genuinely has no target.** `check_dose_compartments` (`src/api/validation.rs`),
a sibling of `check_modeled_dose_rates`, analytical-engine only. Infusion → the compartment must
have a rate channel; bolus → `cmt` must not exceed the state count. Reported once per
`(kind, compartment)` with subject/time context. Wired into `check_model_data` (so `fit()`
returns `Err`), the `assert_*` twin on `predict`/`simulate`/`suggest_start`, and the `Result`
form on the adaptive chokepoint, `run_covariance`, and `run_sir`.

**2. Route every dose to a path that can express it.** `dose_needs_event_walk` (`src/pk/mod.rs`)
encodes what superposition can actually represent — bolus → compartment 1, infusion → central —
and reroutes everything else to the event-driven walk. It **subsumes** `has_oral_depot_infusion`,
which was this same bug fixed for exactly one compartment. Wired into the prediction dispatcher,
the `sens` router (so the gradient follows the value), and the compartment-state helper, whose
cmt-blindness now degrades to `NaN` with an extended warning rather than reporting wrong amounts.

**3. Support infusion into an oral model's peripheral.** Previously rejected: the oral
propagators had no peripheral forcing term where the IV ones did. They need no new closed form —
nothing flows back into the depot, so a rate into a peripheral drives exactly the
central/peripheral sub-system the IV model has, and the oral propagator superposes that same IV
forced response onto its homogeneous evolution.

**4. Two correctness fixes found on the way.**
- `SS=1` with `CMT=0` silently dropped its steady-state accumulation on the walk
  (`equilibrate_ss_state_event_driven` bailed to an all-zero state), returning the single-dose
  curve — ~30 % low, no warning. NONMEM gives identical `PRED` for `CMT=0` and `CMT=1`.
- A zero-amount dose is no longer rejected: `is_infusion()` is `rate > 0 || !is_fixed()`, broader
  than the walk's `rate > 0 && duration > 0`, and an `AMT=0, RATE>0` row delivers nothing on any
  path.

### Result

**Every compartment of every analytical model now accepts both a bolus and an infusion, alone or
together**, with both paths agreeing to 1e-9. Verified per `(model, compartment, kind)` across
all six walk-supported models. What remains rejected is `CMT=0` for an *infusion* (no default
compartment) and anything past the end of the state vector.

## Numerical validation

- [x] Compared against: **NONMEM 7.6.0**

`tests/nonmem_dose_compartment_anchor.rs` — `ADVAN1/2/3/4/11/12`, `MAXEVAL=0`,
`$TABLE FORMAT=,1PE17.10` (11 significant figures). Every case asserts **three ways**: walk vs
NONMEM, default dispatch vs NONMEM, and the two paths against each other. Before the reroute the
second arm failed. Covers the `SS`/`CMT=0` case, a non-default-compartment bolus for every model,
and IV + oral peripheral infusions.

**On the 3-cpt infusion tolerance.** Those anchors use `3e-5` rather than `1e-9`, and the bound is
set by *NONMEM's* accuracy, not ferx's. NONMEM's `ADVAN11/12` forced response differs from ferx by
2.1e-6 (1.1e-5 on the smallest-magnitude case), while ferx's closed form agrees with a `1e-12`
RK45 solve of the same system to **1.8e-12** — both ferx paths land together and NONMEM is the
outlier. Bolus cases on identical eigenvalues match NONMEM to <1e-8, so it is specific to its
infusion path. `tests/oral_peripheral_infusion.rs` is the tight oracle (1e-9 against an ODE twin,
including a peripheral infusion overlapping a depot dose), so the looser cross-tool bound cannot
hide a regression.

## Breaking changes

- [x] None to the API. **Predictions change** for datasets that dose a non-default compartment,
  or use `SS` with `CMT=0` — they were wrong before and are now NONMEM-correct. Datasets that
  previously crashed now either work (oral peripheral infusion) or return an actionable error.
  Per-compartment amounts in sdtab / `[derived]` are `NaN` for rerouted subjects rather than
  wrong; predictions are exact.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change; the new validator is `pub(crate)`, reached through the already-public
`check_model_data`.

## Tests

- [x] Unit test(s) added (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

Tier 1: 22 validator tests (each error code, dedup, boundaries, ODE exemption, transit/IG
deferral, positive controls for every routable `(model, cmt)`), plus `#[should_panic]` tests
pinning the defensive walk guards and a closed-form `SS`/`CMT=0` test anchored on
`(D/V)·e^{−kt}/(1−e^{−k·II})`.

Tier 2: 10 boundary tests, 11 NONMEM anchors, 4 ODE-twin oracles.

```
cargo test --lib   --features ci           -> 2654 passed, 0 failed
cargo test --tests --features ci,survival  -> exit 0, 3388 passed, 0 failed
cargo clippy --features ci,markov          -> 0 errors
```

## Docs

- [x] `docs/faq.qmd` — the "which compartments can an analytical model be infused into?" section
  now says: any compartment the model has, for both dose kinds.
- [x] `CHANGELOG.md` `[Unreleased]` — one `Added` entry (oral peripheral infusion) and two
  `Fixed` entries (non-default-compartment dosing, `SS`/`CMT=0`).

## Reviewer hints

Focus on:

1. **`dose_needs_event_walk`** — the predicate is the crux. It must match what superposition can
   express exactly: too narrow silently keeps wrong answers, too broad costs performance for no
   reason. The NONMEM anchors are what verify it.
2. **The oral-peripheral reduction** — that the IV forced response is the right one for an oral
   model. The overlapping infusion + depot dose test is the one that would catch it being valid
   only for an empty depot.
3. **The 3-cpt infusion tolerance** — I'd rather this be challenged than accepted on my say-so.
   The reasoning and the counter-evidence (analytic vs 1e-12 ODE) are in the test docstring.

Skimmable: the contract-pin updates (routing table, parser `D{cmt}` test), which mechanically
follow from oral peripherals becoming infusable.

## Open questions

Two things deliberately left, both verified rather than assumed:

1. **`predict()`/`simulate()` still panic** rather than returning `Result`, per existing
   convention. A panic reaches R as `"worker thread panicked"`, losing the message — worth its
   own issue, since it affects every `assert_*` validator.
2. **ODE models silently drop an out-of-range `CMT`** (`if cmt_idx < n { … }` with no `else`) —
   the same class this PR removes on the analytical side. Not fixed here because it needs the ODE
   state count rather than `PkModel` topology; the docstring says so rather than implying the
   exemption is a clean bill of health.
