### PR TITLE
feat(api): warn when combined-error additive init is negligible [#847]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Warning when a `combined` error model's additive initial estimate is negligibly
+  small** (#847). A pre-fit check (`W_ADDITIVE_INIT_SCALE`) flags an additive SD start
+  below 1% of the observation scale (median `|DV|`) on that endpoint. A near-zero
+  additive start can trap the fit in a local minimum where the additive term collapses
+  and the proportional term inflates — the worse basin on multimodal / over-parameterised
+  problems (e.g. the cyclophosphamide parent→metabolite fit, where additive variance
+  seeded at 0.5 traps at ≈0.94 instead of the global optimum ≈1878). The initial estimate
+  is never changed — the warning advises a larger start.
 - **Analytic sensitivities for steady-state dosing into a built-in absorption compartment**
   (#835). Fitting a model with an `SS=1` dose into a `first_order` / `transit` / `igd` /
   `weibull` absorption compartment now uses exact analytic FOCEI gradients — the closed-form

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -68,8 +68,8 @@ most damaging on multimodal / over-parameterised models.
 ferx emits a `W_ADDITIVE_INIT_SCALE` warning before fitting when the additive SD
 initial estimate is below **1% of the data scale** (median `|DV|`) on that
 endpoint. It never changes your value — it advises a larger start. As a rule of
-thumb, seed the additive SD at a few percent of the typical observed
-concentration (e.g. `median(|DV|) / 10`) rather than an arbitrary small number.
+thumb, seed the additive SD at roughly **10%** of the typical observed
+concentration (`median(|DV|) / 10`) rather than an arbitrary small number.
 
 **Worked example (cyclophosphamide parent→metabolite).** Metabolite
 concentrations reach the hundreds/thousands of ng/mL. Seeding the additive

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -54,6 +54,31 @@ $$
 
 Use when both proportional and additive error sources are present. Requires two sigma parameters defined in `[parameters]`.
 
+::: {.callout-warning}
+## Choose the additive initial estimate on the scale of your data
+
+A combined error model has a competing local minimum in which the **additive**
+term collapses toward zero and the proportional term inflates to absorb the
+scatter. Starting the additive SD far below the scale of the observations can
+trap the fit in that worse basin: low-magnitude points then carry near-infinite
+`1/Var` weight, and the optimizer is happy to keep the additive term at zero.
+This is not a ferx-specific quirk — NONMEM shows the same trapping, and it is
+most damaging on multimodal / over-parameterised models.
+
+ferx emits a `W_ADDITIVE_INIT_SCALE` warning before fitting when the additive SD
+initial estimate is below **1% of the data scale** (median `|DV|`) on that
+endpoint. It never changes your value — it advises a larger start. As a rule of
+thumb, seed the additive SD at a few percent of the typical observed
+concentration (e.g. `median(|DV|) / 10`) rather than an arbitrary small number.
+
+**Worked example (cyclophosphamide parent→metabolite).** Metabolite
+concentrations reach the hundreds/thousands of ng/mL. Seeding the additive
+*variance* at 0.5 (SD ≈ 0.7) traps both ferx and NONMEM at additive variance
+≈ 0.94, ~50 OFV points worse than the global optimum (additive variance ≈ 1878,
+matching Pumas). Re-seeding the additive SD to a data-scaled value (tens of
+ng/mL) reaches the correct basin.
+:::
+
 ## Time-varying / covariate-dependent magnitude
 
 > **Maturity: experimental** ([#484](https://github.com/FeRx-NLME/ferx-core/issues/484)).

--- a/src/api/tests/additive_init_scale_tests.rs
+++ b/src/api/tests/additive_init_scale_tests.rs
@@ -1,0 +1,78 @@
+//! Tier-1 unit tests for the combined-error additive-init scale warning
+//! (`W_ADDITIVE_INIT_SCALE`). The module is a child of `validation`, so
+//! `super::additive_init_scale_check` resolves the private decision helper
+//! directly — no full `CompiledModel`/`Population` construction needed.
+//!
+//! Regression anchor: the cyclophosphamide parent→metabolite fit, where an
+//! additive variance seeded at 0.5 (SD ≈ 0.707) against metabolite
+//! concentrations in the hundreds/thousands ng/mL traps both ferx and NONMEM in
+//! the additive-collapse local minimum. This warning fires on exactly that
+//! start.
+
+use super::additive_init_scale_check;
+
+/// A negligible additive SD (well under 1% of the data scale) fires the warning
+/// and the message carries the diagnostic code, the endpoint scope, and a
+/// larger suggested start.
+#[test]
+fn negligible_additive_init_warns() {
+    // Metabolite-like concentrations; median = 200.
+    let mut mags = vec![50.0, 100.0, 200.0, 400.0, 1000.0];
+    // sqrt(0.5) ≈ 0.707 — the cyclophosphamide trap start.
+    let d = additive_init_scale_check("CMT=2", "ADD_M1", 0.707, &mut mags)
+        .expect("negligible additive init must warn");
+    assert_eq!(d.code, "W_ADDITIVE_INIT_SCALE");
+    assert!(d.message.contains("CMT=2"));
+    assert!(d.message.contains("ADD_M1"));
+    // Suggested start is 10% of the median (200) = 20.
+    assert!(
+        d.message.contains("20.0000"),
+        "message should suggest ~10% of data scale, got: {}",
+        d.message
+    );
+}
+
+/// An additive SD at exactly the 1% threshold is not negligible (strict `<`).
+#[test]
+fn additive_init_at_threshold_is_silent() {
+    let mut mags = vec![100.0, 200.0, 300.0]; // median 200 → threshold 2.0
+    assert!(additive_init_scale_check("CMT=2", "ADD_M1", 2.0, &mut mags).is_none());
+}
+
+/// A sensibly-scaled additive floor (a few % of the data) does not warn — the
+/// threshold is conservative by design, so well-specified combined models stay
+/// quiet.
+#[test]
+fn reasonable_additive_init_is_silent() {
+    let mut mags = vec![50.0, 100.0, 200.0, 400.0, 1000.0]; // median 200
+                                                            // Pumas optimum additive SD sqrt(1878) ≈ 43.3 — far above 1% of 200.
+    assert!(additive_init_scale_check("CMT=2", "ADD_M1", 43.3, &mut mags).is_none());
+    // Even a modest 5-of-200 (2.5%) floor stays silent.
+    assert!(additive_init_scale_check("CMT=2", "ADD_M1", 5.0, &mut mags).is_none());
+}
+
+/// No observations (empty magnitudes) → nothing to compare against → silent.
+#[test]
+fn empty_observations_is_silent() {
+    let mut mags: Vec<f64> = vec![];
+    assert!(additive_init_scale_check("CMT=2", "ADD_M1", 0.001, &mut mags).is_none());
+}
+
+/// An all-zero data scale (median |DV| = 0) is silent — dividing the threshold
+/// by it is meaningless and there is no scale to anchor a suggestion.
+#[test]
+fn zero_data_scale_is_silent() {
+    let mut mags = vec![0.0, 0.0, 0.0];
+    assert!(additive_init_scale_check("CMT=2", "ADD_M1", 0.001, &mut mags).is_none());
+}
+
+/// Median is computed correctly for an even count (mean of the two middle
+/// order statistics) and the comparison uses it. Even-length median of
+/// [10,20,30,40] is 25 → threshold 0.25; an init of 0.2 warns, 0.3 does not.
+#[test]
+fn even_length_median_threshold() {
+    let mut a = vec![40.0, 10.0, 30.0, 20.0];
+    assert!(additive_init_scale_check("CMT=1", "ADD", 0.2, &mut a).is_some());
+    let mut b = vec![40.0, 10.0, 30.0, 20.0];
+    assert!(additive_init_scale_check("CMT=1", "ADD", 0.3, &mut b).is_none());
+}

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -963,3 +963,79 @@ fn tad_lag_uses_dose_covariate_not_obs() {
         tad[0]
     );
 }
+
+/// #847: `check_model_data_warnings` flags a combined error model whose
+/// **additive** SD initial estimate is negligible relative to the data scale
+/// (median |DV|) on that endpoint — the pre-fit guard against the additive-
+/// collapse local minimum. Exercises the endpoint-enumeration + observation-
+/// gathering plumbing (the median/threshold decision is unit-tested separately
+/// in `additive_init_scale_tests`).
+fn combined_endpoint_model() -> CompiledModel {
+    let mut m = minimal_iov_model(vec![]);
+    m.error_spec = ErrorSpec::PerCmt(HashMap::from([(
+        1,
+        crate::types::EndpointError {
+            error_model: ErrorModel::Combined,
+            sigma_idx: vec![0, 1], // [proportional, additive]
+        },
+    )]));
+    m.error_model = ErrorModel::Combined;
+    m.n_epsilon = 2;
+    m.default_params.sigma = SigmaVector {
+        values: vec![0.2, 0.5], // additive SD 0.5 ≪ 1% of median |DV| (2.0)
+        names: vec!["PROP".into(), "ADD".into()],
+    };
+    m.default_params.sigma_fixed = vec![false, false];
+    m
+}
+
+fn subject_with_obs(cmt: usize, dvs: Vec<f64>) -> Subject {
+    let n = dvs.len();
+    Subject {
+        fremtype: Vec::new(),
+        id: "S1".into(),
+        doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        obs_times: (0..n).map(|i| (i + 1) as f64).collect(),
+        obs_raw_times: (0..n).map(|i| (i + 1) as f64).collect(),
+        observations: dvs,
+        obs_cmts: vec![cmt; n],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1; n],
+        obs_l2: Vec::new(),
+        dose_occasions: vec![1],
+        obs_records: vec![],
+    }
+}
+
+#[test]
+fn additive_init_scale_warns_end_to_end() {
+    let model = combined_endpoint_model();
+    // median |DV| = 200 → 1% threshold = 2.0; additive SD init 0.5 < 2.0 → warn.
+    let pop = population_of(subject_with_obs(1, vec![100.0, 200.0, 300.0]));
+    let diags = check_model_data_warnings(&model, &pop, &model.default_params);
+    let d = diags
+        .iter()
+        .find(|d| d.code == "W_ADDITIVE_INIT_SCALE")
+        .expect("negligible additive init on a combined endpoint must warn");
+    assert!(d.message.contains("CMT=1"), "message: {}", d.message);
+    assert!(d.message.contains("ADD"), "message: {}", d.message);
+}
+
+#[test]
+fn additive_init_scale_silent_when_well_scaled() {
+    let mut model = combined_endpoint_model();
+    // Bump additive SD to 40 (far above 1% of 200) → no warning.
+    model.default_params.sigma.values[1] = 40.0;
+    let pop = population_of(subject_with_obs(1, vec![100.0, 200.0, 300.0]));
+    let diags = check_model_data_warnings(&model, &pop, &model.default_params);
+    assert!(
+        !diags.iter().any(|d| d.code == "W_ADDITIVE_INIT_SCALE"),
+        "a data-scaled additive init must not warn"
+    );
+}

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -1039,3 +1039,40 @@ fn additive_init_scale_silent_when_well_scaled() {
         "a data-scaled additive init must not warn"
     );
 }
+
+/// #847 (Copilot review): `ErrorSpec::Selected` dispatch keys are covariate
+/// **branch indices**, not CMTs — the warning must label them `endpoint={k}`,
+/// not `CMT={k}`. A single-branch selector routes every observation to key 0.
+#[test]
+fn additive_init_scale_selected_labels_endpoint_not_cmt() {
+    let mut model = combined_endpoint_model();
+    model.error_spec = ErrorSpec::Selected {
+        selector: crate::types::ErrorSelector {
+            eval: Box::new(|_cov| 0), // one branch → key 0 for every obs
+            branch_labels: vec!["all".into()],
+        },
+        endpoints: HashMap::from([(
+            0,
+            crate::types::EndpointError {
+                error_model: ErrorModel::Combined,
+                sigma_idx: vec![0, 1],
+            },
+        )]),
+    };
+    let pop = population_of(subject_with_obs(1, vec![100.0, 200.0, 300.0]));
+    let diags = check_model_data_warnings(&model, &pop, &model.default_params);
+    let d = diags
+        .iter()
+        .find(|d| d.code == "W_ADDITIVE_INIT_SCALE")
+        .expect("negligible additive init on a Selected combined endpoint must warn");
+    assert!(
+        d.message.contains("endpoint=0"),
+        "Selected key must be labelled endpoint=, got: {}",
+        d.message
+    );
+    assert!(
+        !d.message.contains("CMT="),
+        "Selected key must not be mislabelled CMT=, got: {}",
+        d.message
+    );
+}

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2194,52 +2194,60 @@ fn additive_init_scale_warnings(
     population: &Population,
     init_params: &ModelParameters,
 ) -> Vec<Diagnostic> {
-    use crate::types::{ErrorModel, ErrorSpec, SigmaType};
+    use crate::types::{EndpointError, ErrorModel, ErrorSpec, SigmaType};
+    use std::collections::HashMap;
 
     let mut diags = Vec::new();
 
-    // (additive global sigma index, endpoint dispatch key or None for `Single`).
-    // For `Combined` the additive sigma is the 2nd sigma (residual_variance uses
-    // sigma[0]=prop, sigma[1]=add); for `Single` the global sigma vector is in
-    // that order, for `PerCmt`/`Selected` the endpoint's `sigma_idx[1]`.
-    let mut combined_endpoints: Vec<(usize, Option<usize>)> = Vec::new();
-    match &model.error_spec {
-        ErrorSpec::Single(ErrorModel::Combined) => combined_endpoints.push((1, None)),
-        ErrorSpec::Single(_) => {}
-        ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
-            for (&key, ee) in map {
-                if ee.error_model == ErrorModel::Combined {
-                    if let Some(pos) = ee
-                        .error_model
-                        .sigma_types()
-                        .iter()
-                        .position(|t| *t == SigmaType::Additive)
-                    {
-                        if let Some(&idx) = ee.sigma_idx.get(pos) {
-                            combined_endpoints.push((idx, Some(key)));
-                        }
+    // (additive global sigma index, endpoint dispatch key or None for `Single`,
+    // scope label). For `Combined` the additive sigma is the 2nd sigma
+    // (residual_variance uses sigma[0]=prop, sigma[1]=add); for `Single` the
+    // global sigma vector is in that order, for `PerCmt`/`Selected` the
+    // endpoint's `sigma_idx[1]`. `PerCmt` keys are 1-based CMTs; `Selected` keys
+    // are 0-based covariate-branch indices — labelled `endpoint=` not `CMT=` so
+    // the message doesn't misname a branch as a compartment.
+    let mut combined_endpoints: Vec<(usize, Option<usize>, String)> = Vec::new();
+    let mut push_endpoints = |map: &HashMap<usize, EndpointError>, label: &str| {
+        for (&key, ee) in map {
+            if ee.error_model == ErrorModel::Combined {
+                if let Some(pos) = ee
+                    .error_model
+                    .sigma_types()
+                    .iter()
+                    .position(|t| *t == SigmaType::Additive)
+                {
+                    if let Some(&idx) = ee.sigma_idx.get(pos) {
+                        combined_endpoints.push((idx, Some(key), format!("{label}={key}")));
                     }
                 }
             }
         }
+    };
+    match &model.error_spec {
+        ErrorSpec::Single(ErrorModel::Combined) => {
+            combined_endpoints.push((1, None, "all observations".to_string()))
+        }
+        ErrorSpec::Single(_) => {}
+        ErrorSpec::PerCmt(map) => push_endpoints(map, "CMT"),
+        ErrorSpec::Selected { endpoints, .. } => push_endpoints(endpoints, "endpoint"),
     }
     // Deterministic order: HashMap iteration (PerCmt/Selected) is unordered.
     combined_endpoints.sort_unstable();
 
-    for (add_idx, key) in combined_endpoints {
+    for (add_idx, key, scope) in combined_endpoints {
         let Some(&add_sd_init) = init_params.sigma.values.get(add_idx) else {
             continue;
         };
         // |DV| of the observations this endpoint covers.
         let mut mags: Vec<f64> = Vec::new();
         for subject in &population.subjects {
-            for j in 0..subject.observations.len() {
+            for (j, &obs) in subject.observations.iter().enumerate() {
                 let covered = match key {
                     None => true,
                     Some(k) => model.error_spec.obs_key(subject, j) == k,
                 };
                 if covered {
-                    let v = subject.observations[j].abs();
+                    let v = obs.abs();
                     if v.is_finite() {
                         mags.push(v);
                     }
@@ -2252,10 +2260,6 @@ fn additive_init_scale_warnings(
             .get(add_idx)
             .cloned()
             .unwrap_or_else(|| format!("SIGMA({})", add_idx + 1));
-        let scope = match key {
-            Some(k) => format!("CMT={k}"),
-            None => "all observations".to_string(),
-        };
         if let Some(d) = additive_init_scale_check(&scope, &sigma_name, add_sd_init, &mut mags) {
             diags.push(d);
         }
@@ -2283,10 +2287,10 @@ fn additive_init_scale_check(
     }
     mags.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let mid = mags.len() / 2;
-    let data_scale = if mags.len() % 2 == 0 {
-        0.5 * (mags[mid - 1] + mags[mid])
-    } else {
+    let data_scale = if mags.len() % 2 == 1 {
         mags[mid]
+    } else {
+        0.5 * (mags[mid - 1] + mags[mid])
     };
     if data_scale <= 0.0 || add_sd_init >= NEGLIGIBLE_ADD_FRACTION * data_scale {
         return None;
@@ -2301,8 +2305,8 @@ fn additive_init_scale_check(
              the additive term collapses and the proportional term inflates — \
              the worse basin on multimodal problems. If the fit converges with \
              this additive variance near zero, retry from a larger additive \
-             initial estimate (e.g. SD ≈ {suggest:.4}, a few % of the data \
-             scale).",
+             initial estimate (e.g. SD ≈ {suggest:.4}, ~10% of the data scale \
+             — median |DV| / 10).",
             pct = NEGLIGIBLE_ADD_FRACTION * 100.0,
             suggest = 0.1 * data_scale,
         ),

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2166,8 +2166,157 @@ pub fn check_model_data_warnings(
         }
     }
 
+    diags.extend(additive_init_scale_warnings(model, population, init_params));
+
     diags
 }
+
+/// Warn when a `combined` error model's **additive** SD initial estimate is
+/// negligible relative to the scale of the observations it covers.
+///
+/// With a combined variance `Var(f) = (f·σ_prop)² + σ_add²`, an additive init
+/// orders of magnitude below the data starts the fit in a near-pure-proportional
+/// regime where low-magnitude observations receive enormous `1/Var` weight. On
+/// multimodal / over-parameterised problems the optimizer can then settle in a
+/// local minimum where the additive term stays collapsed (σ_add ≈ 0) and the
+/// proportional term inflates — the *worse* basin. The cyclophosphamide
+/// parent→metabolite fit is the canonical case: additive variance seeded at 0.5
+/// traps at ≈0.94, whereas the global optimum is ≈1878 (~50 OFV points better);
+/// both ferx and NONMEM miss it from that start, Pumas found it.
+///
+/// This is a **pre-fit heuristic on the initial estimate only** — it never
+/// changes the value (per the warn-only design), it advises a larger start.
+/// The threshold is deliberately conservative (additive SD below 1% of the data
+/// scale): a genuinely small-but-intended additive floor of a few % of the data
+/// does not trip it; only an essentially-zero start does.
+fn additive_init_scale_warnings(
+    model: &CompiledModel,
+    population: &Population,
+    init_params: &ModelParameters,
+) -> Vec<Diagnostic> {
+    use crate::types::{ErrorModel, ErrorSpec, SigmaType};
+
+    let mut diags = Vec::new();
+
+    // (additive global sigma index, endpoint dispatch key or None for `Single`).
+    // For `Combined` the additive sigma is the 2nd sigma (residual_variance uses
+    // sigma[0]=prop, sigma[1]=add); for `Single` the global sigma vector is in
+    // that order, for `PerCmt`/`Selected` the endpoint's `sigma_idx[1]`.
+    let mut combined_endpoints: Vec<(usize, Option<usize>)> = Vec::new();
+    match &model.error_spec {
+        ErrorSpec::Single(ErrorModel::Combined) => combined_endpoints.push((1, None)),
+        ErrorSpec::Single(_) => {}
+        ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
+            for (&key, ee) in map {
+                if ee.error_model == ErrorModel::Combined {
+                    if let Some(pos) = ee
+                        .error_model
+                        .sigma_types()
+                        .iter()
+                        .position(|t| *t == SigmaType::Additive)
+                    {
+                        if let Some(&idx) = ee.sigma_idx.get(pos) {
+                            combined_endpoints.push((idx, Some(key)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Deterministic order: HashMap iteration (PerCmt/Selected) is unordered.
+    combined_endpoints.sort_unstable();
+
+    for (add_idx, key) in combined_endpoints {
+        let Some(&add_sd_init) = init_params.sigma.values.get(add_idx) else {
+            continue;
+        };
+        // |DV| of the observations this endpoint covers.
+        let mut mags: Vec<f64> = Vec::new();
+        for subject in &population.subjects {
+            for j in 0..subject.observations.len() {
+                let covered = match key {
+                    None => true,
+                    Some(k) => model.error_spec.obs_key(subject, j) == k,
+                };
+                if covered {
+                    let v = subject.observations[j].abs();
+                    if v.is_finite() {
+                        mags.push(v);
+                    }
+                }
+            }
+        }
+        let sigma_name = init_params
+            .sigma
+            .names
+            .get(add_idx)
+            .cloned()
+            .unwrap_or_else(|| format!("SIGMA({})", add_idx + 1));
+        let scope = match key {
+            Some(k) => format!("CMT={k}"),
+            None => "all observations".to_string(),
+        };
+        if let Some(d) = additive_init_scale_check(&scope, &sigma_name, add_sd_init, &mut mags) {
+            diags.push(d);
+        }
+    }
+
+    diags
+}
+
+/// Pure decision for [`additive_init_scale_warnings`]: given one combined
+/// endpoint's additive SD initial estimate and the `|DV|` magnitudes of the
+/// observations it covers, return a warning iff the additive start is negligible
+/// (below [`NEGLIGIBLE_ADD_FRACTION`]) relative to the data scale (median `|DV|`).
+///
+/// `mags` is taken by `&mut` because it is sorted in place to find the median;
+/// the caller does not reuse it afterwards. Returns `None` for an empty/all-zero
+/// data scale (nothing to compare against) or a non-negligible additive start.
+fn additive_init_scale_check(
+    scope: &str,
+    sigma_name: &str,
+    add_sd_init: f64,
+    mags: &mut [f64],
+) -> Option<Diagnostic> {
+    if mags.is_empty() {
+        return None;
+    }
+    mags.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = mags.len() / 2;
+    let data_scale = if mags.len() % 2 == 0 {
+        0.5 * (mags[mid - 1] + mags[mid])
+    } else {
+        mags[mid]
+    };
+    if data_scale <= 0.0 || add_sd_init >= NEGLIGIBLE_ADD_FRACTION * data_scale {
+        return None;
+    }
+    Some(Diagnostic::warning(
+        "W_ADDITIVE_INIT_SCALE",
+        format!(
+            "Combined error model on {scope}: additive SD initial estimate \
+             '{sigma_name}' = {add_sd_init:.4} is negligible (< {pct:.0}%) \
+             relative to the data scale (median |DV| = {data_scale:.4}). A \
+             near-zero additive start can trap the fit in a local minimum where \
+             the additive term collapses and the proportional term inflates — \
+             the worse basin on multimodal problems. If the fit converges with \
+             this additive variance near zero, retry from a larger additive \
+             initial estimate (e.g. SD ≈ {suggest:.4}, a few % of the data \
+             scale).",
+            pct = NEGLIGIBLE_ADD_FRACTION * 100.0,
+            suggest = 0.1 * data_scale,
+        ),
+    ))
+}
+
+/// Additive SD init counts as "negligible" below this fraction of the data scale
+/// (median `|DV|`) — deliberately conservative so a genuinely small-but-intended
+/// additive floor of a few % of the data does not trip the warning.
+const NEGLIGIBLE_ADD_FRACTION: f64 = 0.01;
+
+#[cfg(test)]
+#[path = "tests/additive_init_scale_tests.rs"]
+mod additive_init_scale_tests;
 
 /// Feature-presence (data-independent) *warning*-level checks for experimental
 /// features (issue #175). Stochastic differential equations and neural-network


### PR DESCRIPTION
## Why

Combined error models (`DV ~ combined(prop, add)`) have a competing local minimum in which the **additive** term collapses toward zero and the proportional term inflates to absorb the scatter. When the additive SD initial estimate is seeded far below the scale of the observations, the fit is trapped there: low-magnitude points carry near-infinite `1/Var` weight, and the optimizer is content to keep the additive term at zero.

Canonical case — a parent→metabolite fit. Additive **variance** seeded at 0.5 (SD ≈ 0.7) against metabolite concentrations in the hundreds/thousands ng/mL traps **both ferx and NONMEM** at additive variance ≈ 0.94, ~50 OFV points worse than the global optimum (additive variance ≈ 1878, which Pumas found). NONMEM's own naive FOCEI trace (`nm/cyc_focei.ext`) shows the additive variance crawling 0.5 → 0.94 and sticking. The lever is the additive initial estimate, not the optimizer or objective — re-seeding it to a data-scaled value reaches the correct basin.

## What changed

A pre-fit warning `W_ADDITIVE_INIT_SCALE` in `check_model_data_warnings`: for each `combined` endpoint, if the additive SD initial estimate is below **1%** of the observation scale (median `|DV|`) on that endpoint, warn and suggest a larger data-scaled start (≈10% of median).

- `additive_init_scale_check` — pure median/threshold decision (directly unit-tested).
- `additive_init_scale_warnings` — endpoint enumeration (`Single`/`PerCmt`/`Selected`) + per-endpoint observation gathering.

**Warn-only by design.** The initial estimate is never changed. In ferx every `sigma NAME ~ v` is explicit user intent (there is no defaulting), so a silent override would break reproducibility. The warning advises; the user decides.

## Alternatives considered

- **Auto-override / data-scaled multistart** — rejected: silently changes an explicit user value; harms reproducibility.
- **Conditioning / preconditioning** — rejected: the collapse basin is a *genuine interior local minimum* (additive var ≈ 0.94, not a log-param boundary artifact), so no reparameterization convexifies it and preconditioning can't cross the uphill barrier between basins. Start location is the real lever.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

Helper is private; `check_model_data_warnings` signature unchanged; no public API change.

## Breaking changes
- [x] None

## Numerical validation

Not an estimation change — a diagnostic. Validated end-to-end with `ferx check` on the real dataset:

```
# naive additive start (SD 0.7071, var 0.5):
warning[W_ADDITIVE_INIT_SCALE]: Combined error model on CMT=2: additive SD
initial estimate 'ADD_M1' = 0.7071 is negligible (< 1%) relative to the data
scale (median |DV| = 310.4000). ... retry from a larger additive initial
estimate (e.g. SD ≈ 31.0400, ...).

# good seeded model (run2_final, additive SD 43.338):
ok: run2_final — no errors (0 warning(s))
```

Suggested SD ≈ 31 is close to the Pumas optimum additive SD √1878 ≈ 43 — following the advice lands near the correct basin.

- [x] Compared against: NONMEM (naive FOCEI traps at add-var 0.94) (optimum 1878) — see testdata.

## Performance
- [x] No significant impact expected (one median over the observations, pre-fit).

## Tests
- [x] Unit test(s) added (`cargo test --lib` passes): 6 Tier-1 decision tests (`src/api/tests/additive_init_scale_tests.rs`) + 2 end-to-end plumbing tests (`tests_derived_iov_kappa.rs`).

## Checklist
- [x] `cargo clippy` clean (new code; pre-existing warnings unrelated)
- [x] No `Dual2` sensitivity-path code touched

## Docs & examples
- [x] `docs/model-file/error-model.qmd` — callout under Combined error + worked example.
- [x] CHANGELOG.md entry under `[Unreleased] / Added`.

## Reviewer hints

Focus on `additive_init_scale_warnings` endpoint enumeration in `src/api/validation.rs` — the `Single(Combined)` additive index (global sigma[1]) and the `PerCmt`/`Selected` `sigma_idx[1]` mapping (confirmed against `residual_variance`: sigma[0]=prop, sigma[1]=add). Threshold (1%) is deliberately conservative to avoid noise on well-specified combined models.
