### PR TITLE
test(pk): give the 3-cpt IV peripheral infusions a tight oracle

### DIFF
--- a/tests/nonmem_dose_compartment_anchor.rs
+++ b/tests/nonmem_dose_compartment_anchor.rs
@@ -143,6 +143,13 @@ fn assert_both_paths_match(
 /// 1e-12 integration of the same system is ~1e-11 — see
 /// `tests/oral_peripheral_infusion.rs`, which is the tight oracle. This anchor's
 /// job is cross-tool corroboration; that file's job is precision.
+///
+/// **Both** the oral and the IV cases guarded by this constant have a 1e-9
+/// ODE-twin counterpart there, on identical parameters and dose schedules, so
+/// nothing rests on this bound alone. That was not always true: the IV pair had
+/// no tight guard until one was added, and a deliberately injected 9.4e-7 error
+/// in the shared `propagate_three_cpt_core_g` passed *this* assertion while
+/// failing the ODE twin — which is the margin this constant cannot see.
 const NONMEM_3CPT_INFUSION_TOL: f64 = 3e-5;
 
 /// 3-compartment **bolus** cases. Those closed forms obtain their eigenvalues by

--- a/tests/oral_peripheral_infusion.rs
+++ b/tests/oral_peripheral_infusion.rs
@@ -1,6 +1,7 @@
-//! Exact oracle for **infusion into an oral model's peripheral compartment**
-//! (#375) — the closed form versus a tight-tolerance RK45 solve of the *same*
-//! ODE system.
+//! Exact oracle for **infusion into a peripheral compartment** (#375) — the
+//! closed form versus a tight-tolerance RK45 solve of the *same* ODE system.
+//! Covers the oral models (the feature #375 added) and the 3-cpt **IV** models
+//! whose forced response the oral propagators delegate to.
 //!
 //! This is the primary correctness test for that feature, and it is deliberately
 //! independent of NONMEM: NONMEM's `ADVAN11`/`ADVAN12` forced response carries
@@ -299,5 +300,119 @@ fn ss_peripheral_bolus_matches_the_ode_twin() {
         &preds(TWO_CPT_ORAL_ODE, csv),
         1e-6,
         "two_cpt_oral SS peripheral bolus",
+    );
+}
+
+// ── the IV forced response the oral cases delegate to ────────────────────────
+
+const THREE_CPT_IV_CF: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVQ3(1.0, 0.1, 50.0)
+  theta TVV3(120.0, 5.0, 900.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  Q3 = TVQ3
+  V3 = TVV3
+
+[structural_model]
+  pk three_cpt_iv(cl=CL, v=V, q=Q, v2=V2, q3=Q3, v3=V3)
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+const THREE_CPT_IV_ODE: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVQ(3.0, 0.1, 50.0)
+  theta TVV2(80.0, 5.0, 500.0)
+  theta TVQ3(1.0, 0.1, 50.0)
+  theta TVV3(120.0, 5.0, 900.0)
+  omega ETA_CL ~ 0.0
+  sigma PROP ~ 0.01 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  Q3 = TVQ3
+  V3 = TVV3
+
+[structural_model]
+  ode(states=[central, periph1, periph2])
+
+[odes]
+  d/dt(central) = -(CL/V)*central - (Q/V)*central + (Q/V2)*periph1 - (Q3/V)*central + (Q3/V3)*periph2
+  d/dt(periph1) = (Q/V)*central - (Q/V2)*periph1
+  d/dt(periph2) = (Q3/V)*central - (Q3/V3)*periph2
+
+[scaling]
+  y = central / V
+
+[fit_options]
+  ode_reltol = 1e-12
+  ode_abstol = 1e-14
+  ode_max_steps = 10000000
+
+[error_model]
+  DV ~ proportional(PROP)
+"#;
+
+/// `three_cpt_iv`, infusion into each peripheral in turn — the **tight** oracle
+/// for the two cases `tests/nonmem_dose_compartment_anchor.rs` can only pin at
+/// `NONMEM_3CPT_INFUSION_TOL = 3e-5`.
+///
+/// Those two assertions previously had no independent tight guard: the oral
+/// peripheral infusions did (the tests above), and the IV ones — which exercise
+/// the *same* `propagate_three_cpt_core_g` forced response that the oral
+/// propagators delegate to — rested entirely on a cross-tool bound 3400× looser
+/// than the rest of that file, justified by prose about NONMEM's own accuracy.
+/// The parameters, dose amount/rate and observation times below are deliberately
+/// identical to that anchor's `three_cpt_iv` cases, so this pins exactly what the
+/// loose bound cannot rather than a neighbouring configuration.
+#[test]
+fn three_cpt_iv_peripheral_infusion_matches_the_ode_twin() {
+    for cmt in [2usize, 3] {
+        // AMT=100 at RATE=20 → a 5 h window; observations straddle its end.
+        let csv = format!(
+            "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n1,0,.,1,100,{cmt},20,1\n\
+             1,1,5.0,0,.,1,.,0\n1,4,4.0,0,.,1,.,0\n1,8,3.0,0,.,1,.,0\n"
+        );
+        assert_agree(
+            &preds(THREE_CPT_IV_CF, &csv),
+            &preds(THREE_CPT_IV_ODE, &csv),
+            1e-9,
+            &format!("three_cpt_iv infusion CMT={cmt}"),
+        );
+    }
+}
+
+/// The same system with **both** peripherals infused at once, so the two forced
+/// responses superpose. `propagate_three_cpt_core_g` takes `rate_periph1` and
+/// `rate_periph2` as separate arguments; a swap or a clobber between them would
+/// leave the single-channel tests above green.
+#[test]
+fn three_cpt_iv_both_peripherals_infused_matches_the_ode_twin() {
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,RATE,MDV\n\
+               1,0,.,1,100,2,20,1\n\
+               1,0,.,1,60,3,15,1\n\
+               1,1,5.0,0,.,1,.,0\n1,4,4.0,0,.,1,.,0\n1,8,3.0,0,.,1,.,0\n1,12,2.0,0,.,1,.,0\n";
+    assert_agree(
+        &preds(THREE_CPT_IV_CF, csv),
+        &preds(THREE_CPT_IV_ODE, csv),
+        1e-9,
+        "three_cpt_iv both peripherals infused",
     );
 }


### PR DESCRIPTION
## Why

`tests/nonmem_dose_compartment_anchor.rs` asserts four 3-cpt infusion cases at `NONMEM_3CPT_INFUSION_TOL = 3e-5` instead of the file's usual `1e-9`/`1e-8`, because NONMEM's own `ADVAN11`/`ADVAN12` forced response carries ~2e-6 relative error on them. The bound is justified in prose, so the question that matters is whether anything *tighter* guards those cases independently.

Two of the four did. The `three_cpt_oral` peripheral infusions have 1e-9 ODE-twin tests in `tests/oral_peripheral_infusion.rs`. The two `three_cpt_iv` cases had **nothing** — `tests/analytical_ode_equivalence.rs` has a `three_cpt_iv` family, but `DOSE_CMT = 1`, so it never doses a peripheral. Those two assertions rested entirely on a cross-tool bound 3400× looser than the rest of the file.

## What changed

Adds the missing oracle: `three_cpt_iv` infusion into each peripheral, closed form versus an explicit `[odes]` twin at `ode_reltol = 1e-12`, asserted to 1e-9. Same parameters, dose amount/rate and observation times as the anchor cases, so it pins exactly what the loose bound cannot rather than a neighbouring configuration.

Plus a both-peripherals-infused-at-once case: `propagate_three_cpt_core_g` takes `rate_periph1` and `rate_periph2` as separate arguments, and a swap or clobber between them would leave every single-channel test green.

## The gap was real, not theoretical

Injecting a 1e-8 relative perturbation into the shared forced response — 9.4e-7 at the observed prediction — separates the two suites exactly as intended:

```
anchor,   three_cpt_iv_infusion_into_peripherals   (3e-5)  ... ok
ODE twin, three_cpt_iv_peripheral_infusion         (1e-9)  ... FAILED
ODE twin, three_cpt_iv_both_peripherals_infused    (1e-9)  ... FAILED
```

So a ~1e-6 regression in `propagate_three_cpt_core_g` — the core that **both** the IV and the oral paths use — would previously have shipped green.

`NONMEM_3CPT_INFUSION_TOL`'s docstring now records that margin and points at its guard, and the oracle file's module doc no longer describes itself as oral-only (the discoverability problem that let the gap exist: nobody looking for 3-cpt *IV* coverage would open `oral_peripheral_infusion.rs`).

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None — test-only.

## Numerical validation

- [x] Compared against: an explicit `[odes]` RK45 twin of the same system at `ode_reltol = 1e-12`, `ode_abstol = 1e-14`

Agreement is 1e-9 relative on every case. The existing NONMEM anchors are unchanged and still pass.

## Performance

- [x] No significant impact expected — the two new tests add ~0.5 s.

## Tests

- [x] Unit test(s) added (`cargo test` passes)
- [x] Regression test added that fails without this fix — demonstrated above by injected perturbation, which is the only meaningful sense in which a *coverage* gap can be shown closed

```
cargo test --test oral_peripheral_infusion       -> 9 passed, 0 failed (1.4s)
cargo test --test nonmem_dose_compartment_anchor -> 11 passed, 0 failed (1.4s)
```

## Docs

- [x] No user-visible change — test coverage only, no CHANGELOG entry needed.

## Reviewer hints

The interesting part is the injected-perturbation result above, not the test bodies. The bodies deliberately mirror the anchor's fixtures line for line; if they drift from it, the oracle stops guarding the thing it claims to.

## Open questions

None. This closes the last item flagged during the #896/#907 review rounds — the loose cross-tool bound is no longer load-bearing anywhere.
