### PR TITLE
test(iov): assert bit-identical OFV for DSL-vs-column occasion fit

### DIFF
--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -694,9 +694,41 @@ fn test_iov_occasion_dsl_matches_column_fit() {
         r_dsl.ofv,
         r_col.ofv,
     );
+    // The same bit-identity thesis extends to the per-occasion kappa EBEs: same
+    // subject data, same theta/Omega trajectory, same first-occ->g0/second-occ->g1
+    // group map, so every kappa component must match bit-for-bit. This is a
+    // *stricter* guard than the OFV check — a summed OFV can round-trip to the
+    // same bits while a per-kappa ULP diverges — so pin it exactly too.
     assert_eq!(r_col.ebe_kappas.len(), r_dsl.ebe_kappas.len());
-    for (a, b) in r_col.ebe_kappas.iter().zip(&r_dsl.ebe_kappas) {
-        assert_eq!(a.len(), b.len(), "same number of occasions per subject");
+    for (subj, (a, b)) in r_col.ebe_kappas.iter().zip(&r_dsl.ebe_kappas).enumerate() {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "subject {} must have the same number of occasions",
+            subj,
+        );
+        for (k, (ka, kb)) in a.iter().zip(b).enumerate() {
+            assert_eq!(
+                ka.len(),
+                kb.len(),
+                "subject {} occasion {} must have the same kappa dimension",
+                subj,
+                k,
+            );
+            for (j, (va, vb)) in ka.iter().zip(kb.iter()).enumerate() {
+                assert_eq!(
+                    va.to_bits(),
+                    vb.to_bits(),
+                    "subject {} occasion {} kappa[{}]: DSL EBE {} must be \
+                     bit-identical to column EBE {}",
+                    subj,
+                    k,
+                    j,
+                    vb,
+                    va,
+                );
+            }
+        }
     }
 }
 

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -662,11 +662,37 @@ fn test_iov_occasion_dsl_matches_column_fit() {
     let r_dsl = fit(&model, &pop, &model.default_params, &opts_dsl)
         .expect("DSL-occasion fit should succeed");
 
+    // The two fits share model + population and differ only in how each
+    // subject's occasion partition is derived; both produce the identical
+    // partition (relabelled 0/1 vs 1/2 — see above), and the FOCE pipeline is
+    // bit-reproducible regardless of the thread schedule: the per-subject
+    // objective reduces in a fixed subject order (collect-then-serial-sum,
+    // #703) and the inner EBE loop is order-preserving. So the two OFVs are
+    // *bit-identical*, not merely close.
+    //
+    // Assert that exactly. col and dsl run in the same process on the same CPU,
+    // so this compares two values that shared every FP op sequence — it is a
+    // 0-vs-0 check that cannot be perturbed by parallel-reduction order or CPU
+    // load (the class of flakiness a loose tolerance would only paper over).
+    // If it ever fails, do NOT loosen it: a real regression has broken
+    // partition equivalence (independently pinned by the `apply_iov_occasion_*`
+    // derivation tests above) or leaked nondeterminism into estimation. The
+    // sibling `test_iov_ode_fit_matches_analytical_twin` compares two *different*
+    // numeric engines (ODE vs closed form) and rightly uses a basin tolerance;
+    // this test does not.
     assert!(
-        (r_col.ofv - r_dsl.ofv).abs() < 1e-6,
-        "DSL occasion rule OFV {} must match column OFV {}",
+        r_col.ofv.is_finite() && r_dsl.ofv.is_finite(),
+        "both OFVs must be finite (col={}, dsl={})",
+        r_col.ofv,
         r_dsl.ofv,
-        r_col.ofv
+    );
+    assert_eq!(
+        r_col.ofv.to_bits(),
+        r_dsl.ofv.to_bits(),
+        "DSL-occasion OFV {} must be bit-identical to column OFV {} \
+         (same partition + deterministic pipeline)",
+        r_dsl.ofv,
+        r_col.ofv,
     );
     assert_eq!(r_col.ebe_kappas.len(), r_dsl.ebe_kappas.len());
     for (a, b) in r_col.ebe_kappas.iter().zip(&r_dsl.ebe_kappas) {


### PR DESCRIPTION
## Why

`test_iov_occasion_dsl_matches_column_fit` was reported flaky under heavy CPU load: the `(r_col.ofv - r_dsl.ofv).abs() < 1e-6` assertion failed once in a full parallel `cargo test --lib` run, while passing in isolation and on a re-run. The working hypothesis was rayon work-steal reduction-order non-determinism amplified by derivative-free BOBYQA.

Investigation showed the premise no longer holds:
- The FOCE OFV reduction is **already order-stable** — `foce_population_nll{,_iov}` collect per-subject NLLs into an ordered `Vec` then sum serially (#703), so it is thread-count-independent.
- The inner EBE loop (`run_inner_loop_warm`) is order-preserving, and `find_ebe` keys on occasion **structure** (group indices via `split_obs_by_occasion`'s first-appearance order), not label values.
- So the two fits — occasions from `iov_column` `{1,2}` vs the `time(3.5)` DSL rule `{0,1}`, identical partition — are **bit-identical**, not merely close.

Measured: `diff = 0.0` (both OFVs `0x4062a9f411bee591`) across **145 fits** — 25 reps x {1, 8} threads, plus **120/120 under 12-hog CPU load**. The reported failure did not reproduce on current code (likely a stale pre-#703 binary or a misattribution). The `< 1e-6` tolerance was comparing two values that are exactly equal, and loosening it is the one change that would let a *real* future divergence pass silently.

## What changed

Replaced the tolerance assertion with exact bit-equality plus a finite guard:

```rust
assert!(r_col.ofv.is_finite() && r_dsl.ofv.is_finite(), …);
assert_eq!(r_col.ofv.to_bits(), r_dsl.ofv.to_bits(), …);
```

Added a comment explaining why exact equality is correct here and instructing maintainers **not** to loosen it (a failure would mean a real regression — broken partition equivalence or nondeterminism leaking into estimation). No production code touched; the fit result itself is unchanged.

## Alternatives considered

- **Loosen tolerance to ~1e-3** (the originally-proposed fix): rejected — weakens a guarantee that holds exactly (`diff = 0.0`); a genuine col!=dsl regression up to ~1e-3 would pass silently.
- **Make the per-subject reduction order-stable** (the other proposed fix): already implemented in #703 — nothing left to do.
- **Assert partition equivalence directly instead of via two full fits**: redundant — the derivation is already unit-tested (`apply_iov_occasion_*` tests) and the end-to-end numeric equivalence is a stronger, still-non-flaky claim.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (test-only; the fit and its OFV are unchanged — this only tightens how the test compares two already-computed OFVs)

Determinism evidence: `diff = 0.0` across 145 fits (25 reps x {1,8} threads; 120/120 under 12-hog CPU load).

## Performance
- [x] No significant impact expected (test-only)

## Tests
- [x] The modified test **is** the regression guard — it now fails on any real col/dsl divergence instead of only on a >1e-6 one. `cargo test --lib --features ci api::iov_integration::test_iov_occasion_dsl_matches_column_fit` passes.
- [x] No new test file needed (this hardens an existing one)

## Example (user-facing features only)
- [x] Not applicable (internal test change, no API surface)

## Docs
- [x] No user-visible change; no `CHANGELOG.md` entry (test-only, per CLAUDE.md)

## Checklist
- [ ] `cargo clippy` clean — **not run** (trivial `to_bits`/`assert_eq!` edit; rustfmt `--check` clean, target test green)
- [x] `Dual2` sensitivity path — N/A (test-only, not gradient-reachable)
- [x] `Cargo.toml` version bump — N/A (non-breaking)

## Reviewer hints

The one judgment call: is exact bit-equality too strict? Argument that it is not — col and dsl run **in the same process on the same CPU in the same build**, so any libm/FMA quirk hits both identically; the assert compares them *to each other*, never to a golden constant, so it is platform-robust (holds on x86 CI and arm64/Rosetta dev alike). It can only fail on (a) a partition-derivation regression or (b) nondeterminism entering estimation — both real bugs. Full rationale is in the added code comment and the commit body.

## Open questions

- Was the original 2026-07-22 failure on a pre-#703 binary? I could not reproduce it on current `main`; treating it as resolved-unreproducible. Shout if you want a tracking issue instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
