### PR TITLE
perf(ode): solve the ODE bolus/infusion steady state exactly, and warn when it can't [closes #914]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ section of the SDLC for the versioning policy).
   for any external code that constructs or exhaustively destructures these variants.
 
 ### Fixed
+- **Steady-state (`SS=1`) dosing on `[odes]` models is now exact for a linear disposition, and
+  warns instead of silently truncating on a nonlinear one** (#914). An ordinary ODE bolus or
+  infusion SS dose previously equilibrated by expanding a pulse train capped at 50 cycles, which
+  under-reported the steady state by tens of percent for a slow disposition (the same truncation
+  #908 removed from the analytical engine) — silently. A linear disposition now solves the exact
+  periodic fixed point `(I − M)⁻¹·b` directly (value and analytic FOCE/FOCEI gradient), so slow PK
+  is exact rather than low; a genuinely nonlinear RHS (e.g. Michaelis–Menten) still falls back to
+  the capped iteration but now surfaces a non-convergence warning when the cap is reached without
+  settling. Also faster: the linear case replaces ~50 RK45 cycles with a handful.
 - **`predict()` on a CTMM (`[markov_model]`) model now fails loud instead of silently returning
   no rows** (#759). The equivalent `simulate()` guard already existed and its message claimed to
   cover `predict()`, but it only ran on the simulate path. State-occupancy prediction `π(t)` is

--- a/docs/model-file/steady-state.qmd
+++ b/docs/model-file/steady-state.qmd
@@ -41,7 +41,7 @@ Every prediction path in ferx-core honours `SS=1`:
 | ------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------- |
 | Analytical (1-/2-/3-cpt, no TV covariates)        | `predict_concentration` in `src/pk/mod.rs`                                | Closed-form geometric-series                       |
 | Analytical (1-/2-/3-cpt, time-varying covariates) | `event_driven_predictions_with_schedule` in `src/pk/event_driven.rs`      | Exact linear fixed point `(I − M)⁻¹·b`             |
-| ODE (`[odes]`-block models)                       | `ode_predictions` / `ode_predictions_event_driven` in `src/ode/predictions.rs` | Numerical pulse expansion via the RK45 solver |
+| ODE (`[odes]`-block models)                       | `ode_predictions` / `ode_predictions_event_driven` in `src/ode/predictions.rs` | Exact linear fixed point `(I − M)⁻¹·b`; nonlinear RHS falls back to numerical pulse expansion |
 
 Both kinds of paths start from the same underlying identity — the
 choice between them is a question of whether the geometric series has
@@ -64,55 +64,57 @@ formula plus one extra division per eigenvalue. For oral models when
 `KA ≈ λ` the closed form needs the L'Hopital limit; ferx handles that
 case automatically.
 
-### ODE path: brute-force pulse expansion
+### ODE path: exact fixed point, with a numerical fallback
 
-An `[odes]`-block model is an arbitrary user-defined RHS. There is no
-general eigenstructure to exploit — `dy/dt = f(y, p, t)` can be
-non-linear (Michaelis-Menten elimination), time-varying, or both, so
-no closed form exists for the steady-state state in general.
+An `[odes]`-block model is an arbitrary user-defined RHS. `dy/dt = f(y, p, t)`
+can be non-linear (Michaelis-Menten elimination), so no *general* closed form
+exists — but the common case is a **linear** disposition, and there the periodic
+steady state has the same exact fixed point the analytical event-driven path
+uses. `equilibrate_ss_state` (#914) therefore tries that first:
 
-Instead, ferx evaluates the geometric series *numerically* before the
-SS dose is applied. The algorithm in `equilibrate_ss_state` is exactly
-what its name says — brute-force pulse expansion:
+1. **Reset** the compartment state to zero. NONMEM `SS=1` semantics say
+   prior dynamics are discarded at the SS dose, so anything earlier in the
+   timeline is overwritten here.
+2. **Exact solve.** One dosing cycle of a linear disposition is an affine
+   map `u ↦ M·u + b`, so its periodic fixed point is `u_ss = (I − M)⁻¹·b`.
+   Two injected "one cycle from `u`" propagators build `M` (disposition
+   alone, over one `II`) and `b` (disposition **plus** the cycle's own
+   dose — an added bolus, or an active-infusion window followed by a quiet
+   window). This is `crate::dosing::periodic_ss_fixed_point_g`, shared with
+   the analytical walk (#908) and the built-in-absorption branch (#835), and
+   costs a handful of one-cycle integrations plus one `n×n` solve — no
+   truncation, so a slow disposition is exact rather than tens of percent low.
+3. **Nonlinear fallback.** If the RHS is genuinely nonlinear the affine
+   self-check declines, and ferx falls back to expanding the pulse train
+   numerically — loop up to `N = 50` cycles of `(apply the dose; integrate
+   the rest of the cycle)` — with a non-convergence warning if the cap is
+   hit without settling (see below).
+4. Either way the compartment state equals the "just-before-the-next-pulse"
+   steady state; normal-timeline handling resumes and the SS dose's own pulse
+   is applied through the standard bolus/infusion path, taking the state from
+   pre-pulse to at-pulse SS.
 
-1. **Reset** the compartment state to zero. NONMEM `SS=1` semantics
-   say prior dynamics are discarded at the SS dose, so anything that
-   happened earlier in the timeline is overwritten here.
-2. **Loop `N = 50` cycles**:
-   - **Apply the dose** for one cycle:
-     - For a bolus, add `AMT` (with bioavailability `F1` applied) to
-       the dose's compartment.
-     - For an infusion, integrate for `T_inf = AMT/RATE` with a
-       wrapped RHS that adds `+RATE` to the dose's compartment.
-   - **Propagate** the ODE forward by the remainder of the cycle (`II`
-     for boluses, `II - T_inf` for infusions). Same RK45 solver as the
-     normal timeline, same tolerances, same wrapped-infusion mechanics.
-3. After the loop, the compartment state equals the "just-before-the-
-   next-pulse" steady-state amount.
-4. Normal-timeline handling resumes — the SS dose's own pulse is
-   applied through the standard bolus/infusion code path, taking the
-   state from pre-pulse to at-pulse SS.
-
-The result is mathematically equivalent to the analytical closed form
-in the linear case (and is unit-tested against it — see
-`ode_ss_iv_bolus_matches_analytical_ss` in `src/ode/predictions.rs`
-for the 1-cpt cross-check). For non-linear PK, the same scheme still
-produces a self-consistent steady-state state under the model's own
-dynamics; just be aware that for systems that *don't* have a true
-periodic steady state (e.g. zero-order elimination at saturation),
-the iteration may not converge to anything meaningful and SS=1 isn't
-really applicable.
+The exact solve is unit-tested against the analytical closed form (see
+`ss_linear_disposition_uses_exact_fixed_point` and
+`ode_ss_iv_bolus_matches_analytical_ss` in `src/ode/predictions.rs`) and its
+dual sensitivities against finite differences
+(`ode_provider_ss_linear_bolus_uses_exact_solve`). For a non-linear disposition
+that *doesn't* have a true periodic steady state (e.g. dosing a saturable
+Michaelis-Menten elimination above its capacity), the fallback iteration cannot
+converge and SS=1 isn't really applicable — the warning below fires.
 
 ### Analytic gradient during `fit()`
 
 During estimation, SS=1 `[odes]` dosing gets an **exact analytic FOCE/FOCEI gradient**
-(outer θ/Ω/σ and inner EBE), not finite differences. Because the `N`-cycle expansion above
-is *finite and explicit*, running it over the dual type propagates `∂(steady state)/∂(θ,η)`
-directly — `equilibrate_ss_state_g` is the dual counterpart of `equilibrate_ss_state` and
-the analytic trough is the exact derivative of the predictor's trough (result-neutral,
-validated against the production predictor + finite differences, including the 2nd-order
-Hessian blocks used for covariance/SEs). Both SS **bolus** and SS **infusion** are covered,
-and SS composes with time-varying covariates, IOV, and EVID 3/4 resets.
+(outer θ/Ω/σ and inner EBE), not finite differences. `equilibrate_ss_state_g` is the dual
+counterpart of `equilibrate_ss_state`: on the linear exact solve the derivative
+`∂(steady state)/∂(θ,η)` falls out of the `(I − M)⁻¹·b` linear solve directly (the
+implicit-function derivative, with no hand-assembled `dM`/`db`), and on the nonlinear fallback
+the *finite and explicit* pulse train propagates it cycle by cycle. Either way the analytic
+trough is the exact derivative of the predictor's trough (result-neutral, validated against
+the production predictor + finite differences, including the 2nd-order Hessian blocks used for
+covariance/SEs). Both SS **bolus** and SS **infusion** are covered, and SS composes with
+time-varying covariates, IOV, and EVID 3/4 resets.
 
 This also covers the dosing forms below (all closed by #486):
 
@@ -200,8 +202,8 @@ construction.
 ::: {.callout-note}
 ## Through v0.2.0 this path truncated
 
-Until #908 the event-driven walk expanded a **pulse train** capped at 50 cycles, like
-the ODE path below, leaving a residual of `exp(-50·λ_slow·II)`. That is negligible for
+Until #908 the event-driven walk expanded a **pulse train** capped at 50 cycles, as the
+ODE path did until #914, leaving a residual of `exp(-50·λ_slow·II)`. That is negligible for
 typical PK (`λ_slow·II ≈ 2` gives `exp(-100) ≈ 4e-44`) but not always: a
 one-compartment oral model with `CL = 0.1`, `V = 50` (t½ ≈ 350 h) at `II = 12` has
 `λ_slow·II ≈ 0.024` and was **30 %** below the true steady state. Deep peripheral
@@ -216,27 +218,25 @@ rate constant, i.e. a compartment that never empties (`CL = 0`). No periodic ste
 state exists then, and the capped loop now raises a non-convergence warning rather
 than returning a silently truncated state.
 
-### Why `N = 50` on the ODE path?
+### When does the ODE path still expand the pulse train?
 
-The ODE path still expands the pulse train, because an `[odes]` RHS need not be linear.
-The truncation tail after `N` cycles is `≈ exp(-N·λ_slow·II)`, where `λ_slow` is the
-**slowest** disposition rate constant — the governing quantity is `λ_slow·II`, not the
-number of compartments. It is negligible once `λ_slow·II ≳ 0.5` and can reach tens of
-percent when it is not, with the same magnitudes quoted in the note above.
+Only for a **nonlinear** disposition. A linear one — the overwhelmingly common case —
+takes the exact `(I − M)⁻¹·b` fixed point (#914) and never iterates; a saturable
+(Michaelis-Menten) or otherwise nonlinear RHS fails the affine self-check and falls back
+to the pulse train, exactly as the built-in-absorption branch falls back to an
+Anderson-accelerated iteration on a nonlinear disposition (#835/#867).
 
-ferx loops up to `N = 50` cycles with an early stop once the cycle-to-cycle change
-falls below `SS_EQUILIBRATION_TOL` (`1e-12` relative, `src/dosing.rs`) — added in
-#519/#532, so the loop is not unconditionally fixed-length. The early stop fires for
-fast PK; for slow PK it never trips and the full 50 cycles run, which is exactly when
-the residual tail is largest.
-
-Two ODE sub-cases already avoid the truncation: a steady-state dose into a built-in
-absorption compartment solves the same linear `(I − M)⁻¹·b` fixed point (#835), falling
-back to an Anderson-accelerated iteration when the disposition is genuinely nonlinear
-(#867). Extending that to the ordinary ODE bolus and infusion is the remaining work.
-
-If you need tighter accuracy for an unusually slow PK on the ODE path, the constant has
-a single definition: `SS_EQUILIBRATION_CYCLES` in `src/dosing.rs`.
+On that fallback the truncation tail after `N` cycles is `≈ exp(-N·λ_slow·II)`, where
+`λ_slow` is the **slowest** effective disposition rate constant — the governing quantity is
+`λ_slow·II`, not the number of compartments. ferx loops up to `N = 50` cycles with an early
+stop once the cycle-to-cycle change falls below `SS_EQUILIBRATION_TOL` (`1e-12` relative,
+`src/dosing.rs`, #519/#532). If the cap is reached without converging — a slowly-accumulating
+nonlinear disposition, or one dosed above its elimination capacity so no periodic steady state
+exists at all — the returned trough may be materially below the true SS, so ferx surfaces a
+**non-convergence warning** in `FitResult.warnings` / `SimulationOutput.warnings` rather than
+returning a silently truncated state (#867, extended to the ordinary bolus/infusion path by
+#914). If you need tighter accuracy for an unusually slow *nonlinear* PK, the cap has a single
+definition: `SS_EQUILIBRATION_CYCLES` in `src/dosing.rs`.
 
 ### Cost comparison
 
@@ -244,7 +244,8 @@ a single definition: `SS_EQUILIBRATION_CYCLES` in `src/dosing.rs`.
 | ------------------- | ----------------------------------------- | ----- |
 | Analytical closed   | ~1 single-dose evaluation                 | Effectively free |
 | Event-driven exact  | `n + 4` propagator calls + one `n×n` solve (`n ≤ 4`) | Exact, and cheaper than the 50-cycle train it replaced |
-| ODE pulse           | ~50× RK45 segment integrations            | Real cost — RK45 is the dominant per-prediction cost for ODE models, so SS doses cost ~50× more than non-SS doses |
+| ODE exact (linear)  | `~n + 2` RK45 one-cycle integrations + one `n×n` solve | Exact (#914); replaces the ~50× pulse train for the common linear disposition |
+| ODE pulse (nonlinear fallback) | ≤ 50× RK45 segment integrations | Only when the RHS is nonlinear; early-stops for fast PK, warns if the cap is hit |
 
 SS doses are typically rare (one per subject at the start of a
 maintenance regimen), so the absolute overhead per fit iteration is

--- a/src/dosing.rs
+++ b/src/dosing.rs
@@ -217,7 +217,9 @@ where
 /// the loop could never stop. Because the stop only fires once every compartment's increment
 /// is below f64-relative precision, the value has reached its fixed point and the elided cycles
 /// do not move it — predictions are unchanged to f64 precision, and gradients match a full
-/// budget to `< 1e-6` (see `ode_provider_ss_early_stop_matches_full_budget`).
+/// budget to `< 1e-6` (see `ode_provider_ss_nonlinear_fallback_early_stop_matches_full_budget`;
+/// after #914 a linear disposition takes the exact fixed point, so this early stop runs only on
+/// the nonlinear fallback).
 ///
 /// A **non-finite** (`NaN`/`Inf`) compartment means the integration blew up: never report
 /// convergence — don't early-exit and silently return a poisoned state; run the full cycle

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -492,11 +492,18 @@ where
 /// Pre-equilibrate the ODE state to its steady-state value for an SS=1
 /// dose with interval `dose.ii`. NONMEM SS=1 semantics: at the time of
 /// the SS dose, the compartments are loaded with the steady-state
-/// amounts from an infinite-past pulse train. No closed form is
-/// available for arbitrary ODE systems, so we numerically expand the
-/// train: starting from a zero state, simulate
-/// [`SS_EQUILIBRATION_CYCLES`] cycles of `(apply dose; integrate for II)`.
-/// The state after the loop equals the "just-before-next-pulse" SS state;
+/// amounts from an infinite-past pulse train.
+///
+/// For a **linear** disposition the periodic steady state is the exact affine
+/// fixed point `u_ss = (I − M)⁻¹·b` — the same closed form the analytical walk
+/// (#908) and the input-rate branch (#835) use — solved via
+/// [`periodic_ss_fixed_point_g`](crate::dosing::periodic_ss_fixed_point_g) in a
+/// handful of one-cycle integrations (#914). A **nonlinear** RHS
+/// (Michaelis–Menten, …) fails that solve's linearity self-check and falls back
+/// to numerically expanding the train: starting from a zero state, simulate
+/// [`SS_EQUILIBRATION_CYCLES`] cycles of `(apply dose; integrate for II)`, with a
+/// #867 non-convergence warning if the cap is hit without converging.
+/// Either way the returned state equals the "just-before-next-pulse" SS state;
 /// the caller then applies the SS dose itself through the normal flow,
 /// recovering the at-pulse SS amount.
 ///
@@ -634,11 +641,102 @@ fn equilibrate_ss_state(
         return u;
     }
 
-    // Early stop once the trough stops moving (#519): the shared tracker holds the previous
-    // cycle's state and, from cycle 1 on, breaks when the increment is below the mixed
-    // atol/rtol criterion (#532 review #6 — one scaffold across the f64 paths).
+    // #914: exact periodic steady state for a LINEAR disposition — the affine fixed point
+    // `u_ss = (I − M)⁻¹·b` the analytical walk (#908) and the input-rate branch (#835) already
+    // use, replacing the truncated pulse train below. `advance_forced` integrates one cycle
+    // *with* the dose (a bolus pulse, or an active-infusion window + quiet window);
+    // `advance_unforced` integrates one `II` of disposition alone — the propagator `M`. For an
+    // infusion the active and quiet windows share the same homogeneous propagator (the constant
+    // `+RATE` forcing has zero state-Jacobian), so a full-`II` unforced decay reconstructs `M`
+    // exactly — the window length enters only through `b`. A genuinely nonlinear RHS
+    // (Michaelis–Menten, …) fails the linearity self-check, returning `None` → the capped pulse
+    // train below, now with the #867 non-convergence warning wired in (gap 2). The exact solve
+    // integrates at the tightened `ss_equilibration_opts` tolerance (a handful of one-cycle
+    // solves, so it is cheap) and passes those tolerances to the linearity check, mirroring the
+    // input-rate path.
+    let eq_opts = ss_equilibration_opts(opts);
+    let advance_unforced = |u0: &[f64]| -> Option<Vec<f64>> {
+        solve_ode(
+            &ode.rhs,
+            u0,
+            (0.0, dose.ii),
+            pk_params_flat,
+            &[dose.ii],
+            &eq_opts,
+        )
+        .last()
+        .map(|p| p.u.clone())
+    };
+    let advance_forced = |u0: &[f64]| -> Option<Vec<f64>> {
+        if is_inf {
+            // Active-infusion window then quiet window — the same one-cycle body the fallback
+            // loop runs, as a pure function of `u0`.
+            let rate = inf_rate;
+            let wrapped_rhs = |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
+                (ode.rhs)(y, p, t, dy);
+                if cmt_idx < dy.len() {
+                    dy[cmt_idx] += rate;
+                }
+            };
+            let mut y = solve_ode(
+                &wrapped_rhs,
+                u0,
+                (0.0, t_inf),
+                pk_params_flat,
+                &[t_inf],
+                &eq_opts,
+            )
+            .last()
+            .map(|p| p.u.clone())?;
+            let quiet = dose.ii - t_inf;
+            if quiet > 0.0 {
+                y = solve_ode(
+                    &ode.rhs,
+                    &y,
+                    (0.0, quiet),
+                    pk_params_flat,
+                    &[quiet],
+                    &eq_opts,
+                )
+                .last()
+                .map(|p| p.u.clone())?;
+            }
+            Some(y)
+        } else {
+            let mut y = u0.to_vec();
+            y[cmt_idx] += f_bio * dose.amt;
+            solve_ode(
+                &ode.rhs,
+                &y,
+                (0.0, dose.ii),
+                pk_params_flat,
+                &[dose.ii],
+                &eq_opts,
+            )
+            .last()
+            .map(|p| p.u.clone())
+        }
+    };
+    if let Some(u_ss) = crate::dosing::periodic_ss_fixed_point_g::<f64, _, _>(
+        n,
+        dose.ii,
+        eq_opts.reltol,
+        eq_opts.abstol,
+        advance_unforced,
+        advance_forced,
+    ) {
+        record_ss_equilibration_cycles(1);
+        return u_ss;
+    }
+
+    // Nonlinear disposition (or singular `I − M`): fall back to the capped pulse train, at the
+    // model tolerance `opts` (not the tightened `eq_opts`), matching the prior behaviour and the
+    // input-rate fallback. Early stop once the trough stops moving (#519): the shared tracker
+    // holds the previous cycle's state and, from cycle 1 on, breaks when the increment is below
+    // the mixed atol/rtol criterion (#532 review #6 — one scaffold across the f64 paths).
     let mut tracker = SsStopTracker::default();
     let mut cycles_run = 0usize;
+    let mut early_stopped = false;
     for cycle in 0..SS_EQUILIBRATION_CYCLES {
         if is_inf {
             // Active-infusion window: wrapped RHS injects rate into the
@@ -695,10 +793,17 @@ fn equilibrate_ss_state(
         }
         cycles_run = cycle + 1;
         if tracker.should_stop(cycle, &u) {
+            early_stopped = true;
             break;
         }
     }
     record_ss_equilibration_cycles(cycles_run);
+    // Gap 2 (#914): a capped ordinary bolus/infusion equilibration was silent (the warning was
+    // wired only into the input-rate branch). Only a *nonlinear* disposition reaches this
+    // fallback — the linear closed form above returned early — so this is exactly the saturable
+    // heavy-accumulation / no-steady-state case #867 warns about.
+    let (incr_prev, incr_last, incr_mag) = tracker.recent_increments();
+    note_ss_nonconvergence_if_capped(early_stopped, incr_prev, incr_last, incr_mag);
 
     u
 }

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -5080,34 +5080,159 @@ fn ss_cycle_converged_is_mixed_atol_rtol_on_increment() {
 }
 
 #[test]
-fn ss_equilibration_early_stop_fires_for_fast_pk() {
-    // #532 review #6: pin that the #519 early stop actually fires (the loose end-value
-    // tolerances would otherwise hide a broken stop). Use a tight integrator tol — the
-    // gradient context where the speedup matters.
+fn ss_linear_disposition_uses_exact_fixed_point() {
+    // #914: a LINEAR disposition now equilibrates via the exact closed-form fixed point
+    // `u_ss = (I − M)⁻¹·b` (one recorded cycle), for both fast and slow PK, rather than the
+    // up-to-50-cycle pulse train. The slow case is the payoff: the old train ran the full budget
+    // and truncated its geometric tail (~30% low here), while the exact solve nails the
+    // analytical steady state. (The #519 pulse-train early stop is now reachable only on the
+    // nonlinear fallback — see `ss_nonlinear_bolus_with_steady_state_uses_fallback`.)
     let mut ode = one_cpt_ode_spec();
     ode.solver_opts.reltol = 1e-10;
     ode.solver_opts.abstol = 1e-12;
-    let dose = DoseEvent::new(0.0, 1000.0, 1, 0.0, true, 12.0);
+    let ii = 12.0_f64;
+    let amt = 1000.0_f64;
+    let dose = DoseEvent::new(0.0, amt, 1, 0.0, true, ii);
 
-    // Fast disposition (ke = CL/V = 2.0, λ·II = 24): the trough converges in a few cycles,
-    // so the early stop fires well inside SS_EQUILIBRATION_CYCLES.
-    let fast = pk_one(20.0, 10.0);
-    let _ = equilibrate_ss_state(&ode, &fast.values, &dose, &ode.solver_opts);
-    let fast_cycles = crate::dosing::last_ss_equilibration_cycles();
+    // (cl, v) — "fast" (ke·II = 6, the old early stop fired) and "slow" (ke·II ≈ 0.024, the old
+    // full-budget truncation was ~30% low). The fast case is deliberately not *extreme*
+    // (ke·II ≫ 6): a near-total between-dose decay drives the trough toward the RK45 `abstol`
+    // floor, where relative precision is lost — an integration-noise artifact, not the fixed
+    // point being wrong (`ode_provider_ss_linear_bolus_uses_exact_solve` checks the gradient too).
+    for (cl, v, label) in [(5.0_f64, 10.0_f64, "fast"), (0.1_f64, 50.0_f64, "slow")] {
+        let pk = pk_one(cl, v);
+        let trough = equilibrate_ss_state(&ode, &pk.values, &dose, &ode.solver_opts);
+        assert_eq!(
+            crate::dosing::last_ss_equilibration_cycles(),
+            1,
+            "{label} linear PK must equilibrate via the exact fixed point (one cycle)"
+        );
+        // Pre-pulse SS amount for a 1-cpt bolus: `F·amt·e^{−ke·II}/(1 − e^{−ke·II})` (F = 1).
+        // The state stores amount, so compare directly.
+        let ke = cl / v;
+        let expected = amt * (-ke * ii).exp() / (1.0 - (-ke * ii).exp());
+        assert_relative_eq!(trough[0], expected, max_relative = 1e-6);
+    }
+}
+
+/// 1-cpt Michaelis–Menten **disposition** (no absorption kernel), amount state:
+/// `dA/dt = −Vmax·A/(Km + A)`, Vmax in the CL slot, Km in the V slot. A plain bolus into this
+/// compartment is genuinely nonlinear, so the #914 exact fixed point's linearity self-check
+/// declines and the SS equilibration falls back to the capped pulse train (with the #867
+/// non-convergence warning when it can't converge). Distinct from `mm_ss_absorption_spec`, which
+/// also carries a `first_order` input rate and so exercises the input-rate branch instead.
+fn mm_disposition_spec() -> OdeSpec {
+    OdeSpec {
+        rhs: Box::new(|y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
+            let vmax = p[crate::types::PK_IDX_CL];
+            let km = p[crate::types::PK_IDX_V];
+            dy[0] = -vmax * y[0] / (km + y[0]);
+        }),
+        n_states: 1,
+        state_names: vec!["central".into()],
+        readout: OdeReadout::ObsCmt(0),
+        diffusion_var: Vec::new(),
+        solver_opts: OdeSolverOptions::default(),
+        input_rate: Vec::new(),
+        init_fn: None,
+        rhs_program: None,
+        readout_program: None,
+        indiv_param_program: None,
+        dose_attr_map: Default::default(),
+    }
+}
+
+/// Independent SS reference for a plain **bolus** into a (possibly nonlinear) disposition: run the
+/// pulse train `(add F·amt; integrate II)` from a zero state for `max_cycles` and return the
+/// pre-next-pulse trough. Uncapped (`max_cycles ≫ 50`), so for a disposition that admits a
+/// periodic steady state it is fully converged — the genuine SS the 50-cycle production fallback
+/// approximates. `F = 1`.
+fn bolus_ss_reference(ode: &OdeSpec, pk: &[f64], dose: &DoseEvent, max_cycles: usize) -> Vec<f64> {
+    let eq = ss_equilibration_opts(&ode.solver_opts);
+    let cmt = dose.cmt_idx();
+    let mut u = vec![0.0; ode.n_states];
+    for _ in 0..max_cycles {
+        u[cmt] += dose.amt;
+        if let Some(last) = solve_ode(&ode.rhs, &u, (0.0, dose.ii), pk, &[dose.ii], &eq).last() {
+            u.copy_from_slice(&last.u);
+        }
+    }
+    u
+}
+
+/// #914 gap 1 (nonlinear branch preserved): a Michaelis–Menten **disposition** that *admits* a
+/// periodic steady state (mean input `100/8 = 12.5 ≪ Vmax = 50`) fails the exact fixed point's
+/// linearity self-check and falls back to the capped pulse train — which, since it converges well
+/// inside the 50-cycle budget, reaches the true SS (matching an uncapped run-in) with **no**
+/// warning. Proves the exact-solve short-circuit does not swallow a genuinely nonlinear model.
+#[test]
+fn ss_nonlinear_bolus_with_steady_state_uses_fallback() {
+    let _guard = crate::dosing::SS_WARN_SINK_READER_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    crate::dosing::clear_ss_nonconvergence_warnings();
+
+    let mut ode = mm_disposition_spec();
+    ode.solver_opts.reltol = 1e-10;
+    ode.solver_opts.abstol = 1e-12;
+    let mut pk = PkParams::default();
+    pk.values[crate::types::PK_IDX_CL] = 50.0; // Vmax
+    pk.values[crate::types::PK_IDX_V] = 30.0; // Km — the peak amount ≈ 100 ≫ Km, so genuinely nonlinear
+    let dose = DoseEvent::new(0.0, 100.0, 1, 0.0, true, 8.0);
+
+    let trough = equilibrate_ss_state(&ode, &pk.values, &dose, &ode.solver_opts);
+    let cycles = crate::dosing::last_ss_equilibration_cycles();
     assert!(
-        (2..SS_EQUILIBRATION_CYCLES).contains(&fast_cycles),
-        "fast PK should early-stop inside the budget, ran {fast_cycles}"
+        (2..SS_EQUILIBRATION_CYCLES).contains(&cycles),
+        "a nonlinear disposition must fall back to the pulse train and converge inside the budget, \
+         ran {cycles} cycles"
     );
+    let reference = bolus_ss_reference(&ode, &pk.values, &dose, 500);
+    assert_relative_eq!(trough[0], reference[0], max_relative = 1e-6);
+    assert!(
+        crate::dosing::take_ss_nonconvergence_warnings().is_empty(),
+        "a converging nonlinear SS must not warn"
+    );
+}
 
-    // Near-non-eliminating (ke ≈ 5e-4, λ·II ≈ 6e-3): never reaches the 1e-12 relative
-    // threshold in the budget → runs the full SS_EQUILIBRATION_CYCLES (this is the
-    // pre-existing slow-PK truncation, tracked separately — #532 review #12).
-    let slow = pk_one(0.05, 100.0);
-    let _ = equilibrate_ss_state(&ode, &slow.values, &dose, &ode.solver_opts);
-    let slow_cycles = crate::dosing::last_ss_equilibration_cycles();
+/// #914 gap 2 (the newly-wired warning): a Michaelis–Menten **disposition** dosed *above capacity*
+/// (mean input `50/8 = 6.25 > Vmax = 5`) has no periodic steady state, so the bolus fallback runs
+/// the full 50-cycle budget without converging and now surfaces the #867 non-convergence warning
+/// — previously silent for the ordinary bolus/infusion path (it was wired only into the
+/// input-rate branch). Predictions stay finite.
+#[test]
+fn ss_nonlinear_over_capacity_bolus_caps_and_warns() {
+    let _guard = crate::dosing::SS_WARN_SINK_READER_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    crate::dosing::clear_ss_nonconvergence_warnings();
+
+    let ode = mm_disposition_spec();
+    let mut pk = PkParams::default();
+    pk.values[crate::types::PK_IDX_CL] = 5.0; // Vmax
+    pk.values[crate::types::PK_IDX_V] = 8.0; // Km
+    let ss = DoseEvent::new(0.0, 50.0, 1, 0.0, true, 8.0); // mean input 6.25 > Vmax 5
+
+    let trough = equilibrate_ss_state(&ode, &pk.values, &ss, &ode.solver_opts);
     assert_eq!(
-        slow_cycles, SS_EQUILIBRATION_CYCLES,
-        "slow PK should run the full budget, ran {slow_cycles}"
+        crate::dosing::last_ss_equilibration_cycles(),
+        SS_EQUILIBRATION_CYCLES,
+        "an over-capacity (no-SS) nonlinear disposition must run the full capped budget"
+    );
+    assert!(trough.iter().all(|x| x.is_finite()));
+
+    let subj = make_subject(vec![ss], vec![1.0, 4.0, 7.9]);
+    let preds = ode_predictions(&ode, &pk.values, &[], &[], &subj);
+    assert!(
+        preds.iter().all(|p| p.is_finite()),
+        "predictions must stay finite: {preds:?}"
+    );
+    let warnings = crate::dosing::take_ss_nonconvergence_warnings();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("Steady-state (SS=1) equilibration")),
+        "an over-capacity bolus must surface a non-convergence warning; got: {warnings:?}"
     );
 }
 

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -5288,6 +5288,40 @@ fn ode_ss_infusion_matches_analytical_ss() {
     }
 }
 
+/// #914 regression, **infusion** side: the exact solve on a SLOW disposition. At `ke·II ≈ 0.03`
+/// the old 50-cycle pulse train truncated the SS trough ~22% low (`exp(−50·ke·II) ≈ 0.22`); the
+/// exact `(I − M)⁻¹·b` fixed point matches the analytical infusion SS closed form. The fast
+/// `ode_ss_infusion_matches_analytical_ss` above sits at `ke·II = 1.5`, where a 50-cycle residual
+/// is `exp(−75) ≈ 1e-33` — it passes on *both* old and new code and so cannot detect an
+/// infusion truncation-tail bug. This is the infusion analogue of the slow-bolus case in
+/// `ss_linear_disposition_uses_exact_fixed_point`, and it fails against the pre-#914 truncated
+/// train (the only PR-level truncation-sensitive infusion oracle — the `tests/` twin runs nightly).
+#[test]
+fn ode_ss_slow_infusion_matches_analytical_ss() {
+    use crate::pk::one_cpt_infusion_ss;
+    let cl = 0.1_f64;
+    let v = 80.0_f64; // ke = CL/V = 1.25e-3, ke·II = 0.03 → the pre-#914 train was ~22% low
+    let amt = 1000.0_f64;
+    let rate = 100.0_f64; // T_inf = 10 h < II
+    let ii = 24.0_f64;
+    // During-infusion, at the window end, post-infusion within the interval, and beyond it.
+    let obs_times = vec![2.0, 10.0, 12.0, 20.0, 30.0, 48.0];
+    let dose = DoseEvent::new(0.0, amt, 1, rate, true, ii);
+    let subj = make_subject(vec![dose.clone()], obs_times.clone());
+    let pk = pk_one(cl, v);
+    let mut ode = one_cpt_ode_spec();
+    // Tight solver tol so the forward walk tracks the exact analytical SS (the equilibration
+    // itself already runs at ss_equilibration_opts); the 22% truncation gap dwarfs this regardless.
+    ode.solver_opts.reltol = 1e-11;
+    ode.solver_opts.abstol = 1e-13;
+
+    let preds = ode_predictions(&ode, &pk.values, &[], &[], &subj);
+    for (j, &t) in obs_times.iter().enumerate() {
+        let expected = one_cpt_infusion_ss(&dose, t, cl, v);
+        assert_relative_eq!(preds[j] / v, expected, epsilon = 1e-7, max_relative = 1e-6);
+    }
+}
+
 #[test]
 fn ode_ss_resets_prior_state() {
     // SS=1 semantics: at the SS dose time, prior compartment state is

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -3634,6 +3634,107 @@ fn equilibrate_ss_state_g<T: crate::sens::num::PkNum>(
             &mut stack_cell.borrow_mut(),
         );
     };
+
+    // ---- #914 exact solve: closed-form periodic fixed point (linear disposition). ----
+    // The affine fixed point `u_ss = (I − M)⁻¹·b`, carried over the dual `T` so
+    // `∂u_ss/∂(θ,η[,κ])` (and the 2nd order) fall out of the linear solve — the exact analytic
+    // parity with the f64 `equilibrate_ss_state`, the input-rate twin (#835) and the analytical
+    // walk (#908). `advance_forced` integrates one cycle *with* the dose; `advance_unforced`
+    // integrates one `II` of disposition alone (the propagator `M`; the infusion's active and
+    // quiet windows share the same homogeneous propagator, so a full-`II` decay reconstructs it
+    // and the window length enters only through `b`). The moving active/quiet boundary carries
+    // `inf_window`'s jet via the same `inject_rate_saltation` the fallback loop uses
+    // (`dtinf = inf_window − t_inf_val`); its value part is zero, so the value map stays linear
+    // while the window sensitivity rides `b`. A nonlinear RHS fails the self-check and falls to
+    // the pulse train below (the f64 value walk owns the #867 warning — this twin must not
+    // double-count it, matching `equilibrate_ss_input_rate_state_g`).
+    let eq_opts = crate::ode::predictions::ss_equilibration_opts(opts);
+    let d1v: RefCell<Vec<Dual1<1>>> = RefCell::new(Vec::new());
+    let d1s: RefCell<Vec<Dual1<1>>> = RefCell::new(Vec::new());
+    let advance_unforced = |u0: &[T]| -> Option<Vec<T>> {
+        solve_ode_g(&bare_rhs, u0, (0.0, dose.ii), params, &[dose.ii], &eq_opts)
+            .last()
+            .map(|p| p.u.clone())
+    };
+    let advance_forced = |u0: &[T]| -> Option<Vec<T>> {
+        match inf {
+            Some((inf_rate, inf_window)) => {
+                let t_inf_val = inf_window.val();
+                if t_inf_val > dose.ii {
+                    return None; // overlapping pulses — no simple equilibration (→ fallback → zero)
+                }
+                let rate_forcing = inf_rate;
+                let rhs_active = |us: &[T], ps: &[T], t: f64, du: &mut [T]| {
+                    bare_rhs(us, ps, t, du);
+                    if cmt_idx < du.len() {
+                        du[cmt_idx] = du[cmt_idx] + rate_forcing;
+                    }
+                };
+                let mut y = solve_ode_g(
+                    &rhs_active,
+                    u0,
+                    (0.0, t_inf_val),
+                    params,
+                    &[t_inf_val],
+                    &eq_opts,
+                )
+                .last()
+                .map(|p| p.u.clone())?;
+                // Boundary-shift saltation for the (possibly jet-carrying) window `inf_window`,
+                // identical to the fallback loop's per-cycle `inject_rate_saltation`.
+                let dtinf = inf_window - T::from_f64(t_inf_val);
+                inject_rate_saltation::<T>(
+                    &mut y,
+                    cmt_idx,
+                    rate_forcing,
+                    T::from_f64(0.0),
+                    dtinf,
+                    1.0,
+                    program,
+                    params,
+                    t_inf_val,
+                    0.0,
+                    0.0,
+                    &mut d1v.borrow_mut(),
+                    &mut d1s.borrow_mut(),
+                );
+                let quiet_val = dose.ii - t_inf_val;
+                if quiet_val > 0.0 {
+                    y = solve_ode_g(
+                        &bare_rhs,
+                        &y,
+                        (0.0, quiet_val),
+                        params,
+                        &[quiet_val],
+                        &eq_opts,
+                    )
+                    .last()
+                    .map(|p| p.u.clone())?;
+                }
+                Some(y)
+            }
+            None => {
+                let mut y = u0.to_vec();
+                y[cmt_idx] = y[cmt_idx] + f_bio * T::from_f64(dose.amt);
+                solve_ode_g(&bare_rhs, &y, (0.0, dose.ii), params, &[dose.ii], &eq_opts)
+                    .last()
+                    .map(|p| p.u.clone())
+            }
+        }
+    };
+    if let Some(u_ss) = crate::dosing::periodic_ss_fixed_point_g::<T, _, _>(
+        n_states,
+        dose.ii,
+        eq_opts.reltol,
+        eq_opts.abstol,
+        advance_unforced,
+        advance_forced,
+    ) {
+        crate::dosing::record_ss_equilibration_cycles(1);
+        return u_ss;
+    }
+
+    // ---- Fallback: explicit pulse-train iteration (nonlinear disposition / singular `I − M`). ----
     if let Some((inf_rate, inf_window)) = inf {
         // SS infusion: each cycle is an active-rate window `[0, t_inf]` (the wrapped RHS
         // injects the mode-aware bioavailable forcing into the dosing compartment) followed

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -3652,7 +3652,7 @@ fn ode_provider_ss_nonlinear_fallback_early_stop_matches_full_budget() {
         "forced-full must run the whole budget"
     );
     assert!(
-        (1..full_cycles).contains(&early_cycles),
+        (2..full_cycles).contains(&early_cycles),
         "the nonlinear fallback's early stop should run >1 and fewer cycles ({early_cycles}) than \
          the full budget ({full_cycles})"
     );

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -3372,25 +3372,16 @@ fn ode_provider_ss_bolus_matches_production() {
     check_hessian_vs_fd_of_grad(&model, &subject, &[1.0, 10.0], &[0.1]);
 }
 
-/// **Early-stop is value-preserving and gradient-faithful to well within validation
-/// precision** (#532 review #1/#2/#4). On a scale-separated 2-cpt SS=1 fit — small `V2` puts
-/// the peripheral compartment ~50× below central, the regime where a magnitude-only floor
-/// could short-circuit the stop — the early-stopped analytic sensitivities are compared
-/// against a *forced-full-budget* equilibration. The dual decides convergence on the value
-/// parts, so:
-///
-/// - **Predictions** match to f64 precision: the value has reached its fixed point, so the
-///   elided cycles do not move it.
-/// - **Gradients / Hessian blocks** match to `< 1e-6` relative (measured `~1e-8` on this
-///   stressed model). The derivative tails contract at the value's geometric rate but lag by
-///   a constant few cycles, so a small tail survives the value stop (#532 review #2). That
-///   tail is 3–4 orders below the `1e-3` FD gradient-validation tolerance, the `1e-9` ODE
-///   solver `reltol`, and NONMEM's ~`1e-5` SE-matching precision — i.e. invisible to every
-///   reported number, which is the precise sense in which SEs are "unchanged".
-///
-/// Running here also exercises the dual stop end-to-end (#532 review #5).
+/// **Linear bolus SS now uses the exact closed-form fixed point over the dual (#914).** A
+/// scale-separated 2-cpt linear disposition — small `V2` puts the peripheral compartment ~50×
+/// below central — equilibrates via `periodic_ss_fixed_point_g` (one recorded cycle) rather than
+/// the up-to-50-cycle pulse train, so its dual value + `∂/∂η` + `∂/∂θ` + both Hessian blocks must
+/// match the production predictor and its finite differences. (This test previously compared an
+/// early-stopped run against a forced-full-budget run; that comparison no longer applies to a
+/// linear model — the #519 pulse-train early stop is now nonlinear-only, covered by the
+/// input-rate MM tests `ode_provider_ss_absorption_nonlinear_*`.)
 #[test]
-fn ode_provider_ss_early_stop_matches_full_budget() {
+fn ode_provider_ss_linear_bolus_uses_exact_solve() {
     let model = parse_model_string(TWOCPT_ODE).expect("parse 2-cpt SS ODE");
     let mut subject = bolus_subject(&[1.0, 4.0, 8.0, 11.0, 20.0]);
     subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 12.0)];
@@ -3398,48 +3389,21 @@ fn ode_provider_ss_early_stop_matches_full_budget() {
         ode_tvcov_supported(&model, &subject),
         "SS bolus → analytic walk"
     );
-    // CL/V1 fast central; small V2 → a peripheral compartment ~50× below central (scale
-    // separation) whose slow mode still equilibrates inside the cycle budget.
     let theta = [4.0, 50.0, 8.0, 1.0];
     let eta = [0.1, 0.05];
 
-    let early = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
-    let early_cycles = crate::dosing::last_ss_equilibration_cycles();
-    let full = crate::dosing::with_full_ss_equilibration(|| {
-        ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported")
-    });
-    let full_cycles = crate::dosing::last_ss_equilibration_cycles();
-
-    // The dual stop must actually fire on this model, or the comparison is vacuous (#532 #5).
+    // Exact fixed point: one recorded cycle, not the pulse train.
+    let _ = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
     assert_eq!(
-        full_cycles,
-        crate::dosing::SS_EQUILIBRATION_CYCLES,
-        "forced-full must run the whole budget"
-    );
-    assert!(
-        early_cycles < full_cycles,
-        "early stop should run fewer cycles ({early_cycles}) than the full budget ({full_cycles})"
+        crate::dosing::last_ss_equilibration_cycles(),
+        1,
+        "a linear disposition must equilibrate via the closed-form fixed point (#914)"
     );
 
-    // Predictions: value reached its fixed point → preserved tightly.
-    for (e, f) in early.obs.iter().zip(&full.obs) {
-        approx::assert_relative_eq!(e.f, f.f, max_relative = 1e-9, epsilon = 1e-12);
-    }
-    // Gradients / Hessian blocks: the dropped derivative tail is below validation precision.
-    for (e, f) in early.obs.iter().zip(&full.obs) {
-        for (a, b) in e.df_deta.iter().zip(&f.df_deta) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
-        for (a, b) in e.df_dtheta.iter().zip(&f.df_dtheta) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
-        for (a, b) in e.d2f_deta2.iter().zip(&f.d2f_deta2) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
-        for (a, b) in e.d2f_deta_dtheta.iter().zip(&f.d2f_deta_dtheta) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
-    }
+    // Value + ∂/∂η + ∂/∂θ vs the production predictor, and both Hessian blocks vs FD-of-gradient
+    // — the Dual2-vs-FD parity CLAUDE.md requires for the new exact-solve sensitivity path.
+    check_vs_production(&model, &subject, &theta, &eta);
+    check_hessian_vs_fd_of_grad(&model, &subject, &theta, &eta);
 }
 
 // 1-cpt IV with a **TAD-dependent RHS** (`-(CL/V)·central·(1+0.02·TAD)`). Used to
@@ -3605,19 +3569,72 @@ fn ode_provider_ss_rate_defined_infusion_under_f_matches_production() {
     check_hessian_vs_fd_of_grad(&model, &subject, &theta, &eta);
 }
 
-/// **Early-stop stays gradient-faithful with the new per-cycle rate-off saltation**
-/// (#486, mirroring `ode_provider_ss_early_stop_matches_full_budget`): the (b) sub-case's
-/// per-cycle `inject_rate_saltation` call accumulates over however many cycles the SS
-/// loop runs, so an early-stopped run must still match a forced-full-budget run to well
-/// within FD-validation precision — not just for the value, but for the `F`-window
-/// saltation's gradient/Hessian contribution specifically.
+/// **Linear rate-defined infusion under `F` now uses the exact fixed point over the dual
+/// (#914).** The exact-solve `advance_forced` runs the *same* per-cycle `inject_rate_saltation`
+/// for the `F`-scaled active/quiet window the fallback loop did, so the `F`-window saltation's
+/// gradient **and** Hessian contribution is validated here — against the production predictor and
+/// its finite differences — exactly the concern of the early-stop test this replaces (#486/#642
+/// review #2). One recorded cycle confirms the exact path is taken.
 #[test]
-fn ode_provider_ss_rate_under_f_early_stop_matches_full_budget() {
+fn ode_provider_ss_rate_under_f_uses_exact_solve() {
     let model = parse_model_string(ONECPT_IV_F_ODE).expect("parse F ODE");
     let mut subject = bolus_subject(&[1.0, 3.0, 6.0, 9.0]);
     subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 40.0, true, 12.0)];
     assert!(ode_tvcov_supported(&model, &subject), "SS + F → analytic");
     let theta = [1.0, 10.0, 0.7];
+    let eta = [0.1, 0.05];
+
+    let _ = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
+    assert_eq!(
+        crate::dosing::last_ss_equilibration_cycles(),
+        1,
+        "a linear disposition must equilibrate via the closed-form fixed point (#914)"
+    );
+
+    check_vs_production(&model, &subject, &theta, &eta);
+    check_hessian_vs_fd_of_grad(&model, &subject, &theta, &eta);
+}
+
+/// A **Michaelis–Menten disposition** (plain bolus, no absorption kernel): the #914 exact fixed
+/// point declines the nonlinear map and the dual walk falls back to the pulse-train iteration —
+/// the sole path that still exercises the #519/#532 dual early stop after #914 (a linear
+/// disposition now short-circuits to the closed form). This pins that early stop
+/// **gradient-faithful**: an early-stopped run must match a forced-full-budget run to well within
+/// FD-validation precision, and the analytic dual must match the production predictor + FD. (The
+/// linear analogue this replaces was `ode_provider_ss_early_stop_matches_full_budget`.)
+const MM_DISPOSITION_ODE: &str = r#"
+[parameters]
+  theta TVVMAX(50.0, 1.0, 500.0)
+  theta TVKM(30.0, 1.0, 500.0)
+  omega ETA_VMAX ~ 0.09
+  omega ETA_KM   ~ 0.04
+  sigma PROP ~ 0.01 (sd)
+[individual_parameters]
+  VMAX = TVVMAX * exp(ETA_VMAX)
+  KM   = TVKM   * exp(ETA_KM)
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -VMAX * central / (KM + central)
+[error_model]
+  DV ~ proportional(PROP)
+[fit_options]
+  ode_reltol = 1e-10
+  ode_abstol = 1e-12
+"#;
+
+#[test]
+fn ode_provider_ss_nonlinear_fallback_early_stop_matches_full_budget() {
+    let model = parse_model_string(MM_DISPOSITION_ODE).expect("parse MM disposition ODE");
+    let mut subject = bolus_subject(&[1.0, 3.0, 6.0, 7.9]);
+    // Peak amount ≈ 100 ≫ KM ≈ 30 (genuinely nonlinear), mean input 100/8 = 12.5 ≪ VMAX = 50
+    // (admits a steady state and converges well inside the 50-cycle cap, so the early stop fires).
+    subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 8.0)];
+    assert!(
+        ode_tvcov_supported(&model, &subject),
+        "SS bolus → analytic walk"
+    );
+    let theta = [50.0, 30.0];
     let eta = [0.1, 0.05];
 
     let early = ode_subject_sensitivities(&model, &subject, &theta, &eta).expect("supported");
@@ -3627,15 +3644,21 @@ fn ode_provider_ss_rate_under_f_early_stop_matches_full_budget() {
     });
     let full_cycles = crate::dosing::last_ss_equilibration_cycles();
 
+    // The nonlinear fallback (not the exact solve) must run, and its dual early stop must fire —
+    // else the comparison is vacuous. `> 1` rules out the single-cycle exact-solve short-circuit.
     assert_eq!(
         full_cycles,
         crate::dosing::SS_EQUILIBRATION_CYCLES,
         "forced-full must run the whole budget"
     );
     assert!(
-        early_cycles < full_cycles,
-        "early stop should run fewer cycles ({early_cycles}) than the full budget ({full_cycles})"
+        (1..full_cycles).contains(&early_cycles),
+        "the nonlinear fallback's early stop should run >1 and fewer cycles ({early_cycles}) than \
+         the full budget ({full_cycles})"
     );
+
+    // Value reached its fixed point → predictions preserved tightly; the dropped derivative tail
+    // is below FD-validation precision.
     for (e, f) in early.obs.iter().zip(&full.obs) {
         approx::assert_relative_eq!(e.f, f.f, max_relative = 1e-9, epsilon = 1e-12);
         for (a, b) in e.df_deta.iter().zip(&f.df_deta) {
@@ -3644,16 +3667,9 @@ fn ode_provider_ss_rate_under_f_early_stop_matches_full_budget() {
         for (a, b) in e.df_dtheta.iter().zip(&f.df_dtheta) {
             approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
         }
-        // The per-cycle rate-off saltation accumulates into the 2nd-order term across every
-        // cycle, so the Hessian blocks — not just the gradient — must survive early stop
-        // (this is what the docstring claims; #642 review #2).
-        for (a, b) in e.d2f_deta2.iter().zip(&f.d2f_deta2) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
-        for (a, b) in e.d2f_deta_dtheta.iter().zip(&f.d2f_deta_dtheta) {
-            approx::assert_relative_eq!(*a, *b, max_relative = 1e-6, epsilon = 1e-9);
-        }
     }
+    // Teeth: the fallback dual value + gradient must match the production predictor and its FD.
+    check_vs_production(&model, &subject, &theta, &eta);
 }
 
 /// **Modeled-duration dose × SS is now analytic (#486, PR3 sub-case (d) — cheapest,

--- a/src/sens/propagate.rs
+++ b/src/sens/propagate.rs
@@ -1117,7 +1117,8 @@ fn obs_boundary_correction<T: PkNum>(
 /// line search. The variational recursion shares the value iteration's monodromy, so the
 /// derivative tails contract at the same geometric rate — but they lag the value by a constant
 /// few cycles, so a small tail (~`1e-8` on a stressed scale-separated model, see
-/// `ode_provider_ss_early_stop_matches_full_budget`) survives the value stop. That residual is
+/// `ode_provider_ss_nonlinear_fallback_early_stop_matches_full_budget`) survives the value stop.
+/// That residual is
 /// 3–4 orders below the `1e-3` gradient-validation tolerance and NONMEM's SE-matching precision,
 /// so the surviving gradient is faithful for every reported purpose; chasing it to zero would
 /// add a constant per-evaluation cost on the gradient hot path for no observable benefit. A

--- a/tests/oral_peripheral_infusion.rs
+++ b/tests/oral_peripheral_infusion.rs
@@ -282,7 +282,9 @@ fn ss_peripheral_infusion_matches_the_ode_twin() {
     assert_agree(
         &preds(TWO_CPT_ORAL_CF, csv),
         &preds(TWO_CPT_ORAL_ODE, csv),
-        1e-6,
+        // #914: the ODE SS is now the exact `(I − M)⁻¹·b` fixed point, matching the analytical
+        // closed form's exact SS to integration tolerance (was 1e-6 while the ODE truncated).
+        1e-8,
         "two_cpt_oral SS peripheral infusion",
     );
 }
@@ -298,7 +300,8 @@ fn ss_peripheral_bolus_matches_the_ode_twin() {
     assert_agree(
         &preds(TWO_CPT_ORAL_CF, csv),
         &preds(TWO_CPT_ORAL_ODE, csv),
-        1e-6,
+        // #914: ODE SS now exact (see the infusion twin above).
+        1e-8,
         "two_cpt_oral SS peripheral bolus",
     );
 }


### PR DESCRIPTION
## Why

`#908` made the **analytical** event-driven walk solve the periodic steady state exactly as `u_ss = (I − M)⁻¹·b`. The **ODE** engine's ordinary bolus/infusion SS still expanded a truncated pulse train (up to `SS_EQUILIBRATION_CYCLES = 50`), leaving a residual `≈ exp(−50·λ_slow·II)` — negligible for typical PK but tens of percent for a slow disposition, and **silently**. Two gaps, both in `equilibrate_ss_state` and its dual twin `equilibrate_ss_state_g`:

1. **Truncation** — the bolus/infusion branch never used the exact fixed point the analytical walk already had.
2. **Silence** — `note_ss_nonconvergence_if_capped` was wired only into the ODE input-rate branch; a capped ordinary bolus/infusion equilibration emitted no warning.

Closes #914.

## What changed

- **`equilibrate_ss_state` (`src/ode/predictions.rs`)** — a linear disposition now routes its bolus and infusion branches through `crate::dosing::periodic_ss_fixed_point_g` (the same exact solve #908/#835 use), returning `(I − M)⁻¹·b` directly. `advance_forced` integrates one cycle with the dose (bolus pulse, or active-infusion + quiet window); `advance_unforced` integrates one `II` of disposition alone (the propagator `M` — the infusion's active/quiet windows share the homogeneous propagator, so a full-`II` decay reconstructs it and the window length enters only through `b`). The exact solve uses the tightened `ss_equilibration_opts` tolerance and passes it to the linearity self-check.
- A genuinely nonlinear RHS (Michaelis–Menten, …) fails the affine self-check → the capped pulse train, now with `note_ss_nonconvergence_if_capped` wired in (**gap 2**).
- **`equilibrate_ss_state_g` (`src/sens/ode_provider.rs`)** — the dual twin mirrors this so FOCE/FOCEI differentiates the exact steady state. The infusion `advance_forced` carries the moving active/quiet boundary's `inf_window` jet through the same `inject_rate_saltation` the fallback loop uses (`dtinf = inf_window − t_inf_val`, zero value part → the value map stays linear while the window sensitivity rides `b`). The nonlinear fallback loops are unchanged; the value walk owns the #867 warning (the twin must not double-count it).

## Alternatives considered

Routing the nonlinear bolus fallback through Anderson acceleration (as the input-rate branch does for a nonlinear disposition that admits SS) was out of scope per the issue — the ordinary bolus/infusion path keeps the capped train + warning for a nonlinear RHS. The exact solve covers the (overwhelmingly common) linear case.

## Breaking changes
- [x] None — `equilibrate_ss_state`/`equilibrate_ss_state_g` are private; `periodic_ss_fixed_point_g` was already `pub(crate)`. No public API surface. ferx-r unaffected (no pin bump).

## Numerical validation
- **Oracle** — the analytical closed forms, exactly as #908. A linear ODE model's exact SS now matches its analytical twin to integration tolerance (tightened `ss_peripheral_{infusion,bolus}_matches_the_ode_twin` from `1e-6` → `1e-8`; the 1-cpt trough matches the hand-derived geometric-series SS `F·amt·e^{−ke·II}/(1 − e^{−ke·II})` in `ss_linear_disposition_uses_exact_fixed_point`).
- **`Dual2`-vs-FD parity** — `ode_provider_ss_linear_bolus_uses_exact_solve` (bolus) and `ode_provider_ss_rate_under_f_uses_exact_solve` (rate-defined infusion under `F`, exercising the window-jet saltation) check value + `∂/∂η` + `∂/∂θ` + both Hessian blocks against production + FD.
- **Nonlinear fallback preserved** — `ss_nonlinear_bolus_with_steady_state_uses_fallback` (MM disposition that admits SS → correct trough via the fallback, no warning), `ss_nonlinear_over_capacity_bolus_caps_and_warns` (mean input > Vmax → 50-cycle cap + #867 warning), and `ode_provider_ss_nonlinear_fallback_early_stop_matches_full_budget` (the dual early stop is now nonlinear-only; gradient-faithful vs a forced-full-budget run).
- Existing NONMEM SS anchors (`ss_lagtime_nonmem`, `nonmem_dose_compartment_anchor`, `oral_peripheral_infusion`) stay as the cross-tool check.

## Performance
- [x] Faster — the linear case replaces ~50 RK45 one-cycle integrations with `~n+2` integrations + one `n×n` solve.

## Tests
- [x] Unit tests added (`cargo test --lib` passes) — see Numerical validation.
- [x] Regression: the truncation was silent; the new tests fail against the old truncated train.

## Docs
- [x] `docs/model-file/steady-state.qmd` — the "ODE path" section, the `N=50` section, the path/cost tables, and the analytic-gradient section now describe the exact solve + nonlinear fallback; the `#914` caveat is removed.
- [x] `CHANGELOG.md` `[Unreleased]` → Fixed.

## Reviewer hints
The subtle half is the dual infusion `advance_forced`: the `inject_rate_saltation` adds the velocity **jump** (`r·e·dtinf`), which keeps the one-cycle map exactly affine in `u0` with a window-independent `M = e^{A·II}` — so the window sensitivity lands entirely in `b` and `periodic_ss_fixed_point_g` assembles the exact `∂u_ss/∂(θ,η)`. Confirmed by the FD-parity tests.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
