### PR TITLE
test(pk): document the empirical walk-routing verification on the #376 anchor

### DIFF
--- a/tests/oral_central_infusion_nonmem_anchor.rs
+++ b/tests/oral_central_infusion_nonmem_anchor.rs
@@ -103,7 +103,22 @@ fn oral_model(cpt: usize, tvf: f64) -> String {
 
 /// Predictions on the **event-driven walk**, selected by a `WT` column that
 /// varies across rows. The model never references `WT`, so no parameter value
-/// differs from the plain dataset — only the code path does.
+/// differs from the plain dataset — only the code path does: the reader flags a
+/// varying non-model column as a covariate (`datareader.rs`), which makes
+/// `Subject::has_tv_covariates()` true, and `compute_predictions_with_tv`
+/// (`pk/mod.rs`) then routes an analytical + TV-covariate subject to
+/// `event_driven_predictions` (the walk) rather than the superposition closed
+/// form `plain_preds` uses.
+///
+/// That routing was confirmed empirically, not just read off the source: a
+/// temporary ×1.5 scale injected into the walk's sole funnel
+/// (`event_driven_predictions_run`) moved **only** this dataset — `walk_preds`
+/// read 1.5× the true curve while `plain_preds` stayed exactly 1.0×, proving the
+/// two go through different functions (the walk vs `predict_concentration`).
+/// Re-run that differential injection to re-verify if the dispatch in
+/// `compute_predictions_with_tv` is ever refactored — the F=1 walk value here is
+/// ~0.476 (> 0), so a walk that silently fell back to superposition would still
+/// pass this file, but a walk that regressed to the #350 ~0 curve would not.
 fn walk_preds(src: &str, rate: f64) -> Vec<f64> {
     let model: CompiledModel = parse_full_model(src).expect("model parses").model;
     let dose = format!("1,0,.,1,100,2,{rate},1,70");


### PR DESCRIPTION
## Why

Follow-up to #921 (#376). That PR's `walk_preds` helper relies on a varying `WT`
column to route through the event-driven walk (the #350 code) rather than the
superposition closed form — but the file only *asserted* the numbers, it did not
record that the routing had been checked. Since a central-infusion walk and
superposition agree, a silent regression in the routing (walk_preds quietly
falling back to superposition) would not fail the anchor, so the fact that the
walk is genuinely exercised is worth documenting for the next maintainer.

## What changed

Comment-only. Extends the `walk_preds` doc comment with:

- the routing chain — reader flags a varying non-model column as a covariate →
  `Subject::has_tv_covariates()` → `compute_predictions_with_tv` (`pk/mod.rs`)
  routes analytical + TV-covariate to `event_driven_predictions`;
- the **differential-injection proof** that confirmed it empirically: a temporary
  ×1.5 scale in `event_driven_predictions_run` (the walk's sole funnel) moved
  *only* the walk dataset (1.5× the true curve) while the plain dataset stayed
  1.0×, proving the two take different functions;
- the re-verification recipe if the dispatch is ever refactored.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (comment-only; no code path changes)

## Performance
- [x] No significant impact expected (comment-only)

## Tests
- [x] No new tests needed (documents an already-landed anchor; `cargo check
  --test oral_central_infusion_nonmem_anchor` clean, `cargo fmt` clean)

## Docs
- [x] No user-visible change (internal test comment; no CHANGELOG per CLAUDE.md)

## Reviewer hints

Single doc-comment edit in `tests/oral_central_infusion_nonmem_anchor.rs`. The
injection used to prove the routing was temporary and never committed — main is
unchanged apart from this comment.

## Open questions

None.
