### PR TITLE
fix(pk): pure-TTE population declines the predictor instead of panicking on a CMT≥2 dose [closes #905]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ section of the SDLC for the versioning policy).
   no rows** (#759). The equivalent `simulate()` guard already existed and its message claimed to
   cover `predict()`, but it only ran on the simulate path. State-occupancy prediction `π(t)` is
   still to come (#820).
+- **A pure-TTE / pure-discrete population no longer panics on a `CMT ≥ 2` dose** (#905). Such a
+  population is exempt from dose-compartment validation — its `pk` line is a placeholder and the
+  TTE endpoint's `CMT` is routinely ≥ 2 — but the predictor still rerouted the dose onto the
+  event-driven walk, which aborted the process on the very dose the validator had declined to
+  check. The analytical predictor now declines in lockstep with the exemption: a subject with no
+  Gaussian observation returns `NaN` without entering the walk (value and FOCE/FOCEI gradient
+  paths alike), so `predict()`, `simulate()` and `fit()` stay panic-free on such a population
+  through both the endpoint-routed and model-blind loaders.
 
 ### Performance
 - **Closed-form modified-release absorption** (#860). A static multi-route absorption model

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -641,37 +641,37 @@ pub(crate) fn check_modeled_dose_rates(
 /// placeholder's 1-compartment topology would reject a working model over dose
 /// records no PK code ever reads.
 ///
-/// Deliberately a **population**-level predicate, not a per-subject one. "This
-/// subject has no Gaussian observation" does **not** imply the PK path is
-/// skipped for it: the event-driven walk is driven by the subject's event
-/// schedule (doses and `EVID=2` times), and the FOCE/FOCEI sensitivity provider
-/// runs per subject regardless. A per-subject exemption would let a TTE-only
-/// subject *of a joint PK-TTE model* carry an unroutable infusion straight back
-/// into the panics this check exists to prevent — a routine pattern (an early
-/// dropout, or a TTE-only arm, that still has dose records).
+/// Deliberately a **population**-level gate on *whether the dose-compartment check
+/// runs at all*, not a per-subject one. If **any** subject asks the analytical
+/// predictor for a value, the check validates **every** dose in the dataset — so a
+/// TTE-only subject *of a joint PK-TTE model* (an early dropout, or a TTE-only arm,
+/// that still has dose records) has its unroutable infusion caught up front, rather
+/// than carried into the event-driven walk's `panic!`. Making *validation* per
+/// subject would reopen exactly that.
 ///
-/// Non-Gaussian endpoints are registered per CMT in `CompiledModel::endpoints`,
-/// so an observation CMT absent from that map is Gaussian. Without the
-/// `survival` feature no non-Gaussian endpoint can be parsed, so every
-/// observation is Gaussian by construction and this is always `true`.
+/// This is distinct from — and complementary to — the per-subject predictor gate
+/// (`subject_feeds_analytical_pk`, #905): validation is population-scoped so a live
+/// population is fully checked, while the predictor declines the walk per subject for
+/// any subject whose output is unused. In a live population the check already rejects
+/// a bad dose, so the predictor gate never has to; in an exempt population the check
+/// is skipped and the predictor gate is what keeps the walk unreached.
+///
+/// The per-subject truth (which observation CMTs are Gaussian, and the
+/// no-`survival`-feature short circuit) lives in [`crate::pk::subject_feeds_analytical_pk`];
+/// this is `any(...)` of it.
 fn population_uses_analytical_pk(model: &CompiledModel, population: &Population) -> bool {
-    #[cfg(feature = "survival")]
-    {
-        if model.endpoints.is_empty() {
-            return true;
-        }
-        population.subjects.iter().any(|s| {
-            !s.pk_only_times.is_empty()
-                || s.obs_cmts
-                    .iter()
-                    .any(|cmt| !model.endpoints.contains_key(cmt))
-        })
-    }
-    #[cfg(not(feature = "survival"))]
-    {
-        let _ = (model, population);
-        true
-    }
+    // Single source of truth with the predictor gate: `subject_feeds_analytical_pk`
+    // is the per-subject predicate, and this is `any(...)` of it. The two compose —
+    // this population-level test decides whether the dose-compartment check runs at
+    // all (a *live* population validates every dose, including a TTE-only subject's),
+    // while the per-subject gate declines the walk for a subject the analytical
+    // predictor would feed nothing (#905). See `subject_feeds_analytical_pk` for why
+    // "no Gaussian observation" implies "predictor output unused" on an analytical
+    // model.
+    population
+        .subjects
+        .iter()
+        .any(|s| crate::pk::subject_feeds_analytical_pk(model, s))
 }
 
 /// Every dose must name a compartment the **analytical** engine can actually
@@ -761,6 +761,18 @@ pub(crate) fn check_dose_compartments(
     // Nothing in this dataset asks the analytical predictor for a value — the
     // `pk` line is a pure-TTE / pure-discrete model's placeholder. See
     // `population_uses_analytical_pk` for why this is a population-level test.
+    //
+    // **This exemption is safe because the predictor declines in lockstep.** Skipping
+    // the dose-compartment check would be a landmine on its own: `dose_needs_event_walk`
+    // still reroutes a `CMT ≥ 2` dose onto the event-driven walk, whose out-of-range
+    // guard is a `panic!`. That was #905 — the check declined to validate a dose the
+    // walk then aborted on. The fix is the shared predicate: the same
+    // `subject_feeds_analytical_pk` that makes this population exempt also makes
+    // `compute_predictions_with_tv_*` (value) and `subject_routes_to_event_walk`
+    // (gradient) return a NaN/decline for every one of its subjects, so the walk is
+    // never reached. The exemption's safety no longer rests on the far-away
+    // `n_obs == 0` early return in a different module; it is the negation, per subject,
+    // of this very predicate.
     //
     // **Analytical models only.** An `[odes]` block is never a placeholder: a
     // hazard that reads an ODE state has the system integrated for it even when

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -861,6 +861,17 @@ pub fn predict_iov(
     kappas: &[Vec<f64>],
 ) -> Vec<f64> {
     use std::collections::HashMap;
+    // #905: the IOV value funnel is a structural peer of
+    // `compute_predictions_with_tv_into_with_schedule` and needs the same declination —
+    // an analytical subject with no Gaussian observation feeds the predictor nothing,
+    // and its dose compartment is exempt from `check_dose_compartments`, so the walk
+    // below (`event_driven_predictions`) would `panic!` on an unroutable dose nobody
+    // reads. Keyed on the primary `ode_spec` and computed before `effective_for`,
+    // exactly like the non-IOV gate. Returns NaN (empty when `obs_times` is empty — the
+    // endpoint-routed loader's case, which the walk's own `n_obs == 0` already handled).
+    if model.ode_spec.is_none() && !subject_feeds_analytical_pk(model, subject) {
+        return vec![f64::NAN; subject.obs_times.len()];
+    }
     // Closed-form transit/IG IOV reroutes to its `transit()`/`igd()` ODE twin (issue #719):
     // the per-dose superposition cannot carry drug across occasion boundaries (#104), but the
     // twin integrates it exactly (#663). A no-op for every other model (`effective_for` returns
@@ -1948,6 +1959,54 @@ pub(crate) fn dose_needs_event_walk(pk_model: PkModel, subject: &Subject) -> boo
     })
 }
 
+/// True when the analytical PK predictor must produce a value for this subject —
+/// it carries at least one Gaussian observation (an obs whose CMT is **not** a
+/// registered non-Gaussian endpoint) or a pk-only prediction time.
+///
+/// When this is `false` on an analytical (`ode_spec.is_none()`) model, nothing
+/// consumes the predictor's concentration-time output, so the event-driven walk
+/// can be skipped for the subject. Within that domain every consumer of the walk
+/// is a Gaussian observation:
+///   - A TTE hazard that reads a concentration is written `hazard = <expr>`, which
+///     the parser turns into a synthesised `__chz` ODE accumulator state
+///     (`prescan_ode_hazards`), forcing `ode_spec = Some`. So every hazard left on
+///     an analytical model is a closed-form `HazardSpec::Analytic`, whose
+///     parameters are a `Fn(θ, η, covariates)` — no concentration.
+///   - A binary/categorical linear predictor is a
+///     [`crate::types::LinearPredictorFn`] = `Fn(θ, η, covariates) -> f64`; it
+///     cannot read the concentration curve either.
+///   - A Gaussian PD/PK endpoint is *never* inserted into `endpoints`, so its obs
+///     CMT is absent from the map and keeps this `true`.
+///
+/// This is the per-subject source of truth shared with the dose-compartment
+/// validator: `validation::population_uses_analytical_pk` is `subjects.any(...)`
+/// of this predicate. The two compose — in a *live* population the validator still
+/// range-checks **every** dose (so a joint-model TTE-only subject's unroutable dose
+/// is rejected up front), while this per-subject gate additionally declines the
+/// walk for any subject the predictor would feed nothing, which is the case the
+/// exemption leaves unvalidated (#905).
+pub(crate) fn subject_feeds_analytical_pk(model: &CompiledModel, subject: &Subject) -> bool {
+    #[cfg(feature = "survival")]
+    {
+        // No non-Gaussian endpoints ⇒ every observation is Gaussian by construction.
+        if model.endpoints.is_empty() {
+            return true;
+        }
+        !subject.pk_only_times.is_empty()
+            || subject
+                .obs_cmts
+                .iter()
+                .any(|cmt| !model.endpoints.contains_key(cmt))
+    }
+    #[cfg(not(feature = "survival"))]
+    {
+        // Without the `survival` feature no non-Gaussian endpoint can be parsed, so
+        // every observation is Gaussian and the predictor is always live.
+        let _ = (model, subject);
+        true
+    }
+}
+
 /// Compute predictions using ODE integration.
 /// `pk_params_flat` is the flat parameter vector passed to the ODE RHS function.
 /// `theta` and `eta` are forwarded to `OdeSpec::output_fn` for Form C
@@ -2081,6 +2140,23 @@ pub fn compute_predictions_with_tv_into_with_schedule(
     scratch: &mut EventPkParams,
     schedule: Option<&event_driven::EventSchedule>,
 ) -> Vec<f64> {
+    // #905: on an analytical model, a subject with no Gaussian observation feeds the
+    // PK predictor nothing — every hazard left here is closed-form and no
+    // binary/CTMM linear predictor reads a concentration (see
+    // `subject_feeds_analytical_pk`). Such a subject's dose compartment is exempt
+    // from `check_dose_compartments`, so running the event-driven walk would hit the
+    // unroutable-dose `panic!` (`event_driven.rs`) on output nobody consumes. Decline
+    // with NaN — the house "no prediction available" value, the same result the
+    // normal endpoint-routed path reaches via an empty `obs_times` (`n_obs == 0`).
+    // Keyed on the primary `ode_spec`, matching the validator exemption, and judged
+    // before `effective_model_for_eval`: a transit model (primary `ode_spec` None,
+    // rerouted to its ODE twin below) is judged on the primary too. A plain transit PK
+    // subject carries Gaussian obs and is not gated; a transit-plus-TTE TTE-only
+    // subject is gated — correctly, it feeds the predictor nothing like any other
+    // no-Gaussian-obs subject.
+    if model.ode_spec.is_none() && !subject_feeds_analytical_pk(model, subject) {
+        return vec![f64::NAN; subject.obs_times.len()];
+    }
     // A `one_cpt_transit` subject that the closed form can't serve (TIME switch / TV
     // covariates) routes to the exact ODE `transit()` equivalent, which takes the ODE branch
     // below (that branch ignores the cached analytical `schedule`, so a stale one is

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -1416,6 +1416,16 @@ pub fn subject_sensitivities_iov(
     theta: &[f64],
     stacked_eta: &[f64],
 ) -> Option<SubjectSens> {
+    // #905: IOV twin of the non-IOV `subject_routes_to_event_walk` gate. An analytical
+    // subject with no Gaussian observation feeds the predictor nothing; declining here
+    // (→ the caller drops it to FD) keeps FOCE/FOCEI out of the IOV sens walk, whose
+    // dose-routing `panic!`s (`propagate::active_rates_g` / the bolus `cmt_idx` guard)
+    // are the same twins the value gate fences off. Routed TTE-only subjects never reach
+    // here (they carry `obs_records`, so the analytic-IOV gates already decline them);
+    // this fires only on the model-blind loader that put the TTE rows in `obs_times`.
+    if model.ode_spec.is_none() && !crate::pk::subject_feeds_analytical_pk(model, subject) {
+        return None;
+    }
     // Cheap, model/subject-only decline before any dual seeding (#822 review #9) — see
     // `subject_sensitivities_tvcov`. Harmless for the ODE-twin branch below: an ODE model has no
     // closed-form walk to decline for, and `ss_lagtime_walk_unsupported` is about that walk's
@@ -1793,6 +1803,14 @@ fn subject_eta_grad_iov_analytical(
     theta: &[f64],
     stacked_eta: &[f64],
 ) -> Option<Vec<ObsGrad>> {
+    // #905: decline a no-Gaussian-observation analytical subject (→ FD), so the IOV
+    // inner gradient never enters the sens walk on the exempt subject's unroutable dose.
+    // This is the twin the model-blind loader reaches: `analytic_iov_inner`'s
+    // `!subject_has_survival_records` guard fails there (TTE rows sit in `obs_times`, not
+    // `obs_records`), so without this the walk panics at `propagate.rs` bolus/infusion.
+    if model.ode_spec.is_none() && !crate::pk::subject_feeds_analytical_pk(model, subject) {
+        return None;
+    }
     // Cheap decline before any dual seeding (#822 review #9) — see `subject_sensitivities_tvcov`.
     if ss_lagtime_walk_unsupported(model, subject) {
         return None;
@@ -4775,6 +4793,17 @@ pub(crate) fn subject_routes_to_event_walk(model: &CompiledModel, subject: &Subj
     // so a transit subject with time-varying covariates / a `TIME` switch stays analytic
     // (matching production), rather than silently zeroing or dropping to FD.
     if !crate::pk::event_driven::supports_event_driven(model.pk_model) {
+        return false;
+    }
+    // #905: mirror the value path's declination. A subject with no Gaussian
+    // observation on an analytical model feeds the predictor nothing, so
+    // `compute_predictions_with_tv_*` returns NaN without walking. The gradient must
+    // follow — otherwise FOCE/FOCEI would enter the event-driven walk (and its `sens`
+    // twin, `propagate::active_rates_g` and the bolus `cmt_idx` guard, both of which
+    // `panic!` on the very unroutable dose the value path just skipped). The Gaussian
+    // gradient of a subject with no Gaussian obs is an empty sum, so declining the
+    // walk loses nothing. Keyed on the primary `ode_spec`, matching the value gate.
+    if model.ode_spec.is_none() && !crate::pk::subject_feeds_analytical_pk(model, subject) {
         return false;
     }
     subject.has_tv_covariates()

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -10125,3 +10125,55 @@ fn ss_ill_conditioned_gradient_matches_fd_of_production() {
         sd.obs[0].f
     );
 }
+
+/// #905 gradient gate: on an analytical model a subject with no Gaussian observation
+/// feeds the PK predictor nothing, so the value path declines it (NaN, no walk). The
+/// gradient router must decline in lockstep — otherwise FOCE/FOCEI enters the `sens`
+/// event-driven walk and hits the unroutable-dose `panic!` twin
+/// (`propagate::active_rates_g` / the bolus `cmt_idx` guard) on the very dose the
+/// value path skipped. This pins the gate directly: the subject genuinely *would*
+/// route there absent it (its `CMT=2` bolus makes `dose_needs_event_walk` true), so a
+/// reverted gate flips the second assertion (and would panic once the walk ran).
+#[cfg(feature = "survival")]
+#[test]
+fn tte_only_subject_declines_the_event_walk_gradient() {
+    const TTE_ONLY: &str = r#"
+[parameters]
+  theta TVLAMBDA(0.05, 0.001, 5.0)
+  theta DUMMY_CL(1.0, 0.01, 100.0)
+  theta DUMMY_V(10.0, 0.1, 1000.0)
+  omega ETA_LAMBDA ~ 0.0
+  sigma SIGMA_DV ~ 0.1
+[individual_parameters]
+  LAMBDA = TVLAMBDA * exp(ETA_LAMBDA)
+  CL     = DUMMY_CL
+  V      = DUMMY_V
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ additive(SIGMA_DV)
+[event_model]
+  cmt    = 2
+  family = exponential
+  scale  = LAMBDA
+"#;
+    let model = parse_model_string(TTE_ONLY).expect("model parses");
+    // Only observation is the TTE event at CMT=2 (no Gaussian obs); the CMT=2 bolus
+    // is out of range for the 1-cpt placeholder.
+    let mut subj = oral_subject(&[5.0]);
+    subj.doses = vec![DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0)];
+    subj.obs_cmts = vec![2];
+
+    assert!(
+        crate::pk::dose_needs_event_walk(model.pk_model, &subj),
+        "precondition: the CMT=2 bolus makes this subject walk-bound"
+    );
+    assert!(
+        !crate::pk::subject_feeds_analytical_pk(&model, &subj),
+        "a subject whose only obs is a TTE endpoint feeds the analytical predictor nothing"
+    );
+    assert!(
+        !subject_routes_to_event_walk(&model, &subj),
+        "the #905 gate must keep a no-Gaussian-obs subject off the event-driven gradient walk"
+    );
+}

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -541,6 +541,22 @@ pub fn individual_nll_into_with_schedule(
         }
     } else {
         for (j, (&y, &f_pred)) in subject.observations.iter().zip(preds.iter()).enumerate() {
+            // #905: never score a non-Gaussian-endpoint observation as Gaussian. On
+            // the endpoint-routed load path (`read_population_for`) these rows live in
+            // `obs_records`, so this is a no-op; on a model-blind `read_nonmem_csv`
+            // load they sit in the Gaussian Vecs with a NaN `f_pred` (the analytical
+            // predictor declined them, #905) and must be skipped — a `y - NaN`
+            // residual would otherwise poison the whole subject's NLL. Guarded on the
+            // empty-endpoints common case so plain PK models pay nothing.
+            #[cfg(feature = "survival")]
+            if !model.endpoints.is_empty()
+                && subject
+                    .obs_cmts
+                    .get(j)
+                    .is_some_and(|c| model.endpoints.contains_key(c))
+            {
+                continue;
+            }
             // FREM dispatch: covariate pseudo-observations use theta+eta as
             // prediction and a near-zero additive sigma.
             let fremtype_val = subject.fremtype.get(j).copied().unwrap_or(0);
@@ -722,6 +738,20 @@ pub(crate) fn obs_nll_subject_from_preds(
         }
     } else {
         for (j, (&y, &f)) in subject.observations.iter().zip(preds.iter()).enumerate() {
+            // #905: a non-Gaussian-endpoint observation must never be scored as
+            // Gaussian — the SAEM M-step / IS twin of the skip in
+            // `individual_nll_into_with_schedule`. No-op on the endpoint-routed path
+            // (those rows live in `obs_records`); on a model-blind load it keeps a NaN
+            // `f` (the declined predictor) out of the sum. Guarded on empty-endpoints.
+            #[cfg(feature = "survival")]
+            if !model.endpoints.is_empty()
+                && subject
+                    .obs_cmts
+                    .get(j)
+                    .is_some_and(|c| model.endpoints.contains_key(c))
+            {
+                continue;
+            }
             let frem_var = frem_ov.as_ref().and_then(|o| o.get(j)).and_then(|x| *x);
             // FREM covariate pseudo-observations predict a covariate *value* (any
             // real: centered/standardized/log-scale covariates are routinely ≤ 0),

--- a/tests/dose_compartment_routing.rs
+++ b/tests/dose_compartment_routing.rs
@@ -76,6 +76,14 @@ fn pop_of(csv: &str) -> Population {
     read_nonmem_csv(f.path(), None, None).expect("dataset loads")
 }
 
+/// Like [`pop_of`] but reads `iov` as the occasion column (`Subject::occasions` /
+/// `dose_occasions`), so an IOV (`kappa`) model exercises the per-occasion funnels.
+#[cfg(feature = "survival")]
+fn pop_of_iov(csv: &str, iov: &str) -> Population {
+    let f = write_csv(csv);
+    read_nonmem_csv(f.path(), None, Some(iov)).expect("dataset loads")
+}
+
 const OBS_ROWS: &str = "1,1,5.0,0,.,2,.,0,70\n1,4,4.0,0,.,2,.,0,72\n1,8,3.0,0,.,2,.,0,74\n";
 
 /// `RATE>0` into CMT=3 — the oral **peripheral**. This is the original #375
@@ -341,6 +349,206 @@ fn a_tte_only_subject_of_a_pk_tte_dataset_is_still_validated() {
         diags.iter().any(|d| d.code == "E_DOSE_CMT_OUT_OF_RANGE"),
         "the TTE-only subject's out-of-range dose must still be caught: {diags:?}"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  #905: the dose-compartment exemption skips the *check* for a pure-TTE population,
+//  but `dose_needs_event_walk` still reroutes a `CMT ≥ 2` dose onto the event-driven
+//  walk, whose out-of-range guard is a `panic!`. The fix makes the predictor decline
+//  in lockstep with the exemption: `subject_feeds_analytical_pk` is false for every
+//  subject of such a population, so the value path (`compute_predictions_with_tv_*`)
+//  and the gradient path (`subject_routes_to_event_walk`) both return without
+//  entering the walk. Verified through BOTH loaders — model-blind `read_nonmem_csv`
+//  (TTE rows land in `obs_times`, the walk would run) and endpoint-routed
+//  `read_population_for` (TTE rows land in `obs_records`, `obs_times` empty).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The committed form of the adversarial-review repro
+/// `pure_tte_subject_with_a_high_cmt_dose_still_predicts` (surfaced by PR #896).
+/// Model-blind load: the TTE event at `CMT=2` is read as a Gaussian observation into
+/// `obs_times`, and the `CMT=2` dose is out of range for the placeholder
+/// `one_cpt_iv`. Before #905 `predict()` panicked from deep in the event-driven walk
+/// ("dose into compartment 2 but model has 1 states"); now the predictor declines
+/// and reports `NaN` for the (non-Gaussian) row.
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_high_cmt_dose_predicts_without_panicking_model_blind() {
+    let model = model_of(TTE_ONLY);
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    // The obs row really is in the Gaussian grid on this loader — otherwise the test
+    // would pass vacuously (the panic needs `n_obs > 0`).
+    assert_eq!(
+        pop.subjects[0].obs_times,
+        vec![5.0],
+        "model-blind loader keeps the TTE row in obs_times (the reachable path)"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert_eq!(preds.len(), 1);
+    assert!(
+        preds[0].pred.is_nan(),
+        "the analytical predictor declines a subject with no Gaussian obs, got {}",
+        preds[0].pred
+    );
+}
+
+/// `simulate()` on the same model-blind population must not panic either (it shares
+/// the value funnel). The drawn DV for the declined row is `NaN`; the contract under
+/// test is "no panic".
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_high_cmt_dose_simulates_without_panicking_model_blind() {
+    let model = model_of(TTE_ONLY);
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    let sim = simulate(&model, &pop, &model.default_params, 1);
+    // One row (the CMT=2 obs kept in the Gaussian grid), with a NaN individual
+    // prediction — the predictor declined it. The ban is on panics; this pins the
+    // decline so the test fails if the gate is reverted (the panic path).
+    assert_eq!(sim.len(), 1, "simulate returns one row without panicking");
+    assert!(
+        sim[0].ipred.is_nan(),
+        "declined ipred is NaN, got {}",
+        sim[0].ipred
+    );
+}
+
+/// `fit()` on the same model-blind population must not panic — the gradient path
+/// (`subject_routes_to_event_walk`) declines the event-driven walk in lockstep with
+/// the value path, avoiding the `sens::propagate` twin panic. The **contract under
+/// test is strictly "no panic"**: a model-blind load cannot fit the TTE data (it
+/// never reached `obs_records`, so there is no TTE term), and the outer FOCEI OFV is
+/// a degenerate `NaN` that the covariance step declines cleanly — but the process
+/// must not abort. A *correct* TTE fit requires the endpoint-routed loader. Kept fast
+/// (Tier 2): a single outer iteration, no convergence loop. Reverting either gate
+/// makes this panic in the event-driven walk, so the test fails.
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_high_cmt_dose_fit_does_not_panic_model_blind() {
+    let model = model_of(TTE_ONLY);
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    let opts = FitOptions {
+        outer_maxiter: 1,
+        ..FitOptions::default()
+    };
+    // A panic (either gate reverted → the walk runs on the out-of-range dose) fails
+    // the test; reaching the assertion means the run completed without aborting.
+    let _ = fit(&model, &pop, &model.default_params, &opts);
+}
+
+/// The endpoint-routed loader (`read_population_for`, the path `fit_from_files` uses)
+/// moves the `CMT=2` TTE event into `obs_records`, leaving `obs_times` empty — so the
+/// walk's `n_obs == 0` early-return already made this path safe, and it stays safe.
+/// This is the "reachable through both loaders" half of the #905 validation.
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_high_cmt_dose_is_safe_through_the_routed_loader() {
+    let model = model_of(TTE_ONLY);
+    let csv = write_csv("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    let (pop, _) = ferx_core::api::read_population_for(
+        &model,
+        &None,
+        csv.path().to_str().expect("utf-8 path"),
+        None,
+        None,
+        None,
+        &[],
+    )
+    .expect("routed load succeeds");
+    assert!(
+        pop.subjects[0].obs_times.is_empty(),
+        "the TTE row is routed to obs_records, not the Gaussian grid"
+    );
+    let preds = predict(&model, &pop, &model.default_params);
+    assert!(
+        preds.is_empty(),
+        "no Gaussian rows remain to predict on the routed load: {preds:?}"
+    );
+}
+
+/// **Over-fire guard** (#905). The gate must NOT decline a subject that *does* carry a
+/// Gaussian observation, even on a model that also has a TTE endpoint — otherwise the
+/// fix would silently turn working PK predictions into `NaN`. This is the exact
+/// regression a one-CMT typo in `subject_feeds_analytical_pk` would introduce, and the
+/// decline tests above would not catch it (they assert `NaN`). Gaussian PK obs at
+/// CMT=1 (not the endpoint's CMT=2), in-range dose → finite prediction.
+#[cfg(feature = "survival")]
+#[test]
+fn a_gaussian_bearing_subject_on_a_tte_model_still_predicts_finite() {
+    let model = model_of(TTE_ONLY);
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,1,1\n1,3,4.2,0,.,1,0\n");
+    let preds = predict(&model, &pop, &model.default_params);
+    assert_eq!(preds.len(), 1);
+    assert!(
+        preds[0].pred.is_finite() && preds[0].pred > 0.0,
+        "a subject with a Gaussian obs must not be declined by the #905 gate, got {}",
+        preds[0].pred
+    );
+}
+
+/// The IOV (`n_kappa > 0`) prediction and sensitivity funnels — `predict_iov` and the
+/// IOV analytic sensitivity providers — are structural peers of the non-IOV funnel and
+/// must decline the exempt subject in lockstep. Surfaced by the PR #924 adversarial
+/// review: the original fix gated only the non-IOV path, so an analytical IOV model
+/// still panicked in the walk (value: `event_driven.rs`; gradient: `sens/propagate.rs`).
+/// Same placeholder + TTE endpoint as `TTE_ONLY`, plus a per-occasion `kappa` on CL.
+#[cfg(feature = "survival")]
+const TTE_ONLY_IOV: &str = r#"
+[parameters]
+  theta TVLAMBDA(0.05, 0.001, 5.0)
+  theta DUMMY_CL(1.0, 0.01, 100.0)
+  theta DUMMY_V(10.0, 0.1, 1000.0)
+  omega ETA_LAMBDA ~ 0.0
+  kappa KAPPA_CL ~ 0.01
+  sigma SIGMA_DV ~ 0.1
+
+[individual_parameters]
+  LAMBDA = TVLAMBDA * exp(ETA_LAMBDA)
+  CL     = DUMMY_CL * exp(KAPPA_CL)
+  V      = DUMMY_V
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ additive(SIGMA_DV)
+
+[event_model]
+  cmt    = 2
+  family = exponential
+  scale  = LAMBDA
+"#;
+
+/// IOV value twin: `simulate()` routes to `predict_iov` when `n_kappa > 0`. Before the
+/// #924 IOV fix this panicked at `event_driven.rs:785` on the CMT=2 dose (no OCC needed
+/// — `predict_iov` runs with empty `kappas`).
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_iov_high_cmt_dose_simulates_without_panicking() {
+    let model = model_of(TTE_ONLY_IOV);
+    assert_eq!(model.n_kappa, 1, "fixture must exercise the IOV funnel");
+    let pop = pop_of("ID,TIME,DV,EVID,AMT,CMT,MDV\n1,0,.,1,100,2,1\n1,5,1,0,.,2,0\n");
+    let sim = simulate(&model, &pop, &model.default_params, 1);
+    assert_eq!(sim.len(), 1, "IOV simulate returns without panicking");
+}
+
+/// IOV gradient twin: with occasions populated (`OCC` + `iov_column`), `fit()` reaches
+/// the IOV inner analytic gradient (`subject_eta_grad_iov_analytical`), whose walk has
+/// the same dose-routing panic (`sens/propagate.rs:1408`). The existing
+/// `subject_has_survival_records` guard misses the model-blind load (TTE rows in
+/// `obs_times`, `obs_records` empty), so the #924 IOV gate is what fences it off. No
+/// panic is the contract; reverting either IOV gate makes this panic.
+#[cfg(feature = "survival")]
+#[test]
+fn pure_tte_iov_high_cmt_dose_fit_does_not_panic() {
+    let model = model_of(TTE_ONLY_IOV);
+    let pop = pop_of_iov(
+        "ID,TIME,DV,EVID,AMT,CMT,MDV,OCC\n1,0,.,1,100,2,1,1\n1,5,1,0,.,2,0,1\n",
+        "OCC",
+    );
+    let opts = FitOptions {
+        outer_maxiter: 1,
+        ..FitOptions::default()
+    };
+    let _ = fit(&model, &pop, &model.default_params, &opts);
 }
 
 /// A bolus into the same peripheral compartment is *not* rejected — the walk


### PR DESCRIPTION
## Why

A pure-TTE / pure-discrete population aborts the process on a `CMT ≥ 2` dose. Such a
population is **exempt** from dose-compartment validation (`check_dose_compartments`
via `population_uses_analytical_pk`) — its `[structural_model]` is a placeholder
`one_cpt_iv` with dummy `CL`/`V`, and its TTE endpoint's `CMT` is routinely ≥ 2, so
range-checking the dose against the 1-compartment placeholder would reject perfectly
good data. But the **predictor** did not know about that exemption:
`dose_needs_event_walk` still reroutes any `cmt != 1` bolus onto the event-driven
walk, whose out-of-range guard is a `panic!`. So the validator declined to check a
dose that the walk then aborted on (#905).

Reproduced on `main` (adversarial review of PR #896):

```
pk_model = OneCptIv;  obs_times = [5.0];  obs_cmts = [2]
panicked at src/pk/event_driven.rs:785 — "dose into compartment 2 but model has 1 states"
```

Reachable when the population is loaded model-blind (`read_nonmem_csv`, no endpoint
routing → TTE rows land in `obs_times`, so `n_obs > 0` and the walk runs). The
endpoint-routed loader (`read_population_for`, what `fit_from_files` uses) was safe by
accident — it routes TTE rows into `obs_records`, leaving `obs_times` empty, so the
walk's `n_obs == 0` early-return fired. The exemption's safety rested on a guard in a
different module it never referenced.

## What changed

**The predictor now declines in lockstep with the exemption** (issue option 4). One
shared per-subject predicate owns the invariant:

- **`pk::subject_feeds_analytical_pk(model, subject)`** — true iff the subject has a
  Gaussian observation (an obs whose CMT is not a registered non-Gaussian endpoint) or
  a pk-only prediction time. `validation::population_uses_analytical_pk` is now
  `subjects.any(...)` of it — single source of truth.
- **Value gate** — `compute_predictions_with_tv_into_with_schedule` (the one funnel
  behind predict / simulate / likelihood / sdtab / postfit) returns `vec![NaN; n_obs]`
  when `ode_spec.is_none() && !subject_feeds_analytical_pk`, before reaching the walk.
- **Gradient gate** — `sens::provider::subject_routes_to_event_walk` returns `false`
  for the same condition, so FOCE/FOCEI never enters the walk's `sens` twin
  (`propagate::active_rates_g` / the bolus `cmt_idx` guard, both of which `panic!` the
  same way). Load-bearing, not cosmetic: on a model-blind `fit()` the gradient step
  hits the twin panic independently of the value path.
- **IOV twins** — IOV models (`n_kappa > 0`) route through *separate* funnels
  (`pk::predict_iov` for value; `subject_sensitivities_iov` /
  `subject_eta_grad_iov_analytical` for the gradient), which do not consult
  `subject_routes_to_event_walk`. The same decline is added to all three, keyed on the
  same predicate. (The routed loader already declines these via the existing
  `subject_has_survival_records` gate; this only fires on the model-blind loader.)
- **Residual skip** — the Gaussian residual loops in `individual_nll_into_with_schedule`
  and `obs_nll_subject_from_preds` (the SAEM/IS twin) skip an observation whose CMT is a
  non-Gaussian endpoint (no-op on the routed path; keeps a model-blind `NaN` pred from
  poisoning the inner NLL).
- The `check_dose_compartments` exemption comment now states the safety explicitly.

**Why the per-subject gate is safe within `ode_spec.is_none()`:** nothing but a
Gaussian observation consumes the analytical predictor there. A hazard that reads a
concentration is written `hazard = <expr>`, which the parser turns into a synthesised
`__chz` ODE state (`prescan_ode_hazards`) → forces `ode_spec = Some`; every hazard left
on an analytical model is a closed-form `HazardSpec::Analytic` over `(θ, η, cov)`. A
binary/categorical linear predictor is `LinearPredictorFn = Fn(θ, η, cov) -> f64` — no
concentration. So a subject with no Gaussian obs feeds the predictor nothing.

## Alternatives considered

- **Range-check exempt populations anyway** — rejects legitimate TTE data (the
  placeholder has `n_states = 1`, the endpoint's `CMT` ≥ 2). The exemption exists to
  prevent exactly this.
- **Teach `dose_needs_event_walk` the exemption** — it takes `(PkModel, &Subject)`; wiring
  the population's endpoints through it means a signature change across 6 call sites, and
  is the wrong layer.
- **Make the walk's guard non-fatal** — reintroduces the silent dose-dropping #375 removed.
- **Route non-Gaussian obs out of `obs_times` on the in-memory path** (make model-blind ==
  file-load) — stronger (also fixes the latent Gaussian-misclassification), but needs
  reconstructing `ObsRecord`s and is larger than this bug warrants. Deferred.

## Scope / known limitation

The fix guarantees **panic-free on every path**, and **correct on the endpoint-routed
path**. A model-blind `fit()` of a pure-TTE population still cannot fit the TTE data (it
never reached `obs_records`), so its outer FOCEI OFV is a degenerate `NaN` and the
covariance step declines cleanly — no abort. A correct TTE fit requires
`read_population_for` / `fit_from_files`. This is inherent to the model-blind reader, not
a regression.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API signature changed (`subject_feeds_analytical_pk` is `pub(crate)`;
`compute_predictions_with_tv*` bodies only). ferx-r unaffected, no pin bump.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable — this is an error-channel fix, not a numerical path (per the issue:
  "No NONMEM anchor needed"). The routed path's numbers are unchanged (the gate returns the
  same empty `preds` the `n_obs == 0` early-return already produced).

## Performance
- [x] No significant impact expected — one `ode_spec.is_none()` + predicate check per
  prediction call; the predicate short-circuits on `endpoints.is_empty()` (every plain PK
  model), so non-survival builds and ordinary PK models pay a single bool.

## Tests
- [x] Unit test (`sens/provider_tests.rs::tte_only_subject_declines_the_event_walk_gradient`)
  pins the non-IOV gradient gate directly.
- [x] Regression tests that fail without this fix (`tests/dose_compartment_routing.rs`):
  pure-TTE `CMT ≥ 2` dose × predict / simulate / fit, through **both** `read_nonmem_csv`
  and `read_population_for`; the same for the **IOV** funnel (`simulate` + `fit` with `OCC`);
  plus a **positive control** (a Gaussian-bearing subject on a TTE model still predicts
  finite — the gate must not over-fire).
- [x] All new tests **mutation-verified**: reverting each gate makes its test panic —
  value `event_driven.rs:785`, non-IOV gradient (unit-assert flips), IOV value
  `event_driven.rs:785`, IOV gradient `propagate.rs:1408`.
- Full lib suite `--features survival`: **2823 / 0**. Integration
  `dose_compartment_routing --features survival`: **28 / 0**. No-`survival`
  `cargo check --tests` clean. Existing exemption tests stay green.

The IOV funnel gap (item above) was found by an adversarial (xhigh) review of this PR
and fixed in the same change.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added (#905).
- [x] No new DSL / fit option / output field → no `docs/` page change.

## Reviewer hints

The load-bearing claim is *"on an analytical model nothing but a Gaussian observation
consumes the predictor"* — see `subject_feeds_analytical_pk`'s doc. If that held only for
hazards but not for binary/CTMM linear predictors, the value gate would silently kill a
conc-driven discrete endpoint; it holds because `LinearPredictorFn` has no concentration
argument and a conc-driven hazard/intensity forces `ode_spec = Some` (out of the gate's
domain). The gradient gate mirrors the value gate exactly — they must agree or FOCE would
differentiate a different dosing history than it predicted.

## Open questions

Whether to also do the heavier "route non-Gaussian obs out of `obs_times` on the in-memory
path" so a model-blind `fit()` becomes *correct* (not just panic-free). Deferred here as
out of scope for the crash fix.
