### PR TITLE
feat(sim): compose a pre-scheduled base regimen with system resets (EVID=3/4) in adaptive dosing [closes #932]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,23 @@ section of the SDLC for the versioning policy).
   `init(state)=expr`) and turns off controller-issued infusions opened before it, exactly
   as `predict()` / `simulate()` do, and the default-on frozen-replay verifier is
   reset-aware so the reset is validated each run. Previously a reset subject was rejected
-  with a typed error. (An EVID=4 reset+dose row is still rejected by the dose-free-base
-  rule, so only pure EVID=3 resets reach the adaptive path.)
+  with a typed error. (Initially only a pure EVID=3 reset on a **dose-free** base subject;
+  #932 below lifts that to a reset combined with a base regimen, including an EVID=4
+  reset+dose row.)
+- **Base regimen combined with a system reset (EVID=3 / EVID=4) in adaptive-dosing
+  simulation** (#932). `simulate_adaptive()` / `simulate_adaptive_from_spec()` now accept a
+  base subject that carries BOTH a pre-scheduled loading / maintenance regimen (#702) AND a
+  system reset — composing #716's reset machinery with #702's base-dose seeding on the
+  constant-covariate path. The reset zeros the compartments and turns off a base infusion
+  opened before it (the reset floor, previously applied only to controller-issued infusions),
+  and an EVID=4 reset+dose row's dose now reaches the adaptive path — landing after its own
+  reset (Reset < Dose) — instead of tripping the base-regimen guard. Validated by a degenerate
+  oracle (base regimen + mid-horizon EVID=3 + controller reproduces `predict()` on the realized
+  regimen carrying the same reset), a positive control (a base infusion spanning the reset is
+  turned off, so the oracle is not vacuous), an EVID=4 oracle, and a steady-state base × reset
+  oracle; the default-on frozen-replay verifier (reset- and base-aware) checks every run. Lifts
+  the #702/#716 `base × reset` restriction. Base × reset UNDER a time-varying covariate (#930)
+  or IOV (#931) remains a typed error — a #932 follow-up — never a silent mis-integration.
 - **Warning when a `combined` error model's additive initial estimate is negligibly
   small** (#847). A pre-fit check (`W_ADDITIVE_INIT_SCALE`) flags an additive SD start
   below 1% of the observation scale (median `|DV|`) on that endpoint. A near-zero

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -360,11 +360,15 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   bioavailability `F` is resolved from its own snapshot — the covariate active at, and (under IOV)
   the occasion κ of, the dose's administration time (symmetric with a controller dose, whose `F` is
   fixed at injection) — and which is then integrated under the per-segment PK, matching independent
-  mrgsolve loading-dose runs (renal-decline #930, per-occasion κ #931). Still a typed error, never a
-  silent mis-integration of a delivered dose: a base regimen combined with system resets (EVID=3/4,
-  #932), and — under a time-varying covariate or IOV — a steady-state, lagged, built-in input-rate,
-  or modeled-`RATE` base dose (a #930 / #931 follow-up whose per-dose SS / lag / input-rate /
-  rate-resolution bookkeeping the frozen-replay engine does not yet reproduce).
+  mrgsolve loading-dose runs (renal-decline #930, per-occasion κ #931). A base regimen also
+  **composes with system resets** (EVID=3/4) on the constant-covariate path (since #932): the reset
+  zeros the state and turns off a base infusion opened before it, and an EVID=4 reset+dose row's dose
+  lands after its own reset — see *System resets* below. Still a typed error, never a silent
+  mis-integration of a delivered dose: a base regimen combined with a system reset **under a
+  time-varying covariate or IOV** (a #932 follow-up), and — under a time-varying covariate or IOV — a
+  steady-state, lagged, built-in input-rate, or modeled-`RATE` base dose (a #930 / #931 follow-up
+  whose per-dose SS / lag / input-rate / rate-resolution bookkeeping the frozen-replay engine does
+  not yet reproduce).
 - **Time-varying covariates are supported** — the driver recomputes PK per
   event/segment from the covariate active in that segment (the NONMEM
   end-of-interval convention that `predict()` / `simulate()` use), so a covariate
@@ -378,10 +382,12 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   compartments at each reset time (re-seeding any `init(state)=expr`) and turns off
   controller-issued infusions opened before the reset, exactly as `predict()` /
   `simulate()` do on the event-driven path; the frozen-replay verifier is
-  reset-aware, so the reset is honored *and* checked each run. (An EVID=4 reset+dose
-  row carries a dose, so a reset-carrying subject with doses is rejected by the
-  base-regimen combo guard — base × reset is a #702 follow-up — and only pure EVID=3
-  resets on a dose-free base reach the adaptive path.) *Caveat:* declaring `auc_target` on a reset
+  reset-aware, so the reset is honored *and* checked each run. Since #932 a reset also composes with a
+  **pre-scheduled base regimen** on the constant-covariate path: it zeros the base regimen's state and
+  turns off a base infusion opened before it (the reset floor), and an **EVID=4** reset+dose row —
+  which records both a reset and a dose — reaches the adaptive path as a base dose landing *after* its
+  own reset (Reset < Dose), matching `predict()`. Base × reset under a time-varying covariate or IOV
+  stays a typed error (a #932 follow-up). *Caveat:* declaring `auc_target` on a reset
   subject is a typed error — the exposure metric's uniform per-window trapezoid grid
   has no node at the reset instant, so the one window straddling the reset would
   integrate the state discontinuity inaccurately (every other output is reset-aware).

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -193,8 +193,11 @@ pub struct AdaptiveSimulationResult {
 /// - **Pre-scheduled base regimen (#702).** A subject MAY carry pre-scheduled doses
 ///   (a loading / maintenance regimen), which are integrated and augmented by the
 ///   controller. Supported on constant-covariate, time-varying-covariate (#930), and
-///   IOV (#931) models (non-reset); a base regimen combined with a system reset
-///   (EVID=3/4) is a typed error (#932). A steady-state / lagged / built-in-input-rate
+///   IOV (#931) models. Since #932 a base regimen also composes with system resets
+///   (EVID=3/4) on the constant-covariate path (the reset zeros the state and turns off a
+///   base infusion opened before it, and an EVID=4 reset+dose row's dose lands after its own
+///   reset); base × reset under a time-varying covariate or IOV is still a typed error (a
+///   #932 follow-up). A steady-state / lagged / built-in-input-rate
 ///   base dose is supported on the constant-covariate path (#719); under a time-varying
 ///   covariate or IOV those (and a modeled-`RATE` dose) are a typed error — a #930/#931
 ///   follow-up. A dose-free subject is the fully controller-driven special case.

--- a/src/api/tests/adaptive_sim_tests.rs
+++ b/src/api/tests/adaptive_sim_tests.rs
@@ -2191,7 +2191,43 @@ fn adaptive_base_regimen_with_reset_under_iov_is_rejected() {
     )
     .expect_err("base × reset under IOV must be rejected");
     assert!(
-        err.contains("system resets") && err.contains("constant-covariate"),
+        err.contains("system resets") && err.contains("constant-covariate path only"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn adaptive_base_regimen_with_reset_under_tv_covariate_is_rejected() {
+    // #932 scope boundary (the TV-covariate half, distinct from the IOV half above): base ×
+    // reset is supported on the constant-covariate path, but under a TIME-VARYING covariate it
+    // stays a typed error — the per-event-PK replay's reset+base composition is not yet oracle-
+    // verified. A plain bolus base dose under a TV covariate is otherwise supported (#930), so
+    // the reset is what trips the guard. This pins the `&& tv` boundary on the TV-cov path
+    // specifically: a regression to `&& iov` would silently ACCEPT this (iov=false, tv=true),
+    // routing it through the un-oracle-verified TV replay with every other test still green.
+    let model = parse_model_string(ODE_TV_COV).expect("parse TV-cov ODE model");
+    let mut s = subj(
+        "1",
+        vec![6.0, 30.0],
+        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)], // plain bolus (supported under TV alone)
+    );
+    s.reset_times = vec![12.0];
+    s.covariates = HashMap::from([("CRCL".to_string(), 100.0)]);
+    s.obs_covariates = vec![
+        HashMap::from([("CRCL".to_string(), 100.0)]),
+        HashMap::from([("CRCL".to_string(), 80.0)]),
+    ];
+    let mut pop = population(vec![s]);
+    pop.covariate_names = vec!["CRCL".to_string()];
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(1),
+        decision_times: vec![0.0, 24.0],
+        ..Default::default()
+    };
+    let err = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
+        .expect_err("base × reset under a time-varying covariate must be rejected");
+    assert!(
+        err.contains("system resets") && err.contains("constant-covariate path only"),
         "got: {err}"
     );
 }

--- a/src/api/tests/adaptive_sim_tests.rs
+++ b/src/api/tests/adaptive_sim_tests.rs
@@ -1894,25 +1894,304 @@ fn adaptive_base_multiple_doses_across_occasions_pass_verifiers() {
 }
 
 #[test]
-fn adaptive_base_regimen_with_reset_is_rejected() {
-    // #702 scope: base regimen × system reset (EVID=3/4) is a typed error. An EVID=4
-    // (reset+dose) subject carries doses, so it lands here rather than on the reset path.
-    let model = parse_model_string(ODE_NO_IIV).expect("parse");
+fn adaptive_base_regimen_with_reset_matches_static_predict() {
+    // Degenerate oracle for #932: a pre-scheduled base regimen (a loading dose) combined
+    // with a mid-horizon EVID=3 system reset and a fixed-dose controller must reproduce the
+    // trusted static engine — `predict()`, which routes reset subjects to the reset-aware
+    // event-driven walker — on the realized (base ∪ controller) regimen carrying the same
+    // reset. The model is η-invariant, so the adaptive IPRED equals the η=0 static PRED.
+    //
+    // This composes #702's base-dose seeding with #716's reset machinery on the constant-
+    // covariate path: the base 500 mg at t=0 drives the pre-reset observations (t=6, t=30),
+    // the reset at t=36 zeros that mass (t=42 washes out), and the controller's 100 mg at
+    // t=48 drives the post-reset tail (t=54). The default-on frozen-replay verifier (reset-
+    // and base-aware) runs too, so its Ok is part of this assertion.
+    let model = parse_model_string(ODE_NO_IIV).expect("parse no-IIV ODE model");
+    let decisions = vec![24.0, 48.0];
+    let obs = vec![6.0, 30.0, 42.0, 54.0];
+    let reset_at = 36.0;
+    let base_dose = DoseEvent::new(0.0, 500.0, 1, 0.0, false, 0.0);
+
+    let mut base = subj("1", obs.clone(), vec![base_dose.clone()]);
+    base.reset_times = vec![reset_at];
+    let pop = population(vec![base]);
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(7),
+        decision_times: decisions.clone(),
+        ..Default::default() // verify = true
+    };
+    let res = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
+        .expect("adaptive base+reset sim runs and passes the reset-aware verifier");
+    assert_eq!(
+        res.ledger.len(),
+        2,
+        "a controller bolus at each of the two decisions"
+    );
+
+    // Static reference: the base regimen + the realized controller doses pre-scheduled on a
+    // subject carrying the same reset, scored by predict() (η=0, event-driven, reset honored).
+    let mut static_doses = vec![base_dose];
+    static_doses.extend(
+        res.ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0)),
+    );
+    let mut static_subject = subj("1", obs.clone(), static_doses);
+    static_subject.reset_times = vec![reset_at];
+    let preds = predict(
+        &model,
+        &population(vec![static_subject]),
+        &model.default_params,
+    );
+
+    assert_eq!(res.trajectories.len(), obs.len());
+    for (traj, pred) in res.trajectories.iter().zip(preds.iter()) {
+        assert!(
+            (traj.ipred - pred.pred).abs() <= 1e-6 + 1e-4 * pred.pred.abs(),
+            "adaptive IPRED {} != static predict {} at t={} (base 500@0, reset at {reset_at})",
+            traj.ipred,
+            pred.pred,
+            traj.time
+        );
+    }
+}
+
+#[test]
+fn adaptive_base_infusion_spanning_reset_is_turned_off() {
+    // Positive control for #932 (the issue's non-vacuity proof): a PRE-SCHEDULED base infusion
+    // spanning a reset must be turned OFF at the reset by the reset floor — exactly as it turns
+    // off a controller-issued infusion (#716). The same base infusion run with vs without the
+    // reset must diverge (so the degenerate oracle above is not two engines agreeing on an
+    // un-reset trajectory), and the with-reset run must still reproduce predict() on that base
+    // infusion carrying the reset.
+    let model = parse_model_string(ODE_NO_IIV).expect("parse no-IIV ODE model");
+    let decisions = vec![36.0]; // one late decision; the controller only holds
+    let obs = vec![6.0, 18.0, 30.0];
+    let reset_at = 12.0;
+    // Base infusion: 2400 units at rate 100/h ⇒ a 24 h window [0, 24] spanning the reset at 12.
+    let base_inf = DoseEvent::new(0.0, 2400.0, 1, 100.0, false, 0.0);
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(5),
+        decision_times: decisions.clone(),
+        ..Default::default()
+    };
+
+    let mut with_reset = subj("1", obs.clone(), vec![base_inf.clone()]);
+    with_reset.reset_times = vec![reset_at];
+    let res = simulate_adaptive(
+        &model,
+        &population(vec![with_reset]),
+        &model.default_params,
+        1,
+        hold_all,
+        &opts,
+    )
+    .expect("base infusion + reset runs and passes the reset-aware verifier");
+    assert!(res.ledger.is_empty(), "the hold controller issues no doses");
+
+    // Non-vacuity: without the reset the infusion keeps delivering past 12, so t=18 is
+    // materially positive; with the reset it is turned off at 12 and the zeroed state stays ~0.
+    let no_reset = subj("1", obs.clone(), vec![base_inf.clone()]);
+    let res_no = simulate_adaptive(
+        &model,
+        &population(vec![no_reset]),
+        &model.default_params,
+        1,
+        hold_all,
+        &opts,
+    )
+    .expect("no-reset run");
+    let y18 = res
+        .trajectories
+        .iter()
+        .find(|x| (x.time - 18.0).abs() < 1e-12)
+        .expect("t=18 row (with reset)")
+        .ipred;
+    let y18_no = res_no
+        .trajectories
+        .iter()
+        .find(|x| (x.time - 18.0).abs() < 1e-12)
+        .expect("t=18 row (no reset)")
+        .ipred;
+    assert!(
+        y18_no > 10.0 && y18 < 1e-6,
+        "reset must turn the base infusion off: with-reset {y18} (want ~0) vs no-reset {y18_no} (want ≫0)"
+    );
+
+    // Oracle: the with-reset run reproduces predict() on the same base infusion + reset.
+    let mut static_subject = subj("1", obs.clone(), vec![base_inf]);
+    static_subject.reset_times = vec![reset_at];
+    let preds = predict(
+        &model,
+        &population(vec![static_subject]),
+        &model.default_params,
+    );
+    for (traj, pred) in res.trajectories.iter().zip(preds.iter()) {
+        assert!(
+            (traj.ipred - pred.pred).abs() <= 1e-6 + 1e-4 * pred.pred.abs(),
+            "adaptive IPRED {} != static predict {} at t={} (base infusion spanning reset)",
+            traj.ipred,
+            pred.pred,
+            traj.time
+        );
+    }
+}
+
+#[test]
+fn adaptive_evid4_reset_plus_dose_matches_static_predict() {
+    // #932 EVID=4 (reset + dose): a data row that both zeros the state and administers a dose
+    // records BOTH a `reset_times` entry and a `doses` entry at the same instant, so its dose
+    // is a base dose landing exactly at the reset — zeroed first (Reset < Dose), then applied.
+    // Today that dose tripped the base-regimen combo guard before the reset was considered; it
+    // must now reach the adaptive path and reproduce predict() (which sorts Reset < Dose too).
+    let model = parse_model_string(ODE_NO_IIV).expect("parse no-IIV ODE model");
+    let decisions = vec![24.0];
+    let obs = vec![6.0, 18.0, 30.0];
+    let reset_at = 12.0;
+    // A loading dose the reset wipes, plus the EVID=4 dose (300 mg at the reset instant).
+    let loading = DoseEvent::new(0.0, 500.0, 1, 0.0, false, 0.0);
+    let evid4_dose = DoseEvent::new(reset_at, 300.0, 1, 0.0, false, 0.0);
+
+    let mut base = subj("1", obs.clone(), vec![loading.clone(), evid4_dose.clone()]);
+    base.reset_times = vec![reset_at];
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(7),
+        decision_times: decisions.clone(),
+        ..Default::default()
+    };
+    let res = simulate_adaptive(
+        &model,
+        &population(vec![base]),
+        &model.default_params,
+        1,
+        fixed_bolus,
+        &opts,
+    )
+    .expect("EVID=4 (reset+dose) reaches the adaptive path and passes the verifier");
+    assert_eq!(res.ledger.len(), 1, "one controller bolus at t=24");
+
+    // The EVID=4 dose survives its own reset: t=18 reads 300·exp(-0.1·6) ≈ 165, not ~0 (which
+    // a reset that also wiped its coincident dose would give).
+    let y18 = res
+        .trajectories
+        .iter()
+        .find(|x| (x.time - 18.0).abs() < 1e-12)
+        .expect("t=18 row")
+        .ipred;
+    assert!(
+        y18 > 100.0,
+        "the EVID=4 dose must land AFTER its coincident reset (t=18 ≈ 165), got {y18}"
+    );
+
+    let mut static_doses = vec![loading, evid4_dose];
+    static_doses.extend(
+        res.ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0)),
+    );
+    let mut static_subject = subj("1", obs.clone(), static_doses);
+    static_subject.reset_times = vec![reset_at];
+    let preds = predict(
+        &model,
+        &population(vec![static_subject]),
+        &model.default_params,
+    );
+    for (traj, pred) in res.trajectories.iter().zip(preds.iter()) {
+        assert!(
+            (traj.ipred - pred.pred).abs() <= 1e-6 + 1e-4 * pred.pred.abs(),
+            "adaptive IPRED {} != static predict {} at t={} (EVID=4 reset+dose)",
+            traj.ipred,
+            pred.pred,
+            traj.time
+        );
+    }
+}
+
+#[test]
+fn adaptive_ss_base_dose_with_reset_matches_static_predict() {
+    // #932 gate: a steady-state base dose (SS=1, II>0) pre-equilibrated at t=0, then wiped by a
+    // mid-horizon reset, must still reproduce predict() on the same (SS base ∪ ledger) regimen
+    // carrying the reset. Exercises `equilibrate_ss_state` seeding BEFORE the reset zeros it —
+    // the reset floor then keeps the equilibrated tail from re-contributing. (If this ever
+    // diverged, #932 would narrow to reject SS × reset; it holds, so SS base × reset is in.)
+    let model = parse_model_string(ODE_NO_IIV).expect("parse no-IIV ODE model");
+    let decisions = vec![0.0, 24.0];
+    let obs = vec![1.0, 8.0, 20.0];
+    let reset_at = 12.0;
+    let ss = DoseEvent::new(0.0, 300.0, 1, 0.0, true, 24.0); // 300 mg q24h at steady state
+
+    let mut base = subj("1", obs.clone(), vec![ss.clone()]);
+    base.reset_times = vec![reset_at];
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(9),
+        decision_times: decisions.clone(),
+        ..Default::default()
+    };
+    let res = simulate_adaptive(
+        &model,
+        &population(vec![base]),
+        &model.default_params,
+        1,
+        fixed_bolus,
+        &opts,
+    )
+    .expect("SS base dose + reset runs and passes the reset-aware verifier");
+    assert_eq!(res.ledger.len(), 2, "a controller bolus at each decision");
+
+    let mut static_doses = vec![ss];
+    static_doses.extend(
+        res.ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0)),
+    );
+    let mut static_subject = subj("1", obs.clone(), static_doses);
+    static_subject.reset_times = vec![reset_at];
+    let preds = predict(
+        &model,
+        &population(vec![static_subject]),
+        &model.default_params,
+    );
+    for (traj, pred) in res.trajectories.iter().zip(preds.iter()) {
+        assert!(
+            (traj.ipred - pred.pred).abs() <= 1e-6 + 1e-4 * pred.pred.abs(),
+            "adaptive IPRED {} != static predict {} at t={} (SS base dose × reset)",
+            traj.ipred,
+            pred.pred,
+            traj.time
+        );
+    }
+}
+
+#[test]
+fn adaptive_base_regimen_with_reset_under_iov_is_rejected() {
+    // #932 scope boundary: base × reset is supported on the constant-covariate path, but under
+    // inter-occasion variability (or a time-varying covariate) it stays a typed error — the
+    // per-event-PK replay's reset+base composition is not yet oracle-verified, so it must
+    // loud-fail rather than risk a silent mis-integration (a #932 follow-up). IOV sets
+    // `event_pk`/`eta_occ` = Some, so the driver's `&& tv` guard fires.
+    let model = parse_model_string(ODE_IOV).expect("parse IOV ODE model");
     let mut s = subj(
         "1",
         vec![6.0, 30.0],
         vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
     );
     s.reset_times = vec![12.0];
-    let pop = population(vec![s]);
     let opts = AdaptiveSimulateOptions {
+        seed: Some(1),
         decision_times: vec![0.0, 24.0],
         ..Default::default()
     };
-    let err = simulate_adaptive(&model, &pop, &model.default_params, 1, fixed_bolus, &opts)
-        .expect_err("base regimen × reset must be rejected");
+    let err = simulate_adaptive(
+        &model,
+        &population(vec![s]),
+        &model.default_params,
+        1,
+        fixed_bolus,
+        &opts,
+    )
+    .expect_err("base × reset under IOV must be rejected");
     assert!(
-        err.contains("base regimen") && err.contains("system resets"),
+        err.contains("system resets") && err.contains("constant-covariate"),
         "got: {err}"
     );
 }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2912,8 +2912,9 @@ pub(crate) fn ode_predictions_adaptive_impl(
     // On the (common) dose-free path `resolve_subject_doses` borrows `subject` unchanged,
     // `n_base == 0`, and both vectors are empty — so every base-regimen branch below is a
     // no-op and the reactive path stays byte-identical. When base doses ARE present, only a
-    // base × reset subject is rejected upstream; the constant-covariate path governs both the
-    // base and controller doses with this single frozen `pk_params_flat`, while the
+    // base × reset subject UNDER a time-varying covariate / IOV is rejected upstream; the
+    // constant-covariate path governs both the base and controller doses with this single
+    // frozen `pk_params_flat`, while the
     // per-event-PK path (a time-varying covariate #930 and/or IOV #931) overwrites each base
     // dose's F per-occasion from `event_pk.dose[k]` in the block ~40 lines below.
     let resolved_base = resolve_subject_doses(subject, &ode.dose_attr_map, pk_params_flat);
@@ -3109,10 +3110,11 @@ pub(crate) fn ode_predictions_adaptive_impl(
         break_times.extend(shadow.pk_only_times.iter().cloned());
     }
     // System-reset times (EVID=3/4, #716): each is a segment boundary where the state
-    // zeros. Only pure EVID=3 resets reach here — an EVID=4 (reset+dose) row carries a
-    // dose, so a reset-carrying subject with doses is rejected by the base-regimen combo
-    // guard (#702) above (base × reset is a follow-up). Empty for a reset-free subject,
-    // so the bolus-only path stays byte-identical.
+    // zeros. Since #932 a base regimen reaches here alongside its resets on the constant-
+    // covariate path — including an EVID=4 (reset+dose) row, whose dose is a base dose
+    // landing at the reset instant (Reset < Dose). Only base × reset UNDER a time-varying
+    // covariate / IOV is rejected by the guard above. Empty for a reset-free subject, so
+    // the bolus-only path stays byte-identical.
     break_times.extend(subject.reset_times.iter().copied());
     // #702/#930: fold in the pre-scheduled base regimen's breaks via the shared builder so the
     // reactive segmentation matches the static engine's exactly (the frozen-replay oracle).
@@ -3278,8 +3280,12 @@ pub(crate) fn ode_predictions_adaptive_impl(
         // pre-dose (the true trough), symmetric with the controller's own doses (#933 —
         // previously the base bolus landed here, before the hook, and the controller read
         // the post-dose peak). No-op on the dose-free path and for non-SS base doses;
-        // constant path only (`pk_params_flat` is the frozen snapshot, and a base × reset
-        // combo is rejected above so no reset intervenes).
+        // constant path only (`pk_params_flat` is the frozen snapshot). Since #932 a reset MAY
+        // intervene on the constant path — it zeroed `u` earlier in this same break iteration
+        // (Reset < Dose). Correct regardless: this reseed fires only at an SS base dose's own
+        // landing time and `copy_from_slice`s the SS equilibrium/tail, re-establishing steady
+        // state independent of prior state, so a just-applied reset is correctly superseded; the
+        // static engine applies reset-then-reseed in the same order.
         if n_base > 0 {
             reseed_prescheduled_states_at(
                 &mut u,
@@ -3730,9 +3736,10 @@ pub(crate) fn ode_predictions_adaptive_impl(
 /// the driver still breaks at them, so the realized ledger alone cannot
 /// reconstruct the segmentation.
 ///
-/// `base_subject` is the dose-free subject the run was driven from; its
-/// observation grid (and any covariates) carry over, only `doses` are replaced
-/// with the realized ledger. The ledger stores nominal `amt`/`rate`
+/// `base_subject` is the subject the run was driven from — its pre-scheduled base
+/// regimen (doses / reset_times, if any) survives on it (#702/#932); its observation
+/// grid (and any covariates) carry over, and the realized ledger doses are appended
+/// after the base doses. The ledger stores nominal `amt`/`rate`
 /// (pre-bioavailability), exactly as a `subject.doses` entry, so `F`/lag re-apply
 /// downstream identically.
 #[allow(clippy::too_many_arguments)]

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2864,21 +2864,28 @@ pub(crate) fn ode_predictions_adaptive_impl(
     let iov = eta_occ.is_some();
 
     // --- Preconditions (typed errors, never silent) ----------------------
-    // #702/#930/#931: a pre-scheduled base regimen (loading / maintenance dose) IS supported
-    // on the constant-covariate path (the controller augments it), on the time-varying-
-    // covariate path (#930), and — since #931 — under inter-occasion variability (each base
-    // dose's F resolved from its own occasion-κ / covariate snapshot just below). It is not
-    // yet supported together with system resets (#932 — state-zeroing across a base dose):
-    // that threads per-reset bookkeeping the base-dose seeding and the frozen-replay verifier
-    // do not yet reproduce, so loud-fail rather than silently mis-integrate a delivered dose.
-    // (An EVID=4 reset+dose row carries a dose, so a reset-carrying subject with base doses
-    // lands here rather than on the reset path — base × IOV × reset stays rejected too.)
-    if !subject.doses.is_empty() && subject.has_resets() {
+    // #702/#930/#931/#932: a pre-scheduled base regimen (loading / maintenance dose) IS
+    // supported on the constant-covariate path (the controller augments it), on the time-
+    // varying-covariate path (#930), and — since #931 — under inter-occasion variability (each
+    // base dose's F resolved from its own occasion-κ / covariate snapshot just below). Since
+    // #932 it composes with system resets (EVID=3/4) on the CONSTANT-covariate path: the reset
+    // zeros the state and lowers `reset_floor` (which already turns off base infusions opened
+    // before it — they live in `shadow.doses`, gated by `active_infusions`), and both the
+    // reset-aware static verifier (`ode_predictions_with_extra_breaks`) and the reference
+    // event-driven engine apply Reset < Dose identically, so the degenerate oracle holds.
+    // (An EVID=4 reset+dose row records BOTH a reset and a dose, so its dose is just a base
+    // dose landing at the reset instant — zeroed, then re-applied — reaching this path.)
+    //
+    // Base × reset UNDER a time-varying covariate or IOV (`tv`) stays a typed error: the
+    // per-event-PK replay (`adaptive_frozen_replay_tv`) is itself reset-aware, but its
+    // composition with a base regimen across a reset is not yet oracle-verified against the
+    // reference, so loud-fail rather than risk a silent mis-integration (a #932 follow-up).
+    if !subject.doses.is_empty() && subject.has_resets() && tv {
         return Err(
-            "ode_predictions_adaptive: a pre-scheduled base regimen is not yet supported \
-             together with system resets (EVID=3/4); issues #702/#930/#931 support a base \
-             regimen on constant-covariate, time-varying-covariate, and IOV models \
-             (non-reset) only"
+            "ode_predictions_adaptive: a pre-scheduled base regimen combined with system \
+             resets (EVID=3/4) is not yet supported under time-varying covariates or \
+             inter-occasion variability; #932 supports base × reset on the constant-covariate \
+             path only (time-varying-covariate / IOV base × reset is a follow-up)"
                 .to_string(),
         );
     }

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -2207,35 +2207,52 @@ fn adaptive_base_dose_with_lagtime_matches_static_ode() {
 }
 
 #[test]
-fn adaptive_base_regimen_with_reset_is_rejected_driver() {
-    // #702 scope (driver level): tv/iov are off here (event_pk/eta_occ = None), but a base
-    // regimen on a reset-carrying subject still hits the combo guard via `has_resets()` —
-    // never a silent integration that ignores the reset.
+fn adaptive_base_regimen_with_reset_matches_static_ode_driver() {
+    // #932 driver-level oracle (constant covariates, tv/iov off): a base loading regimen on a
+    // reset-carrying subject now integrates — the reset zeros the state and lowers the reset
+    // floor — and must reproduce `ode_predictions` (itself reset-aware) on the realized
+    // (base ∪ ledger) regimen carrying the same reset. On-grid decisions keep the two engines'
+    // segmentation identical, so the match is bit-tight. (Base × reset UNDER a time-varying
+    // covariate / IOV — `event_pk`/`eta_occ` = Some — stays a typed error; that boundary is
+    // covered by `adaptive_base_regimen_with_reset_under_iov_is_rejected`.)
     let ode = one_cpt_ode_spec();
     let pk = pk_one(1.0, 10.0);
-    let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
-    let mut base = make_subject(
-        vec![DoseEvent::new(0.0, 50.0, 1, 0.0, false, 0.0)],
-        vec![1.0],
-    );
-    base.reset_times = vec![12.0];
-    let err = ode_predictions_adaptive(
+    let decisions = [24.0];
+    let obs = vec![6.0, 18.0, 30.0];
+    let reset_at = 12.0;
+    let loading = vec![DoseEvent::new(0.0, 500.0, 1, 0.0, false, 0.0)];
+
+    let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+    let mut base = make_subject(loading.clone(), obs.clone());
+    base.reset_times = vec![reset_at];
+    let run = ode_predictions_adaptive(
         &ode,
         &pk.values,
         &[],
         &[],
         &base,
-        &[0.0],
+        &decisions,
         &[],
         &mut controller,
         100,
         None,
     )
-    .unwrap_err();
-    assert!(
-        err.contains("base regimen") && err.contains("system resets"),
-        "got: {err}"
+    .expect("driver runs with a base regimen across a reset");
+    assert_eq!(run.ledger.len(), 1, "one controller bolus at t=24");
+
+    let mut static_doses = loading;
+    static_doses.extend(
+        run.ledger
+            .iter()
+            .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0)),
     );
+    let mut static_subject = make_subject(static_doses, obs);
+    static_subject.reset_times = vec![reset_at];
+    let static_preds = ode_predictions(&ode, &pk.values, &[], &[], &static_subject);
+    assert_eq!(run.predictions.len(), static_preds.len());
+    for (got, want) in run.predictions.iter().zip(static_preds.iter()) {
+        assert_relative_eq!(*got, *want, max_relative = 1e-9);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

Follow-up to #702. A pre-scheduled **base regimen** combined with a **system reset**
(EVID=3, or an EVID=4 reset+dose row) was a typed error in `ode_predictions_adaptive_impl`
— the base-regimen combo guard rejected the pair before the reset was ever considered. This
composes #716's reset-aware machinery with #702's base-dose seeding so a subject can start on
a fixed loading/maintenance regimen, carry a mid-horizon reset (a washout, a new course), and
still be titrated by the controller — the real TDM/MIPD case. Tracked under #702 / #391.

## What changed

The core turned out to be a **single guard line**: the reactive driver, the reset-aware
static verifier (`ode_predictions_with_extra_breaks`), and the reference event-driven engine
already compose base doses with resets — base doses live in `shadow.doses`, so `active_infusions`
already gates a base infusion by the `reset_floor`, and all three engines apply `Reset < Dose`
at a shared instant. The combo guard was the sole over-conservative barrier.

- Narrowed the guard from `!subject.doses.is_empty() && subject.has_resets()` to
  `… && tv`: base × reset is now supported on the **constant-covariate** path; under a
  time-varying covariate or IOV (`event_pk`/`eta_occ = Some`) it stays a typed error.
- **EVID=4** (reset+dose) records *both* a `reset_times` entry and a `doses` entry, with no
  marker distinguishing its dose from a #702 base dose — so it previously tripped the same
  guard. It now flows through as a base dose landing at the reset instant (zeroed first, then
  applied), matching `predict()`.

## Alternatives considered

- **Enable TV/IOV base × reset in this PR too.** The per-event-PK replay (`adaptive_frozen_replay_tv`)
  *is* reset-aware, so it nearly works — but its composition with a base regimen across a reset
  is not yet oracle-verified against the reference. Deferred as a follow-up, matching the
  one-axis-per-PR discipline of #930/#931.
- **Reject SS base × reset up front.** Gated it on the oracle instead; the SS × reset oracle
  passes (both engines treat an SS dose as re-establishing its own equilibrium), so it is in
  scope rather than rejected.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change — `simulate_adaptive` / `simulate_adaptive_from_spec` signatures are
unchanged; only the set of inputs they accept without erroring widened.

## Breaking changes
- [x] None

## Numerical validation

Per CLAUDE.md, adaptive/feedback dosing does **not** anchor against NONMEM (NONMEM has no native
feedback dosing). Validated instead with degenerate oracles + the default-on frozen-schedule
replay verifier (the internal dose-bookkeeping anchor), all in `src/api/tests/adaptive_sim_tests.rs`:

- **Degenerate oracle** — base 500 mg loading + mid-horizon EVID=3 reset + fixed controller
  reproduces `predict()` (which routes reset subjects to the event-driven walker) on the realized
  (base ∪ ledger) regimen carrying the same reset.
- **Positive control** — a base *infusion* spanning the reset is turned off at the reset (t=18
  reads ~0 vs ≫0 without the reset), so the oracle is not two engines agreeing on an un-reset run.
- **EVID=4 oracle** — a reset+dose row reaches the path and its dose lands *after* its own reset.
- **SS base × reset oracle** — a steady-state base dose wiped by a mid-horizon reset still matches.
- **Boundary** — base × reset under IOV is still rejected with a typed error.

- [x] Compared against: prior ferx engine (`predict()` / event-driven) + frozen-replay verifier
- [x] Full lib suite: `cargo test --lib` → **2746 passed, 0 failed, 18 ignored**

## Performance
- [x] No significant impact expected (one added boolean term in a precondition)

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix (the two prior `…_is_rejected` tests were
  converted to oracles; they fail against the un-narrowed guard)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added; also corrected #716's now-stale "EVID=4 still
  rejected" note. `simulate_adaptive` rustdoc updated.
- [x] `docs/model-file/adaptive-dosing.qmd` updated — the *Pre-scheduled base regimens* and
  *System resets (EVID=3)* bullets now describe base × reset composing on the constant-covariate
  path (EVID=3/4), with time-varying-covariate / IOV base × reset still a typed error. (An earlier
  revision of this PR wrongly claimed there was no dedicated page.)

## Checklist
- [x] `cargo clippy` clean (only pre-existing `src/bin/generate_data.rs` dev-bin warnings)
- [x] Not on the `Dual2` sensitivity path (adaptive driver is `f64`-only)
- [x] No `Cargo.toml` version bump (non-breaking)

## Example (user-facing features only)
- [x] Not a standalone file — programmatic API. Sketch:

```rust
// Base subject: a 500 mg loading dose at t=0 AND a system reset at t=36.
let mut base = subject_with_doses(vec![DoseEvent::new(0.0, 500.0, 1, 0.0, false, 0.0)]);
base.reset_times = vec![36.0];                     // EVID=3 washout mid-horizon
let opts = AdaptiveSimulateOptions { decision_times: vec![24.0, 48.0], ..Default::default() };
// Previously: Err("… base regimen … not yet supported together with system resets …").
// Now: the reset zeros the state, the controller keeps titrating, the frozen-replay verifier passes.
let res = simulate_adaptive(&model, &pop, &params, 1, controller, &opts)?;
```

### Example execution
- [x] No example execution step needed (programmatic adaptive API; no `.ferx` / CLI / data change)

## Reviewer hints

- The whole production change is the guard at `ode_predictions_adaptive_impl` (`src/ode/predictions.rs`)
  — narrowed to `&& tv`. Everything else is tests + docs.
- Worth a look: the `&& tv` boundary (IOV implies `tv`, so both TV-covariate and IOV are caught —
  see `adaptive_base_regimen_with_reset_under_iov_is_rejected`), and the SS × reset gate decision.

## Open questions

- Fast-follow to lift base × reset under a time-varying covariate / IOV? The replay is already
  reset-aware; it needs the base+reset oracle on the per-event-PK path before the guard drops `&& tv`.

