### PR TITLE
fix(sim): integrate the pre-scheduled base regimen in the adaptive auc_target window-AUC pass [closes #940]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ section of the SDLC for the versioning policy).
   for any external code that constructs or exhaustively destructures these variants.
 
 ### Fixed
+- **Adaptive-dosing `auc_target` exposure metric now integrates the pre-scheduled base regimen**
+  (#940). The signal-AUC pass behind `auc_target_attainment` (#391 S2.5b) previously scored each
+  decision window on the controller's realized doses only, dropping any pre-scheduled base regimen
+  (#702 — a loading / maintenance dose), so on a base-regimen run the reported exposure — and hence
+  `auc_target_attainment` — was biased low. Each window now integrates the base regimen (a loading
+  dose before the window and a maintenance dose landing inside it) alongside the realized ledger,
+  matching `predict()` / `simulate()` on the combined regimen. Constant-covariate subjects only, as
+  before (time-varying-covariate / IOV / reset `auc_target` runs remain rejected).
 - **FOCE inner EBE recovery no longer discards a near-optimal partial for a worse fallback**
   (#378). When a subject's individual objective is multimodal (e.g. a 3-cpt IV proportional
   model with six IIV etas conditioned on ten points), the closed-form inner BFGS can reach the

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -53,7 +53,7 @@ with the run, never with a fitted model's parameters.
 | `confirm` | | Debounce: act only after this many *consecutive* matches of the same rule (default `1` = act on the first breach). |
 | `levels` | | Discrete titration ladder `[d1, d2, …]` (oncology). With `levels`, bare `increase`/`decrease` step one rung; without it, use `increase N%` / `decrease N%`. |
 | `target_window` | | Therapeutic band `[low, high]` for the monitored signal, used **only** to report the `pct_time_in_window` outcome metric — it does **not** influence dosing (the `when` rules do). `high` may be `inf` for a one-sided "at or above `low`" target. Omit it to leave `pct_time_in_window` unreported, rather than guessing a band from the rule thresholds. |
-| `auc_target` | | Exposure band `[low, high]` for the **area under the monitored signal** over each inter-decision window (e.g. vancomycin AUC₂₄ when decisions are daily), used **only** to report the `auc_target_attainment` outcome metric — like `target_window` it does **not** influence dosing. `low` must be `≥ 0`; `high` may be `inf`. Declaring it turns on a signal-AUC pass that re-integrates the realized doses on a dense grid; omit it to skip that pass and leave `auc_target_attainment` unreported. |
+| `auc_target` | | Exposure band `[low, high]` for the **area under the monitored signal** over each inter-decision window (e.g. vancomycin AUC₂₄ when decisions are daily), used **only** to report the `auc_target_attainment` outcome metric — like `target_window` it does **not** influence dosing. `low` must be `≥ 0`; `high` may be `inf`. Declaring it turns on a signal-AUC pass that re-integrates any pre-scheduled base regimen (#702) together with the realized controller doses on a dense grid; omit it to skip that pass and leave `auc_target_attainment` unreported. |
 | `with_assay_error` | signal¹ | Titrate on the **noised measurement** of a model output (named by `assay_cmt`) instead of a latent expression (default `false`). The signal's value comes from that output's `[scaling]` readout and its σ from that output's `[error_model]`, so the two are always on the same scale — there is no re-typed `observe` expression to mis-scale. Mutually exclusive with `observe`. |
 | `assay_cmt` | | The 1-based compartment of the model output measured under `with_assay_error` — its `[scaling]` readout is the signal value and its `[error_model]` σ the noise. **Required** with `with_assay_error`. |
 
@@ -345,7 +345,12 @@ slow-gated `tests/adaptive_vanco_anchor.rs` (nightly + on push to `main`).
   through the same dose-resolution, break-timeline, and steady-state machinery as
   `predict()` / `simulate()`, and they appear in the controller's dose `history`; the
   frozen-replay verifier rebuilds the base regimen alongside the realized ledger, so the
-  pre-scheduled + reactive bookkeeping is checked bit-for-bit each run.
+  pre-scheduled + reactive bookkeeping is checked bit-for-bit each run. The `auc_target`
+  exposure metric likewise integrates the base regimen: each window's AUC covers the base
+  doses — a loading dose before the first window and a maintenance dose landing inside a
+  window alike — not just the controller's, so `auc_target_attainment` is not biased low on a
+  base-regimen run (constant-covariate; the time-varying / IOV / reset `auc_target` caveats
+  below are unchanged).
   A base dose that **shares a time with a decision is observed pre-dose** (the trough),
   symmetric with the controller's own doses — the controller reads the level *before* the
   scheduled dose lands, then that dose is applied (#933); for a steady-state base dose the

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -4123,8 +4123,14 @@ const ADAPTIVE_AUC_PANELS: usize = 128;
 /// jump of ≈ ½·Δsignal·(window ⁄ panels) for an instantaneous (bolus) dose (an
 /// infusion delivers ≈0 at its start instant and is unaffected, but the convention
 /// must be correct for both). So each window is solved against a static subject that
-/// drops every dose after `a` — future doses cannot affect `[a, b]`, so this is
-/// exact — leaving `b` a plain pre-dose decay point.
+/// keeps only the doses **before** `b` (`time < b`), leaving `b` a plain pre-dose
+/// decay point. Controller doses sit on the decision grid (window edges), so for them
+/// `time < b` is exactly "at or before `a`" and the window is integrated exactly. A
+/// pre-scheduled base maintenance dose (#702) may instead land strictly inside
+/// `(a, b)`; it is kept — dropping it would under-count this window's exposure — and
+/// is integrated exactly for an infusion / absorption input (whose signal stays
+/// continuous), with only the same ≈ ½·Δsignal·(window ⁄ panels) node-placement error
+/// as above for the rarer instantaneous bolus into the monitored compartment.
 ///
 /// **Cost — `O(m²)`, deliberately.** This is one dense solve per window, and
 /// because [`ode_dense_solve_states`] always starts from `t = 0` (it cannot resume
@@ -4146,11 +4152,15 @@ const ADAPTIVE_AUC_PANELS: usize = 128;
 /// path), else the model's `monitor_cmt` readout (the `Dv` path's underlying
 /// latent — the AUC is always over the un-noised signal, never the assay draw).
 ///
-/// `base_subject` is the dose-free subject the run was driven from; only its doses
-/// are replaced (its covariates carry over). This pass uses a **single** PK snapshot
-/// (`pk_params_flat`), exact only for constant-covariate subjects — a time-varying
-/// (or TIME-in-PK) subject with an `auc_target` is rejected upstream in
-/// `run_adaptive_population` (#700), so it never reaches here.
+/// `base_subject` carries the run's covariates **and** any pre-scheduled base regimen
+/// (#702 — a loading / maintenance dose on `subject.doses`): each window is integrated
+/// against those base doses (kept via clone, so their `SS`/lagtime/infusion attributes
+/// carry over) plus the controller's realized ledger doses, restricted per the window
+/// composition below. On the dose-free path `base_subject.doses` is empty, so this is
+/// the prior ledger-only rebuild. This pass uses a **single** PK snapshot
+/// (`pk_params_flat`), exact only for constant-covariate subjects — a time-varying (or
+/// TIME-in-PK) or IOV subject with an `auc_target` is rejected upstream in
+/// `run_adaptive_population` (#700/#701), so it never reaches here.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn adaptive_window_signal_aucs(
     ode: &OdeSpec,
@@ -4173,23 +4183,38 @@ pub(crate) fn adaptive_window_signal_aucs(
     let cov = &base_subject.covariates;
 
     // One closed window at a time (see "Window convention" above): integrate
-    // `[a, b]` against a static subject carrying only the doses at or before the
-    // window's left edge `a`, so the dose at the right edge `b` (the next window's)
-    // never folds into this window's endpoint.
+    // `[a, b]` against a static subject carrying the base regimen and ledger doses
+    // that can influence this window — everything before the right edge `b` (see the
+    // per-window composition below) — so the dose at `b` (the next window's) never
+    // folds into this window's endpoint.
     (0..m - 1)
         .map(|k| {
             let (a, b) = (decision_times[k], decision_times[k + 1]);
 
-            // Doses at or before `a` (nominal amt/rate; F/lag re-apply downstream
-            // exactly as for a scheduled dose). A dose exactly at `a` is THIS
-            // window's own dose and is kept; the `1e-9` only guards float equality
-            // at the boundary, far below any real decision spacing.
+            // Compose the window's static regimen exactly as
+            // [`verify_adaptive_frozen_replay`] does: the pre-scheduled base regimen
+            // (#702) — CLONED, so each base dose's `SS`/`II`/lagtime/modeled-`RATE`/
+            // infusion attributes survive (a `DoseEvent::new` rebuild would silently
+            // reset them to a plain `Fixed` bolus) — followed by the controller's
+            // realized ledger doses, then restricted to the doses that can influence
+            // this window. A dose strictly after the right edge `b` cannot affect
+            // `[a, b]` (causality); the dose *at* `b` is the next window's left-edge
+            // dose, whose post-dose jump would otherwise fold into this window's right
+            // endpoint ([`ode_dense_solve_states`] saves the post-dose state at a save
+            // point on a dose time). Both are dropped by `time < b`; doses at or before
+            // `a` (state setup) and any base maintenance dose strictly inside `(a, b)`
+            // are kept. Controller doses sit on the decision grid (= window edges), so
+            // for them `time < b` is byte-identical to the old `<= a` — the pure-
+            // controller path is unchanged; only a base regimen (previously dropped by
+            // the `sub.doses = ledger` overwrite) is now integrated. The `1e-9` guards
+            // float equality at `b`, far below any real decision spacing.
             let mut sub = base_subject.clone();
-            sub.doses = ledger
-                .iter()
-                .filter(|e| e.time <= a + 1e-9)
-                .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0))
-                .collect();
+            sub.doses.extend(
+                ledger
+                    .iter()
+                    .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0)),
+            );
+            sub.doses.retain(|d| d.time < b - 1e-9);
 
             // The window's own uniform sub-grid: `panels + 1` points, `grid[0] == a`
             // (post-dose) and `grid[panels] == b` (pre-dose decay).

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -414,6 +414,136 @@ fn adaptive_window_signal_aucs_excludes_boundary_dose() {
     assert_relative_eq!(aucs[1], w1, max_relative = 1e-4);
 }
 
+/// Regression: the metrics-only signal-AUC pass must integrate the pre-scheduled
+/// **base regimen** (#702), not just the controller's realized ledger. The earlier
+/// `sub.doses = ledger` overwrite dropped any loading / maintenance dose carried on
+/// `base_subject.doses`, silently under-counting the exposure behind
+/// `auc_target_attainment`. Here a base IV loading bolus at t = 0 precedes the first
+/// decision window `[24, 48]`, so its decayed contribution to the post-dose amount at
+/// t = 24 must appear in that window's AUC.
+#[test]
+fn adaptive_window_signal_aucs_includes_base_loading_dose() {
+    let ode = one_cpt_ode_spec(); // readout = central amount, RHS = -ke·y
+    let pk = pk_one(10.0, 100.0); // ke = CL/V = 0.1
+    let (ke, d_base, d_ctrl) = (0.1_f64, 200.0_f64, 100.0_f64);
+
+    // Base regimen: a loading bolus at t=0, carried on the SUBJECT (not the ledger).
+    let with_base = make_subject(
+        vec![DoseEvent::new(0.0, d_base, 1, 0.0, false, 0.0)],
+        vec![],
+    );
+    // Controller decisions at 24, 48 ⇒ one window [24, 48]; a controller bolus at 24.
+    let ledger = vec![ledger_bolus(24.0, d_ctrl, 1)];
+    let decisions = [24.0, 48.0];
+
+    let aucs = adaptive_window_signal_aucs(
+        &ode,
+        &pk.values,
+        &[],
+        &[],
+        &with_base,
+        &decisions,
+        &ledger,
+        None,
+        1,
+    );
+    assert_eq!(aucs.len(), 1);
+
+    // Degenerate oracle: post-dose amount at 24⁺ is the base bolus decayed from t=0
+    // PLUS the fresh controller bolus, and the window then decays smoothly (no dose at
+    // 48), so the closed form is exact. A(24⁺) = D_base·e^{−24ke} + D_ctrl.
+    let a24 = d_base * (-ke * 24.0).exp() + d_ctrl;
+    let want = (a24 / ke) * (1.0 - (-ke * 24.0).exp());
+    assert_relative_eq!(aucs[0], want, max_relative = 1e-4);
+
+    // Positive control (non-vacuous): a dose-free base — the pre-fix behaviour, where
+    // only the ledger survived — leaves just the controller bolus and a materially
+    // smaller AUC. The base loading dose adds ≈ 18% here; assert the two differ well
+    // beyond any trapezoid / solver noise so the oracle above has real teeth.
+    let dose_free = make_subject(vec![], vec![]);
+    let without_base = adaptive_window_signal_aucs(
+        &ode,
+        &pk.values,
+        &[],
+        &[],
+        &dose_free,
+        &decisions,
+        &ledger,
+        None,
+        1,
+    );
+    let want_ctrl_only = (d_ctrl / ke) * (1.0 - (-ke * 24.0).exp());
+    assert_relative_eq!(without_base[0], want_ctrl_only, max_relative = 1e-4);
+    assert!(
+        aucs[0] > without_base[0] * 1.1,
+        "base loading dose not reflected: with-base {} vs ledger-only {}",
+        aucs[0],
+        without_base[0]
+    );
+}
+
+/// Regression: a base **maintenance** dose landing strictly INSIDE a decision window
+/// `(a, b)` — the common MIPD pattern of dosing more often than TDM sampling — must
+/// also be integrated (`time < b`, not `<= a`). Dropping it would under-count that
+/// window entirely. Here a base bolus at t = 12 sits inside the single window
+/// `[0, 24]`; the mutation `time <= a` (a = 0) would exclude it and collapse the
+/// with-base AUC onto the ledger-only value, which this test forbids.
+#[test]
+fn adaptive_window_signal_aucs_includes_mid_window_base_dose() {
+    let ode = one_cpt_ode_spec();
+    let pk = pk_one(10.0, 100.0); // ke = 0.1
+    let (ke, d_ctrl, d_mid) = (0.1_f64, 100.0_f64, 300.0_f64);
+
+    // Controller bolus at t=0 (decision at 0); base maintenance bolus at t=12.
+    let with_base = make_subject(
+        vec![DoseEvent::new(12.0, d_mid, 1, 0.0, false, 0.0)],
+        vec![],
+    );
+    let dose_free = make_subject(vec![], vec![]);
+    let ledger = vec![ledger_bolus(0.0, d_ctrl, 1)];
+    let decisions = [0.0, 24.0];
+
+    let call = |sub: &Subject| {
+        adaptive_window_signal_aucs(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            sub,
+            &decisions,
+            &ledger,
+            None,
+            1,
+        )
+    };
+    let with_ = call(&with_base);
+    let without = call(&dose_free);
+    assert_eq!(with_.len(), 1);
+
+    // Closed form, splitting at the mid-window bolus t=12:
+    //   ∫₀¹² D_ctrl·e^{−ke t} dt  +  ∫₁²²⁴ A(12⁺)·e^{−ke(t−12)} dt,
+    // with A(12⁺) = D_ctrl·e^{−12ke} + D_mid. The instantaneous bolus into the
+    // monitored compartment jumps the signal at an off-node instant, so the uniform
+    // 128-panel trapezoid carries the documented ≈ ½·Δ·(span⁄panels) node-placement
+    // bias (measured ≈ +0.94% here) — hence the looser band vs the smooth-decay cases
+    // above. The point is inclusion: dropping the base dose is a ~70% error, far
+    // outside this.
+    let a12_pre = d_ctrl * (-ke * 12.0).exp();
+    let a12_post = a12_pre + d_mid;
+    let seg = 1.0 - (-ke * 12.0).exp();
+    let want = (d_ctrl / ke) * seg + (a12_post / ke) * seg;
+    assert_relative_eq!(with_[0], want, max_relative = 2e-2);
+
+    // The mid-window base dose roughly triples this window's AUC; a `<= a` filter
+    // would drop it and make with == without. Demand a large, unambiguous gap.
+    assert!(
+        with_[0] > without[0] * 2.0,
+        "mid-window base dose not integrated: with-base {} vs ledger-only {}",
+        with_[0],
+        without[0]
+    );
+}
+
 /// Build the per-segment `obs_time -> indices` map the integrator uses.
 fn obs_index_map(obs_times: &[f64]) -> HashMap<u64, Vec<usize>> {
     let mut m: HashMap<u64, Vec<usize>> = HashMap::new();

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -544,6 +544,77 @@ fn adaptive_window_signal_aucs_includes_mid_window_base_dose() {
     );
 }
 
+/// A base **infusion** or **steady-state** dose must reach the AUC pass with its full
+/// attributes — the fix keeps base doses via `clone`, never a `DoseEvent::new` rebuild
+/// (which would flatten `ss`/`ii`/`rate` to a plain `Fixed` bolus). This verifies that
+/// "correct by construction" claim directly, rather than trusting it: both are
+/// integrated by the same `ode_dense_solve_states` machinery `predict()` uses, so the
+/// window AUC matches the closed form, and — critically — differs from the same total
+/// dose given as a plain t=0 bolus. Closes the coverage gap PR #942's bolus-only
+/// oracles left.
+#[test]
+fn adaptive_window_signal_aucs_preserves_ss_and_infusion_base_attrs() {
+    let ode = one_cpt_ode_spec(); // readout = central amount, RHS = -ke·y
+    let pk = pk_one(10.0, 100.0); // ke = 0.1
+    let ke = 0.1_f64;
+    let decisions = [24.0, 48.0]; // one window [24, 48], well after the base dose at 0
+    let ledger = vec![ledger_bolus(24.0, 100.0, 1)];
+    let call = |sub: &Subject| {
+        adaptive_window_signal_aucs(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            sub,
+            &decisions,
+            &ledger,
+            None,
+            1,
+        )
+    };
+
+    // --- Infusion base dose: amt=200 delivered over 20 h (rate=10) at t=0. Because it
+    // is spread over [0,20] rather than dumped at t=0, more drug survives to t=24 than
+    // an equal t=0 bolus would leave. A(24) decays from the end-of-infusion amount
+    // (R/ke)(1 − e^{−20ke}); the window [24,48] is then smooth decay past the ctrl bolus.
+    let inf = make_subject(
+        vec![DoseEvent::new(0.0, 200.0, 1, 10.0, false, 0.0)],
+        vec![],
+    );
+    let a20 = (10.0 / ke) * (1.0 - (-ke * 20.0).exp());
+    let a24_inf = a20 * (-ke * 4.0).exp() + 100.0;
+    let want_inf = (a24_inf / ke) * (1.0 - (-ke * 24.0).exp());
+    assert_relative_eq!(call(&inf)[0], want_inf, max_relative = 1e-3);
+    // Non-vacuous: the SAME 200 units as a plain t=0 bolus give a materially smaller
+    // AUC (≈ −25%). Running the function on both proves it honors the infusion (does
+    // not flatten it), not just that two closed forms differ.
+    let bolus200 = make_subject(vec![DoseEvent::new(0.0, 200.0, 1, 0.0, false, 0.0)], vec![]);
+    assert!(
+        call(&inf)[0] > call(&bolus200)[0] * 1.2,
+        "infusion base dose flattened to a bolus: inf {} vs bolus {}",
+        call(&inf)[0],
+        call(&bolus200)[0]
+    );
+
+    // --- Steady-state bolus base dose: amt=100, II=6, ss=true at t=0. The post-dose
+    // amount is the SS peak D/(1 − e^{−ke·II}) (equilibrate_ss_state trough + the
+    // record's bolus); a single SS record does not re-pulse, so it then decays plainly.
+    let ss = make_subject(vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 6.0)], vec![]);
+    let peak = 100.0 / (1.0 - (-ke * 6.0).exp());
+    let a24_ss = peak * (-ke * 24.0).exp() + 100.0;
+    let want_ss = (a24_ss / ke) * (1.0 - (-ke * 24.0).exp());
+    assert_relative_eq!(call(&ss)[0], want_ss, max_relative = 1e-3);
+    // Non-vacuous: dropping `ss` (a plain 100 bolus at t=0) omits the SS priming and
+    // gives a smaller AUC (≈ −9%), so the SS attribute is genuinely acted upon.
+    let bolus100 = make_subject(vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)], vec![]);
+    assert!(
+        call(&ss)[0] > call(&bolus100)[0] * 1.05,
+        "SS base dose treated as a plain bolus: ss {} vs bolus {}",
+        call(&ss)[0],
+        call(&bolus100)[0]
+    );
+}
+
 /// Build the per-segment `obs_time -> indices` map the integrator uses.
 fn obs_index_map(obs_times: &[f64]) -> HashMap<u64, Vec<usize>> {
     let mut m: HashMap<u64, Vec<usize>> = HashMap::new();


### PR DESCRIPTION
Closes #940.

## Why
`adaptive_window_signal_aucs` — the metrics-only signal-AUC pass behind `auc_target_attainment` (#391 S2.5b) — set its per-window static subject's doses to the controller **ledger only**, dropping any pre-scheduled base regimen (#702 — a loading / maintenance dose on `subject.doses`). On a base-regimen run combined with `auc_target`, the reported exposure — and hence `auc_target_attainment` — was biased low. Reachable on plain constant-covariate subjects: the `auc_target` guard (`api/adaptive.rs:411`) rejects only TV-cov / TIME-in-PK / IOV / reset, so a base-regimen subject slips through. `auc_target` is metrics-only (does not feed the controller), so the symptom is a misreported metric, not a control-loop error. Found during review of #939; out of scope there.

## What changed
- `adaptive_window_signal_aucs`: compose each window's static subject as base ∪ ledger, mirroring `verify_adaptive_frozen_replay` — base doses kept via `clone` (preserving `SS`/`II`/lag/`rate_mode`/infusion attributes a `DoseEvent::new` rebuild would strip), the ledger appended, then `retain(|d| d.time < b)`. `< b` also keeps a base maintenance dose landing strictly inside a window `(a, b)`; byte-identical to the old `<= a` for controller doses (which sit on decision-grid edges), so the pure-controller path is unchanged.
- Refreshed the pass's doc comments (window convention + the stale "dose-free subject" line, both pre-#702).
- Docs: `docs/model-file/adaptive-dosing.qmd` — the `auc_target` row and the base-regimen section now state the exposure metric integrates the base regimen.

## Alternatives considered
`<= a` (as first scoped in the issue) keeps only base doses at/before the window's left edge — correct for a loading dose, but still silently drops a base maintenance dose landing inside a window, a smaller variant of the same bug. `< b` fixes both at no cost on the controller path. The one residual is a ≈ ½·Δsignal·(window/panels) trapezoid node-placement bias for an *instantaneous bolus into the monitored compartment* landing mid-window (≈ 0.9 % in the test); zero for an infusion / absorption base dose (vancomycin, the canonical `auc_target` case, is infused → continuous), and far smaller than dropping the dose.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

(`adaptive_window_signal_aucs` is `pub(crate)`; no public API change.)

## Breaking changes
- [x] None

## Numerical validation
Adaptive dosing uses no NONMEM anchor (CLAUDE.md exception). Two Tier-1 degenerate-oracle tests, mutation-verified:
- `adaptive_window_signal_aucs_includes_base_loading_dose`: base IV loading bolus before the window; window AUC matched to the closed form to `1e-4`; positive control vs the dose-free subject (base adds ≈ 18 %).
- `adaptive_window_signal_aucs_includes_mid_window_base_dose`: base bolus strictly inside the window; AUC matched to closed form (2 % band — documented mid-window bolus node bias) and asserted ≫ ledger-only (ratio ≈ 3.3), which a `<= a` filter would collapse to 1.

Mutation results: reverting the fix (base dropped) fails both; flipping `< b`→`<= a` fails the mid-window test only, the loading test still passes.
- [x] Not NONMEM/nlmixr2 (adaptive-dosing exception)

## Performance
- [x] No significant impact expected (an extra `extend`+`retain` per window; the pass is already O(m²) and runs post-run only).

## Tests
- [x] Unit test(s) added (`cargo test --lib`: 2744 passed, 0 failed)
- [x] Regression test added that fails without this fix (mutation-verified)

## Docs
- [x] `docs/` updated for user-visible changes
- [x] `CHANGELOG.md` `[Unreleased]` Fixed entry added

## Checklist
- [x] `cargo clippy` clean on changed lines (CI invocation; the 4 `approx_constant` errors under `--tests` are pre-existing test code, off CI's clippy path)

## Reviewer hints
Focus on the window composition in `adaptive_window_signal_aucs`. SS / infusion base doses are covered by construction — cloning routes them through the same resolve / break-timeline / SS machinery as `predict()`; the tests use boluses for tight closed forms. The `< b` vs `<= a` choice is deliberate (see Alternatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
