### PR TITLE
perf(estimation): analytic posterior Hessian and analytic grid response for Laplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,22 @@ section of the SDLC for the versioning policy).
   through both the endpoint-routed and model-blind loaders.
 
 ### Performance
+- **`method = laplace` gradients are far more accurate, and its objective is faster.** The
+  posterior Hessian that scales the quadrature grid is now taken analytically — it is the exact
+  conditional `∂²nll/∂b²` the shared sensitivity sweep already assembles — instead of being
+  rebuilt by a `2d²+1` per-subject finite-difference sweep. The grid-response term of the
+  gradient likewise stopped re-sweeping the whole quadrature grid once per parameter: each
+  node's analytic `∂nll/∂b` is computed once and contracted against a node displacement
+  differenced from a cheap exact linear-algebra map. Between them these removed a
+  finite-difference *of* a finite-difference, and the gradient's agreement with a reconverged
+  finite difference of the objective improved by two to three orders of magnitude (warfarin:
+  `2.0e-5` → `6.5e-8` relative at `n_agq = 1`, `2.1e-7` → `1.8e-9` at `n_agq = 7`). The Hessian
+  change also speeds up every objective evaluation, and therefore the covariance step, which
+  evaluates it `~2·n_free²` times. Laplace OFVs and standard errors shift very slightly, since
+  the exact Hessian replaces an approximated one. `method = focei` is unaffected: the two
+  estimators still use **different** Hessians — that is what distinguishes them — and only the
+  computation is now shared. Models outside the analytic sensitivity scope (TTE, categorical)
+  keep the finite-difference path.
 - **Exact analytic inner (EBE) gradients for log-transform-both-sides under inter-occasion
   variability** (#486). Fitting a closed-form model that combines `log(DV) ~ additive(...)`
   with `[iov]` now uses exact analytic sensitivities for the per-subject empirical-Bayes

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -404,14 +404,26 @@ The fit output reports which route ran.
 
 ### Where AGQ stops
 
-AGQ's gradient is exact but **finite-difference-limited**: the grid-response term
-and the posterior Hessian are both central differences, so it carries a noise floor
-(~1e-4 relative). It therefore cannot drive `|g|` arbitrarily low the way an
-analytic-to-machine-precision gradient can.
+AGQ's gradient is exact but still **finite-difference-limited**, though far less so
+than it was. The posterior Hessian is now analytic — the exact conditional
+`∂²nll/∂b²` assembled by the same sensitivity sweep FOCEI's own gradient uses — and
+the grid-response term contracts each node's analytic `∂nll/∂b` against a node
+displacement differenced from a cheap *exact* linear-algebra map. What remains
+finite-differenced is `dH/dx`, which would need a third derivative (`∂³nll/∂η²∂θ`)
+to close.
+
+Removing the previous finite-difference-of-a-finite-difference dropped the noise
+floor by two to three orders of magnitude — measured against a reconverged
+finite-difference of the objective on warfarin, `6.5e-8` relative at `n_agq = 1` and
+`1.8e-9` at `n_agq = 7`, where the same test read `2.0e-5` and `2.1e-7` before. At
+that level the finite-difference *reference* is the inaccurate side, not the gradient.
 
 So AGQ stops on the **objective-change** criterion (`outer_ftol`, default 1e-6) and
 the step-size criterion (`outer_xtol`), not on a gradient norm. That is where its
-objective actually settles.
+objective actually settles. This is deliberately **unchanged** by the accuracy gain
+above: whether the tighter floor now makes a gradient-norm stop reachable is a
+separate question, and re-tuning a convergence criterion is not something to fold
+into a gradient change.
 
 This matters more than it sounds. FOCE/FOCEI are given a `1e-12` stop, which they can
 reach; giving the same to AGQ makes it *unreachable*, and an unreachable stop is not

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -344,18 +344,62 @@ fn fd_posterior_hessian(
     h
 }
 
+/// Both anchor Hessians, from **one** [`score_core`](crate::estimation::sens_outer_gradient::score_core)
+/// sweep. That function already assembles both matrices from a single provider evaluation:
+///
+/// * `htilde` = `H̃ = Ω⁻¹ + Σⱼ pⱼaⱼaⱼᵀ` — the first-order (Almquist) FOCEI Hessian; and
+/// * `h_inner` = `Ω⁻¹ + Σⱼ (∂²Lⱼ/∂f² aⱼaⱼᵀ + ∂Lⱼ/∂f Aⱼ)` — the **exact** conditional Hessian
+///   `∂²nll/∂b²`, which additionally carries the `∂²f/∂b²` term Gauss-Newton drops.
+///
+/// `None` when the model is outside the provider's scope, or `score_core` declines this
+/// subject at runtime (off-diagonal correlated residual, magnitude × M3-censored).
+fn score_core_at(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    stack: &Stack,
+    b_hat: &[f64],
+) -> Option<crate::estimation::sens_outer_gradient::ScoreCore> {
+    // The jet is the stacked (η, κ) one under IOV, so this serves both regimes.
+    let sens = if stack.is_iov() {
+        crate::sens::provider::subject_sensitivities_iov(model, subject, &params.theta, b_hat)?
+    } else {
+        crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b_hat)?
+    };
+    crate::estimation::sens_outer_gradient::score_core(
+        model,
+        subject,
+        params,
+        &sens,
+        stack.d(),
+        &stack.omega_joint_inv,
+        b_hat,
+        model.residual_error_eta,
+    )
+}
+
 /// The Hessian that scales the quadrature grid and enters `½log|H|`, per the anchor.
 ///
-/// * [`HessianAnchor::Exact`] → the exact conditional Hessian `∂²nll/∂b²`
-///   ([`fd_posterior_hessian`]). This is Laplace / adaptive GH quadrature.
-/// * [`HessianAnchor::GaussNewton`] → the Almquist `H̃ = Ω⁻¹ + Σ pⱼaⱼaⱼᵀ`, taken directly
-///   from [`sens_outer_gradient::score_core`] — the *same* Hessian FOCEI's own objective and
-///   gradient use, so `focei` with `n_agq > 1` is a genuine quadrature refinement of FOCEI.
+/// * [`HessianAnchor::Exact`] → the exact conditional Hessian `∂²nll/∂b²`. This is
+///   Laplace / adaptive GH quadrature. Taken **analytically** from `score_core`'s `h_inner`
+///   where the provider reaches, and from the `2d²+1`-evaluation
+///   [`fd_posterior_hessian`] sweep only outside it (TTE, categorical, and the two
+///   per-subject `score_core` declines) — where FD is the only thing that works, since the
+///   likelihood has no `PkNum` twin.
+/// * [`HessianAnchor::GaussNewton`] → the Almquist `H̃`, the *same* Hessian FOCEI's own
+///   objective and gradient use, so `focei` with `n_agq > 1` is a genuine quadrature
+///   refinement of FOCEI.
 ///
-/// Returns `None` when the anchor Hessian cannot be formed: an indefinite exact FD Hessian, or
-/// a Gauss-Newton anchor on a model outside the sensitivity provider's scope (the caller then
+/// **The two anchors stay different matrices — that is the estimator distinction.** Sharing
+/// `score_core` unifies the *computation*, not the result: `laplace, n_agq = 1` is NONMEM
+/// `LAPLACIAN INTER` and `focei, n_agq = 1` is plain FOCEI, and it is exactly the anchor that
+/// separates them. Reading `htilde` here for `Exact` would silently turn Laplace into FOCEI
+/// while it kept reporting Laplace OFVs.
+///
+/// Returns `None` when a Gauss-Newton anchor is out of the provider's scope (the caller then
 /// yields the NLL sentinel, and `api::check_model_options` rejects `focei, n_agq > 1` outside
-/// that scope up front so this does not surprise a fit at runtime).
+/// that scope up front so this does not surprise a fit at runtime). The `Exact` arm always
+/// yields a matrix, falling back to FD.
 fn anchor_hessian(
     anchor: HessianAnchor,
     model: &CompiledModel,
@@ -367,33 +411,22 @@ fn anchor_hessian(
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> Option<DMatrix<f64>> {
     match anchor {
-        HessianAnchor::Exact => Some(fd_posterior_hessian(
-            model, subject, params, stack, b_hat, scratch, schedule,
-        )),
+        HessianAnchor::Exact => {
+            // Gate on the **model-level** predicate before attempting the provider: an
+            // out-of-scope model (TTE, categorical — precisely the ones quadrature exists
+            // for) would otherwise pay a doomed `subject_sensitivities` + `score_core` call
+            // on every evaluation before falling back.
+            if analytic_score_supported(model) {
+                if let Some(core) = score_core_at(model, subject, params, stack, b_hat) {
+                    return Some(core.h_inner);
+                }
+            }
+            Some(fd_posterior_hessian(
+                model, subject, params, stack, b_hat, scratch, schedule,
+            ))
+        }
         HessianAnchor::GaussNewton => {
-            // `H̃ = Ω⁻¹ + Σ pⱼ aⱼaⱼᵀ`, exactly what `score_core` assembles for FOCEI. The jet
-            // is the stacked (η, κ) one under IOV, so this serves both regimes.
-            let sens = if stack.is_iov() {
-                crate::sens::provider::subject_sensitivities_iov(
-                    model,
-                    subject,
-                    &params.theta,
-                    b_hat,
-                )?
-            } else {
-                crate::sens::provider::subject_sensitivities(model, subject, &params.theta, b_hat)?
-            };
-            let core = crate::estimation::sens_outer_gradient::score_core(
-                model,
-                subject,
-                params,
-                &sens,
-                stack.d(),
-                &stack.omega_joint_inv,
-                b_hat,
-                model.residual_error_eta,
-            )?;
-            Some(core.htilde)
+            Some(score_core_at(model, subject, params, stack, b_hat)?.htilde)
         }
     }
 }
@@ -1039,12 +1072,36 @@ fn accumulate_fixed_eta_packed_gradient(
 ///
 /// A fully analytic `dH/dx` would need `∂³nll/∂η²∂θ`; the provider stops at `∂²f/∂η∂θ`, so
 /// this third order is finite-differenced. `analytic_gradient_matches_fd_at_every_node_count`
-/// measures the result against a finite-difference of the real objective: 0.17% at n = 1,
-/// 0.0006% at n = 7 — the FD reference's own noise floor.
+/// measures the result against a finite-difference of the real objective.
 ///
 /// At `n_agq = 1` the grid objective collapses to `½·log|H|` (the single node sits at η̂), so
 /// this reduces to `½·d log|H|/dx` — precisely the Laplace log-determinant term FOCE/FOCEI
 /// carry analytically.
+///
+/// # The node-response term is analytic, not a grid re-sweep
+///
+/// Writing `Φ = ½log|Σ⁻¹| − logΣⱼexp(tⱼ)` with `tⱼ = log wⱼ + ‖zⱼ‖² − nll(bⱼ; x₀)` and
+/// `bⱼ(x) = b̂(x) + √2·Σ^{1/2}(H(x))·zⱼ`, the exact derivative separates:
+///
+/// ```text
+///   dΦ/dx_k = ½·d log|Σ⁻¹|/dx_k  +  Σⱼ softmaxⱼ · ⟨ ∂nll/∂b|_{bⱼ} , dbⱼ/dx_k ⟩
+/// ```
+///
+/// because `nll` is held at `x₀` — only the node *positions* move. Two consequences:
+///
+/// * `∂nll/∂b|_{bⱼ}` is the **inner EBE gradient**, one call per node, and it does not depend
+///   on `k` — so it is computed **once** and reused across every packed coordinate.
+/// * `x ↦ (log|Σ⁻¹|, bⱼ)` is a cheap *analytic* map (a Cholesky and `d` back-solves per node,
+///   no likelihood), so finite-differencing **it** costs no predictions at all.
+///
+/// That replaces `2·n_free · G` likelihood evaluations with `G` gradient evaluations plus
+/// `2·n_free` Hessian rebuilds — the dominant cost at `n_agq > 1`, where `G = n_agq^d` grows
+/// as a tensor product (243 nodes at `d = 5, n = 3`). It also removes the *only* place the
+/// old code differenced a **finite-differenced** quantity in `x`: with the analytic `h_inner`
+/// anchor, `H` is exact and the remaining FD is of an exact function.
+///
+/// Falls back to the previous `phi_grid` re-sweep when the per-node gradient is out of the
+/// provider's scope (TTE, categorical, …) — the same all-or-nothing boundary the anchor uses.
 #[allow(clippy::too_many_arguments)]
 fn grid_response_correction(
     model: &CompiledModel,
@@ -1057,6 +1114,8 @@ fn grid_response_correction(
     b_hat: &[f64],
     nodes: &[f64],
     log_weights: &[f64],
+    bs: &[Vec<f64>],
+    softmax: &[f64],
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
     out: &mut [f64],
@@ -1076,13 +1135,28 @@ fn grid_response_correction(
         model, subject, params, template, stack, x, b_hat, scratch, schedule,
     )?;
 
+    // `∂nll/∂b` at every base node — the node-response factor. Independent of `k`, so this is
+    // the whole per-node likelihood cost of the correction, paid once instead of `2·n_free`
+    // times. `None` if any node is out of the inner provider's scope; the loop then takes the
+    // `phi_grid` re-sweep for every coordinate (all-or-nothing, matching the anchor).
+    // Hoisted once for the whole sweep — see `node_nll_gradient`.
+    let mult = model.ruv_obs_mult(subject, &params.theta);
+    let node_grads: Option<Vec<Vec<f64>>> = bs
+        .iter()
+        .map(|b| node_nll_gradient(model, subject, params, stack, b, schedule, mult.as_deref()))
+        .collect();
+
+    let d = stack.d();
+    let mut z = vec![0.0f64; d];
+    let (mut off_p, mut off_m) = (vec![0.0f64; d], vec![0.0f64; d]);
+
     for k in 0..x.len() {
         if fixed[k] {
             continue;
         }
-        // `H` is itself a finite-difference quantity, so its own error floor is amplified by
-        // 1/step here. The step must stay well above sqrt(that floor); 1e-3 is calibrated by
-        // `analytic_gradient_matches_fd_at_every_node_count`.
+        // Truncation-dominated: `Φ` differences `log|H|`, which curves sharply in the packed
+        // coordinates, so the step wants to be *small* (see `AGQ_GRID_FD_STEP`). With the
+        // analytic `h_inner` anchor there is no FD error floor underneath it to trade against.
         let step = AGQ_GRID_FD_STEP * (1.0 + x[k].abs());
         let mut xp = x.to_vec();
         let mut xm = x.to_vec();
@@ -1112,41 +1186,143 @@ fn grid_response_correction(
         // `nll` stays at the ORIGINAL params — the direct x-dependence is already covered
         // analytically by the fixed-η score — but the grid (centre and scale) is the
         // perturbed one, which is exactly the response term we are after.
-        let phip = phi_grid(
-            model,
-            subject,
-            params,
-            stack,
-            &ep,
-            nodes,
-            log_weights,
-            &hp,
-            &sp.omega_joint_inv,
-            scratch,
-            schedule,
-        );
-        let phim = phi_grid(
-            model,
-            subject,
-            params,
-            stack,
-            &em,
-            nodes,
-            log_weights,
-            &hm,
-            &sm.omega_joint_inv,
-            scratch,
-            schedule,
-        );
-        let (Some(phip), Some(phim)) = (phip, phim) else {
-            continue; // a degenerate perturbed Hessian contributes no correction
+        let r = match &node_grads {
+            // Analytic node response: difference only the cheap `x ↦ (log|Σ⁻¹|, bⱼ)` map and
+            // contract each node's displacement with its own `∂nll/∂b`. No likelihood
+            // evaluations inside this loop at all.
+            Some(gs) => {
+                let (Some(prop_p), Some(prop_m)) = (
+                    build_proposal(&hp, &sp.omega_joint_inv, d),
+                    build_proposal(&hm, &sm.omega_joint_inv, d),
+                ) else {
+                    continue; // degenerate perturbed Hessian contributes no correction
+                };
+                let mut acc =
+                    0.5 * (prop_p.log_det_inv_scale - prop_m.log_det_inv_scale) / (2.0 * step);
+                for (j, g) in gs.iter().enumerate() {
+                    if softmax[j] == 0.0 {
+                        continue; // underflowed node — contributes nothing
+                    }
+                    grid_z_at(j, nodes, d, &mut z);
+                    prop_p.apply_l_sigma(&z, &mut off_p, std::f64::consts::SQRT_2);
+                    prop_m.apply_l_sigma(&z, &mut off_m, std::f64::consts::SQRT_2);
+                    let mut dot = 0.0;
+                    for i in 0..d {
+                        // dbⱼ/dx_k = db̂/dx_k + √2·d(Σ^{1/2})/dx_k · zⱼ, both differenced here.
+                        let dbj = ((ep[i] + off_p[i]) - (em[i] + off_m[i])) / (2.0 * step);
+                        dot += g[i] * dbj;
+                    }
+                    acc += softmax[j] * dot;
+                }
+                acc
+            }
+            // Out of the inner provider's scope: difference the grid objective itself.
+            None => {
+                let phip = phi_grid(
+                    model,
+                    subject,
+                    params,
+                    stack,
+                    &ep,
+                    nodes,
+                    log_weights,
+                    &hp,
+                    &sp.omega_joint_inv,
+                    scratch,
+                    schedule,
+                );
+                let phim = phi_grid(
+                    model,
+                    subject,
+                    params,
+                    stack,
+                    &em,
+                    nodes,
+                    log_weights,
+                    &hm,
+                    &sm.omega_joint_inv,
+                    scratch,
+                    schedule,
+                );
+                let (Some(phip), Some(phim)) = (phip, phim) else {
+                    continue; // a degenerate perturbed Hessian contributes no correction
+                };
+                (phip - phim) / (2.0 * step)
+            }
         };
-        let r = (phip - phim) / (2.0 * step);
         if r.is_finite() {
             out[k] += r;
         }
     }
     Some(())
+}
+
+/// `zⱼ` for tensor-grid node `j`, reconstructed from its mixed-radix index.
+///
+/// [`agq_nodes_and_terms`] enumerates the grid with a mixed-radix counter whose **digit 0
+/// increments fastest**, so node `j` has `idx[k] = (j / nᵏ) mod n`. Recomputing it here (rather
+/// than storing every `zⱼ`) keeps the grid-response term allocation-free at `MAX_AGQ_GRID`
+/// nodes. `grid_z_at_matches_the_sweep_enumeration` pins the two orderings together — they
+/// must not drift, or each node's displacement would be contracted with another node's
+/// gradient.
+#[inline]
+fn grid_z_at(j: usize, nodes: &[f64], d: usize, out: &mut [f64]) {
+    let n = nodes.len();
+    let mut rem = j;
+    for slot in out.iter_mut().take(d) {
+        *slot = nodes[rem % n];
+        rem /= n;
+    }
+}
+
+/// `∂nll/∂b` at one quadrature node — the **inner EBE gradient**, which is exactly the
+/// derivative the node-response term contracts against.
+///
+/// This is the same entry point the inner loop minimises with, so the gradient and the `nll`
+/// [`Stack::nll_at`] scores are consistent by construction rather than by a second derivation.
+/// `None` outside the provider's scope; the caller then falls back to the grid re-sweep.
+///
+/// `schedule` and `mult` are **hoisted by the caller** and threaded through, because this runs
+/// once per quadrature node — up to [`MAX_AGQ_GRID`] times per subject. The bare
+/// `analytic_eta_nll_gradient` rebuilds the `EventSchedule` and recomputes the residual-magnitude
+/// multiplier on every call, which is per-call setup the inner BFGS loop already learned to
+/// hoist (#449 re-review #6); paying it per node made the sweep several times its own cost.
+fn node_nll_gradient(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    stack: &Stack,
+    b: &[f64],
+    schedule: Option<&pk::event_driven::EventSchedule>,
+    mult: Option<&[Vec<f64>]>,
+) -> Option<Vec<f64>> {
+    if stack.is_iov() {
+        let iov = params.omega_iov.as_ref()?;
+        crate::estimation::inner_optimizer::analytic_eta_nll_gradient_iov(
+            model,
+            subject,
+            &params.theta,
+            b,
+            &params.omega,
+            iov,
+            &params.sigma.values,
+            stack.n_eta,
+            stack.n_kappa,
+            stack.n_occ,
+            mult,
+        )
+    } else {
+        crate::estimation::inner_optimizer::analytic_eta_nll_gradient_with_schedule(
+            model,
+            subject,
+            &params.theta,
+            b,
+            &params.omega,
+            &params.sigma.values,
+            schedule,
+            mult,
+        )
+    }
 }
 
 /// `dη̂/dx` — how the EBE mode moves with the population parameters, per packed coordinate.
@@ -1339,8 +1515,12 @@ fn agq_subject_packed_gradient(
         return None;
     }
 
-    for (b_j, &t) in bs.iter().zip(terms.iter()) {
-        let w = (t - lse).exp();
+    // Posterior (softmax) weights, materialised once: the fixed-node score averages against
+    // them here, and the grid-response term contracts each node's displacement against the
+    // same values — so both differentiate the grid the objective actually evaluated.
+    let softmax: Vec<f64> = terms.iter().map(|&t| (t - lse).exp()).collect();
+
+    for (b_j, &w) in bs.iter().zip(softmax.iter()) {
         if w == 0.0 {
             continue; // exp underflow — contributes nothing to the average
         }
@@ -1360,6 +1540,8 @@ fn agq_subject_packed_gradient(
         b_hat,
         nodes,
         log_weights,
+        &bs,
+        &softmax,
         &mut scratch,
         schedule.as_ref(),
         out,
@@ -1842,6 +2024,46 @@ mod tests {
                 analytic_score_supported_model(&model),
                 "{label} must take the analytic score path"
             );
+        }
+    }
+
+    /// [`grid_z_at`] must reproduce **exactly** the node ordering [`agq_nodes_and_terms`]
+    /// sweeps.
+    ///
+    /// The grid-response term contracts node `j`'s displacement against node `j`'s stored
+    /// `∂nll/∂b` and node `j`'s softmax weight. If the two enumerations ever drift, every node
+    /// would be paired with *another* node's gradient — each individually valid, so the result
+    /// stays finite and plausible while being a wrong gradient. That is exactly the failure
+    /// class this module's "share one sweep" rule exists to prevent, and reconstructing `zⱼ`
+    /// from the index (rather than storing it) is the one place the rule is enforced by
+    /// agreement rather than by construction. Hence this test.
+    #[test]
+    fn grid_z_at_matches_the_sweep_enumeration() {
+        for (n, d) in [(1usize, 1usize), (3, 1), (2, 3), (3, 4), (5, 2), (4, 3)] {
+            let (nodes, _w) = gauss_hermite(n);
+            // The mixed-radix counter from `agq_nodes_and_terms`, digit 0 fastest.
+            let mut idx = vec![0usize; d];
+            let mut j = 0usize;
+            let mut got = vec![0.0f64; d];
+            loop {
+                let expect: Vec<f64> = (0..d).map(|k| nodes[idx[k]]).collect();
+                grid_z_at(j, &nodes, d, &mut got);
+                assert_eq!(got, expect, "n={n} d={d}: node {j} z-vector");
+                j += 1;
+                let mut k = 0;
+                while k < d {
+                    idx[k] += 1;
+                    if idx[k] < n {
+                        break;
+                    }
+                    idx[k] = 0;
+                    k += 1;
+                }
+                if k == d {
+                    break;
+                }
+            }
+            assert_eq!(j, grid_size(n, d), "n={n} d={d}: swept node count");
         }
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2313,7 +2313,7 @@ fn dense_residual_inner_gradient(
 /// the non-IOV inner (`analytic_eta_nll_gradient_with_schedule`) — see its doc for
 /// why this is a caller-supplied parameter rather than computed here.
 #[allow(clippy::too_many_arguments)]
-fn analytic_eta_nll_gradient_iov(
+pub(crate) fn analytic_eta_nll_gradient_iov(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],

--- a/tests/agq.rs
+++ b/tests/agq.rs
@@ -474,10 +474,17 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
     // gate: `grid_response_correction` supplies the `∂Φ/∂H·dH/dx` term that the fixed-node
     // score omits, and at n = 1 that term is the entire difference (a 26% error without it).
     //
-    // Measured: 2.0e-5 at n = 1, 1.5e-6 at n = 3, 2.1e-7 at n = 7 — the gradient is exact to
-    // the reference's own precision. (An earlier revision of this test used a 1e-5 FD step and
-    // read 1.6e-3; that was the *reference's* noise, not the gradient's error — see the step
+    // Measured: 6.5e-8 at n = 1, 2.8e-9 at n = 3, 1.8e-9 at n = 7 — the gradient is exact well
+    // past the reference's own precision. (An earlier revision of this test used a 1e-5 FD step
+    // and read 1.6e-3; that was the *reference's* noise, not the gradient's error — see the step
     // comment above. Do not "restore" the smaller step.)
+    //
+    // Those numbers were 2.0e-5 / 1.5e-6 / 2.1e-7 before the anchor and the grid-response term
+    // went analytic: the old path finite-differenced `Φ` in `x` while `H` was *itself* a finite
+    // difference, so an FD-of-an-FD sat under every value. Both layers are gone — `H` is
+    // `score_core`'s exact `h_inner`, and the node response contracts each node's analytic
+    // `∂nll/∂b` against a displacement differenced from the cheap *exact* `x ↦ (log|Σ⁻¹|, bⱼ)`
+    // map — leaving ~2-3 orders of magnitude.
     //
     // The 1e-4 bound also pins `AGQ_GRID_FD_STEP`: at 1e-2 this test fails outright, because
     // the grid-response term is truncation-dominated and a "safe" large step puts the θ
@@ -495,6 +502,16 @@ fn analytic_gradient_matches_fd_at_every_node_count() {
     assert!(
         rel_errs[3] < rel_errs[0],
         "accuracy should improve with node count: {rel_errs:?}"
+    );
+    // A second, tighter bound at n = 1 that the **pre-analytic** path could not have met: it
+    // measured 2.0e-5 there, 300x above this. Deliberately left ~15x above the 6.5e-8 actually
+    // observed, so it pins the analytic anchor + analytic node response against silent
+    // regression to an FD-of-an-FD without being tight enough to flake on reference noise.
+    assert!(
+        rel_errs[0] < 1e-6,
+        "n_agq=1 must stay at analytic-anchor accuracy (was 2.0e-5 on the FD path), \
+         got {:.3e}",
+        rel_errs[0]
     );
 }
 


### PR DESCRIPTION
## Why

The `method = laplace` gradient had **two finite-difference layers stacked on each other**, and the inner one was differencing a matrix the crate already computes exactly.

1. **The anchor Hessian.** `anchor_hessian`'s `Exact` arm rebuilt the conditional Hessian `∂²nll/∂b²` with a `2d²+1`-evaluation per-subject sweep (`fd_posterior_hessian`). Its `GaussNewton` sibling, two lines away, called `score_core` and took `htilde`. But `score_core` returns **both** matrices from one provider evaluation, and its own doc comment already stated what the second one is:

   > `h_inner = Ω⁻¹ + Σⱼ (∂²Lⱼ/∂f² aⱼaⱼᵀ + ∂Lⱼ/∂f Aⱼ)`, which **is** the exact conditional Hessian `∂²nll/∂b²`
   > *Two things here are exactly what an AGQ/Laplace node needs.*

   It was being computed and discarded on every call.

2. **The grid-response term.** `grid_response_correction` differenced `Φ` in each packed coordinate by **re-sweeping the entire quadrature grid** — `2·n_free · G` likelihood evaluations per subject, with `G = n_agq^d` growing as a tensor product (243 nodes at `d = 5, n = 3`). And because `H` was itself a finite difference, this was a finite difference *of* a finite difference.

The cost is real but the accuracy cost was larger, and it is what motivated finishing the job rather than stopping at (1).

## What changed

**Anchor.** Both anchors now come from one shared `score_core_at` sweep; `Exact` reads `h_inner`, `GaussNewton` reads `htilde`. Verified numerically against `fd_posterior_hessian` to ~7 significant figures on plain / `iiv_on_ruv` / LTBS fixtures. `fd_posterior_hessian` is retained for models outside the provider's scope (TTE, categorical, and `score_core`'s two per-subject declines), where finite differences are the only thing that works — the likelihood has no `PkNum` twin.

**Grid response.** Writing `Φ = ½log|Σ⁻¹| − logΣⱼexp(tⱼ)` with `bⱼ(x) = b̂(x) + √2·Σ^{1/2}(H(x))·zⱼ`, and noting `nll` is held at `x₀` so only node *positions* move, the derivative separates exactly:

```
dΦ/dx_k = ½·d log|Σ⁻¹|/dx_k  +  Σⱼ softmaxⱼ · ⟨ ∂nll/∂b|_{bⱼ} , dbⱼ/dx_k ⟩
```

Two properties make this cheap. `∂nll/∂b` is the **inner EBE gradient** and does not depend on `k`, so it is computed once per node and reused across every packed coordinate. And `x ↦ (log|Σ⁻¹|, bⱼ)` is a cheap **exact** map — a Cholesky plus `d` back-solves per node, no likelihood — so finite-differencing *it* costs no predictions. `2·n_free·G` likelihood evaluations become `G` gradient evaluations. `phi_grid` is kept as the fallback when the per-node gradient is out of scope, on the same all-or-nothing boundary the anchor uses.

### The two anchors stay different matrices — that is the estimator distinction

Sharing `score_core` unifies the *computation*, not the result. `laplace, n_agq = 1` is NONMEM `LAPLACIAN INTER`; `focei, n_agq = 1` is plain FOCEI; the anchor is exactly what separates them. Reading `htilde` for `Exact` would have silently converted Laplace into FOCEI while it kept reporting Laplace OFVs. `laplace_one_node_is_not_focei` pins this, and the doc comment says so at the call site.

## Alternatives considered

For the grid response, the obvious route is to differentiate `Σ^{1/2}` analytically — but `build_proposal` Cholesky-factors `Σ⁻¹ = H + jitter` and falls back to the prior scale when `H` is indefinite, so an analytic `dL/dx` would have to reproduce the factorization *and* branch on which arm ran. Differencing the map instead is exact to the same order, needs no Cholesky differential, and cannot disagree with whichever branch `build_proposal` actually took.

A fully analytic `dH/dx` would need `∂³nll/∂η²∂θ`, which does not exist in the codebase (that is #436's Dual3 work). It stays finite-differenced — but now it is a finite difference of an **exact** function rather than of another finite difference, which is where the accuracy gain comes from.

Dropping the Gauss-Newton anchor to the light `Dual1` provider was evaluated and **rejected on measurement**. `htilde` genuinely needs only first derivatives, so it is feasible, but after this change the grid-response term is dominated by the `G` node gradients (243 at `d=5, n=3`), not the `2·n_free` anchor calls (22) — putting its ceiling near 3% of that path, against a refactor of `score_core`, the hottest gradient function in the crate. It also only ever helps `focei, n_agq > 1`.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change; `analytic_eta_nll_gradient_iov` widened from private to `pub(crate)`.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] None

## Numerical validation

The headline result is accuracy. Measured by the existing `analytic_gradient_matches_fd_at_every_node_count`, which references a **reconverged** finite difference of the real objective (inner loop re-solved at every perturbed point), so it is the *total* derivative — EBE response and node movement included — not a fixed-node echo of the analytic formula:

- [x] Compared against: reconverged FD of the AGQ objective, warfarin, at base commit `d9c6e63a`
- [x] Reference values:

```
max relative gradient error vs reconverged FD of the objective (warfarin)

  n_agq        1          3          5          7
  before    2.0e-5     1.5e-6       --       2.1e-7
  after     6.5e-8     2.8e-9     2.0e-9     1.8e-9
             ~310x      ~530x                 ~115x

h_inner vs fd_posterior_hessian, off-mode, 7 obs (spike, not committed):
  plain / iiv_on_ruv / LTBS: agree to ~7 significant figures on every entry,
  while htilde differs visibly (e.g. plain [1,1]: fd 160.369, h_inner 160.369,
  htilde 171.907) -- confirming the exact and Gauss-Newton anchors stayed distinct.
```

At `1.8e-9` the finite-difference **reference** is the inaccurate side, not the gradient. `tests/agq.rs`'s stale `Measured:` comment is corrected, and a second bound `rel_errs[0] < 1e-6` is added — 15× above what is observed, but 20× below what the pre-analytic path measured, so it fails on the old code. That is a negative control against silent regression to an FD-of-an-FD.

No NONMEM anchor: this changes the *derivative* of an already-NONMEM-anchored objective, and `one_node_agq_is_the_laplace_approximation` / `laplace_one_node_is_not_focei` still hold.

**Laplace OFVs and standard errors shift very slightly**, because the exact Hessian replaces an approximated one in `½log|H|`. This is a real numerical change, in the accurate direction, and not bit-identical. FOCEI is numerically untouched.

## Performance
- [x] Faster — but this is the weaker half of the case, and I want to be precise about it.

`h_inner` alone, measured A/B in one binary (optimized `ci-test`, 32 subjects): **2.34×** at `d=3` and **2.15×** at `d=5`, `n_agq=1`. Consistent with debug, because both the predictor and the `Dual2` walk optimize proportionally.

The combined change measured **1.4–1.6× at `d=3`** and roughly break-even at `d=5` in **debug**, which I do not trust for this comparison and did not resolve. The grid redesign trades `2·n_free·G` plain NLLs for `G` dual-walk gradients, so it wins exactly when one gradient costs less than `2·n_free` NLLs — and at `d=5, n_free=11` that crossover (22) sits right on top of debug's dual-walk cost (~25 NLLs). Unlike the `h_inner` comparison, this one is genuinely profile-sensitive, and I did not get an optimized number for it.

The Hessian change also speeds up every **objective** evaluation and therefore the **covariance step**, which evaluates it `~2·n_free²` times.

**So: ship this for the two-to-three orders of magnitude of gradient accuracy, and treat the speed as a bonus that is well-established for the anchor and unmeasured for the grid term.**

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

`grid_z_at_matches_the_sweep_enumeration` (Tier 1) pins the mixed-radix reconstruction against the actual grid sweep. This is the one place the module's "share one sweep" invariant is enforced by *agreement* rather than by construction: if the two enumerations drift, every node's displacement is contracted with another node's gradient — each individually valid, so the result stays finite and plausible while being a wrong gradient.

`tests/agq.rs`: **24/24**, including both reconverged-FD parity tests and the IOV twin.
`cargo test --lib`: **2755 passed, 1 failed** — `ode::predictions::tests::ss_input_rate_over_capacity_deep_saturation_declines`, which reproduces identically on clean `main`. Pre-existing, flagged rather than folded in.

## Example (user-facing features only)
- [x] Not applicable (no new API surface; existing `method = laplace` gets a better gradient)

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` `[Unreleased]` entry added

`docs/estimation/agq.qmd`'s "Where AGQ stops" section claimed the gradient carries a `~1e-4` relative noise floor because "the grid-response term and the posterior Hessian are both central differences". Both halves of that are now wrong, so it is rewritten with the measured figures.

I deliberately did **not** touch the convergence criterion it motivates. AGQ still stops on `outer_ftol`/`outer_xtol` rather than a gradient norm. Whether the tighter floor now makes a gradient-norm stop reachable is a real question, but re-tuning convergence is not something to fold into a gradient change — noted as such in the docs.

## Checklist
- [x] `cargo clippy` clean — CI's exact gate (`cargo clippy --no-default-features --features ci,markov`) emits warnings only, 261 of them, the same count as base; none in the changed functions
- [x] Functions on the `Dual2` sensitivity path stay differentiable
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key
- [ ] New example `.ferx` file
- [ ] New data file

None — no DSL, fit option, example, or data change.

### ferx-book
- [ ] New estimator, DSL feature, or fit option

### Example execution
- [x] No example execution step needed (no user-visible behaviour change beyond gradient accuracy; no `examples/` file affected)

## Reviewer hints

**Focus on the grid-response derivation** (`grid_response_correction`'s doc block and the `Some(gs)` arm). The formula is the whole correctness argument, and this term has history: its own docs record that a *partially* correct version — differencing `H`'s explicit `x`-dependence but not the mode's — was measurably **worse than omitting the term entirely** (26% → 62% on warfarin), because the two halves substantially cancel. Worth checking the three pieces independently: the `½·d log|Σ⁻¹|/dx` term, the sign on the node-response contraction (it is `+`, because `tⱼ` carries `−nll`), and that `softmax` is evaluated at `x₀` rather than at the perturbed points.

**Second, `grid_z_at`.** It must reproduce `agq_nodes_and_terms`'s mixed-radix order exactly — digit 0 fastest. The Tier-1 test covers `(n,d)` up to `(4,3)`.

Skimmable: the `anchor_hessian` refactor is mechanical once you accept that `h_inner` is the exact Hessian, and the numbers in the validation section establish that.

## Open questions

**The grid-response term's speed is unmeasured at an optimized profile**, for the reason given under Performance. If you would rather land only the anchor change (a clean ~2.2× with no open question) and take the grid redesign separately, the two are separable — the second is confined to `grid_response_correction`, `node_nll_gradient`, and `grid_z_at`. My preference is to land both, because the accuracy gain comes mostly from the grid term and it is fully validated on that axis.

Second: with the noise floor down at `1e-8`, the `outer_ftol`-only stopping rule may now be leaving convergence on the table. Deliberately out of scope here; worth its own issue.
