### PR TITLE
test(estimation): exercise the analytic covariance end-to-end for FOCE as well as FOCEI [#436]

### DIFF
--- a/src/estimation/sens_cov_hessian.rs
+++ b/src/estimation/sens_cov_hessian.rs
@@ -2661,9 +2661,10 @@ mod tests {
         let h_mats = vec![DMatrix::zeros(model.n_eta, model.n_eta); n_subj];
         let kappas = vec![vec![]; n_subj];
 
-        let run = |analytic: bool| -> DMatrix<f64> {
+        let run = |analytic: bool, interaction: bool| -> DMatrix<f64> {
             let mut opts = FitOptions {
                 analytic_cov_hessian: analytic,
+                interaction,
                 ..FitOptions::default()
             };
             opts.verbose = false;
@@ -2679,7 +2680,8 @@ mod tests {
             ) {
                 CovarianceStepResult::Success(o) => o.matrix,
                 other => panic!(
-                    "covariance step must succeed (analytic = {analytic}); got {}",
+                    "covariance step must succeed (analytic = {analytic}, \
+                     interaction = {interaction}); got {}",
                     match other {
                         CovarianceStepResult::Unusable(m) => m,
                         CovarianceStepResult::FailedNonPd { reason, .. } => reason,
@@ -2689,45 +2691,56 @@ mod tests {
             }
         };
 
-        // Premise: the analytic route must actually be *taken*. If the scope gate declined,
-        // `compute_covariance` would fall back to the same FD stencil and this test would
-        // compare FD against FD — passing while proving nothing. Assert it at the source.
-        assert!(
-            population
-                .subjects
-                .iter()
-                .zip(eta_hats.iter())
-                .all(
-                    |(s, e)| subject_packed_cov_hessian(&model, s, &params, &x_hat, e.as_slice())
-                        .is_some()
-                ),
-            "fixture must be in analytic scope, else this test compares FD against itself"
-        );
-
-        let cov_fd = run(false);
-        let cov_an = run(true);
+        // Premise: the analytic route must actually be *taken*, on BOTH entry points. If the
+        // scope gate declined, `compute_covariance` would fall back to the same FD stencil and
+        // this test would compare FD against FD — passing while proving nothing. Asserted at
+        // the source, per estimator, because the two assemblies gate independently (the FOCE
+        // one additionally needs an in-scope third-order sweep at η = 0).
+        for (s, e) in population.subjects.iter().zip(eta_hats.iter()) {
+            assert!(
+                subject_packed_cov_hessian(&model, s, &params, &x_hat, e.as_slice()).is_some(),
+                "fixture must be in FOCEI analytic scope, else this compares FD against itself"
+            );
+            assert!(
+                subject_packed_cov_hessian_foce(&model, s, &params, &x_hat, e.as_slice()).is_some(),
+                "fixture must be in FOCE analytic scope, else this compares FD against itself"
+            );
+        }
 
         // Standard errors are what a user sees, so compare those rather than raw entries.
         let se = |c: &DMatrix<f64>| -> Vec<f64> {
             (0..c.nrows()).map(|i| c[(i, i)].max(0.0).sqrt()).collect()
         };
-        let (se_fd, se_an) = (se(&cov_fd), se(&cov_an));
-        let worst = se_fd
-            .iter()
-            .zip(se_an.iter())
-            .filter(|(f, _)| **f > 1e-12)
-            .fold(0.0f64, |m, (f, a)| m.max(((a - f) / f).abs()));
 
-        assert!(
-            worst < 0.05,
-            "analytic SEs must match the FD stencil to 5%: worst relative Δ {worst:.3e}\n\
-             fd = {se_fd:?}\nan = {se_an:?}"
-        );
-        // A √2 (41%) discrepancy is the specific failure this guards; assert it is nowhere near.
-        assert!(
-            worst < 0.2,
-            "SE ratio looks like an OFV scale-factor error (√2 ≈ 0.41): {worst:.3e}"
-        );
+        // Both estimators, because the analytic route dispatches on `options.interaction` into
+        // two *different* marginals — FOCEI's Almquist–Laplace `Φ + ½log|H̃|` and FOCE's
+        // Sheiner–Beal `(y−f₀)ᵀR̃⁻¹(y−f₀) + log|R̃|`. Running only the default (`interaction =
+        // true`) left the FOCE arm of that dispatch, and the OFV `×2` scaling applied to the
+        // FOCE assembly, unexercised end-to-end — which is precisely the untested-wiring shape
+        // that produced the √2 SE inflation on the FOCEI side.
+        for interaction in [true, false] {
+            let label = if interaction { "FOCEI" } else { "FOCE" };
+            let (se_fd, se_an) = (se(&run(false, interaction)), se(&run(true, interaction)));
+            let worst = se_fd
+                .iter()
+                .zip(se_an.iter())
+                .filter(|(f, _)| **f > 1e-12)
+                .fold(0.0f64, |m, (f, a)| m.max(((a - f) / f).abs()));
+
+            // A √2 (41%) discrepancy is the specific failure this guards. Checked before the
+            // tighter bound so a scale error reports as a scale error rather than as generic
+            // disagreement.
+            assert!(
+                worst < 0.2,
+                "{label}: SE ratio looks like an OFV scale-factor error (√2 ≈ 0.41): \
+                 {worst:.3e}\nfd = {se_fd:?}\nan = {se_an:?}"
+            );
+            assert!(
+                worst < 0.05,
+                "{label}: analytic SEs must match the FD stencil to 5%: worst relative Δ \
+                 {worst:.3e}\nfd = {se_fd:?}\nan = {se_an:?}"
+            );
+        }
     }
 
     /// Safety gate: the per-subject analytic covariance Hessian (both FOCEI and


### PR DESCRIPTION
## Why

#953 landed the analytic covariance R-matrix with an end-to-end test —
`analytic_cov_matches_the_fd_stencil_through_compute_covariance` — that ran **FOCEI only**,
because `FitOptions::default()` sets `interaction: true`.

The analytic route dispatches on `options.interaction` into two genuinely different assemblies:

| | FOCEI | FOCE |
|---|---|---|
| Entry point | `subject_packed_cov_hessian` | `subject_packed_cov_hessian_foce` |
| Marginal | Almquist–Laplace `Φ + ½log\|H̃\|` | Sheiner–Beal `(y−f₀)ᵀR̃⁻¹(y−f₀) + log\|R̃\|`, `R̃ = HΩHᵀ + R⁰` |
| Third-order sweeps | one, at `η̂` | **two** — at `η̂` and at `η = 0`, since `R⁰` is frozen at `f(η=0)` |

So the FOCE arm of that dispatch, and the OFV `×2` scaling applied to the FOCE assembly, had
no end-to-end coverage at all.

That gap matters because of its shape, not its size. The `×2` was the defect that silently
inflated every FOCEI standard error by exactly `√2` (41.5%) in #953 — caught late, and only
because a test finally reached `compute_covariance` through the analytic path. The FOCE
assembly has four passing tests against a reconverged finite difference of
`subject_packed_gradient_foce`, but **every one of them is scale-blind**: they difference that
assembly's own gradient, so a uniform factor cancels. Nothing pinned that FOCE shares FOCEI's
`OFV = 2·Σᵢ Fᵢ` convention.

It does. Both estimators now agree with their own FD stencil to well inside 5%.

## What changed

`analytic_cov_matches_the_fd_stencil_through_compute_covariance` is parameterised over
`interaction ∈ {true, false}`, running the full `compute_covariance` → analytic → FD-fallback
comparison for each.

Three details worth keeping:

- The **in-scope premise is asserted per entry point**, not once. The two gate independently —
  the FOCE path additionally needs an in-scope third-order sweep at `η = 0` — so a single
  `subject_packed_cov_hessian(...).is_some()` check would leave the FOCE half of the test able
  to silently degrade into FD-vs-FD.
- The **`√2` bound is asserted before the tighter 5% bound**, so a scale-factor error reports
  as a scale-factor error rather than as generic disagreement. That is the diagnostic that was
  missing the first time.
- Comparison is on **standard errors**, not raw Hessian entries — that is what a user reads,
  and it is where a scale error is visible.

## Alternatives considered

**A separate FOCE test function.** Rejected: it would duplicate the fixture, the population
construction and the SE comparison, and the next estimator or anchor added would need a third
copy. The parameterised loop makes "which estimators are covered end-to-end" a one-line answer.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

Test-only. No production code is touched.

## Numerical validation
- [x] Not applicable — this PR *is* numerical validation. No behaviour changes.

For the record, both estimators pass the same 5% band against their own reconverged FD
stencil, on the warfarin 1-cpt oral fixture (4 subjects, diagonal Ω, proportional error).

## Performance
- [x] No significant impact expected — one extra `compute_covariance` pair in a Tier-1 test.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

`cargo test --lib sens_cov_hessian`: **14 passed, 0 failed**.

To be precise about what "fails without this fix" means here: the FOCE half of the loop is new
coverage, not a fix for a live defect — FOCE's `×2` turned out to be correct. What the test
guards is that it *stays* correct, and that a future change to either marginal cannot alter one
estimator's SE scale while the other's tests keep passing.

## Example (user-facing features only)
- [x] Not applicable (internal / test-only)

## Docs
- [x] No user-visible change — no `CHANGELOG.md` entry (test-only, per the repo's changelog rule)

## Checklist
- [x] `cargo clippy` clean — no production code touched
- [x] Functions on the `Dual2` sensitivity path stay differentiable (none touched)
- [ ] `Cargo.toml` version bumped if breaking

## Reviewer hints

The whole diff is one test function. The substantive question is whether the per-entry-point
in-scope assertion is the right guard — it is what stops the test decaying into FD-vs-FD if
either scope gate narrows later, which is the failure mode that made the original version of
this test nearly vacuous.

## Open questions

None. This closes a coverage gap found by asking, of the merged #953, "does it handle FOCE and
FOCEI differently, and is that difference tested?" — the answer was yes to the first and no to
the second.
