### PR TITLE
fix(stats): make residual-variance derivatives floor-aware [closes #958]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,17 @@ section of the SDLC for the versioning policy).
   for any external code that constructs or exhaustively destructures these variants.
 
 ### Fixed
+- **Gradient-path-dependent FOCE/FOCEI objective on proportional-error models with a
+  near-zero prediction** (#958). The residual-variance floor (`MIN_VARIANCE`, which clamps
+  `(f·σ)²` so a vanishing prediction cannot produce a zero variance) was applied to the
+  variance but **not** to its analytic derivatives `∂R/∂f` / `∂²R/∂f²`. On a row whose
+  prediction is driven to ~0 (e.g. drug fully eliminated at a late sample) the variance is
+  clamped and locally constant in `f`, so its true derivatives are 0, but the accessors
+  returned the raw `2·f·σ²` / `2·σ²`. That made the analytic inner-EBE gradient disagree with
+  the finite-difference objective it minimises, so `gradient = auto` (analytic) and
+  `gradient = fd` could converge to different empirical-Bayes modes and report different
+  objective values (hence different ΔOFV/ΔAIC) for the same model at the same estimates. The
+  variance-derivative accessors are now floor-aware, restoring analytic ↔ FD agreement.
 - **Standard errors for closed-form LTBS models under IOV** (#486). The tighter inner-EBE
   tolerances that log-transform-both-sides models take for the fit and covariance steps
   (`LTBS_FIT_INNER_TOL` / `LTBS_COV_INNER_TOL`, #665) were previously skipped whenever the

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -1151,8 +1151,9 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
     let d_vec: Vec<f64> = (0..n_obs)
         .map(|j| error_spec.dvar_df(err_keys[j], ipreds[j], sigma_values))
         .collect();
-    // ∂²R/∂f² per observation. f-independent for additive/proportional/combined
-    // (0 for additive, 2·σ_prop² otherwise), but the *per-CMT* value can differ
+    // ∂²R/∂f² per observation. Constant for additive/proportional/combined
+    // (0 for additive, 2·σ_prop² otherwise) except where the variance floor
+    // clamps it to 0 (#958), but the *per-CMT* value can differ
     // across observations: e.g. an Emax PK/PD model with proportional error on
     // PK (CMT=2) and additive on PD (CMT=3) needs `d2 = 2·σ_prop²` at PK obs
     // and `d2 = 0` at PD obs. Dispatch through `error_spec.d2var_df2` so the
@@ -1160,7 +1161,7 @@ fn subject_nll_pop_grad_analytical_laplace_cached(
     // the cmt argument and returns the scalar value uniformly. The β_j chain
     // at line ~1095 then reads `d2_vec[j]` per obs.
     let d2_vec: Vec<f64> = (0..n_obs)
-        .map(|j| error_spec.d2var_df2(err_keys[j], sigma_values))
+        .map(|j| error_spec.d2var_df2(err_keys[j], ipreds[j], sigma_values))
         .collect();
 
     // Conditional Hessian H̃ = a'·diag(1/R)·a + ½·c̃'·c̃ + Ω⁻¹.

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -464,6 +464,95 @@ fn analytic_inner_gradient_m3_matches_fd_on_warfarin_bloq() {
     }
 }
 
+/// #958, as reported: a two-state target-binding ODE with a **parameter-
+/// dependent initial condition** (`init(RTOT) = RBASE`) and a `sqrt` binding
+/// quadratic in the RHS, observed at two endpoints under proportional error.
+/// The analytic ODE inner η-gradient must match a central FD of `individual_nll`
+/// at a non-zero η that pushes the drug endpoint's late sample into the
+/// variance floor. This is the exact scenario the issue bisected to; the raw
+/// four-cell design isolates it to `init(θ)` + `sqrt`, but the mechanism is the
+/// floor-unaware `∂R/∂f`, so the reproduction is the analytic-vs-FD inner
+/// gradient here (the prediction sensitivities themselves were never wrong).
+#[test]
+fn analytic_inner_gradient_ode_init_theta_sqrt_matches_fd() {
+    use std::cell::RefCell;
+    let model = crate::parser::model_parser::parse_model_string(
+        "[parameters]\n  theta KEL(0.05,0.001,10)\n  theta VC(5,0.5,100)\n  theta RBASE(20,1,400)\n  theta KINT(0.2,0.001,20)\n  theta KDEG(0.02,0.0001,5)\n  theta KM(10,0.1,1000)\n  omega IIV_KEL   ~ 0.09\n  omega IIV_RBASE ~ 0.09\n  sigma PROP_DRUG ~ 0.15 (sd)\n  sigma PROP_TGT  ~ 0.15 (sd)\n[individual_parameters]\n  KEL   = KEL * exp(IIV_KEL)\n  RBASE = RBASE * exp(IIV_RBASE)\n  VC    = VC\n  KINT  = KINT\n  KDEG  = KDEG\n  KM    = KM\n  KSYN  = RBASE * KDEG\n[structural_model]\n  ode(states=[CENT, RTOT])\n[odes]\n  init(RTOT) = RBASE\n  ct = CENT / VC\n  bb = ct - RTOT - KM\n  cf = 0.5 * (bb + sqrt(bb*bb + 4*KM*ct))\n  fb = cf / (KM + cf)\n  d/dt(CENT) = -KEL * cf * VC - KINT * fb * RTOT * VC\n  d/dt(RTOT) =  KSYN - KDEG * RTOT - KINT * fb * RTOT\n[scaling]\n  y[CMT=1] = CENT / VC\n  y[CMT=2] = RTOT\n[error_model]\n  CMT=1: DV ~ proportional(PROP_DRUG)\n  CMT=2: DV ~ proportional(PROP_TGT)\n[fit_options]\n  method     = focei\n  ode_reltol = 1e-9\n  ode_abstol = 1e-9\n",
+    )
+    .expect("parse binding-quadratic ODE with parameter-dependent init");
+
+    // Drug (CMT 1) at 4 times incl. a far-tail sample where drug ~ 0 (floored
+    // proportional variance), then total target (CMT 2) at the same times.
+    let tms = [1.0, 7.0, 28.0, 120.0];
+    let mut obs_times = Vec::new();
+    let mut obs_cmts = Vec::new();
+    for &t in &tms {
+        obs_times.push(t);
+        obs_cmts.push(1usize);
+    }
+    for &t in &tms {
+        obs_times.push(t);
+        obs_cmts.push(2usize);
+    }
+    let n = obs_times.len();
+    let subject = Subject {
+        id: "1".into(),
+        doses: vec![DoseEvent::new(0.0, 300.0, 1, 0.0, false, 0.0)],
+        obs_times,
+        obs_raw_times: Vec::new(),
+        // Rough noise-free-ish values; exact magnitudes are immaterial — the
+        // analytic gradient is checked against FD of the objective on the SAME
+        // data, so the assertion is a self-consistency (gradient-path) check.
+        observations: vec![
+            30.0, 5.0, 0.5, 0.0, // drug
+            16.0, 10.0, 6.0, 15.0, // target
+        ],
+        obs_cmts,
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1; n],
+        obs_l2: Vec::new(),
+        dose_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+
+    let theta = &model.default_params.theta;
+    let omega = &model.default_params.omega;
+    let sigma = &model.default_params.sigma.values;
+    let eta = vec![0.5, -0.15];
+
+    // Precondition: the drug tail sample really does hit the variance floor.
+    let preds = crate::pk::compute_predictions_with_tv(&model, &subject, theta, &eta);
+    assert!(
+        model.residual_variance_at(1, preds[3], sigma) <= 1e-12,
+        "drug tail prediction {} must drive its proportional variance to the floor",
+        preds[3]
+    );
+
+    let analytic = analytic_eta_nll_gradient(&model, &subject, theta, &eta, omega, sigma)
+        .expect("analytic ODE inner gradient must be supported");
+    let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(&subject));
+    let obj = |e: &[f64]| -> f64 {
+        let mut s = scratch.borrow_mut();
+        individual_nll_into_with_schedule(&model, &subject, theta, e, omega, sigma, &mut s, None)
+    };
+    let fd = gradient_fd(&obj, &eta, model.n_eta);
+    for k in 0..model.n_eta {
+        assert!(
+            (analytic[k] - fd[k]).abs() < 1e-3 * (1.0 + fd[k].abs()),
+            "η[{k}]: analytic {} vs FD {}",
+            analytic[k],
+            fd[k]
+        );
+    }
+}
+
 /// Closed-form `iiv_on_ruv` + M3 BLOQ (#4c): the analytic non-IOV inner
 /// η-gradient must match central FD of `individual_nll`, exercising the censored
 /// `η_ruv` data column `h·z` and the `exp(2·η_ruv)` variance scaling on the

--- a/src/estimation/sens_cov_hessian.rs
+++ b/src/estimation/sens_cov_hessian.rs
@@ -53,8 +53,11 @@ fn sigma_fd_step(sigma_k: f64) -> f64 {
 /// Closed-form error-model scalars and their first **and second** `f`-derivatives
 /// at one observation, built from `R`, `d = ∂R/∂f`, `d2 = ∂²R/∂f²`, `eps = y − f`.
 /// Assumes `∂³R/∂f³ = 0`, which is exact for the additive / proportional /
-/// combined error models (`d2var_df2` is `f`-independent — a constant `2σ²` for
-/// the proportional part, `0` for additive). `α`, `α'`, `β`, `p` reproduce
+/// combined error models away from the variance floor: `d2var_df2` is a
+/// constant `2σ²` for the proportional part (`0` for additive), except where
+/// `variance_at` clamps to `MIN_VARIANCE`, on which flat side `d2var_df2`
+/// returns `0` (#958) — still a locally-constant `∂²R/∂f²`, so `∂³R/∂f³ = 0`
+/// holds. `α`, `α'`, `β`, `p` reproduce
 /// [`super::sens_outer_gradient::err_terms`]; `α''`, `β'` are the new third-order
 /// pieces the M3 covariance Hessian contracts against `∂³f/∂η³` etc.
 struct ErrD2 {
@@ -406,7 +409,7 @@ fn m3_sigma_derivs(
         let f = sens.obs[j].f;
         let r = model.error_spec.variance_at(cmt, f, sig);
         let d = model.error_spec.dvar_df(cmt, f, sig);
-        let d2 = model.error_spec.d2var_df2(cmt, sig);
+        let d2 = model.error_spec.d2var_df2(cmt, f, sig);
         let eps = subject.observations[j] - f;
         err_d2(r, d, d2, eps)
     };
@@ -548,7 +551,7 @@ fn inner_eta_responses(
             let f = sens.obs[j].f;
             let r = model.error_spec.variance_at(cmt, f, &params.sigma.values);
             let d = model.error_spec.dvar_df(cmt, f, &params.sigma.values);
-            let d2 = model.error_spec.d2var_df2(cmt, &params.sigma.values);
+            let d2 = model.error_spec.d2var_df2(cmt, f, &params.sigma.values);
             err_d2(r, d, d2, subject.observations[j] - f)
         })
         .collect();
@@ -756,7 +759,7 @@ pub(crate) fn subject_cov_hessian_m3_natural(
             let f = sens.obs[j].f;
             let r = model.error_spec.variance_at(cmt, f, &params.sigma.values);
             let d = model.error_spec.dvar_df(cmt, f, &params.sigma.values);
-            let d2 = model.error_spec.d2var_df2(cmt, &params.sigma.values);
+            let d2 = model.error_spec.d2var_df2(cmt, f, &params.sigma.values);
             let eps = subject.observations[j] - f;
             err_d2(r, d, d2, eps)
         })
@@ -1090,7 +1093,7 @@ fn foce_sb_fixed_natural(
         }
         r0[i] = r;
         d0[i] = model.error_spec.dvar_df(cmts[i], f0act, sigma);
-        d20[i] = model.error_spec.d2var_df2(cmts[i], sigma);
+        d20[i] = model.error_spec.d2var_df2(cmts[i], f0act, sigma);
     }
     let mut rtilde = &jmat * omega * jmat.transpose();
     for i in 0..nq {
@@ -1319,7 +1322,7 @@ fn subject_cov_hessian_foce_natural(
         }
         r0[i] = r;
         d0[i] = model.error_spec.dvar_df(cmts[i], f0act, sigma);
-        d20[i] = model.error_spec.d2var_df2(cmts[i], sigma);
+        d20[i] = model.error_spec.d2var_df2(cmts[i], f0act, sigma);
     }
     let mut rtilde = &jmat * omega * jmat.transpose();
     for i in 0..nq {
@@ -1855,7 +1858,7 @@ mod tests {
                 let cmt = subject.obs_cmts[j];
                 let r = model.error_spec.variance_at(cmt, f, sigma);
                 let d = model.error_spec.dvar_df(cmt, f, sigma);
-                let d2 = model.error_spec.d2var_df2(cmt, sigma);
+                let d2 = model.error_spec.d2var_df2(cmt, f, sigma);
                 let eps = subject.observations[j] - f;
                 // inner gradient ½α·a, true Hessian ½(α' a aᵀ + α A).
                 let inv_r = 1.0 / r;

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -987,7 +987,7 @@ pub(crate) fn score_core(
             let kern_at = |ff: f64| -> (f64, f64, f64) {
                 let rr_ = model.error_spec.variance_at(cmt, ff, sigma) * ruv_scale;
                 let dd = model.error_spec.dvar_df(cmt, ff, sigma) * ruv_scale;
-                let dd2 = model.error_spec.d2var_df2(cmt, sigma) * ruv_scale;
+                let dd2 = model.error_spec.d2var_df2(cmt, ff, sigma) * ruv_scale;
                 let (_g1, g2, cz, cm) = m3_censored_outer(y, ff, rr_, dd, dd2, cens);
                 (g2, cz, cm)
             };
@@ -1214,7 +1214,7 @@ fn prepare_stacked(
             let kern_scaled = |ff: f64, ss: f64| -> (f64, f64, f64) {
                 let r = model.error_spec.variance_at(cmt, ff, sigma) * ss;
                 let d = model.error_spec.dvar_df(cmt, ff, sigma) * ss;
-                let d2 = model.error_spec.d2var_df2(cmt, sigma) * ss;
+                let d2 = model.error_spec.d2var_df2(cmt, ff, sigma) * ss;
                 let (_g1, g2, cz, cm) = m3_censored_outer(y, ff, r, d, d2, cens);
                 (g2, cz, cm)
             };
@@ -1614,7 +1614,7 @@ fn sigma_block(
                 let kern_at = |sa: &[f64]| -> (f64, f64, f64) {
                     let r = model.error_spec.variance_at(cmt, f, sa) * prep.ruv_scale;
                     let d = model.error_spec.dvar_df(cmt, f, sa) * prep.ruv_scale;
-                    let d2 = model.error_spec.d2var_df2(cmt, sa) * prep.ruv_scale;
+                    let d2 = model.error_spec.d2var_df2(cmt, f, sa) * prep.ruv_scale;
                     let (_g1, g2, cz, cm) = m3_censored_outer(y, f, r, d, d2, prep.et[j].cens_sign);
                     (g2, cz, cm)
                 };

--- a/src/estimation/sens_outer_gradient_tests.rs
+++ b/src/estimation/sens_outer_gradient_tests.rs
@@ -273,12 +273,12 @@ fn precise_ebe(model: &CompiledModel, subject: &Subject, params: &ModelParameter
                 (None, Some(m)) => (
                     model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m),
                     model.error_spec.dvar_df_scaled(cmt, f, sigma, m),
-                    model.error_spec.d2var_df2_scaled(cmt, sigma, m),
+                    model.error_spec.d2var_df2_scaled(cmt, f, sigma, m),
                 ),
                 (None, None) => (
                     model.error_spec.variance_at(cmt, f, sigma),
                     model.error_spec.dvar_df(cmt, f, sigma),
-                    model.error_spec.d2var_df2(cmt, sigma),
+                    model.error_spec.d2var_df2(cmt, f, sigma),
                 ),
             };
             let y = subject.observations[j];
@@ -634,12 +634,12 @@ fn precise_ebe_ruv(model: &CompiledModel, subject: &Subject, params: &ModelParam
                 Some(mr) => (
                     model.error_spec.variance_at_scaled(cmt, f, sigma, &[], mr) * s,
                     model.error_spec.dvar_df_scaled(cmt, f, sigma, mr) * s,
-                    model.error_spec.d2var_df2_scaled(cmt, sigma, mr) * s,
+                    model.error_spec.d2var_df2_scaled(cmt, f, sigma, mr) * s,
                 ),
                 None => (
                     model.error_spec.variance_at(cmt, f, sigma) * s,
                     model.error_spec.dvar_df(cmt, f, sigma) * s,
-                    model.error_spec.d2var_df2(cmt, sigma) * s,
+                    model.error_spec.d2var_df2(cmt, f, sigma) * s,
                 ),
             };
             let y = subject.observations[j];
@@ -3260,12 +3260,12 @@ fn precise_ebe_iov(
                 Some(m) => (
                     model.error_spec.variance_at_scaled(cmt, f, sigma, &[], m) * ruv_scale,
                     model.error_spec.dvar_df_scaled(cmt, f, sigma, m) * ruv_scale,
-                    model.error_spec.d2var_df2_scaled(cmt, sigma, m) * ruv_scale,
+                    model.error_spec.d2var_df2_scaled(cmt, f, sigma, m) * ruv_scale,
                 ),
                 None => (
                     model.error_spec.variance_at(cmt, f, sigma) * ruv_scale,
                     model.error_spec.dvar_df(cmt, f, sigma) * ruv_scale,
-                    model.error_spec.d2var_df2(cmt, sigma) * ruv_scale,
+                    model.error_spec.d2var_df2(cmt, f, sigma) * ruv_scale,
                 ),
             };
             let y = subject.observations[j];

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -300,6 +300,16 @@ impl ErrorSpec {
         if self.variance_at(cmt, f, sigma) <= MIN_VARIANCE {
             return 0.0;
         }
+        self.dvar_df_raw(cmt, f, sigma)
+    }
+
+    /// Raw (unfloored) `∂v/∂f` — the closed-form proportional slope before the
+    /// `MIN_VARIANCE` floor gate. Both floored entry points share it so the
+    /// closed form lives once: [`dvar_df`](Self::dvar_df) gates it on the
+    /// unscaled `variance_at`, while [`dvar_df_scaled`](Self::dvar_df_scaled)
+    /// gates it on the *scaled* variance it actually pairs with. Returns 0 for
+    /// additive endpoints and for an unregistered `PerCmt` cmt.
+    fn dvar_df_raw(&self, cmt: usize, f: f64, sigma: &[f64]) -> f64 {
         let (em, prop_sigma) = match self {
             ErrorSpec::Single(em) => (*em, sigma.first().copied().unwrap_or(0.0)),
             ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
@@ -354,7 +364,19 @@ impl ErrorSpec {
             return 0.0;
         };
         let m = mult.get(prop_slot).copied().unwrap_or(1.0);
-        self.dvar_df(cmt, f, sigma) * m * m
+        // Gate the floor on the *scaled* variance this derivative pairs with —
+        // `variance_at_scaled` folds the magnitude `m` into the loading *before*
+        // clamping, exactly as `residual_rd`/`residual_rd2` compute the R that
+        // consumes this slope. Gating on the unscaled `variance_at` (via
+        // `dvar_df`) puts the floor boundary at a different `f` whenever `m ≠ 1`,
+        // so the objective sees a live variance while the analytic slope reads 0
+        // (or vice-versa) — the #958 analytic-vs-FD gradient mismatch, on the
+        // #484 magnitude path. `&[]`: correlations force FD upstream (diagonal-R
+        // only here), matching the `residual_rd` call.
+        if self.variance_at_scaled(cmt, f, sigma, &[], mult) <= MIN_VARIANCE {
+            return 0.0;
+        }
+        self.dvar_df_raw(cmt, f, sigma) * m * m
     }
 
     /// `d²(residual variance)/d(prediction f)²` for one observation at `cmt`.
@@ -375,6 +397,15 @@ impl ErrorSpec {
         if self.variance_at(cmt, f, sigma) <= MIN_VARIANCE {
             return 0.0;
         }
+        self.d2var_df2_raw(cmt, sigma)
+    }
+
+    /// Raw (unfloored) `∂²v/∂f²` — the constant proportional curvature before the
+    /// `MIN_VARIANCE` floor gate. Shared by [`d2var_df2`](Self::d2var_df2) (gated
+    /// on the unscaled variance) and [`d2var_df2_scaled`](Self::d2var_df2_scaled)
+    /// (gated on the scaled variance it pairs with). `f`-independent, so it takes
+    /// no `f`. Returns 0 for additive endpoints and an unregistered `PerCmt` cmt.
+    fn d2var_df2_raw(&self, cmt: usize, sigma: &[f64]) -> f64 {
         let (em, prop_sigma) = match self {
             ErrorSpec::Single(em) => (*em, sigma.first().copied().unwrap_or(0.0)),
             ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
@@ -418,7 +449,15 @@ impl ErrorSpec {
             return 0.0;
         };
         let m = mult.get(prop_slot).copied().unwrap_or(1.0);
-        self.d2var_df2(cmt, f, sigma) * m * m
+        // Floor on the scaled variance this curvature is the second derivative
+        // of — same reasoning as `dvar_df_scaled`. Gating on the unscaled
+        // `variance_at` (via `d2var_df2`) leaves the M3 covariance Hessian a
+        // spurious `2·m²·σ²` where the scaled variance is floored constant,
+        // biasing the standard errors on the #484 magnitude path.
+        if self.variance_at_scaled(cmt, f, sigma, &[], mult) <= MIN_VARIANCE {
+            return 0.0;
+        }
+        self.d2var_df2_raw(cmt, sigma) * m * m
     }
 
     /// `d(residual variance)/d(log σ_k)` for one observation at `cmt`, where
@@ -2332,6 +2371,79 @@ mod tests {
             + spec.variance_at(1, f - h, &sigma))
             / (h * h);
         assert_relative_eq!(spec.d2var_df2(1, f, &sigma), fd2, max_relative = 1e-4);
+    }
+
+    /// #958 scope gap on the #484 custom-magnitude path: the `_scaled` derivative
+    /// accessors must gate the `MIN_VARIANCE` floor on the *scaled* variance they
+    /// pair with (`variance_at_scaled`), not the unscaled `variance_at`. With a
+    /// magnitude multiplier `m ≠ 1` the two floor at different predictions, so a
+    /// unscaled gate zeroed the analytic slope on a band where the objective's
+    /// variance is still live — reviving the analytic-vs-FD gradient mismatch.
+    #[test]
+    fn dvar_df_scaled_floor_gates_on_scaled_variance() {
+        let spec = ErrorSpec::Single(ErrorModel::Proportional);
+        let sigma = [0.15];
+        let mult = [100.0]; // m = 100 on the proportional sigma slot
+        let corr: [ResidualCorrelation; 0] = [];
+
+        // Band where the UNSCALED variance is floored but the SCALED variance is
+        // still live: 1e-6/(m·σ) < f < 1e-6/σ, i.e. 6.7e-8 < f < 6.7e-6.
+        let f_band = 1e-6_f64;
+        assert!(
+            spec.variance_at(1, f_band, &sigma) <= MIN_VARIANCE,
+            "precondition: unscaled variance is floored here"
+        );
+        assert!(
+            spec.variance_at_scaled(1, f_band, &sigma, &corr, &mult) > MIN_VARIANCE,
+            "precondition: scaled variance (m=100) is above the floor here"
+        );
+        // The old unscaled gate returned 0 here; the derivative must instead be
+        // the live scaled slope, matching central FD of `variance_at_scaled`.
+        assert_ne!(
+            spec.dvar_df_scaled(1, f_band, &sigma, &mult),
+            0.0,
+            "∂v/∂f must be live where the SCALED variance is above the floor"
+        );
+        let h = 1e-8;
+        let fd1 = (spec.variance_at_scaled(1, f_band + h, &sigma, &corr, &mult)
+            - spec.variance_at_scaled(1, f_band - h, &sigma, &corr, &mult))
+            / (2.0 * h);
+        assert_relative_eq!(
+            spec.dvar_df_scaled(1, f_band, &sigma, &mult),
+            fd1,
+            max_relative = 1e-5
+        );
+        let fd2 = (spec.variance_at_scaled(1, f_band + h, &sigma, &corr, &mult)
+            - 2.0 * spec.variance_at_scaled(1, f_band, &sigma, &corr, &mult)
+            + spec.variance_at_scaled(1, f_band - h, &sigma, &corr, &mult))
+            / (h * h);
+        assert_relative_eq!(
+            spec.d2var_df2_scaled(1, f_band, &sigma, &mult),
+            fd2,
+            max_relative = 1e-3
+        );
+
+        // Below the SCALED floor both derivatives are 0 (variance locally flat).
+        let f_floored = 1e-9_f64;
+        assert!(
+            spec.variance_at_scaled(1, f_floored, &sigma, &corr, &mult) <= MIN_VARIANCE,
+            "precondition: scaled variance is floored here"
+        );
+        assert_eq!(spec.dvar_df_scaled(1, f_floored, &sigma, &mult), 0.0);
+        assert_eq!(spec.d2var_df2_scaled(1, f_floored, &sigma, &mult), 0.0);
+
+        // Well above the floor the scaled forms equal the raw m²-scaled values.
+        let f_hi = 10.0_f64;
+        assert_relative_eq!(
+            spec.dvar_df_scaled(1, f_hi, &sigma, &mult),
+            2.0 * f_hi * (100.0 * 0.15) * (100.0 * 0.15),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            spec.d2var_df2_scaled(1, f_hi, &sigma, &mult),
+            2.0 * (100.0 * 0.15) * (100.0 * 0.15),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -283,6 +283,23 @@ impl ErrorSpec {
     /// first sigma for both `Proportional` and `Combined`). `Single` ignores
     /// `cmt`; `PerCmt` dispatches on the endpoint registered for `cmt`.
     pub fn dvar_df(&self, cmt: usize, f: f64, sigma: &[f64]) -> f64 {
+        // Floor-aware derivative: `variance_at` clamps the raw variance to
+        // `MIN_VARIANCE` (`v.max(MIN_VARIANCE)`), so on the clamped side the
+        // variance is locally *constant* in `f` and its true `∂v/∂f` is 0 — not
+        // the raw `2·f·σ²`. Returning the raw slope where the floor is active
+        // makes every analytic path that consumes `∂R/∂f` (the inner-EBE
+        // gradient's `coef`, the FOCEI Laplace `c̃` term, the outer θ-gradient)
+        // disagree with the finite-difference objective, which sees the clamped
+        // function. This bites a proportional-error row whose prediction is
+        // driven to ~0 (drug fully eliminated) — the analytic inner gradient
+        // then leads the EBE search to a different mode than FD, and the FOCEI
+        // objective becomes gradient-path-dependent (#958). `variance_at`
+        // returns exactly `MIN_VARIANCE` iff the raw variance was clamped; a
+        // `NaN` (unregistered `PerCmt` cmt) fails the comparison and falls
+        // through to the `None` arm below, which already returns 0.
+        if self.variance_at(cmt, f, sigma) <= MIN_VARIANCE {
+            return 0.0;
+        }
         let (em, prop_sigma) = match self {
             ErrorSpec::Single(em) => (*em, sigma.first().copied().unwrap_or(0.0)),
             ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
@@ -349,7 +366,15 @@ impl ErrorSpec {
     /// for `cmt`. Used by the Almquist Laplace FOCEI gradient's θ-axis β_j
     /// chain — keeping the per-CMT routing here lets the same closed-form
     /// gradient handle multi-endpoint models without changing the call site.
-    pub fn d2var_df2(&self, cmt: usize, sigma: &[f64]) -> f64 {
+    ///
+    /// Floor-aware in `f` for the same reason as [`dvar_df`](Self::dvar_df):
+    /// where `variance_at` clamps the raw variance to `MIN_VARIANCE`, the
+    /// clamped variance is locally constant in `f`, so `∂²v/∂f² = 0` — not the
+    /// raw `2·σ²` (#958).
+    pub fn d2var_df2(&self, cmt: usize, f: f64, sigma: &[f64]) -> f64 {
+        if self.variance_at(cmt, f, sigma) <= MIN_VARIANCE {
+            return 0.0;
+        }
         let (em, prop_sigma) = match self {
             ErrorSpec::Single(em) => (*em, sigma.first().copied().unwrap_or(0.0)),
             ErrorSpec::PerCmt(map) | ErrorSpec::Selected { endpoints: map, .. } => {
@@ -388,12 +413,12 @@ impl ErrorSpec {
     /// [`dvar_df_scaled`]: ErrorSpec::dvar_df_scaled
     /// [`dvar_df`]: ErrorSpec::dvar_df
     /// [`d2var_df2`]: ErrorSpec::d2var_df2
-    pub fn d2var_df2_scaled(&self, cmt: usize, sigma: &[f64], mult: &[f64]) -> f64 {
+    pub fn d2var_df2_scaled(&self, cmt: usize, f: f64, sigma: &[f64], mult: &[f64]) -> f64 {
         let Some(prop_slot) = self.prop_sigma_slot(cmt) else {
             return 0.0;
         };
         let m = mult.get(prop_slot).copied().unwrap_or(1.0);
-        self.d2var_df2(cmt, sigma) * m * m
+        self.d2var_df2(cmt, f, sigma) * m * m
     }
 
     /// `d(residual variance)/d(log σ_k)` for one observation at `cmt`, where
@@ -2260,6 +2285,55 @@ mod tests {
         assert_relative_eq!(v, MIN_VARIANCE, epsilon = 1e-20);
     }
 
+    /// #958: `variance_at` clamps the raw variance to `MIN_VARIANCE`, so on the
+    /// clamped side the variance is *constant* in `f` and its exact `∂v/∂f` /
+    /// `∂²v/∂f²` are both 0. The derivative accessors must reflect that clamp —
+    /// returning the raw `2·f·σ²` / `2·σ²` there would make every analytic path
+    /// that consumes `∂R/∂f` (inner-EBE gradient, FOCEI Laplace `c̃`, outer
+    /// θ-gradient, covariance) disagree with the finite-difference objective,
+    /// which sees the clamped function. Concretely a proportional-error row
+    /// whose prediction is driven to ~0 (drug fully eliminated) made the FOCEI
+    /// objective gradient-path-dependent.
+    #[test]
+    fn dvar_df_and_d2var_df2_are_floor_aware() {
+        let spec = ErrorSpec::Single(ErrorModel::Proportional);
+        let sigma = [0.15];
+        // Prediction small enough that (f·σ)² < MIN_VARIANCE → variance clamped.
+        let f_floored = 1e-6_f64; // (1e-6·0.15)² = 2.25e-14 < 1e-12
+        assert!(
+            spec.variance_at(1, f_floored, &sigma) <= MIN_VARIANCE,
+            "precondition: variance must be clamped at this prediction"
+        );
+        assert_eq!(
+            spec.dvar_df(1, f_floored, &sigma),
+            0.0,
+            "∂v/∂f must be 0 where the variance floor is active"
+        );
+        assert_eq!(
+            spec.d2var_df2(1, f_floored, &sigma),
+            0.0,
+            "∂²v/∂f² must be 0 where the variance floor is active"
+        );
+
+        // Above the floor, the derivatives are the raw proportional values and
+        // must match central finite differences of `variance_at` itself.
+        let f = 10.0_f64; // (10·0.15)² = 2.25 ≫ MIN_VARIANCE
+        assert!(spec.variance_at(1, f, &sigma) > MIN_VARIANCE);
+        let h = 1e-4;
+        let fd1 =
+            (spec.variance_at(1, f + h, &sigma) - spec.variance_at(1, f - h, &sigma)) / (2.0 * h);
+        assert_relative_eq!(spec.dvar_df(1, f, &sigma), fd1, max_relative = 1e-6);
+        assert_relative_eq!(
+            spec.dvar_df(1, f, &sigma),
+            2.0 * f * 0.15 * 0.15,
+            epsilon = 1e-12
+        );
+        let fd2 = (spec.variance_at(1, f + h, &sigma) - 2.0 * spec.variance_at(1, f, &sigma)
+            + spec.variance_at(1, f - h, &sigma))
+            / (h * h);
+        assert_relative_eq!(spec.d2var_df2(1, f, &sigma), fd2, max_relative = 1e-4);
+    }
+
     #[test]
     fn test_iwres_perfect_prediction() {
         let r = iwres(10.0, 10.0, ErrorModel::Additive, &[1.0]);
@@ -2524,12 +2598,12 @@ pub(crate) fn residual_rd2(
         Some(m) => (
             es.variance_at_scaled(cmt, f, sigma, &[], m),
             es.dvar_df_scaled(cmt, f, sigma, m),
-            es.d2var_df2_scaled(cmt, sigma, m),
+            es.d2var_df2_scaled(cmt, f, sigma, m),
         ),
         None => (
             es.variance_at(cmt, f, sigma),
             es.dvar_df(cmt, f, sigma),
-            es.d2var_df2(cmt, sigma),
+            es.d2var_df2(cmt, f, sigma),
         ),
     }
 }

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -1115,11 +1115,15 @@ fn d2var_df2_scaled_scales_by_mprop_squared() {
     // reproduces the unscaled value; additive stays 0 at any mult.
     let combined = ErrorSpec::Single(ErrorModel::Combined);
     let sigma = [0.3, 2.0];
-    let base = combined.d2var_df2(1, &sigma);
-    assert!((combined.d2var_df2_scaled(1, &sigma, &[3.0, 1.0]) - base * 9.0).abs() < 1e-12);
-    assert!((combined.d2var_df2_scaled(1, &sigma, &[1.0, 1.0]) - base).abs() < 1e-12);
+    // A prediction well away from 0: the combined variance `(f·σ₁)² + σ₂²`
+    // stays far above the `MIN_VARIANCE` floor, so `d2var_df2` returns the raw
+    // `2·σ₁²` and the m² scaling below is unaffected by the floor gate (#958).
+    let f = 5.0;
+    let base = combined.d2var_df2(1, f, &sigma);
+    assert!((combined.d2var_df2_scaled(1, f, &sigma, &[3.0, 1.0]) - base * 9.0).abs() < 1e-12);
+    assert!((combined.d2var_df2_scaled(1, f, &sigma, &[1.0, 1.0]) - base).abs() < 1e-12);
     assert_eq!(
-        ErrorSpec::Single(ErrorModel::Additive).d2var_df2_scaled(1, &[0.5], &[4.0]),
+        ErrorSpec::Single(ErrorModel::Additive).d2var_df2_scaled(1, f, &[0.5], &[4.0]),
         0.0
     );
 }


### PR DESCRIPTION
## Why

`gradient = auto` (analytic `Dual2` inner/outer gradients) and `gradient = fd` produced **different FOCE/FOCEI objectives for the same model at the same estimates** (#958). On the issue's reproducer the first-evaluation OFV was auto `325.90558` vs fd `324.81958` — a 0.33% gap, ~1000× the agreement floor of the control cells. Because the objective is what ΔOFV/ΔAIC model selection compares, this makes model choice gradient-path-dependent with nothing in the output flagging it. `auto` is the default, so users hit it without opting in.

Root cause: the residual-variance floor `MIN_VARIANCE = 1e-12` (which clamps `(f·σ)²` so a vanishing prediction cannot produce a zero variance) is applied in `variance_at`/`residual_variance` but **not** in the derivative accessors `ErrorSpec::dvar_df` / `d2var_df2` (and their `_scaled` variants). Those returned the raw `2·f·σ²` / `2·σ²` even where the variance is clamped constant in `f` (true derivative 0).

On a proportional-error row whose prediction is driven to ~0 (drug fully eliminated at a late sample), the objective's variance is floored and locally constant, so `∂R/∂f = 0`. The analytic inner-EBE gradient used the raw nonzero slope → its per-observation coefficient diverged from FD of `individual_nll` → the EBE search landed on a different mode → different FOCEI objective.

**The issue misdiagnosed this** as a θ-dependent `init()` + `sqrt` sensitivity scope gap. The ODE prediction sensitivities `∂f/∂η` are correct throughout (verified vs FD across an η grid); init sensitivities are already seeded (`init_fd_derivs`). The `init(θ)` + `sqrt` combination is only the *trigger* that pushes a drug row below the floor with non-negligible `∂f/∂η`. Bisection with a per-observation FD confirmed exactly **one** row (the eliminated-drug tail sample) carried the entire gradient error.

## What changed

`dvar_df` / `d2var_df2` (and `dvar_df_scaled` / `d2var_df2_scaled`) return `0` when `variance_at(cmt, f, sigma) <= MIN_VARIANCE` — i.e. exactly where the raw variance was clamped, so `∂v/∂f = ∂²v/∂f² = 0`. `d2var_df2` gained an `f` parameter to test the floor; every call site (`sens_cov_hessian`, `sens_outer_gradient`, `gauss_newton`) already had the prediction in hand. Above the floor the accessors are unchanged (bit-identical to `2·f·σ²` / `2·σ²`), so no non-floored fit moves.

## Alternatives considered

The issue suggested routing θ/η-dependent `init()` to FD via a support predicate. Rejected: the init sensitivities are already correct and are not the cause, so an FD fallback would mask the real bug **and** needlessly disable the (correct) analytic gradient for every parameter-dependent-init model. Fixing the floor-unaware derivative is the general, minimal fix — it also covers any proportional-error model with a near-zero prediction, ODE or closed-form.

## Numerical validation

- [x] Compared against: `gradient = fd` on the same model (the FD objective is the anchor — it already sees the clamped variance) and prior ferx commit.

```
# issue reproducer, first-evaluation OFV
# before
gradient=auto : 325.905579
gradient=fd   : 324.819579     (auto/fd = 1.003343)
# after
gradient=auto : 324.808689
gradient=fd   : 324.808711     (agree to ~7e-8)
```

Per-subject inner EBEs also match between paths after the fix (they diverged before — e.g. subject 3 EBE `[0.517, -0.101]` under auto vs `[0.522, -0.152]` under fd).

## Breaking changes
- [x] None

## Performance
- [x] No significant impact expected (the added `variance_at` call in the derivative accessors is a few flops on a non-hot path relative to ODE integration).

## Tests
- [x] Unit test added (`cargo test --lib` passes — 2801 pass, 0 fail)
- [x] Regression test added that fails without this fix

Both new tests fail on the pre-fix code (verified by neutralizing the floor gate):
- `stats::residual_error::tests::dvar_df_and_d2var_df2_are_floor_aware` — pins the derivatives to 0 at a floored prediction and to central FD of `variance_at` above the floor.
- `estimation::inner_optimizer::tests::analytic_inner_gradient_ode_init_theta_sqrt_matches_fd` — the exact reported scenario (two-state binding ODE, `init(RTOT) = RBASE`, `sqrt` quadratic, per-CMT proportional error); analytic inner η-gradient must match FD of `individual_nll` at a non-zero η that floors the drug tail sample.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` → `Fixed` entry added
- [x] No user-visible API change (behavioural correctness fix)

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] `Dual2` sensitivity path stays differentiable — the change is in the residual-variance derivative accessors, not the `*_g<T: PkNum>` kernels; analytic ↔ FD parity is now *restored*, not broken

## Not in scope

The issue's two "smaller things" are left as follow-ups (unrelated to the root cause): (1) `gradient = ad` accepted by the parser but rejected by the engine — the parse-time message still advertises `ad`; (2) `gn_hybrid`'s FOCEI polish phase appearing near-stalled. Happy to open separate issues/PRs.

## Reviewer hints

Focus on `src/stats/residual_error.rs` — the two floor gates and the `d2var_df2` signature change. The call-site edits are mechanical (thread the already-available `f` into `d2var_df2`); the value at each site is the same prediction already passed to the adjacent `variance_at`/`dvar_df`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)