### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-07
+
 ### Added
 - **New ODE steppers via `[fit_options] ode_method`,** on two independent axes. For
   **stability**: the linearly implicit Rosenbrock methods `rosenbrock23` (order 2, aliases
@@ -3746,7 +3748,8 @@ and `git log v0.1.0..v0.1.5` for details.
 Initial tagged release. See the
 [GitHub release](https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/FeRx-NLME/ferx-core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.0...v0.1.5
 [0.1.0]: https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferx-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "approx",
  "argmin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferx-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Nonlinear Mixed Effects modeling engine with FOCE/FOCEI estimation"
 license = "MIT"


### PR DESCRIPTION
## Why
Cut the 0.3.0 release. All changes accumulated under `[Unreleased]` since 0.2.0 (2026-07-03) are ready to tag.

## What changed
- `Cargo.toml` + `Cargo.lock`: version `0.2.0` → `0.3.0`.
- `CHANGELOG.md`: `[Unreleased]` block promoted to `## [0.3.0] - 2026-08-07`; fresh empty `[Unreleased]` started; compare links updated.

No source changes — release bookkeeping only.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | pending | together |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (release bookkeeping only)

## Tests
- [x] No new tests needed (version/changelog bump only)

## Docs
- [x] `CHANGELOG.md` updated

## Checklist
- [ ] Tag `v0.3.0` pushed after merge (triggers GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)