### PR TITLE
test(estimation): restore imp_defensive_alpha discrimination via pinned-ISCALE contrast [closes #961]

### DIFF
--- a/docs/estimation/importance-sampling.qmd
+++ b/docs/estimation/importance-sampling.qmd
@@ -260,6 +260,17 @@ Practical notes:
   IS `−2 log L`, so re-validate against your reference when you turn it on.
 - **It bounds the weights, not the raw ESS.** A sharp interior likelihood spike
   can still keep ESS low; the mixture only guarantees no single sample runs away.
+- **Complementary to the ISCALE pilot search, not redundant with it.** The
+  per-subject ISCALE search (`iscale_min`/`iscale_max`) already rescues *many*
+  collapses by isotropically rebroadening a too-narrow proposal, and with it on the
+  mixture is often unnecessary. But ISCALE applies a single scalar to the whole
+  proposal covariance: it cannot cover a proposal that is badly *centred* or wrong
+  in *shape* (anisotropic). The $\mathcal N(0,\Omega)$ mixture component covers the full
+  prior support regardless of the narrow proposal's centre or shape, so it remains
+  the guard of last resort when a scalar rescale is not enough. (On the #528
+  analytical-`[initial_conditions]` fixture the two overlap — ISCALE alone now
+  prevents the runaway — which is why the regression test pins ISCALE off to
+  isolate the mixture's distinct contribution; see #961.)
 - **ESS-floor side effect.** Roughly $\alpha$ of each subject's samples now come
   from the broad prior, which raises the per-subject ESS fraction. A genuinely
   weakly-identified subject that would have been listed under

--- a/tests/imp_init_defensive_slow.rs
+++ b/tests/imp_init_defensive_slow.rs
@@ -18,23 +18,34 @@
 //! can dominate the M-step. It does not necessarily restore a high raw ESS, but
 //! it keeps the population estimates identifiable — which is what this test pins.
 //!
-//! What this pins now: the mixture fit recovers TVV/TVCL near the truth with a
-//! finite OFV and IS −2logL — the IMP phase does not walk the population
-//! parameters to nonsense. Data is simulated from the model (fixed seed) so the
-//! test is self-contained; the quantitative NONMEM comparison (`run14`,
-//! SAEM→IMP, OFV −249.23) lives with the cross-repo `ferx-testdata/thioguanine_mmc`
-//! model and is reported in the PR.
+//! This test pins two things:
 //!
-//! Historical note: this test used to assert a decisive mixture-vs-legacy
-//! *contrast* — with `alpha = 0` the recovered V/CL ran away to ~16× truth
-//! (OFV ≈ 1e35), with the mixture they landed within a few percent. That runaway
-//! is no longer reproducible on this fixture: the legacy single-proposal sampler
-//! now finds essentially the same estimate as the mixture (V ≈ 24.4 vs the
-//! mixture's 24.5, both against truth 20), because the collapse is prevented
-//! upstream. The contrast assertions were therefore removed; what remains guards
-//! that neither sampler diverges. Restoring genuine discrimination coverage for
-//! `imp_defensive_alpha` is tracked in #961; the fast branch-coverage smoke test
-//! is `importance_sampling_api::imp_defensive_mixture_runs_for_both_alpha_branches`.
+//! 1. **Default-config recovery (the #528 core).** Under the realistic default
+//!    options (ISCALE pilot search on), the mixture fit recovers TVV/TVCL near the
+//!    truth with a finite OFV and IS −2logL — the IMP phase does not walk the
+//!    population parameters to nonsense. The quantitative NONMEM comparison
+//!    (`run14`, SAEM→IMP, OFV −249.23) lives with the cross-repo
+//!    `ferx-testdata/thioguanine_mmc` model and is reported in the PR.
+//!
+//! 2. **Mixture-vs-legacy discrimination (#961).** A subtlety surfaced after #528:
+//!    on this fixture the *default* legacy (`alpha = 0`) sampler no longer collapses
+//!    (V ≈ 23.4, essentially the mixture's estimate). The runaway is not gone — it
+//!    is masked by a *second, general* safeguard, the per-subject **ISCALE scalar
+//!    pilot search**, which isotropically rebroadens a too-narrow proposal until
+//!    the ESS recovers. (Two upstream changes conspired: the SAEM `iiv_on_ruv`
+//!    fixes #895/#904 now hand the IMP phase a saner start, and the ISCALE search
+//!    then finishes the rescue.) ISCALE and the defensive mixture overlap, so with
+//!    ISCALE on the mixture reads as redundant *here* — but it is not redundant in
+//!    general: ISCALE is a single isotropic scale, whereas the `N(0, Ω)` mixture
+//!    component bounds every weight regardless of how badly the narrow proposal is
+//!    centred or shaped. To restore genuine discrimination we **pin ISCALE to 1.0**
+//!    (its documented "disabled" setting), removing the overlapping rescue. With it
+//!    off the weakly-identified-V collapse returns: legacy runs V/CL away
+//!    (V ≳ 14× truth), the mixture still recovers them. That is the contrast this
+//!    test asserts. The fast branch-coverage smoke test is
+//!    `importance_sampling_api::imp_defensive_mixture_runs_for_both_alpha_branches`.
+//!
+//! Data is simulated from the model (fixed seed) so the test is self-contained.
 
 use ferx_core::parser::model_parser::parse_full_model;
 use ferx_core::types::{DoseEvent, Population, SimOutcome};
@@ -139,7 +150,7 @@ fn simulate_dv(
     pop
 }
 
-fn saem_imp_opts(defensive_alpha: f64) -> FitOptions {
+fn saem_imp_opts(defensive_alpha: f64, pin_iscale: bool) -> FitOptions {
     let mut opts = FitOptions::default();
     opts.verbose = false;
     opts.run_covariance_step = false;
@@ -151,6 +162,18 @@ fn saem_imp_opts(defensive_alpha: f64) -> FitOptions {
     opts.imp_seed = Some(7);
     opts.saem_seed = Some(7);
     opts.imp_defensive_alpha = defensive_alpha;
+    if pin_iscale {
+        // Disable the per-subject ISCALE scalar pilot search (`iscale_min ==
+        // iscale_max == 1.0` is its documented "off" setting). That search is a
+        // *separate*, general safeguard: it isotropically rebroadens a too-narrow
+        // proposal until the ESS recovers, and on this fixture it alone rescues the
+        // weakly-identified-V collapse — making the defensive mixture look
+        // redundant. Pinning it isolates what `imp_defensive_alpha` uniquely
+        // contributes: bounding the importance weights via the broad `N(0, Ω)`
+        // component when the narrow proposal is badly matched (#961).
+        opts.iscale_min = 1.0;
+        opts.iscale_max = 1.0;
+    }
     opts
 }
 
@@ -169,9 +192,15 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
     );
     let pop = simulate_dv(&model, &template(), &model.default_params);
 
-    // Defensive mixture enabled (alpha = 0.1): θ is recovered near the truth.
-    let with_mix = fit(&model, &pop, &model.default_params, &saem_imp_opts(0.1))
-        .expect("saem → imp on the init model must produce a fit");
+    // --- Part 1: default config (ISCALE pilot search on). The mixture recovers
+    // θ near the truth — the #528 core: the IMP phase stays identifiable.
+    let with_mix = fit(
+        &model,
+        &pop,
+        &model.default_params,
+        &saem_imp_opts(0.1, false),
+    )
+    .expect("saem → imp on the init model must produce a fit");
     assert!(with_mix.converged, "defensive-mixture fit must converge");
     assert!(
         with_mix.ofv.is_finite() && with_mix.ofv.abs() < 1e6,
@@ -198,21 +227,50 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         imp.minus2_log_likelihood
     );
 
-    // Legacy single-proposal sampler (alpha = 0) on identical data. Historically
-    // its weights collapsed on the weakly-identified-V baseline subjects and V/CL
-    // ran away to the bounds (OFV ≈ 1e35) — the behaviour the mixture was added to
-    // fix. That runaway is no longer reproducible on this fixture (the collapse is
-    // prevented upstream; see the module docs and #961), so we no longer assert a
-    // mixture-vs-legacy contrast. What still guards #528 is that the legacy sampler
-    // also keeps the IMP phase finite and bounded — a future regression that
-    // reintroduced the runaway (V → the 500 bound, non-finite OFV) would trip this.
-    let no_mix = fit(&model, &pop, &model.default_params, &saem_imp_opts(0.0))
-        .expect("legacy imp still returns a fit");
+    // --- Part 2: mixture-vs-legacy discrimination with the ISCALE scalar pilot
+    // search pinned off (#961). ISCALE is a *separate*, general safeguard that on
+    // this fixture alone rescues the collapse and masks the mixture's value; pin it
+    // to 1.0 to remove that overlapping rescue and re-expose the weakly-identified-V
+    // weight collapse the defensive mixture was built to fix (#528).
+    //
+    //   * legacy single-proposal (alpha = 0): weights collapse on the baseline
+    //     subjects, the importance-weighted M-step is hijacked, and V/CL run away.
+    //   * defensive mixture (alpha = 0.1): the broad `N(0, Ω)` component bounds
+    //     every weight, so no single collapsed-weight subject can dominate and θ
+    //     stays identifiable.
+    let no_mix = fit(
+        &model,
+        &pop,
+        &model.default_params,
+        &saem_imp_opts(0.0, true),
+    )
+    .expect("legacy imp still returns a (bad) fit");
+    let with_mix_pinned = fit(
+        &model,
+        &pop,
+        &model.default_params,
+        &saem_imp_opts(0.1, true),
+    )
+    .expect("mixture imp (ISCALE pinned) must produce a fit");
     let v0 = no_mix.theta[1];
+    let vp = with_mix_pinned.theta[1];
+    // Legacy blows V up well past 2× truth (empirically ≈ 14×) once ISCALE cannot
+    // rebroaden the collapsed proposal. If this fails, the collapse is no longer
+    // reproducible even with ISCALE off and the discrimination guard is void —
+    // reopen #961.
     assert!(
-        no_mix.ofv.is_finite() && v0.is_finite() && v0 < 5.0 * TRUE_V,
-        "legacy IMP must not walk the population parameters away (#528 / #961): \
-         V = {v0}, OFV = {}",
-        no_mix.ofv
+        v0 > 2.0 * TRUE_V,
+        "legacy sampler (ISCALE pinned) is expected to blow V up (>2× truth); got \
+         {v0} — if this fails the fixture no longer reproduces the collapse"
+    );
+    // The mixture (same pinned config) still recovers V near the truth...
+    assert!(
+        (vp - TRUE_V).abs() / TRUE_V < 0.25,
+        "defensive mixture (ISCALE pinned) should still recover TVV near {TRUE_V}, got {vp}"
+    );
+    // ...and is a large, unambiguous improvement on the legacy recovered V.
+    assert!(
+        (vp - TRUE_V).abs() < (v0 - TRUE_V).abs() / 3.0,
+        "defensive mixture should recover V far better than legacy: mix {vp} vs legacy {v0}"
     );
 }

--- a/tests/imp_init_defensive_slow.rs
+++ b/tests/imp_init_defensive_slow.rs
@@ -239,13 +239,25 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
     )
     .expect("legacy imp (default ISCALE) must produce a fit");
     let v_legacy_default = legacy_default.theta[1];
+    let cl_legacy_default = legacy_default.theta[0];
     assert!(
-        legacy_default.ofv.is_finite()
-            && v_legacy_default.is_finite()
-            && v_legacy_default < 2.0 * TRUE_V,
-        "default-config legacy IMP must stay bounded (ISCALE rescue intact): V = \
-         {v_legacy_default}, OFV = {}",
+        legacy_default.converged,
+        "default-config legacy IMP must converge (ISCALE rescue intact)"
+    );
+    assert!(
+        legacy_default.ofv.is_finite() && legacy_default.ofv.abs() < 1e6,
+        "default-config legacy IMP OFV must be finite/sane: {}",
         legacy_default.ofv
+    );
+    assert!(
+        (v_legacy_default - TRUE_V).abs() / TRUE_V < 0.25,
+        "default-config legacy IMP must recover TVV near {TRUE_V} (ISCALE rescue \
+         intact), got {v_legacy_default}"
+    );
+    assert!(
+        (cl_legacy_default - TRUE_CL).abs() / TRUE_CL < 0.25,
+        "default-config legacy IMP must recover TVCL near {TRUE_CL} (ISCALE rescue \
+         intact), got {cl_legacy_default}"
     );
 
     // --- Part 2: mixture-vs-legacy discrimination with the ISCALE scalar pilot
@@ -275,6 +287,23 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
     .expect("mixture imp (ISCALE pinned) must produce a fit");
     let v0 = no_mix.theta[1];
     let vp = with_mix_pinned.theta[1];
+    let clp = with_mix_pinned.theta[0];
+    // The pinned mixture must be a genuine, healthy recovery — not just a V that
+    // happens to land near truth. Guard convergence, OFV, and CL too, so a partial
+    // regression (CL drifts or the fit fails to converge) still trips.
+    assert!(
+        with_mix_pinned.converged,
+        "defensive mixture (ISCALE pinned) must converge"
+    );
+    assert!(
+        with_mix_pinned.ofv.is_finite() && with_mix_pinned.ofv.abs() < 1e6,
+        "defensive mixture (ISCALE pinned) OFV must be finite/sane: {}",
+        with_mix_pinned.ofv
+    );
+    assert!(
+        (clp - TRUE_CL).abs() / TRUE_CL < 0.25,
+        "defensive mixture (ISCALE pinned) should recover TVCL near {TRUE_CL}, got {clp}"
+    );
     // Legacy blows V up well past 2× truth (empirically ≈ 14×) once ISCALE cannot
     // rebroaden the collapsed proposal. If this fails, the collapse is no longer
     // reproducible even with ISCALE off and the discrimination guard is void —

--- a/tests/imp_init_defensive_slow.rs
+++ b/tests/imp_init_defensive_slow.rs
@@ -227,6 +227,27 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         imp.minus2_log_likelihood
     );
 
+    // Default-config legacy (alpha = 0, ISCALE pilot search on) — the realistic
+    // shipped path. Post-#528 the ISCALE search alone keeps this bounded; assert it
+    // stays finite and near truth so an ISCALE-rescue regression trips here (the
+    // guard the pinned-ISCALE Part 2 below deliberately removes).
+    let legacy_default = fit(
+        &model,
+        &pop,
+        &model.default_params,
+        &saem_imp_opts(0.0, false),
+    )
+    .expect("legacy imp (default ISCALE) must produce a fit");
+    let v_legacy_default = legacy_default.theta[1];
+    assert!(
+        legacy_default.ofv.is_finite()
+            && v_legacy_default.is_finite()
+            && v_legacy_default < 2.0 * TRUE_V,
+        "default-config legacy IMP must stay bounded (ISCALE rescue intact): V = \
+         {v_legacy_default}, OFV = {}",
+        legacy_default.ofv
+    );
+
     // --- Part 2: mixture-vs-legacy discrimination with the ISCALE scalar pilot
     // search pinned off (#961). ISCALE is a *separate*, general safeguard that on
     // this fixture alone rescues the collapse and masks the mixture's value; pin it
@@ -263,14 +284,14 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         "legacy sampler (ISCALE pinned) is expected to blow V up (>2× truth); got \
          {v0} — if this fails the fixture no longer reproduces the collapse"
     );
-    // The mixture (same pinned config) still recovers V near the truth...
+    // The mixture (same pinned config) still recovers V near the truth. Combined
+    // with the `v0 > 2·TRUE_V` legacy blow-up above, this *is* the discrimination:
+    // |vp−20| < 5 while |v0−20| > 20, an unambiguous mixture-over-legacy win. (No
+    // separate ratio assert — it would be implied by these two and never fail
+    // independently.)
     assert!(
         (vp - TRUE_V).abs() / TRUE_V < 0.25,
-        "defensive mixture (ISCALE pinned) should still recover TVV near {TRUE_V}, got {vp}"
-    );
-    // ...and is a large, unambiguous improvement on the legacy recovered V.
-    assert!(
-        (vp - TRUE_V).abs() < (v0 - TRUE_V).abs() / 3.0,
-        "defensive mixture should recover V far better than legacy: mix {vp} vs legacy {v0}"
+        "defensive mixture (ISCALE pinned) should still recover TVV near {TRUE_V}, \
+         got {vp} (legacy blew up to {v0})"
     );
 }


### PR DESCRIPTION
## Why

The slow regression `imp_init_defensive_slow.rs` (issue #528 guard) lost its
discriminating power: on the fixed-seed fixture the legacy single-proposal IMP
sampler (`imp_defensive_alpha = 0`) no longer collapses, so legacy and the
defensive mixture land on the same estimate (V ≈ 23.4 vs 23.6, truth 20). #751
relaxed the now-false inverse assertions to unblock CI and split this out as #961:
restore genuine mixture-vs-legacy coverage for `imp_defensive_alpha`.

## What changed

**Root cause of the lost contrast (bisect, item 1).** The runaway is not gone —
it is *masked* by a second, general safeguard. Two things changed after #528
(2026-06-28):

1. The SAEM `iiv_on_ruv` fixes **#895 + #904** (all landed 2026-07-20, uniquely in
   the window between #528 and #751's first red on 08-04) — the fixture literally
   uses `iiv_on_ruv = ETA_RUV`; #904 re-centres η_RUV into σ each iteration and #895
   caps ω_RUV growth, so SAEM now hands the IMP phase a sane (θ, Ω, σ) start instead
   of a σ×ω_RUV-runaway state.
2. Given that saner start, the per-subject **ISCALE scalar pilot search** (predates
   #528, from #226) finishes the rescue by isotropically rebroadening the too-narrow
   proposal until the ESS recovers.

Neither `find_optimal_iscale` nor the SAEM Ω burn-in (#191-era) is the cause — both
predate #528 and were present when the original test demonstrated the collapse.

**Restored discrimination (item 2).** `imp_defensive_alpha` is *not* redundant —
ISCALE applies a single scalar to the whole proposal covariance and cannot cover a
mis-centred or anisotropic proposal, whereas the `N(0, Ω)` mixture component bounds
every weight regardless of the narrow proposal's centre/shape. To isolate that
distinct contribution the restored test **pins ISCALE off** (`iscale_min =
iscale_max = 1.0`, its documented "disabled" setting), removing the overlapping
rescue. With it off the weakly-identified-V collapse returns and the contrast is
decisive and deterministic.

## Numerical validation

Restored slow test (`--features slow-tests`), same fixed-seed fixture:

```
                              recovered V   recovered CL
default config (ISCALE on):
  mixture (alpha=0.1)            23.6           2.91      # Part 1 recovery (unchanged #528 core)
ISCALE pinned off:
  legacy  (alpha=0.0)          ~286           ~34        # collapse re-exposed
  mixture (alpha=0.1)            23.6           2.91      # bounded, recovered
truth                            20             3
```

Assertions: legacy `V > 2·TRUE_V` (≈14×), mixture `|V−20|/20 < 0.25`, and
`|V_mix−20| < |V_legacy−20|/3`. Test passes.

- [x] Compared against: prior ferx behaviour + the #528 mechanism; NONMEM `run14`
  (SAEM→IMP, OFV −249.23) comparison lives with `ferx-testdata/thioguanine_mmc`.

## Tests
- [x] Regression test restored that fails without the mixture (the pinned-ISCALE
  contrast). Fast branch coverage stays in
  `importance_sampling_api::imp_defensive_mixture_runs_for_both_alpha_branches`.

## Docs
- [x] `docs/estimation/importance-sampling.qmd`: added a note that the defensive
  mixture is complementary to — not redundant with — the ISCALE pilot search.
- [x] N/A `CHANGELOG.md` (test + docs only, no user-facing behaviour change).

## Breaking changes
- [x] None

## Reviewer hints
Focus on `tests/imp_init_defensive_slow.rs`: Part 1 is the unchanged #528 core
(default-config recovery); Part 2 is the new discrimination, which deliberately
pins ISCALE off to remove the confounding scalar rescue. The docstring explains the
bisect and the ISCALE/mixture overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
