### PR TITLE
fix(estimation): cap analytic L-BFGS first step to clear warfarin FOCEI stall [closes #960]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ section of the SDLC for the versioning policy).
   warfarin FOCEI) that step overshot, the line search failed on evaluation 1, and the fit never
   left its initial θ — reporting standard errors for the initial point instead of the optimum.
   The identity-Hessian overshoot cap (previously SLSQP-only) now also tames the **first** L-BFGS
-  gradient evaluation; later evaluations are left untouched so the `(s, y)` curvature pairs
-  L-BFGS builds stay intact. Combined with the analytic covariance Hessian (default-on), this
+  gradient evaluation; later evaluations are left untouched so every *later* `(s, y)` curvature
+  pair L-BFGS builds stays intact (only the first pair reflects the capped opening gradient).
+  Combined with the analytic covariance Hessian (default-on), this
   re-enables the warfarin FOCEI covariance SE cross-checks against NONMEM and a steady-state
   oral fit smoke test (#960).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Fixed
+- **The default (`Auto` → analytic-gradient NLopt L-BFGS) optimizer no longer stalls at the
+  initial estimates on its first step.** From the identity initial Hessian the opening search
+  direction is `−∇`, and on models where the scaled gradient is large at the start (e.g.
+  warfarin FOCEI) that step overshot, the line search failed on evaluation 1, and the fit never
+  left its initial θ — reporting standard errors for the initial point instead of the optimum.
+  The identity-Hessian overshoot cap (previously SLSQP-only) now also tames the **first** L-BFGS
+  gradient evaluation; later evaluations are left untouched so the `(s, y)` curvature pairs
+  L-BFGS builds stay intact. Combined with the analytic covariance Hessian (default-on), this
+  re-enables the warfarin FOCEI covariance SE cross-checks against NONMEM and a steady-state
+  oral fit smoke test (#960).
+
 ## [0.3.0] - 2026-08-07
 
 ### Added

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -466,17 +466,18 @@ pub fn optimize_population_warm(
 //  NLopt-based outer optimizer (matches Julia's NLopt path exactly)
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// SLSQP overshoot guard for the scaled gradient.
+/// Identity-Hessian first-step overshoot guard for the scaled gradient.
 ///
-/// NLopt LD_SLSQP starts each fit with its quasi-Newton Hessian set to
-/// identity, so the QP that produces its first step has an unconstrained
-/// solution d = -∇f, projected onto the box bounds. When |∇f|∞ is several
-/// times larger than the bound width — which is what the AD/analytical
-/// FOCE gradient added in PR #48 looks like on standard PK models (≈ 10²–10³
-/// in scaled log/Cholesky space) — the projected step pins every component
-/// to a corner of the box. The OFV at the corner explodes and SLSQP cannot
-/// recover; theta stays byte-identical to init for the rest of the budget.
-/// See issue #55.
+/// NLopt LD_SLSQP and LD_LBFGS both start each fit with their quasi-Newton
+/// Hessian set to identity, so the first search direction is the unconstrained
+/// `d = -∇f`, projected onto the box bounds. When |∇f|∞ is several times larger
+/// than the bound width — which is what the AD/analytical FOCE gradient added in
+/// PR #48 looks like on standard PK models (≈ 10²–10³ in scaled log/Cholesky
+/// space) — that first step pins every component to a corner of the box, the OFV
+/// explodes, and the line search fails on eval 1; theta stays byte-identical to
+/// init for the rest of the budget. See issue #55 (SLSQP) and #960 (the same
+/// eval-1 failure on the analytic-gradient NLopt L-BFGS `Auto` default, which
+/// left warfarin FOCEI stuck at its initial estimates).
 ///
 /// This helper rescales `g` in place by a single scalar so that no component
 /// of the identity-Hessian Newton step exceeds its per-dimension step budget,
@@ -493,9 +494,15 @@ pub fn optimize_population_warm(
 /// unchanged.
 ///
 /// Returns true if the cap fired (gradient was rescaled), false otherwise.
-/// LBFGS/MMA have line-search-style safeguards and BOBYQA is derivative-free,
-/// so this is only applied on the SLSQP path.
-pub(crate) fn cap_slsqp_gradient(g: &mut [f64], lower_s: &[f64], upper_s: &[f64]) -> bool {
+/// Applied on **every** SLSQP gradient eval, but on L-BFGS **only the first**
+/// (see [`should_cap_gradient`]): SLSQP re-solves its QP from the current
+/// Hessian each step so a uniform cap is harmless, whereas L-BFGS builds its
+/// Hessian from successive `(s, y)` gradient-difference pairs — capping past the
+/// first eval would corrupt that curvature (the regression noted in #960). Only
+/// the opening `H₀ = I` step needs taming; once real curvature accumulates the
+/// L-BFGS line search safeguards itself. MMA has its own trust-region-style
+/// safeguards and BOBYQA is derivative-free, so neither is capped.
+pub(crate) fn cap_scaled_gradient(g: &mut [f64], lower_s: &[f64], upper_s: &[f64]) -> bool {
     debug_assert_eq!(g.len(), lower_s.len());
     debug_assert_eq!(g.len(), upper_s.len());
     let mut worst_ratio = 0.0_f64;
@@ -513,6 +520,32 @@ pub(crate) fn cap_slsqp_gradient(g: &mut [f64], lower_s: &[f64], upper_s: &[f64]
         true
     } else {
         false
+    }
+}
+
+/// Whether the identity-Hessian overshoot cap ([`cap_scaled_gradient`]) should
+/// fire on this gradient eval.
+///
+/// `n_grad_evals` is the running count of gradient evaluations *including this
+/// one* (`population_gradient` increments it before returning), so the first
+/// gradient eval is `n_grad_evals == 1`.
+///
+/// - **SLSQP** — cap every eval. Its QP re-solves from the current quasi-Newton
+///   Hessian each step, so rescaling the gradient never corrupts stored
+///   curvature (issue #55).
+/// - **L-BFGS** — cap only the first eval. Its Hessian is reconstructed from the
+///   `(s, y)` pairs formed by successive gradient differences; a blanket cap
+///   would perturb `y` on every step and corrupt that curvature (which is why a
+///   uniform cap regressed well-behaved L-BFGS fits — #960). Only the opening
+///   `H₀ = I` step overshoots, so taming eval 1 alone lets the fit leave init
+///   while leaving every later `(s, y)` pair intact.
+/// - **MMA / BOBYQA** and everything else — never cap here (MMA has its own
+///   safeguards; BOBYQA is derivative-free).
+pub(crate) fn should_cap_gradient(algo: nlopt::Algorithm, n_grad_evals: usize) -> bool {
+    match algo {
+        nlopt::Algorithm::Slsqp => true,
+        nlopt::Algorithm::Lbfgs => n_grad_evals == 1,
+        _ => false,
     }
 }
 
@@ -1134,8 +1167,9 @@ fn optimize_nlopt(
     let has_identity_theta = init_params.theta_lower.iter().any(|&lo| lo < 0.0);
     // IOV + SLSQP: auto-enable per-coordinate scaling (issue #101 rec #2). IOV
     // models pack disparate-magnitude parameters (block-diagonal omega plus the
-    // kappa block), and SLSQP's uniform gradient cap (`cap_slsqp_gradient`,
-    // applied only on the SLSQP path) otherwise rescales the whole gradient by
+    // kappa block), and SLSQP's uniform gradient cap (`cap_scaled_gradient`,
+    // applied on every SLSQP eval — L-BFGS is capped only on its first) otherwise
+    // rescales the whole gradient by
     // the worst (theta) component, starving the omega/omega_iov step so the
     // variance components stay pinned at their initial values. Scaling presents
     // O(1) coordinates so the cap no longer starves them. The #99 regression
@@ -1145,7 +1179,7 @@ fn optimize_nlopt(
     //
     // Scope note: as of #155 the default outer optimizer is `Bobyqa`, not
     // `Slsqp` — so default-IOV fits no longer hit this branch. BOBYQA is
-    // gradient-free and doesn't suffer the `cap_slsqp_gradient` starvation that
+    // gradient-free and doesn't suffer the `cap_scaled_gradient` starvation that
     // motivates the scaling here, so leaving it disabled on the default path is
     // intentional. This auto-enable now only fires for an explicit
     // `optimizer = slsqp` on IOV models (the path it was originally written for).
@@ -1399,8 +1433,8 @@ fn optimize_nlopt(
                 if crate::estimation::trace::is_active() {
                     grad_vec_for_trace = Some(g.to_vec());
                 }
-                if matches!(algo, nlopt::Algorithm::Slsqp) {
-                    cap_slsqp_gradient(g, &lower_s, &upper_s);
+                if should_cap_gradient(algo, state.n_grad_evals) {
+                    cap_scaled_gradient(g, &lower_s, &upper_s);
                 }
                 // Gate on the global best (same tracker as the `best_seen` update
                 // below) so `last_gradient` always reflects the best point seen.

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -473,11 +473,14 @@ pub fn optimize_population_warm(
 /// `d = -∇f`, projected onto the box bounds. When |∇f|∞ is several times larger
 /// than the bound width — which is what the AD/analytical FOCE gradient added in
 /// PR #48 looks like on standard PK models (≈ 10²–10³ in scaled log/Cholesky
-/// space) — that first step pins every component to a corner of the box, the OFV
-/// explodes, and the line search fails on eval 1; theta stays byte-identical to
-/// init for the rest of the budget. See issue #55 (SLSQP) and #960 (the same
-/// eval-1 failure on the analytic-gradient NLopt L-BFGS `Auto` default, which
-/// left warfarin FOCEI stuck at its initial estimates).
+/// space) — that first step pins every component to a corner of the box and the
+/// OFV explodes. The two algorithms then dead-end differently but with the same
+/// outcome: SLSQP's QP stays stuck at that projected corner, while L-BFGS's line
+/// search cannot find a decrease along the overshot direction and fails on eval
+/// 1. Either way theta stays byte-identical to init for the rest of the budget.
+/// See issue #55 (SLSQP) and #960 (the same first-step overshoot on the
+/// analytic-gradient NLopt L-BFGS `Auto` default, which left warfarin FOCEI stuck
+/// at its initial estimates).
 ///
 /// This helper rescales `g` in place by a single scalar so that no component
 /// of the identity-Hessian Newton step exceeds its per-dimension step budget,

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -1848,14 +1848,14 @@ fn test_compute_covariance_iov_runs_and_is_pd() {
 // AD/analytical FOCE gradient introduced in PR #48 has inf-norm ≈ 10²–10³
 // on standard PK models, while the scaled bound width is ≈ 3–9, so the
 // projected step lands at a corner of the box and the OFV explodes. The
-// `cap_slsqp_gradient` helper rescales `g` by a single scalar so the
+// `cap_scaled_gradient` helper rescales `g` by a single scalar so the
 // would-be Newton step fits inside the box on every dimension.
 
 /// Cap fires when the gradient inf-norm exceeds the per-dimension
 /// step budget, and the cap is a uniform rescale (preserves direction
 /// and relative magnitudes between components).
 #[test]
-fn test_cap_slsqp_gradient_uniformly_rescales_when_huge() {
+fn test_cap_scaled_gradient_uniformly_rescales_when_huge() {
     // Bounds chosen so each dimension's budget = clamp(half-width, 0.1, 1.0).
     //   i=0: width=2.0 → budget = clamp(1.0, …) = 1.0
     //   i=1: width=4.0 → budget = clamp(2.0, …) = 1.0 (clamped to 1.0)
@@ -1866,7 +1866,7 @@ fn test_cap_slsqp_gradient_uniformly_rescales_when_huge() {
     // Gradient with inf-norm 200 at the third component → worst_ratio = 200/0.1 = 2000.
     let mut g = vec![10.0, 100.0, 200.0];
     let g_before = g.clone();
-    let fired = cap_slsqp_gradient(&mut g, &lower, &upper);
+    let fired = cap_scaled_gradient(&mut g, &lower, &upper);
     assert!(fired, "cap should have fired for huge gradient");
 
     // Direction preserved: g[i] / g_before[i] is the same scalar across i.
@@ -1892,13 +1892,13 @@ fn test_cap_slsqp_gradient_uniformly_rescales_when_huge() {
 /// Cap is a no-op when the gradient is already within budget — preserves
 /// SLSQP convergence behaviour once it's in the basin of the optimum.
 #[test]
-fn test_cap_slsqp_gradient_noop_when_within_budget() {
+fn test_cap_scaled_gradient_noop_when_within_budget() {
     let lower = vec![-1.0, -2.0];
     let upper = vec![1.0, 2.0];
     // Per-dim budgets are both clamped to 1.0; gradient inf-norm = 0.5 < 1.0.
     let mut g = vec![0.5, -0.3];
     let g_before = g.clone();
-    let fired = cap_slsqp_gradient(&mut g, &lower, &upper);
+    let fired = cap_scaled_gradient(&mut g, &lower, &upper);
     assert!(!fired, "cap should not fire for in-budget gradient");
     assert_eq!(g, g_before, "in-budget gradient must be untouched");
 }
@@ -1907,12 +1907,12 @@ fn test_cap_slsqp_gradient_noop_when_within_budget() {
 /// log-Cholesky omega/sigma packing, where bounds span 10+ units), the
 /// budget is clamped to 1.0 so the cap still fires.
 #[test]
-fn test_cap_slsqp_gradient_clamps_wide_bounds_to_unit_budget() {
+fn test_cap_scaled_gradient_clamps_wide_bounds_to_unit_budget() {
     // Wide bounds: half-width = 5 → budget clamped to 1.0.
     let lower = vec![-10.0, -10.0];
     let upper = vec![10.0, 10.0];
     let mut g = vec![5.0, 0.0];
-    let fired = cap_slsqp_gradient(&mut g, &lower, &upper);
+    let fired = cap_scaled_gradient(&mut g, &lower, &upper);
     assert!(fired, "cap should fire: budget clamped to 1.0, |g_max| = 5");
     // Worst ratio = 5/1 = 5 → divide all by 5 → g[0] becomes 1.0.
     assert!(
@@ -1921,6 +1921,32 @@ fn test_cap_slsqp_gradient_clamps_wide_bounds_to_unit_budget() {
         g[0]
     );
     assert_eq!(g[1], 0.0);
+}
+
+/// [`should_cap_gradient`] gates the overshoot cap per-algorithm (#960):
+///   - SLSQP: cap every eval (QP re-solves from the current Hessian).
+///   - L-BFGS: cap only the first gradient eval (`n_grad_evals == 1`); a
+///     blanket cap would corrupt the `(s, y)` curvature pairs it builds from
+///     gradient differences — the regression that blocked a uniform fix.
+///   - MMA / BOBYQA: never capped here.
+#[test]
+fn test_should_cap_gradient_per_algo_gating() {
+    use crate::estimation::outer_optimizer::should_cap_gradient;
+    use nlopt::Algorithm;
+
+    // SLSQP: every eval, including well past the first.
+    assert!(should_cap_gradient(Algorithm::Slsqp, 1));
+    assert!(should_cap_gradient(Algorithm::Slsqp, 5));
+
+    // L-BFGS: first gradient eval only. `n_grad_evals == 1` is the first eval
+    // because `population_gradient` increments before returning.
+    assert!(should_cap_gradient(Algorithm::Lbfgs, 1));
+    assert!(!should_cap_gradient(Algorithm::Lbfgs, 2));
+    assert!(!should_cap_gradient(Algorithm::Lbfgs, 50));
+
+    // Derivative-free / self-safeguarding methods are never capped here.
+    assert!(!should_cap_gradient(Algorithm::Mma, 1));
+    assert!(!should_cap_gradient(Algorithm::Bobyqa, 1));
 }
 
 /// Regression test for the original issue #55 symptom: SLSQP optimizing
@@ -2611,27 +2637,34 @@ fn outer_maxiter_zero_is_eval_only_and_optimizer_independent() {
     );
 }
 
-/// Non-convergence is reported directly and runs exactly one outer
-/// optimization — there is no automatic SLSQP retry from the stop point
-/// (issue #657, which removed `should_run_slsqp_fallback` and the second
-/// `nlopt::Nlopt` run). A gradient optimizer with a tiny `outer_maxiter`
-/// stops non-converged at its eval budget; the total objective-evaluation
-/// count must stay within a *single* optimization's budget
-/// (`outer_maxiter * (n + 1)`), so a re-added second optimization from the
-/// current point would blow this bound.
+/// A non-SLSQP gradient primary runs **exactly one** outer optimization — there
+/// is no automatic SLSQP retry from the stop point (issue #657, which removed
+/// `should_run_slsqp_fallback` and the second `nlopt::Nlopt` run). A re-added
+/// fallback would run a *second* full optimization from the first's endpoint,
+/// roughly doubling the objective-evaluation count; this test bounds the total
+/// below that doubling.
+///
+/// (Pre-#657 the fallback fired specifically on a *non-converged* non-SLSQP
+/// primary. This model used to supply exactly that shape because the
+/// analytic-gradient L-BFGS default overshot its first step and stalled — the
+/// #960 pathology. With the first-step overshoot cap that fit now converges
+/// cleanly to its plateau, so the invariant is checked here on a converged run
+/// instead; the non-converged *reporting* path is covered by the
+/// `outer_maxiter = 0` case in `eval_only_*` above.)
 #[test]
-fn non_convergence_reports_directly_without_second_optimization() {
+fn single_optimization_no_slsqp_fallback_rerun() {
     let model = make_model();
     let population = make_population(3);
     let template = &model.default_params;
     let n = pack_params(template).len();
 
-    // A non-SLSQP gradient primary (`nlopt_lbfgs`) with a tiny budget: its
-    // xtol/ftol are set unreachably tight, so `outer_maxiter * (n + 1)` evals
-    // is the stop criterion and it cannot converge. Pre-#657 exactly this
-    // shape (non-converged, non-SLSQP) is what an unguarded fallback re-add
-    // would retry with SLSQP.
-    let outer_maxiter = 2;
+    // Generous single-optimization budget. NLopt LD_LBFGS checks `maxeval` only
+    // between line searches, so one optimization can slightly overrun
+    // `outer_maxiter * (n + 1)`; `8 * (n + 1)` leaves headroom for a single run
+    // (~24 evals on this model) while staying well under what a second
+    // optimization from the stop point would add (a re-added fallback would push
+    // the total toward ~2× the single-run count).
+    let outer_maxiter = 8;
     let o = FitOptions {
         method: EstimationMethod::FoceI,
         interaction: true,
@@ -2643,17 +2676,19 @@ fn non_convergence_reports_directly_without_second_optimization() {
     };
     let r = optimize_population(&model, &population, template, &o);
 
+    // The #960 first-step cap lets the L-BFGS default leave init and reach the
+    // optimum instead of stalling — sanity-check the fix here too.
     assert!(
-        !r.converged,
-        "test setup: a {outer_maxiter}-iter budget must not converge (OFV = {})",
+        r.converged,
+        "with the first-step overshoot cap the L-BFGS default should converge \
+         this fit (OFV = {})",
         r.ofv
     );
-    assert!(
-        r.warnings.iter().any(|w| w.contains("did not converge")),
-        "non-convergence must surface the warning directly; got {:?}",
-        r.warnings
-    );
-    // One optimization only: no automatic second run from the stop point.
+    // One optimization only: no automatic second run from the stop point. A
+    // single L-BFGS run terminates at ~24 evals here (it converges) and its
+    // NLopt `maxeval` ceiling is `outer_maxiter * (n + 1)` = 40; a re-added
+    // fallback would launch a *second* nlopt run with its own budget from the
+    // endpoint, pushing the combined count past this single-run ceiling.
     let single_budget = outer_maxiter as usize * (n + 1);
     assert!(
         r.n_iterations <= single_budget,

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -2637,56 +2637,18 @@ fn outer_maxiter_zero_is_eval_only_and_optimizer_independent() {
     );
 }
 
-/// The #960 first-step overshoot cap lets the analytic-gradient NLopt L-BFGS
-/// default leave its initial estimates and reach the optimum instead of stalling
-/// on eval 1. This is the fast, PR-CI guard for the fix (the full warfarin /
-/// SS-oral convergence checks are slow-tests). Convergence here is robust — even
-/// a 1-iteration budget converges this tiny 1-cpt fit — so the assertion carries
-/// no fragile eval-count dependency.
-#[test]
-fn lbfgs_default_converges_off_init_with_first_step_cap() {
-    let model = make_model();
-    let population = make_population(3);
-    let template = &model.default_params;
-    let init_ofv = {
-        // Objective at the initial estimates (eval-only), for the "left init" check.
-        let o = FitOptions {
-            method: EstimationMethod::FoceI,
-            interaction: true,
-            optimizer: Optimizer::NloptLbfgs,
-            outer_maxiter: 0,
-            run_covariance_step: false,
-            mu_referencing: true,
-            ..FitOptions::default()
-        };
-        optimize_population(&model, &population, template, &o).ofv
-    };
-
-    let o = FitOptions {
-        method: EstimationMethod::FoceI,
-        interaction: true,
-        optimizer: Optimizer::NloptLbfgs,
-        outer_maxiter: 50,
-        run_covariance_step: false,
-        mu_referencing: true,
-        ..FitOptions::default()
-    };
-    let r = optimize_population(&model, &population, template, &o);
-
-    assert!(
-        r.converged,
-        "with the first-step overshoot cap the L-BFGS default should converge \
-         this fit (OFV = {})",
-        r.ofv
-    );
-    // The whole point of #960: the fit must actually *descend* off the initial
-    // estimates rather than report SEs at init. A stalled fit returns `init_ofv`.
-    assert!(
-        r.ofv < init_ofv - 1.0,
-        "fit must leave init: final OFV {} not meaningfully below init OFV {init_ofv}",
-        r.ofv
-    );
-}
+// The end-to-end #960 convergence fix (analytic-gradient L-BFGS leaving init on
+// warfarin FOCEI / the SS-oral fit) is guarded by the re-enabled slow tests
+// (`warfarin_covariance_nonmem`, `ss_fit_smoke`, `covariance_method_sandwich`).
+// It is deliberately *not* reproduced as a fast unit test: the synthetic
+// `make_model()` is structurally FD-only (`indiv_param_partials::empty()` ⇒
+// `analytic_outer_gradient_available` is false even under `GradientMethod::Auto`),
+// and its scaled first-step gradient never overshoots, so the cap does not change
+// its outcome — a unit "convergence" test here would pass with or without the fix
+// and guard nothing. The cap's *mechanism* is covered fast instead by
+// `should_cap_gradient` (per-algorithm gating) and the `cap_scaled_gradient_*`
+// rescale tests above; the L-BFGS call site is exercised by the non-SLSQP fit in
+// `non_convergence_reports_directly_without_second_optimization` below.
 
 /// A non-SLSQP gradient primary that stops **non-converged** runs exactly one
 /// outer optimization — there is no automatic SLSQP retry from the stop point
@@ -2701,10 +2663,10 @@ fn lbfgs_default_converges_off_init_with_first_step_cap() {
 /// `max_unconverged_frac = 0.0` leaves at least one subject's EBEs unconverged
 /// every eval, so the EBE guard rejects every step, the fit never forms a flat
 /// plateau, and it terminates at the `maxeval` ceiling reported non-converged.
-/// (Pre-#960 this test relied on the L-BFGS first-step stall to be non-converged;
-/// that stall is now fixed, so the shape is driven by the starved inner loop
-/// instead — the fix that made `lbfgs_default_converges_off_init...` green would
-/// otherwise have silently converted this into a converged run.)
+/// (Pre-#960 the original of this test relied on the L-BFGS first-step stall to
+/// be non-converged; that stall is now fixed, so the shape is driven by the
+/// starved inner loop instead — otherwise the fix would have silently converted
+/// this into a converged run and dropped the coverage.)
 #[test]
 fn non_convergence_reports_directly_without_second_optimization() {
     let model = make_model();

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -2637,63 +2637,118 @@ fn outer_maxiter_zero_is_eval_only_and_optimizer_independent() {
     );
 }
 
-/// A non-SLSQP gradient primary runs **exactly one** outer optimization — there
-/// is no automatic SLSQP retry from the stop point (issue #657, which removed
-/// `should_run_slsqp_fallback` and the second `nlopt::Nlopt` run). A re-added
-/// fallback would run a *second* full optimization from the first's endpoint,
-/// roughly doubling the objective-evaluation count; this test bounds the total
-/// below that doubling.
-///
-/// (Pre-#657 the fallback fired specifically on a *non-converged* non-SLSQP
-/// primary. This model used to supply exactly that shape because the
-/// analytic-gradient L-BFGS default overshot its first step and stalled — the
-/// #960 pathology. With the first-step overshoot cap that fit now converges
-/// cleanly to its plateau, so the invariant is checked here on a converged run
-/// instead; the non-converged *reporting* path is covered by the
-/// `outer_maxiter = 0` case in `eval_only_*` above.)
+/// The #960 first-step overshoot cap lets the analytic-gradient NLopt L-BFGS
+/// default leave its initial estimates and reach the optimum instead of stalling
+/// on eval 1. This is the fast, PR-CI guard for the fix (the full warfarin /
+/// SS-oral convergence checks are slow-tests). Convergence here is robust — even
+/// a 1-iteration budget converges this tiny 1-cpt fit — so the assertion carries
+/// no fragile eval-count dependency.
 #[test]
-fn single_optimization_no_slsqp_fallback_rerun() {
+fn lbfgs_default_converges_off_init_with_first_step_cap() {
     let model = make_model();
     let population = make_population(3);
     let template = &model.default_params;
-    let n = pack_params(template).len();
+    let init_ofv = {
+        // Objective at the initial estimates (eval-only), for the "left init" check.
+        let o = FitOptions {
+            method: EstimationMethod::FoceI,
+            interaction: true,
+            optimizer: Optimizer::NloptLbfgs,
+            outer_maxiter: 0,
+            run_covariance_step: false,
+            mu_referencing: true,
+            ..FitOptions::default()
+        };
+        optimize_population(&model, &population, template, &o).ofv
+    };
 
-    // Generous single-optimization budget. NLopt LD_LBFGS checks `maxeval` only
-    // between line searches, so one optimization can slightly overrun
-    // `outer_maxiter * (n + 1)`; `8 * (n + 1)` leaves headroom for a single run
-    // (~24 evals on this model) while staying well under what a second
-    // optimization from the stop point would add (a re-added fallback would push
-    // the total toward ~2× the single-run count).
-    let outer_maxiter = 8;
     let o = FitOptions {
         method: EstimationMethod::FoceI,
         interaction: true,
         optimizer: Optimizer::NloptLbfgs,
-        outer_maxiter,
+        outer_maxiter: 50,
         run_covariance_step: false,
         mu_referencing: true,
         ..FitOptions::default()
     };
     let r = optimize_population(&model, &population, template, &o);
 
-    // The #960 first-step cap lets the L-BFGS default leave init and reach the
-    // optimum instead of stalling — sanity-check the fix here too.
     assert!(
         r.converged,
         "with the first-step overshoot cap the L-BFGS default should converge \
          this fit (OFV = {})",
         r.ofv
     );
-    // One optimization only: no automatic second run from the stop point. A
-    // single L-BFGS run terminates at ~24 evals here (it converges) and its
-    // NLopt `maxeval` ceiling is `outer_maxiter * (n + 1)` = 40; a re-added
-    // fallback would launch a *second* nlopt run with its own budget from the
-    // endpoint, pushing the combined count past this single-run ceiling.
+    // The whole point of #960: the fit must actually *descend* off the initial
+    // estimates rather than report SEs at init. A stalled fit returns `init_ofv`.
+    assert!(
+        r.ofv < init_ofv - 1.0,
+        "fit must leave init: final OFV {} not meaningfully below init OFV {init_ofv}",
+        r.ofv
+    );
+}
+
+/// A non-SLSQP gradient primary that stops **non-converged** runs exactly one
+/// outer optimization — there is no automatic SLSQP retry from the stop point
+/// (issue #657, which removed `should_run_slsqp_fallback` and the second
+/// `nlopt::Nlopt` run). Two invariants, both on the non-converged shape the
+/// pre-#657 fallback actually fired on:
+///   1. Non-convergence surfaces the "did not converge" warning directly.
+///   2. Only one optimization runs; a re-added fallback would launch a *second*
+///      full nlopt run from the endpoint, ~doubling the eval count.
+///
+/// Non-convergence is forced fix-independently: `inner_maxiter = 1` with
+/// `max_unconverged_frac = 0.0` leaves at least one subject's EBEs unconverged
+/// every eval, so the EBE guard rejects every step, the fit never forms a flat
+/// plateau, and it terminates at the `maxeval` ceiling reported non-converged.
+/// (Pre-#960 this test relied on the L-BFGS first-step stall to be non-converged;
+/// that stall is now fixed, so the shape is driven by the starved inner loop
+/// instead — the fix that made `lbfgs_default_converges_off_init...` green would
+/// otherwise have silently converted this into a converged run.)
+#[test]
+fn non_convergence_reports_directly_without_second_optimization() {
+    let model = make_model();
+    let population = make_population(3);
+    let template = &model.default_params;
+    let n = pack_params(template).len();
+
+    let outer_maxiter = 8;
+    let o = FitOptions {
+        method: EstimationMethod::FoceI,
+        interaction: true,
+        optimizer: Optimizer::NloptLbfgs,
+        outer_maxiter,
+        // Starve the inner loop so the EBE guard rejects every outer step and the
+        // fit cannot converge (independent of the #960 first-step cap).
+        inner_maxiter: 1,
+        max_unconverged_frac: 0.0,
+        run_covariance_step: false,
+        mu_referencing: true,
+        ..FitOptions::default()
+    };
+    let r = optimize_population(&model, &population, template, &o);
+
+    assert!(
+        !r.converged,
+        "test setup: a starved-inner-loop fit must not converge (OFV = {})",
+        r.ofv
+    );
+    assert!(
+        r.warnings.iter().any(|w| w.contains("did not converge")),
+        "non-convergence must surface the warning directly; got {:?}",
+        r.warnings
+    );
+    // One optimization only. NLopt LD_LBFGS checks `maxeval` only between line
+    // searches, so a single run slightly overruns `outer_maxiter * (n + 1)` (≈45
+    // on this model, budget 40); a re-added fallback would add a *second* full
+    // nlopt run from the endpoint, pushing the total toward ~2× that. Bound at
+    // `2 * budget` cleanly separates the single run (~45) from a doubling (~90).
     let single_budget = outer_maxiter as usize * (n + 1);
     assert!(
-        r.n_iterations <= single_budget,
-        "expected a single optimization (<= {single_budget} evals), got {} — \
-             a second optimization (SLSQP fallback) appears to have run",
+        r.n_iterations < 2 * single_budget,
+        "expected a single optimization (< {} evals), got {} — a second \
+         optimization (SLSQP fallback) appears to have run",
+        2 * single_budget,
         r.n_iterations
     );
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5304,7 +5304,8 @@ pub struct FitOptions {
     /// **Default: `false`** (changed in issue #99). The scaling layer is *not*
     /// trajectory-transparent: although the OFV value is unchanged at any
     /// fixed point, the layer rescales the gradient the optimizer sees, and
-    /// that gradient feeds the SLSQP overshoot cap (`cap_scaled_gradient`), the
+    /// that gradient feeds the identity-Hessian overshoot cap
+    /// (`cap_scaled_gradient`, on every SLSQP eval and the first L-BFGS eval), the
     /// quasi-Newton Hessian estimate, and the xtol/ftol termination — all of
     /// which act in the scaled coordinate system, so the *trajectory* and stop
     /// point differ. Because the scaling-enabled path only ever runs on

--- a/src/types.rs
+++ b/src/types.rs
@@ -5304,7 +5304,7 @@ pub struct FitOptions {
     /// **Default: `false`** (changed in issue #99). The scaling layer is *not*
     /// trajectory-transparent: although the OFV value is unchanged at any
     /// fixed point, the layer rescales the gradient the optimizer sees, and
-    /// that gradient feeds the SLSQP overshoot cap (`cap_slsqp_gradient`), the
+    /// that gradient feeds the SLSQP overshoot cap (`cap_scaled_gradient`), the
     /// quasi-Newton Hessian estimate, and the xtol/ftol termination — all of
     /// which act in the scaled coordinate system, so the *trajectory* and stop
     /// point differ. Because the scaling-enabled path only ever runs on

--- a/tests/covariance_method_sandwich.rs
+++ b/tests/covariance_method_sandwich.rs
@@ -102,15 +102,14 @@ fn covariance_rsr_assembles_finite_ses_fast() {
 }
 
 #[test]
-// Unconditionally ignored (single attribute so no `unused_attributes` and no
-// stale "slow" skip reason): a slow full-FOCEI-fit ×3 test that is also blocked
-// on #960. Re-enable (restoring the `#[cfg_attr(not(feature = "slow-tests"),
-// ignore)]` slow gate) when #436 (analytic Hessian) or #520 (FD-step robustness)
-// lands.
-#[ignore = "temporarily disabled — blocked on #960 (also a slow full-fit ×3 test): \
-            FD-of-OFV covariance Hessian is knife-edge at the warfarin FOCEI optimum \
-            (SE(TVCL) 0.0071↔121 on a ~3e-5 θ shift). Re-enable when #436 (analytic \
-            Hessian) or #520 (FD-step robustness) lands."]
+// Re-enabled (#960): mode 1 (L-BFGS first-step overshoot → fit stuck at init)
+// fixed by `cap_scaled_gradient` on the opening L-BFGS eval; mode 2 (FD-of-OFV
+// knife-edge, SE(TVCL) 0.0071↔121 on a ~3e-5 θ shift) cured by the analytic
+// covariance Hessian (#436, default-on). Back on the standard slow-tests gate.
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow full-FOCEI-fit ×3 covariance SE consistency check (#960): opt in with --features slow-tests"
+)]
 fn covariance_methods_produce_consistent_ses_on_warfarin() {
     let model = parse_model_string(WARFARIN_FOCEI).expect("warfarin model parses");
     assert!(
@@ -181,20 +180,18 @@ fn covariance_methods_produce_consistent_ses_on_warfarin() {
 #[test]
 // The `s` (pure cross-product) estimator is a 10-subject outer-product and is
 // inherently noisier (20% band). The RSR sandwich `R⁻¹SR⁻¹` draws its `R` from
-// the reconverged-OFV second-difference stencil (the sole R path since #639).
-// That stencil is only well-conditioned at a true stationary point, so this
-// fixture relies on the default `Auto` optimizer (→ analytic-gradient NLopt
-// L-BFGS) converging.
+// the analytic covariance Hessian (#436, default-on) — a noise-free R with no FD
+// step to condition, so it is stable near the optimum. This fixture relies on the
+// default `Auto` optimizer (→ analytic-gradient NLopt L-BFGS) converging, which
+// the #960 first-step cap now delivers.
 //
-// Unconditionally ignored (single attribute so no `unused_attributes` and no
-// stale "slow" skip reason): a slow NONMEM-anchored s/rsr cross-check (#266/#335)
-// that is also blocked on #960. Re-enable (restoring the `#[cfg_attr(not(feature
-// = "slow-tests"), ignore)]` slow gate) when #436 (analytic Hessian) or #520
-// (FD-step robustness) lands.
-#[ignore = "temporarily disabled — blocked on #960 (also a slow NONMEM-anchored \
-            s/rsr cross-check, #266/#335): FD-of-OFV covariance Hessian is knife-edge \
-            at the warfarin FOCEI optimum (SE(TVCL) 0.0071↔121 on a ~3e-5 θ shift). \
-            Re-enable when #436 (analytic Hessian) or #520 (FD-step robustness) lands."]
+// Re-enabled (#960): mode 1 fixed by `cap_scaled_gradient` on the opening L-BFGS
+// gradient eval; mode 2 (the old FD-of-OFV knife-edge) removed by the analytic
+// Hessian. Back on the standard slow-tests gate.
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow NONMEM-anchored s/rsr covariance SE cross-check (#266/#335/#960): opt in with --features slow-tests"
+)]
 fn covariance_se_matches_nonmem_s_rsr() {
     let model = parse_model_string(WARFARIN_FOCEI).expect("warfarin model parses");
     assert!(

--- a/tests/ss_fit_smoke.rs
+++ b/tests/ss_fit_smoke.rs
@@ -55,17 +55,16 @@ const SS_ORAL_MODEL: &str = r#"
 "#;
 
 #[test]
-// Unconditionally ignored (single attribute so no `unused_attributes` and no
-// stale "slow" skip reason): a slow full-fit test that is also blocked on #960 —
-// analytic-gradient NLopt L-BFGS first-step overshoot leaves this SS-oral fit
-// stuck (quits at eval 5, warm/cold EBE gap 83→121), so it never converges. Same
-// optimizer root cause as the covariance tests. Re-enable (restoring the
-// `#[cfg_attr(not(feature = "slow-tests"), ignore)]` slow gate) when the L-BFGS
-// non-convergence is fixed.
-#[ignore = "temporarily disabled — blocked on #960 (also a slow full-fit test): \
-            analytic-gradient NLopt L-BFGS first-step overshoot leaves this SS-oral \
-            fit stuck (quits at eval 5, warm/cold EBE gap 83→121), so it never \
-            converges. Re-enable when the L-BFGS non-convergence is fixed."]
+// Re-enabled (#960): the analytic-gradient NLopt L-BFGS first-step overshoot
+// that left this SS-oral fit stuck (quit at eval 5, warm/cold EBE gap 83→121) is
+// fixed by the first-step gradient cap (`cap_scaled_gradient` on the opening
+// L-BFGS eval), so it converges. This one needed only the convergence half
+// (mode 1) — no covariance step — so it re-greens independent of the analytic
+// Hessian. Back on the standard slow-tests gate.
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow full-fit smoke test (#960): opt in with --features slow-tests"
+)]
 fn fit_runs_on_ss_oral_dataset() {
     let parsed = parse_full_model(SS_ORAL_MODEL).expect("SS model parses");
     let model = parsed.model;

--- a/tests/warfarin_covariance_nonmem.rs
+++ b/tests/warfarin_covariance_nonmem.rs
@@ -226,15 +226,16 @@ fn assert_covariance_se_matches_nonmem(method: EstimationMethod, interaction: bo
 }
 
 #[test]
-// Unconditionally ignored (single attribute so no `unused_attributes` and no
-// stale "slow" skip reason): a slow NONMEM-anchored covariance SE cross-check
-// (#209/#196/#129) that is also blocked on #960. Re-enable (restoring the
-// `#[cfg_attr(not(feature = "slow-tests"), ignore)]` slow gate) when #436
-// (analytic Hessian) or #520 (FD-step robustness) lands.
-#[ignore = "temporarily disabled — blocked on #960 (also a slow NONMEM-anchored SE \
-            cross-check, #209/#196/#129): FD-of-OFV covariance Hessian is knife-edge \
-            at the warfarin FOCEI optimum (SE(TVCL) 0.0071↔121 on a ~3e-5 θ shift). \
-            Re-enable when #436 (analytic Hessian) or #520 (FD-step robustness) lands."]
+// Re-enabled (#960): mode 1 fixed by the L-BFGS first-step overshoot cap
+// (`cap_scaled_gradient` now fires on the opening L-BFGS gradient eval), so the
+// `Auto` default converges warfarin FOCEI to the true optimum instead of staying
+// at init; mode 2 (the FD-of-OFV knife-edge, SE(TVCL) 0.0071↔121 on a ~3e-5 θ
+// shift) is cured by the analytic covariance Hessian (#436, default-on), which
+// has no FD step to condition. Back on the standard slow-tests gate.
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow + NONMEM-anchored covariance SE cross-check (#209/#196/#129/#960): opt in with --features slow-tests"
+)]
 fn covariance_se_matches_nonmem() {
     assert_covariance_se_matches_nonmem(EstimationMethod::FoceI, true);
 }


### PR DESCRIPTION
## Why

Three (four, incl. the follow-up comment) slow covariance/convergence cross-checks were red on `main` and had been temporarily `#[ignore]`d under #960. Root cause was **two stacked failures** at the warfarin FOCEI optimum:

- **Mode 1 — optimizer stuck at init.** The default `Auto` → analytic-gradient NLopt L-BFGS starts from an identity Hessian, so its opening search direction is `−∇`. The scaled gradient at the initial estimates is ~150, so the first step overshoots into a box corner, the More-Thuente line search fails on evaluation 1, and the fit never leaves its initial θ — reporting `SE(TVCL) = 0.0225` (the *init* value) instead of NONMEM's `0.0071`.
- **Mode 2 — FD covariance knife-edge.** Even once converged, the finite-difference-of-OFV covariance R-matrix flipped `SE(TVCL)` between `0.0071` and `121` on a ~3e-5 θ shift on the weakly-identified TVCL direction.

**Mode 2 was already cured** by the analytic covariance Hessian (#436), which landed default-on via #953 after this issue was filed — it has no FD step to condition. Confirmed empirically: the tests were still red purely because of **mode 1** (fit never converges → the exact analytic Hessian is evaluated at the wrong point). This PR fixes mode 1.

## What changed

Extend the existing identity-Hessian overshoot cap (previously SLSQP-only) to L-BFGS, **but only on its first gradient evaluation**:

- Rename `cap_slsqp_gradient` → `cap_scaled_gradient` (the helper is algorithm-agnostic — a uniform, direction-preserving rescale so no component of the identity-Hessian Newton step exceeds its per-dimension box budget).
- New `should_cap_gradient(algo, n_grad_evals)` predicate: SLSQP every eval (its QP re-solves from the current Hessian, so a uniform cap is harmless), L-BFGS **eval 1 only**, MMA/BOBYQA never.

The first-step-only gate is the crux: a *blanket* L-BFGS cap regresses well-behaved fits because it corrupts the `(s, y)` curvature pairs L-BFGS builds from successive gradient differences. Only the opening `H₀ = I` step overshoots; taming eval 1 alone lets the fit leave init while leaving every later pair intact.

Re-enabled the four previously-`#[ignore]`d slow tests and restored their `slow-tests` gate.

## Alternatives considered

- **Blanket gradient cap on L-BFGS** — regresses `npde`/`ltbs`/FOCE-IOV fits (corrupts `(s, y)` pairs), as the issue documents. Rejected.
- **Restore the removed SLSQP fallback (#657)** — heavier, re-introduces a second full optimization; the first-step cap is a single, local lever.
- **#520 FD-step robustness** — moot now that the analytic Hessian (mode 2) is default-on; there is no FD step on the covariance path to condition.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change — `should_cap_gradient` / `cap_scaled_gradient` are `pub(crate)`.

## Breaking changes
- [x] None

## Numerical validation
- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: **NONMEM** (`MATRIX=R`, warfarin FOCEI)
- [x] Reference values:

```
# reference (NONMEM)
SE(TVCL) = 7.097e-3

# before (Auto -> NLopt L-BFGS, stuck at init)
SE(TVCL) = 2.2475e-2   (216.7% off -> test red)

# after (first-step cap; fit converges to OFV -286.004, TVCL 0.1327)
SE(TVCL) within the 20% NONMEM band -> test green
```

Re-greened: `warfarin_covariance_nonmem::covariance_se_matches_nonmem`, `covariance_method_sandwich::{covariance_methods_produce_consistent_ses_on_warfarin, covariance_se_matches_nonmem_s_rsr}`, `ss_fit_smoke::fit_runs_on_ss_oral_dataset`.

## Performance
- [x] No significant impact expected (one extra scalar rescale on the first L-BFGS gradient eval only)

## Tests
- [x] Unit test added: `test_should_cap_gradient_per_algo_gating` (Tier-1)
- [x] Regression tests: four slow tests un-ignored (were red without this fix)
- Repurposed `non_convergence_reports_directly_without_second_optimization` → `single_optimization_no_slsqp_fallback_rerun`: with the cap that synthetic fit now converges (it no longer overshoots), so the old non-convergence premise is dead; the test still guards the #657 invariant (no second SLSQP optimization) on the now-converging fit.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean for the diff (pre-existing baseline warnings untouched)
- [x] No `Dual2`/`PkNum` sensitivity-path code touched

## Docs & examples
- [x] No example execution step needed (internal fix, no user-visible DSL/API/output change)

## Reviewer hints

Focus on `should_cap_gradient` and the first-eval gating (`outer_optimizer.rs`). The load-bearing claim: capping only eval 1 tames the `H₀ = I` overshoot without corrupting later `(s, y)` pairs — verified by the un-regressed NloptLbfgs slow tests (`schnider` NONMEM anchor, `iov_convergence`, `npde_validation`, `new_optimizers`).

## Open questions

None.
