### PR TITLE
chore(ci): collapse three overlapping test jobs into two non-overlapping ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,65 +35,39 @@ jobs:
         run: cargo check --tests --no-default-features --features ci
 
       # `tests/tte_convergence.rs` is gated on BOTH `survival` and `slow-tests`, and
-      # no other per-PR job sets both (check/test/coverage-pr use `ci`; the survival
-      # job uses `ci,survival`) — so those Tier-3 TTE tests are compiled in *neither*.
-      # Without this step a renamed public API or changed `FitResult` field would land
-      # green and only break the nightly slow-tests run, decoupled from the offending
-      # PR. Compile-only (`cargo check`, no run — the tests themselves stay nightly per
-      # the tier rules), so it is cheap. (#441 review finding #3.)
+      # no other per-PR job sets both — so those Tier-3 TTE tests are compiled in
+      # *neither*. Without this step a renamed public API or changed `FitResult`
+      # field would land green and only break the nightly slow-tests run, decoupled
+      # from the offending PR. Compile-only (`cargo check`, no run — the tests
+      # themselves stay nightly per the tier rules), so it is cheap.
+      # (#441 review finding #3.)
       - name: cargo check (survival + slow-tests gated tests)
         run: cargo check --tests --no-default-features --features ci,survival,slow-tests
 
-      # The `markov` module (CTMM matrix-exp) is behind `#[cfg(feature = "markov")]`
-      # and compiled by neither the base `ci` check nor the survival check. A fast,
-      # uninstrumented compile-check here surfaces a break in ~1 min instead of
-      # waiting on the instrumented markov coverage job below.
+      # This step is also what COMPILE-GATES the whole feature-gated surface. The
+      # `Tests + coverage (TTE/CTMM endpoints)` job below deliberately builds only
+      # the handful of endpoint test binaries, so a break in any *other* test file
+      # under `--features ci,markov` (which implies `survival`) is caught here, in
+      # ~1 min, instead of by an 18-min instrumented build.
       - name: cargo check (markov-gated module + tests)
         run: cargo check --tests --no-default-features --features ci,markov
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-      # `--profile ci-test` keeps release-level optimisation (population-fit
-      # tests — SDE, IOV, FOCEI, GN-hybrid — run 5-10× faster than debug) but
-      # drops fat LTO, whose whole-program link dominated these jobs. Net:
-      # avoids the >80 min debug wall without paying the LTO compile tax.
-      - name: cargo test
-        run: cargo test --lib --no-default-features --features ci --profile ci-test
-
-      # The NONMEM-anchored per-(ID,OCC) CL cross-check for IOV (issue #238)
-      # lives in an integration test, which `--lib` above does not build or run.
-      # Run that one file explicitly so the agreement with NONMEM is guarded on
-      # every PR (not just nightly). It is a FIXed-MLE fit over 10 subjects — no
-      # convergence loop, sub-second — and self-contained (reference fixture
-      # committed at tests/nonmem/warfarin_iov_cl_reference.csv).
-      - name: cargo test (NONMEM IOV CL cross-check, issue #238)
-        run: cargo test --test warfarin_iov_nonmem --no-default-features --features ci --profile ci-test
-
-      # Analytical/ODE equivalence guard for the standard PK models (ferx-r
-      # #127). Like the IOV check above it is an integration test `--lib` does
-      # not run, but it is fast (just `predict()`, no `fit()`), so run it on
-      # every PR rather than only nightly — otherwise a regression in the
-      # analytical or ODE prediction path stays green until the slow-tests run.
-      - name: cargo test (analytical/ODE equivalence, ferx-r #127)
-        run: cargo test --test analytical_ode_equivalence --no-default-features --features ci --profile ci-test
-
-  survival:
-    name: Survival (TTE)
+  # Non-Gaussian endpoint families (TTE/survival + categorical + CTMM), which the
+  # default `ci` build compiles out. This ONE job replaces the former separate
+  # `Survival (TTE)` and `Markov (CTMM)` jobs: `markov = ["survival"]` in
+  # Cargo.toml, so a `--features ci,markov` build is a strict superset of a
+  # `--features ci,survival` one — the old survival job compiled and ran nothing
+  # the markov job did not, and its lcov was a subset. Both Codecov flags are
+  # therefore uploaded from this single report (codecov.yml still names `survival`
+  # and `markov` separately in its patch/project statuses).
+  endpoints:
+    name: Tests + coverage (TTE/CTMM endpoints)
     runs-on: ubuntu-latest
     # Override the global nightly: the crate has no nightly-only code, so this
-    # job (`--features ci,survival`) builds fine on stable. Stable's rustc
-    # version holds for ~6 weeks vs nightly's daily bump, so the instrumented
-    # cache (keyed on rustc version) stays warm instead of cold-rebuilding the
-    # whole dep graph under coverage RUSTFLAGS every run.
+    # job builds fine on stable. Stable's rustc version holds for ~6 weeks vs
+    # nightly's daily bump, so the instrumented cache (keyed on rustc version)
+    # stays warm instead of cold-rebuilding the whole dep graph under coverage
+    # RUSTFLAGS every run.
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -104,73 +78,58 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Instrumented build (coverage RUSTFLAGS) can't share the plain `ci`
-          # caches; own key, like the other coverage jobs (`coverage-pr` -> ci-cov).
-          shared-key: ci-cov-survival
+          # caches; own key, like the other coverage job (`coverage-pr` -> ci-cov).
+          shared-key: ci-cov-endpoints
       - name: Install cargo-llvm-cov
         # Prebuilt binary (no compile) so this job stays fast.
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
 
-      # All TTE/survival code is behind `#[cfg(feature = "survival")]`, so neither
-      # the default `ci` jobs nor the FD coverage jobs (`fast`/`slow` flags)
-      # compile it — Codecov reports those lines as missed even though they're
-      # exercised here, undercounting the true surface (#293). So this job both
-      # GATES the survival code (a break still fails it) and MEASURES it: it runs
-      # under `cargo llvm-cov` and uploads the `survival` flag, which Codecov
-      # merges with `fast`/`slow`. `tte_smoke` is Tier-2 (a handful of outer
-      # iterations), so `--tests` stays fast; `--profile ci-test` (no fat LTO)
-      # keeps it cheap. `--no-fail-fast` mirrors the other coverage jobs.
-      - name: Generate survival coverage report
-        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,survival --profile ci-test --lcov --output-path lcov.info
+      # All TTE/categorical/CTMM code is behind `#[cfg(feature = "survival")]` or
+      # `#[cfg(feature = "markov")]`, so neither the default `ci` jobs nor the
+      # `fast`/`slow` coverage jobs compile it — Codecov would report those lines
+      # as missed even though they are exercised, and a survival- or markov-only
+      # PR would fail its own patch gate at 0% (#293). This job MEASURES that
+      # surface and uploads it under both flags, which Codecov merges with
+      # `fast`/`slow` by summing hits.
+      #
+      # Explicit `--test` list instead of `--tests`: the base suite's 122
+      # integration binaries are already run — and already measured — by
+      # `Tests + coverage (core)`, so re-running them here under a second feature
+      # set bought no coverage (Codecov merges flags by summing hits) and cost
+      # ~15 min of instrumented compile.
+      #
+      # The list is EXACTLY the set of `tests/*.rs` that mention a `survival` or
+      # `markov` cfg, and `tests/ci_workflow_endpoint_coverage.rs` asserts that
+      # equality — so adding a test file that uses either feature without adding
+      # it here fails CI instead of silently reading as uncovered. The two
+      # Tier-3 files (`tte_convergence`, `categorical_convergence`) are in the
+      # list on purpose: without `slow-tests` their tests stay `#[ignore]`d, so
+      # they cost one cheap compile each and keep the invariant a plain set
+      # equality with no exemption rule to get wrong.
+      #
+      # `--lib` stays because the unit tests for `src/survival`, `src/markov` and
+      # the feature-gated branches of the shared modules live there.
+      - name: Generate TTE/CTMM endpoint coverage report
+        run: |
+          cargo llvm-cov --no-fail-fast --no-default-features --features ci,markov --profile ci-test \
+            --lib \
+            --test agq \
+            --test categorical_convergence \
+            --test categorical_smoke \
+            --test dose_compartment_routing \
+            --test markov_nonmem \
+            --test markov_smoke \
+            --test tte_convergence \
+            --test tte_smoke \
+            --lcov --output-path lcov.info
 
-      - name: Upload to Codecov (survival flag)
+      - name: Upload to Codecov (survival + markov flags)
         uses: codecov/codecov-action@v7
         with:
           files: lcov.info
-          flags: survival
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  markov:
-    name: Markov (CTMM)
-    runs-on: ubuntu-latest
-    # Same rationale as the Survival job: no nightly-only code, so pin stable to
-    # keep the instrumented (coverage-RUSTFLAGS) cache warm across runs.
-    env:
-      RUSTUP_TOOLCHAIN: stable
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install stable toolchain
-        run: rustup toolchain install stable --profile minimal -c llvm-tools-preview
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Instrumented build (coverage RUSTFLAGS) needs its own key, like the
-          # other coverage jobs (survival -> ci-cov-survival, coverage-pr -> ci-cov).
-          shared-key: ci-cov-markov
-      - name: Install cargo-llvm-cov
-        # Prebuilt binary (no compile) so this job stays fast.
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      # All CTMM code is behind `#[cfg(feature = "markov")]`, so neither the default
-      # `ci` jobs nor the `fast`/`slow` coverage jobs compile it — Codecov would
-      # report its lines as missed even though they're exercised, so a PR touching
-      # `src/markov` would fail its own patch gate at 0% (#293). Like the survival
-      # job, this both GATES the markov code (a break fails it) and MEASURES it,
-      # uploading the `markov` flag, which Codecov merges with `fast`/`slow`. The
-      # tests are pure matrix math (milliseconds), so `--tests --profile ci-test`
-      # stays cheap.
-      - name: Generate markov coverage report
-        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci,markov --profile ci-test --lcov --output-path lcov.info
-
-      - name: Upload to Codecov (markov flag)
-        uses: codecov/codecov-action@v7
-        with:
-          files: lcov.info
-          flags: markov
+          flags: survival,markov
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -186,9 +145,9 @@ jobs:
         with:
           shared-key: ci
       - name: cargo clippy
-        # Include `markov` so the CTMM module is linted too (it is compiled by
-        # neither the base `ci` build nor the survival job). Survival stays out
-        # of clippy per existing precedent; markov opts in from the start.
+        # Include `markov` so the CTMM module is linted too (it is compiled out
+        # of the base `ci` build). `markov = ["survival"]`, so this lints the
+        # whole non-Gaussian endpoint surface.
         run: cargo clippy --no-default-features --features ci,markov
 
   fmt:
@@ -203,11 +162,11 @@ jobs:
         run: cargo fmt -- --check
 
   coverage:
-    name: Coverage (full)
+    name: Tests + coverage (full, slow-tests)
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     # Stable, not nightly: `--features ci,slow-tests` has no nightly-only code.
-    # Keeps the instrumented `ci-slow` cache warm. See survival.
+    # Keeps the instrumented `ci-slow` cache warm. See the endpoints job.
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -246,16 +205,28 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # The per-PR run of the base (`--features ci`) test suite AND the patch-coverage
+  # gate — one instrumented build serving both. It used to be paired with a
+  # separate uninstrumented `Test` job (`cargo test --lib` + two explicit
+  # `--test`s on nightly); that job was a strict subset of this one — same
+  # features, and `--tests` ⊇ `--lib` plus both of those integration files — so it
+  # was removed rather than kept paying an 11-min lib compile twice over. The
+  # nightly toolchain is still exercised per-PR by `Check`, `Clippy` and `Format`.
   coverage-pr:
-    name: Coverage (fast, patch)
+    name: Tests + coverage (core)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # PRs *and* pushes to `main`. The `push` half matters: the removed `Test` job
+    # had no `if:` and so ran on main pushes, and this is now the only job that
+    # executes the base suite — without `push` a merge commit would run no tests
+    # at all. (It also keeps the `fast` flag fresh on `main`, which
+    # `carryforward: false` in codecov.yml otherwise leaves empty there.)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       contents: read
       pull-requests: write # for the below-floor nudge comment
     # Stable, not nightly: `--features ci` has no nightly-only code.
     # Keeps the instrumented `ci-cov` cache warm across runs
-    # (stable rustc bumps ~6-weekly vs nightly daily). See the survival job.
+    # (stable rustc bumps ~6-weekly vs nightly daily). See the endpoints job.
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -276,11 +247,12 @@ jobs:
 
       - name: Generate fast coverage report
         # Fast tier only: `--features ci` (no `slow-tests`, no `survival`). This
-        # is the per-PR patch gate; the full `ci,slow-tests` run is nightly (the
-        # `coverage` job above). Runs in parallel with the other PR jobs and,
-        # like them, builds with `--profile ci-test` (no fat LTO), so it stays
-        # within the PR wall-clock. `--tests` so the integration tests count
-        # (same rationale as the nightly job).
+        # both RUNS the base suite and is the per-PR patch gate; the full
+        # `ci,slow-tests` run is nightly (the `coverage` job above) and the
+        # feature-gated endpoints are the `endpoints` job. Builds with
+        # `--profile ci-test` (no fat LTO) to stay within the PR wall-clock.
+        # `--tests` so the integration tests both run and count (same rationale
+        # as the nightly job).
         run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --profile ci-test --lcov --output-path lcov.info
 
       - name: Upload to Codecov (fast flag)
@@ -296,8 +268,9 @@ jobs:
         # coverage on `main` is below the 90% floor the weekly run enforces,
         # post/update ONE sticky PR comment so the author is nudged to cover new
         # lines. Self-resolves once the backfill clears 90%. Never fails the PR
-        # (continue-on-error); skipped on forks (read-only token).
-        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        # (continue-on-error); skipped on forks (read-only token) and on the
+        # `push` half of this job's trigger, where there is no PR to comment on.
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SDLC.md
+++ b/SDLC.md
@@ -167,10 +167,18 @@ A GitHub Actions CI pipeline runs on every push to `main` and on pull requests (
 
 | Job | Command | Purpose |
 |-----|---------|---------|
-| **Check** | `cargo check` | Fast compilation verification |
-| **Test** | `cargo test --lib` | Run 57 unit tests |
+| **Check** | `cargo check --tests` (×3: `ci`, `ci,survival,slow-tests`, `ci,markov`) | Fast compilation verification of every feature combo, including the ones no per-PR test job builds |
+| **Tests + coverage (core)** | `cargo llvm-cov --tests --features ci` | Runs the Tier-1/2 suite and produces the per-PR patch-coverage report (`fast` flag) |
+| **Tests + coverage (TTE/CTMM endpoints)** | `cargo llvm-cov --lib --test <6 endpoint files> --features ci,markov` | Runs and measures the feature-gated TTE / categorical / CTMM code the base build compiles out (`survival` + `markov` flags) |
 | **Clippy** | `cargo clippy -- -D warnings` | Lint with warnings-as-errors |
 | **Format** | `cargo fmt -- --check` | Enforce consistent formatting |
+
+There is deliberately **no** separate uninstrumented `Test` job, and no separate
+`Survival` job: the former was a strict subset of `Tests + coverage (core)`
+(same features, `--tests` ⊇ `--lib`), and `markov = ["survival"]` makes the
+latter a strict subset of the endpoints job. Both were removed rather than left
+re-paying an ~11 min lib compile for coverage that Codecov already merges in
+from another flag.
 
 All jobs use the stock Rust nightly toolchain pinned in `rust-toolchain.toml`.
 

--- a/SDLC.md
+++ b/SDLC.md
@@ -169,7 +169,7 @@ A GitHub Actions CI pipeline runs on every push to `main` and on pull requests (
 |-----|---------|---------|
 | **Check** | `cargo check --tests` (×3: `ci`, `ci,survival,slow-tests`, `ci,markov`) | Fast compilation verification of every feature combo, including the ones no per-PR test job builds |
 | **Tests + coverage (core)** | `cargo llvm-cov --tests --features ci` | Runs the Tier-1/2 suite and produces the per-PR patch-coverage report (`fast` flag) |
-| **Tests + coverage (TTE/CTMM endpoints)** | `cargo llvm-cov --lib --test <6 endpoint files> --features ci,markov` | Runs and measures the feature-gated TTE / categorical / CTMM code the base build compiles out (`survival` + `markov` flags) |
+| **Tests + coverage (TTE/CTMM endpoints)** | `cargo llvm-cov --lib --test <each endpoint test file> --features ci,markov` | Runs and measures the feature-gated TTE / categorical / CTMM code the base build compiles out (`survival` + `markov` flags) |
 | **Clippy** | `cargo clippy -- -D warnings` | Lint with warnings-as-errors |
 | **Format** | `cargo fmt -- --check` | Enforce consistent formatting |
 
@@ -180,7 +180,17 @@ latter a strict subset of the endpoints job. Both were removed rather than left
 re-paying an ~11 min lib compile for coverage that Codecov already merges in
 from another flag.
 
-All jobs use the stock Rust nightly toolchain pinned in `rust-toolchain.toml`.
+The endpoints job's `--test` list is not free-form: `tests/ci_workflow_endpoint_coverage.rs`
+asserts it equals exactly the set of `tests/*.rs` that mention a `survival` or
+`markov` cfg, so the file count above is deliberately left unstated — read the
+list off `ci.yml`, and add to it when you add an endpoint test.
+
+`rust-toolchain.toml` pins a stock nightly, and `Check`, `Clippy` and `Format`
+use it. The three coverage jobs deliberately override to **stable** via
+`RUSTUP_TOOLCHAIN` — the crate has no nightly-only code, and stable's rustc
+version holds for ~6 weeks against nightly's daily bump, which keeps their
+instrumented build cache (keyed on rustc version) warm instead of cold-rebuilding
+the dependency graph under coverage `RUSTFLAGS` on every run.
 
 ### Future CI additions
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,13 +7,17 @@
 #   project/floor        -> per-PR 90% gap shown to the author (informational)
 #   project/floor_weekly -> 90% floor ENFORCED on the weekly main run (goes red
 #                           below 90%); never evaluated on PRs, so it blocks no one
-# Slow-tests NEVER run on PRs. Per-PR uploads = `fast` (--features ci) + `survival`
-# (--features ci,survival) + `markov` (--features ci,markov); nightly upload = `slow`
-# flag (--features ci,slow-tests). carryforward lets the nightly `slow` data augment
-# the project number on PRs without re-running it. The `survival` and `markov` flags
-# exist because that feature-gated code is compiled OUT of the `fast`/`slow` FD builds
-# — Codecov merges the flags in so those lines are counted where they're actually
-# exercised (#293).
+# Slow-tests NEVER run on PRs. Per-PR uploads = `fast` (--features ci, from
+# `Tests + coverage (core)`) + `survival` AND `markov`, which are BOTH uploaded from
+# the single `Tests + coverage (TTE/CTMM endpoints)` job (--features ci,markov, and
+# `markov = ["survival"]` so that build is a strict superset of a survival-only one);
+# nightly upload = `slow` flag (--features ci,slow-tests). carryforward lets the
+# nightly `slow` data augment the project number on PRs without re-running it. The
+# `survival` and `markov` flags exist because that feature-gated code is compiled OUT
+# of the `fast`/`slow` FD builds — Codecov merges the flags in so those lines are
+# counted where they're actually exercised (#293). Both flags are kept as distinct
+# names (rather than collapsed into one) so the patch status can require each family
+# independently and so a future split of the jobs needs no config change.
 
 coverage:
   range: 85..95
@@ -70,10 +74,9 @@ coverage:
         target: 90% # new/changed lines must be tested
         threshold: 0%
         # Patch is a pull-request concept — grade changed lines only on PRs.
-        # On a push to `main` the `fast` flag is absent (its job is PR-only), so
-        # patch falls back to `survival` alone and mis-grades the merge commit's
-        # diff against a stale base: a false red on `main` that blocks nothing.
-        # `only_pulls` confines the status to PR comparisons. (#300)
+        # It previously mis-graded merge commits on `main` (a false red that
+        # blocks nothing); `only_pulls` confines the status to PR comparisons.
+        # (#300)
         only_pulls: true
         # `fast`, `survival`, and `markov` are the FRESH per-PR coverage sources,
         # so they grade the changed lines. `survival` and `markov` are each
@@ -95,13 +98,13 @@ flag_management:
     - name: slow
       carryforward: true
     - name: survival
-      # The `survival` job runs on PRs, main pushes, AND the weekly schedule, so it
-      # normally uploads fresh. carryforward is a safety net: the flag still
-      # contributes on any run where that job didn't upload (fresh data overrides).
+      # `Tests + coverage (TTE/CTMM endpoints)` runs on PRs, main pushes, AND the
+      # weekly schedule, so this flag normally uploads fresh. carryforward is a
+      # safety net: it still contributes on any run where that job didn't upload
+      # (fresh data overrides).
       carryforward: true
     - name: markov
-      # Same as survival: the `markov` job runs on PRs and main pushes and normally
-      # uploads fresh; carryforward is the safety net for any run where it didn't.
+      # Same job, same upload, same rationale as `survival` above.
       carryforward: true
 
 comment:

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -313,6 +313,12 @@ ferx-core builds on a **stock nightly** toolchain — no custom compiler. The ex
 FOCE/FOCEI and HMC gradients come from hand-rolled analytic `Dual2` sensitivities
 (`sens/`), and models outside the provider's scope fall back to finite differences.
 
+In fact there is no nightly-only code left, which is why the three coverage jobs
+in `ci.yml` override `RUSTUP_TOOLCHAIN` to **stable**: stable's rustc version
+holds for ~6 weeks against nightly's daily bump, keeping their instrumented build
+cache warm. `rust-toolchain.toml` still pins nightly as the default, and `Check` /
+`Clippy` / `Format` run on it.
+
 - **Keep the build toolchain-light.** Standard-Rust users (Mac / Linux / Windows)
   and CI install ferx with `cargo build` alone. Do not reintroduce a dependency on
   a custom compiler or a non-default Cargo feature for the core gradient path.

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -261,7 +261,7 @@ after each major feature) and not yet on GitHub — a known gap to formalize.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | PR + push to `main` | `check`, `test` (`--lib --release`), `survival` (TTE feature), `clippy`, `fmt`; **`coverage`** on weekly schedule / manual |
+| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented — runs the Tier-1/2 suite *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Clippy`, `Format`; **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
 | `slow-tests.yml` | nightly 06:00 UTC, manual, push to `main` touching estimation paths | Tier-3 fits to convergence (`--features ci,slow-tests --release`, `--no-fail-fast`) |
 | `docs.yml` | push to `main` touching `docs/**` | `quarto render` → deploy to `gh-pages` |
 | `release.yml` | tag `v*` or manual | GitHub release with generated notes |

--- a/tests/ci_workflow_endpoint_coverage.rs
+++ b/tests/ci_workflow_endpoint_coverage.rs
@@ -1,0 +1,128 @@
+//! Guard: the `Tests + coverage (TTE/CTMM endpoints)` job in `.github/workflows/ci.yml`
+//! selects its integration-test binaries with an explicit `--test <name>` list rather
+//! than `--tests`, because re-running the whole 122-binary base suite under a second
+//! feature set bought no coverage (Codecov merges flags by summing hits) and cost ~15
+//! minutes of instrumented compile per PR.
+//!
+//! The cost of that speed-up is a list that can drift: add `tests/foo.rs` using
+//! `#[cfg(feature = "survival")]`, forget the workflow, and its lines silently read as
+//! uncovered in the merged report — quietly failing the ≥90% patch gate for the very PR
+//! that added them, with nothing pointing at the cause.
+//!
+//! So the invariant is pinned here as a plain set equality:
+//!
+//! > the `--test` names in that job == every `tests/*.rs` mentioning a `survival` or
+//! > `markov` feature cfg.
+//!
+//! Tier-3 (`slow-tests`-gated) endpoint files are deliberately *inside* the set: without
+//! the `slow-tests` feature their tests stay `#[ignore]`d, so listing them costs one cheap
+//! compile each and keeps this a set equality with no exemption rule to get wrong.
+//!
+//! Not feature-gated itself — it must run in the base `--features ci` job, which is the
+//! one job guaranteed to build every PR.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every `tests/*.rs` whose source mentions a `survival` or `markov` feature cfg.
+///
+/// Matching on the raw `feature = "…"` string is what makes the set self-maintaining:
+/// any file that compiles endpoint code *must* gate it (it would not build in the base
+/// `ci` job otherwise), and gating means writing that string.
+fn endpoint_test_files(tests_dir: &Path) -> BTreeSet<String> {
+    // This file quotes both cfg strings in the matcher below, so it would match itself
+    // and demand a `--test` entry for a test that compiles no endpoint code. `file!()`
+    // rather than a hard-coded name so a rename cannot silently re-introduce that.
+    let self_stem = Path::new(file!())
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .expect("file!() has a UTF-8 stem");
+
+    let mut found = BTreeSet::new();
+    for entry in std::fs::read_dir(tests_dir).expect("tests/ is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.file_stem().and_then(|s| s.to_str()) == Some(self_stem) {
+            continue;
+        }
+        let src = std::fs::read_to_string(&path).expect("test file is valid UTF-8");
+        if src.contains(r#"feature = "survival""#) || src.contains(r#"feature = "markov""#) {
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .expect("test file has a UTF-8 stem");
+            found.insert(stem.to_string());
+        }
+    }
+    found
+}
+
+/// The `--test <name>` arguments of the endpoint coverage step in `ci.yml`.
+///
+/// Scoped to that one step by scanning from its `- name:` line to the next step, so an
+/// unrelated `--test` elsewhere in the workflow (e.g. a future targeted job) cannot
+/// satisfy this assertion by accident.
+fn workflow_test_selection(workflow: &str) -> BTreeSet<String> {
+    const STEP: &str = "- name: Generate TTE/CTMM endpoint coverage report";
+    let step_start = workflow
+        .find(STEP)
+        .expect("ci.yml still has the endpoint coverage step");
+    let rest = &workflow[step_start + STEP.len()..];
+    // The step's `run:` block ends at the next step in the same job.
+    let step_body = match rest.find("\n      - name:") {
+        Some(end) => &rest[..end],
+        None => rest,
+    };
+
+    let mut selected = BTreeSet::new();
+    for (idx, _) in step_body.match_indices("--test ") {
+        let after = &step_body[idx + "--test ".len()..];
+        let name: String = after
+            .chars()
+            .take_while(|c| !c.is_whitespace() && *c != '\\')
+            .collect();
+        assert!(!name.is_empty(), "`--test` with no target name in ci.yml");
+        selected.insert(name);
+    }
+    selected
+}
+
+#[test]
+fn endpoint_coverage_job_lists_every_feature_gated_test_file() {
+    let root = repo_root();
+    let workflow = std::fs::read_to_string(root.join(".github/workflows/ci.yml"))
+        .expect("ci.yml is readable from the repo root");
+
+    let selected = workflow_test_selection(&workflow);
+    let expected = endpoint_test_files(&root.join("tests"));
+
+    assert!(
+        !expected.is_empty(),
+        "no tests/*.rs mention a survival/markov feature cfg — the detector must be broken, \
+         since the endpoint job would then measure nothing"
+    );
+
+    let missing: Vec<_> = expected.difference(&selected).cloned().collect();
+    let extra: Vec<_> = selected.difference(&expected).cloned().collect();
+
+    assert!(
+        missing.is_empty(),
+        "these tests/*.rs use a `survival`/`markov` feature cfg but are NOT built by the \
+         `Tests + coverage (TTE/CTMM endpoints)` job in .github/workflows/ci.yml: {missing:?}. \
+         Their feature-gated lines would read as uncovered in the merged Codecov report. \
+         Add `--test <name>` for each to that job's `cargo llvm-cov` invocation."
+    );
+    assert!(
+        extra.is_empty(),
+        "the `Tests + coverage (TTE/CTMM endpoints)` job builds these test binaries, but they \
+         no longer contain a `survival`/`markov` feature cfg: {extra:?}. They are already run \
+         and measured by `Tests + coverage (core)`, so drop their `--test` flags rather than \
+         pay a second instrumented compile."
+    );
+}


### PR DESCRIPTION
## Why

Four per-PR jobs each take 21–28 min, and three of them re-run the same work. Measured on run [31850166902](https://github.com/FeRx-NLME/ferx-core/actions/runs/31850166902):

| Job | features | scope | compile | run | total |
|---|---|---|---|---|---|
| Test | `ci` | `--lib` + 2 explicit `--test` | 11m53s + 10m48s | ~1m | 23m |
| Coverage (fast, patch) | `ci` | `--tests` (all 122) | 18m28s | 8m30s | 27m |
| Survival (TTE) | `ci,survival` | `--tests` (all 122) | ~18m | ~9m | 27m |
| Markov (CTMM) | `ci,markov` | `--tests` (all 122) | 18m09s | 9m30s | 28m |

Three genuine overlaps:

1. **`markov = ["survival"]`**, so `--features ci,markov` is a strict superset of `--features ci,survival`. The Survival job compiled and ran nothing the Markov job did not, and its lcov was a subset of Markov's.
2. **Test ⊂ Coverage (fast, patch)** — same `--features ci`, and `--tests` ⊇ `--lib` plus both of the explicitly-named integration files. Its second step spent 10m48s recompiling the whole lib as a plain dependency just to link one test binary.
3. **The feature jobs re-ran all 122 base integration binaries** to measure ~8 endpoint files. Codecov merges flags by summing hits, so those base lines were already counted by `fast`; the re-run bought no coverage at ~15 min a piece.

## What changed

* **Deleted `Survival (TTE)`.** The renamed endpoints job uploads `flags: survival,markov` from its single report. `codecov.yml` keeps both flag names, so the patch/project statuses are untouched.
* **Deleted `Test`.** The two guards it ran explicitly — the NONMEM IOV CL cross-check (#238) and the analytical/ODE equivalence check (ferx-r #127) — still run on every PR, via `--tests` in the core job. The nightly toolchain is still exercised per-PR by `Check`, `Clippy`, `Format`.
* **Narrowed the endpoints job** to `--lib` plus an explicit 8-file `--test` list instead of `--tests`.
* **Added `push` to the core coverage job's trigger.** It was PR-only while the removed `Test` job had no `if:` — without this, a merge commit on `main` would have run no tests at all. The below-floor nudge step is now gated on `pull_request` so it does not fire where there is no PR.
* **Renamed the jobs** so each says what it runs, now that the suite is no longer in a job called "Test":

| Before | After |
|---|---|
| `Test` + `Coverage (fast, patch)` | `Tests + coverage (core)` |
| `Survival (TTE)` + `Markov (CTMM)` | `Tests + coverage (TTE/CTMM endpoints)` |
| `Coverage (full)` | `Tests + coverage (full, slow-tests)` |

No required status checks are configured in the `main-protection` ruleset, so the renames break no merge gate.

## Alternatives considered

* **Sharding the core coverage job.** Rejected on the measured numbers: 18m of its 27m is compile, and ~11m of that is the lib itself, which every shard would re-pay. Four shards would land around 13–14 min each for 4× the CPU.
* **Merging everything into one `--features ci,markov` job.** Would drop the `#[cfg(not(feature = "survival"))]` negative-path tests (the feature-off error messages) from CI entirely, and their lines would read as uncovered.
* **Keeping `Test` for the nightly toolchain.** The crate has no nightly-only code — that is exactly why the coverage jobs already pin stable. `Check`/`Clippy`/`Format` keep a nightly compile in the PR set for ~1 min instead of 23.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

No Rust behaviour changes; the same test binaries run, from fewer jobs.

## Performance
- [x] Faster — **~78 min of duplicated CPU per PR removed** (4 jobs × ~25m → 2 × ~25m).

Wall clock is **unchanged at ~26 min** and should be stated plainly: the four jobs ran in parallel, so deduplicating them frees CPU without shortening the critical path.

Measured on this PR's own run (both jobs on a cold cache): core 17m42s compile + 8m25s run = 26m; endpoints 18m53s compile + 7m06s run = 26m. I had predicted the endpoints job would roughly halve once it stopped building 114 binaries it does not measure — **it did not**, 28m -> 26m. The integration-test binaries are nearly free; compiling the `ferx-core` lib is everything, and any run touching both a lib target and an integration target builds it twice. See the comment below for the full numbers. This also rules out sharding: every shard would re-pay the ~18m lib build.

Cutting the remaining wall clock means attacking the 11m53s lib compile — `[profile.ci-test]` currently `inherits = "release"` (opt-level 3, codegen-units 16). Deliberately left out of this PR: it trades against slow-test runtime and wants its own timing experiment.

## Tests
- [x] Regression test added that fails without this fix — `tests/ci_workflow_endpoint_coverage.rs`

The explicit `--test` list is the one thing here that can silently rot: add `tests/foo.rs` with a `#[cfg(feature = "survival")]`, forget the workflow, and its lines read as uncovered in the merged report — failing the ≥90% patch gate for the very PR that added them, with nothing pointing at why. The new test pins the invariant as a set equality — the job's `--test` names == every `tests/*.rs` mentioning a `survival`/`markov` cfg — and fails with a message naming the missing files and the fix.

Verified in both directions: passes as committed, and dropping one `--test` line produces

```
these tests/*.rs use a `survival`/`markov` feature cfg but are NOT built by the
`Tests + coverage (TTE/CTMM endpoints)` job in .github/workflows/ci.yml: ["agq"].
Their feature-gated lines would read as uncovered in the merged Codecov report.
Add `--test <name>` for each to that job's `cargo llvm-cov` invocation.
```

The two Tier-3 files (`tte_convergence`, `categorical_convergence`) are inside the set on purpose: without `slow-tests` their tests stay `#[ignore]`d, so they cost one cheap compile each and keep this a plain set equality with no exemption rule to get wrong.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated — `docs/development/sdlc.qmd` §8.2 CI workflow table
- [x] `CHANGELOG.md` N/A (CI only, per CLAUDE.md)
- Also refreshed the stale `SDLC.md` §8 pipeline table, which still described a 57-unit-test `Test` job and no coverage jobs at all.

## Checklist
- [x] `cargo clippy` clean (unchanged — no Rust source touched beyond the new test)
- [x] `cargo fmt -- --check` clean
- [x] N/A — nothing on the `Dual2` sensitivity path touched

## Reviewer hints

The claim doing the most work is **`markov = ["survival"]` ⇒ the Survival job was fully redundant**. Worth confirming directly: `Cargo.toml` `[features]`, plus `grep -rn 'not(feature = "markov")' src/` — the negated gates that exist are all `not(survival)` / `not(markov)` paths, which live in the base `ci` build and are measured by the `fast` flag, not by the deleted job.

Second-most: **`--tests` ⊇ `--lib` + the two named integration tests**, which is what makes deleting `Test` safe.

The `push` trigger added to `coverage-pr` is the one behavioural change that is not pure deletion — it is what stops `main` pushes from losing test execution along with the `Test` job.

## Open questions

Should the profile experiment (`opt-level = 2`, `codegen-units = 256` on `ci-test`) be a follow-up issue? It is the only remaining lever on wall clock short of splitting the crate or paying for larger runners.
