### PR TITLE
perf(ci): split per-PR jobs onto a ci-fast (lto="off") profile [#969]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       # the feature-gated branches of the shared modules live there.
       - name: Generate TTE/CTMM endpoint coverage report
         run: |
-          cargo llvm-cov --no-fail-fast --no-default-features --features ci,markov --profile ci-test \
+          cargo llvm-cov --no-fail-fast --no-default-features --features ci,markov --profile ci-fast \
             --lib \
             --test agq \
             --test categorical_convergence \
@@ -250,10 +250,12 @@ jobs:
         # both RUNS the base suite and is the per-PR patch gate; the full
         # `ci,slow-tests` run is nightly (the `coverage` job above) and the
         # feature-gated endpoints are the `endpoints` job. Builds with
-        # `--profile ci-test` (no fat LTO) to stay within the PR wall-clock.
-        # `--tests` so the integration tests both run and count (same rationale
-        # as the nightly job).
-        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --profile ci-test --lcov --output-path lcov.info
+        # `--profile ci-fast` (no fat LTO *and* no local ThinLTO — ~31% off the
+        # lib compile, #969) to stay within the PR wall-clock; the fast Tier-1/2
+        # fits here tolerate the ThinLTO-off fit slowdown that the nightly
+        # `coverage`/`slow-tests` jobs avoid by staying on `ci-test`. `--tests`
+        # so the integration tests both run and count (same rationale as nightly).
+        run: cargo llvm-cov --tests --no-fail-fast --no-default-features --features ci --profile ci-fast --lcov --output-path lcov.info
 
       - name: Upload to Codecov (fast flag)
         uses: codecov/codecov-action@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,16 @@ lto = "fat"
 [profile.ci-test]
 inherits = "release"
 lto = false
+
+# Used by the per-PR `ci.yml` jobs only. `ci-test` sets `lto = false`, which in
+# Cargo means "no *cross-crate* LTO" but still leaves rustc's *local* ThinLTO
+# across the crate's codegen units on — and that local ThinLTO is ~77% of the
+# lib's LLVM time (measured 2026-08-15, #969/#971). `lto = "off"` disables it,
+# cutting the lib compile ~31% (~404s → ~277s locally). The trade is that the
+# population fits run ~20–40% slower without it — which is why this profile is
+# for the per-PR jobs (compile-bound, fits are fast Tier-1/2) and NOT for the
+# heavy Tier-3 fits: `slow-tests.yml` and the nightly full-coverage job stay on
+# `ci-test` so their 5–60 min fits keep the ThinLTO speedup. See #969.
+[profile.ci-fast]
+inherits = "ci-test"
+lto = "off"


### PR DESCRIPTION
## Why

Per-PR CI wall clock (~22 min) is **compile-bound on the `ferx-core` lib**, not on test execution (#969). Local `-Ztime-passes` profiling (2026-08-15) showed the lib compile is ~93% LLVM and, critically, **~77% of that is rustc's *local* ThinLTO** across the crate's 16 codegen units.

`ci-test` sets `lto = false` — but in Cargo that only disables *cross-crate* LTO; local ThinLTO stays **on**. Flipping it to `lto = "off"` kills that pass:

| lib compile (local, 15-core arm64, `RUSTC_WRAPPER=`, `CARGO_INCREMENTAL=0`) | time |
|---|---|
| `ci-test` (`lto = false`, ThinLTO on) — baseline | ~404 s |
| `lto = "off"` (ThinLTO off) | ~277 s (**−31%**) |
| `+ codegen-units = 256` | 357 s (regression) |
| `+ opt-level = 2` (ThinLTO already off) | no further gain |

So `lto = "off"` is the whole win; the other codegen knobs from the issue's lever (1) don't help or regress once ThinLTO is off.

## What changed

`lto = "off"` has a cost: the population fits run **~20–40% slower** without ThinLTO (`iov_convergence` 17.2→20.8 s **+21%**, schnider **+37%**). That matters for the heavy **Tier-3** fits (5–60 min each) but not for the fast **Tier-1/2** fits the per-PR jobs run. Changing `ci-test` globally would slow the nightly `slow-tests.yml` / full-coverage fits by more wall clock than it saves per-PR.

So instead of touching `ci-test`, add a **separate `ci-fast` profile** that inherits `ci-test` and only flips `lto = "off"`, and point the two compile-bound **per-PR** jobs at it:

- `endpoints` (TTE/CTMM coverage) → `ci-fast`
- `coverage-pr` (core suite + patch gate) → `ci-fast`

The nightly `coverage` job and all of `slow-tests.yml` **stay on `ci-test`**, so their Tier-3 fits keep the ThinLTO speedup. The fit-runtime side of the trade is therefore sidestepped by construction, not paid — which is why there is no `slow-tests.yml` regression to measure: that workflow's profile is unchanged.

## Alternatives considered

- **Change `ci-test` globally** — rejected: costs the nightly Tier-3 fits +20–40% wall clock (the table above), more than it saves per-PR.
- **`codegen-units` / `opt-level` knobs** (issue lever 1) — no gain or a regression once ThinLTO is off (table above).
- **Split the crate** (lever 3) — the front end a split would parallelise is ~1% of compile; the cost is generic instantiation, which a split duplicates per crate. NO-GO (#970).

## Numerical validation

- [x] Not applicable *in the estimation sense* — CI-profile change only. But since ThinLTO-off changes inlining (and thus FP rounding), verified it shifts **no** OFV-pinned test: `cargo test --lib --no-default-features --features ci --profile ci-fast` → **2814 passed, 0 failed, 18 ignored**.

## Performance

- [x] Faster — per-PR lib compile ~404 s → ~277 s locally (**−31%**). CI wall-clock delta lands on this PR's own `endpoints` + `coverage-pr` runs; n=1 with ~5 min run-to-run variance on GitHub shared runners, so read it as directional, not settled.

## Tests

- [x] No new tests needed — CI-config change; existing suite runs under the new profile (2814 ok above). `tests/ci_workflow_endpoint_coverage.rs` still guards the endpoints `--test` list, unaffected by the profile flip.

## Docs

- [x] `CHANGELOG.md` — N/A (internal / CI only)

## Reviewer hints

Two-line behavioural change: `[profile.ci-fast]` in `Cargo.toml`, and two `--profile ci-test` → `--profile ci-fast` swaps in `ci.yml` (lines ~116 `endpoints`, ~258 `coverage-pr`). Confirm the nightly `coverage` job (line ~198) and `slow-tests.yml` were left on `ci-test` — that split is the whole point.

## Open questions

Acceptance on #969 asked for CI-measured baseline/variant tables on **both** workflows. This PR's design makes `slow-tests.yml` a no-op (unchanged profile), so only `ci.yml` needs a CI number — which this PR's own run provides. If a cleaner A/B is wanted, I can `workflow_dispatch` baseline vs. this branch a few times to average out the ~5 min variance before merge.
