### PR TITLE
perf(sens): bucket the ODE IOV dual-width dispatch ladder [closes #971]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Performance
+- **The ODE inter-occasion-variability (IOV) analytic sensitivity path now compiles from a
+  bucketed set of dual widths instead of one specialisation per stacked axis count**, cutting
+  the crate's generated LLVM IR by 43 % (17.4 M → 9.8 M lines) and the lib's `-Ztime-passes`
+  total by ~3.2× locally — the direct attack on the compile-bound CI wall clock tracked in
+  #969. Gradients are unchanged: a stacked width that is not a bucket boundary is padded with
+  zero lanes and returns bit-identical `∂f/∂η` / `∂f/∂θ` to the exact-width walk. Widths up to
+  24 axes — the ordinary IOV model — are still specialised exactly, so they pay no runtime
+  cost at all; wider subjects run up to ~1.5× more work in the outer walk for the padded
+  lanes, and the 96-axis cap (past which a subject falls back to finite differences) is
+  unchanged (#971).
+
 ### Fixed
 - **The default (`Auto` → analytic-gradient NLopt L-BFGS) optimizer no longer stalls at the
   initial estimates on its first step.** From the identity initial Hessian the opening search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ section of the SDLC for the versioning policy).
 - **The ODE inter-occasion-variability (IOV) analytic sensitivity path now compiles from a
   bucketed set of dual widths instead of one specialisation per stacked axis count**, cutting
   the crate's generated LLVM IR by 43 % (17.4 M → 9.8 M lines) and the lib's `-Ztime-passes`
-  total by ~3.2× locally — the direct attack on the compile-bound CI wall clock tracked in
+  total by ~2.95× locally (376.7 s → 127.5 s) — the direct attack on the compile-bound CI wall clock tracked in
   #969. Gradients are unchanged: a stacked width that is not a bucket boundary is padded with
   zero lanes and returns bit-identical `∂f/∂η` / `∂f/∂θ` to the exact-width walk. Widths up to
   24 axes — the ordinary IOV model — are still specialised exactly, so they pay no runtime

--- a/src/sens/mod.rs
+++ b/src/sens/mod.rs
@@ -30,3 +30,4 @@ pub mod three_cpt;
 pub mod three_cpt_explicit;
 pub mod two_cpt;
 pub mod two_cpt_explicit;
+pub(crate) mod widths;

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -148,7 +148,10 @@ const _: () = assert!(
 ///   `32/48/64/96` ladder costs.
 ///
 /// The ladder is a tuning parameter: widen it where padding cost bites, narrow it where
-/// compile time does.
+/// compile time does. When you retune it, edit the literal arm list in
+/// [`dispatch_ode_iov_axes`] to match — `macro_rules!` can't iterate a const, so the two are
+/// kept in lockstep by the `slices_eq` compile-time assert in `dispatch_iov_widths!` rather
+/// than shared from one source.
 pub(crate) const ODE_IOV_WIDTH_BUCKETS: [usize; 32] = [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 28, 32,
     40, 48, 56, 64, 80, 96,

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -123,112 +123,93 @@ const _: () = assert!(
      MAX_SCALE_AXES (and its dispatch_init_impulse! table) to at least MAX_ODE_AXES."
 );
 
+/// Monomorphised `(Dual1, Dual2)` widths for the ODE IOV dispatch ladder (#971).
+///
+/// Enumerating every width `1..=MAX_ODE_IOV_AXES` instantiated the entire
+/// ODE-integration and sensitivity stack 96 times per worker — 62 % of the crate's LLVM
+/// IR sat on widths `13..=96` alone, and ~93 % of the lib compile is LLVM (#969/#970). So the ladder is
+/// **bucketed**: the runtime axis count is rounded up to the next width here and the extra
+/// lanes are left zero (see [`crate::sens::widths`] for why padding is semantically inert —
+/// every seeder guards its axis writes with `ax < N` and every readout indexes by the
+/// runtime `n_theta` / `n_stacked`, never by `N`).
+///
+/// Padding is not free at *runtime*: the outer walk is `Dual2<M>` with an `M×M` Hessian per
+/// value, so rounding `M` up costs about `(bucket/exact)²` (measured, #971 — the inner
+/// `Dual1<N>` walk is `O(N)` and two orders of magnitude cheaper either way). The ladder is
+/// therefore split where the two costs actually sit:
+///
+/// * **`1..=24` exact.** These widths are already instantiated by the `MAX_ODE_AXES` /
+///   `MAX_SCALE_AXES = 24` ladders, so the IOV ladder shares their monomorphisations and
+///   each extra width here costs only ~16 k LLVM lines (~0.2 % of the crate). Exactness is
+///   nearly free, and this range covers the ordinary IOV model.
+/// * **`> 24` bucketed.** Past the shared cap the IOV ladder is the sole user, at ~115 k
+///   lines per width (~1.2 % of the crate each), so the tail rounds — with a step chosen to
+///   hold the `O(M²)` padding penalty at ≤ ~1.5× rather than the ~2.1× a coarser
+///   `32/48/64/96` ladder costs.
+///
+/// The ladder is a tuning parameter: widen it where padding cost bites, narrow it where
+/// compile time does.
+pub(crate) const ODE_IOV_WIDTH_BUCKETS: [usize; 32] = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 28, 32,
+    40, 48, 56, 64, 80, 96,
+];
+
+// Tripwire, replacing the old `MAX_ODE_IOV_AXES == 96` literal check: the ladder must be
+// strictly ascending and reach exactly the cap `ode_iov_subject_supported` enforces.
+// Otherwise a subject inside the gate but past the last bucket would hit the ladder's
+// `_ => None` arm and fall **silently** back to FD instead of being declined loudly by the
+// gate (the #438 / #466 / #534 convention, carried over to the bucketed form).
 const _: () = assert!(
-    MAX_ODE_IOV_AXES == 96,
-    "MAX_ODE_IOV_AXES changed: update dispatch_ode_iov_axes! to enumerate the same range"
+    crate::sens::widths::buckets_well_formed(&ODE_IOV_WIDTH_BUCKETS, MAX_ODE_IOV_AXES),
+    "ODE_IOV_WIDTH_BUCKETS must be strictly ascending and end at MAX_ODE_IOV_AXES: the \
+     dispatch ladder has to cover the whole range ode_iov_subject_supported admits, or an \
+     in-scope subject silently falls back to FD"
 );
 
-macro_rules! dispatch_ode_iov_axes {
-    ($dim:expr, $worker:ident, $($arg:expr),+ $(,)?) => {
-        match $dim {
-            1 => $worker::<1>($($arg),+),
-            2 => $worker::<2>($($arg),+),
-            3 => $worker::<3>($($arg),+),
-            4 => $worker::<4>($($arg),+),
-            5 => $worker::<5>($($arg),+),
-            6 => $worker::<6>($($arg),+),
-            7 => $worker::<7>($($arg),+),
-            8 => $worker::<8>($($arg),+),
-            9 => $worker::<9>($($arg),+),
-            10 => $worker::<10>($($arg),+),
-            11 => $worker::<11>($($arg),+),
-            12 => $worker::<12>($($arg),+),
-            13 => $worker::<13>($($arg),+),
-            14 => $worker::<14>($($arg),+),
-            15 => $worker::<15>($($arg),+),
-            16 => $worker::<16>($($arg),+),
-            17 => $worker::<17>($($arg),+),
-            18 => $worker::<18>($($arg),+),
-            19 => $worker::<19>($($arg),+),
-            20 => $worker::<20>($($arg),+),
-            21 => $worker::<21>($($arg),+),
-            22 => $worker::<22>($($arg),+),
-            23 => $worker::<23>($($arg),+),
-            24 => $worker::<24>($($arg),+),
-            25 => $worker::<25>($($arg),+),
-            26 => $worker::<26>($($arg),+),
-            27 => $worker::<27>($($arg),+),
-            28 => $worker::<28>($($arg),+),
-            29 => $worker::<29>($($arg),+),
-            30 => $worker::<30>($($arg),+),
-            31 => $worker::<31>($($arg),+),
-            32 => $worker::<32>($($arg),+),
-            33 => $worker::<33>($($arg),+),
-            34 => $worker::<34>($($arg),+),
-            35 => $worker::<35>($($arg),+),
-            36 => $worker::<36>($($arg),+),
-            37 => $worker::<37>($($arg),+),
-            38 => $worker::<38>($($arg),+),
-            39 => $worker::<39>($($arg),+),
-            40 => $worker::<40>($($arg),+),
-            41 => $worker::<41>($($arg),+),
-            42 => $worker::<42>($($arg),+),
-            43 => $worker::<43>($($arg),+),
-            44 => $worker::<44>($($arg),+),
-            45 => $worker::<45>($($arg),+),
-            46 => $worker::<46>($($arg),+),
-            47 => $worker::<47>($($arg),+),
-            48 => $worker::<48>($($arg),+),
-            49 => $worker::<49>($($arg),+),
-            50 => $worker::<50>($($arg),+),
-            51 => $worker::<51>($($arg),+),
-            52 => $worker::<52>($($arg),+),
-            53 => $worker::<53>($($arg),+),
-            54 => $worker::<54>($($arg),+),
-            55 => $worker::<55>($($arg),+),
-            56 => $worker::<56>($($arg),+),
-            57 => $worker::<57>($($arg),+),
-            58 => $worker::<58>($($arg),+),
-            59 => $worker::<59>($($arg),+),
-            60 => $worker::<60>($($arg),+),
-            61 => $worker::<61>($($arg),+),
-            62 => $worker::<62>($($arg),+),
-            63 => $worker::<63>($($arg),+),
-            64 => $worker::<64>($($arg),+),
-            65 => $worker::<65>($($arg),+),
-            66 => $worker::<66>($($arg),+),
-            67 => $worker::<67>($($arg),+),
-            68 => $worker::<68>($($arg),+),
-            69 => $worker::<69>($($arg),+),
-            70 => $worker::<70>($($arg),+),
-            71 => $worker::<71>($($arg),+),
-            72 => $worker::<72>($($arg),+),
-            73 => $worker::<73>($($arg),+),
-            74 => $worker::<74>($($arg),+),
-            75 => $worker::<75>($($arg),+),
-            76 => $worker::<76>($($arg),+),
-            77 => $worker::<77>($($arg),+),
-            78 => $worker::<78>($($arg),+),
-            79 => $worker::<79>($($arg),+),
-            80 => $worker::<80>($($arg),+),
-            81 => $worker::<81>($($arg),+),
-            82 => $worker::<82>($($arg),+),
-            83 => $worker::<83>($($arg),+),
-            84 => $worker::<84>($($arg),+),
-            85 => $worker::<85>($($arg),+),
-            86 => $worker::<86>($($arg),+),
-            87 => $worker::<87>($($arg),+),
-            88 => $worker::<88>($($arg),+),
-            89 => $worker::<89>($($arg),+),
-            90 => $worker::<90>($($arg),+),
-            91 => $worker::<91>($($arg),+),
-            92 => $worker::<92>($($arg),+),
-            93 => $worker::<93>($($arg),+),
-            94 => $worker::<94>($($arg),+),
-            95 => $worker::<95>($($arg),+),
-            96 => $worker::<96>($($arg),+),
+/// The bucketed const-generic ladder behind [`dispatch_ode_iov_axes`]. Both the runtime
+/// bucket lookup and the `match` arms are driven by the same literal list, and the
+/// `slices_eq` assert pins that list to [`ODE_IOV_WIDTH_BUCKETS`] — so editing the const
+/// without editing the arms (or vice versa) fails to compile rather than dropping a bucket
+/// into the `_ => None` FD arm.
+macro_rules! dispatch_iov_widths {
+    ([$($w:literal),+ $(,)?], $dim:expr, $worker:ident, $args:tt) => {{
+        const _: () = assert!(
+            crate::sens::widths::slices_eq(&[$($w),+], &ODE_IOV_WIDTH_BUCKETS),
+            "dispatch_iov_widths! arms are out of sync with ODE_IOV_WIDTH_BUCKETS"
+        );
+        match crate::sens::widths::bucket_for($dim, &ODE_IOV_WIDTH_BUCKETS) {
+            // The argument list arrives as one `tt` group, not a second repetition —
+            // `$(…)+` cannot nest two repetitions of different lengths, so `call_at_width!`
+            // re-parses it once per width arm.
+            $(Some($w) => call_at_width!($worker::<$w>, $args),)+
+            // Unreachable for `1..=MAX_ODE_IOV_AXES` (the assert above pins the ladder to
+            // the cap); a wider subject is declined by `ode_iov_subject_supported` before
+            // it reaches here. Kept as the belt-and-suspenders FD route.
             _ => None,
         }
+    }};
+}
+
+/// Apply a width-instantiated worker to a parenthesised argument list.
+macro_rules! call_at_width {
+    ($f:expr, ($($arg:expr),* $(,)?)) => {
+        $f($($arg),*)
+    };
+}
+
+/// Dispatch `$worker::<W>` at the bucketed width `W ≥ $dim`, or `None` (→ FD) when `$dim`
+/// is zero or past the last bucket.
+macro_rules! dispatch_ode_iov_axes {
+    ($dim:expr, $worker:ident, $($arg:expr),+ $(,)?) => {
+        dispatch_iov_widths!(
+            [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 28, 32, 40, 48, 56, 64, 80, 96
+            ],
+            $dim,
+            $worker,
+            ($($arg),+)
+        )
     };
 }
 

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -6831,3 +6831,282 @@ fn ode_provider_ss_absorption_nonlinear_converged_dual_matches_production() {
         "a converging nonlinear SS must be solved by Anderson (2..cap cycles), got {cycles}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #971: bucketed ODE IOV dual-width dispatch
+// ---------------------------------------------------------------------------
+
+/// 1-cpt IV with κ on CL — the cheapest fixture that can be widened to an arbitrary
+/// stacked width purely by adding occasion groups (`m_dim = n_theta + n_eta + K·n_kappa`),
+/// with no SS equilibration or absorption in the way.
+const ONECPT_IV_IOV_WIDE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.01, 50.0)
+  theta TVV(20.0, 0.5, 200.0)
+  omega ETA_CL ~ 0.09
+  kappa KAPPA_CL ~ 0.02
+  sigma PROP_ERR ~ 0.01 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -CL/V*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method     = focei
+  iov_column = OCC
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+"#;
+
+/// A subject with `k_groups` occasions (one observation each) and a single bolus, so the
+/// stacked IOV width is `n_eta + k_groups·n_kappa` by construction.
+fn iov_wide_subject(k_groups: usize) -> Subject {
+    let times: Vec<f64> = (1..=k_groups).map(|i| i as f64).collect();
+    let mut s = bolus_subject(&times);
+    s.occasions = (1..=k_groups as u32).collect();
+    s.dose_occasions = vec![1];
+    s
+}
+
+/// Every `ObsSens` field, bit-for-bit — padding a dual with zero lanes must not perturb a
+/// single ULP of the live block (`assert_eq!` on `f64` is exact; the `to_bits` check pins
+/// `+0.0` vs `−0.0` too, which `==` would conflate).
+fn assert_subject_sens_bit_identical(a: &SubjectSens, b: &SubjectSens, what: &str) {
+    assert_eq!(
+        a.obs.len(),
+        b.obs.len(),
+        "{what}: observation count differs"
+    );
+    assert!(!a.obs.is_empty(), "{what}: no observations to compare");
+    let bits = |v: &[f64]| v.iter().map(|x| x.to_bits()).collect::<Vec<_>>();
+    for (j, (x, y)) in a.obs.iter().zip(b.obs.iter()).enumerate() {
+        assert_eq!(
+            x.f.to_bits(),
+            y.f.to_bits(),
+            "{what}: obs {j} value differs"
+        );
+        assert_eq!(bits(&x.df_deta), bits(&y.df_deta), "{what}: obs {j} ∂f/∂η");
+        assert_eq!(
+            bits(&x.df_dtheta),
+            bits(&y.df_dtheta),
+            "{what}: obs {j} ∂f/∂θ"
+        );
+        assert_eq!(
+            bits(&x.d2f_deta2),
+            bits(&y.d2f_deta2),
+            "{what}: obs {j} ∂²f/∂η²"
+        );
+        assert_eq!(
+            bits(&x.d2f_deta_dtheta),
+            bits(&y.d2f_deta_dtheta),
+            "{what}: obs {j} ∂²f/∂η∂θ"
+        );
+    }
+    assert!(
+        a.obs.iter().any(|o| o.f.abs() > 0.0)
+            && a.obs.iter().any(|o| o.df_deta.iter().any(|g| *g != 0.0)),
+        "{what}: reference curve/gradient must be non-trivial, else the comparison is vacuous"
+    );
+}
+
+/// The bucket ladder's contract, pinned on the real const (#971): exact through 12, rounded
+/// up past it, and `None` — the FD route — outside `1..=MAX_ODE_IOV_AXES`.
+#[test]
+fn ode_iov_width_buckets_round_up_and_decline_past_the_cap() {
+    use crate::sens::widths::bucket_for;
+    let l = &ODE_IOV_WIDTH_BUCKETS;
+
+    // The ordinary IOV model is served exactly — no padding cost at all up to the width the
+    // `MAX_ODE_AXES` / `MAX_SCALE_AXES` ladders already instantiate.
+    for w in 1..=24 {
+        assert_eq!(bucket_for(w, l), Some(w), "widths 1..=24 must stay exact");
+    }
+    // Past 24 the tail rounds up. The step holds the `O(M²)` outer padding penalty near
+    // 1.5×; a 33-axis subject runs 40 lanes, not the 48 a coarser ladder would give it.
+    assert_eq!(bucket_for(25, l), Some(28));
+    assert_eq!(bucket_for(29, l), Some(32));
+    assert_eq!(bucket_for(33, l), Some(40));
+    assert_eq!(bucket_for(41, l), Some(48));
+    assert_eq!(bucket_for(49, l), Some(56));
+    assert_eq!(bucket_for(57, l), Some(64));
+    assert_eq!(bucket_for(65, l), Some(80));
+    assert_eq!(bucket_for(81, l), Some(96));
+    assert_eq!(bucket_for(MAX_ODE_IOV_AXES, l), Some(MAX_ODE_IOV_AXES));
+
+    // No round-up may cost more than ~1.5× the exact `Dual2<M>` Hessian area.
+    for w in 1..=MAX_ODE_IOV_AXES {
+        let b = bucket_for(w, l).expect("in-cap width");
+        let area = (b * b) as f64 / (w * w) as f64;
+        assert!(
+            area <= 1.55,
+            "width {w} → bucket {b} pads {area:.2}× the M×M work"
+        );
+    }
+
+    // Past the last bucket there is no instantiation to dispatch to: the ladder declines,
+    // and `ode_iov_subject_supported` declines first (see the gate test below), so such a
+    // subject reaches FD by the loud route, never by a silent `_ => None`.
+    assert_eq!(bucket_for(MAX_ODE_IOV_AXES + 1, l), None);
+    assert_eq!(
+        bucket_for(0, l),
+        None,
+        "a zero-axis subject has nothing to seed"
+    );
+
+    // Every bucket is reachable as its own round-up target, and the ladder covers the whole
+    // gate range with no hole that would drop to FD.
+    for w in 1..=MAX_ODE_IOV_AXES {
+        let b = bucket_for(w, l).expect("every in-cap width must have a bucket");
+        assert!(b >= w && l.contains(&b), "width {w} → bucket {b}");
+    }
+}
+
+/// The teeth on the bucketing itself: for a subject whose stacked width is *not* a bucket
+/// boundary, the padded instantiation the ladder now selects must reproduce the exact-width
+/// instantiation (what the pre-#971 ladder ran) bit-for-bit — outer `Dual2` sensitivities
+/// and inner `Dual1` η-gradient alike. Padded lanes stay zero, so they can neither leak into
+/// the live block nor change the value-only ODE step control.
+#[test]
+fn ode_iov_bucketed_dispatch_is_bit_identical_to_the_exact_width() {
+    // `Dual2<24>` carries a 24×24 Hessian per value and the ODE walk holds several frames
+    // at once — past the 2 MiB default test-thread stack. Production runs fits on a 32 MiB
+    // Rayon stack for exactly this reason; mirror it rather than shrinking the fixture
+    // below the widths the test is about (same pattern as
+    // `provider_tests::ode_iov_above_legacy_axis_cap_stays_analytic`).
+    std::thread::Builder::new()
+        .stack_size(crate::api::FIT_RAYON_STACK_SIZE)
+        .spawn(ode_iov_bucketed_dispatch_body)
+        .expect("spawn wide-stack test thread")
+        .join()
+        .expect("bucketed-vs-exact IOV comparison panicked");
+}
+
+fn ode_iov_bucketed_dispatch_body() {
+    let model = parse_model_string(ONECPT_IV_IOV_WIDE).expect("parse wide-κ IOV");
+    let theta = vec![1.0, 20.0];
+    // 24 occasions ⇒ n_stacked = 25 (→ bucket 28) and m_dim = 27 (→ bucket 28): neither
+    // width is a bucket boundary, which is the whole point of the fixture.
+    let subj = iov_wide_subject(24);
+    let occ_groups = crate::stats::likelihood::iov_occasion_groups(&subj);
+    assert_eq!(
+        occ_groups.len(),
+        24,
+        "fixture must have 24 κ occasion groups"
+    );
+
+    let n_stacked = model.n_eta + occ_groups.len() * model.n_kappa;
+    let m_dim = model.n_theta + n_stacked;
+    assert_eq!(
+        (m_dim, n_stacked),
+        (27, 25),
+        "fixture pins the two widths this test is about"
+    );
+    assert_eq!(
+        crate::sens::widths::bucket_for(m_dim, &ODE_IOV_WIDTH_BUCKETS),
+        Some(28)
+    );
+    assert_eq!(
+        crate::sens::widths::bucket_for(n_stacked, &ODE_IOV_WIDTH_BUCKETS),
+        Some(28)
+    );
+
+    let stacked: Vec<f64> = (0..n_stacked)
+        .map(|k| 0.08 - 0.011 * k as f64)
+        .collect::<Vec<_>>();
+
+    // Outer (`Dual2`): exact width 27 (what the pre-#971 ladder ran) vs the padded width 28
+    // the bucketed ladder picks.
+    let exact = run_subject_iov::<27>(&model, &subj, &theta, &stacked, &occ_groups)
+        .expect("exact-width IOV walk");
+    let padded = run_subject_iov::<28>(&model, &subj, &theta, &stacked, &occ_groups)
+        .expect("bucketed IOV walk");
+    assert_subject_sens_bit_identical(&exact, &padded, "outer 27 vs 28");
+    // …and the public entry point, which is what actually goes through the ladder.
+    let dispatched = ode_subject_sensitivities_iov(&model, &subj, &theta, &stacked)
+        .expect("in-scope IOV subject must stay analytic");
+    assert_subject_sens_bit_identical(&exact, &dispatched, "outer 27 vs dispatched");
+
+    // Inner (`Dual1`): exact width 25 vs the padded width 28.
+    let exact_g = run_subject_iov_eta::<25>(&model, &subj, &theta, &stacked, &occ_groups)
+        .expect("exact-width IOV η-gradient");
+    let padded_g = run_subject_iov_eta::<28>(&model, &subj, &theta, &stacked, &occ_groups)
+        .expect("bucketed IOV η-gradient");
+    let dispatched_g = ode_subject_eta_grad_iov(&model, &subj, &theta, &stacked)
+        .expect("in-scope IOV subject must stay analytic");
+    assert_eq!(exact_g.len(), padded_g.len());
+    for (j, ((x, y), z)) in exact_g
+        .iter()
+        .zip(padded_g.iter())
+        .zip(dispatched_g.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            x.f.to_bits(),
+            y.f.to_bits(),
+            "inner: obs {j} value (padded)"
+        );
+        assert_eq!(
+            x.f.to_bits(),
+            z.f.to_bits(),
+            "inner: obs {j} value (dispatched)"
+        );
+        for k in 0..n_stacked {
+            assert_eq!(
+                x.df_deta[k].to_bits(),
+                y.df_deta[k].to_bits(),
+                "inner: obs {j} ∂f/∂η[{k}] (padded)"
+            );
+            assert_eq!(
+                x.df_deta[k].to_bits(),
+                z.df_deta[k].to_bits(),
+                "inner: obs {j} ∂f/∂η[{k}] (dispatched)"
+            );
+        }
+    }
+    assert!(
+        exact_g
+            .iter()
+            .any(|o| o.df_deta.iter().any(|g| g.abs() > 1e-12)),
+        "η-gradient must be non-trivial, else the comparison is vacuous"
+    );
+}
+
+/// A stacked width past the last bucket must decline **at the gate**, so the caller drops to
+/// FD by the same loud route it always did — not by silently falling through the ladder's
+/// `_ => None`. Both IOV entry points are checked; the observable consequence is `None`
+/// (→ FD) plus the inner router's attribution string naming the cap, not a panic and not a
+/// wrong-width analytic answer.
+#[test]
+fn ode_iov_subject_past_the_last_bucket_declines_to_fd() {
+    let model = parse_model_string(ONECPT_IV_IOV_WIDE).expect("parse wide-κ IOV");
+    let theta = vec![1.0, 20.0];
+    // n_theta(2) + n_eta(1) + K·n_kappa(1) > 96 ⇒ K ≥ 94.
+    let subj = iov_wide_subject(94);
+    let occ_groups = crate::stats::likelihood::iov_occasion_groups(&subj);
+    let n_stacked = model.n_eta + occ_groups.len() * model.n_kappa;
+    let m_dim = model.n_theta + n_stacked;
+    assert!(
+        m_dim > MAX_ODE_IOV_AXES,
+        "fixture must exceed the cap, got {m_dim}"
+    );
+
+    let stacked = vec![0.01; n_stacked];
+    assert!(
+        ode_iov_subject_supported(&model, &subj).is_none(),
+        "a subject past the cap must be declined by the gate, before any dispatch"
+    );
+    assert!(
+        ode_subject_sensitivities_iov(&model, &subj, &theta, &stacked).is_none(),
+        "outer IOV must decline past the cap"
+    );
+    assert!(
+        ode_subject_eta_grad_iov(&model, &subj, &theta, &stacked).is_none(),
+        "inner IOV must decline past the cap"
+    );
+}

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -6915,7 +6915,7 @@ fn assert_subject_sens_bit_identical(a: &SubjectSens, b: &SubjectSens, what: &st
     );
 }
 
-/// The bucket ladder's contract, pinned on the real const (#971): exact through 12, rounded
+/// The bucket ladder's contract, pinned on the real const (#971): exact through 24, rounded
 /// up past it, and `None` — the FD route — outside `1..=MAX_ODE_IOV_AXES`.
 #[test]
 fn ode_iov_width_buckets_round_up_and_decline_past_the_cap() {

--- a/src/sens/widths.rs
+++ b/src/sens/widths.rs
@@ -1,0 +1,139 @@
+//! Monomorphised dual-width buckets for the const-generic dispatch ladders (#971).
+//!
+//! Every analytic sensitivity walk is generic over a compile-time dual width
+//! (`Dual1<N>` / `Dual2<M>`), and the entry points pick the instantiation with a
+//! `match` over the runtime axis count. Enumerating *every* width `1..=cap`
+//! monomorphises the whole ODE-integration + sensitivity stack once per width:
+//! at the `MAX_ODE_IOV_AXES = 96` cap that ladder alone was 38.6 % of the crate's
+//! LLVM IR, and ~93 % of the lib compile is LLVM (#969/#970).
+//!
+//! The fix is to **round the runtime width up to the next bucket** and leave the
+//! extra lanes zero. Padding is semantically inert: the dual arithmetic chains
+//! every lane, and a zero lane stays zero; every seeder guards its axis writes
+//! (`ax < N`) and every readout indexes by the *runtime* axis count
+//! (`n_theta` / `n_stacked`), never by `N`. Padding is not free at *runtime* —
+//! `Dual1` costs `O(N)` per op and `Dual2` costs `O(M²)` — so the small widths,
+//! which are the common case, stay exact and only the tail is bucketed.
+//!
+//! A width past the largest bucket must still route to FD **loudly**, through the
+//! per-subject gate (`ode_iov_subject_supported`) rather than through a dispatch
+//! `_ => None`; [`bucket_for`] returning `None` is the backstop, and the
+//! [`buckets_well_formed`] compile-time check keeps the ladder's last entry pinned
+//! to the cap the gate enforces.
+
+/// Smallest width in `buckets` that can hold `dim` live axes, or `None` when
+/// `dim` is zero or wider than the largest bucket (caller routes to FD).
+///
+/// `buckets` must be strictly ascending — [`buckets_well_formed`] is the
+/// compile-time guard for that at each ladder's definition site.
+pub(crate) const fn bucket_for(dim: usize, buckets: &[usize]) -> Option<usize> {
+    if dim == 0 {
+        return None;
+    }
+    let mut i = 0;
+    while i < buckets.len() {
+        if dim <= buckets[i] {
+            return Some(buckets[i]);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether `buckets` is non-empty, strictly ascending, and ends exactly at `cap`.
+///
+/// Used in a `const _: () = assert!(…)` next to each ladder so a widened cap, a
+/// reordered ladder, or a bucket list that no longer reaches the cap fails to
+/// compile instead of silently sending in-scope subjects to the `_ => None` FD
+/// arm (the #438/#466/#534 tripwire convention, carried over to the bucketed
+/// form).
+pub(crate) const fn buckets_well_formed(buckets: &[usize], cap: usize) -> bool {
+    if buckets.is_empty() {
+        return false;
+    }
+    let mut i = 1;
+    while i < buckets.len() {
+        if buckets[i - 1] >= buckets[i] {
+            return false;
+        }
+        i += 1;
+    }
+    buckets[buckets.len() - 1] == cap
+}
+
+/// Slice equality for `const` contexts — the guard that a dispatch macro's literal
+/// arm list still spells exactly the ladder const it looks buckets up in. Without it
+/// a bucket added to the const (but not to the arms) would fall through to the
+/// `_ => None` FD arm at runtime with nothing complaining at compile time.
+pub(crate) const fn slices_eq(a: &[usize], b: &[usize]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const B: [usize; 6] = [1, 2, 4, 8, 16, 32];
+
+    #[test]
+    fn bucket_for_rounds_up_to_the_next_width() {
+        assert_eq!(bucket_for(1, &B), Some(1));
+        assert_eq!(bucket_for(2, &B), Some(2));
+        assert_eq!(bucket_for(3, &B), Some(4));
+        assert_eq!(bucket_for(5, &B), Some(8));
+        assert_eq!(bucket_for(9, &B), Some(16));
+        assert_eq!(bucket_for(17, &B), Some(32));
+        assert_eq!(bucket_for(32, &B), Some(32));
+    }
+
+    #[test]
+    fn bucket_for_declines_zero_and_past_the_cap() {
+        assert_eq!(bucket_for(0, &B), None, "no live axes → FD");
+        assert_eq!(bucket_for(33, &B), None, "past the last bucket → FD");
+        assert_eq!(bucket_for(usize::MAX, &B), None);
+    }
+
+    #[test]
+    fn bucket_for_is_idempotent_on_bucket_boundaries() {
+        for &b in &B {
+            assert_eq!(bucket_for(b, &B), Some(b));
+        }
+    }
+
+    #[test]
+    fn well_formed_accepts_ascending_ladder_ending_at_cap() {
+        assert!(buckets_well_formed(&B, 32));
+    }
+
+    #[test]
+    fn well_formed_rejects_bad_ladders() {
+        assert!(
+            !buckets_well_formed(&B, 64),
+            "last bucket must equal the cap"
+        );
+        assert!(!buckets_well_formed(&[], 0), "empty ladder");
+        assert!(!buckets_well_formed(&[1, 4, 2], 2), "not ascending");
+        assert!(
+            !buckets_well_formed(&[1, 4, 4], 4),
+            "not strictly ascending"
+        );
+    }
+
+    #[test]
+    fn slices_eq_compares_elementwise() {
+        assert!(slices_eq(&B, &[1, 2, 4, 8, 16, 32]));
+        assert!(slices_eq(&[], &[]));
+        assert!(!slices_eq(&B, &[1, 2, 4, 8, 16]), "length differs");
+        assert!(!slices_eq(&B, &[1, 2, 4, 8, 16, 64]), "element differs");
+    }
+}


### PR DESCRIPTION
## Why

Per-PR CI wall clock is compile-bound (#969), and per `-Ztime-passes` ~93 % of the lib compile is LLVM. `cargo llvm-lines` (#970/#971) traced that cost to monomorphisation over const-generic dual widths rather than to any hot function: the ODE IOV dispatch ladder instantiated `run_subject_iov` / `run_subject_iov_eta` — and with them the whole ODE-integration + sensitivity stack — once for **every** stacked axis count `1..=MAX_ODE_IOV_AXES = 96`. Widths `13..=96` alone were **62 % of the crate's LLVM IR**.

Closes #971.

## What changed

Round the runtime axis count up to the next monomorphised width and leave the extra lanes zero.

Padding is semantically inert on this path, which is why it is safe rather than merely plausible:

* every seeder already guards its axis writes (`seed_pk_dual2_iov` / `seed_pk_dual1_iov` skip `ax >= M`, `eval_scale_dual*` seeds only `dim < M`);
* every readout indexes by the **runtime** `n_theta` / `n_stacked`, never by `N`;
* the dual arithmetic is elementwise over lanes — no cross-lane reduction — so a zero lane stays zero and cannot perturb a live one;
* the adaptive ODE step control uses the **value-only** RMS error norm (`Stepper::attempt`), so padded lanes cannot change step sizes.

New `src/sens/widths.rs` holds `bucket_for` / `buckets_well_formed` / `slices_eq` (all `const fn`), and `ODE_IOV_WIDTH_BUCKETS` in `ode_provider.rs` is the ladder:

```
exact:  1..=24
bucket: 28, 32, 40, 48, 56, 64, 80, 96      (96 instantiations -> 32)
```

The split follows the measured per-width cost, not a guess:

* **`1..=24` exact.** Those widths are already instantiated by the `MAX_ODE_AXES` / `MAX_SCALE_AXES = 24` ladders, so the IOV ladder shares their monomorphisations and each width costs only **~16 k** extra LLVM lines. Exactness is nearly free here, and this range covers the ordinary IOV model — so the common case pays **zero** runtime padding.
* **`> 24` bucketed.** Past that cap the IOV ladder is the sole user, at **~115 k lines per width** (~1.2 % of the post-change crate each). The step is chosen to hold the `O(M²)` outer padding penalty at ~1.5× rather than the ~2.1× a coarser `16/24/32/48/64/96` ladder measured (numbers below).

### Tripwires

The old `const _: () = assert!(MAX_ODE_IOV_AXES == 96, …)` literal check is replaced by a strictly stronger compile-time pair, keeping the #438 / #466 / #534 convention that a scope gap must fail **loudly**:

* `buckets_well_formed(&ODE_IOV_WIDTH_BUCKETS, MAX_ODE_IOV_AXES)` — the ladder must be strictly ascending and end exactly at the cap `ode_iov_subject_supported` enforces, so no in-cap width can fall through to the dispatch `_ => None` and silently reach FD;
* `slices_eq(&[…arms…], &ODE_IOV_WIDTH_BUCKETS)` inside the dispatch macro — the macro's literal arm list and the ladder const cannot desync.

A subject wider than the last bucket is still declined by the per-subject gate before any dispatch, exactly as before.

## Alternatives considered

* **The coarse ladder the issue proposed** (`1..=12` exact, then `16, 24, 32, 48, 64, 96`, 18 widths). Measured: **−47.1 %** IR (vs −43.5 % here) but the outer walk cost up to **3.0×** at the boundary just past 16 — i.e. right where real IOV models live. Trading 3.6 points of compile for that was the wrong side of the trade; hence the exact-through-24 split.
* **Crate split** (#969 lever 3) — measured and rejected as a NO-GO in #970; this supersedes it as the useful outcome of that investigation.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API changed (`widths` is `pub(crate)`, `ODE_IOV_WIDTH_BUCKETS` is `pub(crate)`).

## Breaking changes
- [x] None

## Numerical validation

Gradients are **bit-identical**, not merely close — this is the `Dual2`-vs-FD path, so that is the standard the CLAUDE.md rule sets.

- [x] Compared against prior ferx commit `c56ade0c`
- [x] Existing `*_g_dual_matches_fd` per-kernel checks and the `check_full_provider_vs_fd` harness stay green (full `cargo test --lib`: **2822 passed, 0 failed**)
- [x] New `ode_iov_bucketed_dispatch_is_bit_identical_to_the_exact_width` compares a subject whose widths are *not* bucket boundaries (`m_dim = 27 → 28`, `n_stacked = 25 → 28`) against the exact-width instantiation the pre-#971 ladder ran, on `f`, `∂f/∂η`, `∂f/∂θ`, `∂²f/∂η²`, `∂²f/∂η∂θ` — via `to_bits()`, so even `+0.0` vs `−0.0` would fail
- [x] `iov_convergence` (Tier 3) unchanged: 11 passed, 11.71 s → 10.51 s (best of 3)

## Performance

Measured on a 15-core arm64 macOS box, `RUSTC_WRAPPER=`, `CARGO_INCREMENTAL=0`, `--lib --no-default-features --features ci --profile ci-test`.

**`cargo llvm-lines`**

| | before | after |
|---|---|---|
| total lines | 17,421,539 | **9,846,640 (−43.5 %)** |
| total copies | 340,378 | **189,179 (−44.4 %)** |
| distinct const-generic widths | 99 | 41 |
| `sens::` share | 10,303,251 (59.1 %) | 5,583,666 (56.7 %) |

**`RUSTFLAGS="-Ztime-passes"` (lib only, deps warm)**

| pass | before | after |
|---|---|---|
| `total` | 376.7 s | **127.5 s (−66.1 %, 2.95×)** |
| `LLVM_thinlto` | 294.4 s | **85.0 s (−71.1 %)** |
| `LLVM_passes` | 66.0 s | **31.4 s (−52.4 %)** |

**Runtime** — the padding cost is shown, not assumed:

- [x] Faster (compile) / mixed (runtime), justified below.

| check | before | after |
|---|---|---|
| `iov_convergence` (closed-form IOV, Tier 3) | 11.71 s | 10.51 s |
| pna-scale ODE IOV gradient, `m_dim = 90 → 96` | 0.94 s | 1.10 s (**+17 %**, vs the predicted `(96/90)² = 1.14×`) |

Direct sweep of `ode_subject_sensitivities_iov` (1-cpt IV ODE, κ on CL; `m_dim = 2θ + 1η + k·κ`; best of 5, `ci-test` profile) — the worst measured step-up across a bucket boundary is **~1.5–1.6×**, and everything at `m_dim ≤ 24` pays nothing:

```
 k  m_dim bucket  outer_ms  inner_ms       k  m_dim bucket  outer_ms  inner_ms
 9    12    12      0.23      0.03        37    40    40     12.13      0.29
10    13    13      0.30      0.03        38    41    48     24.57      0.29
13    16    16      0.54      0.05        45    48    48     30.67      0.34
14    17    17      0.71      0.05        46    49    56     45.62      0.34
21    24    24      2.44      0.10        53    56    56     50.88      0.43
22    25    28      3.74      0.10        54    57    64     69.55      0.45
25    28    28      4.29      0.16        61    64    64     78.02      0.56
26    29    32      5.96      0.15        62    65    80    115.26      0.54
29    32    32      6.47      0.20        77    80    80    149.96      0.79
30    33    40     10.32      0.21        78    81    96    232.18      0.79
33    36    40     11.21      0.26        93    96    96    280.35      1.47
34    37    40     11.51      0.27
```

For contrast, the coarse `16/24/32/48/64/96` ladder on the same fixture: `m_dim 16 → 17` cost **0.55 → 1.64 ms (3.0×)** and `32 → 33` cost **6.13 → 16.48 ms (2.7×)`.

## Tests
- [x] Unit tests added in the same module (`cargo test --lib` passes: 2822 passed, 0 failed)
- [x] `src/sens/widths.rs`: `bucket_for` round-up / decline / idempotence, `buckets_well_formed` accept + reject, `slices_eq`
- [x] `ode_iov_width_buckets_round_up_and_decline_past_the_cap` — pins the real ladder (`33 → 40`, `96 → 96`, `97 → None`, `0 → None`), asserts every in-cap width has a bucket, and asserts **no** round-up exceeds ~1.55× the exact `M×M` work
- [x] `ode_iov_bucketed_dispatch_is_bit_identical_to_the_exact_width` — the bit-identity teeth described above, outer `Dual2` and inner `Dual1`, plus the public entry points
- [x] `ode_iov_subject_past_the_last_bucket_declines_to_fd` — a 97-axis subject is declined **at the gate** (observably `None` from `ode_iov_subject_supported` and both entry points), never silently through the ladder

## Example (user-facing features only)
- [x] Not applicable (internal — no new API surface, no DSL change)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added (under `Performance` — the runtime characteristics of wide-IOV ODE fits change)
- [x] No other user-visible change (no new fit option, DSL syntax, or output field)

## Checklist
- [x] `cargo clippy` clean (no new warnings; `cargo fmt --check` clean)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — the walk itself is untouched; only the width selected for it changed, and bit-identity is asserted
- [x] No version bump needed (non-breaking)

## Reviewer hints

Focus on two things:

1. **Is padding really inert?** The four reasons are listed under *What changed*; the load-bearing ones are the `ax < M` seeder guards and the value-only ODE error norm. The bit-identity test is the empirical check, but the argument should stand on its own.
2. **The tripwire swap.** The old assert pinned a literal `96`; the new pair pins *the ladder's last entry to the cap* and *the macro arms to the ladder*. Convince yourself no edit to either can produce an in-cap width that reaches `_ => None`.

Skimmable: the mechanical `dispatch_ode_iov_axes!` rewrite (the 96-arm `match` became a generated one) and the `call_at_width!` helper, which exists only because `macro_rules!` cannot nest two repetitions of different lengths.

## Open questions

The remaining `13..=24` mass (~189 k lines per width, ~23 % of the post-change crate) belongs to the `MAX_ODE_AXES` / `MAX_SCALE_AXES = 24` `disp!` / `dispatch_tv!` / `dispatch_init_impulse!` ladders, which this PR deliberately leaves alone: unlike the IOV workers they carry live-width assumptions (`debug_assert_eq!(N, n_eta)` in `seed_pk_dual1`, `debug_assert_eq!(M, n_theta + n_eta)` in `seed_pk_dual2`) that bucketing would have to relax first. Worth a follow-up issue, or fold into #969?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
