### PR TITLE
feat(io): read a missing DV as a design point when simulating [closes #957]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Added
+- **A missing `DV` no longer empties a simulation.** Simulating from a design — dosing plus
+  sampling times, with `DV = .` because the values are what the run is about to produce — used
+  to return zero rows: every `EVID=0` row with a missing `DV` was skipped as a forgotten
+  `MDV=1` (#258), which is the right reading only when the `DV` is an input. The new
+  `read_population_for_simulation()` reads such a row as a **design point** instead, so the
+  natural template simulates as written and no placeholder number is needed in the column
+  about to be overwritten. Fitting is unchanged, and `MDV=1` still excludes a record on both
+  paths (#957).
+
 ### Performance
 - **The ODE inter-occasion-variability (IOV) analytic sensitivity path now compiles from a
   bucketed set of dual widths instead of one specialisation per stacked axis count**, cutting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ section of the SDLC for the versioning policy).
   `read_population_for_simulation()` reads such a row as a **design point** instead, so the
   natural template simulates as written and no placeholder number is needed in the column
   about to be overwritten. Fitting is unchanged, and `MDV=1` still excludes a record on both
-  paths (#957).
+  paths (#957). Kept design rows are reported as `W_DESIGN_DV`, the simulation-side counterpart
+  of `W_MISSING_DV`, so a simulation run off an *observed* dataset makes its extra rows visible
+  rather than silently carrying more rows than a fit of the same data.
 
 ### Performance
 - **The ODE inter-occasion-variability (IOV) analytic sensitivity path now compiles from a
@@ -42,6 +44,13 @@ section of the SDLC for the versioning policy).
   unchanged (#971).
 
 ### Fixed
+- **A design population is now rejected by `fit()` instead of being fitted to its placeholders.**
+  The population returned by `read_population_for_simulation()` carries a `NaN` placeholder for
+  each not-yet-generated observation, and nothing checked observations for finiteness: with
+  log-transformed-both-sides on natural-scale data the placeholder was floored to a finite,
+  extreme value and the fit ran to completion on fabricated data with no warning. Such a
+  population now fails up front with `E_NONFINITE_DV`, and propensity-score-matched simulation
+  reports the real cause instead of a misleading "EBE did not converge" (#957).
 - **The default (`Auto` → analytic-gradient NLopt L-BFGS) optimizer no longer stalls at the
   initial estimates on its first step.** From the identity initial Hessian the opening search
   direction is `−∇`, and on models where the scaled gradient is large at the start (e.g.

--- a/docs/api/simulation.qmd
+++ b/docs/api/simulation.qmd
@@ -35,6 +35,51 @@ for sim in &sims[..5] {
 }
 ```
 
+## `read_population_for_simulation()`
+
+Read a NONMEM-format CSV that will be **simulated from** rather than fitted.
+
+```rust
+pub fn read_population_for_simulation(
+    model: &CompiledModel,
+    covariate_decls: &Option<Vec<CovariateDecl>>,
+    data_path: &str,
+    fallback_columns: Option<&[&str]>,
+    iov_column: Option<&str>,
+    filter: Option<&SelectionFilter>,
+    column_map: &[(String, String)],
+) -> Result<(Population, Option<CovariateTable>), String>
+```
+
+Identical to `read_population_for()` — the reader every fitting entry point uses
+— except in how it reads a **missing `DV`** on a scored row (`EVID=0`,
+`MDV=0`). For a fit, a missing `DV` means "no observation here", so the row is
+skipped and counted for the `W_MISSING_DV` warning. For a simulation the `DV` is
+the *output*, so the same row is a **design point**: a sampling time whose value
+has not been generated yet.
+
+That makes the natural design template simulate as written:
+
+```csv
+ID,TIME,DV,EVID,AMT,CMT,MDV
+1,0,.,1,100,1,1
+1,0.25,.,0,.,1,0
+1,1,.,0,.,1,0
+1,4,.,0,.,1,0
+```
+
+```rust
+let (population, _covariates) =
+    read_population_for_simulation(&model, &None, "design.csv", None, None, None, &[])?;
+let sims = simulate(&model, &population, &model.default_params, 1000);
+```
+
+Read with `read_population_for()` the same file yields zero simulated rows. Rows
+marked `MDV=1` are excluded on both paths. The retained rows carry a placeholder
+`DV` (`NaN`, or `0` for an integer-coded endpoint) that the simulated value
+replaces, so the returned population is for simulation only — do not pass it to
+`fit()`.
+
 ## `simulate_with_seed()`
 
 Same as `simulate()` but with a fixed random seed for reproducibility.

--- a/docs/api/simulation.qmd
+++ b/docs/api/simulation.qmd
@@ -75,10 +75,19 @@ let sims = simulate(&model, &population, &model.default_params, 1000);
 ```
 
 Read with `read_population_for()` the same file yields zero simulated rows. Rows
-marked `MDV=1` are excluded on both paths. The retained rows carry a placeholder
-`DV` (`NaN`, or `0` for an integer-coded endpoint) that the simulated value
-replaces, so the returned population is for simulation only — do not pass it to
-`fit()`.
+marked `MDV=1` are excluded on both paths. Retained rows are reported once as a
+`W_DESIGN_DV` warning on the returned population, so a simulation run off an
+*observed* dataset makes visible that it kept rows a fit of the same data would
+have skipped.
+
+The retained rows carry a placeholder `DV` (`NaN`, or the endpoint's first
+declared state code for an integer-coded endpoint) that the simulated value
+replaces, so the returned population is **for simulation only** — do not pass it
+to `fit()`. That is enforced, not merely advised: a population carrying
+non-finite observations is rejected by `fit()` (and reported by `ferx check`) as
+`E_NONFINITE_DV`, and propensity-score-matched simulation
+(`SimulateOptions::match_method`) rejects it too, since a design template has
+nothing to compute posthoc etas from.
 
 ## `simulate_with_seed()`
 

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -41,6 +41,15 @@ ferx-core reads data in NONMEM-compatible CSV format. This is the standard forma
 > the row is skipped rather than scored as `DV=0` — and emits a single
 > `W_MISSING_DV` warning reporting how many rows were skipped. Set `MDV=1`
 > explicitly to silence it, or fix the data if the missing values are an error.
+>
+> **Simulation reads it the other way round.** When the dataset is a *design*
+> being simulated from, the `DV` is the column about to be produced, so
+> `DV = .` at every sampling time means "simulate here" rather than "nothing to
+> score here". `simulate()` fed a population read by
+> `read_population_for_simulation()` keeps those rows and emits one simulated
+> record per sampling time; no placeholder number is needed in the `DV` column.
+> `MDV=1` still excludes the record on both paths — that is the explicit
+> statement that the row is not an observation.
 
 ## Inferring doses without an `EVID` column
 

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -48,8 +48,11 @@ ferx-core reads data in NONMEM-compatible CSV format. This is the standard forma
 > score here". `simulate()` fed a population read by
 > `read_population_for_simulation()` keeps those rows and emits one simulated
 > record per sampling time; no placeholder number is needed in the `DV` column.
+> The kept rows are reported once as `W_DESIGN_DV`, so a simulation run off an
+> observed dataset shows that it kept rows a fit would have skipped.
 > `MDV=1` still excludes the record on both paths — that is the explicit
-> statement that the row is not an observation.
+> statement that the row is not an observation. Such a population is for
+> simulation only: passing it to `fit()` is rejected with `E_NONFINITE_DV`.
 
 ## Inferring doses without an `EVID` column
 

--- a/docs/file-formats/check-report.qmd
+++ b/docs/file-formats/check-report.qmd
@@ -76,6 +76,8 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 | `W_ADDL_MISSING_II` | warning | ADDL > 0 on a dose row but II is zero or missing; additional doses were not expanded. |
 | `W_IOV_OCC_MISSING` | warning | Some rows in the IOV occasion column had missing or unparseable values; those rows were assigned occasion=0. |
 | `W_MISSING_DV` | warning | One or more `EVID=0` rows had a missing `DV` (`.`/`NA`/blank) but were not marked `MDV=1`; they were skipped rather than scored as `DV=0`. |
+| `W_DESIGN_DV` | warning | Simulation reader only: one or more `EVID=0` rows had a missing `DV` and were kept as design points to simulate at, so the dataset contributes more rows than a fit of the same file would. |
+| `E_NONFINITE_DV` | error | A subject carries a non-finite (`NaN`/`Inf`) observation. Usually a population read by `read_population_for_simulation()` — a simulation input — passed to `fit()`. |
 | `E_IOV_MISSING_OCC` | error | Model declares kappa (IOV) parameters but no occasion labels were found in the dataset. Set `iov_column` in `[fit_options]`. |
 
 Codes are stable; new ones may be added over time. Treat an unrecognised code

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -60,8 +60,8 @@ pub use predict::{predict, PredictionResult};
 pub use predict::{predict_categorical, predict_survival, SurvivalPredictionResult};
 pub(crate) use run::{build_selection_filter_merged, log_transform_observations};
 pub use run::{
-    read_population_for, resolve_data_path, run_from_file, run_model_simulate, run_model_with_data,
-    run_model_with_data_inits,
+    read_population_for, read_population_for_simulation, resolve_data_path, run_from_file,
+    run_model_simulate, run_model_with_data, run_model_with_data_inits,
 };
 pub(crate) use simulate::obs_row_time;
 pub use simulate::{
@@ -164,6 +164,10 @@ mod tests;
 #[cfg(test)]
 #[path = "tests/dose_compartment_tests.rs"]
 mod dose_compartment_tests;
+
+#[cfg(test)]
+#[path = "tests/simulation_template_tests.rs"]
+mod simulation_template_tests;
 
 // ======================================================================
 // Adaptive (state-reactive / feedback) dosing — epic #391, beta.

--- a/src/api/output_columns.rs
+++ b/src/api/output_columns.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/pool.rs
+++ b/src/api/pool.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/predict.rs
+++ b/src/api/predict.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -45,6 +45,15 @@ pub(crate) fn log_transform_observations(pop: &mut Population) -> usize {
     let mut n_nonpos = 0usize;
     for subject in &mut pop.subjects {
         for v in &mut subject.observations {
+            // A non-finite DV is left alone. `f64::max` returns the *non-NaN*
+            // operand, so `NaN.max(LTBS_FLOOR).ln()` would quietly turn a NaN
+            // design placeholder (#957) into a finite, extreme "observation" and
+            // let a mis-routed simulation population fit to completion. Leave it
+            // non-finite so `E_NONFINITE_DV` (and any downstream `is_finite`
+            // guard) still sees it.
+            if !v.is_finite() {
+                continue;
+            }
             if *v <= 0.0 {
                 n_nonpos += 1;
             }
@@ -786,10 +795,13 @@ pub fn read_population_for(
 /// accepts), so the fitting reading would otherwise return zero simulated rows
 /// for the most idiomatic template there is.
 ///
-/// The kept row carries a placeholder DV (`NaN` for a Gaussian endpoint, `0` for
-/// an integer-coded one) which the simulated value replaces; do **not** pass the
-/// returned population to [`fit`]. `MDV=1` still excludes the record — that is
-/// the user explicitly saying it is not an observation.
+/// The kept row carries a placeholder DV (`NaN` for a Gaussian endpoint, the
+/// endpoint's first declared state code for an integer-coded one) which the
+/// simulated value replaces; do **not** pass the returned population to [`fit`].
+/// That contract is enforced, not merely documented: a non-finite observation is
+/// rejected by `E_NONFINITE_DV` ([`check_model_data`]) at `fit()` entry.
+/// `MDV=1` still excludes the record — that is the user explicitly saying it is
+/// not an observation.
 pub fn read_population_for_simulation(
     model: &CompiledModel,
     covariate_decls: &Option<Vec<CovariateDecl>>,
@@ -865,8 +877,27 @@ fn read_population_for_policy(
     // Gaussian-only model (so no row is routed to `obs_records`), and the reader
     // builds the covariate read set from `decls` when the model declares
     // `[covariates]`, from `fallback_columns` otherwise.
-    let routing =
-        ObsRouting::tte_and_discrete(&tte_cmts, &discrete_cmts).with_missing_dv(missing_dv);
+    // Placeholder DV code for an integer-coded design row: the endpoint's first
+    // declared state code, so a `state_codes` table that is not 0-based (e.g.
+    // `1`/`2`) never gets an undecodable `0` placeholder. Only CTMM declares
+    // codes; Binary is `{0,1}` and keeps the `0` default.
+    #[cfg(feature = "markov")]
+    let design_states: HashMap<usize, usize> = model
+        .endpoints
+        .iter()
+        .filter_map(|(&cmt, ep)| match ep {
+            EndpointLikelihood::Ctmm { state_codes, .. } => {
+                state_codes.first().map(|&code| (cmt, code))
+            }
+            _ => None,
+        })
+        .collect();
+    #[cfg(not(feature = "markov"))]
+    let design_states: HashMap<usize, usize> = HashMap::new();
+
+    let routing = ObsRouting::tte_and_discrete(&tte_cmts, &discrete_cmts)
+        .with_missing_dv(missing_dv)
+        .with_design_states(design_states);
     let (decls, extra) = match covariate_decls {
         Some(d) => (Some(d.as_slice()), undeclared_referenced(model, d)),
         None => (None, Vec::new()),

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped, read_nonmem_csv_routed,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    MissingDvPolicy, ObsRouting, SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;
@@ -764,6 +763,68 @@ pub fn read_population_for(
     filter: Option<&SelectionFilter>,
     column_map: &[(String, String)],
 ) -> Result<(Population, Option<CovariateTable>), String> {
+    read_population_for_policy(
+        model,
+        covariate_decls,
+        data_path,
+        fallback_columns,
+        iov_column,
+        filter,
+        column_map,
+        MissingDvPolicy::Skip,
+    )
+}
+
+/// [`read_population_for`] for a dataset that will be **simulated from** rather
+/// than fitted (#957).
+///
+/// Identical in every respect but one: an `EVID=0`, `MDV=0` record whose `DV`
+/// cell is missing (`.` / `NA` / blank) is kept as a **design point** — a
+/// sampling time whose observation has not been generated yet — instead of being
+/// skipped as a forgotten `MDV=1` (#258). Writing `DV = .` at every sampling time
+/// is the natural way to express a design (and is what NONMEM's `$SIMULATION`
+/// accepts), so the fitting reading would otherwise return zero simulated rows
+/// for the most idiomatic template there is.
+///
+/// The kept row carries a placeholder DV (`NaN` for a Gaussian endpoint, `0` for
+/// an integer-coded one) which the simulated value replaces; do **not** pass the
+/// returned population to [`fit`]. `MDV=1` still excludes the record — that is
+/// the user explicitly saying it is not an observation.
+pub fn read_population_for_simulation(
+    model: &CompiledModel,
+    covariate_decls: &Option<Vec<CovariateDecl>>,
+    data_path: &str,
+    fallback_columns: Option<&[&str]>,
+    iov_column: Option<&str>,
+    filter: Option<&SelectionFilter>,
+    column_map: &[(String, String)],
+) -> Result<(Population, Option<CovariateTable>), String> {
+    read_population_for_policy(
+        model,
+        covariate_decls,
+        data_path,
+        fallback_columns,
+        iov_column,
+        filter,
+        column_map,
+        MissingDvPolicy::KeepAsDesign,
+    )
+}
+
+/// Shared body of [`read_population_for`] (fit: `MissingDvPolicy::Skip`) and
+/// [`read_population_for_simulation`] (`KeepAsDesign`). The policy is the only
+/// difference between them.
+#[allow(clippy::too_many_arguments)]
+fn read_population_for_policy(
+    model: &CompiledModel,
+    covariate_decls: &Option<Vec<CovariateDecl>>,
+    data_path: &str,
+    fallback_columns: Option<&[&str]>,
+    iov_column: Option<&str>,
+    filter: Option<&SelectionFilter>,
+    column_map: &[(String, String)],
+    missing_dv: MissingDvPolicy,
+) -> Result<(Population, Option<CovariateTable>), String> {
     // Extract TTE CMTs from model endpoints so the reader can route TTE rows
     // to obs_records instead of the Gaussian parallel Vecs.
     #[cfg(feature = "survival")]
@@ -800,81 +861,24 @@ pub fn read_population_for(
     #[cfg(not(feature = "survival"))]
     let discrete_cmts: std::collections::HashSet<usize> = std::collections::HashSet::new();
 
-    if tte_cmts.is_empty() && discrete_cmts.is_empty() {
-        // Gaussian-only model: use the existing (faster) path without TTE overhead.
-        match (covariate_decls, filter) {
-            (Some(decls), Some(sel)) => {
-                let extra = undeclared_referenced(model, decls);
-                let (pop, table) = read_nonmem_csv_with_covariates_filtered_mapped(
-                    Path::new(data_path),
-                    decls,
-                    &extra,
-                    iov_column,
-                    sel,
-                    column_map,
-                )?;
-                Ok((pop, Some(table)))
-            }
-            (Some(decls), None) => {
-                let extra = undeclared_referenced(model, decls);
-                let (pop, table) = read_nonmem_csv_with_covariates_mapped(
-                    Path::new(data_path),
-                    decls,
-                    &extra,
-                    iov_column,
-                    column_map,
-                )?;
-                Ok((pop, Some(table)))
-            }
-            (None, Some(sel)) => Ok((
-                read_nonmem_csv_filtered_mapped(
-                    Path::new(data_path),
-                    fallback_columns,
-                    iov_column,
-                    sel,
-                    column_map,
-                )?,
-                None,
-            )),
-            (None, None) => Ok((
-                read_nonmem_csv_mapped(
-                    Path::new(data_path),
-                    fallback_columns,
-                    iov_column,
-                    column_map,
-                )?,
-                None,
-            )),
-        }
-    } else {
-        // Model has TTE endpoints: use TTE-aware reader so obs_records are populated.
-        match covariate_decls {
-            Some(decls) => {
-                let extra = undeclared_referenced(model, decls);
-                let (pop, table) = read_nonmem_csv_with_covariates_tte(
-                    Path::new(data_path),
-                    decls,
-                    &extra,
-                    iov_column,
-                    filter,
-                    &tte_cmts,
-                    &discrete_cmts,
-                    column_map,
-                )?;
-                Ok((pop, Some(table)))
-            }
-            None => {
-                let pop = read_nonmem_csv_filtered_tte(
-                    Path::new(data_path),
-                    fallback_columns,
-                    iov_column,
-                    filter,
-                    &tte_cmts,
-                    &discrete_cmts,
-                    column_map,
-                )?;
-                Ok((pop, None))
-            }
-        }
-    }
+    // One reader call covers every combination: the routing sets are empty for a
+    // Gaussian-only model (so no row is routed to `obs_records`), and the reader
+    // builds the covariate read set from `decls` when the model declares
+    // `[covariates]`, from `fallback_columns` otherwise.
+    let routing =
+        ObsRouting::tte_and_discrete(&tte_cmts, &discrete_cmts).with_missing_dv(missing_dv);
+    let (decls, extra) = match covariate_decls {
+        Some(d) => (Some(d.as_slice()), undeclared_referenced(model, d)),
+        None => (None, Vec::new()),
+    };
+    read_nonmem_csv_routed(
+        Path::new(data_path),
+        fallback_columns,
+        decls,
+        &extra,
+        iov_column,
+        filter,
+        &routing,
+        column_map,
+    )
 }

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -313,8 +313,10 @@ pub fn simulate_with_options(
 /// fitted (posthoc) etas are computed once from `params` + the observed
 /// `population`.
 ///
-/// Returns `Err` if matching is requested but the population is empty or any
-/// subject has no observations.
+/// Returns `Err` if matching is requested but the population is empty, or any
+/// subject has no observations or carries a non-finite DV (a `DV = .` design
+/// template read by [`crate::api::read_population_for_simulation`] is a
+/// simulation input; there is nothing to compute a posthoc eta from).
 ///
 /// This is the diagnostics-returning form: the [`SimulationOutput`] carries both the
 /// rows and any non-fatal per-subject warnings (a degenerate hazard draw, #763; a
@@ -441,6 +443,26 @@ pub fn simulate_with_options_diag(
         return Err(format!(
             "propensity-score matching requires observations for every subject \
              (to compute posthoc etas); subject '{}' has none",
+            s.id
+        ));
+    }
+    // A `DV = .` design template read by `read_population_for_simulation` (#957)
+    // has rows but NaN observations, so the emptiness check above no longer
+    // catches it. Its posthoc EBE would be optimized against a NaN objective —
+    // either tripping the non-finite-eta guard below with a misleading "did not
+    // converge", or (if the inner optimizer hands back its finite starting eta)
+    // matching every subject on all-zero etas and returning an arbitrary
+    // assignment. Reject it here with the real cause.
+    if let Some(s) = population
+        .subjects
+        .iter()
+        .find(|s| s.observations.iter().any(|v| !v.is_finite()))
+    {
+        return Err(format!(
+            "propensity-score matching requires finite observations for every subject \
+             (to compute posthoc etas); subject '{}' has non-finite DV values. A `DV = .` \
+             design template carries NaN placeholders — match against the observed dataset \
+             instead",
             s.id
         ));
     }

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -9,10 +9,9 @@ use crate::estimation::parameterization::{
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
-    read_nonmem_csv_filtered_mapped, read_nonmem_csv_filtered_tte, read_nonmem_csv_mapped,
+    read_nonmem_csv_filtered_mapped, read_nonmem_csv_mapped,
     read_nonmem_csv_with_covariates_filtered_mapped, read_nonmem_csv_with_covariates_mapped,
-    read_nonmem_csv_with_covariates_tte, SelectionFilter, ERR_COV_MISSING_COLUMNS,
-    ERR_COV_NON_NUMERIC,
+    SelectionFilter, ERR_COV_MISSING_COLUMNS, ERR_COV_NON_NUMERIC,
 };
 use crate::pk;
 use crate::propensity_match::MatchMethod;

--- a/src/api/tests/simulation_template_tests.rs
+++ b/src/api/tests/simulation_template_tests.rs
@@ -1,0 +1,93 @@
+//! `read_population_for_simulation` — a `DV = .` design template simulates
+//! instead of reading as zero rows (#957).
+//!
+//! The fitting reader treats a missing DV on a scored row as a forgotten
+//! `MDV=1` and skips it (#258), which is right when the DV is an input. On the
+//! simulation path the DV is the *output*, so the same row is a design point.
+//! These tests pin both readings of one template, and that the simulator
+//! actually emits a row per retained sampling time.
+
+use super::*;
+use std::io::Write;
+
+/// Dose plus three sampling times, `DV = .` everywhere — the natural way to
+/// write a design, and what NONMEM's `$SIMULATION` accepts.
+const TEMPLATE_CSV: &str = "ID,TIME,DV,EVID,AMT,CMT,MDV\n\
+                            1,0,.,1,100,1,1\n\
+                            1,0.25,.,0,.,1,0\n\
+                            1,1,.,0,.,1,0\n\
+                            1,4,.,0,.,1,0\n";
+
+const SIM_MODEL: &str = "
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.04
+  sigma PROP ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP)
+";
+
+fn write_template() -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(TEMPLATE_CSV.as_bytes()).unwrap();
+    f
+}
+
+#[test]
+fn simulation_reader_keeps_a_dv_dot_template_the_fit_reader_drops() {
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+
+    let (sim_pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+    assert_eq!(
+        sim_pop.subjects[0].obs_times,
+        vec![0.25, 1.0, 4.0],
+        "the design's sampling times must survive the read"
+    );
+    assert_eq!(sim_pop.subjects[0].doses.len(), 1);
+
+    // The fitting reader is unchanged: nothing to score, and it says so.
+    let (fit_pop, _) = read_population_for(&model, &None, path, None, None, None, &[]).unwrap();
+    assert!(fit_pop.subjects[0].obs_times.is_empty());
+    assert!(fit_pop
+        .warnings
+        .iter()
+        .any(|w| w.starts_with("W_MISSING_DV")));
+}
+
+#[test]
+fn simulating_a_dv_dot_template_emits_one_row_per_sampling_time() {
+    // The failure this closes: `ferx_simulate()` on a `DV = .` template returned
+    // zero rows, and only a placeholder number in the column about to be
+    // overwritten made it work.
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+    let (pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+
+    let sims = simulate_with_seed(&model, &pop, &model.default_params, 1, 42);
+    assert_eq!(sims.len(), 3, "one simulated row per sampling time");
+    for (r, t) in sims.iter().zip([0.25, 1.0, 4.0]) {
+        assert_eq!(r.time, t);
+        assert!(r.ipred.is_finite() && r.ipred > 0.0, "ipred: {}", r.ipred);
+        match r.outcome {
+            SimOutcome::Continuous { value } => assert!(
+                value.is_finite(),
+                "the NaN DV placeholder must not leak into the simulated value"
+            ),
+            ref other => panic!("expected a continuous outcome, got {other:?}"),
+        }
+    }
+}

--- a/src/api/tests/simulation_template_tests.rs
+++ b/src/api/tests/simulation_template_tests.rs
@@ -91,3 +91,148 @@ fn simulating_a_dv_dot_template_emits_one_row_per_sampling_time() {
         }
     }
 }
+
+// ── The design population is a simulation input, not a fit input ──────────
+// `read_population_for_simulation`'s "do not pass this to `fit()`" contract used
+// to be documentation-only, and the NaN placeholder was not the loud failure it
+// was assumed to be (#957 review). These pin the three places that now catch it.
+
+#[test]
+fn the_simulation_reader_warns_that_it_kept_the_missing_dv_rows() {
+    // A VPC simulated from an *observed* dataset keeps rows the fit skipped, so
+    // the simulated dataset has more rows than the fitted one at times that were
+    // never scored. Silent under either warning before; W_DESIGN_DV is the
+    // simulation-side counterpart of W_MISSING_DV.
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+
+    let (sim_pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+    let design: Vec<_> = sim_pop
+        .warnings
+        .iter()
+        .filter(|w| w.starts_with("W_DESIGN_DV"))
+        .collect();
+    assert_eq!(
+        design.len(),
+        1,
+        "exactly one summary: {:?}",
+        sim_pop.warnings
+    );
+    assert!(
+        design[0].contains("3 observation row(s)"),
+        "the count must match the rows kept: {}",
+        design[0]
+    );
+    assert!(
+        !sim_pop
+            .warnings
+            .iter()
+            .any(|w| w.starts_with("W_MISSING_DV")),
+        "nothing was skipped on this path: {:?}",
+        sim_pop.warnings
+    );
+}
+
+#[test]
+fn fitting_a_design_population_is_rejected_up_front() {
+    // The misuse the contract only documented. Without E_NONFINITE_DV the NaN
+    // placeholders reach the likelihood as a silent NaN objective.
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+    let (sim_pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+
+    let diags = check_model_data(&model, &sim_pop);
+    let d = diags
+        .iter()
+        .find(|d| d.code == "E_NONFINITE_DV")
+        .unwrap_or_else(|| panic!("expected E_NONFINITE_DV, got {diags:?}"));
+    assert!(d.message.contains("3 non-finite observation(s)"), "{d:?}");
+    assert!(
+        d.suggestion
+            .as_deref()
+            .unwrap_or_default()
+            .contains("read_population_for"),
+        "the suggestion must point at the fitting reader: {d:?}"
+    );
+
+    // The same dataset read for fitting is clean — the check keys on the DVs,
+    // not on the dataset.
+    let (fit_pop, _) = read_population_for(&model, &None, path, None, None, None, &[]).unwrap();
+    assert!(
+        !check_model_data(&model, &fit_pop)
+            .iter()
+            .any(|d| d.code == "E_NONFINITE_DV"),
+        "no observations at all is not a non-finite observation"
+    );
+}
+
+#[test]
+fn ltbs_log_transform_does_not_launder_a_nan_placeholder() {
+    // `f64::max` returns the non-NaN operand, so `NaN.max(LTBS_FLOOR).ln()` used
+    // to turn every design point into a finite, extreme "observation" — the fit
+    // then ran to completion on fabricated data with no warning.
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+    let (mut pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+
+    let n_nonpos = log_transform_observations(&mut pop);
+    assert_eq!(n_nonpos, 0, "a NaN is not a non-positive DV");
+    assert!(
+        pop.subjects[0].observations.iter().all(|v| v.is_nan()),
+        "the placeholder must stay non-finite: {:?}",
+        pop.subjects[0].observations
+    );
+
+    // Real values still transform, and the non-positive count is unchanged.
+    let mut real = pop.clone();
+    real.subjects[0].observations = vec![1.0_f64.exp(), -1.0, f64::NAN];
+    assert_eq!(log_transform_observations(&mut real), 1);
+    let obs = &real.subjects[0].observations;
+    assert!((obs[0] - 1.0).abs() < 1e-12, "{obs:?}");
+    assert!(
+        obs[1].is_finite(),
+        "a non-positive DV is still floored: {obs:?}"
+    );
+    assert!(obs[2].is_nan(), "{obs:?}");
+}
+
+#[test]
+fn propensity_matching_rejects_a_design_template() {
+    // Before #957 the reader dropped every row, so the "every subject needs
+    // observations" precondition caught this. Now the rows exist with NaN DVs,
+    // and the posthoc EBE would be optimized against a NaN objective.
+    let model = crate::parser::model_parser::parse_model_string(SIM_MODEL).expect("model parses");
+    let f = write_template();
+    let path = f.path().to_str().unwrap();
+    let (pop, _) =
+        read_population_for_simulation(&model, &None, path, None, None, None, &[]).unwrap();
+
+    let opts = SimulateOptions {
+        seed: Some(1),
+        match_method: Some(crate::propensity_match::MatchMethod::Optimal),
+        ..Default::default()
+    };
+    let err = simulate_with_options(&model, &pop, &model.default_params, 1, &opts).unwrap_err();
+    assert!(
+        err.contains("non-finite DV values") && err.contains("design template"),
+        "the message must name the real cause, not an EBE convergence failure: {err}"
+    );
+
+    // Matching off, the same population simulates as before.
+    let ok = SimulateOptions {
+        seed: Some(1),
+        ..Default::default()
+    };
+    assert_eq!(
+        simulate_with_options(&model, &pop, &model.default_params, 1, &ok)
+            .unwrap()
+            .len(),
+        3
+    );
+}

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -126,7 +126,8 @@ pub fn check_model_data_rule(
     population: &Population,
     iov_rule: &IovOccasionRule,
 ) -> Vec<Diagnostic> {
-    let mut diags = check_covariates(model, population);
+    let mut diags = check_finite_observations(population);
+    diags.extend(check_covariates(model, population));
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
     diags.extend(check_iov_occasions(model, population, iov_rule));
@@ -135,6 +136,49 @@ pub fn check_model_data_rule(
     diags.extend(check_dose_compartments(model, population));
     diags.extend(validate_output_columns(model, population));
     diags
+}
+
+/// Every scored observation must be a finite number.
+///
+/// Nothing else on the fit path tests `observations` for finiteness — TIME is
+/// checked, DV was not — so a `NaN` reached the likelihood as a silent
+/// `NaN` objective, or worse got laundered into a finite value on the way
+/// (LTBS case 2 floors `NaN.max(LTBS_FLOOR)` to `LTBS_FLOOR`, since `f64::max`
+/// returns the non-NaN operand).
+///
+/// The concrete way to get here is misuse of
+/// [`read_population_for_simulation`](crate::api::read_population_for_simulation)
+/// (#957): it keeps a missing `DV` as a design point with a `NaN` placeholder,
+/// and its "do not pass this to `fit()`" contract was documentation-only. This
+/// makes it loud instead. A hand-built `Population` carrying a `NaN` DV is
+/// caught by the same check.
+fn check_finite_observations(population: &Population) -> Vec<Diagnostic> {
+    let Some(subject) = population
+        .subjects
+        .iter()
+        .find(|s| s.observations.iter().any(|v| !v.is_finite()))
+    else {
+        return Vec::new();
+    };
+    let n_bad = subject
+        .observations
+        .iter()
+        .filter(|v| !v.is_finite())
+        .count();
+    vec![Diagnostic::error(
+        "E_NONFINITE_DV",
+        format!(
+            "Subject '{}' has {} non-finite observation(s) (NaN/Inf). A DV must be a finite \
+             number to be scored.",
+            subject.id, n_bad
+        ),
+    )
+    .with_suggestion(
+        "If this population came from `read_population_for_simulation` (a `DV = .` design \
+         template), it is a simulation input, not a fit input — its missing DVs are NaN \
+         placeholders for values that have not been generated yet. Read the dataset with \
+         `read_population_for` to fit it.",
+    )]
 }
 
 /// IOV models require occasion labels in the dataset. When `n_kappa > 0` but

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -387,6 +387,13 @@ pub(crate) struct ObsRouting {
     pub count: HashSet<usize>,
     /// What a missing `DV` on a scored row means — see [`MissingDvPolicy`].
     pub missing_dv: MissingDvPolicy,
+    /// Placeholder DV code to write on an integer-coded design-point row, per
+    /// CMT. Only consulted under [`MissingDvPolicy::KeepAsDesign`]; a CMT absent
+    /// from the map falls back to `0`. Endpoints whose declared `state_codes`
+    /// are not 0-based (e.g. `1`/`2`) would otherwise get an out-of-range `0`
+    /// placeholder that no `state_codes` lookup can map back to a generator
+    /// index (#957 review).
+    pub design_states: HashMap<usize, usize>,
 }
 
 impl ObsRouting {
@@ -400,6 +407,16 @@ impl ObsRouting {
             discrete: discrete.clone(),
             ..Default::default()
         }
+    }
+
+    /// Register the per-CMT placeholder DV code used for integer-coded design
+    /// rows (builder form). `codes` maps a CMT to the DV value written when its
+    /// `DV` cell is missing under [`MissingDvPolicy::KeepAsDesign`] — normally
+    /// the endpoint's first declared state code, so the placeholder is always a
+    /// value the endpoint can decode. CMTs left out keep the `0` default.
+    pub(crate) fn with_design_states(mut self, codes: HashMap<usize, usize>) -> Self {
+        self.design_states = codes;
+        self
     }
 
     /// Set the missing-DV policy (builder form), leaving the routing sets alone.
@@ -1000,16 +1017,29 @@ fn read_nonmem_csv_impl(
         }
     }
 
-    // Missing-DV summary (issue #258): scored observation rows (EVID=0, MDV=0)
-    // whose DV cell was missing were skipped rather than read as DV=0. Surfaced
-    // via FitResult.warnings and `ferx check` (data path).
+    // Missing-DV summary: scored observation rows (EVID=0, MDV=0) whose DV cell
+    // was missing. Both readings change the row count relative to a dataset with
+    // no missing cells, so both get a summary line — under `Skip` the rows are
+    // dropped (issue #258), under `KeepAsDesign` they are kept as extra design
+    // points (#957). A simulation run off an *observed* dataset (a VPC, say)
+    // silently carries more rows than the fit did without this second line.
+    // Surfaced via FitResult.warnings and `ferx check` (data path).
     if total_missing_dv > 0 {
-        population_warnings.push(format!(
-            "W_MISSING_DV: {} observation row(s) (EVID=0) had a missing DV (`.`/`NA`/blank) \
-             but were not marked MDV=1; they were skipped (not scored as DV=0). Set MDV=1 \
-             on intentionally-missing observations to silence this, or check for data errors.",
-            total_missing_dv
-        ));
+        population_warnings.push(match routing.missing_dv {
+            MissingDvPolicy::Skip => format!(
+                "W_MISSING_DV: {} observation row(s) (EVID=0) had a missing DV (`.`/`NA`/blank) \
+                 but were not marked MDV=1; they were skipped (not scored as DV=0). Set MDV=1 \
+                 on intentionally-missing observations to silence this, or check for data errors.",
+                total_missing_dv
+            ),
+            MissingDvPolicy::KeepAsDesign => format!(
+                "W_DESIGN_DV: {} observation row(s) (EVID=0) had a missing DV (`.`/`NA`/blank) \
+                 and were kept as design points to simulate at. A fit of the same dataset would \
+                 skip these rows (W_MISSING_DV), so the simulated dataset has more rows than the \
+                 fitted one. Set MDV=1 on rows that are not sampling times.",
+                total_missing_dv
+            ),
+        });
     }
 
     // Dose-coverage warnings (#262), surfaced via FitResult.warnings. Most
@@ -1413,8 +1443,12 @@ fn parse_subject(
     let mut fremtype: Vec<u16> = Vec::new();
     let mut obs_l2: Vec<i64> = Vec::new();
     let mut occ_parse_failures: usize = 0;
-    // EVID=0/MDV=0 rows whose DV cell was missing and were skipped (issue #258).
-    let mut missing_dv_skipped: usize = 0;
+    // EVID=0/MDV=0 rows whose DV cell was missing, counted under **both**
+    // policies: skipped under `Skip` (issue #258, `W_MISSING_DV`) and kept as
+    // design points under `KeepAsDesign` (#957, `W_DESIGN_DV`). Either reading
+    // changes how many rows the dataset contributes, so either one is worth a
+    // summary line.
+    let mut missing_dv_rows: usize = 0;
     let mut excl_n_obs: usize = 0;
     let mut excl_n_dose: usize = 0;
     let mut excl_n_other: usize = 0;
@@ -1953,17 +1987,22 @@ fn parse_subject(
                 // never records a spurious `state:0` / `count:0`. Otherwise the DV
                 // must be a finite, non-negative, in-range integer (`checked_integer_dv`,
                 // #192); no endpoint math here (Phase 4.0).
+                if dv_missing {
+                    missing_dv_rows += 1;
+                }
                 if skip_missing_dv {
-                    missing_dv_skipped += 1;
                     continue;
                 }
-                // Design-point row under `KeepAsDesign`: `dv` is the `0.0` the
-                // missing cell parsed to, which is a valid state index / count and
-                // is overwritten by the simulated outcome. Skipping
-                // `checked_integer_dv` here is deliberate — it is the *user's* DV
-                // that must be a valid integer, and there isn't one.
+                // Design-point row under `KeepAsDesign`: there is no user DV, so
+                // write the endpoint's registered placeholder code (its first
+                // declared state code; `0` for a count or an unregistered CMT).
+                // The simulated outcome overwrites it. Skipping `checked_integer_dv`
+                // here is deliberate — it is the *user's* DV that must be a valid
+                // integer, and there isn't one — but the placeholder must still be
+                // a code the endpoint can decode, so that a mis-routed design
+                // population cannot silently score as an out-of-range state.
                 let magnitude = if dv_missing {
-                    0.0
+                    routing.design_states.get(&cmt).copied().unwrap_or(0) as f64
                 } else {
                     checked_integer_dv(dv, kind, id, cmt, time)?
                 };
@@ -1985,8 +2024,10 @@ fn parse_subject(
                 // Gaussian path. A missing DV (`.`/`NA`/blank) is skipped as MDV=1
                 // (see the `dv_missing` note above; #258) so a forgotten MDV never
                 // injects a phantom zero observation.
+                if dv_missing {
+                    missing_dv_rows += 1;
+                }
                 if skip_missing_dv {
-                    missing_dv_skipped += 1;
                     continue;
                 }
                 // Design-point row under `KeepAsDesign` (#957): the sampling time
@@ -2158,7 +2199,7 @@ fn parse_subject(
             obs_records,
         },
         occ_parse_failures,
-        missing_dv_skipped,
+        missing_dv_rows,
         SubjectExclusion {
             n_obs_excluded: excl_n_obs,
             n_dose_excluded: excl_n_dose,

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -164,11 +164,12 @@ pub(crate) fn read_nonmem_csv_mapped(
     iov_column: Option<&str>,
     column_map: &[(String, String)],
 ) -> Result<Population, String> {
-    read_nonmem_csv_impl(
+    read_nonmem_csv_routed(
         path,
         covariate_columns,
-        iov_column,
         None,
+        &[],
+        iov_column,
         None,
         &ObsRouting::default(),
         column_map,
@@ -236,13 +237,12 @@ pub(crate) fn read_nonmem_csv_with_covariates_mapped(
 ) -> Result<(Population, CovariateTable), String> {
     // Population reads the union of declared + referenced-but-undeclared columns,
     // declared first so the table's column order matches the declaration.
-    let union = declared_union(decls, extra_columns);
-    let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
-    let (pop, table) = read_nonmem_csv_impl(
+    let (pop, table) = read_nonmem_csv_routed(
         path,
-        Some(&union_refs),
-        iov_column,
+        None,
         Some(decls),
+        extra_columns,
+        iov_column,
         None,
         &ObsRouting::default(),
         column_map,
@@ -273,24 +273,17 @@ pub(crate) fn read_nonmem_csv_filtered_mapped(
     filter: &SelectionFilter,
     column_map: &[(String, String)],
 ) -> Result<Population, String> {
-    // When an explicit covariate list is supplied, make sure every covariate the
-    // filter references is in it — otherwise a filtered column outside the list
-    // would not be read and the condition would silently never fire. (With
-    // `None`, the auto-detect path already reads every non-standard column, so no
-    // augmentation is needed.) Symmetric with the `[covariates]` reader.
-    let augmented: Option<Vec<String>> = covariate_columns.map(|cols| {
-        let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
-        augment_with_filter(&mut v, Some(filter));
-        v
-    });
-    let cols_ref: Option<Vec<&str>> = augmented
-        .as_ref()
-        .map(|v| v.iter().map(|s| s.as_str()).collect());
-    read_nonmem_csv_impl(
+    // When an explicit covariate list is supplied, `read_nonmem_csv_routed` makes
+    // sure every covariate the filter references is in it — otherwise a filtered
+    // column outside the list would not be read and the condition would silently
+    // never fire. (With `None`, the auto-detect path already reads every
+    // non-standard column, so no augmentation is needed.)
+    read_nonmem_csv_routed(
         path,
-        cols_ref.as_deref(),
-        iov_column,
+        covariate_columns,
         None,
+        &[],
+        iov_column,
         Some(filter),
         &ObsRouting::default(),
         column_map,
@@ -326,20 +319,16 @@ pub(crate) fn read_nonmem_csv_with_covariates_filtered_mapped(
     filter: &SelectionFilter,
     column_map: &[(String, String)],
 ) -> Result<(Population, CovariateTable), String> {
-    let mut union = declared_union(decls, extra_columns);
-    // Ensure any covariate column referenced by an ignore/accept clause is read
-    // into each subject's covariate map, even if the model never declared it.
-    // Without this, a filter on an undeclared column would silently never fire
-    // on the declared-`[covariates]` read path (`union` would lack the column,
-    // so it would be absent from `locf_state`). Case-insensitive dedup: the
-    // referenced names are lowercased, declared names may not be.
-    augment_with_filter(&mut union, Some(filter));
-    let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
-    let (pop, table) = read_nonmem_csv_impl(
+    // `read_nonmem_csv_routed` also reads any covariate column referenced by an
+    // ignore/accept clause but never declared — without that, a filter on an
+    // undeclared column would silently never fire on this path (the declared
+    // union would lack the column, so it would be absent from `locf_state`).
+    let (pop, table) = read_nonmem_csv_routed(
         path,
-        Some(&union_refs),
-        iov_column,
+        None,
         Some(decls),
+        extra_columns,
+        iov_column,
         Some(filter),
         &ObsRouting::default(),
         column_map,
@@ -350,9 +339,33 @@ pub(crate) fn read_nonmem_csv_with_covariates_filtered_mapped(
     ))
 }
 
-/// Which non-Gaussian [`ObsRecord`](crate::types::ObsRecord) variant each CMT's
-/// EVID=0 observation rows route to. Empty sets ⇒ every observation row takes the
-/// Gaussian parallel-Vec path (the all-Gaussian default).
+/// How an `EVID=0`, `MDV=0` record whose `DV` cell is missing (`.` / `NA` /
+/// blank) is read.
+///
+/// The two readings are both right, for different callers: when the `DV` is an
+/// *input* (fitting) a missing one means "nothing to score here"; when it is the
+/// *output* (simulation) it means "produce a value here" (#957).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum MissingDvPolicy {
+    /// Skip the row and count it for the single `W_MISSING_DV` summary (#258) —
+    /// a forgotten `MDV=1` must never inject a phantom `DV=0` into the
+    /// likelihood. The default, and the only policy on every fitting path.
+    #[default]
+    Skip,
+    /// Keep the row as a design point: the sampling time is real, only the
+    /// observation is absent because it has not been generated yet. The DV is a
+    /// placeholder (`NaN` for a Gaussian row, `0` for an integer-coded one) and
+    /// is overwritten by the simulated value. Used by the simulation readers
+    /// (#957) so a `DV = .` template — the natural way to write a design —
+    /// simulates instead of returning zero rows. `MDV=1` still excludes the row:
+    /// that is the user explicitly saying it is not an observation.
+    KeepAsDesign,
+}
+
+/// How each `EVID=0` observation row is turned into an observation record:
+/// which non-Gaussian [`ObsRecord`](crate::types::ObsRecord) variant the row's
+/// CMT routes to, plus the missing-DV policy. Empty sets ⇒ every observation row
+/// takes the Gaussian parallel-Vec path (the all-Gaussian default).
 ///
 /// The three sets must be pairwise disjoint — a CMT has exactly one endpoint kind
 /// (§8.1: routing is by the CMT's declared endpoint, never guessed from the DV).
@@ -372,6 +385,8 @@ pub(crate) struct ObsRouting {
     /// CMTs whose non-negative-integer-DV rows become `ObsRecord::Count`
     /// (Poisson / negative-binomial).
     pub count: HashSet<usize>,
+    /// What a missing `DV` on a scored row means — see [`MissingDvPolicy`].
+    pub missing_dv: MissingDvPolicy,
 }
 
 impl ObsRouting {
@@ -385,6 +400,14 @@ impl ObsRouting {
             discrete: discrete.clone(),
             ..Default::default()
         }
+    }
+
+    /// Set the missing-DV policy (builder form), leaving the routing sets alone.
+    /// `api::read_population_for_simulation` uses this to read a `DV = .` design
+    /// template as sampling times rather than as skipped rows (#957).
+    pub(crate) fn with_missing_dv(mut self, policy: MissingDvPolicy) -> Self {
+        self.missing_dv = policy;
+        self
     }
 
     /// The integer-coded non-Gaussian endpoint kind (discrete-state or count) a
@@ -519,81 +542,68 @@ fn checked_integer_dv(
     Ok(dv_rounded)
 }
 
-// ── TTE-aware readers (pub(crate) — used by api::read_population_for) ────────
-
-/// Like [`read_nonmem_csv_filtered`] but routes EVID=0 rows on `tte_cmts` to
-/// `Subject::obs_records` instead of the Gaussian parallel Vecs.
-///
-/// Used by `api::read_population_for` when the model has one or more TTE endpoints.
-pub(crate) fn read_nonmem_csv_filtered_tte(
-    path: &Path,
-    covariate_columns: Option<&[&str]>,
-    iov_column: Option<&str>,
-    filter: Option<&SelectionFilter>,
-    tte_cmts: &HashSet<usize>,
-    discrete_cmts: &HashSet<usize>,
-    column_map: &[(String, String)],
-) -> Result<Population, String> {
-    let augmented: Option<Vec<String>> = covariate_columns.map(|cols| {
-        let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
-        augment_with_filter(&mut v, filter);
-        v
-    });
-    let cols_ref: Option<Vec<&str>> = augmented
-        .as_ref()
-        .map(|v| v.iter().map(|s| s.as_str()).collect());
-    read_nonmem_csv_impl(
-        path,
-        cols_ref.as_deref(),
-        iov_column,
-        None,
-        filter,
-        &ObsRouting::tte_and_discrete(tte_cmts, discrete_cmts),
-        column_map,
-    )
-    .map(|(pop, _)| pop)
-}
-
-/// Like [`read_nonmem_csv_with_covariates_filtered`] but routes EVID=0 rows on
-/// `tte_cmts` to `Subject::obs_records`.
-pub(crate) fn read_nonmem_csv_with_covariates_tte(
-    path: &Path,
-    decls: &[CovariateDecl],
-    extra_columns: &[String],
-    iov_column: Option<&str>,
-    filter: Option<&SelectionFilter>,
-    tte_cmts: &HashSet<usize>,
-    discrete_cmts: &HashSet<usize>,
-    column_map: &[(String, String)],
-) -> Result<(Population, CovariateTable), String> {
-    let mut union = declared_union(decls, extra_columns);
-    augment_with_filter(&mut union, filter);
-    let union_refs: Vec<&str> = union.iter().map(|s| s.as_str()).collect();
-    let (pop, table) = read_nonmem_csv_impl(
-        path,
-        Some(&union_refs),
-        iov_column,
-        Some(decls),
-        filter,
-        &ObsRouting::tte_and_discrete(tte_cmts, discrete_cmts),
-        column_map,
-    )?;
-    Ok((
-        pop,
-        table.expect("covariate table is built whenever table_decls is Some"),
-    ))
-}
-
-/// Reader entry point taking a full [`ObsRouting`] — the general form behind
-/// [`read_nonmem_csv_filtered_tte`]. Phase 4.0 exposes it so the discrete-state /
-/// count routing can be exercised directly from unit tests (no parser produces
-/// those sets yet). Disjointness is validated inside [`read_nonmem_csv_impl`].
+/// Covariate-free shorthand for [`read_nonmem_csv_routed`]. Phase 4.0 exposes it
+/// so the discrete-state / count routing can be exercised directly from unit
+/// tests (no parser produces those sets yet). Disjointness is validated inside
+/// [`read_nonmem_csv_impl`].
 #[cfg(test)]
 pub(crate) fn read_nonmem_csv_filtered_routed(
     path: &Path,
     routing: &ObsRouting,
 ) -> Result<Population, String> {
     read_nonmem_csv_impl(path, None, None, None, None, routing, &[]).map(|(pop, _)| pop)
+}
+
+/// The one reader every wrapper above delegates to: it builds the covariate
+/// read set (declared union, or the explicit lenient list) and augments it with
+/// any `[data_selection]`-referenced column before calling
+/// [`read_nonmem_csv_impl`].
+///
+/// `decls` is `Some` on the strict `[covariates]` path — declared columns are
+/// validated and a [`CovariateTable`] is returned; `None` returns no table and
+/// reads `covariate_columns` leniently (`None` in turn is auto-detect).
+/// `routing` carries both the per-CMT endpoint routing and the missing-DV
+/// policy, so a caller that needs a non-default policy (simulation, #957) can
+/// reach every covariate/filter combination through this single entry point.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn read_nonmem_csv_routed(
+    path: &Path,
+    covariate_columns: Option<&[&str]>,
+    decls: Option<&[CovariateDecl]>,
+    extra_columns: &[String],
+    iov_column: Option<&str>,
+    filter: Option<&SelectionFilter>,
+    routing: &ObsRouting,
+    column_map: &[(String, String)],
+) -> Result<(Population, Option<CovariateTable>), String> {
+    // Declared covariates come first (so the table's column order matches the
+    // declaration); otherwise the caller's explicit list, or `None` for
+    // auto-detect. Either way, a filter's referenced columns must be read or the
+    // condition would silently never fire.
+    let cols: Option<Vec<String>> = match decls {
+        Some(d) => {
+            let mut union = declared_union(d, extra_columns);
+            augment_with_filter(&mut union, filter);
+            Some(union)
+        }
+        None => covariate_columns.map(|cols| {
+            let mut v: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
+            augment_with_filter(&mut v, filter);
+            v
+        }),
+    };
+    let cols_ref: Option<Vec<&str>> = cols
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    read_nonmem_csv_impl(
+        path,
+        cols_ref.as_deref(),
+        iov_column,
+        decls,
+        filter,
+        routing,
+        column_map,
+    )
 }
 
 /// Shared CSV reader. `table_decls`, when `Some`, requests building a
@@ -1823,14 +1833,18 @@ fn parse_subject(
                 })
                 .unwrap_or(1);
 
-            // A missing DV cell (`.` / `NA` / blank) means "no observation":
-            // `parse_f64` coerced it to `0.0` above, so without this guard a
-            // forgotten MDV would inject a phantom scored row. NONMEM convention
-            // marks such rows MDV=1; treat a forgotten one the same way — skip it
-            // and count it for the single W_MISSING_DV summary (#258). Applied to
-            // every scored endpoint below (Gaussian, discrete-state, count); the
-            // TTE `Event` arm keeps its own DV-code semantics and does not use it.
+            // A missing DV cell (`.` / `NA` / blank) means "no observation" when
+            // the DV is an input: `parse_f64` coerced it to `0.0` above, so
+            // without a guard a forgotten MDV would inject a phantom scored row.
+            // NONMEM convention marks such rows MDV=1; treat a forgotten one the
+            // same way — skip it and count it for the single W_MISSING_DV summary
+            // (#258). Under `MissingDvPolicy::KeepAsDesign` the DV is instead the
+            // *output* (simulation, #957) and the row is kept as a design point
+            // with a placeholder DV. Applied to every scored endpoint below
+            // (Gaussian, discrete-state, count); the TTE `Event` arm keeps its own
+            // DV-code semantics and does not use it.
             let dv_missing = is_missing_cell(row.get(dv_col).map(|s| s.as_str()).unwrap_or(""));
+            let skip_missing_dv = dv_missing && routing.missing_dv == MissingDvPolicy::Skip;
 
             // Non-Gaussian row routing: when this CMT belongs to a declared TTE /
             // discrete-state / count endpoint, route the row to `obs_records`
@@ -1939,11 +1953,20 @@ fn parse_subject(
                 // never records a spurious `state:0` / `count:0`. Otherwise the DV
                 // must be a finite, non-negative, in-range integer (`checked_integer_dv`,
                 // #192); no endpoint math here (Phase 4.0).
-                if dv_missing {
+                if skip_missing_dv {
                     missing_dv_skipped += 1;
                     continue;
                 }
-                let magnitude = checked_integer_dv(dv, kind, id, cmt, time)?;
+                // Design-point row under `KeepAsDesign`: `dv` is the `0.0` the
+                // missing cell parsed to, which is a valid state index / count and
+                // is overwritten by the simulated outcome. Skipping
+                // `checked_integer_dv` here is deliberate — it is the *user's* DV
+                // that must be a valid integer, and there isn't one.
+                let magnitude = if dv_missing {
+                    0.0
+                } else {
+                    checked_integer_dv(dv, kind, id, cmt, time)?
+                };
                 obs_records.push(match kind {
                     IntDvKind::DiscreteState => crate::types::ObsRecord::DiscreteState {
                         time,
@@ -1962,10 +1985,17 @@ fn parse_subject(
                 // Gaussian path. A missing DV (`.`/`NA`/blank) is skipped as MDV=1
                 // (see the `dv_missing` note above; #258) so a forgotten MDV never
                 // injects a phantom zero observation.
-                if dv_missing {
+                if skip_missing_dv {
                     missing_dv_skipped += 1;
                     continue;
                 }
+                // Design-point row under `KeepAsDesign` (#957): the sampling time
+                // is real, the observation does not exist yet. `NaN` rather than
+                // the `0.0` the missing cell parsed to, so the placeholder can
+                // never be mistaken for a measured zero — the simulator reads only
+                // the times, and every downstream |DV| consumer already guards on
+                // `is_finite`.
+                let dv = if dv_missing { f64::NAN } else { dv };
                 let cens_flag = cens_col
                     .and_then(|c| row.get(c))
                     .map(|s| parse_cens(s))

--- a/src/io/datareader_tests.rs
+++ b/src/io/datareader_tests.rs
@@ -893,9 +893,18 @@ fn test_tte_entry_time_is_raw_not_origin_shifted() {
     let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT,TENTRY\n\
                    1,100,1,0,0,.,1,90\n";
     let f = write_csv(csv);
-    let pop =
-        read_nonmem_csv_filtered_tte(f.path(), None, None, None, &tte_cmts, &HashSet::new(), &[])
-            .unwrap();
+    let pop = read_nonmem_csv_routed(
+        f.path(),
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &ObsRouting::tte_and_discrete(&tte_cmts, &HashSet::new()),
+        &[],
+    )
+    .map(|(pop, _)| pop)
+    .unwrap();
     let recs = &pop.subjects[0].obs_records;
     assert_eq!(recs.len(), 1);
     let ObsRecord::Event {
@@ -2017,13 +2026,13 @@ fn test_input_columns_preserves_full_header_order() {
 
 #[test]
 fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
-    // `read_nonmem_csv_filtered_tte` / `_with_covariates_tte` (used by
-    // api::read_population_for for [event_model] models) are always compiled
-    // but only *called* on the TTE path, so they read as uncovered in the
-    // FD-only build. With an empty tte_cmts set they delegate to the Gaussian
-    // reader; drive them directly to cover the column-augmentation / union /
-    // delegation lines. (The cfg(survival) row-routing inside the impl is
-    // exercised by the survival job, not here.)
+    // `read_nonmem_csv_routed` (used by api::read_population_for) carries the
+    // TTE routing for [event_model] models, but its column-augmentation / union
+    // lines are shared with the Gaussian path. With an empty tte_cmts set it
+    // reads exactly like the Gaussian reader; drive it directly with both
+    // covariate shapes to cover the augmentation / union / delegation lines.
+    // (The cfg(survival) row-routing inside the impl is exercised by the
+    // survival job, not here.)
     let no_tte = std::collections::HashSet::new();
     let csv = "ID,TIME,DV,EVID,AMT,WT,STUDY,AGE\n\
                    1,0,.,1,100,70,1,30\n\
@@ -2037,16 +2046,21 @@ fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
     // branch; the filter then drops STUDY==2 (subject 2).
     let cols: &[&str] = &["WT"];
     let filter = SelectionFilter::from_opts(&["STUDY == 2".to_string()], &[], &[]).unwrap();
-    let pop = read_nonmem_csv_filtered_tte(
+    let (pop, table_none) = read_nonmem_csv_routed(
         f.path(),
         Some(cols),
         None,
+        &[],
+        None,
         Some(&filter),
-        &no_tte,
-        &HashSet::new(),
+        &ObsRouting::tte_and_discrete(&no_tte, &HashSet::new()),
         &[],
     )
     .unwrap();
+    assert!(
+        table_none.is_none(),
+        "no [covariates] declaration ⇒ no covariate table"
+    );
     assert_eq!(
         pop.subjects
             .iter()
@@ -2068,17 +2082,21 @@ fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
     }];
     let extra = ["STUDY".to_string()];
     let drop_age40 = SelectionFilter::from_opts(&["AGE == 40".to_string()], &[], &[]).unwrap();
-    let (pop2, _table) = read_nonmem_csv_with_covariates_tte(
+    let (pop2, table) = read_nonmem_csv_routed(
         f.path(),
-        &decls,
+        None,
+        Some(&decls),
         &extra,
         None,
         Some(&drop_age40),
-        &no_tte,
-        &HashSet::new(),
+        &ObsRouting::tte_and_discrete(&no_tte, &HashSet::new()),
         &[],
     )
     .unwrap();
+    assert!(
+        table.is_some(),
+        "a [covariates] declaration ⇒ a covariate table"
+    );
     // Subject 2 (AGE=40) is dropped via the merged AGE column; subject 1 remains.
     assert_eq!(
         pop2.subjects
@@ -2088,4 +2106,179 @@ fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
         vec!["1"],
         "AGE==40 must drop subject 2 — proving AGE was pulled into the read union"
     );
+}
+
+// ── Missing DV on the simulation path (#957) ─────────────────────────────
+// `MissingDvPolicy::KeepAsDesign` reads a `DV = .` row as a design point (a
+// sampling time whose observation has not been generated yet) instead of as a
+// forgotten `MDV=1` (#258). The default `Skip` behaviour is unchanged; the two
+// policies are asserted against the same CSV so a regression in either shows up
+// as a diff between them.
+
+/// The canonical simulation template: dosing plus sampling times, `DV = .`
+/// everywhere because the DV is what the run is about to produce.
+const SIM_TEMPLATE_CSV: &str = "ID,TIME,DV,EVID,AMT,CMT,MDV\n\
+                                1,0,.,1,1.0,1,1\n\
+                                1,0.25,.,0,.,1,0\n\
+                                1,1,.,0,.,1,0\n\
+                                1,4,.,0,.,1,0\n";
+
+#[test]
+fn keep_as_design_retains_missing_dv_rows_as_sampling_times() {
+    let f = write_csv(SIM_TEMPLATE_CSV);
+    let routing = ObsRouting::default().with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+    let subj = &pop.subjects[0];
+
+    assert_eq!(
+        subj.obs_times,
+        vec![0.25, 1.0, 4.0],
+        "every sampling time of the template must survive"
+    );
+    assert_eq!(subj.doses.len(), 1, "the dose row is unaffected");
+    assert!(
+        subj.observations.iter().all(|v| v.is_nan()),
+        "a design point carries a NaN placeholder, never a measured 0.0: {:?}",
+        subj.observations
+    );
+    assert!(
+        !pop.warnings.iter().any(|w| w.starts_with("W_MISSING_DV")),
+        "nothing was skipped, so nothing to warn about: {:?}",
+        pop.warnings
+    );
+}
+
+#[test]
+fn skip_policy_still_drops_every_row_of_the_same_template() {
+    // The fitting reading of the exact CSV above — unchanged by #957.
+    let f = write_csv(SIM_TEMPLATE_CSV);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &ObsRouting::default()).unwrap();
+    assert!(
+        pop.subjects[0].obs_times.is_empty(),
+        "under Skip a DV-less template scores nothing"
+    );
+    assert_eq!(
+        pop.warnings
+            .iter()
+            .filter(|w| w.starts_with("W_MISSING_DV"))
+            .count(),
+        1,
+        "…and says so exactly once: {:?}",
+        pop.warnings
+    );
+}
+
+#[test]
+fn keep_as_design_still_excludes_mdv1_rows() {
+    // MDV=1 is the user explicitly saying "this record is not an observation",
+    // which is unambiguous on either path; only the *forgotten* MDV is reread.
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,MDV\n\
+                   1,0,.,1,1.0,1,1\n\
+                   1,0.25,.,0,.,1,1\n\
+                   1,1,.,0,.,1,0\n";
+    let f = write_csv(csv);
+    let routing = ObsRouting::default().with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+    assert_eq!(
+        pop.subjects[0].obs_times,
+        vec![1.0],
+        "the MDV=1 sampling time stays excluded"
+    );
+}
+
+#[test]
+fn keep_as_design_leaves_present_dvs_alone() {
+    // A template that already carries values (the placeholder-number workaround
+    // users resorted to) must read identically under both policies.
+    let csv = "ID,TIME,DV,EVID,AMT,CMT,MDV\n\
+                   1,0,.,1,1.0,1,1\n\
+                   1,1,5.0,0,.,1,0\n\
+                   1,4,7.0,0,.,1,0\n";
+    let f = write_csv(csv);
+    let keep = read_nonmem_csv_filtered_routed(
+        f.path(),
+        &ObsRouting::default().with_missing_dv(MissingDvPolicy::KeepAsDesign),
+    )
+    .unwrap();
+    let skip = read_nonmem_csv_filtered_routed(f.path(), &ObsRouting::default()).unwrap();
+    assert_eq!(keep.subjects[0].observations, vec![5.0, 7.0]);
+    assert_eq!(keep.subjects[0].observations, skip.subjects[0].observations);
+    assert_eq!(keep.subjects[0].obs_times, skip.subjects[0].obs_times);
+}
+
+#[test]
+fn keep_as_design_places_integer_endpoint_rows_with_a_zero_placeholder() {
+    use crate::types::ObsRecord;
+    // Discrete-state and count endpoints route to `obs_records`; their design
+    // rows need the same treatment, with an integer placeholder (`NaN` is not a
+    // state index) that the simulated outcome replaces.
+    let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                   1,1,.,0,0,.,3\n\
+                   1,2,.,0,0,.,4\n";
+    let routing = ObsRouting {
+        discrete: [3].into_iter().collect(),
+        count: [4].into_iter().collect(),
+        ..Default::default()
+    }
+    .with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let f = write_csv(csv);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+    let recs = &pop.subjects[0].obs_records;
+    assert_eq!(recs.len(), 2, "both design rows are kept: {recs:?}");
+    assert!(
+        matches!(
+            recs[0],
+            ObsRecord::DiscreteState {
+                state: 0,
+                cmt: 3,
+                ..
+            }
+        ),
+        "got {:?}",
+        recs[0]
+    );
+    assert!(
+        matches!(
+            recs[1],
+            ObsRecord::Count {
+                count: 0,
+                cmt: 4,
+                ..
+            }
+        ),
+        "got {:?}",
+        recs[1]
+    );
+
+    // Under the fitting policy the same rows are still skipped and counted.
+    let skipped = read_nonmem_csv_filtered_routed(
+        f.path(),
+        &ObsRouting {
+            discrete: [3].into_iter().collect(),
+            count: [4].into_iter().collect(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(skipped.subjects[0].obs_records.is_empty());
+    assert!(skipped
+        .warnings
+        .iter()
+        .any(|w| w.starts_with("W_MISSING_DV")));
+}
+
+#[test]
+fn keep_as_design_still_rejects_an_out_of_range_integer_dv() {
+    // Only a *missing* DV becomes a placeholder — a present but invalid integer
+    // DV is still the user's data error, on either policy.
+    let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                   1,1,-2,0,0,.,4\n";
+    let routing = ObsRouting {
+        count: [4].into_iter().collect(),
+        ..Default::default()
+    }
+    .with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let f = write_csv(csv);
+    let err = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap_err();
+    assert!(err.contains("out-of-range DV"), "{err}");
 }

--- a/src/io/datareader_tests.rs
+++ b/src/io/datareader_tests.rs
@@ -2143,9 +2143,76 @@ fn keep_as_design_retains_missing_dv_rows_as_sampling_times() {
     );
     assert!(
         !pop.warnings.iter().any(|w| w.starts_with("W_MISSING_DV")),
-        "nothing was skipped, so nothing to warn about: {:?}",
+        "nothing was skipped, so the skip warning must not fire: {:?}",
         pop.warnings
     );
+}
+
+#[test]
+fn keep_as_design_reports_the_rows_it_kept() {
+    // The rows are read either way, just differently — and either reading
+    // changes how many rows the dataset contributes. Reporting only the `Skip`
+    // side left a simulation off an observed dataset silently carrying rows the
+    // fit had excluded (#957 review).
+    let f = write_csv(SIM_TEMPLATE_CSV);
+    let routing = ObsRouting::default().with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+    let design: Vec<_> = pop
+        .warnings
+        .iter()
+        .filter(|w| w.starts_with("W_DESIGN_DV"))
+        .collect();
+    assert_eq!(design.len(), 1, "exactly one summary: {:?}", pop.warnings);
+    assert!(
+        design[0].contains("3 observation row(s)"),
+        "the count must be the rows kept as design points: {}",
+        design[0]
+    );
+}
+
+#[test]
+fn keep_as_design_uses_the_registered_placeholder_state_code() {
+    use crate::types::ObsRecord;
+    // A `state_codes` table need not be 0-based — CTMM states are commonly coded
+    // `1`/`2`. A hard `0` placeholder is then a code no `state_codes` lookup can
+    // map to a generator index, so a mis-routed design population would score as
+    // an out-of-range state instead of failing (#957 review). The reader writes
+    // the endpoint's first declared code instead.
+    let csv = "ID,TIME,DV,EVID,MDV,AMT,CMT\n\
+                   1,1,.,0,0,.,3\n";
+    let routing = ObsRouting {
+        discrete: [3].into_iter().collect(),
+        design_states: [(3usize, 1usize)].into_iter().collect(),
+        ..Default::default()
+    }
+    .with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let f = write_csv(csv);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &routing).unwrap();
+    assert!(
+        matches!(
+            pop.subjects[0].obs_records[0],
+            ObsRecord::DiscreteState {
+                state: 1,
+                cmt: 3,
+                ..
+            }
+        ),
+        "got {:?}",
+        pop.subjects[0].obs_records[0]
+    );
+
+    // An unregistered CMT keeps the `0` default (Binary is `{0,1}`; counts start
+    // at 0), so the builder is opt-in per endpoint.
+    let unregistered = ObsRouting {
+        discrete: [3].into_iter().collect(),
+        ..Default::default()
+    }
+    .with_missing_dv(MissingDvPolicy::KeepAsDesign);
+    let pop = read_nonmem_csv_filtered_routed(f.path(), &unregistered).unwrap();
+    assert!(matches!(
+        pop.subjects[0].obs_records[0],
+        ObsRecord::DiscreteState { state: 0, .. }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Why

`src/io/datareader.rs` skips an `EVID=0`, `MDV=0` record whose `DV` cell is `.` / `NA` / blank, and counts it for `W_MISSING_DV` (#258). That is the right reading when the `DV` is an **input**: a forgotten `MDV` must never inject a phantom scored `DV=0` into the likelihood.

It is the wrong reading when the `DV` is the **output**. Simulating from a design — dosing plus sampling times, `DV = .` everywhere because the values are what the run is about to produce — returned **zero rows**. Substituting any number into the column that is then overwritten made it work, which is backwards: the most natural template there is silently produced an empty result.

That template is exactly what NONMEM's `$SIMULATION` accepts, and it is what broke `ferxtranslate`'s concordance-data generator (`data-raw/generate_concordance_data.R`): an empty frame, then an unrelated recycling error downstream.

Closes #957.

## What changed

The split the issue asks for, option 1 (fitting unchanged, simulation rereads the row):

- **`MissingDvPolicy`** (`Skip` | `KeepAsDesign`), carried on `ObsRouting` — the struct that already rides the whole read path describing how an `EVID=0` row becomes an observation record. `Skip` is the `Default` and the policy on every fitting entry point, so fit behaviour is bit-identical.
- **`KeepAsDesign`** keeps the row as a design point: the sampling time is real, only the observation has not been generated yet. The retained row carries a placeholder DV — `NaN` for a Gaussian endpoint (never mistakable for a measured `0.0`; every downstream `|DV|` consumer already guards on `is_finite`), `0` for an integer-coded discrete-state / count endpoint (`NaN` is not a state index). The simulated value replaces it.
- **`MDV=1` still excludes the record on both paths.** That is the user explicitly saying the row is not an observation, and it is unambiguous. Only the *forgotten* `MDV` is reread.
- A present-but-invalid DV is still a hard error under either policy (`checked_integer_dv` is skipped only when the cell is actually missing).
- **`api::read_population_for_simulation()`** is the new public entry point. It shares its body with `read_population_for()` and differs only in the policy passed.

Supporting refactor — what lets a non-default policy reach every covariate / filter / routing combination without a flag on each wrapper:

- The six `read_nonmem_csv_*` wrappers now delegate to one **`read_nonmem_csv_routed`**, which builds the covariate read set (declared union, or the explicit lenient list) and augments it with any `[data_selection]`-referenced column. The union / augmentation logic existed in four near-copies and is now written once.
- `read_population_for`'s six-arm match collapses to a single call. Behaviour is unchanged: the previous "Gaussian-only fast path" differed from the TTE path only in passing an empty routing, which is what `tte_and_discrete` produces for a Gaussian-only model.
- `read_nonmem_csv_filtered_tte` / `read_nonmem_csv_with_covariates_tte` existed solely for `read_population_for` and are now dead, so they are deleted; the coverage test that drove them directly drives the general reader instead (and additionally asserts the covariate-table presence rule).

## Alternatives considered

- **A flag threaded through all six wrappers** — same reach, but a new parameter on each `pub(crate)` reader plus ~30 mechanical test-call-site edits, and the duplicated union/augmentation logic stays duplicated.
- **The issue's fallback** (keep the skip; make "every observation row was skipped" a hard error on the simulate path) — narrower: it converts a silent empty result into a loud one but still refuses the idiomatic template. The split delivers what the user meant to write. Not implemented, since doing both would make the error unreachable on the path that now succeeds.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#287 (Draft until this merges) | open | after |

This PR is the engine capability. `ferx_simulate()` reaches it only once the R glue's four simulate entry points (`ferx_rust_simulate`, `_from_fit`, `_adaptive`, `_with_uncertainty`) call `read_population_for_simulation` instead of `read_population_for`, which needs the `ferx-core` commit in `ferx-r/src/rust/Cargo.lock` bumped first (the `[patch]` only applies to local builds). Nothing here breaks ferx-r as it stands — `read_population_for` is untouched.

## Breaking changes
- [x] None

`read_population_for` keeps its signature and its behaviour; the new function is purely additive.

## Numerical validation
- [x] Not applicable (no estimation / PK / stats path is touched — this is a data-reading policy, and the fitting policy is unchanged)

The external anchor for the *new* behaviour is the convention itself: `DV = .` on a sampling record is what NONMEM's `$SIMULATION` accepts as "simulate here", and `MDV=1` is what NONMEM uses for "not an observation" — this change makes ferx read both the same way. Fit-side reading is byte-identical to before (`Skip` is the default, asserted against the same CSV in `skip_policy_still_drops_every_row_of_the_same_template`).

## Performance
- [x] No significant impact expected

One extra `bool` comparison per observation row; the wrapper collapse removes a `Vec<String>` clone on the declared-covariates path.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 3047 pass, 0 fail)
- [x] Regression test added that fails without this fix

Tier 1, `src/io/datareader_tests.rs` (both policies asserted against the *same* CSV, so a regression in either shows up as a diff between them):

- `keep_as_design_retains_missing_dv_rows_as_sampling_times` — all three sampling times survive, DVs are `NaN`, no `W_MISSING_DV`.
- `skip_policy_still_drops_every_row_of_the_same_template` — the fitting reading of that identical file, unchanged.
- `keep_as_design_still_excludes_mdv1_rows`
- `keep_as_design_leaves_present_dvs_alone` — a valued template reads identically under both policies.
- `keep_as_design_places_integer_endpoint_rows_with_a_zero_placeholder` — discrete-state / count design rows, and the same rows still skipped + warned under `Skip`.
- `keep_as_design_still_rejects_an_out_of_range_integer_dv`

Tier 1, new `src/api/tests/simulation_template_tests.rs`:

- `simulation_reader_keeps_a_dv_dot_template_the_fit_reader_drops` — the API-level split.
- `simulating_a_dv_dot_template_emits_one_row_per_sampling_time` — **the issue's exact failure**: `simulate()` on a `DV = .` template returns 3 rows with finite values instead of 0 rows.

## Example (user-facing features only)
- [x] Example added inline below

<details>
<summary>Example</summary>

```csv
ID,TIME,DV,EVID,AMT,CMT,MDV
1,0,.,1,100,1,1
1,0.25,.,0,.,1,0
1,1,.,0,.,1,0
1,4,.,0,.,1,0
```

```rust
let (population, _covariates) =
    read_population_for_simulation(&model, &None, "design.csv", None, None, None, &[])?;
let sims = simulate(&model, &population, &model.default_params, 1000);
// 3 simulated records per replicate — one per sampling time.
// Read with read_population_for() instead: 0 records, plus a W_MISSING_DV warning.
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes — `docs/data-format.qmd` (the missing-DV note now states the simulation reading) and `docs/api/simulation.qmd` (new `read_population_for_simulation()` section)
- [x] New pages linked in `docs/_quarto.yml` — N/A, no new pages
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean — no new findings in the changed files (the four pre-existing `approx_constant` errors in `src/sens/two_cpt_explicit.rs` are untouched and unrelated)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — not touched
- [x] `Cargo.toml` version bumped if breaking — N/A, additive

## Docs & examples

### ferx-site
- [x] No new `.ferx` DSL syntax or `[fit_options]` key, no new example model, no new data file

### ferx-book
- [x] No new estimator / DSL feature / fit option

### Example execution
- [x] No example execution step needed — no `.ferx` file, CLI path, or example dataset behaviour changes; the CLI's `--simulate` uses the synthetic `[simulation]` block and never reads a CSV

## Reviewer hints

Focus on two things:

1. **The placeholder choice** (`src/io/datareader.rs`, the two `dv_missing` arms). `NaN` for Gaussian is deliberate over `0.0` so a design point can never be read as a measured zero; the population it produces is for simulation only, and `read_population_for_simulation`'s doc says not to hand it to `fit()`. Integer endpoints get `0` because `NaN` is not a state index.
2. **The wrapper collapse** (`read_nonmem_csv_routed` and `read_population_for`) — the only place fit behaviour could have moved. The parity argument is that the deleted Gaussian-only arm and the TTE arm differed solely in the routing sets, which are empty for a Gaussian-only model either way.

The rest is mechanical.

## Open questions

None blocking. One deliberate non-decision: whether `simulate()` should *also* refuse a population with zero observation rows, as the issue's fallback suggests. Left out — with the split in place, the case that motivated it now succeeds, and a hard error there would fire on legitimately dose-only designs.
