### PR TITLE
feat(estimation): Bayesian estimation for mixture models [#985]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Bayesian estimation for mixture models (#985).** `[mixture]` models can now be fit with
+  `method = bayes`. The latent class is Rao-Blackwellised — marginalised out of every Gibbs block
+  rather than sampled — so each subject's likelihood contribution is the K-class marginal
+  `−log Σ_k p_ik·exp(−nll_ik)` and the sampler keeps a smooth continuous target. The η block samples
+  against the class-marginal posterior (HMC is disabled for mixtures; its analytic gradient is
+  single-class), the (θ,σ) block samples the mixing thetas (constant or covariate logit) with no extra
+  machinery, and Ω is drawn from its class-shared conjugate conditional. Reported OFV, per-subject
+  `MIXEST`/`PMIX`, and EBEs are the K-fold marginal values at the posterior mean. Per-class Ω/σ
+  overrides are rejected (Ω/σ are class-shared). Validated by recovering the mixture MLE under diffuse
+  priors (a direct NONMEM `METHOD=BAYES` reference is impractical — its sampler aborts on `$MIX` with
+  FIXed Ω/Σ).
 - **SAEM estimation for mixture models (#985).** `[mixture]` models can now be fit with
   `method = saem`, not only FOCE/FOCEI. The E-step samples the latent class per subject (from the
   current posterior `PMIX_i`) and runs the η-MCMC within the drawn class; the M-step estimates the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@ section of the SDLC for the versioning policy).
   unchanged (#971).
 
 ### Fixed
+- **Per-subject diagnostics now honour `MIXEST` in a mixture fit (#985).** `IPRED`, `PRED`,
+  `IWRES`, `CWRES`, `EBE_OFV`, and `[derived]`/`[output]` columns were computed with `MIXNUM`
+  pinned to class 1 for every subject, even for subjects the fit assigned to another class — so a
+  class-2 subject's sdtab row paired its class-2 EBEs with class-1 typical values. They are now
+  evaluated in each subject's fitted class. Affects FOCE/FOCEI, SAEM, and Bayes mixture fits.
 - **Mixture covariance-step and diagnostics correctness (#984, follow-up to #983).** Five fixes to
   the mixture SE/covariance and checkpoint paths: (1) the covariance step now reconverges its per-class EBEs at
   `cov_inner_tol`, not the fit's `inner_tol`, so a loose fit followed by a tight `cov_inner_tol` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ section of the SDLC for the versioning policy).
   `MIXEST`/`PMIX`, and EBEs are the K-fold marginal values at the posterior mean. Per-class Ω/σ
   overrides are rejected (Ω/σ are class-shared). Validated by recovering the mixture MLE under diffuse
   priors (a direct NONMEM `METHOD=BAYES` reference is impractical — its sampler aborts on `$MIX` with
-  FIXed Ω/Σ).
+  FIXed Ω/Σ). Inter-occasion variability is supported: the κ block samples against the same
+  class-marginal target. A run that asks for HMC (`saem_n_leapfrog > 0`) on a mixture now warns that
+  the Metropolis-Hastings η kernel was used instead, and a high R̂ on a mixture warns about label
+  switching, which would make the reported posterior mean an average across class labels.
 - **SAEM estimation for mixture models (#985).** `[mixture]` models can now be fit with
   `method = saem`, not only FOCE/FOCEI. The E-step samples the latent class per subject (from the
   current posterior `PMIX_i`) and runs the η-MCMC within the drawn class; the M-step estimates the

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -218,11 +218,47 @@ posterior sits almost exactly on the class boundary, which NONMEM SAEM and ferx
 SAEM split marginally differently. Covariate-dependent mixing under SAEM is
 exercised end-to-end in `tests/mixture_nonmem.rs`.
 
+## Bayesian estimation under a mixture
+
+Mixtures can also be fit with full-MCMC Bayesian estimation (`method = bayes`,
+#985). The latent class is handled **Rao-Blackwellised** — marginalised out
+rather than sampled — so the sampler still sees a smooth continuous target: each
+subject's likelihood contribution is the K-class marginal
+$-\log \sum_k p_{ik}\,\exp(-\mathrm{nll}_{ik})$. Because every Gibbs block
+evaluates the per-subject likelihood through this one marginal, the whole
+Gibbs-within-MH sampler becomes mixture-aware in one place:
+
+- the **η block** samples $\eta_i$ against the class-marginal posterior (a
+  `chol(Ω)`-preconditioned random walk; HMC is disabled for mixtures because its
+  analytic gradient is single-class);
+- the **(θ, σ) block** — which also carries the mixing thetas — samples them
+  against the marginal, so the mixing coefficients (constant *or*
+  covariate-dependent logit mixing) are sampled with no extra machinery;
+- the **Ω block** draws the (class-shared) Ω from its conjugate full conditional.
+
+Ω/Σ are shared across classes (the classes differ only through the
+`MIXNUM`-switched typical values); per-class Ω/Σ overrides (`omega(k)`/`sigma(k)`)
+are rejected with a clear error — fit those with FOCE/FOCEI. The reported OFV,
+per-subject `MIXEST`/`PMIX`, and EBEs are the K-fold marginal values at the
+posterior mean.
+
+Under diffuse priors the Bayes posterior mean concentrates at the maximum-
+likelihood optimum, so it recovers the same estimates the FOCEI/SAEM anchors pin
+(observed on `tests/nonmem/mixture_iv.csv`: posterior mean `TVCL1 ≈ 0.94`,
+`TVCL2 ≈ 2.78`, `V ≈ 10.0`, `p(1) ≈ 0.47`, marginal OFV ≈ 301.8, vs the FOCEI
+optimum 0.98 / 2.84 / 9.98 / 0.472 / 301.58). That shared optimum — already
+NONMEM-anchored by the FOCEI run above — is the Bayes cross-check: a direct
+NONMEM `METHOD=BAYES` reference is not used because NONMEM's BAYES sampler aborts
+in burn-in on this model (it insists on Gibbs-sampling Ω, which is FIXed here), a
+known NONMEM `$MIX`+BAYES fragility. The same mixture-marginal machinery is
+anchored directly against NONMEM SAEM above.
+
 ## Not yet supported
 
 The following error clearly rather than silently mis-fitting:
 
-- IMP / IMPMAP and Bayes (HMC) estimators for a mixture (#985); FOCE/FOCEI and
-  SAEM are supported.
+- IMP / IMPMAP estimators for a mixture (#985); FOCE/FOCEI, SAEM, and Bayes are
+  supported.
 - Per-class σ overrides (`sigma(k)`) under SAEM (held at their initial values,
-  with a warning) — use FOCE/FOCEI to fit those.
+  with a warning), and per-class Ω/σ overrides under Bayes (rejected) — use
+  FOCE/FOCEI to fit those.

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -234,7 +234,10 @@ Gibbs-within-MH sampler becomes mixture-aware in one place:
 - the **(θ, σ) block** — which also carries the mixing thetas — samples them
   against the marginal, so the mixing coefficients (constant *or*
   covariate-dependent logit mixing) are sampled with no extra machinery;
-- the **Ω block** draws the (class-shared) Ω from its conjugate full conditional.
+- the **Ω block** draws the (class-shared) Ω from its conjugate full conditional;
+- the **κ block** (inter-occasion variability, #985) samples the per-occasion
+  $\kappa_{ik}$ against the same marginal, so κ targets the class-marginal
+  posterior rather than class 1's.
 
 Ω/Σ are shared across classes (the classes differ only through the
 `MIXNUM`-switched typical values); per-class Ω/Σ overrides (`omega(k)`/`sigma(k)`)
@@ -242,11 +245,35 @@ are rejected with a clear error — fit those with FOCE/FOCEI. The reported OFV,
 per-subject `MIXEST`/`PMIX`, and EBEs are the K-fold marginal values at the
 posterior mean.
 
+### Priors, label switching, and the reported OFV
+
+The population priors are weakly informative normals, $\mathcal{N}(u_0, 10^2)$ on
+the unconstrained scale (log θ where θ is positive, log σ), centred on the
+*initial estimates* $u_0$ from the model file. Any `[parameters]` bounds you
+declare are **not** enforced as a uniform prior inside the (θ, σ) Metropolis
+block — only the mu-referenced conjugate θ move clamps to them — so a mixing
+logit is kept in range by the prior, not by its declared bounds.
+
+Because the classes are identified only through those priors, a chain can
+**swap labels** (class 1 ↔ class 2) and the pooled posterior mean would then
+average across two modes and estimate neither class. The signature is a high
+split-R̂ on the class-switched θ; ferx emits a warning naming label switching
+when R̂ exceeds its convergence threshold on a mixture. Separating the classes in
+the initial estimates is the practical fix.
+
+The OFV reported for a Bayes *mixture* run is the Laplace K-fold marginal at the
+posterior mean (not the posterior-mean joint NLL ×2 that a non-mixture Bayes run
+reports), and — like every mixture marginal — it is the FOCE or FOCEI form
+depending on `interaction`. In a method chain (`method = [saem, bayes]`) that
+flag follows the chain's last estimator, so compare mixture OFVs only across runs
+with the same interaction setting.
+
 Under diffuse priors the Bayes posterior mean concentrates at the maximum-
 likelihood optimum, so it recovers the same estimates the FOCEI/SAEM anchors pin
 (observed on `tests/nonmem/mixture_iv.csv`: posterior mean `TVCL1 ≈ 0.94`,
 `TVCL2 ≈ 2.78`, `V ≈ 10.0`, `p(1) ≈ 0.47`, marginal OFV ≈ 301.8, vs the FOCEI
-optimum 0.98 / 2.84 / 9.98 / 0.472 / 301.58). That shared optimum — already
+optimum 0.98 / 2.84 / 9.98 / 0.472 / 301.58; the two class means sit slightly
+inside the MLE pair, the direction partial label mixing pulls them). That shared optimum — already
 NONMEM-anchored by the FOCEI run above — is the Bayes cross-check: a direct
 NONMEM `METHOD=BAYES` reference is not used because NONMEM's BAYES sampler aborts
 in burn-in on this model (it insists on Gibbs-sampling Ω, which is FIXed here), a

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -85,6 +85,13 @@ NONMEM reserved variables:
 - **`PMIX_1 … PMIX_K`** — the posterior class-membership probabilities
   $\text{PMIX}_{ik} \propto p_{ik}\exp(-\text{nll}_{ik})$, normalised over $k$.
 
+Every other per-subject diagnostic is evaluated **in that subject's `MIXEST`
+class**: the reported $\hat\eta$ are the winning class's EBEs, and `IPRED`,
+`PRED`, `IWRES`, `CWRES`, `EBE_OFV`, and any `[derived]` / `[output]` column
+that branches on `MIXNUM` are all computed with `MIXNUM` set to that class. So a
+subject the fit assigns to class 2 gets class-2 typical values throughout its
+sdtab row, not the class-1 default.
+
 ## Validation against NONMEM
 
 A two-class clearance mixture (`tests/nonmem/mixture_iv.ctl` and the

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1527,7 +1527,14 @@ fn fit_inner(
         }
     }
 
-    // Compute per-subject diagnostics
+    // Compute per-subject diagnostics. For a mixture (#985) each subject's
+    // diagnostics are evaluated under its own MIXEST class: `result.eta_hats` are
+    // the winning class's EBEs, so predictions built with `MIXNUM` at the class-1
+    // default would mix a class-2 η̂ with class-1 typical values.
+    let mixest_classes: Option<Vec<usize>> = result
+        .mixture_posteriors
+        .as_ref()
+        .map(|mp| mp.mixest.clone());
     let mut subjects = compute_subject_results(
         model,
         population,
@@ -1536,6 +1543,7 @@ fn fit_inner(
         &result.h_matrices,
         &result.kappas,
         options.interaction,
+        mixest_classes.as_deref(),
     );
 
     // Mixture (#977 Phase 5): thread the converged per-subject posteriors onto
@@ -1560,6 +1568,7 @@ fn fit_inner(
             &result.params.theta,
             &result.kappas,
             &mut subjects,
+            mixest_classes.as_deref(),
         );
     }
 

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -223,11 +223,14 @@ pub fn fit(
         for m in options.method_chain() {
             if !matches!(
                 m,
-                EstimationMethod::Foce | EstimationMethod::FoceI | EstimationMethod::Saem
+                EstimationMethod::Foce
+                    | EstimationMethod::FoceI
+                    | EstimationMethod::Saem
+                    | EstimationMethod::Bayes
             ) {
                 return Err(format!(
-                    "mixture models (#977) currently support FOCE / FOCEI / SAEM; the {} method \
-                     is not yet wired for mixtures (#985)",
+                    "mixture models (#977) currently support FOCE / FOCEI / SAEM / Bayes; the {} \
+                     method is not yet wired for mixtures (#985)",
                     m.label()
                 ));
             }

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -235,6 +235,24 @@ pub fn fit(
                 ));
             }
         }
+        // Per-class Omega/Sigma overrides under Bayes (#985): the Bayes Omega block
+        // is a single conjugate draw shared across classes, so `omega(k)`/`sigma(k)`
+        // cannot be honoured. `bayes.rs` re-checks this defensively, but reject it
+        // here — before any stage runs — so `method = [focei, bayes]` does not burn a
+        // full FOCEI fit only to fail at the hand-off.
+        if options.method_chain().contains(&EstimationMethod::Bayes) {
+            if let Some(mp) = init_params.mixture.as_ref() {
+                if !mp.omega_override_addr.is_empty() || !mp.sigma_override_addr.is_empty() {
+                    return Err(
+                        "Bayesian estimation (method = bayes) does not yet support per-class \
+                         Omega/Sigma overrides (omega(k)/sigma(k)) in a mixture; Omega/Sigma are \
+                         shared across classes. Fit with FOCE/FOCEI, or drop the per-class \
+                         overrides (#985)."
+                            .to_string(),
+                    );
+                }
+            }
+        }
         // Inter-occasion variability under a mixture (#985): the per-class inner
         // solve carries per-occasion κ for the shared base `omega_iov` (each class's
         // `class_params` keeps it), and the packed layout already interleaves the κ

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -231,6 +231,10 @@ mod sde_integration;
 mod multi_start_tests;
 
 #[cfg(test)]
+#[path = "tests/tests_mixture_postfit.rs"]
+mod tests_mixture_postfit;
+
+#[cfg(test)]
 #[path = "tests/tests_sdtab_tv_cov.rs"]
 mod tests_sdtab_tv_cov;
 

--- a/src/api/output_columns.rs
+++ b/src/api/output_columns.rs
@@ -134,12 +134,17 @@ pub(crate) fn trapezoid(points: &[(f64, f64)]) -> f64 {
 
 /// Compute all [derived] and [output] columns post-fit, storing results in
 /// each SubjectResult's `extra_columns` field.
+/// `mixest` (#985) is the fitted per-subject mixture class (0-based); `None` for
+/// non-mixture fits. `[derived]` / `[output]` expressions and `pk_param_fn` can
+/// branch on `MIXNUM`, so each subject's columns are evaluated under its own class
+/// guard rather than the class-1 default.
 pub(crate) fn compute_extra_output_columns(
     model: &CompiledModel,
     population: &Population,
     theta: &[f64],
     kappas_per_subject: &[Vec<DVector<f64>>],
     subjects: &mut [SubjectResult],
+    mixest: Option<&[usize]>,
 ) {
     use crate::types::{AggFunction, DerivedContext, DerivedKind, IntegralStep, IntegralWindow};
 
@@ -150,6 +155,9 @@ pub(crate) fn compute_extra_output_columns(
         .collect();
 
     for (si, sr) in subjects.iter_mut().enumerate() {
+        let _mix_guard = mixest
+            .and_then(|m| m.get(si))
+            .map(|&c| crate::parser::model_parser::MixtureClassGuard::enter(c + 1));
         let subject = &population.subjects[si];
         let eta_hat = sr.eta.as_slice();
         let n_obs = sr.ipred.len();

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -550,6 +550,14 @@ pub(crate) fn cov_diagnostics(cov: Option<&DMatrix<f64>>) -> (Option<Vec<f64>>, 
 }
 
 /// Compute per-subject diagnostics (IPRED, PRED, IWRES, CWRES)
+///
+/// `mixest` (#985) carries the fitted per-subject mixture class (0-based, from
+/// `OuterResult::mixture_posteriors`) and is `None` for every non-mixture fit.
+/// Every prediction below is evaluated under that subject's class guard: the η̂
+/// handed in are the MIXEST-class EBEs, so building predictions from them with
+/// `MIXNUM` left at its class-1 default would pair a class-2 η̂ with class-1
+/// typical values and silently corrupt IPRED/PRED/IWRES/CWRES (and the per-subject
+/// OFV) for every subject the fit assigned to another class.
 pub(crate) fn compute_subject_results(
     model: &CompiledModel,
     population: &Population,
@@ -558,12 +566,17 @@ pub(crate) fn compute_subject_results(
     h_matrices: &[DMatrix<f64>],
     kappas_per_subject: &[Vec<DVector<f64>>],
     interaction: bool,
+    mixest: Option<&[usize]>,
 ) -> Vec<SubjectResult> {
     population
         .subjects
         .iter()
         .enumerate()
         .map(|(i, subject)| {
+            // Hold this subject's fitted class for the whole per-subject block.
+            let _mix_guard = mixest
+                .and_then(|m| m.get(i))
+                .map(|&c| crate::parser::model_parser::MixtureClassGuard::enter(c + 1));
             let eta = &eta_hats[i];
             let h = &h_matrices[i];
             let kappas: &[DVector<f64>] = if i < kappas_per_subject.len() {

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -193,7 +193,14 @@ fn derived_and_indiv_use_per_occasion_kappa() {
     ]];
     let mut subjects_results = vec![sr_iov(4)];
 
-    compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &[],
+        &kappas,
+        &mut subjects_results,
+        None,
+    );
 
     let cols = &subjects_results[0].extra_columns;
     let cl = &cols.iter().find(|(n, _)| n == "CL_OUT").unwrap().1;
@@ -243,7 +250,14 @@ fn missing_kappa_falls_back_to_zero() {
     let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]];
     let mut subjects_results = vec![sr_iov(4)];
 
-    compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &[],
+        &kappas,
+        &mut subjects_results,
+        None,
+    );
 
     let cl = &subjects_results[0].extra_columns[0].1;
     for (j, &v) in cl.iter().enumerate() {
@@ -321,7 +335,14 @@ fn tad_uses_per_dose_occasion_lag() {
     ]];
     let mut subjects_results = vec![sr_iov(2)];
 
-    compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &[],
+        &kappas,
+        &mut subjects_results,
+        None,
+    );
 
     let tad = &subjects_results[0].per_obs_tad;
     assert!(
@@ -409,7 +430,14 @@ fn tad_uses_per_compartment_alag_on_ode_models() {
     let kappas: Vec<Vec<DVector<f64>>> = Vec::new(); // no IOV
     let mut subjects_results = vec![sr_iov(1)];
 
-    compute_extra_output_columns(&model, &population, &theta, &kappas, &mut subjects_results);
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &theta,
+        &kappas,
+        &mut subjects_results,
+        None,
+    );
 
     let tad = &subjects_results[0].per_obs_tad;
     // 3 − (dose@0 + ALAG2=2) = 1.0; the pre-fix bare-lag path gives 3.0.
@@ -958,7 +986,14 @@ fn tad_lag_uses_dose_covariate_not_obs() {
     let kappas: Vec<Vec<DVector<f64>>> = vec![vec![DVector::from_vec(vec![0.0])]];
     let mut subjects_results = vec![sr_iov(1)];
 
-    compute_extra_output_columns(&model, &population, &[], &kappas, &mut subjects_results);
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &[],
+        &kappas,
+        &mut subjects_results,
+        None,
+    );
 
     let tad = &subjects_results[0].per_obs_tad;
     assert!(

--- a/src/api/tests/tests_derived_session_clock.rs
+++ b/src/api/tests/tests_derived_session_clock.rs
@@ -174,7 +174,7 @@ fn derived_per_row_time_is_raw_clock() {
         warnings: Vec::new(),
     };
     let mut subjects_results = vec![sr_for(6)];
-    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results);
+    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results, None);
     let col = &subjects_results[0].extra_columns[0].1;
     let expected = vec![0.0, 1.0, 4.0, 0.0, 1.0, 4.0];
     for (j, (&got, &exp)) in col.iter().zip(expected.iter()).enumerate() {
@@ -219,7 +219,7 @@ fn derived_aggregate_tmax_returns_raw_time() {
     // ipred peak is at j=4 (shifted t=6, raw t=1) which should give tmax=1.
     sr.ipred = vec![1.0, 2.0, 1.5, 0.5, 3.0, 1.0];
     let mut subjects_results = vec![sr];
-    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results);
+    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results, None);
     let col = &subjects_results[0].extra_columns[0].1;
     // All entries should be 1.0 (raw time of peak at j=4).
     for &v in col {
@@ -263,7 +263,7 @@ fn derived_integral_obs_per_session_explicit_window() {
         warnings: Vec::new(),
     };
     let mut subjects_results = vec![sr_for(6)];
-    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results);
+    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results, None);
     let col = &subjects_results[0].extra_columns[0].1;
     // Expected AUC = 8.0 for every row in each session.
     for (j, &v) in col.iter().enumerate() {
@@ -314,7 +314,7 @@ fn derived_integral_periodic_uses_raw_clock() {
         warnings: Vec::new(),
     };
     let mut subjects_results = vec![sr_for(6)];
-    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results);
+    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results, None);
     let col = &subjects_results[0].extra_columns[0].1;
     // All obs land in the raw-clock window [0,5); all three per-session
     // points contribute → AUC=8.0 for every row.
@@ -374,7 +374,7 @@ fn derived_integral_single_session_unchanged() {
         warnings: Vec::new(),
     };
     let mut subjects_results = vec![sr_for(3)];
-    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results);
+    compute_extra_output_columns(&model, &population, &[], &[], &mut subjects_results, None);
     let col = &subjects_results[0].extra_columns[0].1;
     // AUC = trapezoid([(0,0),(1,1),(4,4)]) = 8.0
     for &v in col {

--- a/src/api/tests/tests_mixture_postfit.rs
+++ b/src/api/tests/tests_mixture_postfit.rs
@@ -1,0 +1,156 @@
+use super::*;
+use nalgebra::{DMatrix, DVector};
+
+/// Two-class model: class 1 clears at `TVCL1 = 1`, class 2 at `TVCL2 = 3`, so
+/// the per-class IPRED curves are far apart and a class mix-up is unmistakable.
+const MIX_MODEL: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta P1(0.5, 0.001, 0.999)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  p(1) = P1
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+
+const TIMES: [f64; 4] = [0.5, 1.0, 2.0, 4.0];
+
+fn one_subject_pop() -> crate::types::Population {
+    use std::io::Write;
+    let mut csv = String::from("ID,TIME,DV,AMT,EVID,CMT\n");
+    csv.push_str("1,0,0,100,1,1\n");
+    for t in TIMES {
+        // DV value is irrelevant to the IPRED assertions below.
+        csv.push_str(&format!("1,{t},1.0,0,0,1\n"));
+    }
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(csv.as_bytes()).unwrap();
+    crate::read_nonmem_csv(f.path(), None, None).unwrap()
+}
+
+/// Closed-form 1-cpt IV bolus concentration at `eta = 0`.
+fn analytic_ipred(cl: f64) -> Vec<f64> {
+    TIMES
+        .iter()
+        .map(|t| (100.0 / 10.0) * (-(cl / 10.0) * t).exp())
+        .collect()
+}
+
+/// Post-fit diagnostics must be computed under each subject's **fitted** class
+/// (#985). `compute_subject_results` receives the MIXEST-class EBEs, so leaving
+/// `MIXNUM` at its class-1 default would pair a class-2 η̂ with class-1 typical
+/// values — IPRED/PRED/IWRES/CWRES for every subject the fit assigned to class 2
+/// would be silently wrong.
+#[test]
+fn subject_results_use_the_fitted_mixture_class() {
+    let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+    let population = one_subject_pop();
+    let params = &model.default_params;
+    let eta_hats = vec![DVector::zeros(1)];
+    let h_matrices = vec![DMatrix::zeros(TIMES.len(), 1)];
+    let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]];
+
+    let run = |mixest: Option<&[usize]>| {
+        compute_subject_results(
+            &model,
+            &population,
+            params,
+            &eta_hats,
+            &h_matrices,
+            &kappas,
+            true,
+            mixest,
+        )
+    };
+
+    // No mixture posteriors (non-mixture caller): the class-1 default stands.
+    let class1 = analytic_ipred(1.0);
+    let default_run = run(None);
+    for (got, want) in default_run[0].ipred.iter().zip(&class1) {
+        assert!(
+            (got - want).abs() < 1e-9,
+            "default IPRED {got} vs class-1 {want}"
+        );
+    }
+
+    // MIXEST = 2 (0-based 1): every prediction must follow TVCL2, not TVCL1.
+    let class2 = analytic_ipred(3.0);
+    let mixest_run = run(Some(&[1]));
+    for (got, want) in mixest_run[0].ipred.iter().zip(&class2) {
+        assert!(
+            (got - want).abs() < 1e-9,
+            "MIXEST=2 IPRED {got} vs class-2 {want}"
+        );
+    }
+    // PRED (population prediction at eta = 0) follows the same class.
+    for (got, want) in mixest_run[0].pred.iter().zip(&class2) {
+        assert!(
+            (got - want).abs() < 1e-9,
+            "MIXEST=2 PRED {got} vs class-2 {want}"
+        );
+    }
+    // Sanity: the two classes are genuinely distinguishable here, so the test
+    // cannot pass by both runs collapsing onto the same curve.
+    assert!(
+        default_run[0]
+            .ipred
+            .iter()
+            .zip(&mixest_run[0].ipred)
+            .any(|(a, b)| (a - b).abs() > 1e-3),
+        "class-1 and class-2 IPRED must differ"
+    );
+}
+
+/// The same guard covers `[derived]` columns, which can branch on `MIXNUM`.
+#[test]
+fn derived_columns_use_the_fitted_mixture_class() {
+    let src = MIX_MODEL.to_string() + "\n[derived]\n  CLD = CL\n";
+    let model = crate::parser::model_parser::parse_model_string(&src).unwrap();
+    let population = one_subject_pop();
+    let params = &model.default_params;
+    let eta_hats = vec![DVector::zeros(1)];
+    let h_matrices = vec![DMatrix::zeros(TIMES.len(), 1)];
+    let kappas: Vec<Vec<DVector<f64>>> = vec![vec![]];
+
+    let mut subjects = compute_subject_results(
+        &model,
+        &population,
+        params,
+        &eta_hats,
+        &h_matrices,
+        &kappas,
+        true,
+        Some(&[1]),
+    );
+    compute_extra_output_columns(
+        &model,
+        &population,
+        &params.theta,
+        &kappas,
+        &mut subjects,
+        Some(&[1]),
+    );
+    let (_, cld) = subjects[0]
+        .extra_columns
+        .iter()
+        .find(|(name, _)| name == "CLD")
+        .expect("[derived] CLD computed");
+    assert!(
+        cld.iter().all(|v| (v - 3.0).abs() < 1e-9),
+        "derived CL must use the MIXEST class (TVCL2 = 3), got {cld:?}"
+    );
+}

--- a/src/api/tests/tests_sdtab_tv_cov.rs
+++ b/src/api/tests/tests_sdtab_tv_cov.rs
@@ -221,6 +221,7 @@ fn test_sdtab_ipred_honours_tv_covariates() {
         &h_matrices,
         &kappas,
         true,
+        None,
     );
     assert_eq!(results.len(), 1);
     let sdtab_ipred = &results[0].ipred;
@@ -346,6 +347,7 @@ fn test_sdtab_iwres_uses_block_sigma_correlation() {
         &h_matrices,
         &kappas,
         false,
+        None,
     );
 
     let f = ipred[0];

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -19,8 +19,10 @@
 //!   - inverse-Wishart via the Bartlett decomposition of a Wishart draw, then
 //!     matrix inversion ([`inverse_wishart_draw`], [`wishart_draw`]).
 
+use crate::estimation::mixture::combine_subject;
 use crate::estimation::outer_optimizer::OuterResult;
 use crate::estimation::saem::{mh_kappa_steps, mh_steps};
+use crate::parser::model_parser::{eval_mixing_log_probs, MixtureClassGuard};
 use crate::pk::EventPkParams;
 use crate::stats::likelihood::{
     individual_nll_into_with_schedule, individual_nll_iov, iov_occasion_groups,
@@ -188,6 +190,16 @@ enum PopCoord {
 /// subject carries per-occasion kappas (`kappas` non-empty) and the plain kernel
 /// otherwise. Centralizes the IOV/non-IOV branch so every sweep site stays
 /// consistent.
+///
+/// **Mixture models (#985)** are handled Rao-Blackwellised: the class indicator
+/// is marginalised out, so this returns the K-class marginal NLL
+/// `−log Σ_k p_ik · exp(−nll_ik)` — a smooth function of η and θ. Because *every*
+/// Gibbs block (η-MH, the (θ,σ) Metropolis block that also carries the mixing
+/// thetas, and the Ω-conjugate baseline) evaluates the per-subject likelihood
+/// through this one function, marginalising here makes the whole sampler
+/// mixture-aware. Ω/Σ are class-shared here (per-class overrides are rejected for
+/// Bayes upstream), so the same `omega`/`sigma` feed every class; the classes
+/// differ only through the `MIXNUM`-switched structural typical values.
 #[allow(clippy::too_many_arguments)]
 fn subject_nll(
     model: &CompiledModel,
@@ -201,6 +213,23 @@ fn subject_nll(
     scratch: &mut EventPkParams,
     schedule: Option<&crate::pk::event_driven::EventSchedule>,
 ) -> f64 {
+    if let Some(spec) = model.mixture.as_ref() {
+        let k = spec.n_classes;
+        let logp = eval_mixing_log_probs(spec, theta, &subject.covariates);
+        let mut nll = vec![0.0f64; k];
+        for (c, slot) in nll.iter_mut().enumerate() {
+            let _g = MixtureClassGuard::enter(c + 1);
+            *slot = if kappas.is_empty() {
+                individual_nll_into_with_schedule(
+                    model, subject, theta, eta, omega, sigma, scratch, schedule,
+                )
+            } else {
+                individual_nll_iov(model, subject, theta, eta, kappas, omega, omega_iov, sigma)
+            };
+        }
+        // combine_subject returns 2·(−lse); the NLL scale wants −lse.
+        return 0.5 * combine_subject(&logp, &nll).0;
+    }
     if kappas.is_empty() {
         individual_nll_into_with_schedule(
             model, subject, theta, eta, omega, sigma, scratch, schedule,
@@ -208,6 +237,54 @@ fn subject_nll(
     } else {
         individual_nll_iov(model, subject, theta, eta, kappas, omega, omega_iov, sigma)
     }
+}
+
+/// Mixture (#985) η-block random walk: `n_steps` symmetric `chol(Ω)·z` proposals
+/// evaluated against the **class-marginal** per-subject NLL (`subject_nll` with a
+/// mixture model), so the sampled η targets `p(η_i | y_i, θ, Ω)` marginalised over
+/// the latent class. Mirrors `saem::mh_steps` but calls `subject_nll` (which does
+/// the K-class log-sum-exp) instead of the single-population `individual_nll`, and
+/// returns the marginal NLL so the sweep's cache stays consistent. HMC is disabled
+/// for mixtures (its Dual2 gradient is single-class), so this is the η kernel.
+#[allow(clippy::too_many_arguments)]
+fn mh_steps_mixture(
+    eta: &mut [f64],
+    nll_current: f64,
+    subject: &Subject,
+    model: &CompiledModel,
+    theta: &[f64],
+    kappas: &[Vec<f64>],
+    omega: &OmegaMatrix,
+    omega_iov: Option<&OmegaMatrix>,
+    sigma: &[f64],
+    step_scale: f64,
+    rng: &mut impl Rng,
+    n_steps: usize,
+    scratch: &mut EventPkParams,
+    schedule: Option<&crate::pk::event_driven::EventSchedule>,
+) -> (usize, f64) {
+    let n_eta = eta.len();
+    let l = &omega.chol;
+    let mut nll = nll_current;
+    let mut n_accepted = 0;
+    for _ in 0..n_steps {
+        let z: Vec<f64> = (0..n_eta).map(|_| rng.sample(StandardNormal)).collect();
+        let perturbation = l * DVector::from_column_slice(&z);
+        let eta_prop: Vec<f64> = (0..n_eta)
+            .map(|j| eta[j] + step_scale * perturbation[j])
+            .collect();
+        let nll_prop = subject_nll(
+            model, subject, theta, &eta_prop, kappas, omega, omega_iov, sigma, scratch, schedule,
+        );
+        // Symmetric proposal cancels; the marginal prior+likelihood difference is
+        // the full acceptance criterion.
+        if rng.random::<f64>().ln() < nll - nll_prop {
+            eta.copy_from_slice(&eta_prop);
+            nll = nll_prop;
+            n_accepted += 1;
+        }
+    }
+    (n_accepted, nll)
 }
 
 /// Re-impose a covariance matrix's structural template onto a fresh draw `m`:
@@ -281,6 +358,22 @@ pub fn run_bayes(
             return Err(
                 "Bayesian estimation (method = bayes) supports zero-mean IOV kappas only \
                  (κ ~ N(0, Ω_iov)); kappa mu-references are not yet supported"
+                    .to_string(),
+            );
+        }
+    }
+
+    // Mixture (#985): Bayes marginalises the latent class (Rao-Blackwell), with
+    // Ω/Σ shared across classes — the Ω-conjugate block draws a single population
+    // Ω. Per-class Ω/Σ overrides (`omega(k)`/`sigma(k)`) would need class-indexed
+    // conjugate draws; reject them here rather than silently ignoring the
+    // override. Class-switched θ and constant/covariate mixing are supported.
+    if let Some(mp) = init_params.mixture.as_ref() {
+        if !mp.omega_override_addr.is_empty() || !mp.sigma_override_addr.is_empty() {
+            return Err(
+                "Bayesian estimation (method = bayes) does not yet support per-class Omega/Sigma \
+                 overrides (omega(k)/sigma(k)) in a mixture; Omega/Sigma are shared across \
+                 classes. Fit with FOCE/FOCEI, or drop the per-class overrides (#985)."
                     .to_string(),
             );
         }
@@ -410,8 +503,14 @@ pub fn run_bayes(
     // `∂NLL/∂η` (no autodiff). HMC is BSV-only (kappa-unaware), so IOV models always
     // use the MH eta kernel.
     let n_leapfrog = options.saem_n_leapfrog;
-    let using_hmc =
-        n_leapfrog > 0 && model.ode_spec.is_none() && model.tv_fn.is_some() && n_kappa == 0;
+    let using_hmc = n_leapfrog > 0
+        && model.ode_spec.is_none()
+        && model.tv_fn.is_some()
+        && n_kappa == 0
+        // Mixture (#985): the η target is the class-marginal log-sum-exp, whose
+        // gradient is a pmix-weighted average of per-class gradients; the HMC
+        // Dual2 kernel is single-class, so use the marginal MH kernel instead.
+        && model.mixture.is_none();
 
     // Post-warmup HMC divergences across all chains (only the HMC η-kernel
     // produces these; the MH kernel never mutates it).
@@ -622,23 +721,45 @@ pub fn run_bayes(
                 };
 
                 if !did_hmc {
-                    // IOV: sample η | κ (kappas held fixed) via the IOV-aware NLL.
-                    let kappas_opt = omega_iov_cur.as_ref().map(|oi| (kappas[i].as_slice(), oi));
-                    let (na, nll_new) = mh_steps(
-                        &mut etas[i],
-                        nll[i],
-                        &population.subjects[i],
-                        model,
-                        &theta,
-                        &omega_cur,
-                        &sigma,
-                        eta_scale,
-                        None,
-                        &mut rng,
-                        n_eta_mh,
-                        &mut scratch,
-                        kappas_opt,
-                    );
+                    // Mixture (#985): target the class-marginal η posterior via the
+                    // marginal MH kernel (HMC is off for mixtures). Otherwise the
+                    // single-population kernel; IOV samples η | κ (kappas fixed).
+                    let (na, nll_new) = if model.mixture.is_some() {
+                        mh_steps_mixture(
+                            &mut etas[i],
+                            nll[i],
+                            &population.subjects[i],
+                            model,
+                            &theta,
+                            &kappas[i],
+                            &omega_cur,
+                            omega_iov_cur.as_ref(),
+                            &sigma,
+                            eta_scale,
+                            &mut rng,
+                            n_eta_mh,
+                            &mut scratch,
+                            schedules[i].as_ref(),
+                        )
+                    } else {
+                        let kappas_opt =
+                            omega_iov_cur.as_ref().map(|oi| (kappas[i].as_slice(), oi));
+                        mh_steps(
+                            &mut etas[i],
+                            nll[i],
+                            &population.subjects[i],
+                            model,
+                            &theta,
+                            &omega_cur,
+                            &sigma,
+                            eta_scale,
+                            None,
+                            &mut rng,
+                            n_eta_mh,
+                            &mut scratch,
+                            kappas_opt,
+                        )
+                    };
                     nll[i] = nll_new;
                     acc_eta += na as u64;
                     prop_eta += n_eta_mh as u64;
@@ -1188,7 +1309,19 @@ pub fn run_bayes(
         sigma_fixed: init_params.sigma_fixed.clone(),
         omega_iov: omega_iov_mean.clone(),
         kappa_fixed: init_params.kappa_fixed.clone(),
-        mixture: None,
+        // Carry the mixture so the post-loop pass sees the structure (#985). Ω/Σ
+        // are class-shared under Bayes (overrides rejected above), so set every
+        // class to the posterior-mean Ω/Σ that this ModelParameters carries.
+        mixture: init_params.mixture.as_ref().map(|mp| {
+            let mut m = mp.clone();
+            for o in m.omega.iter_mut() {
+                *o = omega_mean.clone();
+            }
+            for s in m.sigma.iter_mut() {
+                s.values = sigma_mean.clone();
+            }
+            m
+        }),
     };
 
     // Final EBEs + sensitivity (H) matrices at the posterior mean, warm-started
@@ -1204,44 +1337,64 @@ pub fn run_bayes(
             }
         })
         .collect();
-    let (eta_hats, h_matrices, _inner_stats, kappas) =
-        crate::estimation::inner_optimizer::run_inner_loop_warm(
-            model,
-            population,
-            &mean_params,
-            options.inner_maxiter,
-            options.inner_tol,
-            Some(&warm_etas),
-            None,
-            0,
-            0,
-        );
-
-    // OFV at the posterior mean (2·Σ individual_nll, IOV-aware). NOTE: this is
-    // the posterior-mean joint NLL ×2, NOT a FOCE/Laplace marginal OFV — it is
-    // reported for a rough AIC-style comparison only.
-    let kappas_mean: Vec<Vec<Vec<f64>>> = kappas
-        .iter()
-        .map(|ks| ks.iter().map(|k| k.iter().copied().collect()).collect())
-        .collect();
-    let mut scratch = EventPkParams::default();
-    let ofv = 2.0
-        * (0..n_subjects)
-            .map(|i| {
-                subject_nll(
-                    model,
-                    &population.subjects[i],
-                    &theta_mean,
-                    eta_hats[i].as_slice(),
-                    &kappas_mean[i],
-                    &omega_mean,
-                    omega_iov_mean.as_ref(),
-                    &sigma_mean,
-                    &mut scratch,
-                    schedules[i].as_ref(),
-                )
-            })
-            .sum::<f64>();
+    // Post-loop pass at the posterior mean. For a mixture (#985), the EBEs / OFV /
+    // per-subject posteriors are the MIXEST-class values from `mixture_ofv` (the
+    // K-fold marginal `−2 Σ log Σ_k p_ik L_ik`), matching FOCEI/SAEM; otherwise
+    // the single-population inner solve plus the posterior-mean joint NLL ×2.
+    let (eta_hats, h_matrices, kappas, ofv, mixture_posteriors) = if mean_params.mixture.is_some() {
+        let meval =
+            crate::estimation::mixture::mixture_ofv(model, population, &mean_params, options, None);
+        let posteriors = crate::estimation::outer_optimizer::MixturePosteriors {
+            pmix: meval.pmix.clone(),
+            mixest: meval.mixest.clone(),
+        };
+        (
+            meval.mixest_etas,
+            meval.mixest_h_mats,
+            meval.mixest_kappas,
+            meval.ofv,
+            Some(posteriors),
+        )
+    } else {
+        let (eta_hats, h_matrices, _inner_stats, kappas) =
+            crate::estimation::inner_optimizer::run_inner_loop_warm(
+                model,
+                population,
+                &mean_params,
+                options.inner_maxiter,
+                options.inner_tol,
+                Some(&warm_etas),
+                None,
+                0,
+                0,
+            );
+        // OFV at the posterior mean (2·Σ individual_nll, IOV-aware). NOTE: this is
+        // the posterior-mean joint NLL ×2, NOT a FOCE/Laplace marginal OFV — it is
+        // reported for a rough AIC-style comparison only.
+        let kappas_mean: Vec<Vec<Vec<f64>>> = kappas
+            .iter()
+            .map(|ks| ks.iter().map(|k| k.iter().copied().collect()).collect())
+            .collect();
+        let mut scratch = EventPkParams::default();
+        let ofv = 2.0
+            * (0..n_subjects)
+                .map(|i| {
+                    subject_nll(
+                        model,
+                        &population.subjects[i],
+                        &theta_mean,
+                        eta_hats[i].as_slice(),
+                        &kappas_mean[i],
+                        &omega_mean,
+                        omega_iov_mean.as_ref(),
+                        &sigma_mean,
+                        &mut scratch,
+                        schedules[i].as_ref(),
+                    )
+                })
+                .sum::<f64>();
+        (eta_hats, h_matrices, kappas, ofv, None)
+    };
 
     let bayes = BayesResult {
         summaries,
@@ -1301,7 +1454,7 @@ pub fn run_bayes(
         bayes: Some(bayes),
         cond_dist: None,
         packed_estimate: None,
-        mixture_posteriors: None,
+        mixture_posteriors,
     })
 }
 
@@ -1999,5 +2152,153 @@ mod tests {
             .expect("FitResult.bayes set by dispatch");
         assert!(!b.summaries.is_empty());
         assert!(b.max_rhat.is_finite());
+    }
+
+    // ── Mixture (#985) ──
+
+    const MIX_MODEL: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+
+    fn mix_pop() -> crate::types::Population {
+        use std::io::Write;
+        let mut csv = String::from("ID,TIME,DV,AMT,EVID,CMT,WT\n");
+        for (sid, &(cl, wt)) in [(1.0_f64, 60.0_f64), (3.0, 90.0)].iter().enumerate() {
+            let id = sid + 1;
+            csv.push_str(&format!("{id},0,0,100,1,1,{wt}\n"));
+            for t in [0.5_f64, 1.0, 2.0, 4.0] {
+                let c = (100.0 / 10.0) * (-(cl / 10.0) * t).exp();
+                csv.push_str(&format!("{id},{t},{c:.5},0,0,1,{wt}\n"));
+            }
+        }
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(csv.as_bytes()).unwrap();
+        crate::read_nonmem_csv(f.path(), Some(&["WT"]), None).unwrap()
+    }
+
+    /// `subject_nll` on a mixture returns the K-class log-sum-exp marginal
+    /// `−log Σ_k p_ik exp(−nll_ik)` (the Rao-Blackwell target), not a single class.
+    #[test]
+    fn mixture_subject_nll_is_marginal_lse() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let params = &model.default_params;
+        let subject = &pop.subjects[0];
+        let eta = vec![0.0f64];
+        let mut scratch = EventPkParams::default();
+
+        // Hand-compute the two per-class NLLs under the MIXNUM guard.
+        let spec = model.mixture.as_ref().unwrap();
+        let logp = eval_mixing_log_probs(spec, &params.theta, &subject.covariates);
+        let mut nll = [0.0f64; 2];
+        for (c, slot) in nll.iter_mut().enumerate() {
+            let _g = MixtureClassGuard::enter(c + 1);
+            *slot = individual_nll_into_with_schedule(
+                &model,
+                subject,
+                &params.theta,
+                &eta,
+                &params.omega,
+                &params.sigma.values,
+                &mut scratch,
+                None,
+            );
+        }
+        let expected = 0.5 * combine_subject(&logp, &nll).0;
+
+        let got = subject_nll(
+            &model,
+            subject,
+            &params.theta,
+            &eta,
+            &[],
+            &params.omega,
+            None,
+            &params.sigma.values,
+            &mut scratch,
+            None,
+        );
+        assert!((got - expected).abs() < 1e-9, "got {got} vs {expected}");
+        // Sanity: the marginal is below the larger per-class NLL (mixing helps).
+        assert!(got <= nll[0].max(nll[1]) + 1e-9);
+    }
+
+    /// A short Bayes run on a mixture returns Ok, carries the mixture through to
+    /// the result, and populates per-subject MIXEST (#985).
+    #[test]
+    fn bayes_mixture_fit_populates_mixest() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.method = crate::types::EstimationMethod::Bayes;
+        opts.run_covariance_step = false;
+        opts.bayes_warmup = 10;
+        opts.bayes_iters = 10;
+        opts.bayes_chains = 1;
+        opts.bayes_seed = Some(1);
+        let res =
+            crate::api::fit(&model, &pop, &model.default_params, &opts).expect("bayes mixture");
+        assert!(res.ofv.is_finite());
+        assert!(res.subjects.iter().all(|s| s.mixest.is_some()));
+    }
+
+    /// Bayes rejects a mixture that declares per-class Ω/Σ overrides (Ω/Σ are
+    /// class-shared under the conjugate Ω block) with a clear error (#985).
+    #[test]
+    fn bayes_rejects_per_class_overrides() {
+        const OV: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma EPS ~ 0.04
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+  omega(2) ETA_CL ~ 0.15
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let model = crate::parser::model_parser::parse_model_string(OV).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.method = crate::types::EstimationMethod::Bayes;
+        let err = crate::api::fit(&model, &pop, &model.default_params, &opts)
+            .expect_err("per-class overrides under Bayes must be rejected");
+        assert!(
+            err.contains("per-class Omega/Sigma overrides") && err.contains("bayes"),
+            "got: {err}"
+        );
     }
 }

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -287,6 +287,72 @@ fn mh_steps_mixture(
     (n_accepted, nll)
 }
 
+/// κ-block MH kernel for a mixture model (#985).
+///
+/// [`mh_kappa_steps`](crate::estimation::saem::mh_kappa_steps) scores its proposal
+/// with `individual_nll_iov`, which is *single-class*: it evaluates whichever class
+/// the ambient `MIXNUM` guard names (the default, class 1). Under a mixture the
+/// cached `nll[i]` that the η block just produced is the K-class **marginal**, so
+/// pairing it with a single-class proposal offsets the acceptance ratio by roughly
+/// `−log p_i1` and makes κ target `p(κ | class 1)` rather than the class-marginal
+/// posterior — and it would write a single-class value back into `nll[i]`. Route
+/// the proposal through [`subject_nll`] instead, so both sides of the ratio are the
+/// same Rao-Blackwellised target that every other Gibbs block uses.
+#[allow(clippy::too_many_arguments)]
+fn mh_kappa_steps_mixture(
+    kappas: &mut [Vec<f64>],
+    nll_current: f64,
+    subject: &Subject,
+    model: &CompiledModel,
+    theta: &[f64],
+    eta: &[f64],
+    omega: &OmegaMatrix,
+    omega_iov: &OmegaMatrix,
+    sigma: &[f64],
+    step_scale: f64,
+    rng: &mut impl Rng,
+    scratch: &mut EventPkParams,
+) -> (usize, usize, f64) {
+    let n_kappa = omega_iov.matrix.nrows();
+    let l = &omega_iov.chol;
+    let mut nll = nll_current;
+    let mut n_accepted = 0;
+    let n_occ = kappas.len();
+
+    for k in 0..n_occ {
+        let z: Vec<f64> = (0..n_kappa).map(|_| rng.sample(StandardNormal)).collect();
+        let perturbation = l * DVector::from_column_slice(&z);
+        let kap_prop: Vec<f64> = (0..n_kappa)
+            .map(|j| kappas[k][j] + step_scale * perturbation[j])
+            .collect();
+
+        // Temporarily substitute κ_k with the proposal; restore on reject.
+        let old_kap = std::mem::replace(&mut kappas[k], kap_prop);
+        let nll_prop = subject_nll(
+            model,
+            subject,
+            theta,
+            eta,
+            kappas,
+            omega,
+            Some(omega_iov),
+            sigma,
+            scratch,
+            None,
+        );
+        // Symmetric proposal cancels; the marginal prior+likelihood difference is
+        // the full acceptance criterion.
+        if rng.random::<f64>().ln() < nll - nll_prop {
+            nll = nll_prop;
+            n_accepted += 1;
+        } else {
+            kappas[k] = old_kap;
+        }
+    }
+
+    (n_accepted, n_occ, nll)
+}
+
 /// Re-impose a covariance matrix's structural template onto a fresh draw `m`:
 /// zero structurally-absent entries (`free_mask` false), restore FIX-ed
 /// rows/columns from `original`, and floor the diagonal for positive-
@@ -511,6 +577,9 @@ pub fn run_bayes(
         // gradient is a pmix-weighted average of per-class gradients; the HMC
         // Dual2 kernel is single-class, so use the marginal MH kernel instead.
         && model.mixture.is_none();
+    // Warn rather than silently downgrading: a user who asked for HMC gets the MH
+    // kernel here, and `n_divergent = 0` would otherwise read as "HMC ran cleanly".
+    let hmc_disabled_by_mixture = n_leapfrog > 0 && model.mixture.is_some();
 
     // Post-warmup HMC divergences across all chains (only the HMC η-kernel
     // produces these; the MH kernel never mutates it).
@@ -774,19 +843,39 @@ pub fn run_bayes(
                     .as_ref()
                     .expect("should_sample_kappa_block requires OMEGA_IOV");
                 for i in 0..n_subjects {
-                    let (na, np, nll_new) = mh_kappa_steps(
-                        &mut kappas[i],
-                        nll[i],
-                        &population.subjects[i],
-                        model,
-                        &theta,
-                        &etas[i],
-                        &omega_cur,
-                        oi,
-                        &sigma,
-                        kappa_scale,
-                        &mut rng,
-                    );
+                    // Mixture (#985): the marginal κ kernel, so the acceptance
+                    // ratio compares like with like (`nll[i]` is the K-class
+                    // marginal the η block left behind).
+                    let (na, np, nll_new) = if model.mixture.is_some() {
+                        mh_kappa_steps_mixture(
+                            &mut kappas[i],
+                            nll[i],
+                            &population.subjects[i],
+                            model,
+                            &theta,
+                            &etas[i],
+                            &omega_cur,
+                            oi,
+                            &sigma,
+                            kappa_scale,
+                            &mut rng,
+                            &mut scratch,
+                        )
+                    } else {
+                        mh_kappa_steps(
+                            &mut kappas[i],
+                            nll[i],
+                            &population.subjects[i],
+                            model,
+                            &theta,
+                            &etas[i],
+                            &omega_cur,
+                            oi,
+                            &sigma,
+                            kappa_scale,
+                            &mut rng,
+                        )
+                    };
                     nll[i] = nll_new;
                     acc_kappa += na as u64;
                     prop_kappa += np as u64;
@@ -1341,7 +1430,10 @@ pub fn run_bayes(
     // per-subject posteriors are the MIXEST-class values from `mixture_ofv` (the
     // K-fold marginal `−2 Σ log Σ_k p_ik L_ik`), matching FOCEI/SAEM; otherwise
     // the single-population inner solve plus the posterior-mean joint NLL ×2.
-    let (eta_hats, h_matrices, kappas, ofv, mixture_posteriors) = if mean_params.mixture.is_some() {
+    let (eta_hats, h_matrices, kappas, ofv, mixture_posteriors, ebe_stats) = if mean_params
+        .mixture
+        .is_some()
+    {
         let meval =
             crate::estimation::mixture::mixture_ofv(model, population, &mean_params, options, None);
         let posteriors = crate::estimation::outer_optimizer::MixturePosteriors {
@@ -1354,9 +1446,10 @@ pub fn run_bayes(
             meval.mixest_kappas,
             meval.ofv,
             Some(posteriors),
+            meval.ebe_stats,
         )
     } else {
-        let (eta_hats, h_matrices, _inner_stats, kappas) =
+        let (eta_hats, h_matrices, inner_stats, kappas) =
             crate::estimation::inner_optimizer::run_inner_loop_warm(
                 model,
                 population,
@@ -1393,7 +1486,7 @@ pub fn run_bayes(
                     )
                 })
                 .sum::<f64>();
-        (eta_hats, h_matrices, kappas, ofv, None)
+        (eta_hats, h_matrices, kappas, ofv, None, inner_stats)
     };
 
     let bayes = BayesResult {
@@ -1423,6 +1516,25 @@ pub fn run_bayes(
                 .to_string(),
         );
     }
+    if hmc_disabled_by_mixture {
+        warnings.push(
+            "Bayes: saem_n_leapfrog > 0 is ignored for a mixture model — the eta target is the \
+             class-marginal log-sum-exp and the HMC gradient kernel is single-class, so the \
+             Metropolis-Hastings eta kernel was used instead (n_divergent is reported as 0 \
+             because no HMC step ran) (#985)."
+                .to_string(),
+        );
+    }
+    if model.mixture.is_some() && max_rhat > RHAT_CONVERGENCE_THRESHOLD {
+        warnings.push(
+            "Bayes: mixture classes are identified only by the priors centred on the initial \
+             estimates, so a chain can swap labels (class 1 <-> class 2). A high R-hat on the \
+             class-switched thetas is the signature; the reported posterior mean would then \
+             average across modes and estimate neither class. Inspect the per-chain draws, and \
+             separate the classes more strongly in the initial estimates (#985)."
+                .to_string(),
+        );
+    }
     if partial_mu_ref {
         warnings.push(
             "Bayes: only some random effects are log mu-referenced — the conjugate θ Gibbs \
@@ -1445,9 +1557,12 @@ pub fn run_bayes(
         warnings,
         saem_mu_ref_m_step_evals_saved: None,
         saem_n_subjects_hmc: None,
-        ebe_convergence_warnings: 0,
-        max_unconverged_subjects: 0,
-        total_ebe_fallbacks: 0,
+        // Post-loop EBE health at the posterior mean. Non-convergence is likelier
+        // on the mixture path (K multimodal inner solves per subject), so report it
+        // instead of hardcoding a clean run (#985).
+        ebe_convergence_warnings: ebe_stats.n_unconverged as u32,
+        max_unconverged_subjects: ebe_stats.n_unconverged as u32,
+        total_ebe_fallbacks: ebe_stats.n_fallback as u32,
         final_gradient: None,
         sir_fallback_proposal: None,
         impmap_trace: None,
@@ -2262,6 +2377,213 @@ mod tests {
         assert!(res.subjects.iter().all(|s| s.mixest.is_some()));
     }
 
+    // ── IOV + mixture under Bayes (#985) ──
+
+    /// Same two-class model as `MIX_MODEL` plus a per-occasion κ on CL, so the
+    /// Bayes κ block runs under a mixture.
+    const MIX_IOV_MODEL: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta P1(0.5, 0.001, 0.999)
+  omega ETA_CL ~ 0.05
+  kappa KAPPA_CL ~ 0.02
+  sigma EPS ~ 0.04
+
+[mixture]
+  nsub = 2
+  p(1) = P1
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL + KAPPA_CL) else TVCL2 * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+
+    /// Two subjects × two dosing occasions (`OCC`), bimodal CL.
+    fn mix_iov_pop() -> crate::types::Population {
+        use std::io::Write;
+        let mut csv = String::from("ID,TIME,DV,AMT,EVID,CMT,OCC,WT\n");
+        for (sid, &cl) in [1.0_f64, 3.0].iter().enumerate() {
+            let id = sid + 1;
+            let wt = 60.0 + 30.0 * sid as f64;
+            for (occ, &t0) in [0.0_f64, 24.0].iter().enumerate() {
+                let occ_idx = occ + 1;
+                csv.push_str(&format!("{id},{t0},0,100,1,1,{occ_idx},{wt}\n"));
+                for dt in [0.5_f64, 1.0, 2.0, 4.0] {
+                    let c = (100.0 / 10.0) * (-(cl / 10.0) * dt).exp();
+                    let t = t0 + dt;
+                    csv.push_str(&format!("{id},{t},{c:.5},0,0,1,{occ_idx},{wt}\n"));
+                }
+            }
+        }
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(csv.as_bytes()).unwrap();
+        crate::read_nonmem_csv(f.path(), Some(&["WT"]), Some("OCC")).unwrap()
+    }
+
+    /// The κ block under a mixture must evaluate the **class-marginal** NLL, the
+    /// same target every other Gibbs block uses. The SAEM kernel
+    /// (`mh_kappa_steps`) scores its proposal single-class (`MIXNUM` at its
+    /// default of 1) while the cached baseline is the marginal, so the acceptance
+    /// ratio would carry a ≈ `−log p_i1` offset and κ would target `p(κ | class 1)`.
+    #[test]
+    fn mixture_kappa_kernel_targets_the_marginal() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_IOV_MODEL).unwrap();
+        assert_eq!(model.n_kappa, 1);
+        let pop = mix_iov_pop();
+        let params = &model.default_params;
+        let subject = &pop.subjects[0];
+        let omega_iov = params
+            .omega_iov
+            .as_ref()
+            .expect("kappa declared ⇒ OMEGA_IOV");
+        let n_occ = crate::stats::likelihood::iov_occasion_groups(subject).len();
+        assert_eq!(n_occ, 2, "two dosing occasions per subject");
+
+        let eta = vec![0.0f64];
+        let mut kappas: Vec<Vec<f64>> = vec![vec![0.0; model.n_kappa]; n_occ];
+        let mut scratch = EventPkParams::default();
+
+        let marginal = subject_nll(
+            &model,
+            subject,
+            &params.theta,
+            &eta,
+            &kappas,
+            &params.omega,
+            Some(omega_iov),
+            &params.sigma.values,
+            &mut scratch,
+            None,
+        );
+        // The class-1 value the single-class kernel would score against.
+        let class1 = {
+            let _g = MixtureClassGuard::enter(1);
+            individual_nll_iov(
+                &model,
+                subject,
+                &params.theta,
+                &eta,
+                &kappas,
+                &params.omega,
+                Some(omega_iov),
+                &params.sigma.values,
+            )
+        };
+        assert!(
+            (marginal - class1).abs() > 1e-6,
+            "test is only meaningful when the marginal and class 1 differ ({marginal} vs {class1})"
+        );
+
+        // Zero-scale proposal: κ is unchanged, so every step must accept with the
+        // baseline returned untouched — i.e. the kernel's own evaluation of the
+        // proposal is the marginal, not `class1`.
+        let mut rng = StdRng::seed_from_u64(7);
+        let (na, np, nll_out) = mh_kappa_steps_mixture(
+            &mut kappas,
+            marginal,
+            subject,
+            &model,
+            &params.theta,
+            &eta,
+            &params.omega,
+            omega_iov,
+            &params.sigma.values,
+            0.0,
+            &mut rng,
+            &mut scratch,
+        );
+        assert_eq!((na, np), (n_occ, n_occ));
+        assert!(
+            (nll_out - marginal).abs() < 1e-12,
+            "zero-step κ move must return the marginal baseline, got {nll_out} vs {marginal}"
+        );
+
+        // Live proposal: whatever the accept/reject pattern, the returned NLL must
+        // be the marginal *at the κ actually held* when the kernel returns.
+        let mut rng = StdRng::seed_from_u64(11);
+        let (_, _, nll_out) = mh_kappa_steps_mixture(
+            &mut kappas,
+            marginal,
+            subject,
+            &model,
+            &params.theta,
+            &eta,
+            &params.omega,
+            omega_iov,
+            &params.sigma.values,
+            0.5,
+            &mut rng,
+            &mut scratch,
+        );
+        let recomputed = subject_nll(
+            &model,
+            subject,
+            &params.theta,
+            &eta,
+            &kappas,
+            &params.omega,
+            Some(omega_iov),
+            &params.sigma.values,
+            &mut scratch,
+            None,
+        );
+        assert!(
+            (nll_out - recomputed).abs() < 1e-9,
+            "returned NLL must be the marginal at the retained κ ({nll_out} vs {recomputed})"
+        );
+    }
+
+    /// A short Bayes run on an IOV mixture completes and estimates non-zero κ.
+    #[test]
+    fn bayes_iov_mixture_fit_runs() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_IOV_MODEL).unwrap();
+        let pop = mix_iov_pop();
+        let mut opts = FitOptions::default();
+        opts.method = crate::types::EstimationMethod::Bayes;
+        opts.run_covariance_step = false;
+        opts.bayes_warmup = 10;
+        opts.bayes_iters = 10;
+        opts.bayes_chains = 1;
+        opts.bayes_seed = Some(3);
+        let res =
+            crate::api::fit(&model, &pop, &model.default_params, &opts).expect("bayes IOV mixture");
+        assert!(res.ofv.is_finite());
+        assert!(res.subjects.iter().all(|s| s.mixest.is_some()));
+    }
+
+    /// HMC is unavailable for a mixture (its Dual2 gradient is single-class), so an
+    /// explicit `saem_n_leapfrog > 0` must warn rather than silently downgrade to
+    /// the MH kernel while reporting `n_divergent = 0` (#985).
+    #[test]
+    fn bayes_mixture_warns_when_hmc_requested() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.method = crate::types::EstimationMethod::Bayes;
+        opts.run_covariance_step = false;
+        opts.bayes_warmup = 5;
+        opts.bayes_iters = 5;
+        opts.bayes_chains = 1;
+        opts.bayes_seed = Some(4);
+        opts.saem_n_leapfrog = 4;
+        let res = crate::api::fit(&model, &pop, &model.default_params, &opts).expect("bayes fit");
+        assert!(
+            res.warnings
+                .iter()
+                .any(|w| w.contains("saem_n_leapfrog") && w.contains("mixture")),
+            "expected an HMC-downgrade warning, got: {:?}",
+            res.warnings
+        );
+    }
+
     /// Bayes rejects a mixture that declares per-class Ω/Σ overrides (Ω/Σ are
     /// class-shared under the conjugate Ω block) with a clear error (#985).
     #[test]
@@ -2298,6 +2620,21 @@ mod tests {
             .expect_err("per-class overrides under Bayes must be rejected");
         assert!(
             err.contains("per-class Omega/Sigma overrides") && err.contains("bayes"),
+            "got: {err}"
+        );
+
+        // Same rejection in a method chain, raised by the `fit()` mixture gate
+        // *before* any stage runs — so `method = [focei, bayes]` does not burn a
+        // full FOCEI fit only to fail at the hand-off (#985).
+        let mut chain_opts = FitOptions::default();
+        chain_opts.methods = vec![
+            crate::types::EstimationMethod::FoceI,
+            crate::types::EstimationMethod::Bayes,
+        ];
+        let err = crate::api::fit(&model, &pop, &model.default_params, &chain_opts)
+            .expect_err("per-class overrides in a bayes chain must be rejected");
+        assert!(
+            err.contains("per-class Omega/Sigma overrides"),
             "got: {err}"
         );
     }

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -420,9 +420,11 @@ fn saem_covariate_mixing_separates_and_recovers_beta() {
 /// MLE.
 ///
 /// **Anchor:** the shared maximum-likelihood optimum (the FOCEI `mixture_iv.ctl`
-/// values `NM_*`). Under diffuse priors — here the `$THETA` bounds act as uniform
-/// priors, Ω/Σ FIXed — the Bayes posterior mean concentrates at that optimum, so
-/// recovering it *is* the cross-engine check. A direct NONMEM `METHOD=BAYES` run
+/// values `NM_*`). The population priors are weakly-informative N(u0, 10²) on the
+/// unconstrained scale, centred on this model's initial estimates (the declared
+/// `[parameters]` bounds are *not* enforced as uniform priors inside the (θ, σ)
+/// block), and Ω/Σ are FIXed — diffuse enough that the posterior mean concentrates
+/// at the likelihood optimum, so recovering it *is* the cross-engine check. A direct NONMEM `METHOD=BAYES` run
 /// is **not** used: NONMEM's BAYES sampler aborts in burn-in on this model
 /// (`$MIX` + FIXed `$OMEGA`/`$SIGMA` — it insists on Gibbs-sampling Ω, which is
 /// FIXed), a known NONMEM mixture/BAYES fragility (cf. the covariance-step

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -412,3 +412,84 @@ fn saem_covariate_mixing_separates_and_recovers_beta() {
         assert_eq!(sr.mixest.expect("MIXEST"), expected, "subject {i} MIXEST");
     }
 }
+
+/// Bayesian (full-MCMC) estimation under a mixture (#985). Same two-clearance
+/// model / data as the FOCEI and SAEM anchors. ferx Rao-Blackwellises the latent
+/// class (marginalises it out of every Gibbs block), so the sampler targets the
+/// K-class marginal and the posterior mean is a point estimate of the mixture
+/// MLE.
+///
+/// **Anchor:** the shared maximum-likelihood optimum (the FOCEI `mixture_iv.ctl`
+/// values `NM_*`). Under diffuse priors — here the `$THETA` bounds act as uniform
+/// priors, Ω/Σ FIXed — the Bayes posterior mean concentrates at that optimum, so
+/// recovering it *is* the cross-engine check. A direct NONMEM `METHOD=BAYES` run
+/// is **not** used: NONMEM's BAYES sampler aborts in burn-in on this model
+/// (`$MIX` + FIXed `$OMEGA`/`$SIGMA` — it insists on Gibbs-sampling Ω, which is
+/// FIXed), a known NONMEM mixture/BAYES fragility (cf. the covariance-step
+/// failure on IOV mixtures). The marginal OFV is additionally checked against the
+/// FOCEI optimum, and the same estimator is anchored directly to NONMEM SAEM
+/// above, so the mixture-marginal machinery this shares is cross-validated.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests (Bayes mixture)"
+)]
+fn bayes_mixture_recovers_optimum() {
+    let pop: ferx_core::Population = read_nonmem_csv(
+        Path::new("tests/nonmem/mixture_iv.csv"),
+        Some(&["WT"]),
+        None,
+    )
+    .unwrap();
+    let model = parse_model_string(MODEL).unwrap();
+    let mut opts = FitOptions::default();
+    opts.method = ferx_core::EstimationMethod::Bayes;
+    opts.bayes_warmup = 500;
+    opts.bayes_iters = 500;
+    opts.bayes_chains = 2;
+    opts.bayes_seed = Some(20250818);
+    let res = fit(&model, &pop, &model.default_params, &opts).expect("Bayes mixture fit Ok");
+    let th = &res.theta;
+    let p1 = 1.0 / (1.0 + (-th[3]).exp());
+    eprintln!(
+        "Bayes mixture: TVCL1={:.4} TVCL2={:.4} TVV={:.4} p1={:.4} OFV={:.4}",
+        th[0], th[1], th[2], p1, res.ofv
+    );
+    let rel = |a: f64, b: f64| (a - b).abs() / b.abs();
+
+    // Posterior mean recovers the mixture MLE (the two class clearances are the
+    // discriminating quantities — the sampler must separate them).
+    assert!(
+        rel(th[0], NM_TVCL1) < 0.10,
+        "Bayes TVCL1 {} vs {}",
+        th[0],
+        NM_TVCL1
+    );
+    assert!(
+        rel(th[1], NM_TVCL2) < 0.10,
+        "Bayes TVCL2 {} vs {}",
+        th[1],
+        NM_TVCL2
+    );
+    assert!(
+        rel(th[2], NM_TVV) < 0.05,
+        "Bayes TVV {} vs {}",
+        th[2],
+        NM_TVV
+    );
+    assert!((p1 - NM_P1).abs() < 0.08, "Bayes p(1) {} vs {}", p1, NM_P1);
+
+    // Marginal OFV (K-fold log-sum-exp) comparable to the FOCEI optimum.
+    assert!(
+        (res.ofv - NM_OFV_NO_CONST).abs() < 3.0,
+        "Bayes OFV {} vs {}",
+        res.ofv,
+        NM_OFV_NO_CONST
+    );
+
+    // Per-subject MIXEST populated (recomputed at the posterior mean).
+    assert!(
+        res.subjects.iter().all(|s| s.mixest.is_some()),
+        "MIXEST populated"
+    );
+}


### PR DESCRIPTION
> **Stacked on #987** (SAEM for mixtures). Base is `worktree-985-saem-mixture`; review/merge after #987. The only shared change is the mixture method-gate in `fit.rs`.

## Why

Issue #985's third estimator sub-item: **Bayesian (full-MCMC) estimation** for `[mixture]` models. Until now `fit()` rejected `method = bayes` for a mixture. (SAEM landed in #987; IOV in #986. IMP/IMPMAP remains.)

## What changed

The latent class is **Rao-Blackwellised** — marginalised out of every Gibbs block rather than sampled — so each subject's likelihood contribution is the K-class marginal `−log Σ_k p_ik·exp(−nll_ik)`, a smooth continuous target (the issue's prescribed approach).

The single lever is `subject_nll` (the one per-subject NLL every Gibbs block already calls): making it return the class-marginal (via `combine_subject` over per-class `individual_nll` under a `MixtureClassGuard`) makes the whole sampler mixture-aware at once:

- **η block** — samples against the class-marginal posterior via a new `mh_steps_mixture` (HMC is disabled for mixtures: its Dual2 gradient is single-class);
- **(θ, σ) block** — the componentwise/joint Metropolis already sums `subject_nll`, so the mixing thetas (constant *or* covariate-dependent logit mixing) are sampled with no extra machinery — they enter only through the marginal;
- **Ω block** — the conjugate inverse-Wishart draw from `S = Σ ηη'` gives the class-shared Ω.

Ω/σ are class-shared; per-class overrides (`omega(k)`/`sigma(k)`) are rejected with a clear error. The post-loop pass routes through `mixture_ofv`, so OFV, per-subject `MIXEST`/`PMIX`, and EBEs are the K-fold marginal values at the posterior mean.

## Alternatives considered

Sampling the class indicator (as SAEM does) was the alternative; the issue specifies Rao-Blackwellisation for Bayes so HMC/MH see a continuous target, and it turns out to collapse to a one-line change (`subject_nll` → marginal) rather than a per-class M-step restructure.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation

- [x] Recovers the mixture MLE under diffuse priors:

```
                 ferx Bayes (post. mean)   FOCEI MLE (NONMEM mixture_iv.ctl)
TVCL1            0.94                       0.981
TVCL2            2.78                       2.842
V                10.0                       9.98
p(1)             0.47                       0.472
OFV (marginal)   301.8                      301.58
```

- A direct NONMEM `METHOD=BAYES` reference is **not** used: NONMEM's BAYES sampler aborts in burn-in on this model (`$MIX` + FIXed `$OMEGA`/`$SIGMA` — it insists on Gibbs-sampling Ω, which is FIXed), a known NONMEM fragility (cf. the covariance-step failure on IOV mixtures). The shared optimum the Bayes posterior recovers is itself NONMEM-anchored by the FOCEI run, and the identical mixture-marginal machinery is anchored directly to NONMEM SAEM in #987.

## Tests
- [x] Unit tests (`cargo test --lib` passes): `mixture_subject_nll_is_marginal_lse` (marginal == hand-computed log-sum-exp), `bayes_mixture_fit_populates_mixest` (short fit, MIXEST set), `bayes_rejects_per_class_overrides`.
- [x] Tier-3 slow: `bayes_mixture_recovers_optimum` in `tests/mixture_nonmem.rs`.

## Docs
- [x] `docs/estimation/mixture.qmd` — new "Bayesian estimation under a mixture" section
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (new code warning-free)
- [x] No `Dual2`/`sens` path touched (HMC gradient is disabled for mixtures, not modified)

## Reviewer hints

- The whole feature is `subject_nll`'s mixture branch + `mh_steps_mixture` + the post-loop `mixture_ofv` routing; the rest of `bayes.rs` is untouched. The `mu-ref θ Gibbs` block needs no change: a class-switched typical value cannot be paired to one η, so `full_mu_ref` is already false for these models and all thetas (incl. the mixing thetas) flow through the marginal-aware Metropolis block.

## Open questions
- IMP/IMPMAP for mixtures is the last remaining #985 sub-item.
