### PR TITLE
feat(estimation): IMP/IMPMAP estimation + objective evaluation for mixtures [#985]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,16 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
-- **IMP objective evaluation for mixture models (#985).** Importance sampling now evaluates the
-  class-marginal likelihood `−2 Σ log Σ_k p_ik L_ik` for a `[mixture]` model (`method = imp` with
-  `imp_eval_only`, NONMEM `METHOD=IMP EONLY=1`): per subject and class it runs the class MAP solve and
-  importance-samples the class-conditional marginal, then combines them by log-sum-exp — the true
-  Monte-Carlo marginal for AIC/BIC and NONMEM comparison. The usual use is a chain, e.g.
-  `method = [saem, imp], imp_eval_only = true`. Matches NONMEM to well under a Monte-Carlo SE
-  (`−2 log L = 300.82 ± 0.06` vs NONMEM `300.87` on the two-class anchor). *Estimating* IMP/IMPMAP
-  (parameter updates) for a mixture is not yet class-partitioned and is rejected with a clear pointer
-  to this path; IOV under the mixture IMP objective is likewise rejected.
+- **IMP / IMPMAP estimation and objective evaluation for mixture models (#985).** Importance sampling
+  now both **estimates** a `[mixture]` model (`method = imp` / `impmap`) and **evaluates** its
+  class-marginal likelihood `−2 Σ log Σ_k p_ik L_ik` (`imp_eval_only`, NONMEM `METHOD=IMP EONLY=1`).
+  Estimation runs a class-partitioned MCEM: per subject and class it importance-samples η under the
+  `MIXNUM` guard, forms the responsibilities `PMIX_ik ∝ p_ik L_ik`, and runs responsibility-weighted
+  M-steps for the mixing coefficients, the class-shared Ω, and the class-switched typical values.
+  Objective evaluation combines the per-class IS marginals by log-sum-exp and matches NONMEM to well
+  under a Monte-Carlo SE (`−2 log L = 300.82 ± 0.06` vs NONMEM `300.87` on the two-class anchor).
+  Ω/σ are class-shared (per-class overrides rejected); IOV/FREM/SDE are not supported under the
+  mixture IMP paths.
 - **Bayesian estimation for mixture models (#985).** `[mixture]` models can now be fit with
   `method = bayes`. The latent class is Rao-Blackwellised — marginalised out of every Gibbs block
   rather than sampled — so each subject's likelihood contribution is the K-class marginal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ section of the SDLC for the versioning policy).
   Objective evaluation combines the per-class IS marginals by log-sum-exp and matches NONMEM to well
   under a Monte-Carlo SE (`−2 log L = 300.82 ± 0.06` vs NONMEM `300.87` on the two-class anchor).
   Ω/σ are class-shared (per-class overrides rejected); IOV/FREM/SDE are not supported under the
-  mixture IMP paths.
+  mixture IMP paths, and a theta shared between the mixing expression and a structural typical value
+  is rejected (as under SAEM). The per-class draws use the same ISCALE pilot search and `impmap_mceta`
+  multi-start MAP as the single-population MCEM; objective evaluation reports a real per-subject ESS
+  (the worst ESS among the classes a subject loads on), so `imp_low_ess_threshold` and the
+  proposal-collapse warning apply to mixtures. `impmap_trace` and `impmap_auto` / `imp_auto` are not
+  wired for mixtures and now warn instead of being silently ignored.
 - **Bayesian estimation for mixture models (#985).** `[mixture]` models can now be fit with
   `method = bayes`. The latent class is Rao-Blackwellised — marginalised out of every Gibbs block
   rather than sampled — so each subject's likelihood contribution is the K-class marginal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **IMP objective evaluation for mixture models (#985).** Importance sampling now evaluates the
+  class-marginal likelihood `−2 Σ log Σ_k p_ik L_ik` for a `[mixture]` model (`method = imp` with
+  `imp_eval_only`, NONMEM `METHOD=IMP EONLY=1`): per subject and class it runs the class MAP solve and
+  importance-samples the class-conditional marginal, then combines them by log-sum-exp — the true
+  Monte-Carlo marginal for AIC/BIC and NONMEM comparison. The usual use is a chain, e.g.
+  `method = [saem, imp], imp_eval_only = true`. Matches NONMEM to well under a Monte-Carlo SE
+  (`−2 log L = 300.82 ± 0.06` vs NONMEM `300.87` on the two-class anchor). *Estimating* IMP/IMPMAP
+  (parameter updates) for a mixture is not yet class-partitioned and is rejected with a clear pointer
+  to this path; IOV under the mixture IMP objective is likewise rejected.
 - **Bayesian estimation for mixture models (#985).** `[mixture]` models can now be fit with
   `method = bayes`. The latent class is Rao-Blackwellised — marginalised out of every Gibbs block
   rather than sampled — so each subject's likelihood contribution is the K-class marginal

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -319,7 +319,11 @@ $$
 
 This is the Monte-Carlo marginal likelihood — the number to compare against
 NONMEM's `#OBJV` for `IMP EONLY` — and it is what a chained fit reports on
-`FitResult.importance_sampling`. The usual workflow is to estimate with SAEM (or
+`FitResult.importance_sampling`. The reported per-subject ESS is the worst ESS
+among the classes that subject actually loads on (classes with
+$\mathrm{PMIX}_{ik}\approx 0$ are excluded, since a poor proposal there barely
+enters the marginal), so `imp_low_ess_threshold` flags mixture subjects the same
+way it does single-population ones. The usual workflow is to estimate with SAEM (or
 FOCE/FOCEI) and append an evaluation stage:
 
 ```toml
@@ -330,7 +334,8 @@ FOCE/FOCEI) and append an evaluation stage:
 
 On `tests/nonmem/mixture_iv.csv` this recovers the NONMEM `IMP EONLY` objective to
 well under a Monte-Carlo standard error: ferx `−2 log L = 300.82 ± 0.06` vs NONMEM
-`300.87` (`mixture_iv_saem.ctl`'s second `$EST`).
+`300.87` (`mixture_iv_saem.ctl`'s second `$EST`), with `ess_min/K = 0.82` and
+`ess_med/K = 0.91`.
 
 ### Estimating IMP / IMPMAP
 
@@ -348,12 +353,22 @@ supported (as for the single-population MCEM).
 
 IMP is the noisiest of the mixture estimators — the class-switched typical value
 cannot be mu-referenced, so θ is estimated by the weighted M-step alone, which
-converges more slowly than SAEM's MCMC and typically needs more iterations. On
-the two-class anchor, estimating IMPMAP recovers `TVCL1 ≈ 1.04`, `TVCL2 ≈ 2.58`,
-`V ≈ 9.96`, `p(1) ≈ 0.47` (vs the FOCEI optimum 0.98 / 2.84 / 9.98 / 0.472). For
-a well-identified point estimate prefer SAEM or FOCE/FOCEI and use IMP for the
-marginal likelihood; for the marginal likelihood at those estimates use the
-`imp_eval_only` stage above.
+converges more slowly than SAEM's MCMC and typically needs more iterations. The
+fit warns about this, and separately names any estimated θ that carries no ETA
+(the mixing thetas are excluded — they are owned by the mixing M-step, not the
+weighted one). On the two-class anchor, estimating IMPMAP recovers
+`TVCL1 ≈ 1.00`, `TVCL2 ≈ 2.60`, `V ≈ 10.00`, `p(1) ≈ 0.47` (vs the FOCEI optimum
+0.98 / 2.84 / 9.98 / 0.472); `TVCL2` is the coordinate the weighted M-step
+resolves least well. For a well-identified point estimate prefer SAEM or
+FOCE/FOCEI and use IMP for the marginal likelihood; for the marginal likelihood
+at those estimates use the `imp_eval_only` stage above.
+
+The per-subject proposal machinery is the same as the single-population MCEM:
+each class's draws get their own ISCALE pilot search (the guard against
+importance-weight collapse), and `impmap_mceta` runs its multi-start MAP within
+every class. Two IMPMAP options are **not** wired for mixtures and warn when
+set: `impmap_trace` (no iteration trace is produced) and `impmap_auto` /
+`imp_auto` (the sample count stays fixed).
 
 ## Not yet supported
 
@@ -365,4 +380,6 @@ The following error clearly rather than silently mis-fitting:
 - IOV / FREM / SDE under the mixture IMP paths (objective evaluation and
   estimation) — use FOCE/FOCEI.
 - A theta shared between the `[mixture]` mixing expression and a structural
-  typical value, under SAEM.
+  typical value, under SAEM and under estimating IMP/IMPMAP. Both run the
+  mixing M-step separately from the θ/σ M-step, so a shared theta would be
+  double-owned; FOCE/FOCEI's joint marginal handles it.

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -253,12 +253,45 @@ in burn-in on this model (it insists on Gibbs-sampling Ω, which is FIXed here),
 known NONMEM `$MIX`+BAYES fragility. The same mixture-marginal machinery is
 anchored directly against NONMEM SAEM above.
 
+## IMP objective evaluation under a mixture
+
+Importance sampling evaluates the **class-marginal** likelihood for a mixture
+(`method = imp` with `imp_eval_only`, NONMEM `METHOD=IMP EONLY=1`, #985). For each
+subject and each class it runs the class-`k` MAP inner solve (under the `MIXNUM`
+guard), importance-samples the class-conditional marginal $L_{ik}$, and combines
+them exactly as FOCEI does:
+
+$$
+-2\log L = -2\sum_i \log \sum_k p_{ik}\,L_{ik}.
+$$
+
+This is the Monte-Carlo marginal likelihood — the number to compare against
+NONMEM's `#OBJV` for `IMP EONLY` — and it is what a chained fit reports on
+`FitResult.importance_sampling`. The usual workflow is to estimate with SAEM (or
+FOCE/FOCEI) and append an evaluation stage:
+
+```toml
+[fit_options]
+  method = [saem, imp]
+  imp_eval_only = true
+```
+
+On `tests/nonmem/mixture_iv.csv` this recovers the NONMEM `IMP EONLY` objective to
+well under a Monte-Carlo standard error: ferx `−2 log L = 300.82 ± 0.06` vs NONMEM
+`300.87` (`mixture_iv_saem.ctl`'s second `$EST`).
+
+*Estimating* IMP/IMPMAP (updating parameters via the weighted MCEM M-step) is not
+yet class-partitioned and is rejected with a clear error — estimate with SAEM or
+FOCE/FOCEI and evaluate the marginal with the objective-evaluation stage above.
+
 ## Not yet supported
 
 The following error clearly rather than silently mis-fitting:
 
-- IMP / IMPMAP estimators for a mixture (#985); FOCE/FOCEI, SAEM, and Bayes are
-  supported.
+- *Estimating* IMP / IMPMAP for a mixture (the objective-evaluation `imp_eval_only`
+  path above is supported); FOCE/FOCEI, SAEM, and Bayes estimate a mixture.
 - Per-class σ overrides (`sigma(k)`) under SAEM (held at their initial values,
   with a warning), and per-class Ω/σ overrides under Bayes (rejected) — use
   FOCE/FOCEI to fit those.
+- IOV under the mixture IMP objective evaluation — use FOCE/FOCEI for an IOV
+  mixture.

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -280,18 +280,35 @@ On `tests/nonmem/mixture_iv.csv` this recovers the NONMEM `IMP EONLY` objective 
 well under a Monte-Carlo standard error: ferx `−2 log L = 300.82 ± 0.06` vs NONMEM
 `300.87` (`mixture_iv_saem.ctl`'s second `$EST`).
 
-*Estimating* IMP/IMPMAP (updating parameters via the weighted MCEM M-step) is not
-yet class-partitioned and is rejected with a clear error — estimate with SAEM or
-FOCE/FOCEI and evaluate the marginal with the objective-evaluation stage above.
+### Estimating IMP / IMPMAP
+
+Importance sampling also **estimates** a mixture (`method = imp` / `impmap`
+without `imp_eval_only`) via a class-partitioned MCEM. Each iteration importance-
+samples every subject's η *within each class* (under the `MIXNUM` guard), forms
+the deterministic class responsibilities $\mathrm{PMIX}_{ik} \propto p_{ik}L_{ik}$,
+then runs responsibility-weighted M-steps: the mixing coefficients from the
+responsibilities, the class-shared Ω from
+$\sum_i\sum_k \mathrm{PMIX}_{ik}\,\widehat{\eta\eta^{\top}}_{ik}/N$, and the
+class-switched typical values from a responsibility- and importance-weighted
+observation M-step (each class's samples scored under its own `MIXNUM`). Ω/σ are
+class-shared (per-class overrides are rejected); IOV / FREM / SDE are not
+supported (as for the single-population MCEM).
+
+IMP is the noisiest of the mixture estimators — the class-switched typical value
+cannot be mu-referenced, so θ is estimated by the weighted M-step alone, which
+converges more slowly than SAEM's MCMC and typically needs more iterations. On
+the two-class anchor, estimating IMPMAP recovers `TVCL1 ≈ 1.04`, `TVCL2 ≈ 2.58`,
+`V ≈ 9.96`, `p(1) ≈ 0.47` (vs the FOCEI optimum 0.98 / 2.84 / 9.98 / 0.472). For
+a well-identified point estimate prefer SAEM or FOCE/FOCEI and use IMP for the
+marginal likelihood; for the marginal likelihood at those estimates use the
+`imp_eval_only` stage above.
 
 ## Not yet supported
 
 The following error clearly rather than silently mis-fitting:
 
-- *Estimating* IMP / IMPMAP for a mixture (the objective-evaluation `imp_eval_only`
-  path above is supported); FOCE/FOCEI, SAEM, and Bayes estimate a mixture.
 - Per-class σ overrides (`sigma(k)`) under SAEM (held at their initial values,
-  with a warning), and per-class Ω/σ overrides under Bayes (rejected) — use
-  FOCE/FOCEI to fit those.
-- IOV under the mixture IMP objective evaluation — use FOCE/FOCEI for an IOV
-  mixture.
+  with a warning), and per-class Ω/σ overrides under Bayes and estimating
+  IMP/IMPMAP (rejected) — use FOCE/FOCEI to fit those.
+- IOV / FREM / SDE under the mixture IMP paths (objective evaluation and
+  estimation) — use FOCE/FOCEI.

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -227,16 +227,18 @@ pub fn fit(
                     | EstimationMethod::FoceI
                     | EstimationMethod::Saem
                     | EstimationMethod::Bayes
-                    // IMP is admitted for the objective-evaluation (EONLY) path,
-                    // which forms the class-marginal `−2 Σ log Σ_k p_ik L_ik`;
-                    // the *estimating* IMP/IMPMAP MCEM rejects mixtures in
-                    // `run_mcem` with a clear message (#985).
+                    // IMP / IMPMAP run a class-partitioned MCEM (per-class IS
+                    // E-step + responsibility-weighted M-steps) when estimating,
+                    // and form the class-marginal `−2 Σ log Σ_k p_ik L_ik` on the
+                    // objective-evaluation (EONLY) path (#985). IOV, FREM, SDE
+                    // and per-class Ω/Σ overrides are refused inside
+                    // `run_mcem_mixture`.
                     | EstimationMethod::Imp
                     | EstimationMethod::Impmap
             ) {
                 return Err(format!(
-                    "mixture models (#977) currently support FOCE / FOCEI / SAEM / Bayes, and IMP \
-                     objective evaluation; the {} method is not yet wired for mixtures (#985)",
+                    "mixture models (#977) currently support FOCE / FOCEI / SAEM / Bayes / IMP / \
+                     IMPMAP; the {} method is not yet wired for mixtures (#985)",
                     m.label()
                 ));
             }

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1474,15 +1474,22 @@ fn fit_inner(
                 let df = stage_opts.impmap_proposal_df;
                 marg_opts.imp_proposal_df = if df.is_finite() && df >= 1.0 { df } else { 5.0 };
             }
-            match crate::estimation::importance_sampling::run_importance_sampling(
-                model,
-                population,
-                &r.params,
-                &r.eta_hats,
-                &r.h_matrices,
-                &r.kappas,
-                &marg_opts,
-            ) {
+            let marg_call = if model.mixture.is_some() {
+                crate::estimation::importance_sampling::run_importance_sampling_mixture(
+                    model, population, &r.params, &marg_opts,
+                )
+            } else {
+                crate::estimation::importance_sampling::run_importance_sampling(
+                    model,
+                    population,
+                    &r.params,
+                    &r.eta_hats,
+                    &r.h_matrices,
+                    &r.kappas,
+                    &marg_opts,
+                )
+            };
+            match marg_call {
                 Ok(is) => is_result = Some(is),
                 Err(e) => accumulated_warnings.push(if n_stages > 1 {
                     format!("[{}] marginal −2 log L eval skipped: {}", method.label(), e)

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -227,10 +227,16 @@ pub fn fit(
                     | EstimationMethod::FoceI
                     | EstimationMethod::Saem
                     | EstimationMethod::Bayes
+                    // IMP is admitted for the objective-evaluation (EONLY) path,
+                    // which forms the class-marginal `−2 Σ log Σ_k p_ik L_ik`;
+                    // the *estimating* IMP/IMPMAP MCEM rejects mixtures in
+                    // `run_mcem` with a clear message (#985).
+                    | EstimationMethod::Imp
+                    | EstimationMethod::Impmap
             ) {
                 return Err(format!(
-                    "mixture models (#977) currently support FOCE / FOCEI / SAEM / Bayes; the {} \
-                     method is not yet wired for mixtures (#985)",
+                    "mixture models (#977) currently support FOCE / FOCEI / SAEM / Bayes, and IMP \
+                     objective evaluation; the {} method is not yet wired for mixtures (#985)",
                     m.label()
                 ));
             }
@@ -1311,15 +1317,28 @@ fn fit_inner(
             let prev = result.as_ref().expect(
                 "IMP stage: prior OuterResult must exist (synthesised above when standalone)",
             );
-            match crate::estimation::importance_sampling::run_importance_sampling(
-                model,
-                population,
-                &prev.params,
-                &prev.eta_hats,
-                &prev.h_matrices,
-                &prev.kappas,
-                &stage_opts,
-            ) {
+            // Mixture (#985): evaluate the class-marginal IS objective
+            // −2 Σ log Σ_k p_ik L_ik (per-class MAP + IS, combined), rather than
+            // the single-population marginal.
+            let is_call = if model.mixture.is_some() {
+                crate::estimation::importance_sampling::run_importance_sampling_mixture(
+                    model,
+                    population,
+                    &prev.params,
+                    &stage_opts,
+                )
+            } else {
+                crate::estimation::importance_sampling::run_importance_sampling(
+                    model,
+                    population,
+                    &prev.params,
+                    &prev.eta_hats,
+                    &prev.h_matrices,
+                    &prev.kappas,
+                    &stage_opts,
+                )
+            };
+            match is_call {
                 Ok(r) => {
                     // Surface a *separate* warning for any subject whose
                     // ESS-fraction collapsed to zero. These are already in

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -33,6 +33,7 @@
 
 use crate::estimation::importance_sampling::{
     compute_posterior_hessian, find_optimal_iscale, subject_is_draws, SubjectDraws,
+    MIX_ESS_PMIX_FLOOR,
 };
 use crate::estimation::inner_optimizer::{find_ebe, EbeResult, InnerLoopStats};
 use crate::estimation::outer_optimizer::{pop_nll, OuterResult};
@@ -174,6 +175,69 @@ pub(crate) fn non_fixed_thetas_without_eta(
         .collect()
 }
 
+/// One subject's multi-start MAP: the warm-start (or cold-start) solve plus
+/// `mceta` additional random starting points drawn from N(0, Ω) via the supplied
+/// Cholesky factor. The start with the lowest NLL wins; `omega_chol = None` (or
+/// `mceta == 0`) degrades to the single warm-start solve.
+///
+/// Shared by the single-population MAP sweep ([`run_map_multistart`]) and the
+/// mixture MCEM E-step, which runs the same multi-start *per class* inside the
+/// subject's rayon task (so `MIXNUM` stays correct on the worker thread).
+#[allow(clippy::too_many_arguments)]
+fn find_ebe_multistart(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    inner_maxiter: usize,
+    inner_tol: f64,
+    warm: Option<&[f64]>,
+    mu: Option<&[f64]>,
+    inner_restarts: usize,
+    mceta: usize,
+    omega_chol: Option<&DMatrix<f64>>,
+    subj_seed: u64,
+) -> EbeResult {
+    // Baseline: warm-start (or cold-start from η = 0).
+    let mut best = find_ebe(
+        model,
+        subject,
+        params,
+        inner_maxiter,
+        inner_tol,
+        warm,
+        mu,
+        inner_restarts,
+    );
+    let Some(l_omega) = omega_chol else {
+        return best;
+    };
+    let n_eta = l_omega.nrows();
+    let mut rng = StdRng::seed_from_u64(subj_seed);
+    for _start in 0..mceta {
+        // Draw z ~ N(0, I), compute eta_start = L_Ω · z.
+        let z: Vec<f64> = (0..n_eta)
+            .map(|_| StandardNormal.sample(&mut rng))
+            .collect();
+        let eta_start = l_omega * DVector::from_vec(z);
+        let eta_slice: Vec<f64> = eta_start.iter().copied().collect();
+
+        let candidate = find_ebe(
+            model,
+            subject,
+            params,
+            inner_maxiter,
+            inner_tol,
+            Some(&eta_slice),
+            mu,
+            inner_restarts,
+        );
+        if candidate.nll < best.nll {
+            best = candidate;
+        }
+    }
+    best
+}
+
 /// Multi-start MAP: for each subject, run `find_ebe` with the warm-start (or
 /// cold-start) and then `mceta` additional random starting points drawn from
 /// N(0, Ω). The start with the lowest NLL wins. When `mceta == 0` this
@@ -194,8 +258,6 @@ fn run_map_multistart(
     seed: u64,
     iteration: usize,
 ) -> (Vec<DVector<f64>>, Vec<DMatrix<f64>>, InnerLoopStats) {
-    let n_eta = model.n_eta;
-
     // Cholesky of Ω for drawing random starts (computed once, outside the
     // per-subject parallel loop).
     let omega_chol = if mceta > 0 {
@@ -210,54 +272,24 @@ fn run_map_multistart(
         .enumerate()
         .map(|(i, subject)| {
             let warm = prev_etas.map(|pe| pe[i].as_slice());
-            let mu = Some(mu_k);
-
-            // Baseline: warm-start (or cold-start from η = 0).
-            let mut best = find_ebe(
+            // Deterministic per-subject, per-iteration seed, separated from IS draws.
+            let subj_seed = seed
+                .wrapping_add(i as u64)
+                .wrapping_add((iteration as u64) << 32)
+                .wrapping_add(0x4D43_4554_4100u64);
+            find_ebe_multistart(
                 model,
                 subject,
                 params,
                 inner_maxiter,
                 inner_tol,
                 warm,
-                mu,
+                Some(mu_k),
                 0,
-            );
-
-            if let Some(ref l_omega) = omega_chol {
-                // Deterministic per-subject, per-iteration seed, separated from IS draws.
-                let subj_seed = seed
-                    .wrapping_add(i as u64)
-                    .wrapping_add((iteration as u64) << 32)
-                    .wrapping_add(0x4D43_4554_4100u64);
-                let mut rng = StdRng::seed_from_u64(subj_seed);
-
-                for _start in 0..mceta {
-                    // Draw z ~ N(0, I), compute eta_start = L_Ω · z.
-                    let z: Vec<f64> = (0..n_eta)
-                        .map(|_| StandardNormal.sample(&mut rng))
-                        .collect();
-                    let z_dv = DVector::from_vec(z);
-                    let eta_start = l_omega * &z_dv;
-                    let eta_slice: Vec<f64> = eta_start.iter().copied().collect();
-
-                    let candidate = find_ebe(
-                        model,
-                        subject,
-                        params,
-                        inner_maxiter,
-                        inner_tol,
-                        Some(&eta_slice),
-                        mu,
-                        0,
-                    );
-                    if candidate.nll < best.nll {
-                        best = candidate;
-                    }
-                }
-            }
-
-            best
+                mceta,
+                omega_chol.as_ref(),
+                subj_seed,
+            )
         })
         .collect();
 
@@ -415,6 +447,8 @@ fn run_mcem(
             threshold,
             mceta,
             use_sobol,
+            collect_trace,
+            auto,
         );
     }
     if n_eta == 0 {
@@ -1370,14 +1404,14 @@ fn run_mcem_mixture(
     threshold: f64,
     mceta: usize,
     use_sobol: bool,
+    collect_trace: bool,
+    auto: bool,
 ) -> Result<OuterResult, String> {
     use crate::estimation::importance_sampling::{
         compute_posterior_hessian, subject_is_draws, DefensiveMixture,
     };
-    use crate::estimation::inner_optimizer::find_ebe;
     use crate::estimation::mixture::combine_subject;
     use crate::parser::model_parser::{eval_mixing_log_probs, MixtureClassGuard};
-    let _ = (df_key, threshold);
 
     let n_subjects = population.subjects.len();
     let n_eta = model.n_eta;
@@ -1504,14 +1538,105 @@ fn run_mcem_mixture(
     let mut mix =
         crate::estimation::saem_mixture::SaemMixture::build(model, init_params, population);
 
+    // Reject a theta that drives both the mixing expression and a structural
+    // typical value. Like SAEM (`run_saem`), this MCEM runs *separated* M-steps:
+    // `theta_sigma_weighted_mstep_mixture` fits such a theta from the weighted
+    // observation likelihood and `mstep_mixing` then overwrites it from the
+    // responsibilities, silently discarding the structural estimate. FOCEI's
+    // joint marginal handles the shared parameter, so route there (#992 review).
+    let overlap = crate::estimation::saem_mixture::mixing_structural_overlap(
+        model,
+        init_params,
+        population,
+        &mix.mixing_theta_idx,
+    );
+    if !overlap.is_empty() {
+        let names: Vec<String> = overlap
+            .iter()
+            .map(|&j| {
+                init_params
+                    .theta_names
+                    .get(j)
+                    .cloned()
+                    .unwrap_or_else(|| format!("theta[{j}]"))
+            })
+            .collect();
+        return Err(format!(
+            "{label} cannot fit a mixture where a mixing-coefficient theta also drives the \
+             structural model: {} appear(s) in both the [mixture] mixing expression and an \
+             [individual_parameters] typical value. The weighted θ/σ M-step and the mixing \
+             M-step run separately, so a shared parameter would be double-owned. Split it into \
+             two thetas (one for structure, one for mixing), or fit with FOCE/FOCEI (whose \
+             joint marginal handles the shared parameter) (#985).",
+            names.join(", ")
+        ));
+    }
+
     let mut warnings: Vec<String> = Vec::new();
+
+    // The mixture MCEM never uses the closed-form log-mu-ref θ shift (a
+    // class-switched typical value cannot be paired to a single η), so *every* θ
+    // is estimated through the importance-weighted M-step alone — the channel
+    // that is biased for weakly-identified parameters. The single-population
+    // `run_mcem` pushes the equivalent warnings before this delegation point;
+    // repeat them here so a mixture fit is not silently unwarned (#992 review).
+    let mixing_names: std::collections::HashSet<&str> = mix
+        .mixing_theta_idx
+        .iter()
+        .filter_map(|&j| model.theta_names.get(j).map(String::as_str))
+        .collect();
+    // Mixing thetas are excluded: they are estimated by `mstep_mixing` from the
+    // class responsibilities, not by the weighted M-step, so an ETA on them is
+    // neither expected nor useful.
+    let thetas_without_eta: Vec<String> =
+        non_fixed_thetas_without_eta(model, &init_params.theta_fixed)
+            .into_iter()
+            .filter(|n| !mixing_names.contains(n.as_str()))
+            .collect();
+    if !thetas_without_eta.is_empty() {
+        warnings.push(format!(
+            "{label}: estimated parameter(s) [{}] have NO associated ETA. NONMEM's \
+             IMP/IMPMAP require every estimated parameter to carry a random effect; a \
+             fixed-effect-only parameter is estimated solely through the importance-weighted \
+             M-step, which is biased for weakly-identified parameters and may converge to the \
+             wrong value. STRONGLY add an ETA to each (e.g. `P = TVP * exp(ETA_P)` with a small, \
+             optionally FIX, omega), or hold the parameter FIX, or use FOCEI.",
+            thetas_without_eta.join(", ")
+        ));
+    }
+    warnings.push(format!(
+        "{label}: under a mixture the closed-form mu-referencing θ update does not apply (a \
+         class-switched typical value has no single paired η), so every typical value is \
+         estimated through the importance-weighted M-step alone and may converge poorly. \
+         Cross-check the typical values against a FOCEI fit."
+    ));
+    if collect_trace {
+        warnings.push(format!(
+            "{label}: iteration trace collection (impmap_trace) is not implemented for mixture \
+             models; no trace is reported (#985)."
+        ));
+    }
+    if auto {
+        warnings.push(format!(
+            "{label}: adaptive sampling (auto) is not implemented for mixture models; the sample \
+             count stays at K={k_samples} for every iteration (#985)."
+        ));
+    }
+
     let mut theta_cur = init_params.theta.clone();
     let mut sigma_cur = init_params.sigma.values.clone();
     let mut omega_mat = init_params.omega.matrix.clone();
 
     // Previous iteration's per-class weighted draws (for the IMP `SampleMoments`
-    // recenter). `None` on iteration 1 and always for IMPMAP.
+    // recenter, which rebuilds the proposal from their second moments). `None` on
+    // iteration 1 and — as in `run_mcem` — never retained on the IMPMAP (`Map`)
+    // path, which re-runs the MAP solve and only needs the previous weighted
+    // means as warm starts. Holding the full `K · n_subjects · n_classes` sample
+    // sets there would cost `K×` the memory for nothing (#992 review).
     let mut prev_draws: Option<Vec<Vec<SubjectDraws>>> = None;
+    // Previous iteration's per-class weighted posterior means, `[class][subject]`
+    // — the warm start for the next iteration's inner solve on both paths.
+    let mut prev_means: Option<Vec<Vec<Vec<f64>>>> = None;
     let warm0: Option<Vec<DVector<f64>>> = warm_etas.map(|e| e.to_vec());
 
     // Running average of the estimates over the final `n_avg` iterations.
@@ -1560,6 +1685,14 @@ fn run_mcem_mixture(
         };
         let run_inner = recenter == ProposalRecenter::Map || prev_draws.is_none();
         let prev = prev_draws.as_ref();
+        let prev_mean = prev_means.as_ref();
+        // Cholesky of the shared Ω for the MCETA random restarts (computed once
+        // per iteration, outside the parallel loop). `None` when MCETA is off.
+        let omega_chol = if mceta > 0 && run_inner {
+            omega_mat.clone().cholesky().map(|c| c.l())
+        } else {
+            None
+        };
 
         // ---- E-step: per subject, per class IS draws + class responsibilities ----
         // Parallel over subjects; the class loop runs inside each worker so the
@@ -1570,16 +1703,28 @@ fn run_mcem_mixture(
             .par_iter()
             .enumerate()
             .map_init(EventPkParams::default, |scratch, (i, subject)| {
+                // Poll per subject: one subject's E-step is `n_classes` inner
+                // solves plus `n_classes · K` importance draws — the dominant
+                // per-iteration cost — so without this a cancel set mid-sweep is
+                // not observed until the whole subject × class loop finishes.
+                // Mirrors `run_mcem`; the driver breaks right after the collect,
+                // so the placeholder draws never reach an M-step.
+                if crate::cancel::is_cancelled(cancel) {
+                    let class_draws: Vec<SubjectDraws> = (0..n_classes)
+                        .map(|_| SubjectDraws::cancelled(n_eta))
+                        .collect();
+                    return (class_draws, vec![1.0 / n_classes as f64; n_classes], 0.0);
+                }
                 let logp = eval_mixing_log_probs(spec, &theta_cur, &subject.covariates);
                 let mut class_draws: Vec<SubjectDraws> = Vec::with_capacity(n_classes);
                 let mut nll = vec![0.0f64; n_classes];
                 for c in 0..n_classes {
                     let _g = MixtureClassGuard::enter(c + 1);
                     let (center, h_post) = if run_inner {
-                        let warm_i = prev
-                            .map(|pd| DVector::from_row_slice(&pd[c][i].mean))
+                        let warm_i = prev_mean
+                            .map(|pm| DVector::from_row_slice(&pm[c][i]))
                             .or_else(|| warm0.as_ref().map(|w| w[i].clone()));
-                        let ebe = find_ebe(
+                        let ebe = find_ebe_multistart(
                             model,
                             subject,
                             &params_iter,
@@ -1588,6 +1733,12 @@ fn run_mcem_mixture(
                             warm_i.as_ref().map(|v| v.as_slice()),
                             None,
                             options.inner_restarts,
+                            mceta,
+                            omega_chol.as_ref(),
+                            seed.wrapping_add(i as u64)
+                                .wrapping_add((k as u64) << 32)
+                                .wrapping_add((c as u64) << 48)
+                                .wrapping_add(0x4D43_4554_4100u64),
                         );
                         let h_post = compute_posterior_hessian(
                             model,
@@ -1616,6 +1767,29 @@ fn run_mcem_mixture(
                         .wrapping_add(i as u64)
                         .wrapping_add((k as u64) << 32)
                         .wrapping_add((c as u64) << 48);
+                    // Per-subject, per-class ISCALE pilot search — the same guard
+                    // the single-population E-step runs (#528/#961): it rescues
+                    // subjects whose posterior Hessian is a poor curvature
+                    // estimate, whose IS weights would otherwise collapse and
+                    // drive the weighted M-step to the bounds. Skipping it is
+                    // materially riskier under a mixture, where an off-class
+                    // proposal is a poor fit by construction (#992 review).
+                    let iscale = find_optimal_iscale(
+                        model,
+                        subject,
+                        &params_iter.theta,
+                        &params_iter.sigma.values,
+                        &center,
+                        &h_post,
+                        &omega_inv,
+                        log_det_omega,
+                        n_eta,
+                        nu,
+                        subj_seed,
+                        scratch,
+                        options.iscale_min,
+                        options.iscale_max,
+                    );
                     let d = subject_is_draws(
                         model,
                         subject,
@@ -1630,7 +1804,7 @@ fn run_mcem_mixture(
                         nu,
                         subj_seed,
                         scratch,
-                        1.0,
+                        iscale,
                         use_sobol,
                         defensive.as_ref(),
                     );
@@ -1660,11 +1834,37 @@ fn run_mcem_mixture(
             ofv += contribution;
         }
         if verbose {
-            eprintln!("{label} (mixture) iter {k}: marginal −2 log L = {ofv:.4}");
+            // Per-subject ESS: the worst per-class proposal among the classes the
+            // subject actually contributes to (a collapsed proposal in a class
+            // with PMIX ≈ 0 does not degrade that subject's marginal).
+            let n_low_ess = (0..n_subjects)
+                .filter(|&i| {
+                    let worst = (0..n_classes)
+                        .filter(|&c| pmix[i][c] > MIX_ESS_PMIX_FLOOR)
+                        .map(|c| draws_by_class[c][i].ess_fraction)
+                        .fold(f64::INFINITY, f64::min);
+                    worst.is_finite() && worst < threshold
+                })
+                .count();
+            eprintln!(
+                "{label} (mixture) iter {k}: marginal −2 log L = {ofv:.4} \
+                 (low-ESS subjects: {n_low_ess})"
+            );
         }
 
         // ---- M-step ----
         // (a) θ / σ from the responsibility- and importance-weighted obs NLL.
+        // The mixing thetas are pinned out of this M-step: they do not enter
+        // `obs_nll_subject_into` at all, so leaving them free only inflates the
+        // BOBYQA dimension with degenerate directions and can park them at an
+        // arbitrary point that `mstep_mixing` (4–8 evals) then has to recover
+        // from (#992 review). `mstep_mixing` below is their sole owner.
+        let mut mstep_theta_lower = log_theta_lower.clone();
+        let mut mstep_theta_upper = log_theta_upper.clone();
+        for &j in &mix.mixing_theta_idx {
+            mstep_theta_lower[j] = log_theta[j];
+            mstep_theta_upper[j] = log_theta[j];
+        }
         let mstep_maxiter: u32 = if k <= n_iter / 2 { 4 } else { 8 };
         let (new_log_theta, new_log_sigma) = theta_sigma_weighted_mstep_mixture(
             model,
@@ -1673,8 +1873,8 @@ fn run_mcem_mixture(
             &pmix,
             &log_theta,
             &log_sigma,
-            &log_theta_lower,
-            &log_theta_upper,
+            &mstep_theta_lower,
+            &mstep_theta_upper,
             &log_sigma_lower,
             &log_sigma_upper,
             n_theta,
@@ -1743,7 +1943,25 @@ fn run_mcem_mixture(
             n_acc += 1;
         }
 
-        prev_draws = Some(draws_by_class);
+        prev_means = Some(
+            draws_by_class
+                .iter()
+                .map(|class| class.iter().map(|d| d.mean.clone()).collect())
+                .collect(),
+        );
+        prev_draws = if recenter == ProposalRecenter::SampleMoments {
+            Some(draws_by_class)
+        } else {
+            None
+        };
+    }
+
+    // A cancel observed inside (or at the top of) the loop breaks out with
+    // parameters from a truncated MCEM. Return before the K-class marginal pass
+    // and the covariance step — together the most expensive part of the run —
+    // rather than paying for them and handing back a bogus `Ok` (#992 review).
+    if crate::cancel::is_cancelled(cancel) {
+        return Err("cancelled by user".to_string());
     }
 
     // ---- Point estimate: average over the final n_avg iterations ----
@@ -1796,7 +2014,6 @@ fn run_mcem_mixture(
         kappa_fixed: init_params.kappa_fixed.clone(),
         mixture: final_mixture,
     };
-    let _ = mceta;
 
     // ---- Final EBEs / OFV / posteriors via the K-fold marginal ----
     let meval =
@@ -2347,6 +2564,230 @@ mod tests {
         assert!(
             err.contains("per-class Omega/Sigma overrides"),
             "got: {err}"
+        );
+    }
+    /// A theta that drives both the mixing expression and a structural typical
+    /// value is rejected up front: the weighted θ/σ M-step would fit it from the
+    /// observation likelihood and `mstep_mixing` would then overwrite it,
+    /// silently discarding the structural estimate (#992 review). SAEM rejects
+    /// the same shape; the estimating IMP/IMPMAP MCEM must too.
+    #[test]
+    fn estimating_imp_rejects_mixing_theta_that_drives_structure() {
+        const SHARED: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta MIXL(0.5, 0.01, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = 10.0 * MIXL
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let model = crate::parser::model_parser::parse_model_string(SHARED).unwrap();
+        let pop = mix_pop();
+        let opts = FitOptions::default();
+        let err = match run_impmap(&model, &pop, &model.default_params, None, &opts) {
+            Ok(_) => panic!("a mixing theta driving the structural model must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("also drives the structural model") && err.contains("MIXL"),
+            "got: {err}"
+        );
+    }
+
+    /// The mixture MCEM delegates before `run_mcem` builds its mu-ref warnings,
+    /// so it must push its own: the no-ETA warning (naming `TVV`, but *not* the
+    /// mixing theta `MIXL`, which `mstep_mixing` owns) and the mixture mu-ref
+    /// caveat that every typical value rides the weighted M-step alone.
+    #[test]
+    fn mixture_mcem_warns_about_weighted_mstep_only_thetas() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.impmap_iterations = 1;
+        opts.impmap_samples = 50;
+        opts.impmap_seed = Some(1);
+        opts.run_covariance_step = false;
+        let res =
+            run_impmap(&model, &pop, &model.default_params, None, &opts).expect("impmap mixture");
+        let joined = res.warnings.join("\n");
+        assert!(
+            joined.contains("have NO associated ETA") && joined.contains("TVV"),
+            "no-ETA warning missing: {joined}"
+        );
+        assert!(
+            !joined.contains("MIXL"),
+            "the mixing theta must not be flagged as a missing-ETA parameter: {joined}"
+        );
+        assert!(
+            joined.contains("closed-form mu-referencing"),
+            "mixture mu-ref caveat missing: {joined}"
+        );
+    }
+
+    /// `impmap_trace` and `impmap_auto` are not implemented for mixtures; they
+    /// must warn rather than be silently ignored (#992 review).
+    #[test]
+    fn mixture_mcem_warns_that_trace_and_auto_are_ignored() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.impmap_iterations = 1;
+        opts.impmap_samples = 50;
+        opts.impmap_seed = Some(1);
+        opts.impmap_trace = true;
+        opts.impmap_auto = true;
+        opts.run_covariance_step = false;
+        let res =
+            run_impmap(&model, &pop, &model.default_params, None, &opts).expect("impmap mixture");
+        let joined = res.warnings.join("\n");
+        assert!(
+            joined.contains("trace collection") && joined.contains("adaptive sampling"),
+            "trace/auto no-op warnings missing: {joined}"
+        );
+        assert!(res.impmap_trace.is_none(), "no trace is produced");
+    }
+
+    /// A cancel set before the run returns `Err` instead of falling through to
+    /// the K-class marginal pass and the covariance step — the most expensive
+    /// part of the run — with parameters from a truncated MCEM (#992 review).
+    #[test]
+    fn mixture_mcem_cancel_returns_err() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.impmap_iterations = 5;
+        opts.impmap_samples = 200;
+        opts.impmap_seed = Some(1);
+        let flag = crate::cancel::CancelFlag::new();
+        flag.cancel();
+        opts.cancel = Some(flag);
+        let err = match run_impmap(&model, &pop, &model.default_params, None, &opts) {
+            Ok(_) => panic!("a cancelled mixture MCEM must not return Ok"),
+            Err(e) => e,
+        };
+        assert!(err.contains("cancelled by user"), "got: {err}");
+    }
+
+    /// `find_ebe_multistart` degrades to the plain warm-start solve when no Ω
+    /// Cholesky is supplied, and never returns a worse start than the baseline
+    /// when MCETA restarts are requested.
+    #[test]
+    fn find_ebe_multistart_never_worse_than_baseline() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let params = &model.default_params;
+        let subject = &pop.subjects[0];
+
+        let baseline =
+            find_ebe_multistart(&model, subject, params, 50, 1e-4, None, None, 0, 0, None, 7);
+        let direct = find_ebe(&model, subject, params, 50, 1e-4, None, None, 0);
+        assert!(
+            (baseline.nll - direct.nll).abs() < 1e-12,
+            "no Cholesky must reproduce find_ebe exactly: {} vs {}",
+            baseline.nll,
+            direct.nll
+        );
+
+        let chol = params.omega.matrix.clone().cholesky().unwrap().l();
+        let multi = find_ebe_multistart(
+            &model,
+            subject,
+            params,
+            50,
+            1e-4,
+            None,
+            None,
+            0,
+            4,
+            Some(&chol),
+            7,
+        );
+        assert!(
+            multi.nll <= baseline.nll + 1e-12,
+            "MCETA restarts must not return a worse mode: {} vs {}",
+            multi.nll,
+            baseline.nll
+        );
+    }
+
+    /// The weighted θ/σ M-step honours a pinned coordinate (`lower == upper`),
+    /// which is how the mixture MCEM keeps the mixing thetas — absent from the
+    /// observation likelihood — out of the BOBYQA search (#992 review).
+    #[test]
+    fn weighted_mstep_mixture_honours_pinned_theta_bounds() {
+        use crate::estimation::importance_sampling::SubjectDraws;
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let params = &model.default_params;
+        let n_theta = params.theta.len();
+        let n_sigma = params.sigma.values.len();
+        let n_eta = model.n_eta;
+
+        // One (degenerate, single-sample) draw set per class per subject.
+        let draws_by_class: Vec<Vec<SubjectDraws>> = (0..2)
+            .map(|_| {
+                pop.subjects
+                    .iter()
+                    .map(|_| {
+                        let mut d = SubjectDraws::cancelled(n_eta);
+                        d.etas = vec![vec![0.0; n_eta]];
+                        d.weights = vec![1.0];
+                        d
+                    })
+                    .collect()
+            })
+            .collect();
+        let pmix: Vec<Vec<f64>> = pop.subjects.iter().map(|_| vec![0.5, 0.5]).collect();
+
+        let log_theta: Vec<f64> = params.theta.iter().map(|&t| t.max(1e-10).ln()).collect();
+        let log_sigma: Vec<f64> = params
+            .sigma
+            .values
+            .iter()
+            .map(|&s| s.max(1e-10).ln())
+            .collect();
+        let mask = vec![true; n_theta];
+        let mut lower = vec![-10.0; n_theta];
+        let mut upper = vec![10.0; n_theta];
+        // Pin theta 0 exactly, as the mixing-theta pin does.
+        lower[0] = log_theta[0];
+        upper[0] = log_theta[0];
+
+        let (out_theta, _out_sigma) = theta_sigma_weighted_mstep_mixture(
+            &model,
+            &pop,
+            &draws_by_class,
+            &pmix,
+            &log_theta,
+            &log_sigma,
+            &lower,
+            &upper,
+            &vec![-8.0; n_sigma],
+            &vec![5.0; n_sigma],
+            n_theta,
+            n_sigma,
+            8,
+            &mask,
+        );
+        assert!(
+            (out_theta[0] - log_theta[0]).abs() < 1e-12,
+            "pinned theta must not move: {} vs {}",
+            out_theta[0],
+            log_theta[0]
         );
     }
 }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -393,17 +393,29 @@ fn run_mcem(
     let n_sigma = init_params.sigma.values.len();
 
     // ---- Validation ----
-    // Mixture (#985): the estimating IMP/IMPMAP MCEM (weighted M-step over the
-    // per-subject IS draws) is not yet class-partitioned. The class-marginal IS
-    // *objective* is available via `method = imp` with `imp_eval_only` (typically
-    // as the last stage of a `[saem, imp]` / `[focei, imp]` chain); route
-    // parameter estimation through SAEM or FOCE/FOCEI.
+    // Mixture (#985): estimating IMP/IMPMAP runs a class-partitioned MCEM
+    // (per-class IS E-step + responsibility-weighted M-step). Delegate to the
+    // mixture core, which reuses this function's option resolution via the same
+    // arguments.
     if model.mixture.is_some() {
-        return Err(format!(
-            "{label} (estimating IMP/IMPMAP) is not yet wired for mixture models. Estimate with \
-             SAEM or FOCE/FOCEI, then evaluate the class-marginal likelihood with an IMP \
-             objective-evaluation stage (`imp_eval_only`), e.g. method = [saem, imp] (#985)."
-        ));
+        return run_mcem_mixture(
+            model,
+            population,
+            init_params,
+            warm_etas,
+            options,
+            recenter,
+            label,
+            df_key,
+            n_iter_opt,
+            k_opt,
+            nu,
+            n_avg_opt,
+            seed,
+            threshold,
+            mceta,
+            use_sobol,
+        );
     }
     if n_eta == 0 {
         return Err(format!(
@@ -1323,6 +1335,532 @@ fn run_mcem(
     })
 }
 
+/// Estimating IMP / IMPMAP under a mixture model (#985): a class-partitioned
+/// MCEM. Each iteration importance-samples each subject's η *within every class*
+/// (under a [`MixtureClassGuard`], so `MIXNUM` resolves to that class), forms the
+/// deterministic class responsibilities `PMIX_ik ∝ p_ik · L_ik`, then runs the
+/// responsibility-weighted M-steps:
+///
+/// * mixing coefficients — from the responsibilities (reusing SAEM's mixing
+///   M-step with `r̄ = PMIX`);
+/// * Ω (class-shared) — `Σ_i Σ_k PMIX_ik · secondmoment_ik / N`;
+/// * θ / σ — the responsibility- and importance-weighted observation M-step
+///   ([`theta_sigma_weighted_mstep_mixture`]), which recovers the class-switched
+///   typical values from each class's own weighted samples.
+///
+/// Ω/σ are class-shared (per-class overrides are rejected); IOV, FREM and SDE are
+/// not supported here (as for the single-population MCEM). The final OFV,
+/// per-subject `MIXEST`/`PMIX`, and EBEs come from the K-fold marginal
+/// (`mixture_ofv`) at the estimates, matching FOCEI/SAEM.
+#[allow(clippy::too_many_arguments)]
+fn run_mcem_mixture(
+    model: &CompiledModel,
+    population: &Population,
+    init_params: &ModelParameters,
+    warm_etas: Option<&[DVector<f64>]>,
+    options: &FitOptions,
+    recenter: ProposalRecenter,
+    label: &str,
+    df_key: &str,
+    n_iter_opt: usize,
+    k_opt: usize,
+    nu: f64,
+    n_avg_opt: usize,
+    seed: u64,
+    threshold: f64,
+    mceta: usize,
+    use_sobol: bool,
+) -> Result<OuterResult, String> {
+    use crate::estimation::importance_sampling::{
+        compute_posterior_hessian, subject_is_draws, DefensiveMixture,
+    };
+    use crate::estimation::inner_optimizer::find_ebe;
+    use crate::estimation::mixture::combine_subject;
+    use crate::parser::model_parser::{eval_mixing_log_probs, MixtureClassGuard};
+    let _ = (df_key, threshold);
+
+    let n_subjects = population.subjects.len();
+    let n_eta = model.n_eta;
+    let n_theta = init_params.theta.len();
+    let n_sigma = init_params.sigma.values.len();
+    let spec = model
+        .mixture
+        .as_ref()
+        .expect("run_mcem_mixture on non-mixture model");
+    let mp0 = init_params
+        .mixture
+        .as_ref()
+        .ok_or_else(|| format!("{label} mixture requires params.mixture (per-class Ω/Σ)"))?;
+
+    // ---- Validation (mixture scope) ----
+    if n_eta == 0 {
+        return Err(format!(
+            "{label} requires at least one random effect (n_eta = 0)."
+        ));
+    }
+    if model.n_kappa > 0 {
+        return Err(format!(
+            "{label} for a mixture does not yet support inter-occasion variability (IOV); use \
+             SAEM or FOCE/FOCEI (#985)."
+        ));
+    }
+    if model.frem_config.is_some() {
+        return Err(format!(
+            "{label} for a mixture does not support FREM models (#985)."
+        ));
+    }
+    if model.is_sde() {
+        return Err(format!(
+            "{label} for a mixture does not support SDE / [diffusion] models."
+        ));
+    }
+    if !mp0.omega_override_addr.is_empty() || !mp0.sigma_override_addr.is_empty() {
+        return Err(format!(
+            "{label} for a mixture does not yet support per-class Omega/Sigma overrides \
+             (omega(k)/sigma(k)); Omega/Sigma are class-shared. Use FOCE/FOCEI for per-class \
+             overrides (#985)."
+        ));
+    }
+    if nu.is_finite() && nu < 1.0 {
+        return Err(format!(
+            "{label}: {df_key} must be >= 1.0 (or +inf), got {nu}"
+        ));
+    }
+
+    let n_iter = n_iter_opt.max(1);
+    let k_samples = k_opt.max(2);
+    let n_avg = n_avg_opt.min(n_iter);
+    let verbose = options.verbose;
+    let cancel = &options.cancel;
+    let n_classes = spec.n_classes;
+
+    // ---- Packing scaffolding (mirrors run_mcem / SAEM) ----
+    let theta_packs_log_mask: Vec<bool> = init_params
+        .theta_lower
+        .iter()
+        .map(|&lo| theta_packs_log(lo))
+        .collect();
+    let pack_theta = |i: usize, t: f64| -> f64 {
+        if theta_packs_log_mask[i] {
+            t.max(1e-10).ln()
+        } else {
+            t
+        }
+    };
+    let mut log_theta: Vec<f64> = (0..n_theta)
+        .map(|i| pack_theta(i, init_params.theta[i]))
+        .collect();
+    let mut log_sigma: Vec<f64> = init_params
+        .sigma
+        .values
+        .iter()
+        .map(|&s| s.max(1e-10).ln())
+        .collect();
+    let mut log_theta_lower: Vec<f64> = (0..n_theta)
+        .map(|i| {
+            if theta_packs_log_mask[i] {
+                init_params.theta_lower[i].max(1e-10).ln()
+            } else {
+                init_params.theta_lower[i]
+            }
+        })
+        .collect();
+    let mut log_theta_upper: Vec<f64> = (0..n_theta)
+        .map(|i| {
+            if theta_packs_log_mask[i] {
+                init_params.theta_upper[i].min(1e9).ln()
+            } else {
+                init_params.theta_upper[i]
+            }
+        })
+        .collect();
+    let mut log_sigma_lower = vec![-8.0f64; n_sigma];
+    let mut log_sigma_upper = vec![5.0f64; n_sigma];
+    for i in 0..n_theta {
+        if init_params.theta_fixed.get(i).copied().unwrap_or(false) {
+            log_theta_lower[i] = log_theta[i];
+            log_theta_upper[i] = log_theta[i];
+        }
+    }
+    for i in 0..n_sigma {
+        if init_params.sigma_fixed.get(i).copied().unwrap_or(false) {
+            log_sigma_lower[i] = log_sigma[i];
+            log_sigma_upper[i] = log_sigma[i];
+        }
+    }
+    let unpack_theta = |i: usize, v: f64| -> f64 {
+        if theta_packs_log_mask[i] {
+            v.exp()
+        } else {
+            v
+        }
+    };
+
+    // Mixing state: detects the mixing thetas and drives the mixing M-step from
+    // the deterministic responsibilities (no stochastic averaging — `rbar` is set
+    // to the current `PMIX` each iteration). The closed-form mu-ref θ shift is not
+    // used for a mixture (the class-switched typical value can't pair to one η);
+    // every θ flows through the responsibility-weighted M-step.
+    let mut mix =
+        crate::estimation::saem_mixture::SaemMixture::build(model, init_params, population);
+
+    let mut warnings: Vec<String> = Vec::new();
+    let mut theta_cur = init_params.theta.clone();
+    let mut sigma_cur = init_params.sigma.values.clone();
+    let mut omega_mat = init_params.omega.matrix.clone();
+
+    // Previous iteration's per-class weighted draws (for the IMP `SampleMoments`
+    // recenter). `None` on iteration 1 and always for IMPMAP.
+    let mut prev_draws: Option<Vec<Vec<SubjectDraws>>> = None;
+    let warm0: Option<Vec<DVector<f64>>> = warm_etas.map(|e| e.to_vec());
+
+    // Running average of the estimates over the final `n_avg` iterations.
+    let mut acc_theta = vec![0.0f64; n_theta];
+    let mut acc_sigma = vec![0.0f64; n_sigma];
+    let mut acc_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
+    let mut n_acc = 0usize;
+
+    if verbose {
+        eprintln!(
+            "{label} (mixture): {n_subjects} subjects × {n_classes} classes, {n_eta} ETAs, \
+             {n_iter} iters, K={k_samples}/subject/class, seed={seed}"
+        );
+    }
+
+    for k in 1..=n_iter {
+        if crate::cancel::is_cancelled(cancel) {
+            break;
+        }
+        // Shared Ω/σ view for this iteration (identical across classes; the class
+        // enters only through the `MIXNUM` guard on the structural model).
+        let omega_k = OmegaMatrix::from_matrix(
+            omega_mat.clone(),
+            init_params.omega.eta_names.clone(),
+            init_params.omega.diagonal,
+        );
+        let omega_inv = omega_k.inv.clone();
+        let log_det_omega = omega_k.log_det;
+        let defensive = DefensiveMixture::new(&omega_inv, n_eta, options.imp_defensive_alpha);
+        let params_iter = ModelParameters {
+            theta: theta_cur.clone(),
+            theta_names: init_params.theta_names.clone(),
+            theta_lower: init_params.theta_lower.clone(),
+            theta_upper: init_params.theta_upper.clone(),
+            theta_fixed: init_params.theta_fixed.clone(),
+            omega: omega_k.clone(),
+            omega_fixed: init_params.omega_fixed.clone(),
+            sigma: SigmaVector {
+                values: sigma_cur.clone(),
+                names: init_params.sigma.names.clone(),
+            },
+            sigma_fixed: init_params.sigma_fixed.clone(),
+            omega_iov: None,
+            kappa_fixed: init_params.kappa_fixed.clone(),
+            mixture: None,
+        };
+        let run_inner = recenter == ProposalRecenter::Map || prev_draws.is_none();
+        let prev = prev_draws.as_ref();
+
+        // ---- E-step: per subject, per class IS draws + class responsibilities ----
+        // Parallel over subjects; the class loop runs inside each worker so the
+        // `MIXNUM` guard is entered on the same thread as the solve/draws.
+        #[allow(clippy::type_complexity)]
+        let per_subject: Vec<(Vec<SubjectDraws>, Vec<f64>, f64)> = population
+            .subjects
+            .par_iter()
+            .enumerate()
+            .map_init(EventPkParams::default, |scratch, (i, subject)| {
+                let logp = eval_mixing_log_probs(spec, &theta_cur, &subject.covariates);
+                let mut class_draws: Vec<SubjectDraws> = Vec::with_capacity(n_classes);
+                let mut nll = vec![0.0f64; n_classes];
+                for c in 0..n_classes {
+                    let _g = MixtureClassGuard::enter(c + 1);
+                    let (center, h_post) = if run_inner {
+                        let warm_i = prev
+                            .map(|pd| DVector::from_row_slice(&pd[c][i].mean))
+                            .or_else(|| warm0.as_ref().map(|w| w[i].clone()));
+                        let ebe = find_ebe(
+                            model,
+                            subject,
+                            &params_iter,
+                            options.inner_maxiter,
+                            options.inner_tol,
+                            warm_i.as_ref().map(|v| v.as_slice()),
+                            None,
+                            options.inner_restarts,
+                        );
+                        let h_post = compute_posterior_hessian(
+                            model,
+                            subject,
+                            &params_iter.theta,
+                            &ebe.eta,
+                            &params_iter.sigma.values,
+                            &ebe.h_matrix,
+                            &omega_inv,
+                            n_eta,
+                            scratch,
+                        );
+                        (ebe.eta, h_post)
+                    } else {
+                        let pd = &prev.expect("prev set when !run_inner")[c][i];
+                        let center = DVector::from_row_slice(&pd.mean);
+                        let cov = &pd.second_moment - &center * center.transpose();
+                        let h_post = covariance_to_proposal_hessian(
+                            &cov,
+                            &omega_mat,
+                            IMP_PROPOSAL_COV_FLOOR,
+                        );
+                        (center, h_post)
+                    };
+                    let subj_seed = seed
+                        .wrapping_add(i as u64)
+                        .wrapping_add((k as u64) << 32)
+                        .wrapping_add((c as u64) << 48);
+                    let d = subject_is_draws(
+                        model,
+                        subject,
+                        &params_iter.theta,
+                        &params_iter.sigma.values,
+                        &center,
+                        &h_post,
+                        &omega_inv,
+                        log_det_omega,
+                        n_eta,
+                        k_samples,
+                        nu,
+                        subj_seed,
+                        scratch,
+                        1.0,
+                        use_sobol,
+                        defensive.as_ref(),
+                    );
+                    nll[c] = -d.log_marginal;
+                    class_draws.push(d);
+                }
+                let (contribution, pmix_i, _mixest) = combine_subject(&logp, &nll);
+                (class_draws, pmix_i, contribution)
+            })
+            .collect();
+
+        if crate::cancel::is_cancelled(cancel) {
+            break;
+        }
+
+        // Reorganize into [class][subject] draws + [subject][class] responsibilities.
+        let mut draws_by_class: Vec<Vec<SubjectDraws>> = (0..n_classes)
+            .map(|_| Vec::with_capacity(n_subjects))
+            .collect();
+        let mut pmix: Vec<Vec<f64>> = Vec::with_capacity(n_subjects);
+        let mut ofv = 0.0f64;
+        for (class_draws, pmix_i, contribution) in per_subject {
+            for (c, d) in class_draws.into_iter().enumerate() {
+                draws_by_class[c].push(d);
+            }
+            pmix.push(pmix_i);
+            ofv += contribution;
+        }
+        if verbose {
+            eprintln!("{label} (mixture) iter {k}: marginal −2 log L = {ofv:.4}");
+        }
+
+        // ---- M-step ----
+        // (a) θ / σ from the responsibility- and importance-weighted obs NLL.
+        let mstep_maxiter: u32 = if k <= n_iter / 2 { 4 } else { 8 };
+        let (new_log_theta, new_log_sigma) = theta_sigma_weighted_mstep_mixture(
+            model,
+            population,
+            &draws_by_class,
+            &pmix,
+            &log_theta,
+            &log_sigma,
+            &log_theta_lower,
+            &log_theta_upper,
+            &log_sigma_lower,
+            &log_sigma_upper,
+            n_theta,
+            n_sigma,
+            mstep_maxiter,
+            &theta_packs_log_mask,
+        );
+        log_theta = new_log_theta;
+        log_sigma = new_log_sigma;
+        theta_cur = (0..n_theta)
+            .map(|i| unpack_theta(i, log_theta[i]))
+            .collect();
+        sigma_cur = log_sigma.iter().map(|&v| v.exp()).collect();
+
+        // (b) mixing coefficients from the class responsibilities.
+        mix.rbar = pmix.clone();
+        crate::estimation::saem_mixture::mstep_mixing(
+            model,
+            population,
+            &mix,
+            &mut theta_cur,
+            &init_params.theta_lower,
+            &init_params.theta_upper,
+            mstep_maxiter,
+        );
+        for &j in &mix.mixing_theta_idx {
+            log_theta[j] = if theta_packs_log_mask[j] {
+                theta_cur[j].max(1e-12).ln()
+            } else {
+                theta_cur[j]
+            };
+        }
+
+        // (c) Ω (class-shared): responsibility-weighted second moment, masked/floored.
+        let mut new_omega = DMatrix::<f64>::zeros(n_eta, n_eta);
+        for (c, class) in draws_by_class.iter().enumerate() {
+            for (i, d) in class.iter().enumerate() {
+                new_omega += pmix[i][c] * &d.second_moment;
+            }
+        }
+        new_omega /= n_subjects as f64;
+        for a in 0..n_eta {
+            for b in 0..n_eta {
+                if !init_params.omega.free_mask[(a, b)] {
+                    new_omega[(a, b)] = 0.0;
+                }
+                let fa = init_params.omega_fixed.get(a).copied().unwrap_or(false);
+                let fb = init_params.omega_fixed.get(b).copied().unwrap_or(false);
+                if fa || fb {
+                    new_omega[(a, b)] = init_params.omega.matrix[(a, b)];
+                }
+            }
+        }
+        floor_omega_diagonal(&mut new_omega, &init_params.omega_fixed, OMEGA_DIAG_FLOOR);
+        omega_mat = new_omega;
+
+        // Accumulate the final `n_avg` iterations for the reported point estimate.
+        if k > n_iter - n_avg {
+            for (a, &v) in acc_theta.iter_mut().zip(&theta_cur) {
+                *a += v;
+            }
+            for (a, &v) in acc_sigma.iter_mut().zip(&sigma_cur) {
+                *a += v;
+            }
+            acc_omega += &omega_mat;
+            n_acc += 1;
+        }
+
+        prev_draws = Some(draws_by_class);
+    }
+
+    // ---- Point estimate: average over the final n_avg iterations ----
+    let (final_theta, final_sigma, final_omega_mat) = if n_acc > 0 {
+        (
+            acc_theta
+                .iter()
+                .map(|&v| v / n_acc as f64)
+                .collect::<Vec<_>>(),
+            acc_sigma
+                .iter()
+                .map(|&v| v / n_acc as f64)
+                .collect::<Vec<_>>(),
+            acc_omega / n_acc as f64,
+        )
+    } else {
+        (theta_cur.clone(), sigma_cur.clone(), omega_mat.clone())
+    };
+    let final_omega = OmegaMatrix::from_matrix(
+        final_omega_mat,
+        init_params.omega.eta_names.clone(),
+        init_params.omega.diagonal,
+    );
+    // Rebuild the per-class Ω/Σ as the (shared) final estimates so the marginal
+    // post-loop pass and covariance step see the mixture structure.
+    let final_mixture = init_params.mixture.as_ref().map(|m| {
+        let mut mm = m.clone();
+        for o in mm.omega.iter_mut() {
+            *o = final_omega.clone();
+        }
+        for s in mm.sigma.iter_mut() {
+            s.values = final_sigma.clone();
+        }
+        mm
+    });
+    let final_params = ModelParameters {
+        theta: final_theta,
+        theta_names: init_params.theta_names.clone(),
+        theta_lower: init_params.theta_lower.clone(),
+        theta_upper: init_params.theta_upper.clone(),
+        theta_fixed: init_params.theta_fixed.clone(),
+        omega: final_omega,
+        omega_fixed: init_params.omega_fixed.clone(),
+        sigma: SigmaVector {
+            values: final_sigma,
+            names: init_params.sigma.names.clone(),
+        },
+        sigma_fixed: init_params.sigma_fixed.clone(),
+        omega_iov: None,
+        kappa_fixed: init_params.kappa_fixed.clone(),
+        mixture: final_mixture,
+    };
+    let _ = mceta;
+
+    // ---- Final EBEs / OFV / posteriors via the K-fold marginal ----
+    let meval =
+        crate::estimation::mixture::mixture_ofv(model, population, &final_params, options, None);
+    let eta_hats = meval.mixest_etas;
+    let h_matrices = meval.mixest_h_mats;
+    let final_kappas = meval.mixest_kappas;
+    let ofv = meval.ofv;
+    let mixture_posteriors = Some(crate::estimation::outer_optimizer::MixturePosteriors {
+        pmix: meval.pmix,
+        mixest: meval.mixest,
+    });
+
+    // ---- Covariance step (mixture-aware) ----
+    let packed = pack_params(&final_params);
+    let cov_out = crate::estimation::covariance::run_covariance_step(
+        &packed,
+        &final_params,
+        model,
+        population,
+        &eta_hats,
+        &h_matrices,
+        &final_kappas,
+        options,
+        verbose.then_some("Running covariance step..."),
+    );
+    let crate::estimation::covariance::CovStepOutcome {
+        matrix: covariance_matrix,
+        wall_time_secs: covariance_wall_time_secs,
+        warnings: cov_warnings,
+        sir_fallback_proposal,
+    } = cov_out;
+    warnings.extend(cov_warnings);
+
+    if verbose {
+        eprintln!("{label} (mixture) completed. Final marginal OFV = {ofv:.4}");
+    }
+
+    Ok(OuterResult {
+        params: final_params,
+        ofv,
+        converged: objective_converged(ofv),
+        n_iterations: n_iter,
+        eta_hats,
+        h_matrices,
+        kappas: final_kappas,
+        covariance_matrix,
+        covariance_wall_time_secs,
+        warnings,
+        saem_mu_ref_m_step_evals_saved: None,
+        saem_n_subjects_hmc: None,
+        ebe_convergence_warnings: 0,
+        max_unconverged_subjects: 0,
+        total_ebe_fallbacks: 0,
+        final_gradient: None,
+        sir_fallback_proposal,
+        impmap_trace: None,
+        bayes: None,
+        cond_dist: None,
+        packed_estimate: None,
+        mixture_posteriors,
+    })
+}
+
 /// Extract the lower triangle of a square matrix in row-major order:
 /// `(0,0), (1,0), (1,1), (2,0), (2,1), (2,2), …`
 fn lower_triangle(m: &DMatrix<f64>) -> Vec<f64> {
@@ -1438,6 +1976,112 @@ fn theta_sigma_weighted_mstep(
     let log_theta_new = xs[..n_theta].to_vec();
     let log_sigma_new = xs[n_theta..].to_vec();
     (log_theta_new, log_sigma_new)
+}
+
+/// Mixture (#985) weighted θ/σ M-step. Minimises the class-responsibility- and
+/// importance-weighted observation NLL
+/// `Σᵢ Σ_c PMIX_ic · Σₖ w̃_ick · obs_nll(yᵢ | η_ick, θ, σ | MIXNUM = c)` over the
+/// per-(subject,class) sample sets. Each class's samples were drawn under that
+/// class's proposal, and its `obs_nll` runs under a [`MixtureClassGuard`] on the
+/// worker thread, so a class-switched typical value (`if MIXNUM == c …`) is
+/// estimated from its own class's weighted samples. `draws[c][i]` is class `c`'s
+/// draws for subject `i`; `pmix[i][c]` is the class responsibility.
+#[allow(clippy::too_many_arguments)]
+fn theta_sigma_weighted_mstep_mixture(
+    model: &CompiledModel,
+    population: &Population,
+    draws: &[Vec<crate::estimation::importance_sampling::SubjectDraws>],
+    pmix: &[Vec<f64>],
+    log_theta_init: &[f64],
+    log_sigma_init: &[f64],
+    log_theta_lower: &[f64],
+    log_theta_upper: &[f64],
+    log_sigma_lower: &[f64],
+    log_sigma_upper: &[f64],
+    n_theta: usize,
+    n_sigma: usize,
+    maxiter: u32,
+    theta_packs_log_mask: &[bool],
+) -> (Vec<f64>, Vec<f64>) {
+    use crate::parser::model_parser::MixtureClassGuard;
+    let n = n_theta + n_sigma;
+    let n_classes = draws.len();
+
+    let mut x: Vec<f64> = Vec::with_capacity(n);
+    x.extend_from_slice(log_theta_init);
+    x.extend_from_slice(log_sigma_init);
+    let mut lower: Vec<f64> = Vec::with_capacity(n);
+    lower.extend_from_slice(log_theta_lower);
+    lower.extend_from_slice(log_sigma_lower);
+    let mut upper: Vec<f64> = Vec::with_capacity(n);
+    upper.extend_from_slice(log_theta_upper);
+    upper.extend_from_slice(log_sigma_upper);
+    for i in 0..n {
+        x[i] = x[i].clamp(lower[i], upper[i]);
+    }
+
+    let unpack_thetas = |packed: &[f64]| -> Vec<f64> {
+        (0..n_theta)
+            .map(|i| {
+                if theta_packs_log_mask[i] {
+                    packed[i].exp()
+                } else {
+                    packed[i]
+                }
+            })
+            .collect()
+    };
+
+    let obj = |xv: &[f64], _: Option<&mut [f64]>, _: &mut ()| -> f64 {
+        let th: Vec<f64> = unpack_thetas(&xv[..n_theta]);
+        let sg: Vec<f64> = xv[n_theta..].iter().map(|&v| v.exp()).collect();
+        let per_subj: Vec<f64> = population
+            .subjects
+            .par_iter()
+            .enumerate()
+            .map_init(EventPkParams::default, |scratch, (i, subject)| {
+                let mut s = 0.0f64;
+                for c in 0..n_classes {
+                    let p = pmix[i][c];
+                    if p == 0.0 {
+                        continue;
+                    }
+                    let _g = MixtureClassGuard::enter(c + 1);
+                    let d = &draws[c][i];
+                    let mut sc = 0.0f64;
+                    for (w, eta) in d.weights.iter().zip(d.etas.iter()) {
+                        if *w == 0.0 {
+                            continue;
+                        }
+                        sc += w * obs_nll_subject_into(model, subject, &th, &sg, eta, scratch);
+                    }
+                    s += p * sc;
+                }
+                s
+            })
+            .collect();
+        let val: f64 = per_subj.iter().sum();
+        if val.is_finite() {
+            val
+        } else {
+            1e20
+        }
+    };
+
+    let mut opt = nlopt::Nlopt::new(
+        nlopt::Algorithm::Bobyqa,
+        n,
+        obj,
+        nlopt::Target::Minimize,
+        (),
+    );
+    opt.set_lower_bounds(&lower).unwrap();
+    opt.set_upper_bounds(&upper).unwrap();
+    opt.set_maxeval(maxiter * (n as u32 + 1)).unwrap();
+    opt.set_ftol_rel(1e-4).unwrap();
+    let mut xs = x.clone();
+    let _ = opt.optimize(&mut xs);
+    (xs[..n_theta].to_vec(), xs[n_theta..].to_vec())
 }
 
 #[cfg(test)]
@@ -1586,6 +2230,123 @@ mod tests {
         assert!(
             h.iter().all(|&v| v == 0.0),
             "non-PD covariance must yield the zero fallback"
+        );
+    }
+
+    // ── Estimating IMP/IMPMAP under a mixture (#985) ──
+
+    const MIX_MODEL: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+
+    fn mix_pop() -> Population {
+        use std::io::Write;
+        let mut csv = String::from("ID,TIME,DV,AMT,EVID,CMT,WT\n");
+        for (sid, &(cl, wt)) in [(1.0_f64, 60.0_f64), (3.0, 90.0)].iter().enumerate() {
+            let id = sid + 1;
+            csv.push_str(&format!("{id},0,0,100,1,1,{wt}\n"));
+            for t in [0.5_f64, 1.0, 2.0, 4.0] {
+                let c = (100.0 / 10.0) * (-(cl / 10.0) * t).exp();
+                csv.push_str(&format!("{id},{t},{c:.5},0,0,1,{wt}\n"));
+            }
+        }
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(csv.as_bytes()).unwrap();
+        crate::read_nonmem_csv(f.path(), Some(&["WT"]), None).unwrap()
+    }
+
+    /// A short estimating IMPMAP (Map recenter) run on a mixture returns Ok,
+    /// carries the mixture through, and populates per-subject MIXEST + posteriors.
+    #[test]
+    fn impmap_mixture_short_run_populates_posteriors() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.impmap_iterations = 2;
+        opts.impmap_samples = 200;
+        opts.impmap_seed = Some(1);
+        opts.run_covariance_step = false;
+        let res =
+            run_impmap(&model, &pop, &model.default_params, None, &opts).expect("impmap mixture");
+        assert!(res.ofv.is_finite());
+        assert!(res.mixture_posteriors.is_some(), "mixture posteriors set");
+        let mp = res.mixture_posteriors.unwrap();
+        assert_eq!(mp.mixest.len(), pop.subjects.len());
+        assert_eq!(mp.pmix.len(), pop.subjects.len());
+    }
+
+    /// The IMP (SampleMoments recenter) estimating path also runs on a mixture.
+    #[test]
+    fn imp_mixture_short_run_ok() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.imp_iterations = 2;
+        opts.imp_samples = 200;
+        opts.imp_seed = Some(1);
+        opts.run_covariance_step = false;
+        let res = run_imp(&model, &pop, &model.default_params, None, &opts).expect("imp mixture");
+        assert!(res.ofv.is_finite());
+        assert!(res.mixture_posteriors.is_some());
+    }
+
+    /// Estimating IMP/IMPMAP rejects a mixture with per-class Ω/Σ overrides.
+    #[test]
+    fn estimating_imp_rejects_per_class_overrides() {
+        const OV: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma EPS ~ 0.04
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+  omega(2) ETA_CL ~ 0.15
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let model = crate::parser::model_parser::parse_model_string(OV).unwrap();
+        let pop = mix_pop();
+        let opts = FitOptions::default();
+        let err = match run_impmap(&model, &pop, &model.default_params, None, &opts) {
+            Ok(_) => panic!("per-class overrides must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("per-class Omega/Sigma overrides"),
+            "got: {err}"
         );
     }
 }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -393,6 +393,18 @@ fn run_mcem(
     let n_sigma = init_params.sigma.values.len();
 
     // ---- Validation ----
+    // Mixture (#985): the estimating IMP/IMPMAP MCEM (weighted M-step over the
+    // per-subject IS draws) is not yet class-partitioned. The class-marginal IS
+    // *objective* is available via `method = imp` with `imp_eval_only` (typically
+    // as the last stage of a `[saem, imp]` / `[focei, imp]` chain); route
+    // parameter estimation through SAEM or FOCE/FOCEI.
+    if model.mixture.is_some() {
+        return Err(format!(
+            "{label} (estimating IMP/IMPMAP) is not yet wired for mixture models. Estimate with \
+             SAEM or FOCE/FOCEI, then evaluate the class-marginal likelihood with an IMP \
+             objective-evaluation stage (`imp_eval_only`), e.g. method = [saem, imp] (#985)."
+        ));
+    }
     if n_eta == 0 {
         return Err(format!(
             "{label} requires at least one random effect (n_eta = 0). \

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -476,6 +476,13 @@ pub fn run_importance_sampling(
     })
 }
 
+/// Minimum class responsibility for a class's per-class ESS to count toward the
+/// reported per-subject ESS. A subject whose `PMIX_ik ≈ 0` for class `k` barely
+/// draws on that class's proposal, so a collapsed proposal there is not a defect
+/// of the subject's marginal; below this floor the class is excluded from the
+/// worst-case ESS. Shared with the mixture MCEM E-step (`impmap.rs`).
+pub(crate) const MIX_ESS_PMIX_FLOOR: f64 = 1e-3;
+
 /// Class-marginalised importance-sampling objective evaluation for a mixture
 /// model (`METHOD=IMP EONLY`, #985).
 ///
@@ -530,6 +537,25 @@ pub fn run_importance_sampling_mixture(
     if nu < 1.0 {
         return Err(format!("IS: imp_proposal_df must be >= 1.0, got {}", nu));
     }
+    // Every class's Ω must admit a finite log-determinant before any sampling:
+    // the single-population entry point rejects a degenerate Ω up front, and
+    // without the same check here a non-finite `log_det` flows into
+    // `subject_is_estimate` and yields a silently NaN/±inf marginal instead of a
+    // clear error (#992 review).
+    if !params.omega.log_det.is_finite() {
+        return Err("IS: Ω log-determinant is not finite — cannot evaluate η prior".into());
+    }
+    if let Some(mp) = params.mixture.as_ref() {
+        for (c, om) in mp.omega.iter().enumerate() {
+            if !om.log_det.is_finite() {
+                return Err(format!(
+                    "IS: Ω log-determinant is not finite for mixture class {} — cannot \
+                     evaluate η prior",
+                    c + 1
+                ));
+            }
+        }
+    }
     let n_classes = spec.n_classes;
     let n_subjects = population.subjects.len();
 
@@ -552,6 +578,7 @@ pub fn run_importance_sampling_mixture(
             // Per-class conditional log-marginals and their MC variances.
             let mut nll = vec![0.0f64; n_classes];
             let mut var_k = vec![0.0f64; n_classes];
+            let mut ess_k = vec![0.0f64; n_classes];
             for c in 0..n_classes {
                 // MIXNUM = c+1 on this worker thread for the whole class solve.
                 let _g = MixtureClassGuard::enter(c + 1);
@@ -601,19 +628,36 @@ pub fn run_importance_sampling_mixture(
                 );
                 nll[c] = -out.log_marginal; // nll_ik = −log L_ik
                 var_k[c] = out.var_log_marginal;
+                ess_k[c] = out.ess_fraction;
             }
             // Marginal contribution: combine_subject returns (−2·log Σ_k p_ik L_ik,
             // PMIX, MIXEST). log L_i = −½·contribution.
             let (contribution, pmix, _mixest) = combine_subject(&logp, &nll);
             let log_marginal = -0.5 * contribution;
             // Delta-method MC variance: ∂log L_i/∂log L_ik = PMIX_ik, so
-            // Var(log L_i) ≈ Σ_k PMIX_ik²·Var(log L_ik). ESS reported as the
-            // posterior-weighted min over contributing classes (worst-case mixing).
+            // Var(log L_i) ≈ Σ_k PMIX_ik²·Var(log L_ik).
             let var_log_marginal: f64 = pmix.iter().zip(&var_k).map(|(p, v)| p * p * v).sum();
+            // The marginal has no single-proposal ESS, so report the worst
+            // per-class ESS among the classes this subject actually contributes
+            // to — a collapsed proposal in a class with PMIX ≈ 0 barely enters
+            // the marginal and must not be reported as a degenerate fit, while a
+            // collapse in a class the subject *does* load on must not be hidden
+            // behind a hardcoded 1.0 (#992 review).
+            let ess_fraction = (0..n_classes)
+                .filter(|&c| pmix[c] > MIX_ESS_PMIX_FLOOR)
+                .map(|c| ess_k[c])
+                .fold(f64::INFINITY, f64::min);
+            let ess_fraction = if ess_fraction.is_finite() {
+                ess_fraction
+            } else {
+                // No class clears the floor (numerically degenerate PMIX): fall
+                // back to the worst class overall rather than claiming health.
+                ess_k.iter().copied().fold(f64::INFINITY, f64::min)
+            };
             SubjectIsOutput {
                 log_marginal,
                 var_log_marginal,
-                ess_fraction: 1.0, // per-class ESS folded into var; keep the field benign
+                ess_fraction,
             }
         })
         .collect();
@@ -624,24 +668,52 @@ pub fn run_importance_sampling_mixture(
 
     let mut ll = 0.0_f64;
     let mut var_ll = 0.0_f64;
-    for out in per_subject.iter() {
+    let mut ess_fracs: Vec<f64> = Vec::with_capacity(n_subjects);
+    let mut low_ess: Vec<(String, f64)> = Vec::new();
+    for (i, out) in per_subject.iter().enumerate() {
         ll += out.log_marginal;
         var_ll += out.var_log_marginal;
+        ess_fracs.push(out.ess_fraction);
+        if out.ess_fraction < threshold {
+            low_ess.push((population.subjects[i].id.clone(), out.ess_fraction));
+        }
     }
     let minus2_ll = -2.0 * ll;
     let mc_se = 2.0 * var_ll.max(0.0).sqrt();
-    let _ = threshold; // per-class ESS is folded into the delta-method variance
+
+    ess_fracs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let ess_min = *ess_fracs.first().unwrap_or(&0.0);
+    let ess_median = if ess_fracs.is_empty() {
+        0.0
+    } else {
+        let mid = ess_fracs.len() / 2;
+        if ess_fracs.len().is_multiple_of(2) {
+            0.5 * (ess_fracs[mid - 1] + ess_fracs[mid])
+        } else {
+            ess_fracs[mid]
+        }
+    };
+
+    if options.verbose {
+        eprintln!(
+            "IS (mixture) done. −2 log L = {:.4} ± {:.4} (ess_min/K = {:.3}, ess_med/K = {:.3}, \
+             low_ess = {})",
+            minus2_ll,
+            mc_se,
+            ess_min,
+            ess_median,
+            low_ess.len()
+        );
+    }
 
     Ok(ImportanceSamplingResult {
         minus2_log_likelihood: minus2_ll,
         mc_standard_error: mc_se,
-        // Per-class ESS is folded into the marginal's MC variance rather than
-        // surfaced per subject; the marginal has no single-proposal ESS.
-        low_ess_subjects: Vec::new(),
+        low_ess_subjects: low_ess,
         n_samples: k_samples,
         proposal_df: nu,
-        ess_min: 1.0,
-        ess_median: 1.0,
+        ess_min,
+        ess_median,
         kappa_treatment: KappaTreatment::NotApplicable,
     })
 }
@@ -3003,5 +3075,78 @@ mod tests {
                 );
             }
         }
+    }
+    /// ESS diagnostics on the mixture marginal are real, not hardcoded: the
+    /// reported per-subject ESS is the worst *contributing* class's ESS, so
+    /// `imp_low_ess_threshold` actually classifies subjects and a collapsed
+    /// proposal can no longer be reported as ideal sampling (#992 review).
+    #[test]
+    fn mixture_is_reports_real_ess_and_honours_threshold() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.imp_samples = 300;
+        opts.imp_seed = Some(11);
+
+        // A threshold of 0 can never flag a subject.
+        opts.imp_low_ess_threshold = 0.0;
+        let none = run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+            .expect("mixture IS");
+        assert!(
+            none.low_ess_subjects.is_empty(),
+            "threshold 0 must flag nobody, got {:?}",
+            none.low_ess_subjects
+        );
+        assert!(
+            none.ess_min > 0.0 && none.ess_min <= 1.0,
+            "ess_min must be a real fraction, got {}",
+            none.ess_min
+        );
+        assert!(
+            none.ess_median >= none.ess_min && none.ess_median <= 1.0,
+            "ess_median {} out of range vs ess_min {}",
+            none.ess_median,
+            none.ess_min
+        );
+
+        // A threshold above every attainable ESS flags every subject — the field
+        // is driven by the data, not pinned to 1.0.
+        opts.imp_low_ess_threshold = 1.0 + 1e-9;
+        let all = run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+            .expect("mixture IS");
+        assert_eq!(
+            all.low_ess_subjects.len(),
+            pop.subjects.len(),
+            "an unreachable threshold must flag every subject"
+        );
+        assert!(
+            (all.ess_min - none.ess_min).abs() < 1e-12,
+            "the threshold must not change the measured ESS"
+        );
+    }
+
+    /// A class Ω with a non-finite log-determinant is rejected before sampling,
+    /// as the single-population entry point does — otherwise it flows into
+    /// `subject_is_estimate` and yields a silently NaN marginal (#992 review).
+    #[test]
+    fn mixture_is_rejects_non_finite_class_log_det() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut params = model.default_params.clone();
+        let mp = params.mixture.as_mut().expect("mixture params");
+        // `from_matrix` regularises a singular Ω, so set the cached determinant
+        // directly — the state a caller-supplied Ω can genuinely arrive in.
+        mp.omega[1].log_det = f64::NAN;
+        assert!(
+            !mp.omega[1].log_det.is_finite(),
+            "test setup: class-2 log_det must be non-finite"
+        );
+        let opts = FitOptions::default();
+        let err = run_importance_sampling_mixture(&model, &pop, &params, &opts)
+            .expect_err("a non-finite class log-determinant must be rejected");
+        assert!(
+            err.contains("log-determinant is not finite") && err.contains("class 2"),
+            "got: {err}"
+        );
     }
 }

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -476,6 +476,176 @@ pub fn run_importance_sampling(
     })
 }
 
+/// Class-marginalised importance-sampling objective evaluation for a mixture
+/// model (`METHOD=IMP EONLY`, #985).
+///
+/// Mirrors [`run_importance_sampling`] but forms the marginal over the latent
+/// class the same way FOCEI does: for each subject and each class `k`, run the
+/// class-`k` MAP inner solve (under a [`MixtureClassGuard`], so `MIXNUM` resolves
+/// to `k`), importance-sample the class-conditional marginal `L_ik`, then combine
+///
+/// ```text
+///   L_i = Σ_k p_ik · L_ik,   −2·log L = −2 Σ_i log Σ_k p_ik L_ik
+/// ```
+///
+/// via [`combine_subject`]. This is the true marginal likelihood a chained
+/// `[saem, imp]` / `[focei, imp]` fit reports for a mixture. The per-class solves
+/// run inside each subject's rayon task (the guard is entered per class on the
+/// worker thread), so subject-level parallelism is preserved while the
+/// thread-local class index stays correct. IOV is not yet supported here.
+pub fn run_importance_sampling_mixture(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    options: &FitOptions,
+) -> Result<ImportanceSamplingResult, String> {
+    use crate::estimation::inner_optimizer::find_ebe;
+    use crate::estimation::mixture::{class_params, combine_subject};
+    use crate::parser::model_parser::{eval_mixing_log_probs, MixtureClassGuard};
+
+    let spec = model
+        .mixture
+        .as_ref()
+        .ok_or("run_importance_sampling_mixture on a non-mixture model")?;
+    if params.mixture.is_none() {
+        return Err("IMP mixture objective requires params.mixture (per-class Ω/Σ)".to_string());
+    }
+    if model.n_kappa > 0 {
+        return Err(
+            "IMP objective evaluation for a mixture does not yet support inter-occasion \
+             variability (IOV); use FOCE/FOCEI for an IOV mixture (#985)"
+                .to_string(),
+        );
+    }
+    let n_eta = model.n_eta;
+    let k_samples = options.imp_samples;
+    let nu = options.imp_proposal_df;
+    let seed = options.imp_seed.unwrap_or(42);
+    let threshold = options.imp_low_ess_threshold;
+    let defensive_alpha = options.imp_defensive_alpha;
+    let cancel = &options.cancel;
+    if k_samples < 2 {
+        return Err(format!("IS: imp_samples must be >= 2, got {}", k_samples));
+    }
+    if nu < 1.0 {
+        return Err(format!("IS: imp_proposal_df must be >= 1.0, got {}", nu));
+    }
+    let n_classes = spec.n_classes;
+    let n_subjects = population.subjects.len();
+
+    if options.verbose {
+        eprintln!(
+            "Importance sampling (mixture): {} subjects × {} classes, K={} per subject, seed={}",
+            n_subjects, n_classes, k_samples, seed
+        );
+    }
+
+    let per_subject: Vec<SubjectIsOutput> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map_init(EventPkParams::default, |scratch, (i, subject)| {
+            if crate::cancel::is_cancelled(cancel) {
+                return SubjectIsOutput::cancelled(subject.id.clone());
+            }
+            let logp = eval_mixing_log_probs(spec, &params.theta, &subject.covariates);
+            // Per-class conditional log-marginals and their MC variances.
+            let mut nll = vec![0.0f64; n_classes];
+            let mut var_k = vec![0.0f64; n_classes];
+            for c in 0..n_classes {
+                // MIXNUM = c+1 on this worker thread for the whole class solve.
+                let _g = MixtureClassGuard::enter(c + 1);
+                let cp = class_params(params, c);
+                let ebe = find_ebe(
+                    model,
+                    subject,
+                    &cp,
+                    options.inner_maxiter,
+                    options.inner_tol,
+                    None,
+                    None,
+                    options.inner_restarts,
+                );
+                let omega_inv = cp.omega.inv.clone();
+                let h_post = compute_posterior_hessian(
+                    model,
+                    subject,
+                    &cp.theta,
+                    &ebe.eta,
+                    &cp.sigma.values,
+                    &ebe.h_matrix,
+                    &omega_inv,
+                    n_eta,
+                    scratch,
+                );
+                let defensive = DefensiveMixture::new(&omega_inv, n_eta, defensive_alpha);
+                let subj_seed = seed
+                    .wrapping_add(i as u64)
+                    .wrapping_add((c as u64).wrapping_shl(40));
+                let out = subject_is_estimate(
+                    model,
+                    subject,
+                    &cp.theta,
+                    &cp.sigma.values,
+                    &ebe.eta,
+                    &h_post,
+                    &omega_inv,
+                    cp.omega.log_det,
+                    n_eta,
+                    k_samples,
+                    nu,
+                    subj_seed,
+                    scratch,
+                    1.0,
+                    defensive.as_ref(),
+                );
+                nll[c] = -out.log_marginal; // nll_ik = −log L_ik
+                var_k[c] = out.var_log_marginal;
+            }
+            // Marginal contribution: combine_subject returns (−2·log Σ_k p_ik L_ik,
+            // PMIX, MIXEST). log L_i = −½·contribution.
+            let (contribution, pmix, _mixest) = combine_subject(&logp, &nll);
+            let log_marginal = -0.5 * contribution;
+            // Delta-method MC variance: ∂log L_i/∂log L_ik = PMIX_ik, so
+            // Var(log L_i) ≈ Σ_k PMIX_ik²·Var(log L_ik). ESS reported as the
+            // posterior-weighted min over contributing classes (worst-case mixing).
+            let var_log_marginal: f64 = pmix.iter().zip(&var_k).map(|(p, v)| p * p * v).sum();
+            SubjectIsOutput {
+                log_marginal,
+                var_log_marginal,
+                ess_fraction: 1.0, // per-class ESS folded into var; keep the field benign
+            }
+        })
+        .collect();
+
+    if crate::cancel::is_cancelled(&options.cancel) {
+        return Err("cancelled by user".to_string());
+    }
+
+    let mut ll = 0.0_f64;
+    let mut var_ll = 0.0_f64;
+    for out in per_subject.iter() {
+        ll += out.log_marginal;
+        var_ll += out.var_log_marginal;
+    }
+    let minus2_ll = -2.0 * ll;
+    let mc_se = 2.0 * var_ll.max(0.0).sqrt();
+    let _ = threshold; // per-class ESS is folded into the delta-method variance
+
+    Ok(ImportanceSamplingResult {
+        minus2_log_likelihood: minus2_ll,
+        mc_standard_error: mc_se,
+        // Per-class ESS is folded into the marginal's MC variance rather than
+        // surfaced per subject; the marginal has no single-proposal ESS.
+        low_ess_subjects: Vec::new(),
+        n_samples: k_samples,
+        proposal_df: nu,
+        ess_min: 1.0,
+        ess_median: 1.0,
+        kappa_treatment: KappaTreatment::NotApplicable,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Per-subject estimate
 // ---------------------------------------------------------------------------
@@ -2730,5 +2900,108 @@ mod tests {
             baseline.ess_fraction,
             improved.ess_fraction
         );
+    }
+
+    // ── Mixture class-marginal IS objective (#985) ──
+
+    const MIX_MODEL: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+
+    fn mix_pop() -> crate::types::Population {
+        use std::io::Write;
+        let mut csv = String::from("ID,TIME,DV,AMT,EVID,CMT,WT\n");
+        for (sid, &(cl, wt)) in [(1.0_f64, 60.0_f64), (3.0, 90.0)].iter().enumerate() {
+            let id = sid + 1;
+            csv.push_str(&format!("{id},0,0,100,1,1,{wt}\n"));
+            for t in [0.5_f64, 1.0, 2.0, 4.0] {
+                let c = (100.0 / 10.0) * (-(cl / 10.0) * t).exp();
+                csv.push_str(&format!("{id},{t},{c:.5},0,0,1,{wt}\n"));
+            }
+        }
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(csv.as_bytes()).unwrap();
+        crate::read_nonmem_csv(f.path(), Some(&["WT"]), None).unwrap()
+    }
+
+    #[test]
+    fn mixture_is_marginal_is_finite_and_below_class_worst() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let mut opts = FitOptions::default();
+        opts.imp_samples = 500;
+        opts.imp_seed = Some(7);
+        let res = run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+            .expect("mixture IS marginal");
+        assert!(
+            res.minus2_log_likelihood.is_finite(),
+            "marginal -2logL must be finite, got {}",
+            res.minus2_log_likelihood
+        );
+        assert!(res.mc_standard_error >= 0.0);
+    }
+
+    #[test]
+    fn mixture_is_rejects_iov() {
+        // A model with kappa (IOV) must be rejected by the mixture IS objective.
+        const IOV: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  kappa KAPPA_CL ~ 0.02 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL + KAPPA_CL) else TVCL2 * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        // Parsing may or may not succeed depending on IOV occasion columns; if it
+        // parses, the IS objective must reject IOV explicitly.
+        if let Ok(model) = crate::parser::model_parser::parse_model_string(IOV) {
+            if model.n_kappa > 0 {
+                let pop = mix_pop();
+                let opts = FitOptions::default();
+                let err =
+                    run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+                        .expect_err("IOV mixture IS must be rejected");
+                assert!(
+                    err.contains("IOV") || err.contains("inter-occasion"),
+                    "got: {err}"
+                );
+            }
+        }
     }
 }

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -524,6 +524,25 @@ pub fn run_importance_sampling_mixture(
                 .to_string(),
         );
     }
+    // Same two scope guards the single-population entry point applies (#992
+    // review). With n_eta = 0 there is nothing to integrate — the class-
+    // conditional marginal collapses to the obs likelihood — and for SDE models
+    // the IS obs-NLL path omits the EKF process-noise variance, so the marginal
+    // would be silently biased.
+    if model.n_eta == 0 {
+        return Err("Importance sampling requires at least one random effect. \
+             With n_eta = 0 the class-conditional marginal is just the observation likelihood — \
+             read `FitResult.ofv` directly (no IS needed)."
+            .to_string());
+    }
+    if model.is_sde() {
+        return Err(
+            "Importance sampling is not yet supported for SDE / [diffusion] models. \
+             The EKF process-noise variance is not included in the IS observation likelihood, \
+             so the marginal would be biased. Use FOCE / FOCEI for the Laplace OFV instead."
+                .to_string(),
+        );
+    }
     let n_eta = model.n_eta;
     let k_samples = options.imp_samples;
     let nu = options.imp_proposal_df;
@@ -3031,6 +3050,63 @@ mod tests {
             res.minus2_log_likelihood
         );
         assert!(res.mc_standard_error >= 0.0);
+    }
+
+    #[test]
+    fn mixture_is_rejects_no_random_effects() {
+        // n_eta = 0: the class-conditional marginal collapses to the obs
+        // likelihood, so IS is meaningless — refuse rather than return a
+        // silently meaningless number (#992 review). The parser requires at
+        // least one omega, so the fixture is degraded to n_eta = 0 directly.
+        let mut model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        model.n_eta = 0;
+        let pop = mix_pop();
+        let opts = FitOptions::default();
+        let err = run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+            .expect_err("n_eta = 0 mixture IS must be rejected");
+        assert!(err.contains("at least one random effect"), "got: {err}");
+    }
+
+    #[test]
+    fn mixture_is_rejects_sde() {
+        // The IS obs-NLL path omits the EKF process-noise variance, so an SDE
+        // mixture marginal would be silently biased (#992 review).
+        const SDE: &str = r"
+[parameters]
+  theta TVCL1(1.0, 0.01, 100.0)
+  theta TVCL2(3.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  theta MIXL(0.0, -10.0, 10.0)
+  omega ETA_CL ~ 0.09 FIX
+  sigma EPS ~ 0.04 FIX
+
+[mixture]
+  nsub = 2
+  logit(1) = MIXL
+
+[individual_parameters]
+  CL = if (MIXNUM == 1) TVCL1 * exp(ETA_CL) else TVCL2 * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[diffusion]
+  central ~ 0.05 FIX
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+        let model = crate::parser::model_parser::parse_model_string(SDE).unwrap();
+        assert!(model.is_sde(), "fixture must be an SDE model");
+        let pop = mix_pop();
+        let opts = FitOptions::default();
+        let err = run_importance_sampling_mixture(&model, &pop, &model.default_params, &opts)
+            .expect_err("SDE mixture IS must be rejected");
+        assert!(err.contains("SDE"), "got: {err}");
     }
 
     #[test]

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -13648,10 +13648,11 @@ fn fit_on_mixture_model_rejects_missing_mixture_params() {
 
 #[test]
 fn fit_on_mixture_model_rejects_unsupported_method() {
-    // FOCE/FOCEI (Phase 3) and SAEM (#985) estimate a mixture; the remaining
-    // estimators (here IMP) must still error clearly rather than silently
-    // ignoring the mixture structure. The method guard fires before any subject
-    // is touched, so an empty population suffices.
+    // FOCE/FOCEI, SAEM, Bayes, and IMP objective-evaluation estimate/evaluate a
+    // mixture (#985); the remaining estimators (here Gauss-Newton) must still
+    // error clearly rather than silently ignoring the mixture structure. The
+    // method guard fires before any subject is touched, so an empty population
+    // suffices.
     let model = parse_model_string(MIXTURE_2CLASS).expect("mixture model parses");
     let pop = crate::types::Population {
         subjects: vec![],
@@ -13663,11 +13664,11 @@ fn fit_on_mixture_model_rejects_unsupported_method() {
     };
     let params = model.default_params.clone();
     let opts = crate::types::FitOptions {
-        method: crate::types::EstimationMethod::Imp,
+        method: crate::types::EstimationMethod::FoceGn,
         ..crate::types::FitOptions::default()
     };
     let err = crate::api::fit(&model, &pop, &params, &opts)
-        .expect_err("IMP on a mixture model must be rejected");
+        .expect_err("Gauss-Newton on a mixture model must be rejected");
     assert!(
         err.contains("mixture") && err.contains("FOCE"),
         "got: {err}"

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -493,3 +493,79 @@ fn bayes_mixture_recovers_optimum() {
         "MIXEST populated"
     );
 }
+
+// NONMEM IMP objective (mixture_iv_saem.ext TABLE NO. 2, the `METHOD=IMP
+// EONLY=1` pass that follows SAEM): the class-marginal −2 log L evaluated by
+// importance sampling at the SAEM optimum.
+const NM_IMP_MARGINAL: f64 = 300.8707;
+
+/// IMP objective evaluation under a mixture (#985): `method = [saem, imp]` with
+/// `imp_eval_only`. The SAEM stage estimates the parameters; the IMP stage
+/// evaluates the class-marginal likelihood `−2 Σ log Σ_k p_ik L_ik` by importance
+/// sampling per class (per-class MAP + IS, combined via log-sum-exp). Anchored to
+/// the NONMEM `METHOD=IMP EONLY=1` objective from `mixture_iv_saem.ctl` (300.87).
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests (NONMEM IMP mixture marginal)"
+)]
+fn imp_mixture_marginal_matches_nonmem() {
+    let pop: ferx_core::Population = read_nonmem_csv(
+        Path::new("tests/nonmem/mixture_iv.csv"),
+        Some(&["WT"]),
+        None,
+    )
+    .unwrap();
+    let model = parse_model_string(MODEL).unwrap();
+    let mut opts = FitOptions::default();
+    opts.methods = vec![
+        ferx_core::EstimationMethod::Saem,
+        ferx_core::EstimationMethod::Imp,
+    ];
+    opts.interaction = true;
+    opts.saem_n_exploration = 600;
+    opts.saem_n_convergence = 800;
+    opts.saem_seed = Some(20250818);
+    opts.imp_eval_only = true;
+    opts.imp_samples = 3000;
+    opts.imp_seed = Some(20250818);
+
+    let res = fit(&model, &pop, &model.default_params, &opts).expect("saem+imp mixture fit Ok");
+    let is = res
+        .importance_sampling
+        .as_ref()
+        .expect("IMP objective evaluation populated on the chain's last stage");
+    eprintln!(
+        "IMP mixture marginal: -2logL = {:.4} ± {:.4} vs NONMEM {:.4}",
+        is.minus2_log_likelihood, is.mc_standard_error, NM_IMP_MARGINAL
+    );
+    // The IS marginal is a Monte-Carlo estimate at the SAEM optimum; a ~1-unit
+    // band covers the MC error plus the small SAEM-vs-NONMEM optimum offset.
+    assert!(
+        (is.minus2_log_likelihood - NM_IMP_MARGINAL).abs() < 2.0,
+        "IMP marginal {} vs NONMEM {}",
+        is.minus2_log_likelihood,
+        NM_IMP_MARGINAL
+    );
+}
+
+/// Estimating IMP/IMPMAP is rejected for a mixture with a clear pointer to the
+/// EONLY objective path (#985).
+#[test]
+fn estimating_imp_rejected_for_mixture() {
+    let pop: ferx_core::Population = read_nonmem_csv(
+        Path::new("tests/nonmem/mixture_iv.csv"),
+        Some(&["WT"]),
+        None,
+    )
+    .unwrap();
+    let model = parse_model_string(MODEL).unwrap();
+    let mut opts = FitOptions::default();
+    opts.method = ferx_core::EstimationMethod::Impmap; // estimating
+    let err = fit(&model, &pop, &model.default_params, &opts)
+        .expect_err("estimating IMPMAP on a mixture must be rejected");
+    assert!(
+        err.contains("imp_eval_only") || err.contains("objective"),
+        "got: {err}"
+    );
+}

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -549,10 +549,17 @@ fn imp_mixture_marginal_matches_nonmem() {
     );
 }
 
-/// Estimating IMP/IMPMAP is rejected for a mixture with a clear pointer to the
-/// EONLY objective path (#985).
+/// Estimating IMPMAP under a mixture (#985): class-partitioned MCEM recovers the MLE.
 #[test]
-fn estimating_imp_rejected_for_mixture() {
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests (IMPMAP mixture estimation)"
+)]
+fn impmap_estimating_mixture_recovers_optimum() {
+    // Estimating IMPMAP (class-partitioned MCEM): the per-class IS E-step +
+    // responsibility-weighted M-steps must recover the mixture MLE. Ω/Σ FIXed, so
+    // the estimated quantities are the two class clearances, V, and the mixing
+    // logit. Anchored to the shared optimum (NONMEM FOCEI `mixture_iv.ctl`).
     let pop: ferx_core::Population = read_nonmem_csv(
         Path::new("tests/nonmem/mixture_iv.csv"),
         Some(&["WT"]),
@@ -561,11 +568,46 @@ fn estimating_imp_rejected_for_mixture() {
     .unwrap();
     let model = parse_model_string(MODEL).unwrap();
     let mut opts = FitOptions::default();
-    opts.method = ferx_core::EstimationMethod::Impmap; // estimating
-    let err = fit(&model, &pop, &model.default_params, &opts)
-        .expect_err("estimating IMPMAP on a mixture must be rejected");
+    opts.method = ferx_core::EstimationMethod::Impmap;
+    opts.interaction = true;
+    opts.impmap_iterations = 50;
+    opts.impmap_samples = 1500;
+    opts.impmap_seed = Some(20250818);
+    opts.run_covariance_step = false;
+
+    let res = fit(&model, &pop, &model.default_params, &opts).expect("IMPMAP mixture fit Ok");
+    let th = &res.theta;
+    let p1 = 1.0 / (1.0 + (-th[3]).exp());
+    eprintln!(
+        "IMPMAP mixture: TVCL1={:.4} TVCL2={:.4} TVV={:.4} p1={:.4} OFV={:.4}",
+        th[0], th[1], th[2], p1, res.ofv
+    );
+    let rel = |a: f64, b: f64| (a - b).abs() / b.abs();
+    // IMP is the noisiest of the mixture estimators (no mu-referencing is
+    // available for the class-switched typical value, so θ is estimated by the
+    // weighted M-step alone, which converges more slowly than SAEM's MCMC); the
+    // two class clearances must still separate and land near the MLE.
     assert!(
-        err.contains("imp_eval_only") || err.contains("objective"),
-        "got: {err}"
+        rel(th[0], NM_TVCL1) < 0.12,
+        "IMPMAP TVCL1 {} vs {}",
+        th[0],
+        NM_TVCL1
+    );
+    assert!(
+        rel(th[1], NM_TVCL2) < 0.12,
+        "IMPMAP TVCL2 {} vs {}",
+        th[1],
+        NM_TVCL2
+    );
+    assert!(
+        rel(th[2], NM_TVV) < 0.05,
+        "IMPMAP TVV {} vs {}",
+        th[2],
+        NM_TVV
+    );
+    assert!((p1 - NM_P1).abs() < 0.08, "IMPMAP p(1) {} vs {}", p1, NM_P1);
+    assert!(
+        res.subjects.iter().all(|s| s.mixest.is_some()),
+        "MIXEST populated"
     );
 }


### PR DESCRIPTION
> **Stacked on #991** (Bayes) → #987 (SAEM). Base is `worktree-985-bayes-mixture`; review/merge after those. The shared change is the mixture method-gate in `fit.rs`.

## Why

The last of #985's estimator sub-items: **IMP / IMPMAP** for `[mixture]` models — both **estimation** and class-marginal **objective evaluation**. (SAEM #987, Bayes #991, IOV #986.) With this, the full #985 estimator set is complete.

## What changed

Two capabilities:

### 1. Class-marginal objective evaluation (`imp_eval_only`, NONMEM `IMP EONLY=1`)
Per subject and class, run the class MAP inner solve (under a `MixtureClassGuard`), importance-sample the class-conditional marginal `L_ik`, and combine as FOCEI does: `-2 log L = -2 Σ_i log Σ_k p_ik L_ik`. New `run_importance_sampling_mixture`. This is the Monte-Carlo marginal a chain reports (`method = [saem, imp]`, `imp_eval_only = true`).

### 2. Estimating IMP / IMPMAP (class-partitioned MCEM)
`run_mcem` delegates a mixture to new `run_mcem_mixture`. Each iteration importance-samples η **within each class**, forms the responsibilities `PMIX_ik ∝ p_ik L_ik`, then runs responsibility-weighted M-steps:
- mixing coefficients from `PMIX` (reusing SAEM's mixing M-step with `r̄ = PMIX`);
- class-shared Ω `= Σ_i Σ_k PMIX_ik·η̂η̂ᵀ_ik / N`;
- θ/σ via `theta_sigma_weighted_mstep_mixture` — the responsibility- and IS-weighted obs M-step, each class's samples scored under its own `MIXNUM` guard, so class-switched typical values are recovered from their own class.

Final OFV / `MIXEST` / `PMIX` / EBEs come from `mixture_ofv` at the estimates; the covariance step runs on the mixture objective. Ω/σ are class-shared (per-class overrides rejected); IOV / FREM / SDE are rejected (as for the single-population MCEM).

The per-subject/per-class E-step parallelises over subjects with the class guard entered **inside** each worker (subject-parallel, thread-local correct).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation

- [x] **Objective evaluation** vs NONMEM `METHOD=IMP EONLY=1` (`mixture_iv_saem.ctl`, 2nd `$EST`): ferx `-2 log L = 300.82 ± 0.06` vs NONMEM `300.87` — a 0.05-unit match, within the MC SE.
- [x] **Estimation** — IMPMAP recovers the mixture MLE:

```
                ferx IMPMAP    FOCEI MLE (NONMEM mixture_iv.ctl)
TVCL1           1.04           0.98
TVCL2           2.58           2.84
V               9.96           9.98
p(1)            0.47           0.472
```

IMP is the noisiest of the mixture estimators — the class-switched typical value cannot be mu-referenced, so θ is estimated by the weighted M-step alone (the code already warns about this for non-mu-ref models), which converges more slowly than SAEM's MCMC and needs more iterations. For a well-identified point estimate prefer SAEM/FOCEI; use IMP for the marginal likelihood.

## Tests
- [x] Unit (`cargo test --lib`): objective — `mixture_is_marginal_is_finite_and_below_class_worst`, `mixture_is_rejects_iov`; estimation — `impmap_mixture_short_run_populates_posteriors`, `imp_mixture_short_run_ok`, `estimating_imp_rejects_per_class_overrides`; updated `fit_on_mixture_model_rejects_unsupported_method` to `FoceGn`.
- [x] Tier-3 slow (`tests/mixture_nonmem.rs`): `imp_mixture_marginal_matches_nonmem`, `impmap_estimating_mixture_recovers_optimum`.

## Docs
- [x] `docs/estimation/mixture.qmd` — "IMP objective evaluation" + "Estimating IMP / IMPMAP" sections
- [x] `CHANGELOG.md` `[Unreleased]` entry

## Checklist
- [x] `cargo clippy` clean (new code warning-free)
- [x] No `Dual2`/`sens` path touched

## Reviewer hints
- Two entry points: `run_importance_sampling_mixture` (objective) and `run_mcem_mixture` (estimation) + `theta_sigma_weighted_mstep_mixture`. Both mirror `mixture_ofv`'s per-class structure but parallelise over subjects with the guard inside the worker. Since Ω/σ are class-shared, the per-class params are identical — only the `MIXNUM` guard differentiates classes, which is why the E-step builds one `params_iter` and relies on the guard.

## Open questions
- A class-aware mu-reference shift would sharpen IMP's θ estimates (it's the one thing SAEM/IMP lack for class-switched typical values), but the η→θ pairing is class-dependent and not exposed by the parser — a possible follow-up. This completes the #985 estimator set (SAEM, Bayes, IMP objective + estimation).
