### PR TITLE
fix(estimation): recover a runaway inner EBE instead of certifying it [closes #958]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,21 @@ section of the SDLC for the versioning policy).
   unchanged (#971).
 
 ### Fixed
+- **Inner EBE no longer certifies a runaway mode, so the FOCE/FOCEI objective is
+  gradient-path-independent (#958).** On a model where a prediction is driven toward zero under
+  proportional error, that observation's variance is clamped to the floor and its residual term
+  amplifies the ODE solver's local error by ~1e8 — enough for the *finite-difference* inner
+  gradient to come back with the wrong sign. The inner search then walked tens of prior SDs away
+  from η = 0 and accepted the point it landed on, because a noise-driven search satisfies the
+  objective-stall convergence test exactly like a converged one. `gradient = fd` and
+  `gradient = auto` therefore reported different objectives for the same model at the same
+  estimates, which made ΔOFV/ΔAIC model selection depend on the gradient route. The inner loop now
+  re-solves derivative-free from the prior mean whenever the returned EBE's Mahalanobis distance
+  `ηᵀΩ⁻¹η` exceeds 10 prior SDs per random effect, and keeps whichever point has the lower
+  objective. On the reported reproducer the first-evaluation objective goes from `fd` 6082.24 /
+  `auto` −5.478 to −5.479 / −5.478, and both routes now recover the simulating parameters. The
+  analytic (`Dual2`) sensitivities were correct throughout — verified against finite differences of
+  the predictor to 2.6e-7 — so `gradient = auto`, the default, was never affected.
 - **Per-subject diagnostics now honour `MIXEST` in a mixture fit (#985).** `IPRED`, `PRED`,
   `IWRES`, `CWRES`, `EBE_OFV`, and `[derived]`/`[output]` columns were computed with `MIXNUM`
   pinned to class 1 for every subject, even for subjects the fit assigned to another class — so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ section of the SDLC for the versioning policy).
   `auto` −5.478 to −5.479 / −5.478, and both routes now recover the simulating parameters. The
   analytic (`Dual2`) sensitivities were correct throughout — verified against finite differences of
   the predictor to 2.6e-7 — so `gradient = auto`, the default, was never affected.
+- **`gradient` option error no longer advertises the retired `ad` route (#958).** The parse-time
+  message for an unknown `gradient` value listed `'auto'`, `'ad'`, or `'fd'`, but no fit accepts
+  `ad` — the Enzyme automatic-differentiation path was retired in #428 and the engine rejects it —
+  so a mistyped option pointed users at a setting that cannot work. The message now lists only
+  `'auto'` and `'fd'`. Writing `gradient = ad` still parses, so it continues to reach the engine's
+  specific "no longer supported" error rather than a generic one.
 - **Per-subject diagnostics now honour `MIXEST` in a mixture fit (#985).** `IPRED`, `PRED`,
   `IWRES`, `CWRES`, `EBE_OFV`, and `[derived]`/`[output]` columns were computed with `MIXNUM`
   pinned to class 1 for every subject, even for subjects the fit assigned to another class — so a

--- a/docs/estimation/foce.qmd
+++ b/docs/estimation/foce.qmd
@@ -53,6 +53,30 @@ This `gradient:` line appears for gradient-driven estimators (FOCE/FOCEI/GN) and
 
 If the EBE search wanders into a region where the individual NLL evaluates to a non-finite value (for example, an ODE model whose integration blows up at extreme $\eta$), that point is treated as the worst possible objective rather than aborting the fit. The subject is reported as non-converged and estimation continues for the remaining subjects.
 
+**Runaway EBEs are re-checked (#958).** A subject's inner search can be led somewhere its
+own objective does not actually have a minimum, and then stop there: once the steps are noise
+rather than descent the objective stops improving and the gradient norm plateaus, which is
+exactly what the convergence test looks for. The usual cause is a **finite-difference** inner
+gradient on an objective whose value carries the ODE solver's local error. That error is
+normally far below the signal being differenced, but a prediction driven toward zero under a
+proportional error model has its residual variance clamped to the floor, and the resulting
+`(y − f)² / R` term amplifies solver noise by many orders of magnitude — enough for the FD
+gradient to come back with the wrong sign. No FD step size repairs that: too small and it is
+noise, too large and it truncates on a very curved objective.
+
+So whenever the returned η̂ sits further than about ten prior standard deviations per random
+effect from the prior mean (measured as `ηᵀΩ⁻¹η`, the prior's own metric), the inner loop
+re-solves derivative-free from the prior mean and keeps whichever point has the **lower**
+objective. The check can only improve the objective — a genuinely extreme EBE that a
+derivative-free search cannot beat is the objective's own minimum and is returned unchanged —
+so fits whose inner loop was already right are unaffected.
+
+The practical guidance is unchanged: leave `gradient_method` at its default `auto`. The
+analytic route differentiates the *same* integration it predicts from, so it has no
+differencing step to be swamped and is immune to this failure mode; `gradient_method = fd` on
+a model with near-zero predictions is accuracy-limited by `ode_abstol`, not by the step size.
+
+
 ### Gradient accuracy vs cost (reconverged EBEs)
 
 By default the population gradient holds each subject's EBEs ($\hat\eta$) and FOCE Hessian fixed while perturbing the population parameters — the *fixed-EBE* gradient. This is cheap, but it omits the response of the inner solution to $\theta$ and $\Omega$. On well-conditioned problems that omitted term is negligible and a gradient optimizer matches the derivative-free `bobyqa` (see [Outer Optimizers](optimizers.qmd)). On **ill-conditioned** problems it is not: the omitted term is what separates a true descent direction from a flat-looking plateau, and `slsqp` can report `converged` at an OFV far above the `bobyqa` optimum — which is exactly why the default `optimizer = auto` falls back to `bobyqa` on the FD-only fits where this bias bites.

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -913,7 +913,7 @@ pub fn find_ebe(
     //     mis-center the FREM/IMP proposal, so recover with NM from η=0 (or the warm partial)
     //     exactly as prior releases — bit-identical for analytical/FREM fits.
     let bfgs_converged = result;
-    let (nm_converged, used_fallback) = if !bfgs_converged {
+    let (nm_converged, mut used_fallback) = if !bfgs_converged {
         let partial = eta.clone();
         let cold = vec![0.0; n_eta];
         if enable_stall {
@@ -1021,6 +1021,60 @@ pub fn find_ebe(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // ── Runaway-EBE guard (#958) ───────────────────────────────────────────
+    // A gradient the search cannot trust can march the inner BFGS tens of prior
+    // SDs away from η = 0 and then *certify* the point it lands on: the objective
+    // stops improving (the steps are noise, not descent) and the gradient norm
+    // plateaus, which is exactly the objective-stall stop's acceptance condition
+    // (#555). Nothing downstream re-checks the result, so the subject contributes
+    // a mode that is not a mode to the FOCE/FOCEI objective, and the reported OFV
+    // becomes gradient-path-dependent.
+    //
+    // The trigger is not exotic. Finite-difference inner gradients difference an
+    // objective whose value carries the ODE solver's local error (~`ode_abstol`),
+    // amplified in the residual term by `1/R`. Once a prediction is driven toward
+    // zero under a proportional error model, `R` hits `MIN_VARIANCE` (1e-12) while
+    // the noise stays at `ode_abstol` (1e-9 by default), so the differenced signal
+    // is ~1e8 × smaller than the noise riding on it and the FD gradient can come
+    // back with the wrong *sign*. No FD step size repairs that — too small and it
+    // is noise, too large and it truncates on a very curved objective — so the
+    // inner loop needs a correctness backstop rather than a better step.
+    //
+    // `ηᵀΩ⁻¹η` is the natural detector: it is the prior's own metric (χ²(n_eta) at
+    // the truth), it is scale-free, and it is already what the objective penalises.
+    // The threshold is deliberately far out — [`RUNAWAY_EBE_MAHA_PER_ETA`] is 10
+    // prior SDs per random effect — so a merely-unusual subject never trips it and
+    // every fit whose EBEs are plausible stays bit-identical.
+    //
+    // Recovery is Nelder–Mead from the prior mean: derivative-free, so it is immune
+    // to the noise that produced the runaway in the first place (the objective's
+    // *value* is fine — only its finite difference is not).
+    //
+    // The guard is deliberately **strictly objective-improving**: it swaps in the
+    // recovered point only when that point has a lower objective, and it leaves the
+    // convergence flag alone otherwise. A far-out EBE is not by itself proof of a
+    // numerical artifact — a grossly misspecified subject can have its true posterior
+    // mode tens of prior SDs out, and if a derivative-free search from the prior mean
+    // cannot beat that point then it *is* the objective's minimum and there is no
+    // evidence against it. So a distance check alone never demotes a result or
+    // rewrites one; only actually finding something better does. That keeps every fit
+    // whose inner loop was already right bit-identical, whether its EBEs are plausible
+    // or merely extreme.
+    let runaway_limit = RUNAWAY_EBE_MAHA_PER_ETA * n_eta as f64;
+    if ebe_prior_maha(&eta, &params.omega) > runaway_limit {
+        let mut cold = vec![0.0; n_eta];
+        let nm_ok = nelder_mead_minimize(&obj, &mut cold, n_eta, max_iter * 5, tol);
+        if cold.iter().all(|v| v.is_finite()) {
+            let cold_nll = obj(&cold);
+            if cold_nll < nll {
+                nll = cold_nll;
+                eta = cold;
+                ebe_converged = nm_ok;
+                used_fallback = true;
             }
         }
     }
@@ -1263,7 +1317,7 @@ fn find_ebe_iov(
     // lower-objective of {BFGS partial, NM restart} so a correct η̂ floored above `tol` by
     // solver noise is never discarded (#555); for exact objectives recover with NM from the
     // cold seed, as prior releases, so a non-stationary low-objective partial can't be kept.
-    let (nm_converged, used_fallback) = if !bfgs_converged {
+    let (nm_converged, mut used_fallback) = if !bfgs_converged {
         let partial = x.clone();
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
@@ -1282,6 +1336,35 @@ fn find_ebe_iov(
     } else {
         (false, false)
     };
+
+    // ── Runaway-EBE guard (#958), IOV twin ─────────────────────────────────
+    // Same failure and same detector as the non-IOV `find_ebe` (see the comment there):
+    // a noise-dominated inner gradient can march the search tens of prior SDs out and
+    // then satisfy the objective-stall stop, certifying a point that is not a mode. The
+    // metric is the joint prior's, so it spans both blocks of the flat vector —
+    // `bsv_etaᵀΩ⁻¹bsv_eta` plus each occasion's `κᵀΩ_iov⁻¹κ`.
+    //
+    // Recovery differs in one respect: an ODE+IOV model deliberately declines the
+    // Nelder–Mead fallback, because every simplex vertex is a full ODE + steady-state
+    // solve and one bad outer line-search point would launch a very expensive search
+    // ([`skip_ode_iov_nm_fallback`]). That policy stands here, so such a subject keeps
+    // whatever the BFGS returned.
+    let mut bfgs_converged = bfgs_converged;
+    let mut nm_converged = nm_converged;
+    let runaway_limit = RUNAWAY_EBE_MAHA_PER_ETA * n_flat as f64;
+    if !skip_ode_iov_nm_fallback(model)
+        && iov_prior_maha(&x, &mu, n_eta, n_kappa, k_occasions, params) > runaway_limit
+    {
+        let mut cold = vec![0.0; n_flat];
+        cold[..n_eta].copy_from_slice(&mu);
+        let ok = nelder_mead_minimize(&obj, &mut cold, n_flat, max_iter * 5, tol);
+        if cold.iter().all(|v| v.is_finite()) && obj(&cold) < obj(&x) {
+            x = cold;
+            bfgs_converged = false;
+            nm_converged = ok;
+            used_fallback = true;
+        }
+    }
 
     let nll = obj(&x);
     // Recover bsv_eta = psi - mu (mean-zero, NONMEM-compatible output).
@@ -2980,6 +3063,65 @@ const INNER_STALL_LIMIT: u32 = 3;
 /// dropping by more than this fraction the search is still descending, so the stall is held
 /// off; once it plateaus (no such decrease) the search is at the noise floor.
 const INNER_FTOL_GNORM_PLATEAU: f64 = 1e-3;
+
+/// Per-random-effect budget on the returned inner EBE's squared Mahalanobis distance
+/// `ηᵀΩ⁻¹η`, above which the point is treated as a numerical runaway rather than a mode
+/// (#958). `100` is 10 prior SDs per random effect — `ηᵀΩ⁻¹η` is χ²(n_eta) at the truth,
+/// so for `n_eta = 3` the limit of 300 sits past any quantile a real subject reaches
+/// (χ²₃ = 300 has p ≈ 1e-63), while the observed failure lands at ~9000. Deliberately far
+/// out: below it the guard is a no-op and the EBE is bit-identical to prior releases, so
+/// the threshold only has to separate "unusual subject" from "not a mode at all".
+///
+/// The one legitimate large-|η| family — FREM covariate pseudo-observation etas, which sit
+/// at `cov_obs − TV` and can reach ±40 (#406) — is large in *raw* η only: its Ω carries the
+/// covariate's own variance, so its Mahalanobis distance stays O(1) and it never trips this.
+const RUNAWAY_EBE_MAHA_PER_ETA: f64 = 100.0;
+
+/// Squared Mahalanobis distance of an EBE under the prior, `ηᵀΩ⁻¹η` — the metric the
+/// runaway guard (see [`RUNAWAY_EBE_MAHA_PER_ETA`]) tests. Uses the cached `Ω⁻¹` the
+/// individual objective already carries, so this costs `O(n_eta²)` flops and no
+/// factorisation. Non-finite η (a diverged search) reports `INFINITY` so it trips the
+/// guard rather than comparing false.
+fn ebe_prior_maha(eta: &[f64], omega: &crate::types::OmegaMatrix) -> f64 {
+    if !eta.iter().all(|v| v.is_finite()) {
+        return f64::INFINITY;
+    }
+    let n = eta.len().min(omega.inv.nrows());
+    let mut q = 0.0;
+    for i in 0..n {
+        for j in 0..n {
+            q += eta[i] * omega.inv[(i, j)] * eta[j];
+        }
+    }
+    q
+}
+
+/// [`ebe_prior_maha`] for the IOV inner loop's flat vector `[bsv_psi, κ_1, …, κ_K]`: the
+/// joint prior's quadratic form, `(ψ−μ)ᵀΩ⁻¹(ψ−μ) + Σ_k κ_kᵀΩ_iov⁻¹κ_k`. The BSV block is
+/// shifted back out of ψ-space first, since the prior is centred on `μ`, not on 0. A model
+/// with no `omega_iov` contributes only the BSV block (its κ block is not a random effect
+/// with a prior to be far from).
+fn iov_prior_maha(
+    x: &[f64],
+    mu: &[f64],
+    n_eta: usize,
+    n_kappa: usize,
+    k_occasions: usize,
+    params: &ModelParameters,
+) -> f64 {
+    let bsv: Vec<f64> = x[..n_eta]
+        .iter()
+        .zip(mu.iter())
+        .map(|(p, m)| p - m)
+        .collect();
+    let mut q = ebe_prior_maha(&bsv, &params.omega);
+    if let Some(oi) = params.omega_iov.as_ref() {
+        for k in 0..k_occasions {
+            q += ebe_prior_maha(&x[n_eta + k * n_kappa..n_eta + (k + 1) * n_kappa], oi);
+        }
+    }
+    q
+}
 
 /// True once the objective has failed to improve by more than `INNER_FTOL_REL·(1+|f|)`
 /// for [`INNER_STALL_LIMIT`] consecutive accepted steps. Shared verbatim by the dense and

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1333,3 +1333,134 @@ fn inner_restarts_bit_identical_on_wellidentified_subject() {
         );
     }
 }
+
+/// `ebe_prior_maha` is the runaway guard's detector: the squared Mahalanobis distance
+/// `ηᵀΩ⁻¹η` under the prior. Pinned on a diagonal Ω where the value is hand-computable,
+/// and on the non-finite η a diverged search can return — which must report `INFINITY`
+/// so it *trips* the guard rather than comparing false against the threshold.
+#[test]
+fn ebe_prior_maha_is_the_omega_inverse_quadratic_form() {
+    let omega =
+        crate::types::OmegaMatrix::from_diagonal(&[0.04, 0.09], vec!["A".into(), "B".into()]);
+    // (0.4²/0.04) + (0.9²/0.09) = 4 + 9 = 13 — i.e. 2 SD and 3 SD.
+    assert!((ebe_prior_maha(&[0.4, 0.9], &omega) - 13.0).abs() < 1e-9);
+    assert_eq!(ebe_prior_maha(&[0.0, 0.0], &omega), 0.0);
+    assert!(ebe_prior_maha(&[f64::NAN, 0.0], &omega).is_infinite());
+    assert!(ebe_prior_maha(&[f64::INFINITY, 0.0], &omega).is_infinite());
+}
+
+/// Subject 7 of the #958 gist reproducer (`synthetic_tmdd_init_sqrt`): a quasi-steady-state
+/// target-binding ODE whose terminal drug sample is `4.7e-5` while the prediction at η = 0 is
+/// ~`7.5e-9`. Under proportional error that row's variance is clamped to `MIN_VARIANCE`
+/// (1e-12), so its residual term `(y−f)²/R` amplifies the ODE solver's local error
+/// (`ode_abstol = 1e-9`) by ~1e8 — and the **finite-difference** inner gradient, which
+/// differences that objective, comes back with the wrong *sign*.
+///
+/// The inner BFGS then marched to η ≈ `[2.49, 16.20, 14.52]` — `ηᵀΩ⁻¹η ≈ 9000`, ~80 prior SDs
+/// on two axes — and *certified* it, because a noise-driven search satisfies the
+/// objective-stall stop exactly like a converged one (the objective stops improving and the
+/// gradient norm plateaus). Nothing downstream re-checked it, so `gradient = fd` and
+/// `gradient = auto` reported first-evaluation objectives of `6082.24` and `−5.48` for the
+/// same model at the same estimates, making ΔOFV model selection gradient-path-dependent.
+///
+/// This EBE is **not** multimodal — eight seeds under the analytic gradient (itself verified
+/// against FD of the predictor to 2.6e-7) all reach the same mode — so the two routes must
+/// return it. Fails without the runaway guard: the FD route returns the runaway instead.
+#[test]
+fn fd_inner_ebe_runaway_on_floored_row_is_recovered() {
+    let model_src = "[parameters]\n  theta KEL(0.05, 0.001, 5.0)\n  theta VC(3, 0.1, 100.0)\n  theta KSS(10, 0.1, 500.0)\n  theta KINT(0.5, 0.01, 50.0)\n  theta KDEG(0.05, 0.001, 5.0)\n  theta RBASE(20, 0.5, 500.0)\n  omega IIV_KEL   ~ 0.09\n  omega IIV_VC    ~ 0.04\n  omega IIV_RBASE ~ 0.09\n  sigma PROP_DRUG ~ 0.15 (sd)\n  sigma PROP_TGT  ~ 0.20 (sd)\n[individual_parameters]\n  KEL   = KEL * exp(IIV_KEL)\n  VC    = VC * exp(IIV_VC)\n  RBASE = RBASE * exp(IIV_RBASE)\n  KSS   = KSS\n  KINT  = KINT\n  KDEG  = KDEG\n  KSYN  = RBASE * KDEG\n[structural_model]\n  ode(states=[CENT, RTOT])\n[odes]\n  init(RTOT) = RBASE\n  CT = CENT / VC\n  RT = RTOT\n  BB = CT - RT - KSS\n  CF = 0.5 * (BB + sqrt(BB*BB + 4*KSS*CT))\n  FB = CF / (KSS + CF)\n  d/dt(CENT) = -KEL * CF * VC - RT * KINT * FB * VC\n  d/dt(RTOT) = KSYN - KDEG * RT - (KINT - KDEG) * RT * FB\n[scaling]\n  y[CMT=1] = CENT / VC\n  y[CMT=3] = RTOT\n[error_model]\n  CMT=1: DV ~ proportional(PROP_DRUG)\n  CMT=3: DV ~ proportional(PROP_TGT)\n[fit_options]\n  method     = focei\n  ode_reltol = 1e-9\n  ode_abstol = 1e-9\n";
+
+    // (time, cmt, DV) exactly as the gist's subject 7 — the `112 / cmt 1 / 4.7e-05` row is
+    // the one whose proportional variance floors.
+    let rows: [(f64, usize, f64); 23] = [
+        (0.083, 1, 183.756742),
+        (0.083, 3, 15.161013),
+        (0.25, 1, 204.703415),
+        (0.25, 3, 14.124375),
+        (1.0, 1, 194.836064),
+        (1.0, 3, 11.059003),
+        (3.0, 1, 189.142239),
+        (3.0, 3, 5.061678),
+        (7.0, 1, 112.589072),
+        (7.0, 3, 2.117357),
+        (14.0, 1, 121.725206),
+        (14.0, 3, 1.917394),
+        (28.0, 1, 72.126391),
+        (28.0, 3, 2.068264),
+        (42.0, 1, 25.918106),
+        (42.0, 3, 2.43914),
+        (56.0, 1, 15.509434),
+        (56.0, 3, 3.649646),
+        (84.0, 1, 0.161923),
+        (84.0, 3, 12.591933),
+        (112.0, 1, 4.7e-05),
+        (112.0, 3, 18.294563),
+        (126.0, 3, 17.544296),
+    ];
+    let n = rows.len();
+    let subject = Subject {
+        id: "7".into(),
+        doses: vec![DoseEvent::new(0.0, 600.0, 1, 0.0, false, 0.0)],
+        obs_times: rows.iter().map(|r| r.0).collect(),
+        obs_raw_times: Vec::new(),
+        observations: rows.iter().map(|r| r.2).collect(),
+        obs_cmts: rows.iter().map(|r| r.1).collect(),
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1; n],
+        obs_l2: Vec::new(),
+        dose_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+
+    let base = crate::parser::model_parser::parse_model_string(model_src)
+        .expect("QSS TMDD model with a parameter-dependent init parses");
+    let params = base.default_params.clone();
+
+    // Precondition: the terminal drug row really is at the variance floor at η = 0. Without
+    // this the test would pass vacuously if the model or data ever drifted out of the regime
+    // that produces the runaway.
+    let preds = crate::pk::compute_predictions_with_tv(&base, &subject, &params.theta, &[0.0; 3]);
+    assert!(
+        base.residual_variance_at(1, preds[20], &params.sigma.values) <= 1e-12,
+        "terminal drug prediction {} must drive its proportional variance to the floor",
+        preds[20]
+    );
+
+    let solve = |gm: GradientMethod| -> Vec<f64> {
+        let mut m = crate::parser::model_parser::parse_model_string(model_src).unwrap();
+        m.gradient_method = gm;
+        find_ebe(&m, &subject, &params, 50, 1e-5, None, None, 0)
+            .eta
+            .iter()
+            .copied()
+            .collect()
+    };
+    let eta_auto = solve(GradientMethod::Auto);
+    let eta_fd = solve(GradientMethod::Fd);
+
+    // Both routes must land in the prior-plausible region — the runaway sat at ~9000.
+    for (label, eta) in [("auto", &eta_auto), ("fd", &eta_fd)] {
+        let maha = ebe_prior_maha(eta, &params.omega);
+        assert!(
+            maha < RUNAWAY_EBE_MAHA_PER_ETA * base.n_eta as f64,
+            "{label} EBE {eta:?} is a prior runaway (ηᵀΩ⁻¹η = {maha})"
+        );
+    }
+    // …and on the *same* mode, since this subject's individual objective is unimodal.
+    for k in 0..base.n_eta {
+        assert!(
+            (eta_auto[k] - eta_fd[k]).abs() < 1e-3,
+            "η[{k}]: analytic {} vs FD {} — the FOCEI objective must not depend on the \
+             gradient route",
+            eta_auto[k],
+            eta_fd[k]
+        );
+    }
+}

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -6349,11 +6349,16 @@ pub fn apply_fit_option(opts: &mut FitOptions, key: &str, value: &str) -> Result
         "gradient" | "gradient_method" => {
             opts.gradient_method = match value.to_lowercase().as_str() {
                 "auto" => GradientMethod::Auto,
+                // `ad` still *parses* so that requesting it reaches the engine's specific
+                // "the Enzyme AD path was retired, use auto/fd" error (#428) rather than a
+                // generic unknown-value one. It is not advertised below: listing it as a
+                // valid value in the message shown for some *other* typo pointed users at a
+                // setting no fit accepts (#958).
                 "ad" | "autodiff" => GradientMethod::Ad,
                 "fd" | "finite" | "finite_difference" | "finite-difference" => GradientMethod::Fd,
                 other => {
                     return Err(format!(
-                        "fit option `gradient`: unknown value `{other}` — expected 'auto', 'ad', or 'fd'"
+                        "fit option `gradient`: unknown value `{other}` — expected 'auto' or 'fd'"
                     ));
                 }
             };

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -13904,3 +13904,34 @@ fn mixture_block_omega_override_rejected() {
     let err = parse_model_string(src).expect_err("block-omega override must be rejected");
     assert!(err.contains("diagonal base omega"), "got: {err}");
 }
+
+/// #958 (second reported item): the parse-time error for an unknown `gradient` value
+/// advertised `'ad'`, but no fit accepts it — the Enzyme AD path was retired in #428 and
+/// the engine rejects `gradient = ad` at fit time. So a user who mistyped the option was
+/// pointed at a setting that cannot work. The message now lists only what a fit will take.
+/// `ad` itself still parses, so requesting it deliberately still reaches the engine's
+/// specific "no longer supported, use auto or fd" error rather than a generic one.
+#[test]
+fn unknown_gradient_value_does_not_advertise_the_retired_ad_route() {
+    let err = parse_model_string(
+        "[parameters]\n  theta CL(1.0,0.1,10)\n  omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.1\n[individual_parameters]\n  CL = CL * exp(ETA_CL)\n  V = 10\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP)\n[fit_options]\n  gradient = enzyme\n",
+    )
+    .expect_err("an unknown `gradient` value must be rejected at parse time");
+    assert!(
+        err.contains("expected 'auto' or 'fd'"),
+        "message must list only the values a fit accepts, got: {err}"
+    );
+    assert!(
+        !err.contains("'ad'"),
+        "the retired AD route must not be advertised, got: {err}"
+    );
+
+    // `ad` still parses — the engine, not the parser, owns its retirement message.
+    assert!(
+        parse_model_string(
+            "[parameters]\n  theta CL(1.0,0.1,10)\n  omega ETA_CL ~ 0.09\n  sigma PROP ~ 0.1\n[individual_parameters]\n  CL = CL * exp(ETA_CL)\n  V = 10\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP)\n[fit_options]\n  gradient = ad\n",
+        )
+        .is_ok(),
+        "`gradient = ad` must still parse so the engine can emit its own retirement error"
+    );
+}


### PR DESCRIPTION
## Why

The FOCE/FOCEI objective was **gradient-path-dependent** on the reproducer in #958: `gradient = fd` and `gradient = auto` reported first-evaluation objectives of **6082.24** and **−5.478** for the same model at the same estimates. The objective is what ΔOFV/ΔAIC model selection compares, so which model "wins" depended on which gradient route ran, with nothing in the output indicating a problem.

#958 was closed by #963 (the floor-aware `dvar_df`/`d2var_df2` fix). That fix is real and holds — the four-cell reproducer from the issue body still agrees to ~1e-7 relative — but a [second reproducer](https://gist.github.com/TeunP/63e48001ac71843870d1e63060e9768b) posted afterwards survived it. This PR fixes that one.

**The analytic sensitivities were never the problem.** On the reported model:

| check | result |
|---|---|
| analytic `∂f/∂η` vs central FD of the production predictor | ≤ **2.6e-7** rel |
| analytic `∂nll/∂η` vs FD of `individual_nll` | ~**1e-5** rel |

Per-subject decomposition put the **entire** discrepancy on **one subject of twelve**, and it was the **FD** route that was wrong there:

| route | η̂ | nll | `converged` |
|---|---|---|---|
| `auto` | `[−0.493, −0.263, −0.252]` | **18.09** | true |
| `fd` | `[2.49, 16.20, 14.52]` | **4942** | **true** |

`ηᵀΩ⁻¹η = 8974` — about 80 prior SDs on two axes — reported as converged. And the subject's objective is **not** multimodal: eight seeds under the analytic gradient all reach the same mode, so both routes should return it.

**Mechanism.** That subject's terminal drug sample is `4.7e-5` while its prediction at η = 0 is `~7.5e-9`. Under proportional error the row's variance is clamped to `MIN_VARIANCE` (1e-12), so its residual term `(y−f)²/R` amplifies the ODE solver's local error (`ode_abstol`, 1e-9) by ~1e8. The differenced signal is then far below the noise riding on it, and the FD gradient comes back with the **wrong sign**:

```
at η = [2.49, 16.20, 14.52]
  analytic  [ 27.7,  455.2,  575.3]     ← prior pull, correct
  FD        [844.1, −725.5, −6347.6]    ← two signs flipped
```

A search driven by that noise satisfies the objective-stall convergence stop (#555) exactly like a converged one — the objective stops improving and the gradient norm plateaus — and nothing downstream re-checked the result. No FD step size repairs this: too small and it is noise, too large and it truncates on a very curved objective.

This answers the reporter's first question (["settle which path is the reference before anything else"](https://github.com/FeRx-NLME/ferx-core/issues/958#issuecomment-5341026743)): **`auto` is the reference; `fd` is the unstable side**, as they suspected. Their points 2 and 3 come out negative — the second-order η path is fine, and the existing regression test's shape was not the gap.

## What changed

A **runaway-EBE guard** at the end of `find_ebe` (and its IOV twin). If the returned EBE's squared Mahalanobis distance under the prior, `ηᵀΩ⁻¹η`, exceeds 10 prior SDs per random effect, re-solve derivative-free (Nelder–Mead) from the prior mean and keep whichever point has the **lower** objective.

Three deliberate design choices:

- **`ηᵀΩ⁻¹η` as the detector.** It is the prior's own metric (χ²(n_eta) at the truth), scale-free, and already what the objective penalises — so no per-model tuning, and the one legitimate large-|η| family (FREM covariate pseudo-observation etas, which reach ±40, #406) never trips it, because its Ω carries the covariate's own variance and its Mahalanobis distance stays O(1).
- **Nelder–Mead for recovery.** Derivative-free, so it is immune to the noise that caused the runaway. The objective's *value* is fine here — only its finite difference is not.
- **Strictly objective-improving, never demotes.** A far-out EBE is not by itself proof of an artifact: a grossly misspecified subject can genuinely have its posterior mode tens of prior SDs out, and if a derivative-free search from the prior mean cannot beat it, it *is* the objective's minimum. So a distance check alone never rewrites a result or clears a convergence flag — only actually finding something better does. Fits whose inner loop was already right stay bit-identical.

The IOV twin uses the joint prior (`(ψ−μ)ᵀΩ⁻¹(ψ−μ) + Σₖ κₖᵀΩ_iov⁻¹κₖ`) and honours ODE+IOV's deliberate Nelder–Mead skip (`skip_ode_iov_nm_fallback`, where each simplex vertex is a full ODE + steady-state solve).

Second commit: the parse-time error for an unknown `gradient` value advertised `'ad'`, which no fit accepts (the Enzyme path was retired in #428). Reported as the first of the two smaller items in #958.

## Alternatives considered

- **Fix the FD step size.** Does not exist: the amplification is `1/R` with `R` clamped at 1e-12 against solver noise at `ode_abstol`. Too small a step is noise, too large truncates on a very curved objective. The inner loop needs a correctness backstop, not a better step.
- **Lower `MIN_VARIANCE`, or make it relative.** Rejected — it is not creating the pathology (the unfloored proportional variance at `f ≈ 7.5e-9` is *worse*), and changing it moves every existing model's OFV.
- **Rely on `inner_restarts`.** Measured: it does not help. Under FD, subject 7 returns Mahalanobis 8974 / 3875 / 2446 at `restarts = 0 / 3 / 5` — wrong at every setting, because every restart is driven by the same noise-dominated gradient.
- **Also mark an unrecovered runaway `converged = false`.** Tried, reverted. It changes results for legitimate far-out modes — `test_find_ebe_iov_honors_mu_shift`'s fixture has a genuine mode at η̂ ≈ −7.6 with ω = 0.09 — and would emit spurious warnings and (for ODE+IOV) spurious trial rejections. Recovering without demoting keeps the fix strictly additive.
- **Cheaper Nelder–Mead budget (`max_iter` rather than `max_iter * 5`).** Tried, reverted: the regression test fails at 50 iterations. `max_iter * 5` matches the budget this function's other Nelder–Mead fallbacks already use.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change; no `FitResult` / sdtab field change.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] **None**

## Numerical validation

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: **NONMEM 7.6** (licensed `pmx` container) and prior ferx commit `e8a18b1a`
- [x] Reference values:

**The reported reproducer** (gist model + data, first-evaluation objective, `optimizer = bobyqa` pinned):

```
# before                          # after
fd     6082.236409                fd      -5.479368
auto     -5.478157                auto    -5.478157
ratio    -0.0009                  ratio    1.00022
```

Full fits now agree and both recover the simulating parameters (truth `KEL 0.05, VC 3, KSS 10, KINT 0.5, KDEG 0.05, RBASE 20`):

```
        KEL      VC      KSS     KINT    KDEG     RBASE     OFV
fd    0.0530   3.054    9.876   0.502   0.0454   20.20    -18.01
auto  0.0533   3.045    9.838   0.501   0.0441   20.41    -20.97
```

**The four-cell reproducer from the issue body** — already fixed by #963, unchanged here:

```
mm_const_fd     -57.859149     qss_const_fd    329.581550
mm_const_auto   -57.859015     qss_const_auto  329.581531
mm_param_fd     -42.154022     qss_param_fd    324.808711
mm_param_auto   -42.153846     qss_param_auto  324.808689
```

**Warfarin control** (never trips the guard) — matches its NONMEM-validated reference exactly:

```
OFV -280.3640 (ref -280.3639), TVCL 0.132969 (ref 0.1330), TVKA 0.725207 (ref 0.7252)
```

### NONMEM 7.6 cross-check

Control stream: `ADVAN13 TOL=9`, `A_0(2) = RBASE` (the `init(RTOT) = RBASE` twin), `METHOD=1 INTER`.

**On the reproducer as published, NONMEM is not a usable anchor**, and that is itself informative:

- NONMEM has **no residual-variance floor**, so on rows whose prediction reaches ~1e-9 under proportional error the two engines do not evaluate the same objective by construction: NONMEM's `MAXEVAL=0` evaluation at ferx's estimates returns **3.0e15**.
- At `TOL=9`, NONMEM's **own inner search runs away the same way** — `ETA3 = 18.5` on subject 3 — and the run dies with `ERROR IN LSODA: CODE -1`. Independent confirmation that this failure mode is a property of the objective, not of ferx.
- At `TOL=6` NONMEM completes but converges to a much worse optimum (OFV 732.18 on the LLOQ twin, `KSS = 48.4` against a truth of 10, `ω²_VC` collapsed to 4e-6 at the boundary).

**On an LLOQ-censored twin** (28 of 281 rows below 1e-3 dropped — what a real analysis does), where the floor is inactive and both engines evaluate the same likelihood:

- **Model translation confirmed**: `PRED` at η = 0 agrees to **7.7e-3** worst case across all 241 matched rows (and that worst case is on a value of 6e-5, where NONMEM's 5-significant-digit table dominates).
- **At identical fixed (θ, Ω, Σ), ferx's EBEs have a strictly lower individual objective than NONMEM's on 12 of 12 subjects** (Σ nll **228.99** vs **414.23**). Since `PRED` matches, the individual objective is the same function of η, so this is a like-for-like comparison of the inner solutions.
- Both ferx routes agree there too: Eval-1 `664.317232` (fd) vs `664.317139` (auto); final `647.949` vs `647.983`.

## Performance

- [x] **Faster** on the models the guard actually fixes; a bounded cost where it fires on an already-correct fit; unmeasurable elsewhere.

Wall clock, `ci-fast` profile, guard ON = mean of 3 reps, guard OFF = 1 rep:

| fit | guard OFF | guard ON | Δ |
|---|---|---|---|
| gist `fd` | 42.05s | **25.7s** | −39% |
| gist `auto` | 22.19s | **15.7s** | −29% |
| lloq `fd` | 21.11s | **16.7s** | −21% |
| lloq `auto` | 3.76s | 5.3s | +41% |
| 4-cell `qss_param fd` | 8.43s | 9.9s | +18% |
| 4-cell `qss_param auto` | 5.01s | 5.5s | +10% |
| **warfarin (control)** | 0.19s | **0.17s** | noise — guard never fires |

Where the guard fires and the EBEs were wrong it is a net **speedup**: correct EBEs let the outer optimizer converge in fewer evaluations. Where it fires on a fit that was already fine it costs 10–40% on small pathological models. Below the threshold it is one `O(n_eta²)` dot product per `find_ebe` — not measurable.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes: **2923 passed, 0 failed**)
- [x] Regression test added that fails without this fix

| test | pins |
|---|---|
| `estimation::inner_optimizer::tests::fd_inner_ebe_runaway_on_floored_row_is_recovered` | subject 7 inlined; asserts both routes land in the prior-plausible region and on the same mode. Fails without the fix with `fd EBE [2.49, 16.20, 14.52] is a prior runaway (ηᵀΩ⁻¹η = 8973.66)` |
| `estimation::inner_optimizer::tests::ebe_prior_maha_is_the_omega_inverse_quadratic_form` | the detector itself, including non-finite η → `INFINITY` so a diverged search *trips* the guard rather than comparing false |
| `parser::model_parser::tests::unknown_gradient_value_does_not_advertise_the_retired_ad_route` | the message lists only `'auto'`/`'fd'`, and `ad` still parses so the engine keeps owning its retirement error |

The regression test carries a **precondition assert** that the terminal drug row really is at the variance floor at η = 0, so it cannot pass vacuously if the model or data ever drift out of the regime that produces the runaway.

## Example (user-facing features only)
- [x] Not applicable — internal robustness fix, no new API surface. The reproducer is the gist linked above.

## Docs
- [x] `docs/` updated — `docs/estimation/foce.qmd` gains a "Runaway EBEs are re-checked (#958)" subsection under **Gradient route (analytic vs FD)**, covering the mechanism, the guard, and the guidance that `gradient_method = auto` (the default) is immune because it differentiates the same integration it predicts from
- [x] No new pages, so no `docs/_quarto.yml` change
- [x] `CHANGELOG.md` `[Unreleased]` → `### Fixed`, two entries

## Checklist
- [x] `cargo clippy` clean — warning count unchanged at 260 vs `e8a18b1a` baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — **no `sens/` or `pk/` code touched**; this PR changes only the inner optimizer's post-search acceptance and one parser message
- [x] `Cargo.toml` version bump not needed (no breaking change)

## Docs & examples

### ferx-site / ferx-book
- [x] No new `.ferx` DSL syntax or `[fit_options]` key
- [x] No new example or data file
- [x] No new estimator, DSL feature, or fit option — behaviour of an existing one is corrected

### Example execution
- [x] Warfarin runs cleanly via CLI and matches its reference (above)
- [x] `cargo check --tests` passes (Tier-2 compile gate)

## Reviewer hints

Focus on **`RUNAWAY_EBE_MAHA_PER_ETA` and the "never demotes" property** — those are the two decisions that determine whether this can regress an existing fit. The guard is written so that below the threshold it is a no-op, and above it the only possible effect is replacing a point with a strictly lower-objective one. If that property holds, the blast radius is bounded to fits that were already producing runaways.

`iov_prior_maha` is worth a look for the ψ-space shift: the BSV block is optimised as `ψ = η + μ` but the prior is centred on `μ`, so it must be shifted back before the quadratic form.

Skimmable: the docs paragraph and the CHANGELOG entries.

## Open questions

1. **The threshold is a judgement call.** 100 per random effect (10 prior SDs) is far outside anything a real subject reaches — χ²₃ = 300 has p ≈ 1e-63 — and the observed failure lands at 8974, so there is a lot of daylight. But it is a constant, not a derived quantity. Happy to make it a `[fit_options]` key if that is preferred; I left it internal because a user should never need to think about it.

2. **`gn_hybrid`'s FOCEI polish** (the second smaller item in #958 — the polish phase producing no second evaluation in ~15 minutes) is **not** addressed here. Different subsystem, and I did not want to bundle it. Worth its own issue.

3. **The ferx-vs-NONMEM EBE gap on the LLOQ twin is larger than I expected** even though ferx wins on all 12 subjects. `PRED` matching to 7.7e-3 says the models agree, and ferx's inner solutions are strictly better on the shared objective, so I read this as NONMEM's inner loop leaving objective on the table on this QSS TMDD model (consistent with it outright diverging at `TOL=9`). But it is a bigger gap than a well-behaved model would show, and I did not chase it further — flagging it rather than claiming a clean anchor.
