### PR TITLE
docs(claude): downstream repos pin ferx-core transitively via ferx-r's lock, not directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,18 @@ The R wrapper package lives at `../ferx-r` (sibling directory). The R package's 
 
 Note that ferx-r's **CI** does not get the change automatically: it builds from the ferx-core commit pinned in `ferx-r/src/rust/Cargo.lock` (the patch only applies locally). A ferx-r PR that needs a new ferx-core commit — e.g. a newly-`pub` API — must bump that lock, via `ferx-r/tools/update-ferx-core-lock.sh` (never a bare `cargo update`, which the patch will unpin). Otherwise CI fails with `error[E0603]: ... is private`.
 
+### Downstream repos pin ferx-core *transitively* — there is no ferx-core SHA to hand out
+
+`ferxtranslate` (and anything else built on the R package) does not depend on ferx-core directly: it pins **ferx-r** at a commit, and that ferx-r commit's `src/rust/Cargo.lock` pins ferx-core. So a merge here is **not** reachable downstream until two bumps land, in order — ferx-r's `Cargo.lock`, then the downstream repo's ferx-r pin. Do not tell a downstream maintainer to "pin ferx-core at `<sha>`"; there is no such knob on their side.
+
+The trap that makes this easy to get wrong: reading `ferx-r/src/rust/Cargo.toml` alone shows `branch = "main"` and reads as *unpinned*. **The lock is the pin.** Check it, don't infer it:
+
+```bash
+git -C ../ferx-r show origin/main:src/rust/Cargo.lock | grep -A2 'name = "ferx-core"'
+```
+
+When a change here matters to a downstream consumer, tell them the two-step and the current lock rev — not a ferx-core SHA.
+
 ## Worktree isolation
 
 When working on a feature branch or any branch other than `main`, always use `EnterWorktree` at the start of the session. This prevents uncommitted WIP from one session contaminating another session on a different branch (a real problem when two chats share the same checkout directory).


### PR DESCRIPTION
## Why

I got this wrong in practice, which is why it is worth writing down.

Handing #993's new `E_DOSE_ATTR_DOUBLE_USE` behaviour to the ferxtranslate maintainer, I told them "`25b5f473` is the commit a translator engine-CI pin should target". There is no such knob on their side. ferxtranslate pins **ferx-r** at a commit, and that ferx-r commit's `src/rust/Cargo.lock` pins ferx-core. They caught it and measured the actual chain:

```
ferx-r@7889719 (their CI pin)  -> ferx-core 6c0f317f   (2026-08-07)
ferx-r origin/main             -> ferx-core 59065317   (2026-08-20 16:46)
#1003 merge                    -> ferx-core 25b5f473   (2026-08-20 21:54)
```

Verified both lock revs myself before writing this. Both predate the merge, so the new diagnostic is not live downstream and will not become live on its own — it needs two bumps in order: ferx-r's lock, then their ferx-r pin.

## What this changes

CLAUDE.md already carried the lock-is-the-pin rule, but addressed only to someone working *inside* ferx-r — "a ferx-r PR that needs a new ferx-core commit must bump that lock". It said nothing to a third repo consuming ferx-r transitively, which is precisely the reader who gets it wrong. That is the gap I reasoned from when I gave the bad advice.

Adds, under **Sibling repositories**:

- the two-step bump, in order;
- "do not tell a downstream maintainer to pin ferx-core at `<sha>`";
- the trap — reading `ferx-r/src/rust/Cargo.toml` alone shows `branch = "main"` and reads as *unpinned*;
- a one-line check for the current lock rev, run as written rather than composed from memory:

```bash
git -C ../ferx-r show origin/main:src/rust/Cargo.lock | grep -A2 'name = "ferx-core"'
```

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit
- [ ] Reference values
- [x] Not applicable — documentation only

## Performance
- [x] No significant impact expected — no code touched.

## Tests
- [ ] Unit test(s) added in the same module
- [ ] Regression test added that fails without this fix
- [x] No new tests needed — CLAUDE.md is guidance, not code. The one factual claim it makes (the shape of the lock entry) was verified by running the documented command.

## Example
- [ ] Example added to `examples/`
- [x] Inline below

<details>
<summary>Example</summary>

```
$ git -C ../ferx-r show origin/main:src/rust/Cargo.lock | grep -A2 'name = "ferx-core"'
name = "ferx-core"
version = "0.3.0"
source = "git+https://github.com/FeRx-NLME/ferx-core?branch=main#59065317b265c0eb978cce3b5b9e257333f5c140"
```

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml`
- [ ] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible change — contributor/agent guidance only, so no CHANGELOG entry (CLAUDE.md rule: internal-only changes need none).

## Checklist
- [x] `cargo clippy` — no code changed
- [x] Functions on the `Dual2` sensitivity path stay differentiable — none touched
- [ ] `Cargo.toml` version bumped if breaking
