### PR TITLE
fix(api): report a missing omega_iov instead of panicking when simulating an IOV model [closes #1019]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,13 @@ section of the SDLC for the versioning policy).
   unchanged (#971).
 
 ### Fixed
+- **Simulating an IOV (`kappa`) model with parameters that carry no IOV covariance now reports an
+  error instead of panicking (#1019).** `simulate()` draws one κ per occasion from `omega_iov`; a
+  caller that rebuilds `ModelParameters` from a fit and drops that block (the R
+  `ferx_simulate(..., fit = f)` bridge did) hit an `expect()` deep in the row emitter, which crossed
+  the FFI boundary as a process panic. `simulate_with_options`/`_diag` now return a clean `Err`
+  naming the missing `omega_iov` and the fix; the `Vec`-returning `simulate`/`simulate_with_seed`
+  fail loud with the same message rather than emitting rows with no inter-occasion variability.
 - **Log-mu-referenced θ with a negative lower bound no longer takes the wrong closed-form update
   (#996).** Such a θ is packed on the identity scale, so the SAEM/IMP `log θ += mean(η)` shift was not
   its EM optimum — it applied `θ += mean(η)` where the closed form means `θ *= exp(mean(η))`. It is

--- a/docs/model-file/iov.qmd
+++ b/docs/model-file/iov.qmd
@@ -219,6 +219,12 @@ When the dataset has occasion labels the sdtab CSV gains an `OCC` column (one ro
 
 > **Note**: `shrinkage_kappa` exists as a placeholder field on `FitResult` but is not yet computed — it is always returned as an empty `Vec`. Use `ebe_kappas` directly if you need a manual shrinkage diagnostic.
 
+## Simulation
+
+`simulate()` is occasion-aware for a `kappa` model: it draws one independent κ ~ N(0, Ω~IOV~) per occasion group, so a VPC from an IOV model carries the inter-occasion spread the fit estimated (drawing a single κ for the whole subject would silently under-disperse it).
+
+That draw needs Ω~IOV~ in the parameters you hand to `simulate()`. The model's own parameters (`model.default_params`) always carry it, but a caller that **rebuilds** parameters from a fit must thread the fitted IOV covariance through as well — `estimation::uncertainty_samples::fitted_params_from_result()` does this and is the supported way to go from a `FitResult` to a simulate-ready `ModelParameters`. Parameters with a missing `omega_iov` are rejected: `simulate_with_options()` / `simulate_with_options_diag()` return an `Err` naming the omission, and the `Vec`-returning `simulate()` / `simulate_with_seed()` panic with the same message rather than silently emitting occasion-free draws (issue #1019).
+
 ## Limitations
 
 - **Cross-occasion dose carryover.** Predictions are computed by `pk::predict_iov`, which builds per-event PK parameters carrying each event's occasion kappa and propagates the compartment amounts *continuously* across occasion boundaries (via the event-driven solver). A dose from an earlier occasion is therefore eliminated through a later occasion with the later occasion's clearance — matching NONMEM's integration model (this replaced the earlier "Option A" superposition, which used a single clearance for the whole dose history and biased no-washout designs; issue #104). On the warfarin IOV reference, ferx's population prediction now matches NONMEM's to 5 significant figures on every row. A ~17 OFV-unit gap versus NONMEM remains at matched parameters, but it is *not* a prediction difference — it is a cross-engine FOCEI marginal/EBE difference for this weakly-identified multi-random-effect model (and NONMEM's reference itself did not converge cleanly here). See `tests/warfarin_iov_nonmem.rs`.

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -288,6 +288,31 @@ pub(crate) fn validate_tte_simulatable(
     Ok(())
 }
 
+/// Reject a `params` value that cannot drive an IOV (`kappa`) simulation.
+///
+/// An IOV model draws one κ ~ N(0, Ω_IOV) per occasion, so `params.omega_iov` must
+/// be present whenever `model.n_kappa > 0`. The parser guarantees that for
+/// `CompiledModel::default_params`, but a caller that *rebuilds* `ModelParameters`
+/// from a fit — e.g. the R `ferx_simulate(..., fit = f)` bridge (#1019) — can drop
+/// the IOV block and reach the emitter with `None`. That is a caller bug rather than
+/// a user-fixable model error, but it must be reported, not panicked across an FFI
+/// boundary. Silently substituting the model's *initial* Ω_IOV is not an option: it
+/// would under- or over-disperse every simulated occasion with no diagnostic.
+pub(crate) fn validate_iov_simulatable(
+    model: &CompiledModel,
+    params: &ModelParameters,
+) -> Result<(), String> {
+    if model.n_kappa > 0 && params.omega_iov.is_none() {
+        return Err(format!(
+            "model declares {} kappa (IOV) but the supplied parameters carry no omega_iov; \
+             simulation draws one kappa vector per occasion from it. Rebuild the parameters \
+             with the fitted IOV covariance (see `fitted_params_from_result`) before simulating",
+            model.n_kappa
+        ));
+    }
+    Ok(())
+}
+
 /// Simulate observations under `opts`, returning only the observation rows.
 ///
 /// Thin wrapper over [`simulate_with_options_diag`] that discards the per-subject
@@ -343,6 +368,11 @@ pub fn simulate_with_options_diag(
     // not yet supported for an ODE hazard).
     #[cfg(feature = "survival")]
     validate_tte_simulatable(model, population, opts.horizon)?;
+
+    // An IOV model needs the fitted Ω_IOV in `params` (#1019). Report a missing one
+    // as a clean Err here; the Vec-returning entry points enforce the same contract
+    // as a panic at the chokepoint below, since they cannot signal.
+    validate_iov_simulatable(model, params)?;
 
     // Parity with `fit()`: a referenced covariate absent from the data would
     // silently read 0.0 (e.g. a `Selected` error model's `if (FREE==0)` selector
@@ -580,10 +610,10 @@ fn emit_subject_rows<R: rand::Rng>(
     // Non-IOV models keep the TV-covariate-aware fast-path dispatcher unchanged
     // and draw no extra randoms, so their output is byte-identical.
     let ipreds = if model.n_kappa > 0 {
-        let omega_iov = params
-            .omega_iov
-            .as_ref()
-            .expect("omega_iov is present whenever the model declares kappa (n_kappa > 0)");
+        let omega_iov = params.omega_iov.as_ref().expect(
+            "omega_iov is present whenever the model declares kappa (n_kappa > 0) — \
+                 guaranteed by `validate_iov_simulatable` at every simulate entry point (#1019)",
+        );
         // One κ vector per occasion group, in `iov_occasion_groups` order — the
         // exact order `predict_iov` indexes its `kappas` argument by. Empty when
         // the subject carries no occasion labels, in which case `predict_iov`
@@ -858,6 +888,14 @@ fn simulate_inner_with_draw<R: rand::Rng>(
     // enforce the identical contract as a panic rather than emitting wrong rows.
     #[cfg(feature = "survival")]
     if let Err(e) = validate_tte_simulatable(model, population, horizon) {
+        panic!("{e}");
+    }
+
+    // Same split for the IOV precondition (#1019): `simulate_with_options*` already
+    // returned a clean Err; the Vec-returning `simulate` / `simulate_with_seed` and the
+    // uncertainty path funnel through here, where the only way to enforce the contract
+    // is to fail loud rather than emit rows with no inter-occasion variability.
+    if let Err(e) = validate_iov_simulatable(model, params) {
         panic!("{e}");
     }
 

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -1,5 +1,6 @@
 use super::fit;
 use super::simulate_with_seed;
+use super::{simulate_with_options, SimOutcome};
 use crate::types::*;
 
 use std::collections::HashMap;
@@ -1807,4 +1808,93 @@ fn analytical_oral_depot_infusion_with_compartments_derived_emits_warning() {
             "predictions must be finite"
         );
     }
+}
+
+// ── #1019: simulating an IOV model from caller-rebuilt parameters ────────
+//
+// The R bridge rebuilds `ModelParameters` from a fit object; before #1019 it
+// dropped `omega_iov`, and the per-occasion κ draw in `emit_subject_rows`
+// unwrapped that `None` — a panic across the FFI boundary that took the R
+// session's error handling with it. The contract is now enforced at every
+// simulate entry point: a clean `Err` where one can be returned, a loud panic
+// on the Vec-returning chokepoint.
+
+/// `params` with the IOV block stripped — exactly what a fit-rebuilt
+/// `ModelParameters` looked like before the fix.
+fn iov_params_without_omega_iov(model: &CompiledModel) -> ModelParameters {
+    let mut params = model.default_params.clone();
+    params.omega_iov = None;
+    params
+}
+
+#[test]
+fn test_simulate_with_options_errs_when_omega_iov_missing() {
+    let model = make_iov_model();
+    let population = make_iov_population();
+    let params = iov_params_without_omega_iov(&model);
+
+    let err = simulate_with_options(
+        &model,
+        &population,
+        &params,
+        2,
+        &crate::SimulateOptions {
+            seed: Some(1),
+            ..Default::default()
+        },
+    )
+    .expect_err("an IOV model with no omega_iov must not simulate");
+    assert!(
+        err.contains("omega_iov") && err.contains("kappa"),
+        "error must name the missing IOV covariance; got: {err}"
+    );
+}
+
+#[test]
+#[should_panic(expected = "carry no omega_iov")]
+fn test_simulate_with_seed_panics_when_omega_iov_missing() {
+    let model = make_iov_model();
+    let population = make_iov_population();
+    let params = iov_params_without_omega_iov(&model);
+    // No Err channel on this entry point: fail loud rather than emit rows with
+    // zero inter-occasion variability.
+    let _ = simulate_with_seed(&model, &population, &params, 1, 1);
+}
+
+#[test]
+fn test_simulate_from_fitted_params_carries_omega_iov() {
+    let model = make_iov_model();
+    let population = make_iov_population();
+    let opts = fast_opts(EstimationMethod::Foce, Optimizer::Bobyqa, false);
+    let fit_result = fit(&model, &population, &model.default_params.clone(), &opts)
+        .expect("IOV fit must succeed");
+
+    // The supported way to rebuild parameters from a fit — the fix the R bridge
+    // mirrors. It must carry the IOV covariance through, and simulate cleanly.
+    let params =
+        crate::estimation::uncertainty_samples::fitted_params_from_result(&fit_result, &model);
+    assert!(
+        params.omega_iov.is_some(),
+        "fitted_params_from_result must thread omega_iov through for a kappa model"
+    );
+
+    let results = simulate_with_options(
+        &model,
+        &population,
+        &params,
+        2,
+        &crate::SimulateOptions {
+            seed: Some(7),
+            ..Default::default()
+        },
+    )
+    .expect("simulating from fitted params must succeed");
+    assert_eq!(
+        results.len(),
+        2 * population.subjects.len() * population.subjects[0].obs_times.len()
+    );
+    assert!(results.iter().all(|r| {
+        r.ipred.is_finite()
+            && matches!(&r.outcome, SimOutcome::Continuous { value } if value.is_finite())
+    }));
 }


### PR DESCRIPTION
## Why

`ferx_simulate(model, data, fit = f)` panicked for **every** model that declares a `kappa` (#1019):

```
thread '<unnamed>' panicked at src/api/simulate.rs:586:14:
omega_iov is present whenever the model declares kappa (n_kappa > 0)
```

The IOV branch of `emit_subject_rows` draws one κ per occasion from `params.omega_iov` and `expect()`ed it on the parser's invariant. That invariant holds for `CompiledModel::default_params` — but not for parameters a *caller* rebuilds from a fit. The R bridge's `params_from_fit()` hardcodes `omega_iov: None`, so the fit path reached the emitter with `None` and aborted the process, taking the R session's error handling with it. Any VPC or trial simulation from a fitted IOV model was blocked (concretely: MBMA models carrying between-treatment-arm variability as a `kappa`).

This PR is the ferx-core half: a caller bug must not be reported as a panic across an FFI boundary. The ferx-r half threads the fitted Ω_IOV through so the path actually works.

## What changed

- New `validate_iov_simulatable(model, params)` in `api/simulate.rs`: `Err` when `model.n_kappa > 0 && params.omega_iov.is_none()`, naming the omission and pointing at `fitted_params_from_result()`.
- Enforced with the same split the TTE preconditions already use:
  - `simulate_with_options` / `simulate_with_options_diag` → clean `Err`;
  - the `simulate_inner_with_draw` chokepoint (`simulate`, `simulate_with_seed`, the uncertainty path) → panic with the identical message, since those entry points return a `Vec` and have no error channel.
- The surviving `expect()` in the emitter now documents that the guard upstream is what makes it unreachable.
- `docs/model-file/iov.qmd` gains a **Simulation** section (per-occasion κ draw; how to build simulate-ready parameters from a `FitResult`); `CHANGELOG.md` `[Unreleased] → Fixed`.

## Alternatives considered

**Fall back to the model's initial Ω_IOV when `params.omega_iov` is `None`.** Rejected: it makes the call succeed while simulating the *wrong* inter-occasion dispersion, with no diagnostic — exactly the silent-VPC-bias failure mode the occasion-aware draw exists to prevent. Failing is the honest outcome; the fix belongs in the caller.

**Return `Err` from every entry point.** Would change the signature of the public `simulate` / `simulate_with_seed`. The panic-at-chokepoint split is what `validate_tte_simulatable` already does for the same reason.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#301 | open | together — this PR turns the panic into an error; the ferx-r PR makes the path work |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

A call that previously panicked now returns `Err` (or panics with a better message on the `Vec`-returning forms). No call that previously succeeded changes behaviour.

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values:
- [x] Not applicable — error-path only. No numerical result changes: the guard is a no-op whenever `omega_iov` is present, which is every path that produced numbers before. The positive test asserts a fitted-parameter IOV simulation still runs and emits finite rows.

## Performance
- [x] No significant impact expected — one `Option::is_none()` per simulate call.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — `api::iov_integration`, 44 passed)
- [x] Regression test added that fails without this fix (`test_simulate_with_options_errs_when_omega_iov_missing` panicked instead of returning `Err` before)
- [ ] No new tests needed

Three tests in `src/api/tests/iov_integration.rs`, all on the existing 1-kappa IOV model/population:
- `test_simulate_with_options_errs_when_omega_iov_missing` — clean `Err` naming `omega_iov` + `kappa`;
- `test_simulate_with_seed_panics_when_omega_iov_missing` — `#[should_panic]` on the `Vec` path;
- `test_simulate_from_fitted_params_carries_omega_iov` — fits the IOV model, rebuilds via `fitted_params_from_result()`, asserts `omega_iov.is_some()` and that the simulation returns the expected row count with finite IPRED/DV. This is the in-core analogue of the R path the issue reports.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes (`docs/model-file/iov.qmd` → new **Simulation** section)
- [x] New pages linked in `docs/_quarto.yml` — N/A, existing page
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean (no new warnings)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — not touched
- [ ] `Cargo.toml` version bumped if breaking — not breaking

## Docs & examples

### ferx-site
- [x] No new DSL syntax / `[fit_options]` key / example file / data file

### ferx-book
- [x] No new estimator, DSL feature, or fit option

### Example execution
- [x] No example execution step needed (error-path fix; no user-visible numerical change)

## Reviewer hints

Focus on `validate_iov_simulatable` and its two call sites — the question worth checking is whether the chokepoint panic is reachable from any path that *should* have gotten an `Err` instead. It mirrors `validate_tte_simulatable` exactly: `simulate_with_options_diag` validates first and returns `Err`, so only the `Vec`-returning entry points (and `simulate_with_uncertainty`, which builds params via `fitted_params_from_result` and therefore always carries `omega_iov` for a kappa model) can reach the panic.

`src/api/adaptive.rs:463` has a structurally identical `expect`, but its parameters come from the parsed model rather than a caller rebuild, so it is not reachable the same way; left alone rather than widened into this fix.

## Open questions

None.
