### PR TITLE
fix(parser): reject unknown [block] names instead of silently ignoring them [closes #1040]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Changed
+- **An unrecognised `[block]` name is now an error (#1040).** Blocks were read by name lookup, so a
+  header the parser did not know was never read and never reported: a misspelled `[fit_option]` left
+  `ferx check` saying `valid: true` while the fit ran with the default method, the default iteration
+  cap and **no covariance step** — returning without standard errors and no indication why. The same
+  went for `[scalings]`, `[outputs]`, `[derived]`, `[covariates]` and friends. Block names are now
+  closed-world, like the keys inside a block already were: an unknown header is `E_UNKNOWN_BLOCK`,
+  listing every offender with its line, the full valid set, and a did-you-mean for a near match. Two
+  neighbouring silent drops go with it — an instance name where none is taken (`[fit_options DOSE]`)
+  or missing where one is required (`[covariate_nn]`) is `E_BLOCK_INSTANCE_NAME`, and a block whose
+  cargo feature this binary lacks (`[event_model]` without `--features survival`, `[markov_model]`
+  without `--features markov`) is `E_BLOCK_FEATURE_DISABLED` instead of being parsed away. The
+  recognised block names are exported as `known_block_names()` so wrappers can read the list from the
+  engine rather than keeping their own copy.
 - **A dose attribute that is also read by the model is now an error (#993).** `F`,
   `LAGTIME`/`ALAG` and the compartment-indexed `F{n}`/`ALAG{n}`/`LAGTIME{n}` are applied by the
   engine **at the dose event**. A model that declares one and *also* references it in `[odes]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,13 @@ section of the SDLC for the versioning policy).
   neighbouring silent drops go with it — an instance name where none is taken (`[fit_options DOSE]`)
   or missing where one is required (`[covariate_nn]`) is `E_BLOCK_INSTANCE_NAME`, and a block whose
   cargo feature this binary lacks (`[event_model]` without `--features survival`, `[markov_model]`
-  without `--features markov`) is `E_BLOCK_FEATURE_DISABLED` instead of being parsed away. The
-  recognised block names are exported as `known_block_names()` so wrappers can read the list from the
-  engine rather than keeping their own copy.
+  without `--features markov`) is `E_BLOCK_FEATURE_DISABLED` instead of being parsed away, and
+  `[initial_values]` — ferx's own former spelling for initial estimates, unread since they moved
+  inline into `[parameters]` — is `E_DEPRECATED_BLOCK`, naming the replacement rather than offering
+  a did-you-mean that does not exist. The recognised block names are exported as
+  `known_block_names()` so wrappers can read the list from the engine rather than keeping their own
+  copy; it reflects the features the binary was built with, so it never advertises a name the same
+  binary would refuse.
 - **A dose attribute that is also read by the model is now an error (#993).** `F`,
   `LAGTIME`/`ALAG` and the compartment-indexed `F{n}`/`ALAG{n}`/`LAGTIME{n}` are applied by the
   engine **at the dose event**. A model that declares one and *also* references it in `[odes]`

--- a/docs/file-formats/check-report.qmd
+++ b/docs/file-formats/check-report.qmd
@@ -54,6 +54,9 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 |------|----------|---------|
 | `E_PARSE` | error | The model file failed to parse (catch-all for parser errors). |
 | `E_MISSING_BLOCK` | error | A required `[block]` is absent. `block` names which one. |
+| `E_UNKNOWN_BLOCK` | error | A `[block]` header is not a recognised block name. The message lists every offending header with its line, the full valid set, and a did-you-mean when there is a near match; `suggestion` carries the near match on its own. See [#1040](https://github.com/FeRx-NLME/ferx-core/issues/1040). |
+| `E_BLOCK_INSTANCE_NAME` | error | A `[block NAME]` instance name is given for a block that takes none (e.g. `[fit_options DOSE]`), or omitted for one that requires it (`[covariate_nn NAME]`). |
+| `E_BLOCK_FEATURE_DISABLED` | error | A recognised block needs a cargo feature this binary was not built with — `[event_model]` / `[binary_model]` need `--features survival`, `[markov_model]` needs `--features markov`. (`[covariate_nn]` has its own `E_NN_FEATURE_DISABLED`.) |
 | `E_NN_FEATURE_DISABLED` | error | A `[covariate_nn]` block requires building with `--features nn`. |
 | `E_MISSING_COVARIATE` | error | The model references a covariate not present in the data (case-sensitive). |
 | `E_ETA_NOT_DECLARED` | error | An unresolved identifier reads as a random effect (`ETA…` / `KAPPA…`) but no `omega` / `kappa` declaration defines it, and the data carries no such column. Usually a deleted `omega` line whose `exp(ETA_…)` term was left behind. |

--- a/docs/file-formats/check-report.qmd
+++ b/docs/file-formats/check-report.qmd
@@ -54,7 +54,8 @@ Optional fields are omitted entirely when absent (not emitted as `null`).
 |------|----------|---------|
 | `E_PARSE` | error | The model file failed to parse (catch-all for parser errors). |
 | `E_MISSING_BLOCK` | error | A required `[block]` is absent. `block` names which one. |
-| `E_UNKNOWN_BLOCK` | error | A `[block]` header is not a recognised block name. The message lists every offending header with its line, the full valid set, and a did-you-mean when there is a near match; `suggestion` carries the near match on its own. See [#1040](https://github.com/FeRx-NLME/ferx-core/issues/1040). |
+| `E_UNKNOWN_BLOCK` | error | A `[block]` header is not a recognised block name. The message lists every offending header with its line, the valid set **this build accepts**, and a did-you-mean when there is a near match; `suggestion` carries the near match on its own. See [#1040](https://github.com/FeRx-NLME/ferx-core/issues/1040). |
+| `E_DEPRECATED_BLOCK` | error | A `[block]` that *was* ferx syntax and is no longer read — currently `[initial_values]`, whose contents moved inline into `[parameters]`. Reported separately from `E_UNKNOWN_BLOCK` so the message can name the replacement instead of offering a did-you-mean that does not exist. |
 | `E_BLOCK_INSTANCE_NAME` | error | A `[block NAME]` instance name is given for a block that takes none (e.g. `[fit_options DOSE]`), or omitted for one that requires it (`[covariate_nn NAME]`). |
 | `E_BLOCK_FEATURE_DISABLED` | error | A recognised block needs a cargo feature this binary was not built with — `[event_model]` / `[binary_model]` need `--features survival`, `[markov_model]` needs `--features markov`. (`[covariate_nn]` has its own `E_NN_FEATURE_DISABLED`.) |
 | `E_NN_FEATURE_DISABLED` | error | A `[covariate_nn]` block requires building with `--features nn`. |

--- a/docs/model-file/index.qmd
+++ b/docs/model-file/index.qmd
@@ -37,7 +37,15 @@ covariance step while `ferx check` still reported `valid: true`.
 The same applies to the instance-name form: `[covariate_nn NAME]` requires a
 name, and every other block refuses one (`E_BLOCK_INSTANCE_NAME`). A block whose
 cargo feature this binary lacks is refused too, rather than quietly dropped
-(`E_BLOCK_FEATURE_DISABLED`).
+(`E_BLOCK_FEATURE_DISABLED`); the valid-set the error message enumerates is
+likewise the set *this* build accepts, so a default build does not advertise
+`[event_model]`.
+
+`[initial_values]` is **not** a block. Initial estimates are declared inline in
+`[parameters]` (`theta NAME(init, lower, upper)`, `omega NAME ~ variance`); the
+separate block predates that and has not been read for several releases. A file
+still carrying one is now rejected with `E_DEPRECATED_BLOCK` naming the
+replacement — delete the block.
 
 ## Minimal Example
 

--- a/docs/model-file/index.qmd
+++ b/docs/model-file/index.qmd
@@ -11,9 +11,33 @@ ferx-core models are defined in `.ferx` files using a declarative DSL. Each file
 | `[structural_model]` | Yes | Specify the PK model (analytical or ODE) |
 | `[error_model]` | Yes | Define the residual error model |
 | `[odes]` | If ODE | ODE right-hand-side equations |
+| `[adaptive_dosing]` | No | Feedback / TDM dose controller for `simulate()` |
+| `[covariates]` | No | Declare which data columns are covariates (and how they interpolate) |
+| `[covariate_nn NAME]` | No | Neural-network covariate model (needs `--features nn`) |
 | `[data]` | No | Point at the dataset CSV (`$DATA` equivalent); overridden by an explicit CLI/R path |
+| `[data_selection]` | No | Row/subject filters applied to the dataset |
+| `[derived]` | No | Post-hoc derived quantities written to sdtab |
+| `[diffusion]` | No | SDE diffusion terms |
 | `[fit_options]` | No | Configure estimation method and optimizer |
+| `[initial_conditions]` | No | Non-zero compartment initial amounts |
+| `[mixture]` | No | Mixture (subpopulation) model |
+| `[output]` | No | Extra sdtab output columns |
+| `[scaling]` | No | Compartment scaling / observation readouts |
 | `[simulation]` | No | Define a simulation trial design |
+| `[binary_model]` | No | Binary / logistic endpoint (needs `--features survival`) |
+| `[event_model]` | No | Time-to-event endpoint (needs `--features survival`) |
+| `[markov_model]` | No | Continuous-time Markov endpoint (needs `--features markov`) |
+
+Block names are **closed-world**: a header that is not in this table is an error
+(`E_UNKNOWN_BLOCK`), reported with its line number and a did-you-mean when there
+is a near match. A misspelled optional block used to be ignored in silence — a
+`[fit_option]` typo left the fit running with the default method and no
+covariance step while `ferx check` still reported `valid: true`.
+
+The same applies to the instance-name form: `[covariate_nn NAME]` requires a
+name, and every other block refuses one (`E_BLOCK_INSTANCE_NAME`). A block whose
+cargo feature this binary lacks is refused too, rather than quietly dropped
+(`E_BLOCK_FEATURE_DISABLED`).
 
 ## Minimal Example
 

--- a/docs/model-file/neural-networks.qmd
+++ b/docs/model-file/neural-networks.qmd
@@ -69,6 +69,16 @@ DOI [10.1002/psp4.12808](https://doi.org/10.1002/psp4.12808).
 
 ### `[dynamics_nn]` — Low-dimensional Neural ODEs
 
+::: {.callout-important}
+## Not accepted yet — design sketch only
+
+`[dynamics_nn]` is **Phase B** and the parser does not read it. Since block
+names became closed-world, a file containing one is rejected outright with
+`E_UNKNOWN_BLOCK` rather than parsed with the block ignored (see the
+[check report](../file-formats/check-report.qmd)). The syntax below shows the
+intended shape; it is not usable in this release.
+:::
+
 A small neural network appears on the **right-hand side of an ODE**,
 replacing mechanistic terms like Michaelis–Menten or linear elimination
 when the dynamics are unknown:

--- a/src/api/tests/block_name_diagnostic_tests.rs
+++ b/src/api/tests/block_name_diagnostic_tests.rs
@@ -1,0 +1,83 @@
+//! `parse_error_to_diagnostic` mapping for the closed-world `[block]`-name
+//! errors (#1040).
+//!
+//! A parse failure is terminal — `validate_model_file` returns before it has a
+//! `ParsedModel` to read `block_lines` from — so the block and line in the
+//! check report are recovered from the message text itself. These pin that
+//! recovery, and the codes, against the exact strings `check_block_names`
+//! emits (the parser side pins the strings themselves).
+
+use super::parse_error_to_diagnostic;
+
+#[test]
+fn unknown_block_maps_to_e_unknown_block_with_block_line_and_suggestion() {
+    let err = "Unknown block `[fit_option]` (line 16) — did you mean `[fit_options]`. \
+               Valid blocks: adaptive_dosing, fit_options.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("fit_option"));
+    assert_eq!(d.line, Some(16));
+    assert_eq!(
+        d.suggestion.as_deref(),
+        Some("did you mean `[fit_options]`?")
+    );
+}
+
+#[test]
+fn unknown_block_with_no_near_match_carries_no_suggestion() {
+    let err = "Unknown block `[qqqqqqqq]` (line 4). Valid blocks: parameters.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("qqqqqqqq"));
+    assert_eq!(d.line, Some(4));
+    assert!(d.suggestion.is_none());
+}
+
+#[test]
+fn wrong_instance_name_form_maps_to_e_block_instance_name() {
+    // Instance name on a block that takes none: `block` is the block *type*,
+    // not `fit_options DOSE`, so it matches every other block-scoped diagnostic.
+    let err = "Block `[fit_options DOSE]` (line 16) does not take an instance name \
+               — write `[fit_options]`.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_BLOCK_INSTANCE_NAME");
+    assert_eq!(d.block.as_deref(), Some("fit_options"));
+    assert_eq!(d.line, Some(16));
+
+    // The mirror case: a named-only block written without one.
+    let err = "Block `[covariate_nn]` (line 9) requires an instance name \
+               — write `[covariate_nn NAME]`.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_BLOCK_INSTANCE_NAME");
+    assert_eq!(d.block.as_deref(), Some("covariate_nn"));
+    assert_eq!(d.line, Some(9));
+}
+
+#[test]
+fn disabled_feature_block_maps_to_e_block_feature_disabled() {
+    let err = "Block `[event_model]` (line 16) requires building ferx-core with \
+               `--features survival`.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_BLOCK_FEATURE_DISABLED");
+    assert_eq!(d.block.as_deref(), Some("event_model"));
+    assert_eq!(d.line, Some(16));
+}
+
+/// `[covariate_nn]` keeps its own, more specific code — the generic
+/// feature-disabled branch must not swallow it.
+#[test]
+fn covariate_nn_feature_gate_keeps_its_dedicated_code() {
+    let err = "[covariate_nn] blocks require building ferx-core with `--features nn`. \
+               See plans/dcm-and-low-dim-node.md for the design and roadmap.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_NN_FEATURE_DISABLED");
+}
+
+/// Anything else still falls through to the catch-all.
+#[test]
+fn unrelated_parse_error_stays_e_parse() {
+    let d = parse_error_to_diagnostic("Unknown PK model: one_cpt");
+    assert_eq!(d.code, "E_PARSE");
+    assert!(d.block.is_none());
+    assert!(d.line.is_none());
+}

--- a/src/api/tests/block_name_diagnostic_tests.rs
+++ b/src/api/tests/block_name_diagnostic_tests.rs
@@ -21,6 +21,61 @@ fn unknown_block_maps_to_e_unknown_block_with_block_line_and_suggestion() {
         d.suggestion.as_deref(),
         Some("did you mean `[fit_options]`?")
     );
+    // The line moved into the structured field, so it is gone from the message:
+    // the renderer already prints `fit_option:16` ahead of it.
+    assert_eq!(
+        d.message,
+        "Unknown block `[fit_option]` — did you mean `[fit_options]`. \
+         Valid blocks: adaptive_dosing, fit_options."
+    );
+}
+
+/// With more than one offending header the structured `line` would have to pick
+/// one and mislocate the rest, so none is attached and every parenthetical
+/// stays in the message.
+#[test]
+fn several_unknown_blocks_keep_their_lines_in_the_message() {
+    let err = "Unknown block `[scalings]` (line 16) — did you mean `[scaling]`; \
+               `[outputs]` (line 20) — did you mean `[output]`. Valid blocks: output, scaling.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("scalings"));
+    assert!(d.line.is_none());
+    assert_eq!(d.message, err);
+}
+
+/// An unknown header written with an instance name is echoed as written, so the
+/// text can be grepped for in the user's file — but `block` is still the type.
+#[test]
+fn unknown_named_block_keeps_its_instance_name_in_the_message() {
+    let err = "Unknown block `[foo BAR]` (line 9). Valid blocks: parameters.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("foo"));
+    assert_eq!(d.line, Some(9));
+    assert!(d.message.contains("`[foo BAR]`"), "{}", d.message);
+}
+
+/// A malformed parenthetical is not a line: the block still transfers, the
+/// message is left alone, and nothing is mis-parsed into `line`.
+#[test]
+fn unparseable_line_parenthetical_is_ignored() {
+    let err = "Unknown block `[foo]` (line later). Valid blocks: parameters.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("foo"));
+    assert!(d.line.is_none());
+    assert_eq!(d.message, err);
+}
+
+#[test]
+fn deprecated_block_maps_to_e_deprecated_block() {
+    let err = "Deprecated block `[initial_values]` (line 25) is no longer read: \
+               initial estimates are declared inline in `[parameters]` — delete it.";
+    let d = parse_error_to_diagnostic(err);
+    assert_eq!(d.code, "E_DEPRECATED_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("initial_values"));
+    assert_eq!(d.line, Some(25));
 }
 
 #[test]
@@ -71,6 +126,17 @@ fn covariate_nn_feature_gate_keeps_its_dedicated_code() {
                See plans/dcm-and-low-dim-node.md for the design and roadmap.";
     let d = parse_error_to_diagnostic(err);
     assert_eq!(d.code, "E_NN_FEATURE_DISABLED");
+}
+
+/// `E_BLOCK_FEATURE_DISABLED` is matched on its own sentinel, not taken as the
+/// `else` of the instance-name branch: a future ``Block `[…]`` message that is
+/// neither shape must fall through to `E_PARSE` rather than be mis-coded.
+#[test]
+fn other_block_prefixed_errors_fall_through_to_e_parse() {
+    let d = parse_error_to_diagnostic("Block `[odes]` (line 3) has something else wrong.");
+    assert_eq!(d.code, "E_PARSE");
+    assert!(d.block.is_none());
+    assert!(d.line.is_none());
 }
 
 /// Anything else still falls through to the catch-all.

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2934,30 +2934,39 @@ fn parse_error_to_diagnostic(err: &str) -> Diagnostic {
     if err.contains("reserved dose-attribute name") {
         return Diagnostic::error("E_DOSE_ATTR_DOUBLE_USE", err.to_string());
     }
-    // #1040: the three block-header shapes the parser used to drop silently.
-    // `check_block_names` writes the offending header as ``[name] (line N)``, so
-    // the block / line the check report wants come straight out of the message —
-    // this path has no `ParsedModel` to read `block_lines` from, since a parse
-    // error is terminal.
+    // #1040: the block-header shapes the parser used to drop silently.
+    // `check_block_names` writes each offending header as ``[name] (line N)``,
+    // so the block / line the check report wants come straight out of the
+    // message — this path has no `ParsedModel` to read `block_lines` from,
+    // since a parse error is terminal.
     if let Some(rest) = err.strip_prefix("Unknown block `[") {
-        let (block, line) = block_and_line(rest);
-        let mut d = Diagnostic::error("E_UNKNOWN_BLOCK", err.to_string());
-        if let Some(near) = block
-            .as_deref()
-            .and_then(crate::parser::model_parser::nearest_block_name)
+        let mut d = Diagnostic::error("E_UNKNOWN_BLOCK", String::new());
+        if let Some(near) =
+            block_type(rest).and_then(|b| crate::parser::model_parser::nearest_block_name(&b))
         {
             d = d.with_suggestion(format!("did you mean `[{near}]`?"));
         }
-        return attach(d, block, line);
+        return locate(d, err, rest);
+    }
+    if let Some(rest) = err.strip_prefix("Deprecated block `[") {
+        return locate(
+            Diagnostic::error("E_DEPRECATED_BLOCK", String::new()),
+            err,
+            rest,
+        );
     }
     if let Some(rest) = err.strip_prefix("Block `[") {
-        let (block, line) = block_and_line(rest);
+        // Match each shape on its own sentinel rather than letting one be the
+        // `else` of the other: a future ``Block `[…]`` message that is neither
+        // must fall through to `E_PARSE`, not be mis-coded as the last branch.
         let code = if err.contains("instance name") {
             "E_BLOCK_INSTANCE_NAME"
-        } else {
+        } else if err.contains("requires building ferx-core with `--features") {
             "E_BLOCK_FEATURE_DISABLED"
+        } else {
+            return Diagnostic::error("E_PARSE", err.to_string());
         };
-        return attach(Diagnostic::error(code, err.to_string()), block, line);
+        return locate(Diagnostic::error(code, String::new()), err, rest);
     }
     Diagnostic::error("E_PARSE", err.to_string())
 }
@@ -2966,37 +2975,61 @@ fn parse_error_to_diagnostic(err: &str) -> Diagnostic {
 #[path = "tests/block_name_diagnostic_tests.rs"]
 mod block_name_diagnostic_tests;
 
-/// Attach an optional block / line to a diagnostic (builder style, but for
-/// `Option`s).
-fn attach(mut d: Diagnostic, block: Option<String>, line: Option<usize>) -> Diagnostic {
-    if let Some(b) = block {
+/// Give a block-header diagnostic its message plus whatever location the
+/// message text carries.
+///
+/// `err` is the whole parser error; `rest` is its tail, starting just after the
+/// opening ``` `[ ```. The block type always transfers to `block`.
+///
+/// The line is only lifted into `line` when the message names exactly **one**
+/// header — the structured field points at a single place, so promoting the
+/// first of several would silently mislocate the rest. In that unambiguous case
+/// the ` (line N)` is also *removed* from the message, since the renderer
+/// already prints `block:line` ahead of it and repeating it reads as
+/// `fit_option:16: … (line 16)`. With several headers the message keeps every
+/// parenthetical (each finding needs its own) and no `line` is attached.
+fn locate(mut d: Diagnostic, err: &str, rest: &str) -> Diagnostic {
+    if let Some(b) = block_type(rest) {
         d = d.with_block(b);
     }
-    if let Some(l) = line {
-        d = d.with_line(l);
+    let mut lines = line_spans(err);
+    match (lines.next(), lines.next()) {
+        (Some((span, n)), None) => {
+            let mut message = String::with_capacity(err.len());
+            message.push_str(&err[..span.0]);
+            message.push_str(&err[span.1..]);
+            d.message = message;
+            d.with_line(n)
+        }
+        _ => {
+            d.message = err.to_string();
+            d
+        }
     }
-    d
 }
 
-/// Read the block type and 1-based header line out of the tail of a
-/// `check_block_names` message — `rest` starts just after the opening
-/// ``` `[ ```, e.g. ``covariate_nn X]` (line 7) requires …``. The instance name,
-/// when present, is dropped: `block` names the block *type*, matching every
-/// other block-scoped diagnostic.
-fn block_and_line(rest: &str) -> (Option<String>, Option<usize>) {
-    let block = rest.find(']').map(|end| {
-        rest[..end]
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .to_string()
-    });
-    let line = rest
-        .find("(line ")
-        .map(|i| &rest[i + "(line ".len()..])
-        .and_then(|t| t.split(')').next())
-        .and_then(|n| n.parse::<usize>().ok());
-    (block.filter(|b| !b.is_empty()), line)
+/// The block *type* out of the tail of a `check_block_names` message — `rest`
+/// starts just after the opening ``` `[ ```, e.g. ``covariate_nn X]` (line 7)
+/// requires …``. An instance name, when present, is dropped: `block` names the
+/// type, matching every other block-scoped diagnostic.
+fn block_type(rest: &str) -> Option<String> {
+    rest.find(']')
+        .and_then(|end| rest[..end].split_whitespace().next())
+        .filter(|b| !b.is_empty())
+        .map(str::to_string)
+}
+
+/// Every ` (line N)` in `msg`, as `((start, end), N)` byte spans over `msg`.
+/// The leading space is part of the span so removing one leaves no double
+/// space behind.
+fn line_spans(msg: &str) -> impl Iterator<Item = ((usize, usize), usize)> + '_ {
+    msg.match_indices(" (line ").filter_map(move |(at, pat)| {
+        let digits_at = at + pat.len();
+        let digits = &msg[digits_at..];
+        let end = digits.find(')')?;
+        let n = digits[..end].parse::<usize>().ok()?;
+        Some(((at, digits_at + end + 1), n))
+    })
 }
 
 /// Validate a model file (and optionally a dataset) **without fitting**.

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2934,7 +2934,69 @@ fn parse_error_to_diagnostic(err: &str) -> Diagnostic {
     if err.contains("reserved dose-attribute name") {
         return Diagnostic::error("E_DOSE_ATTR_DOUBLE_USE", err.to_string());
     }
+    // #1040: the three block-header shapes the parser used to drop silently.
+    // `check_block_names` writes the offending header as ``[name] (line N)``, so
+    // the block / line the check report wants come straight out of the message —
+    // this path has no `ParsedModel` to read `block_lines` from, since a parse
+    // error is terminal.
+    if let Some(rest) = err.strip_prefix("Unknown block `[") {
+        let (block, line) = block_and_line(rest);
+        let mut d = Diagnostic::error("E_UNKNOWN_BLOCK", err.to_string());
+        if let Some(near) = block
+            .as_deref()
+            .and_then(crate::parser::model_parser::nearest_block_name)
+        {
+            d = d.with_suggestion(format!("did you mean `[{near}]`?"));
+        }
+        return attach(d, block, line);
+    }
+    if let Some(rest) = err.strip_prefix("Block `[") {
+        let (block, line) = block_and_line(rest);
+        let code = if err.contains("instance name") {
+            "E_BLOCK_INSTANCE_NAME"
+        } else {
+            "E_BLOCK_FEATURE_DISABLED"
+        };
+        return attach(Diagnostic::error(code, err.to_string()), block, line);
+    }
     Diagnostic::error("E_PARSE", err.to_string())
+}
+
+#[cfg(test)]
+#[path = "tests/block_name_diagnostic_tests.rs"]
+mod block_name_diagnostic_tests;
+
+/// Attach an optional block / line to a diagnostic (builder style, but for
+/// `Option`s).
+fn attach(mut d: Diagnostic, block: Option<String>, line: Option<usize>) -> Diagnostic {
+    if let Some(b) = block {
+        d = d.with_block(b);
+    }
+    if let Some(l) = line {
+        d = d.with_line(l);
+    }
+    d
+}
+
+/// Read the block type and 1-based header line out of the tail of a
+/// `check_block_names` message — `rest` starts just after the opening
+/// ``` `[ ```, e.g. ``covariate_nn X]` (line 7) requires …``. The instance name,
+/// when present, is dropped: `block` names the block *type*, matching every
+/// other block-scoped diagnostic.
+fn block_and_line(rest: &str) -> (Option<String>, Option<usize>) {
+    let block = rest.find(']').map(|end| {
+        rest[..end]
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_string()
+    });
+    let line = rest
+        .find("(line ")
+        .map(|i| &rest[i + "(line ".len()..])
+        .and_then(|t| t.split(')').next())
+        .and_then(|n| n.parse::<usize>().ok());
+    (block.filter(|b| !b.is_empty()), line)
 }
 
 /// Validate a model file (and optionally a dataset) **without fitting**.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -22,6 +22,7 @@
 //! | `E_PARSE`                 | the model file failed to parse |
 //! | `E_MISSING_BLOCK`         | a required `[block]` is absent |
 //! | `E_UNKNOWN_BLOCK`         | a `[block]` header is not a recognised block name |
+//! | `E_DEPRECATED_BLOCK`      | a `[block]` that was ferx syntax and is no longer read |
 //! | `E_BLOCK_INSTANCE_NAME`   | a `[block NAME]` instance name is present where none is taken, or missing where one is required |
 //! | `E_BLOCK_FEATURE_DISABLED`| a `[block]` needs a cargo feature this binary was not built with |
 //! | `E_NN_FEATURE_DISABLED`   | a `[covariate_nn]` block needs `--features nn` |

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -21,6 +21,9 @@
 //! |------|---------|
 //! | `E_PARSE`                 | the model file failed to parse |
 //! | `E_MISSING_BLOCK`         | a required `[block]` is absent |
+//! | `E_UNKNOWN_BLOCK`         | a `[block]` header is not a recognised block name |
+//! | `E_BLOCK_INSTANCE_NAME`   | a `[block NAME]` instance name is present where none is taken, or missing where one is required |
+//! | `E_BLOCK_FEATURE_DISABLED`| a `[block]` needs a cargo feature this binary was not built with |
 //! | `E_NN_FEATURE_DISABLED`   | a `[covariate_nn]` block needs `--features nn` |
 //! | `E_MISSING_COVARIATE`     | the model references a covariate not present in the data |
 //! | `E_PER_CMT_SCALING`       | an observed compartment lacks a per-CMT scaling entry |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@ pub use estimation::run_sir::run_sir;
 pub use estimation::uncertainty_samples::UncertaintyMethod;
 pub use frem::{prepare_frem, FremDataInfo, FremFitInit, FremPrepareResult};
 pub use io::datareader::{read_nonmem_csv, read_nonmem_csv_with_covariates};
-pub use parser::model_parser::{parse_full_model_file, parse_model_file, parse_model_string};
+pub use parser::model_parser::{
+    known_block_names, parse_full_model_file, parse_model_file, parse_model_string,
+};
 pub use propensity_match::MatchMethod;
 // Adaptive (feedback) dosing vocabulary (#391). Re-exported at the crate root so
 // the public `simulate_adaptive` API — its controller, monitors, and the fields

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -10079,15 +10079,46 @@ const BLOCK_REGISTRY: &[(&str, BlockForm, Option<&str>)] = &[
     ("structural_model", BlockForm::Unnamed, None),
 ];
 
-/// The name of every `[block]` this build of the parser recognises, in the
+/// Blocks that *were* ferx syntax and are no longer read, with the remediation
+/// to print. Kept separate from [`BLOCK_REGISTRY`] because they are neither
+/// valid (they must not appear in the "valid blocks" enumeration) nor unknown
+/// (a bare "unknown block, did you mean …" is unhelpful for something that was
+/// once the documented spelling, and the nearest valid name is often far enough
+/// away that no did-you-mean fires at all).
+///
+/// `initial_values` is the one live case: initial estimates moved inline into
+/// `[parameters]`, the parser stopped reading the block, and — because unknown
+/// names were silently dropped — nothing ever said so. `ferx-r` still lists it
+/// in its section docs and three of its checked-in example models still carry
+/// one, so this fires for real files (#1040).
+const DEPRECATED_BLOCKS: &[(&str, &str)] = &[(
+    "initial_values",
+    "initial estimates are declared inline in `[parameters]` \
+     (`theta NAME(init, lower, upper)`, `omega NAME ~ variance`); \
+     the block has not been read for several releases — delete it",
+)];
+
+/// The name of every `[block]` **this build** of the parser will accept, in the
 /// order they appear in the error message (alphabetical).
+///
+/// Feature-gated blocks are filtered out when their feature is off: a default
+/// build cannot use `[event_model]`, so listing it as valid would advertise a
+/// name the same binary then rejects with `E_BLOCK_FEATURE_DISABLED`. The
+/// registry itself still *recognises* those names in every build — that is what
+/// makes the rejection a specific "build with `--features …`" error rather than
+/// a bare "unknown block".
 ///
 /// Exposed so downstream consumers (`ferx-r`'s `ferx_model_validate()`,
 /// `ferxtranslate`) can source the block list from the engine instead of
 /// keeping their own copy — the duplicated R-side list had already drifted
-/// from this one (#1040).
+/// from this one (#1040). Because the result is build-dependent, a consumer
+/// must read it from the same binary it will parse with.
 pub fn known_block_names() -> Vec<&'static str> {
-    BLOCK_REGISTRY.iter().map(|(n, _, _)| *n).collect()
+    BLOCK_REGISTRY
+        .iter()
+        .filter(|(_, _, feature)| feature.is_none_or(block_feature_enabled))
+        .map(|(n, _, _)| *n)
+        .collect()
 }
 
 /// Whether the cargo feature a registry entry names is enabled in this build.
@@ -10133,38 +10164,54 @@ pub(crate) fn nearest_block_name(name: &str) -> Option<&'static str> {
 /// Reject any `[block]` header the parser would otherwise drop on the floor.
 ///
 /// `headers` is every header seen, in source order, as
-/// `(type, instance, 1-based line)`. Three silent-drop shapes are caught, in
+/// `(type, instance, 1-based line)`. Four silent-drop shapes are caught, in
 /// the order a user is most likely to hit them:
 ///
-/// 1. an unrecognised block name (`E_UNKNOWN_BLOCK`),
-/// 2. a known block written in the wrong header form — an instance name on a
+/// 1. a block that was ferx syntax and is no longer read
+///    (`E_DEPRECATED_BLOCK`),
+/// 2. an unrecognised block name (`E_UNKNOWN_BLOCK`),
+/// 3. a known block written in the wrong header form — an instance name on a
 ///    block that takes none, or a missing one on `[covariate_nn NAME]`
 ///    (`E_BLOCK_INSTANCE_NAME`),
-/// 3. a known block whose cargo feature this binary was not built with
+/// 4. a known block whose cargo feature this binary was not built with
 ///    (`E_BLOCK_FEATURE_DISABLED`).
 ///
 /// All findings of the first non-empty class are reported together, so an
 /// author fixing a batch of typos sees them in one pass.
 fn check_block_names(headers: &[(String, Option<String>, usize)]) -> Result<(), String> {
+    let mut deprecated: Vec<String> = Vec::new();
     let mut unknown: Vec<String> = Vec::new();
     let mut wrong_form: Vec<String> = Vec::new();
     let mut disabled: Vec<String> = Vec::new();
-    let mut seen: Vec<(&str, bool)> = Vec::new();
+    let mut seen: Vec<(&str, Option<&str>)> = Vec::new();
 
     for (ty, instance, line) in headers {
-        // Report each distinct (name, named-or-not) shape once, however many
-        // times it is repeated in the file.
-        let key = (ty.as_str(), instance.is_some());
+        // Report each distinct header once, however many times it is repeated.
+        // Keyed on the instance name too, so `[foo A]` and `[foo B]` are two
+        // findings rather than one entry that names only the first.
+        let key = (ty.as_str(), instance.as_deref());
         if seen.contains(&key) {
             continue;
         }
         seen.push(key);
+        // Echo the header exactly as written, instance name included, so the
+        // text is greppable in the user's own file.
+        let header = match instance {
+            Some(inst) => format!("[{ty} {inst}]"),
+            None => format!("[{ty}]"),
+        };
+        if let Some((name, remedy)) = DEPRECATED_BLOCKS.iter().find(|(n, _)| *n == ty) {
+            deprecated.push(format!(
+                "`[{name}]` (line {line}) is no longer read: {remedy}"
+            ));
+            continue;
+        }
         let Some((name, form, feature)) = BLOCK_REGISTRY.iter().find(|(n, _, _)| n == ty) else {
             let hint = match nearest_block_name(ty) {
                 Some(near) => format!(" — did you mean `[{near}]`"),
                 None => String::new(),
             };
-            unknown.push(format!("`[{ty}]` (line {line}){hint}"));
+            unknown.push(format!("`{header}` (line {line}){hint}"));
             continue;
         };
         match (form, instance) {
@@ -10185,6 +10232,9 @@ fn check_block_names(headers: &[(String, Option<String>, usize)]) -> Result<(), 
         }
     }
 
+    if !deprecated.is_empty() {
+        return Err(format!("Deprecated block {}.", deprecated.join("; ")));
+    }
     if !unknown.is_empty() {
         return Err(format!(
             "Unknown block {}. Valid blocks: {}.",

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -10026,6 +10026,181 @@ struct ParsedKappas {
 
 // --- Block extraction ---
 
+/// Which header form a `[block]` accepts.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BlockForm {
+    /// `[name]` only.
+    Unnamed,
+    /// `[name]` or `[name INSTANCE]` — several instances may coexist.
+    Either,
+    /// `[name INSTANCE]` only.
+    Named,
+}
+
+/// Every `[block]` name the parser reads, with the header form it accepts and
+/// the cargo feature it needs (`None` = always compiled in).
+///
+/// This is the closed-world registry behind `E_UNKNOWN_BLOCK` (#1040). Blocks
+/// are consumed by *name lookup* — `blocks.get("fit_options")` and friends —
+/// never by an exhaustive match, so without this table a block the parser does
+/// not know is simply never read: a misspelled `[fit_option]` used to leave
+/// `ferx check` reporting `valid: true` while the fit silently ran with the
+/// default method and no covariance step. Keys inside a block are already
+/// closed-world (`[event_model]: unknown key ...`); this closes the same door
+/// on the block names themselves.
+///
+/// **Teaching the parser a new block means adding it here in the same PR** —
+/// otherwise the new block is rejected as unknown.
+///
+/// `covariate_nn` carries no feature here on purpose: it has its own, more
+/// specific `E_NN_FEATURE_DISABLED` error (which points at the design doc)
+/// raised further down in `parse_full_model`.
+const BLOCK_REGISTRY: &[(&str, BlockForm, Option<&str>)] = &[
+    ("adaptive_dosing", BlockForm::Unnamed, None),
+    ("binary_model", BlockForm::Either, Some("survival")),
+    ("covariate_nn", BlockForm::Named, None),
+    ("covariates", BlockForm::Unnamed, None),
+    ("data", BlockForm::Unnamed, None),
+    ("data_selection", BlockForm::Unnamed, None),
+    ("derived", BlockForm::Unnamed, None),
+    ("diffusion", BlockForm::Unnamed, None),
+    ("error_model", BlockForm::Unnamed, None),
+    ("event_model", BlockForm::Either, Some("survival")),
+    ("fit_options", BlockForm::Unnamed, None),
+    ("individual_parameters", BlockForm::Unnamed, None),
+    ("initial_conditions", BlockForm::Unnamed, None),
+    ("markov_model", BlockForm::Either, Some("markov")),
+    ("mixture", BlockForm::Unnamed, None),
+    ("odes", BlockForm::Unnamed, None),
+    ("output", BlockForm::Unnamed, None),
+    ("parameters", BlockForm::Unnamed, None),
+    ("scaling", BlockForm::Unnamed, None),
+    ("simulation", BlockForm::Unnamed, None),
+    ("structural_model", BlockForm::Unnamed, None),
+];
+
+/// The name of every `[block]` this build of the parser recognises, in the
+/// order they appear in the error message (alphabetical).
+///
+/// Exposed so downstream consumers (`ferx-r`'s `ferx_model_validate()`,
+/// `ferxtranslate`) can source the block list from the engine instead of
+/// keeping their own copy — the duplicated R-side list had already drifted
+/// from this one (#1040).
+pub fn known_block_names() -> Vec<&'static str> {
+    BLOCK_REGISTRY.iter().map(|(n, _, _)| *n).collect()
+}
+
+/// Whether the cargo feature a registry entry names is enabled in this build.
+fn block_feature_enabled(feature: &str) -> bool {
+    match feature {
+        "survival" => cfg!(feature = "survival"),
+        "markov" => cfg!(feature = "markov"),
+        "nn" => cfg!(feature = "nn"),
+        // An unrecognised feature name can only be a registry typo; treating it
+        // as enabled keeps a mistake here from rejecting a valid model.
+        _ => true,
+    }
+}
+
+/// Levenshtein distance, used only to offer a did-you-mean for a misspelled
+/// block name.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != *cb);
+            cur[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// The registry name closest to `name`, when one is close enough to be worth
+/// suggesting: an edit distance of at most 2, or a plain prefix relationship
+/// (which catches `fit_option` → `fit_options` and `param` → `parameters`).
+pub(crate) fn nearest_block_name(name: &str) -> Option<&'static str> {
+    BLOCK_REGISTRY
+        .iter()
+        .map(|(n, _, _)| *n)
+        .filter(|n| n.starts_with(name) || name.starts_with(*n) || edit_distance(name, n) <= 2)
+        .min_by_key(|n| edit_distance(name, n))
+}
+
+/// Reject any `[block]` header the parser would otherwise drop on the floor.
+///
+/// `headers` is every header seen, in source order, as
+/// `(type, instance, 1-based line)`. Three silent-drop shapes are caught, in
+/// the order a user is most likely to hit them:
+///
+/// 1. an unrecognised block name (`E_UNKNOWN_BLOCK`),
+/// 2. a known block written in the wrong header form — an instance name on a
+///    block that takes none, or a missing one on `[covariate_nn NAME]`
+///    (`E_BLOCK_INSTANCE_NAME`),
+/// 3. a known block whose cargo feature this binary was not built with
+///    (`E_BLOCK_FEATURE_DISABLED`).
+///
+/// All findings of the first non-empty class are reported together, so an
+/// author fixing a batch of typos sees them in one pass.
+fn check_block_names(headers: &[(String, Option<String>, usize)]) -> Result<(), String> {
+    let mut unknown: Vec<String> = Vec::new();
+    let mut wrong_form: Vec<String> = Vec::new();
+    let mut disabled: Vec<String> = Vec::new();
+    let mut seen: Vec<(&str, bool)> = Vec::new();
+
+    for (ty, instance, line) in headers {
+        // Report each distinct (name, named-or-not) shape once, however many
+        // times it is repeated in the file.
+        let key = (ty.as_str(), instance.is_some());
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.push(key);
+        let Some((name, form, feature)) = BLOCK_REGISTRY.iter().find(|(n, _, _)| n == ty) else {
+            let hint = match nearest_block_name(ty) {
+                Some(near) => format!(" — did you mean `[{near}]`"),
+                None => String::new(),
+            };
+            unknown.push(format!("`[{ty}]` (line {line}){hint}"));
+            continue;
+        };
+        match (form, instance) {
+            (BlockForm::Unnamed, Some(inst)) => wrong_form.push(format!(
+                "`[{name} {inst}]` (line {line}) does not take an instance name — write `[{name}]`"
+            )),
+            (BlockForm::Named, None) => wrong_form.push(format!(
+                "`[{name}]` (line {line}) requires an instance name — write `[{name} NAME]`"
+            )),
+            _ => {}
+        }
+        if let Some(feature) = feature {
+            if !block_feature_enabled(feature) {
+                disabled.push(format!(
+                    "`[{name}]` (line {line}) requires building ferx-core with `--features {feature}`"
+                ));
+            }
+        }
+    }
+
+    if !unknown.is_empty() {
+        return Err(format!(
+            "Unknown block {}. Valid blocks: {}.",
+            unknown.join("; "),
+            known_block_names().join(", ")
+        ));
+    }
+    if !wrong_form.is_empty() {
+        return Err(format!("Block {}.", wrong_form.join("; ")));
+    }
+    if !disabled.is_empty() {
+        return Err(format!("Block {}.", disabled.join("; ")));
+    }
+    Ok(())
+}
+
 fn extract_model_name(content: &str) -> String {
     let re = Regex::new(r"(?m)^\s*model\s+(\w+)").unwrap();
     re.captures(content)
@@ -10069,6 +10244,10 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
         Named { ty: String, name: String },
     }
     let mut current: Option<BlockTarget> = None;
+    // Every header seen, in source order, as `(type, instance, 1-based line)`.
+    // Validated against `BLOCK_REGISTRY` once the whole file has been scanned
+    // (#1040) so a misspelled block name is an error rather than a silent drop.
+    let mut headers: Vec<(String, Option<String>, usize)> = Vec::new();
 
     for (idx, line) in content.lines().enumerate() {
         let without_comment = match line.find('#').into_iter().chain(line.find("//")).min() {
@@ -10082,6 +10261,11 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
 
         if let Some(caps) = block_re.captures(trimmed) {
             let ty = caps[1].to_lowercase();
+            headers.push((
+                ty.clone(),
+                caps.get(2).map(|m| m.as_str().to_string()),
+                idx + 1,
+            ));
             current = match caps.get(2) {
                 Some(m) => Some(BlockTarget::Named {
                     ty,
@@ -10118,6 +10302,8 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
             None => { /* lines before any block header are ignored */ }
         }
     }
+
+    check_block_names(&headers)?;
 
     Ok(out)
 }

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -9417,10 +9417,10 @@ fn test_unknown_block_name_is_rejected_with_line_and_valid_set() {
         "near miss should be suggested, got: {err}"
     );
     // The valid set is enumerated, in the `[event_model]: unknown key ...` style.
-    assert!(
-        err.contains("Valid blocks: adaptive_dosing, binary_model"),
-        "{err}"
-    );
+    // Assert on names present in every build — the enumeration is filtered by
+    // the features this binary carries (see `known_block_names`).
+    assert!(err.contains("Valid blocks: adaptive_dosing, "), "{err}");
+    assert!(err.contains("fit_options, "), "{err}");
     assert!(err.contains("structural_model."), "{err}");
 }
 
@@ -9536,6 +9536,65 @@ fn test_known_block_names_are_sorted_and_unique() {
     sorted.dedup();
     assert_eq!(names, sorted, "BLOCK_REGISTRY must be sorted and unique");
     assert!(names.contains(&"fit_options"));
+    // Deprecated names are not valid, so they must never be advertised.
+    assert!(!names.contains(&"initial_values"));
+}
+
+/// The advertised list is what *this* binary accepts. A build without a
+/// feature must not name the blocks it would then refuse — a consumer told to
+/// source the list from the engine (`ferx-r`) would otherwise call
+/// `[markov_model]` valid against a core that rejects it.
+#[test]
+fn test_known_block_names_track_the_build_features() {
+    let names = known_block_names();
+    assert_eq!(
+        names.contains(&"event_model"),
+        cfg!(feature = "survival"),
+        "event_model must be advertised iff `survival` is on"
+    );
+    assert_eq!(
+        names.contains(&"markov_model"),
+        cfg!(feature = "markov"),
+        "markov_model must be advertised iff `markov` is on"
+    );
+    // Ungated blocks are there whatever the build.
+    assert!(names.contains(&"parameters") && names.contains(&"odes"));
+    // A registry entry naming a feature this function does not know can only be
+    // a typo in the table; treat it as enabled so the mistake never rejects a
+    // valid model.
+    assert!(block_feature_enabled("not-a-real-feature"));
+}
+
+/// A block that *was* ferx syntax gets its own code and remediation rather
+/// than a bare "unknown block": `initial_values` predates inline inits, the
+/// parser stopped reading it silently, and `nearest_block_name` finds nothing
+/// close enough to suggest (`initial_conditions` is far past edit distance 2),
+/// so the generic path would leave the user with no explanation at all.
+#[test]
+fn test_deprecated_block_is_rejected_with_its_remediation() {
+    assert_eq!(nearest_block_name("initial_values"), None);
+    let src = model_with_extra_block("[initial_values]\n  theta = [0.2, 10.0]\n  sigma = [0.02]\n");
+    let err = parse_model_string(&src).expect_err("deprecated block must be an error");
+    assert!(
+        err.starts_with("Deprecated block `[initial_values]` (line 16) is no longer read:"),
+        "{err}"
+    );
+    assert!(err.contains("declared inline in `[parameters]`"), "{err}");
+    assert!(err.contains("delete it"), "{err}");
+    // Not the generic bucket: no "valid blocks" dump, no did-you-mean.
+    assert!(!err.contains("Valid blocks"), "{err}");
+}
+
+/// An unknown header written with an instance name is echoed as written, so
+/// the message can be grepped for in the user's own file — and two instances
+/// of the same unknown type are two findings, not one entry that names only
+/// the first.
+#[test]
+fn test_unknown_named_block_reports_its_instance_name() {
+    let src = model_with_extra_block("[foo BAR]\n  k = 1\n\n[foo BAZ]\n  k = 2\n");
+    let err = parse_model_string(&src).expect_err("unknown block must be an error");
+    assert!(err.contains("`[foo BAR]` (line 16)"), "{err}");
+    assert!(err.contains("`[foo BAZ]` (line 19)"), "{err}");
 }
 
 // ─── [covariate_nn] dot-access + pk_param_fn dispatch (Phase A M1 step 3) ────

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -3664,35 +3664,28 @@ fn test_parse_all_example_ferx_files() {
                 continue;
             }
         }
-        // Endpoint-only files (no [structural_model] block) — TTE `[event_model]` or the
-        // #760 `[binary_model]` — require the survival feature to parse (the endpoint
-        // block is unrecognized without it, so the parser demands the Gaussian PK blocks).
-        // Use a line-start check so a comment like "# Note: [structural_model] ..." in an
+        // A file declaring a feature-gated endpoint block — TTE `[event_model]` /
+        // `[binary_model]` (`survival`), or the CTMM `[markov_model]` (`markov`,
+        // which implies `survival`) — cannot parse in a build without that feature:
+        // since #1040 the parser rejects the block outright rather than reading the
+        // file as a Gaussian-only model. Skip those files here; the rejection itself
+        // is pinned by `test_feature_gated_block_rejected_without_its_feature`.
+        // Line-start checks so a comment like "# Note: [structural_model] ..." in an
         // example header does not falsely count as a block.
+        let block_at_line_start = |src: &str, block: &str| {
+            src.lines()
+                .any(|l| l.trim_start().starts_with(&format!("[{block}")))
+        };
         if !cfg!(feature = "survival") {
             let src = std::fs::read_to_string(&path).unwrap_or_default();
-            let has_nongaussian_endpoint =
-                src.contains("[event_model") || src.contains("[binary_model");
-            let has_struct_block = src
-                .lines()
-                .any(|l| l.trim_start().starts_with("[structural_model"));
-            if has_nongaussian_endpoint && !has_struct_block {
+            if block_at_line_start(&src, "event_model") || block_at_line_start(&src, "binary_model")
+            {
                 continue;
             }
         }
-        // A `[markov_model]` (CTMM) endpoint-only file needs the `markov` feature
-        // specifically (`markov` implies `survival`, so the `survival`-only build above
-        // does not cover it): without `markov` the block is unrecognized and the parser
-        // demands the Gaussian PK blocks. Skip such a file whenever `markov` is off.
         if !cfg!(feature = "markov") {
             let src = std::fs::read_to_string(&path).unwrap_or_default();
-            let has_markov_endpoint = src
-                .lines()
-                .any(|l| l.trim_start().starts_with("[markov_model"));
-            let has_struct_block = src
-                .lines()
-                .any(|l| l.trim_start().starts_with("[structural_model"));
-            if has_markov_endpoint && !has_struct_block {
+            if block_at_line_start(&src, "markov_model") {
                 continue;
             }
         }
@@ -9357,14 +9350,16 @@ fn test_covariate_nn_block_without_nn_feature_errors() {
 }
 
 /// Sanity for the named-block parser extension itself (independent of the
-/// NN feature). `[block_type NAME]` should be recognised and parsed.
+/// NN feature). `[block_type NAME]` should be recognised and parsed. Uses a
+/// registry block (`covariate_nn`, which is named-only) rather than an invented
+/// name — since #1040 `extract_blocks` rejects unknown block names.
 #[test]
 fn test_extract_blocks_recognizes_named_block_form() {
     let src = "
 [parameters]
   theta T1(1.0, 0.001, 10.0)
 
-[some_named_block FOO]
+[covariate_nn FOO]
   key = value
 ";
     let extracted = extract_blocks(src).unwrap();
@@ -9373,11 +9368,174 @@ fn test_extract_blocks_recognizes_named_block_form() {
     // Named block captured by type + instance.
     let by_inst = extracted
         .named
-        .get("some_named_block")
+        .get("covariate_nn")
         .expect("named block extracted");
     let lines = by_inst.get("FOO").expect("instance FOO present");
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0], "key = value");
+}
+
+// ─── Closed-world `[block]` names (#1040) ────────────────────────────────────
+
+/// A minimal but complete model, with `{extra}` spliced in after the required
+/// blocks so a test can add one offending header.
+fn model_with_extra_block(extra: &str) -> String {
+    format!(
+        "\
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+{extra}"
+    )
+}
+
+/// The headline regression: a misspelled optional block used to be dropped on
+/// the floor — `[fit_option]` left the fit running with the default method and
+/// no covariance step while `ferx check` still said `valid: true`.
+#[test]
+fn test_unknown_block_name_is_rejected_with_line_and_valid_set() {
+    let src = model_with_extra_block("[fit_option]\n  method = focei\n");
+    let err = parse_model_string(&src).expect_err("unknown block must be an error");
+    assert!(
+        err.starts_with("Unknown block `[fit_option]` (line 16)"),
+        "message should name the block and its header line, got: {err}"
+    );
+    assert!(
+        err.contains("did you mean `[fit_options]`"),
+        "near miss should be suggested, got: {err}"
+    );
+    // The valid set is enumerated, in the `[event_model]: unknown key ...` style.
+    assert!(
+        err.contains("Valid blocks: adaptive_dosing, binary_model"),
+        "{err}"
+    );
+    assert!(err.contains("structural_model."), "{err}");
+}
+
+/// Every offender is reported in one pass, so a batch of typos does not turn
+/// into a fix-one-reparse loop.
+#[test]
+fn test_unknown_block_names_are_all_reported_together() {
+    let src = model_with_extra_block("[scalings]\n  V = 1.0\n\n[outputs]\n  CL\n");
+    let err = parse_model_string(&src).expect_err("unknown blocks must be an error");
+    assert!(err.contains("`[scalings]`"), "{err}");
+    assert!(err.contains("`[outputs]`"), "{err}");
+    assert!(err.contains("did you mean `[scaling]`"), "{err}");
+    assert!(err.contains("did you mean `[output]`"), "{err}");
+}
+
+/// An invented name with no near miss still errors — just without a hint.
+#[test]
+fn test_unknown_block_without_near_match_has_no_suggestion() {
+    let src = model_with_extra_block("[qqqqqqqq]\n  key = value\n");
+    let err = parse_model_string(&src).expect_err("unknown block must be an error");
+    assert!(err.contains("`[qqqqqqqq]`"), "{err}");
+    assert!(!err.contains("did you mean"), "{err}");
+}
+
+/// A repeated unknown header is reported once, not once per occurrence.
+#[test]
+fn test_unknown_block_reported_once_per_name() {
+    let src =
+        model_with_extra_block("[fit_option]\n  method = focei\n\n[fit_option]\n  maxiter = 5\n");
+    let err = parse_model_string(&src).expect_err("unknown block must be an error");
+    assert_eq!(err.matches("`[fit_option]`").count(), 1, "{err}");
+}
+
+/// Block names are case-folded before the lookup, as they always have been —
+/// `[FIT_OPTIONS]` is valid, not unknown.
+#[test]
+fn test_uppercase_block_name_is_not_unknown() {
+    let src = model_with_extra_block("[FIT_OPTIONS]\n  maxiter = 5\n");
+    assert!(parse_model_string(&src).is_ok());
+}
+
+/// An instance name on a block that takes none is the same silent drop by
+/// another route: it lands in the `named` map that nothing reads.
+#[test]
+fn test_instance_name_on_unnamed_only_block_is_rejected() {
+    let src = model_with_extra_block("[fit_options DOSE]\n  maxiter = 5\n");
+    let err = parse_model_string(&src).expect_err("instance name must be an error");
+    assert!(
+        err.contains("`[fit_options DOSE]` (line 16) does not take an instance name"),
+        "{err}"
+    );
+    assert!(err.contains("write `[fit_options]`"), "{err}");
+}
+
+/// The mirror case: `[covariate_nn]` is read only out of the named map, so an
+/// unnamed one was silently ignored.
+#[test]
+fn test_named_only_block_without_instance_name_is_rejected() {
+    let src = model_with_extra_block("[covariate_nn]\n  inputs = [WT]\n");
+    let err = parse_model_string(&src).expect_err("missing instance name must be an error");
+    assert!(
+        err.contains("`[covariate_nn]` (line 16) requires an instance name"),
+        "{err}"
+    );
+    assert!(err.contains("write `[covariate_nn NAME]`"), "{err}");
+}
+
+/// A block whose cargo feature is off is *known* but unusable — reject it
+/// rather than parse the file as if the endpoint were not there.
+#[cfg(not(feature = "survival"))]
+#[test]
+fn test_feature_gated_block_rejected_without_its_feature() {
+    let src = model_with_extra_block("[event_model]\n  family = exponential\n");
+    let err = parse_model_string(&src).expect_err("feature-gated block must be an error");
+    assert!(
+        err.contains(
+            "`[event_model]` (line 16) requires building ferx-core with `--features survival`"
+        ),
+        "{err}"
+    );
+}
+
+/// With the feature on, the same file parses — the gate is the only reason the
+/// block is refused above.
+#[cfg(feature = "survival")]
+#[test]
+fn test_feature_gated_block_accepted_with_its_feature() {
+    let src = model_with_extra_block(
+        "[event_model]\n  cmt = 2\n  family = exponential\n  scale = TVCL\n",
+    );
+    assert!(parse_model_string(&src).is_ok());
+}
+
+#[test]
+fn test_nearest_block_name_thresholds() {
+    // Prefix relationship, either direction.
+    assert_eq!(nearest_block_name("fit_option"), Some("fit_options"));
+    assert_eq!(nearest_block_name("parameters_pk"), Some("parameters"));
+    // Within edit distance 2.
+    assert_eq!(nearest_block_name("odez"), Some("odes"));
+    // Far enough away that a suggestion would be noise.
+    assert_eq!(nearest_block_name("qqqqqqqq"), None);
+}
+
+/// The registry is what the rest of the parser looks up, so nothing may be in
+/// one and not the other. `known_block_names` is also the list `ferx-r` and
+/// `ferxtranslate` are meant to read instead of keeping their own copy.
+#[test]
+fn test_known_block_names_are_sorted_and_unique() {
+    let names = known_block_names();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(names, sorted, "BLOCK_REGISTRY must be sorted and unique");
+    assert!(names.contains(&"fit_options"));
 }
 
 // ─── [covariate_nn] dot-access + pk_param_fn dispatch (Phase A M1 step 3) ────

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -80,6 +80,50 @@ fn missing_block_is_reported_as_e_missing_block() {
     let _ = std::fs::remove_file(&model);
 }
 
+/// #1040: a misspelled optional block used to leave `ferx check` reporting
+/// `valid: true` while the fit silently ran with the default method and no
+/// covariance step. It is now an error, located at the offending header.
+#[test]
+fn unknown_block_is_reported_as_e_unknown_block() {
+    let model = temp_model(
+        "unknown_block",
+        &format!("{COV_MODEL}\n[fit_option]\n  method = focei\n  covariance = true\n"),
+    );
+    let report = validate_model_file(model.to_str().unwrap(), None);
+    assert!(!report.valid, "unknown block must invalidate the report");
+    let d = &report.diagnostics[0];
+    assert_eq!(d.code, "E_UNKNOWN_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("fit_option"));
+    assert_eq!(d.line, Some(17));
+    assert_eq!(
+        d.suggestion.as_deref(),
+        Some("did you mean `[fit_options]`?")
+    );
+    assert!(
+        d.message.contains("Valid blocks: "),
+        "message must enumerate the valid set: {}",
+        d.message
+    );
+    let _ = std::fs::remove_file(&model);
+}
+
+/// The same rejection reaches `fit()` through `first_error`, byte-identical —
+/// there is no separate path for the batch and the fail-fast callers.
+#[test]
+fn unknown_block_also_fails_the_parser_directly() {
+    let model = temp_model(
+        "unknown_block_parse",
+        &format!("{COV_MODEL}\n[scalings]\n  V = 1.0\n"),
+    );
+    let err = match parse_full_model_file(Path::new(model.to_str().unwrap())) {
+        Err(e) => e,
+        Ok(_) => panic!("unknown block must fail the parse"),
+    };
+    assert!(err.starts_with("Unknown block `[scalings]`"), "{err}");
+    assert!(err.contains("did you mean `[scaling]`"), "{err}");
+    let _ = std::fs::remove_file(&model);
+}
+
 #[test]
 fn missing_covariate_is_reported_with_data() {
     // bioavailability.csv carries no covariate columns, but the model references WGT.

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -107,6 +107,35 @@ fn unknown_block_is_reported_as_e_unknown_block() {
     let _ = std::fs::remove_file(&model);
 }
 
+/// `[initial_values]` was ferx's own spelling for initial estimates before they
+/// moved inline into `[parameters]`. The parser stopped reading it and — because
+/// unknown names were dropped in silence — never said so. It gets its own code
+/// and a remediation rather than a bare "unknown block", since no valid name is
+/// close enough for a did-you-mean.
+#[test]
+fn deprecated_block_is_reported_as_e_deprecated_block() {
+    let model = temp_model(
+        "deprecated_block",
+        &format!("{COV_MODEL}\n[initial_values]\n  theta = [0.2, 10.0]\n"),
+    );
+    let report = validate_model_file(model.to_str().unwrap(), None);
+    assert!(
+        !report.valid,
+        "a deprecated block must invalidate the report"
+    );
+    let d = &report.diagnostics[0];
+    assert_eq!(d.code, "E_DEPRECATED_BLOCK");
+    assert_eq!(d.block.as_deref(), Some("initial_values"));
+    assert_eq!(d.line, Some(17));
+    assert!(
+        d.message.contains("`[parameters]`") && d.message.contains("delete it"),
+        "message must name the replacement: {}",
+        d.message
+    );
+    assert!(d.suggestion.is_none());
+    let _ = std::fs::remove_file(&model);
+}
+
 /// The same rejection reaches `fit()` through `first_error`, byte-identical —
 /// there is no separate path for the batch and the fail-fast callers.
 #[test]


### PR DESCRIPTION
## Why

Reported downstream (InsightRX/pharma_ai_llm#1100) while evaluating ferx as a third PopPK
engine alongside NONMEM and nlmixr2, and copied here as #1040.

An unrecognised `[block]` header produced **no diagnostic at all**. `extract_blocks` collects
every `[name]` header it sees into a map, and the rest of `compile_model` reads blocks by *name
lookup* — `blocks.get("individual_parameters")`, `blocks.get("fit_options")`, … — never by an
exhaustive match. A block whose name nothing looks up is simply never read.

So a misspelled optional block was silently dropped:

```
[fit_option]          # note: singular
  method     = focei
  maxiter    = 500
  covariance = true
```

`ferx check` reported `valid: true`. The fit then ran with the *default* method and iteration
cap and **no covariance step** — returning without standard errors, and nothing said why. Same
shape for `[scalings]`, `[outputs]`, `[derived]`, `[covariates]`, `[simulation]`: each silently
dropped the behaviour it was meant to configure.

Unknown *keys* inside a known block were already hard errors that enumerate the valid set
(`[event_model]: unknown key 'foo' — valid keys: cmt, family, scale, …`). Keys were
closed-world; block names were open-world. This was the one failure mode in the validation
surface that is silent rather than loud, and the one that yields a plausible-looking fit built
on ignored input.

It matters more than a typical typo class because the `.ferx` grammar is new enough that LLM
authoring tools have essentially no training data for it, so invented and misspelled block
names are the highest-probability authoring error, not an edge case.

## What changed

`BLOCK_REGISTRY` in `parser/model_parser.rs` is now the closed-world list of block names, each
with the header form it accepts (`[name]`, `[name INSTANCE]`, or either) and the cargo feature
it needs. `extract_blocks` records every header it sees as `(type, instance, line)` and
validates the lot in one pass before returning, so three silent-drop shapes are now errors:

| Code | Meaning |
|---|---|
| `E_UNKNOWN_BLOCK` | header is not a recognised block name |
| `E_DEPRECATED_BLOCK` | header *was* ferx syntax and is no longer read — currently `[initial_values]` |
| `E_BLOCK_INSTANCE_NAME` | instance name given where none is taken (`[fit_options DOSE]`), or omitted where one is required (`[covariate_nn]`) |
| `E_BLOCK_FEATURE_DISABLED` | recognised block needs a feature this binary lacks — `[event_model]` / `[binary_model]` without `--features survival`, `[markov_model]` without `--features markov` |

The message follows the `[event_model]` convention — every offender, the valid set, and a
did-you-mean for a near match (prefix relation or edit distance ≤ 2):

```
$ ferx check typo.ferx
error[E_UNKNOWN_BLOCK] fit_option:35: Unknown block `[fit_option]` — did you mean
  `[fit_options]`. Valid blocks: adaptive_dosing, covariate_nn, covariates, data, data_selection,
  derived, diffusion, error_model, fit_options, individual_parameters, initial_conditions,
  mixture, odes, output, parameters, scaling, simulation, structural_model.
    help: did you mean `[fit_options]`?
invalid: typo — 1 error(s), 0 warning(s)
```

`[initial_values]` is the one deprecated name that matters in practice. It was ferx's own
spelling for initial estimates before they moved inline into `[parameters]`; the parser stopped
reading it and, because unknown names were dropped in silence, never said so. Three of ferx-r's
checked-in example models still carry one, and no valid name is within suggesting distance
(`initial_conditions` is well past edit distance 2), so it gets a remediation instead of a bare
"unknown block":

```
error[E_DEPRECATED_BLOCK] initial_values:43: Deprecated block `[initial_values]` is no longer
  read: initial estimates are declared inline in `[parameters]` (`theta NAME(init, lower,
  upper)`, `omega NAME ~ variance`); the block has not been read for several releases — delete it.
```

Emitted at parse time, so it reaches `ferx check` (batch, via `parse_error_to_diagnostic`) and
`fit()` (via `first_error`) with no separate path. Since a parse failure is terminal — there is
no `ParsedModel` to read `block_lines` from — the check report recovers `block` and `line` from
the message text; the mapping is pinned by unit tests on both sides. When the message names
exactly one header the line is lifted into the structured `line` field and removed from the
message, since the renderer already prints `block:line` ahead of it; with several headers each
keeps its own parenthetical and no `line` is attached, because promoting the first would
mislocate the rest.

The registry is exported as `known_block_names()` (re-exported at the crate root) so `ferx-r`
and `ferxtranslate` can read the list from the engine instead of keeping their own copy. It is
filtered by the features the binary carries, so a default build does not advertise
`[event_model]` and then refuse it — the registry still *recognises* the name in every build,
which is what keeps that refusal a specific "build with `--features survival`" rather than a bare
unknown. The duplicated R-side list in `ferx_model_validate.R` has already drifted — its
`optional_sections` omits `covariates`, `event_model`, `binary_model`, `markov_model`,
`data_selection`, `adaptive_dosing` and `simulation`, so
`ferx_model_validate(ferx_example("two_cpt_oral_cov")$model)` prints `covariates [unknown section]`
today.

Two existing tests needed updating, both because they relied on the old permissiveness:

- `test_extract_blocks_recognizes_named_block_form` used an invented `[some_named_block FOO]`;
  it now uses `[covariate_nn FOO]`, a real named-only block.
- `test_parse_all_example_ferx_files` skipped a feature-gated example only when it had no
  `[structural_model]`. That nuance existed because a joint PK + CTMM file like
  `examples/ctmm_pd_2state.ferx` used to parse in a default build — as a *PK-only model*, with
  the endpoint silently discarded. The skip is now simply "this build lacks the feature the file
  needs", and the rejection itself is pinned by
  `test_feature_gated_block_rejected_without_its_feature`.

## Alternatives considered

**`warning` rather than `error`.** Rejected: a silently-dropped block changes the numerical
result, and warnings keep `valid: true` per the check-report doc, which is exactly the state
that was misleading. The counter-argument is forward compatibility — an older binary reading a
file that uses a newer block now hard-fails — but a version gate is the better answer there
than ignoring unknown names.

**Leaving the feature-gated blocks alone.** They are *known* names, so `E_UNKNOWN_BLOCK` would
not have covered them, and they fail in exactly the same way: a default build reading a
`[markov_model]` file quietly produced a model with no CTMM endpoint. Same class, same pass.

**A closed-world check in each consumer** (the shape the downstream report first considered).
Rejected there and here: it puts the check at the wrong layer and means maintaining another
copy of a registry that has already drifted once.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#303 | open (draft) | after |

The paired `ferx-r` fix is FeRx-NLME/ferx-r#303, held as a draft until this merges and its
`src/rust/Cargo.lock` is bumped to a commit carrying `known_block_names()`. There,
`ferx_model_validate()` computed an `unknown` section list and printed `[unknown section]` but
left it out of the returned status (`ok <- isTRUE(rust_result$ok) && length(missing) == 0L`), so
`res$ok` was `TRUE` for a model with an unrecognised block; #303 folds `unknown` into `ok` and
takes the section list from `known_block_names()` instead of its own drifted copy.

Nothing in this PR breaks the current ferx-r build — `known_block_names` is purely additive, and
ferx-r's own bundled examples use only registry names. The one file class that does break is a
`.ferx` carrying `[initial_values]`, a block ferx-core has never read: #303 strips it from the
three legacy files under ferx-r's `examples/models/`.

## Breaking changes
- [x] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [ ] None

<details>
<summary>Migration notes</summary>

A model file that parsed before and carried an unrecognised `[block]` header now fails to
parse. In every such case the block was being ignored, so the fix is either to correct the name
(the error names the near match) or to delete the block. Nothing that was actually being read
changes behaviour.

The one case worth calling out: a file with `[event_model]` / `[binary_model]` /
`[markov_model]` built **without** the matching cargo feature used to parse as a Gaussian-only
model with the endpoint discarded. It now errors, naming the feature to build with.

</details>

## Numerical validation
- [x] Not applicable — parse-time validation only. No estimation, PK, or stats path is touched;
  every model that parsed *and was fully read* before parses identically now (`cargo test --lib`
  green on default, `--features survival`, `--features markov`, `--features nn`).

## Performance
- [x] No significant impact expected — one pass over the block headers already collected, at
  parse time.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

Tier 1, `src/parser/model_parser_tests.rs`: unknown name rejected with line + valid set +
did-you-mean; all offenders reported together; no-near-match case carries no hint; repeated
header reported once; uppercase `[FIT_OPTIONS]` still valid; instance name on an unnamed-only
block; named-only block without one; feature-gated block rejected without / accepted with its
feature; `nearest_block_name` thresholds; registry sorted and unique.

Tier 1, `src/api/tests/block_name_diagnostic_tests.rs` (new sibling): the
`parse_error_to_diagnostic` mapping — code, `block`, `line` and `suggestion` for each shape,
`[covariate_nn]` keeping its dedicated `E_NN_FEATURE_DISABLED`, and everything else still
falling through to `E_PARSE`.

Tier 2, `tests/check_command.rs`: `ferx check` end-to-end on a `[fit_option]` typo, and the
same rejection reaching the parser directly.

## Example (user-facing features only)
- [x] Example added inline below

<details>
<summary>Example</summary>

```toml
[parameters]
  theta TVCL(0.2, 0.001, 10.0)
  theta TVV(10.0, 0.1, 500.0)
  sigma PROP_ERR ~ 0.02

[individual_parameters]
  CL = TVCL
  V  = TVV

[structural_model]
  pk one_cpt_iv(cl=CL, v=V)

[error_model]
  DV ~ proportional(PROP_ERR)

[fit_option]            # typo: singular
  method = focei
```

```
error[E_UNKNOWN_BLOCK] fit_option:16: Unknown block `[fit_option]` (line 16) — did you mean
  `[fit_options]`. Valid blocks: adaptive_dosing, binary_model, covariate_nn, covariates, data,
  data_selection, derived, diffusion, error_model, event_model, fit_options,
  individual_parameters, initial_conditions, markov_model, mixture, odes, output, parameters,
  scaling, simulation, structural_model.
    help: did you mean `[fit_options]`?
invalid: model — 1 error(s), 0 warning(s)
```

Before this PR: `ok: model — no errors (0 warning(s))`, and the fit ran with the default method
and no covariance step.

</details>

## Docs
- [x] `docs/` updated for user-visible changes — `docs/file-formats/check-report.qmd` gains the
  four codes; `docs/model-file/index.qmd`'s block overview is completed to the full registry
  (it listed 8 of 21) with the closed-world rule and the `[initial_values]` retirement spelled
  out; `docs/model-file/neural-networks.qmd` flags `[dynamics_nn]` as not accepted yet — it is
  shown there as syntax, and with closed-world names such a file is now rejected outright rather
  than parsed with the block ignored.
- [x] No new pages, so `_quarto.yml` is unchanged
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (no new warnings; the pre-existing ones in `sir.rs` / `validation.rs`
  are untouched)
- [x] No `Dual2` / sensitivity code touched
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples
- [x] No new DSL syntax, `[fit_options]` key, example file, or data file — nothing to mirror to
  ferx-site or ferx-book.
- [x] No example execution needed: no example changed, and all of `examples/` still parses
  (`test_parse_all_example_ferx_files`, on default, `survival` and `markov` builds).

## Reviewer hints

Focus on `BLOCK_REGISTRY` — is anything missing or mis-formed? The list was derived by grepping
every `blocks.get(…)` / `extracted.named.get(…)` in `model_parser.rs`; if a block is read
somewhere I missed, it is now rejected as unknown. `test_parse_all_example_ferx_files` covers
everything the bundled examples use, which is all 21 minus `data` and `mixture`.

Second: the `BlockForm` calls. `covariate_nn` is `Named` (only read out of the `named` map),
`event_model` / `binary_model` / `markov_model` are `Either` (both maps are read), everything
else is `Unnamed`.

Third: recovering `block` / `line` from the message text in `parse_error_to_diagnostic` is
unlovely but is what the terminal-parse-error path forces. Both ends are pinned by tests, so a
reworded message fails loudly rather than silently downgrading to `E_PARSE`.

## Open questions

Forward compatibility: an older binary now hard-fails on a file using a block a newer version
added. The issue's position — and mine — is that a version gate is the right answer to that,
not tolerating unknown names, but if we want the gate first this PR should wait for it.
