### PR TITLE
fix(ode): gate the adaptive DV monitor assay clamp on the readout [closes #1039]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **An adaptive-dosing `dv` monitor no longer floors a negative Form C `[scaling]` readout at zero
+  (#1039).** The assay floor on the `ObserveMode::Dv` path ("an assay cannot read below zero") was
+  written when every monitored readout was a compartment amount or concentration, and was applied
+  unconditionally after the residual draw. A Form C `y = <expr>` readout is an arbitrary
+  expression — a change from baseline, a difference from a comparator, a z-score, the
+  `sqrt(N) * logit(p)` transform — so the *same model* read correctly under `mode = ipred` and
+  came back as exactly `0` under `mode = dv` for every negative sample, silently: a controller
+  thresholding a change-from-baseline signal saw `0` over precisely the region it was written to
+  react to, and dosed accordingly. The floor is now gated on the same predicate as the prediction
+  path (#1020), so it applies only to the bare-state readout and to Forms A/B, which keep it. With
+  `sigma → 0` a `dv` monitor again reproduces the `ipred` monitor sample for sample, negative
+  samples included.
 - **SAEM no longer lets a fixed-effect-only theta drift away from the marginal optimum (#1011).** The
   numerical θ/σ M-step assigned NLopt's maximiser outright, re-maximising against a *single* MCMC η
   draw each iteration — `argmax` of one draw rather than the stochastic-approximation average of

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -182,8 +182,9 @@ expression may be legitimately signed (a change from baseline, a z-score, a
 difference from comparator), so its negative samples reach the controller
 unchanged, exactly as they do under `Ipred`. See
 [Scaling](scaling.qmd#signed-readouts-since-1020). With `sigma → 0` a `Dv`
-monitor therefore reproduces the `Ipred` monitor sample for sample on *any*
-readout, negative samples included.
+monitor therefore reproduces the `Ipred` monitor sample for sample on a Form C
+readout, negative samples included; on the bare-state readout the floor still
+applies, so the two agree only where the latent value is non-negative.
 
 ## Example
 

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -175,7 +175,15 @@ draws (under a fixed `seed`):
   draws, so the frozen-replay verifier stays exact.
 
 A `Dv` monitor on a compartment with no `[error_model]` is a typed error (never a
-fabricated σ), and a noised reading below zero is clamped to 0.
+fabricated σ), and a noised reading below zero is clamped to 0 — but **only on the
+default bare-state readout**, where non-negativity is a physical property of the
+quantity. Since #1039 a Form C `[scaling] y = <expr>` readout is exempt: the
+expression may be legitimately signed (a change from baseline, a z-score, a
+difference from comparator), so its negative samples reach the controller
+unchanged, exactly as they do under `Ipred`. See
+[Scaling](scaling.qmd#signed-readouts-since-1020). With `sigma → 0` a `Dv`
+monitor therefore reproduces the `Ipred` monitor sample for sample on *any*
+readout, negative samples included.
 
 ## Example
 

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -115,6 +115,12 @@ PK concentration), where non-negativity is a physical property of the quantity
 and a negative value can only be integration overshoot. It is not applied to
 Form C.
 
+The same gate applies to the adaptive-dosing monitor path: a `Dv` monitor's
+assay floor (`max(0)` after the residual draw) fires only on the bare-state
+readout, so a Form C signal a controller thresholds is not silently floored at
+`0` over its whole negative region (#1039). See
+[Adaptive dosing](adaptive-dosing.qmd).
+
 Forms A and B (`obs_scale = <expr>` / `obs_scale[CMT=n] = <expr>`) keep the
 default bare-state readout — the divisor is applied *downstream* of it — so the
 clamp still guards the compartment state they read. Only Form C (`y = <expr>`)

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -3409,9 +3409,23 @@ pub(crate) fn ode_predictions_adaptive_impl(
                             // finiteness guard. Value-pathology (a NaN/∞ in `sigma`, a
                             // diverged IPRED) is whole-sim garbage-in, out of scope here.
                             let eps = assay_standard_normal(a.base_seed, decision_index, &m.name);
+                            let noised = latent + var.sqrt() * eps;
                             // Edge (b): an assay cannot read below zero; clamp the
                             // noised value at 0 (BLQ-blinding is deferred to Part F).
-                            (latent + var.sqrt() * eps).max(0.0)
+                            // Gated on the same predicate as the prediction path
+                            // (#1039): "cannot read below zero" is a statement about a
+                            // compartment amount / concentration, not about a Form C
+                            // `[scaling]` readout, which is an arbitrary expression
+                            // (change from baseline, z-score, `sqrt(N)*logit(p)`) and is
+                            // legitimately signed. Without the gate the *same* model
+                            // read `mode = ipred` correctly and `mode = dv` floored at 0,
+                            // so a controller thresholding a signed signal silently saw
+                            // `0` over the whole negative region.
+                            if ode.readout.clamps_negative() {
+                                noised.max(0.0)
+                            } else {
+                                noised
+                            }
                         }
                     };
                     signals.insert(m.name.clone(), value);

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -2124,9 +2124,11 @@ fn adaptive_dv_noised_and_deterministic() {
 
 #[test]
 fn adaptive_dv_clamps_negative_at_zero() {
-    // Edge (b): the noised value cannot read below zero. At t=0 the pre-dose
-    // trough is 0, so a negative assay draw with a large sigma would push it
-    // negative; assert it clamps to exactly 0.
+    // Edge (b): on a *bare-state* readout (`OdeReadout::ObsCmt`, a compartment
+    // amount / concentration) the noised value cannot read below zero. At t=0 the
+    // pre-dose trough is 0, so a negative assay draw with a large sigma would push
+    // it negative; assert it clamps to exactly 0. Form C readouts are exempt —
+    // see `adaptive_dv_form_c_monitor_keeps_negative_sample` (#1039).
     let ode = one_cpt_ode_spec();
     let pk = pk_one(1.0, 10.0);
     let neg_seed = (0u64..)
@@ -2155,6 +2157,113 @@ fn adaptive_dv_clamps_negative_at_zero() {
     assert_eq!(
         run.decisions[0].observed_signals[0].value, 0.0,
         "a negative assay reading must clamp at 0"
+    );
+}
+
+/// A Form C `[scaling]` monitor read in `dv` mode must keep its negative
+/// samples (#1039). The assay floor is a statement about a compartment amount,
+/// not about an arbitrary user expression — a change-from-baseline signal that
+/// a controller thresholds is legitimately negative, and flooring it at 0 made
+/// the controller blind over exactly the region it reacts to.
+#[test]
+fn adaptive_dv_form_c_monitor_keeps_negative_sample() {
+    // `clock - 5`: latent = -5 at t=0. sd = 0.1, so no draw of a standard normal
+    // this test could see reaches 0 — the sample must stay negative *and* noised.
+    let ode = signed_readout_clock_spec(OdeReadout::Single(Box::new(
+        |s: &[f64], _pk: &[f64], _t: &[f64], _e: &[f64], _c: &HashMap<String, f64>| s[0] - 5.0,
+    )));
+    let pk = pk_one(1.0, 1.0);
+    let small_var = |_cmt: usize, _ipred: f64| Some(0.01);
+    let assay = AssayNoise {
+        resid_var: &small_var,
+        base_seed: 4242,
+    };
+    let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
+    let base = make_subject(
+        vec![DoseEvent::new(0.0, 0.0, 1, 0.0, false, 0.0)],
+        vec![1.0],
+    );
+    let run = ode_predictions_adaptive(
+        &ode,
+        &pk.values,
+        &[],
+        &[],
+        &base,
+        &[0.0],
+        &dv_monitor(),
+        &mut controller,
+        100,
+        Some(&assay),
+    )
+    .expect("dv run");
+    let value = run.decisions[0].observed_signals[0].value;
+    assert!(
+        value < 0.0,
+        "a Form C dv monitor must keep its negative sample, got {value}"
+    );
+    assert!(
+        (value + 5.0).abs() > 1e-12,
+        "expected the assay to perturb the latent value, got {value}"
+    );
+    assert!(
+        (value + 5.0).abs() < 1.0,
+        "expected a sd=0.1 perturbation around -5, got {value}"
+    );
+}
+
+/// Degenerate oracle for #1039 (epic #391 validation rule — no NONMEM anchor):
+/// with `sigma -> 0` a `dv` monitor on a Form C model must equal the `ipred`
+/// monitor on the same model, decision for decision, *including* the negative
+/// samples. That equality is exactly what the ungated assay clamp broke.
+#[test]
+fn adaptive_dv_zero_variance_equals_ipred_on_signed_form_c() {
+    let ode = signed_readout_clock_spec(OdeReadout::Single(Box::new(
+        |s: &[f64], _pk: &[f64], _t: &[f64], _e: &[f64], _c: &HashMap<String, f64>| s[0] - 5.0,
+    )));
+    let pk = pk_one(1.0, 1.0);
+    // Straddle the sign change at t=5: two negative samples, then two positive.
+    let decisions = [0.0, 2.0, 6.0, 10.0];
+    let base = make_subject(
+        vec![DoseEvent::new(0.0, 0.0, 1, 0.0, false, 0.0)],
+        vec![1.0],
+    );
+    let hold = |_ctx: &ControllerCtx| vec![DoseAction::Hold];
+
+    let sample = |monitors: &[MonitorSpec], assay: Option<&AssayNoise>| -> Vec<f64> {
+        let mut ctrl = hold;
+        ode_predictions_adaptive(
+            &ode,
+            &pk.values,
+            &[],
+            &[],
+            &base,
+            &decisions,
+            monitors,
+            &mut ctrl,
+            100,
+            assay,
+        )
+        .expect("adaptive run")
+        .decisions
+        .iter()
+        .map(|d| d.observed_signals[0].value)
+        .collect()
+    };
+
+    let ipred = sample(&[MonitorSpec::new("A", 1, ObserveMode::Ipred)], None);
+    let zero_var = |_cmt: usize, _ipred: f64| Some(0.0);
+    let assay = AssayNoise {
+        resid_var: &zero_var,
+        base_seed: 7,
+    };
+    let dv = sample(&dv_monitor(), Some(&assay));
+
+    for (got, want) in ipred.iter().zip([-5.0, -3.0, 1.0, 5.0]) {
+        assert_relative_eq!(*got, want, epsilon = 1e-9);
+    }
+    assert_eq!(
+        dv, ipred,
+        "a zero-variance dv monitor must reproduce the ipred monitor sample for sample"
     );
 }
 


### PR DESCRIPTION
## Why

Closes #1039.

After #1020 / #1038 a Form C `[scaling]` readout keeps its negative part on the
prediction path — but an adaptive-dosing monitor reading the *same model* still
got opposite sign semantics depending on its `ObserveMode`:

- `ObserveMode::Ipred` — reads the (now signed) prediction path, negative readout
  returned as-is.
- `ObserveMode::Dv` — added the assay residual draw and then applied `.max(0.0)`
  unconditionally (`src/ode/predictions.rs`, "Edge (b): an assay cannot read below
  zero"), so every negative sample collapsed to exactly `0`.

That floor was written when every monitored readout was a compartment amount /
concentration, where non-negativity is physical. It is not true of a Form C
readout, which is an arbitrary expression: a change from baseline, a difference
from comparator, a z-score, or the `sqrt(N) * logit(p)` transform used in
model-based meta-analysis.

Concretely: a controller thresholding `y = central / V - BASE` silently read `0`
for every sample below baseline — exactly the region such a controller exists to
react to — with no warning, and dosed on the floored signal. The asymmetry was the
sharp edge: the same model behaved correctly under `mode = ipred` and not under
`mode = dv`.

## What changed

Gate the DV clamp on `OdeReadout::clamps_negative()` — the same predicate the
prediction path (`clamp_negative_predictions`, the event-driven inline clamp) and
the `sens` providers already consult:

```rust
let noised = latent + var.sqrt() * eps;
if ode.readout.clamps_negative() { noised.max(0.0) } else { noised }
```

The assay floor therefore stays exactly where it is physically true — bare-state
(`obs_cmt`) readouts and Forms A/B, which keep the default bare-state readout —
and drops for both Form C variants, matching the prediction path.

## Alternatives considered

Clamping the *latent* value instead of the noised one: same defect, and it would
diverge from the prediction path, which clamps neither for Form C. Warning on a
negative DV sample: noise on a legitimately-signed signal makes negatives the
normal case, so the warning would fire on every well-behaved run.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change: the gate is internal to `ode_predictions_adaptive_impl`.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

Behaviour change is confined to Form C models with a `dv` monitor, where the
previous output (`0`) was the bug.

## Numerical validation

Per the epic #391 exception in `CLAUDE.md`, adaptive / feedback dosing is **not**
NONMEM-anchored — NONMEM has no controller reading simulated state. Validated with
the **degenerate oracle** that rule prescribes:

- `adaptive_dv_zero_variance_equals_ipred_on_signed_form_c` — with `sigma -> 0`, a
  `dv` monitor on a signed Form C model (`clock - 5`) equals the `ipred` monitor
  decision for decision across the sign change: `[-5, -3, 1, 5]` at
  t = `[0, 2, 6, 10]`, negative samples included. This equality is exactly what the
  ungated clamp broke (it returned `[0, 0, 1, 5]`).

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Not applicable (adaptive-dosing family — degenerate oracle above per #391)

## Performance
- [x] No significant impact expected — one predicate call (a match on an enum
  discriminant) per DV monitor per decision.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 3068 passed, 0 failed)
- [x] Regression test added that fails without this fix

Tier 1, in `src/ode/predictions_tests.rs`:

- `adaptive_dv_form_c_monitor_keeps_negative_sample` — a noised (`sd = 0.1`) Form C
  `dv` monitor returns a negative, genuinely perturbed sample. Returns `0.0` without
  the fix.
- `adaptive_dv_zero_variance_equals_ipred_on_signed_form_c` — the degenerate oracle
  above.
- `adaptive_dv_clamps_negative_at_zero` — **kept**; it already exercises a bare-state
  (`OdeReadout::ObsCmt`) readout, and its comment is re-scoped to say so explicitly
  and point at the Form C exemption. It still pins the floor where it is real.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (fix with no new API surface)

The shape of the affected model, for reference:

```toml
[scaling]
  y[CMT=1] = central / V - BASE     # change from baseline: signed by construction

[adaptive_dosing]
  monitor CHANGE = cmt 1, mode = dv  # now sees the negative arm; previously read 0
```

## Docs
- [x] `docs/` updated for user-visible changes — `docs/model-file/adaptive-dosing.qmd`
  (the "noised reading below zero is clamped to 0" sentence now states the readout
  gate and the `sigma -> 0` equality) and `docs/model-file/scaling.qmd` (the signed-
  readout section now covers the monitor path too).
- [ ] New pages linked in `docs/_quarto.yml` — no new pages.
- [x] `CHANGELOG.md` `[Unreleased]` entry added under `### Fixed`.

## Checklist
- [x] `cargo clippy` clean — no new findings. (`--lib --tests` has 4 pre-existing
  `approx_constant` denies in `src/sens/two_cpt_explicit.rs`, untouched by this PR.)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — not touched;
  `sens/ode_provider.rs` already gates its clamp on the same predicate (#1020).
- [ ] `Cargo.toml` version bumped if breaking — not breaking.

## Docs & examples

### ferx-site
- [x] No new DSL syntax, `[fit_options]` key, example, or data file.

### ferx-book
- [x] No new estimator, DSL feature, or fit option.

### Example execution
- [x] No example execution step needed — no `examples/*.ferx` model uses a Form C
  readout with a `dv` monitor, so no example output changes.

## Reviewer hints

Focus on the one gated expression in `src/ode/predictions.rs` (the `ObserveMode::Dv`
arm) and on which test now owns which semantic: the bare-state floor
(`adaptive_dv_clamps_negative_at_zero`) versus the Form C exemption (the two new
tests). Worth confirming the claim in the surrounding comment still holds — under
`Dv` the declarative path compiles no `observe` expression, so `latent` is the
model's own readout and σ comes from the same output, which is what makes
"gate on the model's readout" the right predicate here rather than something
monitor-local. The docs and changelog edits can be skimmed.

## Open questions

The asymmetry in the *other* direction is left as-is and is not a bug: on a
bare-state readout an `ipred` monitor can still return a negative solver-overshoot
value while a `dv` monitor floors it at `0`. Clamping the `ipred` monitor would be
a separate change to the latent readout path, out of scope for #1039.
