### PR TITLE
fix(scaling): put the adaptive readout on the #1028 data clock, and fix the `T` escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **An adaptive-dosing run now reads a `TIME`-dependent `[scaling]` Form C readout on the same
+  clock as `fit()` / `predict()` (#1028 follow-up).** #1028 moved the readout's `TIME` to the raw
+  data-file clock (the `$ERROR` convention shared by sdtab, `predict()`/`simulate()` and `[derived]`
+  windows) on the static predictors, but the reactive driver and the frozen-schedule replay
+  verifier kept feeding it the integrator break the observation was keyed to. For a subject with
+  stacked reset occasions — whose data `TIME` restarts while the internal timeline stays monotonic —
+  those are different numbers, so the *same record* got one `TIME` under `simulate_adaptive` and
+  another under `fit()`, and the replay verifier's bit-equality against the static engine no longer
+  held. Both now use the raw clock. Also in the same area: a `T` / `t` declared in `[covariates]` is
+  now honoured **case-insensitively** (declaring `T` protects a `t` reference and vice versa —
+  previously the case-mismatched pair silently folded to the model clock in `y`, and raised the
+  time-in-`obs_scale` error against a legitimately declared column), and the declaration now reaches
+  `[adaptive_dosing] observe`, which compiles through the same readout compiler — so a declared `T`
+  can no longer be the data column in `[scaling]` and the clock in `observe` for one model. The
+  `T`-fold warning for `observe` is emitted at parse time, since the block is compiled at simulate
+  time where there is no warnings channel.
 - **`TIME` now works in a `[scaling]` Form C readout, and an undefined name in `[scaling]` is no
   longer a silent zero (#1028).** A `y = <expr>` / `y[CMT=N] = <expr>` readout referencing the
   `TIME` built-in parsed fine but was never bound to the observation — the integrator's model-time

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -83,6 +83,13 @@ protocol-time-dependent target such as `observe = central / V - TARGET * TIME /
 (TIME + T50)` therefore titrates against the intended ramp
 ([#1028](https://github.com/FeRx-NLME/ferx-core/issues/1028)).
 
+The shared name scope includes the `T` precedence rule: a `T` (or `t`) declared in
+`[covariates]` is the **data column**, in `observe` exactly as in `[scaling]`, so
+one model can never read the column in one block and the clock in the other. When
+`T` does fold into the built-in, the warning is reported at parse time — `observe`
+itself is compiled at simulate time, where there is no warnings channel. See
+[Scaling](scaling.qmd#if-your-dataset-has-a-column-named-t).
+
 ¹ **The signal source is exactly one of `observe` (a latent expression, un-noised) or `with_assay_error = true` + `assay_cmt` (a noised model output).** Setting both, or neither, is a parse error. Titrating on a *measured* quantity uses the model's own output (so its value and σ can never disagree on scale); titrating on a *derived latent* quantity (effect-site, a ratio — anything with no error model) uses `observe`.
 
 ### Rules — `when signal <op> <value> : <action>`

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -213,6 +213,17 @@ silently replaced by the clock. Declaring it wins:
   y = central / V * T     # the column, not the clock
 ```
 
+The declaration is matched **case-insensitively** against both spellings, so
+declaring `T` also protects a `t` reference and vice versa — the fold treats the
+two as one built-in, so the escape hatch has to as well. It covers the whole
+block: Form C `y`, and `obs_scale`, where an undeclared `T` is instead rejected
+as a time reference in a subject-static divisor.
+
+The declaration also reaches `[adaptive_dosing] observe`, which compiles through
+the same readout compiler — so a declared `T` is the data column there too,
+rather than the same model reading the column in `[scaling]` and the clock in
+`observe`.
+
 Whenever `T` / `t` *is* folded into the built-in, ferx emits a parse warning
 saying so and naming both escapes (spell it `TIME`, or declare the column).
 Writing `TIME` is unambiguous and never warns.

--- a/src/api/tests/adaptive_sim_tests.rs
+++ b/src/api/tests/adaptive_sim_tests.rs
@@ -2726,6 +2726,7 @@ const SPEC_TIME_OBSERVE: &str = r#"
 fn simple_titration_spec() -> AdaptiveDosingSpec {
     AdaptiveDosingSpec {
         observe: Some("central".to_string()),
+        observe_declared_covariates: Vec::new(),
         with_assay_error: false,
         assay_cmt: None,
         at: vec![0.0, 24.0],
@@ -3438,6 +3439,7 @@ fn from_spec_three_witnesses_equals_handwritten_closure() {
 
     let spec = AdaptiveDosingSpec {
         observe: Some("central".to_string()),
+        observe_declared_covariates: Vec::new(),
         with_assay_error: false,
         assay_cmt: None,
         at: at.clone(),
@@ -3645,6 +3647,85 @@ fn from_spec_observe_reads_the_time_builtin_at_the_decision() {
     approx::assert_relative_eq!(amts[0], 125.0, max_relative = 1e-9);
     approx::assert_relative_eq!(amts[1], 156.25, max_relative = 1e-9);
     approx::assert_relative_eq!(amts[2], 156.25, max_relative = 1e-9);
+}
+
+#[test]
+fn from_spec_observe_t_alias_loses_to_a_declared_covariate() {
+    // `observe` compiles through the same `build_y_output_fn` as a `[scaling]` Form C
+    // readout, so it must apply the same `T` / `t` name precedence — otherwise the
+    // *same* model reads a declared `T` as the data column in `[scaling]` and as the
+    // model-time built-in in `observe` (#1042 review of #1028). The declarations reach
+    // the simulate-time compiler via `AdaptiveDosingSpec::observe_declared_covariates`,
+    // captured at parse time.
+    //
+    // `T` is declared but referenced *only* by `observe`, which is exactly the case a
+    // `referenced_covariates`-based precedence list would have missed.
+    let src = SPEC_TIME_OBSERVE.replace("observe = TIME", "observe = T")
+        + "[covariates]\n  T continuous\n";
+    let parsed = parse_full_model(&src).expect("a declared T covariate parses");
+    let spec = parsed.adaptive_dosing.as_ref().expect("block present");
+    assert!(
+        spec.observe_declared_covariates.iter().any(|c| c == "T"),
+        "the spec must carry the [covariates] declarations, got {:?}",
+        spec.observe_declared_covariates
+    );
+
+    // The controller reads the column (60.0 for this subject), not the decision time —
+    // so `signal < 30` never fires and the dose is re-issued unchanged at all three
+    // decisions. Under the model-time reading it would have fired at t=0 and t=24.
+    let mut s = subj("P", vec![60.0], vec![]);
+    s.covariates.insert("T".to_string(), 60.0);
+    let mut pop = population(vec![s]);
+    pop.covariate_names = vec!["T".to_string()];
+    let opts = AdaptiveSimulateOptions {
+        seed: Some(3),
+        ..Default::default()
+    };
+    let res = simulate_adaptive_from_spec(
+        &parsed.model,
+        &pop,
+        &parsed.model.default_params,
+        1,
+        spec,
+        &opts,
+    )
+    .expect("the covariate-driven controller runs");
+    for d in &res.decisions {
+        approx::assert_relative_eq!(d.observed_signals[0].value, 60.0, epsilon = 1e-9);
+    }
+    let amts: Vec<f64> = res.ledger.iter().map(|d| d.amt).collect();
+    assert_eq!(amts, vec![100.0, 100.0, 100.0], "no rule may fire on 60.0");
+}
+
+#[test]
+fn from_spec_observe_t_alias_fold_warns_at_parse_time() {
+    // `observe` is compiled at simulate time, where `parse_warnings` is long sealed
+    // and the adaptive result has no warnings channel — so the parser emits the
+    // `T`-alias note itself, from the same helper the compiler runs. Without it the
+    // fold would be silent on this one path (#1042 review of #1028).
+    let src = SPEC_TIME_OBSERVE.replace("observe = TIME", "observe = T");
+    let parsed = parse_full_model(&src).expect("the T alias parses");
+    assert!(
+        parsed
+            .model
+            .parse_warnings
+            .iter()
+            .any(|w| w.contains("[adaptive_dosing] observe") && w.contains("model-time built-in")),
+        "expected a fold warning naming the block, got {:?}",
+        parsed.model.parse_warnings
+    );
+
+    // The unambiguous `TIME` spelling stays quiet.
+    let parsed_time = parse_full_model(SPEC_TIME_OBSERVE).expect("TIME parses");
+    assert!(
+        !parsed_time
+            .model
+            .parse_warnings
+            .iter()
+            .any(|w| w.contains("model-time built-in")),
+        "`TIME` must not warn, got {:?}",
+        parsed_time.model.parse_warnings
+    );
 }
 
 #[test]
@@ -3909,6 +3990,7 @@ fn from_spec_rejects_observe_covariate_absent_from_data() {
     let model = parse_model_string(ODE_NO_IIV).expect("parse");
     let spec = AdaptiveDosingSpec {
         observe: Some("central / BADCOV".to_string()),
+        observe_declared_covariates: Vec::new(),
         ..simple_titration_spec()
     };
     let pop = population(vec![subj("1", vec![6.0], vec![])]); // no covariate columns
@@ -3936,6 +4018,7 @@ fn from_spec_dv_collapses_to_ipred_as_sigma_to_zero() {
 
     let ipred_spec = AdaptiveDosingSpec {
         observe: Some("central".to_string()),
+        observe_declared_covariates: Vec::new(),
         with_assay_error: false,
         assay_cmt: None,
         at: at.clone(),
@@ -3957,6 +4040,7 @@ fn from_spec_dv_collapses_to_ipred_as_sigma_to_zero() {
     // observes) with assay noise.
     let dv_spec = AdaptiveDosingSpec {
         observe: None,
+        observe_declared_covariates: Vec::new(),
         with_assay_error: true,
         assay_cmt: Some(1),
         ..ipred_spec.clone()

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -3689,7 +3689,15 @@ pub(crate) fn ode_predictions_adaptive_impl(
                     obs_eta,
                     shadow.obs_cov(obs_idx),
                     cmt,
-                    t_start,
+                    // The readout's `TIME` is the user clock, not `t_start` — the
+                    // integrator break this observation was keyed to. `obs_map` keys off
+                    // `shadow.obs_times`, so `t_start` is the shifted monotonic timeline
+                    // (and, thanks to the reader's pre-dose trough nudge, 1 ULP off the
+                    // data value even with no resets). Using it here would give
+                    // `simulate_adaptive` a different `TIME` than `predict()`/`fit()` for
+                    // the same record, and break the frozen-schedule replay oracle's
+                    // bit-equality against the static engine (#1028).
+                    shadow.readout_time(obs_idx),
                 );
             }
         }
@@ -4134,7 +4142,11 @@ fn adaptive_frozen_replay_tv(
                     obs_eta,
                     subject.obs_cov(obs_idx),
                     cmt,
-                    t_start,
+                    // User clock, not the integrator break — see the matching note in
+                    // `ode_predictions_adaptive_impl`. This is the replay verifier, so it
+                    // is the one path that *must* agree with the static engine bit for
+                    // bit (#1028).
+                    subject.readout_time(obs_idx),
                 );
             }
         }

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -810,6 +810,129 @@ fn adaptive_state_independent_controller_matches_static_ode() {
 }
 
 #[test]
+fn adaptive_form_c_readout_time_matches_the_static_engine() {
+    // Degenerate oracle for the readout clock (#1028). The adaptive driver used to
+    // feed the readout `t_start` — the integrator break the observation was keyed to,
+    // off `shadow.obs_times` — while the static predictor reads the raw data clock.
+    // For a subject with stacked reset occasions the two are *different numbers*, so
+    // a `TIME`-reading Form C readout returned one answer under `simulate_adaptive`
+    // and another under `predict()`/`fit()` for the same record.
+    //
+    // The readout here returns nothing but the model-time thread-local, so each
+    // prediction *is* the `TIME` the readout saw. A fixed-dose controller keeps the
+    // dynamics identical to the static twin, isolating the clock.
+    let ode = time_readout_ode_spec();
+    let pk = pk_one(1.0, 10.0);
+    let decisions = [0.0, 24.0];
+    let obs = vec![6.0, 30.0, 54.0, 78.0];
+    // Two occasions whose data TIME restarts: the internal grid stays monotonic
+    // while the user clock repeats 6/30.
+    let raw = vec![6.0, 30.0, 6.0, 30.0];
+
+    let mut controller = |_ctx: &ControllerCtx| vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }];
+    let mut base = make_subject(vec![], obs.clone());
+    base.obs_raw_times = raw.clone();
+    let run = ode_predictions_adaptive(
+        &ode,
+        &pk.values,
+        &[],
+        &[],
+        &base,
+        &decisions,
+        &[],
+        &mut controller,
+        100,
+        None,
+    )
+    .expect("driver runs");
+
+    assert_eq!(
+        run.predictions, raw,
+        "the adaptive readout must see the raw data-file TIME, got {:?}",
+        run.predictions
+    );
+
+    // …and agree with the static engine on the realized doses, record for record.
+    let static_doses: Vec<DoseEvent> = decisions
+        .iter()
+        .map(|&t| DoseEvent::new(t, 100.0, 1, 0.0, false, 0.0))
+        .collect();
+    let mut static_subject = make_subject(static_doses, obs);
+    static_subject.obs_raw_times = raw;
+    let static_preds = ode_predictions(&ode, &pk.values, &[], &[], &static_subject);
+    assert_eq!(
+        run.predictions, static_preds,
+        "adaptive and static readouts must be on the same clock"
+    );
+}
+
+#[test]
+fn adaptive_tv_frozen_replay_readout_time_matches_the_driver() {
+    // The same clock split in `adaptive_frozen_replay_tv` (#1028) — the replay
+    // verifier, whose entire job is to prove bit-equality with the static engine, so
+    // it is the one path that must not be on the other convention. Same TIME-returning
+    // readout; the replay must reproduce the driver's `TIME` values exactly.
+    let ode = time_readout_ode_spec();
+    let v = 10.0;
+    let obs_times = [0.0, 24.0, 48.0, 72.0];
+    let raw = vec![0.0, 24.0, 0.0, 24.0];
+    let cls = [1.0, 0.7, 0.5, 0.3];
+    let obs_pk: Vec<PkParams> = cls.iter().map(|&cl| pk_one(cl, v)).collect();
+    let event_pk = crate::pk::EventPkParams {
+        dose: Vec::new(),
+        obs: obs_pk.clone(),
+        pk_only: Vec::new(),
+    };
+    let decisions = [0.0, 24.0, 48.0];
+    let mut decide = |_ctx: &ControllerCtx| ControllerDecision {
+        actions: vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+        rule: None,
+    };
+    let mut base = make_subject(vec![], obs_times.to_vec());
+    base.obs_raw_times = raw.clone();
+    let run = ode_predictions_adaptive_impl(
+        &ode,
+        &obs_pk[0].values,
+        Some(&event_pk),
+        None,
+        None,
+        &[],
+        &[],
+        &base,
+        &decisions,
+        &[],
+        &mut decide,
+        100,
+        None,
+    )
+    .expect("driver runs");
+    assert_eq!(run.predictions, raw, "driver reads the raw data clock");
+
+    let mut static_subject = base.clone();
+    static_subject.doses = run
+        .ledger
+        .iter()
+        .map(|e| DoseEvent::new(e.time, e.amt, e.cmt, e.rate, false, 0.0))
+        .collect();
+    let dose_f: Vec<f64> = run.ledger.iter().map(|e| e.f_applied).collect();
+    let replay = adaptive_frozen_replay_tv(
+        &ode,
+        &event_pk,
+        None,
+        None,
+        &[],
+        &[],
+        &static_subject,
+        &dose_f,
+        &decisions,
+    );
+    assert_eq!(
+        replay, run.predictions,
+        "the frozen replay must be on the driver's clock, bit for bit"
+    );
+}
+
+#[test]
 fn adaptive_tv_covariate_controller_matches_static_event_driven() {
     // Degenerate oracle on the time-varying-covariate path (#700): a controller
     // that ignores state and gives a fixed bolus at every decision must

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2414,11 +2414,22 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .get("simulation")
         .map(|lines| parse_simulation_block(lines))
         .transpose()?;
+    // Peek the `[covariates]` declarations (parsed for real further down, at the
+    // block's own site) purely for name precedence: a declared `T` / `t` is a data
+    // column, not the `[odes]` model-time alias, in `[scaling]` and in
+    // `[adaptive_dosing] observe` alike (#1028). Peeked rather than hoisted so a
+    // malformed `[covariates]` block still reports its own error at its own site, in
+    // the existing order — hence the `.ok()`.
+    let declared_covariate_names: Vec<String> = blocks
+        .get("covariates")
+        .and_then(|lines| parse_covariates_block(lines).ok())
+        .map(|decls| decls.into_iter().map(|d| d.name).collect())
+        .unwrap_or_default();
     // Declarative reactive-dosing controller (#391 S2). Parsed and validated here;
     // compiled to a controller and run by the adaptive simulate path in a later slice.
     let adaptive_dosing = blocks
         .get("adaptive_dosing")
-        .map(|lines| parse_adaptive_dosing_block(lines))
+        .map(|lines| parse_adaptive_dosing_block(lines, &declared_covariate_names))
         .transpose()?;
     let mut fit_options = if let Some(lines) = blocks.get("fit_options") {
         parse_fit_options(lines)?
@@ -2532,6 +2543,20 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             &model.indiv_param_names,
             "[adaptive_dosing] observe",
         )?;
+        // The `T` / `t` model-time fold warns wherever it fires — but `observe` is
+        // compiled at *simulate* time (`sim::adaptive_control::compile_observe`), long
+        // after `parse_warnings` is sealed, and the adaptive result has no warnings
+        // channel of its own. Emit the note here instead, from the same helper the
+        // compiler will run, so the fold is not silent on this one path (#1028).
+        warn_if_time_alias_folds(
+            observe,
+            "[adaptive_dosing] observe",
+            &model.theta_names,
+            &model.eta_names,
+            &model.indiv_param_names,
+            &declared_covariate_names,
+            &mut model.parse_warnings,
+        );
         if let Some(ode) = model.ode_spec.as_ref() {
             let n_states = ode.state_names.len();
             check_dose_attr_double_use(
@@ -2674,17 +2699,6 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
                 .cloned()
         };
         let mut scaling_parse_warnings: Vec<String> = Vec::new();
-        // Peek the `[covariates]` declarations (parsed for real further down, at the
-        // block's own site) purely for name precedence inside `[scaling]`: a declared
-        // `T` is a data column, not the model-time alias, and a declared `TAD` is a
-        // data column rather than the rejected `[odes]` built-in (#1028). Peeked
-        // rather than hoisted so a malformed `[covariates]` block still reports its
-        // own error at its own site, in the existing order — hence the `.ok()`.
-        let declared_covariates_for_scaling: Vec<String> = blocks
-            .get("covariates")
-            .and_then(|lines| parse_covariates_block(lines).ok())
-            .map(|decls| decls.into_iter().map(|d| d.name).collect())
-            .unwrap_or_default();
 
         let (scaling, output_fn, output_program, scaling_covariates) = parse_scaling_block(
             scaling_lines,
@@ -2698,7 +2712,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             &model.kappa_names,
             &readout_synth_params,
             volume_indiv_name_for_scaling.as_deref(),
-            &declared_covariates_for_scaling,
+            &declared_covariate_names,
             &mut scaling_parse_warnings,
         )?;
         model.parse_warnings.extend(scaling_parse_warnings);
@@ -5666,7 +5680,10 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
 /// is the S2.2 step. The one ambiguity this parser *can* settle without the model
 /// — `with_assay_error` on an expression `observe` with no designated endpoint —
 /// is rejected here rather than left to guess a σ downstream.
-fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, String> {
+fn parse_adaptive_dosing_block(
+    lines: &[String],
+    declared_covariates: &[String],
+) -> Result<AdaptiveDosingSpec, String> {
     let mut observe: Option<String> = None;
     let mut with_assay_error = false;
     let mut assay_cmt: Option<usize> = None;
@@ -5831,6 +5848,7 @@ fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, S
     // controller with a contradiction the parser would have rejected here.
     let spec = AdaptiveDosingSpec {
         observe,
+        observe_declared_covariates: declared_covariates.to_vec(),
         with_assay_error,
         assay_cmt,
         at,
@@ -7397,7 +7415,7 @@ fn rewrite_scaling_time_alias(
     let mut folded: Option<String> = None;
     visit_expr_nodes_mut(expr, &mut |e: &mut Expression| {
         if let Expression::Covariate(name) = e {
-            if (name == "T" || name == "t") && !declared_covariates.iter().any(|d| d == name) {
+            if is_time_alias(name) && !declares_time_alias(declared_covariates) {
                 if folded.is_none() {
                     folded = Some(name.clone());
                 }
@@ -7415,6 +7433,31 @@ fn rewrite_scaling_time_alias(
     }
 }
 
+/// Run [`rewrite_scaling_time_alias`] on a *throwaway* parse of `src` purely to
+/// collect the warning it would emit, discarding the rewritten expression.
+///
+/// For `[adaptive_dosing] observe`, which is stored as a raw string and compiled at
+/// simulate time — where `parse_warnings` is long sealed and the adaptive result has
+/// no warnings channel — this is what keeps the fold from being silent on that path.
+/// The expression is re-parsed rather than duplicating the alias test, so the note
+/// can never disagree with the fold that actually happens (#1028). A parse failure is
+/// ignored: the real compile reports it, with its own context.
+#[allow(clippy::too_many_arguments)]
+fn warn_if_time_alias_folds(
+    src: &str,
+    context: &str,
+    theta_names: &[String],
+    eta_names: &[String],
+    indiv_var_names: &[String],
+    declared_covariates: &[String],
+    parse_warnings: &mut Vec<String>,
+) {
+    let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
+    if let Ok(mut expr) = parse_scalar_expression(src, ctx) {
+        rewrite_scaling_time_alias(&mut expr, context, declared_covariates, parse_warnings);
+    }
+}
+
 /// Whether `expr` reads the model-time built-in, under either spelling: the
 /// `Expression::Time` node a bare `TIME` parses to, or the `T` / `t` alias
 /// [`rewrite_scaling_time_alias`] folds into it. Drives the `obs_scale`
@@ -7428,13 +7471,36 @@ fn expr_references_time_builtin(expr: &Expression, declared_covariates: &[String
     visit_expr_nodes(expr, &mut |e: &Expression| match e {
         Expression::Time => found = true,
         Expression::Covariate(n)
-            if (n == "T" || n == "t") && !declared_covariates.iter().any(|d| d == n) =>
+            if is_time_alias(n) && !declares_time_alias(declared_covariates) =>
         {
             found = true
         }
         _ => {}
     });
     found
+}
+
+/// Whether `name` is the `[odes]` model-time alias, i.e. `T` under either case.
+/// The two spellings are one built-in, so every guard that keys on the alias must
+/// treat them as one name.
+fn is_time_alias(name: &str) -> bool {
+    name == "T" || name == "t"
+}
+
+/// Whether `[covariates]` declares the model-time alias, in *either* case.
+///
+/// Deliberately case-insensitive while ordinary covariate resolution is
+/// case-sensitive: since [`is_time_alias`] collapses `T` and `t` into one
+/// built-in, a case-exact check would let `[covariates] T` fail to protect a
+/// `y = ... t ...` reference (silently folding it to the clock even though the
+/// user took the documented escape hatch) and, in `obs_scale`, would raise the
+/// `TIME`-rejection error against a legitimately declared column. Matching the
+/// declaration the same way the reference is matched keeps the escape hatch
+/// working for both spellings (#1028).
+fn declares_time_alias(declared_covariates: &[String]) -> bool {
+    declared_covariates
+        .iter()
+        .any(|d| d.eq_ignore_ascii_case("T"))
 }
 
 /// Build an `OdeOutputFn` from one `y[…] = value` line. Shared between

--- a/src/parser/model_parser_adaptive_dosing_tests.rs
+++ b/src/parser/model_parser_adaptive_dosing_tests.rs
@@ -4,6 +4,15 @@ fn lines(body: &[&str]) -> Vec<String> {
     body.iter().map(|s| s.to_string()).collect()
 }
 
+/// Block-parse with no `[covariates]` declarations, which is what every test here
+/// wants: these exercise the block's own grammar and validation, not the `T`/`t`
+/// name precedence the declarations feed (#1028 — that has its own tests against
+/// the whole model). Shadows the parser's two-argument function so the 37 call
+/// sites below stay on the shape they were written in.
+fn parse_adaptive_dosing_block(lines: &[String]) -> Result<AdaptiveDosingSpec, String> {
+    super::parse_adaptive_dosing_block(lines, &[])
+}
+
 /// A minimal block that parses — the base every "one thing wrong" error test
 /// mutates. Continuous (percentage) titration, bare-endpoint observe.
 fn valid_min() -> Vec<&'static str> {

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -11173,6 +11173,49 @@ fn scaling_y_readout_t_alias_loses_to_a_declared_covariate() {
     }
 }
 
+/// The alias collapses `T` and `t` into one built-in, so the declaration that
+/// protects it has to be matched the same way. A case-exact guard let
+/// `[covariates] T` fail to protect a `y = ... t ...` reference — silently folding
+/// it to the clock even though the user took the documented escape hatch — and, in
+/// `obs_scale`, raised the `TIME`-rejection error against a legitimately declared
+/// column. Both spellings of the declaration must cover both spellings of the
+/// reference (#1042 review).
+#[test]
+fn scaling_time_alias_declaration_is_case_insensitive() {
+    for declared in ["T", "t"] {
+        for used in ["T", "t"] {
+            let src = ode_model_with_scaling(
+                "ode(states=[depot, central])",
+                Some(&format!("  y = central / V * {used}\n")),
+            ) + &format!("\n[covariates]\n  {declared} continuous\n");
+            let model = parse_model_string(&src)
+                .unwrap_or_else(|e| panic!("declared `{declared}`, used `{used}`: {e}"));
+            assert_eq!(
+                model.referenced_covariates,
+                vec![used.to_string()],
+                "declared `{declared}` must protect the `{used}` reference"
+            );
+            assert!(
+                !readout_reads_time(&model),
+                "declared `{declared}`, used `{used}`: must not fold to the clock"
+            );
+        }
+    }
+}
+
+/// The same case-insensitivity on the `obs_scale` side, where the mismatch was not
+/// a silent fold but a hard error thrown at a column the model legitimately
+/// declared.
+#[test]
+fn obs_scale_time_rejection_respects_a_case_mismatched_declaration() {
+    let src = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some("  obs_scale = 1000 / t\n  y = central\n"),
+    ) + "\n[covariates]\n  T continuous\n";
+    let model = parse_model_string(&src).expect("a declared `T` column is not the TIME built-in");
+    assert_eq!(model.referenced_covariates, vec!["t".to_string()]);
+}
+
 /// …and when the fold *does* fire (no declaration), it says so. The undeclared
 /// case is the one the parser cannot disambiguate — a dataset column named `T` is
 /// only a warning elsewhere — so the note names both escapes: spell it `TIME`, or

--- a/src/sim/adaptive.rs
+++ b/src/sim/adaptive.rs
@@ -703,6 +703,19 @@ pub struct AdaptiveDosingSpec {
     /// (the signal is then the noised model output named by `assay_cmt`, not a
     /// re-typed expression). The `when` rules compare the keyword `signal` to it.
     pub observe: Option<String>,
+    /// Covariate names the model's `[covariates]` block declares, captured at parse
+    /// time (empty when the block is absent).
+    ///
+    /// `observe` is stored as a raw string and compiled only at simulate time, by
+    /// `sim::adaptive_control::compile_observe`, through the very same
+    /// `build_y_output_fn` a `[scaling]` Form C readout uses. That compiler needs the
+    /// declarations to apply the `T` / `t` name precedence — a declared `T` is a data
+    /// column, not the model-time built-in (#1028) — and they are not otherwise
+    /// reachable from a `CompiledModel` (`referenced_covariates` holds names the model
+    /// *reads*, which is a declared-and-unreferenced `T` short). Carried here so
+    /// `observe` and `[scaling]` resolve the name identically, rather than the same
+    /// model reading the column in one block and the clock in the other.
+    pub observe_declared_covariates: Vec<String>,
     /// Titrate on the assay-noised measurement of a model output (`true`) rather
     /// than a latent expression (`false`, the default). When set, the signal's
     /// value *and* its σ both come from the output named by `assay_cmt`, so they
@@ -1109,6 +1122,7 @@ mod tests {
     fn base_spec() -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
             observe: Some("central".to_string()),
+            observe_declared_covariates: Vec::new(),
             with_assay_error: false,
             assay_cmt: None,
             at: vec![24.0],

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -242,9 +242,15 @@ pub(crate) fn build_adaptive_controller(
 /// would predict — `observe = central / V` yields the concentration, not the raw
 /// amount. ODE-only (the adaptive engine runs on the ODE path); an unknown name
 /// or an IOV reference in `observe` is rejected by the shared compiler.
+/// `declared_covariates` is the model's `[covariates]` declarations, carried on the
+/// spec as [`AdaptiveDosingSpec::observe_declared_covariates`]: `observe` must apply
+/// the same `T` / `t` name precedence a `[scaling]` expression gets, or the same
+/// model reads a declared `T` as the data column in `[scaling]` and as the
+/// model-time built-in here (#1028).
 pub(crate) fn compile_observe(
     model: &CompiledModel,
     observe: &str,
+    declared_covariates: &[String],
 ) -> Result<(OdeOutputFn, Vec<String>), String> {
     let ode = model.ode_spec.as_ref().ok_or_else(|| {
         "[adaptive_dosing] requires an ODE model (the analytical engine is a follow-up)".to_string()
@@ -253,13 +259,13 @@ pub(crate) fn compile_observe(
     // caller validates them against the data so a misspelt name fails loudly
     // instead of silently reading 0.0 (the readout leaves an absent covariate at
     // 0.0, which would drive the controller off a wrong signal).
-    // `[adaptive_dosing]` compiles at simulate time, long after `parse_warnings` has
-    // been sealed onto the model, so the `T`-alias note the shared compiler emits has
-    // no sink here and is dropped (#1028). The precedence half of that guard still
-    // applies: `referenced_covariates` is every name the rest of the model reads as a
-    // covariate, so a data column named `T` that the model actually uses keeps
-    // winning over the model-time alias, exactly as a `[covariates]` declaration does
-    // in `[scaling]`.
+    //
+    // The shared compiler's `T`-alias note is discarded *here* on purpose: this runs at
+    // simulate time, long after `model.parse_warnings` was sealed, and the adaptive
+    // result has no warnings channel. The parser emits the identical note for this same
+    // `observe` string at parse time, from the same helper
+    // (`warn_if_time_alias_folds`), so the fold is not silent — it is just reported
+    // earlier (#1028).
     let mut observe_warnings: Vec<String> = Vec::new();
     let (out_fn, _program, cov_names) = crate::parser::model_parser::build_y_output_fn(
         observe,
@@ -275,7 +281,7 @@ pub(crate) fn compile_observe(
         &[],
         // ODE-only path: any integrated state is valid, no forbidden names (#650).
         &[],
-        &model.referenced_covariates,
+        declared_covariates,
         &mut observe_warnings,
     )?;
     Ok((out_fn, cov_names))
@@ -340,7 +346,7 @@ pub(crate) fn compile_adaptive(
             .observe
             .as_deref()
             .expect("validate() requires observe without with_assay_error");
-        let (out_fn, cov) = compile_observe(model, observe_src)?;
+        let (out_fn, cov) = compile_observe(model, observe_src, &spec.observe_declared_covariates)?;
         (ObserveMode::Ipred, Some(out_fn), cov, 1)
     };
     let monitors = vec![MonitorSpec::new(ADAPTIVE_SIGNAL, cmt, mode)];
@@ -369,6 +375,7 @@ mod tests {
     ) -> AdaptiveDosingSpec {
         AdaptiveDosingSpec {
             observe: Some("central".to_string()),
+            observe_declared_covariates: Vec::new(),
             with_assay_error: false,
             assay_cmt: None,
             at: vec![24.0, 48.0],
@@ -721,6 +728,7 @@ mod tests {
             // `observe` is the latent (Ipred) signal; under assay error there is no
             // expression — the signal is the named model output (`assay_cmt`).
             observe: (!with_assay_error).then(|| observe.to_string()),
+            observe_declared_covariates: Vec::new(),
             with_assay_error,
             assay_cmt,
             at: vec![24.0, 48.0],
@@ -738,7 +746,8 @@ mod tests {
     #[test]
     fn compile_observe_yields_concentration_not_amount() {
         let model = parse_full_model(ODE_MODEL).expect("ODE model parses").model;
-        let (observe, _cov) = compile_observe(&model, "central / V").expect("observe compiles");
+        let (observe, _cov) =
+            compile_observe(&model, "central / V", &[]).expect("observe compiles");
         let theta = model.default_params.theta.clone();
         let eta = vec![0.0; model.n_eta + model.n_kappa];
         let cov = HashMap::new();
@@ -754,7 +763,7 @@ mod tests {
     #[test]
     fn compile_observe_requires_ode_model() {
         let model = parse_full_model(ANALYTICAL_MODEL).unwrap().model;
-        let err = compile_observe(&model, "central / V")
+        let err = compile_observe(&model, "central / V", &[])
             .err()
             .expect("analytical model must error");
         assert!(err.contains("requires an ODE model"), "got: {err}");

--- a/src/types.rs
+++ b/src/types.rs
@@ -3760,8 +3760,8 @@ impl CompiledModel {
     /// θ, observation covariates, and TIME — never on η), so the FOCE/FOCEI
     /// data term, Laplace curvature term, and inner EBE objective can all share
     /// one matrix and stay mutually consistent. The TIME fed to each row is the
-    /// raw data-file time (`obs_raw_times`, matching what NONMEM's `$ERROR`
-    /// sees), falling back to `obs_times` for in-memory subjects.
+    /// raw data-file time ([`Subject::readout_time`], matching what NONMEM's
+    /// `$ERROR` sees), falling back to `obs_times` for in-memory subjects.
     pub fn ruv_obs_mult(&self, subject: &Subject, theta: &[f64]) -> Option<Vec<Vec<f64>>> {
         let rm = self.ruv_magnitude.as_ref()?;
         if !rm.is_active() {
@@ -3770,12 +3770,7 @@ impl CompiledModel {
         let n = subject.observations.len();
         let mut out = Vec::with_capacity(n);
         for j in 0..n {
-            let time = subject
-                .obs_raw_times
-                .get(j)
-                .copied()
-                .unwrap_or_else(|| subject.obs_times.get(j).copied().unwrap_or(0.0));
-            out.push(rm.eval_obs(theta, subject.obs_cov(j), time));
+            out.push(rm.eval_obs(theta, subject.obs_cov(j), subject.readout_time(j)));
         }
         Some(out)
     }
@@ -3802,12 +3797,7 @@ impl CompiledModel {
         let n = subject.observations.len();
         let mut out = Vec::with_capacity(n);
         for j in 0..n {
-            let time = subject
-                .obs_raw_times
-                .get(j)
-                .copied()
-                .unwrap_or_else(|| subject.obs_times.get(j).copied().unwrap_or(0.0));
-            out.push(rm.eval_obs_theta_grad(theta, subject.obs_cov(j), time)?);
+            out.push(rm.eval_obs_theta_grad(theta, subject.obs_cov(j), subject.readout_time(j))?);
         }
         Some(out)
     }


### PR DESCRIPTION
## Why

Post-merge review of #1042 (the #1028 `[scaling]` `TIME` work) turned up four defects in that change. #1042 was already merged, so these land as a follow-up.

The two that matter are a **cross-path clock split** — exactly the class of bug #1028 set out to remove. #1028 moved the Form C readout's `TIME` onto the raw data-file clock (the `$ERROR` convention shared by sdtab, `predict()`/`simulate()` and `[derived]` windows) and threaded a new `Subject::readout_time` through the readout seams — but it reached five of seven. The reactive driver (`ode_predictions_adaptive_impl`) and the frozen-schedule replay verifier (`adaptive_frozen_replay_tv`) kept feeding the readout `t_start`, the integrator break the observation was keyed to off `shadow.obs_times`.

For a subject with stacked reset occasions — supported on the adaptive constant-covariate path per #932 — the two clocks are different numbers, so a `TIME`-reading readout evaluated differently under `simulate_adaptive` than under `predict()`/`fit()` for the same record. Worse, `adaptive_frozen_replay_tv` is the verifier whose entire job is bit-equality with the static engine, so the one path that exists to prove the two agree was itself on the other convention. The reader's pre-dose trough `.next_down()` nudge puts the two 1 ULP apart even with no resets, so this was never only a reset-dataset concern.

The other two are in the `T` / `t` name-precedence escape hatch #1042 added:

- `[adaptive_dosing] observe` was handed `model.referenced_covariates` as its "declared covariates" list, but that holds names the model *reads* — a `[covariates]` declaration only lands there once something references it. So the hatch the docs promise ("declare `T` and it is read as the column") did not work for `observe`, and one model could read a declared `T` as the data column in `[scaling]` and as the model clock in `observe`.
- The guard matched case-exactly while the fold treats `T` and `t` as one built-in, so `[covariates] T` failed to protect a `t` reference: silently folded to the clock in `y`, and in `obs_scale` the mismatch instead raised the time-in-a-subject-static-divisor error *against a legitimately declared column*.

## What changed

- **`src/ode/predictions.rs`** — both adaptive readout seams call `readout_time` (`shadow.readout_time(obs_idx)` in the driver, `subject.readout_time(obs_idx)` in the TV replay). The integrator keeps `obs_times`, exactly as NONMEM's `$DES` clock is not its `$ERROR` `TIME`.
- **`AdaptiveDosingSpec::observe_declared_covariates`** — the `[covariates]` names, captured at parse time and carried to the simulate-time `compile_observe`. This is the smallest carrier that reaches the compile site: `observe` is stored as a raw string and compiled long after the parser is gone, and the declarations are not otherwise reachable from a `CompiledModel`.
- **`warn_if_time_alias_folds`** — the parser emits the `T`-fold warning for `observe` too, by running the *same* `rewrite_scaling_time_alias` over a throwaway parse. `observe` compiles at simulate time, where `parse_warnings` is sealed and the adaptive result has no warnings channel, so reporting it earlier is what keeps the fold from being silent on that one path. Re-parsing rather than duplicating the alias test means the note can never disagree with the fold that actually happens.
- **`is_time_alias` / `declares_time_alias`** — the declaration is matched case-insensitively, so both spellings of the declaration cover both spellings of the reference. Deliberately narrower than ordinary covariate resolution, which stays case-sensitive.
- **`ruv_obs_mult` / `ruv_obs_mult_theta_grad`** — call `Subject::readout_time` instead of open-coding the same raw-with-fallback lookup.

## Alternatives considered

For the `observe` precedence list, the natural home for the declarations is `CompiledModel` — but it has no `Default` and 32 struct-literal construction sites, and the data is only needed at one call site that already has the spec in hand. `AdaptiveDosingSpec` is on the path from parser to compiler and cost 7 literals.

For the `observe` warning, plumbing a warnings channel out through `CompiledAdaptive` → `simulate_adaptive_from_spec` → the adaptive result would be a public-API expansion well beyond a follow-up fix (and the absence of that channel is a pre-existing, documented limitation — see the note at `api/adaptive.rs:396`). Emitting at parse time uses the sink that already exists.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change reaches the R glue: `Subject::readout_time` is additive, and `AdaptiveDosingSpec`'s new field is populated by the parser.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [x] Public Rust API (`api.rs` / `types.rs`) — additive only
- [ ] None

<details>
<summary>Migration notes</summary>

`AdaptiveDosingSpec` gains a public field, so a caller constructing one with a struct literal (rather than through the parser) must add `observe_declared_covariates: Vec::new()`. `Subject::readout_time` is a new method. Nothing existing changes shape.

</details>

## Numerical validation

Behavioural change is confined to models whose Form C readout reads `TIME` *and* whose data has a restarting `TIME` (or which run through the adaptive driver, where the 1 ULP trough nudge applied). Both NONMEM anchors from the parent work still pass unchanged:

```
running 2 tests
test the_nonmem_anchor_discriminates_a_stale_time_of_zero ... ok
test ferx_form_c_time_readout_matches_nonmem_error_block ... ok

running 1 test
test ferx_form_c_readout_reproduces_nonmem_including_its_negative_predictions ... ok
```

Per the epic-#391 exception in `CLAUDE.md`, the adaptive paths are anchored by degenerate oracle and frozen-schedule replay rather than NONMEM (which has no feedback dosing); both are exercised directly by the new tests below.

- [x] Compared against: NONMEM (both anchors above), plus the static engine as the in-repo oracle

## Performance
- [x] No significant impact expected — one `Vec::get` per observation in place of another.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes: 3119 passed, 0 failed)
- [x] Regression test added that fails without this fix

New tests:

| Test | Pins |
|---|---|
| `adaptive_form_c_readout_time_matches_the_static_engine` | driver reads the raw clock, and agrees with `ode_predictions` record for record |
| `adaptive_tv_frozen_replay_readout_time_matches_the_driver` | the replay verifier is on the driver's clock, bit for bit |
| `from_spec_observe_t_alias_loses_to_a_declared_covariate` | a declared-but-otherwise-unreferenced `T` is the column in `observe` |
| `from_spec_observe_t_alias_fold_warns_at_parse_time` | the fold is not silent on the `observe` path; `TIME` stays quiet |
| `scaling_time_alias_declaration_is_case_insensitive` | all four declared×used spellings of `T`/`t` |
| `obs_scale_time_rejection_respects_a_case_mismatched_declaration` | a declared `T` does not trip the `obs_scale` time rejection when written `t` |

The two adaptive tests use a readout that returns nothing but the model-time thread-local, so a prediction vector *is* the sequence of `TIME` values the readout saw. Both were confirmed to fail against the pre-fix `t_start` —

```
assertion `left == right` failed: the adaptive readout must see the raw data-file TIME
  left: [6.0, 30.0, 6.0, 78.0]
 right: [6.0, 30.0, 6.0, 30.0]
```

— and to pass, matching the static engine exactly, after it.

## Example (user-facing features only)
- [x] Not applicable — no new API surface; this makes the documented #1028 behaviour hold on the paths that missed it.

## Docs
- [x] `docs/` updated for user-visible changes — `docs/model-file/scaling.qmd` (case-insensitive declaration; the hatch reaches `observe`) and `docs/model-file/adaptive-dosing.qmd` (the shared `T` precedence rule and the parse-time warning)
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean — no new warnings on the touched files
- [x] Functions on the `Dual2` sensitivity path stay differentiable — the analytic and dual-walk readout seams already moved to `readout_time` in #1042 and are untouched here; this PR only brings the two adaptive f64 seams onto the same clock
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### Example execution
- [x] No example execution step needed — no user-visible change to any shipped example (the fix is a clock convention on paths no `examples/*.ferx` exercises with a restarting `TIME`).

## Reviewer hints

Focus on `src/ode/predictions.rs` — the two `read_observable` call sites now passing `readout_time`, and whether any *other* readout seam still takes an integrator time. I claimed "all five seams" on the parent PR and it was seven, so the seam inventory is the thing worth re-deriving from scratch rather than trusting.

Second, `warn_if_time_alias_folds`: it re-parses `observe` purely to collect a warning and throws the expression away. That is deliberate (a duplicated alias test could drift from the real fold) but it is an odd-looking function; if there is a cleaner sink for a simulate-time warning I have missed, say so.

Skimmable: the `ruv_obs_mult` dedup, and the mechanical `observe_declared_covariates: Vec::new()` additions to test literals.

## Open questions

The review also noted, as a non-blocking observation, that on the ODE Form C path the compartment state is no longer clamped anywhere before the readout while the analytic Form C path still clamps the concentration (`c_clamped`) — so the two engines can disagree in sign under RK overshoot near zero. That is from #1020, not this PR, and I have deliberately left it alone. Worth its own issue?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APmhz6bhu1Y63RMbjoqAA2
