### PR TITLE
feat(parser): [scaling] intermediates, continuation lines, and 2-arg min/max [closes #1030]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,24 @@ section of the SDLC for the versioning policy).
   stopped theta from fixing.
 
 ### Added
+- **`[scaling]` accepts named intermediates, expressions can be split across lines, and `min`/`max`
+  take two arguments (#1030).** Three restrictions that individually looked defensible combined to
+  make a standard bounded-endpoint readout unmaintainable: a model-based meta-analysis logit-Emax
+  readout with the published `[0.01, 0.99]` clamp came out as one ~200-character line with the same
+  sub-expression written four times, because there was nowhere to name it. Now: (1) any `[scaling]`
+  line whose key is not `obs_scale` / `y` declares a **named intermediate** usable by the entries
+  below it, following the same define-above-use-below rule as `[individual_parameters]` —
+  intermediates are inlined, so covariates reached only through one are still required data columns
+  and the dose-attribute double-use rejection still sees them; (2) a long expression may be
+  **continued across lines** by starting the continued line with an operator or ending the previous
+  one with it, in `[individual_parameters]`, `[odes]`, `[scaling]`, and `[derived]`; (3) **`min(a, b)`
+  and `max(a, b)`** are available everywhere the DSL parses expressions, desugaring to the inline
+  conditional so they differentiate and compile exactly like the hand-written `if (a >= b) a else b`.
+  The three-line readout now reads the way the published Mlxtran does. Two smaller diagnostics come
+  with it: `max(a, b)` used to report `Missing closing parenthesis for function max`, which sent the
+  reader after a bracket bug that did not exist — arity errors now say so — and a `[scaling]` key
+  that is neither `obs_scale`/`y` nor read by any entry is rejected, so a misspelt `obs_scal = V`
+  still fails loudly instead of silently disabling scaling.
 - **SAEM now warns when an estimated theta carries no ETA at all.** A fixed-effect-only theta is not
   mu-referenced, so it never gets the γ-damped closed-form `log θ += γ·mean(η)` update and is moved
   only by the η-frozen numerical M-step — which re-maximises against a *single* MCMC η draw with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,8 @@ section of the SDLC for the versioning policy).
   intermediates are inlined, so covariates reached only through one are still required data columns
   and the dose-attribute double-use rejection still sees them; (2) a long expression may be
   **continued across lines** by starting the continued line with an operator or ending the previous
-  one with it, in `[individual_parameters]`, `[odes]`, `[scaling]`, and `[derived]`; (3) **`min(a, b)`
+  one with it, in `[individual_parameters]`, `[odes]`, `[scaling]`, `[derived]`, and
+  `[initial_conditions]`; (3) **`min(a, b)`
   and `max(a, b)`** are available everywhere the DSL parses expressions, desugaring to the inline
   conditional so they differentiate and compile exactly like the hand-written `if (a >= b) a else b`.
   The three-line readout now reads the way the published Mlxtran does. Two smaller diagnostics come

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **A `[derived]` row aggregate followed by more expression is now an error instead of silently
+  dropping the rest (#1030 review).** `CMAX = max(IPRED) * 2` parsed as the aggregate and discarded
+  the `* 2`, reporting the unscaled maximum. There is no aggregate form that continues into a larger
+  expression, so it now says so rather than returning a wrong number.
 - **A sigma declared past the ones a `combined` `[error_model]` names no longer perturbs the FOCE
   score or the `s` / `rsr` standard errors (#1001 review).** `dr_diag_d_log_sigma`'s `Combined` arm
   answered every `sigma_k >= 1` with the *additive* sigma's derivative, where its `additive` and
@@ -241,7 +245,10 @@ section of the SDLC for the versioning policy).
   one with it, in `[individual_parameters]`, `[odes]`, `[scaling]`, `[derived]`, and
   `[initial_conditions]`; (3) **`min(a, b)`
   and `max(a, b)`** are available everywhere the DSL parses expressions, desugaring to the inline
-  conditional so they differentiate and compile exactly like the hand-written `if (a >= b) a else b`.
+  conditional so they differentiate and compile exactly like the hand-written `if (a >= b) a else b`
+  — each argument appears twice in the desugared tree, so clamp a named intermediate rather than a
+  long expression. In `[derived]`, where `min`/`max` also name the row aggregate, the two are told
+  apart by the second argument: a comparison is a row filter, anything else is the numeric clamp.
   The three-line readout now reads the way the published Mlxtran does. Two smaller diagnostics come
   with it: `max(a, b)` used to report `Missing closing parenthesis for function max`, which sent the
   reader after a bracket bug that did not exist — arity errors now say so — and a `[scaling]` key

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -79,8 +79,9 @@ This is the natural layout for an additive-on-logit covariate model — one
 covariate per line — which previously had to be collapsed onto a single line
 ([#1030](https://github.com/FeRx-NLME/ferx-core/issues/1030)). A trailing `=`
 continues too, so `LEMAX =` on its own line followed by an indented expression is
-accepted. The same applies in `[odes]`, `[scaling]`, and `[derived]`; newlines
-*inside* `(...)` or `[...]` have always been ignored and still are.
+accepted. The same applies in `[odes]`, `[scaling]`, `[derived]`, and
+`[initial_conditions]`; newlines *inside* `(...)` or `[...]` have always been
+ignored and still are.
 
 ## Conditional Logic (`if` / `else`)
 

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -45,10 +45,42 @@ name from quietly reading as zero and collapsing the formula.
 | `log()`, `ln()` | `log(TVCL)` |
 | `sqrt()` | `sqrt(WT)` |
 | `abs()` | `abs(ETA_CL)` |
+| `min(a, b)`, `max(a, b)` | `max(TVCL * WT / 70, 0.1)` |
 | Parentheses | `TVCL * (WT/70)^0.75` |
 | Comparisons (in `if` conditions) | `WT > 70`, `SEX == 1`, `AGE != 0` |
 | Logical (in `if` conditions) | `&&` (and), `\|\|` (or), `!` (not) |
 | Inline conditional | `if (SEX == 1) TVCL * 1.5 else TVCL` |
+
+`min` / `max` take **exactly two** arguments and desugar to the inline
+conditional (`max(a, b)` → `if (a >= b) a else b`), so they differentiate and
+compile identically to the hand-written form. A one-argument `max(x)` is a parse
+error rather than the silent identity it used to be
+([#1030](https://github.com/FeRx-NLME/ferx-core/issues/1030)).
+
+## Continuation Lines
+
+A long expression may be split across several physical lines. Two spellings work,
+and both are unambiguous because no statement can *begin* with a binary operator:
+put the operator at the start of the continued line, or at the end of the line
+being continued.
+
+```
+[individual_parameters]
+  LEMAX = LEMAX0
+          + log(OR_ABATA) * ABATA
+          + log(OR_ADALI) * ADALI
+          + ETA_EMAX
+
+  KEL   = CL /
+          V
+```
+
+This is the natural layout for an additive-on-logit covariate model — one
+covariate per line — which previously had to be collapsed onto a single line
+([#1030](https://github.com/FeRx-NLME/ferx-core/issues/1030)). A trailing `=`
+continues too, so `LEMAX =` on its own line followed by an indented expression is
+accepted. The same applies in `[odes]`, `[scaling]`, and `[derived]`; newlines
+*inside* `(...)` or `[...]` have always been ignored and still are.
 
 ## Conditional Logic (`if` / `else`)
 

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -335,6 +335,62 @@ bit-for-bit-equal predictions on the analytic and ODE paths at matched
 parameters — the analytic-vs-ODE equivalence is checked by
 `analytic_form_c_matches_ode_form_c_binding_readout`.
 
+## Named intermediates (since #1030)
+
+Any line in `[scaling]` whose key is **not** `obs_scale` or `y` declares a
+**named intermediate** — a local binding the `obs_scale` / `y` entries below it
+can reference, exactly as `[individual_parameters]` already allows. This is what
+makes a bounded-endpoint readout writable once instead of once per occurrence.
+
+The standard model-based meta-analysis readout — a weighted logit of an Emax time
+course with the published `[0.01, 0.99]` clamp — reads as three lines:
+
+```ferx
+[scaling]
+  ACR20    = EMAX * TIME / (TIME + T50)
+  ACR20SAT = min(max(ACR20, 0.01), 0.99)
+  y        = log(ACR20SAT / (1 - ACR20SAT)) * sqrt(NARM)
+```
+
+Before intermediates existed the same model was one ~200-character line with the
+guarded sub-expression written four times, because there was nowhere to name it.
+
+The rules are the ones `[individual_parameters]` uses, plus two that follow from
+`[scaling]`'s two reserved keys:
+
+- **Define above, use below.** An intermediate may reference intermediates
+  declared above it; a forward or self reference is a parse error, not a silent
+  `0.0`. Reference cycles are therefore unrepresentable.
+- **No `[CMT=N]` subscript.** That belongs to `obs_scale` / `y`; a subscripted
+  unknown key is still an unknown-key error.
+- **No shadowing.** A name that is already a theta, an eta, an individual
+  parameter, or a compartment is rejected — a reference to it would resolve to
+  the thing already in scope, never to the binding, so the binding would be
+  silently dead. The same goes for the `TIME` / `T` built-ins.
+- **No dead bindings.** An intermediate that no `obs_scale` / `y` entry reaches
+  is a parse error. Before #1030 every key other than `obs_scale` / `y` was
+  rejected outright, which is what caught a misspelt `obs_scal = V`; now that any
+  key is legal syntax, rejecting the unread binding is what keeps that typo from
+  silently disabling scaling.
+
+Intermediates are **inlined** into the entry that uses them, so they are not a
+separate evaluation stage and nothing downstream can tell them from the
+hand-expanded form: covariates reached only through an intermediate are required
+data columns just the same (see *Undefined names are data columns, not zeros*
+above), the dose-attribute double-use rejection sees through them, and the
+analytic-sensitivity path is unaffected. The one consequence of inlining is that
+an intermediate used twice is *evaluated* twice — which is exactly what writing
+it out by hand costs.
+
+### `min(a, b)` and `max(a, b)`
+
+Two-argument `min` / `max` are available in every expression the DSL parses —
+`[scaling]`, `[individual_parameters]`, `[odes]`, `[derived]`. They desugar to the
+inline conditional (`max(a, b)` → `if (a >= b) a else b`), so they differentiate
+and compile exactly like the hand-written form. Because the desugaring duplicates
+the guarded expression in the tree, clamp a *named* value rather than a long
+expression when you can — that is the pairing the block above uses.
+
 ## Runtime behaviour on bad scales
 
 If an expression scale (Form B or C) evaluates to a non-positive or

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -360,13 +360,19 @@ The rules are the ones `[individual_parameters]` uses, plus two that follow from
 
 - **Define above, use below.** An intermediate may reference intermediates
   declared above it; a forward or self reference is a parse error, not a silent
-  `0.0`. Reference cycles are therefore unrepresentable.
+  `0.0`. Reference cycles are therefore unrepresentable. The rule binds the
+  `obs_scale` / `y` entries too: an entry may only read an intermediate declared
+  above it, so the block always reads top-to-bottom.
 - **No `[CMT=N]` subscript.** That belongs to `obs_scale` / `y`; a subscripted
   unknown key is still an unknown-key error.
 - **No shadowing.** A name that is already a theta, an eta, an individual
   parameter, or a compartment is rejected — a reference to it would resolve to
   the thing already in scope, never to the binding, so the binding would be
-  silently dead. The same goes for the `TIME` / `T` built-ins.
+  silently dead. The same goes for the `TIME` / `T` built-ins and the eval-time
+  built-ins `TAD`, `TAFD`, `MACHEPS`. A name declared in `[covariates]` is
+  rejected for the mirror-image reason: there the *binding* would win, silently
+  shadowing the data column and dropping it from the required-column set. Either
+  way, one name means one thing.
 - **No dead bindings.** An intermediate that no `obs_scale` / `y` entry reaches
   is a parse error. Before #1030 every key other than `obs_scale` / `y` was
   rejected outright, which is what caught a misspelt `obs_scal = V`; now that any
@@ -380,16 +386,28 @@ data columns just the same (see *Undefined names are data columns, not zeros*
 above), the dose-attribute double-use rejection sees through them, and the
 analytic-sensitivity path is unaffected. The one consequence of inlining is that
 an intermediate used twice is *evaluated* twice — which is exactly what writing
-it out by hand costs.
+it out by hand costs. Note that `min` / `max` count as two uses each (see below),
+so a two-sided clamp on a named value expands that value eight times.
 
 ### `min(a, b)` and `max(a, b)`
 
 Two-argument `min` / `max` are available in every expression the DSL parses —
 `[scaling]`, `[individual_parameters]`, `[odes]`, `[derived]`. They desugar to the
 inline conditional (`max(a, b)` → `if (a >= b) a else b`), so they differentiate
-and compile exactly like the hand-written form. Because the desugaring duplicates
-the guarded expression in the tree, clamp a *named* value rather than a long
-expression when you can — that is the pairing the block above uses.
+and compile exactly like the hand-written form.
+
+The desugaring puts **both** arguments in the guard *and* in a branch, so each one
+appears twice in the compiled tree, and the duplication multiplies through nesting:
+`min(max(x, 0.01), 0.99)` contains four copies of `x`, and reading that clamp from
+two places in a readout makes eight. Clamp a *named* value rather than a long
+expression — that is the pairing the block above uses, and it keeps the growth on a
+short leaf instead of on a whole sub-model.
+
+In `[derived]`, `min` / `max` also name the row aggregate (`max(IPRED, TIME > 0)` is
+"the largest `IPRED` over rows where `TIME > 0`"). The two are told apart by the
+second argument: a comparison is a row filter, anything else is the numeric clamp.
+An aggregate cannot be combined into a larger expression — `max(IPRED) * 2` is an
+error, not a scaled maximum.
 
 ## Runtime behaviour on bad scales
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2552,6 +2552,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
             &model.theta_names,
             &model.eta_names,
             &model.indiv_param_names,
+            &[],
             "[adaptive_dosing] observe",
         )?;
         // The `T` / `t` model-time fold warns wherever it fires — but `observe` is
@@ -2752,6 +2753,12 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         // below splits on the engine (ODE via `ode_slot_map`, analytical via the
         // `pk(...)` mapping — #1004), the `D{n}`/`R{n}` recording does not.
         let mut scaling_reads: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Named intermediates are inlined first (#1030), so a readout that reaches
+        // `F` through one is caught by the double-use rejection exactly as if it had
+        // been written inline. Scanning the intermediate lines directly instead would
+        // over-report — an intermediate no entry uses is rejected upstream, but one
+        // used by `y` only would still be charged against `obs_scale`.
+        let scaling_intermediates_for_reads = scaling_intermediates(scaling_lines)?;
         for line in scaling_lines {
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -2767,6 +2774,7 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
                 &theta_names_for_scaling,
                 &eta_names_for_scaling,
                 &indiv_var_names_for_scaling,
+                &scaling_intermediates_for_reads,
                 &format!("[scaling] {base}"),
             )?);
         }
@@ -7094,6 +7102,7 @@ fn compile_scale_deriv_program(
 /// amount, not concentration) — on a `pk` block it silently divides by `v` a
 /// second time. Since ferx can't tell intent from mistake here, it warns
 /// (`parse_warnings`) rather than erroring (#712).
+#[allow(clippy::too_many_arguments)]
 fn build_obs_scale_spec(
     value: &str,
     theta_names: &[String],
@@ -7102,6 +7111,7 @@ fn build_obs_scale_spec(
     pk_indices: &[usize],
     volume_indiv_name: Option<&str>,
     declared_covariates: &[String],
+    intermediates: &[(String, String)],
     parse_warnings: &mut Vec<String>,
 ) -> Result<(ScalingSpec, Vec<String>), String> {
     // Try scalar first (Form A). Otherwise parse as expression (Form B).
@@ -7117,8 +7127,11 @@ fn build_obs_scale_spec(
         return Ok((ScalingSpec::ScalarScale(k), Vec::new()));
     }
     let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
-    let expr =
+    let mut expr =
         parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] obs_scale: {}", e))?;
+    // Named intermediates are inlined before any of the checks below, so each one
+    // sees the expression the user would have had to write by hand (#1030).
+    inline_scaling_intermediates(&mut expr, intermediates, ctx)?;
     // `obs_scale` is a **subject-static** divisor: `apply_scaling` evaluates it once
     // per subject against the baseline covariate map and a `t = 0` `pk_param_fn`
     // snapshot, then divides the whole prediction vector by the result. A `TIME`
@@ -7597,6 +7610,7 @@ pub(crate) fn build_y_output_fn(
     readout_synth: &[ReadoutSynthParam],
     forbidden_state_names: &[String],
     declared_covariates: &[String],
+    intermediates: &[(String, String)],
     parse_warnings: &mut Vec<String>,
 ) -> Result<(crate::ode::OdeOutputFn, OdeOutputProgram, Vec<String>), String> {
     // Form C: expression may reference state names, individual params,
@@ -7609,6 +7623,11 @@ pub(crate) fn build_y_output_fn(
     }
     let ctx = ParseCtx::new(theta_names, eta_names, &defined);
     let mut expr = parse_scalar_expression(value, ctx).map_err(|e| format!("{context}: {e}"))?;
+
+    // Named intermediates are inlined first, so every check and rewrite below —
+    // the `T` fold, the forbidden-compartment and kappa rejections, the #486
+    // desugaring, the covariate scan — runs on the fully expanded readout (#1030).
+    inline_scaling_intermediates(&mut expr, intermediates, ctx)?;
 
     // `T` / `t` is the `[odes]` spelling of the model-time built-in; fold it into
     // the `Expression::Time` node a bare `TIME` already parses to, so the two
@@ -7889,6 +7908,35 @@ fn parse_scaling_block(
     let mut y_uniform_program: Option<OdeOutputProgram> = None;
     let mut scaling_covariates: Vec<String> = Vec::new();
 
+    // Named intermediates (#1030): every non-`obs_scale`/`y` key. Collected up
+    // front — this is the one place with the full name scope in hand, so it owns
+    // the shadowing rejection the pre-scans can't make.
+    let intermediates = scaling_intermediates(lines)?;
+    for (name, _) in &intermediates {
+        // An intermediate whose name is already a θ / η / individual parameter /
+        // state would never be read: the expression parser binds those before it
+        // consults the intermediate table, so the binding would be silently dead.
+        let clash = theta_names
+            .iter()
+            .map(|n| (n, "a theta"))
+            .chain(eta_names.iter().map(|n| (n, "an eta")))
+            .chain(
+                indiv_var_names
+                    .iter()
+                    .map(|n| (n, "an individual parameter")),
+            )
+            .chain(state_names.iter().map(|n| (n, "a compartment")))
+            .find(|(n, _)| *n == name);
+        if let Some((_, what)) = clash {
+            return Err(format!(
+                "[scaling]: `{name}` is already {what}, so it cannot also be a named \
+                 intermediate — a reference to it would resolve to {what}, never to this \
+                 line. Rename the intermediate."
+            ));
+        }
+    }
+    check_scaling_intermediates_used(lines, &intermediates)?;
+
     for line in lines {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -7910,6 +7958,7 @@ fn parse_scaling_block(
                     pk_indices,
                     volume_indiv_name,
                     declared_covariates,
+                    &intermediates,
                     parse_warnings,
                 )?;
                 // Form B `obs_scale` covariate leaves are required data columns too
@@ -7971,6 +8020,7 @@ fn parse_scaling_block(
                     readout_synth,
                     &forbidden,
                     declared_covariates,
+                    &intermediates,
                     parse_warnings,
                 )?;
                 for cov in cov_names {
@@ -8010,9 +8060,10 @@ fn parse_scaling_block(
                     }
                 }
             }
-            _ => {
-                return Err(format!("[scaling]: unknown key `{}`", base));
-            }
+            // A named intermediate (#1030). Already collected and validated above,
+            // and inlined into the entries that reference it — nothing left to do
+            // on its own line.
+            _ => {}
         }
     }
 
@@ -9210,10 +9261,13 @@ fn collect_indiv_param_reads(
     theta_names: &[String],
     eta_names: &[String],
     indiv_var_names: &[String],
+    intermediates: &[(String, String)],
     context: &str,
 ) -> Result<std::collections::HashSet<String>, String> {
     let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
-    let expr = parse_scalar_expression(src, ctx).map_err(|e| format!("{context}: {e}"))?;
+    let mut expr = parse_scalar_expression(src, ctx).map_err(|e| format!("{context}: {e}"))?;
+    // `[scaling]` named intermediates (#1030); empty for every other caller.
+    inline_scaling_intermediates(&mut expr, intermediates, ctx)?;
     let mut reads: std::collections::HashSet<String> = std::collections::HashSet::new();
     visit_expr_nodes(&expr, &mut |e: &Expression| {
         if let Expression::Variable(name) = e {
@@ -10837,6 +10891,16 @@ fn extract_blocks(content: &str) -> Result<ExtractedBlocks, String> {
 
     check_block_names(&headers)?;
 
+    // Fold operator continuation lines into single logical lines before anyone
+    // reads the block (#1030). Done here rather than in each block's parser so the
+    // token-stream consumers (`[individual_parameters]`, `[odes]`) and the
+    // line-oriented ones (`[scaling]`) can't drift on what a "line" is.
+    for ty in CONTINUATION_BLOCKS {
+        if let Some(lines) = out.unnamed.get_mut(*ty) {
+            *lines = join_continuation_lines(lines);
+        }
+    }
+
     Ok(out)
 }
 
@@ -10888,6 +10952,71 @@ fn join_bracketed_lines(lines: &[String]) -> Vec<String> {
     // rather than the line silently vanishing.
     if !buf.is_empty() {
         out.push(buf);
+    }
+    out
+}
+
+/// Block types whose lines are expression statements, and therefore accept
+/// operator continuation lines (#1030). Everything else (`[parameters]`,
+/// `[fit_options]`, …) keeps its strict one-declaration-per-line grammar.
+const CONTINUATION_BLOCKS: &[&str] = &["individual_parameters", "odes", "scaling", "derived"];
+
+/// Leading characters that mark a line as the continuation of the previous one.
+/// Every statement in a continuation block starts with an identifier, `d/dt(`,
+/// `if`, or a brace — never with a binary operator — so a line opening with one
+/// of these can only be a continuation, and joining it strictly widens the
+/// accepted grammar rather than reinterpreting anything that parsed before.
+const CONTINUATION_LEADERS: &[char] = &['+', '-', '*', '/', '^'];
+
+/// Trailing characters that mark a line as unfinished, so the *next* line
+/// continues it. `=` is included so `LEMAX =` followed by an indented expression
+/// works; `,` so a multi-line argument list does.
+const CONTINUATION_TRAILERS: &[char] = &['+', '-', '*', '/', '^', ',', '='];
+
+/// Join operator continuation lines into single logical lines (#1030).
+///
+/// A long `[individual_parameters]` expression — the additive-on-logit covariate
+/// model, one covariate per line — is unreadable collapsed onto one line, but the
+/// statement parser treats a newline as an end-of-statement marker, so the natural
+/// layout used to fail with ``Expected an assignment, an `if` block, or
+/// `d/dt(...)`, got Plus``. Two spellings are accepted, both unambiguous because
+/// no statement can begin with a binary operator:
+///
+/// ```text
+///   LEMAX = LEMAX0                     LEMAX = LEMAX0 +
+///           + log(OR_ABATA) * ABATA            log(OR_ABATA) * ABATA
+/// ```
+///
+/// Newlines inside `(...)` / `[...]` are already dropped by
+/// [`strip_newlines_in_groups`], so this only has to cover the top level. It runs
+/// on the comment-stripped, trimmed lines [`extract_blocks`] produces, and is
+/// applied there so every consumer of a block's lines — including the
+/// line-oriented `[scaling]` scans, which never see the token stream — gets the
+/// joined form.
+fn join_continuation_lines(lines: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let starts_continuation = trimmed
+            .chars()
+            .next()
+            .is_some_and(|c| CONTINUATION_LEADERS.contains(&c));
+        let prev_unfinished = out
+            .last()
+            .and_then(|l: &String| l.trim_end().chars().last())
+            .is_some_and(|c| CONTINUATION_TRAILERS.contains(&c));
+        match out.last_mut() {
+            Some(last) if starts_continuation || prev_unfinished => {
+                last.push(' ');
+                last.push_str(trimmed);
+            }
+            // A block's first line can't continue anything; leave it alone so the
+            // downstream parser reports its own error.
+            _ => out.push(trimmed.to_string()),
+        }
     }
     out
 }
@@ -14019,6 +14148,262 @@ fn split_scaling_entry(trimmed: &str) -> Result<(&str, &str), String> {
     Ok((trimmed[..split_at].trim(), trimmed[split_at + 1..].trim()))
 }
 
+// ── [scaling] named intermediates (#1030) ───────────────────────────────────
+//
+// `[scaling]` used to accept exactly two keys, so a bounded-endpoint readout had
+// to repeat its guarded sub-expression once per occurrence — four times for the
+// standard `min(max(x, 0.01), 0.99)` clamp, on a single ~200-character line that
+// no reviewer can check. Any other key is now a *named intermediate*: a local
+// binding usable by the `obs_scale` / `y` entries below it, exactly as
+// `[individual_parameters]` already allows.
+//
+// Intermediates are **inlined into the AST** of each entry that references them,
+// right after that entry is parsed and before anything else looks at it. That is
+// deliberate: it means every downstream consumer — bytecode compilation, the
+// `Dual2` sensitivity programs, the covariate/required-column scan (#1028), the
+// dose-attribute double-use rejection (#993/#1004), the `T`-alias fold, the
+// direct-θ/η desugaring (#486), the readout slot allocator (#650) — sees exactly
+// the expression the user would have written by hand, with no new node type to
+// teach any of them about. The cost is that a repeated intermediate is evaluated
+// once per occurrence, which is what hand-expansion costs today.
+
+/// Whether `base` is one of the two reserved `[scaling]` entry keys. Anything else
+/// on the left of an `=` is a named intermediate.
+fn is_scaling_entry_key(base: &str) -> bool {
+    base == "y" || base == "obs_scale"
+}
+
+/// Whether `name` is a syntactically valid DSL identifier (the shape the
+/// tokenizer produces for `Token::Ident`).
+fn is_plain_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Names a `[scaling]` intermediate may not take: the built-ins the expression
+/// parser resolves before it would ever consult the intermediate table, so a
+/// binding under one of these names would silently never be read.
+fn scaling_intermediate_reserved(name: &str) -> Option<&'static str> {
+    if name == "TIME" || name == "time" {
+        return Some("the model-time built-in");
+    }
+    if is_time_alias(name) {
+        return Some("the `[odes]` model-time alias for `TIME`");
+    }
+    if name.eq_ignore_ascii_case("MIXNUM") {
+        return Some("the mixture subpopulation index");
+    }
+    if name.eq_ignore_ascii_case("if") || name.eq_ignore_ascii_case("else") {
+        return Some("an inline-conditional keyword");
+    }
+    if is_synthetic_readout_param(name) {
+        return Some("a reserved internal parameter prefix");
+    }
+    None
+}
+
+/// Collect the `[scaling]` block's named intermediates, in declaration order, as
+/// `(name, source expression)` pairs.
+///
+/// Shared by every scan over `[scaling]` lines — `parse_scaling_block` itself and
+/// the three pre-scans that run before it (`collect_readout_theta_eta_synth`,
+/// `allocate_readout_extra_slots`, and the dose-attribute read scan in
+/// `parse_model_file`) — so none of them can disagree about which lines are
+/// entries and which are bindings.
+fn scaling_intermediates(lines: &[String]) -> Result<Vec<(String, String)>, String> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (key, value) = split_scaling_entry(trimmed)?;
+        let (base, cmt) = parse_scaling_key(key)?;
+        if is_scaling_entry_key(base) {
+            continue;
+        }
+        if cmt.is_some() {
+            return Err(format!(
+                "[scaling]: unknown key `{base}` — only `obs_scale` and `y` take a \
+                 `[CMT=N]` subscript. A named intermediate is written `{base} = <expr>`, \
+                 with no subscript."
+            ));
+        }
+        if !is_plain_identifier(base) {
+            return Err(format!("[scaling]: unknown key `{base}`"));
+        }
+        if let Some(what) = scaling_intermediate_reserved(base) {
+            return Err(format!(
+                "[scaling]: `{base}` cannot be used as a named intermediate — it is \
+                 {what}. Pick another name."
+            ));
+        }
+        if out.iter().any(|(n, _)| n == base) {
+            return Err(format!(
+                "[scaling]: duplicate named intermediate `{base}` — each one is assigned once."
+            ));
+        }
+        if value.is_empty() {
+            return Err(format!(
+                "[scaling]: named intermediate `{base}` has no right-hand side."
+            ));
+        }
+        out.push((base.to_string(), value.to_string()));
+    }
+    Ok(out)
+}
+
+/// Replace every leaf that names one of `expanded` with a clone of that
+/// intermediate's (already fully expanded) expression.
+///
+/// Both leaf spellings are matched: `[scaling]` parses with
+/// `fallback_covariate = true`, so an unresolved identifier arrives as
+/// `Covariate(name)`, while `Variable(name)` is what it becomes in the contexts
+/// that put states / individual parameters in scope.
+///
+/// [`visit_expr_nodes_mut`] descends into the node it just replaced, which is safe
+/// here precisely because `expanded` holds *expanded* bodies: an intermediate can
+/// only reference intermediates declared above it (enforced in
+/// [`inline_scaling_intermediates`]), so a substituted body contains no
+/// intermediate name and the walk cannot re-fire on its own output.
+fn substitute_scaling_intermediates(expr: &mut Expression, expanded: &[(String, Expression)]) {
+    if expanded.is_empty() {
+        return;
+    }
+    visit_expr_nodes_mut(expr, &mut |e: &mut Expression| {
+        let name = match e {
+            Expression::Covariate(n) | Expression::Variable(n) => n.as_str(),
+            _ => return,
+        };
+        if let Some((_, body)) = expanded.iter().find(|(n, _)| n == name) {
+            *e = body.clone();
+        }
+    });
+}
+
+/// First identifier in `expr` that names one of `names`, if any.
+fn first_scaling_intermediate_ref(expr: &Expression, names: &[(String, String)]) -> Option<String> {
+    let mut found: Option<String> = None;
+    visit_expr_nodes(expr, &mut |e: &Expression| {
+        if found.is_some() {
+            return;
+        }
+        let name = match e {
+            Expression::Covariate(n) | Expression::Variable(n) => n.as_str(),
+            _ => return,
+        };
+        if names.iter().any(|(m, _)| m == name) {
+            found = Some(name.to_string());
+        }
+    });
+    found
+}
+
+/// Inline the `[scaling]` named intermediates into a just-parsed entry expression.
+///
+/// `ctx` must be the same `ParseCtx` the entry itself was parsed with, so an
+/// intermediate resolves its θ / η / individual-parameter / state names against the
+/// scope of the entry that uses it. (`obs_scale` has no states in scope; `y` does —
+/// an intermediate that reads a state is therefore legal in `y` and becomes a
+/// required data column in `obs_scale`, the same as writing it inline.)
+///
+/// Forward and self references are rejected: intermediate `i` is expanded against
+/// `0..i` only, which makes a reference cycle unrepresentable rather than a
+/// recursion guard to get right.
+fn inline_scaling_intermediates(
+    expr: &mut Expression,
+    intermediates: &[(String, String)],
+    ctx: ParseCtx<'_>,
+) -> Result<(), String> {
+    if intermediates.is_empty() {
+        return Ok(());
+    }
+    let mut expanded: Vec<(String, Expression)> = Vec::with_capacity(intermediates.len());
+    for (i, (name, src)) in intermediates.iter().enumerate() {
+        let mut body =
+            parse_scalar_expression(src, ctx).map_err(|e| format!("[scaling] {name}: {e}"))?;
+        substitute_scaling_intermediates(&mut body, &expanded);
+        if let Some(later) = first_scaling_intermediate_ref(&body, &intermediates[i..]) {
+            return Err(format!(
+                "[scaling] {name}: references the named intermediate `{later}`, which is \
+                 declared on or below this line. An intermediate may only use ones \
+                 declared above it."
+            ));
+        }
+        expanded.push((name.clone(), body));
+    }
+    substitute_scaling_intermediates(expr, &expanded);
+    Ok(())
+}
+
+/// Every identifier appearing in a `[scaling]` source expression, as raw tokens.
+/// Used for the reachability scan behind the unused-intermediate rejection, which
+/// needs names only and must not depend on how any particular scope resolves them.
+fn source_identifiers(src: &str) -> Vec<String> {
+    match tokenize(src) {
+        Ok(toks) => toks
+            .into_iter()
+            .filter_map(|t| match t {
+                Token::Ident(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
+        // A malformed expression is reported with full context by the real parse;
+        // contributing no names here just means it reaches nothing.
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Reject a named intermediate that no `obs_scale` / `y` entry reaches (#1030).
+///
+/// Before intermediates existed, every key other than `obs_scale` / `y` was an
+/// error — which is what caught a typo like `obs_scal = V`. Now that any key is
+/// syntactically legal, that typo would silently disable scaling instead, so the
+/// same protection is re-established from the other side: a binding nothing reads
+/// is a mistake, and is rejected with both readings named.
+fn check_scaling_intermediates_used(
+    lines: &[String],
+    intermediates: &[(String, String)],
+) -> Result<(), String> {
+    if intermediates.is_empty() {
+        return Ok(());
+    }
+    let mut reached: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut queue: Vec<String> = Vec::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (key, value) = split_scaling_entry(trimmed)?;
+        let (base, _cmt) = parse_scaling_key(key)?;
+        if is_scaling_entry_key(base) {
+            queue.extend(source_identifiers(value));
+        }
+    }
+    while let Some(name) = queue.pop() {
+        let Some((n, src)) = intermediates.iter().find(|(n, _)| *n == name) else {
+            continue;
+        };
+        if reached.insert(n.as_str()) {
+            queue.extend(source_identifiers(src));
+        }
+    }
+    if let Some((unused, _)) = intermediates
+        .iter()
+        .find(|(n, _)| !reached.contains(n.as_str()))
+    {
+        return Err(format!(
+            "[scaling]: `{unused}` is never used. If it is a named intermediate, \
+             reference it from an `obs_scale` / `y` entry below it; if it is a \
+             misspelled `obs_scale` / `y` key, fix the spelling — as written it does \
+             nothing."
+        ));
+    }
+    Ok(())
+}
+
 /// Outcome of [`allocate_readout_extra_slots`]: the `(indiv param name, PK slot)` pairs the
 /// analytic Form-C readout needs, plus — for the analytical engine only — which synthetic
 /// θ/η parameters (#486) actually got a slot and, if they did not, the FD-fallback note.
@@ -14070,6 +14455,9 @@ fn allocate_readout_extra_slots(
         indiv_var_names.iter().map(|s| s.as_str()).collect();
     let mut referenced: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // An individual parameter can be referenced only from a named intermediate the
+    // readout uses (#1030); it still needs a slot, so inline before scanning.
+    let intermediates = scaling_intermediates(lines)?;
     for line in lines {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -14083,7 +14471,9 @@ fn allocate_readout_extra_slots(
         // Individual params in scope resolve to `Variable(name)`; θ/η/covariate
         // references resolve elsewhere and are ignored here.
         let ctx = ParseCtx::new(theta_names, eta_names, indiv_var_names);
-        let expr = parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] y: {e}"))?;
+        let mut expr =
+            parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] y: {e}"))?;
+        inline_scaling_intermediates(&mut expr, &intermediates, ctx)?;
         visit_expr_nodes(&expr, &mut |e: &Expression| {
             if let Expression::Variable(name) = e {
                 if indiv_set.contains(name.as_str())
@@ -14196,6 +14586,10 @@ fn collect_readout_theta_eta_synth(
 ) -> Result<Vec<ReadoutSynthParam>, String> {
     let mut thetas: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
     let mut etas: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+    // A θ/η reference can sit inside a named intermediate the readout uses (#1030);
+    // inline them here too, or the desugaring would miss it and drop an otherwise
+    // analytic readout to the FD fallback.
+    let intermediates = scaling_intermediates(scaling_lines)?;
     for line in scaling_lines {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -14209,7 +14603,9 @@ fn collect_readout_theta_eta_synth(
         // θ/η names resolve to `Theta`/`Eta`; every other identifier falls back to a
         // covariate (no `defined` set needed) since we only collect the θ/η axes.
         let ctx = ParseCtx::new(theta_names, eta_names, &[]);
-        let expr = parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] y: {e}"))?;
+        let mut expr =
+            parse_scalar_expression(value, ctx).map_err(|e| format!("[scaling] y: {e}"))?;
+        inline_scaling_intermediates(&mut expr, &intermediates, ctx)?;
         visit_expr_nodes(&expr, &mut |e: &Expression| match e {
             Expression::Theta(i) => {
                 thetas.insert(*i);
@@ -18094,12 +18490,58 @@ fn parse_atom(
                 ));
             }
 
-            // Check if it's a function call: name(expr)
+            // Check if it's a function call: `name(expr)` — or, for `min` / `max`,
+            // the two-argument `name(a, b)` form (#1030).
             if pos + 1 < tokens.len() && tokens[pos + 1] == Token::LParen {
                 let func_name = name.to_lowercase();
+                let is_min_max = matches!(func_name.as_str(), "min" | "max");
                 let (arg, p) = parse_add_sub(tokens, pos + 2, ctx)?;
-                if p >= tokens.len() || tokens[p] != Token::RParen {
+                if is_min_max && tokens.get(p) == Some(&Token::Comma) {
+                    let (arg2, p) = parse_add_sub(tokens, p + 1, ctx)?;
+                    if tokens.get(p) != Some(&Token::RParen) {
+                        return Err(format!(
+                            "Missing closing parenthesis for function {} — `{}` takes exactly \
+                             two arguments, `{}(a, b)`.",
+                            name, name, func_name
+                        ));
+                    }
+                    // Desugar to the inline conditional rather than adding a
+                    // two-argument AST node: `Expression::Conditional` is already
+                    // evaluated, bytecode-compiled, `Dual2`-differentiated and
+                    // index-resolved everywhere in the pipeline, so `min`/`max` gets
+                    // all of that for free and cannot drift from the hand-written
+                    // `if (a > b) a else b` it replaces. The guarded expression is
+                    // duplicated in the tree, exactly as it is when written by hand;
+                    // name it with an intermediate to keep the source readable.
+                    let op = if func_name == "min" {
+                        CmpOp::Le
+                    } else {
+                        CmpOp::Ge
+                    };
+                    let cond = Condition::Compare(arg.clone(), op, arg2.clone());
+                    return Ok((
+                        Expression::Conditional(Box::new(cond), Box::new(arg), Box::new(arg2)),
+                        p + 1,
+                    ));
+                }
+                if tokens.get(p) != Some(&Token::RParen) {
+                    // Say what's actually wrong. A stray `,` used to be reported as a
+                    // missing `)`, which sends the reader looking for a bracket bug
+                    // that doesn't exist (#1030).
+                    if tokens.get(p) == Some(&Token::Comma) {
+                        return Err(format!(
+                            "function `{}` takes 1 argument, but a `,` was found — only \
+                             `min(a, b)` and `max(a, b)` take two.",
+                            name
+                        ));
+                    }
                     return Err(format!("Missing closing parenthesis for function {}", name));
+                }
+                if is_min_max {
+                    return Err(format!(
+                        "`{}` takes exactly two arguments: `{}(a, b)`.",
+                        name, func_name
+                    ));
                 }
                 return Ok((Expression::UnaryFn(func_name, Box::new(arg)), p + 1));
             }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4079,8 +4079,36 @@ fn parse_derived_block(
                         }
                     );
                     (kind, uses)
+                } else if matches!(fname_lc.as_str(), "max" | "min")
+                    && args.len() == 2
+                    && !tokens_contain_comparison(args[1])
+                {
+                    // Two-argument numeric `min(a, b)` / `max(a, b)` (#1030) shares a
+                    // spelling with the aggregate's `min(<value>, <row filter>)`.
+                    // Disambiguate the way the rest of the parser already does: a
+                    // second argument with no comparison operator cannot be a row
+                    // filter, so this is the numeric form. Parsed as a plain expression
+                    // over the *whole* statement, so it means the same thing at
+                    // statement top level as it does nested one level in.
+                    let expr = parse_derived_expr(&tokens, ctx)?;
+                    let uses = expr_refs_compartments(&expr, ctx.ode_state_names);
+                    (
+                        DerivedKind::PerRow {
+                            eval: build_derived_eval_fn(expr),
+                        },
+                        uses,
+                    )
                 } else {
                     // max / min / tmax
+                    // Trailing tokens after the aggregate's closing `)` used to be
+                    // silently dropped: `max(A1) * 2` computed `max(A1)`. No aggregate
+                    // form continues into a larger expression, so say so.
+                    if close_idx + 1 != tokens.len() {
+                        return Err(format!(
+                            "[derived] `{name}`: unexpected token(s) after `{fname_lc}(…)` — an \
+                             aggregate over rows cannot be combined into a larger expression."
+                        ));
+                    }
                     let agg_fn = match fname_lc.as_str() {
                         "max" => AggFunction::Max,
                         "min" => AggFunction::Min,
@@ -7916,6 +7944,12 @@ fn parse_scaling_block(
         // An intermediate whose name is already a θ / η / individual parameter /
         // state would never be read: the expression parser binds those before it
         // consults the intermediate table, so the binding would be silently dead.
+        //
+        // A declared covariate clashes the other way round — an unresolved
+        // identifier in `[scaling]` parses as `Covariate(name)`, which the
+        // substituter *does* rewrite, so the binding would silently shadow the data
+        // column and drop it from the required-column set (#1030). Rejected either
+        // way: one name, one meaning.
         let clash = theta_names
             .iter()
             .map(|n| (n, "a theta"))
@@ -7926,12 +7960,17 @@ fn parse_scaling_block(
                     .map(|n| (n, "an individual parameter")),
             )
             .chain(state_names.iter().map(|n| (n, "a compartment")))
+            .chain(
+                declared_covariates
+                    .iter()
+                    .map(|n| (n, "a declared covariate")),
+            )
             .find(|(n, _)| *n == name);
         if let Some((_, what)) = clash {
             return Err(format!(
                 "[scaling]: `{name}` is already {what}, so it cannot also be a named \
-                 intermediate — a reference to it would resolve to {what}, never to this \
-                 line. Rename the intermediate."
+                 intermediate — one name cannot mean two things here. Rename the \
+                 intermediate."
             ));
         }
     }
@@ -14212,6 +14251,12 @@ fn scaling_intermediate_reserved(name: &str) -> Option<&'static str> {
     if is_synthetic_readout_param(name) {
         return Some("a reserved internal parameter prefix");
     }
+    if matches!(
+        name.to_ascii_uppercase().as_str(),
+        "TAD" | "TAFD" | "MACHEPS"
+    ) {
+        return Some("an eval-time built-in");
+    }
     None
 }
 
@@ -14349,22 +14394,31 @@ fn inline_scaling_intermediates(
     Ok(())
 }
 
-/// Every identifier appearing in a `[scaling]` source expression, as raw tokens.
+/// Every identifier appearing in a `[scaling]` source expression **in a position
+/// the AST substituter can reach**, as raw tokens.
+///
 /// Used for the reachability scan behind the unused-intermediate rejection, which
 /// needs names only and must not depend on how any particular scope resolves them.
+/// The one thing it must agree with is [`substitute_scaling_intermediates`], which
+/// only rewrites `Variable` / `Covariate` *leaves*: an identifier followed by `(`
+/// parses as a function call and one followed by `.` as an `[covariate_nn]` output
+/// access, so an intermediate named in either position is never inlined and must
+/// still be reported as unused rather than counted as a read (#1030).
 fn source_identifiers(src: &str) -> Vec<String> {
-    match tokenize(src) {
-        Ok(toks) => toks
-            .into_iter()
-            .filter_map(|t| match t {
-                Token::Ident(s) => Some(s),
-                _ => None,
-            })
-            .collect(),
-        // A malformed expression is reported with full context by the real parse;
-        // contributing no names here just means it reaches nothing.
-        Err(_) => Vec::new(),
+    // A malformed expression is reported with full context by the real parse;
+    // contributing no names here just means it reaches nothing.
+    let Ok(toks) = tokenize(src) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (i, tok) in toks.iter().enumerate() {
+        let Token::Ident(name) = tok else { continue };
+        if matches!(toks.get(i + 1), Some(Token::LParen) | Some(Token::Dot)) {
+            continue;
+        }
+        out.push(name.clone());
     }
+    out
 }
 
 /// Reject a named intermediate that no `obs_scale` / `y` entry reaches (#1030).
@@ -14383,6 +14437,7 @@ fn check_scaling_intermediates_used(
     }
     let mut reached: std::collections::HashSet<&str> = std::collections::HashSet::new();
     let mut queue: Vec<String> = Vec::new();
+    let mut declared_above: Vec<&str> = Vec::new();
     for line in lines {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -14390,9 +14445,26 @@ fn check_scaling_intermediates_used(
         }
         let (key, value) = split_scaling_entry(trimmed)?;
         let (base, _cmt) = parse_scaling_key(key)?;
-        if is_scaling_entry_key(base) {
-            queue.extend(source_identifiers(value));
+        if !is_scaling_entry_key(base) {
+            declared_above.push(base);
+            continue;
         }
+        // Entries obey the same define-above-use-below rule the intermediates
+        // themselves do. `inline_scaling_intermediates` substitutes an entry
+        // against the whole table regardless of source order, so without this the
+        // rule would be enforced on one side only (#1030).
+        for name in source_identifiers(value) {
+            if intermediates.iter().any(|(n, _)| *n == name)
+                && !declared_above.contains(&name.as_str())
+            {
+                return Err(format!(
+                    "[scaling] {key}: references the named intermediate `{name}`, which is \
+                     declared on or below this line. An intermediate must be declared above \
+                     every entry that uses it."
+                ));
+            }
+        }
+        queue.extend(source_identifiers(value));
     }
     while let Some(name) = queue.pop() {
         let Some((n, src)) = intermediates.iter().find(|(n, _)| *n == name) else {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -10959,7 +10959,19 @@ fn join_bracketed_lines(lines: &[String]) -> Vec<String> {
 /// Block types whose lines are expression statements, and therefore accept
 /// operator continuation lines (#1030). Everything else (`[parameters]`,
 /// `[fit_options]`, …) keeps its strict one-declaration-per-line grammar.
-const CONTINUATION_BLOCKS: &[&str] = &["individual_parameters", "odes", "scaling", "derived"];
+///
+/// The entry criterion is that a *statement* in the block can never begin with a
+/// binary operator — see [`join_continuation_lines`] for why that is what makes
+/// joining a strict widening rather than a reinterpretation.
+const CONTINUATION_BLOCKS: &[&str] = &[
+    "individual_parameters",
+    "odes",
+    "scaling",
+    "derived",
+    // `init(NAME) = <expr>` — line-oriented like `[scaling]`, and every line must
+    // start with `init(`, so a line opening with an operator is unreachable here too.
+    "initial_conditions",
+];
 
 /// Leading characters that mark a line as the continuation of the previous one.
 /// Every statement in a continuation block starts with an identifier, `d/dt(`,

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -11630,6 +11630,53 @@ fn test_scaling_continuation_lines() {
     assert!((y - 4.0).abs() < 1e-12, "expected 100/50*2 = 4, got {y}");
 }
 
+/// `[initial_conditions]` is line-oriented too (`init(NAME) = <expr>`, one per
+/// line), so its continuation support is pinned on its own path — and the joined
+/// expression must actually reach the init amount, not just parse.
+#[test]
+fn test_initial_conditions_continuation_lines() {
+    let content = r#"
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(10.0, 0.1, 1000.0)
+  omega ETA_CL ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[initial_conditions]
+  init(central) = CONC0 * V
+                  + 5.0
+
+[error_model]
+  DV ~ proportional(EPS)
+"#;
+    let model = parse_model_string(content).expect("continuation line parses in the init block");
+    assert_eq!(model.analytical_init.len(), 1, "init block parsed");
+    assert!(
+        model.referenced_covariates.iter().any(|c| c == "CONC0"),
+        "the continued line's covariate must still be a required column, got: {:?}",
+        model.referenced_covariates
+    );
+    // CONC0 = 2, V = 10 → 2*10 + 5 = 25. The `+ 5.0` line has to be part of the
+    // expression, not silently dropped.
+    let mut covs = HashMap::new();
+    covs.insert("CONC0".to_string(), 2.0);
+    let theta = vec![1.0, 10.0];
+    let eta = vec![0.0];
+    let pk = (model.pk_param_fn)(&theta, &eta, &covs, 0.0);
+    let amount = (model.analytical_init[0].amount_fn)(&theta, &eta, &covs, &pk);
+    assert!(
+        (amount - 25.0).abs() < 1e-12,
+        "expected 2*10 + 5 = 25, got {amount}"
+    );
+}
+
 #[test]
 fn test_parse_scaling_y_form_c_on_ode() {
     // ODE form C: ode(states=...) without obs_cmt, and `y = central / V`

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -11472,6 +11472,93 @@ fn test_scaling_intermediate_reserved_name_rejected() {
     );
 }
 
+/// `TAD` / `TAFD` / `MACHEPS` are supplied by the evaluator, so a binding under one
+/// of those names is either dead or a silent override. Rejected like `TIME`.
+#[test]
+fn test_scaling_intermediate_eval_builtin_name_rejected() {
+    for name in ["TAD", "TAFD", "MACHEPS"] {
+        let src =
+            analytical_model_with_scaling(Some(&format!("  {name} = 2\n  obs_scale = {name}\n")));
+        let err = parse_model_string(&src)
+            .expect_err("an eval-time built-in must be rejected as an intermediate");
+        assert!(
+            err.contains("eval-time built-in") && err.contains(name),
+            "expected built-in shadowing error for {name}, got: {}",
+            err
+        );
+    }
+}
+
+/// A declared covariate clashes the *other* way round from a θ/η/state: an
+/// unresolved `[scaling]` identifier parses as `Covariate(name)`, which the
+/// substituter does rewrite — so an intermediate named after a data column would
+/// silently shadow it and drop it from the required-column set. Rejected too.
+#[test]
+fn test_scaling_intermediate_covariate_shadowing_rejected() {
+    let src = "\
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(50.0, 0.1, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.05 (sd)
+
+[covariates]
+  WT continuous
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[scaling]
+  WT = 70
+  obs_scale = WT
+";
+    let err = parse_model_string(src)
+        .expect_err("an intermediate named after a declared covariate must be rejected");
+    assert!(
+        err.contains("a declared covariate") && err.contains("WT"),
+        "expected covariate shadowing error, got: {}",
+        err
+    );
+}
+
+/// Define-above-use-below is enforced on both sides: an *entry* may not read an
+/// intermediate declared below it either, even though the substitution itself is
+/// order-independent.
+#[test]
+fn test_scaling_entry_forward_reference_rejected() {
+    let src = analytical_model_with_scaling(Some("  obs_scale = FOO * 2\n  FOO = 3\n"));
+    let err = parse_model_string(&src)
+        .expect_err("an entry reading an intermediate declared below it must be rejected");
+    assert!(
+        err.contains("declared on or below this line") && err.contains("FOO"),
+        "expected entry forward-reference error, got: {}",
+        err
+    );
+}
+
+/// The dead-binding guard scans tokens while the substitution walks the AST, so the
+/// two must agree on what counts as a *read*. An identifier followed by `(` parses
+/// as a function call, never a `Variable`/`Covariate` leaf — so the intermediate is
+/// not inlined, and must be reported rather than silently vanishing.
+#[test]
+fn test_scaling_intermediate_in_unreachable_position_is_reported() {
+    let src = analytical_model_with_scaling(Some("  FOO = 2\n  obs_scale = FOO(V)\n"));
+    let err = parse_model_string(&src)
+        .expect_err("an intermediate the substituter cannot reach must be reported unused");
+    assert!(
+        err.contains("is never used") && err.contains("FOO"),
+        "expected unused-intermediate error, got: {}",
+        err
+    );
+}
+
 // ── Two-argument min / max (#1030) ──────────────────────────────────────────
 
 #[test]
@@ -14488,6 +14575,72 @@ fn parse_derived_per_row() {
     } else {
         panic!("expected PerRow");
     }
+}
+
+/// `min`/`max` at a `[derived]` statement's top level used to be read *only* as the
+/// row aggregate, so the two-argument numeric form (#1030) meant one thing nested
+/// (`1 * max(CL, 2)`) and failed outright unnested. A second argument with no
+/// comparison operator cannot be a row filter, so both spellings now agree.
+#[test]
+fn parse_derived_two_arg_max_at_statement_top_level() {
+    let (theta, eta, indiv_params, covariates, prev_derived) = make_derived_ctx_simple();
+    let eval_one = |derived: &str| {
+        let src = minimal_model_with_derived(derived);
+        let parsed = parse_full_model(&src).expect("two-arg max at top level parses");
+        let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind else {
+            panic!("expected PerRow, got the row aggregate");
+        };
+        let ctx = DerivedContext {
+            theta: &theta,
+            eta: &eta,
+            indiv_params: &indiv_params,
+            covariates: &covariates,
+            ipred: 0.0,
+            pred: 0.0,
+            dv: 0.0,
+            time: 1.0,
+            tafd: 1.0,
+            tad: 1.0,
+            prev_derived: &prev_derived,
+            compartments: &[],
+            compartment_names: &[],
+        };
+        eval(&ctx)
+    };
+    // CL = 1: the floor bites at top level exactly as it does nested.
+    assert_eq!(eval_one("X = max(CL, 2.0)"), 2.0);
+    assert_eq!(eval_one("X = 1 * max(CL, 2.0)"), 2.0);
+    assert_eq!(eval_one("X = min(CL, 2.0)"), 1.0);
+    // Still an expression, not a call: trailing operators are honoured.
+    assert_eq!(eval_one("X = max(CL, 2.0) * 3"), 6.0);
+}
+
+/// A second argument that *is* a comparison keeps meaning the row filter.
+#[test]
+fn parse_derived_aggregate_filter_still_parses() {
+    let src = minimal_model_with_derived("CMAX = max(IPRED, TIME > 0)");
+    let parsed = parse_full_model(&src).expect("aggregate with a row filter parses");
+    assert!(matches!(
+        parsed.model.derived_exprs[0].kind,
+        DerivedKind::Aggregate { .. }
+    ));
+}
+
+/// Trailing tokens after a row aggregate's `)` used to be dropped in silence, so
+/// `max(IPRED) * 2` computed `max(IPRED)`. No aggregate form continues into a
+/// larger expression, so it is now an error rather than a wrong number.
+#[test]
+fn parse_derived_aggregate_rejects_trailing_tokens() {
+    let src = minimal_model_with_derived("CMAX = max(IPRED) * 2");
+    let err = match parse_full_model(&src) {
+        Ok(_) => panic!("trailing tokens after an aggregate must error"),
+        Err(e) => e,
+    };
+    assert!(
+        err.contains("unexpected token(s) after"),
+        "expected the trailing-token error, got: {}",
+        err
+    );
 }
 
 #[test]

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -2601,6 +2601,25 @@ fn analytical_dose_attr_read_in_scaling_is_rejected() {
 }
 
 #[test]
+fn analytical_dose_attr_read_through_scaling_intermediate_is_rejected() {
+    // #1030 must not open a hole in #1004: naming the doubled read does not make it
+    // stop happening, so a readout that reaches `F` only through a named
+    // intermediate is rejected exactly as the inline spelling is. This is the
+    // read-scan half of the inlining contract — the scan runs on the expanded AST,
+    // not on the raw line.
+    let src = analytical_dose_attr_src(
+        "f=F",
+        "F  = TVF",
+        "[scaling]\n  SCALE = 50.0 * F\n  obs_scale = SCALE",
+    );
+    let err = expect_parse_err(&src);
+    assert!(
+        err.contains("[scaling]:") && err.contains("remove the `f=F` mapping"),
+        "a dose attribute reached through an intermediate must still be rejected, got: {err}"
+    );
+}
+
+#[test]
 fn analytical_lag_mapping_read_in_scaling_is_rejected() {
     // The lag half, and both spellings of the mapping (`lagtime=` and the NONMEM
     // alias `alag=`, which `PkParams::name_to_index` routes to the same slot). A
@@ -11169,13 +11188,446 @@ fn test_parse_scaling_y_and_obs_scale_mix_rejected_on_analytical() {
 
 #[test]
 fn test_parse_scaling_unknown_key_errors() {
+    // Since #1030 any key other than `obs_scale`/`y` is a *named intermediate*, so
+    // the old blanket "unknown key" rejection is gone. The protection it provided —
+    // catching a misspelt `obs_scale`, which would otherwise silently disable
+    // scaling — is re-established from the other side: an intermediate no entry
+    // reads is rejected, and the error names both readings.
     let src = analytical_model_with_scaling(Some("  foo = 1000\n"));
-    let err = parse_model_string(&src).expect_err("unknown scaling key must be rejected");
+    let err = parse_model_string(&src).expect_err("an unread scaling key must be rejected");
+    assert!(
+        err.contains("foo") && err.contains("never used") && err.contains("misspelled"),
+        "expected unused-intermediate error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_parse_scaling_unknown_key_with_cmt_subscript_errors() {
+    // `[CMT=N]` belongs to `obs_scale`/`y` only — an intermediate takes no
+    // subscript, so this stays an unknown-key error rather than becoming a
+    // legal-but-unread binding (#1030).
+    let src = analytical_model_with_scaling(Some("  foo[CMT=1] = 1000\n"));
+    let err = parse_model_string(&src).expect_err("subscripted unknown key must be rejected");
     assert!(
         err.contains("unknown key") && err.contains("foo"),
         "expected unknown-key error, got: {}",
         err
     );
+}
+
+// ── [scaling] named intermediates (#1030) ───────────────────────────────────
+
+/// The headline case: a readout written with named intermediates must compile to
+/// the *same* function as the hand-expanded one-liner it replaces. That is the
+/// whole contract — intermediates are inlined into the AST, so nothing downstream
+/// can tell the two apart.
+#[test]
+fn test_scaling_intermediates_match_hand_expanded_readout() {
+    let with_names = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some(
+            "  ACR20    = central / V\n\
+             \x20 ACR20SAT = max(ACR20, 0.01)\n\
+             \x20 y        = log(ACR20SAT / (1 - ACR20SAT))\n",
+        ),
+    );
+    // What the block had to say before #1030: the same sub-expression four times,
+    // guarded with the inline conditional that `max` desugars to.
+    let hand = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some(
+            "  y = log((if (central / V > 0.01) central / V else 0.01) \
+             / (1 - (if (central / V > 0.01) central / V else 0.01)))\n",
+        ),
+    );
+
+    let readout = |src: &str| -> crate::ode::OdeOutputFn {
+        let model = parse_model_string(src).expect("model parses");
+        let ode = model.ode_spec.expect("ODE spec present");
+        match ode.readout {
+            crate::ode::OdeReadout::Single(f) => f,
+            _ => panic!("Form C must set OdeReadout::Single"),
+        }
+    };
+    let f_named = readout(&with_names);
+    let f_hand = readout(&hand);
+
+    let cov = HashMap::new();
+    let mut pk = vec![0.0f64; crate::types::MAX_PK_PARAMS];
+    pk[0] = 1.0; // CL
+    pk[1] = 50.0; // V
+    pk[2] = 1.0; // KA
+                 // Above the clamp, below it, and far above — `max` uses `>=` where the hand
+                 // form uses `>`, so the two agree everywhere except exactly at the bound.
+    for central in [0.0, 0.05, 20.0, 100.0] {
+        let state = vec![0.0, central];
+        let a = f_named(&state, &pk, &[], &[], &cov);
+        let b = f_hand(&state, &pk, &[], &[], &cov);
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "named-intermediate readout must equal the hand-expanded one at \
+             central={central} (named={a}, hand={b})"
+        );
+    }
+}
+
+/// `min(a, b)` / `max(a, b)` compose into the published `[0.01, 0.99]` clamp, and
+/// the clamp actually bites on both sides.
+#[test]
+fn test_scaling_intermediates_two_sided_clamp() {
+    let src = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some(
+            "  RAW = central / V\n\
+             \x20 SAT = min(max(RAW, 0.01), 0.99)\n\
+             \x20 y   = SAT\n",
+        ),
+    );
+    let model = parse_model_string(&src).expect("model parses");
+    let ode = model.ode_spec.expect("ODE spec present");
+    let f = match ode.readout {
+        crate::ode::OdeReadout::Single(f) => f,
+        _ => panic!("Form C must set OdeReadout::Single"),
+    };
+    let cov = HashMap::new();
+    let mut pk = vec![0.0f64; crate::types::MAX_PK_PARAMS];
+    pk[1] = 100.0; // V — so y = central / 100
+    for (central, want) in [(0.0, 0.01), (5.0, 0.05), (500.0, 0.99)] {
+        let y = f(&vec![0.0, central], &pk, &[], &[], &cov);
+        assert!(
+            (y - want).abs() < 1e-12,
+            "central={central} → expected {want}, got {y}"
+        );
+    }
+}
+
+/// A covariate reachable only through an intermediate is still a required data
+/// column — intermediates participate in the #1028 "defined" set, as the issue
+/// asked, because they are inlined before the covariate scan runs.
+#[test]
+fn test_scaling_intermediate_covariate_is_registered() {
+    let src = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some("  W = sqrt(NARM)\n  y = central / V * W\n"),
+    );
+    let model = parse_model_string(&src).expect("model parses");
+    assert!(
+        model.referenced_covariates.iter().any(|c| c == "NARM"),
+        "a covariate reached through an intermediate must be a required column, got {:?}",
+        model.referenced_covariates
+    );
+}
+
+/// Intermediates work on the `obs_scale` (Form B) half of the block too.
+#[test]
+fn test_scaling_intermediate_in_obs_scale() {
+    let src = analytical_model_with_scaling(Some("  K = MW * 1000\n  obs_scale = K\n"));
+    let model = parse_model_string(&src).expect("model parses");
+    assert!(
+        matches!(
+            model.scaling,
+            crate::types::ScalingSpec::ExpressionScale { .. }
+        ),
+        "obs_scale built from an intermediate must be a Form B expression scale"
+    );
+    assert!(
+        model.referenced_covariates.iter().any(|c| c == "MW"),
+        "obs_scale covariate reached through an intermediate must be registered, got {:?}",
+        model.referenced_covariates
+    );
+}
+
+/// Order is the same rule `[individual_parameters]` already enforces: define
+/// above, use below. That makes a reference cycle unrepresentable rather than a
+/// recursion guard to get right.
+#[test]
+fn test_scaling_intermediate_forward_reference_rejected() {
+    let src = analytical_model_with_scaling(Some("  A = B * 2\n  B = 3\n  y = A\n"));
+    let err = parse_model_string(&src).expect_err("forward reference must be rejected");
+    assert!(
+        err.contains("declared on or below"),
+        "expected forward-reference error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_scaling_intermediate_self_reference_rejected() {
+    let src = analytical_model_with_scaling(Some("  A = A + 1\n  y = A\n"));
+    let err = parse_model_string(&src).expect_err("self reference must be rejected");
+    assert!(
+        err.contains("declared on or below"),
+        "expected self-reference error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_scaling_intermediate_duplicate_rejected() {
+    let src = analytical_model_with_scaling(Some("  A = 2\n  A = 3\n  y = A\n"));
+    let err = parse_model_string(&src).expect_err("duplicate intermediate must be rejected");
+    assert!(
+        err.contains("duplicate named intermediate"),
+        "expected duplicate error, got: {}",
+        err
+    );
+}
+
+/// A binding named after something already in scope would never be read — the
+/// expression parser binds θ / η / individual parameters / states first — so it is
+/// rejected rather than left silently dead.
+#[test]
+fn test_scaling_intermediate_shadowing_rejected() {
+    for (name, what) in [
+        ("V", "an individual parameter"),
+        ("TVCL", "a theta"),
+        ("ETA_CL", "an eta"),
+    ] {
+        let src = analytical_model_with_scaling(Some(&format!("  {name} = 2\n  y = {name}\n")));
+        let err = parse_model_string(&src)
+            .expect_err("a name already in scope must be rejected as an intermediate");
+        assert!(
+            err.contains(what) && err.contains(name),
+            "expected shadowing error naming {what}, got: {}",
+            err
+        );
+    }
+}
+
+/// The three pre-scans that run *before* `parse_scaling_block` — the #486 direct-θ/η
+/// desugaring and the #650 readout slot allocator — must see through intermediates
+/// too, or a readout that was analytic when written inline would silently drop to
+/// finite-difference sensitivities once it was named.
+#[test]
+fn test_scaling_intermediate_keeps_the_analytic_readout_path() {
+    let model_src = |scaling: &str| {
+        format!(
+            r#"
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(50.0, 0.1, 500.0)
+  theta TVBMAX(2.0, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.05 (sd)
+
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV
+  BMAX = TVBMAX
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[scaling]
+{scaling}
+"#
+        )
+    };
+    // A non-structural individual parameter (`BMAX`) reached only through an
+    // intermediate still earns a differentiable PK slot; and a bare theta inside an
+    // intermediate is still desugared into a synthetic readout parameter.
+    for scaling in [
+        "  C   = central / V\n  SIG = BMAX * C\n  y   = SIG\n",
+        "  G = TVCL * 2\n  y = central / V + G\n",
+    ] {
+        let model = parse_model_string(&model_src(scaling)).expect("model parses");
+        assert!(
+            !model
+                .parse_warnings
+                .iter()
+                .any(|w| w.contains("finite-difference")),
+            "readout `{scaling}` must stay on the analytic path, warnings: {:?}",
+            model.parse_warnings
+        );
+    }
+}
+
+/// `obs_scale` is a subject-static divisor, so a `TIME` reference in it is
+/// rejected (#1028). Routing that reference through an intermediate must not
+/// launder it — the inlining happens before the check.
+#[test]
+fn test_scaling_intermediate_cannot_smuggle_time_into_obs_scale() {
+    let src = analytical_model_with_scaling(Some("  K = 1 + TIME\n  obs_scale = K\n"));
+    let err = parse_model_string(&src).expect_err("TIME in obs_scale must be rejected");
+    assert!(
+        err.contains("subject-static divisor"),
+        "expected the obs_scale TIME rejection, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_scaling_intermediate_reserved_name_rejected() {
+    let src = analytical_model_with_scaling(Some("  TIME = 2\n  y = TIME\n"));
+    let err = parse_model_string(&src).expect_err("`TIME` must be rejected as an intermediate");
+    assert!(
+        err.contains("model-time built-in"),
+        "expected reserved-name error, got: {}",
+        err
+    );
+}
+
+// ── Two-argument min / max (#1030) ──────────────────────────────────────────
+
+#[test]
+fn test_min_max_two_args_in_individual_parameters() {
+    let content = r#"
+[parameters]
+  theta TVCL(2.0, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = max(TVCL * WT / 70, 1.0)
+  V  = min(TVV, 20.0)
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let parsed = parse_full_model(content).unwrap();
+    let theta = vec![2.0, 10.0];
+    let eta = vec![0.0];
+    let mut covs = HashMap::new();
+
+    covs.insert("WT".to_string(), 70.0);
+    let p = (parsed.model.pk_param_fn)(&theta, &eta, &covs, 0.0);
+    assert!(
+        (p.values[0] - 2.0).abs() < 1e-12,
+        "WT=70 → CL = max(2, 1) = 2"
+    );
+    assert!((p.values[1] - 10.0).abs() < 1e-12, "V = min(10, 20) = 10");
+
+    // Below the floor: the clamp bites.
+    covs.insert("WT".to_string(), 7.0);
+    let p = (parsed.model.pk_param_fn)(&theta, &eta, &covs, 0.0);
+    assert!(
+        (p.values[0] - 1.0).abs() < 1e-12,
+        "WT=7 → CL = max(0.2, 1) = 1, got {}",
+        p.values[0]
+    );
+}
+
+/// The arity diagnostic the issue called out: a one-argument `max` used to be
+/// silently the identity, and a stray comma in a one-argument function reported a
+/// missing `)`, sending the reader after a bracket bug that does not exist.
+#[test]
+fn test_min_max_arity_diagnostics() {
+    let one_arg = analytical_model_with_scaling(Some("  y = max(central)\n"));
+    let err = parse_model_string(&one_arg).expect_err("one-argument max must be rejected");
+    assert!(
+        err.contains("two arguments") && err.contains("max(a, b)"),
+        "expected an arity error, got: {}",
+        err
+    );
+
+    let extra_arg = analytical_model_with_scaling(Some("  y = exp(central, 2)\n"));
+    let err = parse_model_string(&extra_arg).expect_err("two-argument exp must be rejected");
+    assert!(
+        err.contains("takes 1 argument") && err.contains("min(a, b)"),
+        "expected an arity error naming the two-argument functions, got: {}",
+        err
+    );
+}
+
+// ── Operator continuation lines (#1030) ─────────────────────────────────────
+
+#[test]
+fn test_join_continuation_lines() {
+    let join = |lines: &[&str]| -> Vec<String> {
+        super::join_continuation_lines(&lines.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    };
+    // Leading operator continues the previous line...
+    assert_eq!(
+        join(&["A = B", "+ C", "- D", "E = F"]),
+        vec!["A = B + C - D".to_string(), "E = F".to_string()]
+    );
+    // ...as does a trailing one.
+    assert_eq!(
+        join(&["A = B +", "C", "E = F"]),
+        vec!["A = B + C".to_string(), "E = F".to_string()]
+    );
+    // A trailing `=` continues too, so `LEMAX =` on its own line works.
+    assert_eq!(join(&["A =", "B * 2"]), vec!["A = B * 2".to_string()]);
+    // A leading operator on the very first line has nothing to join to; leave it
+    // for the statement parser to reject with its own message.
+    assert_eq!(join(&["+ C"]), vec!["+ C".to_string()]);
+    // Ordinary lines are untouched.
+    assert_eq!(
+        join(&["A = B", "C = D"]),
+        vec!["A = B".to_string(), "C = D".to_string()]
+    );
+}
+
+/// The additive-on-logit covariate model from the issue: one covariate per line,
+/// which used to fail with ``Expected an assignment, … got Plus``.
+#[test]
+fn test_individual_parameters_operator_continuation_lines() {
+    let content = r#"
+[parameters]
+  theta LEMAX0(0.5, -5.0, 5.0)
+  theta OR_ABATA(1.5, 0.1, 10.0)
+  theta OR_ADALI(2.0, 0.1, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  omega ETA_EMAX ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = LEMAX0
+       + log(OR_ABATA) * ABATA
+       + log(OR_ADALI) * ADALI
+       + ETA_EMAX
+  V  = TVV *
+       2.0
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let parsed = parse_full_model(content).expect("continuation lines parse");
+    let theta = vec![0.5, 1.5, 2.0, 10.0];
+    let eta = vec![0.25];
+    let mut covs = HashMap::new();
+    covs.insert("ABATA".to_string(), 1.0);
+    covs.insert("ADALI".to_string(), 0.0);
+    let p = (parsed.model.pk_param_fn)(&theta, &eta, &covs, 0.0);
+    let want = 0.5 + 1.5f64.ln() + 0.25;
+    assert!(
+        (p.values[0] - want).abs() < 1e-12,
+        "expected {want}, got {}",
+        p.values[0]
+    );
+    assert!((p.values[1] - 20.0).abs() < 1e-12, "trailing `*` continues");
+}
+
+/// `[scaling]` is scanned line by line rather than through the token stream, so
+/// its continuation support is worth pinning separately.
+#[test]
+fn test_scaling_continuation_lines() {
+    let src = ode_model_with_scaling(
+        "ode(states=[depot, central])",
+        Some("  y = central / V\n      * 2.0\n"),
+    );
+    let model = parse_model_string(&src).expect("continuation line parses in [scaling]");
+    let ode = model.ode_spec.expect("ODE spec present");
+    let f = match ode.readout {
+        crate::ode::OdeReadout::Single(f) => f,
+        _ => panic!("Form C must set OdeReadout::Single"),
+    };
+    let mut pk = vec![0.0f64; crate::types::MAX_PK_PARAMS];
+    pk[1] = 50.0;
+    let y = f(&vec![0.0, 100.0], &pk, &[], &[], &HashMap::new());
+    assert!((y - 4.0).abs() < 1e-12, "expected 100/50*2 = 4, got {y}");
 }
 
 #[test]

--- a/src/sim/adaptive_control.rs
+++ b/src/sim/adaptive_control.rs
@@ -282,6 +282,9 @@ pub(crate) fn compile_observe(
         // ODE-only path: any integrated state is valid, no forbidden names (#650).
         &[],
         declared_covariates,
+        // `[scaling]` named intermediates (#1030) are local to that block; the
+        // `observe` expression is its own one-line readout with nothing to inline.
+        &[],
         &mut observe_warnings,
     )?;
     Ok((out_fn, cov_names))


### PR DESCRIPTION
## Why

Closes #1030 (part of the MBMA umbrella #1032).

Three individually-defensible restrictions collided and produced model files that
are effectively unreviewable. The standard bounded-endpoint MBMA readout — a
weighted logit of an Emax time course with the published `[0.01, 0.99]` clamp —
came out as **one ~200-character line with the same sub-expression written four
times**, because `[scaling]` had nowhere to name it:

```ferx
[scaling]
  y[CMT=1] = sqrt(NARM) * log((if (EMAX * clock / (clock + T50) > 0.01) EMAX * clock / (clock + T50) else 0.01) / (1 - (if (EMAX * clock / (clock + T50) > 0.01) EMAX * clock / (clock + T50) else 0.01)))
```

The published Mlxtran for the identical model is three readable lines. It now
reads that way in ferx too:

```ferx
[scaling]
  ACR20    = EMAX * TIME / (TIME + T50)
  ACR20SAT = min(max(ACR20, 0.01), 0.99)
  y        = log(ACR20SAT / (1 - ACR20SAT)) * sqrt(NARM)
```

## What changed

**1. Named intermediates in `[scaling]`.** Any line whose key is not
`obs_scale` / `y` declares a local binding the entries below it can reference,
following the same define-above-use-below rule `[individual_parameters]` already
uses.

The implementation choice that matters: intermediates are **inlined into the
entry's AST**, immediately after that entry parses and before anything else looks
at it. There is no new `Expression` variant and no new evaluation stage, so every
downstream consumer sees exactly the expression the user would otherwise have
written by hand — bytecode compilation, the `Dual2` sensitivity programs, the
#1028 required-data-column scan, the #993/#1004 dose-attribute double-use
rejection, the `T`-alias fold, the #486 direct-θ/η desugaring, and the #650
readout slot allocator all keep working with no changes to their logic. The three
pre-scans that run *before* `parse_scaling_block` inline through the same shared
helper, so they can't drift on which lines are entries and which are bindings.
The cost of inlining is that an intermediate used twice is evaluated twice, which
is precisely what hand-expansion costs today.

Rejected, each with its own message: forward and self references (which makes
cycles unrepresentable rather than a recursion guard to get right), a name that is
already a theta / eta / individual parameter / compartment (a reference would
resolve to that, never to the binding), duplicates, reserved names (`TIME`, `T`,
`MIXNUM`), and `[CMT=N]` subscripts.

One rejection is worth calling out separately: **an intermediate no entry reads is
an error.** Before this PR every key other than `obs_scale` / `y` was rejected
outright, and that is what caught a misspelt `obs_scal = V`. Now that any key is
legal syntax, that typo would silently disable scaling instead — so the same
protection is re-established from the other side, with the error naming both
readings.

**2. Operator continuation lines** in `[individual_parameters]`, `[odes]`,
`[scaling]`, `[derived]`, and `[initial_conditions]`. Start the continued line with
an operator, or end the previous one with it:

```ferx
LEMAX = LEMAX0
        + log(OR_ABATA) * ABATA
        + log(OR_ADALI) * ADALI
        + ETA_EMAX
```

Both spellings are unambiguous because no statement in these blocks can *begin*
with a binary operator, so this strictly widens the accepted grammar rather than
reinterpreting anything that parsed before. Applied at block extraction, so the
token-stream consumers (`[individual_parameters]`, `[odes]`) and the line-oriented
one (`[scaling]`) cannot disagree about what a line is.

**3. Two-argument `min(a, b)` / `max(a, b)`,** available everywhere the DSL parses
expressions. They desugar to `Expression::Conditional` — the `if (a >= b) a else b`
form they replace — which is already evaluated, bytecode-compiled,
`Dual2`-differentiated and index-resolved throughout the pipeline. So they get all
of that for free and cannot drift from the hand-written equivalent.

Two diagnostics come with it. `max(a, b)` used to report **`Missing closing
parenthesis for function max`**, sending the reader after a bracket bug that does
not exist; arity errors now say what is actually wrong. And a one-argument
`max(x)`, previously the silent identity, is now rejected.

## Alternatives considered

- **A two-argument AST node for `min`/`max`** instead of desugaring. Rejected:
  ~30 match sites (eval, bytecode, differentiation, index resolution, the
  `Dual2` walk) would each need a new arm, and a missed one is a silently wrong
  gradient. The desugaring has one source of truth.
- **Textual substitution of intermediates** before parsing. Rejected: error
  messages would quote the expanded text, and identifier-boundary handling is a
  hazard with no upside over AST substitution.
- **A separate evaluation stage for intermediates** (compile them to their own
  program, evaluate, feed into the entry). Rejected for this phase: it would need
  the sensitivity chain, the covariate scan, and the dose-attribute scan each
  taught about a new stage, for a saving (re-evaluating a shared sub-expression)
  that nobody gets today either.
- **Trailing `\` for continuation.** The issue offered it as an alternative;
  leading/trailing operators need no new lexical token and match the layout the
  issue itself shows.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change in practice: `build_y_output_fn` gained a parameter, but it is
reached only from within this crate (`sim::adaptive_control`), which is updated
here.

## Breaking changes

- [x] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [ ] None

<details>
<summary>Migration notes</summary>

Two narrow behaviours change, both of which only affect model files that were
already doing something inert or wrong:

1. **A one-argument `min(x)` / `max(x)` is now a parse error.** It used to be the
   silent identity (the parser has no known-function list, so an unrecognised
   one-argument call returns its argument unchanged). Any model relying on that
   was not clamping anything.

2. **A `[scaling]` key that is neither `obs_scale`/`y` nor read by any entry is
   rejected as an unused intermediate,** with a different message than the old
   `unknown key`. Same set of files rejected, different wording — except that such
   a key *is* now accepted when an entry reads it, which is the feature.

</details>

## Numerical validation

- [x] Not applicable in the NONMEM-anchor sense — this is DSL surface only and
  introduces no new numerical path.

The equivalence is pinned directly instead, which is the stronger statement here:
`test_scaling_intermediates_match_hand_expanded_readout` compiles the
intermediate-based readout and the hand-expanded one-liner it replaces and asserts
the two output functions agree **bit-for-bit** (`to_bits()`) at four points
spanning both sides of the clamp. Since the hand-expanded form is the one already
anchored (Form C's NONMEM anchor in `docs/model-file/scaling.qmd`), the named form
inherits that anchor exactly.

`test_scaling_intermediate_keeps_the_analytic_readout_path` pins the other half:
a readout that was analytic when written inline must not drop to
finite-difference sensitivities once it is named. It was verified non-vacuous by
temporarily disabling the pre-scan inlining, which makes it fail.

## Performance

- [x] No significant impact expected — parse-time only. An intermediate used
  twice is evaluated twice at runtime, identical to hand-expansion.

## Tests

- [x] Unit tests added in the same module (`cargo test --lib` passes: 3190 passed, 0 failed)
- [x] Regression tests that fail without the change

New Tier-1 tests:

| Test | Pins |
|---|---|
| `test_scaling_intermediates_match_hand_expanded_readout` | bit-identity with the hand-expanded readout |
| `test_scaling_intermediates_two_sided_clamp` | `min`/`max` compose into the `[0.01, 0.99]` clamp, biting on both sides |
| `test_scaling_intermediate_covariate_is_registered` | a covariate reached only through an intermediate is a required data column (#1028) |
| `test_scaling_intermediate_in_obs_scale` | intermediates work on the Form B half too |
| `test_scaling_intermediate_keeps_the_analytic_readout_path` | #486 / #650 pre-scans see through intermediates |
| `analytical_dose_attr_read_through_scaling_intermediate_is_rejected` | #1004 is not laundered by naming the read |
| `test_scaling_intermediate_cannot_smuggle_time_into_obs_scale` | #1028's `obs_scale`-is-subject-static rejection still fires |
| `test_scaling_intermediate_{forward,self}_reference_rejected`, `_duplicate_`, `_shadowing_`, `_reserved_name_` | the rejection surface |
| `test_parse_scaling_unknown_key_errors` (updated), `..._with_cmt_subscript_errors` | the typo guard survives the syntax widening |
| `test_join_continuation_lines` | the joiner, including the leading-operator-on-first-line no-op |
| `test_individual_parameters_operator_continuation_lines` | the issue's covariate model, evaluated |
| `test_scaling_continuation_lines` | continuation on the line-oriented `[scaling]` path |
| `test_initial_conditions_continuation_lines` | continuation on the `[initial_conditions]` path, pinned on the init *amount* (a silently-dropped continuation would still parse) |
| `test_min_max_two_args_in_individual_parameters` | two-arg `min`/`max` evaluate, and the clamp bites |
| `test_min_max_arity_diagnostics` | both new arity messages |

## Example (user-facing features only)

- [x] Inline below (no standalone `examples/` file: the MBMA model has no committed
  dataset to run it against, so a file there would not be exercised)

<details>
<summary>Example</summary>

```ferx
[scaling]
  ACR20    = EMAX * TIME / (TIME + T50)
  ACR20SAT = min(max(ACR20, 0.01), 0.99)
  y        = log(ACR20SAT / (1 - ACR20SAT)) * sqrt(NARM)
```

```ferx
[individual_parameters]
  LEMAX = LEMAX0
          + log(OR_ABATA) * ABATA
          + log(OR_ADALI) * ADALI
          + ETA_EMAX
          + KAPPA_EMAX / sqrt(NARM)
```

</details>

## Docs

- [x] `docs/model-file/scaling.qmd` — new *Named intermediates* section (rules,
  the inlining consequence, `min`/`max`)
- [x] `docs/model-file/individual-parameters.qmd` — new *Continuation Lines*
  section, `min`/`max` in the function table
- [x] No new pages, so `docs/_quarto.yml` unchanged
- [x] `CHANGELOG.md` `[Unreleased]` → `Added`

## Checklist

- [x] `cargo clippy --no-default-features --features ci,markov` clean — no new warnings (the pre-existing `approx_constant` errors that appear under `--all-targets` are in `sens/two_cpt_explicit.rs` test data and are not linted by CI)
- [x] `cargo fmt --check` clean
- [x] `cargo check --tests` clean
- [x] No `Dual2`-path formula touched — `min`/`max` reuse `Expression::Conditional`, which is already differentiated

## Docs & examples

### Example execution
- [x] No example execution step needed — no `examples/*.ferx` or dataset touched.

## Reviewer hints

Focus on **`inline_scaling_intermediates` and its call sites**. That is the whole
correctness argument: if a scan over `[scaling]` lines does not inline, it sees the
un-expanded readout and its check silently under-fires. The sites are
`build_obs_scale_spec`, `build_y_output_fn`, `collect_readout_theta_eta_synth`
(#486), `allocate_readout_extra_slots` (#650), and `collect_indiv_param_reads` for
the #993/#1004 read scan. One further scan needs nothing: the `downstream_refs`
scan in `parse_model_file` matches raw block text, so it already sees names inside
intermediate lines.

`join_continuation_lines` is worth a second look for the claim that it only widens
the grammar: it joins when the current line starts with `+ - * / ^`, or the previous
ends with one of those plus `,` or `=`. The argument is that no statement in a
continuation block can start with a binary operator, so any such line was
previously a parse error.

Skimmable: the tests, the docs, and the `CHANGELOG` entry.

## Open questions

- The unused-intermediate rejection is an **error**, not a warning. I chose the
  error because the alternative silently disables `obs_scale` on a typo, but it is
  the one place a user could reasonably want laxer behaviour (e.g. keeping a
  commented-out readout's intermediate around). Confirmed as-is by Ron.

*(Resolved: `initial_conditions` is now in `CONTINUATION_BLOCKS` — its grammar is
`init(NAME) = <expr>`, one per line, so a line opening with a binary operator is
unreachable there too.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APmhz6bhu1Y63RMbjoqAA2
