### PR TITLE
feat(api): let a [simulation] design state the covariates of the arms it invents [closes #1083]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **`[simulation]` can now state the covariates of the arms it invents (#1083).** `covariate NAME = <value>`
+  — a scalar for every subject, or `= [v1, v2, ...]` with one value per subject — gives the synthetic
+  subjects a covariate value, which a `[simulation]` design previously had no way to express at all.
+  This is what makes trial simulation work for a model-based meta-analysis: `kappa K ~ γ² weight = NARM`
+  and `DV ~ additive(S) weight = WPSE` both read a data column, and the arm a simulation is proposing
+  has no row to read it from. A model that references a covariate the design does not supply is now
+  refused by name, with the fix in the message, rather than reported as a column "not found in data" on
+  a path that has no data file. See `docs/model-file/simulation.qmd`.
+
 - **`ode_method = auto` picks the ODE stepper for you, and is now the default (#978).** An a-priori stiffness probe builds
   the Jacobian `J = ∂f/∂u` of the `[odes]` right-hand side at the state each integration segment
   starts from and reads its fastest mode, `max |Re λ(J)|`; a system above `30` per time unit starts
@@ -175,6 +184,18 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **`simulate()` silently removed an arm's residual noise when its `weight = <expr>` column was blank
+  or zero (#1083).** `fit()` has rejected a non-positive residual magnitude since #1029, but no
+  `simulate()` entry point ran that check — each ran its own subset of the model-vs-data checks and
+  this one was in none of them. Because the modifier multiplies the *additive* loading, a zero weight
+  did not blow up: it removed that arm's residual variability entirely, and the simulated observation
+  came back equal to its own IPRED — finite, plottable, and wrong. The weighted-kappa check had the
+  same uneven coverage: present on `simulate_with_options*` but absent from `simulate` /
+  `simulate_with_seed` and from the adaptive-dosing path, where `κ/√W` with a zero `W` evaluates to
+  zero rather than to infinity, so the arm quietly lost its between-arm variability with no `NaN` to
+  trip over. Every simulate entry point now runs one shared list of checks; the two that return a
+  bare `Vec` and cannot signal enforce it as a panic, matching the existing IOV precondition.
+
 - **An estimated lagtime whose lagged dose arrival crossed a time-varying covariate change got a
   silently wrong analytic gradient on ODE models (#1060).** The dose lands at a moving boundary
   `t + ALAG`, and the walk injects the resulting jump as a saltation. The segment ending at that

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -351,6 +351,18 @@ The same modifier rides an IOV `kappa` declaration, where it weights the
 `κ ~ N(0, Ω_IOV / N)` — the arm-level random effect of a longitudinal MBMA. See
 [Sample-size-weighted IOV](iov.qmd#sample-size-weighted-iov-weight-).
 
+### Simulating an arm that is not in the data
+
+The weight is a data column. `fit()` always has one — the arm exists, and its
+reported standard error is a column — but a simulated trial frequently does not,
+because the point of simulating one is to propose arms that are not in the data.
+So a `[simulation]` design must state the weight with `covariate WPSE = [...]`,
+and one that omits it is refused rather than defaulted: the modifier scales the
+*additive* loading, so a weight silently read as zero does not blow up — it
+removes the arm's residual noise entirely and the simulated observation equals its
+own prediction. See
+[Covariates in simulation](simulation.qmd#sim-covariates-required).
+
 ## Log-transform-both-sides (LTBS)
 
 For data whose residual error is *multiplicative* (a constant CV across the

--- a/docs/model-file/iov.qmd
+++ b/docs/model-file/iov.qmd
@@ -197,6 +197,16 @@ This is the random-effect sibling of the residual
 [`weight = ...`](error-model.qmd#residual-weighting-weight-...) modifier, and the
 two share syntax and validation.
 
+### Simulating an arm that is not in the data
+
+The weight is a data column, and `fit()` always has one — the arm exists, and its
+size is a column. A simulated trial frequently does not: the point of simulating
+one is to propose arms that are *not* in the data. Arm sizes are therefore part of
+a `[simulation]` design and must be stated with `covariate NARM = [...]`; a design
+that omits one is refused rather than defaulted. See
+[Covariates in simulation](simulation.qmd#sim-covariates-required) for why neither
+silent default is safe.
+
 ## Model File Setup
 
 ```

--- a/docs/model-file/simulation.qmd
+++ b/docs/model-file/simulation.qmd
@@ -14,6 +14,7 @@ The optional `[simulation]` block defines a virtual clinical trial design for ge
   seed       = SEED
   times      = [t1, t2, t3, ...]
   horizon    = T          # TTE only — administrative censoring time
+  covariate NAME = VALUE  # or = [v1, v2, ...], one per subject
 ```
 
 | Key | Aliases | Description |
@@ -24,6 +25,7 @@ The optional `[simulation]` block defines a virtual clinical trial design for ge
 | `seed` | | Random seed for reproducible simulations |
 | `times` | | Continuous observation time points (Gaussian endpoints) |
 | `horizon` | | Administrative censoring time for TTE endpoints (finite, `> 0`) |
+| `covariate NAME` | | Value of covariate `NAME` for the simulated subjects — a scalar, or one value per subject (see [Covariates in simulation](#covariates-in-simulation)) |
 
 A block must define **at least one of `times` or `horizon`**, matched to the
 model's endpoints:
@@ -159,6 +161,73 @@ unbounded), which biases the simulated event-time distribution. Supplying
 censors at the planned study end. The same control is available on the library
 API as `SimulateOptions { horizon, .. }`.
 
-## Covariates in Simulation
+## Covariates in simulation
 
-Covariates can be specified per subject in the `[simulation]` block. Currently, the simulated population uses default covariate values (covariates are not randomized).
+A `covariate` statement gives the simulated subjects a covariate value. Write a
+scalar to use the same value for every subject, or a list with one value per
+subject:
+
+```
+[simulation]
+  n_subjects = 3
+  times      = [1, 2, 4, 8]
+  covariate WT   = 70                # every subject weighs 70 kg
+  covariate NARM = [400, 200, 50]    # one arm size per subject
+```
+
+A list must have exactly `n_subjects` entries — a short one is a parse error, not
+a silently recycled or zero-filled tail. The keys are order-independent, so the
+`covariate` line may precede the `n_subjects` it is checked against. When the
+model has a `[covariates]` block, that block is authoritative: a name it does not
+declare is rejected here too.
+
+Values are constant per subject. Time-varying covariates are not expressible in a
+`[simulation]` design; read a dataset with `--data` for those. Covariates are not
+randomised — each subject gets exactly the value the design states.
+
+### A referenced covariate must be supplied {#sim-covariates-required}
+
+If the model references a covariate that the `[simulation]` block does not
+supply, simulation is refused and the message names the covariate and the fix.
+There is no default, and that is deliberate.
+
+This matters most for the two `weight = <expr>` modifiers, both of which read a
+data column:
+
+- `kappa K ~ γ² weight = NARM` ([IOV](iov.qmd)) — an arm-level random effect that
+  scales with the number of subjects behind the arm, `κ ~ N(0, γ²/N)`;
+- `DV ~ additive(S) weight = WPSE` ([error model](error-model.qmd)) — inverse-variance
+  weighting for a trial-level mean with a known standard error.
+
+`fit()` always has a row to read those from: the arm exists, and its size and its
+reported standard error are columns in the dataset. A simulated trial frequently
+does not — the point of simulating one is to invent arms that are *not* in the
+data ("what would a 300-subject arm of this design look like?"), and an arm that
+does not exist yet has no row.
+
+So the arm sizes of a simulated trial are part of the design being evaluated, and
+stating them is the question, not a burden:
+
+```
+[parameters]
+  kappa KAPPA_EMAX ~ 2.0 (sd) weight = NARM
+
+[covariates]
+  NARM continuous
+
+[simulation]
+  n_subjects = 3
+  times      = [1, 2, 4, 8]
+  covariate NARM = [400, 200, 50]
+```
+
+Falling back to a typical value from the fitted data would answer a different
+question than the one asked, and either silent default is worse than an error: a
+weight read as `1` gives a simulated arm the variability of a *single-subject*
+arm, and one read as `0` gives it none at all — `κ/√0` evaluates to zero rather
+than blowing up, and a zeroed residual weight makes the simulated observation
+equal its own prediction. Both produce plausible-looking plots.
+
+If you do want the fitted data's own weights, simulate against that dataset
+(`--data`, or pass the fitted `Population` to `simulate()`) rather than writing a
+synthetic design — then the weights come from the rows they were fitted from.

--- a/src/api/adaptive.rs
+++ b/src/api/adaptive.rs
@@ -1081,8 +1081,11 @@ pub fn simulate_adaptive_from_spec(
     let compiled = crate::sim::adaptive_control::compile_adaptive(model, spec)
         .map_err(|e| format!("simulate_adaptive_from_spec: {e}"))?;
     // Parity with `fit()`: model-referenced covariates (e.g. a `Selected` error
-    // model's selector) must be present too, not just the `observe` signal (#658).
-    first_error(&check_covariates(model, population))?;
+    // model's selector) must be present too, not just the `observe` signal (#658) —
+    // and a weighted κ / weighted residual must resolve to a positive weight before
+    // it silently underflows to zero (#1083). Same list every other simulate entry
+    // point runs.
+    first_error(&check_simulation_data(model, population))?;
     // A `Selected` error model keys endpoints by selector branch, not CMT, so the
     // compartment-keyed assay would draw NaN — reject it (see the helper's note, #658).
     reject_selected_error_for_adaptive(model)?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,6 +11,11 @@ use std::path::Path;
 
 // ── validation subsystem (extracted verbatim; see src/api/validation.rs) ──
 mod validation;
+// `check_covariates` / `check_kappa_weights` / `check_residual_magnitude` are the
+// *parts* of `check_simulation_data` (#1083). Production now calls the bundle, so
+// the parts are re-exported for the unit tests that pin each one's message
+// individually — hence the allow, which would otherwise fire on a non-test build.
+#[allow(unused_imports)]
 pub(crate) use validation::{
     apply_iov_occasion_rule, assert_absorption_closed_form_support,
     assert_absorption_dosing_supported, assert_absorption_flip_flop_no_twin,
@@ -18,6 +23,7 @@ pub(crate) use validation::{
     assert_modeled_doses_supported, check_absorption_closed_form_support, check_absorption_dosing,
     check_absorption_flip_flop_no_twin, check_analytic_readout_support, check_covariates,
     check_dose_compartments, check_kappa_weights, check_modeled_dose_rates,
+    check_residual_magnitude, check_simulation_data,
 };
 #[cfg(feature = "survival")]
 pub(crate) use validation::{
@@ -173,6 +179,10 @@ mod scaling_undefined_tests;
 #[cfg(test)]
 #[path = "tests/simulation_template_tests.rs"]
 mod simulation_template_tests;
+
+#[cfg(test)]
+#[path = "tests/simulation_design_covariates_tests.rs"]
+mod simulation_design_covariates_tests;
 
 // ======================================================================
 // Adaptive (state-reactive / feedback) dosing — epic #391, beta.

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -239,6 +239,75 @@ pub(crate) fn derive_output_occasions(
 
 /// Run a model file with simulated data (from [simulation] block).
 /// Returns (FitResult, Population) so caller can write sdtab.
+/// What [`simulation_design_covariates`] returns: the population's covariate
+/// names, in declaration order, plus one covariate map per synthetic subject.
+pub(crate) type SimulationDesignCovariates = (Vec<String>, Vec<HashMap<String, f64>>);
+
+/// Resolve `[simulation] covariate NAME = ...` into the population's covariate
+/// names plus one covariate map per synthetic subject (#1083).
+///
+/// A simulated trial exists to invent arms that are in no dataset — *"what would
+/// a 300-subject arm of this design look like?"* — so there is no row to read
+/// `NARM` or `WPSE` from, and the covariates the design turns on have to be
+/// stated as part of the design. Requiring them is the convention: an unresolved
+/// weight has no defensible default (a silent `1` gives a simulated arm the
+/// variability of a single-subject arm, a silent `0` gives it none, and
+/// `BinOp::Div` underflows to `0.0` rather than `inf`, so neither shows up as a
+/// `NaN`).
+///
+/// The missing-value report is deliberately *not* the shared `check_covariates`
+/// message: on this path there is no data file, so "not found in data … Available
+/// covariate columns: (none)" reads as a typo report on a column that was never
+/// going to exist, and it names no fix.
+///
+/// Returned in declaration order. The per-subject vector has one entry per
+/// subject; the parser has already broadcast a scalar and checked every list
+/// against `n_subjects`, so a short list cannot reach here.
+///
+/// Subject-level only: `obs_cov` / `dose_cov` fall back to `Subject::covariates`
+/// when the per-record vectors are empty, and a synthetic arm's design covariates
+/// — its size, its reported standard error — are constant over the arm by
+/// construction.
+pub(crate) fn simulation_design_covariates(
+    sim_spec: &SimulationSpec,
+    model: &CompiledModel,
+) -> Result<SimulationDesignCovariates, String> {
+    let names: Vec<String> = sim_spec.covariates.iter().map(|(n, _)| n.clone()).collect();
+
+    let missing: Vec<&str> = model
+        .referenced_covariates
+        .iter()
+        .filter(|name| !names.iter().any(|n| n == *name))
+        .map(|s| s.as_str())
+        .collect();
+    if !missing.is_empty() {
+        return Err(format!(
+            "[simulation]: the model references covariate(s) {} that the simulation design \
+             does not supply. A simulated trial invents arms that are in no dataset, so their \
+             covariates — an arm size behind `weight = N`, a reported standard error behind \
+             `weight = SE`, a body weight — are part of the design and must be stated: add \
+             `covariate {} = <value>` (or `= [v1, ...]`, one per subject) to [simulation].",
+            missing
+                .iter()
+                .map(|n| format!("`{n}`"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            missing[0],
+        ));
+    }
+
+    let per_subject: Vec<HashMap<String, f64>> = (0..sim_spec.n_subjects)
+        .map(|i| {
+            sim_spec
+                .covariates
+                .iter()
+                .map(|(n, vals)| (n.clone(), vals[i]))
+                .collect()
+        })
+        .collect();
+    Ok((names, per_subject))
+}
+
 pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), String> {
     use crate::parser::model_parser::parse_full_model_file;
     use std::collections::HashMap;
@@ -343,6 +412,16 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
     } else {
         0
     };
+    // Per-subject covariate values from `[simulation] covariate NAME = ...` (#1083).
+    let (sim_covariate_names, sim_subject_covariates) =
+        simulation_design_covariates(&sim_spec, &parsed.model)?;
+    let subject_covariates = |i: usize| -> HashMap<String, f64> {
+        sim_subject_covariates
+            .get(i - 1)
+            .cloned()
+            .unwrap_or_default()
+    };
+
     // Build template population
     let subjects: Vec<Subject> = (1..=sim_spec.n_subjects)
         .map(|i| Subject {
@@ -363,7 +442,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
             obs_raw_times: Vec::new(),
             observations: vec![0.0; n_gauss],
             obs_cmts: vec![1; n_gauss],
-            covariates: HashMap::new(),
+            covariates: subject_covariates(i),
             dose_covariates: Vec::new(),
             obs_covariates: Vec::new(),
             pk_only_times: Vec::new(),
@@ -418,7 +497,7 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         .collect();
     let template = Population {
         subjects,
-        covariate_names: vec![],
+        covariate_names: sim_covariate_names,
         dv_column: "dv".into(),
         input_columns: vec![],
         exclusions: None,

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -377,15 +377,13 @@ pub fn simulate_with_options_diag(
     // Parity with `fit()`: a referenced covariate absent from the data would
     // silently read 0.0 (e.g. a `Selected` error model's `if (FREE==0)` selector
     // would route every row to branch 0, applying the wrong residual variance
-    // with no diagnostic). Reject it here the same way `fit()` does (#658).
-    first_error(&check_covariates(model, population))?;
-
-    // Same parity for a sample-size-weighted kappa (#1031): the weight is applied
-    // as `κ/√W`, so a blank or zero arm-size cell — the exact MBMA case the check
-    // exists for — divides an individual parameter by zero and yields NaN/Inf DV
-    // instead of an up-front error. Only the fatal half; the within-occasion
-    // variation warning belongs to `fit()`'s warning list.
-    first_error(&check_kappa_weights(model, population))?;
+    // with no diagnostic), a blank arm-size cell would collapse a weighted κ
+    // (#1031), and a blank standard-error cell would collapse a `weight = <expr>`
+    // residual magnitude (#1029). One shared list so no simulate entry point can
+    // carry a different subset than the others (#658 / #1083). Only the fatal
+    // half; the within-occasion variation warning belongs to `fit()`'s warning
+    // list.
+    first_error(&check_simulation_data(model, population))?;
 
     // Validate the TTE horizon on the library path too — the `.ferx` parser
     // already rejects a non-finite / non-positive horizon, but a direct caller of
@@ -906,6 +904,23 @@ fn simulate_inner_with_draw<R: rand::Rng>(
         panic!("{e}");
     }
 
+    // Same split again for the model-vs-population checks (#1083). The
+    // `Result`-returning entry points above have already run this list and
+    // returned a clean `Err`; `simulate` / `simulate_with_seed` funnel through
+    // here and cannot signal, and the failures this catches are silent by
+    // construction — a weight that underflows to zero produces finite, plottable
+    // rows with the variability quietly removed.
+    //
+    // Redundant on those `Result` paths, and `simulate_with_uncertainty` reaches
+    // here once per draw, so the walk repeats. It is affordable because both
+    // expensive halves are gated on the model actually declaring a weight
+    // (`has_weighted_kappa` / `has_custom_ruv_magnitude`), which is false for
+    // every model that does not use one; and where it is true, the pass is linear
+    // in the observations the draw is about to simulate anyway.
+    if let Err(e) = first_error(&check_simulation_data(model, population)) {
+        panic!("{e}");
+    }
+
     let normal = Normal::new(0.0, 1.0).unwrap();
     let n_eta = model.n_eta;
 
@@ -1014,10 +1029,10 @@ pub fn simulate_with_uncertainty(
 
     // Parity with `fit()`: reject a referenced covariate absent from the data
     // rather than silently reading it as 0.0 (a `Selected` error-model selector
-    // would otherwise route every row to branch 0). See #658 — and, for a
-    // weighted kappa, a non-positive weight before it divides by zero (#1031).
-    first_error(&check_covariates(model, population))?;
-    first_error(&check_kappa_weights(model, population))?;
+    // would otherwise route every row to branch 0). See #658 — and, for a weighted
+    // κ or a weighted residual, a non-positive weight before it collapses to zero
+    // (#1031 / #1029 / #1083).
+    first_error(&check_simulation_data(model, population))?;
 
     let mut rng: rand::rngs::StdRng = match opts.seed {
         Some(seed) => rand::rngs::StdRng::seed_from_u64(seed),

--- a/src/api/tests/kappa_weight_tests.rs
+++ b/src/api/tests/kappa_weight_tests.rs
@@ -222,3 +222,102 @@ fn positive_arm_sizes_pass_on_the_simulate_path() {
         "a positive weight must not be rejected: {out:?}"
     );
 }
+
+// ── The Vec-returning entry points, and the degenerate oracle (#1083) ────────
+//
+// `κ/√W` with `W = 0` does *not* blow up: `BinOp::Div` returns `0.0` when its
+// divisor underflows, so a blank arm-size cell removes the arm's between-arm
+// variability and leaves finite, plottable rows behind. `check_kappa_weights`
+// was therefore the entire defence — and it was absent from `simulate` /
+// `simulate_with_seed`, which return a bare `Vec` and had no check at all.
+
+#[test]
+#[should_panic(expected = "weight `NARM` evaluates to 0")]
+fn the_vec_returning_entry_point_panics_on_a_zero_arm_size() {
+    let model = weighted_kappa_model();
+    let pop = population_with_arm_sizes(&[(1, 200.0), (2, 0.0)]);
+    let _ = crate::api::simulate_with_seed(&model, &pop, &model.default_params, 1, 42);
+}
+
+/// [`population_with_arm_sizes`] plus a bolus at t = 0, so the simulated rows
+/// carry a *non-zero* prediction. Without a dose every IPRED is 0.0 and the two
+/// tests below compare zeros to zeros — passing while measuring nothing.
+fn dosed_population_with_arm_sizes(rows: &[(u32, f64)]) -> Population {
+    let mut pop = population_with_arm_sizes(rows);
+    let subj = &mut pop.subjects[0];
+    subj.doses = vec![crate::types::DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+    subj.dose_occasions = vec![rows[0].0];
+    subj.dose_covariates = vec![subj.covariates.clone()];
+    pop
+}
+
+/// The degenerate oracle for the weighted-κ simulate path: `weight = NARM` is
+/// applied by desugaring every reference into `KAPPA_CL / sqrt(NARM)`, so a
+/// dataset whose arm sizes are all exactly 1 must simulate **bit-identically** to
+/// the same model with no `weight =` modifier at all. A scaling applied on the
+/// wrong side, or applied twice, disagrees here and nowhere else.
+#[test]
+fn an_arm_size_of_one_simulates_bit_identically_to_an_unweighted_kappa() {
+    let weighted = weighted_kappa_model();
+    let plain = parse_model_string(
+        "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  omega ETA_CL ~ 0.09\n  \
+         kappa KAPPA_CL ~ 2.0 (sd)\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  \
+         CL = TVCL * exp(ETA_CL + KAPPA_CL)\n  V  = TVV\n[structural_model]\n  \
+         pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ \
+         proportional(PROP_ERR)\n[fit_options]\n  iov_column = OCC\n",
+    )
+    .expect("parse");
+    let pop = dosed_population_with_arm_sizes(&[(1, 1.0), (2, 1.0), (2, 1.0)]);
+    let opts = crate::api::SimulateOptions {
+        seed: Some(11),
+        ..Default::default()
+    };
+
+    let a = crate::api::simulate_with_options(&weighted, &pop, &weighted.default_params, 1, &opts)
+        .expect("weighted simulates");
+    let b = crate::api::simulate_with_options(&plain, &pop, &plain.default_params, 1, &opts)
+        .expect("unweighted simulates");
+    assert_eq!(a.len(), b.len());
+    assert!(
+        !a.is_empty(),
+        "the oracle is vacuous with no simulated rows"
+    );
+    assert!(
+        a.iter().any(|r| r.ipred.abs() > 1e-9),
+        "the oracle is vacuous if every prediction is zero"
+    );
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert_eq!(
+            x.ipred.to_bits(),
+            y.ipred.to_bits(),
+            "weight = 1 must be bit-identical to no weight at TIME {}",
+            x.time
+        );
+    }
+}
+
+/// …and the weight must actually *reach* the draw. Same seed, so the κ draws are
+/// shared: a larger arm divides κ down, so the arm's individual CL sits closer to
+/// its typical value and the spread of IPRED across occasions shrinks.
+#[test]
+fn a_larger_arm_size_shrinks_the_between_arm_spread() {
+    let model = weighted_kappa_model();
+    let spread = |n: f64| -> f64 {
+        let pop = dosed_population_with_arm_sizes(&[(1, n), (2, n), (3, n)]);
+        let opts = crate::api::SimulateOptions {
+            seed: Some(11),
+            ..Default::default()
+        };
+        let rows = crate::api::simulate_with_options(&model, &pop, &model.default_params, 1, &opts)
+            .expect("simulates");
+        let ipreds: Vec<f64> = rows.iter().map(|r| r.ipred).collect();
+        let hi = ipreds.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let lo = ipreds.iter().cloned().fold(f64::INFINITY, f64::min);
+        hi - lo
+    };
+    let (small_arms, large_arms) = (spread(4.0), spread(400.0));
+    assert!(
+        large_arms < small_arms,
+        "κ ~ N(0, γ²/N): larger arms must vary less, got {small_arms} then {large_arms}"
+    );
+}

--- a/src/api/tests/residual_magnitude_tests.rs
+++ b/src/api/tests/residual_magnitude_tests.rs
@@ -96,3 +96,120 @@ fn a_model_with_no_magnitude_is_not_checked() {
         .iter()
         .all(|d| d.code != "E_RUV_MAGNITUDE_NONPOSITIVE"));
 }
+
+// ── simulate() parity (#1083) ────────────────────────────────────────────────
+//
+// `fit()` has rejected a non-positive magnitude since #1029, but every
+// `simulate()` entry point ran its own hand-picked subset of the model-vs-data
+// checks and this one was in none of them. The failure is silent in the worst
+// way: a `weight = <expr>` modifier multiplies the *additive* loading, so a zero
+// weight removes that arm's residual noise entirely and the simulated
+// observation comes back equal to its own IPRED — finite, plottable, and wrong.
+
+use crate::api::{simulate_with_options_diag, simulate_with_seed};
+use crate::types::SimOutcome;
+use crate::SimulateOptions;
+
+/// The Gaussian value on a simulated row, or a panic for a non-Gaussian one.
+fn continuous(r: &crate::api::SimulationResult) -> f64 {
+    match r.outcome {
+        SimOutcome::Continuous { value } => value,
+        _ => panic!("expected a Gaussian row"),
+    }
+}
+
+fn sim_opts() -> SimulateOptions {
+    SimulateOptions {
+        seed: Some(42),
+        match_method: None,
+        horizon: None,
+    }
+}
+
+#[test]
+fn simulate_rejects_a_zero_weight_the_way_fit_does() {
+    let model = weighted_model();
+    let pop = population_with_weights(&[0.5, 0.0, 2.0]);
+    let err = simulate_with_options_diag(&model, &pop, &model.default_params, 1, &sim_opts())
+        .expect_err("a zero weight must not simulate");
+    assert!(
+        err.contains("sigma slot 0") && err.contains("TIME 2"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn simulate_still_runs_with_positive_weights() {
+    // The guard must not cost the working case: the same fixture with every
+    // weight positive simulates one row per observation, as before.
+    let model = weighted_model();
+    let pop = population_with_weights(&[0.5, 1.5, 2.0]);
+    let out = simulate_with_options_diag(&model, &pop, &model.default_params, 1, &sim_opts())
+        .expect("positive weights simulate");
+    assert_eq!(out.results.len(), 3);
+}
+
+#[test]
+#[should_panic(expected = "sigma slot 0")]
+fn the_vec_returning_entry_point_panics_on_a_zero_weight() {
+    // `simulate` / `simulate_with_seed` return a bare `Vec` and cannot signal, so
+    // the contract is enforced as a panic at the shared chokepoint — the same
+    // split `validate_iov_simulatable` already uses. Failing loud beats emitting
+    // rows whose variability has been quietly removed.
+    let model = weighted_model();
+    let pop = population_with_weights(&[0.5, 0.0, 2.0]);
+    let _ = simulate_with_seed(&model, &pop, &model.default_params, 1, 42);
+}
+
+#[test]
+fn a_weight_of_one_is_bit_identical_to_no_weight() {
+    // The degenerate oracle for the whole mechanism: `weight = W` desugars to a
+    // magnitude multiplying the additive loading, so `W ≡ 1` must reproduce the
+    // unweighted model's draws exactly — same seed, same epsilons, same rows. A
+    // scaling applied on the wrong side, or applied twice, shows up here and
+    // nowhere else, because the two models are otherwise identical.
+    let weighted = weighted_model();
+    let plain = parse_model_string(
+        "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  omega ETA_CL ~ 0.09\n  \
+         sigma ADD_ERR ~ 1.0 (variance) FIX\n[individual_parameters]\n  CL = TVCL * \
+         exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  pk one_cpt_iv(cl=CL, \
+         v=V)\n[error_model]\n  DV ~ additive(ADD_ERR)\n",
+    )
+    .expect("parse");
+    let pop = population_with_weights(&[1.0, 1.0, 1.0]);
+
+    let a = simulate_with_options_diag(&weighted, &pop, &weighted.default_params, 1, &sim_opts())
+        .expect("weighted simulates");
+    let b = simulate_with_options_diag(&plain, &pop, &plain.default_params, 1, &sim_opts())
+        .expect("unweighted simulates");
+    assert_eq!(a.results.len(), b.results.len());
+    for (x, y) in a.results.iter().zip(b.results.iter()) {
+        assert_eq!(
+            continuous(x).to_bits(),
+            continuous(y).to_bits(),
+            "weight = 1 must be bit-identical to no weight at TIME {}",
+            x.time
+        );
+    }
+}
+
+#[test]
+fn a_larger_weight_widens_the_simulated_residual() {
+    // The half the degenerate oracle can't see: the weight must actually reach
+    // the draw, and in the right direction. Same seed and same single-observation
+    // subject, so the standard normal is shared and only the loading differs —
+    // the deviation from IPRED then scales with the weight.
+    let model = weighted_model();
+    let dev = |w: f64| -> f64 {
+        let pop = population_with_weights(&[w]);
+        let out = simulate_with_options_diag(&model, &pop, &model.default_params, 1, &sim_opts())
+            .expect("simulates");
+        let r = &out.results[0];
+        (continuous(r) - r.ipred).abs()
+    };
+    let (small, large) = (dev(0.5), dev(2.0));
+    assert!(
+        large > small * 3.0,
+        "a 4x weight must widen the residual ~4x: {small} then {large}"
+    );
+}

--- a/src/api/tests/simulation_design_covariates_tests.rs
+++ b/src/api/tests/simulation_design_covariates_tests.rs
@@ -1,0 +1,91 @@
+//! `[simulation] covariate NAME = ...` — the design covariates of an invented
+//! arm (#1083).
+//!
+//! `fit()` always has a data row to read `weight = NARM` / `weight = WPSE` from:
+//! the arm exists, and its size and reported standard error are columns.
+//! `simulate()` frequently does not — the point of simulating a trial is to
+//! invent arms that are not in the data. These pin the convention: the values are
+//! part of the design and must be stated, and a design that omits one is refused
+//! by name rather than defaulted.
+
+use super::run::simulation_design_covariates;
+use crate::parser::model_parser::parse_model_string;
+use crate::types::SimulationSpec;
+
+const WEIGHTED_RUV: &str = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  \
+     omega ETA_CL ~ 0.09\n  sigma ADD_ERR ~ 1.0\n[individual_parameters]\n  \
+     CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  \
+     pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ additive(ADD_ERR) weight = WPSE\n\
+     [covariates]\n  WPSE continuous\n";
+
+const UNWEIGHTED: &str = "[parameters]\n  theta TVCL(0.2)\n  theta TVV(10.0)\n  \
+     omega ETA_CL ~ 0.09\n  sigma ADD_ERR ~ 1.0\n[individual_parameters]\n  \
+     CL = TVCL * exp(ETA_CL)\n  V  = TVV\n[structural_model]\n  \
+     pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ additive(ADD_ERR)\n";
+
+fn spec(n_subjects: usize, covariates: Vec<(String, Vec<f64>)>) -> SimulationSpec {
+    SimulationSpec {
+        n_subjects,
+        dose_amt: 100.0,
+        dose_cmt: 1,
+        obs_times: vec![1.0, 2.0],
+        seed: 7,
+        horizon: None,
+        covariates,
+    }
+}
+
+#[test]
+fn each_subject_gets_its_own_arm_value() {
+    let model = parse_model_string(WEIGHTED_RUV).expect("parse");
+    let s = spec(3, vec![("WPSE".to_string(), vec![0.5, 1.0, 2.0])]);
+    let (names, per_subject) = simulation_design_covariates(&s, &model).expect("resolves");
+    assert_eq!(names, vec!["WPSE".to_string()]);
+    assert_eq!(per_subject.len(), 3);
+    for (i, want) in [0.5, 1.0, 2.0].iter().enumerate() {
+        assert_eq!(
+            per_subject[i].get("WPSE"),
+            Some(want),
+            "subject {i} must carry its own arm's value, not the first arm's"
+        );
+    }
+}
+
+#[test]
+fn a_design_that_omits_a_referenced_weight_is_refused_by_name() {
+    // The failure this whole feature exists to remove. Note what the message may
+    // *not* be: "not found in data" names no fix on a path that has no data file.
+    let model = parse_model_string(WEIGHTED_RUV).expect("parse");
+    let err = simulation_design_covariates(&spec(3, vec![]), &model)
+        .expect_err("an unresolved weight must not be defaulted");
+    assert!(err.starts_with("[simulation]:"), "got: {err}");
+    assert!(err.contains("`WPSE`"), "got: {err}");
+    assert!(
+        err.contains("covariate WPSE = <value>"),
+        "the message must name the fix: {err}"
+    );
+}
+
+#[test]
+fn a_model_that_references_nothing_needs_no_design_covariates() {
+    // The overwhelmingly common case must stay a no-op — every pre-#1083
+    // `[simulation]` block declares no covariates at all.
+    let model = parse_model_string(UNWEIGHTED).expect("parse");
+    let (names, per_subject) = simulation_design_covariates(&spec(2, vec![]), &model)
+        .expect("an unweighted model needs no design covariates");
+    assert!(names.is_empty());
+    assert_eq!(per_subject.len(), 2);
+    assert!(per_subject.iter().all(|m| m.is_empty()));
+}
+
+#[test]
+fn an_extra_design_covariate_the_model_ignores_is_allowed() {
+    // Stating a covariate the model happens not to reference is not an error:
+    // it lands on the simulated subjects and shows up in the written dataset,
+    // which is how a design carries an arm label the model does not use.
+    let model = parse_model_string(UNWEIGHTED).expect("parse");
+    let s = spec(2, vec![("NARM".to_string(), vec![400.0, 25.0])]);
+    let (names, per_subject) = simulation_design_covariates(&s, &model).expect("resolves");
+    assert_eq!(names, vec!["NARM".to_string()]);
+    assert_eq!(per_subject[1].get("NARM"), Some(&25.0));
+}

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -241,7 +241,10 @@ fn check_per_cmt_error_model(model: &CompiledModel, population: &Population) -> 
 /// for one arm — which evaluates the covariate to `0` and silently gives that
 /// row infinite precision. A negative multiplier squares away to the same
 /// variance as its absolute value, so it is never what was meant either.
-fn check_residual_magnitude(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
+pub(crate) fn check_residual_magnitude(
+    model: &CompiledModel,
+    population: &Population,
+) -> Vec<Diagnostic> {
     if !model.has_custom_ruv_magnitude() {
         return Vec::new();
     }
@@ -423,6 +426,30 @@ fn check_kappa_weight_variation(model: &CompiledModel, population: &Population) 
 /// column") is wrong rather than merely noisy.
 pub(crate) fn reader_warning_suppressed(model: &CompiledModel, warning: &str) -> bool {
     model.is_algebraic() && warning.starts_with("W_NO_DOSES")
+}
+
+/// The *fatal* model-vs-population checks every `simulate()` entry point owes its
+/// caller (#1083).
+///
+/// `fit()` runs these through [`check_model_data`]; the simulation paths used to
+/// each pick their own subset, and the subsets disagreed. That mattered because a
+/// weight is the one covariate whose failure mode is silent in both directions:
+/// `BinOp::Div` returns `0.0` rather than `inf` when its divisor underflows, so a
+/// missing arm size makes `κ/√W` collapse to *zero* — the arm simply loses its
+/// between-arm variability, with no `NaN` to trip over — and a missing standard
+/// error makes the `weight = <expr>` residual magnitude collapse the additive
+/// loading, so the simulated observation *is* its own IPRED. Both produce plots.
+///
+/// Ordered covariates-first so the first error reported by the existing callers is
+/// unchanged.
+pub(crate) fn check_simulation_data(
+    model: &CompiledModel,
+    population: &Population,
+) -> Vec<Diagnostic> {
+    let mut diags = check_covariates(model, population);
+    diags.extend(check_kappa_weights(model, population));
+    diags.extend(check_residual_magnitude(model, population));
+    diags
 }
 
 /// All data-dependent *fatal* compatibility checks between a compiled model and

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2675,10 +2675,6 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
     };
 
     // ── Optional blocks ──
-    let simulation = blocks
-        .get("simulation")
-        .map(|lines| parse_simulation_block(lines))
-        .transpose()?;
     // Peek the `[covariates]` declarations (parsed for real further down, at the
     // block's own site) purely for name precedence: a declared `T` / `t` is a data
     // column, not the `[odes]` model-time alias, in `[scaling]` and in
@@ -2690,6 +2686,13 @@ pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
         .and_then(|lines| parse_covariates_block(lines).ok())
         .map(|decls| decls.into_iter().map(|d| d.name).collect())
         .unwrap_or_default();
+    // Parsed after the peek (and still before `[adaptive_dosing]`, so the existing
+    // first-error ordering is unchanged) because `[simulation] covariate NAME = ...`
+    // is validated against the declared names (#1083).
+    let simulation = blocks
+        .get("simulation")
+        .map(|lines| parse_simulation_block(lines, &declared_covariate_names))
+        .transpose()?;
     // Declarative reactive-dosing controller (#391 S2). Parsed and validated here;
     // compiled to a controller and run by the adaptive simulate path in a later slice.
     let adaptive_dosing = blocks
@@ -6014,13 +6017,21 @@ fn prescan_ode_hazards(extracted: &ExtractedBlocks) -> Result<Vec<(usize, String
 
 // ── [simulation] block parser ───────────────────────────────────────────────
 
-fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
+fn parse_simulation_block(
+    lines: &[String],
+    declared_covariate_names: &[String],
+) -> Result<SimulationSpec, String> {
     let mut n_subjects = 10;
     let mut dose_amt = 100.0;
     let mut dose_cmt = 1;
     let mut obs_times = Vec::new();
     let mut seed = 42u64;
     let mut horizon: Option<f64> = None;
+    // `covariate NAME = ...` statements, in declaration order (#1083). Collected
+    // raw and validated after the loop, so the block's keys stay order-independent
+    // — a `covariate` line may precede the `n_subjects` its length is checked
+    // against.
+    let mut covariates: Vec<(String, Vec<f64>)> = Vec::new();
 
     for line in lines {
         let parts: Vec<&str> = line.splitn(2, '=').map(|s| s.trim()).collect();
@@ -6080,7 +6091,91 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
                 }
                 horizon = Some(t);
             }
+            // Per-subject covariate values (#1083). A simulated trial's design
+            // *is* its covariates — an MBMA arm size (`weight = NARM`) or a
+            // reported within-arm SE (`weight = WPSE`) has no data row to be read
+            // from, because the arm being simulated does not exist yet. Either a
+            // scalar (broadcast to every subject) or one value per subject:
+            //
+            //   covariate NARM = 200               # every arm has 200 subjects
+            //   covariate NARM = [400, 200, 50]    # one per simulated subject
+            //
+            // Matched on the `covariate` *word*, not the prefix, so a future key
+            // that merely starts with it (`covariates = ...`) is still reported as
+            // unknown rather than read as a covariate named `s`.
+            other
+                if other == "covariate"
+                    || other
+                        .strip_prefix("covariate")
+                        .is_some_and(|r| r.starts_with(char::is_whitespace)) =>
+            {
+                let name = other["covariate".len()..].trim();
+                if name.is_empty() {
+                    return Err(
+                        "[simulation]: `covariate` needs a name: `covariate NAME = <value>` \
+                         (or `= [v1, v2, ...]`, one per subject)"
+                            .to_string(),
+                    );
+                }
+                if !is_plain_identifier(name) {
+                    return Err(format!(
+                        "[simulation]: `covariate {name}` is not a valid covariate name — \
+                         expected `covariate NAME = <value>`"
+                    ));
+                }
+                if covariates.iter().any(|(n, _)| n == name) {
+                    return Err(format!(
+                        "[simulation]: covariate `{name}` is declared twice"
+                    ));
+                }
+                // A `[covariates]` block is authoritative when present, exactly as
+                // it is for the data readers: simulating a name the model never
+                // declared is a typo, and one that silently reached `Subject`
+                // would be read by nothing.
+                if !declared_covariate_names.is_empty()
+                    && !declared_covariate_names.iter().any(|n| n == name)
+                {
+                    return Err(format!(
+                        "[simulation]: covariate `{name}` is not declared in [covariates] \
+                         (declared: {})",
+                        declared_covariate_names.join(", ")
+                    ));
+                }
+                let raw = parts[1].trim();
+                let values = if raw.starts_with('[') {
+                    parse_float_array(raw)
+                        .map_err(|e| format!("[simulation]: bad covariate `{name}`: {e}"))?
+                } else {
+                    vec![raw.parse::<f64>().map_err(|_| {
+                        format!("[simulation]: bad covariate `{name}`: {}", line.trim())
+                    })?]
+                };
+                if let Some(bad) = values.iter().find(|v| !v.is_finite()) {
+                    return Err(format!(
+                        "[simulation]: covariate `{name}` has a non-finite value ({bad})"
+                    ));
+                }
+                covariates.push((name.to_string(), values));
+            }
             other => return Err(format!("[simulation]: unknown key `{}`", other)),
+        }
+    }
+    // Length rule, now that `n_subjects` is known regardless of key order: a
+    // scalar broadcasts, a list must name every subject. A short list silently
+    // recycled (or zero-filled) would give the unnamed arms a weight of 0 — which
+    // divides an individual parameter by zero, or collapses a residual variance
+    // onto the floor, with no diagnostic (#1083).
+    for (name, values) in &mut covariates {
+        match values.len() {
+            1 => values.resize(n_subjects, values[0]),
+            n if n == n_subjects => {}
+            n => {
+                return Err(format!(
+                    "[simulation]: covariate `{name}` has {n} value(s) but there are \
+                     {n_subjects} subject(s) — give one value per subject, or a single \
+                     scalar to use for all of them"
+                ))
+            }
         }
     }
     // A synthetic design needs *something* to observe: continuous `times` for a
@@ -6101,7 +6196,7 @@ fn parse_simulation_block(lines: &[String]) -> Result<SimulationSpec, String> {
         obs_times,
         seed,
         horizon,
-        covariates: vec![],
+        covariates,
     })
 }
 

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -16484,12 +16484,19 @@ fn sim_lines(body: &[&str]) -> Vec<String> {
     body.iter().map(|s| s.to_string()).collect()
 }
 
+/// [`parse_simulation_block`] with no declared covariates — the shape every key
+/// test below wants. The declared-name list only gates `covariate NAME = ...`
+/// (#1083); an empty list means "no `[covariates]` block", which accepts any name.
+fn parse_sim_block(lines: &[String]) -> Result<SimulationSpec, String> {
+    parse_simulation_block(lines, &[])
+}
+
 #[test]
 fn simulation_long_form_keys_apply() {
     // The canonical (and example-file) spellings must actually be honored —
     // the bug was that `n_subjects`/`dose_amt`/`dose_cmt` were silently ignored
     // and fell back to the defaults (10 / 100 / 1).
-    let spec = parse_simulation_block(&sim_lines(&[
+    let spec = parse_sim_block(&sim_lines(&[
         "n_subjects = 7",
         "dose_amt = 50",
         "dose_cmt = 2",
@@ -16509,7 +16516,7 @@ fn simulation_short_form_aliases_apply() {
     // Back-compat: the short `subjects`/`dose`/`cmt` forms (the previously
     // documented spelling) remain valid aliases for the same fields, and the
     // defaults hold for the keys we omit (seed = 42).
-    let spec = parse_simulation_block(&sim_lines(&[
+    let spec = parse_sim_block(&sim_lines(&[
         "subjects = 3",
         "dose = 25",
         "cmt = 4",
@@ -16526,7 +16533,7 @@ fn simulation_short_form_aliases_apply() {
 fn simulation_unknown_key_errors() {
     // A typo (e.g. `n_subject`) must be a hard error, not a silent default —
     // this is the silent-failure class the fix closes.
-    let err = parse_simulation_block(&sim_lines(&[
+    let err = parse_sim_block(&sim_lines(&[
         "n_subject = 5", // typo: missing the trailing 's'
         "times = [1.0]",
     ]))
@@ -16543,7 +16550,7 @@ fn simulation_unknown_key_errors() {
 fn simulation_malformed_line_errors() {
     // A non-blank line with no `=` (e.g. a forgotten `=`) is malformed and must
     // error rather than being silently skipped into the default.
-    let err = parse_simulation_block(&sim_lines(&["n_subjects 5", "times = [1.0]"])).unwrap_err();
+    let err = parse_sim_block(&sim_lines(&["n_subjects 5", "times = [1.0]"])).unwrap_err();
     assert!(
         err.starts_with("[simulation]:") && err.contains("malformed line"),
         "got: {err}"
@@ -16562,7 +16569,7 @@ fn simulation_bad_value_errors_per_key() {
         ("seed = -1", "seed"),          // seed is u64
         ("times = [1.0, oops]", "times"),
     ] {
-        let err = parse_simulation_block(&sim_lines(&[line, "times = [1.0]"])).unwrap_err();
+        let err = parse_sim_block(&sim_lines(&[line, "times = [1.0]"])).unwrap_err();
         assert!(
             err.starts_with("[simulation]:") && err.contains(key),
             "key `{key}` on `{line}` gave: {err}"
@@ -16572,18 +16579,18 @@ fn simulation_bad_value_errors_per_key() {
 
 #[test]
 fn simulation_requires_times() {
-    let err = parse_simulation_block(&sim_lines(&["n_subjects = 5"])).unwrap_err();
+    let err = parse_sim_block(&sim_lines(&["n_subjects = 5"])).unwrap_err();
     assert!(err.contains("times"), "got: {err}");
 }
 
 #[test]
 fn simulation_horizon_parses() {
     // `horizon = <t>` is captured as the administrative censoring window (#522).
-    let spec = parse_simulation_block(&sim_lines(&["horizon = 14", "times = [1.0]"]))
-        .expect("horizon parses");
+    let spec =
+        parse_sim_block(&sim_lines(&["horizon = 14", "times = [1.0]"])).expect("horizon parses");
     assert_eq!(spec.horizon, Some(14.0));
     // Absent ⇒ None (the per-record window path).
-    let spec = parse_simulation_block(&sim_lines(&["times = [1.0]"])).expect("no horizon");
+    let spec = parse_sim_block(&sim_lines(&["times = [1.0]"])).expect("no horizon");
     assert_eq!(spec.horizon, None);
 }
 
@@ -16591,7 +16598,7 @@ fn simulation_horizon_parses() {
 fn simulation_horizon_satisfies_observe_requirement() {
     // A TTE-only design has no continuous `times`; a `horizon` alone is enough
     // to make the block valid (the relaxed times-OR-horizon rule).
-    let spec = parse_simulation_block(&sim_lines(&["n_subjects = 5", "horizon = 14"]))
+    let spec = parse_sim_block(&sim_lines(&["n_subjects = 5", "horizon = 14"]))
         .expect("horizon alone is a valid design");
     assert_eq!(spec.horizon, Some(14.0));
     assert!(spec.obs_times.is_empty());
@@ -16605,7 +16612,7 @@ fn simulation_horizon_rejects_nonpositive_and_nonfinite() {
         "horizon = inf",
         "horizon = nan",
     ] {
-        let err = parse_simulation_block(&sim_lines(&[bad, "times = [1.0]"])).unwrap_err();
+        let err = parse_sim_block(&sim_lines(&[bad, "times = [1.0]"])).unwrap_err();
         assert!(
             err.starts_with("[simulation]:") && err.contains("horizon"),
             "`{bad}` gave: {err}"
@@ -16615,10 +16622,123 @@ fn simulation_horizon_rejects_nonpositive_and_nonfinite() {
 
 #[test]
 fn simulation_horizon_bad_value_errors() {
-    let err = parse_simulation_block(&sim_lines(&["horizon = abc", "times = [1.0]"])).unwrap_err();
+    let err = parse_sim_block(&sim_lines(&["horizon = abc", "times = [1.0]"])).unwrap_err();
     assert!(
         err.starts_with("[simulation]:") && err.contains("horizon"),
         "got: {err}"
+    );
+}
+
+// ── [simulation] per-subject covariates (#1083) ──────────────────────────
+//
+// A simulated trial invents arms that are in no dataset, so the covariates its
+// design turns on — an MBMA arm size behind `weight = NARM`, a reported standard
+// error behind `weight = WPSE` — have no row to be read from and must be stated
+// here. Before #1083 `SimulationSpec::covariates` was a field the parser always
+// wrote empty and nothing ever read.
+
+#[test]
+fn simulation_covariate_list_is_read_per_subject() {
+    let spec = parse_sim_block(&sim_lines(&[
+        "n_subjects = 3",
+        "times = [1.0]",
+        "covariate NARM = [400, 200, 50]",
+    ]))
+    .expect("per-subject covariate list parses");
+    assert_eq!(
+        spec.covariates,
+        vec![("NARM".to_string(), vec![400.0, 200.0, 50.0])]
+    );
+}
+
+#[test]
+fn simulation_covariate_scalar_broadcasts_to_every_subject() {
+    let spec = parse_sim_block(&sim_lines(&[
+        "n_subjects = 4",
+        "times = [1.0]",
+        "covariate WT = 70",
+    ]))
+    .expect("scalar covariate parses");
+    assert_eq!(spec.covariates, vec![("WT".to_string(), vec![70.0; 4])]);
+}
+
+#[test]
+fn simulation_covariate_length_is_checked_regardless_of_key_order() {
+    // `n_subjects` deliberately *follows* the covariate line: the length rule runs
+    // after the whole block is read, so the keys stay order-independent like every
+    // other key in this block.
+    let err = parse_sim_block(&sim_lines(&[
+        "covariate NARM = [400, 200]",
+        "n_subjects = 3",
+        "times = [1.0]",
+    ]))
+    .unwrap_err();
+    assert!(
+        err.starts_with("[simulation]:")
+            && err.contains("NARM")
+            && err.contains("2 value(s)")
+            && err.contains("3 subject(s)"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn simulation_covariate_must_be_declared_when_a_covariates_block_exists() {
+    // The `[covariates]` block is authoritative when present, exactly as it is for
+    // the data readers — a name it never declared is a typo, and one that reached
+    // `Subject` silently would be read by nothing.
+    let declared = vec!["NARM".to_string()];
+    let err = parse_simulation_block(
+        &sim_lines(&["n_subjects = 2", "times = [1.0]", "covariate NARN = 100"]),
+        &declared,
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("NARN") && err.contains("not declared in [covariates]"),
+        "got: {err}"
+    );
+    // …and the correctly-spelled one is accepted against the same list.
+    parse_simulation_block(
+        &sim_lines(&["n_subjects = 2", "times = [1.0]", "covariate NARM = 100"]),
+        &declared,
+    )
+    .expect("a declared covariate is accepted");
+}
+
+#[test]
+fn simulation_covariate_rejects_duplicates_and_bad_values() {
+    let dup = parse_sim_block(&sim_lines(&[
+        "n_subjects = 2",
+        "times = [1.0]",
+        "covariate NARM = 100",
+        "covariate NARM = 50",
+    ]))
+    .unwrap_err();
+    assert!(dup.contains("declared twice"), "got: {dup}");
+
+    let bad = parse_sim_block(&sim_lines(&[
+        "n_subjects = 1",
+        "times = [1.0]",
+        "covariate NARM = many",
+    ]))
+    .unwrap_err();
+    assert!(
+        bad.starts_with("[simulation]:") && bad.contains("NARM"),
+        "got: {bad}"
+    );
+
+    let nameless = parse_sim_block(&sim_lines(&["times = [1.0]", "covariate = 100"])).unwrap_err();
+    assert!(nameless.contains("needs a name"), "got: {nameless}");
+}
+
+#[test]
+fn simulation_covariate_matches_the_word_not_the_prefix() {
+    // `covariates = ...` must stay an unknown key rather than being read as a
+    // covariate named `s` — the arm is keyed on the word, not on `starts_with`.
+    let err = parse_sim_block(&sim_lines(&["times = [1.0]", "covariates = [1, 2]"])).unwrap_err();
+    assert!(
+        err.contains("unknown key `covariates`"),
+        "a prefix match would have accepted this: {err}"
     );
 }
 


### PR DESCRIPTION
## Why

`kappa K ~ γ² weight = NARM` (#1031) and `DV ~ additive(S) weight = WPSE` (#1029) both read a data column. `fit()` always has one — the arm exists, and its size and its reported standard error are columns in the dataset. `simulate()` frequently does not: the point of simulating a trial is to propose arms that are **not** in the data, and an arm that does not exist yet has no row. #1083 asked what happens today and what the convention should be.

The investigation (posted [on the issue](https://github.com/FeRx-NLME/ferx-core/issues/1083#issuecomment-5418309064)) found two defects.

**1. `[simulation]` could not express a covariate at all.** `SimulationSpec::covariates` was a field the parser always wrote empty (`model_parser.rs:6104`) and nothing ever read; `run_model_simulate` built every synthetic subject with `covariates: HashMap::new()`. A weighted model reaching `--simulate` was rejected with:

```
Error: simulation failed: Model references covariate(s) not found in data
(case-sensitive): NARM. Available covariate columns: (none).
```

— a message that names no fix, on a path that has no data file. Meanwhile `docs/model-file/simulation.qmd:164` documented the feature as though it worked ("Covariates can be specified per subject in the `[simulation]` block"), which was false.

**2. The weight guards had uneven coverage across the simulate entry points.** Each ran its own hand-picked subset of the model-vs-data checks:

| entry point | `check_covariates` | `check_kappa_weights` | `check_residual_magnitude` |
|---|---|---|---|
| `simulate_with_options_diag` (what ferx-r calls) | ✅ | ✅ | ❌ |
| `simulate_with_uncertainty` | ✅ | ✅ | ❌ |
| `simulate_adaptive_*` | ✅ | ❌ | ❌ |
| `simulate` / `simulate_with_seed` | ❌ | ❌ | ❌ |
| `fit()` | ✅ | ✅ | ✅ |

That mattered more than it looks, because **`BinOp::Div` returns `0.0` when its divisor underflows** (`model_parser.rs:16145`, bytecode twin at `:16749`). An unresolved weight therefore does not blow up:

- `κ/√0` evaluates to **zero**, so the arm quietly loses its between-arm variability — no `NaN`, no `inf`, nothing to trip over;
- a zeroed residual weight collapses the *additive* loading, so the simulated observation comes back equal to its own IPRED. Reproduced on `main`:

```
id=1 time=1 ipred=8.2104679996  value=21.5042801990   <- NARM=100, noisy
id=2 time=1 ipred=7.3464335261  value=7.3464328618    <- NARM=0, noise gone
```

Both produce plausible-looking plots. The guards were the entire defence, and two of them were missing where it counted.

## What changed

**`[simulation] covariate NAME = ...`** — a scalar (broadcast to every subject) or a list (one value per subject):

```
[simulation]
  n_subjects = 3
  times      = [1, 2, 4, 8]
  covariate NARM = [400, 200, 50]
```

Validated against the `[covariates]` block when one exists, against `n_subjects` (a short list is an error, never a recycled or zero-filled tail), for duplicates, and for finiteness. Keys stay order-independent — the length rule runs after the block is read, so a `covariate` line may precede its `n_subjects`. The arm is matched on the `covariate` *word*, not the prefix, so a future `covariates = ...` key is still reported as unknown rather than read as a covariate named `s`.

**Required, not defaulted.** A model that references a covariate the design does not supply is refused, in the terms this path has:

```
[simulation]: the model references covariate(s) `NARM` that the simulation design does
not supply. A simulated trial invents arms that are in no dataset, so their covariates —
an arm size behind `weight = N`, a reported standard error behind `weight = SE`, a body
weight — are part of the design and must be stated: add `covariate NARM = <value>` (or
`= [v1, ...]`, one per subject) to [simulation].
```

**One shared check list.** `check_simulation_data` = covariates + kappa weights + residual magnitude, called from every simulate entry point. The two Vec-returning ones cannot signal, so they enforce it as a panic at the same chokepoint `validate_iov_simulatable` already uses. Ordered covariates-first so existing callers' first error is unchanged.

## Alternatives considered

The issue listed three options and recommended the first; the investigation agreed and the implementation follows it.

- **Carry the weight expression and evaluate it against the simulated row** — works only when the weight is a function of columns the simulation already defines, and still needs an answer when it is not. It does not remove the question, it relocates it.
- **Fall back to the fitted data's typical (median) arm size, reported loudly** — silently answers a different question than the one asked. It is still available, explicitly: simulate against the fitted dataset (`--data`, or pass the fitted `Population` to `simulate()`) and the weights come from the rows they were fitted from. That is documented in `simulation.qmd`.

On the guard side, the alternative was to add `check_residual_magnitude` to each entry point individually. Bundling is what stops the subsets from drifting apart again — the drift is the defect, not any one missing call.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust signature changed. ferx-r calls `simulate_with_options_diag` / `simulate_with_uncertainty`, both of which keep their signatures; they now reject a case they previously mis-simulated.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] None

`[simulation] covariate NAME = ...` is new syntax, not changed syntax — no existing model file means anything different. The guard additions turn previously-silent wrong output into an error, which is the point of the fix; no working model is affected (all 22 bundled `[simulation]` examples were re-run, see below).

## Numerical validation
- [x] Not applicable — this adds a DSL statement and restores guards that already existed on `fit()`. No estimator, likelihood, gradient or PK solution is touched.

The correctness claims that *are* numerical are pinned as degenerate oracles rather than against NONMEM (NONMEM has no equivalent single object here — it is the simulate side of an already-anchored `fit()` construction, and #1031/#1029 carry the NONMEM anchors for the scoring itself):

- `weight ≡ 1` simulates **bit-identically** to the same model with no `weight =` modifier, on both families (`a_weight_of_one_is_bit_identical_to_no_weight`, `an_arm_size_of_one_simulates_bit_identically_to_an_unweighted_kappa`). Both assert non-vacuity — the κ one needed a dose added to its fixture, since without one every IPRED is `0.0` and the oracle would compare zeros.
- The weight reaches the draw in the right direction: a 4× residual weight widens the deviation from IPRED ~4×; larger arms shrink the between-arm spread of IPRED, which is `κ ~ N(0, γ²/N)` doing what it says.

## Performance
- [x] No significant impact expected

The chokepoint check repeats per uncertainty draw. Both expensive halves are gated on the model actually declaring a weight (`has_weighted_kappa` / `has_custom_ruv_magnitude`), false for every model that does not use one; where true, the pass is linear in the observations the draw is about to simulate anyway. Noted in the comment at the call site.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 3371, and 3544 with `--features "survival markov"`)
- [x] Regression test added that fails without this fix

New coverage:

- **Parser** (`model_parser_tests.rs`): scalar broadcast, per-subject list, length rule checked under either key order, undeclared-name rejection against `[covariates]`, duplicates, bad values, nameless `covariate =`, and the `covariates = ...` prefix trap.
- **Design resolution** (`tests/simulation_design_covariates_tests.rs`, new): per-subject values land on the right subject; a design omitting a referenced weight is refused by name with the fix in the message; an unweighted model needs nothing; an extra covariate the model ignores is allowed.
- **Guards** — these fail on `main`: `simulate_rejects_a_zero_weight_the_way_fit_does`, `the_vec_returning_entry_point_panics_on_a_zero_weight` (both families).
- **Oracles**: as described under Numerical validation.

## Example (user-facing features only)
- [x] Example added inline below (and in `docs/model-file/simulation.qmd`)

<details>
<summary>Weighted residual, end-to-end via <code>--simulate</code></summary>

```toml
[parameters]
  theta TVE0(10.0, 0.1, 100.0)
  theta TVEMAX(6.0, 0.1, 100.0)
  theta TVET50(2.0, 0.01, 100.0)
  omega ETA_E0 ~ 0.09
  sigma ADD ~ 1.0 (sd)

[individual_parameters]
  E0   = TVE0 * exp(ETA_E0)
  EMAX = TVEMAX
  ET50 = TVET50

[structural_model]
  y = E0 - EMAX * TIME / (ET50 + TIME)

[error_model]
  DV ~ additive(ADD) weight = WPSE

[covariates]
  WPSE continuous

[simulation]
  n_subjects = 5
  times      = [1.0, 2.0, 4.0, 8.0]
  seed       = 7
  covariate WPSE = [0.5, 0.7, 1.0, 1.4, 2.0]
```

```
Model: mbma_ruv_ok
Simulating 5 subjects (seed=7)...
Loaded 5 subjects, 20 observations
...
Final OFV = 30.929362
```

Dropping the `covariate WPSE` line now gives the `[simulation]:` message quoted above, instead of "not found in data".

</details>

## Docs
- [x] `docs/` updated — `simulation.qmd` (new syntax in the table and the code block; the false "Covariates in Simulation" paragraph replaced with the real behaviour plus a `#sim-covariates-required` section on why neither silent default is safe), cross-linked from `iov.qmd` and `error-model.qmd` at each `weight =` section
- [x] New pages linked in `docs/_quarto.yml` — N/A, no new page
- [x] `CHANGELOG.md` `[Unreleased]` entry added (one under Added, one under Fixed)

## Checklist
- [x] `cargo clippy` clean (no new warnings on touched code; pre-existing `approx_constant` in `sens/two_cpt_explicit.rs` and `manual_contains` in `validation.rs:2263+` are untouched)
- [x] `Dual2` sensitivity path untouched
- [x] `Cargo.toml` version bump — not needed (additive)

## Docs & examples

### Example execution
- [x] All 22 bundled `examples/*.ferx` carrying a `[simulation]` block were re-run through `--simulate` against this branch; none newly hits the design-covariate gate.
- [x] `cargo check --tests` and `cargo check --tests --features "survival markov"` clean.

## Reviewer hints

Worth a close look:

- **`parse_simulation_block`'s new match arm** (`model_parser.rs`). The `covariate`-word match rather than a `starts_with` prefix is deliberate and has its own test; without it `covariates = ...` would parse as a covariate named `s`.
- **Where the `[simulation]` parse moved** (`parse_full_model`). It now runs *after* the `[covariates]` peek so it can validate declared names, but still *before* `[adaptive_dosing]`, so first-error ordering is unchanged. The peek uses `.ok()` and cannot itself error, so nothing was reordered into it.
- **The panic at `simulate_inner_with_draw`.** Failing loud is the right call here specifically because the failure it catches is silent — but it is a panic on a shared path, so it deserves scrutiny. It matches the existing `validate_iov_simulatable` precedent two lines above.

Skimmable: the docs prose, and the mechanical `parse_sim_block` test-helper rename (11 call sites gained a second argument via a one-line wrapper).

## Open questions

**A weighted κ still cannot complete `--simulate` end-to-end, for a reason orthogonal to this PR.** Synthetic `[simulation]` subjects carry no occasion labels, so *any* κ model — weighted or not — simulates fine and then fails at the subsequent fit with `Model declares kappa (IOV) parameters but no occasion labels were found`. Verified as pre-existing on `main` with an unweighted κ.

I did not fix it here because deciding what an occasion *means* for a synthetic subject is a real design call (arm-as-occasion for MBMA, dose-as-occasion for PK IOV) that belongs with #1031/#391, not with this issue. The library path — a real `Population` whose occasions come from the design or the data, which is how ferx-r does trial simulation — works, and is what the new κ oracles exercise. Happy to open a follow-up issue for the `--simulate` occasion gap if you agree it should be one.

Closes #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ezut1SKUEWZ9YBEf1jbj4
