### PR TITLE
feat(parser): three-argument clamp(x, lo, hi) in the model DSL [closes #1092]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ section of the SDLC for the versioning policy).
   conditional, so it differentiates and compiles exactly like the nested form. `clamp` with any
   arity other than three is a parse error — a one-argument `clamp(x)` would otherwise have been
   read as the silent identity — and literal bounds given the wrong way round (`clamp(x, 0.9, 0.1)`)
-  are rejected rather than quietly returning `0.9` for every `x`.
+  are rejected rather than quietly returning a bound for every `x`. One input is deliberately not
+  the nested form: `NaN` fails both bound tests, so `clamp` propagates it into the objective
+  function, where `min(max(x, lo), hi)` would have pinned it to `lo` and let a wrong number fit.
 - **`[simulation]` can now state the covariates of the arms it invents (#1083).** `covariate NAME = <value>`
   — a scalar for every subject, or `= [v1, v2, ...]` with one value per subject — gives the synthetic
   subjects a covariate value, which a `[simulation]` design previously had no way to express at all.
@@ -235,6 +237,11 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **A third argument to a `[derived]` row aggregate was dropped in silence (#1092).**
+  `CMAX = max(IPRED, TIME > 0, 99)` computed `max(IPRED, TIME > 0)` — the aggregate form reads only
+  the value and the optional row filter, and never looked at what followed. It is now a parse error
+  that names `clamp(x, lo, hi)`, which is what the extra argument usually means. The same mistake
+  written inside a larger expression was already rejected.
 - **`simulate()` silently removed an arm's residual noise when its `weight = <expr>` column was blank
   or zero (#1083).** `fit()` has rejected a non-positive residual magnitude since #1029, but no
   `simulate()` entry point ran that check — each ran its own subset of the model-vs-data checks and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Three-argument `clamp(x, lo, hi)` in the model DSL (#1092).** Bounding a readout into an
+  interval no longer has to be written as the nested `min(max(x, lo), hi)`, whose argument order
+  flips between the inner and outer call. Available in every expression the DSL parses
+  (`[individual_parameters]`, `[scaling]`, `[odes]`, `[derived]`); it desugars to the inline
+  conditional, so it differentiates and compiles exactly like the nested form. `clamp` with any
+  arity other than three is a parse error — a one-argument `clamp(x)` would otherwise have been
+  read as the silent identity — and literal bounds given the wrong way round (`clamp(x, 0.9, 0.1)`)
+  are rejected rather than quietly returning `0.9` for every `x`.
 - **`[simulation]` can now state the covariates of the arms it invents (#1083).** `covariate NAME = <value>`
   — a scalar for every subject, or `= [v1, v2, ...]` with one value per subject — gives the synthetic
   subjects a covariate value, which a `[simulation]` design previously had no way to express at all.

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -46,6 +46,7 @@ name from quietly reading as zero and collapsing the formula.
 | `sqrt()` | `sqrt(WT)` |
 | `abs()` | `abs(ETA_CL)` |
 | `min(a, b)`, `max(a, b)` | `max(TVCL * WT / 70, 0.1)` |
+| `clamp(x, lo, hi)` | `clamp(ACR20, 0.01, 0.99)` |
 | Parentheses | `TVCL * (WT/70)^0.75` |
 | Comparisons (in `if` conditions) | `WT > 70`, `SEX == 1`, `AGE != 0` |
 | Logical (in `if` conditions) | `&&` (and), `\|\|` (or), `!` (not) |
@@ -56,6 +57,16 @@ conditional (`max(a, b)` → `if (a >= b) a else b`), so they differentiate and
 compile identically to the hand-written form. A one-argument `max(x)` is a parse
 error rather than the silent identity it used to be
 ([#1030](https://github.com/FeRx-NLME/ferx-core/issues/1030)).
+
+`clamp(x, lo, hi)` takes **exactly three** arguments and is the two-sided bound:
+`clamp(ACR20, 0.01, 0.99)` says what `min(max(ACR20, 0.01), 0.99)` says, without
+the argument order flipping between the inner and outer call. It desugars to the
+same nested conditional — `if (x <= lo) lo else if (x >= hi) hi else x` — so on
+each bound the *bound* is returned and the derivative there is zero. Any other
+arity is a parse error, and literal bounds the wrong way round
+(`clamp(x, 0.9, 0.1)`) are rejected rather than silently returning `0.9` for
+every `x`; bounds that are not both literals are not checked
+([#1092](https://github.com/FeRx-NLME/ferx-core/issues/1092)).
 
 ## Continuation Lines
 

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -399,7 +399,7 @@ above), the dose-attribute double-use rejection sees through them, and the
 analytic-sensitivity path is unaffected. The one consequence of inlining is that
 an intermediate used twice is *evaluated* twice — which is exactly what writing
 it out by hand costs. Note that `min` / `max` count as two uses each (see below),
-so a two-sided clamp on a named value expands that value eight times — or three
+so a two-sided clamp on a named value expands that value four times — or three
 times written as `clamp(x, lo, hi)`.
 
 ### `min(a, b)`, `max(a, b)` and `clamp(x, lo, hi)`
@@ -423,8 +423,19 @@ On each bound the *bound* is returned, so the derivative there is zero. It puts 
 in the tree three times rather than the nested form's four, but the advice above is
 unchanged — clamp a named value, not a long expression. Any arity other than three
 is a parse error, and literal bounds the wrong way round (`clamp(x, 0.9, 0.1)`) are
-rejected rather than silently returning `0.9` for every `x`; bounds that are not both
-literals are not checked.
+rejected rather than silently returning a bound for every `x`; bounds that are not
+both literals are not checked.
+
+`clamp` differs from the nested pair in one place, deliberately: on a `NaN` input.
+`NaN` fails both `x <= lo` and `x >= hi`, so `clamp` falls through to `x` and the
+`NaN` propagates — into the prediction, and from there into the objective
+function, where it is caught. The nested `min(max(x, lo), hi)` instead returns
+`lo`, because `max`'s `x >= lo` is false for `NaN` and the `else` branch is the
+bound. So if you rewrite an existing `min`/`max` pair as `clamp` around a
+quantity that can go `NaN` — a `log` or `sqrt` of something that dips negative
+mid-search, say — that model was being quietly pinned to `lo`, and will now
+surface the `NaN` instead. That is the intended direction: a silently bounded
+`NaN` is a wrong number that fits.
 
 In `[derived]`, `min` / `max` also name the row aggregate (`max(IPRED, TIME > 0)` is
 "the largest `IPRED` over rows where `TIME > 0`"). The two are told apart by the

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -399,14 +399,16 @@ above), the dose-attribute double-use rejection sees through them, and the
 analytic-sensitivity path is unaffected. The one consequence of inlining is that
 an intermediate used twice is *evaluated* twice — which is exactly what writing
 it out by hand costs. Note that `min` / `max` count as two uses each (see below),
-so a two-sided clamp on a named value expands that value eight times.
+so a two-sided clamp on a named value expands that value eight times — or three
+times written as `clamp(x, lo, hi)`.
 
-### `min(a, b)` and `max(a, b)`
+### `min(a, b)`, `max(a, b)` and `clamp(x, lo, hi)`
 
-Two-argument `min` / `max` are available in every expression the DSL parses —
-`[scaling]`, `[individual_parameters]`, `[odes]`, `[derived]`. They desugar to the
-inline conditional (`max(a, b)` → `if (a >= b) a else b`), so they differentiate
-and compile exactly like the hand-written form.
+Two-argument `min` / `max` and three-argument `clamp` are available in every
+expression the DSL parses — `[scaling]`, `[individual_parameters]`, `[odes]`,
+`[derived]`. They desugar to the inline conditional (`max(a, b)` →
+`if (a >= b) a else b`), so they differentiate and compile exactly like the
+hand-written form.
 
 The desugaring puts **both** arguments in the guard *and* in a branch, so each one
 appears twice in the compiled tree, and the duplication multiplies through nesting:
@@ -415,11 +417,21 @@ two places in a readout makes eight. Clamp a *named* value rather than a long
 expression — that is the pairing the block above uses, and it keeps the growth on a
 short leaf instead of on a whole sub-model.
 
+`clamp(x, lo, hi)` is the two-sided bound written as one call, and desugars to the
+same nested conditional the pair does: `if (x <= lo) lo else if (x >= hi) hi else x`.
+On each bound the *bound* is returned, so the derivative there is zero. It puts `x`
+in the tree three times rather than the nested form's four, but the advice above is
+unchanged — clamp a named value, not a long expression. Any arity other than three
+is a parse error, and literal bounds the wrong way round (`clamp(x, 0.9, 0.1)`) are
+rejected rather than silently returning `0.9` for every `x`; bounds that are not both
+literals are not checked.
+
 In `[derived]`, `min` / `max` also name the row aggregate (`max(IPRED, TIME > 0)` is
 "the largest `IPRED` over rows where `TIME > 0`"). The two are told apart by the
 second argument: a comparison is a row filter, anything else is the numeric clamp.
 An aggregate cannot be combined into a larger expression — `max(IPRED) * 2` is an
-error, not a scaled maximum.
+error, not a scaled maximum. `clamp` has no aggregate spelling, so it is
+unambiguous there.
 
 ## Runtime behaviour on bad scales
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -19773,14 +19773,72 @@ fn parse_atom(
             }
 
             // Check if it's a function call: `name(expr)` — or, for `min` / `max`,
-            // the two-argument `name(a, b)` form (#1030).
+            // the two-argument `name(a, b)` form (#1030), or the three-argument
+            // `clamp(x, lo, hi)` (#1092).
             if pos + 1 < tokens.len() && tokens[pos + 1] == Token::LParen {
                 let func_name = name.to_lowercase();
                 let is_min_max = matches!(func_name.as_str(), "min" | "max");
+                let is_clamp = func_name == "clamp";
                 let (arg, p) = parse_add_sub(tokens, pos + 2, ctx)?;
-                if is_min_max && tokens.get(p) == Some(&Token::Comma) {
+                if (is_min_max || is_clamp) && tokens.get(p) == Some(&Token::Comma) {
                     let (arg2, p) = parse_add_sub(tokens, p + 1, ctx)?;
+                    if is_clamp {
+                        if tokens.get(p) != Some(&Token::Comma) {
+                            return Err(format!(
+                                "`{func_name}` takes exactly three arguments: \
+                                 `clamp(x, lo, hi)`."
+                            ));
+                        }
+                        let (arg3, p) = parse_add_sub(tokens, p + 1, ctx)?;
+                        if tokens.get(p) != Some(&Token::RParen) {
+                            return Err(format!(
+                                "Missing closing parenthesis for function {name} — `{func_name}` \
+                                 takes exactly three arguments, `clamp(x, lo, hi)`."
+                            ));
+                        }
+                        // An inverted *literal* interval can only be a typo: the
+                        // desugaring below would return `lo` for every `x`, quietly.
+                        // Non-literal bounds are left alone rather than paying an
+                        // ordering test on every evaluation of every clamp.
+                        if let (Expression::Literal(lo), Expression::Literal(hi)) = (&arg2, &arg3) {
+                            if lo > hi {
+                                return Err(format!(
+                                    "`clamp(x, {lo}, {hi})` has its bounds inverted — the lower \
+                                     bound must not be above the upper bound."
+                                ));
+                            }
+                        }
+                        // Desugar to nested inline conditionals, exactly as `min` /
+                        // `max` do just below:
+                        //   `clamp(x, lo, hi)` → `if (x <= lo) lo else if (x >= hi) hi else x`
+                        // `Expression::Conditional` is already evaluated,
+                        // bytecode-compiled, `Dual2`-differentiated and index-resolved
+                        // everywhere in the pipeline, so `clamp` inherits all of it and
+                        // cannot drift from the `min(max(x, lo), hi)` it replaces.
+                        // `x` lands in the tree three times (`lo` and `hi` twice each) —
+                        // the same cost as writing the nested form by hand, so clamp a
+                        // *named* value rather than a long expression.
+                        let inner = Expression::Conditional(
+                            Box::new(Condition::Compare(arg.clone(), CmpOp::Ge, arg3.clone())),
+                            Box::new(arg3),
+                            Box::new(arg.clone()),
+                        );
+                        return Ok((
+                            Expression::Conditional(
+                                Box::new(Condition::Compare(arg, CmpOp::Le, arg2.clone())),
+                                Box::new(arg2),
+                                Box::new(inner),
+                            ),
+                            p + 1,
+                        ));
+                    }
                     if tokens.get(p) != Some(&Token::RParen) {
+                        if tokens.get(p) == Some(&Token::Comma) {
+                            return Err(format!(
+                                "function `{name}` takes 2 arguments, but a third `,` was found — \
+                                 a two-sided bound is `clamp(x, lo, hi)`."
+                            ));
+                        }
                         return Err(format!(
                             "Missing closing parenthesis for function {} — `{}` takes exactly \
                              two arguments, `{}(a, b)`.",
@@ -19813,7 +19871,8 @@ fn parse_atom(
                     if tokens.get(p) == Some(&Token::Comma) {
                         return Err(format!(
                             "function `{}` takes 1 argument, but a `,` was found — only \
-                             `min(a, b)` and `max(a, b)` take two.",
+                             `min(a, b)` and `max(a, b)` take two, and `clamp(x, lo, hi)` \
+                             takes three.",
                             name
                         ));
                     }
@@ -19823,6 +19882,15 @@ fn parse_atom(
                     return Err(format!(
                         "`{}` takes exactly two arguments: `{}(a, b)`.",
                         name, func_name
+                    ));
+                }
+                if is_clamp {
+                    // A one-argument `clamp(x)` used to fall through to
+                    // `UnaryFn("clamp", x)`, which every consumer evaluates as the
+                    // identity — a no-op that fits, converges and gives wrong
+                    // numbers (#1092). Reject it by name.
+                    return Err(format!(
+                        "`{func_name}` takes exactly three arguments: `clamp(x, lo, hi)`."
                     ));
                 }
                 return Ok((Expression::UnaryFn(func_name, Box::new(arg)), p + 1));

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -4434,6 +4434,26 @@ fn parse_derived_block(
                              aggregate over rows cannot be combined into a larger expression."
                         ));
                     }
+                    // Only `args[0]` (the value) and `args[1]` (the row filter) are
+                    // read below, so a third argument used to be dropped in silence —
+                    // the same class of bug as the trailing-token drop just above.
+                    // Reject it, and point at what the extra argument usually means:
+                    // a two-sided bound is `clamp`, not a three-argument `min`/`max`
+                    // (#1092). The `parse_atom` path already says this; say it here
+                    // too, since a statement-top-level `min`/`max` in `[derived]`
+                    // never reaches that path.
+                    if args.len() > 2 {
+                        let hint = if fname_lc == "tmax" {
+                            ""
+                        } else {
+                            " — a two-sided bound is `clamp(x, lo, hi)`"
+                        };
+                        return Err(format!(
+                            "[derived] `{name}`: `{fname_lc}(…)` takes at most two arguments (a \
+                             value and an optional row filter), but {} were found{hint}.",
+                            args.len()
+                        ));
+                    }
                     let agg_fn = match fname_lc.as_str() {
                         "max" => AggFunction::Max,
                         "min" => AggFunction::Min,
@@ -19797,7 +19817,8 @@ fn parse_atom(
                             ));
                         }
                         // An inverted *literal* interval can only be a typo: the
-                        // desugaring below would return `lo` for every `x`, quietly.
+                        // desugaring below never returns `x` at all, quietly handing
+                        // back `lo` below the crossing and `hi` above it.
                         // Non-literal bounds are left alone rather than paying an
                         // ordering test on every evaluation of every clamp.
                         if let (Expression::Literal(lo), Expression::Literal(hi)) = (&arg2, &arg3) {
@@ -19813,8 +19834,20 @@ fn parse_atom(
                         //   `clamp(x, lo, hi)` → `if (x <= lo) lo else if (x >= hi) hi else x`
                         // `Expression::Conditional` is already evaluated,
                         // bytecode-compiled, `Dual2`-differentiated and index-resolved
-                        // everywhere in the pipeline, so `clamp` inherits all of it and
-                        // cannot drift from the `min(max(x, lo), hi)` it replaces.
+                        // everywhere in the pipeline, so `clamp` inherits all of it.
+                        // On every *finite* `x` it returns bit-for-bit what the
+                        // `min(max(x, lo), hi)` it replaces returns. The two forms are
+                        // deliberately not identical where no branch test can be true:
+                        // a NaN `x` fails both `<=` and `>=`, so `clamp` falls through
+                        // to `x` and propagates the NaN, while the nested form's `max`
+                        // takes its `else` and pins the result to `lo`. Propagating is
+                        // the wanted behaviour — a NaN readout silently bounded to `lo`
+                        // is a wrong number that survives into the OFV, where a NaN
+                        // does not. The same branch choice puts the derivative at 0
+                        // *on* each bound where the nested form passes 1 through; both
+                        // conventions are pinned in
+                        // `clamp_derivative_convention_on_the_bounds` and
+                        // `clamp_propagates_nan_where_nested_pins_to_lo`.
                         // `x` lands in the tree three times (`lo` and `hi` twice each) —
                         // the same cost as writing the nested form by hand, so clamp a
                         // *named* value rather than a long expression.

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -12053,11 +12053,13 @@ fn parse_indexed_expr(src: &str) -> Expression {
     expr
 }
 
-/// `clamp(x, lo, hi)` is defined as the nested form it replaces, so the two must
-/// agree everywhere — including *on* both bounds, where the branch taken decides
-/// which of two equal values is returned.
+/// `clamp(x, lo, hi)` is defined as the nested form it replaces, so on every
+/// finite `x` the two must agree — including *on* both bounds, where the branch
+/// taken decides which of two equal values is returned. (`NaN` is the one input
+/// where they deliberately part; see
+/// `clamp_propagates_nan_where_nested_pins_to_lo`.)
 #[test]
-fn clamp_matches_nested_min_max_everywhere() {
+fn clamp_matches_nested_min_max_on_every_finite_x() {
     let clamped = parse_indexed_expr("clamp(X, 0.01, 0.99)");
     let nested = parse_indexed_expr("min(max(X, 0.01), 0.99)");
     let nn: Vec<Vec<f64>> = Vec::new();
@@ -12072,6 +12074,36 @@ fn clamp_matches_nested_min_max_everywhere() {
         );
         assert_eq!(a, x.clamp(0.01, 0.99), "at x = {x}");
     }
+}
+
+/// The one input where `clamp` and `min(max(..))` part company, pinned so the
+/// divergence stays a decision rather than an accident. `NaN` fails both
+/// `x <= lo` and `x >= hi`, so `clamp` falls through to `x` and propagates it;
+/// the nested form's `max` sees `x >= lo` false and returns the bound, and the
+/// outer `min` keeps it — so a `NaN` readout comes back silently pinned to `lo`.
+/// Propagating is what we want: a `NaN` reaches the OFV, where it is caught.
+#[test]
+fn clamp_propagates_nan_where_nested_pins_to_lo() {
+    let clamped = parse_indexed_expr("clamp(X, 0.01, 0.99)");
+    let nested = parse_indexed_expr("min(max(X, 0.01), 0.99)");
+    let nn: Vec<Vec<f64>> = Vec::new();
+    let vars = [f64::NAN, 0.0];
+    assert!(
+        eval_expression_indexed(&clamped, &[], &[], &[], &vars, &nn).is_nan(),
+        "clamp must propagate a NaN input"
+    );
+    assert_eq!(
+        eval_expression_indexed(&nested, &[], &[], &[], &vars, &nn),
+        0.01,
+        "the nested form pins a NaN to `lo` — the behaviour clamp does not copy"
+    );
+    // The bytecode VM takes the same branches as the AST evaluator.
+    let bc = compile_bytecode(&clamped);
+    let mut stack: Vec<f64> = Vec::new();
+    assert!(
+        eval_bytecode_g::<f64>(&bc, &[], &[], &[], &vars, &nn, &mut stack).is_nan(),
+        "the compiled clamp must propagate a NaN too"
+    );
 }
 
 /// The desugared tree compiles: the bytecode VM and the AST evaluator must agree
@@ -12210,8 +12242,9 @@ fn test_clamp_arity_diagnostics() {
     );
 }
 
-/// `clamp(x, 0.9, 0.1)` would quietly return `0.9` for every `x`. With both
-/// bounds literal that can only be a typo, so it is a parse error; bounds that
+/// `clamp(x, 0.9, 0.1)` would never return `x` at all — quietly handing back
+/// `0.9` below the crossing and `0.1` above it. With both bounds literal that
+/// can only be a typo, so it is a parse error; bounds that
 /// are not both literals are left to run rather than paying an ordering test on
 /// every evaluation.
 #[test]
@@ -15259,6 +15292,33 @@ fn parse_derived_clamp_is_unambiguous() {
     assert_eq!(eval_one("X = clamp(V, 2.0, 50.0)"), 10.0);
     // Still an expression, not a call: trailing operators are honoured.
     assert_eq!(eval_one("X = clamp(CL, 2.0, 5.0) * 3"), 6.0);
+}
+
+/// A third argument to a statement-top-level `[derived]` aggregate used to be
+/// dropped in silence — `args[2..]` is never read — so `max(IPRED, TIME > 0, Q)`
+/// computed `max(IPRED, TIME > 0)`. Reject it, and name `clamp` for `min`/`max`,
+/// which is what the extra argument usually means (#1092).
+#[test]
+fn parse_derived_aggregate_rejects_a_third_argument() {
+    for (derived, names_clamp) in [
+        ("CMAX = max(IPRED, TIME > 0, 99)", true),
+        ("CMIN = min(IPRED, TIME > 0, 99)", true),
+        ("TP = tmax(IPRED, TIME > 0, 99)", false),
+    ] {
+        let src = minimal_model_with_derived(derived);
+        let err = parse_full_model(&src)
+            .err()
+            .unwrap_or_else(|| panic!("a third argument must be rejected: `{derived}`"));
+        assert!(
+            err.contains("at most two arguments"),
+            "expected the aggregate arity error for `{derived}`, got: {err}"
+        );
+        assert_eq!(
+            err.contains("clamp(x, lo, hi)"),
+            names_clamp,
+            "only `min`/`max` should point at clamp: `{derived}` gave: {err}"
+        );
+    }
 }
 
 /// A second argument that *is* a comparison keeps meaning the row filter.

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -12036,6 +12036,203 @@ fn test_min_max_arity_diagnostics() {
     );
 }
 
+// ── Three-argument clamp (#1092) ────────────────────────────────────────────
+
+/// Parse a single expression with `X` / `Y` bound to variable slots 0 and 1, so
+/// the bytecode and `Dual2` helpers above can drive whatever the parser built.
+fn parse_indexed_expr(src: &str) -> Expression {
+    let toks = tokenize(src).expect("tokenizes");
+    let defined = vec!["X".to_string(), "Y".to_string()];
+    let ctx = ParseCtx::new(&[], &[], &defined);
+    let (mut expr, p) = parse_add_sub(&toks, 0, ctx).expect("parses");
+    assert_eq!(p, toks.len(), "trailing tokens in `{src}`");
+    let var_idx: HashMap<String, usize> = [("X".to_string(), 0), ("Y".to_string(), 1)]
+        .into_iter()
+        .collect();
+    resolve_expr_indices(&mut expr, &var_idx, &HashMap::new());
+    expr
+}
+
+/// `clamp(x, lo, hi)` is defined as the nested form it replaces, so the two must
+/// agree everywhere — including *on* both bounds, where the branch taken decides
+/// which of two equal values is returned.
+#[test]
+fn clamp_matches_nested_min_max_everywhere() {
+    let clamped = parse_indexed_expr("clamp(X, 0.01, 0.99)");
+    let nested = parse_indexed_expr("min(max(X, 0.01), 0.99)");
+    let nn: Vec<Vec<f64>> = Vec::new();
+    for x in [-1.0, 0.0, 0.005, 0.01, 0.5, 0.99, 1.0, 2.0] {
+        let vars = [x, 0.0];
+        let a = eval_expression_indexed(&clamped, &[], &[], &[], &vars, &nn);
+        let b = eval_expression_indexed(&nested, &[], &[], &[], &vars, &nn);
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "clamp != min(max(..)) at x = {x}: {a} vs {b}"
+        );
+        assert_eq!(a, x.clamp(0.01, 0.99), "at x = {x}");
+    }
+}
+
+/// The desugared tree compiles: the bytecode VM and the AST evaluator must agree
+/// bit-for-bit in each of the three regimes and on both bounds.
+#[test]
+fn clamp_bytecode_matches_ast() {
+    let clamped = parse_indexed_expr("clamp(X, 0.01, 0.99)");
+    for x in [-1.0, 0.005, 0.01, 0.5, 0.99, 2.0] {
+        bc_vs_ast(clamped.clone(), &[x, 0.0], &[], &[], &[]);
+    }
+    // Variable bounds are ordinary expressions, not literals-only.
+    let var_bound = parse_indexed_expr("clamp(X, Y, 2 * Y)");
+    for x in [-1.0, 0.5, 1.0, 5.0] {
+        bc_vs_ast(var_bound.clone(), &[x, 0.75], &[], &[], &[]);
+    }
+}
+
+/// Derivatives across both bounds: flat (∂/∂x = 0) outside, pass-through
+/// (∂/∂x = 1) inside, and the bound's own derivative when the bound is a
+/// variable. Checked against central FD of the `f64` evaluator, with the probe
+/// steps kept clear of the kinks.
+#[test]
+fn clamp_dual2_matches_fd_in_every_regime() {
+    let expr = parse_indexed_expr("clamp(X, 0.2, 0.8) * Y");
+    for x in [0.05, 0.5, 0.95] {
+        bc_g_dual2_fd(&expr, x, 1.5, 1e-6, 1e-3);
+    }
+    // A variable lower bound: below it, the value *is* `Y`, so the gradient
+    // moves off `X` and onto `Y`.
+    let var_lo = parse_indexed_expr("clamp(X, Y, 0.9)");
+    bc_g_dual2_fd(&var_lo, 0.1, 0.3, 1e-6, 1e-3);
+    bc_g_dual2_fd(&var_lo, 0.5, 0.3, 1e-6, 1e-3);
+}
+
+/// The convention at the bounds themselves, where FD cannot speak: `x <= lo` and
+/// `x >= hi` take the *bound* branch, so the derivative is 0 on both bounds and 1
+/// strictly between them. Pinned so a later `<`/`<=` edit is a test failure.
+#[test]
+fn clamp_derivative_convention_on_the_bounds() {
+    use crate::sens::dual2::Dual2;
+    let bc = compile_bytecode(&parse_indexed_expr("clamp(X, 0.2, 0.8)"));
+    let nn: Vec<Vec<f64>> = Vec::new();
+    let grad_at = |x: f64| {
+        let vd = [Dual2::<2>::var(x, 0), Dual2::<2>::var(0.0, 1)];
+        let mut s: Vec<Dual2<2>> = Vec::new();
+        eval_bytecode_g::<Dual2<2>>(&bc, &[], &[], &[], &vd, &nn, &mut s).grad[0]
+    };
+    assert_eq!(
+        grad_at(0.2),
+        0.0,
+        "on the lower bound the `lo` branch is taken"
+    );
+    assert_eq!(
+        grad_at(0.8),
+        0.0,
+        "on the upper bound the `hi` branch is taken"
+    );
+    assert_eq!(grad_at(0.5), 1.0, "strictly inside, clamp is the identity");
+    assert_eq!(grad_at(0.1), 0.0, "below the lower bound");
+    assert_eq!(grad_at(0.9), 0.0, "above the upper bound");
+}
+
+/// End to end through a real model: the clamp bites at both bounds and passes
+/// through in between, after index resolution and bytecode compilation.
+#[test]
+fn test_clamp_in_individual_parameters() {
+    let content = r#"
+[parameters]
+  theta TVCL(2.0, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = clamp(TVCL * WT / 70, 1.0, 3.0)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let parsed = parse_full_model(content).unwrap();
+    let theta = vec![2.0, 10.0];
+    let eta = vec![0.0];
+    let mut covs = HashMap::new();
+
+    let mut cl_at = |wt: f64, covs: &mut HashMap<String, f64>| {
+        covs.insert("WT".to_string(), wt);
+        (parsed.model.pk_param_fn)(&theta, &eta, covs, 0.0).values[0]
+    };
+    assert!(
+        (cl_at(70.0, &mut covs) - 2.0).abs() < 1e-12,
+        "inside: CL = 2"
+    );
+    assert!((cl_at(7.0, &mut covs) - 1.0).abs() < 1e-12, "floor bites");
+    assert!(
+        (cl_at(700.0, &mut covs) - 3.0).abs() < 1e-12,
+        "ceiling bites"
+    );
+}
+
+/// `clamp` with one, two or four arguments must be a hard error naming the
+/// three-argument form. The one-argument case is the trap the feature invites:
+/// an unknown `name(arg)` used to become `UnaryFn`, which every consumer
+/// evaluates as the identity — a no-op that fits, converges and gives wrong
+/// numbers.
+#[test]
+fn test_clamp_arity_diagnostics() {
+    for bad in [
+        "  y = clamp(central)\n",
+        "  y = clamp(central, 0.1)\n",
+        "  y = clamp(central, 0.1, 0.9, 2)\n",
+    ] {
+        let src = analytical_model_with_scaling(Some(bad));
+        let err = parse_model_string(&src)
+            .err()
+            .unwrap_or_else(|| panic!("`{}` must be rejected", bad.trim()));
+        assert!(
+            err.contains("three arguments") && err.contains("clamp(x, lo, hi)"),
+            "expected a clamp arity error for `{}`, got: {}",
+            bad.trim(),
+            err
+        );
+    }
+
+    // The reverse mistake: a third argument to `min`/`max` points at `clamp`
+    // rather than at a bracket bug.
+    let src = analytical_model_with_scaling(Some("  y = min(central, 0.1, 0.9)\n"));
+    let err = parse_model_string(&src).expect_err("three-argument min must be rejected");
+    assert!(
+        err.contains("clamp(x, lo, hi)"),
+        "expected the three-argument min error to name clamp, got: {}",
+        err
+    );
+}
+
+/// `clamp(x, 0.9, 0.1)` would quietly return `0.9` for every `x`. With both
+/// bounds literal that can only be a typo, so it is a parse error; bounds that
+/// are not both literals are left to run rather than paying an ordering test on
+/// every evaluation.
+#[test]
+fn test_clamp_rejects_inverted_literal_bounds() {
+    let src = analytical_model_with_scaling(Some("  y = clamp(central, 0.9, 0.1)\n"));
+    let err = parse_model_string(&src).expect_err("inverted literal bounds must be rejected");
+    assert!(
+        err.contains("bounds inverted"),
+        "expected the inverted-bounds error, got: {}",
+        err
+    );
+
+    // Equal bounds are a degenerate but well-defined constant, not an error.
+    let src = analytical_model_with_scaling(Some("  y = clamp(central, 0.5, 0.5)\n"));
+    parse_model_string(&src).expect("equal bounds are legal");
+
+    // A non-literal bound is not checked — no runtime ordering test.
+    let src = analytical_model_with_scaling(Some("  y = clamp(central, V, 0.1)\n"));
+    parse_model_string(&src).expect("non-literal bounds parse");
+}
+
 // ── Operator continuation lines (#1030) ─────────────────────────────────────
 
 #[test]
@@ -15024,6 +15221,44 @@ fn parse_derived_two_arg_max_at_statement_top_level() {
     assert_eq!(eval_one("X = min(CL, 2.0)"), 1.0);
     // Still an expression, not a call: trailing operators are honoured.
     assert_eq!(eval_one("X = max(CL, 2.0) * 3"), 6.0);
+}
+
+/// `clamp` has no row-aggregate spelling, so it is unambiguous in `[derived]`:
+/// it means the same thing at statement top level as it does nested one level
+/// in, and it stays an expression that trailing operators continue.
+#[test]
+fn parse_derived_clamp_is_unambiguous() {
+    let (theta, eta, indiv_params, covariates, prev_derived) = make_derived_ctx_simple();
+    let eval_one = |derived: &str| {
+        let src = minimal_model_with_derived(derived);
+        let parsed = parse_full_model(&src).expect("clamp in [derived] parses");
+        let DerivedKind::PerRow { eval } = &parsed.model.derived_exprs[0].kind else {
+            panic!("expected PerRow, got the row aggregate");
+        };
+        let ctx = DerivedContext {
+            theta: &theta,
+            eta: &eta,
+            indiv_params: &indiv_params,
+            covariates: &covariates,
+            ipred: 0.0,
+            pred: 0.0,
+            dv: 0.0,
+            time: 1.0,
+            tafd: 1.0,
+            tad: 1.0,
+            prev_derived: &prev_derived,
+            compartments: &[],
+            compartment_names: &[],
+        };
+        eval(&ctx)
+    };
+    // CL = 1, V = 10.
+    assert_eq!(eval_one("X = clamp(CL, 2.0, 5.0)"), 2.0);
+    assert_eq!(eval_one("X = 1 * clamp(CL, 2.0, 5.0)"), 2.0);
+    assert_eq!(eval_one("X = clamp(V, 2.0, 5.0)"), 5.0);
+    assert_eq!(eval_one("X = clamp(V, 2.0, 50.0)"), 10.0);
+    // Still an expression, not a call: trailing operators are honoured.
+    assert_eq!(eval_one("X = clamp(CL, 2.0, 5.0) * 3"), 6.0);
 }
 
 /// A second argument that *is* a comparison keeps meaning the row filter.


### PR DESCRIPTION
## Why

Closes #1092.

Bounding a readout into an open interval — a logit-scale response, a fraction, a probability — could only be written as the nested form:

```
  SAT = min(max(ACR20, 0.01), 0.99)
```

which reads poorly exactly where it matters: the reader has to unpick the nesting to see which bound is which, and the argument order flips between the inner and outer call. `clamp(ACR20, 0.01, 0.99)` says it directly. It is also the name Rust uses (`f64::clamp`) and the name the parser already uses internally (`v.clamp(1e-15, 1.0 - 1e-15)` inside the `logit` evaluator), so it is already the house idiom.

The motivating case is the MBMA book's Case Study 2 chapter, which guards the logit transform of an ACR20 rate this way in three places.

There is also a trap worth closing while here. An unrecognised one-argument function name was **not** an error: `parse_atom` turned any `name(arg)` into `Expression::UnaryFn(name, arg)`, and every consumer falls through to identity for a name it does not know — `eval_expr` (`_ => v`), the bytecode compiler (leaves the argument on the stack), `differentiate_with_chain` (returns `da`). So `clamp(x)` — a plausible typo while reaching for this feature — silently became a no-op that fits, converges and gives wrong numbers.

## What changed

**Desugared at the parse site**, exactly as the two-argument `min` / `max` from #1030 are, rather than adding a three-argument AST node:

```
clamp(x, lo, hi)  →  if (x <= lo) lo else if (x >= hi) hi else x
```

`Expression::Conditional` is already evaluated, bytecode-compiled, `Dual2`-differentiated and index-resolved throughout the pipeline, so `clamp` inherits all of it and cannot drift from the nested form it replaces. It works in every expression the DSL parses — `[individual_parameters]`, `[scaling]`, `[odes]`, `[derived]`.

Two details the issue asked to decide rather than inherit:

1. **Argument duplication.** `x` lands in the tree three times, `lo` and `hi` twice each — one copy of `x` fewer than the nested `min(max(...))` it replaces. Same advice as `min`/`max`: clamp a *named* value, not a long expression. Restated in the docs, where the "eight copies" figure for the nested form already lives.
2. **`lo > hi`.** The desugaring would return `lo` for every `x`, silently. With **both bounds literal** that can only be a typo, so it is a parse error. Bounds that are not both literals are left to run — a runtime ordering test would be paid on every evaluation of every clamp.

**Arity diagnostics** are kept honest rather than falling through to `UnaryFn`:

- `clamp` with one, two or four arguments → hard error naming `clamp(x, lo, hi)`.
- A third argument to `min` / `max` now points at `clamp` rather than reporting a missing `)`.
- The existing one-argument-with-a-comma message now names all three forms.

**`[derived]` disambiguation.** `min` / `max` there also name the row aggregate and are told apart by the second argument (a comparison is a row filter). `clamp` has no aggregate meaning and is not in the aggregate dispatch list, so it parses as a plain expression at statement top level and nested alike. Asserted by a test.

## Alternatives considered

A dedicated three-argument AST node (`Expression::Clamp`) would need adding to the evaluator, the bytecode compiler, `differentiate_with_chain`, the index resolver and the generic `PkNum` VM — five places that can disagree with each other, for a form that is exactly two nested conditionals. Desugaring has no such surface.

A **runtime** `lo > hi` check was rejected: it costs an ordering test on every evaluation of every clamp on the hot path, to catch a mistake that is a typo in a model file.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `pub` API change — this is parser-internal DSL surface.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

`clamp` is new syntax, purely additive. The one behaviour that changes for existing files is that a one-argument `clamp(x)` is now rejected instead of being the silent identity — that was the bug, and any model relying on it was already producing wrong numbers.

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

The comparator here is not NONMEM but the exact form `clamp` replaces: `clamp` is *defined* as the nested `min(max(x, lo), hi)`, so the anchor is bit-equality with it, pinned by test rather than by a fit.

```
# clamp_matches_nested_min_max_everywhere
# clamp(X, 0.01, 0.99) vs min(max(X, 0.01), 0.99), bit-for-bit,
# at x = -1, 0, 0.005, 0.01, 0.5, 0.99, 1.0, 2.0  — including *on* both
# bounds, where the branch taken decides which of two equal values is
# returned.  Also checked against Rust's own f64::clamp at each point.
```

Derivatives are checked against central finite differences of the `f64` evaluator in all three regimes (below `lo`, inside, above `hi`) with the probe steps kept clear of the kinks, and the convention *on* the bounds — where FD cannot speak — is pinned exactly: `x <= lo` and `x >= hi` take the bound branch, so ∂/∂x is 0 on both bounds and 1 strictly between them.

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

Parse-time only. The compiled tree is one conditional shallower than the `min(max(...))` it replaces and holds one fewer copy of `x`.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Eight Tier-1 tests in `src/parser/model_parser_tests.rs`:

| Test | Pins |
|---|---|
| `clamp_matches_nested_min_max_everywhere` | bit-equality with `min(max(..))` and with `f64::clamp`, on and around both bounds |
| `clamp_bytecode_matches_ast` | bytecode VM ≡ AST evaluator, literal *and* variable bounds |
| `clamp_dual2_matches_fd_in_every_regime` | `Dual2` value/grad/Hessian vs central FD, all three regimes + a variable lower bound |
| `clamp_derivative_convention_on_the_bounds` | ∂/∂x = 0 on each bound, 1 strictly inside — so a later `<`/`<=` edit fails |
| `test_clamp_in_individual_parameters` | end to end through `parse_full_model` → `pk_param_fn`, both bounds biting |
| `test_clamp_arity_diagnostics` | 1/2/4-argument `clamp` rejected; 3-argument `min` points at `clamp` |
| `test_clamp_rejects_inverted_literal_bounds` | inverted literals rejected; equal bounds legal; non-literal bounds unchecked |
| `parse_derived_clamp_is_unambiguous` | `[derived]` top level ≡ nested, trailing operators honoured |

`cargo test --lib`: 3403 passed, 0 failed.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

Inline below rather than a new `examples/` file — this is one expression form, not a model.

<details>
<summary>Example (if not a standalone file)</summary>

```toml
[individual_parameters]
  # before
  SAT = min(max(ACR20, 0.01), 0.99)
  # after
  SAT = clamp(ACR20, 0.01, 0.99)
```

```
# identical predictions, identical gradients — clamp is defined as the
# nested form, and the tests pin the two bit-for-bit.

# the arity trap that is now an error rather than a silent no-op:
  SAT = clamp(ACR20)
  → `clamp` takes exactly three arguments: `clamp(x, lo, hi)`.

# bounds the wrong way round, which used to return 0.99 for every ACR20:
  SAT = clamp(ACR20, 0.99, 0.01)
  → `clamp(x, 0.99, 0.01)` has its bounds inverted — the lower bound must
    not be above the upper bound.
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

Both pages that describe the two-argument `min` / `max`:

- `docs/model-file/individual-parameters.qmd` — operator table row + the arity/desugaring paragraph.
- `docs/model-file/scaling.qmd` — section retitled, the duplication note extended with `clamp`'s three copies, and the `[derived]` paragraph noting `clamp` has no aggregate spelling.

No new page, so nothing to add to `_quarto.yml`.

## Checklist
- [x] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

`cargo clippy --lib --tests` reports no new findings; the four pre-existing `approximate value of PI` errors in `src/sens/two_cpt_explicit.rs` (test fixtures using `3.14` as a parameter value) are untouched by this PR.

Nothing in `sens/` or `pk/` is edited. The desugared tree is `Expression::Conditional`, which the generic `PkNum` VM already handles — `clamp_dual2_matches_fd_in_every_regime` and `clamp_derivative_convention_on_the_bounds` exercise that path directly.

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

This is new DSL syntax, so a ferx-site `model-dsl/` follow-up is warranted — flagged under Open questions rather than claimed here.

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

The MBMA book's Case Study 2 chapter is the motivating caller (three occurrences of the nested form) and can be simplified once this lands. Not blocking — the nested form stays correct.

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly
- [ ] All affected ferx-book chapters render cleanly
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

No `examples/*.ferx` uses `clamp` — the syntax is new, and nothing existing changes meaning.

## Reviewer hints

Focus on `src/parser/model_parser.rs` in `parse_atom`, the `(is_min_max || is_clamp)` branch. Two things are subtle:

- **Branch order and the `<=` / `>=` choice.** `x <= lo` is tested first, so with `lo == hi` the lower bound wins, and on either bound the *bound* is returned rather than `x`. Numerically identical either way, but it fixes which side of the kink the derivative comes from — `clamp_derivative_convention_on_the_bounds` pins it.
- **The clone pattern.** `arg` appears three times in the tree, so two clones and one move; `arg2` / `arg3` twice each. Worth a glance that no clone was dropped, since a missed one would be a borrow error rather than a wrong tree.

The rest — tests, docs, changelog — can be skimmed.

## Open questions

Should the inverted-bounds check extend to a *partially* literal case, e.g. `clamp(x, 1.0, SOME_THETA)` where the θ's upper init is below `1.0`? It is checkable at parse time from the bounds declaration, but it reaches into `[parameters]` from the expression parser and would fire on models that are fine at the initial estimate. Left out deliberately; happy to add it if you'd rather be strict.
