### PR TITLE
docs: document packed parameter space and uncertainty draws

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -91,6 +91,7 @@ website:
           - estimation/frem.qmd
           - estimation/impmap.qmd
           - estimation/bayes.qmd
+          - estimation/parameterization.qmd
           - estimation/optimizers.qmd
           - estimation/tte.qmd
           - estimation/categorical.qmd

--- a/docs/api/simulation.qmd
+++ b/docs/api/simulation.qmd
@@ -344,9 +344,10 @@ parameter draws:
 1. **Outer loop** — for each of `n_uncertainty_draws`, draw a population
    parameter set $(\theta_k, \Omega_k, \Sigma_k)$ from the uncertainty
    distribution.
-   - **Asymptotic**: $x_k = \hat{x} + L_\text{cov} z$ in packed log-space
-     (theta, Cholesky-omega, sigma share one packed vector), then unpack —
-     theta, Omega, and Sigma are perturbed coherently from a single MVN draw.
+   - **Asymptotic**: $x_k = \hat{x} + L_\text{cov} z$ in
+     [packed log-space](../estimation/parameterization.qmd) (theta,
+     Cholesky-omega, sigma share one packed vector), then unpack — theta,
+     Omega, and Sigma are perturbed coherently from a single MVN draw.
    - **SIR**: pick a parameter vector at random from
      `FitResult.sir_resamples_packed` (the resampled pool retained from the
      SIR step).
@@ -363,3 +364,55 @@ The resulting `SimulationResult` rows are tagged with both `draw` and `sim`
 so downstream code can compute either marginal bands (over all draws and
 sims) or hierarchical bands (e.g. median across sims within each draw, then
 percentiles across draws).
+
+## What the uncertainty distribution is {#uncertainty-distribution}
+
+**There is no inverse-Wishart draw here.** Ω uncertainty is *not* sampled
+from a conjugate matrix distribution; the inverse-Wishart in ferx belongs to
+the [Bayesian MCMC estimator](../estimation/bayes.qmd), which is a separate
+code path (`estimation/bayes.rs`) and is not used by
+`simulate_with_uncertainty()`.
+
+What actually happens, for `UncertaintyMethod::Asymptotic`:
+
+- The proposal is a plain multivariate normal, and it lives in the
+  [**packed parameter space**](../estimation/parameterization.qmd) — theta
+  (log), the Omega Cholesky factor (log-diagonal), and sigma (log) in one
+  vector. `FitResult.covariance_matrix` is the inverse FD Hessian of the OFV
+  *in that same space*, so it is the natural — and the only dimensionally
+  consistent — place to draw. Its off-diagonal blocks are what makes each
+  draw's θ, Ω and Σ move together instead of independently.
+- Because the Omega segment is $\log L_{ii}$, the implied marginal on an
+  Omega diagonal is roughly **log-normal on the standard-deviation scale**,
+  and every draw yields a positive-definite Ω by construction — no rejection
+  of non-PD matrices needed. Off-diagonal Cholesky entries are drawn on the
+  identity scale.
+- If `covariance_matrix` is not positive-definite, it is symmetrised and
+  eigenvalue-floored before the Cholesky (`regularised_cholesky`). A draw
+  from the regularised factor is slightly wider than the raw covariance in
+  the corrected directions.
+- **FIX'd parameters carry no uncertainty**: any packed index flagged FIX is
+  reset to its fitted value on every draw, so a FIX'd theta, omega, sigma or
+  kappa is identical across all draws. (`compute_bounds()` pins fixed indices
+  with `lower == upper`, so an unpinned continuous draw would otherwise be
+  rejected for every model with a FIX.)
+- A draw that lands outside the packed bounds, or that unpacks to a
+  non-positive theta / sigma / Omega diagonal, is discarded and redrawn, up
+  to `10 × n_uncertainty_draws` attempts in total; exhausting that budget is
+  an `Err`, and usually means an ill-conditioned covariance matrix or an
+  estimate sitting on a bound.
+- If a *valid* draw then fails during simulation (e.g. the drawn parameters
+  make the ODE solver fail), that single draw is skipped with a
+  `uncertainty draw k skipped — …` warning rather than aborting the whole
+  run, so the returned set may contain fewer than `n_uncertainty_draws`
+  distinct draws.
+
+`UncertaintyMethod::Sir` makes none of these distributional assumptions: it
+resamples whole parameter vectors from the SIR pool, so its shape is whatever
+the [SIR](../estimation/sir.qmd) step found. Prefer it when the asymptotic
+normal approximation is suspect (parameters near a bound, a banana-shaped
+likelihood) — at the cost of running SIR with `sir_keep_samples = true` at
+fit time.
+
+Bootstrap (subject resampling + refit) is not implemented; the
+`UncertaintyMethod` enum is deliberately open for it.

--- a/docs/estimation/index.qmd
+++ b/docs/estimation/index.qmd
@@ -24,6 +24,15 @@ These chain after a primary method via `methods = [...]` and refine the result r
 
 - **[SIR](sir.qmd)** — Sampling Importance Resampling. Provides non-parametric 95% CIs for all parameters, more robust than the asymptotic covariance matrix. Appended automatically when `sir = true` in `[fit_options]`.
 
+## Parameterization
+
+All of these methods optimize the same **[packed parameter
+vector](parameterization.qmd)** — theta on the log (or identity) scale, Omega
+by its Cholesky factor, sigma on the log scale, in one flat vector. That page
+documents the layout, the bounds, how FIX is enforced, and where the packed
+space shows up in output (the covariance matrix, SIR resamples, uncertainty
+draws).
+
 ## Outer optimizers
 
 The outer loop optimizer is selected independently of the method. See **[Outer Optimizers](optimizers.qmd)** for a full comparison of BOBYQA, SLSQP, trust-region, BFGS, and the others. Short version: keep the default (`auto`, which picks `nlopt_lbfgs` for analytic-gradient models and the derivative-free `bobyqa` for ODE/PD models and sparse data); name a specific optimizer only to override that choice.

--- a/docs/estimation/parameterization.qmd
+++ b/docs/estimation/parameterization.qmd
@@ -1,0 +1,122 @@
+# Packed Parameter Space
+
+Every optimizer, the covariance step, SIR, and simulation-with-uncertainty
+work on a single flat `Vec<f64>` — the **packed parameter vector** — rather
+than on the model's natural $(\theta, \Omega, \Sigma)$ values. This page is
+the canonical description of that vector: its layout, its bounds, and the
+consequences of living in it.
+
+The packing and unpacking live in `estimation/parameterization.rs`
+(`pack_params` / `unpack_params`); they are exact inverses.
+
+## Why transform at all
+
+The natural parameters are constrained: $\theta$ and $\Sigma$ are (usually)
+positive, and $\Omega$ must be symmetric positive-definite. General-purpose
+optimizers want an unconstrained (or box-constrained) real vector. Packing
+maps the constrained parameters onto one such vector, so the constraints hold
+**by construction** on unpacking rather than by rejection:
+
+- a log-packed value can only unpack to a positive number;
+- $\Omega$ is stored by its lower Cholesky factor $L$ and rebuilt as
+  $\Omega = L L^\top$, which is positive semi-definite for any $L$, and
+  positive-definite whenever the diagonal is non-zero — which log-packing the
+  diagonal guarantees.
+
+## Layout
+
+The vector is built in fixed segment order. Later segments are appended, so
+adding IOV or mixture parameters never shifts an existing index.
+
+| Segment | Packed as | Notes |
+|---|---|---|
+| Theta | $\log \theta_i$ when `theta_lower` $\ge 0$; $\theta_i$ itself otherwise | See [Theta: log vs identity](#theta-log-vs-identity) |
+| Omega (BSV) | $\log L_{ii}$ on the diagonal, raw $L_{ij}$ off-diagonal | $\Omega = L L^\top$; a diagonal Ω packs only the diagonal entries |
+| Sigma | $\log \sigma_k$ | |
+| Omega (IOV) | same as BSV Omega | Only when the model has an `[iov]` block |
+| Mixture overrides | $\log$ of the class Cholesky diagonal / $\log$ class $\sigma$ | Only per-class Ω/Σ overrides are packed (#977) |
+
+For a two-eta diagonal model with two thetas and one sigma:
+
+$$
+x = \bigl[\log \theta_1,\ \log \theta_2,\ \log L_{11},\ \log L_{22},\ \log \sigma_1\bigr]
+$$
+
+and for a `block_omega` on the same two etas the Omega segment becomes
+$\bigl[\log L_{11},\ L_{21},\ \log L_{22}\bigr]$ — the off-diagonal is packed
+untransformed, because it is genuinely sign-free.
+
+Note the Omega diagonal is $\log L_{ii}$, i.e. the log of a **standard
+deviation**, not of the variance: $\omega^2_{ii} = \exp(2 x_{ii})$ for a
+diagonal Ω.
+
+### Theta: log vs identity {#theta-log-vs-identity}
+
+A theta is log-packed when its declared lower bound is $\ge 0$ — the usual
+case for CL, V, KA. A **negative** lower bound is the opt-in to identity
+packing, for parameters that must be able to be negative: covariate exponents
+(`(DOSE/100)^γ`, $\gamma \in [-3, 3]$), additive covariate effects, logit-scale
+parameters, and neural-network weights. Log-packing those would clamp them at
+`1e-10` and the optimizer could never reach the true value.
+
+`theta_lower = 0` still log-packs (the `max(1e-10)` floor handles the
+boundary), so declaring a lower bound of exactly zero does not silently change
+the parameterization.
+
+## Bounds
+
+`compute_bounds()` returns a box in packed space:
+
+| Segment | Lower | Upper |
+|---|---|---|
+| Theta (log-packed) | $\log$ `theta_lower` | $\log$ `theta_upper` |
+| Theta (identity-packed) | `theta_lower` | `theta_upper` |
+| Omega / Omega-IOV diagonal | $-6$ | $6$ ($L_{ii} \le e^6 \approx 403$, variance $\approx 1.6\times10^5$ — wide enough for FREM covariate omegas) |
+| Omega / Omega-IOV off-diagonal | $-10$ | $10$ |
+| Sigma | $-8$ ($\approx 3\times10^{-4}$) | $5$ ($\approx 148$) |
+
+**FIX'd parameters are pinned by setting `lower == upper == packed value`.**
+That is how every bound-respecting optimizer (NLopt SLSQP / L-BFGS / MMA, the
+built-in BFGS, the Gauss-Newton step clamp) holds them fixed — there is no
+separate free-subspace vector.
+
+## Where the packed space surfaces
+
+It is not purely internal; it shows up in several user-visible places.
+
+- **Covariance matrix.** `FitResult.covariance_matrix` — and the
+  `covariance_matrix:` block in the fit YAML — is the inverse FD Hessian of
+  the OFV **with respect to the packed vector**, not with respect to
+  $(\theta, \Omega, \Sigma)$. Its `parameters:` list names the packed
+  coordinates: `log_chol_<eta>` for an Omega diagonal, `chol_<i>_<j>` for an
+  off-diagonal. Reported standard errors on the natural scale are obtained
+  from it by the delta method. See [Output Files](../output.qmd).
+- **SIR.** The proposal, the resamples, and the retained
+  `sir_resamples_packed` pool are all in packed space; SIR's bound-collapse
+  diagnostics are phrased in it too. See [SIR](sir.qmd).
+- **Simulation with uncertainty.** Asymptotic draws are MVN **in packed
+  space**, which is what keeps every draw a valid parameter set. See
+  [Simulation](../api/simulation.qmd#uncertainty-distribution).
+- **Parameter scaling.** `parameter_scaling` / `scale_params` rescale packed
+  coordinates, which is why dividing by $|\log V|$ is a poor idea — see
+  [Fit Options](../model-file/fit-options.qmd).
+- **Multi-start.** `start_sigma` perturbs log-packed thetas multiplicatively
+  (`× exp(N(0, start_sigma))`) and identity-packed thetas additively.
+- **Gradients.** The analytic outer gradient is assembled directly in packed
+  coordinates (including the $\times L_{ii}$ chain factor on the log-Cholesky
+  diagonal), which is what analytic-vs-finite-difference parity tests compare.
+
+## Consequences worth knowing
+
+- A symmetric Gaussian step in packed space is **asymmetric** on the natural
+  scale: log-normal for theta, sigma, and the Omega Cholesky diagonal. Uphill
+  moves are wider than downhill ones, and no draw or step can produce a
+  non-positive value.
+- $\Omega$ never has to be checked for positive-definiteness after an
+  optimizer step or an uncertainty draw. It is PD by construction.
+- The number of packed Omega entries depends on the declared structure: a
+  diagonal Ω contributes $n_\eta$ entries, a full block contributes
+  $n_\eta(n_\eta+1)/2$. Structurally-zero off-diagonals are not parameters.
+- Two fits with the same OFV surface but different packing (e.g. a theta
+  re-declared with a negative lower bound) will follow different optimizer
+  trajectories, even though the optimum itself is unchanged.

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -220,7 +220,8 @@ the canonical column order; `rows:` keys match that order. Omega and kappa
 diagonal entries appear as `log_chol_<eta>` — the packed value is `log(L_ii)`
 where `omega = L Lᵀ` (log of the Cholesky diagonal, **not** the variance).
 Off-diagonal Cholesky entries appear as `chol_<eta_row>_<eta_col>` (`L_ij`,
-not log-transformed).
+not log-transformed). See [Packed Parameter
+Space](estimation/parameterization.qmd) for the full layout and bounds.
 
 ### Key Fields
 


### PR DESCRIPTION
## Why

Two questions came up that the docs could not answer directly.

Also undocumented: the asymptotic covariance is expressed *in* packed space (so that is where the draw must happen), FIX'd parameters are pinned to their fitted value and carry no uncertainty, and a draw that fails during simulation is skipped with a warning rather than aborting the run.

## What changed

**New page `docs/estimation/parameterization.qmd`** — canonical description of the packed parameter vector:

- why the transform exists (constraints hold by construction on unpacking);
- the segment layout table (theta, BSV omega Cholesky, sigma, IOV omega, mixture overrides), with the fixed append order that keeps existing indices stable;
- log vs identity theta packing and the `theta_lower < 0` opt-in rule;
- the bounds table, and how FIX is enforced via `lower == upper`;
- where the packed space surfaces for users: the fit-YAML `covariance_matrix:` block, SIR resamples, uncertainty draws, `parameter_scaling`, `start_sigma`, analytic gradients;
- consequences (asymmetric-on-the-natural-scale steps, Ω PD by construction, entry counts for diagonal vs block Ω).

Linked from `docs/_quarto.yml` (Estimation section, before `optimizers.qmd`), `docs/estimation/index.qmd`, `docs/output.qmd`, and `docs/api/simulation.qmd`.

**New section in `docs/api/simulation.qmd`** — "What the uncertainty distribution is" (`#uncertainty-distribution`): states up front that there is no inverse-Wishart draw, then documents the MVN-in-packed-space proposal, the roughly log-normal marginal on the Ω Cholesky diagonal, `regularised_cholesky` widening a non-PD covariance, FIX'd parameters pinned, bounds-rejection resampling with the `10 × n_uncertainty_draws` budget, the `uncertainty draw k skipped — …` warning path, when to prefer SIR instead, and that bootstrap is not implemented.

No source changes.

## Alternatives considered

Folding the packed-space description into `docs/estimation/foce.qmd` (which already has a three-bullet summary). Rejected: the packed vector is shared by every estimator, SIR, the covariance step, and the simulation path, so burying it under FOCE would leave the same discoverability problem. `foce.qmd`'s existing bullets stay as the short form.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: docs-only change, no source touched)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI) — N/A: documentation only, no behaviour change
- [ ] No user-visible change

## Checklist
- [x] `cargo clippy` clean — no source changed
- [x] Functions on the `Dual2` sensitivity path stay differentiable — no source changed
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site
- [x] New `.ferx` DSL syntax or `[fit_options]` key → N/A, no new syntax or option
- [x] New example `.ferx` file → N/A
- [x] New data file → N/A

### ferx-book
- [ ] New estimator, DSL feature, or fit option → N/A, no new feature. The book may eventually want to reference the new parameterization page, but nothing there is stale as a result of this PR.

### Example execution
- [x] No example execution step needed (docs-only / no user-visible change)

Both touched pages were rendered locally to check syntax (`quarto render docs/estimation/parameterization.qmd`, `quarto render docs/api/simulation.qmd`); the rendered output was deleted and is not committed.

## Reviewer hints

Worth checking for accuracy rather than prose:

- the bounds table in `parameterization.qmd` against `compute_bounds()` in `src/estimation/parameterization.rs` (omega diagonal `[-6, 6]`, off-diagonal `[-10, 10]`, sigma `[-8, 5]`);
- the claim that the Ω diagonal is `log(L_ii)` — the log of an SD, not a variance — against `pack_params`;
- the mixture-override row (only overridden class entries are packed, appended after the IOV segment);
- in `simulation.qmd`, the skipped-draw behaviour against `src/api/simulate.rs:1068-1074`.

## Open questions

Should `docs/warnings.qmd` also list the `uncertainty draw k skipped` message? It is a plain `Vec<String>` simulation warning, not a typed `WarningCode`, and that page is specifically about the structured channel — so it is documented in `simulation.qmd` instead. Happy to move or duplicate it if you'd rather that page be the single index of all warning text.
