### PR TITLE
feat(api): retain block_sigma correlations in FitResult [closes #1100]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ section of the SDLC for the versioning policy).
 ### Added
 - **Correlated-residual fits now retain their fixed `block_sigma` correlations (#1100).**
   `FitResult.residual_correlations`, JSON, `.fitrx`, and fit YAML now carry the declared
-  correlations, so consumers can reconstruct the fitted residual covariance without re-reading
-  the model source; diagonal-sigma output remains unchanged.
+  correlations, so consumers can reconstruct the sigma-scale residual covariance without re-reading
+  the model source; diagonal-sigma output remains unchanged. The fit YAML's `block_sigma` section
+  reports `correlation_fixed` (always true) separately from `covariance_fixed`, which is true only
+  when both sigma SDs were declared `FIX`.
 - **Theta level blocks — hundreds of fixed effects from one declaration (#1064).**
   `theta PLACEBO[800](0.0, -10.0, 10.0)` declares 800 thetas sharing one init/bounds triple, read back
   by a *gather* — `PL = PLACEBO[PLA_IDX]`, where `PLA_IDX` is a 1-based data column. The data-driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **Correlated-residual fits now retain their fixed `block_sigma` correlations (#1100).**
+  `FitResult.residual_correlations`, JSON, `.fitrx`, and fit YAML now carry the declared
+  correlations, so consumers can reconstruct the fitted residual covariance without re-reading
+  the model source; diagonal-sigma output remains unchanged.
 - **Theta level blocks — hundreds of fixed effects from one declaration (#1064).**
   `theta PLACEBO[800](0.0, -10.0, 10.0)` declares 800 thetas sharing one init/bounds triple, read back
   by a *gather* — `PL = PLACEBO[PLA_IDX]`, where `PLA_IDX` is a 1-based data column. The data-driven

--- a/docs/api/types.qmd
+++ b/docs/api/types.qmd
@@ -147,9 +147,18 @@ pub struct FitResult {
 
 For a model declared with `block_sigma`, `residual_correlations` contains the
 fixed off-diagonal correlations used by the fit. Together with the fitted
-sigma SDs, each residual covariance is reconstructible as
-`rho * sigma[sigma_i] * sigma[sigma_j]`. The field is empty for diagonal
+sigma SDs they reconstruct the **sigma-scale** covariance
+`Cov(EPS_i, EPS_j) = rho * sigma[sigma_i] * sigma[sigma_j]` — the same quantity
+NONMEM reports in a `$SIGMA BLOCK`. The field is empty for diagonal
 residual-error models.
+
+Note that this is *not* the entry of a subject's residual covariance matrix
+`R`. Each observation applies its own sigma *loadings* first, so the `R` term
+pairing observations `j` and `k` is `c_j * c_k * rho * sigma_i * sigma_j`,
+where `c` is `1` for an additive component and the individual prediction `f`
+for a proportional one. A consumer rebuilding `R` for, say, a paired
+total/unbound model must include the `f_total * f_unbound` factor; see
+[Error models](../model-file/error-model.qmd) for the full formula.
 
 ## SubjectResult
 

--- a/docs/api/types.qmd
+++ b/docs/api/types.qmd
@@ -129,6 +129,8 @@ pub struct FitResult {
     pub theta_names: Vec<String>,
     pub omega: DMatrix<f64>,
     pub sigma: Vec<f64>,
+    pub sigma_names: Vec<String>,
+    pub residual_correlations: Vec<ResidualCorrelation>,
     pub covariance_matrix: Option<DMatrix<f64>>,
     pub se_theta: Option<Vec<f64>>,
     pub se_omega: Option<Vec<f64>>,
@@ -142,6 +144,12 @@ pub struct FitResult {
     pub warnings: Vec<String>,
 }
 ```
+
+For a model declared with `block_sigma`, `residual_correlations` contains the
+fixed off-diagonal correlations used by the fit. Together with the fitted
+sigma SDs, each residual covariance is reconstructible as
+`rho * sigma[sigma_i] * sigma[sigma_j]`. The field is empty for diagonal
+residual-error models.
 
 ## SubjectResult
 

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -701,7 +701,27 @@ identical exclusion in the likelihood) and stay independent.
 The fixed correlations are copied to `FitResult.residual_correlations`, so the
 residual covariance assumed by a fit remains available without re-reading the
 model source. The human-readable fit YAML also emits a `block_sigma` section
-with each named pair's fitted covariance and declared correlation.
+with each named pair's covariance and declared correlation:
+
+```yaml
+block_sigma:
+  ADD_ERR__PROP_ERR:
+    covariance: 0.100000
+    covariance_fixed: false
+    correlation: 0.500000
+    correlation_fixed: true
+```
+
+`covariance` is the **sigma-scale** covariance `rho * sigma_i * sigma_j`, the
+same quantity NONMEM prints for a `$SIGMA BLOCK` — not an entry of a subject's
+residual covariance matrix `R`. Each observation applies its own sigma loadings
+first, so the `R` term is `c_j * c_k * rho * sigma_i * sigma_j` with `c = 1`
+for an additive component and `c = f` (the individual prediction) for a
+proportional one — the `f_total * f_unbound * Cov(EPS_total, EPS_unbound)` form
+above. `correlation_fixed` is always `true` (the off-diagonal is converted to a
+fixed correlation); `covariance_fixed` is `true` only when both sigma SDs in
+the pair were declared `FIX`, since otherwise the SDs — and hence the
+covariance — moved during estimation.
 
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -691,12 +691,17 @@ include the process-noise inflation.
 `simulate()` draws the full residual vector for each subject's paired
 observations (same subject time and occasion) from the dense covariance `R`
 built by `compute_r_matrix_with_correlations` — the same matrix FOCE/FOCEI/SAEM/
-`imp` evaluate the likelihood against — so a fitted or fixed `block_sigma`
+`imp` evaluate the likelihood against — so a fixed `block_sigma`
 off-diagonal is reproduced in simulated total/unbound (or cross-branch, for a
 covariate-selected model) rows, and a VPC or posterior-predictive check of the
 correlated endpoints recovers the specified correlation (#672). FREM covariate
 pseudo-observations are excluded from the correlated draw (mirroring the
 identical exclusion in the likelihood) and stay independent.
+
+The fixed correlations are copied to `FitResult.residual_correlations`, so the
+residual covariance assumed by a fit remains available without re-reading the
+model source. The human-readable fit YAML also emits a `block_sigma` section
+with each named pair's fitted covariance and declared correlation.
 
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -2132,6 +2132,7 @@ fn fit_inner(
         omega: result.params.omega.matrix.clone(),
         sigma: result.params.sigma.values.clone(),
         sigma_names: result.params.sigma.names.clone(),
+        residual_correlations: model.residual_correlations.clone(),
         error_model: model.error_model,
         covariance_matrix: result.covariance_matrix,
         // The optimizer's exact packed vector (FOCE/FOCEI paths), so a later

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -401,6 +401,7 @@ fn synthetic_fit(template: &ModelParameters) -> FitResult {
         omega: template.omega.matrix.clone(),
         sigma: template.sigma.values.clone(),
         sigma_names: template.sigma.names.clone(),
+        residual_correlations: Vec::new(),
         error_model: ErrorModel::Proportional,
         covariance_matrix: Some(cov),
         se_theta: None,

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -345,6 +345,7 @@ mod tests {
             omega: template.omega.matrix.clone(),
             sigma: template.sigma.values.clone(),
             sigma_names: template.sigma.names.clone(),
+            residual_correlations: Vec::new(),
             error_model: ErrorModel::Proportional,
             covariance_matrix: Some(cov),
             se_theta: None,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1619,6 +1619,7 @@ fn validate_parallel_lengths(w: &FitWire) -> Result<(), FitrxError> {
             n_sigma
         ));
     }
+    let mut seen_corr_pairs = std::collections::HashSet::new();
     for corr in &w.sigma.residual_correlations {
         if corr.sigma_i >= n_sigma || corr.sigma_j >= n_sigma {
             return bail(format!(
@@ -1626,10 +1627,26 @@ fn validate_parallel_lengths(w: &FitWire) -> Result<(), FitrxError> {
                 corr.sigma_i, corr.sigma_j, n_sigma
             ));
         }
-        if corr.sigma_i == corr.sigma_j || !corr.rho.is_finite() || corr.rho.abs() > 1.0 {
+        // `|rho| == 1` is rejected alongside `> 1`: a perfectly correlated pair
+        // makes the subject-level `R` exactly singular, which would otherwise
+        // surface as a NaN/Inf OFV on the next evaluation rather than as a
+        // load-time error.
+        if corr.sigma_i == corr.sigma_j || !corr.rho.is_finite() || corr.rho.abs() >= 1.0 {
             return bail(format!(
                 "invalid sigma residual correlation ({}, {}, rho={})",
                 corr.sigma_i, corr.sigma_j, corr.rho
+            ));
+        }
+        // A repeated (i, j) pair would double-count the cross term in
+        // `cross_observation_covariance` and emit duplicate YAML keys.
+        let pair = (
+            corr.sigma_i.min(corr.sigma_j),
+            corr.sigma_i.max(corr.sigma_j),
+        );
+        if !seen_corr_pairs.insert(pair) {
+            return bail(format!(
+                "duplicate sigma residual correlation for pair ({}, {})",
+                pair.0, pair.1
             ));
         }
     }
@@ -2242,10 +2259,56 @@ mod tests {
                 sigma_j: 0,
                 rho: 1.5,
             },
+            // |rho| == 1 is singular, not merely extreme: reject it too.
+            crate::types::ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: 1.0,
+            },
+            crate::types::ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: -1.0,
+            },
+            crate::types::ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: f64::NAN,
+            },
         ] {
             wire.sigma.residual_correlations = vec![invalid];
-            assert!(validate_parallel_lengths(&wire).is_err());
+            assert!(
+                validate_parallel_lengths(&wire).is_err(),
+                "accepted invalid correlation: {invalid:?}"
+            );
         }
+
+        // The same (i, j) pair twice would double-count the cross term.
+        wire.sigma.residual_correlations = vec![
+            crate::types::ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: 0.5,
+            },
+            crate::types::ResidualCorrelation {
+                sigma_i: 0,
+                sigma_j: 1,
+                rho: 0.25,
+            },
+        ];
+        let err = validate_parallel_lengths(&wire).unwrap_err();
+        assert!(
+            format!("{err}").contains("duplicate sigma residual correlation"),
+            "got: {err}"
+        );
+
+        // A well-formed single pair still loads.
+        wire.sigma.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        assert!(validate_parallel_lengths(&wire).is_ok());
     }
 
     #[test]

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -235,6 +235,10 @@ struct SigmaWire {
     /// for backward compatibility with .fitrx files from before issue #5.
     #[serde(default)]
     init_as_sd: Vec<bool>,
+    /// Fixed `block_sigma` correlations. Absent in bundles written before
+    /// issue #1100 and omitted for the common diagonal-sigma case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    residual_correlations: Vec<crate::types::ResidualCorrelation>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -601,6 +605,7 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
                 .map(|t| sigma_type_to_str(*t).into())
                 .collect(),
             init_as_sd: r.sigma_init_as_sd.clone(),
+            residual_correlations: r.residual_correlations.clone(),
         },
         error_model: error_model_to_str(r.error_model).into(),
         shrinkage_eps: r.shrinkage_eps,
@@ -1614,6 +1619,20 @@ fn validate_parallel_lengths(w: &FitWire) -> Result<(), FitrxError> {
             n_sigma
         ));
     }
+    for corr in &w.sigma.residual_correlations {
+        if corr.sigma_i >= n_sigma || corr.sigma_j >= n_sigma {
+            return bail(format!(
+                "sigma residual correlation index ({}, {}) is out of bounds for {} sigmas",
+                corr.sigma_i, corr.sigma_j, n_sigma
+            ));
+        }
+        if corr.sigma_i == corr.sigma_j || !corr.rho.is_finite() || corr.rho.abs() > 1.0 {
+            return bail(format!(
+                "invalid sigma residual correlation ({}, {}, rho={})",
+                corr.sigma_i, corr.sigma_j, corr.rho
+            ));
+        }
+    }
     // IOV init_as_sd: same backward-compat rule as omega/sigma. Only validate
     // when an `iov` section is present (otherwise there's no n_kappa to match
     // against).
@@ -1779,6 +1798,7 @@ fn wire_to_fit_result(
         omega,
         sigma: w.sigma.estimates,
         sigma_names: w.sigma.names,
+        residual_correlations: w.sigma.residual_correlations,
         error_model: error_model_from_str(&w.error_model)?,
         covariance_matrix,
         se_theta: w.theta.se,
@@ -2028,6 +2048,7 @@ mod tests {
             omega: DMatrix::from_row_slice(2, 2, &[0.1, 0.0, 0.0, 0.2]),
             sigma: vec![0.05],
             sigma_names: vec!["prop".into()],
+            residual_correlations: Vec::new(),
             error_model: ErrorModel::Proportional,
             covariance_matrix: Some(DMatrix::<f64>::identity(3, 3)),
             se_theta: Some(vec![0.01, 0.02, 0.005]),
@@ -2161,11 +2182,70 @@ mod tests {
         assert_eq!(v1["omega"]["cols"], 2);
         assert_eq!(v1["omega"]["data"], serde_json::json!([0.1, 0.0, 0.0, 0.2]));
         assert_eq!(v1["subjects"][0]["eta"].as_array().unwrap().len(), 2);
+        assert!(
+            v1.get("residual_correlations").is_none(),
+            "diagonal-sigma JSON must remain byte-compatible"
+        );
 
         // Round-trip: unknown `schema_version` is ignored on the way back in.
         let back: FitResult = serde_json::from_value(v1.clone()).unwrap();
         let v2 = back.to_json_value();
         assert_eq!(v1, v2, "JSON round-trip is not idempotent (lossy field?)");
+    }
+
+    #[test]
+    fn json_result_includes_residual_correlations() {
+        let mut fit = minimal_fit_result();
+        fit.sigma.push(1.0);
+        fit.sigma_names.push("add".into());
+        fit.sigma_fixed.push(false);
+        fit.sigma_types.push(SigmaType::Additive);
+        fit.sigma_init_as_sd.push(false);
+        fit.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+
+        let value = fit.to_json_value();
+        assert_eq!(
+            value["residual_correlations"],
+            serde_json::json!([{"sigma_i": 1, "sigma_j": 0, "rho": 0.5}])
+        );
+        let restored: FitResult = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.residual_correlations, fit.residual_correlations);
+    }
+
+    #[test]
+    fn fitrx_rejects_invalid_residual_correlations() {
+        let mut fit = minimal_fit_result();
+        fit.sigma.push(1.0);
+        fit.sigma_names.push("add".into());
+        fit.sigma_fixed.push(false);
+        fit.sigma_types.push(SigmaType::Additive);
+        fit.sigma_init_as_sd.push(false);
+        let mut wire = build_fit_wire(&fit);
+
+        for invalid in [
+            crate::types::ResidualCorrelation {
+                sigma_i: 0,
+                sigma_j: 2,
+                rho: 0.5,
+            },
+            crate::types::ResidualCorrelation {
+                sigma_i: 0,
+                sigma_j: 0,
+                rho: 0.5,
+            },
+            crate::types::ResidualCorrelation {
+                sigma_i: 1,
+                sigma_j: 0,
+                rho: 1.5,
+            },
+        ] {
+            wire.sigma.residual_correlations = vec![invalid];
+            assert!(validate_parallel_lengths(&wire).is_err());
+        }
     }
 
     #[test]
@@ -2258,6 +2338,31 @@ mod tests {
         assert_eq!(loaded.model_source, "model source\n");
         assert!(loaded.population.is_none());
         assert_eq!(loaded.manifest.format_version, FORMAT_VERSION);
+    }
+
+    #[test]
+    fn roundtrip_preserves_residual_correlations() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("block-sigma.fitrx");
+        let mut r = minimal_fit_result();
+        r.sigma = vec![0.2, 1.0];
+        r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.sigma_fixed = vec![true, true];
+        r.sigma_init_as_sd = vec![false, false];
+        r.sigma_types = vec![SigmaType::Proportional, SigmaType::Additive];
+        r.sigma_init = r.sigma.clone();
+        r.se_sigma = None;
+        r.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+
+        let p = dummy_population(&["S1", "S2"], 3);
+        save_fit(&r, &p, "model source\n", &path, SaveFitOptions::default()).unwrap();
+
+        let loaded = load_fit(&path).unwrap();
+        assert_eq!(loaded.fit.residual_correlations, r.residual_correlations);
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2116,6 +2116,41 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
         }
     }
 
+    if !result.residual_correlations.is_empty() {
+        writeln!(f, "\nblock_sigma:").map_err(|e| e.to_string())?;
+        for corr in &result.residual_correlations {
+            let name_i = result.sigma_names.get(corr.sigma_i).ok_or_else(|| {
+                format!(
+                    "residual correlation sigma_i index {} is out of bounds",
+                    corr.sigma_i
+                )
+            })?;
+            let name_j = result.sigma_names.get(corr.sigma_j).ok_or_else(|| {
+                format!(
+                    "residual correlation sigma_j index {} is out of bounds",
+                    corr.sigma_j
+                )
+            })?;
+            let sigma_i = result.sigma.get(corr.sigma_i).ok_or_else(|| {
+                format!(
+                    "residual correlation sigma_i index {} has no estimate",
+                    corr.sigma_i
+                )
+            })?;
+            let sigma_j = result.sigma.get(corr.sigma_j).ok_or_else(|| {
+                format!(
+                    "residual correlation sigma_j index {} has no estimate",
+                    corr.sigma_j
+                )
+            })?;
+            writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
+            writeln!(f, "    covariance: {:.6}", corr.rho * sigma_i * sigma_j)
+                .map_err(|e| e.to_string())?;
+            writeln!(f, "    correlation: {:.6}", corr.rho).map_err(|e| e.to_string())?;
+            writeln!(f, "    fixed: true").map_err(|e| e.to_string())?;
+        }
+    }
+
     // IOV (KAPPA) block
     if let Some(ref iov) = result.omega_iov {
         writeln!(f, "\nomega_iov:").map_err(|e| e.to_string())?;
@@ -2446,6 +2481,7 @@ mod tests {
             omega: DMatrix::zeros(0, 0),
             sigma,
             sigma_names: (0..n).map(|i| format!("EPS_{}", i + 1)).collect(),
+            residual_correlations: Vec::new(),
             error_model,
             covariance_matrix: None,
             se_theta: None,
@@ -3142,6 +3178,7 @@ mod tests {
             omega: DMatrix::zeros(0, 0),
             sigma: vec![0.1],
             sigma_names: vec!["eps".to_string()],
+            residual_correlations: Vec::new(),
             error_model: ErrorModel::Proportional,
             covariance_matrix: None,
             se_theta: None,
@@ -3877,6 +3914,27 @@ mod tests {
             yaml_quote(&r.environment.username)
         )));
         assert!(yaml.contains(&format!("  ferx_version: {}", r.ferx_version)));
+    }
+
+    #[test]
+    fn write_yaml_emits_reconstructible_block_sigma() {
+        let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
+        r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        assert!(yaml.contains("\nblock_sigma:"), "{yaml}");
+        assert!(yaml.contains("  PROP_ERR__ADD_ERR:"), "{yaml}");
+        assert!(yaml.contains("    covariance: 0.100000"), "{yaml}");
+        assert!(yaml.contains("    correlation: 0.500000"), "{yaml}");
+        assert!(yaml.contains("    fixed: true"), "{yaml}");
     }
 
     #[test]

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2143,11 +2143,18 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                     corr.sigma_j
                 )
             })?;
+            // The correlation itself is always fixed by the `block_sigma`
+            // declaration, but the covariance it scales is only fixed when both
+            // sigma SDs were declared `FIX` — a bare `block_sigma (...) = [...]`
+            // estimates the diagonal, so its covariance moves during the fit.
+            let sigma_is_fixed = |i: usize| result.sigma_fixed.get(i).copied().unwrap_or(false);
+            let covariance_fixed = sigma_is_fixed(corr.sigma_i) && sigma_is_fixed(corr.sigma_j);
             writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
             writeln!(f, "    covariance: {:.6}", corr.rho * sigma_i * sigma_j)
                 .map_err(|e| e.to_string())?;
+            writeln!(f, "    covariance_fixed: {}", covariance_fixed).map_err(|e| e.to_string())?;
             writeln!(f, "    correlation: {:.6}", corr.rho).map_err(|e| e.to_string())?;
-            writeln!(f, "    fixed: true").map_err(|e| e.to_string())?;
+            writeln!(f, "    correlation_fixed: true").map_err(|e| e.to_string())?;
         }
     }
 
@@ -3918,11 +3925,17 @@ mod tests {
 
     #[test]
     fn write_yaml_emits_reconstructible_block_sigma() {
+        // Index order mirrors what `build_residual_correlations` actually
+        // emits: `sigma_i` is the block's *row* name and `sigma_j` its
+        // *column* name, so `block_sigma (PROP_ERR, ADD_ERR)` yields (1, 0)
+        // and the key `ADD_ERR__PROP_ERR`. Pinning (0, 1) would assert an
+        // ordering the parser can never produce, hiding an i/j swap.
         let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
         r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.sigma_fixed = vec![false, false];
         r.residual_correlations = vec![crate::types::ResidualCorrelation {
-            sigma_i: 0,
-            sigma_j: 1,
+            sigma_i: 1,
+            sigma_j: 0,
             rho: 0.5,
         }];
         let dir = tempfile::tempdir().expect("tempdir");
@@ -3931,10 +3944,34 @@ mod tests {
         let yaml = std::fs::read_to_string(&path).expect("yaml read");
 
         assert!(yaml.contains("\nblock_sigma:"), "{yaml}");
-        assert!(yaml.contains("  PROP_ERR__ADD_ERR:"), "{yaml}");
+        assert!(yaml.contains("  ADD_ERR__PROP_ERR:"), "{yaml}");
         assert!(yaml.contains("    covariance: 0.100000"), "{yaml}");
         assert!(yaml.contains("    correlation: 0.500000"), "{yaml}");
-        assert!(yaml.contains("    fixed: true"), "{yaml}");
+        // The correlation is fixed by the declaration; the covariance is not,
+        // because neither sigma SD was declared `FIX`.
+        assert!(yaml.contains("    correlation_fixed: true"), "{yaml}");
+        assert!(yaml.contains("    covariance_fixed: false"), "{yaml}");
+    }
+
+    #[test]
+    fn write_yaml_block_sigma_marks_covariance_fixed_when_sigmas_are_fixed() {
+        // `block_sigma (...) = [...] FIX` marks every sigma in the block fixed,
+        // so the covariance those SDs scale is fixed as well.
+        let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
+        r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.sigma_fixed = vec![true, true];
+        r.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        assert!(yaml.contains("    covariance_fixed: true"), "{yaml}");
+        assert!(yaml.contains("    correlation_fixed: true"), "{yaml}");
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -11444,7 +11444,6 @@ struct SigmaSpec {
 struct BlockSigmaSpec {
     names: Vec<String>,
     lower_triangle: Vec<f64>,
-    fixed: bool,
 }
 
 /// Diagonal inter-occasion variability (kappa) specification.
@@ -12732,7 +12731,6 @@ fn parse_parameters(
             block_sigmas.push(BlockSigmaSpec {
                 names,
                 lower_triangle: values,
-                fixed,
             });
         } else if let Some(caps) = block_kappa_re.captures(line) {
             let names: Vec<String> = caps[1].split(',').map(|s| s.trim().to_string()).collect();
@@ -13294,7 +13292,6 @@ fn build_residual_correlations(
                 pos += 1;
             }
         }
-        let _fixed = block.fixed;
     }
     Ok(out)
 }

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13264,10 +13264,18 @@ fn build_residual_correlations(
                             block.names[row], block.names[col]
                         ));
                     }
-                    let rho = value / (vi.sqrt() * vj.sqrt());
-                    if !(rho.is_finite() && (-1.0..=1.0).contains(&rho)) {
+                    // Compare on the covariance scale with a single sqrt:
+                    // `sqrt(vi) * sqrt(vj)` rounds `cov == sqrt(vi·vj)` down to
+                    // rho = 0.999...8, which would slip past a `|rho| < 1` test.
+                    let max_abs_cov = (vi * vj).sqrt();
+                    let rho = value / max_abs_cov;
+                    // `|rho| == 1` is rejected alongside `> 1`: a perfectly
+                    // correlated pair makes the subject-level `R` exactly
+                    // singular, which would otherwise surface as a NaN/Inf OFV
+                    // mid-fit rather than as a parse-time error.
+                    if !(max_abs_cov.is_finite() && value.abs() < max_abs_cov) {
                         return Err(format!(
-                            "block_sigma covariance between '{}' and '{}' implies invalid correlation {}",
+                            "block_sigma covariance between '{}' and '{}' implies invalid correlation {} (must satisfy |rho| < 1)",
                             block.names[row], block.names[col], rho
                         ));
                     }

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -5688,6 +5688,22 @@ fn test_build_residual_correlations_invalid_rho_errs() {
 }
 
 #[test]
+fn test_build_residual_correlations_unit_rho_errs() {
+    // cov 0.04 with both variances 0.04 implies rho = 1 exactly, which makes
+    // the residual covariance matrix singular: reject it at parse time rather
+    // than let it surface as a NaN/Inf OFV mid-fit.
+    for cov in [0.04_f64, -0.04_f64] {
+        let block = BlockSigmaSpec {
+            names: vec!["A".to_string(), "B".to_string()],
+            lower_triangle: vec![0.04, cov, 0.04],
+        };
+        let names = vec!["A".to_string(), "B".to_string()];
+        let err = build_residual_correlations(&[block], &names).unwrap_err();
+        assert!(err.contains("|rho| < 1"), "got: {err}");
+    }
+}
+
+#[test]
 fn test_build_residual_correlations_unknown_name_errs() {
     // Valid covariance, but the block names are absent from `sigma_names`.
     let block = BlockSigmaSpec {

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -5630,10 +5630,9 @@ fn test_parse_block_sigma_builds_sigmas_and_correlation() {
 #[test]
 fn test_parse_block_sigma_fix_marks_sigmas_fixed() {
     let lines = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0] FIX".to_string()];
-    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas.iter().all(|s| s.fixed));
-    assert!(block_sigmas[0].fixed);
 }
 
 #[test]
@@ -5670,7 +5669,6 @@ fn test_build_residual_correlations_zero_diagonal_errs() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.0, 0.1, 1.0],
-        fixed: true,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5683,7 +5681,6 @@ fn test_build_residual_correlations_invalid_rho_errs() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.04, 0.10, 0.04],
-        fixed: true,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5696,7 +5693,6 @@ fn test_build_residual_correlations_unknown_name_errs() {
     let block = BlockSigmaSpec {
         names: vec!["X".to_string(), "Y".to_string()],
         lower_triangle: vec![1.0, 0.5, 1.0],
-        fixed: true,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5709,7 +5705,6 @@ fn test_build_residual_correlations_zero_covariance_omitted() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.04, 0.0, 1.0],
-        fixed: true,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let corrs = build_residual_correlations(&[block], &names).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1456,7 +1456,7 @@ pub struct SigmaVector {
 /// at runtime is `rho * sigma_i * sigma_j`, so the existing positive SD
 /// parameterization remains unchanged while off-diagonal residual covariance is
 /// carried into subject-level R matrices.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ResidualCorrelation {
     pub sigma_i: usize,
     pub sigma_j: usize,
@@ -4932,6 +4932,13 @@ pub struct FitResult {
     pub sigma: Vec<f64>,
     /// Names of the sigma parameters, parallel to `sigma`.
     pub sigma_names: Vec<String>,
+    /// Residual-error correlations in force for this fit, copied from the model.
+    ///
+    /// These correlations are fixed by the `block_sigma` declaration rather
+    /// than estimated. Together with `sigma`, they make the fitted residual
+    /// covariance reconstructible as `rho * sigma[i] * sigma[j]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub residual_correlations: Vec<ResidualCorrelation>,
     /// Residual error model (additive, proportional, combined).
     ///
     /// For multi-endpoint (per-CMT) models this is only the *representative*

--- a/tests/fit_result_residual_correlations.rs
+++ b/tests/fit_result_residual_correlations.rs
@@ -1,0 +1,46 @@
+use ferx_core::parser::model_parser::parse_model_string;
+use ferx_core::{fit, read_nonmem_csv, FitOptions};
+use std::path::Path;
+
+const MODEL: &str = "\
+[parameters]
+  theta TVCL(1.0, 0.01, 10.0)
+  theta TVV(10.0, 0.1, 100.0)
+  omega ETA_CL ~ 0.04
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+[error_model]
+  DV ~ combined(PROP_ERR, ADD_ERR)
+";
+
+#[test]
+fn fit_result_carries_fixed_block_sigma_correlations() {
+    let model = parse_model_string(MODEL).expect("block_sigma model must parse");
+    let population = read_nonmem_csv(
+        Path::new("data/correlated_residual_combined.csv"),
+        None,
+        None,
+    )
+    .expect("correlated residual data must load");
+    let options = FitOptions {
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        verbose: false,
+        ..FitOptions::default()
+    };
+
+    let result = fit(&model, &population, &model.default_params, &options)
+        .expect("initial correlated-residual evaluation must succeed");
+
+    assert_eq!(result.residual_correlations, model.residual_correlations);
+    let corr = result.residual_correlations[0];
+    assert_eq!(result.sigma_names[corr.sigma_i], "ADD_ERR");
+    assert_eq!(result.sigma_names[corr.sigma_j], "PROP_ERR");
+    assert!((corr.rho - 0.5).abs() < 1e-12);
+    let covariance = corr.rho * result.sigma[corr.sigma_i] * result.sigma[corr.sigma_j];
+    assert!((covariance - 0.1).abs() < 1e-12);
+}


### PR DESCRIPTION
## Why

`FitResult` retained the fitted diagonal sigma SDs but dropped the fixed correlations declared by
`block_sigma`. A consumer holding only the result therefore could not reconstruct the residual
covariance, write fitted error parameters back into a model, or present the correlation structure.

Closes #1100.

## What changed

- Add `FitResult.residual_correlations` with backward-compatible serde defaults and omission for
  diagonal residual models.
- Copy the model correlations into every live fit result and preserve them through JSON and `.fitrx`
  save/load.
- Emit named `block_sigma` pairs in fit YAML with both the declared correlation and the covariance
  reconstructed from the fitted sigma SDs.
- Validate correlation indices and values when loading `.fitrx` bundles.
- Remove the redundant `BlockSigmaSpec.fixed` state/no-op; the parser already applies `FIX` to the
  diagonal `SigmaSpec` entries.
- Correct the documentation's misleading reference to a "fitted" off-diagonal and document the new
  result/output field.

## Alternatives considered

Storing the fully assembled covariance matrix was considered. Retaining the raw fixed correlations
is smaller, matches `CompiledModel`, and is directly usable when rewriting a `block_sigma`
declaration. The human YAML also reports the assembled covariance for convenience.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | **required follow-up** | after this merges |

**Correction (review):** the earlier "not needed" row was wrong. `residual_correlations` is a
*required* public field, and `ferx-r/src/rust/src/lib.rs` builds `FitResult` with three
**exhaustive** struct literals (lines 1660, 3278, 3635 — no `..Default::default()`). Because
`ferx-r/src/rust/.cargo/config.toml` patches in the local `../ferx-core`, a local
`cd ../ferx-r && R CMD INSTALL .` fails with `E0063: missing field residual_correlations` as soon as
this branch is checked out beside it. Serde defaulting does not help struct-literal construction.

The follow-up is ordered, not optional (per `CLAUDE.md`):

1. Merge this PR.
2. ferx-r PR: add `residual_correlations: Vec::new()` to the three literals **and** bump the
   ferx-core pin via `ferx-r/tools/update-ferx-core-lock.sh` (never a bare `cargo update`).
   Both must be in the same PR — the field does not exist on ferx-core `main`, so the literal
   change cannot compile in ferx-r CI before the lock bump.
3. Any downstream repo (e.g. `ferxtranslate`) bumps its ferx-r pin.

Local ferx-r builds are broken between step 1 and step 2 for anyone with both checkouts.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [x] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [x] Public Rust API (`api.rs` / `types.rs`)
- [ ] None

<details>
<summary>Migration notes (if breaking)</summary>

Serialized JSON and `.fitrx` data are backward compatible: missing correlations default to an empty
vector, and the field is omitted for diagonal-sigma models. External Rust code that constructs a
`FitResult` with a struct literal must add `residual_correlations: Vec::new()` (or the applicable
correlations).

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: NONMEM 7.5.1 and the existing correlated-residual anchor
- [x] Reference values (paste key theta/omega/OFV, or link to output file):

```
# existing reference: data/correlated_residual_combined.csv
block_sigma = [0.04, 0.10, 1.00] FIX
rho = 0.10 / (sqrt(0.04) * sqrt(1.00)) = 0.5
NONMEM METHOD=1 MAXEVAL=0 OFV: 18.722087

# after
ferx initial-evaluation OFV: unchanged by this result-only wiring
FitResult rho: 0.5
fit YAML covariance: 0.5 * 0.2 * 1.0 = 0.100000
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

## Example (user-facing features only)
- [x] Example added to `examples/` or inline below
- [ ] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```toml
[parameters]
  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX

[error_model]
  DV ~ combined(PROP_ERR, ADD_ERR)
```

```yaml
block_sigma:
  ADD_ERR__PROP_ERR:
    covariance: 0.100000        # sigma-scale rho*sigma_i*sigma_j, NOT an entry of R
    covariance_fixed: true      # both SDs were declared FIX; false for a bare block_sigma
    correlation: 0.500000
    correlation_fixed: true     # always true: the off-diagonal is a fixed correlation
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml` — N/A; no new page was added
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean — repository-wide clippy currently stops on four pre-existing
  `approx_constant` errors in `src/sens/two_cpt_explicit.rs`; no changed file produced an error
- [x] Functions on the `Dual2` sensitivity path stay differentiable — N/A; no sensitivity or PK
  formula changed
- [ ] `Cargo.toml` version bumped if breaking — no serialized-format version bump is required for
  this additive, defaulted field

## Docs & examples

### ferx-site
- [x] New `.ferx` DSL syntax or `[fit_options]` key — N/A; neither changed
- [x] New example `.ferx` file added — N/A; no example file added
- [x] New data file added — N/A; no data file added

### ferx-book
- [x] New estimator, DSL feature, or fit option — N/A; none added

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [x] All affected documentation pages render cleanly: `quarto render docs`
- [x] No external site/book example execution needed; no DSL, estimator, data, or example changed

## Reviewer hints

The important wiring is the copy in `api/fit.rs`, the serde behavior on `FitResult`, and the
`SigmaWire` `.fitrx` round-trip. The YAML covariance deliberately uses the fitted sigma SDs while
retaining the declared fixed rho. Diagonal-sigma JSON and `.fitrx` output remain unchanged because
the empty vector is skipped.

Verification performed:

- `cargo fmt --all -- --check`
- `cargo check --tests`
- `cargo test --lib` — 3,530 passed, 22 ignored, 0 failed
- `cargo test --test fit_result_residual_correlations`
- focused JSON, `.fitrx`, parser, and YAML tests
- `quarto render docs`

## Open questions

None for the core change. ferx-r can expose `residual_correlations` in a follow-up after this merges.

