### PR TITLE
fix(api): warn on hidden parameter guards [closes #1099]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,11 +310,13 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
-- **Hidden Omega/Sigma runaway guards now produce a fit warning (#1099).** A free
-  Omega, Omega-IOV, Sigma, or mixture override pinned to an internal packed-space
-  safety limit emits the typed `parameter_at_runaway_guard` warning; FIX'd
-  coordinates remain excluded, and user-declared Theta bounds continue to use
-  the separate `boundary_estimate` warning.
+- **Hidden parameter guards now produce a fit warning (#1099).** A free Theta at
+  the implicit `1e-10` / `1e9` cap, or an Omega, Omega-IOV, Sigma, or mixture
+  override pinned to an internal packed-space safety limit, emits the typed
+  `parameter_at_runaway_guard` warning. FIX'd coordinates remain excluded;
+  user-declared Theta bounds continue to use the separate `boundary_estimate`
+  warning. Lower hits are identified as collapse toward zero, while upper hits
+  are identified as runaway estimates.
 - **A closed-form model with IOV and a `[scaling] y = <expr>` readout evaluated the readout's
   individual parameters at `kappa = 0` — predictions and the objective were silently wrong
   (#1079).** The readout is the analogue of NONMEM's `$ERROR` and is evaluated per record, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,11 @@ section of the SDLC for the versioning policy).
   with no diagnostic from NONMEM (`nonmem_anchor/dose_attr_double_use_{A,B}.ctl`).
 
 ### Fixed
+- **Hidden Omega/Sigma runaway guards now produce a fit warning (#1099).** A free
+  Omega, Omega-IOV, Sigma, or mixture override pinned to an internal packed-space
+  safety limit emits the typed `parameter_at_runaway_guard` warning; FIX'd
+  coordinates remain excluded, and user-declared Theta bounds continue to use
+  the separate `boundary_estimate` warning.
 - **A closed-form model with IOV and a `[scaling] y = <expr>` readout evaluated the readout's
   individual parameters at `kappa = 0` — predictions and the objective were silently wrong
   (#1079).** The readout is the analogue of NONMEM's `$ERROR` and is evaluated per record, so an

--- a/docs/estimation/parameterization.qmd
+++ b/docs/estimation/parameterization.qmd
@@ -80,6 +80,13 @@ That is how every bound-respecting optimizer (NLopt SLSQP / L-BFGS / MMA, the
 built-in BFGS, the Gauss-Newton step clamp) holds them fixed — there is no
 separate free-subspace vector.
 
+The Omega and Sigma limits above are internal runaway guards, not model-file
+bounds. If a free estimate reaches one exactly, the fit emits the structured
+`parameter_at_runaway_guard` warning. FIX'd coordinates are excluded because
+their equal bounds are intentional. The check is made in packed space, so it
+compares directly with the literal guard even though fit output reports Omega
+on the variance/covariance scale and Sigma on its stored SD scale.
+
 ## Where the packed space surfaces
 
 It is not purely internal; it shows up in several user-visible places.

--- a/docs/estimation/parameterization.qmd
+++ b/docs/estimation/parameterization.qmd
@@ -80,12 +80,15 @@ That is how every bound-respecting optimizer (NLopt SLSQP / L-BFGS / MMA, the
 built-in BFGS, the Gauss-Newton step clamp) holds them fixed — there is no
 separate free-subspace vector.
 
-The Omega and Sigma limits above are internal runaway guards, not model-file
-bounds. If a free estimate reaches one exactly, the fit emits the structured
+The Omega and Sigma limits above, plus the `1e-10` / `1e9` caps substituted for
+a log-packed Theta range that extends beyond them, are internal guards rather than
+model-file bounds. If a free estimate reaches one (within the few ULPs that
+optimizer scaling can introduce), the fit emits the structured
 `parameter_at_runaway_guard` warning. FIX'd coordinates are excluded because
 their equal bounds are intentional. The check is made in packed space, so it
 compares directly with the literal guard even though fit output reports Omega
-on the variance/covariance scale and Sigma on its stored SD scale.
+on the variance/covariance scale and Sigma on its stored SD scale. A lower hit
+means the component collapsed toward zero; an upper hit means it ran away.
 
 ## Where the packed space surfaces
 

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -54,6 +54,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
+| `parameter_at_runaway_guard` | Warning | One or more free OMEGA / SIGMA coordinates are pinned to an internal optimizer safety guard. | The affected value is not an interior optimum — do not treat it as a reliable estimate; revisit the model, data, initial estimates, or method. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
@@ -84,6 +85,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
 | `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
+| `parameter_at_runaway_guard` | `guard_space` (`"packed"`), `parameters` (array of `{parameter, estimate, packed_estimate, packed_guard, side}`) |
 | `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
 | `high_correlation` | `threshold`, `pairs` (array of `{parameter_a, parameter_b, correlation}`) |
 | `flip_flop` | `phase` (`"ebe"`), `model`, `subjects` (array of affected subject IDs) |

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -54,7 +54,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
-| `parameter_at_runaway_guard` | Warning | One or more free OMEGA / SIGMA coordinates are pinned to an internal optimizer safety guard. | The affected value is not an interior optimum — do not treat it as a reliable estimate; revisit the model, data, initial estimates, or method. |
+| `parameter_at_runaway_guard` | Warning | One or more free coordinates are pinned to a hidden optimizer guard: an implicit THETA cap or an OMEGA / SIGMA safety rail. | A lower hit means the component collapsed toward zero — consider removing or simplifying it. An upper hit is a runaway estimate — revisit the model, data, initial estimates, or method. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1981,6 +1981,13 @@ fn fit_inner(
         warnings.push(msg);
         native_warnings.push(entry);
     }
+    // OMEGA / SIGMA estimates pinned to hidden packed-space runaway guards.
+    // This is distinct from a user-declared theta bound: the affected result
+    // reached an implementation safety limit (#1099).
+    if let Some((msg, entry)) = runaway_guard_warning(&result.params) {
+        warnings.push(msg);
+        native_warnings.push(entry);
+    }
     // Imprecisely estimated thetas (high relative standard error) — likewise
     // emitted typed at source with `details` (#781).
     if let Some((msg, entry)) = inflated_rse_warning(&se_theta, &result.params) {

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1981,7 +1981,7 @@ fn fit_inner(
         warnings.push(msg);
         native_warnings.push(entry);
     }
-    // OMEGA / SIGMA estimates pinned to hidden packed-space runaway guards.
+    // Parameter estimates pinned to hidden packed-space implementation guards.
     // This is distinct from a user-declared theta bound: the affected result
     // reached an implementation safety limit (#1099).
     if let Some((msg, entry)) = runaway_guard_warning(&result.params) {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -62,7 +62,8 @@ pub(crate) use postfit::{
     eta_shrinkage_warning, extract_standard_errors, high_correlation_warning, inflated_rse_warning,
     integrates_odes, is_last_estimating_stage, kappa_weight_typicals, keep_gn_zero_eta_warning,
     ode_solver_diagnostics_warning, probe_nlopt_algorithms, rebuild_warnings_structured,
-    resolve_covariance_status, resolve_sir_fallback, sir_unavailable_warning,
+    resolve_covariance_status, resolve_sir_fallback, runaway_guard_warning,
+    sir_unavailable_warning,
 };
 pub use predict::{predict, PredictionResult};
 #[cfg(feature = "survival")]
@@ -96,8 +97,8 @@ pub(crate) use output_columns::build_indiv_map;
 pub(crate) use pool::{cap_default_threads, default_thread_count, FIT_RAYON_STACK_SIZE};
 #[cfg(test)]
 pub(crate) use postfit::{
-    diagnostic_details, high_correlation_pairs, should_run_sir_fallback, theta_boundary_side,
-    DiagStats,
+    diagnostic_details, high_correlation_pairs, packed_guard_side, should_run_sir_fallback,
+    theta_boundary_side, DiagStats,
 };
 #[cfg(all(test, feature = "survival"))]
 pub(crate) use predict::grid_median_from_cumhaz;

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1076,6 +1076,23 @@ fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'stat
         if let Some((side, bound)) =
             theta_boundary_side(est, params.theta_lower[i], params.theta_upper[i])
         {
+            // A log-packed theta whose declared range reaches past ferx's
+            // 1e-10 / 1e9 implementation caps did not hit a user bound. Route
+            // an actual cap hit to `parameter_at_runaway_guard` instead, where
+            // the remediation does not tell the user to relax a bound they
+            // never declared (or cannot relax past the internal cap).
+            if theta_guard_is_internal(params, i, side) {
+                // Internal theta guards exist only on the log-packed path.
+                let packed_est = est.max(1e-10).ln();
+                let packed_bound = if side == "lower" {
+                    params.theta_lower[i].max(1e-10).ln()
+                } else {
+                    params.theta_upper[i].min(1e9).ln()
+                };
+                if packed_guard_eq(packed_est, packed_bound) {
+                    continue;
+                }
+            }
             let name = params
                 .theta_names
                 .get(i)
@@ -1087,9 +1104,23 @@ fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'stat
     hits
 }
 
-/// A free OMEGA / SIGMA coordinate pinned to one of the internal packed-space
-/// runaway guards. `estimate` is the ordinary reporting-scale value, while the
-/// packed values identify the literal optimizer guard that was reached.
+/// Whether a THETA bound reported by `compute_bounds` is an implementation cap
+/// rather than the user's effective declared limit.
+fn theta_guard_is_internal(params: &ModelParameters, i: usize, side: &str) -> bool {
+    use crate::estimation::parameterization::theta_packs_log;
+    let lower = params.theta_lower.get(i).copied().unwrap_or(f64::NAN);
+    let upper = params.theta_upper.get(i).copied().unwrap_or(f64::NAN);
+    theta_packs_log(lower)
+        && match side {
+            "lower" => lower <= 1e-10,
+            "upper" => upper >= 1e9,
+            _ => false,
+        }
+}
+
+/// A free parameter coordinate pinned to one of the internal packed-space
+/// guards. `estimate` is the ordinary reporting-scale value, while the packed
+/// values identify the literal optimizer guard that was reached.
 struct RunawayGuardHit {
     name: String,
     estimate: f64,
@@ -1098,10 +1129,20 @@ struct RunawayGuardHit {
     side: &'static str,
 }
 
-/// Return the exact bound reached by a packed coordinate. Internal guards are
-/// implementation constants, so this deliberately uses equality rather than the
-/// relative proximity threshold used for user-declared THETA bounds: a value
-/// merely near a wide safety rail is still an interior estimate.
+/// Tiny packed-space tolerance for an optimizer guard hit. The optimizer may
+/// clamp exactly in scaled space, then recover the packed coordinate through
+/// `(bound / scale) * scale`; that round-trip can land a few ULPs off the literal
+/// guard. This tolerance admits that arithmetic noise without treating a value
+/// merely near a wide safety rail as a hit.
+const INTERNAL_GUARD_REL_TOL: f64 = 4.0 * f64::EPSILON;
+
+fn packed_guard_eq(estimate: f64, guard: f64) -> bool {
+    estimate == guard || (estimate - guard).abs() <= INTERNAL_GUARD_REL_TOL * guard.abs().max(1.0)
+}
+
+/// Return the bound reached by a packed coordinate, allowing only the few ULPs
+/// introduced by optimizer scaling/unscaling. Degenerate or non-finite bounds
+/// are never internal guard hits.
 pub(crate) fn packed_guard_side(
     estimate: f64,
     lower: f64,
@@ -1110,20 +1151,21 @@ pub(crate) fn packed_guard_side(
     if !estimate.is_finite() || !lower.is_finite() || !upper.is_finite() || lower >= upper {
         return None;
     }
-    if estimate == lower {
+    if packed_guard_eq(estimate, lower) {
         Some(("lower", lower))
-    } else if estimate == upper {
+    } else if packed_guard_eq(estimate, upper) {
         Some(("upper", upper))
     } else {
         None
     }
 }
 
-/// Free OMEGA / SIGMA coordinates pinned to their internal packed-space guards.
+/// Free coordinates pinned to internal packed-space guards.
 ///
 /// The walk uses the same packing, bounds, names, and FIX mask as the optimizer.
-/// Starting after THETA includes base OMEGA/SIGMA, OMEGA_IOV, and mixture
-/// overrides without duplicating their layout here.
+/// THETA coordinates are included only where `compute_bounds` substituted its
+/// hidden 1e-10 / 1e9 cap for the declared range; every later coordinate is an
+/// internal OMEGA/SIGMA, OMEGA_IOV, or mixture guard.
 fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
     use crate::estimation::parameterization::{
         compute_bounds, coordinate_names, coordinate_values, pack_params, packed_fixed_mask,
@@ -1141,16 +1183,21 @@ fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
         .min(names.len())
         .min(estimates.len());
 
-    (params.theta.len()..end)
+    (0..end)
         .filter(|&i| !fixed.get(i).copied().unwrap_or(false))
         .filter_map(|i| {
-            packed_guard_side(packed[i], bounds.lower[i], bounds.upper[i]).map(
-                |(side, packed_guard)| RunawayGuardHit {
-                    name: names[i].clone(),
-                    estimate: estimates[i],
-                    packed_estimate: packed[i],
-                    packed_guard,
-                    side,
+            packed_guard_side(packed[i], bounds.lower[i], bounds.upper[i]).and_then(
+                |(side, packed_guard)| {
+                    if i < params.theta.len() && !theta_guard_is_internal(params, i, side) {
+                        return None;
+                    }
+                    Some(RunawayGuardHit {
+                        name: names[i].clone(),
+                        estimate: estimates[i],
+                        packed_estimate: packed[i],
+                        packed_guard,
+                        side,
+                    })
                 },
             )
         })
@@ -1227,45 +1274,67 @@ pub(crate) fn boundary_estimate_warning(
     )
 }
 
-/// Build the warning for OMEGA / SIGMA estimates pinned to an internal
+/// Build the warning for parameter estimates pinned to an internal
 /// runaway guard, or `None` when every free coordinate is interior.
 pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
-    list_warning(
-        runaway_guard_estimates(params),
-        WarningCode::ParameterAtRunawayGuard,
-        |hit| {
+    let hits = runaway_guard_estimates(params);
+    if hits.is_empty() {
+        return None;
+    }
+    let list = hits
+        .iter()
+        .map(|hit| {
             format!(
                 "{} (estimate {:.4}; packed coordinate {:.4} at {} guard)",
                 hit.name, hit.estimate, hit.packed_estimate, hit.side
             )
-        },
-        |list| {
-            format!(
-                "Internal optimizer runaway guard reached by parameter estimate(s): {list}. \
-                 The fit reached an implementation safety limit rather than an interior \
-                 optimum; do not treat the affected value(s) as reliable estimates. \
-                 Revisit the model, data, initial estimates, or estimation method."
-            )
-        },
-        |hits| {
-            let params_json: Vec<serde_json::Value> = hits
-                .iter()
-                .map(|hit| {
-                    serde_json::json!({
-                        "parameter": hit.name,
-                        "estimate": hit.estimate,
-                        "packed_estimate": hit.packed_estimate,
-                        "packed_guard": hit.packed_guard,
-                        "side": hit.side,
-                    })
-                })
-                .collect();
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let has_lower = hits.iter().any(|hit| hit.side == "lower");
+    let has_upper = hits.iter().any(|hit| hit.side == "upper");
+    let guidance = match (has_lower, has_upper) {
+        (true, false) => {
+            "The affected parameter(s) collapsed toward zero at an implementation floor \
+             rather than reaching an interior optimum; consider removing or simplifying \
+             the unsupported parameter, random effect, or error component."
+        }
+        (false, true) => {
+            "The affected parameter(s) ran to an implementation ceiling rather than \
+             reaching an interior optimum; do not treat the value(s) as reliable estimates. \
+             Revisit the model, data, initial estimates, or estimation method."
+        }
+        (true, true) => {
+            "Lower-guard hits indicate parameters collapsing toward zero; consider removing \
+             or simplifying those unsupported components. Upper-guard hits indicate runaway \
+             estimates; revisit the model, data, initial estimates, or estimation method."
+        }
+        (false, false) => unreachable!("every guard hit has a lower or upper side"),
+    };
+    let msg =
+        format!("Internal optimizer parameter guard reached by estimate(s): {list}. {guidance}");
+    let params_json: Vec<serde_json::Value> = hits
+        .iter()
+        .map(|hit| {
             serde_json::json!({
-                "guard_space": "packed",
-                "parameters": params_json,
+                "parameter": hit.name,
+                "estimate": hit.estimate,
+                "packed_estimate": hit.packed_estimate,
+                "packed_guard": hit.packed_guard,
+                "side": hit.side,
             })
-        },
-    )
+        })
+        .collect();
+    let details = serde_json::json!({
+        "guard_space": "packed",
+        "parameters": params_json,
+    });
+    let entry = warning_entry(
+        WarningCode::ParameterAtRunawayGuard,
+        msg.clone(),
+        Some(details),
+    );
+    Some((msg, entry))
 }
 
 /// Relative-standard-error threshold (percent) above which a free THETA is

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1087,6 +1087,76 @@ fn boundary_estimates(params: &ModelParameters) -> Vec<(String, f64, f64, &'stat
     hits
 }
 
+/// A free OMEGA / SIGMA coordinate pinned to one of the internal packed-space
+/// runaway guards. `estimate` is the ordinary reporting-scale value, while the
+/// packed values identify the literal optimizer guard that was reached.
+struct RunawayGuardHit {
+    name: String,
+    estimate: f64,
+    packed_estimate: f64,
+    packed_guard: f64,
+    side: &'static str,
+}
+
+/// Return the exact bound reached by a packed coordinate. Internal guards are
+/// implementation constants, so this deliberately uses equality rather than the
+/// relative proximity threshold used for user-declared THETA bounds: a value
+/// merely near a wide safety rail is still an interior estimate.
+pub(crate) fn packed_guard_side(
+    estimate: f64,
+    lower: f64,
+    upper: f64,
+) -> Option<(&'static str, f64)> {
+    if !estimate.is_finite() || !lower.is_finite() || !upper.is_finite() || lower >= upper {
+        return None;
+    }
+    if estimate == lower {
+        Some(("lower", lower))
+    } else if estimate == upper {
+        Some(("upper", upper))
+    } else {
+        None
+    }
+}
+
+/// Free OMEGA / SIGMA coordinates pinned to their internal packed-space guards.
+///
+/// The walk uses the same packing, bounds, names, and FIX mask as the optimizer.
+/// Starting after THETA includes base OMEGA/SIGMA, OMEGA_IOV, and mixture
+/// overrides without duplicating their layout here.
+fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
+    use crate::estimation::parameterization::{
+        compute_bounds, coordinate_names, coordinate_values, pack_params, packed_fixed_mask,
+    };
+
+    let packed = pack_params(params);
+    let bounds = compute_bounds(params);
+    let fixed = packed_fixed_mask(params);
+    let names = coordinate_names(params);
+    let estimates = coordinate_values(params);
+    let end = packed
+        .len()
+        .min(bounds.lower.len())
+        .min(bounds.upper.len())
+        .min(names.len())
+        .min(estimates.len());
+
+    (params.theta.len()..end)
+        .filter(|&i| !fixed.get(i).copied().unwrap_or(false))
+        .filter_map(|i| {
+            packed_guard_side(packed[i], bounds.lower[i], bounds.upper[i]).map(
+                |(side, packed_guard)| RunawayGuardHit {
+                    name: names[i].clone(),
+                    estimate: estimates[i],
+                    packed_estimate: packed[i],
+                    packed_guard,
+                    side,
+                },
+            )
+        })
+        .collect()
+}
+
 /// Construct a fit-end [`WarningEntry`] with the invariant fields every native
 /// emitter shares (`severity: Warning`, `source_method: None`), varying only
 /// `category`, `message`, and `details`.
@@ -1153,6 +1223,47 @@ pub(crate) fn boundary_estimate_warning(
                 })
                 .collect();
             serde_json::json!({ "parameters": params_json })
+        },
+    )
+}
+
+/// Build the warning for OMEGA / SIGMA estimates pinned to an internal
+/// runaway guard, or `None` when every free coordinate is interior.
+pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
+    list_warning(
+        runaway_guard_estimates(params),
+        WarningCode::ParameterAtRunawayGuard,
+        |hit| {
+            format!(
+                "{} (estimate {:.4}; packed coordinate {:.4} at {} guard)",
+                hit.name, hit.estimate, hit.packed_estimate, hit.side
+            )
+        },
+        |list| {
+            format!(
+                "Internal optimizer runaway guard reached by parameter estimate(s): {list}. \
+                 The fit reached an implementation safety limit rather than an interior \
+                 optimum; do not treat the affected value(s) as reliable estimates. \
+                 Revisit the model, data, initial estimates, or estimation method."
+            )
+        },
+        |hits| {
+            let params_json: Vec<serde_json::Value> = hits
+                .iter()
+                .map(|hit| {
+                    serde_json::json!({
+                        "parameter": hit.name,
+                        "estimate": hit.estimate,
+                        "packed_estimate": hit.packed_estimate,
+                        "packed_guard": hit.packed_guard,
+                        "side": hit.side,
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "guard_space": "packed",
+                "parameters": params_json,
+            })
         },
     )
 }

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1151,6 +1151,15 @@ fn packed_guard_side_requires_an_exact_non_degenerate_hit() {
         Some(("upper", 5.0))
     );
     assert_eq!(super::packed_guard_side(5.0 - 1e-12, -8.0, 5.0), None);
+    // An optimizer can hit the rail exactly in scaled space but recover a
+    // packed value one ULP away through `(bound / scale) * scale`.
+    let scale = 10.0_f64.ln();
+    let recovered = (-8.0 / scale) * scale;
+    assert_ne!(recovered, -8.0);
+    assert_eq!(
+        super::packed_guard_side(recovered, -8.0, 5.0),
+        Some(("lower", -8.0))
+    );
     assert_eq!(super::packed_guard_side(1.0, 1.0, 1.0), None);
     assert_eq!(super::packed_guard_side(f64::NAN, -8.0, 5.0), None);
 }
@@ -1164,7 +1173,7 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
 
     params.sigma.values[0] = 5.0_f64.exp();
     let (msg, entry) = super::runaway_guard_warning(&params).expect("sigma guard hit");
-    assert!(msg.contains("implementation safety limit"));
+    assert!(msg.contains("implementation ceiling"));
     assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
     let details = entry.details.as_ref().expect("details");
     assert_eq!(details["guard_space"], "packed");
@@ -1180,6 +1189,16 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
     params.sigma_fixed[0] = false;
     params.sigma.values[0] = (5.0_f64 - 1e-12).exp();
     assert!(super::runaway_guard_warning(&params).is_none());
+
+    // The lower rail has opposite meaning and remediation: collapse to zero.
+    params.sigma.values[0] = (-8.0_f64).exp();
+    let (msg, entry) = super::runaway_guard_warning(&params).expect("sigma lower guard hit");
+    assert!(msg.contains("collapsed toward zero"));
+    assert!(msg.contains("removing or simplifying"));
+    assert_eq!(
+        entry.details.as_ref().unwrap()["parameters"][0]["side"],
+        "lower"
+    );
 }
 
 #[test]
@@ -1208,7 +1227,60 @@ fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
     assert_eq!(hit["side"], "upper");
     assert!((hit["estimate"].as_f64().unwrap() - 12.0_f64.exp()).abs() < 1e-6);
 
+    // A simultaneous lower collapse and upper runaway gets advice for both.
+    params.sigma.values[0] = (-8.0_f64).exp();
+    let (msg, _entry) = super::runaway_guard_warning(&params).expect("mixed guard hits");
+    assert!(msg.contains("Lower-guard hits"));
+    assert!(msg.contains("Upper-guard hits"));
+
+    params.sigma.values[0] = 1.0;
     params.omega_fixed[0] = true;
+    assert!(super::runaway_guard_warning(&params).is_none());
+}
+
+#[test]
+fn hidden_theta_caps_use_internal_guard_warning_not_user_boundary_warning() {
+    use crate::types::WarningCode;
+    let mut params = tiny_model().default_params;
+    params.sigma.values.fill(1.0);
+    params.sigma_fixed = vec![false; params.sigma.values.len()];
+    params.theta_fixed = vec![false; params.theta.len()];
+    params.theta_lower[0] = 0.0;
+    params.theta_upper[0] = f64::INFINITY;
+
+    params.theta[0] = 1e9;
+    assert!(super::boundary_estimate_warning(&params).is_none());
+    let (upper_msg, upper_entry) =
+        super::runaway_guard_warning(&params).expect("hidden theta upper cap");
+    assert!(upper_msg.contains("implementation ceiling"));
+    assert_eq!(upper_entry.category, WarningCode::ParameterAtRunawayGuard);
+    assert_eq!(
+        upper_entry.details.as_ref().unwrap()["parameters"][0]["parameter"],
+        params.theta_names[0].as_str()
+    );
+
+    params.theta[0] = 1e-10;
+    assert!(super::boundary_estimate_warning(&params).is_none());
+    let (lower_msg, lower_entry) =
+        super::runaway_guard_warning(&params).expect("hidden theta lower cap");
+    assert!(lower_msg.contains("collapsed toward zero"));
+    assert_eq!(
+        lower_entry.details.as_ref().unwrap()["parameters"][0]["side"],
+        "lower"
+    );
+
+    // A genuine finite user bound keeps the existing warning and remediation.
+    params.theta_lower[0] = 0.1;
+    params.theta_upper[0] = 100.0;
+    params.theta[0] = 0.1;
+    assert!(super::boundary_estimate_warning(&params).is_some());
+    assert!(super::runaway_guard_warning(&params).is_none());
+
+    // FIX'd hidden-cap coordinates remain intentional and excluded.
+    params.theta_lower[0] = 0.0;
+    params.theta_upper[0] = f64::INFINITY;
+    params.theta[0] = 1e9;
+    params.theta_fixed[0] = true;
     assert!(super::runaway_guard_warning(&params).is_none());
 }
 

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1141,6 +1141,78 @@ fn boundary_estimate_warning_emits_typed_entry_with_details() {
 }
 
 #[test]
+fn packed_guard_side_requires_an_exact_non_degenerate_hit() {
+    assert_eq!(
+        super::packed_guard_side(-8.0, -8.0, 5.0),
+        Some(("lower", -8.0))
+    );
+    assert_eq!(
+        super::packed_guard_side(5.0, -8.0, 5.0),
+        Some(("upper", 5.0))
+    );
+    assert_eq!(super::packed_guard_side(5.0 - 1e-12, -8.0, 5.0), None);
+    assert_eq!(super::packed_guard_side(1.0, 1.0, 1.0), None);
+    assert_eq!(super::packed_guard_side(f64::NAN, -8.0, 5.0), None);
+}
+
+#[test]
+fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
+    use crate::types::WarningCode;
+    let mut params = tiny_model().default_params;
+    params.sigma.values.fill(1.0);
+    params.sigma_fixed = vec![false; params.sigma.values.len()];
+
+    params.sigma.values[0] = 5.0_f64.exp();
+    let (msg, entry) = super::runaway_guard_warning(&params).expect("sigma guard hit");
+    assert!(msg.contains("implementation safety limit"));
+    assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
+    let details = entry.details.as_ref().expect("details");
+    assert_eq!(details["guard_space"], "packed");
+    assert_eq!(details["parameters"][0]["side"], "upper");
+    assert_eq!(details["parameters"][0]["packed_estimate"], 5.0);
+    assert_eq!(details["parameters"][0]["packed_guard"], 5.0);
+
+    // FIX creates lower == upper at this value, but is intentional and excluded.
+    params.sigma_fixed[0] = true;
+    assert!(super::runaway_guard_warning(&params).is_none());
+
+    // A free value arbitrarily near the safety rail is still an interior result.
+    params.sigma_fixed[0] = false;
+    params.sigma.values[0] = (5.0_f64 - 1e-12).exp();
+    assert!(super::runaway_guard_warning(&params).is_none());
+}
+
+#[test]
+fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
+    use crate::types::{OmegaMatrix, WarningCode};
+    let mut params = tiny_model().default_params;
+    params.sigma.values.fill(1.0);
+    params.sigma_fixed = vec![false; params.sigma.values.len()];
+    params.omega_fixed = vec![false; params.omega.dim()];
+
+    let mut chol = params.omega.chol.clone();
+    chol[(0, 0)] = 6.0_f64.exp();
+    params.omega = OmegaMatrix::from_chol_factor(
+        chol,
+        params.omega.eta_names.clone(),
+        params.omega.diagonal,
+        params.omega.free_mask.clone(),
+    );
+
+    let (_msg, entry) = super::runaway_guard_warning(&params).expect("omega guard hit");
+    assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
+    let hit = &entry.details.as_ref().unwrap()["parameters"][0];
+    assert_eq!(hit["parameter"], params.omega.eta_names[0].as_str());
+    assert_eq!(hit["packed_estimate"], 6.0);
+    assert_eq!(hit["packed_guard"], 6.0);
+    assert_eq!(hit["side"], "upper");
+    assert!((hit["estimate"].as_f64().unwrap() - 12.0_f64.exp()).abs() < 1e-6);
+
+    params.omega_fixed[0] = true;
+    assert!(super::runaway_guard_warning(&params).is_none());
+}
+
+#[test]
 fn inflated_rse_warning_emits_typed_entry_with_details() {
     use crate::types::WarningCode;
     let mut params = tiny_model().default_params;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4574,10 +4574,10 @@ pub enum WarningCode {
     /// One or more THETA estimates are pinned to an optimizer bound — a sign of
     /// non-identifiability or a too-tight bound.
     BoundaryEstimate,
-    /// One or more OMEGA / SIGMA optimizer coordinates are pinned to an internal
-    /// runaway guard. Unlike a THETA bound, this is an implementation safety
-    /// limit rather than a user-declared constraint, so the affected fit result
-    /// is not an interior optimum.
+    /// One or more optimizer coordinates are pinned to an internal guard: an
+    /// implicit THETA cap or an OMEGA / SIGMA safety limit. Unlike a declared
+    /// THETA bound, this is an implementation constraint, so the affected fit
+    /// result is not an interior optimum.
     ParameterAtRunawayGuard,
     /// One or more THETA estimates have a large relative standard error — poorly
     /// estimated / imprecise parameters.
@@ -4851,7 +4851,7 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
     } else if lower.starts_with("eta shrinkage") || lower.contains(" eta shrinkage") {
         // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
-    } else if lower.contains("internal optimizer runaway guard") {
+    } else if lower.contains("internal optimizer parameter guard") {
         (
             WarningSeverity::Warning,
             WarningCode::ParameterAtRunawayGuard,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4574,6 +4574,11 @@ pub enum WarningCode {
     /// One or more THETA estimates are pinned to an optimizer bound — a sign of
     /// non-identifiability or a too-tight bound.
     BoundaryEstimate,
+    /// One or more OMEGA / SIGMA optimizer coordinates are pinned to an internal
+    /// runaway guard. Unlike a THETA bound, this is an implementation safety
+    /// limit rather than a user-declared constraint, so the affected fit result
+    /// is not an interior optimum.
+    ParameterAtRunawayGuard,
     /// One or more THETA estimates have a large relative standard error — poorly
     /// estimated / imprecise parameters.
     InflatedRse,
@@ -4654,6 +4659,7 @@ impl WarningCode {
             WarningCode::EpsShrinkage => "eps_shrinkage",
             WarningCode::EtaShrinkage => "eta_shrinkage",
             WarningCode::BoundaryEstimate => "boundary_estimate",
+            WarningCode::ParameterAtRunawayGuard => "parameter_at_runaway_guard",
             WarningCode::InflatedRse => "inflated_rse",
             WarningCode::HighCorrelation => "high_correlation",
             WarningCode::DataQuality => "data_quality",
@@ -4845,6 +4851,11 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
     } else if lower.starts_with("eta shrinkage") || lower.contains(" eta shrinkage") {
         // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
+    } else if lower.contains("internal optimizer runaway guard") {
+        (
+            WarningSeverity::Warning,
+            WarningCode::ParameterAtRunawayGuard,
+        )
     } else if lower.contains("optimizer bound") {
         // Distinctive phrase; the eps-shrinkage message's "sigma at a bound" is
         // matched earlier and never reaches here.

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -675,9 +675,8 @@ fn classify_warning_eta_shrinkage_is_word_bounded() {
 
 #[test]
 fn classify_warning_recognizes_internal_runaway_guard() {
-    let warning = classify_warning(
-        "Internal optimizer runaway guard reached by parameter estimate(s): PROP_ERR",
-    );
+    let warning =
+        classify_warning("Internal optimizer parameter guard reached by estimate(s): PROP_ERR");
     assert_eq!(warning.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(warning.severity, WarningSeverity::Warning);
 }

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -673,6 +673,15 @@ fn classify_warning_eta_shrinkage_is_word_bounded() {
     );
 }
 
+#[test]
+fn classify_warning_recognizes_internal_runaway_guard() {
+    let warning = classify_warning(
+        "Internal optimizer runaway guard reached by parameter estimate(s): PROP_ERR",
+    );
+    assert_eq!(warning.category, WarningCode::ParameterAtRunawayGuard);
+    assert_eq!(warning.severity, WarningSeverity::Warning);
+}
+
 /// #778: the `WarningCode` serde token is a public API an agent / the R
 /// wrapper pins against. This snapshot fails loudly if a variant's token
 /// drifts, and asserts `as_str()` and the serde representation agree.
@@ -695,6 +704,7 @@ fn warning_code_tokens_are_stable() {
         (EpsShrinkage, "eps_shrinkage"),
         (EtaShrinkage, "eta_shrinkage"),
         (BoundaryEstimate, "boundary_estimate"),
+        (ParameterAtRunawayGuard, "parameter_at_runaway_guard"),
         (InflatedRse, "inflated_rse"),
         (HighCorrelation, "high_correlation"),
         (DataQuality, "data_quality"),


### PR DESCRIPTION
## Why

Free parameter estimates could finish on ferx's hidden packed-space guards while the fit reported no appropriate warning. This made an implementation safety constant such as `exp(5) = 148.413159` look like an ordinary fitted sigma. Theta bounds were diagnosed separately, but that path also mislabeled ferx's implicit `1e-10` / `1e9` theta caps as user-declared bounds.

Closes #1099.

## What changed

- Add the typed `parameter_at_runaway_guard` warning code.
- Inspect packed coordinates using the same `pack_params`, `compute_bounds`, coordinate labels, reporting values, and FIX mask used by optimization.
- Accept only a few ULPs of packed-space arithmetic noise, covering exact scaled-space clamps after unscaling without classifying values merely near a wide safety rail.
- Route implicit theta cap hits to the new warning while keeping genuine user-declared theta bounds on `boundary_estimate`.
- Cover base Omega/Sigma, Omega-IOV, and mixture overrides while excluding every FIX'd coordinate.
- Give lower hits collapse-to-zero guidance and upper hits runaway-estimate guidance, including both remedies when a fit hits both sides.
- Include reporting-scale and packed-space values in structured warning details.

This does not change the fitted values or the `converged` flag.

## Alternatives considered

- Reusing `boundary_estimate` for every parameter would give hidden safety guards the wrong remediation ("relax the bound") and would prevent consumers from distinguishing a declared constraint from a diverged coordinate.
- Comparing reporting-scale values would round-trip Omega through variance/covariance output. Comparing the optimizer coordinate directly tests the literal `-8/5`, `-6/6`, and `-10/10` guards.
- A range-relative proximity tolerance was rejected because these are broad safety rails, not inferential boundaries. The implemented tolerance is only four machine epsilons in packed space, enough for scaled clamp/unscale round-off.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r already surfaces structured warning codes generically; no glue or lockfile update is required.

## Breaking changes

- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

The new `WarningCode` variant is additive, and the public enum is already `#[non_exhaustive]`.

<details>
<summary>Migration notes (if breaking)</summary>

Not applicable.

</details>

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):

```text
Not applicable: this post-fit diagnostic does not alter estimation, fitted values, OFV, or convergence.
```

- [x] Not applicable (diagnostic-only change; numerical results are unchanged)

## Performance

- [x] No significant impact expected — one linear packed-vector scan at fit end
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes: 3,531 passed, 22 ignored)
- [x] Regression tests added that fail without this fix: sigma and Omega guard hits, FIX exclusion, scaled-space ULP recovery, exact-vs-near behavior, lower/upper/mixed guidance, hidden theta caps versus user bounds, warning classification, and stable serde token
- [ ] No new tests needed (why: `______`)

Additional checks:

- `cargo check --tests` passes.
- `cargo fmt --all -- --check` passes.
- `quarto render docs` passes.
- `cargo clippy --lib` passes (with the repository's existing warnings).
- `cargo clippy --lib --tests` reaches four pre-existing `clippy::approx_constant` denials in `src/sens/two_cpt_explicit.rs`; it reports no new error from this diff.

## Example (user-facing features only)

- [x] Example included inline below
- [ ] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (structured output)</summary>

When a free `PROP_ERR` sigma finishes at the internal packed upper guard `5.0`, `warnings_structured` contains:

```json
{
  "severity": "Warning",
  "category": "parameter_at_runaway_guard",
  "message": "Internal optimizer parameter guard reached by estimate(s): PROP_ERR (estimate 148.4132; packed coordinate 5.0000 at upper guard). ...",
  "source_method": null,
  "details": {
    "guard_space": "packed",
    "parameters": [{
      "parameter": "PROP_ERR",
      "estimate": 148.4131591025766,
      "packed_estimate": 5.0,
      "packed_guard": 5.0,
      "side": "upper"
    }]
  }
}
```

</details>

## Docs

- [x] `docs/` updated for user-visible changes (`warnings.qmd` and `estimation/parameterization.qmd`)
- [x] No new page was added, so `docs/_quarto.yml` is unchanged; generated `docs/_site/` remains ignored
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [ ] No user-visible change

## Checklist

- [ ] `cargo clippy` clean — blocked by four pre-existing `approx_constant` denials outside this diff, noted above
- [x] Sensitivity-path differentiability is unaffected; no `sens/` or generic PK code changed
- [x] `Cargo.toml` version bump not required; the API addition is non-breaking

## Docs & examples

### ferx-site

- [x] No new `.ferx` syntax or `[fit_options]` key; external model-DSL docs are not affected
- [x] No new example `.ferx` file
- [x] No new data file

### ferx-book

- [x] No new estimator, DSL feature, or fit option; book update is not applicable

### Example execution (run locally before marking ready for review)

- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (fit-end diagnostic only; no estimator, DSL, data, or example behavior changed)

## Reviewer hints

The subtle point is the split between spaces: guard proximity is checked within four machine epsilons of the literal packed bounds, while the warning also reports the ordinary natural-scale value. Please focus on `runaway_guard_estimates` using the optimizer's existing layout/mask helpers, implicit-theta-cap routing, and side-specific guidance. Genuine user-declared theta bounds deliberately remain a separate warning category.

## Open questions

None for this PR. Whether an internal guard hit should also force `converged = false` remains separate behavior covered by #1098.
