### PR TITLE
fix(estimation): demote VI bad-basin convergence [closes #1098]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Fixed
+- **VI's bad-basin detector now reports `converged: false` (#1098).** An implausibly loose
+  final ELBO already identified a fit trapped far from a usable variational approximation, but
+  the result still exposed `converged: true` to programmatic consumers. Such fits are now demoted,
+  omit the misleading "increase `vi_iters`" warning, and carry the critical structured warning
+  code `vi_bad_basin`.
 - **`methods = [vi, laplace]` with `n_agq > 1` is no longer rejected (#1017).** `n_agq` is a
   chain-wide option, so the documented VI readout — `methods = [vi, laplace]`,
   `agq_eval_only = true`, which turns VI's ELBO lower bound into a real `−2 log L` — carries it

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -45,6 +45,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `covariance_step` | Info | Covariance-step informational note (e.g. evaluation cost). | None. |
 | `condition_number` | Critical | Ill-conditioned covariance / high condition number. | Over-parameterized — drop a random effect or covariate. |
 | `optimizer_health` | Warning | Trust-radius collapse / degeneracy. | Try a different optimizer or re-scale parameters. |
+| `vi_bad_basin` | Critical | VI's final ELBO tightness check found that a flat objective is an unusable variational bound, not convergence. | Reject the fit; use better starting values or initialize VI from a fitted point with `method = [focei, vi]`. |
 | `dw_autocorrelation` | Warning | IWRES autocorrelation (Durbin–Watson out of range). | Revisit the residual-error / structural model. |
 | `eta_normality` | Warning | ETA departs from normality. | Consider a mixture or transform. |
 | `experimental` | Warning | An experimental feature (SDE, neural-network) was used. | Treat results with caution; validate. |

--- a/src/estimation/vi/run.rs
+++ b/src/estimation/vi/run.rs
@@ -43,7 +43,7 @@ use crate::types::{
 use super::adam::{averaging_start, AdamConfig, AdamState, PolyakAverager};
 use super::elbo::{
     closed_form_omega, closed_form_sigma, closed_form_sigma_support, population_neg_elbo,
-    stacked_prior, unsupported_data_term_reason, ElboConfig, Families, PackedLayout,
+    stacked_prior, unsupported_data_term_reason, ElboConfig, ElboTightness, Families, PackedLayout,
 };
 use super::family::{FullRank, MeanField, VariationalFamily};
 
@@ -317,6 +317,40 @@ pub(crate) fn kl_fallback_warning(
              vi_mc_samples, or set vi_kl = mc to silence this."
         )
     })
+}
+
+/// Demote a fit whose final ELBO diagnostic says the optimizer stopped in a bad basin.
+///
+/// Kept separate from [`ElboTightness::is_implausible`] because that method diagnoses the
+/// bound, while this one owns the user-visible consequence: a flat objective in the wrong
+/// basin is not convergence.
+fn bad_basin_warning(converged: &mut bool, tightness: &ElboTightness) -> Option<String> {
+    if !tightness.is_implausible() {
+        return None;
+    }
+
+    *converged = false;
+    Some(format!(
+        "W_VI_BAD_BASIN: VI: the ELBO is not a usable bound at this estimate — the data term \
+         sits {:.0}x further above its value at the variational means than a posterior-shaped \
+         q would put it ({:.3e} against an expected {:.3e}). The optimizer has almost \
+         certainly settled in a bad basin. Reported converged: false. Re-run from better \
+         starting values (for a [covariate_nn] model, declare `init` so the network starts at \
+         plausible parameter values), or chain `method = [focei, vi]` to start VI from a \
+         fitted point.",
+        tightness.ratio(),
+        tightness.excess,
+        tightness.expected
+    ))
+}
+
+/// Whether a generic iteration-budget warning adds information after quality checks.
+fn needs_iteration_budget_warning(
+    converged: bool,
+    noise_floor_stop: bool,
+    bad_basin_stop: bool,
+) -> bool {
+    !converged && !noise_floor_stop && !bad_basin_stop
 }
 
 fn build_family(kind: ViFamily, d: usize) -> Box<dyn VariationalFamily> {
@@ -876,10 +910,29 @@ pub fn run_vi(
             options.vi_mc_samples
         ));
     }
-    // Skipped when the drift check just demoted `converged`: that warning already says
-    // what happened, and more precisely — "raise vi_iters" is the wrong advice for a run
-    // that is noise-limited rather than budget-limited.
-    if !converged && !noise_floor_stop {
+    // Is the bound we are about to report actually tight? A stuck optimizer produces a
+    // flat trace and stable parameters — indistinguishable, to the convergence test, from
+    // a converged one. This is the check that tells them apart, and it is the difference
+    // between reporting a bad fit as successful and saying so.
+    let tightness = super::elbo::elbo_tightness(
+        model,
+        population,
+        &final_params,
+        final_eval.data_term,
+        &eta_means,
+        &kappa_means,
+    );
+    let bad_basin_stop = if let Some(warning) = bad_basin_warning(&mut converged, &tightness) {
+        warnings.push(warning);
+        true
+    } else {
+        false
+    };
+
+    // Skipped when either quality check just demoted `converged`: those warnings already
+    // say what happened, and more precisely — "increase vi_iters" is wrong advice for a
+    // noise-limited stop or a fit trapped in a bad basin.
+    if needs_iteration_budget_warning(converged, noise_floor_stop, bad_basin_stop) {
         warnings.push(format!(
             "VI: neither the objective nor the parameter estimates had settled after \
              {n_iters_run} iterations (see vi.elbo_trace). Increase vi_iters, or lower \
@@ -895,33 +948,6 @@ pub fn run_vi(
     }
     if let Some(w) = kl_fallback_warning(n_kl_fallback_subjects, n_subjects, families[0].label()) {
         warnings.push(w);
-    }
-
-    // Is the bound we are about to report actually tight? A stuck optimizer produces a
-    // flat trace and stable parameters — indistinguishable, to the convergence test, from
-    // a converged one. This is the check that tells them apart, and it is the difference
-    // between reporting a bad fit as successful and saying so.
-    let tightness = super::elbo::elbo_tightness(
-        model,
-        population,
-        &final_params,
-        final_eval.data_term,
-        &eta_means,
-        &kappa_means,
-    );
-    if tightness.is_implausible() {
-        warnings.push(format!(
-            "VI: the ELBO is not a usable bound at this estimate — the data term sits \
-             {:.0}x further above its value at the variational means than a posterior-shaped \
-             q would put it ({:.3e} against an expected {:.3e}). The optimizer has almost \
-             certainly settled in a bad basin: `converged` reflects a flat objective, not a \
-             good one. Re-run from better starting values (for a [covariate_nn] model, \
-             declare `init` so the network starts at plausible parameter values), or chain \
-             `method = [focei, vi]` to start VI from a fitted point.",
-            tightness.ratio(),
-            tightness.excess,
-            tightness.expected
-        ));
     }
 
     // The ELBO is a lower bound, so it is never reported as the OFV. See

--- a/src/estimation/vi/run_tests.rs
+++ b/src/estimation/vi/run_tests.rs
@@ -179,6 +179,50 @@ fn systematic_drift_is_detected_below_the_settling_test_noise_floor() {
     assert!(!trace_still_drifting(&poisoned, 40));
 }
 
+/// #1098: an implausibly loose ELBO is evidence that a flat trace is a bad basin,
+/// not successful convergence. It must also suppress the generic iteration-budget
+/// advice, which does not address this failure mode.
+#[test]
+fn bad_basin_guard_demotes_convergence_and_uses_its_own_warning() {
+    let tightness = super::ElboTightness {
+        excess: 260.0,
+        expected: 10.0,
+    };
+    let mut converged = true;
+
+    let warning = super::bad_basin_warning(&mut converged, &tightness)
+        .expect("a ratio above the implausibility threshold must warn");
+
+    assert!(!converged, "a detected bad basin is not convergence");
+    assert!(warning.starts_with("W_VI_BAD_BASIN:"));
+    assert!(warning.contains("Reported converged: false"));
+    assert!(!warning.contains("`converged` reflects a flat objective"));
+    assert!(
+        !super::needs_iteration_budget_warning(converged, false, true),
+        "bad-basin guidance must replace the generic increase-vi_iters warning"
+    );
+
+    let structured = crate::types::classify_warning(&warning);
+    assert_eq!(structured.category, crate::types::WarningCode::ViBadBasin);
+    assert_eq!(structured.severity, crate::types::WarningSeverity::Critical);
+}
+
+/// A healthy ELBO must leave convergence untouched, and an ordinary exhausted run
+/// still gets the iteration-budget warning.
+#[test]
+fn healthy_tightness_does_not_change_convergence_reporting() {
+    let tightness = super::ElboTightness {
+        excess: 10.0,
+        expected: 10.0,
+    };
+    let mut converged = true;
+
+    assert!(super::bad_basin_warning(&mut converged, &tightness).is_none());
+    assert!(converged);
+    assert!(super::needs_iteration_budget_warning(false, false, false));
+    assert!(!super::needs_iteration_budget_warning(false, true, false));
+}
+
 // ---------------------------------------------------------------------------
 // End-to-end behaviour
 // ---------------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -4684,6 +4684,9 @@ pub enum WarningCode {
     ConditionNumber,
     /// Optimizer-health issue (trust-radius collapse, degeneracy).
     OptimizerHealth,
+    /// VI's final ELBO tightness diagnostic found that a flat objective represents
+    /// a bad basin rather than a usable variational approximation.
+    ViBadBasin,
     /// Residual (IWRES) autocorrelation — Durbin–Watson out of range.
     DwAutocorrelation,
     /// ETA distribution departs from normality (Shapiro–Wilk).
@@ -4775,6 +4778,7 @@ impl WarningCode {
             WarningCode::CovarianceRegularized => "covariance_regularized",
             WarningCode::ConditionNumber => "condition_number",
             WarningCode::OptimizerHealth => "optimizer_health",
+            WarningCode::ViBadBasin => "vi_bad_basin",
             WarningCode::DwAutocorrelation => "dw_autocorrelation",
             WarningCode::EtaNormality => "eta_normality",
             WarningCode::Experimental => "experimental",
@@ -4873,7 +4877,12 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
     // rewrite instead of a one-line edit. Scoped to this statement rather than
     // the whole fn so a future duplicated arm in another chain still lints.
     #[allow(clippy::if_same_then_else)]
-    let (severity, category) = if lower.contains("w_absorption_twin_declined") {
+    let (severity, category) = if lower.contains("w_vi_bad_basin") {
+        // #1098: VI's final bound-quality check demotes `converged`; keep this
+        // distinct from a budget-limited convergence failure so programmatic
+        // consumers can choose new starts or a chained initializer.
+        (WarningSeverity::Critical, WarningCode::ViBadBasin)
+    } else if lower.contains("w_absorption_twin_declined") {
         // #1008: the analytic absorption model kept no ODE twin. Not an estimation problem —
         // the fit that follows is a pure closed form — but the model has silently lost the
         // reroute, so it is worth its own code rather than the `general` bucket.

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -686,6 +686,7 @@ fn warning_code_tokens_are_stable() {
         (CovarianceRegularized, "covariance_regularized"),
         (ConditionNumber, "condition_number"),
         (OptimizerHealth, "optimizer_health"),
+        (ViBadBasin, "vi_bad_basin"),
         (DwAutocorrelation, "dw_autocorrelation"),
         (EtaNormality, "eta_normality"),
         (Experimental, "experimental"),


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #1017, whose current head is this branch's parent commit. Keep this PR draft until #1017 merges; the diff against `main` will then collapse to commit `2f5716b4`.

## Why

VI already detects an implausibly loose final ELBO and warns that the optimizer almost certainly settled in a bad basin. Despite that diagnosis, the fit still returned `converged: true`, so programmatic consumers could retain a fit known to be unusable. This closes #1098.

## What changed

- Demote `converged` whenever the final ELBO tightness diagnostic is implausible.
- Suppress the generic “increase `vi_iters`” warning for this failure mode because more iterations are not the relevant remedy.
- Emit `W_VI_BAD_BASIN` and classify it as the critical, machine-readable `vi_bad_basin` warning code.
- Add focused regression tests for demotion, warning selection, severity/category, and the healthy-control path.
- Document the warning code and add the `[Unreleased]` changelog entry.

## Alternatives considered

Classifying the existing prose as ordinary `convergence` would make the boolean accurate but would lose the distinction between an exhausted iteration budget and a fit trapped in a bad basin. A dedicated warning code preserves actionable machine-readable semantics.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | follow-up not yet open | required after core lands | after |

The core change is additive and ferx-r already transports unknown structured warning categories. A follow-up should add `vi_bad_basin` to ferx-r's guidance vocabulary when its ferx-core lock is bumped.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [x] Public Rust API (`api.rs` / `types.rs`)
- [ ] None

Additive, non-breaking API change: `WarningCode` is `#[non_exhaustive]`, and this adds the `ViBadBasin` variant / `vi_bad_basin` serialization token.

<details>
<summary>Migration notes (if breaking)</summary>

No migration is required. Consumers should continue handling unknown warning codes generically.

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):

```text
Not applicable: this changes result reporting after estimation and does not alter estimates,
the ELBO, OFV, residuals, or diagnostics.
```

- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

The ELBO tightness calculation already ran; the patch only changes handling of its result.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

Verification:

- `cargo fmt --check`
- `cargo test --lib`: 3,641 passed; 23 ignored
- `cargo check --tests`
- `cargo clippy --lib` completes with the branch's existing warnings
- `cargo clippy --all-targets` remains blocked by four pre-existing `clippy::approx_constant` errors in `src/sens/two_cpt_explicit.rs`

## Example (user-facing features only)
- [x] Example added to `examples/` or inline below
- [ ] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

```text
# Before
converged: true
warning: VI: the ELBO is not a usable bound at this estimate ...

# After
converged: false
warnings_structured:
  - severity: Critical
    category: vi_bad_basin
    message: "W_VI_BAD_BASIN: VI: the ELBO is not a usable bound at this estimate ..."
```

</details>

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

## Checklist
- [ ] `cargo clippy` clean
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [ ] `Cargo.toml` version bumped if breaking

No gradient-reachable code is changed, and the additive `#[non_exhaustive]` warning variant is not breaking, so no version bump is needed.

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

No DSL, example, or data changes.

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

No new estimator, DSL feature, or fit option.

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [ ] No example execution step needed (internal refactor / docs-only / no user-visible change)

No example execution step applies: this is a reporting-only fix exercised by the unit regression tests above; it changes no model, estimator calculation, DSL, or example.

## Reviewer hints

Review commit `2f5716b4` while #1017 is still open. The key policy is in `run.rs`: the tightness check now runs before the generic non-convergence warning, demotes the boolean, and records a dedicated stop reason so the generic advice is skipped.

## Open questions

None.
