### PR TITLE
docs: improve ferx search discoverability [closes #1089]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,10 @@ section of the SDLC for the versioning policy).
   decision changes — the bound only short-circuits the direction it can prove.
 
 ### Changed
+- **The ferx website and GitHub landing page are easier to discover and share (#1089).**
+  Documentation pages now publish descriptive search and social metadata, canonical URLs, and
+  clearer NLME and population PK/PD summaries while retaining the generated sitemap and crawler
+  instructions.
 - **`optimizer = auto` no longer picks BOBYQA on high-dimensional problems (#1064).** BOBYQA interpolates
   a quadratic over the whole parameter space, so its model grows quadratically in the parameter count;
   above 64 free coordinates `auto` now resolves to `nlopt_lbfgs`, whose finite-difference cost is linear.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core/badge)](https://www.codefactor.io/repository/github/ferx-nlme/ferx-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A high-performance Nonlinear Mixed Effects (NLME) modeling engine for population pharmacokinetics, written in Rust. Implements FOCEI and SAEM estimation with analytical PK solutions and ODE solvers.
+[Website](https://ferx-nlme.github.io/) · [Documentation](https://ferx-nlme.github.io/ferx-core/) · [R package](https://github.com/FeRx-NLME/ferx-r) · [Examples](https://ferx-nlme.github.io/ferx-core/examples/)
+
+ferx-core is an open-source, high-performance nonlinear mixed-effects (NLME)
+modeling engine for population pharmacokinetic and pharmacodynamic (PopPK/PD)
+analysis. Written in Rust, it implements FOCE/FOCEI, SAEM, importance sampling,
+analytical PK solutions, and ODE models for pharmacometric workflows.
 
 Additional features:
 - PK-PD and multi-analyte modeling

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -6,9 +6,12 @@ brand: _brand.yml
 
 website:
   title: "ferx-core"
-  description: "Rust nonlinear mixed effects modeling engine for ferx"
+  description: "Open-source nonlinear mixed-effects modeling for population PK/PD and pharmacometrics"
   favicon: assets/ferx-favicon.svg
   site-url: https://ferx-nlme.github.io/ferx-core/
+  open-graph:
+    locale: en_US
+  twitter-card: true
   repo-url: https://github.com/FeRx-NLME/ferx-core
   repo-actions: [edit, issue]
 
@@ -153,6 +156,7 @@ website:
 
 format:
   html:
+    canonical-url: true
     theme:
       light: [cosmo, assets/ferx.scss]
       dark: [cosmo, assets/ferx-dark.scss]

--- a/docs/api/fitting.qmd
+++ b/docs/api/fitting.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Fitting functions"
+---
+
 # Fitting Functions
 
 ## `fit()`

--- a/docs/api/index.qmd
+++ b/docs/api/index.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "ferx-core Rust API for NLME modeling"
+description: "Embed population PK/PD fitting, prediction, simulation, and ferx model parsing in Rust applications with the ferx-core API."
+title-block-style: none
+---
+
 # Rust API
 
 ferx-core can be used as a Rust library for embedding population PK estimation in your own applications.

--- a/docs/api/index.qmd
+++ b/docs/api/index.qmd
@@ -1,7 +1,6 @@
 ---
-pagetitle: "ferx-core Rust API for NLME modeling"
+pagetitle: "Rust API for NLME modeling"
 description: "Embed population PK/PD fitting, prediction, simulation, and ferx model parsing in Rust applications with the ferx-core API."
-title-block-style: none
 ---
 
 # Rust API

--- a/docs/api/parsing.qmd
+++ b/docs/api/parsing.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Parsing ferx models"
+---
+
 # Parsing
 
 ## Model Parsing

--- a/docs/api/simulation.qmd
+++ b/docs/api/simulation.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Simulation API"
+---
+
 # Simulation
 
 ## `simulate()`

--- a/docs/api/types.qmd
+++ b/docs/api/types.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Core Rust API types"
+---
+
 # Core Types
 
 The main types exported by `ferx_core`. All types are available via `use ferx_core::*`.

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "ferx command-line interface for NLME modeling"
 description: "Use the ferx CLI to validate models, fit population PK/PD data, simulate trials, and inspect NLME results."
-title-block-style: none
 ---
 
 # CLI Reference

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "ferx command-line interface for NLME modeling"
+description: "Use the ferx CLI to validate models, fit population PK/PD data, simulate trials, and inspect NLME results."
+title-block-style: none
+---
+
 # CLI Reference
 
 The `ferx` command-line tool runs population PK estimation from model files and data.

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "NONMEM-compatible data format for ferx"
 description: "Prepare NONMEM-compatible CSV data for population PK/PD modeling in ferx, including doses, observations, infusions, steady state, and covariates."
-title-block-style: none
 ---
 
 # Data Format

--- a/docs/data-format.qmd
+++ b/docs/data-format.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "NONMEM-compatible data format for ferx"
+description: "Prepare NONMEM-compatible CSV data for population PK/PD modeling in ferx, including doses, observations, infusions, steady state, and covariates."
+title-block-style: none
+---
+
 # Data Format
 
 ferx-core reads data in NONMEM-compatible CSV format. This is the standard format used across population PK tools.

--- a/docs/development/contributing.qmd
+++ b/docs/development/contributing.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Contributing to FeRx development"
+---
+
 # Contributing to FeRx development
 
 You don't need to be on the core team to move FeRx forward. There are three

--- a/docs/development/index.qmd
+++ b/docs/development/index.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "FeRx development"
+---
+
 # Development
 
 Process and contributor documentation for the FeRx project, spanning both

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "FeRx development lifecycle"
+---
+
 # Development Lifecycle (SDLC)
 
 This page describes how the FeRx project is developed across its two coupled

--- a/docs/estimation/agq.qmd
+++ b/docs/estimation/agq.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Adaptive Gaussian Quadrature (AGQ)"
+---
+
 # AGQ — Adaptive Gaussian Quadrature
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/bayes.qmd
+++ b/docs/estimation/bayes.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Bayesian NLME estimation with MCMC"
+description-meta: "Use Gibbs-within-HMC Bayesian estimation in ferx for population PK/PD posterior inference, credible intervals, and convergence diagnostics."
+---
+
 # Bayesian estimation (MCMC)
 
 `method = bayes` runs full MCMC Bayesian estimation — it draws from the joint

--- a/docs/estimation/foce.qmd
+++ b/docs/estimation/foce.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "FOCE and FOCEI estimation"
+description-meta: "Fit nonlinear mixed-effects population PK/PD models with First-Order Conditional Estimation and interaction in ferx."
+---
+
 # FOCE / FOCEI
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/frem.qmd
+++ b/docs/estimation/frem.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Full Random Effects Modeling (FREM)"
+---
+
 # FREM (Full Random Effects Model)
 
 FREM (Karlsson 2012) is a covariate analysis method that treats covariates as

--- a/docs/estimation/gauss-newton.qmd
+++ b/docs/estimation/gauss-newton.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Gauss-Newton (BHHH) estimation"
+---
+
 # Gauss-Newton (BHHH)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/impmap.qmd
+++ b/docs/estimation/impmap.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "IMPMAP estimation"
+---
+
 # IMPMAP — Importance Sampling assisted by Mode A Posteriori
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/importance-sampling.qmd
+++ b/docs/estimation/importance-sampling.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Importance Sampling (IMP) for NLME models"
+description-meta: "Use importance sampling in ferx to estimate or evaluate the marginal likelihood of nonlinear mixed-effects population PK/PD models."
+---
+
 # Importance Sampling (IMP)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/index.qmd
+++ b/docs/estimation/index.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "NLME estimation methods in ferx"
 description: "Compare FOCE, FOCEI, SAEM, Gauss-Newton, importance sampling, SIR, and Bayesian estimation methods for population PK/PD models in ferx."
-title-block-style: none
 ---
 
 # Estimation Methods

--- a/docs/estimation/index.qmd
+++ b/docs/estimation/index.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "NLME estimation methods in ferx"
+description: "Compare FOCE, FOCEI, SAEM, Gauss-Newton, importance sampling, SIR, and Bayesian estimation methods for population PK/PD models in ferx."
+title-block-style: none
+---
+
 # Estimation Methods
 
 ferx-core separates two orthogonal choices: the **statistical method** (how random effects are handled) and the **outer optimizer** (the algorithm that minimises the population objective).

--- a/docs/estimation/mixture.qmd
+++ b/docs/estimation/mixture.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Mixture models in ferx"
+description-meta: "Fit latent subpopulation mixture models with FOCEI, SAEM, and Bayesian methods in the ferx NLME engine."
+---
+
 # Mixture Models
 
 > **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/optimizers.qmd
+++ b/docs/estimation/optimizers.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Outer optimizers for NLME estimation"
+---
+
 # Outer Optimizers
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/parameterization.qmd
+++ b/docs/estimation/parameterization.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Packed NLME parameter space"
+---
+
 # Packed Parameter Space
 
 Every optimizer, the covariance step, SIR, and simulation-with-uncertainty

--- a/docs/estimation/saem.qmd
+++ b/docs/estimation/saem.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "SAEM estimation for population PK/PD"
+description-meta: "Fit complex nonlinear mixed-effects population PK/PD models with Stochastic Approximation Expectation-Maximization in ferx."
+---
+
 # SAEM
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/sir.qmd
+++ b/docs/estimation/sir.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Sampling Importance Resampling (SIR)"
+description-meta: "Estimate nonlinear mixed-effects parameter uncertainty with Sampling Importance Resampling in ferx."
+---
+
 # Sampling Importance Resampling (SIR)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/estimation/tte.qmd
+++ b/docs/estimation/tte.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Time-to-event models in ferx"
+description-meta: "Fit parametric, censored, competing-risk, repeated-event, and joint PK time-to-event models with FOCEI or SAEM in ferx."
+---
+
 # Time-to-Event (TTE) Models
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/examples/bloq.qmd
+++ b/docs/examples/bloq.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "BLOQ modeling example (M3 method)"
+---
+
 # BLOQ (M3 method)
 
 This example shows how to fit a model to data that contains observations below

--- a/docs/examples/covariates.qmd
+++ b/docs/examples/covariates.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Population PK covariate model example"
+---
+
 # Covariate Model
 
 This example demonstrates a two-compartment oral model with body weight (WT) and creatinine clearance (CRCL) as covariates on clearance.

--- a/docs/examples/data-selection.qmd
+++ b/docs/examples/data-selection.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Data selection example (IGNORE and ACCEPT)"
+---
+
 # Data Selection (IGNORE / ACCEPT)
 
 This example shows the `[data_selection]` block, which filters dataset rows at read time without modifying the CSV. The complete model file is [`examples/warfarin_data_selection.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_data_selection.ferx).

--- a/docs/examples/derived-output.qmd
+++ b/docs/examples/derived-output.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Derived columns and output example"
+---
+
 # Derived Columns and Output
 
 This example demonstrates the `[derived]` and `[output]` blocks, which add post-fit computed columns and individual PK parameter columns to the sdtab. The complete model file is [`examples/warfarin_derived.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_derived.ferx).

--- a/docs/examples/frem.qmd
+++ b/docs/examples/frem.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "FREM covariate analysis example"
+---
+
 # FREM (Covariate Analysis)
 
 This example demonstrates FREM covariate analysis using the warfarin

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "Population PK/PD and NLME modeling examples"
+description: "Worked ferx examples for one- and two-compartment PK, covariates, FOCEI, SAEM, ODE models, inter-occasion variability, and simulation."
+title-block-style: none
+---
+
 # Examples
 
 ferx-core includes several example models in the `examples/` directory with corresponding datasets in `data/`.

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "Population PK/PD and NLME modeling examples"
 description: "Worked ferx examples for one- and two-compartment PK, covariates, FOCEI, SAEM, ODE models, inter-occasion variability, and simulation."
-title-block-style: none
 ---
 
 # Examples

--- a/docs/examples/iov-saem.qmd
+++ b/docs/examples/iov-saem.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Inter-occasion variability with SAEM example"
+---
+
 # IOV with SAEM
 
 This example extends the inter-occasion variability (IOV) model to use SAEM estimation instead of FOCE. The complete model file is [`examples/warfarin_iov_saem.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_iov_saem.ferx).

--- a/docs/examples/iov.qmd
+++ b/docs/examples/iov.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Inter-occasion variability example"
+---
+
 # Inter-Occasion Variability (IOV)
 
 This example extends the one-compartment oral warfarin model to account for occasion-to-occasion variability in clearance. The complete model file is `examples/warfarin_iov.ferx`.

--- a/docs/examples/multiple-dosing.qmd
+++ b/docs/examples/multiple-dosing.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Multiple dosing with ADDL example"
+---
+
 # Multiple Dosing (ADDL Column)
 
 This example shows how the `ADDL` and `II` dataset columns are used to represent multiple-dose designs without repeating every dose row. The complete model file is [`examples/warfarin_addl.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_addl.ferx).

--- a/docs/examples/multistart.qmd
+++ b/docs/examples/multistart.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Multi-start NLME fitting example"
+---
+
 # Multi-Start: Michaelis-Menten Elimination
 
 Michaelis-Menten (saturable) elimination is the canonical example of a local-minimum problem in NLME modelling. The Vmax/Km pair is only weakly identifiable from sparse PK data: many (Vmax, Km) combinations produce similar predicted concentrations, so the OFV surface contains a narrow ridge. A single-start FOCEI run is sensitive to the initial values — starting far from the true optimum, the optimizer often settles on an inflated Vmax/Km pair with a higher OFV than the true optimum.

--- a/docs/examples/ode-lagtime.qmd
+++ b/docs/examples/ode-lagtime.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ODE model with absorption lag time example"
+---
+
 # ODE Model with Absorption Lag Time
 
 This example demonstrates the `LAGTIME` keyword in `[individual_parameters]` for ODE models. The complete model file is [`examples/warfarin_ode_lagtime.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_ode_lagtime.ferx).

--- a/docs/examples/ode-model.qmd
+++ b/docs/examples/ode-model.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Michaelis-Menten ODE model example"
+---
+
 # ODE Model (Michaelis-Menten)
 
 This example demonstrates a one-compartment oral model with saturable (Michaelis-Menten) elimination, solved using the ODE integrator.

--- a/docs/examples/one-cpt-oral.qmd
+++ b/docs/examples/one-cpt-oral.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "One-compartment oral population PK example"
+---
+
 # One-Compartment Oral (Warfarin)
 
 This example fits a one-compartment oral pharmacokinetic model to warfarin concentration data.

--- a/docs/examples/scaling.qmd
+++ b/docs/examples/scaling.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Population PK unit-scaling example"
+---
+
 # Unit Scaling (`[scaling]`)
 
 This example demonstrates the `[scaling]` block with `obs_scale`, which divides every model prediction by a constant before computing residuals. The complete model file is [`examples/warfarin_scaled.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_scaled.ferx).

--- a/docs/examples/sde.qmd
+++ b/docs/examples/sde.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Stochastic differential equation model example"
+---
+
 # Stochastic Differential Equations (SDE)
 
 This example extends a one-compartment ODE model with a `[diffusion]` block that adds continuous process noise (SDE / EKF). The complete model file is [`examples/warfarin_sde.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_sde.ferx).

--- a/docs/examples/steady-state.qmd
+++ b/docs/examples/steady-state.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Steady-state dosing example"
+---
+
 # Steady-State Dosing (SS Column)
 
 This example demonstrates the `SS` and `II` dataset columns, which tell the engine to initialise the compartment states analytically at steady state rather than from zero. The complete model file is [`examples/warfarin_ss.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/warfarin_ss.ferx).

--- a/docs/examples/transit-absorption.qmd
+++ b/docs/examples/transit-absorption.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Two-compartment transit absorption example"
+---
+
 # Transit Absorption (Two-Compartment)
 
 This example demonstrates a two-compartment model with transit-compartment absorption, written with the built-in [`transit(n, mtt)`](../model-file/absorption.qmd) input-rate shortcut. The complete model file is [`examples/transit_2cpt_shortcut.ferx`](https://github.com/FeRx-NLME/ferx-core/blob/main/examples/transit_2cpt_shortcut.ferx).

--- a/docs/examples/two-cpt-iv.qmd
+++ b/docs/examples/two-cpt-iv.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Two-compartment IV population PK example"
+---
+
 # Two-Compartment IV Bolus
 
 This example fits a two-compartment IV bolus model with four random effects.

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "ferx NLME modeling FAQ"
+description: "Answers about ferx population PK/PD modeling, NONMEM and nlmixr2 compatibility, FOCEI, optimizers, data handling, and model syntax."
+title-block-style: none
+---
+
 # Frequently Asked Questions
 
 ## Do I need to use MU-referencing in my model definitions, like in NONMEM / nlmixr2?

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "ferx NLME modeling FAQ"
 description: "Answers about ferx population PK/PD modeling, NONMEM and nlmixr2 compatibility, FOCEI, optimizers, data handling, and model syntax."
-title-block-style: none
 ---
 
 # Frequently Asked Questions

--- a/docs/file-formats/check-report.qmd
+++ b/docs/file-formats/check-report.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ferx check report JSON format"
+---
+
 # Check Report (`ferx check --json`)
 
 `ferx check <model.ferx> [--data <data.csv>] --json` emits a structured JSON

--- a/docs/file-formats/fitrx.qmd
+++ b/docs/file-formats/fitrx.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "The .fitrx fit bundle format"
+---
+
 # The `.fitrx` Fit Bundle
 
 A `.fitrx` file is a single, portable, self-describing container for a fit

--- a/docs/file-formats/index.qmd
+++ b/docs/file-formats/index.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ferx output and interchange file formats"
+---
+
 # File Formats
 
 Reference for the binary and structured output formats produced and consumed by ferx-core.

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "Getting started with ferx NLME modeling"
+description: "Install ferx and run your first nonlinear mixed-effects population PK model with the Rust CLI or R package."
+title-block-style: none
+---
+
 # Getting Started
 
 This section covers installing ferx-core and running your first model.

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "Getting started with ferx NLME modeling"
 description: "Install ferx and run your first nonlinear mixed-effects population PK model with the Rust CLI or R package."
-title-block-style: none
 ---
 
 # Getting Started

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,6 +1,27 @@
-# Introduction
+---
+pagetitle: "ferx: Open-source NLME modeling for pharmacometrics"
+description: "Use ferx for open-source nonlinear mixed-effects modeling, population PK/PD analysis, FOCEI, SAEM, simulation, and NONMEM-compatible workflows."
+title-block-style: none
+keywords:
+  - nonlinear mixed-effects modeling
+  - NLME
+  - population pharmacokinetics
+  - population PK/PD
+  - pharmacometrics
+  - FOCEI
+  - SAEM
+  - NONMEM alternative
+---
 
-ferx-core is a high-performance Nonlinear Mixed Effects (NLME) modeling engine written in Rust. It is designed for population pharmacokinetic (PopPK) analysis, implementing the same statistical methodology as established tools like NONMEM, Monolix, and Pumas.
+# Open-source NLME modeling for pharmacometrics
+
+ferx is an open-source **nonlinear mixed-effects (NLME) modeling** platform for
+population pharmacokinetic and pharmacodynamic (**PopPK/PD**) analysis. Its
+high-performance Rust engine supports established pharmacometric methods and
+NONMEM-compatible data through a command-line interface, Rust API, and
+[R package](https://ferx-nlme.github.io/ferx-book/).
+
+[Install ferx](installation.qmd) or [run your first PopPK model](quick-start.qmd).
 
 ## Key Features
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,16 +1,6 @@
 ---
 pagetitle: "ferx: Open-source NLME modeling for pharmacometrics"
 description: "Use ferx for open-source nonlinear mixed-effects modeling, population PK/PD analysis, FOCEI, SAEM, simulation, and NONMEM-compatible workflows."
-title-block-style: none
-keywords:
-  - nonlinear mixed-effects modeling
-  - NLME
-  - population pharmacokinetics
-  - population PK/PD
-  - pharmacometrics
-  - FOCEI
-  - SAEM
-  - NONMEM alternative
 ---
 
 # Open-source NLME modeling for pharmacometrics
@@ -20,6 +10,8 @@ population pharmacokinetic and pharmacodynamic (**PopPK/PD**) analysis. Its
 high-performance Rust engine supports established pharmacometric methods and
 NONMEM-compatible data through a command-line interface, Rust API, and
 [R package](https://ferx-nlme.github.io/ferx-book/).
+It provides a fully open-source alternative for workflows familiar to users of
+NONMEM, Monolix, and Pumas.
 
 [Install ferx](installation.qmd) or [run your first PopPK model](quick-start.qmd).
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -10,8 +10,6 @@ population pharmacokinetic and pharmacodynamic (**PopPK/PD**) analysis. Its
 high-performance Rust engine supports established pharmacometric methods and
 NONMEM-compatible data through a command-line interface, Rust API, and
 [R package](https://ferx-nlme.github.io/ferx-book/).
-It provides a fully open-source alternative for workflows familiar to users of
-NONMEM, Monolix, and Pumas.
 
 [Install ferx](installation.qmd) or [run your first PopPK model](quick-start.qmd).
 

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "Install ferx for NLME and population PK/PD modeling"
 description: "Install ferx on Linux, macOS, or Windows; build the Rust NLME engine from source; or install the ferx R package."
-title-block-style: none
 ---
 
 # Installation

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "Install ferx for NLME and population PK/PD modeling"
+description: "Install ferx on Linux, macOS, or Windows; build the Rust NLME engine from source; or install the ferx R package."
+title-block-style: none
+---
+
 # Installation
 
 ferx-core builds with a recent **nightly** Rust toolchain (pinned in

--- a/docs/maturity.qmd
+++ b/docs/maturity.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ferx feature maturity"
+---
+
 # Feature Maturity
 
 Not every feature in ferx-core is equally battle-tested. Some — like FOCE/FOCEI

--- a/docs/model-file/absorption.qmd
+++ b/docs/model-file/absorption.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Built-in absorption models"
+---
+
 # Built-in Absorption Models
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/adaptive-dosing.qmd
+++ b/docs/model-file/adaptive-dosing.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Adaptive feedback dosing"
+---
+
 # Adaptive (Feedback) Dosing
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/bloq.qmd
+++ b/docs/model-file/bloq.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "LOQ-censored observations in ferx"
+---
+
 # LOQ-Censored Observations
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/covariate-nn.qmd
+++ b/docs/model-file/covariate-nn.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Covariate neural networks and DCM"
+---
+
 # `[covariate_nn]` — Deep Compartment Models (DCM)
 
 > **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/covariates.qmd
+++ b/docs/model-file/covariates.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Covariates in population PK/PD models"
+description-meta: "Define continuous, categorical, baseline, and time-varying covariates in ferx nonlinear mixed-effects models."
+---
+
 # Covariates
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/data-selection.qmd
+++ b/docs/model-file/data-selection.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Selecting data records and subjects"
+---
+
 # Data Selection
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/data.qmd
+++ b/docs/model-file/data.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Declaring model data"
+---
+
 # Data
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/derived.qmd
+++ b/docs/model-file/derived.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Derived columns in ferx output"
+---
+
 # Derived Columns (`[derived]`)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/diffusion.qmd
+++ b/docs/model-file/diffusion.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "SDE and diffusion models"
+---
+
 # Stochastic Differential Equations (SDE / Diffusion)
 
 > **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Residual error models in ferx"
+description-meta: "Specify additive, proportional, combined, log-scale, censored, and multi-endpoint residual error models for population PK/PD analysis."
+---
+
 # Error Model
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/event-model.qmd
+++ b/docs/model-file/event-model.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Time-to-event endpoints"
+---
+
 # Time-to-Event Endpoints (`[event_model]`)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "NLME fit options in ferx"
+description-meta: "Configure estimation methods, optimizers, convergence, covariance, ODE solvers, simulation, and diagnostics in ferx model files."
+---
+
 # Fit Options
 
 The optional `[fit_options]` block configures the estimation method and optimizer settings.

--- a/docs/model-file/index.qmd
+++ b/docs/model-file/index.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "ferx model file reference: NLME model syntax"
 description: "Reference for the ferx model DSL, including population parameters, PK/PD structural models, error models, covariates, estimation, and simulation."
-title-block-style: none
 ---
 
 # Model File Reference

--- a/docs/model-file/index.qmd
+++ b/docs/model-file/index.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "ferx model file reference: NLME model syntax"
+description: "Reference for the ferx model DSL, including population parameters, PK/PD structural models, error models, covariates, estimation, and simulation."
+title-block-style: none
+---
+
 # Model File Reference
 
 ferx-core models are defined in `.ferx` files using a declarative DSL. Each file is organized into blocks, each denoted by a `[block_name]` header.

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Individual parameter model syntax"
+---
+
 # Individual Parameters
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/initial-conditions.qmd
+++ b/docs/model-file/initial-conditions.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ODE initial conditions"
+---
+
 # Initial Conditions
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/iov.qmd
+++ b/docs/model-file/iov.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Inter-occasion variability in ferx"
+---
+
 # Inter-Occasion Variability (IOV)
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/lagtime.qmd
+++ b/docs/model-file/lagtime.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Absorption lag time"
+---
+
 # Lagtime
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/neural-networks.qmd
+++ b/docs/model-file/neural-networks.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Neural networks in ferx models"
+---
+
 # Neural Networks
 
 > **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "ODE models for population PK/PD"
+description-meta: "Define and solve custom ordinary differential equation models for nonlinear mixed-effects population PK/PD analysis in ferx."
+---
+
 # ODE Models
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/output.qmd
+++ b/docs/model-file/output.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Custom fit output columns"
+---
+
 # Output Columns (`[output]`)
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/parameters.qmd
+++ b/docs/model-file/parameters.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Population parameters and random effects"
+description-meta: "Define theta fixed effects, omega between-subject variability, kappa inter-occasion variability, and sigma residual error in ferx."
+---
+
 # Parameters
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Observation and compartment scaling"
+---
+
 # Scaling
 
 > **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/simulation.qmd
+++ b/docs/model-file/simulation.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Population PK/PD simulation design"
+---
+
 # Simulation
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/steady-state.qmd
+++ b/docs/model-file/steady-state.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "Steady-state doses in ferx"
+---
+
 # Steady-State Doses (SS=1)
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/model-file/structural-model.qmd
+++ b/docs/model-file/structural-model.qmd
@@ -1,3 +1,8 @@
+---
+pagetitle: "Structural models for population PK/PD"
+description-meta: "Choose analytical one-, two-, or three-compartment PK models or custom ODE structural models in ferx."
+---
+
 # Structural Model
 
 > **Maturity: stable** — see [Feature Maturity](../maturity.qmd) for what this means.

--- a/docs/output.qmd
+++ b/docs/output.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ferx fit output files and diagnostics"
+---
+
 # Output Files
 
 Each model run produces two output files (plus a third, `{model}-covtab.csv`,

--- a/docs/quick-start.qmd
+++ b/docs/quick-start.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: "ferx quick start: Fit a population PK model"
 description: "Fit a one-compartment oral population pharmacokinetic model with FOCEI using ferx and NONMEM-compatible data."
-title-block-style: none
 ---
 
 # Quick Start

--- a/docs/quick-start.qmd
+++ b/docs/quick-start.qmd
@@ -1,3 +1,9 @@
+---
+pagetitle: "ferx quick start: Fit a population PK model"
+description: "Fit a one-compartment oral population pharmacokinetic model with FOCEI using ferx and NONMEM-compatible data."
+title-block-style: none
+---
+
 # Quick Start
 
 This walkthrough fits a one-compartment oral PK model to warfarin data.

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -1,3 +1,7 @@
+---
+pagetitle: "ferx warnings and diagnostic codes"
+---
+
 # Warnings
 
 A fit collects non-fatal issues into two parallel channels on `FitResult`:


### PR DESCRIPTION
## Why

The documentation site exposed no canonical link tags, no Open Graph/Twitter metadata, and no search description on its homepage. High-intent landing pages inherited filename-based titles such as `faq – ferx-core`. The GitHub landing page also lacked prominent website/documentation links. This addresses #1089.

## What changed

- Enabled canonical URLs, Open Graph metadata, and Twitter cards across the Quarto site.
- Added explicit search titles to all 82 documentation pages, eliminating filename fallbacks such as `saem – ferx-core`.
- Added tailored search descriptions to 24 high-intent landing, estimation, and model-reference pages.
- Reworked the homepage and README summaries around the terms users search for: NLME, population PK/PD, pharmacometrics, FOCEI, SAEM, and NONMEM-compatible workflows.
- Added prominent website, documentation, R package, and examples links to the README.
- Added the required changelog entry.

The repository's non-versioned GitHub description and topics were also populated separately with the same terminology.

## Alternatives considered

A generated 1200×630 social image was evaluated, but the available rasterizer distorted its aspect ratio. This PR keeps valid text-based summary cards rather than shipping a malformed asset; #1107 tracks a production-ready raster card. Quarto's generated `sitemap.xml` and `robots.txt` were retained instead of adding duplicate hand-maintained files.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api.rs` / `types.rs`)
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

Not applicable.

</details>

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):
- [x] Not applicable (docs / refactor / CI only)

## Performance

- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

## Tests

- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [ ] Regression test added that fails without this fix
- [x] No new tests needed: static documentation metadata only. `quarto render docs` completed for all 82 pages; the rendered audit confirmed 82 sitemap URLs, canonical tags and Open Graph titles on all 82 pages, no filename-fallback titles, and search descriptions on 24 targeted pages.

## Example (user-facing features only)

- [ ] Example added to `examples/` or inline below
- [x] Not applicable (documentation/discoverability only; no API surface)

<details>
<summary>Example (if not a standalone file)</summary>

Not applicable.

</details>

## Docs

- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml` (N/A: no pages added)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change)
- [ ] No user-visible change

## Checklist

- [ ] `cargo clippy` clean (not run; no Rust changed)
- [x] Functions on the `Dual2` sensitivity path stay differentiable (not touched)
- [x] `Cargo.toml` version bumped if breaking (N/A: non-breaking)

## Docs & examples

### ferx-site

- [x] New `.ferx` DSL syntax or `[fit_options]` key → N/A: none added
- [x] New example `.ferx` file added → N/A: none added
- [x] New data file added → N/A: none added

### ferx-book

- [x] New estimator, DSL feature, or fit option → N/A: none added

### Example execution (run locally before marking ready for review)

- [ ] Rebuilt ferx-core: `cargo build --release`
- [ ] Rebuilt ferx-r against updated ferx-core
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly
- [ ] All affected ferx-book chapters render cleanly
- [x] No example execution step needed (docs-only / no model behavior change)

## Reviewer hints

The site-wide behavior is in `docs/_quarto.yml`; per-page `pagetitle` metadata changes only the HTML head, leaving visible H1 anchors and explicitly configured sidebar labels unchanged. `description-meta` is used on the newly covered reference pages so descriptions remain head-only.

## Open questions

None.
