### PR TITLE
test: fix the three slow-test failures keeping the nightly red [closes #1113]

### DIFF
--- a/tests/imp_init_defensive_slow.rs
+++ b/tests/imp_init_defensive_slow.rs
@@ -27,25 +27,55 @@
 //!    (`run14`, SAEM→IMP, OFV −249.23) lives with the cross-repo
 //!    `ferx-testdata/thioguanine_mmc` model and is reported in the PR.
 //!
-//! 2. **Mixture-vs-legacy discrimination (#961).** A subtlety surfaced after #528:
-//!    on this fixture the *default* legacy (`alpha = 0`) sampler no longer collapses
-//!    (V ≈ 23.4, essentially the mixture's estimate). The runaway is not gone — it
-//!    is masked by a *second, general* safeguard, the per-subject **ISCALE scalar
-//!    pilot search**, which isotropically rebroadens a too-narrow proposal until
-//!    the ESS recovers. (Two upstream changes conspired: the SAEM `iiv_on_ruv`
-//!    fixes #895/#904 now hand the IMP phase a saner start, and the ISCALE search
-//!    then finishes the rescue.) ISCALE and the defensive mixture overlap, so with
-//!    ISCALE on the mixture reads as redundant *here* — but it is not redundant in
-//!    general: ISCALE is a single isotropic scale, whereas the `N(0, Ω)` mixture
-//!    component bounds every weight regardless of how badly the narrow proposal is
-//!    centred or shaped. To restore genuine discrimination we **pin ISCALE to 1.0**
-//!    (its documented "disabled" setting), removing the overlapping rescue. With it
-//!    off the weakly-identified-V collapse returns: legacy runs V/CL away
-//!    (> 50% off truth, and > 3× the mixture's error), the mixture still recovers
-//!    them. That is the contrast this test asserts. The guard is deliberately
-//!    relative — the runaway's *magnitude* is chaotic and libm-dependent (macOS
-//!    V ≈ 40+, glibc V ≈ 36.5), so an absolute multiple-of-truth threshold reads
-//!    as a platform-dependent failure rather than a lost contrast (#751). The fast branch-coverage smoke test is
+//! 2. **Mixture-vs-legacy discrimination (#961, re-based in #1113).** The
+//!    discrimination is the *negative* half of the test: legacy
+//!    (`imp_defensive_alpha = 0`) must run the population parameters away on a
+//!    fixture the mixture recovers, or the fixture has stopped reproducing the
+//!    defect the option exists for.
+//!
+//!    Two safeguards have masked that contrast in turn, and the fixture has been
+//!    re-based once for each:
+//!
+//!    * #961 — the per-subject **ISCALE scalar pilot search** (a *separate*,
+//!      general rescue that isotropically rebroadens a too-narrow proposal until
+//!      the ESS recovers) alone kept legacy bounded on the original fixture. That
+//!      was worked around by **pinning ISCALE to 1.0** (its documented "disabled"
+//!      setting) for the discrimination arm.
+//!    * #1113 — #1017's LTBS prediction floor (`CompiledModel::floor_prediction`)
+//!      then removed the *fabricated* residuals that were doing much of the work:
+//!      the old `f.max(1e-12)` clamp was replacing a legitimately negative
+//!      log-prediction (this fixture's error model is `log_additive`, so `f` is
+//!      `log(c)` and is negative for any concentration below one unit) with ~0.
+//!      With that fixed, legacy landed `V = 19.84` — 1 % off truth — and the
+//!      contrast was gone even with ISCALE pinned. The floor fix is
+//!      unconditionally correct and stays.
+//!
+//!    So the fixture itself was re-based on the mechanism rather than on either
+//!    safeguard: **three quarters** of the subjects are now the weakly-identified
+//!    baseline case (was one half) and `ETA_V`'s prior is wider (variance 0.25,
+//!    was 0.09), so the single-proposal sampler faces the collapse #528 reported
+//!    without help from a clamp artefact. On that fixture the runaway returns in
+//!    the **shipped default config** — ISCALE on — which is a strictly stronger
+//!    statement than #961's pinned-only contrast: the defensive mixture is not
+//!    redundant with the ISCALE search, it is what keeps this fit identifiable.
+//!    The pinned-ISCALE arm is kept as a second, independent reading.
+//!
+//!    The mixture's answer is anchored *within the test* against a deterministic
+//!    **FOCEI** fit of the same model and data (`CL 2.618, V 16.963`): the
+//!    mixture must land on that optimum, not merely inside a band around the
+//!    simulation truth — one noisy realization's MLE sits ~15% below truth here,
+//!    and "near truth" alone would not distinguish a real fit from a fit stuck at
+//!    its starting values.
+//!
+//!    The failure guard is deliberately **relative** and taken over *both* `CL`
+//!    and `V`: the runaway's magnitude and which coordinate absorbs it are
+//!    chaotic and libm-dependent (a seed sweep put legacy anywhere from
+//!    `V +160%` with `CL +684%` to `V +9%` with `CL +1903%`), so an absolute
+//!    multiple-of-truth threshold on one coordinate reads as a platform-dependent
+//!    failure rather than a lost contrast (#751). Across the five seeds swept,
+//!    legacy's worse coordinate was off by at least 90% in every default-config
+//!    run and 160% in every pinned run, while the mixture stayed at 13-15% (the
+//!    FOCEI optimum) throughout. The fast branch-coverage smoke test is
 //!    `importance_sampling_api::imp_defensive_mixture_runs_for_both_alpha_branches`.
 //!
 //! Data is simulated from the model (fixed seed) so the test is self-contained.
@@ -71,7 +101,7 @@ const MODEL_SRC: &str = r"
   theta TVKA(1.0, 0.01, 50.0)
 
   omega ETA_CL  ~ 0.09
-  omega ETA_V   ~ 0.09
+  omega ETA_V   ~ 0.25
   omega ETA_RUV ~ 0.05
 
   sigma ADD_ERR ~ 0.1 (sd)
@@ -93,13 +123,16 @@ const MODEL_SRC: &str = r"
   iiv_on_ruv = ETA_RUV
 ";
 
-/// Template population: half the subjects carry a pre-dose baseline with only a
-/// trace dose (`CONC0 > 0`, observed on the decay tail — the weakly-identified-V
-/// case), the rest are ordinary oral-dose subjects with informative absorption.
+/// Template population: **three quarters** of the subjects carry a pre-dose
+/// baseline with only a trace dose (`CONC0 > 0`, observed on the decay tail — the
+/// weakly-identified-V case), the rest are ordinary oral-dose subjects with
+/// informative absorption. The 3:1 split (was 1:1) is what re-exposes the #528
+/// weight collapse now that #1017's LTBS prediction floor no longer fabricates
+/// residuals on this log-scale model — see the module docs.
 fn template() -> Population {
     let mut subjects = Vec::new();
     for i in 0..24 {
-        let baseline = i % 2 == 0;
+        let baseline = i % 4 != 0;
         let (conc0, amt, obs_times) = if baseline {
             (20.0, 0.01, vec![2.0, 8.0, 24.0])
         } else {
@@ -180,6 +213,32 @@ fn saem_imp_opts(defensive_alpha: f64, pin_iscale: bool) -> FitOptions {
     opts
 }
 
+/// Worst relative error over the two identifiable typical values (`TVCL`, `TVV`)
+/// against a reference pair. Which of the two absorbs a collapsed-weight runaway
+/// is chaotic — a seed sweep produced legacy fits that ran `V` away with `CL`
+/// almost intact and fits that did the reverse — so every guard below reads the
+/// worse coordinate rather than `V` alone (#1113).
+fn max_rel_err(theta: &[f64], ref_cl: f64, ref_v: f64) -> f64 {
+    ((theta[0] - ref_cl).abs() / ref_cl).max((theta[1] - ref_v).abs() / ref_v)
+}
+
+/// Deterministic FOCEI reference fit of the same model and data: the optimum the
+/// stochastic SAEM→IMP chain is expected to land on. Anchoring the mixture here
+/// rather than on the simulation truth alone matters because this realization's
+/// MLE sits ~15% below truth (`CL 2.618, V 16.963` vs `3, 20`) — a band around
+/// truth wide enough to admit the MLE would also admit a fit that never moved
+/// from its starting values.
+fn focei_reference(
+    model: &ferx_core::types::CompiledModel,
+    pop: &Population,
+) -> ferx_core::types::FitResult {
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    opts.run_covariance_step = false;
+    opts.interaction = true;
+    fit(model, pop, &model.default_params, &opts).expect("FOCEI reference fit must produce a fit")
+}
+
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
@@ -195,8 +254,21 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
     );
     let pop = simulate_dv(&model, &template(), &model.default_params);
 
-    // --- Part 1: default config (ISCALE pilot search on). The mixture recovers
-    // θ near the truth — the #528 core: the IMP phase stays identifiable.
+    // Deterministic optimum of this realization — the target for every recovering
+    // arm below, and a sanity check that the fixture is still an identifiable
+    // problem for a non-sampling estimator.
+    let focei = focei_reference(&model, &pop);
+    let (ref_cl, ref_v) = (focei.theta[0], focei.theta[1]);
+    assert!(
+        focei.ofv.is_finite() && max_rel_err(&focei.theta, TRUE_CL, TRUE_V) < 0.25,
+        "FOCEI reference must itself sit near the truth (CL {ref_cl}, V {ref_v}, OFV {}) — \
+         otherwise the fixture no longer poses an identifiable problem",
+        focei.ofv
+    );
+
+    // --- Part 1: default config (ISCALE pilot search on) — the shipped path. The
+    // mixture recovers the FOCEI optimum: the #528 core, the IMP phase stays
+    // identifiable.
     let with_mix = fit(
         &model,
         &pop,
@@ -210,15 +282,21 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         "OFV must be sane with the mixture, got {}",
         with_mix.ofv
     );
-    let v = with_mix.theta[1];
-    let cl = with_mix.theta[0];
+    let err_mix_default = max_rel_err(&with_mix.theta, ref_cl, ref_v);
     assert!(
-        (v - TRUE_V).abs() / TRUE_V < 0.25,
-        "TVV should be recovered near {TRUE_V}, got {v}"
+        err_mix_default < 0.10,
+        "defensive mixture must land on the FOCEI optimum (CL {ref_cl:.3}, V {ref_v:.3}), got \
+         CL {} / V {} ({:.0}% off)",
+        with_mix.theta[0],
+        with_mix.theta[1],
+        err_mix_default * 100.0
     );
     assert!(
-        (cl - TRUE_CL).abs() / TRUE_CL < 0.25,
-        "TVCL should be recovered near {TRUE_CL}, got {cl}"
+        max_rel_err(&with_mix.theta, TRUE_CL, TRUE_V) < 0.25,
+        "defensive mixture must also stay near the simulation truth (TVCL {TRUE_CL}, \
+         TVV {TRUE_V}), got CL {} / V {}",
+        with_mix.theta[0],
+        with_mix.theta[1]
     );
     let imp = with_mix
         .importance_sampling
@@ -230,50 +308,53 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         imp.minus2_log_likelihood
     );
 
-    // Default-config legacy (alpha = 0, ISCALE pilot search on) — the realistic
-    // shipped path. Post-#528 the ISCALE search alone keeps this bounded; assert it
-    // stays finite and near truth so an ISCALE-rescue regression trips here (the
-    // guard the pinned-ISCALE Part 2 below deliberately removes).
+    // --- Part 2: mixture-vs-legacy discrimination in the **default** config
+    // (#1113). On the re-based fixture the ISCALE scalar pilot search no longer
+    // rescues the legacy single-proposal sampler, so the contrast the defensive
+    // mixture exists for is visible on the shipped path — no knob has to be turned
+    // off to see it:
+    //
+    //   * legacy single-proposal (alpha = 0): weights collapse on the baseline
+    //     subjects, the importance-weighted M-step is hijacked, and CL/V run away.
+    //   * defensive mixture (alpha = 0.1): the broad `N(0, Ω)` component bounds
+    //     every weight, so no single collapsed-weight subject can dominate and θ
+    //     stays identifiable.
     let legacy_default = fit(
         &model,
         &pop,
         &model.default_params,
         &saem_imp_opts(0.0, false),
     )
-    .expect("legacy imp (default ISCALE) must produce a fit");
-    let v_legacy_default = legacy_default.theta[1];
-    let cl_legacy_default = legacy_default.theta[0];
+    .expect("legacy imp (default ISCALE) still returns a (bad) fit");
+    let err_legacy_default = max_rel_err(&legacy_default.theta, TRUE_CL, TRUE_V);
     assert!(
-        legacy_default.converged,
-        "default-config legacy IMP must converge (ISCALE rescue intact)"
+        err_legacy_default > 0.5,
+        "legacy sampler (default config) is expected to run CL/V far off truth (>50% error); \
+         got CL {} / V {} ({:.0}% off) — if this fails the fixture no longer reproduces the \
+         collapse and the negative control must be re-based, not weakened (#961 / #1113)",
+        legacy_default.theta[0],
+        legacy_default.theta[1],
+        err_legacy_default * 100.0
     );
+    let err_mix_vs_truth = max_rel_err(&with_mix.theta, TRUE_CL, TRUE_V);
     assert!(
-        legacy_default.ofv.is_finite() && legacy_default.ofv.abs() < 1e6,
-        "default-config legacy IMP OFV must be finite/sane: {}",
-        legacy_default.ofv
-    );
-    assert!(
-        (v_legacy_default - TRUE_V).abs() / TRUE_V < 0.25,
-        "default-config legacy IMP must recover TVV near {TRUE_V} (ISCALE rescue \
-         intact), got {v_legacy_default}"
-    );
-    assert!(
-        (cl_legacy_default - TRUE_CL).abs() / TRUE_CL < 0.25,
-        "default-config legacy IMP must recover TVCL near {TRUE_CL} (ISCALE rescue \
-         intact), got {cl_legacy_default}"
+        err_legacy_default > 3.0 * err_mix_vs_truth,
+        "defensive mixture must beat legacy by a wide margin in the default config: mixture \
+         CL {} / V {} ({:.0}% off truth) vs legacy CL {} / V {} ({:.0}% off) — only {:.1}× better",
+        with_mix.theta[0],
+        with_mix.theta[1],
+        err_mix_vs_truth * 100.0,
+        legacy_default.theta[0],
+        legacy_default.theta[1],
+        err_legacy_default * 100.0,
+        err_legacy_default / err_mix_vs_truth
     );
 
-    // --- Part 2: mixture-vs-legacy discrimination with the ISCALE scalar pilot
-    // search pinned off (#961). ISCALE is a *separate*, general safeguard that on
-    // this fixture alone rescues the collapse and masks the mixture's value; pin it
-    // to 1.0 to remove that overlapping rescue and re-expose the weakly-identified-V
-    // weight collapse the defensive mixture was built to fix (#528).
-    //
-    //   * legacy single-proposal (alpha = 0): weights collapse on the baseline
-    //     subjects, the importance-weighted M-step is hijacked, and V/CL run away.
-    //   * defensive mixture (alpha = 0.1): the broad `N(0, Ω)` component bounds
-    //     every weight, so no single collapsed-weight subject can dominate and θ
-    //     stays identifiable.
+    // --- Part 3: the same contrast with the ISCALE scalar pilot search pinned off
+    // (#961). ISCALE is a *separate*, general safeguard; pinning it to 1.0 (its
+    // documented "disabled" setting) reads the discrimination with that overlapping
+    // rescue removed, so a future ISCALE change cannot silently become the reason
+    // Part 2 passes.
     let no_mix = fit(
         &model,
         &pop,
@@ -288,12 +369,9 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         &saem_imp_opts(0.1, true),
     )
     .expect("mixture imp (ISCALE pinned) must produce a fit");
-    let v0 = no_mix.theta[1];
-    let vp = with_mix_pinned.theta[1];
-    let clp = with_mix_pinned.theta[0];
-    // The pinned mixture must be a genuine, healthy recovery — not just a V that
-    // happens to land near truth. Guard convergence, OFV, and CL too, so a partial
-    // regression (CL drifts or the fit fails to converge) still trips.
+    // The pinned mixture must be a genuine, healthy recovery — not just a θ that
+    // happens to land near truth. Guard convergence and OFV too, so a partial
+    // regression (the fit fails to converge, or the objective blows up) still trips.
     assert!(
         with_mix_pinned.converged,
         "defensive mixture (ISCALE pinned) must converge"
@@ -303,40 +381,44 @@ fn saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture() {
         "defensive mixture (ISCALE pinned) OFV must be finite/sane: {}",
         with_mix_pinned.ofv
     );
+    let err_mixture = max_rel_err(&with_mix_pinned.theta, ref_cl, ref_v);
     assert!(
-        (clp - TRUE_CL).abs() / TRUE_CL < 0.25,
-        "defensive mixture (ISCALE pinned) should recover TVCL near {TRUE_CL}, got {clp}"
-    );
-    // The mixture (same pinned config) recovers V near the truth.
-    assert!(
-        (vp - TRUE_V).abs() / TRUE_V < 0.25,
-        "defensive mixture (ISCALE pinned) should still recover TVV near {TRUE_V}, \
-         got {vp} (legacy landed at {v0})"
+        err_mixture < 0.10,
+        "defensive mixture (ISCALE pinned) must still land on the FOCEI optimum \
+         (CL {ref_cl:.3}, V {ref_v:.3}), got CL {} / V {} ({:.0}% off)",
+        with_mix_pinned.theta[0],
+        with_mix_pinned.theta[1],
+        err_mixture * 100.0
     );
     // ...and the legacy sampler does not: with ISCALE unable to rebroaden the
-    // collapsed proposal, its V runs far outside the 25% band the mixture stays
-    // inside. The guard is stated as *relative* discrimination rather than an
-    // absolute multiple of truth on purpose: how far the runaway travels is a
-    // chaotic property of the collapsed weights and differs by libm — macOS lands
-    // above 40 (> 2× truth) where glibc lands at 36.5 (1.8×), and pinning the
-    // absolute magnitude turned a real, reproducible contrast into a
-    // platform-dependent red (#751 / #961). What the test actually needs is that
+    // collapsed proposal, its worse coordinate runs far outside the band the
+    // mixture stays inside. Stated as *relative* discrimination rather than an
+    // absolute multiple of truth on purpose — how far the runaway travels, and in
+    // which coordinate, is a chaotic property of the collapsed weights and differs
+    // by libm; pinning the absolute magnitude turned a real, reproducible contrast
+    // into a platform-dependent red (#751 / #961). What the test needs is that
     // legacy is *badly* wrong and the mixture is not.
-    let err_legacy = (v0 - TRUE_V).abs() / TRUE_V;
-    let err_mixture = (vp - TRUE_V).abs() / TRUE_V;
+    let err_legacy = max_rel_err(&no_mix.theta, TRUE_CL, TRUE_V);
+    let err_mixture_vs_truth = max_rel_err(&with_mix_pinned.theta, TRUE_CL, TRUE_V);
     assert!(
         err_legacy > 0.5,
-        "legacy sampler (ISCALE pinned) is expected to run V far off truth \
-         (>50% error); got {v0} ({:.0}% off) — if this fails the fixture no \
-         longer reproduces the collapse",
+        "legacy sampler (ISCALE pinned) is expected to run CL/V far off truth (>50% error); \
+         got CL {} / V {} ({:.0}% off) — if this fails the fixture no longer reproduces the \
+         collapse",
+        no_mix.theta[0],
+        no_mix.theta[1],
         err_legacy * 100.0
     );
     assert!(
-        err_legacy > 3.0 * err_mixture,
-        "defensive mixture must beat legacy by a wide margin: mixture V = {vp} \
-         ({:.0}% off truth) vs legacy V = {v0} ({:.0}% off) — only {:.1}× better",
-        err_mixture * 100.0,
+        err_legacy > 3.0 * err_mixture_vs_truth,
+        "defensive mixture must beat legacy by a wide margin: mixture CL {} / V {} \
+         ({:.0}% off truth) vs legacy CL {} / V {} ({:.0}% off) — only {:.1}× better",
+        with_mix_pinned.theta[0],
+        with_mix_pinned.theta[1],
+        err_mixture_vs_truth * 100.0,
+        no_mix.theta[0],
+        no_mix.theta[1],
         err_legacy * 100.0,
-        err_legacy / err_mixture
+        err_legacy / err_mixture_vs_truth
     );
 }

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -249,6 +249,14 @@ const NM_SAEM_MIXEST: [usize; 30] = [
     2, 2, 2, 2, 2, // IDs 26..=30
 ];
 
+/// Seeds swept by [`saem_mixture_fit_matches_nonmem_saem`] (#1053 / #1113). The
+/// first is the seed the single-realization version of this test shipped with;
+/// the rest are the arbitrary seeds of the sweep recorded in #1053, so the
+/// distribution measured there describes exactly this set.
+const SAEM_ANCHOR_SEEDS: [u64; 10] = [
+    20250818, 1, 7, 42, 1234, 99991, 20240101, 555555, 8675309, 20260823,
+];
+
 /// SAEM under a mixture (#985): NONMEM `METHOD=SAEM` cross-check. Same
 /// two-clearance-class model and data as `mixture_fit_matches_nonmem`, estimated
 /// with SAEM instead of FOCEI. Ω/Σ are FIXed, so the estimated quantities are
@@ -256,8 +264,36 @@ const NM_SAEM_MIXEST: [usize; 30] = [
 /// latent class each E-step (drawn from the current posterior `PMIX_i`) and runs
 /// η-MCMC within the drawn class; the M-step updates the class-switched thetas
 /// (each from its own class members) and the mixing coefficient (from the
-/// SA-averaged class frequencies) — the same scheme NONMEM SAEM uses. Estimates
-/// agree with NONMEM SAEM to ≤3%.
+/// SA-averaged class frequencies) — the same scheme NONMEM SAEM uses.
+///
+/// ## Why this anchors a seed-**mean**, not one realization (#1053 / #1113)
+///
+/// SAEM is a stochastic-approximation estimator: one chain's endpoint is a draw,
+/// not a number. Anchoring one ferx realization against one NONMEM realization is
+/// therefore a coin flip, and it landed red — the version of this test that
+/// shipped with #987 asserted `TVCL2` within 3 % of NONMEM's single SAEM run
+/// (2.73543) and was red on every nightly from the day it merged.
+///
+/// The seed sweep in #1053 settled that this is Monte-Carlo spread, not bias:
+/// over ten seeds at this chain length `TVCL2` has sd ≈ 0.13 (CV ≈ 4.7 %), so the
+/// old 3 % band was **0.6 sd** wide — narrower than one standard deviation — and
+/// `TVCL1` and `p(1)` were just as fragile (3/10 seeds each; **0/10** seeds
+/// passed all five assertions together). Lengthening the chain behaves the way a
+/// consistent estimator should: sd falls ~28 % from the 600/800 chain and the
+/// mean moves *toward* the optimum.
+///
+/// So the anchor is the **mean over `SAEM_ANCHOR_SEEDS`**, compared against the
+/// NONMEM **FOCEI MLE** — the deterministic optimum both engines' SAEM chains are
+/// sampling around, and itself a NONMEM number (`mixture_iv.ext`). NONMEM's own
+/// single SAEM realization sits 3.75 % *below* that MLE, comfortably inside the
+/// observed per-seed range, so it is quoted below as a reference point rather
+/// than used as the target. Bands are set from the sweep's sd: each is at least
+/// the observed mean offset plus ~3 standard errors of the mean, so the test
+/// fails on a shifted estimator rather than on a low draw.
+///
+/// The chain is NONMEM's (`NBURN=1000 NITER=1000`) rather than the shorter
+/// 600/800 the single-seed version used — same reason: it is the lower-variance
+/// configuration, and it matches the control stream being anchored against.
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
@@ -272,78 +308,129 @@ fn saem_mixture_fit_matches_nonmem_saem() {
     .unwrap();
     let model = parse_model_string(MODEL).unwrap();
 
-    let mut opts = FitOptions::default();
-    opts.method = ferx_core::EstimationMethod::Saem;
-    opts.interaction = true;
-    opts.saem_n_exploration = 600;
-    opts.saem_n_convergence = 800;
-    opts.saem_seed = Some(20250818);
+    let k = SAEM_ANCHOR_SEEDS.len() as f64;
+    let (mut sum_cl1, mut sum_cl2, mut sum_v, mut sum_p1, mut sum_ofv) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    let mut worst_agree = usize::MAX;
+    // Per-subject class-1 vote count across the seeds — the discrete analogue of
+    // the seed-mean used for the thetas.
+    let mut class1_votes = [0usize; NM_SAEM_MIXEST.len()];
 
-    let res = fit(&model, &pop, &model.default_params, &opts).expect("SAEM mixture fit Ok");
+    for seed in SAEM_ANCHOR_SEEDS {
+        let mut opts = FitOptions::default();
+        opts.method = ferx_core::EstimationMethod::Saem;
+        opts.interaction = true;
+        opts.saem_n_exploration = 1000;
+        opts.saem_n_convergence = 1000;
+        opts.saem_seed = Some(seed);
 
-    let th = &res.theta;
-    let rel = |a: f64, b: f64| (a - b).abs() / b.abs();
+        let res = fit(&model, &pop, &model.default_params, &opts).expect("SAEM mixture fit Ok");
+        let th = &res.theta;
+        let p1 = 1.0 / (1.0 + (-th[3]).exp());
+
+        // Per-subject MIXEST (recomputed at the SAEM optimum via the mixture
+        // marginal). Tallied into `class1_votes` for the modal classification
+        // asserted below, and tracked per seed for the loose per-realization floor.
+        assert_eq!(res.subjects.len(), NM_SAEM_MIXEST.len());
+        let mut agree = 0;
+        for (i, sr) in res.subjects.iter().enumerate() {
+            let cls = sr.mixest.expect("MIXEST populated");
+            if cls == 1 {
+                class1_votes[i] += 1;
+            }
+            if cls == NM_SAEM_MIXEST[i] {
+                agree += 1;
+            }
+        }
+        worst_agree = worst_agree.min(agree);
+
+        eprintln!(
+            "ferx SAEM mixture seed {seed}: TVCL1={:.4} TVCL2={:.4} TVV={:.4} p1={:.4} \
+             OFV={:.4} MIXEST {agree}/{}",
+            th[0],
+            th[1],
+            th[2],
+            p1,
+            res.ofv,
+            NM_SAEM_MIXEST.len()
+        );
+
+        sum_cl1 += th[0];
+        sum_cl2 += th[1];
+        sum_v += th[2];
+        sum_p1 += p1;
+        sum_ofv += res.ofv;
+    }
+
+    let (m_cl1, m_cl2, m_v, m_p1, m_ofv) =
+        (sum_cl1 / k, sum_cl2 / k, sum_v / k, sum_p1 / k, sum_ofv / k);
     eprintln!(
-        "ferx SAEM mixture: TVCL1={:.4} TVCL2={:.4} TVV={:.4} MIXL={:.4} p1={:.4} OFV={:.4}",
-        th[0],
-        th[1],
-        th[2],
-        th[3],
-        1.0 / (1.0 + (-th[3]).exp()),
-        res.ofv
+        "ferx SAEM mixture seed-mean (K={k}): TVCL1={m_cl1:.4} TVCL2={m_cl2:.4} TVV={m_v:.4} \
+         p1={m_p1:.4} OFV={m_ofv:.4} (worst MIXEST {worst_agree}/{})",
+        NM_SAEM_MIXEST.len()
     );
 
-    // ── Estimated typical values vs NONMEM SAEM ──
+    let rel = |a: f64, b: f64| (a - b).abs() / b.abs();
+
+    // ── Seed-mean typical values vs the NONMEM FOCEI MLE ──
+    // Bands: observed mean offset + ~3 sem over these seeds (sd/√K), rounded up.
+    // NONMEM's single SAEM realization (TVCL1 1.00205, TVCL2 2.73543, TVV 9.99346)
+    // is a draw from the same distribution and sits inside every band below.
     assert!(
-        rel(th[0], NM_SAEM_TVCL1) < 0.03,
-        "SAEM TVCL1 {} vs {}",
-        th[0],
-        NM_SAEM_TVCL1
+        rel(m_cl1, NM_TVCL1) < 0.12,
+        "SAEM seed-mean TVCL1 {m_cl1} vs NONMEM MLE {NM_TVCL1}"
     );
     assert!(
-        rel(th[1], NM_SAEM_TVCL2) < 0.03,
-        "SAEM TVCL2 {} vs {}",
-        th[1],
-        NM_SAEM_TVCL2
+        rel(m_cl2, NM_TVCL2) < 0.10,
+        "SAEM seed-mean TVCL2 {m_cl2} vs NONMEM MLE {NM_TVCL2}"
     );
     assert!(
-        rel(th[2], NM_SAEM_TVV) < 0.03,
-        "SAEM TVV {} vs {}",
-        th[2],
-        NM_SAEM_TVV
+        rel(m_v, NM_TVV) < 0.03,
+        "SAEM seed-mean TVV {m_v} vs NONMEM MLE {NM_TVV}"
+    );
+    assert!(
+        (m_p1 - NM_P1).abs() < 0.08,
+        "SAEM seed-mean p(1) {m_p1} vs NONMEM MLE {NM_P1}"
     );
 
-    // Mixing fraction p(1) = σ(MIXL), from the sampled class frequencies.
-    let p1 = 1.0 / (1.0 + (-th[3]).exp());
+    // Final OFV (K-fold mixture marginal) comparable to NONMEM's IMP objective —
+    // the objective is far more stable across seeds than the thetas (sd ≈ 0.8),
+    // so this keeps a tight absolute band on the seed mean.
     assert!(
-        (p1 - NM_SAEM_P1).abs() < 0.03,
-        "SAEM p(1) {} vs NONMEM {}",
-        p1,
-        NM_SAEM_P1
+        (m_ofv - NM_SAEM_OFV_IMP).abs() < 4.0,
+        "SAEM seed-mean OFV {m_ofv} vs NONMEM IMP {NM_SAEM_OFV_IMP}"
     );
 
-    // Final OFV (K-fold mixture marginal) comparable to NONMEM's IMP objective.
-    assert!(
-        (res.ofv - NM_SAEM_OFV_IMP).abs() < 3.0,
-        "SAEM OFV {} vs NONMEM IMP {}",
-        res.ofv,
-        NM_SAEM_OFV_IMP
-    );
-
-    // Per-subject MIXEST (recomputed at the SAEM optimum via the mixture
-    // marginal) agrees with NONMEM SAEM on every subject bar at most one
-    // borderline draw.
-    assert_eq!(res.subjects.len(), NM_SAEM_MIXEST.len());
-    let agree = res
-        .subjects
-        .iter()
-        .enumerate()
-        .filter(|(i, sr)| sr.mixest.expect("MIXEST populated") == NM_SAEM_MIXEST[*i])
+    // Classification (#1053 triage step 4: this check was never reached while the
+    // test failed on `TVCL2`). Anchored the same way as the thetas — on the
+    // *modal* class over the seeds, the discrete analogue of the seed-mean —
+    // because a single chain's per-subject draw is as stochastic as its endpoint:
+    // the observed per-seed agreement ranged 27/30 to 30/30 while the modal
+    // classification is stable.
+    let modal_agree = (0..NM_SAEM_MIXEST.len())
+        .filter(|&i| {
+            let modal = if 2 * class1_votes[i] >= SAEM_ANCHOR_SEEDS.len() {
+                1
+            } else {
+                2
+            };
+            modal == NM_SAEM_MIXEST[i]
+        })
         .count();
+    eprintln!(
+        "ferx SAEM mixture modal MIXEST agreement {modal_agree}/{} (worst seed {worst_agree})",
+        NM_SAEM_MIXEST.len()
+    );
     assert!(
-        agree >= NM_SAEM_MIXEST.len() - 1,
-        "SAEM MIXEST agreement {}/{}",
-        agree,
+        modal_agree >= NM_SAEM_MIXEST.len() - 1,
+        "modal SAEM MIXEST agreement {modal_agree}/{}",
+        NM_SAEM_MIXEST.len()
+    );
+    // Per-realization floor: no single chain may disagree with NONMEM SAEM on more
+    // than a tenth of the subjects. Loose on purpose — it guards a collapse of the
+    // classification, not the borderline subjects the modal check covers.
+    assert!(
+        worst_agree >= NM_SAEM_MIXEST.len() - 3,
+        "worst-seed SAEM MIXEST agreement {worst_agree}/{}",
         NM_SAEM_MIXEST.len()
     );
 }

--- a/tests/ss_absorption_nonmem_anchor.rs
+++ b/tests/ss_absorption_nonmem_anchor.rs
@@ -29,6 +29,36 @@
 use ferx_core::parser::model_parser::parse_full_model;
 use ferx_core::{fit, predict, read_nonmem_csv, simulate_with_options_diag, SimulateOptions};
 
+/// Serializes every test in this binary that runs an `SS=1` model (#1113).
+///
+/// The #867 SS-equilibration non-convergence warning is collected in a
+/// **process-global** sink (`dosing::ss_nonconvergence_sink`) because the capped
+/// pulse train runs deep inside the rayon-parallelised per-subject prediction walk
+/// and its numeric signatures carry no warning channel. Each draining `api`
+/// entrypoint brackets its own run — `clear` on entry, `take` on exit — which is
+/// correct for one top-level operation at a time, but cargo runs the tests in a
+/// binary as **threads of one process**. So a warning written by one test's fit can
+/// land inside another test's clear→take window and be drained by it.
+///
+/// That is exactly what made `simulate_stays_silent_for_benign_nonlinear_ss_absorption`
+/// flap in the nightly: `fit_on_ss_absorption_converges` (slow-gated, so it only
+/// runs there) writes ~100 warnings over its lifetime — legitimately, since the
+/// outer optimizer probes `CL → 0`, where the pulse train genuinely stops
+/// contracting — and the benign test, whose own simulate produces none, drained one
+/// of them and failed on a message about a model it never ran.
+///
+/// The lock is taken by *every* test here, writers included: a reader-only guard
+/// would not keep a writer out of the reader's window. Poisoning is ignored
+/// (`into_inner`) so one failing test reports its own failure instead of cascading
+/// the rest into panics.
+static SS_WARN_SINK_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn ss_sink_guard() -> std::sync::MutexGuard<'static, ()> {
+    SS_WARN_SINK_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 // `first_order(ka)` appears in central directly (its R_in is the appearance rate of an
 // ADVAN2 depot→central first-order absorption), and the readout `y = central/V` matches
 // NONMEM's `S2 = V` concentration. Thetas are FIXed at the NONMEM values.
@@ -66,6 +96,8 @@ const SS_FIRST_ORDER_MODEL: &str = r#"
 
 #[test]
 fn predict_matches_nonmem_ss_first_order_absorption() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let parsed = parse_full_model(SS_FIRST_ORDER_MODEL).expect("model parses");
     let model = parsed.model;
 
@@ -119,6 +151,8 @@ fn predict_matches_nonmem_ss_first_order_absorption() {
     ignore = "slow: analytic FOCEI to convergence on an SS-absorption model; opt in with --features slow-tests"
 )]
 fn fit_on_ss_absorption_converges() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let src = SS_FIRST_ORDER_MODEL.replace("omega ETA_CL ~ 0.0", "omega ETA_CL ~ 0.05");
     let parsed = parse_full_model(&src).expect("model parses");
     let model = parsed.model;
@@ -236,6 +270,8 @@ const SS_MM_MODEL: &str = r#"
 
 #[test]
 fn predict_matches_nonmem_mm_ss_absorption() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let parsed = parse_full_model(SS_MM_MODEL).expect("model parses");
     let model = parsed.model;
     let population =
@@ -270,6 +306,8 @@ fn predict_matches_nonmem_mm_ss_absorption() {
 
 #[test]
 fn simulate_surfaces_ss_nonconvergence_warning_when_no_steady_state() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let parsed = parse_full_model(SS_MM_NO_STEADY_STATE_MODEL).expect("model parses");
     let model = parsed.model;
     let population = read_nonmem_csv(std::path::Path::new("data/ss_first_order.csv"), None, None)
@@ -306,6 +344,8 @@ fn simulate_surfaces_ss_nonconvergence_warning_when_no_steady_state() {
 /// covariance is off to keep it quick.
 #[test]
 fn fit_surfaces_ss_nonconvergence_warning_for_over_capacity_dosing() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let parsed = parse_full_model(SS_MM_NO_STEADY_STATE_MODEL).expect("model parses");
     let model = parsed.model;
     let population = read_nonmem_csv(std::path::Path::new("data/ss_first_order.csv"), None, None)
@@ -335,6 +375,8 @@ fn fit_surfaces_ss_nonconvergence_warning_for_over_capacity_dosing() {
 /// solver-noise jitter (the `rho ≥ 1` noise-floor short-circuit).
 #[test]
 fn simulate_stays_silent_for_benign_nonlinear_ss_absorption() {
+    // Serialize against the other SS tests in this binary (#1113).
+    let _sink_guard = ss_sink_guard();
     let src = SS_MM_NO_STEADY_STATE_MODEL.replace(
         "theta TVVMAX(10.0, 1.0, 100.0)",
         "theta TVVMAX(500.0, 1.0, 5000.0)",


### PR DESCRIPTION
## Why

`slow-tests.yml` has not been green in the last 100 runs (#1113). Three tests
were failing, none of them a live estimator regression:

1. `imp_init_defensive_slow::saem_imp_on_analytical_init_recovers_parameters_with_defensive_mixture`
   — a **stale negative control**. #1017's LTBS prediction floor
   (`CompiledModel::floor_prediction`) removed the fabricated residuals that were
   driving this fixture's legacy-sampler collapse: on a `log_additive` model `f`
   is `log(c)` and is legitimately negative below one unit, and the old
   `f.max(1e-12)` clamp replaced it with ~0. With that fixed, legacy landed
   `V = 19.844` (1 % off truth) and the mixture-vs-legacy contrast was gone — even
   with ISCALE pinned. The floor fix is unconditionally correct and stays.
2. `mixture_nonmem::saem_mixture_fit_matches_nonmem_saem` — a **single-realization
   anchor on a stochastic estimator** (#1053). One ferx SAEM chain compared against
   one NONMEM SAEM chain on a 3 % band that is 0.6 sd wide; 0/10 seeds passed all
   five assertions.
3. `ss_absorption_nonmem_anchor::simulate_stays_silent_for_benign_nonlinear_ss_absorption`
   — an **intermittent** failure the issue attributed to a marginal fixture. It is
   not: it is a cross-test race on the process-global #867 warning sink.

## What changed

### 1. Re-based the IMP negative control on the mechanism, not on a safeguard

The fixture was a stand-in for the NONMEM `run14` / `ferx-testdata/thioguanine_mmc`
collapse, and two safeguards have masked its contrast in turn (ISCALE in #961, the
LTBS floor now). Rather than turn a third knob off — there isn't one — the fixture
itself is re-based on the weak-identification mechanism it is meant to reproduce:

* three quarters of the subjects are now the weakly-identified-V baseline case
  (was one half), and
* `ETA_V`'s prior is wider (variance 0.25, was 0.09).

On that fixture the runaway returns in the **shipped default config** (ISCALE pilot
search on), which is a strictly stronger statement than #961's pinned-only
contrast: the defensive mixture is not redundant with the ISCALE search. The
pinned-ISCALE arm is kept as a second, independent reading.

Two assertion changes make the control robust rather than merely re-tuned:

* Guards read the **worse of `TVCL`/`TVV`**. A seed sweep showed either coordinate
  can absorb the collapse (`V +160 % / CL +684 %` at one seed, `V +9 % / CL +1903 %`
  at another), so a `V`-only guard would read as a platform-dependent red (#751).
* The mixture is anchored on a **deterministic FOCEI fit of the same data**,
  computed in-test (`CL 2.618, V 16.963`). This realization's MLE sits ~15 % below
  the simulation truth, so a band around truth wide enough to admit it would also
  admit a fit that never moved from its starting values.

The module doc-comment is rewritten: it previously explained the ISCALE masking as
the only thing that had ever masked this, which is no longer true.

### 2. Anchored the SAEM mixture test on a seed-mean (#1053)

Sweeps ten seeds (the shipped one plus the nine from #1053's sweep) at NONMEM's own
chain length (`NBURN=1000 NITER=1000`, also the lower-variance configuration) and
compares the **seed-mean** against the NONMEM **FOCEI MLE** — the deterministic
optimum both engines' SAEM chains sample around, and itself a NONMEM number.
NONMEM's single SAEM realization sits 3.75 % below that MLE and is quoted as a
reference point rather than used as the target.

Bands are the observed mean offset plus ~3 standard errors of the mean.
Classification is anchored the same way, on the **modal** class over the seeds —
per-seed agreement ranges 27–30/30 while the modal classification is stable at
30/30. This is the first time `NM_SAEM_MIXEST` has actually been exercised: the old
test panicked on `TVCL2` before reaching it (#1053 triage step 4).

### 3. Serialized the process-global SS warning sink

The #867 non-convergence warning is collected in a process-global sink because the
capped pulse train runs inside the rayon-parallelised prediction walk. Each draining
`api` entrypoint brackets its own run (`clear` on entry, `take` on exit) — correct
for one top-level operation at a time, but cargo runs a binary's tests as **threads
of one process**.

Instrumenting the sink showed the benign fixture writes **0** warnings of its own,
while `fit_on_ss_absorption_converges` — slow-gated, so it only runs in the nightly,
which is exactly where the flake appears — writes ~100. Those writes are legitimate:
the outer optimizer probes `CL → 0`, where the pulse train genuinely stops
contracting (`params[0] = 8.3e-16`, trough growing by the full 100-unit dose each
cycle). They simply land inside the benign test's clear→take window.

Every test in the file now takes a file-local guard. Under deliberate concurrency
(a background thread running the over-capacity fit while the benign simulate runs
200 times) the unguarded leak rate measured **25/200**; the guard removes it.

This is **not** #533 and not a marginal fixture — the benign model contracts in ~2
cycles and can never trip the warning on its own.

## Alternatives considered

* **Item 1 — retire the negative control** (the issue's option 2). Rejected: a
  fixture that still discriminates was found, and it discriminates in the *default*
  config, which is a better test than the one that was there. Re-measuring the
  cross-repo `thioguanine_mmc` model (option 1) cannot be committed here — the test
  must stay self-contained.
* **Item 1 — silently widen the threshold.** Explicitly rejected by the issue and
  by the assertion's own wording; the fixture was re-based instead.
* **Item 2 — widen only `TVCL2`.** Rejected: `TVCL1` and `p(1)` are just as fragile
  (3/10 seeds each), so the test would still fail most reseeds.
* **Item 3 — re-pin the fixture's contraction rate.** Rejected once the sink race
  was measured: the fixture is already benign and writes nothing.
* **Item 3 — give the sink per-operation scoping** instead of a global. A real
  improvement, but a wide change to the prediction walk's plumbing for a rare
  diagnostic; the test-side guard is documented against it.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation

Test-only change; no estimator behaviour is modified. The anchors themselves are
the validation, and all three targets were run on **linux/arm64** (which reproduces
CI's glibc numerics; macOS numbers are quoted alongside where they differ).

SAEM mixture seed-mean, K = 10 at 1000/1000, vs the NONMEM FOCEI MLE:

```
                Linux mean   macOS mean   NONMEM MLE   offset (Linux)   band
TVCL1              0.9500       0.9500      0.980833      -3.1 %        12 %
TVCL2              2.8097       2.7755      2.84198       -1.1 %        10 %
TVV                9.9773       9.9797      9.97859       -0.01 %        3 %
p(1)               0.4362       0.4363      0.471970      -0.036 abs     0.08 abs
OFV              302.4384     302.8336    300.8707 (NM SAEM/IMP)  +1.57 abs   4.0 abs
MIXEST (modal)     30/30        30/30       -             -            >= 29/30
```

IMP defensive mixture, re-based fixture (Linux, seed 7):

```
FOCEI reference (same data)   CL 2.618   V 16.963   OFV -202.28
mixture, default ISCALE       CL 2.620   V 16.999   OFV -199.91   IS -2logL -202.29
legacy,  default ISCALE       CL 76.84   V  2.076   OFV  574.05   IS -2logL  617.83
```

Seed sweep behind the guards (5 seeds x {legacy, mixture} x {default, pinned}):
legacy's worse coordinate was off by >= 90 % in every default-config run and
>= 160 % in every pinned run; the mixture stayed at 13–15 % (the FOCEI optimum)
throughout.

- [x] Compared against: NONMEM (`mixture_iv.ext` FOCEI MLE, `mixture_iv_saem.ext`)

## Performance
- [x] No significant impact expected — the SAEM anchor runs 10 short chains (3.5 s
  on Linux, was 1 chain); the IMP test runs one extra FOCEI reference fit (~21 s
  total); the SS file is now serialized (1.6 s total).

## Tests
- [x] Regression test added that fails without this fix — all three changes *are*
  test changes; each was verified to fail before and pass after on both platforms.

## Docs
- [x] No user-visible change — test-only, so no `CHANGELOG.md` entry per CLAUDE.md.

## Checklist
- [x] `cargo clippy` clean (no new warnings; the two in the touched files are the
  pre-existing `field_reassign_with_default` style used throughout these tests)
- [x] `cargo fmt`

## Reviewer hints

* The substantive judgement call is **item 1**: the negative control's fixture
  changed, so it is worth checking that the new fixture is still the #528 mechanism
  (weakly-identified `V` through `A₀/V · e^{−kt}`) and not just a harder problem.
  The in-test FOCEI reference is the guard against that reading.
* **Item 2** deliberately loosens per-quantity bands relative to the old test. The
  justification is in the doc-comment: the old bands were sub-1-sd on a stochastic
  estimator. The new bands are ~3 sem on a mean of 10 chains, which is tighter in
  standard-error terms than what it replaces.
* **Item 3** is mechanical once the diagnosis is accepted; the evidence for the
  diagnosis (0 writes from the benign model, ~100 from the concurrent fit, 25/200
  measured leak rate) is in the guard's doc-comment and the commit message.

## Open questions

The issue's Meta item — whether an estimator PR should be able to merge without its
anchors ever having run, e.g. an opt-in label that dispatches `slow-tests.yml`
against the PR head — is left as the separate decision #1113 asks for. All three
failures here landed red or went red unseen for exactly that reason.

---

### Whole-suite verification

The full slow suite (`cargo test --no-default-features --features ci,survival,slow-tests --profile ci-test --no-fail-fast`) was run on **linux/arm64** at this branch's head: **154 test binaries, 0 failures**. Nothing else stands between `main` and a green nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui7XuNiKxbVwbYMcv2CVcr
