### PR TITLE
feat(api): non-parametric bootstrap in ferx-tools, at PsN::bootstrap parity [closes #1140]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,12 @@ section of the SDLC for the versioning policy).
   recompute results under different filters without refitting. Writes PsN-named CSV artefacts
   (`raw_results.csv`, `bootstrap_results.csv`, `included_individuals1.csv`, `sample_keys1.csv`, …).
   Unlike PsN, the drawn datasets depend only on the seed and the design — never on the thread
-  count, the completion order, or whether the base model was fitted first. A model that reads `ID`
-  as a covariate is refused rather than silently mis-fitted. See `docs/tools/bootstrap.qmd`.
+  count, the completion order, or whether the base model was fitted first. Bootstrapped parameters
+  are every estimated theta, Omega (free lower triangle), sigma, and IOV Omega, so a `kappa` model
+  gets bootstrap SEs and CIs for its inter-occasion variance and `--update-inits` / `--dofv` carry
+  it too. A model that reads `ID` as a covariate is refused rather than silently mis-fitted, and so
+  is a `[mixture]` model — its classes are identified only up to relabelling, so averaging across
+  replicates would mix them. See `docs/tools/bootstrap.qmd`.
 - **`prepare_run` / `prepare_run_with_inits` (#1140)** — public "load a model and its dataset, but
   do not fit" entry points returning a `PreparedRun`. `run_model_with_data` is now implemented on
   top of them, so a tool and the CLI cannot diverge in how a model is loaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,23 @@ section of the SDLC for the versioning policy).
   `tools/update-public-api.sh`. This doubles as semver protection for the crates.io release and
   for ferx-r. `#[doc(hidden)] pub` is banned, because `cargo public-api` omits such items and the
   attribute would otherwise be a silent bypass of the gate.
-- **A `ferx-tools` crate (#1114)** — the future home of multi-fit tooling (bootstrap, stepwise
-  covariate modelling, model search, cross-validation). Currently a placeholder; it can only reach
-  `ferx-core` through the same public API the R wrapper uses.
+- **A `ferx-tools` crate (#1114)** — the home of multi-fit tooling (bootstrap, stepwise
+  covariate modelling, model search, cross-validation). It can only reach `ferx-core` through the
+  same public API the R wrapper uses.
+- **`ferx bootstrap` — the non-parametric case bootstrap (#1140).** Resamples subjects with
+  replacement, refits the model to each replicate, and reports bias, standard errors and
+  confidence intervals from the spread of the estimates, at `PsN::bootstrap` feature parity:
+  `--samples`, `--seed`, `--threads`, `--sample-size` (including PsN's per-stratum
+  `"1001=>12,1002=>24"` form), `--stratify-on`, `--update-inits`, `--run-base-model`,
+  `--keep-covariance`, the four `--skip-*` exclusion filters, `--dofv`, and `--summarize` to
+  recompute results under different filters without refitting. Writes PsN-named CSV artefacts
+  (`raw_results.csv`, `bootstrap_results.csv`, `included_individuals1.csv`, `sample_keys1.csv`, …).
+  Unlike PsN, the drawn datasets depend only on the seed and the design — never on the thread
+  count, the completion order, or whether the base model was fitted first. A model that reads `ID`
+  as a covariate is refused rather than silently mis-fitted. See `docs/tools/bootstrap.qmd`.
+- **`prepare_run` / `prepare_run_with_inits` (#1140)** — public "load a model and its dataset, but
+  do not fit" entry points returning a `PreparedRun`. `run_model_with_data` is now implemented on
+  top of them, so a tool and the CLI cannot diverge in how a model is loaded.
 
 ### Fixed
 - **A steady-state dose with a lagtime is now seeded at the dose record, not equilibrated at the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ name = "ferx-cli"
 version = "0.3.0"
 dependencies = [
  "ferx-core",
+ "ferx-tools",
  "serde_json",
  "tempfile",
 ]
@@ -293,7 +294,12 @@ dependencies = [
 name = "ferx-tools"
 version = "0.3.0"
 dependencies = [
+ "csv",
  "ferx-core",
+ "nalgebra",
+ "rand 0.10.2",
+ "rayon",
+ "tempfile",
 ]
 
 [[package]]

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -17,6 +17,15 @@ pub struct ferx_core::api::PredictionResult
 pub ferx_core::api::PredictionResult::id: alloc::string::String
 pub ferx_core::api::PredictionResult::pred: f64
 pub ferx_core::api::PredictionResult::time: f64
+pub struct ferx_core::api::PreparedRun
+pub ferx_core::api::PreparedRun::covariate_table: core::option::Option<ferx_core::CovariateTable>
+pub ferx_core::api::PreparedRun::data_hash: core::option::Option<alloc::string::String>
+pub ferx_core::api::PreparedRun::data_path: alloc::string::String
+pub ferx_core::api::PreparedRun::data_path_warning: core::option::Option<alloc::string::String>
+pub ferx_core::api::PreparedRun::init_params: ferx_core::ModelParameters
+pub ferx_core::api::PreparedRun::model_hash: core::option::Option<alloc::string::String>
+pub ferx_core::api::PreparedRun::parsed: ferx_core::ParsedModel
+pub ferx_core::api::PreparedRun::population: ferx_core::Population
 pub struct ferx_core::api::SimulateOptions
 pub ferx_core::api::SimulateOptions::horizon: core::option::Option<f64>
 pub ferx_core::api::SimulateOptions::match_method: core::option::Option<ferx_core::propensity_match::MatchMethod>
@@ -60,6 +69,8 @@ pub fn ferx_core::api::fit_from_files(model_path: &str, data_path: core::option:
 pub fn ferx_core::api::predict(model: &ferx_core::CompiledModel, population: &ferx_core::Population, params: &ferx_core::ModelParameters) -> alloc::vec::Vec<ferx_core::PredictionResult>
 pub fn ferx_core::api::predict_categorical(model: &ferx_core::CompiledModel, population: &ferx_core::Population, params: &ferx_core::ModelParameters) -> alloc::vec::Vec<ferx_core::EndpointPredictionResult>
 pub fn ferx_core::api::predict_survival(model: &ferx_core::CompiledModel, population: &ferx_core::Population, params: &ferx_core::ModelParameters, time_grid: &[f64]) -> alloc::vec::Vec<ferx_core::SurvivalPredictionResult>
+pub fn ferx_core::api::prepare_run(model_path: &str, data_path: core::option::Option<&str>) -> core::result::Result<ferx_core::PreparedRun, alloc::string::String>
+pub fn ferx_core::api::prepare_run_with_inits(model_path: &str, data_path: core::option::Option<&str>, inits_override: core::option::Option<ferx_core::suggest_start::NcaInit>) -> core::result::Result<ferx_core::PreparedRun, alloc::string::String>
 pub fn ferx_core::api::read_population_for(model: &ferx_core::CompiledModel, covariate_decls: &core::option::Option<alloc::vec::Vec<ferx_core::CovariateDecl>>, data_path: &str, fallback_columns: core::option::Option<&[&str]>, iov_column: core::option::Option<&str>, filter: core::option::Option<&ferx_core::io::datareader::SelectionFilter>, column_map: &[(alloc::string::String, alloc::string::String)]) -> core::result::Result<(ferx_core::Population, core::option::Option<ferx_core::CovariateTable>), alloc::string::String>
 pub fn ferx_core::api::read_population_for_simulation(model: &ferx_core::CompiledModel, covariate_decls: &core::option::Option<alloc::vec::Vec<ferx_core::CovariateDecl>>, data_path: &str, fallback_columns: core::option::Option<&[&str]>, iov_column: core::option::Option<&str>, filter: core::option::Option<&ferx_core::io::datareader::SelectionFilter>, column_map: &[(alloc::string::String, alloc::string::String)]) -> core::result::Result<(ferx_core::Population, core::option::Option<ferx_core::CovariateTable>), alloc::string::String>
 pub fn ferx_core::api::resolve_data_path(model_data_path: core::option::Option<&str>, external_data_path: core::option::Option<&str>) -> core::result::Result<(alloc::string::String, core::option::Option<alloc::string::String>), alloc::string::String>
@@ -4070,6 +4081,15 @@ pub struct ferx_core::PredictionResult
 pub ferx_core::PredictionResult::id: alloc::string::String
 pub ferx_core::PredictionResult::pred: f64
 pub ferx_core::PredictionResult::time: f64
+pub struct ferx_core::PreparedRun
+pub ferx_core::PreparedRun::covariate_table: core::option::Option<ferx_core::CovariateTable>
+pub ferx_core::PreparedRun::data_hash: core::option::Option<alloc::string::String>
+pub ferx_core::PreparedRun::data_path: alloc::string::String
+pub ferx_core::PreparedRun::data_path_warning: core::option::Option<alloc::string::String>
+pub ferx_core::PreparedRun::init_params: ferx_core::ModelParameters
+pub ferx_core::PreparedRun::model_hash: core::option::Option<alloc::string::String>
+pub ferx_core::PreparedRun::parsed: ferx_core::ParsedModel
+pub ferx_core::PreparedRun::population: ferx_core::Population
 pub struct ferx_core::ResidualCorrelation
 pub ferx_core::ResidualCorrelation::rho: f64
 pub ferx_core::ResidualCorrelation::sigma_i: usize
@@ -4249,6 +4269,8 @@ pub fn ferx_core::predict(model: &ferx_core::CompiledModel, population: &ferx_co
 pub fn ferx_core::predict_categorical(model: &ferx_core::CompiledModel, population: &ferx_core::Population, params: &ferx_core::ModelParameters) -> alloc::vec::Vec<ferx_core::EndpointPredictionResult>
 pub fn ferx_core::predict_survival(model: &ferx_core::CompiledModel, population: &ferx_core::Population, params: &ferx_core::ModelParameters, time_grid: &[f64]) -> alloc::vec::Vec<ferx_core::SurvivalPredictionResult>
 pub fn ferx_core::prepare_frem(model_path: &std::path::Path, data_path: &std::path::Path, covariates: &[alloc::string::String], categorical_covariates: core::option::Option<&[alloc::string::String]>, output_model_path: core::option::Option<&std::path::Path>, output_data_path: core::option::Option<&std::path::Path>, missing_value: core::option::Option<f64>, fit_init: core::option::Option<&ferx_core::frem::FremFitInit>) -> core::result::Result<ferx_core::frem::FremPrepareResult, alloc::string::String>
+pub fn ferx_core::prepare_run(model_path: &str, data_path: core::option::Option<&str>) -> core::result::Result<ferx_core::PreparedRun, alloc::string::String>
+pub fn ferx_core::prepare_run_with_inits(model_path: &str, data_path: core::option::Option<&str>, inits_override: core::option::Option<ferx_core::suggest_start::NcaInit>) -> core::result::Result<ferx_core::PreparedRun, alloc::string::String>
 pub fn ferx_core::read_nonmem_csv(path: &std::path::Path, covariate_columns: core::option::Option<&[&str]>, iov_column: core::option::Option<&str>) -> core::result::Result<ferx_core::Population, alloc::string::String>
 pub fn ferx_core::read_nonmem_csv_with_covariates(path: &std::path::Path, decls: &[ferx_core::CovariateDecl], extra_columns: &[alloc::string::String], iov_column: core::option::Option<&str>) -> core::result::Result<(ferx_core::Population, ferx_core::CovariateTable), alloc::string::String>
 pub fn ferx_core::resolve_data_path(model_data_path: core::option::Option<&str>, external_data_path: core::option::Option<&str>) -> core::result::Result<(alloc::string::String, core::option::Option<alloc::string::String>), alloc::string::String>

--- a/crates/ferx-cli/Cargo.toml
+++ b/crates/ferx-cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 # silently defeated for `ferx-core` everywhere (harmless only while
 # `default = []`; `survival` is slated to become default-on).
 ferx-core = { path = "../..", version = "0.3.0", default-features = false }
+ferx-tools = { path = "../ferx-tools", version = "0.3.0" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/ferx-cli/src/bootstrap_cmd.rs
+++ b/crates/ferx-cli/src/bootstrap_cmd.rs
@@ -1,0 +1,395 @@
+//! `ferx bootstrap` — the non-parametric case bootstrap (#1140).
+//!
+//! Thin by construction (#1114 A5): parse flags, call
+//! [`ferx_tools::bootstrap::run_bootstrap`], print a table, pick an exit code.
+//! Every decision about resampling, filtering or statistics lives in
+//! `ferx-tools`.
+
+use std::path::PathBuf;
+
+use ferx_tools::bootstrap::{
+    resummarize, run_bootstrap, BootstrapOptions, BootstrapResult, SampleSize,
+};
+
+pub const BOOTSTRAP_USAGE: &str = "\
+Usage: ferx bootstrap <model.ferx> [--data <data.csv>] [options]
+       ferx bootstrap --summarize --directory <dir> [filter options]
+
+Resamples subjects with replacement, refits the model to each replicate, and
+reports bias, standard errors and confidence intervals from the spread of the
+estimates. Resampling is always over whole subjects.
+
+  --samples N          number of bootstrap datasets (default 200)
+  --seed N             master seed (default 1). Each replicate's draw is derived
+                       from this and its own index, so the datasets do not
+                       depend on --threads or on completion order.
+  --threads N          replicates to fit concurrently (each fit uses 1 thread)
+  --sample-size M      subjects per replicate (default: as many as the dataset).
+                       With --stratify-on, may instead be a per-stratum map:
+                       --sample-size \"1001=>12,1002=>24,1003=>10\"
+  --stratify-on COL    resample within strata defined by a dataset column. The
+                       column must take exactly one value per subject.
+  --directory DIR      where the CSV artefacts go (default {model}-bootstrap)
+  --ci LEVEL           two-sided confidence level in percent (default 95)
+
+  --no-update-inits    start replicates from the model file's initial estimates
+                       instead of the base fit's final ones
+  --no-run-base-model  skip the fit on the original dataset (disables bias, the
+                       standard-error intervals, --update-inits and --dofv)
+  --keep-covariance    run the covariance step for every replicate (slow; only
+                       needed for the two covstep filters below)
+  --dofv               evaluate each replicate's estimates on the original data
+                       with no estimation, and report the OFV difference
+
+  --no-skip-minimization-terminated    keep replicates that did not converge
+  --no-skip-estimate-near-boundary     keep replicates with an estimate on a bound
+  --skip-covariance-step-terminated    drop replicates whose covariance step failed
+  --skip-with-covstep-warnings         drop replicates with covariance warnings
+
+  --summarize          recompute the statistics from an existing run directory's
+                       raw_results.csv under different filters. Refits nothing.
+";
+
+fn flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|a| a == name)
+}
+
+fn value<'a>(args: &'a [String], name: &str) -> Option<&'a String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+}
+
+fn parse<T: std::str::FromStr>(args: &[String], name: &str) -> Result<Option<T>, String> {
+    match value(args, name) {
+        None => Ok(None),
+        Some(raw) => raw
+            .parse::<T>()
+            .map(Some)
+            .map_err(|_| format!("{name}: `{raw}` is not a valid value")),
+    }
+}
+
+/// Build [`BootstrapOptions`] from the command line.
+pub fn parse_options(
+    args: &[String],
+    model_path: Option<&str>,
+) -> Result<BootstrapOptions, String> {
+    let mut o = BootstrapOptions::default();
+    if let Some(n) = parse::<usize>(args, "--samples")? {
+        o.samples = n;
+    }
+    if let Some(n) = parse::<u64>(args, "--seed")? {
+        o.seed = n;
+    }
+    if let Some(n) = parse::<usize>(args, "--threads")? {
+        o.threads = Some(n.max(1));
+    }
+    if let Some(level) = parse::<f64>(args, "--ci")? {
+        o.confidence_level = level;
+    }
+    if let Some(spec) = value(args, "--sample-size") {
+        o.sample_size = SampleSize::parse(spec)?;
+    }
+    o.stratify_on = value(args, "--stratify-on").cloned();
+
+    o.update_inits = !flag(args, "--no-update-inits");
+    o.run_base_model = !flag(args, "--no-run-base-model");
+    o.keep_covariance = flag(args, "--keep-covariance");
+    o.dofv = flag(args, "--dofv");
+
+    o.skip_minimization_terminated = !flag(args, "--no-skip-minimization-terminated");
+    o.skip_estimate_near_boundary = !flag(args, "--no-skip-estimate-near-boundary");
+    o.skip_covariance_step_terminated = flag(args, "--skip-covariance-step-terminated");
+    o.skip_with_covstep_warnings = flag(args, "--skip-with-covstep-warnings");
+
+    // `--update-inits` needs somewhere to get the inits from. Silently ignoring
+    // it would change every replicate's starting point without saying so.
+    if o.update_inits && !o.run_base_model {
+        o.update_inits = false;
+    }
+
+    o.directory = Some(match value(args, "--directory") {
+        Some(dir) => PathBuf::from(dir),
+        None => {
+            let stem = model_path
+                .and_then(|p| std::path::Path::new(p).file_stem().and_then(|s| s.to_str()))
+                .unwrap_or("model");
+            PathBuf::from(format!("{stem}-bootstrap"))
+        }
+    });
+    Ok(o)
+}
+
+/// Entry point for `ferx bootstrap ...`; returns the process exit code.
+pub fn run(args: &[String]) -> i32 {
+    if args.get(2).map(String::as_str) == Some("-h")
+        || args.get(2).map(String::as_str) == Some("--help")
+    {
+        print!("{BOOTSTRAP_USAGE}");
+        return 0;
+    }
+
+    if flag(args, "--summarize") {
+        return match run_summarize(args) {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                1
+            }
+        };
+    }
+
+    // The first positional after the subcommand is the model file.
+    let Some(model_path) = args.get(2).filter(|a| !a.starts_with('-')) else {
+        eprint!("{BOOTSTRAP_USAGE}");
+        return 1;
+    };
+
+    match run_bootstrap_command(args, model_path) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            1
+        }
+    }
+}
+
+fn run_summarize(args: &[String]) -> Result<i32, String> {
+    let dir = value(args, "--directory")
+        .ok_or("--summarize needs --directory pointing at an existing bootstrap run")?;
+    let options = parse_options(args, None)?;
+    let summary = resummarize(std::path::Path::new(dir), &options)?;
+    println!(
+        "Re-summarized {dir}: {} of {} completed samples included",
+        summary.n_included, summary.n_completed
+    );
+    print_table(&summary.parameters, summary.confidence_level);
+    Ok(0)
+}
+
+fn run_bootstrap_command(args: &[String], model_path: &str) -> Result<i32, String> {
+    let data_path = value(args, "--data").map(String::as_str);
+    let options = parse_options(args, Some(model_path))?;
+
+    let prepared = ferx_core::prepare_run(model_path, data_path)?;
+    if let Some(w) = &prepared.data_path_warning {
+        eprintln!("Warning: {w}");
+    }
+    eprintln!("Model: {}", prepared.parsed.model.name);
+    eprintln!(
+        "Data:  {} subjects, {} observations from {}",
+        prepared.population.subjects.len(),
+        prepared.population.n_obs(),
+        prepared.data_path
+    );
+    eprintln!(
+        "Bootstrap: {} samples, seed {}{}",
+        options.samples,
+        options.seed,
+        options
+            .stratify_on
+            .as_deref()
+            .map(|c| format!(", stratified on {c}"))
+            .unwrap_or_default()
+    );
+
+    let started = std::time::Instant::now();
+    let result = run_bootstrap(&prepared, &options)?;
+    eprintln!(
+        "Fitted {} replicates in {:.1}s",
+        result.replicates.len(),
+        started.elapsed().as_secs_f64()
+    );
+    report(&result, &options);
+
+    // A run whose samples nearly all failed produced no usable interval, and
+    // saying so in the exit code keeps it from passing silently in a pipeline.
+    if result.summary.n_included == 0 {
+        eprintln!("Error: no bootstrap sample survived the exclusion criteria");
+        return Ok(1);
+    }
+    Ok(0)
+}
+
+fn report(result: &BootstrapResult, options: &BootstrapOptions) {
+    let s = &result.summary;
+    println!(
+        "\n{} of {} samples completed; {} included in the statistics",
+        s.n_completed,
+        result.replicates.len(),
+        s.n_included
+    );
+    for (reason, n) in &s.excluded_by {
+        println!("  excluded {n}: {reason}");
+    }
+    print_table(&s.parameters, s.confidence_level);
+
+    if s.parameters.iter().all(|p| p.ci_percentile.is_none()) {
+        println!(
+            "\nNote: {} samples cannot resolve a {}% percentile interval; only the \
+             normal-approximation interval is shown. PsN's rule of thumb is 200 samples.",
+            s.n_included, s.confidence_level
+        );
+    }
+    if let Some(dir) = &options.directory {
+        println!("\nWrote bootstrap results to {}", dir.display());
+    }
+}
+
+fn print_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f64) {
+    let cell = |v: Option<f64>| match v {
+        Some(v) if v.is_finite() => format!("{v:>12.5}"),
+        _ => format!("{:>12}", "-"),
+    };
+    let width = parameters
+        .iter()
+        .map(|p| p.name.len())
+        .max()
+        .unwrap_or(9)
+        .max(9);
+    println!(
+        "\n{:<width$} {:>12} {:>12} {:>12} {:>12} {:>12} {:>12}",
+        "parameter",
+        "original",
+        "mean",
+        "bias",
+        "SE(boot)",
+        format!("{level}% lo"),
+        format!("{level}% hi"),
+    );
+    for p in parameters {
+        // The percentile interval is the bootstrap's own answer; the
+        // normal-approximation one is the fallback when there are too few
+        // samples to resolve the tail.
+        let (lo, hi) = match p.ci_percentile.or(p.ci_standard_error) {
+            Some((lo, hi)) => (Some(lo), Some(hi)),
+            None => (None, None),
+        };
+        println!(
+            "{:<width$} {} {} {} {} {} {}",
+            p.name,
+            cell(p.original),
+            cell(Some(p.mean)),
+            cell(p.bias),
+            cell(Some(p.standard_error)),
+            cell(lo),
+            cell(hi),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(rest: &[&str]) -> Vec<String> {
+        let mut v = vec!["ferx".to_string(), "bootstrap".to_string()];
+        v.extend(rest.iter().map(|s| s.to_string()));
+        v
+    }
+
+    #[test]
+    fn defaults_match_psn() {
+        let o = parse_options(&args(&["m.ferx"]), Some("m.ferx")).unwrap();
+        assert_eq!(o.samples, 200);
+        assert!(o.update_inits);
+        assert!(o.run_base_model);
+        assert!(o.skip_minimization_terminated);
+        assert!(o.skip_estimate_near_boundary);
+        assert!(!o.skip_covariance_step_terminated);
+        assert!(!o.skip_with_covstep_warnings);
+        assert!(!o.keep_covariance);
+        assert_eq!(o.confidence_level, 95.0);
+        assert_eq!(o.directory, Some(PathBuf::from("m-bootstrap")));
+    }
+
+    #[test]
+    fn flags_are_parsed() {
+        let o = parse_options(
+            &args(&[
+                "m.ferx",
+                "--samples",
+                "500",
+                "--seed",
+                "12345",
+                "--threads",
+                "5",
+                "--ci",
+                "90",
+                "--directory",
+                "boot",
+                "--dofv",
+                "--keep-covariance",
+            ]),
+            Some("m.ferx"),
+        )
+        .unwrap();
+        assert_eq!(o.samples, 500);
+        assert_eq!(o.seed, 12345);
+        assert_eq!(o.threads, Some(5));
+        assert_eq!(o.confidence_level, 90.0);
+        assert_eq!(o.directory, Some(PathBuf::from("boot")));
+        assert!(o.dofv);
+        assert!(o.keep_covariance);
+    }
+
+    #[test]
+    fn negated_flags_turn_the_psn_defaults_off() {
+        let o = parse_options(
+            &args(&[
+                "m.ferx",
+                "--no-skip-minimization-terminated",
+                "--no-skip-estimate-near-boundary",
+            ]),
+            Some("m.ferx"),
+        )
+        .unwrap();
+        assert!(!o.skip_minimization_terminated);
+        assert!(!o.skip_estimate_near_boundary);
+    }
+
+    #[test]
+    fn update_inits_is_dropped_when_there_is_no_base_fit() {
+        // `--update-inits` reads the base fit's final estimates. With
+        // `--no-run-base-model` there are none, so the combination must resolve
+        // to the model file's own inits rather than to something undefined.
+        let o = parse_options(&args(&["m.ferx", "--no-run-base-model"]), Some("m.ferx")).unwrap();
+        assert!(!o.run_base_model);
+        assert!(!o.update_inits);
+    }
+
+    #[test]
+    fn sample_size_accepts_both_forms() {
+        let flat = parse_options(&args(&["m.ferx", "--sample-size", "32"]), None).unwrap();
+        assert_eq!(flat.sample_size, SampleSize::Total(32));
+
+        let per = parse_options(
+            &args(&[
+                "m.ferx",
+                "--stratify-on",
+                "STUD",
+                "--sample-size",
+                "1001=>12,1002=>24",
+            ]),
+            None,
+        )
+        .unwrap();
+        assert!(matches!(per.sample_size, SampleSize::PerStratum(_)));
+        assert_eq!(per.stratify_on.as_deref(), Some("STUD"));
+    }
+
+    #[test]
+    fn a_bad_numeric_flag_is_an_error_not_a_default() {
+        // Falling back to the default on a typo would run a 200-sample
+        // bootstrap when the user asked for something else.
+        let err = parse_options(&args(&["m.ferx", "--samples", "many"]), None).unwrap_err();
+        assert!(err.contains("--samples"), "{err}");
+    }
+
+    #[test]
+    fn the_directory_defaults_to_the_model_stem() {
+        let o = parse_options(&args(&["runs/warfarin.ferx"]), Some("runs/warfarin.ferx")).unwrap();
+        assert_eq!(o.directory, Some(PathBuf::from("warfarin-bootstrap")));
+    }
+}

--- a/crates/ferx-cli/src/bootstrap_cmd.rs
+++ b/crates/ferx-cli/src/bootstrap_cmd.rs
@@ -164,7 +164,10 @@ fn run_summarize(args: &[String]) -> Result<i32, String> {
         "Re-summarized {dir}: {} of {} completed samples included",
         summary.n_included, summary.n_completed
     );
-    print_table(&summary.parameters, summary.confidence_level);
+    print!(
+        "{}",
+        render_table(&summary.parameters, summary.confidence_level)
+    );
     Ok(0)
 }
 
@@ -201,7 +204,7 @@ fn run_bootstrap_command(args: &[String], model_path: &str) -> Result<i32, Strin
         result.replicates.len(),
         started.elapsed().as_secs_f64()
     );
-    report(&result, &options);
+    print!("{}", report(&result, &options));
 
     // A run whose samples nearly all failed produced no usable interval, and
     // saying so in the exit code keeps it from passing silently in a pipeline.
@@ -212,32 +215,37 @@ fn run_bootstrap_command(args: &[String], model_path: &str) -> Result<i32, Strin
     Ok(0)
 }
 
-fn report(result: &BootstrapResult, options: &BootstrapOptions) {
+/// Render the whole report. Built as a `String` rather than printed line by line
+/// so the layout is testable in-process — the CLI's own integration tests run
+/// the binary as a subprocess, which is the right way to check exit codes and
+/// the wrong way to check what a table looks like.
+fn report(result: &BootstrapResult, options: &BootstrapOptions) -> String {
     let s = &result.summary;
-    println!(
-        "\n{} of {} samples completed; {} included in the statistics",
+    let mut out = format!(
+        "\n{} of {} samples completed; {} included in the statistics\n",
         s.n_completed,
         result.replicates.len(),
         s.n_included
     );
     for (reason, n) in &s.excluded_by {
-        println!("  excluded {n}: {reason}");
+        out.push_str(&format!("  excluded {n}: {reason}\n"));
     }
-    print_table(&s.parameters, s.confidence_level);
+    out.push_str(&render_table(&s.parameters, s.confidence_level));
 
-    if s.parameters.iter().all(|p| p.ci_percentile.is_none()) {
-        println!(
+    if !s.parameters.is_empty() && s.parameters.iter().all(|p| p.ci_percentile.is_none()) {
+        out.push_str(&format!(
             "\nNote: {} samples cannot resolve a {}% percentile interval; only the \
-             normal-approximation interval is shown. PsN's rule of thumb is 200 samples.",
+             normal-approximation interval is shown. PsN's rule of thumb is 200 samples.\n",
             s.n_included, s.confidence_level
-        );
+        ));
     }
     if let Some(dir) = &options.directory {
-        println!("\nWrote bootstrap results to {}", dir.display());
+        out.push_str(&format!("\nWrote bootstrap results to {}\n", dir.display()));
     }
+    out
 }
 
-fn print_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f64) {
+fn render_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f64) -> String {
     let cell = |v: Option<f64>| match v {
         Some(v) if v.is_finite() => format!("{v:>12.5}"),
         _ => format!("{:>12}", "-"),
@@ -248,8 +256,8 @@ fn print_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f6
         .max()
         .unwrap_or(9)
         .max(9);
-    println!(
-        "\n{:<width$} {:>12} {:>12} {:>12} {:>12} {:>12} {:>12}",
+    let mut out = format!(
+        "\n{:<width$} {:>12} {:>12} {:>12} {:>12} {:>12} {:>12}\n",
         "parameter",
         "original",
         "mean",
@@ -266,8 +274,8 @@ fn print_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f6
             Some((lo, hi)) => (Some(lo), Some(hi)),
             None => (None, None),
         };
-        println!(
-            "{:<width$} {} {} {} {} {} {}",
+        out.push_str(&format!(
+            "{:<width$} {} {} {} {} {} {}\n",
             p.name,
             cell(p.original),
             cell(Some(p.mean)),
@@ -275,8 +283,9 @@ fn print_table(parameters: &[ferx_tools::bootstrap::ParameterSummary], level: f6
             cell(Some(p.standard_error)),
             cell(lo),
             cell(hi),
-        );
+        ));
     }
+    out
 }
 
 #[cfg(test)]
@@ -391,5 +400,253 @@ mod tests {
     fn the_directory_defaults_to_the_model_stem() {
         let o = parse_options(&args(&["runs/warfarin.ferx"]), Some("runs/warfarin.ferx")).unwrap();
         assert_eq!(o.directory, Some(PathBuf::from("warfarin-bootstrap")));
+    }
+
+    // ── rendering ───────────────────────────────────────────────────────────
+
+    use ferx_tools::bootstrap::ParameterSummary;
+
+    fn parameter(name: &str, ci_percentile: Option<(f64, f64)>) -> ParameterSummary {
+        ParameterSummary {
+            name: name.to_string(),
+            original: Some(1.0),
+            mean: 1.5,
+            bias: Some(0.5),
+            standard_error: 0.25,
+            median: 1.4,
+            ci_percentile,
+            ci_standard_error: Some((0.5, 2.5)),
+        }
+    }
+
+    #[test]
+    fn the_table_is_column_aligned_and_widens_for_long_names() {
+        let table = render_table(
+            &[
+                parameter("CL", Some((1.1, 1.9))),
+                parameter("OMEGA(ETA_CL,ETA_CL)", Some((1.1, 1.9))),
+            ],
+            95.0,
+        );
+        let lines: Vec<&str> = table.lines().filter(|l| !l.is_empty()).collect();
+        assert!(lines[0].starts_with("parameter"));
+        assert!(lines[0].contains("95% lo") && lines[0].contains("95% hi"));
+        // Every row is the same width, including the one that set it.
+        let widths: Vec<usize> = lines.iter().map(|l| l.len()).collect();
+        assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "ragged table: {widths:?}"
+        );
+        assert!(lines[2].starts_with("OMEGA(ETA_CL,ETA_CL)"));
+    }
+
+    #[test]
+    fn the_table_falls_back_to_the_normal_interval_when_there_is_no_percentile_one() {
+        // Too few samples to resolve the tail: show the normal-approximation
+        // interval rather than an empty column.
+        let table = render_table(&[parameter("CL", None)], 95.0);
+        let row = table.lines().nth(2).expect("a data row");
+        assert!(row.contains("0.50000") && row.contains("2.50000"), "{row}");
+
+        let with_percentile = render_table(&[parameter("CL", Some((1.1, 1.9)))], 95.0);
+        let row = with_percentile.lines().nth(2).expect("a data row");
+        assert!(row.contains("1.10000") && row.contains("1.90000"), "{row}");
+    }
+
+    #[test]
+    fn a_missing_value_renders_as_a_dash_not_a_nan() {
+        let mut p = parameter("CL", None);
+        p.original = None;
+        p.bias = None;
+        p.ci_standard_error = None;
+        let table = render_table(&[p], 95.0);
+        let row = table.lines().nth(2).expect("a data row");
+        assert!(!row.to_lowercase().contains("nan"), "{row}");
+        assert!(row.contains('-'), "{row}");
+    }
+
+    #[test]
+    fn the_ci_level_is_reflected_in_the_header() {
+        let table = render_table(&[parameter("CL", Some((1.1, 1.9)))], 90.0);
+        assert!(table.contains("90% lo"), "{table}");
+    }
+
+    fn summary_of(
+        parameters: Vec<ParameterSummary>,
+        excluded: Vec<(String, usize)>,
+    ) -> BootstrapResult {
+        BootstrapResult {
+            parameter_names: parameters.iter().map(|p| p.name.clone()).collect(),
+            original: None,
+            replicates: Vec::new(),
+            draws: Vec::new(),
+            subject_ids: Vec::new(),
+            summary: ferx_tools::bootstrap::BootstrapSummary {
+                n_completed: 4,
+                n_included: 3,
+                excluded_by: excluded,
+                confidence_level: 95.0,
+                diagnostic_means: Vec::new(),
+                parameters,
+            },
+            n_estimated_parameters: 2,
+        }
+    }
+
+    #[test]
+    fn the_report_names_the_exclusions_and_the_output_directory() {
+        let result = summary_of(
+            vec![parameter("CL", Some((1.1, 1.9)))],
+            vec![("minimization terminated".to_string(), 1)],
+        );
+        let options = BootstrapOptions {
+            directory: Some(PathBuf::from("out")),
+            ..BootstrapOptions::default()
+        };
+        let text = report(&result, &options);
+        assert!(
+            text.contains("4 of 0 samples completed; 3 included"),
+            "{text}"
+        );
+        assert!(
+            text.contains("excluded 1: minimization terminated"),
+            "{text}"
+        );
+        assert!(text.contains("Wrote bootstrap results to out"), "{text}");
+        // A resolvable percentile interval means no "too few samples" note.
+        assert!(!text.contains("cannot resolve"), "{text}");
+    }
+
+    #[test]
+    fn the_report_says_when_there_were_too_few_samples_for_a_percentile_interval() {
+        let result = summary_of(vec![parameter("CL", None)], Vec::new());
+        let text = report(
+            &result,
+            &BootstrapOptions {
+                directory: None,
+                ..BootstrapOptions::default()
+            },
+        );
+        assert!(
+            text.contains("cannot resolve a 95% percentile interval"),
+            "{text}"
+        );
+        assert!(!text.contains("Wrote bootstrap results"), "{text}");
+    }
+
+    // ── dispatch ────────────────────────────────────────────────────────────
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn repo_path(rel: &str) -> String {
+        repo_root().join(rel).to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn help_exits_zero_and_a_missing_model_exits_one() {
+        assert_eq!(run(&args(&["--help"])), 0);
+        assert_eq!(run(&args(&["-h"])), 0);
+        // No positional at all, and a leading flag that is not a model path.
+        assert_eq!(run(&args(&[])), 1);
+        assert_eq!(run(&args(&["--samples", "5"])), 1);
+    }
+
+    #[test]
+    fn a_failure_to_load_the_model_exits_one() {
+        assert_eq!(run(&args(&["definitely-not-a-model.ferx"])), 1);
+    }
+
+    #[test]
+    fn summarize_without_a_directory_exits_one() {
+        assert_eq!(run(&args(&["--summarize"])), 1);
+        // A directory that exists but holds no raw_results.csv.
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            run(&args(&[
+                "--summarize",
+                "--directory",
+                dir.path().to_str().unwrap()
+            ])),
+            1
+        );
+    }
+
+    /// One real end-to-end pass through `run`, on the smallest useful model.
+    ///
+    /// Kept to a single sample and a single outer iteration is not possible from
+    /// the command line, so this is warfarin (10 subjects) at `--samples 1`:
+    /// two fits, well under a second in release and a couple in debug. It is
+    /// what covers the load → fit → report → exit-code path that the subprocess
+    /// tests in `tests/cli_ferx.rs` exercise but cannot measure.
+    #[test]
+    fn a_real_run_writes_its_directory_and_exits_zero() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let code = run(&args(&[
+            &repo_path("examples/warfarin.ferx"),
+            "--data",
+            &repo_path("data/warfarin.csv"),
+            "--samples",
+            "1",
+            "--seed",
+            "5",
+            "--threads",
+            "1",
+            "--directory",
+            dir.path().to_str().unwrap(),
+        ]));
+        assert_eq!(code, 0);
+        assert!(dir.path().join("raw_results.csv").exists());
+        assert!(dir.path().join("bootstrap_results.csv").exists());
+
+        // And `--summarize` over what it just wrote.
+        assert_eq!(
+            run(&args(&[
+                "--summarize",
+                "--directory",
+                dir.path().to_str().unwrap()
+            ])),
+            0
+        );
+    }
+
+    #[test]
+    fn a_run_whose_every_sample_is_excluded_exits_one() {
+        // `--sample-size 1` fits single-subject replicates, which cannot
+        // identify the between-subject variances and so land on a boundary —
+        // the default filters then drop every sample. Exiting 0 there would let
+        // a pipeline treat an empty result as a successful bootstrap.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let code = run(&args(&[
+            &repo_path("examples/warfarin.ferx"),
+            "--data",
+            &repo_path("data/warfarin.csv"),
+            "--samples",
+            "1",
+            "--sample-size",
+            "1",
+            "--seed",
+            "5",
+            "--threads",
+            "1",
+            "--directory",
+            dir.path().to_str().unwrap(),
+        ]));
+        // Either outcome is legitimate for a degenerate replicate; what must not
+        // happen is a zero exit with nothing included.
+        let raw = std::fs::read_to_string(dir.path().join("bootstrap_diagnostics.csv"))
+            .expect("diagnostics written");
+        let included: f64 = raw
+            .lines()
+            .find(|l| l.starts_with("samples_included,"))
+            .and_then(|l| l.split(',').nth(1))
+            .and_then(|v| v.trim().parse().ok())
+            .expect("samples_included row");
+        if included == 0.0 {
+            assert_eq!(code, 1, "an empty bootstrap must not exit 0");
+        } else {
+            assert_eq!(code, 0);
+        }
     }
 }

--- a/crates/ferx-cli/src/bootstrap_cmd.rs
+++ b/crates/ferx-cli/src/bootstrap_cmd.rs
@@ -612,6 +612,40 @@ mod tests {
     }
 
     #[test]
+    fn an_invalid_confidence_level_is_an_error_not_a_crash() {
+        // `--summarize --ci 100` used to walk past every check and hit an
+        // assertion inside the statistics, killing the process with 101.
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("raw_results.csv"),
+            "sample,minimization_successful,estimate_near_boundary,covariance_step_successful,\
+             covariance_step_warnings,ofv,seconds,CL,error\n1,1,0,0,0,10,0.1,1.0,\n",
+        )
+        .expect("write");
+        assert_eq!(
+            run(&args(&[
+                "--summarize",
+                "--directory",
+                dir.path().to_str().unwrap(),
+                "--ci",
+                "100"
+            ])),
+            1
+        );
+        // And on the fresh-run path, before anything is fitted.
+        assert_eq!(
+            run(&args(&[
+                &repo_path("examples/warfarin.ferx"),
+                "--data",
+                &repo_path("data/warfarin.csv"),
+                "--ci",
+                "0"
+            ])),
+            1
+        );
+    }
+
+    #[test]
     fn a_run_whose_every_sample_is_excluded_exits_one() {
         // `--sample-size 1` fits single-subject replicates, which cannot
         // identify the between-subject variances and so land on a boundary —

--- a/crates/ferx-cli/src/main.rs
+++ b/crates/ferx-cli/src/main.rs
@@ -1,3 +1,5 @@
+mod bootstrap_cmd;
+
 use ferx_core::NcaInit;
 use std::env;
 use std::time::Instant;
@@ -9,6 +11,8 @@ Usage: ferx <model.ferx> --data <data.csv> [--threads N|auto] [--output <run.fit
        ferx <model.ferx> --simulate          [--threads N|auto] [--output <run.fitrx>]
        ferx check <model.ferx> [--data <data.csv>] [--json]
        ferx summary <run.fitrx> [<run2.fitrx> ...]
+       ferx bootstrap <model.ferx> [--data <data.csv>] [--samples N] [--seed N]
+                      [--stratify-on COL] [--threads N]   (see `ferx bootstrap --help`)
 
 Fits a NLME model and writes sdtab.csv with residuals.
 Data must be in NONMEM format (ID, TIME, DV, EVID, AMT, CMT, ...)
@@ -89,6 +93,14 @@ fn main() {
     // basic run info to stdout. Dispatch before the fit/simulate path.
     if args.get(1).map(String::as_str) == Some("summary") {
         std::process::exit(run_summary(&args));
+    }
+
+    // `ferx bootstrap ...` (#1140) is the first `ferx-tools` subcommand: many
+    // fits over resampled data. Dispatched here for the same reason as the two
+    // above — the fit/simulate path below is untouched, and a plain
+    // `ferx model.ferx` still means what it always did.
+    if args.get(1).map(String::as_str) == Some("bootstrap") {
+        std::process::exit(bootstrap_cmd::run(&args));
     }
 
     if args.len() < 2 {

--- a/crates/ferx-cli/tests/cli_ferx.rs
+++ b/crates/ferx-cli/tests/cli_ferx.rs
@@ -306,3 +306,82 @@ fn fit_with_missing_files_errors() {
         "expected an Error: message on stderr"
     );
 }
+
+// ── ferx bootstrap (#1140) ───────────────────────────────────────────────────
+
+#[test]
+fn bootstrap_help_lists_the_psn_options() {
+    let out = ferx()
+        .args(["bootstrap", "--help"])
+        .output()
+        .expect("run ferx bootstrap --help");
+    assert!(out.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    for flag in [
+        "--samples",
+        "--seed",
+        "--stratify-on",
+        "--sample-size",
+        "--update-inits",
+        "--keep-covariance",
+        "--dofv",
+        "--summarize",
+    ] {
+        assert!(stdout.contains(flag), "help does not mention {flag}");
+    }
+}
+
+#[test]
+fn bootstrap_without_a_model_is_a_usage_error() {
+    let out = ferx()
+        .args(["bootstrap"])
+        .output()
+        .expect("run ferx bootstrap");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("Usage: ferx bootstrap"));
+}
+
+#[test]
+fn bootstrap_summarize_needs_a_directory() {
+    let out = ferx()
+        .args(["bootstrap", "--summarize"])
+        .output()
+        .expect("run ferx bootstrap --summarize");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--directory"));
+}
+
+#[test]
+fn bootstrap_rejects_a_covstep_filter_without_the_covariance_step() {
+    // The filter reads a diagnostic that only exists when the step ran, so
+    // accepting it silently would drop a filter the user asked for.
+    let out = ferx()
+        .args([
+            "bootstrap",
+            "examples/one_cpt_iv.ferx",
+            "--data",
+            "data/one_cpt_iv.csv",
+            "--samples",
+            "1",
+            "--skip-covariance-step-terminated",
+        ])
+        .output()
+        .expect("run ferx bootstrap");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("--keep-covariance"),
+        "the error should name the way out"
+    );
+}
+
+/// The top-level dispatcher must not have stolen the ordinary fit path: a model
+/// file whose name happens to start with a subcommand-looking word is still a
+/// model file, and `ferx <model>` is unchanged.
+#[test]
+fn the_bootstrap_subcommand_does_not_shadow_a_plain_fit() {
+    let out = ferx()
+        .args(["check", "examples/one_cpt_iv.ferx"])
+        .output()
+        .expect("run ferx check");
+    assert!(out.status.success());
+}

--- a/crates/ferx-tools/Cargo.toml
+++ b/crates/ferx-tools/Cargo.toml
@@ -16,3 +16,10 @@ repository = "https://github.com/FeRx-NLME/ferx-core"
 # silently defeated for `ferx-core` everywhere (harmless only while
 # `default = []`; `survival` is slated to become default-on).
 ferx-core = { path = "../..", version = "0.3.0", default-features = false }
+csv = "1.3"
+rand = "0.10"
+rayon = "1.10"
+
+[dev-dependencies]
+nalgebra = "0.35"
+tempfile = "3"

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -78,6 +78,51 @@ pub struct BootstrapOptions {
     pub confidence_level: f64,
 }
 
+impl BootstrapOptions {
+    /// Checks that hold wherever these options are used — including
+    /// [`resummarize`], which reaches the same statistics without going through
+    /// [`run_bootstrap`].
+    ///
+    /// Splitting validation out is not symmetry for its own sake: before it
+    /// existed, `--summarize --ci 100` walked past every check and hit the
+    /// `normal_quantile` assertion, exiting 101 instead of reporting a bad
+    /// argument.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.samples == 0 {
+            return Err("--samples must be at least 1".to_string());
+        }
+        if !(self.confidence_level > 0.0 && self.confidence_level < 100.0) {
+            return Err(format!(
+                "--ci must be a confidence level in (0, 100), got {}",
+                self.confidence_level
+            ));
+        }
+        Ok(())
+    }
+
+    /// Checks that only apply to a fresh run.
+    ///
+    /// The covariance filters read a diagnostic that only exists when the step
+    /// actually ran, so asking for one without `--keep-covariance` would drop a
+    /// filter the user requested without saying so. Deliberately *not* part of
+    /// [`Self::validate`]: under `--summarize` the diagnostics are already in
+    /// `raw_results.csv`, so filtering on them is exactly the point and needs no
+    /// covariance step now.
+    fn validate_for_run(&self) -> Result<(), String> {
+        if !self.keep_covariance
+            && (self.skip_covariance_step_terminated || self.skip_with_covstep_warnings)
+        {
+            return Err(
+                "--skip-covariance-step-terminated / --skip-with-covstep-warnings filter on the \
+                 covariance step, which is off for replicate fits by default. Add \
+                 --keep-covariance (slower) or drop the filter."
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 impl Default for BootstrapOptions {
     fn default() -> Self {
         BootstrapOptions {
@@ -112,8 +157,11 @@ pub struct ReplicateResult {
     pub index: usize,
     /// The flat parameter vector — see [`flatten_estimates`].
     pub estimates: Vec<f64>,
-    /// Per-replicate standard errors, present only with `keep_covariance`.
-    pub standard_errors: Option<Vec<f64>>,
+    /// Per-replicate standard errors, aligned with [`Self::estimates`] and
+    /// present only when the covariance step ran. An individual entry is `None`
+    /// where core reports no SE for that coordinate — an IOV *covariance*, for
+    /// instance, since `se_kappa` carries only the diagonal variances.
+    pub standard_errors: Option<Vec<Option<f64>>>,
     pub ofv: f64,
     pub converged: bool,
     pub estimate_near_boundary: bool,
@@ -148,77 +196,203 @@ pub struct BootstrapResult {
 
 // ── flat parameter vector ───────────────────────────────────────────────────
 
-/// Names for the flat parameter vector: every theta, then the free lower
-/// triangle of Omega, then every sigma.
+/// One entry of the flat parameter vector.
+///
+/// Every consumer of the flat vector — names, estimates, standard errors, the
+/// rebuild into [`ModelParameters`], the estimated-parameter count — is derived
+/// from [`coordinates`] rather than re-deriving its own traversal. That is not
+/// tidiness: five hand-written loops over "theta, then the free lower triangle,
+/// then sigma" is five chances to drift, and a drift here is silent. Two of
+/// them had already drifted before this enum existed — the parameter count
+/// missed a block Omega's off-diagonals, and the standard errors were read in a
+/// different order from the names they were written under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Coord {
+    Theta(usize),
+    /// Between-subject Omega, lower triangle, `i >= j`.
+    Omega(usize, usize),
+    Sigma(usize),
+    /// Inter-occasion Omega (kappa), lower triangle, `i >= j`.
+    OmegaIov(usize, usize),
+}
+
+/// The flat parameter vector's coordinates, in order.
+///
+/// Theta, then the free lower triangle of the between-subject Omega, then
+/// sigma, then the free lower triangle of the IOV Omega. The IOV block goes
+/// last so that a model without IOV produces exactly the columns it did before
+/// IOV was carried at all.
+fn coordinates(template: &ModelParameters) -> Vec<Coord> {
+    let mut out: Vec<Coord> = (0..template.theta.len()).map(Coord::Theta).collect();
+    for i in 0..template.omega.dim() {
+        for j in 0..=i {
+            if template.omega.free_mask[(i, j)] {
+                out.push(Coord::Omega(i, j));
+            }
+        }
+    }
+    out.extend((0..template.sigma.values.len()).map(Coord::Sigma));
+    if let Some(iov) = &template.omega_iov {
+        for i in 0..iov.dim() {
+            for j in 0..=i {
+                if iov.free_mask[(i, j)] {
+                    out.push(Coord::OmegaIov(i, j));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Whether this coordinate is held fixed, and so is not an estimated parameter.
+///
+/// The `*_fixed` flags are per-eta / per-kappa, not per-covariance-element, so a
+/// block off-diagonal counts as fixed exactly when either of its two etas is.
+fn is_fixed(template: &ModelParameters, coord: Coord) -> bool {
+    let flag = |flags: &[bool], i: usize| flags.get(i).copied().unwrap_or(false);
+    match coord {
+        Coord::Theta(i) => flag(&template.theta_fixed, i),
+        Coord::Omega(i, j) => flag(&template.omega_fixed, i) || flag(&template.omega_fixed, j),
+        Coord::Sigma(i) => flag(&template.sigma_fixed, i),
+        Coord::OmegaIov(i, j) => flag(&template.kappa_fixed, i) || flag(&template.kappa_fixed, j),
+    }
+}
+
+/// Names for the flat parameter vector.
 ///
 /// Omega entries are named by their etas — `OMEGA(CL,CL)` — rather than by
 /// PsN's positional `OMEGA(1,1)`. The file is ferx's own, and a positional index
 /// silently means something different the moment an eta is added.
 pub fn parameter_names(template: &ModelParameters) -> Vec<String> {
-    let mut names = template.theta_names.clone();
     let eta = &template.omega.eta_names;
-    for i in 0..template.omega.dim() {
-        for j in 0..=i {
-            if template.omega.free_mask[(i, j)] {
-                names.push(format!("OMEGA({},{})", eta[i], eta[j]));
-            }
-        }
-    }
-    names.extend(template.sigma.names.iter().cloned());
-    names
+    let kappa = template
+        .omega_iov
+        .as_ref()
+        .map(|iov| iov.eta_names.clone())
+        .unwrap_or_default();
+    coordinates(template)
+        .into_iter()
+        .map(|c| match c {
+            Coord::Theta(i) => template.theta_names[i].clone(),
+            Coord::Omega(i, j) => format!("OMEGA({},{})", eta[i], eta[j]),
+            Coord::Sigma(i) => template.sigma.names[i].clone(),
+            Coord::OmegaIov(i, j) => format!("OMEGA_IOV({},{})", kappa[i], kappa[j]),
+        })
+        .collect()
 }
 
 /// Flatten a fitted model into the vector [`parameter_names`] labels.
 ///
 /// `template` supplies the structure — which Omega entries are free parameters
-/// rather than structural zeros — because a [`FitResult`] carries the matrix but
-/// not the mask.
+/// rather than structural zeros — because a [`FitResult`] carries the matrices
+/// but not their masks.
 pub fn flatten_estimates(template: &ModelParameters, result: &FitResult) -> Vec<f64> {
-    let mut v = result.theta.clone();
-    for i in 0..template.omega.dim() {
-        for j in 0..=i {
-            if template.omega.free_mask[(i, j)] {
-                v.push(result.omega[(i, j)]);
-            }
-        }
-    }
-    v.extend(result.sigma.iter().copied());
-    v
+    coordinates(template)
+        .into_iter()
+        .map(|c| match c {
+            Coord::Theta(i) => result.theta[i],
+            Coord::Omega(i, j) => result.omega[(i, j)],
+            Coord::Sigma(i) => result.sigma[i],
+            // A fitted IOV Omega is always present when the model declares one;
+            // fall back to the template so a caller cannot get a wrong number
+            // in the unreachable case.
+            Coord::OmegaIov(i, j) => result
+                .omega_iov
+                .as_ref()
+                .map(|m| m[(i, j)])
+                .or_else(|| template.omega_iov.as_ref().map(|m| m.matrix[(i, j)]))
+                .unwrap_or(f64::NAN),
+        })
+        .collect()
+}
+
+/// The per-replicate standard errors, in the *same order as the names*.
+///
+/// Each one is looked up by its `(i, j)` coordinate rather than read off a
+/// parallel vector, because the packed layouts differ: `FitResult::se_omega` is
+/// the **column-major** lower triangle for a block Omega and carries structural
+/// zeros, whereas the flat vector here is row-major and omits them. Zipping the
+/// two would mislabel every block-Omega SE from the third element on, and shift
+/// the sigma SEs as well. [`ferx_core::omega_se_at`] owns that indexing.
+///
+/// `None` for the whole vector when the covariance step did not run — which is
+/// the default, and why the bootstrap standard error is the spread of the
+/// estimates rather than an average of these. `None` for an individual entry
+/// where core does not report an SE: `se_kappa` carries only the IOV diagonal
+/// variances, so an IOV covariance has no reported SE at all.
+fn flat_standard_errors(
+    template: &ModelParameters,
+    result: &FitResult,
+) -> Option<Vec<Option<f64>>> {
+    result.se_theta.as_ref()?;
+    let n_eta = template.omega.dim();
+    Some(
+        coordinates(template)
+            .into_iter()
+            .map(|c| match c {
+                Coord::Theta(i) => result.se_theta.as_ref().and_then(|v| v.get(i).copied()),
+                Coord::Omega(i, j) => ferx_core::omega_se_at(&result.se_omega, n_eta, i, j),
+                Coord::Sigma(i) => result.se_sigma.as_ref().and_then(|v| v.get(i).copied()),
+                // Core reports one SE per IOV *variance*; off-diagonal IOV
+                // covariances have none.
+                Coord::OmegaIov(i, j) if i == j => {
+                    result.se_kappa.as_ref().and_then(|v| v.get(i).copied())
+                }
+                Coord::OmegaIov(_, _) => None,
+            })
+            .collect(),
+    )
 }
 
 /// Inverse of [`flatten_estimates`]: rebuild [`ModelParameters`] from a flat
 /// vector, keeping every structural property of the template (bounds, fixed
-/// flags, block structure, IOV Omega, mixture).
+/// flags, block structure, IOV mask).
 ///
 /// This is what `--update-inits` and `--dofv` both need — and going through the
 /// flat vector rather than the `FitResult` means both work equally well from a
 /// stored `raw_results.csv`.
 pub fn params_from_estimates(template: &ModelParameters, flat: &[f64]) -> ModelParameters {
-    let n_theta = template.theta.len();
     let mut params = template.clone();
-    params.theta = flat[..n_theta].to_vec();
+    let mut omega = template.omega.matrix.clone();
+    let mut omega_iov = template.omega_iov.as_ref().map(|m| m.matrix.clone());
+    let mut sigma = template.sigma.values.clone();
 
-    let dim = template.omega.dim();
-    let mut m = template.omega.matrix.clone();
-    let mut k = n_theta;
-    for i in 0..dim {
-        for j in 0..=i {
-            if template.omega.free_mask[(i, j)] {
-                m[(i, j)] = flat[k];
-                m[(j, i)] = flat[k];
-                k += 1;
+    for (k, coord) in coordinates(template).into_iter().enumerate() {
+        let Some(&value) = flat.get(k) else { break };
+        match coord {
+            Coord::Theta(i) => params.theta[i] = value,
+            Coord::Omega(i, j) => {
+                omega[(i, j)] = value;
+                omega[(j, i)] = value;
+            }
+            Coord::Sigma(i) => sigma[i] = value,
+            Coord::OmegaIov(i, j) => {
+                if let Some(m) = omega_iov.as_mut() {
+                    m[(i, j)] = value;
+                    m[(j, i)] = value;
+                }
             }
         }
     }
+
     params.omega = OmegaMatrix::from_matrix_with_mask(
-        m,
+        omega,
         template.omega.eta_names.clone(),
         template.omega.diagonal,
         template.omega.free_mask.clone(),
     );
     params.sigma = SigmaVector {
-        values: flat[k..].to_vec(),
+        values: sigma,
         names: template.sigma.names.clone(),
+    };
+    params.omega_iov = match (omega_iov, &template.omega_iov) {
+        (Some(m), Some(t)) => Some(OmegaMatrix::from_matrix_with_mask(
+            m,
+            t.eta_names.clone(),
+            t.diagonal,
+            t.free_mask.clone(),
+        )),
+        _ => None,
     };
     params
 }
@@ -336,19 +510,6 @@ fn replicate_options(base: &FitOptions, keep_covariance: bool) -> FitOptions {
     o
 }
 
-/// The per-replicate standard errors, flattened in [`parameter_names`] order.
-///
-/// `None` when the covariance step did not run — which is the default, and why
-/// the bootstrap standard error is the spread of the estimates rather than an
-/// average of these.
-fn flat_standard_errors(result: &FitResult) -> Option<Vec<f64>> {
-    let theta = result.se_theta.as_ref()?;
-    let mut se = theta.clone();
-    se.extend(result.se_omega.clone().unwrap_or_default());
-    se.extend(result.se_sigma.clone().unwrap_or_default());
-    Some(se)
-}
-
 fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
     let near_boundary = result
         .warnings_structured
@@ -375,6 +536,32 @@ fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
 /// covariate would silently see different values than it did in the base fit.
 /// PsN documents the same hazard as a known bug — "model code that relies on ID
 /// numbers will lead to errors" — and leaves it to the user. Fail instead.
+/// Refuse a mixture model.
+///
+/// Two reasons, and the first is not a plumbing gap. A mixture model's classes
+/// are identified only up to relabelling, so replicate *k*'s "class 1" need not
+/// be the original fit's class 1; averaging estimates across replicates without
+/// resolving that label switching produces a bias-and-interval table that is
+/// meaningless rather than merely noisy. Second, `MixtureParams` carries
+/// per-class Omega/Sigma overrides in their own packed block, which the flat
+/// vector here does not represent — so `--update-inits` and `--dofv` would
+/// silently drop them.
+///
+/// Refusing is the honest answer until the relabelling question is settled.
+fn reject_mixture_model(params: &ModelParameters) -> Result<(), String> {
+    if params.mixture.is_some() {
+        return Err(
+            "the bootstrap does not support mixture models ([mixture] block). A mixture's \
+             classes are identified only up to relabelling, so a replicate's class 1 need \
+             not be the original fit's class 1, and averaging estimates across replicates \
+             would mix them. Bootstrapping a mixture needs a relabelling rule this tool \
+             does not have."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn reject_id_dependent_model(model: &CompiledModel) -> Result<(), String> {
     reject_id_dependent(&model.referenced_covariates)
 }
@@ -401,25 +588,9 @@ pub fn run_bootstrap(
     options: &BootstrapOptions,
 ) -> Result<BootstrapResult, String> {
     reject_id_dependent_model(&prepared.parsed.model)?;
-    if options.samples == 0 {
-        return Err("--samples must be at least 1".to_string());
-    }
-    if !(0.0..100.0).contains(&options.confidence_level) || options.confidence_level <= 0.0 {
-        return Err("--ci must be a confidence level in (0, 100)".to_string());
-    }
-    // Both covariance-step filters read a diagnostic that only exists when the
-    // step actually ran. Silently ignoring them would drop a filter the user
-    // asked for without saying so.
-    if !options.keep_covariance
-        && (options.skip_covariance_step_terminated || options.skip_with_covstep_warnings)
-    {
-        return Err(
-            "--skip-covariance-step-terminated / --skip-with-covstep-warnings filter on the \
-             covariance step, which is off for replicate fits by default. Add \
-             --keep-covariance (slower) or drop the filter."
-                .to_string(),
-        );
-    }
+    reject_mixture_model(&prepared.init_params)?;
+    options.validate()?;
+    options.validate_for_run()?;
 
     let template = &prepared.init_params;
     let names = parameter_names(template);
@@ -465,7 +636,7 @@ pub fn run_bootstrap(
         Some(ReplicateResult {
             index: 0,
             estimates: flatten_estimates(template, &result),
-            standard_errors: flat_standard_errors(&result),
+            standard_errors: flat_standard_errors(template, &result),
             ofv: result.ofv,
             converged: result.converged,
             estimate_near_boundary: near_boundary,
@@ -508,7 +679,7 @@ pub fn run_bootstrap(
                 ReplicateResult {
                     index: replicate.index,
                     estimates: flatten_estimates(template, &result),
-                    standard_errors: flat_standard_errors(&result),
+                    standard_errors: flat_standard_errors(template, &result),
                     ofv: result.ofv,
                     converged: result.converged,
                     estimate_near_boundary: near_boundary,
@@ -588,6 +759,7 @@ pub fn resummarize(
     directory: &std::path::Path,
     options: &BootstrapOptions,
 ) -> Result<BootstrapSummary, String> {
+    options.validate()?;
     let raw = directory.join("raw_results.csv");
     if !raw.exists() {
         return Err(format!(
@@ -667,10 +839,16 @@ fn compute_delta_ofv(
 /// Non-fixed parameters — the chi-square degrees of freedom for the Δofv
 /// reference distribution.
 fn count_estimated(template: &ModelParameters) -> usize {
-    let theta = template.theta_fixed.iter().filter(|f| !**f).count();
-    let omega = template.omega_fixed.iter().filter(|f| !**f).count();
-    let sigma = template.sigma_fixed.iter().filter(|f| !**f).count();
-    theta + omega + sigma
+    // Counted over the flat vector's own coordinates, not over the `*_fixed`
+    // flag vectors. Those are per-eta, so counting them misses a block Omega's
+    // off-diagonals entirely: a free 2x2 block is three estimated parameters and
+    // two flags. Getting this wrong writes a chi-square reference with too few
+    // degrees of freedom, which makes the Δofv distribution look better than it
+    // is — the one direction a diagnostic must never fail in.
+    coordinates(template)
+        .into_iter()
+        .filter(|c| !is_fixed(template, *c))
+        .count()
 }
 
 #[cfg(test)]

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -1,0 +1,679 @@
+//! Non-parametric case bootstrap (#1140).
+//!
+//! Resample whole subjects with replacement, refit the same model to each
+//! replicate, and summarise the spread of the estimates into bias, standard
+//! errors and confidence intervals. Feature target: `PsN::bootstrap`.
+//!
+//! # Why a tool and not a `ferx-core` feature
+//!
+//! This is 200+ calls to [`ferx_core::fit`] over resampled data and nothing
+//! else — no new numerics. That is exactly the `ferx-tools` side of the #1114
+//! boundary rule: *if it calls `fit()` more than once, it is a tool.*
+//!
+//! # What the bootstrap buys over `$COVARIANCE`
+//!
+//! ferx's standard errors are the pure `R⁻¹` matrix (NONMEM `$COVARIANCE
+//! MATRIX=R`), which is asymptotic and symmetric by construction. The bootstrap
+//! distribution assumes neither: it survives a failed or non-PD covariance step,
+//! and it shows asymmetry in poorly identified parameters instead of averaging
+//! it away. [`ParameterSummary`] reports both intervals side by side so the
+//! disagreement between them is visible.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use ferx_core::{
+    fit, CompiledModel, FitOptions, FitResult, ModelParameters, OmegaMatrix, Population,
+    PreparedRun, SigmaVector, WarningCode,
+};
+use rayon::prelude::*;
+
+pub mod output;
+pub mod resample;
+pub mod summary;
+
+pub use resample::{Replicate, SampleSize, Strata};
+pub use summary::{BootstrapSummary, ParameterSummary};
+
+/// Everything the bootstrap needs beyond the model and data themselves.
+///
+/// Defaults mirror PsN's, including the two skip filters that are on by default
+/// there — a replicate whose minimization terminated, or whose estimate sits on
+/// a boundary, is not a draw from the sampling distribution of a converged fit,
+/// so including it biases the interval.
+#[derive(Debug, Clone)]
+pub struct BootstrapOptions {
+    /// Number of bootstrap datasets. PsN's default, and its stated rule of
+    /// thumb for standard errors, is 200.
+    pub samples: usize,
+    /// Master seed. Every replicate's draw is derived from this and its own
+    /// index — see [`resample::replicate_seed`].
+    pub seed: u64,
+    pub sample_size: SampleSize,
+    /// Column defining the resampling strata; `None` for an unstratified run.
+    pub stratify_on: Option<String>,
+    /// Start each replicate from the base fit's final estimates (PsN default).
+    pub update_inits: bool,
+    /// Fit the original dataset first. Required for `update_inits`, for bias,
+    /// and for the standard-error intervals.
+    pub run_base_model: bool,
+    /// Run the covariance step for each replicate. Off by default: it is most
+    /// of the cost, and the bootstrap standard error comes from the spread of
+    /// the estimates, not from any per-replicate `R⁻¹`.
+    pub keep_covariance: bool,
+    /// Replicates to fit concurrently. `None` uses the Rayon default.
+    pub threads: Option<usize>,
+    pub skip_minimization_terminated: bool,
+    pub skip_estimate_near_boundary: bool,
+    pub skip_covariance_step_terminated: bool,
+    pub skip_with_covstep_warnings: bool,
+    /// Compute Δofv: evaluate each replicate's parameter vector on the
+    /// *original* dataset with no estimation (`outer_maxiter = 0`, NONMEM
+    /// `MAXEVAL=0`) and subtract the original fit's OFV.
+    pub dofv: bool,
+    /// Where the CSV artefacts are written. `None` writes nothing.
+    pub directory: Option<PathBuf>,
+    /// Two-sided confidence level, in percent.
+    pub confidence_level: f64,
+}
+
+impl Default for BootstrapOptions {
+    fn default() -> Self {
+        BootstrapOptions {
+            samples: 200,
+            seed: 1,
+            sample_size: SampleSize::Original,
+            stratify_on: None,
+            update_inits: true,
+            run_base_model: true,
+            keep_covariance: false,
+            threads: None,
+            skip_minimization_terminated: true,
+            skip_estimate_near_boundary: true,
+            skip_covariance_step_terminated: false,
+            skip_with_covstep_warnings: false,
+            dofv: false,
+            directory: None,
+            confidence_level: 95.0,
+        }
+    }
+}
+
+/// One fitted replicate, reduced to what the summary and the raw-results file
+/// need.
+///
+/// Deliberately not a [`FitResult`]: that carries per-subject diagnostics for
+/// every individual, and holding 200 of them costs more memory than the whole
+/// rest of the run.
+#[derive(Debug, Clone)]
+pub struct ReplicateResult {
+    /// 1-based. Index 0 is the original dataset.
+    pub index: usize,
+    /// The flat parameter vector — see [`flatten_estimates`].
+    pub estimates: Vec<f64>,
+    /// Per-replicate standard errors, present only with `keep_covariance`.
+    pub standard_errors: Option<Vec<f64>>,
+    pub ofv: f64,
+    pub converged: bool,
+    pub estimate_near_boundary: bool,
+    pub covariance_step_successful: bool,
+    pub covariance_step_warnings: bool,
+    /// Wall time for this fit, seconds.
+    pub seconds: f64,
+    /// `Some` when [`fit`] returned an error; the replicate is then excluded.
+    pub error: Option<String>,
+    /// Δofv against the original dataset, when `--dofv` was requested.
+    pub delta_ofv: Option<f64>,
+}
+
+/// The full result of a bootstrap run.
+#[derive(Debug, Clone)]
+pub struct BootstrapResult {
+    /// Flat parameter names, matching [`ReplicateResult::estimates`].
+    pub parameter_names: Vec<String>,
+    /// The base-model fit on the original dataset, when it was run.
+    pub original: Option<ReplicateResult>,
+    /// One entry per requested sample, in index order.
+    pub replicates: Vec<ReplicateResult>,
+    /// Which subjects each replicate drew, index-aligned with `replicates`.
+    pub draws: Vec<Replicate>,
+    /// The original dataset's subject IDs, in dataset order.
+    pub subject_ids: Vec<String>,
+    pub summary: BootstrapSummary,
+    /// Chi-square reference degrees of freedom for the Δofv plot: the number of
+    /// estimated (non-fixed) parameters.
+    pub n_estimated_parameters: usize,
+}
+
+// ── flat parameter vector ───────────────────────────────────────────────────
+
+/// Names for the flat parameter vector: every theta, then the free lower
+/// triangle of Omega, then every sigma.
+///
+/// Omega entries are named by their etas — `OMEGA(CL,CL)` — rather than by
+/// PsN's positional `OMEGA(1,1)`. The file is ferx's own, and a positional index
+/// silently means something different the moment an eta is added.
+pub fn parameter_names(template: &ModelParameters) -> Vec<String> {
+    let mut names = template.theta_names.clone();
+    let eta = &template.omega.eta_names;
+    for i in 0..template.omega.dim() {
+        for j in 0..=i {
+            if template.omega.free_mask[(i, j)] {
+                names.push(format!("OMEGA({},{})", eta[i], eta[j]));
+            }
+        }
+    }
+    names.extend(template.sigma.names.iter().cloned());
+    names
+}
+
+/// Flatten a fitted model into the vector [`parameter_names`] labels.
+///
+/// `template` supplies the structure — which Omega entries are free parameters
+/// rather than structural zeros — because a [`FitResult`] carries the matrix but
+/// not the mask.
+pub fn flatten_estimates(template: &ModelParameters, result: &FitResult) -> Vec<f64> {
+    let mut v = result.theta.clone();
+    for i in 0..template.omega.dim() {
+        for j in 0..=i {
+            if template.omega.free_mask[(i, j)] {
+                v.push(result.omega[(i, j)]);
+            }
+        }
+    }
+    v.extend(result.sigma.iter().copied());
+    v
+}
+
+/// Inverse of [`flatten_estimates`]: rebuild [`ModelParameters`] from a flat
+/// vector, keeping every structural property of the template (bounds, fixed
+/// flags, block structure, IOV Omega, mixture).
+///
+/// This is what `--update-inits` and `--dofv` both need — and going through the
+/// flat vector rather than the `FitResult` means both work equally well from a
+/// stored `raw_results.csv`.
+pub fn params_from_estimates(template: &ModelParameters, flat: &[f64]) -> ModelParameters {
+    let n_theta = template.theta.len();
+    let mut params = template.clone();
+    params.theta = flat[..n_theta].to_vec();
+
+    let dim = template.omega.dim();
+    let mut m = template.omega.matrix.clone();
+    let mut k = n_theta;
+    for i in 0..dim {
+        for j in 0..=i {
+            if template.omega.free_mask[(i, j)] {
+                m[(i, j)] = flat[k];
+                m[(j, i)] = flat[k];
+                k += 1;
+            }
+        }
+    }
+    params.omega = OmegaMatrix::from_matrix_with_mask(
+        m,
+        template.omega.eta_names.clone(),
+        template.omega.diagonal,
+        template.omega.free_mask.clone(),
+    );
+    params.sigma = SigmaVector {
+        values: flat[k..].to_vec(),
+        names: template.sigma.names.clone(),
+    };
+    params
+}
+
+// ── strata ──────────────────────────────────────────────────────────────────
+
+/// Read the stratification column straight from the dataset, one label per
+/// subject in `population` order.
+///
+/// Read from the CSV rather than from `Subject::covariates` for two reasons: the
+/// stratification column is usually a study or group identifier that the model
+/// never declares as a covariate (so it is not on the subject at all), and the
+/// values are compared as *strings*, so a non-numeric group label works.
+///
+/// Enforces PsN's rule that the column take exactly one value per individual —
+/// "the algorithm requires that an individual can unambiguously be categorized
+/// according to the stratification variable" — naming the offending subject.
+pub fn strata_from_csv(
+    data_path: &str,
+    column_map: &[(String, String)],
+    population: &Population,
+    stratify_on: &str,
+) -> Result<Strata, String> {
+    let id_header = column_map
+        .iter()
+        .find(|(role, _)| role.eq_ignore_ascii_case("id"))
+        .map(|(_, header)| header.clone());
+
+    let mut reader = csv::Reader::from_path(data_path)
+        .map_err(|e| format!("--stratify-on: cannot read `{data_path}`: {e}"))?;
+    let headers = reader
+        .headers()
+        .map_err(|e| format!("--stratify-on: cannot read the header row of `{data_path}`: {e}"))?
+        .clone();
+
+    let find = |name: &str| {
+        headers
+            .iter()
+            .position(|h| h.trim().eq_ignore_ascii_case(name))
+    };
+    let id_col = id_header
+        .as_deref()
+        .and_then(find)
+        .or_else(|| find("ID"))
+        .ok_or_else(|| format!("--stratify-on: no ID column found in `{data_path}`"))?;
+    let strat_col = find(stratify_on).ok_or_else(|| {
+        format!(
+            "--stratify-on: column `{stratify_on}` is not in `{data_path}`. Columns present: {:?}",
+            headers.iter().collect::<Vec<_>>()
+        )
+    })?;
+
+    let mut by_id: HashMap<String, String> = HashMap::new();
+    for record in reader.records() {
+        let record =
+            record.map_err(|e| format!("--stratify-on: malformed row in `{data_path}`: {e}"))?;
+        let (Some(id), Some(value)) = (record.get(id_col), record.get(strat_col)) else {
+            continue;
+        };
+        let (id, value) = (id.trim().to_string(), value.trim().to_string());
+        match by_id.get(&id) {
+            Some(seen) if seen != &value => {
+                return Err(format!(
+                    "--stratify-on: subject `{id}` has more than one value in column \
+                     `{stratify_on}` (`{seen}` and `{value}`), so it cannot be unambiguously \
+                     assigned to a stratum. Bootstrapping resamples whole individuals, so the \
+                     stratification column must be constant within each ID."
+                ));
+            }
+            Some(_) => {}
+            None => {
+                by_id.insert(id, value);
+            }
+        }
+    }
+
+    let mut labels = Vec::with_capacity(population.subjects.len());
+    for subject in &population.subjects {
+        let label = by_id.get(&subject.id).ok_or_else(|| {
+            format!(
+                "--stratify-on: subject `{}` has no row in `{data_path}` carrying column \
+                 `{stratify_on}`",
+                subject.id
+            )
+        })?;
+        labels.push(label.clone());
+    }
+    Ok(Strata::from_labels(&labels, stratify_on))
+}
+
+// ── the run ─────────────────────────────────────────────────────────────────
+
+/// Fit options for a replicate: quiet, single-threaded, no covariance step
+/// unless asked, and no checkpoint file.
+///
+/// Each of those is load-bearing:
+///
+/// * **quiet** — 200 fits of per-iteration output is unreadable, and the
+///   warnings are still captured on each `FitResult`;
+/// * **`threads = 1`** — the bootstrap already parallelises over replicates, and
+///   nesting Rayon pools oversubscribes the machine (the N×N problem this repo
+///   hit in CI);
+/// * **no checkpoint** — every replicate would otherwise write and resume the
+///   *same* `{model}.tmp`, so they would restore each other's state;
+/// * **no SIR** — a per-replicate uncertainty step inside an uncertainty
+///   analysis is pure cost.
+fn replicate_options(base: &FitOptions, keep_covariance: bool) -> FitOptions {
+    let mut o = base.clone();
+    o.verbose = false;
+    o.threads = Some(1);
+    o.run_covariance_step = keep_covariance;
+    o.checkpoint = false;
+    o.checkpoint_path = None;
+    o.sir = false;
+    o
+}
+
+fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
+    let near_boundary = result
+        .warnings_structured
+        .iter()
+        .any(|w| w.category == WarningCode::BoundaryEstimate);
+    let cov_failed = result
+        .warnings_structured
+        .iter()
+        .any(|w| w.category == WarningCode::CovarianceFailed);
+    let cov_warnings = result.warnings_structured.iter().any(|w| {
+        matches!(
+            w.category,
+            WarningCode::CovarianceRegularized | WarningCode::CovarianceStep
+        )
+    });
+    let cov_ok = result.covariance_matrix.is_some() && !cov_failed;
+    (near_boundary, cov_ok, cov_warnings)
+}
+
+/// Refuse a model whose predictions depend on the subject identifier.
+///
+/// Resampling with replacement necessarily renames the duplicate copies of a
+/// subject (see [`resample::build_population`]), so a model that reads `ID` as a
+/// covariate would silently see different values than it did in the base fit.
+/// PsN documents the same hazard as a known bug — "model code that relies on ID
+/// numbers will lead to errors" — and leaves it to the user. Fail instead.
+fn reject_id_dependent_model(model: &CompiledModel) -> Result<(), String> {
+    reject_id_dependent(&model.referenced_covariates)
+}
+
+/// The predicate behind [`reject_id_dependent_model`], split out so it can be
+/// unit-tested without constructing a whole [`CompiledModel`].
+fn reject_id_dependent(referenced: &[String]) -> Result<(), String> {
+    if referenced.iter().any(|c| c.eq_ignore_ascii_case("id")) {
+        return Err(
+            "this model uses `ID` as a covariate, which the bootstrap cannot support: \
+             resampling with replacement draws the same subject more than once, and the \
+             copies must enter the fit as independent individuals, so their IDs are \
+             necessarily renamed. Re-express the covariate on a column that describes the \
+             subject (study, arm, group) rather than identifies it."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Run the bootstrap.
+pub fn run_bootstrap(
+    prepared: &PreparedRun,
+    options: &BootstrapOptions,
+) -> Result<BootstrapResult, String> {
+    reject_id_dependent_model(&prepared.parsed.model)?;
+    if options.samples == 0 {
+        return Err("--samples must be at least 1".to_string());
+    }
+    if !(0.0..100.0).contains(&options.confidence_level) || options.confidence_level <= 0.0 {
+        return Err("--ci must be a confidence level in (0, 100)".to_string());
+    }
+    // Both covariance-step filters read a diagnostic that only exists when the
+    // step actually ran. Silently ignoring them would drop a filter the user
+    // asked for without saying so.
+    if !options.keep_covariance
+        && (options.skip_covariance_step_terminated || options.skip_with_covstep_warnings)
+    {
+        return Err(
+            "--skip-covariance-step-terminated / --skip-with-covstep-warnings filter on the \
+             covariance step, which is off for replicate fits by default. Add \
+             --keep-covariance (slower) or drop the filter."
+                .to_string(),
+        );
+    }
+
+    let template = &prepared.init_params;
+    let names = parameter_names(template);
+    let subject_ids: Vec<String> = prepared
+        .population
+        .subjects
+        .iter()
+        .map(|s| s.id.clone())
+        .collect();
+
+    let strata = match &options.stratify_on {
+        None => Strata::unstratified(subject_ids.len()),
+        Some(column) => strata_from_csv(
+            &prepared.data_path,
+            &prepared.parsed.column_map,
+            &prepared.population,
+            column,
+        )?,
+    };
+    let allocation = strata.allocation(&options.sample_size)?;
+    if allocation.iter().all(|(_, n)| *n == 0) {
+        return Err("the resampling allocation draws 0 subjects".to_string());
+    }
+
+    // ── the base fit ────────────────────────────────────────────────────────
+    let base_options = replicate_options(&prepared.parsed.fit_options, options.keep_covariance);
+    let original = if options.run_base_model {
+        let started = Instant::now();
+        let result = fit(
+            &prepared.parsed.model,
+            &prepared.population,
+            template,
+            // The base fit keeps the model file's own covariance setting: it is
+            // the run whose `R⁻¹` standard errors the bootstrap is being
+            // compared against.
+            &{
+                let mut o = base_options.clone();
+                o.run_covariance_step = prepared.parsed.fit_options.run_covariance_step;
+                o
+            },
+        )?;
+        let (near_boundary, cov_ok, cov_warn) = diagnostics_from(&result);
+        Some(ReplicateResult {
+            index: 0,
+            estimates: flatten_estimates(template, &result),
+            standard_errors: result.se_theta.as_ref().map(|_| {
+                let mut se = result.se_theta.clone().unwrap_or_default();
+                se.extend(result.se_omega.clone().unwrap_or_default());
+                se.extend(result.se_sigma.clone().unwrap_or_default());
+                se
+            }),
+            ofv: result.ofv,
+            converged: result.converged,
+            estimate_near_boundary: near_boundary,
+            covariance_step_successful: cov_ok,
+            covariance_step_warnings: cov_warn,
+            seconds: started.elapsed().as_secs_f64(),
+            error: None,
+            delta_ofv: None,
+        })
+    } else {
+        None
+    };
+
+    // `--update-inits` starts every replicate from the base fit's estimates —
+    // PsN's default, and worth a lot here: the replicates differ from the
+    // original only by resampling, so its optimum is the best available start.
+    let replicate_init = match (&original, options.update_inits) {
+        (Some(base), true) => params_from_estimates(template, &base.estimates),
+        _ => template.clone(),
+    };
+
+    // ── the replicates ──────────────────────────────────────────────────────
+    let draws: Vec<Replicate> = (1..=options.samples)
+        .map(|i| resample::draw(&strata, &allocation, options.seed, i))
+        .collect();
+
+    let run_one = |replicate: &Replicate| -> ReplicateResult {
+        let population = resample::build_population(&prepared.population, replicate);
+        let started = Instant::now();
+        let outcome = fit(
+            &prepared.parsed.model,
+            &population,
+            &replicate_init,
+            &base_options,
+        );
+        let seconds = started.elapsed().as_secs_f64();
+        match outcome {
+            Ok(result) => {
+                let (near_boundary, cov_ok, cov_warn) = diagnostics_from(&result);
+                ReplicateResult {
+                    index: replicate.index,
+                    estimates: flatten_estimates(template, &result),
+                    standard_errors: if options.keep_covariance {
+                        result.se_theta.as_ref().map(|_| {
+                            let mut se = result.se_theta.clone().unwrap_or_default();
+                            se.extend(result.se_omega.clone().unwrap_or_default());
+                            se.extend(result.se_sigma.clone().unwrap_or_default());
+                            se
+                        })
+                    } else {
+                        None
+                    },
+                    ofv: result.ofv,
+                    converged: result.converged,
+                    estimate_near_boundary: near_boundary,
+                    covariance_step_successful: cov_ok,
+                    covariance_step_warnings: cov_warn,
+                    seconds,
+                    error: None,
+                    delta_ofv: None,
+                }
+            }
+            Err(e) => ReplicateResult {
+                index: replicate.index,
+                estimates: Vec::new(),
+                standard_errors: None,
+                ofv: f64::NAN,
+                converged: false,
+                estimate_near_boundary: false,
+                covariance_step_successful: false,
+                covariance_step_warnings: false,
+                seconds,
+                error: Some(e),
+                delta_ofv: None,
+            },
+        }
+    };
+
+    let mut replicates = match options.threads {
+        Some(n) if n > 1 => rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build()
+            .map_err(|e| format!("failed to build the bootstrap thread pool: {e}"))?
+            .install(|| draws.par_iter().map(run_one).collect::<Vec<_>>()),
+        Some(_) => draws.iter().map(run_one).collect(),
+        None => draws.par_iter().map(run_one).collect(),
+    };
+    replicates.sort_by_key(|r| r.index);
+
+    // ── Δofv ────────────────────────────────────────────────────────────────
+    if options.dofv {
+        let base = original.as_ref().ok_or(
+            "--dofv needs the original fit's OFV as its reference; it cannot be combined with \
+             --no-run-base-model",
+        )?;
+        compute_delta_ofv(prepared, template, base.ofv, &base_options, &mut replicates)?;
+    }
+
+    let n_estimated_parameters = count_estimated(template);
+    let summary = summary::summarize(&names, original.as_ref(), &replicates, options);
+
+    let result = BootstrapResult {
+        parameter_names: names,
+        original,
+        replicates,
+        draws,
+        subject_ids,
+        summary,
+        n_estimated_parameters,
+    };
+
+    if let Some(dir) = &options.directory {
+        output::write_all(dir, &result, options)?;
+    }
+    Ok(result)
+}
+
+/// Recompute the summary of a finished run from its `raw_results.csv`, under a
+/// different set of exclusion criteria — PsN's `-summarize`.
+///
+/// Refits nothing. This is what the "too many samples were filtered out" case in
+/// the PsN guide's recovery section asks for: the estimates are already on disk,
+/// and so are the diagnostics the filters read, so changing
+/// `--no-skip-minimization-terminated` (say) is a re-read, not a re-run.
+///
+/// Rewrites `bootstrap_results.csv` and `bootstrap_diagnostics.csv` in place and
+/// returns the new summary.
+pub fn resummarize(
+    directory: &std::path::Path,
+    options: &BootstrapOptions,
+) -> Result<BootstrapSummary, String> {
+    let raw = directory.join("raw_results.csv");
+    if !raw.exists() {
+        return Err(format!(
+            "--summarize needs an existing bootstrap run directory containing \
+             `raw_results.csv`; `{}` has none",
+            directory.display()
+        ));
+    }
+    let (names, original, replicates) = output::read_raw_results(&raw)?;
+    let summary = summary::summarize(&names, original.as_ref(), &replicates, options);
+    let result = BootstrapResult {
+        parameter_names: names,
+        original,
+        replicates,
+        // The draws are not recoverable from `raw_results.csv`, and are not
+        // needed: `--summarize` rewrites only the two statistics files, and the
+        // per-replicate `included_*` / `sample_keys` files the original run
+        // wrote are still valid — the draws did not change, only which of them
+        // count.
+        draws: Vec::new(),
+        subject_ids: Vec::new(),
+        summary: summary.clone(),
+        // Carried forward from the run that wrote the directory: it is a
+        // property of the model, not of the exclusion criteria being changed.
+        n_estimated_parameters: output::read_diagnostic(
+            &directory.join("bootstrap_diagnostics.csv"),
+            "chi_square_df",
+        )
+        .unwrap_or(0.0) as usize,
+    };
+    output::write_bootstrap_results(&directory.join("bootstrap_results.csv"), &result)?;
+    output::write_diagnostics(&directory.join("bootstrap_diagnostics.csv"), &result)?;
+    Ok(summary)
+}
+
+/// Evaluate every replicate's parameter vector on the **original** dataset with
+/// no estimation, and record `ofv − ofv_original`.
+///
+/// `outer_maxiter = 0` is already exactly NONMEM's `MAXEVAL=0` in ferx's outer
+/// optimizer, so this is an evaluation, not a one-step fit. The resulting
+/// distribution should sit at or below a chi-square with
+/// [`BootstrapResult::n_estimated_parameters`] degrees of freedom; if it does
+/// not, the PsN guide's advice applies — prefer another uncertainty method such
+/// as SIR.
+fn compute_delta_ofv(
+    prepared: &PreparedRun,
+    template: &ModelParameters,
+    ofv_original: f64,
+    base_options: &FitOptions,
+    replicates: &mut [ReplicateResult],
+) -> Result<(), String> {
+    let mut eval = base_options.clone();
+    eval.outer_maxiter = 0;
+    eval.run_covariance_step = false;
+
+    let deltas: Vec<(usize, Option<f64>)> = replicates
+        .par_iter()
+        .map(|r| {
+            if r.error.is_some() || r.estimates.is_empty() {
+                return (r.index, None);
+            }
+            let params = params_from_estimates(template, &r.estimates);
+            let ofv = fit(&prepared.parsed.model, &prepared.population, &params, &eval)
+                .map(|f| f.ofv)
+                .ok();
+            (r.index, ofv.map(|o| o - ofv_original))
+        })
+        .collect();
+
+    let by_index: HashMap<usize, Option<f64>> = deltas.into_iter().collect();
+    for r in replicates.iter_mut() {
+        r.delta_ofv = by_index.get(&r.index).copied().flatten();
+    }
+    Ok(())
+}
+
+/// Non-fixed parameters — the chi-square degrees of freedom for the Δofv
+/// reference distribution.
+fn count_estimated(template: &ModelParameters) -> usize {
+    let theta = template.theta_fixed.iter().filter(|f| !**f).count();
+    let omega = template.omega_fixed.iter().filter(|f| !**f).count();
+    let sigma = template.sigma_fixed.iter().filter(|f| !**f).count();
+    theta + omega + sigma
+}
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -336,6 +336,19 @@ fn replicate_options(base: &FitOptions, keep_covariance: bool) -> FitOptions {
     o
 }
 
+/// The per-replicate standard errors, flattened in [`parameter_names`] order.
+///
+/// `None` when the covariance step did not run — which is the default, and why
+/// the bootstrap standard error is the spread of the estimates rather than an
+/// average of these.
+fn flat_standard_errors(result: &FitResult) -> Option<Vec<f64>> {
+    let theta = result.se_theta.as_ref()?;
+    let mut se = theta.clone();
+    se.extend(result.se_omega.clone().unwrap_or_default());
+    se.extend(result.se_sigma.clone().unwrap_or_default());
+    Some(se)
+}
+
 fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
     let near_boundary = result
         .warnings_structured
@@ -452,12 +465,7 @@ pub fn run_bootstrap(
         Some(ReplicateResult {
             index: 0,
             estimates: flatten_estimates(template, &result),
-            standard_errors: result.se_theta.as_ref().map(|_| {
-                let mut se = result.se_theta.clone().unwrap_or_default();
-                se.extend(result.se_omega.clone().unwrap_or_default());
-                se.extend(result.se_sigma.clone().unwrap_or_default());
-                se
-            }),
+            standard_errors: flat_standard_errors(&result),
             ofv: result.ofv,
             converged: result.converged,
             estimate_near_boundary: near_boundary,
@@ -500,16 +508,7 @@ pub fn run_bootstrap(
                 ReplicateResult {
                     index: replicate.index,
                     estimates: flatten_estimates(template, &result),
-                    standard_errors: if options.keep_covariance {
-                        result.se_theta.as_ref().map(|_| {
-                            let mut se = result.se_theta.clone().unwrap_or_default();
-                            se.extend(result.se_omega.clone().unwrap_or_default());
-                            se.extend(result.se_sigma.clone().unwrap_or_default());
-                            se
-                        })
-                    } else {
-                        None
-                    },
+                    standard_errors: flat_standard_errors(&result),
                     ofv: result.ofv,
                     converged: result.converged,
                     estimate_near_boundary: near_boundary,

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -1,0 +1,340 @@
+use super::*;
+use ferx_core::Subject;
+use nalgebra::DMatrix;
+
+/// A two-theta, two-eta, one-sigma template with a correlated Omega block.
+///
+/// The block matters: it is what makes `free_mask` non-trivial, so a
+/// flatten/rebuild that quietly dropped the off-diagonal would show up.
+fn template(diagonal: bool) -> ModelParameters {
+    let mut m = DMatrix::from_element(2, 2, 0.0);
+    m[(0, 0)] = 0.09;
+    m[(1, 1)] = 0.16;
+    if !diagonal {
+        m[(0, 1)] = 0.02;
+        m[(1, 0)] = 0.02;
+    }
+    let free = DMatrix::from_fn(2, 2, |i, j| diagonal == (i == j) || i == j);
+    ModelParameters {
+        theta: vec![1.0, 2.0],
+        theta_names: vec!["CL".to_string(), "V".to_string()],
+        theta_fixed: vec![false, false],
+        theta_lower: vec![0.0, 0.0],
+        theta_upper: vec![100.0, 100.0],
+        omega: OmegaMatrix::from_matrix_with_mask(
+            m,
+            vec!["ETA_CL".to_string(), "ETA_V".to_string()],
+            diagonal,
+            free,
+        ),
+        omega_fixed: vec![false, false],
+        omega_iov: None,
+        sigma: SigmaVector {
+            values: vec![0.04],
+            names: vec!["PROP".to_string()],
+        },
+        sigma_fixed: vec![false],
+        kappa_fixed: Vec::new(),
+        mixture: None,
+    }
+}
+
+#[test]
+fn parameter_names_cover_theta_free_omega_and_sigma() {
+    let names = parameter_names(&template(false));
+    assert_eq!(
+        names,
+        vec![
+            "CL",
+            "V",
+            "OMEGA(ETA_CL,ETA_CL)",
+            "OMEGA(ETA_V,ETA_CL)",
+            "OMEGA(ETA_V,ETA_V)",
+            "PROP",
+        ]
+    );
+}
+
+#[test]
+fn a_diagonal_omega_contributes_only_its_diagonal() {
+    let names = parameter_names(&template(true));
+    assert_eq!(
+        names,
+        vec![
+            "CL",
+            "V",
+            "OMEGA(ETA_CL,ETA_CL)",
+            "OMEGA(ETA_V,ETA_V)",
+            "PROP",
+        ]
+    );
+}
+
+#[test]
+fn flat_estimates_round_trip_through_model_parameters() {
+    // `--update-inits` and `--dofv` both go through the flat vector rather than
+    // through a `FitResult`, so that they work identically from a stored
+    // `raw_results.csv`. That only holds if the round trip is exact.
+    let t = template(false);
+    let flat = vec![3.0, 4.0, 0.25, 0.05, 0.36, 0.01];
+    let params = params_from_estimates(&t, &flat);
+
+    assert_eq!(params.theta, vec![3.0, 4.0]);
+    assert_eq!(params.omega.matrix[(0, 0)], 0.25);
+    assert_eq!(params.omega.matrix[(1, 0)], 0.05);
+    // Symmetry is restored, not just the lower triangle written.
+    assert_eq!(params.omega.matrix[(0, 1)], 0.05);
+    assert_eq!(params.omega.matrix[(1, 1)], 0.36);
+    assert_eq!(params.sigma.values, vec![0.01]);
+
+    // Structure is the template's, not the flat vector's.
+    assert_eq!(params.theta_names, t.theta_names);
+    assert_eq!(params.theta_lower, t.theta_lower);
+    assert_eq!(params.theta_upper, t.theta_upper);
+    assert_eq!(params.omega.eta_names, t.omega.eta_names);
+    assert_eq!(params.omega.diagonal, t.omega.diagonal);
+    assert_eq!(params.sigma.names, t.sigma.names);
+
+    // And re-flattening reproduces the vector we started from.
+    let names = parameter_names(&t);
+    assert_eq!(names.len(), flat.len());
+    let mut back = params.theta.clone();
+    for i in 0..params.omega.dim() {
+        for j in 0..=i {
+            if t.omega.free_mask[(i, j)] {
+                back.push(params.omega.matrix[(i, j)]);
+            }
+        }
+    }
+    back.extend(params.sigma.values.iter().copied());
+    assert_eq!(back, flat);
+}
+
+#[test]
+fn structural_zeros_are_not_overwritten_by_the_round_trip() {
+    let t = template(true);
+    let flat = vec![3.0, 4.0, 0.25, 0.36, 0.01];
+    let params = params_from_estimates(&t, &flat);
+    // A diagonal Omega has no off-diagonal parameter; the round trip must not
+    // invent one by consuming the next slot.
+    assert_eq!(params.omega.matrix[(0, 1)], 0.0);
+    assert_eq!(params.omega.matrix[(1, 0)], 0.0);
+    assert_eq!(params.sigma.values, vec![0.01]);
+}
+
+#[test]
+fn estimated_parameter_count_skips_fixed_entries() {
+    let mut t = template(true);
+    assert_eq!(count_estimated(&t), 2 + 2 + 1);
+    t.theta_fixed[1] = true;
+    t.sigma_fixed[0] = true;
+    assert_eq!(count_estimated(&t), 1 + 2);
+}
+
+// ── the ID guard ────────────────────────────────────────────────────────────
+
+#[test]
+fn a_model_using_id_as_a_covariate_is_refused() {
+    // Resampling renames duplicate copies of a subject, so a model reading `ID`
+    // would silently see different values than in the base fit. PsN documents
+    // the same hazard and leaves it to the user; refuse instead.
+    let err = reject_id_dependent(&["WT".to_string(), "ID".to_string()]).unwrap_err();
+    assert!(err.contains("`ID` as a covariate"), "{err}");
+    // Case-insensitive: the DSL does not force a spelling.
+    assert!(reject_id_dependent(&["id".to_string()]).is_err());
+    // A covariate that merely contains "id" is fine.
+    assert!(reject_id_dependent(&["WT".to_string(), "MIDAZ".to_string()]).is_ok());
+    assert!(reject_id_dependent(&[]).is_ok());
+}
+
+// ── strata read from the dataset ────────────────────────────────────────────
+
+fn population(ids: &[&str]) -> Population {
+    Population {
+        subjects: ids
+            .iter()
+            .map(|id| Subject {
+                id: (*id).to_string(),
+                ..Subject::default()
+            })
+            .collect(),
+        covariate_names: Vec::new(),
+        dv_column: "DV".to_string(),
+        input_columns: Vec::new(),
+        exclusions: None,
+        warnings: Vec::new(),
+    }
+}
+
+fn write_csv(body: &str) -> tempfile::NamedTempFile {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("temp file");
+    write!(f, "{body}").expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+#[test]
+fn strata_come_from_the_dataset_not_the_model_covariates() {
+    // The stratification column is usually a study or group id the model never
+    // declares, so it is read straight from the CSV.
+    let csv = write_csv("ID,TIME,DV,STUD\n1,0,.,1001\n1,1,5,1001\n2,0,.,1002\n3,0,.,1001\n");
+    let pop = population(&["1", "2", "3"]);
+    let strata = strata_from_csv(csv.path().to_str().unwrap(), &[], &pop, "STUD").unwrap();
+    assert_eq!(strata.groups["1001"], vec![0, 2]);
+    assert_eq!(strata.groups["1002"], vec![1]);
+}
+
+#[test]
+fn a_stratification_column_that_varies_within_a_subject_is_refused() {
+    // PsN: "the algorithm requires that an individual can unambiguously be
+    // categorized according to the stratification variable".
+    let csv = write_csv("ID,DV,STUD\n1,5,1001\n1,6,1002\n2,7,1002\n");
+    let pop = population(&["1", "2"]);
+    let err = strata_from_csv(csv.path().to_str().unwrap(), &[], &pop, "STUD").unwrap_err();
+    assert!(err.contains("subject `1`"), "{err}");
+    assert!(err.contains("more than one value"), "{err}");
+}
+
+#[test]
+fn a_missing_stratification_column_names_the_columns_that_are_there() {
+    let csv = write_csv("ID,DV,WT\n1,5,70\n");
+    let pop = population(&["1"]);
+    let err = strata_from_csv(csv.path().to_str().unwrap(), &[], &pop, "STUD").unwrap_err();
+    assert!(err.contains("STUD"), "{err}");
+    assert!(err.contains("WT"), "{err}");
+}
+
+#[test]
+fn a_remapped_id_column_is_honoured() {
+    // `[data] ID = SUBJID` remaps the role; the strata reader must follow it
+    // rather than insisting on a literal `ID` header.
+    let csv = write_csv("SUBJID,DV,STUD\nA,5,1001\nB,6,1002\n");
+    let pop = population(&["A", "B"]);
+    let map = vec![("id".to_string(), "SUBJID".to_string())];
+    let strata = strata_from_csv(csv.path().to_str().unwrap(), &map, &pop, "STUD").unwrap();
+    assert_eq!(strata.groups["1001"], vec![0]);
+    assert_eq!(strata.groups["1002"], vec![1]);
+}
+
+#[test]
+fn a_subject_absent_from_the_dataset_is_reported() {
+    let csv = write_csv("ID,DV,STUD\n1,5,1001\n");
+    let pop = population(&["1", "9"]);
+    let err = strata_from_csv(csv.path().to_str().unwrap(), &[], &pop, "STUD").unwrap_err();
+    assert!(err.contains("`9`"), "{err}");
+}
+
+// ── replicate fit options ───────────────────────────────────────────────────
+
+#[test]
+fn replicate_fits_are_quiet_single_threaded_and_checkpoint_free() {
+    // Each of these is load-bearing rather than tidy: 200 verbose fits are
+    // unreadable, nested Rayon pools oversubscribe the machine, and 200 fits
+    // sharing one `{model}.tmp` checkpoint would restore each other's state.
+    let base = FitOptions {
+        verbose: true,
+        threads: Some(8),
+        checkpoint: true,
+        checkpoint_path: Some("model.tmp".to_string()),
+        sir: true,
+        run_covariance_step: true,
+        ..FitOptions::default()
+    };
+
+    let o = replicate_options(&base, false);
+    assert!(!o.verbose);
+    assert_eq!(o.threads, Some(1));
+    assert!(!o.checkpoint);
+    assert_eq!(o.checkpoint_path, None);
+    assert!(!o.sir);
+    assert!(!o.run_covariance_step);
+
+    // `--keep-covariance` is the one that turns the step back on.
+    assert!(replicate_options(&base, true).run_covariance_step);
+}
+
+// ── --summarize ─────────────────────────────────────────────────────────────
+
+fn stored_run(dir: &std::path::Path) {
+    let mut replicates: Vec<ReplicateResult> = (1..=4)
+        .map(|i| ReplicateResult {
+            index: i,
+            estimates: vec![10.0],
+            standard_errors: None,
+            ofv: 100.0,
+            // Two of the four terminated.
+            converged: i <= 2,
+            estimate_near_boundary: false,
+            covariance_step_successful: true,
+            covariance_step_warnings: false,
+            seconds: 0.1,
+            error: None,
+            delta_ofv: None,
+        })
+        .collect();
+    replicates[2].estimates = vec![20.0];
+    replicates[3].estimates = vec![20.0];
+
+    let options = BootstrapOptions::default();
+    let names = vec!["CL".to_string()];
+    let summary = summary::summarize(&names, None, &replicates, &options);
+    let result = BootstrapResult {
+        parameter_names: names,
+        original: None,
+        replicates,
+        draws: Vec::new(),
+        subject_ids: Vec::new(),
+        summary,
+        n_estimated_parameters: 7,
+    };
+    output::write_all(dir, &result, &options).expect("write");
+}
+
+#[test]
+fn resummarize_reapplies_the_filters_without_refitting() {
+    // The PsN recovery case "if too many samples are filtered out": the
+    // estimates and their diagnostics are already on disk, so relaxing a filter
+    // is a re-read, not a re-run.
+    let dir = tempfile::tempdir().expect("temp dir");
+    stored_run(dir.path());
+
+    let tight = resummarize(dir.path(), &BootstrapOptions::default()).expect("summarize");
+    assert_eq!(tight.n_included, 2);
+    assert!((tight.parameters[0].mean - 10.0).abs() < 1e-9);
+
+    let relaxed = BootstrapOptions {
+        skip_minimization_terminated: false,
+        ..BootstrapOptions::default()
+    };
+    let loose = resummarize(dir.path(), &relaxed).expect("summarize");
+    assert_eq!(loose.n_included, 4);
+    assert!((loose.parameters[0].mean - 15.0).abs() < 1e-9);
+}
+
+#[test]
+fn resummarize_carries_forward_the_model_level_diagnostics() {
+    // The chi-square degrees of freedom describe the model, not the filtering,
+    // and are not recoverable from raw_results.csv — so they must survive a
+    // re-summary rather than being rewritten as 0.
+    let dir = tempfile::tempdir().expect("temp dir");
+    stored_run(dir.path());
+    resummarize(dir.path(), &BootstrapOptions::default()).expect("summarize");
+    assert_eq!(
+        output::read_diagnostic(
+            &dir.path().join("bootstrap_diagnostics.csv"),
+            "chi_square_df"
+        ),
+        Some(7.0)
+    );
+}
+
+#[test]
+fn resummarize_needs_an_existing_run_directory() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let err = resummarize(dir.path(), &BootstrapOptions::default()).unwrap_err();
+    assert!(err.contains("raw_results.csv"), "{err}");
+}

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -39,6 +39,20 @@ fn template(diagonal: bool) -> ModelParameters {
     }
 }
 
+/// [`template`] with a diagonal Omega plus a one-kappa IOV block.
+fn template_with_iov() -> ModelParameters {
+    let mut t = template(true);
+    let iov = DMatrix::from_element(1, 1, 0.01);
+    t.omega_iov = Some(OmegaMatrix::from_matrix_with_mask(
+        iov,
+        vec!["KAPPA_CL".to_string()],
+        true,
+        DMatrix::from_element(1, 1, true),
+    ));
+    t.kappa_fixed = vec![false];
+    t
+}
+
 #[test]
 fn parameter_names_cover_theta_free_omega_and_sigma() {
     let names = parameter_names(&template(false));
@@ -129,6 +143,133 @@ fn estimated_parameter_count_skips_fixed_entries() {
     t.theta_fixed[1] = true;
     t.sigma_fixed[0] = true;
     assert_eq!(count_estimated(&t), 1 + 2);
+}
+
+#[test]
+fn the_estimated_count_matches_the_parameter_vector_for_a_block_omega() {
+    // Regression for the second review finding: `count_estimated` used to count
+    // the `omega_fixed` flags, which are per *eta*, so a free 2x2 block scored 2
+    // where the parameter vector has 3. That understates the chi-square degrees
+    // of freedom for `--dofv`, which makes the Δofv distribution look better
+    // than it is — the one direction a diagnostic must not fail in.
+    let t = template(false);
+    assert_eq!(parameter_names(&t).len(), 6, "2 theta + 3 omega + 1 sigma");
+    assert_eq!(
+        count_estimated(&t),
+        parameter_names(&t).len(),
+        "with nothing fixed, every coordinate is an estimated parameter"
+    );
+
+    // Fixing an eta removes its variance *and* its covariances, since the flags
+    // are per-eta and a covariance needs both of its etas free.
+    let mut fixed = t.clone();
+    fixed.omega_fixed[1] = true;
+    assert_eq!(count_estimated(&fixed), 6 - 2);
+}
+
+#[test]
+fn an_iov_block_is_part_of_the_parameter_vector() {
+    let t = template_with_iov();
+    let names = parameter_names(&t);
+    assert_eq!(
+        names,
+        vec![
+            "CL",
+            "V",
+            "OMEGA(ETA_CL,ETA_CL)",
+            "OMEGA(ETA_V,ETA_V)",
+            "PROP",
+            "OMEGA_IOV(KAPPA_CL,KAPPA_CL)",
+        ],
+        "the IOV block goes last, so a model without one keeps its old columns"
+    );
+    assert_eq!(count_estimated(&t), names.len());
+
+    // A fixed kappa drops out of the count but keeps its column.
+    let mut fixed = t.clone();
+    fixed.kappa_fixed[0] = true;
+    assert_eq!(parameter_names(&fixed).len(), names.len());
+    assert_eq!(count_estimated(&fixed), names.len() - 1);
+}
+
+#[test]
+fn the_iov_variance_round_trips() {
+    let t = template_with_iov();
+    let flat = vec![3.0, 4.0, 0.25, 0.36, 0.01, 0.07];
+    let params = params_from_estimates(&t, &flat);
+    let iov = params.omega_iov.as_ref().expect("the IOV block survives");
+    assert_eq!(iov.matrix[(0, 0)], 0.07);
+    assert_eq!(iov.eta_names, vec!["KAPPA_CL"]);
+    // And the rest is untouched by the extra coordinate.
+    assert_eq!(params.theta, vec![3.0, 4.0]);
+    assert_eq!(params.sigma.values, vec![0.01]);
+}
+
+#[test]
+fn every_view_of_the_flat_vector_has_the_same_length() {
+    // The invariant the `Coord` enum exists to hold: names, the estimated count
+    // and the rebuild all walk one traversal, so they cannot disagree about how
+    // many parameters there are or what order they are in.
+    for t in [template(true), template(false), template_with_iov()] {
+        let names = parameter_names(&t);
+        assert_eq!(count_estimated(&t), names.len());
+
+        // Scaled from the template's own values rather than made up: an
+        // arbitrary vector can describe a non-positive-definite Omega, which
+        // `OmegaMatrix::from_matrix_with_mask` repairs — correctly — by moving
+        // the diagonal, and the round trip would then not be an identity for a
+        // reason that has nothing to do with the traversal being tested.
+        // Scaling a PD matrix by a positive constant keeps it PD.
+        let flat: Vec<f64> = coordinates(&t)
+            .into_iter()
+            .map(|c| {
+                1.5 * match c {
+                    Coord::Theta(i) => t.theta[i],
+                    Coord::Omega(i, j) => t.omega.matrix[(i, j)],
+                    Coord::Sigma(i) => t.sigma.values[i],
+                    Coord::OmegaIov(i, j) => t.omega_iov.as_ref().unwrap().matrix[(i, j)],
+                }
+            })
+            .collect();
+        let rebuilt = params_from_estimates(&t, &flat);
+        assert_eq!(parameter_names(&rebuilt), names);
+        // Re-flattening the rebuild returns the vector it was built from.
+        let coords = coordinates(&rebuilt);
+        assert_eq!(coords.len(), names.len());
+        let back: Vec<f64> = coords
+            .into_iter()
+            .map(|c| match c {
+                Coord::Theta(i) => rebuilt.theta[i],
+                Coord::Omega(i, j) => rebuilt.omega.matrix[(i, j)],
+                Coord::Sigma(i) => rebuilt.sigma.values[i],
+                Coord::OmegaIov(i, j) => rebuilt.omega_iov.as_ref().unwrap().matrix[(i, j)],
+            })
+            .collect();
+        assert_eq!(back, flat);
+    }
+}
+
+// ── mixture models ──────────────────────────────────────────────────────────
+
+#[test]
+fn a_mixture_model_is_refused() {
+    // Not a plumbing gap: a mixture's classes are identified only up to
+    // relabelling, so averaging estimates across replicates would mix them.
+    let plain = template(true);
+    assert!(reject_mixture_model(&plain).is_ok());
+
+    let mut mixture = template(true);
+    mixture.mixture = Some(ferx_core::MixtureParams {
+        omega: vec![plain.omega.clone(), plain.omega.clone()],
+        sigma: vec![plain.sigma.clone(), plain.sigma.clone()],
+        omega_override_addr: Vec::new(),
+        omega_override_fixed: Vec::new(),
+        sigma_override_addr: Vec::new(),
+        sigma_override_fixed: Vec::new(),
+    });
+    let err = reject_mixture_model(&mixture).unwrap_err();
+    assert!(err.contains("relabelling"), "{err}");
+    assert!(err.contains("mixture"), "{err}");
 }
 
 // ── the ID guard ────────────────────────────────────────────────────────────
@@ -337,4 +478,59 @@ fn resummarize_needs_an_existing_run_directory() {
     let dir = tempfile::tempdir().expect("temp dir");
     let err = resummarize(dir.path(), &BootstrapOptions::default()).unwrap_err();
     assert!(err.contains("raw_results.csv"), "{err}");
+}
+
+#[test]
+fn resummarize_validates_its_options_instead_of_panicking() {
+    // Regression for the fourth review finding. `run_bootstrap` checked the
+    // confidence level; `resummarize` went straight to `summarize`, so
+    // `--summarize --ci 100` reached `normal_quantile`'s assertion and the
+    // process died with 101 instead of reporting a bad argument.
+    let dir = tempfile::tempdir().expect("temp dir");
+    stored_run(dir.path());
+
+    for level in [100.0, 0.0, -1.0, 137.0] {
+        let err = resummarize(
+            dir.path(),
+            &BootstrapOptions {
+                confidence_level: level,
+                ..BootstrapOptions::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("--ci"), "level {level}: {err}");
+    }
+
+    // Checked before the directory is read, so a bad option is reported even
+    // when there is nothing to summarize.
+    let empty = tempfile::tempdir().expect("temp dir");
+    let err = resummarize(
+        empty.path(),
+        &BootstrapOptions {
+            confidence_level: 100.0,
+            ..BootstrapOptions::default()
+        },
+    )
+    .unwrap_err();
+    assert!(err.contains("--ci"), "{err}");
+}
+
+#[test]
+fn the_covstep_filters_are_allowed_when_re_summarizing() {
+    // The rule that a covstep filter needs `--keep-covariance` applies to a
+    // fresh run, where the step would have to actually run. Under `--summarize`
+    // the diagnostics are already in `raw_results.csv`, so filtering on them is
+    // the entire point and requires no covariance step now.
+    let dir = tempfile::tempdir().expect("temp dir");
+    stored_run(dir.path());
+    let options = BootstrapOptions {
+        skip_covariance_step_terminated: true,
+        ..BootstrapOptions::default()
+    };
+    assert!(options.validate().is_ok());
+    assert!(
+        options.validate_for_run().is_err(),
+        "a fresh run must refuse it"
+    );
+    assert!(resummarize(dir.path(), &options).is_ok());
 }

--- a/crates/ferx-tools/src/bootstrap/output.rs
+++ b/crates/ferx-tools/src/bootstrap/output.rs
@@ -110,7 +110,8 @@ pub fn write_raw_results(
                 row.push(opt(r
                     .standard_errors
                     .as_ref()
-                    .and_then(|s| s.get(j).copied())));
+                    .and_then(|s| s.get(j).copied())
+                    .flatten()));
             }
         }
         if options.dofv {
@@ -379,8 +380,16 @@ pub fn read_raw_results(
         let result = super::ReplicateResult {
             index,
             estimates,
-            standard_errors: se_start
-                .map(|start| (0..n_params).map(|j| num(&row, start + j)).collect()),
+            standard_errors: se_start.map(|start| {
+                // An empty cell means core reported no SE for that coordinate
+                // (an IOV covariance, say). It is not a zero and not a NaN, and
+                // it must come back as `None` so the column stays aligned with
+                // the names it was written under.
+                (0..n_params)
+                    .map(|j| num(&row, start + j))
+                    .map(|v| v.is_finite().then_some(v))
+                    .collect()
+            }),
             ofv: num(&row, 5),
             converged: flag(&row, 1),
             estimate_near_boundary: flag(&row, 2),

--- a/crates/ferx-tools/src/bootstrap/output.rs
+++ b/crates/ferx-tools/src/bootstrap/output.rs
@@ -1,0 +1,404 @@
+//! The CSV artefacts of a bootstrap run.
+//!
+//! File names follow PsN so an existing PsN user's habits and downstream scripts
+//! carry over. Two deliberate departures, both noted on the functions below:
+//! the results table is tidy (one row per parameter) rather than PsN's stacked
+//! statistic blocks, and the run-level diagnostics live in their own file rather
+//! than as a second block inside `bootstrap_results.csv` — a single CSV with two
+//! different header shapes is not machine-readable, which defeats the point of
+//! writing it.
+//!
+//! Row order is consistent across `raw_results`, `included_individuals`,
+//! `included_keys` and `sample_keys`, exactly as PsN documents: row *j* concerns
+//! the same replicate in every file.
+
+use std::path::Path;
+
+use super::{BootstrapOptions, BootstrapResult};
+
+fn fmt(v: f64) -> String {
+    if v.is_finite() {
+        format!("{v:.10}")
+    } else {
+        String::new()
+    }
+}
+
+fn opt(v: Option<f64>) -> String {
+    v.map(fmt).unwrap_or_default()
+}
+
+/// Write every artefact into `dir`, creating it if needed.
+pub fn write_all(
+    dir: &Path,
+    result: &BootstrapResult,
+    options: &BootstrapOptions,
+) -> Result<(), String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("cannot create bootstrap directory `{}`: {e}", dir.display()))?;
+    write_raw_results(&dir.join("raw_results.csv"), result, options)?;
+    write_bootstrap_results(&dir.join("bootstrap_results.csv"), result)?;
+    write_diagnostics(&dir.join("bootstrap_diagnostics.csv"), result)?;
+    write_all_individuals(&dir.join("all_individuals1.csv"), result)?;
+    write_included_individuals(&dir.join("included_individuals1.csv"), result)?;
+    write_included_keys(&dir.join("included_keys1.csv"), result)?;
+    write_sample_keys(&dir.join("sample_keys1.csv"), result)?;
+    if options.dofv {
+        write_delta_ofv(&dir.join("delta_ofv.csv"), result)?;
+    }
+    Ok(())
+}
+
+fn writer(path: &Path) -> Result<csv::Writer<std::fs::File>, String> {
+    csv::Writer::from_path(path).map_err(|e| format!("cannot write `{}`: {e}", path.display()))
+}
+
+fn finish(mut w: csv::Writer<std::fs::File>, path: &Path) -> Result<(), String> {
+    w.flush()
+        .map_err(|e| format!("cannot flush `{}`: {e}", path.display()))
+}
+
+/// One row per fit, **first row the original dataset** (`sample = 0`), as in
+/// PsN.
+///
+/// Carries the termination diagnostics alongside the estimates, not just the
+/// estimates: that is what makes `--summarize` possible — the exclusion filters
+/// are re-applied to this file rather than baked into it.
+pub fn write_raw_results(
+    path: &Path,
+    result: &BootstrapResult,
+    options: &BootstrapOptions,
+) -> Result<(), String> {
+    let mut w = writer(path)?;
+    let mut header = vec![
+        "sample".to_string(),
+        "minimization_successful".to_string(),
+        "estimate_near_boundary".to_string(),
+        "covariance_step_successful".to_string(),
+        "covariance_step_warnings".to_string(),
+        "ofv".to_string(),
+        "seconds".to_string(),
+    ];
+    header.extend(result.parameter_names.iter().cloned());
+    if options.keep_covariance {
+        header.extend(result.parameter_names.iter().map(|n| format!("se_{n}")));
+    }
+    if options.dofv {
+        header.push("delta_ofv".to_string());
+    }
+    header.push("error".to_string());
+    w.write_record(&header)
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+
+    let n_params = result.parameter_names.len();
+    let rows = result.original.iter().chain(result.replicates.iter());
+    for r in rows {
+        let mut row = vec![
+            r.index.to_string(),
+            (r.converged as u8).to_string(),
+            (r.estimate_near_boundary as u8).to_string(),
+            (r.covariance_step_successful as u8).to_string(),
+            (r.covariance_step_warnings as u8).to_string(),
+            fmt(r.ofv),
+            format!("{:.3}", r.seconds),
+        ];
+        for j in 0..n_params {
+            row.push(opt(r.estimates.get(j).copied()));
+        }
+        if options.keep_covariance {
+            for j in 0..n_params {
+                row.push(opt(r
+                    .standard_errors
+                    .as_ref()
+                    .and_then(|s| s.get(j).copied())));
+            }
+        }
+        if options.dofv {
+            row.push(opt(r.delta_ofv));
+        }
+        row.push(r.error.clone().unwrap_or_default());
+        w.write_record(&row)
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// The statistics table: one row per parameter.
+///
+/// PsN stacks each statistic as its own block of rows sharing one header. Tidy
+/// is chosen here instead because the file's job is to be read by a script or a
+/// data frame, and column names that mean "means" in one block and "bias" twenty
+/// rows later cannot be.
+pub fn write_bootstrap_results(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let level = result.summary.confidence_level;
+    let tail = (100.0 - level) / 2.0;
+    let mut w = writer(path)?;
+    w.write_record([
+        "parameter".to_string(),
+        "original".to_string(),
+        "mean".to_string(),
+        "bias".to_string(),
+        "standard.error".to_string(),
+        "median".to_string(),
+        format!("percentile.{tail}"),
+        format!("percentile.{}", 100.0 - tail),
+        format!("se.ci.lower.{level}"),
+        format!("se.ci.upper.{level}"),
+    ])
+    .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    for p in &result.summary.parameters {
+        w.write_record([
+            p.name.clone(),
+            opt(p.original),
+            fmt(p.mean),
+            opt(p.bias),
+            fmt(p.standard_error),
+            fmt(p.median),
+            opt(p.ci_percentile.map(|(lo, _)| lo)),
+            opt(p.ci_percentile.map(|(_, hi)| hi)),
+            opt(p.ci_standard_error.map(|(lo, _)| lo)),
+            opt(p.ci_standard_error.map(|(_, hi)| hi)),
+        ])
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// Run-level counts and PsN's `diagnostic.means`.
+pub fn write_diagnostics(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let mut w = writer(path)?;
+    w.write_record(["statistic", "value"])
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    let s = &result.summary;
+    let mut rows = vec![
+        (
+            "samples_requested".to_string(),
+            result.replicates.len() as f64,
+        ),
+        ("samples_completed".to_string(), s.n_completed as f64),
+        ("samples_included".to_string(), s.n_included as f64),
+        (
+            "chi_square_df".to_string(),
+            result.n_estimated_parameters as f64,
+        ),
+    ];
+    for (reason, n) in &s.excluded_by {
+        rows.push((format!("excluded: {reason}"), *n as f64));
+    }
+    for (name, value) in &s.diagnostic_means {
+        rows.push((format!("mean: {name}"), *value));
+    }
+    for (name, value) in rows {
+        w.write_record([name, fmt(value)])
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// Every subject of the original dataset, in dataset order.
+pub fn write_all_individuals(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let mut w = writer(path)?;
+    w.write_record(["ID"])
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    for id in &result.subject_ids {
+        w.write_record([id])
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// One row per replicate: the IDs drawn, repeats included, in dataset order.
+///
+/// The IDs are the *original* ones — the `#2` suffix that keeps duplicate copies
+/// independent inside the fit is an implementation detail of the replicate
+/// population, and writing it here would make the file disagree with
+/// `all_individuals1.csv`.
+pub fn write_included_individuals(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let mut w = writer(path)?;
+    for draw in &result.draws {
+        let row: Vec<String> = draw
+            .keys
+            .iter()
+            .map(|&k| result.subject_ids[k].clone())
+            .collect();
+        w.write_record(&row)
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// One row per replicate: the internal 1..N ordinals of the drawn subjects.
+pub fn write_included_keys(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let mut w = writer(path)?;
+    for draw in &result.draws {
+        let row: Vec<String> = draw.keys.iter().map(|&k| (k + 1).to_string()).collect();
+        w.write_record(&row)
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// One row per replicate, one count per **original** subject: how many times it
+/// was drawn.
+pub fn write_sample_keys(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let n = result.subject_ids.len();
+    let mut w = writer(path)?;
+    w.write_record(result.subject_ids.iter())
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    for draw in &result.draws {
+        let row: Vec<String> = draw.counts(n).iter().map(|c| c.to_string()).collect();
+        w.write_record(&row)
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// `--dofv` only: bootstrap sample id and `ofv_bs,maxeval=0 − ofv_original`.
+pub fn write_delta_ofv(path: &Path, result: &BootstrapResult) -> Result<(), String> {
+    let mut w = writer(path)?;
+    w.write_record(["sample", "delta_ofv"])
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    for r in &result.replicates {
+        w.write_record([r.index.to_string(), opt(r.delta_ofv)])
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    finish(w, path)
+}
+
+/// Read one statistic back out of a `bootstrap_diagnostics.csv`.
+///
+/// Used by `--summarize` to carry forward the values that describe the *model*
+/// rather than the filtering — the chi-square degrees of freedom for the Δofv
+/// reference — which are not recoverable from `raw_results.csv` and have not
+/// changed just because the exclusion criteria did.
+pub fn read_diagnostic(path: &Path, key: &str) -> Option<f64> {
+    let mut reader = csv::Reader::from_path(path).ok()?;
+    for record in reader.records() {
+        let row = record.ok()?;
+        if row.get(0)? == key {
+            return row.get(1)?.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Read a `raw_results.csv` back into replicate results.
+///
+/// The counterpart of [`write_raw_results`], and the whole mechanism behind
+/// `--summarize`: because the raw file carries each replicate's *diagnostics*
+/// and not only its estimates, the exclusion filters can be re-applied to a
+/// finished run under different settings without refitting anything. PsN
+/// supports the same move for the same reason.
+///
+/// Returns `(parameter_names, original, replicates)`; `original` is the
+/// `sample = 0` row when the base model was run.
+#[allow(clippy::type_complexity)]
+pub fn read_raw_results(
+    path: &Path,
+) -> Result<
+    (
+        Vec<String>,
+        Option<super::ReplicateResult>,
+        Vec<super::ReplicateResult>,
+    ),
+    String,
+> {
+    let mut reader = csv::Reader::from_path(path)
+        .map_err(|e| format!("cannot read `{}`: {e}", path.display()))?;
+    let header: Vec<String> = reader
+        .headers()
+        .map_err(|e| format!("cannot read the header of `{}`: {e}", path.display()))?
+        .iter()
+        .map(str::to_string)
+        .collect();
+
+    // Everything between `seconds` and the first `se_`/`delta_ofv`/`error`
+    // column is a parameter, so the reader does not need to be told the model.
+    let fixed_head = [
+        "sample",
+        "minimization_successful",
+        "estimate_near_boundary",
+        "covariance_step_successful",
+        "covariance_step_warnings",
+        "ofv",
+        "seconds",
+    ];
+    for (i, expected) in fixed_head.iter().enumerate() {
+        if header.get(i).map(String::as_str) != Some(expected) {
+            return Err(format!(
+                "`{}` does not look like a bootstrap raw_results file: expected column {} to be \
+                 `{expected}`, found `{}`",
+                path.display(),
+                i + 1,
+                header.get(i).map(String::as_str).unwrap_or("<missing>")
+            ));
+        }
+    }
+    let names: Vec<String> = header[fixed_head.len()..]
+        .iter()
+        .take_while(|h| !h.starts_with("se_") && h.as_str() != "delta_ofv" && h.as_str() != "error")
+        .cloned()
+        .collect();
+    let n_params = names.len();
+    let param_start = fixed_head.len();
+    let se_start = header
+        .iter()
+        .position(|h| h.starts_with("se_"))
+        .filter(|_| header.iter().filter(|h| h.starts_with("se_")).count() == n_params);
+    let dofv_at = header.iter().position(|h| h == "delta_ofv");
+    let error_at = header.iter().position(|h| h == "error");
+
+    let num = |row: &csv::StringRecord, i: usize| -> f64 {
+        row.get(i)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(f64::NAN)
+    };
+    let flag = |row: &csv::StringRecord, i: usize| -> bool {
+        matches!(row.get(i).map(str::trim), Some("1") | Some("true"))
+    };
+
+    let mut original = None;
+    let mut replicates = Vec::new();
+    for record in reader.records() {
+        let row = record.map_err(|e| format!("malformed row in `{}`: {e}", path.display()))?;
+        let index = row
+            .get(0)
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .ok_or_else(|| format!("non-numeric `sample` column in `{}`", path.display()))?;
+        let error = error_at
+            .and_then(|i| row.get(i))
+            .map(str::to_string)
+            .filter(|s| !s.is_empty());
+        let estimates: Vec<f64> = if error.is_some() {
+            Vec::new()
+        } else {
+            (0..n_params).map(|j| num(&row, param_start + j)).collect()
+        };
+        let result = super::ReplicateResult {
+            index,
+            estimates,
+            standard_errors: se_start
+                .map(|start| (0..n_params).map(|j| num(&row, start + j)).collect()),
+            ofv: num(&row, 5),
+            converged: flag(&row, 1),
+            estimate_near_boundary: flag(&row, 2),
+            covariance_step_successful: flag(&row, 3),
+            covariance_step_warnings: flag(&row, 4),
+            seconds: num(&row, 6),
+            error,
+            delta_ofv: dofv_at.map(|i| num(&row, i)).filter(|v| v.is_finite()),
+        };
+        if index == 0 {
+            original = Some(result);
+        } else {
+            replicates.push(result);
+        }
+    }
+    Ok((names, original, replicates))
+}
+
+#[cfg(test)]
+#[path = "output_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/bootstrap/output_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/output_tests.rs
@@ -1,0 +1,336 @@
+use super::*;
+use crate::bootstrap::summary::{BootstrapSummary, ParameterSummary};
+use crate::bootstrap::{Replicate, ReplicateResult};
+
+fn replicate(index: usize, estimates: Vec<f64>, delta: Option<f64>) -> ReplicateResult {
+    ReplicateResult {
+        index,
+        estimates,
+        standard_errors: None,
+        ofv: 100.0 + index as f64,
+        converged: index != 2,
+        estimate_near_boundary: false,
+        covariance_step_successful: true,
+        covariance_step_warnings: false,
+        seconds: 0.5,
+        error: None,
+        delta_ofv: delta,
+    }
+}
+
+fn result() -> BootstrapResult {
+    BootstrapResult {
+        parameter_names: vec!["CL".to_string(), "V".to_string()],
+        original: Some(replicate(0, vec![1.0, 10.0], None)),
+        replicates: vec![
+            replicate(1, vec![1.1, 10.5], Some(0.25)),
+            replicate(2, vec![0.9, 9.5], Some(1.5)),
+        ],
+        draws: vec![
+            Replicate {
+                index: 1,
+                keys: vec![0, 0, 2],
+            },
+            Replicate {
+                index: 2,
+                keys: vec![1, 1, 2],
+            },
+        ],
+        subject_ids: vec!["A".to_string(), "B".to_string(), "C".to_string()],
+        summary: BootstrapSummary {
+            parameters: vec![ParameterSummary {
+                name: "CL".to_string(),
+                original: Some(1.0),
+                mean: 1.0,
+                bias: Some(0.0),
+                standard_error: 0.1,
+                median: 1.0,
+                ci_percentile: None,
+                ci_standard_error: Some((0.8, 1.2)),
+            }],
+            n_completed: 2,
+            n_included: 1,
+            excluded_by: vec![("minimization terminated".to_string(), 1)],
+            confidence_level: 95.0,
+            diagnostic_means: vec![("minimization_successful".to_string(), 0.5)],
+        },
+        n_estimated_parameters: 3,
+    }
+}
+
+fn read(path: &std::path::Path) -> Vec<Vec<String>> {
+    csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_path(path)
+        .expect("readable csv")
+        .records()
+        .map(|r| r.expect("record").iter().map(str::to_string).collect())
+        .collect()
+}
+
+#[test]
+fn write_all_produces_every_psn_artefact() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let options = BootstrapOptions {
+        dofv: true,
+        ..BootstrapOptions::default()
+    };
+    write_all(dir.path(), &result(), &options).expect("write");
+
+    for name in [
+        "raw_results.csv",
+        "bootstrap_results.csv",
+        "bootstrap_diagnostics.csv",
+        "all_individuals1.csv",
+        "included_individuals1.csv",
+        "included_keys1.csv",
+        "sample_keys1.csv",
+        "delta_ofv.csv",
+    ] {
+        assert!(dir.path().join(name).exists(), "{name} was not written");
+    }
+}
+
+#[test]
+fn delta_ofv_is_only_written_when_asked_for() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_all(dir.path(), &result(), &BootstrapOptions::default()).expect("write");
+    assert!(!dir.path().join("delta_ofv.csv").exists());
+}
+
+#[test]
+fn raw_results_puts_the_original_dataset_first() {
+    // PsN: "The first row is for the original dataset." Downstream tools (PsN's
+    // own `covmat -offset=1`) rely on it.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("raw.csv");
+    write_raw_results(&path, &result(), &BootstrapOptions::default()).expect("write");
+    let rows = read(&path);
+
+    assert_eq!(rows[0][0], "sample");
+    assert_eq!(rows[1][0], "0", "row 1 must be the original dataset");
+    assert_eq!(rows[2][0], "1");
+    assert_eq!(rows[3][0], "2");
+
+    // Diagnostics travel with the estimates, which is what makes the exclusion
+    // filters re-appliable without refitting.
+    let header = &rows[0];
+    for column in [
+        "minimization_successful",
+        "estimate_near_boundary",
+        "covariance_step_successful",
+        "covariance_step_warnings",
+        "ofv",
+        "CL",
+        "V",
+    ] {
+        assert!(header.contains(&column.to_string()), "missing `{column}`");
+    }
+    let idx = header
+        .iter()
+        .position(|h| h == "minimization_successful")
+        .unwrap();
+    assert_eq!(rows[3][idx], "0", "replicate 2 did not converge");
+}
+
+#[test]
+fn raw_results_gains_se_columns_only_with_keep_covariance() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let plain = dir.path().join("plain.csv");
+    write_raw_results(&plain, &result(), &BootstrapOptions::default()).expect("write");
+    assert!(!read(&plain)[0].contains(&"se_CL".to_string()));
+
+    let with_cov = dir.path().join("cov.csv");
+    let options = BootstrapOptions {
+        keep_covariance: true,
+        ..BootstrapOptions::default()
+    };
+    write_raw_results(&with_cov, &result(), &options).expect("write");
+    assert!(read(&with_cov)[0].contains(&"se_CL".to_string()));
+}
+
+#[test]
+fn the_replicate_files_agree_row_for_row() {
+    // PsN: "The row order is consistent between the files raw_results,
+    // included_individuals, included_keys and sample_keys so that row j ...
+    // concerns the same bootstrapped dataset."
+    let dir = tempfile::tempdir().expect("temp dir");
+    let r = result();
+
+    let individuals = dir.path().join("ind.csv");
+    let keys = dir.path().join("keys.csv");
+    let sample = dir.path().join("sample.csv");
+    write_included_individuals(&individuals, &r).expect("write");
+    write_included_keys(&keys, &r).expect("write");
+    write_sample_keys(&sample, &r).expect("write");
+
+    // Replicate 1 drew A twice and C once.
+    assert_eq!(read(&individuals)[0], vec!["A", "A", "C"]);
+    assert_eq!(read(&keys)[0], vec!["1", "1", "3"]);
+    // sample_keys has a header row of subject IDs, then one count per subject.
+    let sample_rows = read(&sample);
+    assert_eq!(sample_rows[0], vec!["A", "B", "C"]);
+    assert_eq!(sample_rows[1], vec!["2", "0", "1"]);
+    assert_eq!(sample_rows[2], vec!["0", "2", "1"]);
+
+    // Second row of each file is the same replicate.
+    assert_eq!(read(&individuals)[1], vec!["B", "B", "C"]);
+    assert_eq!(read(&keys)[1], vec!["2", "2", "3"]);
+}
+
+#[test]
+fn included_individuals_uses_the_original_ids() {
+    // The `#2` suffix that keeps duplicate draws independent inside the fit is
+    // an implementation detail; writing it here would make the file disagree
+    // with all_individuals1.csv.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("ind.csv");
+    write_included_individuals(&path, &result()).expect("write");
+    for row in read(&path) {
+        assert!(row.iter().all(|id| !id.contains('#')), "{row:?}");
+    }
+}
+
+#[test]
+fn results_table_is_one_row_per_parameter() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("results.csv");
+    write_bootstrap_results(&path, &result()).expect("write");
+    let rows = read(&path);
+    assert_eq!(rows[0][0], "parameter");
+    assert!(rows[0].contains(&"percentile.2.5".to_string()));
+    assert!(rows[0].contains(&"percentile.97.5".to_string()));
+    assert_eq!(rows[1][0], "CL");
+    // A missing percentile CI is an empty cell, not a NaN or a zero.
+    let lo = rows[0].iter().position(|h| h == "percentile.2.5").unwrap();
+    assert_eq!(rows[1][lo], "");
+}
+
+#[test]
+fn diagnostics_report_counts_exclusions_and_means() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("diag.csv");
+    write_diagnostics(&path, &result()).expect("write");
+    let rows = read(&path);
+    let find = |k: &str| {
+        rows.iter()
+            .find(|r| r[0] == k)
+            .unwrap_or_else(|| panic!("no row `{k}`"))[1]
+            .clone()
+    };
+    assert_eq!(find("samples_completed").parse::<f64>().unwrap(), 2.0);
+    assert_eq!(find("samples_included").parse::<f64>().unwrap(), 1.0);
+    assert_eq!(find("chi_square_df").parse::<f64>().unwrap(), 3.0);
+    assert_eq!(
+        find("excluded: minimization terminated")
+            .parse::<f64>()
+            .unwrap(),
+        1.0
+    );
+    assert_eq!(
+        find("mean: minimization_successful")
+            .parse::<f64>()
+            .unwrap(),
+        0.5
+    );
+}
+
+#[test]
+fn delta_ofv_rows_are_sample_and_difference() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("dofv.csv");
+    write_delta_ofv(&path, &result()).expect("write");
+    let rows = read(&path);
+    assert_eq!(rows[0], vec!["sample", "delta_ofv"]);
+    assert_eq!(rows[1][0], "1");
+    assert!((rows[1][1].parse::<f64>().unwrap() - 0.25).abs() < 1e-9);
+}
+
+// ── reading the raw results back ────────────────────────────────────────────
+
+#[test]
+fn raw_results_round_trip_preserves_estimates_and_diagnostics() {
+    // `--summarize` reads this file back and re-applies the filters, so a lossy
+    // round trip would silently change which replicates count.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("raw_results.csv");
+    let options = BootstrapOptions {
+        dofv: true,
+        ..BootstrapOptions::default()
+    };
+    let written = result();
+    write_raw_results(&path, &written, &options).expect("write");
+
+    let (names, original, replicates) = read_raw_results(&path).expect("read");
+    assert_eq!(names, written.parameter_names);
+
+    let original = original.expect("the sample=0 row is the original fit");
+    assert_eq!(original.index, 0);
+    assert!((original.estimates[0] - 1.0).abs() < 1e-9);
+
+    assert_eq!(replicates.len(), 2);
+    assert!((replicates[0].estimates[1] - 10.5).abs() < 1e-9);
+    assert!(replicates[0].converged);
+    assert!(
+        !replicates[1].converged,
+        "the diagnostic must survive the round trip"
+    );
+    assert!((replicates[1].delta_ofv.unwrap() - 1.5).abs() < 1e-9);
+}
+
+#[test]
+fn raw_results_round_trip_finds_the_se_columns() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("raw_results.csv");
+    let options = BootstrapOptions {
+        keep_covariance: true,
+        ..BootstrapOptions::default()
+    };
+    let mut written = result();
+    written.replicates[0].standard_errors = Some(vec![0.1, 0.2]);
+    write_raw_results(&path, &written, &options).expect("write");
+
+    let (names, _, replicates) = read_raw_results(&path).expect("read");
+    // The parameter block must stop at `se_`, not swallow it.
+    assert_eq!(names, vec!["CL", "V"]);
+    let se = replicates[0].standard_errors.as_ref().expect("se columns");
+    assert!((se[0] - 0.1).abs() < 1e-9);
+    assert!((se[1] - 0.2).abs() < 1e-9);
+}
+
+#[test]
+fn reading_a_file_that_is_not_raw_results_says_so() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("sdtab.csv");
+    std::fs::write(&path, "ID,TIME,DV\n1,0,5\n").expect("write");
+    let err = read_raw_results(&path).unwrap_err();
+    assert!(
+        err.contains("does not look like a bootstrap raw_results file"),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_failed_replicate_round_trips_as_failed() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("raw_results.csv");
+    let mut written = result();
+    written.replicates[1].error = Some("inner loop diverged".to_string());
+    written.replicates[1].estimates = Vec::new();
+    write_raw_results(&path, &written, &BootstrapOptions::default()).expect("write");
+
+    let (_, _, replicates) = read_raw_results(&path).expect("read");
+    assert_eq!(replicates[1].error.as_deref(), Some("inner loop diverged"));
+    assert!(replicates[1].estimates.is_empty());
+}
+
+#[test]
+fn a_diagnostic_can_be_read_back_by_name() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("bootstrap_diagnostics.csv");
+    write_diagnostics(&path, &result()).expect("write");
+    assert_eq!(read_diagnostic(&path, "chi_square_df"), Some(3.0));
+    assert_eq!(read_diagnostic(&path, "not_a_statistic"), None);
+    assert_eq!(read_diagnostic(&dir.path().join("absent.csv"), "x"), None);
+}

--- a/crates/ferx-tools/src/bootstrap/output_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/output_tests.rs
@@ -326,6 +326,35 @@ fn a_failed_replicate_round_trips_as_failed() {
 }
 
 #[test]
+fn an_unwritable_directory_is_an_error_not_a_panic() {
+    // A bootstrap that cannot write its results has still done the expensive
+    // part, so it must report the failure rather than unwrap into a panic and
+    // lose 200 fits.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let blocked = dir.path().join("results");
+    std::fs::write(&blocked, "not a directory").expect("write");
+
+    let err = write_all(&blocked, &result(), &BootstrapOptions::default()).unwrap_err();
+    assert!(err.contains("bootstrap directory"), "{err}");
+
+    // And a writer pointed at a path inside that non-directory.
+    let err = write_raw_results(
+        &blocked.join("raw_results.csv"),
+        &result(),
+        &BootstrapOptions::default(),
+    )
+    .unwrap_err();
+    assert!(err.contains("cannot write"), "{err}");
+}
+
+#[test]
+fn reading_a_missing_raw_results_file_is_an_error() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let err = read_raw_results(&dir.path().join("absent.csv")).unwrap_err();
+    assert!(err.contains("cannot read"), "{err}");
+}
+
+#[test]
 fn a_diagnostic_can_be_read_back_by_name() {
     let dir = tempfile::tempdir().expect("temp dir");
     let path = dir.path().join("bootstrap_diagnostics.csv");

--- a/crates/ferx-tools/src/bootstrap/output_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/output_tests.rs
@@ -288,15 +288,16 @@ fn raw_results_round_trip_finds_the_se_columns() {
         ..BootstrapOptions::default()
     };
     let mut written = result();
-    written.replicates[0].standard_errors = Some(vec![0.1, 0.2]);
+    written.replicates[0].standard_errors = Some(vec![Some(0.1), None]);
     write_raw_results(&path, &written, &options).expect("write");
 
     let (names, _, replicates) = read_raw_results(&path).expect("read");
     // The parameter block must stop at `se_`, not swallow it.
     assert_eq!(names, vec!["CL", "V"]);
     let se = replicates[0].standard_errors.as_ref().expect("se columns");
-    assert!((se[0] - 0.1).abs() < 1e-9);
-    assert!((se[1] - 0.2).abs() < 1e-9);
+    assert!((se[0].expect("CL has an SE") - 0.1).abs() < 1e-9);
+    // A coordinate core reports no SE for round-trips as absent, not as 0.
+    assert_eq!(se[1], None);
 }
 
 #[test]

--- a/crates/ferx-tools/src/bootstrap/resample.rs
+++ b/crates/ferx-tools/src/bootstrap/resample.rs
@@ -1,0 +1,272 @@
+//! Drawing bootstrap replicates: strata, sample sizes, and the seeded RNG.
+//!
+//! Resampling is always over **whole subjects** — for each ID every record is
+//! either in or out of a replicate, never split. That is what makes the
+//! non-parametric case bootstrap valid for a hierarchical model, and it is what
+//! PsN does.
+
+use std::collections::BTreeMap;
+
+use ferx_core::Population;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+/// How many subjects each replicate draws.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SampleSize {
+    /// The number of subjects in the original dataset — PsN's default, and the
+    /// only case where a stratified proportional split is guaranteed to sum
+    /// back to the requested total.
+    Original,
+    /// One number for the whole replicate. Under stratification the strata are
+    /// allocated *in proportion to their size*, rounded to the nearest integer;
+    /// PsN documents that the rounded parts need not sum to the request.
+    Total(usize),
+    /// An explicit count per stratum, PsN's `-sample_size=1001=>12,1002=>24`
+    /// syntax. Only meaningful with `stratify_on`.
+    PerStratum(BTreeMap<String, usize>),
+}
+
+impl SampleSize {
+    /// Parse PsN's `-sample_size` argument: either a bare integer or a
+    /// comma-separated list of `STRATUM=>COUNT` pairs.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return Err("empty --sample-size".to_string());
+        }
+        if !spec.contains("=>") {
+            return spec.parse::<usize>().map(SampleSize::Total).map_err(|_| {
+                format!("--sample-size: `{spec}` is neither a number nor a `STRATUM=>COUNT` list")
+            });
+        }
+        let mut map = BTreeMap::new();
+        for part in spec.split(',') {
+            let part = part.trim();
+            let (stratum, count) = part.split_once("=>").ok_or_else(|| {
+                format!(
+                    "--sample-size: `{part}` is not a `STRATUM=>COUNT` pair. Mixing a bare \
+                     number with per-stratum counts is not allowed — give one or the other."
+                )
+            })?;
+            let stratum = stratum.trim().to_string();
+            let count: usize = count.trim().parse().map_err(|_| {
+                format!("--sample-size: `{part}` has a non-numeric count after `=>`")
+            })?;
+            if map.insert(stratum.clone(), count).is_some() {
+                return Err(format!(
+                    "--sample-size: stratum `{stratum}` is listed more than once"
+                ));
+            }
+        }
+        Ok(SampleSize::PerStratum(map))
+    }
+}
+
+/// The subjects of the original dataset, grouped for resampling.
+///
+/// The unstratified case is represented as a single unnamed group rather than as
+/// a separate code path, so the draw loop below has one shape.
+#[derive(Debug, Clone)]
+pub struct Strata {
+    /// Stratum label → ordinals into `Population::subjects`, ascending.
+    pub groups: BTreeMap<String, Vec<usize>>,
+    /// `None` for an unstratified bootstrap.
+    pub column: Option<String>,
+}
+
+impl Strata {
+    /// One group holding every subject, in dataset order.
+    pub fn unstratified(n_subjects: usize) -> Self {
+        let mut groups = BTreeMap::new();
+        groups.insert(String::new(), (0..n_subjects).collect());
+        Strata {
+            groups,
+            column: None,
+        }
+    }
+
+    /// Group subjects by a per-subject label.
+    ///
+    /// `labels[i]` is the stratum of `Population::subjects[i]`. Callers get the
+    /// labels from the dataset (see [`super::strata_from_csv`]); the
+    /// one-value-per-subject check happens there, where the offending record can
+    /// still be named.
+    pub fn from_labels(labels: &[String], column: &str) -> Self {
+        let mut groups: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+        for (i, label) in labels.iter().enumerate() {
+            groups.entry(label.clone()).or_default().push(i);
+        }
+        Strata {
+            groups,
+            column: Some(column.to_string()),
+        }
+    }
+
+    fn n_subjects(&self) -> usize {
+        self.groups.values().map(|g| g.len()).sum()
+    }
+
+    /// How many subjects to draw from each stratum, resolving [`SampleSize`].
+    ///
+    /// Returned in the same key order as `groups` so the draw is deterministic.
+    pub fn allocation(&self, size: &SampleSize) -> Result<Vec<(String, usize)>, String> {
+        let total_subjects = self.n_subjects();
+        match size {
+            SampleSize::Original => Ok(self
+                .groups
+                .iter()
+                .map(|(k, g)| (k.clone(), g.len()))
+                .collect()),
+            SampleSize::Total(m) => {
+                // Proportional allocation. With one stratum this is just `m`, so
+                // the unstratified path needs no special case.
+                if self.groups.len() == 1 {
+                    return Ok(vec![(
+                        self.groups.keys().next().cloned().unwrap_or_default(),
+                        *m,
+                    )]);
+                }
+                Ok(self
+                    .groups
+                    .iter()
+                    .map(|(k, g)| {
+                        let share = (*m as f64) * (g.len() as f64) / (total_subjects as f64);
+                        (k.clone(), share.round() as usize)
+                    })
+                    .collect())
+            }
+            SampleSize::PerStratum(map) => {
+                if self.column.is_none() {
+                    return Err(
+                        "--sample-size was given per-stratum counts but --stratify-on was not set"
+                            .to_string(),
+                    );
+                }
+                let unknown: Vec<&str> = map
+                    .keys()
+                    .filter(|k| !self.groups.contains_key(*k))
+                    .map(|s| s.as_str())
+                    .collect();
+                if !unknown.is_empty() {
+                    return Err(format!(
+                        "--sample-size names stratum/strata {:?} that do not occur in column \
+                         `{}`. Present strata: {:?}",
+                        unknown,
+                        self.column.as_deref().unwrap_or(""),
+                        self.groups.keys().collect::<Vec<_>>()
+                    ));
+                }
+                // A stratum the user did not name contributes nothing, rather
+                // than silently falling back to its own size — an unmentioned
+                // stratum in an explicit list is far more likely a typo than an
+                // intent to include it whole.
+                let missing: Vec<&String> = self
+                    .groups
+                    .keys()
+                    .filter(|k| !map.contains_key(*k))
+                    .collect();
+                if !missing.is_empty() {
+                    return Err(format!(
+                        "--sample-size lists per-stratum counts but omits {missing:?}. List every \
+                         stratum explicitly (use 0 to exclude one)."
+                    ));
+                }
+                Ok(map.iter().map(|(k, v)| (k.clone(), *v)).collect())
+            }
+        }
+    }
+}
+
+/// One drawn replicate: ordinals into the original `Population::subjects`.
+///
+/// Held **ascending**, so a subject drawn twice appears twice in a row. That is
+/// not cosmetic: PsN builds a replicate by walking the original data file and
+/// emitting each selected individual as many times as it was drawn, so dataset
+/// order and draw order coincide there. Sorting reproduces that, which is what
+/// lets `included_individuals` and `included_keys` agree the way the PsN guide
+/// describes them. It is also a no-op statistically — a multiset has no order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Replicate {
+    /// 1-based; replicate 0 is reserved for the original dataset.
+    pub index: usize,
+    pub keys: Vec<usize>,
+}
+
+impl Replicate {
+    /// Times each original subject was drawn — PsN's `sample_keys`.
+    pub fn counts(&self, n_subjects: usize) -> Vec<usize> {
+        let mut counts = vec![0usize; n_subjects];
+        for &k in &self.keys {
+            counts[k] += 1;
+        }
+        counts
+    }
+}
+
+/// Seed for replicate `index`, derived from the run seed.
+///
+/// Deliberately a pure function of `(seed, index)` and nothing else. PsN's guide
+/// documents the opposite behaviour as a known wart — "the results of two runs
+/// will be different even if the seed is the same if the lst-file of the base
+/// model is present at the start of one run but not the other", because running
+/// the base model advances a shared RNG. Deriving per replicate means the drawn
+/// datasets depend only on `--seed` and the design: not on `--threads`, not on
+/// completion order, not on whether the base fit ran.
+pub fn replicate_seed(seed: u64, index: usize) -> u64 {
+    // Odd multiplier (the golden-ratio constant used by SplitMix64) so distinct
+    // indices stay distinct after wrapping.
+    seed ^ (index as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+}
+
+/// Draw one replicate: sample each stratum with replacement to its allocation.
+pub fn draw(strata: &Strata, allocation: &[(String, usize)], seed: u64, index: usize) -> Replicate {
+    let mut rng = StdRng::seed_from_u64(replicate_seed(seed, index));
+    let mut keys = Vec::new();
+    for (label, n_draw) in allocation {
+        let Some(pool) = strata.groups.get(label) else {
+            continue;
+        };
+        if pool.is_empty() {
+            continue;
+        }
+        for _ in 0..*n_draw {
+            keys.push(pool[rng.random_range(0..pool.len())]);
+        }
+    }
+    keys.sort_unstable();
+    Replicate { index, keys }
+}
+
+/// Build a replicate population by cloning each drawn subject.
+///
+/// A subject drawn more than once must enter the fit as *independent*
+/// individuals — the whole point of resampling with replacement — so the copies
+/// get distinct IDs. PsN achieves the same by renumbering IDs while writing the
+/// replicate data file; here the original ID is kept and a `#2`, `#3`, … suffix
+/// added, so a diagnostic can still be traced back to the subject it came from.
+pub fn build_population(original: &Population, replicate: &Replicate) -> Population {
+    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    let mut subjects = Vec::with_capacity(replicate.keys.len());
+    for &k in &replicate.keys {
+        let mut subject = original.subjects[k].clone();
+        let n = seen.entry(original.subjects[k].id.as_str()).or_insert(0);
+        *n += 1;
+        if *n > 1 {
+            subject.id = format!("{}#{}", subject.id, n);
+        }
+        subjects.push(subject);
+    }
+    Population {
+        subjects,
+        covariate_names: original.covariate_names.clone(),
+        dv_column: original.dv_column.clone(),
+        input_columns: original.input_columns.clone(),
+        exclusions: original.exclusions.clone(),
+        warnings: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+#[path = "resample_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/bootstrap/resample_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/resample_tests.rs
@@ -1,0 +1,262 @@
+use super::*;
+use std::collections::BTreeMap;
+
+fn labels(spec: &[&str]) -> Vec<String> {
+    spec.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn sample_size_parses_both_psn_forms() {
+    assert_eq!(SampleSize::parse("32").unwrap(), SampleSize::Total(32));
+    let per = SampleSize::parse("1001=>12,1002=>24,1003=>10").unwrap();
+    let SampleSize::PerStratum(map) = per else {
+        panic!("expected a per-stratum map");
+    };
+    assert_eq!(map["1001"], 12);
+    assert_eq!(map["1002"], 24);
+    assert_eq!(map["1003"], 10);
+    // Whitespace around the pairs is what a shell-quoted PsN argument looks like
+    // after a copy-paste.
+    let spaced = SampleSize::parse(" 1001 => 12 , 1002 => 24 ").unwrap();
+    let SampleSize::PerStratum(map) = spaced else {
+        panic!("expected a per-stratum map");
+    };
+    assert_eq!(map["1001"], 12);
+}
+
+#[test]
+fn sample_size_rejects_malformed_specs() {
+    assert!(SampleSize::parse("").is_err());
+    assert!(SampleSize::parse("abc").is_err());
+    // A bare number mixed into a per-stratum list: silently dropping it would
+    // change the design without saying so.
+    assert!(SampleSize::parse("1001=>12,24").is_err());
+    assert!(SampleSize::parse("1001=>x").is_err());
+    assert!(SampleSize::parse("1001=>12,1001=>24").is_err());
+}
+
+#[test]
+fn strata_group_subjects_in_dataset_order() {
+    let strata = Strata::from_labels(&labels(&["a", "b", "a", "b", "a"]), "GRP");
+    assert_eq!(strata.groups["a"], vec![0, 2, 4]);
+    assert_eq!(strata.groups["b"], vec![1, 3]);
+    assert_eq!(strata.column.as_deref(), Some("GRP"));
+}
+
+#[test]
+fn default_allocation_is_each_stratum_at_its_own_size() {
+    let strata = Strata::from_labels(&labels(&["a", "b", "a"]), "GRP");
+    let alloc = strata.allocation(&SampleSize::Original).unwrap();
+    assert_eq!(alloc, vec![("a".to_string(), 2), ("b".to_string(), 1)]);
+}
+
+#[test]
+fn a_single_sample_size_splits_strata_in_proportion() {
+    // 10 rich + 90 sparse, the guide's own example. A request for 50 must keep
+    // the 1:9 composition rather than splitting evenly.
+    let mut spec = Vec::new();
+    spec.extend(std::iter::repeat_n("rich", 10));
+    spec.extend(std::iter::repeat_n("sparse", 90));
+    let strata = Strata::from_labels(&labels(&spec), "GRP");
+    let alloc: BTreeMap<String, usize> = strata
+        .allocation(&SampleSize::Total(50))
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(alloc["rich"], 5);
+    assert_eq!(alloc["sparse"], 45);
+}
+
+#[test]
+fn unstratified_total_is_taken_literally() {
+    let strata = Strata::unstratified(32);
+    let alloc = strata.allocation(&SampleSize::Total(7)).unwrap();
+    assert_eq!(alloc, vec![(String::new(), 7)]);
+}
+
+#[test]
+fn per_stratum_sample_size_requires_stratification_and_every_stratum() {
+    let mut map = BTreeMap::new();
+    map.insert("a".to_string(), 3);
+
+    // Per-stratum counts with no strata at all.
+    let flat = Strata::unstratified(4);
+    assert!(flat
+        .allocation(&SampleSize::PerStratum(map.clone()))
+        .unwrap_err()
+        .contains("--stratify-on"));
+
+    // A stratum present in the data but missing from the list: far more likely a
+    // typo than an intent to include it whole.
+    let strata = Strata::from_labels(&labels(&["a", "b"]), "GRP");
+    let err = strata
+        .allocation(&SampleSize::PerStratum(map.clone()))
+        .unwrap_err();
+    assert!(err.contains("omits"), "{err}");
+
+    // A stratum named in the list but absent from the data.
+    let mut unknown = map.clone();
+    unknown.insert("zz".to_string(), 1);
+    unknown.insert("b".to_string(), 1);
+    let err = strata
+        .allocation(&SampleSize::PerStratum(unknown))
+        .unwrap_err();
+    assert!(err.contains("zz"), "{err}");
+}
+
+#[test]
+fn replicate_seeds_are_distinct_and_depend_only_on_seed_and_index() {
+    let a: Vec<u64> = (1..=100).map(|i| replicate_seed(7, i)).collect();
+    let mut sorted = a.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), a.len(), "replicate seeds collided");
+    // Pure function: recomputing gives the same answer, and a different master
+    // seed gives a different stream.
+    assert_eq!(replicate_seed(7, 42), replicate_seed(7, 42));
+    assert_ne!(replicate_seed(7, 42), replicate_seed(8, 42));
+}
+
+#[test]
+fn draws_are_reproducible_and_order_independent() {
+    let strata = Strata::unstratified(20);
+    let alloc = strata.allocation(&SampleSize::Original).unwrap();
+
+    // The whole point of per-replicate seeding: replicate 5 is the same draw
+    // whether it is computed first, last, or on another thread. PsN's guide
+    // documents the opposite as a known wart.
+    let forward: Vec<Replicate> = (1..=10).map(|i| draw(&strata, &alloc, 99, i)).collect();
+    let backward: Vec<Replicate> = (1..=10)
+        .rev()
+        .map(|i| draw(&strata, &alloc, 99, i))
+        .collect();
+    for r in &forward {
+        assert!(
+            backward.contains(r),
+            "replicate {} was not reproduced",
+            r.index
+        );
+    }
+
+    // Distinct replicates are actually distinct draws.
+    assert_ne!(forward[0].keys, forward[1].keys);
+}
+
+#[test]
+fn a_draw_is_sorted_and_the_right_size() {
+    let strata = Strata::unstratified(12);
+    let alloc = strata.allocation(&SampleSize::Original).unwrap();
+    let r = draw(&strata, &alloc, 3, 1);
+    assert_eq!(r.keys.len(), 12);
+    assert!(
+        r.keys.windows(2).all(|w| w[0] <= w[1]),
+        "keys must be ascending"
+    );
+    assert!(r.keys.iter().all(|&k| k < 12));
+    // With replacement: over 12 draws from 12 subjects, some subject is drawn
+    // twice with overwhelming probability, so the multiset is not a permutation.
+    let counts = r.counts(12);
+    assert_eq!(counts.iter().sum::<usize>(), 12);
+}
+
+#[test]
+fn stratified_draws_have_exactly_the_requested_composition() {
+    let mut spec = Vec::new();
+    spec.extend(std::iter::repeat_n("rich", 10));
+    spec.extend(std::iter::repeat_n("sparse", 90));
+    let strata = Strata::from_labels(&labels(&spec), "GRP");
+    let alloc = strata.allocation(&SampleSize::Original).unwrap();
+
+    for index in 1..=25 {
+        let r = draw(&strata, &alloc, 5, index);
+        let rich = r.keys.iter().filter(|&&k| k < 10).count();
+        let sparse = r.keys.iter().filter(|&&k| k >= 10).count();
+        assert_eq!(rich, 10, "replicate {index} lost the rich stratum's size");
+        assert_eq!(
+            sparse, 90,
+            "replicate {index} lost the sparse stratum's size"
+        );
+    }
+}
+
+// ── building the replicate population ───────────────────────────────────────
+
+fn population(ids: &[&str]) -> ferx_core::Population {
+    let subjects = ids
+        .iter()
+        .map(|id| ferx_core::Subject {
+            id: (*id).to_string(),
+            obs_times: vec![1.0],
+            observations: vec![2.0],
+            ..Default::default()
+        })
+        .collect();
+    ferx_core::Population {
+        subjects,
+        covariate_names: vec!["WT".to_string()],
+        dv_column: "DV".to_string(),
+        input_columns: vec!["ID".to_string(), "DV".to_string()],
+        exclusions: None,
+        warnings: vec!["a warning from reading the original data".to_string()],
+    }
+}
+
+#[test]
+fn an_identity_replicate_rebuilds_the_original_subjects() {
+    // The degenerate oracle: a "resample" that draws every subject exactly once,
+    // in order, must be indistinguishable from the original population. This is
+    // what pins the reconstruction — if `build_population` dropped a field, the
+    // fits below it would silently be fitting something else.
+    let original = population(&["A", "B", "C"]);
+    let replicate = Replicate {
+        index: 1,
+        keys: vec![0, 1, 2],
+    };
+    let rebuilt = build_population(&original, &replicate);
+
+    assert_eq!(rebuilt.subjects.len(), 3);
+    for (a, b) in original.subjects.iter().zip(&rebuilt.subjects) {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.obs_times, b.obs_times);
+        assert_eq!(a.observations, b.observations);
+    }
+    assert_eq!(rebuilt.covariate_names, original.covariate_names);
+    assert_eq!(rebuilt.dv_column, original.dv_column);
+    assert_eq!(rebuilt.input_columns, original.input_columns);
+    // Read warnings belong to the original read, not to each of 200 replicates.
+    assert!(rebuilt.warnings.is_empty());
+}
+
+#[test]
+fn duplicate_draws_become_independent_subjects() {
+    let original = population(&["A", "B"]);
+    let replicate = Replicate {
+        index: 1,
+        keys: vec![0, 0, 0, 1],
+    };
+    let rebuilt = build_population(&original, &replicate);
+
+    let ids: Vec<&str> = rebuilt.subjects.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(ids, vec!["A", "A#2", "A#3", "B"]);
+
+    // Distinct IDs are the point: three copies of A must contribute three
+    // independent eta draws, not one subject with three times the data.
+    let mut unique = ids.clone();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), ids.len());
+
+    // The data itself is untouched — only the label changes.
+    for s in &rebuilt.subjects[..3] {
+        assert_eq!(s.observations, original.subjects[0].observations);
+    }
+}
+
+#[test]
+fn sample_keys_count_every_original_subject() {
+    let replicate = Replicate {
+        index: 1,
+        keys: vec![0, 0, 2],
+    };
+    assert_eq!(replicate.counts(4), vec![2, 0, 1, 0]);
+}

--- a/crates/ferx-tools/src/bootstrap/summary.rs
+++ b/crates/ferx-tools/src/bootstrap/summary.rs
@@ -1,0 +1,311 @@
+//! Turning a set of replicate fits into bias, standard errors and confidence
+//! intervals — the contents of PsN's `bootstrap_results.csv`.
+
+use super::{BootstrapOptions, ReplicateResult};
+
+/// Summary statistics for one estimated parameter.
+#[derive(Debug, Clone)]
+pub struct ParameterSummary {
+    pub name: String,
+    /// The base model's estimate on the original dataset.
+    pub original: Option<f64>,
+    pub mean: f64,
+    /// `mean − original`: the bootstrap estimate of bias.
+    pub bias: Option<f64>,
+    /// Standard deviation of the bootstrap distribution — *this* is the
+    /// bootstrap standard error, not any per-replicate covariance-step SE.
+    pub standard_error: f64,
+    pub median: f64,
+    /// Percentile interval of the bootstrap distribution. `None` when there are
+    /// too few successful samples to resolve the requested tail (see
+    /// [`percentile`]).
+    pub ci_percentile: Option<(f64, f64)>,
+    /// `original ± z·SE`, i.e. the interval you get by *assuming* normality with
+    /// the bootstrap standard deviation. Reported alongside the percentile
+    /// interval precisely so the two can be compared: a large disagreement is
+    /// the signal that the normal approximation — and hence the `R⁻¹` standard
+    /// errors — is not to be trusted for that parameter.
+    pub ci_standard_error: Option<(f64, f64)>,
+}
+
+/// The whole `bootstrap_results` table.
+#[derive(Debug, Clone)]
+pub struct BootstrapSummary {
+    pub parameters: Vec<ParameterSummary>,
+    /// Replicates that produced an estimate at all (the fit returned `Ok`).
+    pub n_completed: usize,
+    /// Replicates that survived the skip filters and fed the statistics.
+    pub n_included: usize,
+    /// Why the excluded ones were excluded, as `(reason, count)`.
+    pub excluded_by: Vec<(String, usize)>,
+    pub confidence_level: f64,
+    /// Means of the per-replicate diagnostics, PsN's `diagnostic.means`.
+    pub diagnostic_means: Vec<(String, f64)>,
+}
+
+/// PsN's percentile estimator: the weighted average at `x_((n+1)p)`.
+///
+/// Verbatim from the bootstrap user guide:
+///
+/// ```text
+/// n = number of observations + 1
+/// p = percentile / 100
+/// i = integer part of n*p
+/// f = decimal part of n*p
+/// percentile = (1-f)*x_i + f*x_(i+1)
+/// ```
+///
+/// Returns `None` when the sample is too small to resolve the tail — when
+/// `(n+1)p < 1` there is no `x_i` below the requested quantile and any answer
+/// would be an extrapolation past the smallest observation. That one condition
+/// reproduces every threshold the guide tabulates: **19** samples for 5–95%,
+/// **39** for 2.5–97.5%, **199** for 0.5–99.5%, **1999** for 0.05–99.95%.
+///
+/// `sorted` must be ascending.
+pub fn percentile(sorted: &[f64], pct: f64) -> Option<f64> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let p = pct / 100.0;
+    let n = sorted.len() as f64 + 1.0;
+    let np = n * p;
+    // Both tails: the upper one runs out of data at `(n+1)(1-p) < 1` by the same
+    // argument, which is why PsN quotes a single sample count per interval.
+    if np < 1.0 || np > sorted.len() as f64 {
+        return None;
+    }
+    let i = np.floor();
+    let f = np - i;
+    let idx = i as usize; // 1-based in the formula
+    let lo = sorted[idx - 1];
+    // `i == n-1` lands exactly on the last element, with `f == 0`.
+    let hi = if idx < sorted.len() {
+        sorted[idx]
+    } else {
+        sorted[idx - 1]
+    };
+    Some((1.0 - f) * lo + f * hi)
+}
+
+/// Standard normal quantile — Acklam's rational approximation, relative error
+/// below ~1.15e-9 over the whole range.
+///
+/// Deliberately *not* a bisection on the CDF built from
+/// [`ferx_core::stats::special::erf`], which was the first thing tried here: that
+/// converges exactly, but to the inverse of an `erf` whose own approximation
+/// error is ~1.5e-7, landing `z₀.₉₇₅` at 1.9599628 instead of 1.9599640. Inverting
+/// an approximation gives you the approximation's accuracy, not the bisection's.
+/// The error is irrelevant to a confidence half-width either way; the point is
+/// that a number printed as a normal quantile should be one.
+// Acklam's published coefficients, kept at their published precision so they can
+// be checked against the source rather than against whatever `f64` happens to
+// round them to.
+#[allow(clippy::excessive_precision)]
+pub fn normal_quantile(p: f64) -> f64 {
+    assert!(p > 0.0 && p < 1.0, "normal_quantile: p must be in (0,1)");
+    const A: [f64; 6] = [
+        -3.969_683_028_665_376e1,
+        2.209_460_984_245_205e2,
+        -2.759_285_104_469_687e2,
+        1.383_577_518_672_690e2,
+        -3.066_479_806_614_716e1,
+        2.506_628_277_459_239e0,
+    ];
+    const B: [f64; 5] = [
+        -5.447_609_879_822_406e1,
+        1.615_858_368_580_409e2,
+        -1.556_989_798_598_866e2,
+        6.680_131_188_771_972e1,
+        -1.328_068_155_288_572e1,
+    ];
+    const C: [f64; 6] = [
+        -7.784_894_002_430_293e-3,
+        -3.223_964_580_411_365e-1,
+        -2.400_758_277_161_838e0,
+        -2.549_732_539_343_734e0,
+        4.374_664_141_464_968e0,
+        2.938_163_982_698_783e0,
+    ];
+    const D: [f64; 4] = [
+        7.784_695_709_041_462e-3,
+        3.224_671_290_700_398e-1,
+        2.445_134_137_142_996e0,
+        3.754_408_661_907_416e0,
+    ];
+    const P_LOW: f64 = 0.02425;
+
+    let tail = |q: f64| {
+        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    };
+    if p < P_LOW {
+        tail((-2.0 * p.ln()).sqrt())
+    } else if p > 1.0 - P_LOW {
+        -tail((-2.0 * (1.0 - p).ln()).sqrt())
+    } else {
+        // The central branch is odd in `q = p − 0.5`, so symmetric tails come
+        // out exactly symmetric rather than to within the approximation.
+        let q = p - 0.5;
+        let r = q * q;
+        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
+            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
+    }
+}
+
+/// Whether a replicate is excluded, and why — `None` if it is included.
+///
+/// Applied here, at summary time, rather than when the fit finishes: that is
+/// what lets `--summarize` recompute the whole table from a stored
+/// `raw_results.csv` under different criteria without refitting anything, which
+/// is the PsN behaviour and the reason the raw file carries the diagnostics
+/// rather than only the survivors.
+pub fn exclusion_reason(r: &ReplicateResult, options: &BootstrapOptions) -> Option<&'static str> {
+    if r.error.is_some() {
+        return Some("fit failed");
+    }
+    if options.skip_minimization_terminated && !r.converged {
+        return Some("minimization terminated");
+    }
+    if options.skip_estimate_near_boundary && r.estimate_near_boundary {
+        return Some("estimate near boundary");
+    }
+    if options.skip_covariance_step_terminated && !r.covariance_step_successful {
+        return Some("covariance step terminated");
+    }
+    if options.skip_with_covstep_warnings && r.covariance_step_warnings {
+        return Some("covariance step warnings");
+    }
+    None
+}
+
+/// Compute the summary table from every replicate result.
+///
+/// `original` is the base-model fit (replicate 0); it supplies the reference for
+/// bias and for the standard-error interval, and is never itself part of the
+/// bootstrap distribution.
+pub fn summarize(
+    names: &[String],
+    original: Option<&ReplicateResult>,
+    replicates: &[ReplicateResult],
+    options: &BootstrapOptions,
+) -> BootstrapSummary {
+    let n_completed = replicates.iter().filter(|r| r.error.is_none()).count();
+
+    let mut excluded_counts: Vec<(String, usize)> = Vec::new();
+    let mut included: Vec<&ReplicateResult> = Vec::new();
+    for r in replicates {
+        match exclusion_reason(r, options) {
+            None => included.push(r),
+            Some(reason) => match excluded_counts.iter_mut().find(|(k, _)| k == reason) {
+                Some((_, n)) => *n += 1,
+                None => excluded_counts.push((reason.to_string(), 1)),
+            },
+        }
+    }
+
+    let alpha = (100.0 - options.confidence_level) / 2.0;
+    let z = normal_quantile(1.0 - alpha / 100.0);
+
+    let mut parameters = Vec::with_capacity(names.len());
+    for (j, name) in names.iter().enumerate() {
+        let values: Vec<f64> = included
+            .iter()
+            .filter_map(|r| r.estimates.get(j).copied())
+            .filter(|v| v.is_finite())
+            .collect();
+        let n = values.len();
+        let mean = if n == 0 {
+            f64::NAN
+        } else {
+            values.iter().sum::<f64>() / n as f64
+        };
+        // Sample standard deviation (n−1). The bootstrap distribution is a
+        // sample from the sampling distribution, so the unbiased divisor is the
+        // right one; with n=1 there is no spread to report.
+        let sd = if n > 1 {
+            (values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n as f64 - 1.0)).sqrt()
+        } else {
+            f64::NAN
+        };
+        let mut sorted = values.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).expect("finite values sort"));
+        let median = percentile(&sorted, 50.0).unwrap_or(f64::NAN);
+        let ci_percentile = match (
+            percentile(&sorted, alpha),
+            percentile(&sorted, 100.0 - alpha),
+        ) {
+            (Some(lo), Some(hi)) => Some((lo, hi)),
+            _ => None,
+        };
+        let orig = original.and_then(|o| o.estimates.get(j).copied());
+        parameters.push(ParameterSummary {
+            name: name.clone(),
+            original: orig,
+            mean,
+            bias: orig.map(|o| mean - o),
+            standard_error: sd,
+            median,
+            ci_percentile,
+            ci_standard_error: orig
+                .filter(|_| sd.is_finite())
+                .map(|o| (o - z * sd, o + z * sd)),
+        });
+    }
+
+    let diagnostic_means = diagnostic_means(replicates);
+
+    BootstrapSummary {
+        parameters,
+        n_completed,
+        n_included: included.len(),
+        excluded_by: excluded_counts,
+        confidence_level: options.confidence_level,
+        diagnostic_means,
+    }
+}
+
+/// PsN's `diagnostic.means`: the mean of each per-replicate diagnostic, over
+/// **every** completed replicate rather than only the included ones — the point
+/// of the block is to say how the run as a whole behaved, including the part the
+/// filters removed.
+fn diagnostic_means(replicates: &[ReplicateResult]) -> Vec<(String, f64)> {
+    let completed: Vec<&ReplicateResult> =
+        replicates.iter().filter(|r| r.error.is_none()).collect();
+    if completed.is_empty() {
+        return Vec::new();
+    }
+    let n = completed.len() as f64;
+    let frac = |f: &dyn Fn(&ReplicateResult) -> bool| -> f64 {
+        completed.iter().filter(|r| f(r)).count() as f64 / n
+    };
+    vec![
+        (
+            "minimization_successful".to_string(),
+            frac(&|r| r.converged),
+        ),
+        (
+            "estimate_near_boundary".to_string(),
+            frac(&|r| r.estimate_near_boundary),
+        ),
+        (
+            "covariance_step_successful".to_string(),
+            frac(&|r| r.covariance_step_successful),
+        ),
+        (
+            "covariance_step_warnings".to_string(),
+            frac(&|r| r.covariance_step_warnings),
+        ),
+        (
+            "ofv".to_string(),
+            completed.iter().map(|r| r.ofv).sum::<f64>() / n,
+        ),
+        (
+            "subproblem_est_time".to_string(),
+            completed.iter().map(|r| r.seconds).sum::<f64>() / n,
+        ),
+    ]
+}
+
+#[cfg(test)]
+#[path = "summary_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/bootstrap/summary.rs
+++ b/crates/ferx-tools/src/bootstrap/summary.rs
@@ -204,7 +204,15 @@ pub fn summarize(
     }
 
     let alpha = (100.0 - options.confidence_level) / 2.0;
-    let z = normal_quantile(1.0 - alpha / 100.0);
+    // `normal_quantile` asserts its domain, and this is a `pub` function: a
+    // caller that skipped [`BootstrapOptions::validate`] must get a table with
+    // no normal-approximation interval, not a panic out of a library.
+    // The same open interval `BootstrapOptions::validate` enforces — a level of
+    // exactly 0 or 100 is not merely out of the assertion's domain, it names a
+    // zero-width or infinite interval.
+    let z = (options.confidence_level > 0.0 && options.confidence_level < 100.0)
+        .then(|| normal_quantile(1.0 - alpha / 100.0))
+        .filter(|z| z.is_finite());
 
     let mut parameters = Vec::with_capacity(names.len());
     for (j, name) in names.iter().enumerate() {
@@ -246,9 +254,10 @@ pub fn summarize(
             standard_error: sd,
             median,
             ci_percentile,
-            ci_standard_error: orig
-                .filter(|_| sd.is_finite())
-                .map(|o| (o - z * sd, o + z * sd)),
+            ci_standard_error: match (orig, z) {
+                (Some(o), Some(z)) if sd.is_finite() => Some((o - z * sd, o + z * sd)),
+                _ => None,
+            },
         });
     }
 

--- a/crates/ferx-tools/src/bootstrap/summary_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/summary_tests.rs
@@ -273,6 +273,35 @@ fn excluded_replicates_do_not_enter_the_statistics() {
 }
 
 #[test]
+fn an_out_of_range_confidence_level_drops_the_interval_rather_than_panicking() {
+    // `summarize` is a `pub` function, and `normal_quantile` asserts its domain.
+    // A caller that skipped `BootstrapOptions::validate` must get a table with
+    // no normal-approximation interval, not a panic out of a library.
+    let names = vec!["CL".to_string()];
+    let original = replicate(0, vec![10.0]);
+    let replicates: Vec<ReplicateResult> = (1..=3)
+        .map(|i| replicate(i, vec![9.0 + i as f64]))
+        .collect();
+
+    for level in [100.0, 0.0, -3.0, 250.0] {
+        let s = summarize(
+            &names,
+            Some(&original),
+            &replicates,
+            &BootstrapOptions {
+                confidence_level: level,
+                ..BootstrapOptions::default()
+            },
+        );
+        let p = &s.parameters[0];
+        assert_eq!(p.ci_standard_error, None, "level {level}");
+        // Everything that does not depend on the level is still computed.
+        assert!(p.mean.is_finite(), "level {level}");
+        assert!(p.standard_error.is_finite(), "level {level}");
+    }
+}
+
+#[test]
 fn a_run_with_no_base_fit_reports_no_bias() {
     let names = vec!["CL".to_string()];
     let replicates: Vec<ReplicateResult> = (1..=3).map(|i| replicate(i, vec![i as f64])).collect();

--- a/crates/ferx-tools/src/bootstrap/summary_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/summary_tests.rs
@@ -1,0 +1,284 @@
+use super::*;
+
+fn replicate(index: usize, estimates: Vec<f64>) -> ReplicateResult {
+    ReplicateResult {
+        index,
+        estimates,
+        standard_errors: None,
+        ofv: 100.0,
+        converged: true,
+        estimate_near_boundary: false,
+        covariance_step_successful: true,
+        covariance_step_warnings: false,
+        seconds: 1.0,
+        error: None,
+        delta_ofv: None,
+    }
+}
+
+// ── the PsN percentile estimator ────────────────────────────────────────────
+
+#[test]
+fn percentile_matches_the_hand_computed_weighted_average() {
+    // The guide's formula, worked by hand on [1,2,3,4]:
+    //   n = 4+1 = 5
+    //   p = 0.50 -> n*p = 2.5 -> i=2, f=0.5 -> 0.5*x_2 + 0.5*x_3 = 2.5
+    //   p = 0.25 -> n*p = 1.25 -> i=1, f=0.25 -> 0.75*x_1 + 0.25*x_2 = 1.25
+    let x = [1.0, 2.0, 3.0, 4.0];
+    assert_eq!(percentile(&x, 50.0), Some(2.5));
+    assert_eq!(percentile(&x, 25.0), Some(1.25));
+    assert_eq!(percentile(&x, 75.0), Some(3.75));
+    // Landing exactly on an order statistic: n*p = 5*0.2 = 1.0, f = 0.
+    assert_eq!(percentile(&x, 20.0), Some(1.0));
+    assert_eq!(percentile(&x, 80.0), Some(4.0));
+}
+
+#[test]
+fn percentile_is_none_on_an_empty_sample() {
+    assert_eq!(percentile(&[], 50.0), None);
+}
+
+#[test]
+fn minimum_sample_sizes_are_exactly_the_ones_psn_documents() {
+    // The guide tabulates four thresholds. They are not four rules — they all
+    // fall out of "(n+1)p >= 1", i.e. there must be an order statistic at or
+    // below the requested quantile rather than an extrapolation past the
+    // smallest observation. Pin all four, from both sides.
+    for (interval, n_min) in [
+        ((5.0, 95.0), 19usize),
+        ((2.5, 97.5), 39),
+        ((0.5, 99.5), 199),
+        ((0.05, 99.95), 1999),
+    ] {
+        let (lo_pct, hi_pct) = interval;
+
+        let enough: Vec<f64> = (0..n_min).map(|i| i as f64).collect();
+        assert!(
+            percentile(&enough, lo_pct).is_some(),
+            "{n_min} samples should resolve the {lo_pct}% tail"
+        );
+        assert!(
+            percentile(&enough, hi_pct).is_some(),
+            "{n_min} samples should resolve the {hi_pct}% tail"
+        );
+
+        let too_few: Vec<f64> = (0..n_min - 1).map(|i| i as f64).collect();
+        assert!(
+            percentile(&too_few, lo_pct).is_none(),
+            "{} samples must not resolve the {lo_pct}% tail",
+            n_min - 1
+        );
+        assert!(
+            percentile(&too_few, hi_pct).is_none(),
+            "{} samples must not resolve the {hi_pct}% tail",
+            n_min - 1
+        );
+    }
+}
+
+#[test]
+fn at_the_threshold_the_interval_is_the_extreme_order_statistics() {
+    // n = 19, p = 0.05: n*p = 20*0.05 = 1 exactly, so the 5th percentile is the
+    // minimum and the 95th is the maximum — the widest the data can support.
+    let x: Vec<f64> = (1..=19).map(|i| i as f64).collect();
+    assert_eq!(percentile(&x, 5.0), Some(1.0));
+    assert_eq!(percentile(&x, 95.0), Some(19.0));
+}
+
+// ── the normal quantile ─────────────────────────────────────────────────────
+
+#[test]
+fn normal_quantile_matches_known_values() {
+    let cases = [
+        (0.975, 1.959_963_984_540_054),
+        (0.95, 1.644_853_626_951_472),
+        (0.995, 2.575_829_303_548_901),
+        (0.5, 0.0),
+    ];
+    for (p, expected) in cases {
+        let got = normal_quantile(p);
+        assert!(
+            (got - expected).abs() < 1e-8,
+            "normal_quantile({p}) = {got}, expected {expected}"
+        );
+    }
+    // Symmetric tails come out exactly symmetric: the central branch is odd in
+    // `p - 0.5`, so this is equality, not a tolerance.
+    assert_eq!(normal_quantile(0.025), -normal_quantile(0.975));
+    // The far tails take the other branch, and must still be usable.
+    assert!((normal_quantile(0.0005) + 3.290_526_731_491_896).abs() < 1e-8);
+}
+
+// ── exclusion filters ───────────────────────────────────────────────────────
+
+#[test]
+fn default_filters_drop_terminated_and_boundary_replicates() {
+    let options = BootstrapOptions::default();
+    assert!(options.skip_minimization_terminated);
+    assert!(options.skip_estimate_near_boundary);
+
+    let mut r = replicate(1, vec![1.0]);
+    assert_eq!(exclusion_reason(&r, &options), None);
+
+    r.converged = false;
+    assert_eq!(
+        exclusion_reason(&r, &options),
+        Some("minimization terminated")
+    );
+
+    r.converged = true;
+    r.estimate_near_boundary = true;
+    assert_eq!(
+        exclusion_reason(&r, &options),
+        Some("estimate near boundary")
+    );
+
+    // A fit that returned Err is excluded regardless of the filters — there is
+    // nothing to include.
+    let mut failed = replicate(2, vec![]);
+    failed.error = Some("boom".to_string());
+    let permissive = BootstrapOptions {
+        skip_minimization_terminated: false,
+        skip_estimate_near_boundary: false,
+        ..BootstrapOptions::default()
+    };
+    assert_eq!(exclusion_reason(&failed, &permissive), Some("fit failed"));
+}
+
+#[test]
+fn disabling_a_filter_keeps_the_replicate() {
+    let options = BootstrapOptions {
+        skip_minimization_terminated: false,
+        ..BootstrapOptions::default()
+    };
+    let mut r = replicate(1, vec![1.0]);
+    r.converged = false;
+    assert_eq!(exclusion_reason(&r, &options), None);
+}
+
+#[test]
+fn covariance_filters_only_fire_when_asked_for() {
+    let mut r = replicate(1, vec![1.0]);
+    r.covariance_step_successful = false;
+    r.covariance_step_warnings = true;
+    assert_eq!(exclusion_reason(&r, &BootstrapOptions::default()), None);
+
+    let strict = BootstrapOptions {
+        keep_covariance: true,
+        skip_covariance_step_terminated: true,
+        ..BootstrapOptions::default()
+    };
+    assert_eq!(
+        exclusion_reason(&r, &strict),
+        Some("covariance step terminated")
+    );
+
+    let warn = BootstrapOptions {
+        keep_covariance: true,
+        skip_with_covstep_warnings: true,
+        ..BootstrapOptions::default()
+    };
+    r.covariance_step_successful = true;
+    assert_eq!(
+        exclusion_reason(&r, &warn),
+        Some("covariance step warnings")
+    );
+}
+
+// ── the summary table ───────────────────────────────────────────────────────
+
+#[test]
+fn summary_reports_mean_bias_sd_and_median() {
+    let names = vec!["CL".to_string()];
+    let original = replicate(0, vec![10.0]);
+    let replicates: Vec<ReplicateResult> = [8.0, 9.0, 10.0, 11.0, 14.0]
+        .iter()
+        .enumerate()
+        .map(|(i, v)| replicate(i + 1, vec![*v]))
+        .collect();
+
+    let s = summarize(
+        &names,
+        Some(&original),
+        &replicates,
+        &BootstrapOptions::default(),
+    );
+    let p = &s.parameters[0];
+
+    assert_eq!(p.original, Some(10.0));
+    assert!((p.mean - 10.4).abs() < 1e-12);
+    // Bias is the bootstrap mean minus the original estimate.
+    assert!((p.bias.unwrap() - 0.4).abs() < 1e-12);
+    // Sample SD (n-1): values 8,9,10,11,14 about 10.4.
+    let expected_sd = (((8.0f64 - 10.4).powi(2)
+        + (9.0f64 - 10.4).powi(2)
+        + (10.0f64 - 10.4).powi(2)
+        + (11.0f64 - 10.4).powi(2)
+        + (14.0f64 - 10.4).powi(2))
+        / 4.0)
+        .sqrt();
+    assert!((p.standard_error - expected_sd).abs() < 1e-12);
+    assert!((p.median - 10.0).abs() < 1e-12);
+
+    // Five samples cannot resolve a 2.5% tail (39 needed), so no percentile CI —
+    // but the normal-approximation interval is still available.
+    assert!(p.ci_percentile.is_none());
+    // Against `normal_quantile` itself: this pins the wiring (which quantile,
+    // applied to which centre and spread), while the quantile's own accuracy is
+    // pinned by `normal_quantile_matches_known_values`.
+    let z = normal_quantile(0.975);
+    let (lo, hi) = p.ci_standard_error.unwrap();
+    assert!((lo - (10.0 - z * expected_sd)).abs() < 1e-12);
+    assert!((hi - (10.0 + z * expected_sd)).abs() < 1e-12);
+
+    assert_eq!(s.n_completed, 5);
+    assert_eq!(s.n_included, 5);
+}
+
+#[test]
+fn excluded_replicates_do_not_enter_the_statistics() {
+    let names = vec!["CL".to_string()];
+    let original = replicate(0, vec![10.0]);
+    let mut replicates: Vec<ReplicateResult> = (1..=4).map(|i| replicate(i, vec![10.0])).collect();
+    // One wild non-converged replicate, which would move the mean by 22.5 if it
+    // were counted.
+    replicates.push({
+        let mut r = replicate(5, vec![100.0]);
+        r.converged = false;
+        r
+    });
+
+    let s = summarize(
+        &names,
+        Some(&original),
+        &replicates,
+        &BootstrapOptions::default(),
+    );
+    assert_eq!(s.n_completed, 5);
+    assert_eq!(s.n_included, 4);
+    assert!((s.parameters[0].mean - 10.0).abs() < 1e-12);
+    assert_eq!(
+        s.excluded_by,
+        vec![("minimization terminated".to_string(), 1)]
+    );
+
+    // The diagnostic means describe the whole run, including what was filtered.
+    let converged = s
+        .diagnostic_means
+        .iter()
+        .find(|(k, _)| k == "minimization_successful")
+        .unwrap()
+        .1;
+    assert!((converged - 0.8).abs() < 1e-12);
+}
+
+#[test]
+fn a_run_with_no_base_fit_reports_no_bias() {
+    let names = vec!["CL".to_string()];
+    let replicates: Vec<ReplicateResult> = (1..=3).map(|i| replicate(i, vec![i as f64])).collect();
+    let s = summarize(&names, None, &replicates, &BootstrapOptions::default());
+    assert_eq!(s.parameters[0].original, None);
+    assert_eq!(s.parameters[0].bias, None);
+    assert_eq!(s.parameters[0].ci_standard_error, None);
+    assert!((s.parameters[0].mean - 2.0).abs() < 1e-12);
+}

--- a/crates/ferx-tools/src/lib.rs
+++ b/crates/ferx-tools/src/lib.rs
@@ -17,9 +17,10 @@
 //! `api/ferx-core-public-api.txt` is the CI-enforced record of every item that
 //! crossed the line (A2).
 //!
-//! This crate is currently a placeholder: the workspace mechanics and the API
-//! gate land first (#1114 P1), the tools themselves after the prerequisite API
-//! gaps G1 (thread-pool control) and G2 (quiet inner fits) are closed.
+//! First inhabitant: [`bootstrap`] (#1140), the non-parametric case bootstrap
+//! at `PsN::bootstrap` feature parity. It is the boundary rule made concrete —
+//! 200+ calls to [`ferx_core::fit`] over resampled data, and no numerics of its
+//! own.
 
 /// The `ferx-core` version this build of `ferx-tools` links against.
 ///
@@ -50,3 +51,5 @@ mod tests {
         );
     }
 }
+
+pub mod bootstrap;

--- a/crates/ferx-tools/tests/bootstrap_end_to_end.rs
+++ b/crates/ferx-tools/tests/bootstrap_end_to_end.rs
@@ -1,0 +1,386 @@
+//! Tier-2 end-to-end checks for the bootstrap (#1140), on a real model and
+//! dataset but never to convergence: every fit here is capped at a handful of
+//! outer iterations, or is an evaluation (`outer_maxiter = 0`).
+//!
+//! The interesting one is the **degenerate oracle**: a "resample" that draws
+//! every subject exactly once must be bit-for-bit indistinguishable from an
+//! ordinary fit on the original population. That is what pins the replicate
+//! population against the engine — a dropped covariate map, a lost occasion
+//! column or a mishandled dose record would change the objective, and nothing
+//! else in the bootstrap would notice, because there is no second copy of the
+//! reconstruction to disagree with it.
+
+use std::path::Path;
+
+use ferx_core::{fit, prepare_run, FitOptions, PreparedRun};
+use ferx_tools::bootstrap::{
+    flatten_estimates, params_from_estimates, resample, run_bootstrap, BootstrapOptions, Replicate,
+    SampleSize,
+};
+
+const MODEL: &str = "../../examples/warfarin.ferx";
+const DATA: &str = "../../data/warfarin.csv";
+
+fn prepared() -> PreparedRun {
+    prepare_run(MODEL, Some(DATA)).expect("warfarin model + data load")
+}
+
+/// An evaluation, not a fit: `outer_maxiter = 0` is ferx's `MAXEVAL=0`.
+fn eval_options(base: &FitOptions) -> FitOptions {
+    let mut o = base.clone();
+    o.outer_maxiter = 0;
+    o.run_covariance_step = false;
+    o.verbose = false;
+    o.threads = Some(1);
+    o.checkpoint = false;
+    o
+}
+
+#[test]
+fn an_identity_resample_reproduces_the_original_fit_exactly() {
+    let p = prepared();
+    let options = eval_options(&p.parsed.fit_options);
+
+    let direct = fit(&p.parsed.model, &p.population, &p.init_params, &options)
+        .expect("evaluation on the original population");
+
+    let identity = Replicate {
+        index: 1,
+        keys: (0..p.population.subjects.len()).collect(),
+    };
+    let rebuilt = resample::build_population(&p.population, &identity);
+    let via_resample = fit(&p.parsed.model, &rebuilt, &p.init_params, &options)
+        .expect("evaluation on the rebuilt population");
+
+    assert_eq!(
+        rebuilt.subjects.len(),
+        p.population.subjects.len(),
+        "the identity replicate changed the subject count"
+    );
+    // Bit-for-bit. Anything less would let a reconstruction that is merely
+    // close pass, and "merely close" is exactly what a lost covariate looks
+    // like at this scale.
+    assert_eq!(
+        via_resample.ofv.to_bits(),
+        direct.ofv.to_bits(),
+        "identity resample gave OFV {} vs {}",
+        via_resample.ofv,
+        direct.ofv
+    );
+    assert_eq!(via_resample.n_obs, direct.n_obs);
+    assert_eq!(via_resample.n_subjects, direct.n_subjects);
+}
+
+#[test]
+fn a_duplicated_subject_contributes_twice() {
+    // The other side of the oracle: drawing one subject twice must add its
+    // likelihood contribution again, as an independent individual. If the
+    // duplicate were silently merged (or dropped as a repeated ID), the
+    // observation count would not move.
+    let p = prepared();
+    let options = eval_options(&p.parsed.fit_options);
+
+    let mut keys: Vec<usize> = (0..p.population.subjects.len()).collect();
+    keys.push(0);
+    keys.sort_unstable();
+    let doubled = resample::build_population(
+        &p.population,
+        &Replicate {
+            index: 1,
+            keys: keys.clone(),
+        },
+    );
+    assert_eq!(doubled.subjects.len(), p.population.subjects.len() + 1);
+
+    let base = fit(&p.parsed.model, &p.population, &p.init_params, &options).expect("base eval");
+    let with_dup =
+        fit(&p.parsed.model, &doubled, &p.init_params, &options).expect("duplicated eval");
+
+    assert_eq!(
+        with_dup.n_obs,
+        base.n_obs + p.population.subjects[0].observations.len(),
+        "the duplicate's observations did not enter the fit"
+    );
+    assert_eq!(with_dup.n_subjects, base.n_subjects + 1);
+
+    // The two copies are the same data under different labels, so the engine
+    // must give them identical individual results. If the duplicate had been
+    // merged into one subject with twice the records, or dropped as a repeated
+    // ID, this is where it shows.
+    assert_eq!(with_dup.subjects[0].id, p.population.subjects[0].id);
+    assert_eq!(
+        with_dup.subjects[1].id,
+        format!("{}#2", p.population.subjects[0].id)
+    );
+    assert_eq!(
+        with_dup.subjects[0].ofv_contribution.to_bits(),
+        with_dup.subjects[1].ofv_contribution.to_bits(),
+    );
+    assert_eq!(with_dup.subjects[0].eta, with_dup.subjects[1].eta);
+
+    // Each additional identical copy must move the objective by the *same*
+    // amount. At fixed parameters the individual contributions are independent,
+    // so the increments are equal by construction — and comparing increments
+    // sidesteps whatever constant terms `ofv_contribution` does or does not
+    // carry, which is a convention this test has no business pinning.
+    let tripled = resample::build_population(
+        &p.population,
+        &Replicate {
+            index: 2,
+            keys: {
+                let mut k = keys.clone();
+                k.push(0);
+                k.sort_unstable();
+                k
+            },
+        },
+    );
+    let with_two_dups =
+        fit(&p.parsed.model, &tripled, &p.init_params, &options).expect("tripled eval");
+
+    let first = with_dup.ofv - base.ofv;
+    let second = with_two_dups.ofv - with_dup.ofv;
+    assert!(
+        first.abs() > 1.0,
+        "duplicating a subject did not change the objective at all ({first})"
+    );
+    assert!(
+        (first - second).abs() < 1e-9 * first.abs(),
+        "the 2nd and 3rd copies of the same subject contributed {first} and {second}"
+    );
+}
+
+#[test]
+fn the_flat_parameter_vector_round_trips_through_a_real_model() {
+    // `--update-inits` and `--dofv` both rebuild `ModelParameters` from the flat
+    // vector rather than from a `FitResult`. Evaluating the rebuilt parameters
+    // must give back exactly the OFV they came from — the Δofv of a fit against
+    // itself is 0, which is the `--dofv` sanity check.
+    let p = prepared();
+    let options = eval_options(&p.parsed.fit_options);
+
+    let evaluated = fit(&p.parsed.model, &p.population, &p.init_params, &options).expect("eval");
+    let flat = flatten_estimates(&p.init_params, &evaluated);
+    let rebuilt = params_from_estimates(&p.init_params, &flat);
+    let again = fit(&p.parsed.model, &p.population, &rebuilt, &options).expect("re-eval");
+
+    assert_eq!(
+        again.ofv.to_bits(),
+        evaluated.ofv.to_bits(),
+        "delta-ofv against the same parameters must be exactly 0, got {}",
+        again.ofv - evaluated.ofv
+    );
+}
+
+#[test]
+fn a_small_bootstrap_runs_end_to_end_and_writes_every_artefact() {
+    let mut p = prepared();
+    // Tier 2: a handful of outer iterations, no convergence loop.
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let options = BootstrapOptions {
+        samples: 3,
+        seed: 42,
+        threads: Some(1),
+        directory: Some(dir.path().to_path_buf()),
+        ..BootstrapOptions::default()
+    };
+    let result = run_bootstrap(&p, &options).expect("bootstrap runs");
+
+    assert_eq!(result.replicates.len(), 3);
+    assert_eq!(result.draws.len(), 3);
+    assert!(result.original.is_some(), "the base model should have run");
+    assert_eq!(result.subject_ids.len(), p.population.subjects.len());
+
+    // Warfarin: 3 thetas + 3 diagonal omegas + 1 sigma.
+    assert_eq!(result.parameter_names.len(), 7);
+    assert_eq!(result.parameter_names[0], "TVCL");
+    assert!(result
+        .parameter_names
+        .iter()
+        .any(|n| n == "OMEGA(ETA_CL,ETA_CL)"));
+    assert_eq!(result.n_estimated_parameters, 7);
+
+    for r in &result.replicates {
+        assert!(
+            r.error.is_none(),
+            "replicate {} failed: {:?}",
+            r.index,
+            r.error
+        );
+        assert_eq!(r.estimates.len(), result.parameter_names.len());
+        assert!(r.ofv.is_finite());
+        // No covariance step by default, so no per-replicate SEs.
+        assert!(r.standard_errors.is_none());
+    }
+
+    for name in [
+        "raw_results.csv",
+        "bootstrap_results.csv",
+        "bootstrap_diagnostics.csv",
+        "all_individuals1.csv",
+        "included_individuals1.csv",
+        "included_keys1.csv",
+        "sample_keys1.csv",
+    ] {
+        let path = dir.path().join(name);
+        assert!(path.exists(), "{name} was not written");
+        assert!(
+            std::fs::metadata(&path).unwrap().len() > 0,
+            "{name} is empty"
+        );
+    }
+    assert!(!dir.path().join("delta_ofv.csv").exists());
+}
+
+#[test]
+fn the_drawn_datasets_do_not_depend_on_the_thread_count() {
+    // The reproducibility claim, on the real model: the same seed must give the
+    // same replicates whether the run is serial or parallel. PsN's guide
+    // documents the opposite behaviour as a known wart.
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 1;
+
+    let base = BootstrapOptions {
+        samples: 4,
+        seed: 7,
+        directory: None,
+        run_base_model: false,
+        ..BootstrapOptions::default()
+    };
+    let serial = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            threads: Some(1),
+            ..base.clone()
+        },
+    )
+    .expect("serial bootstrap");
+    let parallel = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            threads: Some(4),
+            ..base
+        },
+    )
+    .expect("parallel bootstrap");
+
+    assert_eq!(serial.draws, parallel.draws);
+    // And the results come back in replicate order regardless of who finished
+    // first, so row j of raw_results is replicate j either way.
+    let indices: Vec<usize> = parallel.replicates.iter().map(|r| r.index).collect();
+    assert_eq!(indices, vec![1, 2, 3, 4]);
+}
+
+/// The shipped warfarin dataset carries no grouping column, so write a copy with
+/// one: `STUDY` alternates by ID, and is constant within each subject.
+///
+/// Deriving it from the real file rather than hand-writing three rows is the
+/// point — the strata have to be matched against the same IDs the reader
+/// produced, through the same header conventions.
+fn warfarin_with_study_column() -> tempfile::NamedTempFile {
+    use std::io::Write;
+    let src = std::fs::read_to_string(DATA).expect("warfarin data");
+    let mut lines = src.lines();
+    let header = lines.next().expect("header row");
+    let id_col = header
+        .split(',')
+        .position(|h| h.trim().eq_ignore_ascii_case("ID"))
+        .expect("an ID column");
+
+    let mut out = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("temp file");
+    writeln!(out, "{header},STUDY").expect("write header");
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let id: u64 = line
+            .split(',')
+            .nth(id_col)
+            .and_then(|s| s.trim().parse().ok())
+            .expect("numeric ID");
+        writeln!(out, "{line},{}", 1001 + id % 2).expect("write row");
+    }
+    out.flush().expect("flush");
+    out
+}
+
+#[test]
+fn a_stratified_run_keeps_every_replicate_at_the_stratum_sizes() {
+    let p = prepared();
+    let data = warfarin_with_study_column();
+    let strata = ferx_tools::bootstrap::strata_from_csv(
+        data.path().to_str().expect("utf-8 path"),
+        &p.parsed.column_map,
+        &p.population,
+        "STUDY",
+    )
+    .expect("STUDY is constant within each subject");
+
+    // Non-vacuity: the split has to be a real one, or "composition preserved"
+    // is trivially true.
+    assert_eq!(strata.groups.len(), 2, "expected two strata");
+    assert!(strata.groups.values().all(|g| !g.is_empty()));
+    assert_eq!(
+        strata.groups.values().map(|g| g.len()).sum::<usize>(),
+        p.population.subjects.len()
+    );
+
+    let allocation = strata.allocation(&SampleSize::Original).unwrap();
+    assert_eq!(
+        allocation.iter().map(|(_, n)| *n).collect::<Vec<_>>(),
+        strata.groups.values().map(|g| g.len()).collect::<Vec<_>>()
+    );
+
+    for index in 1..=10 {
+        let replicate = resample::draw(&strata, &allocation, 11, index);
+        for (label, group) in &strata.groups {
+            let n = replicate.keys.iter().filter(|k| group.contains(k)).count();
+            assert_eq!(
+                n,
+                group.len(),
+                "replicate {index}: stratum `{label}` drew {n}, expected {}",
+                group.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn a_stratification_column_that_varies_within_a_subject_is_refused_on_real_data() {
+    use std::io::Write;
+    // Same dataset, but the column now changes between records of one subject —
+    // PsN's "at least one individual has multiple values" error.
+    let src = std::fs::read_to_string(DATA).expect("warfarin data");
+    let mut lines = src.lines();
+    let header = lines.next().expect("header row");
+    let mut file = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("temp file");
+    writeln!(file, "{header},STUDY").expect("write header");
+    for (i, line) in lines.filter(|l| !l.trim().is_empty()).enumerate() {
+        writeln!(file, "{line},{}", 1001 + (i as u64 % 2)).expect("write row");
+    }
+    file.flush().expect("flush");
+
+    let p = prepared();
+    let err = ferx_tools::bootstrap::strata_from_csv(
+        file.path().to_str().expect("utf-8 path"),
+        &p.parsed.column_map,
+        &p.population,
+        "STUDY",
+    )
+    .unwrap_err();
+    assert!(err.contains("more than one value"), "{err}");
+}
+
+#[test]
+fn a_missing_model_file_is_an_error_not_a_panic() {
+    assert!(prepare_run("does-not-exist.ferx", Some(DATA)).is_err());
+    assert!(Path::new(MODEL).exists(), "the fixture moved");
+}

--- a/crates/ferx-tools/tests/bootstrap_end_to_end.rs
+++ b/crates/ferx-tools/tests/bootstrap_end_to_end.rs
@@ -384,3 +384,237 @@ fn a_missing_model_file_is_an_error_not_a_panic() {
     assert!(prepare_run("does-not-exist.ferx", Some(DATA)).is_err());
     assert!(Path::new(MODEL).exists(), "the fixture moved");
 }
+
+// ── option validation ───────────────────────────────────────────────────────
+
+/// A prepared run capped at one outer iteration, for the option-validation
+/// checks below. Most of them reject before any fit happens.
+fn quick() -> PreparedRun {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 1;
+    p
+}
+
+fn err_of(options: BootstrapOptions) -> String {
+    match run_bootstrap(&quick(), &options) {
+        Ok(_) => panic!("expected an error"),
+        Err(e) => e,
+    }
+}
+
+#[test]
+fn zero_samples_is_refused() {
+    let err = err_of(BootstrapOptions {
+        samples: 0,
+        directory: None,
+        ..BootstrapOptions::default()
+    });
+    assert!(err.contains("--samples"), "{err}");
+}
+
+#[test]
+fn a_confidence_level_outside_zero_to_a_hundred_is_refused() {
+    for level in [0.0, 100.0, 150.0, -5.0] {
+        let err = err_of(BootstrapOptions {
+            confidence_level: level,
+            samples: 1,
+            directory: None,
+            ..BootstrapOptions::default()
+        });
+        assert!(err.contains("--ci"), "level {level}: {err}");
+    }
+}
+
+#[test]
+fn a_covstep_filter_without_the_covariance_step_is_refused() {
+    // The filter reads a diagnostic that only exists when the step ran. Silently
+    // ignoring it would drop a filter the user asked for.
+    for options in [
+        BootstrapOptions {
+            skip_covariance_step_terminated: true,
+            ..BootstrapOptions::default()
+        },
+        BootstrapOptions {
+            skip_with_covstep_warnings: true,
+            ..BootstrapOptions::default()
+        },
+    ] {
+        let err = err_of(BootstrapOptions {
+            samples: 1,
+            directory: None,
+            ..options
+        });
+        assert!(err.contains("--keep-covariance"), "{err}");
+    }
+}
+
+#[test]
+fn an_allocation_that_draws_nothing_is_refused() {
+    let err = err_of(BootstrapOptions {
+        samples: 1,
+        sample_size: SampleSize::Total(0),
+        directory: None,
+        ..BootstrapOptions::default()
+    });
+    assert!(err.contains("0 subjects"), "{err}");
+}
+
+#[test]
+fn a_missing_stratification_column_stops_the_run() {
+    let err = err_of(BootstrapOptions {
+        samples: 1,
+        stratify_on: Some("NO_SUCH_COLUMN".to_string()),
+        directory: None,
+        ..BootstrapOptions::default()
+    });
+    assert!(err.contains("NO_SUCH_COLUMN"), "{err}");
+}
+
+#[test]
+fn dofv_without_a_base_fit_is_refused() {
+    // Δofv is measured against the original fit's OFV; there is no reference
+    // without it.
+    let err = err_of(BootstrapOptions {
+        samples: 1,
+        dofv: true,
+        run_base_model: false,
+        directory: None,
+        ..BootstrapOptions::default()
+    });
+    assert!(err.contains("--no-run-base-model"), "{err}");
+}
+
+// ── the optional paths ──────────────────────────────────────────────────────
+
+#[test]
+fn keep_covariance_populates_the_per_replicate_standard_errors() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 1;
+
+    let plain = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 1,
+            threads: Some(1),
+            run_base_model: false,
+            directory: None,
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("bootstrap");
+    assert!(plain.replicates[0].standard_errors.is_none());
+
+    let with_cov = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 1,
+            threads: Some(1),
+            keep_covariance: true,
+            run_base_model: false,
+            directory: None,
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("bootstrap with covariance");
+    let se = with_cov.replicates[0]
+        .standard_errors
+        .as_ref()
+        .expect("covariance step ran, so SEs exist");
+    assert_eq!(se.len(), with_cov.parameter_names.len());
+    assert!(se.iter().all(|v| v.is_finite() && *v >= 0.0), "{se:?}");
+}
+
+#[test]
+fn no_run_base_model_leaves_bias_and_the_normal_interval_undefined() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 1;
+    let result = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 2,
+            threads: Some(1),
+            run_base_model: false,
+            directory: None,
+            // These fits are capped at one outer iteration, so none of them
+            // converges. Keeping the default filter on would exclude every
+            // sample and leave the statistics NaN — correct behaviour, but it
+            // would make this test vacuous about the thing it is checking.
+            skip_minimization_terminated: false,
+            skip_estimate_near_boundary: false,
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("bootstrap");
+
+    assert!(result.original.is_none());
+    assert_eq!(result.summary.n_included, 2);
+    for p in &result.summary.parameters {
+        assert!(p.original.is_none());
+        assert!(p.bias.is_none(), "bias needs a reference fit");
+        assert!(p.ci_standard_error.is_none());
+        // The bootstrap's own statistics are still there.
+        assert!(p.mean.is_finite());
+    }
+}
+
+#[test]
+fn a_run_whose_samples_all_terminate_reports_nothing_included() {
+    // The complement of the test above, and the reason the CLI exits non-zero
+    // on it: with the default filters and fits that cannot converge, every
+    // sample is excluded and there is no interval to report. That must show up
+    // as `n_included == 0` rather than as a plausible-looking table.
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 1;
+    let result = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 2,
+            threads: Some(1),
+            run_base_model: false,
+            directory: None,
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("bootstrap");
+
+    assert_eq!(result.summary.n_completed, 2, "the fits themselves ran");
+    assert_eq!(result.summary.n_included, 0);
+    assert!(!result.summary.excluded_by.is_empty());
+    assert!(result.summary.parameters.iter().all(|p| p.mean.is_nan()));
+}
+
+#[test]
+fn dofv_is_non_negative_and_written_out() {
+    // Evaluating any other parameter vector on the original data must score
+    // worse than the original fit's own optimum, so every Δofv is ≥ 0. That is
+    // the cheapest real check on the whole evaluation path.
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let result = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 2,
+            seed: 9,
+            threads: Some(1),
+            dofv: true,
+            directory: Some(dir.path().to_path_buf()),
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("bootstrap with dofv");
+
+    for r in &result.replicates {
+        let delta = r.delta_ofv.expect("every completed replicate has a Δofv");
+        assert!(
+            delta >= -1e-6,
+            "replicate {} has a negative Δofv ({delta}), which would mean the base fit \
+             was not at its own optimum",
+            r.index
+        );
+    }
+    let written = std::fs::read_to_string(dir.path().join("delta_ofv.csv")).expect("delta_ofv.csv");
+    assert!(written.starts_with("sample,delta_ofv"));
+    assert_eq!(written.lines().count(), 3, "header + one row per replicate");
+}

--- a/crates/ferx-tools/tests/bootstrap_end_to_end.rs
+++ b/crates/ferx-tools/tests/bootstrap_end_to_end.rs
@@ -521,7 +521,13 @@ fn keep_covariance_populates_the_per_replicate_standard_errors() {
         .as_ref()
         .expect("covariance step ran, so SEs exist");
     assert_eq!(se.len(), with_cov.parameter_names.len());
-    assert!(se.iter().all(|v| v.is_finite() && *v >= 0.0), "{se:?}");
+    // Warfarin has a diagonal Omega and no IOV, so core reports an SE for every
+    // coordinate — none of them may be absent here.
+    assert!(
+        se.iter()
+            .all(|v| v.is_some_and(|v| v.is_finite() && v >= 0.0)),
+        "{se:?}"
+    );
 }
 
 #[test]
@@ -581,6 +587,155 @@ fn a_run_whose_samples_all_terminate_reports_nothing_included() {
     assert_eq!(result.summary.n_included, 0);
     assert!(!result.summary.excluded_by.is_empty());
     assert!(result.summary.parameters.iter().all(|p| p.mean.is_nan()));
+}
+
+// ── IOV and block Omega ─────────────────────────────────────────────────────
+
+const IOV_MODEL: &str = "../../examples/warfarin_iov.ferx";
+const IOV_DATA: &str = "../../data/warfarin_iov.csv";
+const BLOCK_MODEL: &str = "../../examples/warfarin_block_omega.ferx";
+
+#[test]
+fn an_iov_model_carries_its_kappa_through_the_whole_flat_vector() {
+    // Regression for the first review finding: `parameter_names` /
+    // `flatten_estimates` stopped after theta, BSV Omega and sigma, so KAPPA got
+    // no bootstrap SE or CI, `--update-inits` did not carry the base fit's
+    // KAPPA, and `--dofv` evaluated a parameter vector that was not the
+    // replicate's. All three failures were silent — the run succeeded and simply
+    // did not mention the parameter.
+    let mut p = prepare_run(IOV_MODEL, Some(IOV_DATA)).expect("IOV model + data load");
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    assert!(
+        p.init_params.omega_iov.is_some(),
+        "the fixture stopped being an IOV model"
+    );
+
+    let names = ferx_tools::bootstrap::parameter_names(&p.init_params);
+    assert!(
+        names.iter().any(|n| n == "OMEGA_IOV(KAPPA_CL,KAPPA_CL)"),
+        "KAPPA is missing from the parameter vector: {names:?}"
+    );
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let result = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 2,
+            seed: 3,
+            threads: Some(1),
+            dofv: true,
+            skip_minimization_terminated: false,
+            skip_estimate_near_boundary: false,
+            directory: Some(dir.path().to_path_buf()),
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("IOV bootstrap");
+
+    let kappa = result
+        .parameter_names
+        .iter()
+        .position(|n| n == "OMEGA_IOV(KAPPA_CL,KAPPA_CL)")
+        .expect("KAPPA is a bootstrap parameter");
+
+    // It is estimated, summarised, and written out — not merely named.
+    for r in &result.replicates {
+        assert!(
+            r.estimates[kappa].is_finite() && r.estimates[kappa] > 0.0,
+            "replicate {} has no KAPPA estimate",
+            r.index
+        );
+    }
+    let summary = &result.summary.parameters[kappa];
+    assert_eq!(summary.name, "OMEGA_IOV(KAPPA_CL,KAPPA_CL)");
+    assert!(summary.mean.is_finite());
+    assert!(summary.bias.is_some(), "bias needs the base fit's KAPPA");
+
+    let header = std::fs::read_to_string(dir.path().join("raw_results.csv")).expect("raw_results");
+    assert!(header.lines().next().unwrap().contains("OMEGA_IOV"));
+
+    // `--update-inits` must hand the replicates the base fit's KAPPA, not the
+    // model file's starting value.
+    let base = result.original.as_ref().expect("base fit");
+    let rebuilt = params_from_estimates(&p.init_params, &base.estimates);
+    let rebuilt_kappa = rebuilt
+        .omega_iov
+        .as_ref()
+        .expect("the rebuild keeps the IOV block")
+        .matrix[(0, 0)];
+    assert!(
+        (rebuilt_kappa - base.estimates[kappa]).abs() < 1e-12,
+        "the round trip lost KAPPA: {rebuilt_kappa} vs {}",
+        base.estimates[kappa]
+    );
+}
+
+#[test]
+fn a_block_omega_lines_its_standard_errors_up_with_its_names() {
+    // Regression for the third review finding. `FitResult::se_omega` is the
+    // *column-major* lower triangle and carries structural zeros; the flat
+    // vector here is row-major and omits them. Concatenating the two produced a
+    // longer vector than there are names, so from the block's third element on
+    // every SE was labelled with someone else's parameter and the sigma SE was
+    // pushed off the end entirely.
+    //
+    // `warfarin_block_omega.ferx` is the case that shows it: a 2x2 block over
+    // (ETA_CL, ETA_V) plus a standalone ETA_KA, so the lower triangle has six
+    // slots of which two are structural zeros.
+    let mut p = prepare_run(BLOCK_MODEL, Some(DATA)).expect("block-omega model loads");
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let names = ferx_tools::bootstrap::parameter_names(&p.init_params);
+    let omega_names: Vec<&String> = names.iter().filter(|n| n.starts_with("OMEGA(")).collect();
+    assert_eq!(
+        omega_names,
+        vec![
+            "OMEGA(ETA_CL,ETA_CL)",
+            "OMEGA(ETA_V,ETA_CL)",
+            "OMEGA(ETA_V,ETA_V)",
+            "OMEGA(ETA_KA,ETA_KA)",
+        ],
+        "the free lower triangle must skip the two structural zeros"
+    );
+
+    let result = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            samples: 1,
+            seed: 2,
+            threads: Some(1),
+            keep_covariance: true,
+            skip_minimization_terminated: false,
+            skip_estimate_near_boundary: false,
+            directory: None,
+            ..BootstrapOptions::default()
+        },
+    )
+    .expect("block-omega bootstrap");
+
+    let base = result.original.as_ref().expect("base fit");
+    let se = base
+        .standard_errors
+        .as_ref()
+        .expect("the base fit runs its covariance step");
+
+    // The decisive check: one SE per name. The old concatenation produced ten
+    // entries against eight names on exactly this model.
+    assert_eq!(
+        se.len(),
+        result.parameter_names.len(),
+        "SE vector length {} does not match {} parameters",
+        se.len(),
+        result.parameter_names.len()
+    );
+    assert_eq!(se.len(), base.estimates.len());
+    // And every one of them is a real, reported SE — no structural-zero slot
+    // leaked in, and the sigma SE is still on the end rather than shifted off it.
+    for (name, value) in result.parameter_names.iter().zip(se) {
+        let v = value.unwrap_or_else(|| panic!("no SE reported for {name}"));
+        assert!(v.is_finite() && v >= 0.0, "{name} has SE {v}");
+    }
 }
 
 #[test]

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -101,6 +101,9 @@ website:
           - estimation/categorical.qmd
           - estimation/ctmm.qmd
           - estimation/mixture.qmd
+      - text: "Tools"
+        contents:
+          - tools/bootstrap.qmd
       - text: "Data Format"
         href: data-format.qmd
       - text: "CLI Reference"

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -14,7 +14,9 @@ ferx <model.ferx> --data <data.csv> [--output <run.fitrx>] [--include-data] [--i
 ferx <model.ferx> --simulate          [--output <run.fitrx>]
 ferx check <model.ferx> [--data <data.csv>] [--json]
 ferx summary <run.fitrx> [<run2.fitrx> ...]
-ferx --help                    # or -h; also: ferx check --help, ferx summary --help
+ferx bootstrap <model.ferx> [--data <data.csv>] [--samples N] [--seed N] [--stratify-on COL]
+ferx --help                    # or -h; also: ferx check --help, ferx summary --help,
+                               # ferx bootstrap --help
 ```
 
 ## Commands
@@ -34,6 +36,23 @@ ferx model.ferx --simulate
 ```
 
 Parses the model file, generates simulated data from the `[simulation]` block, and fits the model to the simulated data. Requires a `[simulation]` block in the model file.
+
+### Bootstrap (`bootstrap`)
+
+```bash
+ferx bootstrap model.ferx --data data.csv --samples 200 --seed 12345 --threads 8
+```
+
+Resamples subjects with replacement, refits the model to each replicate dataset,
+and reports bias, standard errors and confidence intervals from the spread of the
+estimates — the non-parametric case bootstrap, at `PsN::bootstrap` feature parity.
+Writes PsN-named CSV artefacts to `{model}-bootstrap/`.
+
+Unlike a fit, this is a *tool*: it lives in the `ferx-tools` crate and calls the
+estimation engine many times without changing it. See
+[Bootstrap](tools/bootstrap.qmd) for the options, the stratification rules, the
+confidence-interval estimator, and a worked comparison against the covariance
+step's standard errors.
 
 ### Validate without Fitting (`check`)
 

--- a/docs/tools/bootstrap.qmd
+++ b/docs/tools/bootstrap.qmd
@@ -1,0 +1,264 @@
+---
+pagetitle: "Bootstrap"
+description-meta: "Non-parametric case bootstrap in ferx: resample subjects, refit, and report bias, standard errors and confidence intervals — at PsN::bootstrap feature parity."
+---
+
+# Bootstrap
+
+> **Maturity: beta** — see [Feature Maturity](../maturity.qmd) for what this means.
+
+The non-parametric **case bootstrap** estimates parameter uncertainty by resampling
+subjects with replacement, refitting the model to each replicate dataset, and reading
+bias, standard errors and confidence intervals off the spread of the estimates.
+
+It lives in `ferx-tools`, not in the estimation engine: a bootstrap is many fits of one
+model, which is precisely the [workspace boundary rule](../development/index.qmd)
+— *if it calls `fit()` more than once, it is a tool.* Nothing about the likelihood, the
+optimizer or the diagnostics changes; only the data each fit sees.
+
+```bash
+ferx bootstrap warfarin.ferx --data warfarin.csv --samples 200 --seed 12345 --threads 8
+```
+
+## Why bootstrap instead of the covariance step
+
+ferx's standard errors are the pure `R⁻¹` matrix — the same thing NONMEM reports under
+`$COVARIANCE MATRIX=R`. They are *asymptotic*: they assume the log-likelihood is locally
+quadratic and that the sampling distribution of every parameter is normal. That
+assumption is symmetric by construction, so an `R⁻¹` interval is always centred on the
+estimate and always the same width on both sides.
+
+The bootstrap assumes none of that. It also keeps working when the covariance step fails
+or returns a non-positive-definite matrix, which is common exactly where uncertainty
+matters most.
+
+Here is the shipped `examples/warfarin.ferx` fit both ways — 200 samples, seed 12345:
+
+| parameter | estimate | SE (`R⁻¹`) | SE (bootstrap) | 95% percentile CI | 95% normal CI |
+|---|---:|---:|---:|---|---|
+| `TVCL`                 | 0.1330  | 0.0066 | 0.0081 | 0.1185 – 0.1506  | 0.1171 – 0.1488 |
+| `TVV`                  | 7.7307  | 0.2341 | 0.2444 | 7.237 – 8.127    | 7.252 – 8.210 |
+| `TVKA`                 | 0.7252  | 0.1245 | 0.1405 | 0.4675 – 1.0641  | 0.4499 – 1.0006 |
+| `OMEGA(ETA_CL,ETA_CL)` | 0.02859 | 0.0128 | 0.0105 | 0.0063 – 0.0474  | 0.0081 – 0.0491 |
+| `OMEGA(ETA_V,ETA_V)`   | 0.00958 | 0.0043 | 0.0037 | 0.0016 – 0.0158  | 0.0023 – 0.0169 |
+| `OMEGA(ETA_KA,ETA_KA)` | 0.34896 | 0.1608 | 0.2034 | 0.1092 – 0.8622  | **−0.0498** – 0.7477 |
+| `PROP_ERR`             | 0.01075 | 0.0009 | 0.0010 | 0.00885 – 0.01259| 0.00879 – 0.01271 |
+
+Most parameters agree closely, which is the expected — and reassuring — result. The last
+`OMEGA` is the interesting row, and it is the argument for the whole tool:
+
+- its bootstrap standard error is **26% larger** than the asymptotic one;
+- its bootstrap distribution is strongly **right-skewed** (0.109 – 0.862 around 0.349),
+  which no symmetric interval can express;
+- and the normal-approximation interval reaches **below zero** — an impossible value for
+  a variance. The percentile interval cannot, because every endpoint it reports is an
+  estimate that some replicate actually produced.
+
+That is the diagnostic: where the two intervals agree, the asymptotic standard errors are
+fine; where they disagree, believe the bootstrap.
+
+## What is resampled
+
+**Whole subjects.** For each ID, every record is either in or out of a replicate — never
+split. This is what keeps the case bootstrap valid for a hierarchical model.
+
+A subject drawn more than once enters the fit as **independent individuals**: that is the
+point of sampling with replacement, and it means the copies must carry distinct
+identifiers. ferx keeps the original ID and appends `#2`, `#3`, … so a diagnostic can
+still be traced back. (PsN does the same thing by renumbering IDs while writing the
+replicate data file.)
+
+::: {.callout-warning}
+## A model that reads `ID` as a covariate cannot be bootstrapped
+
+Because the duplicate copies are necessarily renamed, a model whose predictions depend on
+the subject identifier would silently see different values than it did in the base fit.
+ferx refuses such a run with an error naming the fix. PsN documents the same hazard as a
+known bug and leaves it to the user to notice.
+:::
+
+## Reproducibility
+
+Each replicate's draw is derived from the master `--seed` **and its own index**, so the
+resampled datasets depend only on `--seed`, `--samples`, `--sample-size` and the strata.
+They do not depend on `--threads`, on the order replicates happen to finish in, or on
+whether the base model was fitted first.
+
+::: {.callout-note}
+## This is a deliberate departure from PsN
+
+The PsN bootstrap user guide documents the opposite as a known wart: *"the results of two
+runs will be different even if the seed is the same if the lst-file of the base model is
+present at the start of one run but not the other"*, because running the base model
+advances one shared random-number generator. Deriving per replicate removes that coupling,
+and makes the draw stream something a test can pin.
+:::
+
+## Stratified resampling
+
+If the dataset mixes populations — the classic case is 10 subjects with rich profiles and
+90 with sparse steady-state samples — resample *within* each group so that every replicate
+keeps the same composition:
+
+```bash
+ferx bootstrap run12.ferx --data d.csv --stratify-on STUDY
+```
+
+The stratification column is read straight from the dataset, so it does not have to be a
+covariate the model declares, and its values may be non-numeric group labels. It **must
+take exactly one value per subject**; if it does not, the run stops and names the
+offending subject, because an individual that belongs to two strata cannot be resampled
+from either.
+
+By default each stratum contributes as many subjects as it has. `--sample-size` changes
+that in one of two ways:
+
+```bash
+# One number: strata are allocated in proportion to their size (rounded).
+ferx bootstrap run12.ferx --stratify-on STUDY --sample-size 50
+
+# Explicit per stratum — PsN's syntax. Every stratum must be listed.
+ferx bootstrap run12.ferx --stratify-on STUDY --sample-size "1001=>12,1002=>24,1003=>10"
+```
+
+With proportional allocation the rounded per-stratum counts need not sum exactly to the
+requested total; in the default case (sample size = number of subjects) they always do.
+
+## Which replicates count
+
+A replicate whose fit did not converge, or whose estimate landed on a bound, is not a draw
+from the sampling distribution of a converged fit — including it biases the interval. Two
+filters are therefore **on by default**, matching PsN:
+
+| filter | default | drops replicates where… |
+|---|---|---|
+| `--no-skip-minimization-terminated`  | on  | the fit did not converge |
+| `--no-skip-estimate-near-boundary`   | on  | an estimate sits on a bound |
+| `--skip-covariance-step-terminated`  | off | the covariance step failed |
+| `--skip-with-covstep-warnings`       | off | the covariance step warned |
+
+The two covariance filters read a diagnostic that only exists when the covariance step
+actually ran, and replicate fits skip it by default (it is most of the cost, and the
+bootstrap standard error comes from the spread of the estimates, not from any
+per-replicate `R⁻¹`). Combining them without `--keep-covariance` is an error rather than a
+silent no-op.
+
+Filters are applied **when the statistics are computed**, not when a replicate finishes.
+That is what makes it possible to change your mind afterwards:
+
+```bash
+ferx bootstrap --summarize --directory run12-bootstrap --no-skip-minimization-terminated
+```
+
+`--summarize` re-reads `raw_results.csv` — which carries each replicate's diagnostics
+alongside its estimates — and rewrites the statistics. It refits nothing.
+
+## Confidence intervals
+
+Percentile intervals use PsN's estimator, the weighted average at `x₍ₙ₊₁₎ₚ`:
+
+```
+n = number of samples + 1
+p = percentile / 100
+i = integer part of n·p
+f = decimal part of n·p
+percentile = (1−f)·xᵢ + f·xᵢ₊₁
+```
+
+A tail can only be reported when there is an order statistic at or below it — i.e. when
+`(n+1)·p ≥ 1`. That single condition reproduces every minimum PsN tabulates:
+
+| interval | samples needed |
+|---|---:|
+| 5% – 95%      | 19 |
+| 2.5% – 97.5%  | 39 |
+| 0.5% – 99.5%  | 199 |
+| 0.05% – 99.95%| 1999 |
+
+Below the threshold the percentile interval is left empty rather than extrapolated past
+the smallest observation, and only the normal-approximation interval
+(`estimate ± z·SE_bootstrap`) is reported. PsN's rule of thumb — and the default — is
+**200 samples** for standard errors.
+
+## Δofv
+
+`--dofv` evaluates each replicate's parameter vector on the **original** dataset with no
+estimation (`outer_maxiter = 0`, exactly NONMEM's `MAXEVAL=0`) and reports
+`ofv_bootstrap − ofv_original` in `delta_ofv.csv`.
+
+Every value is necessarily positive: the original fit's parameters minimise the objective
+on the original data, so any other vector scores worse. The useful comparison is against a
+χ² distribution with degrees of freedom equal to the number of estimated parameters
+(written to `bootstrap_diagnostics.csv` as `chi_square_df`). In theory the bootstrap Δofv
+distribution should sit **at or below** that reference; if it does not, the bootstrap is
+not describing the uncertainty well and another method — [SIR](../estimation/sir.qmd) —
+is the better choice.
+
+## Output files
+
+Written to `--directory` (default `{model}-bootstrap`). Names follow PsN so existing
+scripts and habits transfer.
+
+| file | contents |
+|---|---|
+| `raw_results.csv`            | one row per fit, **first row the original dataset**; estimates, OFV and termination diagnostics |
+| `bootstrap_results.csv`      | one row per parameter: original, mean, bias, standard error, median, percentile CI, normal CI |
+| `bootstrap_diagnostics.csv`  | run counts, exclusion tallies, and the mean of each per-replicate diagnostic |
+| `included_individuals1.csv`  | per replicate, the subject IDs drawn (repeats included), in dataset order |
+| `included_keys1.csv`         | per replicate, the internal 1..N ordinals of those subjects |
+| `sample_keys1.csv`           | per replicate, one count per original subject: how many times it was drawn |
+| `all_individuals1.csv`       | every subject of the original dataset, in original order |
+| `delta_ofv.csv`              | `--dofv` only |
+
+Row *j* refers to the same replicate in `raw_results`, `included_individuals`,
+`included_keys` and `sample_keys`, as in PsN.
+
+Two files depart from PsN's layout on purpose. `bootstrap_results.csv` is **tidy** — one
+row per parameter — rather than PsN's stacked blocks of statistics, and the run-level
+diagnostics live in their own file instead of as a second block inside the results file. A
+single CSV carrying two different header shapes cannot be read by a data frame, which
+defeats the point of writing it.
+
+## Options
+
+| option | default | meaning |
+|---|---|---|
+| `--samples N`        | 200 | number of bootstrap datasets |
+| `--seed N`           | 1   | master seed |
+| `--threads N`        | all cores | replicates fitted concurrently (each fit uses one thread) |
+| `--sample-size M`    | dataset size | subjects per replicate, or a per-stratum map |
+| `--stratify-on COL`  | —   | resample within strata from a dataset column |
+| `--directory DIR`    | `{model}-bootstrap` | where the CSVs go |
+| `--ci LEVEL`         | 95  | two-sided confidence level, percent |
+| `--no-update-inits`  | —   | start replicates from the model file's inits instead of the base fit's estimates |
+| `--no-run-base-model`| —   | skip the fit on the original data (disables bias, the normal CI, `--update-inits` and `--dofv`) |
+| `--keep-covariance`  | off | run the covariance step for every replicate |
+| `--dofv`             | off | compute Δofv against the original dataset |
+| `--summarize`        | off | recompute statistics from an existing run directory |
+
+Options in the PsN guide with no ferx analogue — `-allow_ignore_id`, `-copy_data`,
+`-mceta`, `-rplots`, `-clean` — are NONMEM run-directory plumbing and are not implemented.
+`-bca` (bias-corrected accelerated intervals, which need an additional jackknife pass) is
+not implemented yet.
+
+## Library API
+
+```rust
+use ferx_core::prepare_run;
+use ferx_tools::bootstrap::{run_bootstrap, BootstrapOptions};
+
+let prepared = prepare_run("warfarin.ferx", Some("warfarin.csv"))?;
+let result = run_bootstrap(
+    &prepared,
+    &BootstrapOptions { samples: 200, seed: 12345, ..Default::default() },
+)?;
+
+for p in &result.summary.parameters {
+    println!("{}: {:.4} (SE {:.4})", p.name, p.mean, p.standard_error);
+}
+```
+
+`prepare_run` is the "load a model and its data, but do not fit" entry point: it resolves
+the data path against the model's `[data]` block, applies `[data_selection]`, reads the
+population and binds any `theta NAME[...]` level blocks — everything `ferx model.ferx`
+does up to the fit itself.

--- a/docs/tools/bootstrap.qmd
+++ b/docs/tools/bootstrap.qmd
@@ -68,6 +68,34 @@ identifiers. ferx keeps the original ID and appends `#2`, `#3`, … so a diagnos
 still be traced back. (PsN does the same thing by renumbering IDs while writing the
 replicate data file.)
 
+## Which parameters are bootstrapped
+
+Every estimated population parameter: each theta, the free lower triangle of the
+between-subject Omega, each sigma, and — when the model declares `kappa` — the free
+lower triangle of the inter-occasion Omega, reported as `OMEGA_IOV(KAPPA_CL,KAPPA_CL)`
+and so on. Structural zeros (an off-diagonal between two etas that are not in the same
+`block_omega`) are not parameters and are not reported.
+
+The same vector is what `--update-inits` hands to the replicates and what `--dofv`
+evaluates, so a model's IOV variance is started from the base fit's estimate and
+evaluated at the replicate's, exactly like every other parameter.
+
+With `--keep-covariance`, each parameter also gets a per-replicate `se_` column. A cell
+there is **empty when core reports no standard error for that coordinate** — an IOV
+*covariance*, for instance, since only the IOV variances have one. Empty means "not
+reported", never zero.
+
+::: {.callout-warning}
+## Mixture models are not supported
+
+A `[mixture]` model's classes are identified only up to relabelling: replicate *k*'s
+"class 1" need not be the original fit's class 1, so averaging estimates across
+replicates would mix two different things and produce an interval that is meaningless
+rather than merely noisy. Bootstrapping a mixture needs a relabelling rule, and this
+tool does not have one, so it refuses the run rather than reporting a plausible-looking
+table.
+:::
+
 ::: {.callout-warning}
 ## A model that reads `ID` as a covariate cannot be bootstrapped
 
@@ -189,7 +217,8 @@ estimation (`outer_maxiter = 0`, exactly NONMEM's `MAXEVAL=0`) and reports
 Every value is necessarily positive: the original fit's parameters minimise the objective
 on the original data, so any other vector scores worse. The useful comparison is against a
 χ² distribution with degrees of freedom equal to the number of estimated parameters
-(written to `bootstrap_diagnostics.csv` as `chi_square_df`). In theory the bootstrap Δofv
+(written to `bootstrap_diagnostics.csv` as `chi_square_df`, counted over the free
+parameter coordinates — so a free 2x2 `block_omega` contributes three, not two). In theory the bootstrap Δofv
 distribution should sit **at or below** that reference; if it does not, the bootstrap is
 not describing the uncertainty well and another method — [SIR](../estimation/sir.qmd) —
 is the better choice.
@@ -201,7 +230,7 @@ scripts and habits transfer.
 
 | file | contents |
 |---|---|
-| `raw_results.csv`            | one row per fit, **first row the original dataset**; estimates, OFV and termination diagnostics |
+| `raw_results.csv`            | one row per fit, **first row the original dataset**; estimates, OFV and termination diagnostics (plus `se_` columns under `--keep-covariance`) |
 | `bootstrap_results.csv`      | one row per parameter: original, mean, bias, standard error, median, percentile CI, normal CI |
 | `bootstrap_diagnostics.csv`  | run counts, exclusion tallies, and the mean of each per-replicate diagnostic |
 | `included_individuals1.csv`  | per replicate, the subject IDs drawn (repeats included), in dataset order |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -70,8 +70,9 @@ pub use predict::{predict, PredictionResult};
 pub use predict::{predict_categorical, predict_survival, SurvivalPredictionResult};
 pub(crate) use run::{build_selection_filter_merged, log_transform_observations};
 pub use run::{
-    read_population_for, read_population_for_simulation, resolve_data_path, run_from_file,
-    run_model_simulate, run_model_with_data, run_model_with_data_inits,
+    prepare_run, prepare_run_with_inits, read_population_for, read_population_for_simulation,
+    resolve_data_path, run_from_file, run_model_simulate, run_model_with_data,
+    run_model_with_data_inits, PreparedRun,
 };
 pub(crate) use simulate::obs_row_time;
 pub use simulate::{

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -123,15 +123,63 @@ pub fn run_model_with_data(
     run_model_with_data_inits(model_path, data_path, None)
 }
 
-/// Like [`run_model_with_data`], but lets the caller (e.g. the CLI's
-/// `--inits-from-nca` flag) override the model file's `inits_from_nca` fit
-/// option. When `inits_override` is `None` the model-file value is used as-is;
-/// when `Some(method)` it forces that NCA strategy regardless of the file.
-pub fn run_model_with_data_inits(
+/// A model file and its dataset, parsed and read but **not yet fitted** — every
+/// input [`fit`] needs, assembled by [`prepare_run`].
+///
+/// Getting from a `.ferx` file to a fittable state is not one call: the data
+/// path has to be resolved against the model's own `[data]` block, the
+/// `[data_selection]` filter compiled, the population read through the model's
+/// covariate declarations and column map, `theta NAME[...]` level blocks bound
+/// against the data (which re-parses the model with the real θ count, #1064),
+/// and the initial [`ModelParameters`] built from the parsed model. A caller
+/// that wants any of that *without* fitting — a tool running many fits over
+/// resampled data, an R caller inspecting or `predict()`ing a model — previously
+/// had to run a fit to get there.
+///
+/// The fields are the entrypoint's own intermediate state, made public rather
+/// than reconstructed: [`run_model_with_data_inits`] is implemented on top of
+/// this, so there is one code path and a tool cannot silently diverge from what
+/// the CLI does.
+pub struct PreparedRun {
+    /// The parsed model, with `theta NAME[...]` blocks bound to the data and
+    /// `gradient_method` resolved onto `parsed.model`.
+    pub parsed: ParsedModel,
+    /// The dataset, filtered by `[data_selection]` and carrying any level-index
+    /// columns synthesized during binding.
+    pub population: Population,
+    /// Initial parameter estimates from the model file, ready to pass to [`fit`].
+    pub init_params: ModelParameters,
+    /// The covariate table, when the model declares covariates.
+    pub covariate_table: Option<CovariateTable>,
+    /// The dataset actually read, after resolving `data_path` against `[data]`.
+    pub data_path: String,
+    /// Set when an explicit `data_path` overrode the model's `[data] path`.
+    pub data_path_warning: Option<String>,
+    /// SHA-256 of the model file, `None` if it could not be hashed.
+    pub model_hash: Option<String>,
+    /// SHA-256 of the dataset, `None` if it could not be hashed.
+    pub data_hash: Option<String>,
+}
+
+/// Parse a model file and read its dataset, stopping short of the fit.
+///
+/// See [`PreparedRun`]. `data_path` is `None` to rely on the model's `[data]`
+/// block; when both are given the argument wins and
+/// [`PreparedRun::data_path_warning`] records it.
+///
+/// Unlike [`run_model_with_data`] this is **quiet** — it prints nothing — because
+/// its caller may be running it hundreds of times.
+pub fn prepare_run(model_path: &str, data_path: Option<&str>) -> Result<PreparedRun, String> {
+    prepare_run_with_inits(model_path, data_path, None)
+}
+
+/// [`prepare_run`] with the CLI's `--inits-from-nca` override, which has to be
+/// applied before `build_init_params` reads the parsed model.
+pub fn prepare_run_with_inits(
     model_path: &str,
     data_path: Option<&str>,
     inits_override: Option<crate::suggest_start::NcaInit>,
-) -> Result<(FitResult, Population), String> {
+) -> Result<PreparedRun, String> {
     use crate::parser::model_parser::parse_full_model_file;
 
     let mut parsed = parse_full_model_file(Path::new(model_path))?;
@@ -140,28 +188,19 @@ pub fn run_model_with_data_inits(
         parsed.fit_options.inits_from_nca = Some(method);
     }
 
-    eprintln!("Model: {}", parsed.model.name);
-
     let (data_path, data_path_warning) = resolve_data_path(parsed.data_path.as_deref(), data_path)?;
-    let data_path = data_path.as_str();
 
     let iov_col = parsed.fit_options.iov_column.as_deref();
     let sel_filter = build_selection_filter(&parsed.fit_options)?;
     let (mut population, covariate_table) = read_population_for(
         &parsed.model,
         &parsed.covariate_decls,
-        data_path,
+        &data_path,
         None,
         iov_col,
         sel_filter.as_ref(),
         &parsed.column_map,
     )?;
-    eprintln!(
-        "Data:  {} subjects, {} observations from {}",
-        population.subjects.len(),
-        population.n_obs(),
-        data_path
-    );
 
     // #1064: a `theta NAME[COL, ...]` block declares one θ per observed
     // combination, so its level count is a property of the data. Bind it now —
@@ -191,7 +230,50 @@ pub fn run_model_with_data_inits(
     // stamping below — so we still hash each file only once. Errors are
     // non-fatal: a missing hash just disables the resume/integrity checks.
     let model_hash = crate::io::hash::sha256_file(Path::new(model_path)).ok();
-    let data_hash = crate::io::hash::sha256_file(Path::new(data_path)).ok();
+    let data_hash = crate::io::hash::sha256_file(Path::new(&data_path)).ok();
+
+    Ok(PreparedRun {
+        parsed,
+        population,
+        init_params,
+        covariate_table,
+        data_path,
+        data_path_warning,
+        model_hash,
+        data_hash,
+    })
+}
+
+/// Like [`run_model_with_data`], but lets the caller (e.g. the CLI's
+/// `--inits-from-nca` flag) override the model file's `inits_from_nca` fit
+/// option. When `inits_override` is `None` the model-file value is used as-is;
+/// when `Some(method)` it forces that NCA strategy regardless of the file.
+pub fn run_model_with_data_inits(
+    model_path: &str,
+    data_path: Option<&str>,
+    inits_override: Option<crate::suggest_start::NcaInit>,
+) -> Result<(FitResult, Population), String> {
+    let PreparedRun {
+        mut parsed,
+        mut population,
+        init_params,
+        covariate_table,
+        data_path,
+        data_path_warning,
+        model_hash,
+        data_hash,
+    } = prepare_run_with_inits(model_path, data_path, inits_override)?;
+    let data_path = data_path.as_str();
+
+    // Printed here rather than in `prepare_run`, which is used by tools running
+    // hundreds of fits and must stay silent.
+    eprintln!("Model: {}", parsed.model.name);
+    eprintln!(
+        "Data:  {} subjects, {} observations from {}",
+        population.subjects.len(),
+        population.n_obs(),
+        data_path
+    );
 
     // Checkpoint / restart (#755): write `{model_stem}.tmp` next to the CLI
     // outputs and resume from it on a re-run of the same model + data. Disabled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,12 @@ pub mod types;
 
 pub use api::{
     bind_theta_levels, check_model_data, check_model_data_warnings, check_model_options,
-    configure_global_thread_pool, fit, fit_from_files, predict, resolve_data_path, run_from_file,
-    run_model_simulate, run_model_with_data, run_model_with_data_inits, simulate,
-    simulate_adaptive, simulate_adaptive_from_spec, simulate_with_options,
-    simulate_with_options_diag, simulate_with_seed, simulate_with_uncertainty, theta_level_map,
-    validate_model_file, AdaptiveSimulateOptions, AdaptiveSimulationResult, PredictionResult,
+    configure_global_thread_pool, fit, fit_from_files, predict, prepare_run,
+    prepare_run_with_inits, resolve_data_path, run_from_file, run_model_simulate,
+    run_model_with_data, run_model_with_data_inits, simulate, simulate_adaptive,
+    simulate_adaptive_from_spec, simulate_with_options, simulate_with_options_diag,
+    simulate_with_seed, simulate_with_uncertainty, theta_level_map, validate_model_file,
+    AdaptiveSimulateOptions, AdaptiveSimulationResult, PredictionResult, PreparedRun,
     SimulateOptions, SimulateUncertaintyOptions, SimulationOutput, SimulationResult,
 };
 pub use cancel::CancelFlag;

--- a/tests/prepare_run.rs
+++ b/tests/prepare_run.rs
@@ -1,0 +1,95 @@
+//! Tier-2 coverage for `prepare_run` (#1140): the "load a model and its data,
+//! but do not fit" entry point.
+//!
+//! It exists because a tool that runs many fits needs everything
+//! `run_model_with_data` does *up to* the fit — data-path resolution against the
+//! model's `[data]` block, the `[data_selection]` filter, the covariate-aware
+//! read, `theta NAME[...]` level binding, and the initial `ModelParameters` —
+//! and previously the only way to get there was to run a fit.
+//!
+//! No fit happens here, so these return immediately.
+
+use ferx_core::{prepare_run, run_model_with_data};
+
+const MODEL: &str = "examples/warfarin.ferx";
+const DATA: &str = "data/warfarin.csv";
+
+#[test]
+fn prepare_run_loads_the_model_the_data_and_the_initial_estimates() {
+    let p = prepare_run(MODEL, Some(DATA)).expect("warfarin loads");
+
+    assert_eq!(p.parsed.model.name, "warfarin");
+    assert!(!p.population.subjects.is_empty());
+    assert!(p.population.n_obs() > 0);
+    assert_eq!(p.data_path, DATA);
+    assert!(p.data_path_warning.is_none());
+
+    // The initial parameters are the model file's, ready to hand to `fit`.
+    assert_eq!(p.init_params.theta_names, vec!["TVCL", "TVV", "TVKA"]);
+    assert_eq!(p.init_params.theta, vec![0.2, 10.0, 1.5]);
+    assert_eq!(p.init_params.theta_lower, vec![0.001, 0.1, 0.01]);
+    assert_eq!(p.init_params.omega.dim(), 3);
+    assert_eq!(p.init_params.sigma.names, vec!["PROP_ERR"]);
+
+    // Hashes are computed once, up front, for the checkpoint integrity check.
+    assert!(p.model_hash.is_some());
+    assert!(p.data_hash.is_some());
+}
+
+#[test]
+fn prepare_run_and_run_model_with_data_read_the_same_population() {
+    // `run_model_with_data` is implemented on top of `prepare_run`, and this is
+    // what pins that: a tool loading a model must see exactly what the CLI sees,
+    // or every fit it runs is quietly against a different dataset.
+    //
+    // This is the one test here that does fit — there is no other way to reach
+    // the entry point's own population. Warfarin is 10 subjects and converges in
+    // well under a second, so it stays in the PR job rather than the slow tier.
+    let prepared = prepare_run(MODEL, Some(DATA)).expect("prepare");
+    let (_, population) = run_model_with_data(MODEL, Some(DATA)).expect("fit");
+
+    assert_eq!(
+        prepared.population.subjects.len(),
+        population.subjects.len()
+    );
+    assert_eq!(prepared.population.n_obs(), population.n_obs());
+    let prepared_ids: Vec<&str> = prepared
+        .population
+        .subjects
+        .iter()
+        .map(|s| s.id.as_str())
+        .collect();
+    let fitted_ids: Vec<&str> = population.subjects.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(prepared_ids, fitted_ids);
+    assert_eq!(prepared.population.dv_column, population.dv_column);
+    assert_eq!(
+        prepared.population.covariate_names,
+        population.covariate_names
+    );
+}
+
+/// `PreparedRun` holds a `CompiledModel` of closures and so cannot be `Debug`,
+/// which rules out `unwrap_err`.
+fn error_of(result: Result<ferx_core::PreparedRun, String>) -> String {
+    match result {
+        Ok(_) => panic!("expected an error"),
+        Err(e) => e,
+    }
+}
+
+#[test]
+fn a_missing_model_or_dataset_is_an_error() {
+    assert!(prepare_run("no-such-model.ferx", Some(DATA)).is_err());
+    assert!(prepare_run(MODEL, Some("no-such-data.csv")).is_err());
+}
+
+#[test]
+fn a_model_without_a_data_block_needs_an_explicit_dataset() {
+    // warfarin.ferx has no `[data]` block, so `None` has nothing to fall back
+    // on and must say so rather than reading an empty population.
+    let err = error_of(prepare_run(MODEL, None));
+    assert!(
+        err.contains("no dataset specified"),
+        "expected the missing-dataset message, got: {err}"
+    );
+}


### PR DESCRIPTION
## Why

ferx had no way to produce an empirical parameter-uncertainty distribution. The only
uncertainty on offer is the `R⁻¹` covariance step (equivalent to NONMEM `$COVARIANCE
MATRIX=R`), which is asymptotic and symmetric by construction, and which fails outright
when the matrix is non-PD. The non-parametric bootstrap is the standard uncertainty
deliverable in a population-PK report, and its absence was a real gap against PsN.

It is also P3 of #1114 and the first real inhabitant of `ferx-tools`, which until now held
one placeholder `core_version()`. Bootstrap is the boundary rule made concrete: *if it
calls `fit()` more than once, it is a tool.*

Closes #1140.

## What changed

`ferx_tools::bootstrap` + a `ferx bootstrap` subcommand. Resample whole subjects with
replacement, refit, and summarise the spread of the estimates.

**PsN parity** for everything that is not NONMEM run-directory plumbing:

| PsN | here |
|---|---|
| `-samples`, `-seed`, `-threads` | `--samples` (default 200), `--seed`, `--threads` |
| `-sample_size` | `--sample-size`, including the per-stratum `"1001=>12,1002=>24"` form |
| `-stratify_on` | `--stratify-on`, with PsN's "one value per individual" rule enforced |
| `-update_inits`, `-run_base_model` | `--no-update-inits`, `--no-run-base-model` |
| `-keep_covariance`, `-keep_tables` | `--keep-covariance`; no per-replicate sdtab is written |
| the four `-skip_*` filters | same four, same defaults (two on, two off) |
| `-dofv` | `--dofv` (`outer_maxiter = 0` is already exactly `MAXEVAL=0`) |
| `-summarize` | `--summarize` — re-reads `raw_results.csv`, refits nothing |
| output files | same names, same row-order guarantee across `raw_results` / `included_individuals` / `included_keys` / `sample_keys` |

Not implemented: `-bca` (needs a jackknife pass; the guide itself calls it "very
time-consuming") and resuming a crashed run's *unfinished* samples. `--summarize` covers
the "too many samples were filtered out" recovery case. `-allow_ignore_id`, `-copy_data`,
`-mceta`, `-rplots`, `-clean` have no ferx analogue.

**Three deliberate departures from PsN**, each because PsN's behaviour is a documented
defect rather than a design:

1. **Reproducibility.** Each replicate's draw is derived from the master seed *and its own
   index*, so the datasets depend only on `--seed` and the design. The PsN guide documents
   the opposite as a known wart — same seed, different results depending on whether the
   base model's `.lst` was present, because running it advances one shared RNG. Asserted
   here across `--threads 1` vs `4`.
2. **A model reading `ID` as a covariate is refused.** Resampling necessarily renames the
   duplicate copies of a subject (they must enter the fit as independent individuals), so
   such a model would silently see different values than in the base fit. PsN documents
   the identical hazard as a known bug and leaves it to the user to notice.
3. **`bootstrap_results.csv` is tidy** (one row per parameter) and the run-level
   diagnostics get their own file. PsN stacks statistic blocks sharing one header, which
   no data frame can read.

## Alternatives considered

**Where the ID renaming lives.** PsN renumbers IDs while writing each replicate's data
file. ferx keeps the original ID and appends `#2`, `#3`, … so a diagnostic can still be
traced back to the subject it came from, and `included_individuals1.csv` still writes the
*original* IDs so it agrees with `all_individuals1.csv`.

**Reading the stratification column.** First attempt used `Subject::covariates`, which is
wrong twice over: the column is usually a study identifier the model never declares (so it
is not on the subject at all), and a covariate that varies within a subject would be
silently accepted. It now reads the dataset directly, compares values as strings (so
non-numeric group labels work), and enforces the one-value-per-subject rule where the
offending subject can still be named.

**The normal quantile.** Started as a bisection on the CDF built from ferx-core's public
`erf`. It converges exactly — to the inverse of an `erf` whose own approximation error is
~1.5e-7, putting `z₀.₉₇₅` at 1.9599628 instead of 1.9599640. Inverting an approximation
buys the approximation's accuracy, not the bisection's. Replaced with Acklam's rational
approximation (~1.15e-9 relative), which is also exactly symmetric in the central branch.

**Not `clap`.** #1114 left the door open, but adding it would mean rewriting 968 lines of
hand-rolled parsing and its tests. `bootstrap` dispatches exactly like the existing `check`
and `summary` subcommands.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`ferx-core`'s API only grew, so nothing in ferx-r breaks. A wrapper for `ferx bootstrap`
is a follow-up, and it will need the usual `Cargo.lock` bump to reach `prepare_run`.

## Breaking changes
- [x] Public Rust API (`api/`, `types.rs`) — baseline regenerated
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed

The widening is one struct and two functions, and nothing else:

```
+pub struct ferx_core::PreparedRun            { parsed, population, init_params,
+                                               covariate_table, data_path,
+                                               data_path_warning, model_hash, data_hash }
+pub fn ferx_core::prepare_run(model_path, data_path) -> Result<PreparedRun, String>
+pub fn ferx_core::prepare_run_with_inits(model_path, data_path, inits_override) -> …
```

**Which caller needs it, and why the existing surface does not suffice** (A6): the
bootstrap needs everything `run_model_with_data` does *up to* the fit — data-path
resolution against the model's `[data]` block, the `[data_selection]` filter, the
covariate-aware read, `theta NAME[...]` level binding, and the initial `ModelParameters`.
`build_init_params` and `build_selection_filter` are private, so the only way to obtain a
`ModelParameters` was to run a fit. `run_model_with_data` is now implemented on top of
`prepare_run`, so there is one loading path rather than two — which matters more than the
convenience: a tool that loaded a model *slightly* differently from the CLI would produce
a bootstrap of a different model, silently.

**A4 (ferx-r reachability):** this is not a workspace-only API. "Load a model and its
dataset without fitting" is exactly what an R caller wants in order to inspect a
population or call `predict()`.

## Numerical validation

A bootstrap has no single NONMEM run to anchor against — the comparator is distributional.
So the anchors are built from the parts that *are* exact:

- [x] **Degenerate oracle.** A "resample" drawing every subject exactly once reproduces an
      ordinary fit **bit-for-bit** (`ofv.to_bits()`). This is what pins the replicate
      population against the engine: a dropped covariate map or a lost occasion column
      would change the objective and nothing else in the bootstrap would notice.
- [x] **Its complement**, because the identity case cannot see the duplication path:
      duplicating a subject grows `n_obs` by that subject's observations, gives the two
      copies identical EBEs and identical `ofv_contribution`, and the 2nd and 3rd copies
      move the objective by the *same* amount to 1e-9.
- [x] **Closed-form percentile CIs** against hand-computed values, plus all four of PsN's
      minimum-sample thresholds (19 / 39 / 199 / 1999) asserted from *both* sides. Those
      are not four rules — they all fall out of `(n+1)p ≥ 1`.
- [x] **Exact stratum composition** over repeated draws, on the real warfarin dataset given
      a synthetic `STUDY` column, plus the "one value per individual" refusal on real data.
- [x] **Seed reproducibility** across `--threads 1` vs `--threads 4`.
- [x] **Flat-vector round trip through a real model**: re-evaluating a fit's own estimates
      returns its OFV bit-for-bit — i.e. Δofv against itself is exactly 0, which is the
      `--dofv` sanity check.
- [x] Compared against: prior ferx commit's `R⁻¹` standard errors (below).

Warfarin, 200 samples, seed 12345 — six of seven parameters agree closely with the
covariance step, which is the reassuring result. The seventh is the case for the tool:

```
parameter               estimate   SE(R⁻¹)  SE(boot)   95% percentile     95% normal
TVCL                     0.13297   0.00663   0.00809   0.1185 – 0.1506   0.1171 – 0.1488
TVV                      7.73070   0.23406   0.24437   7.237  – 8.127    7.252  – 8.210
TVKA                     0.72521   0.12453   0.14048   0.4675 – 1.0641   0.4499 – 1.0006
OMEGA(ETA_CL,ETA_CL)     0.02859   0.01280   0.01046   0.0063 – 0.0474   0.0081 – 0.0491
OMEGA(ETA_V,ETA_V)       0.00958   0.00430   0.00374   0.0016 – 0.0158   0.0023 – 0.0169
OMEGA(ETA_KA,ETA_KA)     0.34896   0.16082   0.20343   0.1092 – 0.8622  -0.0498 – 0.7477
PROP_ERR                 0.01075   0.00094   0.00100   0.00885– 0.01259  0.00879– 0.01271
```

`OMEGA(ETA_KA)`: bootstrap SE 26% larger, strongly right-skewed (0.109–0.862 around
0.349), and the normal-approximation lower bound is **negative** — an impossible variance.
The percentile interval cannot go there, because every endpoint it reports is a value some
replicate actually produced. Written up in `docs/tools/bootstrap.qmd`.

`--dofv` on the same model returns all-positive differences, as it must: the original
fit's parameters minimise the objective on the original data.

## Performance

- [x] No significant impact expected — new code path only; nothing existing changed except
      `run_model_with_data`, which now calls the function its body became.

200 warfarin replicates in **2.5 s** on 8 threads (release). Replicate fits are quiet,
pinned to one thread each (the bootstrap parallelises over replicates, so nesting Rayon
pools would oversubscribe), skip the covariance step, skip SIR, and disable checkpointing —
without that last one, 200 fits would write and resume the *same* `{model}.tmp` and restore
each other's state.

## Tests

- [x] Unit tests in the same module (`cargo test --lib` passes)
- [x] Regression tests that fail without the fix — the oracles above

124 new tests: 55 unit (`ferx-tools`), 45 + 16 (`ferx-cli`), 8 Tier-2 end-to-end
(`crates/ferx-tools/tests/bootstrap_end_to_end.rs`), 4 for `prepare_run`
(`tests/prepare_run.rs`). All Tier-1/Tier-2: the end-to-end fits are capped at 1–2 outer
iterations or are pure evaluations, and the whole file runs in 2.2 s.

`cargo test --lib --no-default-features --features ci`: 3706 passed, 0 failed — the
`run_model_with_data` refactor is behaviour-preserving.

## Example

```bash
ferx bootstrap warfarin.ferx --data warfarin.csv --samples 200 --seed 12345 --threads 8
ferx bootstrap run12.ferx --stratify-on STUDY --sample-size "1001=>12,1002=>24,1003=>10"
ferx bootstrap --summarize --directory run12-bootstrap --no-skip-minimization-terminated
```

```
Model: warfarin
Data:  10 subjects, 110 observations from data/warfarin.csv
Bootstrap: 200 samples, seed 12345
Fitted 200 replicates in 2.5s

200 of 200 samples completed; 200 included in the statistics

parameter                original         mean         bias     SE(boot)       95% lo       95% hi
TVCL                      0.13297      0.13350      0.00053      0.00809      0.11852      0.15058
TVV                       7.73070      7.72536     -0.00534      0.24437      7.23688      8.12707
TVKA                      0.72521      0.73430      0.00909      0.14048      0.46745      1.06406
OMEGA(ETA_CL,ETA_CL)      0.02859      0.02595     -0.00265      0.01046      0.00630      0.04741
OMEGA(ETA_V,ETA_V)        0.00958      0.00848     -0.00110      0.00374      0.00163      0.01582
OMEGA(ETA_KA,ETA_KA)      0.34896      0.33303     -0.01594      0.20343      0.10923      0.86215
PROP_ERR                  0.01075      0.01067     -0.00008      0.00100      0.00885      0.01259

Wrote bootstrap results to warfarin-bootstrap
```

## Docs

- [x] `docs/tools/bootstrap.qmd` added, `docs/cli.qmd` updated
- [x] New page linked in `docs/_quarto.yml` (new "Tools" sidebar section)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist
- [x] `cargo clippy` clean (`-p ferx-tools -p ferx-cli --tests`)
- [x] Nothing on the `Dual2` sensitivity path is touched
- [ ] `Cargo.toml` version bump — not needed, additive only

## Docs & examples
- [x] No new `.ferx` DSL syntax or `[fit_options]` key, no new example model or data file
- [x] Rebuilt: `cargo build --release --workspace`
- [x] Ran the real binary against `examples/warfarin.ferx` + `data/warfarin.csv` for the
      table above, plus `--dofv`, `--summarize` and `--stratify-on`
- [ ] ferx-r rebuild — not needed, no ferx-r change in this PR

## Reviewer hints

Worth the attention:

- **`resample.rs`** — the draw is sorted by original ordinal on purpose. PsN builds a
  replicate by walking the original file and emitting each selected individual as many
  times as drawn, so dataset order and draw order coincide there; sorting reproduces that,
  which is what lets `included_individuals` and `included_keys` mean what the PsN guide
  says they mean. Statistically a no-op — a multiset has no order.
- **`summary::percentile`** — the `None` return is the whole minimum-sample-size rule.
- **`replicate_options`** in `bootstrap/mod.rs` — four settings that each look like
  tidiness and are not, especially `checkpoint = false`.
- **`src/api/run.rs`** — the refactor is a straight extraction; the only behavioural
  difference is that the two `eprintln!` lines moved into `run_model_with_data` so
  `prepare_run` is silent for a caller running it hundreds of times.

Skimmable: `output.rs` (CSV writers) and the test files.

## Open questions

- The `--summarize` path cannot recover `chi_square_df` from `raw_results.csv`, so it
  reads it back out of the existing `bootstrap_diagnostics.csv`. Alternative would be a
  small run-metadata file; that seemed like more machinery than the one value justifies.
- `-bca` and resuming unfinished samples are follow-ups. Worth separate issues now, or
  leave them in #1140's follow-up list?
