### PR TITLE
docs(api): record the mixture-bootstrap refusal as decided [#1145]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ section of the SDLC for the versioning policy).
   gets bootstrap SEs and CIs for its inter-occasion variance and `--update-inits` / `--dofv` carry
   it too. A model that reads `ID` as a covariate is refused rather than silently mis-fitted, and so
   is a `[mixture]` model — its classes are identified only up to relabelling, so averaging across
-  replicates would mix them. See `docs/tools/bootstrap.qmd`.
+  replicates would mix them; use SIR for uncertainty on a mixture model instead (#1145).
+  See `docs/tools/bootstrap.qmd`.
 - **`prepare_run` / `prepare_run_with_inits` (#1140)** — public "load a model and its dataset, but
   do not fit" entry points returning a `PreparedRun`. `run_model_with_data` is now implemented on
   top of them, so a tool and the CLI cannot diverge in how a model is loaded.

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -529,6 +529,51 @@ fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
     (near_boundary, cov_ok, cov_warnings)
 }
 
+/// Refuse a mixture model. **Settled, not pending** — see #1145.
+///
+/// A mixture's classes are identified only up to relabelling, so replicate *k*'s
+/// "class 1" need not be the original fit's class 1. Averaging estimates across
+/// replicates without resolving that label switching inflates the standard error
+/// toward the *between-class separation*, which is a property of the model and
+/// not a sampling uncertainty — and it does so while every replicate converges
+/// and the table looks entirely reasonable. The error grows with how well
+/// separated the classes are, i.e. it is worst exactly when the mixture is best
+/// identified and therefore most likely to be believed.
+///
+/// Relabelling rules exist (ordering on a canonical statistic; matching each
+/// replicate's per-subject `mixest` assignments against the base fit's) and would
+/// work most of the time. #1145 closed on the judgement that "most of the time"
+/// is the wrong standard for the artefact a reader trusts *instead of* redoing
+/// the analysis, and that each rule adds a knob whose setting silently changes
+/// the answer.
+///
+/// The alternative offered in the message is [SIR], which never re-optimises —
+/// it samples around the ML estimates and reweights by the likelihood — so there
+/// is no second basin to fall into and no labelling to resolve. The covariance
+/// step is likewise well defined at a single fit's fixed labelling.
+///
+/// Consequence for this module: `MixtureParams`' per-class Omega/Sigma overrides
+/// are deliberately *not* represented in [`coordinates`]. There is no longer a
+/// reason to add them.
+///
+/// [SIR]: https://ferx-nlme.github.io/ferx-core/estimation/sir.html
+fn reject_mixture_model(params: &ModelParameters) -> Result<(), String> {
+    if params.mixture.is_some() {
+        return Err(
+            "the bootstrap does not support mixture models ([mixture] block), and will not: \
+             a mixture's classes are identified only up to relabelling, so a replicate's \
+             class 1 need not be the original fit's class 1, and averaging estimates across \
+             replicates mixes them — inflating the standard error toward the between-class \
+             separation while every replicate converges and the table looks reasonable. \
+             For parameter uncertainty on a mixture model use SIR (`sir = true`), which \
+             reweights samples around the estimates instead of re-fitting and so cannot \
+             switch labels."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Refuse a model whose predictions depend on the subject identifier.
 ///
 /// Resampling with replacement necessarily renames the duplicate copies of a
@@ -536,32 +581,6 @@ fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
 /// covariate would silently see different values than it did in the base fit.
 /// PsN documents the same hazard as a known bug — "model code that relies on ID
 /// numbers will lead to errors" — and leaves it to the user. Fail instead.
-/// Refuse a mixture model.
-///
-/// Two reasons, and the first is not a plumbing gap. A mixture model's classes
-/// are identified only up to relabelling, so replicate *k*'s "class 1" need not
-/// be the original fit's class 1; averaging estimates across replicates without
-/// resolving that label switching produces a bias-and-interval table that is
-/// meaningless rather than merely noisy. Second, `MixtureParams` carries
-/// per-class Omega/Sigma overrides in their own packed block, which the flat
-/// vector here does not represent — so `--update-inits` and `--dofv` would
-/// silently drop them.
-///
-/// Refusing is the honest answer until the relabelling question is settled.
-fn reject_mixture_model(params: &ModelParameters) -> Result<(), String> {
-    if params.mixture.is_some() {
-        return Err(
-            "the bootstrap does not support mixture models ([mixture] block). A mixture's \
-             classes are identified only up to relabelling, so a replicate's class 1 need \
-             not be the original fit's class 1, and averaging estimates across replicates \
-             would mix them. Bootstrapping a mixture needs a relabelling rule this tool \
-             does not have."
-                .to_string(),
-        );
-    }
-    Ok(())
-}
-
 fn reject_id_dependent_model(model: &CompiledModel) -> Result<(), String> {
     reject_id_dependent(&model.referenced_covariates)
 }

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -270,6 +270,10 @@ fn a_mixture_model_is_refused() {
     let err = reject_mixture_model(&mixture).unwrap_err();
     assert!(err.contains("relabelling"), "{err}");
     assert!(err.contains("mixture"), "{err}");
+    // #1145 closed this as decided, not deferred, so the message must name the
+    // method that does work rather than read as a missing feature.
+    assert!(err.contains("will not"), "{err}");
+    assert!(err.contains("SIR"), "{err}");
 }
 
 // ── the ID guard ────────────────────────────────────────────────────────────

--- a/docs/tools/bootstrap.qmd
+++ b/docs/tools/bootstrap.qmd
@@ -86,14 +86,26 @@ there is **empty when core reports no standard error for that coordinate** — a
 reported", never zero.
 
 ::: {.callout-warning}
-## Mixture models are not supported
+## Mixture models cannot be bootstrapped — use SIR
 
 A `[mixture]` model's classes are identified only up to relabelling: replicate *k*'s
-"class 1" need not be the original fit's class 1, so averaging estimates across
-replicates would mix two different things and produce an interval that is meaningless
-rather than merely noisy. Bootstrapping a mixture needs a relabelling rule, and this
-tool does not have one, so it refuses the run rather than reporting a plausible-looking
-table.
+"class 1" need not be the original fit's class 1. Averaging estimates across replicates
+without resolving that mixes two different things, inflating the standard error toward
+the **between-class separation** — a property of the model, not a sampling uncertainty —
+while every replicate converges and the table looks entirely reasonable. The error grows
+with how well separated the classes are, so it is worst exactly when the mixture is best
+identified and most likely to be believed.
+
+Relabelling rules exist and would work most of the time. That is the wrong standard for
+the artefact a reader trusts *instead of* redoing the analysis, so `ferx bootstrap`
+refuses a mixture model rather than reporting a plausible-looking table. This is a
+settled decision, not a missing feature.
+
+For parameter uncertainty on a mixture model, use [SIR](../estimation/sir.qmd)
+(`sir = true`). SIR never re-optimises — it samples around the maximum-likelihood
+estimates and reweights by the likelihood — so there is no second basin to fall into and
+no labelling to resolve. The covariance step is likewise well defined at a single fit's
+fixed labelling.
 :::
 
 ::: {.callout-warning}


### PR DESCRIPTION
## Why

#1145 is closed with a decision: **mixture models will not be bootstrapped.** The code
merged in #1141 already refuses them, but its wording read as a placeholder —

> Bootstrapping a mixture needs a relabelling rule this tool does not have.

— which invites the next reader to go and add one. That is the opposite of what was
decided, and the doc comment said so explicitly ("Refusing is the honest answer *until*
the relabelling question is settled"). It is settled.

## What changed

Wording only in `ferx-tools`; no behaviour change, no API change.

The refusal now states the reasoning and, more usefully, names the method that *does*
work:

- **Why it is refused.** Label switching inflates the standard error toward the
  between-class separation — a property of the model, not a sampling uncertainty — while
  every replicate converges and the table looks entirely reasonable. The error grows with
  how well separated the classes are, so it is worst exactly when the mixture is best
  identified and most likely to be believed. Relabelling rules would work most of the
  time, which is the wrong standard for the artefact a reader trusts *instead of* redoing
  the analysis.
- **What to use instead.** SIR. It samples around the ML estimates and reweights by the
  likelihood rather than re-fitting, so there is no second basin to fall into and no
  labelling to resolve. The covariance step is likewise well defined at a single fit's
  fixed labelling. Both the error message and `docs/tools/bootstrap.qmd` now point there.

Also fixes a doc-comment bug introduced in #1141: inserting `reject_mixture_model` ahead
of `reject_id_dependent_model` left the ID guard's `///` block attached to the mixture
function, so `reject_id_dependent_model` ended up undocumented and the mixture guard
carried the wrong explanation.

## Alternatives considered

Leaving the wording alone and letting the closed issue carry the reasoning. Rejected: the
error message is what a user actually hits, and "this tool does not have one" reads as a
gap someone should fill. A refusal a reader cannot distinguish from an unimplemented
feature will be re-litigated.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / comment wording only)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test updated: `a_mixture_model_is_refused` now pins that the message reads as
      decided rather than deferred (asserts on `"will not"` and `"SIR"`), so a future edit
      softening it back to "not yet supported" fails.

`cargo test -p ferx-tools -p ferx-cli` — 158 passed. Clippy clean.

## Docs
- [x] `docs/tools/bootstrap.qmd` — the callout is retitled "Mixture models cannot be
      bootstrapped — use SIR", states the decision as settled, and links
      `estimation/sir.qmd`
- [x] `CHANGELOG.md` entry updated to name SIR and reference #1145
- [x] No new pages, so no `_quarto.yml` change

## Reviewer hints

The substance is the reasoning, not the diff. The one functional detail worth a look is
the orphaned doc comment — worth confirming `reject_id_dependent_model` and
`reject_mixture_model` each now carry their own explanation.

Closes the loop on #1145. #1142 (BCa), #1143 (resume) and #1144 (ferx-r wrapper) are
unaffected.
