### PR TITLE
fix(pk): check the disposition off the axes, not only along them [closes #1149]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,19 @@ section of the SDLC for the versioning policy).
   top of them, so a tool and the CLI cannot diverge in how a model is loaded.
 
 ### Fixed
+- **An `[odes]` right-hand side that is nonlinear in the compartment amounts is no longer
+  served by the closed-form fast path (#1149).** Linearity was established by evaluating the
+  right-hand side one compartment at a time with every other amount held at zero, so a term
+  that only switches on away from those points was invisible to it: a product of two amounts
+  (`- KON*central*periph`, the target-binding/TMDD shape) is exactly zero whenever either is
+  zero, and a branch testing an amount (`if (central > 10)`) was never entered, because the
+  largest amount probed was 2. Such models were admitted to the closed form, which does not
+  evaluate the right-hand side at all, so the term was **dropped from the predictions** —
+  the same silent failure as #1124, with no time variable involved. Identification now also
+  checks the right-hand side against the recovered linear system away from the axes, across
+  six decades of amount. Models that are linear in the amounts are unaffected and keep the
+  fast path, including those whose coefficients are arbitrary functions of `θ`, `η`, and
+  covariates.
 - **An `EVID=2` record no longer aborts a fit on a parameter-static subject (#1124 review).**
   Any subject routed to the event-driven walker while its PK parameters are constant — an
   `EVID=3/4` reset, or (since the change above) an `[odes]` right-hand side that reads model

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -277,6 +277,49 @@ concentration by 12 h, and each of the four spellings read from an untaken `if` 
 wrong by 4.0e-1 relative. Models that do not mention model time in `[odes]` are unaffected.
 :::
 
+### A right-hand side that is nonlinear in the state is always integrated {#nonlinear-rhs}
+
+The same shortcut also needs the disposition to be **linear in the compartment amounts**, so
+it does not apply to a right-hand side where a state multiplies another state, or where a
+branch tests one:
+
+```
+[odes]
+  # nonlinear: integrated, never served by the closed form
+  d/dt(central) = first_order(ka=KA) - CL/V*central - Q/V*central + Q/V2*periph
+                  - KON*central*periph          # target binding (TMDD)
+  d/dt(periph)  = Q/V*central - Q/V2*periph
+```
+
+```
+[odes]
+  # state-triggered branch: also integrated
+  if (central > 10.0) { KE = 3.0*CL/V } else { KE = CL/V }
+  d/dt(central) = first_order(ka=KA) - KE*central
+```
+
+Saturable elimination (`- VMAX*central/(KM + central)`) has always been integrated for the
+same reason. As with model time, there is nothing to configure — the only consequence is
+that these models step the system rather than evaluating a closed form. If they are also
+stiff, see [Stiff systems](#stiff-systems) below.
+
+::: {.callout-warning}
+## Nonlinear disposition: affects results from ferx 0.3.0 and earlier
+
+Until [#1149](https://github.com/FeRx-NLME/ferx-core/issues/1149) ferx established linearity
+by evaluating the right-hand side one compartment at a time, with every *other* amount held
+at zero. A term that only switches on away from those points was therefore invisible:
+`KON*central*periph` is exactly zero whenever either amount is zero, and a threshold above
+the probe's amplitude was never crossed. Such a model was admitted to the closed-form path,
+which does not evaluate the right-hand side at all, so the term was **dropped from the
+predictions** — the same silent failure as the model-time case above, and with no time
+variable involved.
+
+Re-run any earlier result whose `[odes]` block multiplies two compartment amounts together,
+or branches on one. A right-hand side that is linear in the amounts is unaffected, including
+one whose *coefficients* are arbitrary functions of `θ`, `η`, and covariates.
+:::
+
 ### Stiff systems
 
 An explicit method like RK45 is *stability*-limited on a stiff system: it keeps shrinking

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -113,6 +113,22 @@ const LINEARITY_TOL: f64 = 1e-7;
 /// two-compartment `k12`/`k21` pair from a one-way depot→central drain).
 const COUPLING_EPS: f64 = 1e-9;
 
+/// State amplitudes for [`identify_disposition`]'s off-axis residual check
+/// (#1149). Spans six decades because a state-triggered branch fires at whatever
+/// amount the model author wrote, and identification has no subject to derive a
+/// dose scale from. A genuinely linear RHS satisfies `f(u) = A·u` at every
+/// amplitude, so each extra rung costs one RHS evaluation and cannot cause a
+/// false decline.
+///
+/// Cost, stated rather than waved at: identification goes from `3n + 1` RHS
+/// evaluations to `3n + 5` — 7 to 11 for a two-compartment model, ~57% more
+/// probing. [`MrDisposition`]'s own doc already calls that probing a
+/// second-order cost (the fast path avoids ODE integration entirely) and notes
+/// it repeats on every value/gradient evaluation because the result is not yet
+/// memoised; this makes that pending memoisation worth a little more, and
+/// changes nothing about its correctness.
+const OFF_AXIS_PROBE_SCALES: [f64; 4] = [1.0, 1e2, 1e4, 1e6];
+
 /// Probe the forcing-free disposition RHS `du = f(u, p, t)` in `f64` at state
 /// `u`. Returns `None` when the spec has no compiled RHS program (hand-built
 /// specs / out of analytic scope). The forcings are applied by a separate
@@ -212,6 +228,66 @@ pub fn identify_disposition(spec: &OdeSpec, p: &[f64], t: f64) -> Option<MrDispo
                 return None; // time-varying
             }
             jac[i][j] = ei[j];
+        }
+    }
+
+    // **Off-axis residual.** Everything above probes one state at a time — every
+    // sample has all *other* states at zero — so the axes fix `A` but say nothing
+    // about terms that only switch on away from them. Two classes slip through,
+    // and both reproduce #1124's shape (a term silently absent from the
+    // predictions, no error, `converged: true`) with no time variable anywhere,
+    // so `mr_scope`'s model-time gate cannot see them either:
+    //
+    //   - a **product of two distinct states** — `- KON*central*periph`, the
+    //     TMDD/binding shape — is *exactly* zero at `0`, `eᵢ` and `2eᵢ`, so
+    //     `f(0) ≈ 0` passes, `f(2eᵢ) = 2f(eᵢ)` passes, the sign and
+    //     mass-conservation patterns pass, and a clean 2-cpt is identified with
+    //     the binding term dropped;
+    //   - a branch on the **state** — `if (central > 10) { KE = 3*CL/V }` — is
+    //     never entered, because the largest state any probe above reaches is
+    //     `2.0`.
+    //
+    // Two things catch them, and they are separate — for a one-compartment model
+    // there is only one axis, so "off-axis" is vacuous there and it is purely the
+    // amplitude that does the work:
+    //
+    //   - **mixed states** (`n ≥ 2`, every amount non-zero at once) reach the
+    //     state-product class, which no single-axis sample can;
+    //   - **amplitude** reaches anything whose behaviour changes with the amount
+    //     — a state threshold, or saturation. That is the whole mechanism at
+    //     `n = 1`, and it is what declines a Michaelis–Menten elimination whose
+    //     `KM` is large enough to look linear at amounts of 1–2.
+    //
+    // Both fall out of one question the axis probes never ask: does `f` actually
+    // equal `A·u` away from where `A` was measured? `f(0) ≈ 0` is already established,
+    // so a genuinely linear disposition satisfies `f(u) = A·u` at every `u`, and
+    // the residual is exact to rounding — this compares two evaluations of the
+    // same RHS, with no integration in it, so `LINEARITY_TOL` governs it exactly
+    // as it governs the on-axis `f(2eᵢ) = 2f(eᵢ)` check. Nothing here is
+    // calibrated against solver error; do not confuse it with
+    // `verify_against_ode_twin`'s tolerance, which compares two *integrations*
+    // and must scale with `reltol`.
+    //
+    // The ladder spans six decades because a state-triggered threshold sits at
+    // whatever amount the model author wrote, and this function has no subject
+    // and so no dose scale to derive it from. A truly linear RHS passes at every
+    // amplitude, so extra rungs cost four RHS evaluations and no false declines;
+    // the per-state multipliers are distinct so a term antisymmetric in two
+    // states cannot cancel itself. Declining is the safe direction: it routes the
+    // model to the ODE engine, which is slower and correct.
+    for &scale in &OFF_AXIS_PROBE_SCALES {
+        let u: Vec<f64> = (0..n).map(|i| scale * (1.0 + 0.5 * i as f64)).collect();
+        let f_u = probe_rhs_f64(spec, &u, p, t)?;
+        for j in 0..n {
+            // (A·u)_j = Σ_i jac[i][j]·u_i — `jac[i]` is the response to `eᵢ`, i.e.
+            // column `i` of `A`, so the sum runs over the *first* index.
+            let au: f64 = (0..n).map(|i| jac[i][j] * u[i]).sum();
+            if !f_u[j].is_finite() {
+                return None; // NaN/Inf probe — see the `du0` guard above
+            }
+            if (f_u[j] - au).abs() > LINEARITY_TOL * (1.0 + au.abs()) {
+                return None; // nonlinear or state-switched away from the axes
+            }
         }
     }
 
@@ -1465,6 +1541,219 @@ mod tests {
         assert!(
             identify_disposition(spec, &p, 1.0).is_none(),
             "MM elimination must be declined (nonlinear)"
+        );
+    }
+
+    /// Saturable elimination with a **`KM` far above the probe amplitude** must
+    /// be declined (#1149).
+    ///
+    /// `declines_nonlinear_michaelis_menten` above uses `KM = 5`, which is
+    /// nonlinear enough to fail the on-axis `f(2eᵢ) = 2f(eᵢ)` check outright. The
+    /// interesting case is the one that *passes* it: for `KM = 1e5` the on-axis
+    /// residual is `2·VMAX/((KM+1)(KM+2)) ≈ 2e-9`, comfortably inside
+    /// `LINEARITY_TOL`, because at amounts of 1–2 the model genuinely is linear.
+    /// It is saturated at the amounts a real dose produces, and nothing on the
+    /// axes can see that.
+    ///
+    /// This is why the ladder spans decades rather than adding one off-axis
+    /// point: whether a model is "nonlinear" is a question about the amounts it
+    /// actually reaches, and identification has no dose to scale to. Note the
+    /// unit-dependence this removes — the same model written in ng instead of mg
+    /// has a `KM` a million times larger, so before this it flipped from declined
+    /// to admitted on a change of units alone.
+    #[test]
+    fn declines_saturable_elimination_that_is_linear_at_the_axis_amplitudes() {
+        let src = r#"
+[parameters]
+  theta TVVMAX(10.0, 0.01, 1000.0)
+  theta TVKM(100000.0, 1.0, 1e9)
+  theta TVV(20.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 100.0)
+  omega ETA_V ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  VMAX = TVVMAX
+  KM = TVKM
+  V = TVV * exp(ETA_V)
+  KA = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = first_order(ka=KA) - VMAX*central/(KM + central)
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+        let model = crate::parser::model_parser::parse_model_string(src).unwrap();
+        let spec = model.ode_spec.as_ref().expect("ode model");
+        let theta = [10.0, 1.0e5, 20.0, 1.5];
+        let eta = [0.0];
+        let p = flat_params(&model, &theta, &eta);
+
+        // Non-vacuity: the on-axis homogeneity check must actually pass here,
+        // otherwise this is just another copy of the KM = 5 test.
+        let e1 = probe_rhs_f64(spec, &[1.0], &p, 1.0).expect("probe");
+        let two_e1 = probe_rhs_f64(spec, &[2.0], &p, 1.0).expect("probe");
+        let on_axis_residual = (two_e1[0] - 2.0 * e1[0]).abs();
+        assert!(
+            on_axis_residual <= LINEARITY_TOL * (1.0 + two_e1[0].abs()),
+            "precondition: this model must LOOK linear on the axes (residual \
+             {on_axis_residual:e}), else the off-axis ladder is not what declines it"
+        );
+        assert!(
+            identify_disposition(spec, &p, 1.0).is_none(),
+            "saturable elimination must be declined even when it is linear at \
+             amounts of 1-2"
+        );
+    }
+
+    /// A 2-cpt model with a **binding term that is a product of two distinct
+    /// states** must be declined (#1149).
+    ///
+    /// This is the class the axis probes structurally cannot see:
+    /// `KON*central*periph` is *exactly* zero at `u = 0`, `eᵢ` and `2eᵢ`, so
+    /// every on-axis check passes — `f(0) ≈ 0`, `f(2eᵢ) = 2f(eᵢ)`, both
+    /// couplings above `COUPLING_EPS`, the mass-conservation and sign patterns —
+    /// and a clean canonical 2-cpt used to be identified with the binding term
+    /// dropped from the predictions entirely. That is #1124's failure shape with
+    /// no time variable in it, so `mr_scope`'s model-time gate never applied.
+    ///
+    /// The paired control is what makes this non-vacuous: the identical model
+    /// with `KON = 0` must still be **admitted**, so the test pins the term and
+    /// not merely the model's shape.
+    #[test]
+    fn declines_a_bilinear_binding_term_but_keeps_its_linear_control() {
+        let src = |kon: &str| {
+            format!(
+                r#"
+[parameters]
+  theta TVCL(1.0, 0.01, 100.0)
+  theta TVV(20.0, 0.1, 500.0)
+  theta TVQ(0.5, 0.01, 100.0)
+  theta TVV2(30.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+[structural_model]
+  ode(states=[central, periph])
+[odes]
+  d/dt(central) = first_order(ka=KA) - (CL/V)*central - (Q/V)*central + (Q/V2)*periph - {kon}*central*periph
+  d/dt(periph)  = (Q/V)*central - (Q/V2)*periph
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#
+            )
+        };
+        let theta = [1.0, 20.0, 0.5, 30.0, 1.5];
+        let eta = [0.0];
+
+        let control = crate::parser::model_parser::parse_model_string(&src("0.0")).unwrap();
+        let cspec = control.ode_spec.as_ref().expect("ode model");
+        let cp = flat_params(&control, &theta, &eta);
+        assert!(
+            identify_disposition(cspec, &cp, 1.0).is_some(),
+            "precondition: with KON = 0 this is an ordinary linear 2-cpt and must \
+             still be admitted — otherwise the decline below proves nothing about \
+             the binding term"
+        );
+
+        let bound = crate::parser::model_parser::parse_model_string(&src("0.002")).unwrap();
+        let bspec = bound.ode_spec.as_ref().expect("ode model");
+        let bp = flat_params(&bound, &theta, &eta);
+        // The term really is invisible on the axes: assert that, so a future
+        // change that made it visible there would surface here rather than
+        // silently turning this into a test of something else.
+        let on_axis_probe = probe_rhs_f64(bspec, &[1.0, 0.0], &bp, 1.0).expect("probe");
+        let control_probe = probe_rhs_f64(cspec, &[1.0, 0.0], &cp, 1.0).expect("probe");
+        assert_eq!(
+            on_axis_probe[0].to_bits(),
+            control_probe[0].to_bits(),
+            "the binding term must be exactly invisible at u = e_central — that \
+             is why the axis probes cannot decide it"
+        );
+        assert!(
+            identify_disposition(bspec, &bp, 1.0).is_none(),
+            "a bilinear central*periph term must be declined"
+        );
+    }
+
+    /// A branch on the **state** must be declined (#1149).
+    ///
+    /// The largest state any axis probe reaches is `2.0`, so a threshold above
+    /// that is never entered and the `else` arm is identified as if it were the
+    /// whole model — here a 1-cpt with `ke = CL/V`, under-predicting elimination
+    /// threefold over the whole range above the threshold.
+    ///
+    /// Note `mr_scope_declines_every_model_time_spelling` already exercises this
+    /// exact branch shape, but only with a *time* variable inside it; the state
+    /// version was a one-token edit away from the tests we shipped.
+    #[test]
+    fn declines_a_state_triggered_branch_but_keeps_its_unbranched_control() {
+        let src = |cond: &str| {
+            format!(
+                r#"
+[parameters]
+  theta TVCL(1.0, 0.01, 100.0)
+  theta TVV(20.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+{cond}  d/dt(central) = first_order(ka=KA) - KE*central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#
+            )
+        };
+        let theta = [1.0, 20.0, 1.5];
+        let eta = [0.0];
+
+        let control =
+            crate::parser::model_parser::parse_model_string(&src("  KE = CL/V\n")).unwrap();
+        let cspec = control.ode_spec.as_ref().expect("ode model");
+        let cp = flat_params(&control, &theta, &eta);
+        assert!(
+            identify_disposition(cspec, &cp, 1.0).is_some(),
+            "precondition: the unbranched model must still be admitted"
+        );
+
+        let branched = crate::parser::model_parser::parse_model_string(&src(
+            "  if (central > 10.0) {\n    KE = 3.0*CL/V\n  } else {\n    KE = CL/V\n  }\n",
+        ))
+        .unwrap();
+        let bspec = branched.ode_spec.as_ref().expect("ode model");
+        let bp = flat_params(&branched, &theta, &eta);
+        // Non-vacuity: every on-axis probe takes the `else` arm, so on the axes
+        // the branched model is bit-identical to the control.
+        for u in [vec![1.0], vec![2.0]] {
+            let b = probe_rhs_f64(bspec, &u, &bp, 1.0).expect("probe");
+            let c = probe_rhs_f64(cspec, &u, &cp, 1.0).expect("probe");
+            assert_eq!(
+                b[0].to_bits(),
+                c[0].to_bits(),
+                "at u = {u:?} the branch must be untaken, matching the control"
+            );
+        }
+        assert!(
+            identify_disposition(bspec, &bp, 1.0).is_none(),
+            "a state-triggered branch must be declined"
         );
     }
 

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -1757,6 +1757,121 @@ mod tests {
         );
     }
 
+    /// An off-axis probe that returns **NaN** must decline, not slip through (#1149).
+    ///
+    /// This is the one branch of the off-axis residual that the three decline tests
+    /// above cannot reach — they all produce finite probes. It matters for a reason
+    /// the neighbouring `du0` guard already states at the top of this function: a
+    /// bare `>` comparison lets NaN pass, because `NaN > TOL` is **false**. So
+    /// without the `is_finite` check the residual below would compute
+    /// `(NaN - au).abs() > tol` → `false` and **admit** the model, serving NaN
+    /// predictions from the fast path.
+    ///
+    /// Note the asymmetry, which decides how this test has to be written: for
+    /// ±`Inf` the residual check declines on its own (`inf > tol` is true), so an
+    /// `Inf` fixture would cover the line while proving nothing. The fixture must
+    /// produce NaN, and the test asserts that it does.
+    ///
+    /// The model is exactly linear on every on-axis sample — `u = 0`, `eᵢ`, `2eᵢ`,
+    /// at both probe times — so it passes `du0`, homogeneity and time-invariance,
+    /// and is declined *only* at the off-axis ladder's top rung.
+    ///
+    /// **Getting a NaN out of this DSL takes work, and that is worth recording.**
+    /// The evaluator is deliberately hardened (`model_parser.rs`): `BinOp::Div`
+    /// returns `0.0` when `|denominator| < 1e-30`, `log`/`ln` clamp with
+    /// `v.max(1e-30)`, and `sqrt` clamps with `v.max(0.0)`. None of the usual
+    /// routes produce NaN. What is *not* clamped is `exp`, which overflows to
+    /// `+inf` above ~709 — so `exp(central) - exp(central)`, identically `0.0`
+    /// while `exp` is finite, becomes `inf - inf = NaN` once it is not.
+    ///
+    /// It has to sit behind the state branch rather than in the RHS directly. Left
+    /// bare, `exp(100)` is `2.7e43`, which *absorbs* the `-CL/V*central` term in
+    /// floating point: the probe at scale `1e2` returns `0.0` instead of `-5`, and
+    /// the model is declined by the residual comparison one rung early, never
+    /// reaching the guard under test. Gated above `1e5`, the first three rungs are
+    /// untouched and the top rung is NaN.
+    #[test]
+    fn declines_an_off_axis_probe_that_returns_nan() {
+        let src = |branch: &str| {
+            format!(
+                r#"
+[parameters]
+  theta TVCL(1.0, 0.01, 100.0)
+  theta TVV(20.0, 0.1, 500.0)
+  theta TVKA(1.5, 0.01, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL  = TVCL * exp(ETA_CL)
+  V   = TVV
+  KA  = TVKA
+[structural_model]
+  ode(states=[central])
+[odes]
+{branch}  d/dt(central) = first_order(ka=KA) - CL/V*central + EXTRA
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#
+            )
+        };
+        let theta = [1.0, 20.0, 1.5];
+        let eta = [0.0];
+
+        // Control: no branch, so the disposition is an ordinary linear 1-cpt and
+        // must still be admitted. Without this the decline below would not pin the
+        // NaN branch as the cause.
+        let control =
+            crate::parser::model_parser::parse_model_string(&src("  EXTRA = 0.0\n")).unwrap();
+        let cspec = control.ode_spec.as_ref().expect("ode model");
+        let cp = flat_params(&control, &theta, &eta);
+        assert!(
+            identify_disposition(cspec, &cp, 1.0).is_some(),
+            "precondition: the unbranched control must stay admitted"
+        );
+
+        // The branch fires only above 1e5, i.e. only at the ladder's top rung
+        // (`OFF_AXIS_PROBE_SCALES` = 1, 1e2, 1e4, 1e6).
+        let nan_src = src(
+            "  if (central > 1.0e5) {\n    EXTRA = exp(central) - exp(central)\n  } else {\n    EXTRA = 0.0\n  }\n",
+        );
+        let bad = crate::parser::model_parser::parse_model_string(&nan_src).unwrap();
+        let bspec = bad.ode_spec.as_ref().expect("ode model");
+        let bp = flat_params(&bad, &theta, &eta);
+
+        // Non-vacuity 1: every on-axis sample is finite AND matches the control, so
+        // the model reaches the off-axis loop rather than being declined earlier.
+        for u in [vec![0.0], vec![1.0], vec![2.0]] {
+            let f_bad = probe_rhs_f64(bspec, &u, &bp, 1.0).expect("probe");
+            let f_ctl = probe_rhs_f64(cspec, &u, &cp, 1.0).expect("probe");
+            assert!(
+                f_bad[0].is_finite(),
+                "on-axis probe at {u:?} must be finite, got {f_bad:?}"
+            );
+            assert!(
+                (f_bad[0] - f_ctl[0]).abs() < LINEARITY_TOL,
+                "on-axis probe at {u:?} must be bit-comparable to the control: \
+                 {f_bad:?} vs {f_ctl:?}"
+            );
+        }
+
+        // Non-vacuity 2: the top rung really is NaN, not Inf. An Inf probe would be
+        // declined by the residual comparison below the guard, so this test would
+        // pass with the guard removed and prove nothing.
+        let top = probe_rhs_f64(bspec, &[1.0e6], &bp, 1.0).expect("probe");
+        assert!(
+            top[0].is_nan(),
+            "the top rung must be NaN — Inf is caught by the residual check instead \
+             and would make this test vacuous: got {top:?}"
+        );
+
+        assert!(
+            identify_disposition(bspec, &bp, 1.0).is_none(),
+            "an off-axis probe returning NaN must be declined"
+        );
+    }
+
     // ── Layer 3 (the anchor): the admitted closed form must reduce to its own
     //    integrated OdeSpec twin, to solver tolerance. This is what ties the
     //    fast path to the (NONMEM-anchored) ODE path. Tight solver tol so the


### PR DESCRIPTION
## Why

`identify_disposition` decides whether an `[odes]` right-hand side is a linear 1-/2-compartment disposition — and so whether the closed-form fast path may serve it, skipping integration entirely. It establishes linearity **behaviourally**, by evaluating the right-hand side at `u = 0`, `eᵢ` and `2eᵢ`.

Every one of those samples holds all *other* amounts at zero, and none exceeds 2. A term that only switches on away from those points is therefore invisible to every check the function runs, and the model is admitted to a path that never evaluates the right-hand side at all — so the term is **dropped from the predictions**, silently, with `converged: true`. That is #1124's failure shape with no time variable in it, which is why `mr_scope`'s model-time gate does not apply.

Three classes are reachable today:

- **a product of two distinct amounts** — `- KON*central*periph`, the target-binding/TMDD shape — is *exactly* zero whenever either amount is zero. `f(0) ≈ 0` passes, `f(2eᵢ) = 2f(eᵢ)` passes, both couplings clear `COUPLING_EPS`, the sign and mass-conservation patterns pass, and a clean canonical 2-cpt is identified with the binding term gone.
- **a branch on an amount** — `if (central > 10) { KE = 3*CL/V }` — is never entered, so the `else` arm is identified as the whole model.
- **saturable elimination with a large `KM`** is genuinely linear at amounts of 1–2, so it passes the homogeneity check while being saturated at the amounts a real dose produces. This one also made admission depend on the model's **units**: the same model written in ng rather than mg has a `KM` a million times larger, so it flipped from declined to admitted on a change of units alone.

Found while reviewing #1130 (#1124), filed as #1149.

## What changed

After the axis probes fix `A`, check the residual `‖f(u) − A·u‖` at mixed states across six decades of amount. `f(0) ≈ 0` is already established, so a genuinely linear disposition satisfies `f(u) = A·u` at every `u`.

Two mechanisms, deliberately separate — for a one-compartment model there is only one axis, so "off-axis" is vacuous there and the amplitude is doing all the work:

- **mixed states** (`n ≥ 2`, every amount non-zero at once) reach the state-product class, which no single-axis sample can;
- **amplitude** reaches anything whose behaviour changes with the amount — a threshold, or saturation.

The tolerance is `LINEARITY_TOL`, the same constant the on-axis homogeneity check uses, and for the same reason: this compares two *evaluations* of one right-hand side, with no integration in it, so for a linear system the residual is exact to rounding. It is **not** calibrated against solver error and must not be confused with `verify_against_ode_twin`'s bound, which compares two integrations and has to scale with `reltol`.

The ladder spans decades rather than adding one off-axis point because a threshold sits at whatever amount the model author wrote, and identification has no subject to derive a dose scale from. A linear right-hand side passes at every amplitude, so extra rungs cannot cause a false decline. Declining is the safe direction: the model routes to the ODE engine, which is slower and correct.

## Alternatives considered

**Pass the subject's dose scale in** (the shape #1149 suggested). `identify_disposition` is `pub` and takes `(spec, p, t)`; threading an amplitude through means either a signature change or a second public entry point. The ladder gets the same coverage without touching the public API, and is strictly broader — a dose-scaled probe still misses a threshold below the dose.

**Declining anything with an `if` in the right-hand side.** Far blunter: it would decline models whose branch is on a covariate or a parameter, which are perfectly linear in the amounts and are the common case for a class-switched baseline.

**Leaving it to `verify_against_ode_twin`.** It does catch this class — with the new check disabled, the gate fires on the bilinear model at the second observation of the grid below (`t = 2`, closed form 4.270073 vs twin 4.250366). But it is `#[cfg(debug_assertions)]`, and both profiles CI builds tests with — `ci-test` and `ci-fast` — inherit `release` (#344), so it runs in neither CI nor a user's fit. It is a development aid, not a guard.

## Numerical validation

Reference is the ODE engine, which the `mr_tad` / `tad_lag_{A,B}` NONMEM anchors already pin. Two doses (0 and 12 h), `KON = 0.002`, `ode_reltol = 1e-10`, measured with the new check disabled so the closed form is still admitted:

| t | closed form | ODE truth | rel. err |
|---|---|---|---|
| 0.5 | 2.583358 | 2.583093 | 1.0e-4 |
| 2 | 4.270073 | 4.250366 | 4.6e-3 |
| 8 | 2.926096 | 2.633272 | 1.1e-1 |
| 12 | 2.212366 | 1.775333 | 2.5e-1 |
| 24 | 3.249428 | 1.687115 | **9.3e-1** |

Worst 9.3e-1 at 24 h — **1.93× overprediction**, growing monotonically, at a modest binding rate. With the check in place the model declines and production returns the ODE values.

Re-measured after the rebase onto `main`; both value columns reproduce bit-for-bit. The error column previously read `|Δ|/(1+|ODE|)` (the codebase's assertion form) under a `rel` header, which made it disagree with the `1.93×` in the same sentence — it is now true relative error, `|Δ|/|ODE|`, and the two agree.

`--lib`: 3843 passed, 0 failed (3840 on `main` + this PR's 3). **No model in the existing fixture zoo was newly declined** — that is the load-bearing result for a change that can only make admission stricter. Concretely it is pinned by ~19 admission assertions: 9 `assert_reduces_to_ode` call sites (each `.expect("MR-supported")`), 8 `identify_disposition(...).is_some()` asserts, and 2 further `mr_predictions(...).expect(...)` sites. A newly-declined fixture returns `None` and fails at that `expect`.

## Performance

Identification goes from `3n + 1` right-hand-side evaluations to `3n + 5` — 7 to 11 for a two-compartment model. `MrDisposition`'s own doc already calls that probing a second-order cost (the fast path avoids ODE integration entirely) and notes it repeats on every value/gradient evaluation because the result is not yet memoised; this makes that pending memoisation worth slightly more. Models that newly decline pay the ODE path, which is the point.

## Tests

Three decline tests, each **paired with a control that must still be admitted**, so the assert pins the offending term rather than the model's shape, and each asserting **non-vacuity** — that the term really is invisible on the axes:

- bilinear: axis probes bit-identical to the `KON = 0` control;
- state branch: axis probes at `u = 1` and `u = 2` bit-identical to the unbranched control;
- large `KM`: the on-axis homogeneity residual is asserted to be *inside* `LINEARITY_TOL`, so the test cannot degenerate into a copy of the existing `KM = 5` case.

Mutation-tested: disabling the residual check fails all three.

## Docs

New section in `docs/model-file/ode-models.qmd`, parallel to the existing model-time one, with a warning callout for results from 0.3.0 and earlier. `CHANGELOG.md` `[Unreleased]` entry added.

The new callout is titled **"Nonlinear disposition: affects results from ferx 0.3.0 and earlier"** rather than repeating the model-time callout's title verbatim. This PR predates the docs-lint gate (#1163), and on rebase R3 caught the duplicate — two headings on one page generating the same id means the second is addressed as `…-1`. Disambiguating also tells a reader which of the two callouts they are in. Nothing links to either anchor, so no inbound reference breaks.

## Rebase

Originally branched on `worktree-fix-1124-mr-tad-drop` (#1130), which is now merged (`764784c8`). Rebased onto `main` and retargeted; the code diff is byte-identical, and the only content change is the docs heading above.

Rebasing also cleared this PR's `verify_against_ode_twin` failure on the `mr_tad` per-route-lag anchor. That was never this PR's defect: it was the tolerance artifact fixed in #1130 by `8cf01026` and `8528baab`, which the old base predated.

This is deliberately *not* part of #1130: that PR decides **routing** (which engine serves a model), this one changes **admission** (whether the closed form is valid at all). Different blast radii, and #1130 had already been through two review rounds — folding a new admission rule into it would have given the newest behaviour the least scrutiny.

