### PR TITLE
feat(parser): [covariate_model] block — declarative covariate relationships at PsN scm parity [closes #1111]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,15 @@ section of the SDLC for the versioning policy).
   `center`/`breakpoint`/`ref` accept a literal or a data-derived statistic (`median`, `mean`,
   `min`, `max`, `mode`), and `[covariates]` gains `categorical(levels = [0, 1])` /
   `levels = auto`. The relations are echoed on `FitResult.covariate_relations` and in the fit
-  YAML, and `ferx check` prints the desugared block. Each relation owns its own θ (as in `scm`);
+  YAML — each θ naming the categorical `level` it contrasts, each `expr(…)` relation carrying
+  the expression that ran, and a relation with no θ emitting `thetas: []` rather than a bare key.
+  Statistics summarise every event record (observations, doses, `EVID=2` markers, `EVID=3/4`
+  resets), so the default bounds cover the range the fit evaluates over. Centres that would break
+  their own form are refused up front: outside the observed range for the linear family (whose
+  default bounds would come back reversed), non-positive for `power`, zero for `linear_relative`;
+  so is a categorical value the block never declared, which would otherwise be modelled silently
+  as the reference level (`E_COV_LEVEL_UNKNOWN`). `ferx check` prints the desugared block. Each
+  relation owns its own θ (as in `scm`);
   a θ shared across relations is still written classically. Relations are line-oriented and
   independent,
   so a covariate search rewrites this one block instead of doing surgery on an expression. See

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ section of the SDLC for the versioning policy).
   still `ferx-core`.
 
 ### Added
+- **A `present(COV)` condition for covariates that may be missing (#1111).** A missing covariate
+  value is `NaN`, and division by it underflows to `0.0` here rather than erroring, so an
+  unguarded `(CRCL/100)^THETA` silently zeroes the parameter on a row with no `CRCL`.
+  `if (present(CRCL)) ... else 1.0` says the guard plainly; the equivalent `CRCL == CRCL` idiom
+  still works. Usable anywhere a condition is (`!present(X)`, `present(X) && X > 100`), and it is
+  what `[covariate_model]` wraps every generated factor in.
 - **A `[covariate_model]` block: covariate–parameter relationships declared as data (#1111).**
   `CL ~ WT power(center = median)` desugars into exactly the classical
   `[individual_parameters]` expression — with the theta declaration, the centering constant and a
@@ -40,7 +46,9 @@ section of the SDLC for the versioning policy).
   `center`/`breakpoint`/`ref` accept a literal or a data-derived statistic (`median`, `mean`,
   `min`, `max`, `mode`), and `[covariates]` gains `categorical(levels = [0, 1])` /
   `levels = auto`. The relations are echoed on `FitResult.covariate_relations` and in the fit
-  YAML, and `ferx check` prints the desugared block. Relations are line-oriented and independent,
+  YAML, and `ferx check` prints the desugared block. Each relation owns its own θ (as in `scm`);
+  a θ shared across relations is still written classically. Relations are line-oriented and
+  independent,
   so a covariate search rewrites this one block instead of doing surgery on an expression. See
   `docs/model-file/covariate-model.qmd`.
 - **A CI-enforced public-API baseline for `ferx-core` (#1114).** `api/ferx-core-public-api.txt` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ section of the SDLC for the versioning policy).
   still `ferx-core`.
 
 ### Added
+- **A `[covariate_model]` block: covariate–parameter relationships declared as data (#1111).**
+  `CL ~ WT power(center = median)` desugars into exactly the classical
+  `[individual_parameters]` expression — with the theta declaration, the centering constant and a
+  missing-value guard filled in — so the OFV and estimates are identical to writing it by hand.
+  All five PsN `scm` states are expressible (`none`, `linear`, `hockey`, `exponential`, `power`,
+  plus `categorical` and an `expr("…")` escape hatch) with PsN's default inits and bounds;
+  `center`/`breakpoint`/`ref` accept a literal or a data-derived statistic (`median`, `mean`,
+  `min`, `max`, `mode`), and `[covariates]` gains `categorical(levels = [0, 1])` /
+  `levels = auto`. The relations are echoed on `FitResult.covariate_relations` and in the fit
+  YAML, and `ferx check` prints the desugared block. Relations are line-oriented and independent,
+  so a covariate search rewrites this one block instead of doing surgery on an expression. See
+  `docs/model-file/covariate-model.qmd`.
 - **A CI-enforced public-API baseline for `ferx-core` (#1114).** `api/ferx-core-public-api.txt` is
   a committed snapshot of the crate's public surface; a CI job regenerates and diffs it, so any
   widening of the API fails until the baseline is updated in the same PR. Regenerate with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ section of the SDLC for the versioning policy).
   write them package-qualified (`--features ferx-core/ci`). Consumers of the `ferx-core` crate —
   including the ferx-r wrapper, which patches the repo root — are unaffected: the root package is
   still `ferx-core`.
+- **A covariate column with no value for a subject now reads as `NaN`, not as a dropped key
+  (#1111).** Previously the key was simply absent from that subject's covariate map, and every
+  evaluation site resolves an absent covariate to `0.0` — so a subject whose `WT` column was `.`
+  on every row was fitted at `WT = 0`, indistinguishable from a genuine zero, and `present(WT)`
+  reported it as present. The reader now stores `NaN` and warns, naming the covariate and the
+  affected subjects, so the gap is either guarded with `present(...)`, imputed, or fails loudly.
 
 ### Added
 - **A `present(COV)` condition for covariates that may be missing (#1111).** A missing covariate

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -57,6 +57,8 @@ pub ferx_core::api::SurvivalPredictionResult::median_survival: f64
 pub ferx_core::api::SurvivalPredictionResult::survival: f64
 pub ferx_core::api::SurvivalPredictionResult::survival_all: f64
 pub ferx_core::api::SurvivalPredictionResult::time: f64
+pub fn ferx_core::api::assert_covariate_model_bound(model: &ferx_core::CompiledModel) -> core::result::Result<(), alloc::string::String>
+pub fn ferx_core::api::bind_covariate_stats(parsed: &mut ferx_core::ParsedModel, model_text: &str, population: &ferx_core::Population) -> core::result::Result<(), alloc::string::String>
 pub fn ferx_core::api::bind_theta_levels(parsed: &mut ferx_core::ParsedModel, model_text: &str, population: &mut ferx_core::Population) -> core::result::Result<(), alloc::string::String>
 pub fn ferx_core::api::check_experimental_features(model: &ferx_core::CompiledModel) -> alloc::vec::Vec<ferx_core::diagnostics::Diagnostic>
 pub fn ferx_core::api::check_model_data(model: &ferx_core::CompiledModel, population: &ferx_core::Population) -> alloc::vec::Vec<ferx_core::diagnostics::Diagnostic>
@@ -123,6 +125,7 @@ pub ferx_core::diagnostics::Severity::Error
 pub ferx_core::diagnostics::Severity::Warning
 pub struct ferx_core::diagnostics::CheckReport
 pub ferx_core::diagnostics::CheckReport::data: core::option::Option<alloc::string::String>
+pub ferx_core::diagnostics::CheckReport::desugared_individual_parameters: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::diagnostics::CheckReport::diagnostics: alloc::vec::Vec<ferx_core::diagnostics::Diagnostic>
 pub ferx_core::diagnostics::CheckReport::model: alloc::string::String
 pub ferx_core::diagnostics::CheckReport::valid: bool
@@ -1028,6 +1031,8 @@ pub fn ferx_core::ode::solve_ode_with_stats(rhs: &dyn core::ops::function::Fn(&[
 pub type ferx_core::ode::OdeOutputFn = alloc::boxed::Box<(dyn core::ops::function::Fn(&[f64], &[f64], &[f64], &[f64], &std::collections::hash::map::HashMap<alloc::string::String, f64>) -> f64 + core::marker::Send + core::marker::Sync)>
 pub type ferx_core::ode::OdeRhsFn = alloc::boxed::Box<(dyn core::ops::function::Fn(&[f64], &[f64], f64, &mut [f64]) + core::marker::Send + core::marker::Sync)>
 pub mod ferx_core::parser
+pub mod ferx_core::parser::covariate_model
+pub type ferx_core::parser::covariate_model::CovariateStatBindings = std::collections::hash::map::HashMap<alloc::string::String, ferx_core::CovariateSummary>
 pub mod ferx_core::parser::model_parser
 pub enum ferx_core::parser::model_parser::LevelContrast
 pub ferx_core::parser::model_parser::LevelContrast::Auto
@@ -1054,6 +1059,9 @@ pub fn ferx_core::parser::model_parser::LevelBlockDecl::name(&self) -> &str
 pub fn ferx_core::parser::model_parser::LevelBlockDecl::shares_scale_with_eta(&self) -> bool
 pub struct ferx_core::parser::model_parser::OdeOutputProgram
 pub struct ferx_core::parser::model_parser::OdeRhsProgram
+pub struct ferx_core::parser::model_parser::ParseBindings
+pub ferx_core::parser::model_parser::ParseBindings::covariate_stats: ferx_core::parser::covariate_model::CovariateStatBindings
+pub ferx_core::parser::model_parser::ParseBindings::levels: ferx_core::parser::model_parser::LevelBindings
 pub struct ferx_core::parser::model_parser::RuvMagDerivProgram
 pub struct ferx_core::parser::model_parser::ScaleDerivProgram
 pub struct ferx_core::parser::model_parser::ThetaBlocks
@@ -1072,6 +1080,7 @@ pub fn ferx_core::parser::model_parser::known_block_names() -> alloc::vec::Vec<&
 pub fn ferx_core::parser::model_parser::parse_full_model(content: &str) -> core::result::Result<ferx_core::ParsedModel, alloc::string::String>
 pub fn ferx_core::parser::model_parser::parse_full_model_bound(content: &str, level_bindings: &ferx_core::parser::model_parser::LevelBindings) -> core::result::Result<ferx_core::ParsedModel, alloc::string::String>
 pub fn ferx_core::parser::model_parser::parse_full_model_file(path: &std::path::Path) -> core::result::Result<ferx_core::ParsedModel, alloc::string::String>
+pub fn ferx_core::parser::model_parser::parse_full_model_with(content: &str, bindings: &ferx_core::parser::model_parser::ParseBindings) -> core::result::Result<ferx_core::ParsedModel, alloc::string::String>
 pub fn ferx_core::parser::model_parser::parse_model_file(path: &std::path::Path) -> core::result::Result<ferx_core::CompiledModel, alloc::string::String>
 pub fn ferx_core::parser::model_parser::parse_model_string(content: &str) -> core::result::Result<ferx_core::CompiledModel, alloc::string::String>
 pub type ferx_core::parser::model_parser::LevelBindings = std::collections::hash::map::HashMap<alloc::string::String, ferx_core::parser::model_parser::LevelBinding>
@@ -1876,11 +1885,38 @@ pub ferx_core::types::CovarianceStatus::Computed
 pub ferx_core::types::CovarianceStatus::Failed
 pub ferx_core::types::CovarianceStatus::NotRequested
 pub ferx_core::types::CovarianceStatus::SirFallback
+pub enum ferx_core::types::CovariateForm
+pub ferx_core::types::CovariateForm::Categorical
+pub ferx_core::types::CovariateForm::Exponential
+pub ferx_core::types::CovariateForm::Expr(alloc::string::String)
+pub ferx_core::types::CovariateForm::Hockey
+pub ferx_core::types::CovariateForm::Linear
+pub ferx_core::types::CovariateForm::LinearRelative
+pub ferx_core::types::CovariateForm::None
+pub ferx_core::types::CovariateForm::Power
+impl ferx_core::CovariateForm
+pub fn ferx_core::CovariateForm::is_categorical(&self) -> bool
+pub fn ferx_core::CovariateForm::label(&self) -> &'static str
 pub enum ferx_core::types::CovariateKind
 pub ferx_core::types::CovariateKind::Categorical
 pub ferx_core::types::CovariateKind::Continuous
 impl ferx_core::CovariateKind
 pub fn ferx_core::CovariateKind::label(&self) -> &'static str
+pub enum ferx_core::types::CovariateLevels
+pub ferx_core::types::CovariateLevels::Auto
+pub ferx_core::types::CovariateLevels::Declared(alloc::vec::Vec<f64>)
+impl ferx_core::CovariateLevels
+pub fn ferx_core::CovariateLevels::declared(&self) -> core::option::Option<&[f64]>
+pub enum ferx_core::types::CovariateStat
+pub ferx_core::types::CovariateStat::Literal(f64)
+pub ferx_core::types::CovariateStat::Max
+pub ferx_core::types::CovariateStat::Mean
+pub ferx_core::types::CovariateStat::Median
+pub ferx_core::types::CovariateStat::Min
+pub ferx_core::types::CovariateStat::Mode
+impl ferx_core::CovariateStat
+pub fn ferx_core::CovariateStat::label(&self) -> alloc::string::String
+pub fn ferx_core::CovariateStat::literal(&self) -> core::option::Option<f64>
 pub enum ferx_core::types::DerivedKind
 pub ferx_core::types::DerivedKind::Aggregate
 pub ferx_core::types::DerivedKind::Aggregate::filter: core::option::Option<ferx_core::DerivedFilterFn>
@@ -2215,6 +2251,7 @@ pub ferx_core::types::CompiledModel::absorption_ode_equivalent: core::option::Op
 pub ferx_core::types::CompiledModel::analytic_readout: core::option::Option<ferx_core::AnalyticReadout>
 pub ferx_core::types::CompiledModel::analytical_init: alloc::vec::Vec<ferx_core::AnalyticalInit>
 pub ferx_core::types::CompiledModel::bloq_method: ferx_core::BloqMethod
+pub ferx_core::types::CompiledModel::covariate_model: core::option::Option<ferx_core::CovariateModelSpec>
 pub ferx_core::types::CompiledModel::covariate_nns: alloc::vec::Vec<ferx_core::nn::CovariateNn>
 pub ferx_core::types::CompiledModel::default_params: ferx_core::ModelParameters
 pub ferx_core::types::CompiledModel::derived_exprs: alloc::vec::Vec<ferx_core::DerivedExprSpec>
@@ -2307,16 +2344,64 @@ pub ferx_core::types::CondDist::samples: alloc::vec::Vec<alloc::vec::Vec<alloc::
 pub ferx_core::types::CondDist::shrinkage: alloc::vec::Vec<f64>
 pub struct ferx_core::types::CovariateDecl
 pub ferx_core::types::CovariateDecl::kind: ferx_core::CovariateKind
+pub ferx_core::types::CovariateDecl::levels: core::option::Option<ferx_core::CovariateLevels>
 pub ferx_core::types::CovariateDecl::name: alloc::string::String
+impl ferx_core::CovariateDecl
+pub fn ferx_core::CovariateDecl::new(name: impl core::convert::Into<alloc::string::String>, kind: ferx_core::CovariateKind) -> Self
+pub struct ferx_core::types::CovariateModelSpec
+pub ferx_core::types::CovariateModelSpec::desugared_individual_parameters: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::types::CovariateModelSpec::generated_thetas: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::types::CovariateModelSpec::relations: alloc::vec::Vec<ferx_core::CovariateRelation>
+impl ferx_core::CovariateModelSpec
+pub fn ferx_core::CovariateModelSpec::unresolved(&self) -> alloc::vec::Vec<&ferx_core::CovariateRelation>
+pub struct ferx_core::types::CovariateRelation
+pub ferx_core::types::CovariateRelation::center: core::option::Option<ferx_core::CovariateStat>
+pub ferx_core::types::CovariateRelation::covariate: alloc::string::String
+pub ferx_core::types::CovariateRelation::fix: core::option::Option<f64>
+pub ferx_core::types::CovariateRelation::form: ferx_core::CovariateForm
+pub ferx_core::types::CovariateRelation::parameter: alloc::string::String
+pub ferx_core::types::CovariateRelation::resolved_center: core::option::Option<f64>
+pub ferx_core::types::CovariateRelation::source_line: alloc::string::String
+pub ferx_core::types::CovariateRelation::thetas: alloc::vec::Vec<ferx_core::CovariateTheta>
+impl ferx_core::CovariateRelation
+pub fn ferx_core::CovariateRelation::needs_data(&self) -> bool
+pub struct ferx_core::types::CovariateRelationEstimate
+pub ferx_core::types::CovariateRelationEstimate::center: core::option::Option<f64>
+pub ferx_core::types::CovariateRelationEstimate::center_source: core::option::Option<alloc::string::String>
+pub ferx_core::types::CovariateRelationEstimate::covariate: alloc::string::String
+pub ferx_core::types::CovariateRelationEstimate::form: alloc::string::String
+pub ferx_core::types::CovariateRelationEstimate::parameter: alloc::string::String
+pub ferx_core::types::CovariateRelationEstimate::thetas: alloc::vec::Vec<ferx_core::CovariateThetaEstimate>
 pub struct ferx_core::types::CovariateRow
 pub ferx_core::types::CovariateRow::evid: u32
 pub ferx_core::types::CovariateRow::id: alloc::string::String
 pub ferx_core::types::CovariateRow::time: f64
 pub ferx_core::types::CovariateRow::values: alloc::vec::Vec<f64>
+pub struct ferx_core::types::CovariateSummary
+pub ferx_core::types::CovariateSummary::levels: alloc::vec::Vec<f64>
+pub ferx_core::types::CovariateSummary::max: f64
+pub ferx_core::types::CovariateSummary::mean: f64
+pub ferx_core::types::CovariateSummary::median: f64
+pub ferx_core::types::CovariateSummary::min: f64
+pub ferx_core::types::CovariateSummary::mode: f64
+impl ferx_core::CovariateSummary
+pub fn ferx_core::CovariateSummary::value_of(&self, stat: ferx_core::CovariateStat) -> f64
 pub struct ferx_core::types::CovariateTable
 pub ferx_core::types::CovariateTable::kinds: alloc::vec::Vec<ferx_core::CovariateKind>
 pub ferx_core::types::CovariateTable::names: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::types::CovariateTable::rows: alloc::vec::Vec<ferx_core::CovariateRow>
+pub struct ferx_core::types::CovariateTheta
+pub ferx_core::types::CovariateTheta::fixed: bool
+pub ferx_core::types::CovariateTheta::init: f64
+pub ferx_core::types::CovariateTheta::level: core::option::Option<f64>
+pub ferx_core::types::CovariateTheta::lower: f64
+pub ferx_core::types::CovariateTheta::name: alloc::string::String
+pub ferx_core::types::CovariateTheta::upper: f64
+pub struct ferx_core::types::CovariateThetaEstimate
+pub ferx_core::types::CovariateThetaEstimate::estimate: f64
+pub ferx_core::types::CovariateThetaEstimate::fixed: bool
+pub ferx_core::types::CovariateThetaEstimate::name: alloc::string::String
+pub ferx_core::types::CovariateThetaEstimate::se: core::option::Option<f64>
 pub struct ferx_core::types::DerivedContext<'a>
 pub ferx_core::types::DerivedContext::compartment_names: &'a [alloc::string::String]
 pub ferx_core::types::DerivedContext::compartments: &'a [f64]
@@ -2545,6 +2630,7 @@ pub ferx_core::types::FitResult::covariance_n_evals_estimated: core::option::Opt
 pub ferx_core::types::FitResult::covariance_status: ferx_core::CovarianceStatus
 pub ferx_core::types::FitResult::covariance_wall_time_secs: f64
 pub ferx_core::types::FitResult::covariate_names: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::types::FitResult::covariate_relations: alloc::vec::Vec<ferx_core::CovariateRelationEstimate>
 pub ferx_core::types::FitResult::covariate_table: core::option::Option<ferx_core::CovariateTable>
 pub ferx_core::types::FitResult::data_hash: core::option::Option<alloc::string::String>
 pub ferx_core::types::FitResult::data_path: core::option::Option<alloc::string::String>
@@ -2749,6 +2835,7 @@ pub fn ferx_core::OmegaMatrix::from_matrix(m: nalgebra::base::alias::DMatrix<f64
 pub fn ferx_core::OmegaMatrix::from_matrix_with_mask(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool, free_mask: nalgebra::base::alias::DMatrix<bool>) -> Self
 pub struct ferx_core::types::ParsedModel
 pub ferx_core::types::ParsedModel::adaptive_dosing: core::option::Option<ferx_core::sim::adaptive::AdaptiveDosingSpec>
+pub ferx_core::types::ParsedModel::bindings: ferx_core::parser::model_parser::ParseBindings
 pub ferx_core::types::ParsedModel::block_lines: std::collections::hash::map::HashMap<alloc::string::String, usize>
 pub ferx_core::types::ParsedModel::column_map: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub ferx_core::types::ParsedModel::covariate_decls: core::option::Option<alloc::vec::Vec<ferx_core::CovariateDecl>>
@@ -2976,11 +3063,38 @@ pub ferx_core::CovarianceStatus::Computed
 pub ferx_core::CovarianceStatus::Failed
 pub ferx_core::CovarianceStatus::NotRequested
 pub ferx_core::CovarianceStatus::SirFallback
+pub enum ferx_core::CovariateForm
+pub ferx_core::CovariateForm::Categorical
+pub ferx_core::CovariateForm::Exponential
+pub ferx_core::CovariateForm::Expr(alloc::string::String)
+pub ferx_core::CovariateForm::Hockey
+pub ferx_core::CovariateForm::Linear
+pub ferx_core::CovariateForm::LinearRelative
+pub ferx_core::CovariateForm::None
+pub ferx_core::CovariateForm::Power
+impl ferx_core::CovariateForm
+pub fn ferx_core::CovariateForm::is_categorical(&self) -> bool
+pub fn ferx_core::CovariateForm::label(&self) -> &'static str
 pub enum ferx_core::CovariateKind
 pub ferx_core::CovariateKind::Categorical
 pub ferx_core::CovariateKind::Continuous
 impl ferx_core::CovariateKind
 pub fn ferx_core::CovariateKind::label(&self) -> &'static str
+pub enum ferx_core::CovariateLevels
+pub ferx_core::CovariateLevels::Auto
+pub ferx_core::CovariateLevels::Declared(alloc::vec::Vec<f64>)
+impl ferx_core::CovariateLevels
+pub fn ferx_core::CovariateLevels::declared(&self) -> core::option::Option<&[f64]>
+pub enum ferx_core::CovariateStat
+pub ferx_core::CovariateStat::Literal(f64)
+pub ferx_core::CovariateStat::Max
+pub ferx_core::CovariateStat::Mean
+pub ferx_core::CovariateStat::Median
+pub ferx_core::CovariateStat::Min
+pub ferx_core::CovariateStat::Mode
+impl ferx_core::CovariateStat
+pub fn ferx_core::CovariateStat::label(&self) -> alloc::string::String
+pub fn ferx_core::CovariateStat::literal(&self) -> core::option::Option<f64>
 pub enum ferx_core::DecisionOutcome
 pub ferx_core::DecisionOutcome::Dosed
 pub ferx_core::DecisionOutcome::Dosed::n: usize
@@ -3406,6 +3520,7 @@ pub fn ferx_core::cancel::CancelFlag::is_cancelled(&self) -> bool
 pub fn ferx_core::cancel::CancelFlag::new() -> Self
 pub struct ferx_core::CheckReport
 pub ferx_core::CheckReport::data: core::option::Option<alloc::string::String>
+pub ferx_core::CheckReport::desugared_individual_parameters: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::CheckReport::diagnostics: alloc::vec::Vec<ferx_core::diagnostics::Diagnostic>
 pub ferx_core::CheckReport::model: alloc::string::String
 pub ferx_core::CheckReport::valid: bool
@@ -3418,6 +3533,7 @@ pub ferx_core::CompiledModel::absorption_ode_equivalent: core::option::Option<fe
 pub ferx_core::CompiledModel::analytic_readout: core::option::Option<ferx_core::AnalyticReadout>
 pub ferx_core::CompiledModel::analytical_init: alloc::vec::Vec<ferx_core::AnalyticalInit>
 pub ferx_core::CompiledModel::bloq_method: ferx_core::BloqMethod
+pub ferx_core::CompiledModel::covariate_model: core::option::Option<ferx_core::CovariateModelSpec>
 pub ferx_core::CompiledModel::covariate_nns: alloc::vec::Vec<ferx_core::nn::CovariateNn>
 pub ferx_core::CompiledModel::default_params: ferx_core::ModelParameters
 pub ferx_core::CompiledModel::derived_exprs: alloc::vec::Vec<ferx_core::DerivedExprSpec>
@@ -3519,16 +3635,64 @@ impl ferx_core::sim::adaptive::ControllerCtx<'_>
 pub fn ferx_core::sim::adaptive::ControllerCtx<'_>::signal(&self, name: &str) -> core::option::Option<f64>
 pub struct ferx_core::CovariateDecl
 pub ferx_core::CovariateDecl::kind: ferx_core::CovariateKind
+pub ferx_core::CovariateDecl::levels: core::option::Option<ferx_core::CovariateLevels>
 pub ferx_core::CovariateDecl::name: alloc::string::String
+impl ferx_core::CovariateDecl
+pub fn ferx_core::CovariateDecl::new(name: impl core::convert::Into<alloc::string::String>, kind: ferx_core::CovariateKind) -> Self
+pub struct ferx_core::CovariateModelSpec
+pub ferx_core::CovariateModelSpec::desugared_individual_parameters: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::CovariateModelSpec::generated_thetas: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::CovariateModelSpec::relations: alloc::vec::Vec<ferx_core::CovariateRelation>
+impl ferx_core::CovariateModelSpec
+pub fn ferx_core::CovariateModelSpec::unresolved(&self) -> alloc::vec::Vec<&ferx_core::CovariateRelation>
+pub struct ferx_core::CovariateRelation
+pub ferx_core::CovariateRelation::center: core::option::Option<ferx_core::CovariateStat>
+pub ferx_core::CovariateRelation::covariate: alloc::string::String
+pub ferx_core::CovariateRelation::fix: core::option::Option<f64>
+pub ferx_core::CovariateRelation::form: ferx_core::CovariateForm
+pub ferx_core::CovariateRelation::parameter: alloc::string::String
+pub ferx_core::CovariateRelation::resolved_center: core::option::Option<f64>
+pub ferx_core::CovariateRelation::source_line: alloc::string::String
+pub ferx_core::CovariateRelation::thetas: alloc::vec::Vec<ferx_core::CovariateTheta>
+impl ferx_core::CovariateRelation
+pub fn ferx_core::CovariateRelation::needs_data(&self) -> bool
+pub struct ferx_core::CovariateRelationEstimate
+pub ferx_core::CovariateRelationEstimate::center: core::option::Option<f64>
+pub ferx_core::CovariateRelationEstimate::center_source: core::option::Option<alloc::string::String>
+pub ferx_core::CovariateRelationEstimate::covariate: alloc::string::String
+pub ferx_core::CovariateRelationEstimate::form: alloc::string::String
+pub ferx_core::CovariateRelationEstimate::parameter: alloc::string::String
+pub ferx_core::CovariateRelationEstimate::thetas: alloc::vec::Vec<ferx_core::CovariateThetaEstimate>
 pub struct ferx_core::CovariateRow
 pub ferx_core::CovariateRow::evid: u32
 pub ferx_core::CovariateRow::id: alloc::string::String
 pub ferx_core::CovariateRow::time: f64
 pub ferx_core::CovariateRow::values: alloc::vec::Vec<f64>
+pub struct ferx_core::CovariateSummary
+pub ferx_core::CovariateSummary::levels: alloc::vec::Vec<f64>
+pub ferx_core::CovariateSummary::max: f64
+pub ferx_core::CovariateSummary::mean: f64
+pub ferx_core::CovariateSummary::median: f64
+pub ferx_core::CovariateSummary::min: f64
+pub ferx_core::CovariateSummary::mode: f64
+impl ferx_core::CovariateSummary
+pub fn ferx_core::CovariateSummary::value_of(&self, stat: ferx_core::CovariateStat) -> f64
 pub struct ferx_core::CovariateTable
 pub ferx_core::CovariateTable::kinds: alloc::vec::Vec<ferx_core::CovariateKind>
 pub ferx_core::CovariateTable::names: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::CovariateTable::rows: alloc::vec::Vec<ferx_core::CovariateRow>
+pub struct ferx_core::CovariateTheta
+pub ferx_core::CovariateTheta::fixed: bool
+pub ferx_core::CovariateTheta::init: f64
+pub ferx_core::CovariateTheta::level: core::option::Option<f64>
+pub ferx_core::CovariateTheta::lower: f64
+pub ferx_core::CovariateTheta::name: alloc::string::String
+pub ferx_core::CovariateTheta::upper: f64
+pub struct ferx_core::CovariateThetaEstimate
+pub ferx_core::CovariateThetaEstimate::estimate: f64
+pub ferx_core::CovariateThetaEstimate::fixed: bool
+pub ferx_core::CovariateThetaEstimate::name: alloc::string::String
+pub ferx_core::CovariateThetaEstimate::se: core::option::Option<f64>
 pub struct ferx_core::DecisionLogEntry
 pub ferx_core::DecisionLogEntry::decision_idx: usize
 pub ferx_core::DecisionLogEntry::draw: usize
@@ -3801,6 +3965,7 @@ pub ferx_core::FitResult::covariance_n_evals_estimated: core::option::Option<usi
 pub ferx_core::FitResult::covariance_status: ferx_core::CovarianceStatus
 pub ferx_core::FitResult::covariance_wall_time_secs: f64
 pub ferx_core::FitResult::covariate_names: alloc::vec::Vec<alloc::string::String>
+pub ferx_core::FitResult::covariate_relations: alloc::vec::Vec<ferx_core::CovariateRelationEstimate>
 pub ferx_core::FitResult::covariate_table: core::option::Option<ferx_core::CovariateTable>
 pub ferx_core::FitResult::data_hash: core::option::Option<alloc::string::String>
 pub ferx_core::FitResult::data_path: core::option::Option<alloc::string::String>
@@ -4033,6 +4198,7 @@ pub fn ferx_core::OmegaMatrix::from_matrix(m: nalgebra::base::alias::DMatrix<f64
 pub fn ferx_core::OmegaMatrix::from_matrix_with_mask(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool, free_mask: nalgebra::base::alias::DMatrix<bool>) -> Self
 pub struct ferx_core::ParsedModel
 pub ferx_core::ParsedModel::adaptive_dosing: core::option::Option<ferx_core::sim::adaptive::AdaptiveDosingSpec>
+pub ferx_core::ParsedModel::bindings: ferx_core::parser::model_parser::ParseBindings
 pub ferx_core::ParsedModel::block_lines: std::collections::hash::map::HashMap<alloc::string::String, usize>
 pub ferx_core::ParsedModel::column_map: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub ferx_core::ParsedModel::covariate_decls: core::option::Option<alloc::vec::Vec<ferx_core::CovariateDecl>>

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -2369,6 +2369,7 @@ pub struct ferx_core::types::CovariateRelationEstimate
 pub ferx_core::types::CovariateRelationEstimate::center: core::option::Option<f64>
 pub ferx_core::types::CovariateRelationEstimate::center_source: core::option::Option<alloc::string::String>
 pub ferx_core::types::CovariateRelationEstimate::covariate: alloc::string::String
+pub ferx_core::types::CovariateRelationEstimate::expression: core::option::Option<alloc::string::String>
 pub ferx_core::types::CovariateRelationEstimate::form: alloc::string::String
 pub ferx_core::types::CovariateRelationEstimate::parameter: alloc::string::String
 pub ferx_core::types::CovariateRelationEstimate::thetas: alloc::vec::Vec<ferx_core::CovariateThetaEstimate>
@@ -2400,6 +2401,7 @@ pub ferx_core::types::CovariateTheta::upper: f64
 pub struct ferx_core::types::CovariateThetaEstimate
 pub ferx_core::types::CovariateThetaEstimate::estimate: f64
 pub ferx_core::types::CovariateThetaEstimate::fixed: bool
+pub ferx_core::types::CovariateThetaEstimate::level: core::option::Option<f64>
 pub ferx_core::types::CovariateThetaEstimate::name: alloc::string::String
 pub ferx_core::types::CovariateThetaEstimate::se: core::option::Option<f64>
 pub struct ferx_core::types::DerivedContext<'a>
@@ -3660,6 +3662,7 @@ pub struct ferx_core::CovariateRelationEstimate
 pub ferx_core::CovariateRelationEstimate::center: core::option::Option<f64>
 pub ferx_core::CovariateRelationEstimate::center_source: core::option::Option<alloc::string::String>
 pub ferx_core::CovariateRelationEstimate::covariate: alloc::string::String
+pub ferx_core::CovariateRelationEstimate::expression: core::option::Option<alloc::string::String>
 pub ferx_core::CovariateRelationEstimate::form: alloc::string::String
 pub ferx_core::CovariateRelationEstimate::parameter: alloc::string::String
 pub ferx_core::CovariateRelationEstimate::thetas: alloc::vec::Vec<ferx_core::CovariateThetaEstimate>
@@ -3691,6 +3694,7 @@ pub ferx_core::CovariateTheta::upper: f64
 pub struct ferx_core::CovariateThetaEstimate
 pub ferx_core::CovariateThetaEstimate::estimate: f64
 pub ferx_core::CovariateThetaEstimate::fixed: bool
+pub ferx_core::CovariateThetaEstimate::level: core::option::Option<f64>
 pub ferx_core::CovariateThetaEstimate::name: alloc::string::String
 pub ferx_core::CovariateThetaEstimate::se: core::option::Option<f64>
 pub struct ferx_core::DecisionLogEntry

--- a/crates/ferx-cli/src/main.rs
+++ b/crates/ferx-cli/src/main.rs
@@ -464,6 +464,16 @@ fn print_check_human(report: &ferx_core::CheckReport) {
             println!("    help: {}", s);
         }
     }
+    // #1111: a `[covariate_model]` block is sugar over `[individual_parameters]`,
+    // so show what it built. Without this the modeller cannot check the
+    // generated expression against a NONMEM control stream.
+    if !report.desugared_individual_parameters.is_empty() {
+        println!("\n[individual_parameters] as built from [covariate_model]:");
+        for line in &report.desugared_individual_parameters {
+            println!("  {}", line.trim());
+        }
+        println!();
+    }
     if report.valid {
         println!(
             "ok: {} — no errors ({} warning(s))",

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -60,6 +60,7 @@ website:
           - model-file/iov.qmd
           - model-file/individual-parameters.qmd
           - model-file/covariates.qmd
+          - model-file/covariate-model.qmd
           - model-file/structural-model.qmd
           - model-file/lagtime.qmd
           - model-file/steady-state.qmd

--- a/docs/model-file/covariate-model.qmd
+++ b/docs/model-file/covariate-model.qmd
@@ -1,0 +1,238 @@
+---
+pagetitle: "Declarative covariate models in ferx"
+description-meta: "Declare covariate-parameter relationships as data with the [covariate_model] block — PsN scm parity, data-derived centering, and a machine-readable relation table."
+---
+
+# Covariate model
+
+> **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.
+
+The optional `[covariate_model]` block declares covariate–parameter
+relationships as **structured data** instead of as free-text expressions inside
+[`[individual_parameters]`](individual-parameters.qmd).
+
+It is **sugar**: each relation is rewritten into exactly the classical
+expression you would have written by hand, before anything else reads the
+model. Same OFV, same estimates, same gradients — the classical form stays
+fully supported and nothing about it changes.
+
+```
+[covariates]
+  WT   continuous
+  CRCL continuous
+  SEX  categorical(levels = [0, 1])
+
+[covariate_model]
+  CL ~ WT   power(center = median)
+  CL ~ CRCL linear(center = 100)
+  V  ~ WT   power(center = 70, fix = 0.75)
+  CL ~ SEX  categorical(ref = mode)
+```
+
+## Why declare them this way
+
+Writing the factor out by hand is fine for one model. It is the wrong shape for
+a machine writing a hundred:
+
+- **One line per relation, no cross-line dependencies.** A covariate search
+  (PsN `scm`, `ferx_cov_screen()`, an agent) adds or drops a relation with a
+  pure line insert/delete, and rewrites this block only — the rest of the file
+  is invariant.
+- **Nothing to hand-write.** The centering constant, the θ declaration with
+  sensible bounds, and the missing-data guard all come from the form.
+- **The relations come back on the result.** `FitResult.covariate_relations`
+  (and a `covariate_model:` section in the fit YAML) states what covariate model
+  ran, what each centring statistic resolved to, and each θ's estimate and SE —
+  so downstream tooling never parses a `.ferx` file to find out.
+
+If you are writing one model by hand and prefer to see the expression, keep
+writing it classically. Both are first-class.
+
+## Grammar
+
+```
+PARAM ~ COV form(kwargs) [=> THETA_NAME(init, lower, upper)[, ...]]
+```
+
+- `PARAM` — a top-level `[individual_parameters]` name.
+- `COV` — a column declared in [`[covariates]`](covariates.qmd). Unlike the
+  lenient classical path, which warns about an undeclared covariate and reads it
+  anyway, **the declaration is required here**: the form and the levels are read
+  off it, so guessing would make the generated θ vector depend on the dataset.
+- `=> …` — optional. Left out, the θ is named `THETA_<PARAM>_<COV>` (with
+  `_LO`/`_HI` for `hockey` and `_<LEVEL>` for `categorical`) and takes the
+  form's default init and bounds. A `theta` of that name already declared in
+  `[parameters]` takes precedence and is used as declared.
+
+`fix = v` on any form pins the θ at `v` and declares it `FIX`.
+
+## Forms
+
+| form | factor | notes |
+|---|---|---|
+| `none` | `1` | declares no θ, changes no expression |
+| `linear(center=c)` | `1 + θ·(COV − c)` | θ carries the reciprocal of the covariate's units |
+| `linear_relative(center=c)` | `1 + θ·(COV/c − 1)` | dimensionless θ; exact reparameterization of `linear` (θ_rel = c·θ_abs) |
+| `exponential(center=c)` | `exp(θ·(COV − c))` | |
+| `power(center=c)` | `(COV/c)^θ` | the classical allometric factor |
+| `hockey(breakpoint=b)` | `1 + θ_lo·(COV − b)` below `b`, `1 + θ_hi·(COV − b)` above | **two** θ |
+| `categorical(ref=r)` | `1 + θ_k` at each non-reference level, `1` at `r` | one θ per non-reference level |
+| `expr("…")` | verbatim | escape hatch |
+
+`none` exists so a search can record "tested, rejected" in the file and have the
+generated model round-trip through the parser unchanged.
+
+### Coming from PsN `scm`
+
+Every `scm` state is expressible:
+
+| PsN state | PsN code | ferx form |
+|---|---|---|
+| 1 `none` | `PARCOV = 1` | `none` |
+| 2 `linear` (continuous) | `1 + THETA(1)*(COV - median)` | `linear(center = median)` |
+| 2 `linear` (categorical) | `IF(COV.EQ.mode) PARCOV=1; ELSE PARCOV = 1 + THETA(1)` | `categorical(ref = mode)` |
+| 3 `hockey-stick` | two slopes, breakpoint at median | `hockey(breakpoint = median)` |
+| 4 `exponential` | `EXP(THETA(1)*(COV - median))` | `exponential(center = median)` |
+| 5 `power` | `(COV/median)**THETA(1)` | `power(center = median)` |
+| arbitrary `[code]` | NONMEM verbatim | `expr("…")` |
+
+The **default inits and bounds are PsN's, verbatim**:
+
+| form | init | lower | upper |
+|---|---|---|---|
+| `linear` | `0.001/(c−min)` | `1/(c−max)` | `1/(c−min)` |
+| `categorical` | `−0.001` | `−1` | `5` |
+| `hockey` (θ_lo, θ_hi) | `0.001/(c−min)`, `0.001/(c−max)` | `−1e6`, `1/(c−max)` | `1/(c−min)`, `1e6` |
+| `exponential` | `0.001` | `−100` | `1e6` |
+| `power` | `0.001` | `−100` | `1e6` |
+
+The linear bounds are not cosmetic: `θ ∈ [1/(c−max), 1/(c−min)]` is exactly what
+keeps `1 + θ·(COV − c)` positive over the observed covariate range. A covariate
+that does not vary around its centre makes both bounds infinite, and is rejected
+with a message rather than given a θ the optimiser cannot move.
+
+What PsN calls `[test_relations]`, `valid_states`, `included_relations` and
+`p_forward` is **search configuration, not model**. It belongs in an SCM harness
+that reads the relation table and rewrites these lines; the block does not try
+to express the search.
+
+## Data-derived statistics
+
+`center` / `breakpoint` accept `median`, `mean`, `min`, `max` or a literal
+number; `ref` accepts a level literal or `mode`; `[covariates]` accepts
+`categorical(levels = auto)`.
+
+Statistics are computed **one value per subject** (PsN's weighting — a subject
+with forty samples must not drag the median toward their own weight); a
+time-varying covariate contributes each distinct value it takes within the
+subject.
+
+**Recommendation: literals for a final model, symbolic for an automated
+search.** A literal centre is reproducible from the file alone. A symbolic one
+keeps a generated covariate model portable across datasets — and the value it
+resolved to is written into the fit YAML, so the run stays reproducible:
+
+```yaml
+covariate_model:
+  - parameter: "CL"
+    covariate: "WT"
+    form: "power"
+    center: 70.2  # resolved from median
+    thetas:
+      - name: "THETA_CL_WT"
+        estimate: 0.712431
+        se: 0.083120
+```
+
+A symbolic statistic can only be resolved once a dataset has been seen. Fits
+launched from a data file (`ferx <model> --data …`, `fit_from_files`, `ferx
+check --data`) bind it automatically. Driving the API directly, call
+`bind_covariate_stats(&mut parsed, model_text, &population)` before `fit`.
+Reaching a fit with one still unbound is a hard error
+(`E_COVSTAT_UNRESOLVED`) — never a quiet fit with the covariate effect missing.
+
+## Where the factor is inserted
+
+The parameter's right-hand side is split into top-level product factors, and the
+covariate factors are multiplied into the **non-η half**, immediately before the
+first η/κ-bearing factor:
+
+```
+CL = TVCL * exp(ETA_CL)
+  →  CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)
+```
+
+Appending at the end of the expression would be numerically identical but would
+take the typical value out of the shape the SAEM mu-reference detector reads, and
+the covariate effect would be silently dropped under `method = saem`.
+
+When the RHS is **not** a top-level product — a sum, a logit transform, a
+mixture branch — there is no unambiguous place for the factor, and that is a
+hard error rather than a guess. Wire it by hand instead:
+
+```
+[individual_parameters]
+  CL = TVCL * COV_CL * exp(ETA_CL)   # COV_CL = the factor, placed where you want it
+```
+
+::: {.callout-note}
+`categorical` builds a conditional factor, which is not log-linear in one θ. As
+with a hand-written conditional, that is outside the SAEM mu-reference detector's
+scope — prefer FOCEI for a categorical covariate effect, or check that the effect
+is actually estimated when using SAEM.
+:::
+
+## Missing covariate values
+
+Every generated factor is wrapped in a neutral guard:
+
+```
+(if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0)
+```
+
+`NaN == NaN` is false, so a missing covariate contributes a factor of exactly
+`1.0`. This is not belt-and-braces: division by a missing value **underflows to
+`0.0`** in ferx rather than producing an infinity, so an unguarded factor would
+zero the parameter silently instead of failing loudly.
+
+## Seeing what was built
+
+`ferx check` prints the desugared `[individual_parameters]`, and the same lines
+are on `CheckReport.desugared_individual_parameters` in `--json`:
+
+```
+$ ferx check examples/two_cpt_oral_covmodel.ferx
+
+[individual_parameters] as built from [covariate_model]:
+  CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * (if (CRCL == CRCL) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)
+  V1 = TVV1 * (if (WT == WT) (WT / 70)^THETA_V1_WT else 1.0) * exp(ETA_V1)
+  ...
+```
+
+A declaratively stated covariate model is otherwise unauditable — nothing in the
+file spells out the resolved constant, the guard, or where the factor landed.
+This is the text to compare against a NONMEM control stream.
+
+## Validation
+
+All of these are errors, not warnings:
+
+- a covariate not declared in `[covariates]`
+- a `PARAM` that is not a top-level `[individual_parameters]` name
+- a duplicate `(PARAM, COV)` pair, or two relations generating the same θ name
+- an explicit `=> NAME(...)` whose name is already declared in `[parameters]`
+- `categorical` on a covariate declared `continuous`, or a continuous form on a
+  categorical one
+- `categorical` on a covariate with no `levels` and no `levels = auto`
+- a reference level outside the declared levels
+- an unknown form or keyword argument (with a did-you-mean)
+- a right-hand side that is not a top-level product
+- a symbolic statistic still unresolved when the model reaches a fit
+
+## Example
+
+See `examples/two_cpt_oral_covmodel.ferx`, which is
+`examples/two_cpt_oral_cov.ferx` restated with the block. The two are checked
+against each other in `tests/covariate_model_equivalence.rs`: bit-identical
+predictions at a fixed parameter vector, and a bit-identical OFV from the same
+start.

--- a/docs/model-file/covariate-model.qmd
+++ b/docs/model-file/covariate-model.qmd
@@ -116,6 +116,42 @@ What PsN calls `[test_relations]`, `valid_states`, `included_relations` and
 that reads the relation table and rewrites these lines; the block does not try
 to express the search.
 
+## One θ per relation
+
+Each relation declares its own θ. Two relations cannot **share** one, so the
+common hand-written idiom — a single allometric exponent estimated jointly on
+`CL` and `V` — has no spelling in this block:
+
+```
+# Not expressible: both lines would have to own the same θ.
+CL ~ WT power(center = 70) => THETA_WT(0.75, 0.1, 1.5)
+V  ~ WT power(center = 70) => THETA_WT(0.75, 0.1, 1.5)   # error: duplicate θ
+```
+
+This follows PsN, whose `scm` also gives every (parameter, covariate) relation
+its own θ, and it is what keeps a relation a self-contained line — sharing would
+couple two lines, and a search could no longer drop one without reasoning about
+the other.
+
+Write a shared exponent classically instead; a θ declared in `[parameters]` can
+appear in as many `[individual_parameters]` expressions as you like, and a model
+may mix the two styles:
+
+```
+[parameters]
+  theta THETA_WT(0.75, 0.1, 1.5)
+
+[individual_parameters]
+  CL = TVCL * (WT/70)^THETA_WT * exp(ETA_CL)
+  V  = TVV  * (WT/70)^THETA_WT * exp(ETA_V)
+
+[covariate_model]
+  CL ~ CRCL power(center = median)   # the un-shared effects stay declarative
+```
+
+(A *fixed* exponent shared by convention — 0.75 on clearances, 1 on volumes —
+needs no sharing at all: write `fix = 0.75` on each relation.)
+
 ## Data-derived statistics
 
 `center` / `breakpoint` accept `median`, `mean`, `min`, `max` or a literal
@@ -159,7 +195,7 @@ first η/κ-bearing factor:
 
 ```
 CL = TVCL * exp(ETA_CL)
-  →  CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)
+  →  CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)
 ```
 
 Appending at the end of the expression would be numerically identical but would
@@ -187,13 +223,18 @@ is actually estimated when using SAEM.
 Every generated factor is wrapped in a neutral guard:
 
 ```
-(if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0)
+(if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0)
 ```
 
-`NaN == NaN` is false, so a missing covariate contributes a factor of exactly
-`1.0`. This is not belt-and-braces: division by a missing value **underflows to
-`0.0`** in ferx rather than producing an infinity, so an unguarded factor would
-zero the parameter silently instead of failing loudly.
+A missing covariate is `NaN`, so `present(...)` is false and the factor is
+exactly `1.0`. This is not belt-and-braces: division by a missing value
+**underflows to `0.0`** in ferx rather than producing an infinity, so an
+unguarded factor would zero the parameter silently instead of failing loudly.
+
+`present(...)` is an ordinary condition available anywhere in
+[`[individual_parameters]`](individual-parameters.qmd), not something this block
+invented for itself — see
+[Conditional Logic](individual-parameters.qmd#conditional-logic-if-else).
 
 ## Seeing what was built
 
@@ -204,8 +245,8 @@ are on `CheckReport.desugared_individual_parameters` in `--json`:
 $ ferx check examples/two_cpt_oral_covmodel.ferx
 
 [individual_parameters] as built from [covariate_model]:
-  CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * (if (CRCL == CRCL) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)
-  V1 = TVV1 * (if (WT == WT) (WT / 70)^THETA_V1_WT else 1.0) * exp(ETA_V1)
+  CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * (if (present(CRCL)) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)
+  V1 = TVV1 * (if (present(WT)) (WT / 70)^THETA_V1_WT else 1.0) * exp(ETA_V1)
   ...
 ```
 

--- a/docs/model-file/covariate-model.qmd
+++ b/docs/model-file/covariate-model.qmd
@@ -252,11 +252,22 @@ the covariate effect would be silently dropped under `method = saem`.
 
 When the RHS is **not** a top-level product — a sum, a logit transform, a
 mixture branch — there is no unambiguous place for the factor, and that is a
-hard error rather than a guess. Wire it by hand instead:
+hard error rather than a guess. Every factor of the product has to be a plain
+multiplicative term, so `CL = TVCL * exp(ETA_CL) + BASE_CL` is rejected too: the
+factor would otherwise scale the first addend alone. Wire it by hand instead:
 
 ```
 [individual_parameters]
   CL = TVCL * COV_CL * exp(ETA_CL)   # COV_CL = the factor, placed where you want it
+```
+
+An η reached through an intermediate still counts as η-bearing, so the factor
+lands in front of it:
+
+```
+CLI = exp(ETA_CL)
+CL  = TVCL * CLI
+  →  CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * CLI
 ```
 
 ::: {.callout-note}
@@ -278,6 +289,19 @@ A missing covariate is `NaN`, so `present(...)` is false and the factor is
 exactly `1.0`. This is not belt-and-braces: division by a missing value
 **underflows to `0.0`** in ferx rather than producing an infinity, so an
 unguarded factor would zero the parameter silently instead of failing loudly.
+
+For this to hold on real data, "missing" has to survive the reader. A covariate
+column that exists but carries no value for a subject — every cell `.` — is read
+as `NaN` for that subject rather than being dropped from its covariate map,
+because a dropped key resolves to the map's `0.0` default and would be
+indistinguishable from a genuine zero. The reader also warns, naming the
+covariate and the subjects:
+
+```
+covariate CRCL has no value for 3 of 32 subjects (12, 17, 25); it evaluates to
+NaN for them. Impute the column, exclude the subjects, or guard the relation
+with `present(CRCL)`.
+```
 
 `present(...)` is an ordinary condition available anywhere in
 [`[individual_parameters]`](individual-parameters.qmd), not something this block
@@ -313,9 +337,13 @@ All of these are errors, not warnings:
 - `categorical` on a covariate declared `continuous`, or a continuous form on a
   categorical one
 - `categorical` on a covariate with no `levels` and no `levels = auto`
+- `categorical` on a covariate with only one level — there is no contrast to
+  estimate, so the relation spends no θ
 - a reference level outside the declared levels
 - an unknown form or keyword argument (with a did-you-mean)
-- a right-hand side that is not a top-level product
+- `fix` on `none` or `expr(...)`, which declare no θ for it to pin
+- a right-hand side that is not a top-level product, including a product that is
+  one addend of a sum
 - a symbolic statistic still unresolved when the model reaches a fit
 
 ## Example

--- a/docs/model-file/covariate-model.qmd
+++ b/docs/model-file/covariate-model.qmd
@@ -107,9 +107,25 @@ The **default inits and bounds are PsN's, verbatim**:
 | `power` | `0.001` | `−100` | `1e6` |
 
 The linear bounds are not cosmetic: `θ ∈ [1/(c−max), 1/(c−min)]` is exactly what
-keeps `1 + θ·(COV − c)` positive over the observed covariate range. A covariate
-that does not vary around its centre makes both bounds infinite, and is rejected
-with a message rather than given a θ the optimiser cannot move.
+keeps `1 + θ·(COV − c)` positive over the observed covariate range.
+
+Those bounds only exist, and only come back ordered, when the centre lies
+**strictly inside** the observed range, so the linear family requires it:
+
+- a covariate that does not vary around its centre makes both bounds infinite;
+- a centre *outside* the range makes both the same sign, which would emit
+  `lower > upper` (centre `100` over a `50..90` range gives `(0.1, 0.02)`).
+
+Both are rejected with a message rather than given a θ the optimiser cannot
+move. State the θ yourself (`=> NAME(init, lower, upper)`) if you really want a
+centre outside the data.
+
+Two forms **divide** by the centre, so it also has to be usable as a divisor —
+this engine underflows `x/0` to `0` rather than raising, so an unusable centre
+would silently flatten the covariate factor instead of failing. `power` needs a
+positive centre (a negative base is `NaN` for a non-integer θ) and
+`linear_relative` a non-zero one; both are checked when the model is parsed.
+`linear` and `exponential` subtract, and accept any finite centre.
 
 What PsN calls `[test_relations]`, `valid_states`, `included_relations` and
 `p_forward` is **search configuration, not model**. It belongs in an SCM harness
@@ -161,7 +177,11 @@ number; `ref` accepts a level literal or `mode`; `[covariates]` accepts
 Statistics are computed **one value per subject** (PsN's weighting — a subject
 with forty samples must not drag the median toward their own weight); a
 time-varying covariate contributes each distinct value it takes within the
-subject.
+subject, counting **every** record — observations, doses, `EVID=2` covariate
+change markers and `EVID=3/4` resets alike. A value the evaluator reads is a
+value the summary sees, so the default bounds always cover the range the fit
+actually evaluates over, and `levels = auto` cannot miss a level that only
+appears on a dose row.
 
 **Recommendation: literals for a final model, symbolic for an automated
 search.** A literal centre is reproducible from the file alone. A symbolic one
@@ -178,7 +198,26 @@ covariate_model:
       - name: "THETA_CL_WT"
         estimate: 0.712431
         se: 0.083120
+  - parameter: "CL"
+    covariate: "SEX"
+    form: "categorical"
+    center: 0  # resolved from mode
+    thetas:
+      - name: "THETA_CL_SEX_1"
+        estimate: 0.184220
+        se: 0.061400
+        level: 1          # which level this contrast belongs to
+  - parameter: "V"
+    covariate: "WT"
+    form: "expr"
+    expression: "1 + 0.1 * WT"   # the hand-written factor, verbatim
+    thetas: []                   # `none` and `expr` generate no θ
 ```
+
+The table is meant to be read by a program: a categorical θ names its `level`,
+an `expr` relation carries the `expression` that actually ran, and a relation
+with no θ emits an empty *sequence* (`thetas: []`), never a bare key — so
+`thetas` always deserializes as a list.
 
 A symbolic statistic can only be resolved once a dataset has been seen. Fits
 launched from a data file (`ferx <model> --data …`, `fit_from_files`, `ferx
@@ -186,6 +225,15 @@ check --data`) bind it automatically. Driving the API directly, call
 `bind_covariate_stats(&mut parsed, model_text, &population)` before `fit`.
 Reaching a fit with one still unbound is a hard error
 (`E_COVSTAT_UNRESOLVED`) — never a quiet fit with the covariate effect missing.
+
+## Declared levels are exhaustive
+
+A `categorical` factor is an `if (COV == l₁) 1 + θ₁ else … else 1` chain whose
+trailing `1` *is* the reference level's factor, so an undeclared code would be
+modelled as the reference with nothing in the output to say so. A value in the
+data that is not one of the relation's declared levels is therefore refused
+before the fit starts (`E_COV_LEVEL_UNKNOWN`). List every level, use
+`categorical(levels = auto)` to read them off the data, or filter the rows out.
 
 ## Where the factor is inserted
 

--- a/docs/model-file/covariates.qmd
+++ b/docs/model-file/covariates.qmd
@@ -42,6 +42,17 @@ The built-ins `TIME` and `time` are not covariates and should not be declared
 here; they are always available in `[individual_parameters]` expressions and as
 direct `pk(...=TIME)` / `pk(...=time)` mappings.
 
+## Declaring covariate *effects*
+
+This block declares which columns *are* covariates. To state how one acts on a
+parameter, either write the factor into
+[`[individual_parameters]`](individual-parameters.qmd) yourself, or declare the
+relation in [`[covariate_model]`](covariate-model.qmd) and let ferx build the
+expression — one line per relation, with PsN `scm`-parity forms and defaults.
+A categorical covariate used by a `[covariate_model]` relation must declare its
+levels here (`SEX categorical(levels = [0, 1])`, or `levels = auto` to read them
+off the data).
+
 ## Semantics
 
 - **Optional & backward-compatible.** When the block is absent, behaviour is

--- a/docs/model-file/covariates.qmd
+++ b/docs/model-file/covariates.qmd
@@ -78,7 +78,14 @@ value in a declared covariate is a hard error rather than a silent coercion to
 covariate value fails to parse, is dropped, and the covariate evaluates to `0.0`
 in the model, preserving prior behaviour.)
 
-Missing values (blank, `.`, `NA`) are permitted and recorded as missing.
+Missing values (blank, `.`, `NA`) are permitted and recorded as missing. Within a
+subject they are carried forward from the last record that had one (see
+[Time-varying covariates](#time-varying-covariates)). A subject with **no** value
+anywhere in the column — every cell `.` — has the covariate recorded as `NaN`
+rather than dropped, so it cannot be mistaken for a genuine zero, and the reader
+warns naming the covariate and the subjects. Guard such a relation with
+`present(COV)`, impute the column, or exclude the subjects; unguarded, the
+covariate expression evaluates to `NaN` for them and the fit fails.
 
 `ferx check` reads through the same covariate-aware path the fit uses, so a
 declared column that is absent (`E_MISSING_COVARIATE`) or non-numeric

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -320,6 +320,12 @@ For example, in `CL = TVCL * (WT/70)^0.75 * exp(ETA_CL)`:
 - `ETA_CL` matches an omega parameter
 - `WT` matches neither, so it is treated as a covariate column
 
+A covariate factor like the one above can also be declared as data in
+[`[covariate_model]`](covariate-model.qmd) — `CL ~ WT power(center = 70)` —
+which desugars into exactly this expression, with the theta declaration, the
+PsN `scm` default bounds and a missing-value guard filled in. That form is worth
+reaching for when a covariate search or an agent will be rewriting the model.
+
 ### Forgetting an omega declaration
 
 Because unmatched names fall through to covariates, deleting an `omega` line while

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -51,6 +51,7 @@ name from quietly reading as zero and collapsing the formula.
 | `abs()` | `abs(ETA_CL)` |
 | `min(a, b)`, `max(a, b)` | `max(TVCL * WT / 70, 0.1)` |
 | `clamp(x, lo, hi)` | `clamp(ACR20, 0.01, 0.99)` |
+| `present(x)` (condition only) | `if (present(WT)) (WT/70)^0.75 else 1.0` |
 | Parentheses | `TVCL * (WT/70)^0.75` |
 | Comparisons (in `if` conditions) | `WT > 70`, `SEX == 1`, `AGE != 0` |
 | Logical (in `if` conditions) | `&&` (and), `\|\|` (or), `!` (not) |
@@ -131,6 +132,35 @@ operators (`<`, `<=`, `>`, `>=`, `==`, `!=`) and logical operators (`&&`,
 
 The inline form produces a value and can appear anywhere an expression is
 allowed. Both `then` and `else` branches are required.
+
+### `present(...)` — guarding a covariate that may be missing
+
+A missing covariate value (blank, `.`, `NA` in the data) is carried as `NaN`.
+`present(X)` is true whenever `X` is not missing:
+
+```
+[individual_parameters]
+  CL = TVCL * (if (present(CRCL)) (CRCL / 100)^THETA_CRCL else 1.0) * exp(ETA_CL)
+```
+
+Guard any covariate that can be missing. Without the guard the factor above
+evaluates to `0` on a row with no `CRCL` — **not** to an error or a `NaN` you
+would notice — because division by a missing value underflows to zero here. The
+parameter is silently zeroed for that subject.
+
+`present(...)` takes any expression (`present(WT * 2)`), negates (`!present(WT)`)
+and combines (`present(WT) && WT > 100`) like any other condition. It is
+equivalent to the older idiom `X == X`, which works for the same reason (`NaN`
+compares false against itself) but reads like a typo.
+
+It is a *condition*, not a value-returning function, so `TVCL * present(WT)` is
+not valid — deliberately: as arithmetic it would produce exactly the silently
+zeroed parameter the guard exists to prevent. A covariate column actually named
+`present` is unaffected; the name is only special immediately followed by `(`
+at the head of a condition.
+
+The [`[covariate_model]`](covariate-model.qmd) block emits this guard around
+every factor it generates.
 
 ### Time-dependent parameters
 

--- a/examples/two_cpt_oral_covmodel.ferx
+++ b/examples/two_cpt_oral_covmodel.ferx
@@ -1,0 +1,68 @@
+# Two-compartment oral PK model, covariate effects stated declaratively.
+#
+# The same model as `two_cpt_oral_cov.ferx`, whose [individual_parameters]
+# block writes each covariate factor out by hand. Here the relations are
+# declared as data in [covariate_model] and desugared into exactly that
+# expression before anything else reads the model — same OFV, same estimates.
+#
+# Why state them this way: a covariate search (PsN scm, ferx_cov_screen(), an
+# agent) rewrites this one block and nothing else. The lines are independent,
+# so adding or dropping a relation is a line insert/delete rather than a regex
+# over an arbitrary expression — and the relations come back on the fit result
+# as a table, so the search never parses this file to learn what was run.
+#
+# `ferx check examples/two_cpt_oral_covmodel.ferx` prints the desugared
+# [individual_parameters] block, which is what to compare against NONMEM.
+
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV1(40.0, 1.0, 500.0)
+  theta TVQ(8.0, 0.1, 100.0)
+  theta TVV2(80.0, 1.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+
+  omega ETA_CL ~ 0.15
+  omega ETA_V1 ~ 0.15
+  omega ETA_Q  ~ 0.08
+  omega ETA_V2 ~ 0.08
+  omega ETA_KA ~ 0.20
+
+  sigma PROP_ERR ~ 0.04 (sd)
+
+# No covariate factors here — they are multiplied in by the desugar, into the
+# non-eta half of each product.
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q  = TVQ  * exp(ETA_Q)
+  V2 = TVV2 * exp(ETA_V2)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2, ka=KA)
+
+[covariates]
+  WT   continuous
+  CRCL continuous
+
+# One relation per line. `center` may be a literal (as here — reproducible from
+# this file alone, which is what a final model wants) or a data-derived
+# statistic (`median`, `mean`, `min`, `max`; `mode` for a reference level),
+# which is what an automated search wants. A symbolic centre is resolved
+# against the dataset and written back into the fit YAML.
+#
+# Each relation declares its own theta. Left implicit, the name is
+# THETA_<PARAM>_<COV> and the init/bounds are PsN's scm defaults for the form;
+# `=> NAME(init, lower, upper)` states them instead.
+[covariate_model]
+  CL ~ WT   power(center = 70)  => THETA_CL_WT(0.6, 0.01, 5.0)
+  CL ~ CRCL power(center = 100) => THETA_CL_CRCL(0.3, 0.01, 5.0)
+  V1 ~ WT   power(center = 70)  => THETA_V1_WT(0.6, 0.01, 5.0)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  maxiter    = 500
+  covariance = true

--- a/examples/two_cpt_oral_covmodel.ferx
+++ b/examples/two_cpt_oral_covmodel.ferx
@@ -66,3 +66,9 @@
   method     = focei
   maxiter    = 500
   covariance = true
+  # Derivative-free outer optimizer. The gradient-based default does not leave
+  # the initial estimates on this start — an init stall of the #751 family, and
+  # nothing to do with [covariate_model]: the hand-written model this block
+  # desugars to stalls identically at the same OFV. BOBYQA converges to
+  # OFV -1199.02, below the -1168.48 of the classical `two_cpt_oral_cov.ferx`.
+  optimizer  = bobyqa

--- a/src/api/covariate_stats.rs
+++ b/src/api/covariate_stats.rs
@@ -29,7 +29,7 @@ use std::collections::HashSet;
 
 use crate::parser::covariate_model::CovariateStatBindings;
 use crate::parser::model_parser::parse_full_model_with;
-use crate::types::{CompiledModel, CovariateSummary, ParsedModel, Population};
+use crate::types::{CompiledModel, CovariateSummary, ParsedModel, Population, Subject};
 
 /// Resolve every symbolic statistic in `parsed`'s `[covariate_model]` block
 /// against `population`, re-parsing the model so the desugared expressions
@@ -110,23 +110,17 @@ pub fn assert_covariate_model_bound(model: &CompiledModel) -> Result<(), String>
 /// not drag the median toward their own weight. A time-varying covariate
 /// contributes each distinct value it takes within the subject, so a weight that
 /// changes across an admission is not collapsed to its first record.
+///
+/// **Every** event snapshot counts, not only the observation ones: a covariate
+/// change carried on a dose (EVID=1), a covariate-change marker (EVID=2) or a
+/// reset (EVID=3/4) is read by the event-driven evaluator, so a value the model
+/// actually evaluates at must not be missing from `min`/`max` (which become
+/// default θ bounds) or from `levels = auto` (where an omitted level silently
+/// collapses to the reference factor).
 fn summarize(name: &str, population: &Population) -> Result<CovariateSummary, String> {
     let mut values: Vec<f64> = Vec::with_capacity(population.subjects.len());
     for subject in &population.subjects {
-        let mut seen: Vec<f64> = Vec::new();
-        if let Some(v) = subject.covariates.get(name) {
-            if v.is_finite() {
-                seen.push(*v);
-            }
-        }
-        for snapshot in &subject.obs_covariates {
-            if let Some(v) = snapshot.get(name) {
-                if v.is_finite() && !seen.contains(v) {
-                    seen.push(*v);
-                }
-            }
-        }
-        values.extend(seen);
+        values.extend(subject_covariate_values(subject, name));
     }
     if values.is_empty() {
         return Err(format!(
@@ -149,6 +143,37 @@ fn summarize(name: &str, population: &Population) -> Result<CovariateSummary, St
         mode: mode_of(&values),
         levels: distinct(&values),
     })
+}
+
+/// Every distinct finite value `name` takes within one subject, in first-seen
+/// order: the subject-static fallback, then each observation, dose, EVID=2
+/// covariate-change marker and EVID=3/4 reset snapshot.
+///
+/// Shared with [`crate::api::validation`]'s categorical-level check, so the
+/// values a summary is built from and the values a declared level set is
+/// checked against are, by construction, the same set.
+pub(crate) fn subject_covariate_values(subject: &Subject, name: &str) -> Vec<f64> {
+    let mut seen: Vec<f64> = Vec::new();
+    let mut push = |v: f64| {
+        if v.is_finite() && !seen.contains(&v) {
+            seen.push(v);
+        }
+    };
+    if let Some(v) = subject.covariates.get(name) {
+        push(*v);
+    }
+    for snapshot in subject
+        .obs_covariates
+        .iter()
+        .chain(&subject.dose_covariates)
+        .chain(&subject.pk_only_covariates)
+        .chain(&subject.reset_covariates)
+    {
+        if let Some(v) = snapshot.get(name) {
+            push(*v);
+        }
+    }
+    seen
 }
 
 /// The most common value in a sorted slice. Ties break toward the smaller

--- a/src/api/covariate_stats.rs
+++ b/src/api/covariate_stats.rs
@@ -1,0 +1,190 @@
+//! Binding `[covariate_model]` statistics to data (#1111).
+//!
+//! A relation may state its centring constant symbolically — `center = median`,
+//! `ref = mode`, `levels = auto`. That is deliberate: requiring a literal would
+//! make every generated covariate model dataset-specific, which defeats the
+//! automation the block exists for. But `median` is a property of the dataset,
+//! which the model file cannot know.
+//!
+//! This closes that gap the same way `theta NAME[COL, ...]` level blocks close
+//! theirs (#1064, [`super::levels`]):
+//!
+//! 1. **Summarise** each covariate the relations need, one value per subject.
+//! 2. **Re-parse** the model with the statistics known, so the desugared
+//!    expression carries the resolved literal and the compiled closures are
+//!    built once against the real θ vector.
+//!
+//! Re-parsing costs milliseconds. The alternative — a late-bound slot the
+//! compiled closures read at evaluation time — would put a data-dependent value
+//! behind every covariate factor for the life of the model, and a model reused
+//! against a second dataset (a bootstrap resample, a VPC on new data) would
+//! silently keep the first dataset's centres.
+//!
+//! An **unbound** model is never allowed to run: [`assert_covariate_model_bound`]
+//! is called from every entry point, so a symbolic statistic that never reached
+//! a population is a loud error rather than a fit that quietly drops the
+//! covariate effect it declared.
+
+use std::collections::HashSet;
+
+use crate::parser::covariate_model::CovariateStatBindings;
+use crate::parser::model_parser::parse_full_model_with;
+use crate::types::{CompiledModel, CovariateSummary, ParsedModel, Population};
+
+/// Resolve every symbolic statistic in `parsed`'s `[covariate_model]` block
+/// against `population`, re-parsing the model so the desugared expressions
+/// carry the resolved values.
+///
+/// A no-op (and no re-parse) for the overwhelming majority of models: those
+/// with no `[covariate_model]` block, and those whose relations are all stated
+/// with literal centres and explicit θ.
+pub fn bind_covariate_stats(
+    parsed: &mut ParsedModel,
+    model_text: &str,
+    population: &Population,
+) -> Result<(), String> {
+    let Some(spec) = parsed.model.covariate_model.as_ref() else {
+        return Ok(());
+    };
+    if spec.unresolved().is_empty() {
+        return Ok(());
+    }
+    // Summarise every covariate any relation reads, not only the unresolved
+    // ones: a second relation on the same covariate costs one pass either way,
+    // and the resulting table is what the fit YAML echoes.
+    let wanted: HashSet<&str> = spec
+        .relations
+        .iter()
+        .map(|r| r.covariate.as_str())
+        .collect();
+    let mut stats = CovariateStatBindings::new();
+    for name in wanted {
+        stats.insert(name.to_string(), summarize(name, population)?);
+    }
+
+    let model_name = parsed.model.name.clone();
+    parsed.bindings.covariate_stats = stats;
+    let rebound = parse_full_model_with(model_text, &parsed.bindings)?;
+    parsed.model = rebound.model;
+    parsed.model.name = model_name;
+    assert_covariate_model_bound(&parsed.model)
+}
+
+/// Reject a model whose `[covariate_model]` still carries a relation waiting on
+/// data-derived statistics.
+///
+/// Called from `fit` / `predict` / `simulate` / `check_model_data`, so the
+/// failure mode a symbolic centre could otherwise have — running the fit with
+/// the covariate effect silently absent — cannot happen. (A missing covariate
+/// divides to `0.0` rather than `inf` in this engine, so nothing downstream
+/// would have complained.)
+pub fn assert_covariate_model_bound(model: &CompiledModel) -> Result<(), String> {
+    let Some(spec) = model.covariate_model.as_ref() else {
+        return Ok(());
+    };
+    let unresolved = spec.unresolved();
+    if unresolved.is_empty() {
+        return Ok(());
+    }
+    let lines: Vec<String> = unresolved
+        .iter()
+        .map(|r| format!("  {}", r.source_line))
+        .collect();
+    Err(format!(
+        "[covariate_model] relations still need data-derived statistics:\n\
+         {}\n\
+         They are stated symbolically (`median` / `mean` / `min` / `max` / `mode` / \
+         `levels = auto`), or use a form whose default bounds are functions of the covariate's \
+         spread, so they can only be built once a dataset has been seen. Launch the fit from a \
+         data file (`fit_from_files`, `ferx <model> --data ...`), which binds them; call \
+         `ferx_core::api::bind_covariate_stats` before `fit` when driving the API directly; or \
+         state the constants as literals (`center = 70`) and the θ explicitly \
+         (`=> NAME(init, lower, upper)`), which needs no data at all.",
+        lines.join("\n")
+    ))
+}
+
+/// Summarise one covariate over the population.
+///
+/// Weighting is **per subject**, matching PsN: a subject with forty samples must
+/// not drag the median toward their own weight. A time-varying covariate
+/// contributes each distinct value it takes within the subject, so a weight that
+/// changes across an admission is not collapsed to its first record.
+fn summarize(name: &str, population: &Population) -> Result<CovariateSummary, String> {
+    let mut values: Vec<f64> = Vec::with_capacity(population.subjects.len());
+    for subject in &population.subjects {
+        let mut seen: Vec<f64> = Vec::new();
+        if let Some(v) = subject.covariates.get(name) {
+            if v.is_finite() {
+                seen.push(*v);
+            }
+        }
+        for snapshot in &subject.obs_covariates {
+            if let Some(v) = snapshot.get(name) {
+                if v.is_finite() && !seen.contains(v) {
+                    seen.push(*v);
+                }
+            }
+        }
+        values.extend(seen);
+    }
+    if values.is_empty() {
+        return Err(format!(
+            "[covariate_model] needs summary statistics for covariate \
+             `{name}`, but the dataset carries no non-missing value for it"
+        ));
+    }
+    values.sort_by(f64::total_cmp);
+    let n = values.len();
+    let median = if n % 2 == 1 {
+        values[n / 2]
+    } else {
+        0.5 * (values[n / 2 - 1] + values[n / 2])
+    };
+    Ok(CovariateSummary {
+        median,
+        mean: values.iter().sum::<f64>() / n as f64,
+        min: values[0],
+        max: values[n - 1],
+        mode: mode_of(&values),
+        levels: distinct(&values),
+    })
+}
+
+/// The most common value in a sorted slice. Ties break toward the smaller
+/// value, so the reference level a `categorical(ref = mode)` picks is
+/// reproducible run to run rather than a function of iteration order.
+fn mode_of(sorted: &[f64]) -> f64 {
+    let mut best = sorted[0];
+    let mut best_count = 0usize;
+    let mut current = sorted[0];
+    let mut count = 0usize;
+    for v in sorted {
+        if *v == current {
+            count += 1;
+        } else {
+            current = *v;
+            count = 1;
+        }
+        if count > best_count {
+            best_count = count;
+            best = current;
+        }
+    }
+    best
+}
+
+/// Distinct values of a sorted slice, ascending — what `levels = auto` binds to.
+fn distinct(sorted: &[f64]) -> Vec<f64> {
+    let mut out: Vec<f64> = Vec::new();
+    for v in sorted {
+        if out.last() != Some(v) {
+            out.push(*v);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "tests/covariate_stats_tests.rs"]
+mod tests;

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -2272,6 +2272,9 @@ fn fit_inner(
 
     let mut fit_result = FitResult {
         restored_from_checkpoint: false,
+        // #1111: the `[covariate_model]` echo, joined to the θ this fit
+        // estimated. Filled in just below, once `fit_result` owns the θ vector.
+        covariate_relations: Vec::new(),
         method: final_method,
         method_chain: chain.clone(),
         method_wall_times_secs,
@@ -2482,6 +2485,17 @@ fn fit_inner(
         fit_result.warnings.push(msg);
         fit_result.warnings_structured.push(entry);
     }
+
+    // The `[covariate_model]` echo (#1111): the relations as declared, joined to
+    // the θ this fit estimated and their standard errors. Built here rather than
+    // in the literal above because it reads the assembled θ vector.
+    fit_result.covariate_relations = crate::api::covariate_relation_estimates(
+        model,
+        &fit_result.theta_names,
+        &fit_result.theta,
+        fit_result.se_theta.as_ref(),
+        &fit_result.theta_fixed,
+    );
 
     Ok(fit_result)
 }

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -101,6 +101,11 @@ pub fn fit_from_files(
         let model_text = std::fs::read_to_string(model_path)
             .map_err(|e| format!("Failed to re-read model file for level binding: {e}"))?;
         crate::api::bind_theta_levels(&mut parsed, &model_text, &mut population)?;
+        // #1111: resolve any symbolic `[covariate_model]` statistic
+        // (`center = median`, `ref = mode`, `levels = auto`) against the same
+        // dataset. `assert_covariate_model_bound` names this entry point as one
+        // that binds them, so it has to actually do it.
+        crate::api::bind_covariate_stats(&mut parsed, &model_text, &population)?;
     }
     let mut model = parsed.model;
     model.bloq_method = opts.bloq_method;

--- a/src/api/levels.rs
+++ b/src/api/levels.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 
 use crate::parser::model_parser::{
-    level_index_column, parse_full_model_bound, LevelBinding, LevelBindings, LevelBlockDecl,
+    level_index_column, parse_full_model_with, LevelBinding, LevelBindings, LevelBlockDecl,
     LevelContrast,
 };
 use crate::types::{ParsedModel, Population, Subject};
@@ -75,7 +75,12 @@ pub fn bind_theta_levels(
     }
 
     let model_name = parsed.model.name.clone();
-    let rebound = parse_full_model_bound(model_text, &bindings)?;
+    // Re-parse with *every* binding this model has been given, not just the
+    // level ones: a model that also declares `[covariate_model]` statistics
+    // (#1111) may have had those bound already, and re-parsing with the level
+    // bindings alone would drop them.
+    parsed.bindings.levels = bindings;
+    let rebound = parse_full_model_with(model_text, &parsed.bindings)?;
     parsed.model = rebound.model;
     parsed.model.name = model_name;
     Ok(())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -36,6 +36,7 @@ pub use validation::{
 
 // ── production submodules (peeled from this file) ──
 mod adaptive;
+mod covariate_stats;
 mod fit;
 mod levels;
 mod output_columns;
@@ -49,6 +50,7 @@ pub use adaptive::{
     simulate_adaptive, simulate_adaptive_from_spec, AdaptiveSimulateOptions,
     AdaptiveSimulationResult,
 };
+pub use covariate_stats::{assert_covariate_model_bound, bind_covariate_stats};
 pub use fit::{fit, fit_from_files};
 pub use levels::{bind_theta_levels, level_map as theta_level_map};
 pub use output_columns::tafd_tad_for_subject;
@@ -58,12 +60,12 @@ pub(crate) use pool::{build_fit_pool, default_fit_pool};
 pub(crate) use postfit::{
     absorption_flip_flop_ebe_warning, boundary_estimate_warning, compute_eps_shrinkage,
     compute_eta_shrinkage, compute_kappa_shrinkage, compute_kappa_shrinkage_by_occ,
-    compute_param_corr, compute_subject_results, cov_diagnostics, eps_shrinkage_warning,
-    eta_shrinkage_warning, extract_standard_errors, high_correlation_warning, inflated_rse_warning,
-    integrates_odes, is_last_estimating_stage, kappa_weight_typicals, keep_gn_zero_eta_warning,
-    ode_solver_diagnostics_warning, probe_nlopt_algorithms, rebuild_warnings_structured,
-    resolve_covariance_status, resolve_sir_fallback, runaway_guard_warning,
-    sir_unavailable_warning,
+    compute_param_corr, compute_subject_results, cov_diagnostics, covariate_relation_estimates,
+    eps_shrinkage_warning, eta_shrinkage_warning, extract_standard_errors,
+    high_correlation_warning, inflated_rse_warning, integrates_odes, is_last_estimating_stage,
+    kappa_weight_typicals, keep_gn_zero_eta_warning, ode_solver_diagnostics_warning,
+    probe_nlopt_algorithms, rebuild_warnings_structured, resolve_covariance_status,
+    resolve_sir_fallback, runaway_guard_warning, sir_unavailable_warning,
 };
 pub use predict::{predict, PredictionResult};
 #[cfg(feature = "survival")]

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1243,6 +1243,56 @@ fn list_warning<H>(
     Some((msg, entry))
 }
 
+/// The `[covariate_model]` relation table echoed on [`FitResult`] (#1111),
+/// with each relation's θ estimate and standard error joined on.
+///
+/// This is what an SCM harness or an agent reads back after a fit: the
+/// covariate model that ran, the constants it resolved to, and the effect
+/// sizes. Without it the caller would have to re-derive which θ belongs to
+/// which relation by parsing θ names — exactly the string surgery this block
+/// exists to remove.
+pub(crate) fn covariate_relation_estimates(
+    model: &crate::types::CompiledModel,
+    theta_names: &[String],
+    theta: &[f64],
+    se_theta: Option<&Vec<f64>>,
+    theta_fixed: &[bool],
+) -> Vec<crate::types::CovariateRelationEstimate> {
+    let Some(spec) = model.covariate_model.as_ref() else {
+        return Vec::new();
+    };
+    spec.relations
+        .iter()
+        .map(|rel| crate::types::CovariateRelationEstimate {
+            parameter: rel.parameter.clone(),
+            covariate: rel.covariate.clone(),
+            form: rel.form.label().to_string(),
+            center_source: rel.center.map(|c| c.label()),
+            center: rel.resolved_center,
+            thetas: rel
+                .thetas
+                .iter()
+                .map(|t| {
+                    let idx = theta_names.iter().position(|n| *n == t.name);
+                    let fixed = idx.is_some_and(|i| theta_fixed.get(i).copied().unwrap_or(false));
+                    crate::types::CovariateThetaEstimate {
+                        name: t.name.clone(),
+                        estimate: idx.and_then(|i| theta.get(i).copied()).unwrap_or(t.init),
+                        // A FIXed θ has no standard error to report, and a fit
+                        // with no covariance step has none for any θ.
+                        se: if fixed {
+                            None
+                        } else {
+                            idx.and_then(|i| se_theta.and_then(|se| se.get(i).copied()))
+                        },
+                        fixed,
+                    }
+                })
+                .collect(),
+        })
+        .collect()
+}
+
 /// Build the human message + native structured entry (with `details`) for
 /// theta estimates pinned to an optimizer bound, or `None` when none are.
 pub(crate) fn boundary_estimate_warning(

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1269,6 +1269,10 @@ pub(crate) fn covariate_relation_estimates(
             form: rel.form.label().to_string(),
             center_source: rel.center.map(|c| c.label()),
             center: rel.resolved_center,
+            expression: match &rel.form {
+                crate::types::CovariateForm::Expr(text) => Some(text.clone()),
+                _ => None,
+            },
             thetas: rel
                 .thetas
                 .iter()
@@ -1286,6 +1290,7 @@ pub(crate) fn covariate_relation_estimates(
                             idx.and_then(|i| se_theta.and_then(|se| se.get(i).copied()))
                         },
                         fixed,
+                        level: t.level,
                     }
                 })
                 .collect(),

--- a/src/api/predict.rs
+++ b/src/api/predict.rs
@@ -61,6 +61,11 @@ pub fn predict(
     // the model (notably `[scaling]`, #1028) silently collapsed the prediction. `fit()`
     // and `simulate()` already refuse this; match them here.
     assert_covariates_present(model, population);
+    // …and that no `[covariate_model]` relation is still waiting on the
+    // data-derived statistics that build it (#1111): an unresolved relation
+    // simply is not in the compiled expression, and a dropped covariate effect
+    // is invisible in a prediction.
+    crate::api::validation::assert_covariate_model_bound(model);
     // …and that every dose names a compartment the analytical engine can route
     // it into, so an unroutable infusion errors here with subject/time context
     // instead of panicking deep inside the event-driven walk (#375).

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -211,6 +211,11 @@ pub fn prepare_run_with_inits(
         let model_text = std::fs::read_to_string(model_path)
             .map_err(|e| format!("Failed to re-read model file for level binding: {e}"))?;
         crate::api::bind_theta_levels(&mut parsed, &model_text, &mut population)?;
+        // #1111: and resolve any symbolic `[covariate_model]` statistic
+        // (`center = median`, `ref = mode`, `levels = auto`) against the same
+        // dataset, which likewise re-parses so the desugared expression carries
+        // the resolved constant.
+        crate::api::bind_covariate_stats(&mut parsed, &model_text, &population)?;
     }
 
     let init_params = build_init_params(&parsed);
@@ -615,6 +620,9 @@ pub fn run_model_simulate(model_path: &str) -> Result<(FitResult, Population), S
         let model_text = std::fs::read_to_string(model_path)
             .map_err(|e| format!("Failed to re-read model file for level binding: {e}"))?;
         crate::api::bind_theta_levels(&mut parsed, &model_text, &mut template)?;
+        // #1111: the simulation design is the dataset here, so a symbolic
+        // covariate statistic resolves against the simulated covariates.
+        crate::api::bind_covariate_stats(&mut parsed, &model_text, &template)?;
     }
     let template = template;
 

--- a/src/api/tests/covariate_stats_tests.rs
+++ b/src/api/tests/covariate_stats_tests.rs
@@ -53,17 +53,8 @@ fn population(name: &str, values: &[f64]) -> Population {
                 observations: vec![1.0],
                 obs_cmts: vec![1],
                 covariates,
-                dose_covariates: Vec::new(),
-                obs_covariates: Vec::new(),
-                pk_only_times: Vec::new(),
-                pk_only_covariates: Vec::new(),
-                reset_times: Vec::new(),
                 cens: vec![0],
-                occasions: Vec::new(),
-                obs_l2: Vec::new(),
-                dose_occasions: Vec::new(),
-                fremtype: Vec::new(),
-                obs_records: Vec::new(),
+                ..Default::default()
             }
         })
         .collect();
@@ -226,12 +217,171 @@ fn hockey_bounds_follow_the_psn_table() {
     assert!((thetas[1].upper - 1e6).abs() < 1e-9);
 }
 
+/// A covariate value carried on a non-observation record still reaches the
+/// evaluator, so it has to reach the summary (#1111 review).
+///
+/// Snapshots live on four vectors — observations, doses (EVID=1), covariate
+/// change markers (EVID=2) and resets (EVID=3/4). Summarising only the first
+/// two sources understates the spread, which is what the default θ bounds and
+/// `levels = auto` are built from.
+#[test]
+fn every_event_snapshot_feeds_the_summary_not_only_the_observations() {
+    for source in ["dose", "pk_only", "reset"] {
+        let text = model("  WT continuous", "  CL ~ WT power(center = max)");
+        // Two subjects at 50 and 60 by the static fallback; the largest value
+        // in the dataset, 90, exists *only* on the event record under test.
+        let mut pop = population("WT", &[50.0, 60.0]);
+        let extreme = HashMap::from([("WT".to_string(), 90.0)]);
+        let s = &mut pop.subjects[0];
+        match source {
+            "dose" => s.dose_covariates = vec![extreme],
+            "pk_only" => {
+                s.pk_only_times = vec![0.5];
+                s.pk_only_covariates = vec![extreme];
+            }
+            _ => {
+                s.reset_times = vec![0.5];
+                s.reset_covariates = vec![extreme];
+            }
+        }
+        let bound = bind(&text, &pop).expect("binding should succeed");
+        let rel = &bound.covariate_model.as_ref().unwrap().relations[0];
+        assert_eq!(
+            rel.resolved_center,
+            Some(90.0),
+            "`max` must see the {source} snapshot"
+        );
+    }
+}
+
+/// A centre outside the observed range emits `lower > upper` under the PsN
+/// default bounds (`center = 100` over 50..90 gives `(0.1, 0.02)`), so it is
+/// rejected rather than handed to the optimiser (#1111 review).
+#[test]
+fn a_centre_outside_the_observed_range_is_rejected() {
+    let text = model("  WT continuous", "  CL ~ WT linear(center = 100)");
+    let pop = population("WT", &[50.0, 70.0, 90.0]);
+    let e = bind(&text, &pop).expect_err("an out-of-range centre has no ordered default bounds");
+    assert!(e.contains("lie strictly inside"), "{e}");
+}
+
+/// `power` and `linear_relative` divide by the centre, and division by zero
+/// underflows to `0.0` in this engine — the covariate factor would collapse
+/// silently. Both are rejected at parse time (#1111 review).
+#[test]
+fn a_centre_the_form_divides_by_must_be_usable() {
+    for (form, needle) in [
+        ("power(center = 0)", "positive centre"),
+        ("power(center = -70)", "positive centre"),
+        ("linear_relative(center = 0)", "non-zero centre"),
+    ] {
+        let text = model("  WT continuous", &format!("  CL ~ WT {form}"));
+        let e = parse_full_model(&text)
+            .err()
+            .unwrap_or_else(|| panic!("`{form}` must be rejected"));
+        assert!(e.contains(needle), "{form}: {e}");
+    }
+    // …while `linear`, which subtracts, is untouched by the same centre.
+    let text = model("  WT continuous", "  CL ~ WT linear(center = 0)");
+    let pop = population("WT", &[-10.0, 0.0, 10.0]);
+    bind(&text, &pop).expect("`linear` may centre on zero");
+}
+
+/// `linear_relative` scales its bounds by the centre, so a negative centre
+/// reverses them. They must come back ordered (#1111 review).
+#[test]
+fn a_negative_relative_centre_still_emits_ordered_bounds() {
+    let text = model(
+        "  TEMP continuous",
+        "  CL ~ TEMP linear_relative(center = -5)",
+    );
+    let pop = population("TEMP", &[-10.0, -5.0, 10.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    let theta = &bound.covariate_model.as_ref().unwrap().relations[0].thetas[0];
+    assert!(
+        theta.lower < theta.upper,
+        "lower {} must be below upper {}",
+        theta.lower,
+        theta.upper
+    );
+    assert!(
+        theta.init > theta.lower && theta.init < theta.upper,
+        "init {} must lie inside ({}, {})",
+        theta.init,
+        theta.lower,
+        theta.upper
+    );
+}
+
+/// A categorical value the block never declared takes the same factor as the
+/// reference level — the fit would silently model it as reference. The data
+/// check refuses it (#1111 review).
+#[test]
+fn a_categorical_value_outside_the_declared_levels_is_rejected() {
+    let text = model(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX categorical(ref = 0)",
+    );
+    let parsed = parse_full_model(&text).expect("model should parse");
+
+    // Declared levels only: clean.
+    let clean = population("SEX", &[0.0, 1.0, 0.0]);
+    assert!(
+        crate::api::check_model_data(&parsed.model, &clean)
+            .iter()
+            .all(|d| d.code != "E_COV_LEVEL_UNKNOWN"),
+        "a dataset inside the declared levels must pass"
+    );
+
+    // A third code in the data — the silent-reference case.
+    let dirty = population("SEX", &[0.0, 1.0, 2.0]);
+    let diags = crate::api::check_model_data(&parsed.model, &dirty);
+    let hit = diags
+        .iter()
+        .find(|d| d.code == "E_COV_LEVEL_UNKNOWN")
+        .unwrap_or_else(|| panic!("{diags:?}"));
+    assert!(hit.message.contains("2.0"), "{}", hit.message);
+}
+
+/// The echoed relation table has to be machine-readable on its own: which
+/// level each categorical θ belongs to, and the body of an `expr(...)`
+/// relation, are otherwise recoverable only by re-parsing the model file
+/// (#1111 review).
+#[test]
+fn the_echoed_relation_table_keeps_level_and_expression() {
+    let text = model(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX categorical(ref = 0)\n  V ~ SEX expr(\"1 + 0.1 * SEX\")",
+    );
+    let parsed = parse_full_model(&text).expect("model should parse");
+    let names = parsed.model.theta_names.clone();
+    let theta = parsed.model.default_params.theta.clone();
+    let fixed = vec![false; theta.len()];
+    let rels =
+        crate::api::covariate_relation_estimates(&parsed.model, &names, &theta, None, &fixed);
+
+    let cat = rels
+        .iter()
+        .find(|r| r.form == "categorical")
+        .expect("the categorical relation is echoed");
+    assert_eq!(cat.thetas.len(), 1, "one contrast against the reference");
+    assert_eq!(cat.thetas[0].level, Some(1.0));
+    assert_eq!(cat.expression, None);
+
+    let expr = rels
+        .iter()
+        .find(|r| r.form == "expr")
+        .expect("the expr relation is echoed");
+    assert_eq!(expr.expression.as_deref(), Some("1 + 0.1 * SEX"));
+    assert!(expr.thetas.is_empty());
+}
+
 #[test]
 fn a_constant_covariate_is_rejected_rather_than_given_infinite_bounds() {
     let text = model("  WT continuous", "  CL ~ WT linear(center = median)");
     let pop = population("WT", &[70.0, 70.0, 70.0]);
     let e = bind(&text, &pop).expect_err("a constant covariate has no spread to bound against");
-    assert!(e.contains("varies around its centre"), "{e}");
+    assert!(e.contains("lie strictly inside"), "{e}");
 }
 
 #[test]

--- a/src/api/tests/covariate_stats_tests.rs
+++ b/src/api/tests/covariate_stats_tests.rs
@@ -105,7 +105,7 @@ fn a_symbolic_median_resolves_to_the_data_median() {
     let bound = bind(&text, &pop).expect("binding should succeed");
     assert_eq!(
         cl_line(&bound),
-        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
     );
     let rel = &bound.covariate_model.as_ref().unwrap().relations[0];
     assert_eq!(rel.resolved_center, Some(70.0));

--- a/src/api/tests/covariate_stats_tests.rs
+++ b/src/api/tests/covariate_stats_tests.rs
@@ -1,0 +1,346 @@
+//! Binding `[covariate_model]` statistics to data (#1111).
+
+use std::collections::HashMap;
+
+use crate::parser::model_parser::parse_full_model;
+use crate::types::{CompiledModel, DoseEvent, Population, Subject};
+
+/// A one-compartment model whose `[covariate_model]` block is supplied by the
+/// caller, so each test states only the relation it is about.
+fn model(covariates: &str, covariate_model: &str) -> String {
+    format!(
+        r#"
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV(40.0, 1.0, 500.0)
+
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[covariates]
+{covariates}
+
+[covariate_model]
+{covariate_model}
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#
+    )
+}
+
+/// One subject per value of `WT`, each with one observation — so the summary is
+/// exactly the values listed.
+fn population(name: &str, values: &[f64]) -> Population {
+    let subjects = values
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let mut covariates = HashMap::new();
+            covariates.insert(name.to_string(), *v);
+            Subject {
+                id: format!("{}", i + 1),
+                doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                obs_times: vec![1.0],
+                obs_raw_times: Vec::new(),
+                observations: vec![1.0],
+                obs_cmts: vec![1],
+                covariates,
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                cens: vec![0],
+                occasions: Vec::new(),
+                obs_l2: Vec::new(),
+                dose_occasions: Vec::new(),
+                fremtype: Vec::new(),
+                obs_records: Vec::new(),
+            }
+        })
+        .collect();
+    Population {
+        subjects,
+        covariate_names: vec![name.to_string()],
+        dv_column: "DV".to_string(),
+        input_columns: Vec::new(),
+        exclusions: None,
+        warnings: Vec::new(),
+    }
+}
+
+/// Bind `text` against `pop`, returning the re-parsed model.
+fn bind(text: &str, pop: &Population) -> Result<CompiledModel, String> {
+    let mut parsed = parse_full_model(text)?;
+    crate::api::bind_covariate_stats(&mut parsed, text, pop)?;
+    Ok(parsed.model)
+}
+
+/// The desugared `CL = ...` line of a bound model.
+fn cl_line(model: &CompiledModel) -> String {
+    model
+        .covariate_model
+        .as_ref()
+        .expect("the block is recorded")
+        .desugared_individual_parameters
+        .iter()
+        .find(|l| l.trim_start().starts_with("CL "))
+        .expect("CL is assigned")
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_symbolic_median_resolves_to_the_data_median() {
+    let text = model("  WT continuous", "  CL ~ WT power(center = median)");
+    let pop = population("WT", &[50.0, 60.0, 70.0, 80.0, 90.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    assert_eq!(
+        cl_line(&bound),
+        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+    );
+    let rel = &bound.covariate_model.as_ref().unwrap().relations[0];
+    assert_eq!(rel.resolved_center, Some(70.0));
+    // The source form survives alongside the resolved value, so a run launched
+    // symbolically is still reproducible from the fit output.
+    assert_eq!(rel.center.unwrap().label(), "median");
+}
+
+#[test]
+fn each_statistic_resolves_to_its_own_summary() {
+    for (keyword, expected) in [("mean", 70.0), ("min", 50.0), ("max", 90.0)] {
+        let text = model(
+            "  WT continuous",
+            &format!("  CL ~ WT power(center = {keyword})"),
+        );
+        let pop = population("WT", &[50.0, 60.0, 70.0, 80.0, 90.0]);
+        let bound = bind(&text, &pop).expect("binding should succeed");
+        assert_eq!(
+            bound.covariate_model.as_ref().unwrap().relations[0].resolved_center,
+            Some(expected),
+            "center = {keyword}"
+        );
+    }
+}
+
+#[test]
+fn the_median_weights_one_value_per_subject() {
+    // A subject with many records must not drag the median toward their own
+    // covariate value — PsN's weighting, and the reason this walks subjects
+    // rather than observations.
+    let mut pop = population("WT", &[50.0, 60.0, 70.0, 80.0, 90.0]);
+    pop.subjects[0].obs_times = vec![1.0; 40];
+    pop.subjects[0].observations = vec![1.0; 40];
+    pop.subjects[0].obs_cmts = vec![1; 40];
+    pop.subjects[0].cens = vec![0; 40];
+    let text = model("  WT continuous", "  CL ~ WT power(center = median)");
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    assert_eq!(
+        bound.covariate_model.as_ref().unwrap().relations[0].resolved_center,
+        Some(70.0)
+    );
+}
+
+#[test]
+fn a_time_varying_covariate_contributes_each_distinct_value() {
+    let mut pop = population("WT", &[50.0, 90.0]);
+    // Subject 1's weight drifts across the admission.
+    let mut later = HashMap::new();
+    later.insert("WT".to_string(), 70.0);
+    pop.subjects[0].obs_covariates = vec![later];
+    let text = model("  WT continuous", "  CL ~ WT power(center = median)");
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    // Values are 50, 70, 90 → median 70, not the 70 the two-subject static case
+    // would have averaged to.
+    assert_eq!(
+        bound.covariate_model.as_ref().unwrap().relations[0].resolved_center,
+        Some(70.0)
+    );
+}
+
+#[test]
+fn the_mode_is_the_reference_level_of_a_categorical_relation() {
+    let text = model(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX categorical(ref = mode)",
+    );
+    let pop = population("SEX", &[0.0, 1.0, 1.0, 1.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    let rel = &bound.covariate_model.as_ref().unwrap().relations[0];
+    assert_eq!(rel.resolved_center, Some(1.0));
+    // …so the θ contrasts the *other* level.
+    assert_eq!(rel.thetas.len(), 1);
+    assert_eq!(rel.thetas[0].name, "THETA_CL_SEX_0");
+}
+
+#[test]
+fn auto_levels_are_discovered_from_the_data() {
+    let text = model(
+        "  SEX categorical(levels = auto)",
+        "  CL ~ SEX categorical(ref = 0)",
+    );
+    let pop = population("SEX", &[0.0, 1.0, 2.0, 2.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    let names: Vec<String> = bound.covariate_model.as_ref().unwrap().relations[0]
+        .thetas
+        .iter()
+        .map(|t| t.name.clone())
+        .collect();
+    assert_eq!(names, vec!["THETA_CL_SEX_1", "THETA_CL_SEX_2"]);
+}
+
+#[test]
+fn linear_bounds_follow_the_psn_table() {
+    // PsN state 2: init 0.001/(med−min), lower 1/(med−max), upper 1/(med−min).
+    // These bounds are what keep `1 + θ(COV − med)` positive over the observed
+    // range, so they are adopted verbatim rather than re-invented.
+    let text = model("  WT continuous", "  CL ~ WT linear(center = median)");
+    let pop = population("WT", &[50.0, 60.0, 70.0, 80.0, 90.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    let theta = &bound.covariate_model.as_ref().unwrap().relations[0].thetas[0];
+    assert!((theta.init - 0.001 / 20.0).abs() < 1e-15);
+    assert!((theta.lower - 1.0 / -20.0).abs() < 1e-15);
+    assert!((theta.upper - 1.0 / 20.0).abs() < 1e-15);
+}
+
+#[test]
+fn hockey_bounds_follow_the_psn_table() {
+    let text = model("  WT continuous", "  CL ~ WT hockey(breakpoint = median)");
+    let pop = population("WT", &[50.0, 60.0, 70.0, 80.0, 90.0]);
+    let bound = bind(&text, &pop).expect("binding should succeed");
+    let thetas = &bound.covariate_model.as_ref().unwrap().relations[0].thetas;
+    assert_eq!(thetas.len(), 2);
+    assert_eq!(thetas[0].name, "THETA_CL_WT_LO");
+    assert!((thetas[0].lower + 1e6).abs() < 1e-9);
+    assert!((thetas[0].upper - 1.0 / 20.0).abs() < 1e-15);
+    assert_eq!(thetas[1].name, "THETA_CL_WT_HI");
+    assert!((thetas[1].lower - 1.0 / -20.0).abs() < 1e-15);
+    assert!((thetas[1].upper - 1e6).abs() < 1e-9);
+}
+
+#[test]
+fn a_constant_covariate_is_rejected_rather_than_given_infinite_bounds() {
+    let text = model("  WT continuous", "  CL ~ WT linear(center = median)");
+    let pop = population("WT", &[70.0, 70.0, 70.0]);
+    let e = bind(&text, &pop).expect_err("a constant covariate has no spread to bound against");
+    assert!(e.contains("varies around its centre"), "{e}");
+}
+
+#[test]
+fn a_covariate_absent_from_the_data_is_rejected() {
+    let text = model("  AGE continuous", "  CL ~ AGE power(center = median)");
+    let pop = population("WT", &[50.0, 70.0, 90.0]);
+    let e = bind(&text, &pop).expect_err("no value to summarise");
+    assert!(e.contains("no non-missing value"), "{e}");
+}
+
+#[test]
+fn a_literal_centred_model_needs_no_binding_at_all() {
+    // The common case: nothing symbolic, so `bind` is a no-op and the model was
+    // already fully desugared at parse time.
+    let text = model(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70) => T(0.75, 0.1, 1.5)",
+    );
+    let parsed = parse_full_model(&text).expect("model should parse");
+    assert!(parsed
+        .model
+        .covariate_model
+        .as_ref()
+        .unwrap()
+        .unresolved()
+        .is_empty());
+    assert!(crate::api::assert_covariate_model_bound(&parsed.model).is_ok());
+}
+
+#[test]
+fn an_unbound_symbolic_statistic_is_a_hard_error() {
+    // The failure this guards against is silent: an unresolved relation is
+    // simply absent from the compiled expression, and a missing covariate
+    // divides to 0.0 rather than inf here, so nothing downstream would notice.
+    let text = model("  WT continuous", "  CL ~ WT power(center = median)");
+    let parsed = parse_full_model(&text).expect("model should parse");
+    let e = crate::api::assert_covariate_model_bound(&parsed.model)
+        .expect_err("an unbound symbolic statistic must not reach a fit");
+    assert!(e.contains("data-derived statistics"), "{e}");
+    assert!(e.contains("bind_covariate_stats"), "{e}");
+    // …and the check the fit path runs reports it under its own code.
+    let pop = population("WT", &[50.0, 70.0, 90.0]);
+    let diags = crate::api::check_model_data(&parsed.model, &pop);
+    assert!(
+        diags.iter().any(|d| d.code == "E_COVSTAT_UNRESOLVED"),
+        "{diags:?}"
+    );
+}
+
+#[test]
+fn binding_preserves_a_level_block_binding_made_first() {
+    // A model may declare both a `theta NAME[COL]` level block (#1064) and a
+    // symbolic covariate statistic (#1111). Each binder re-parses, so the
+    // second must carry the first one's bindings — otherwise binding the
+    // statistics would silently un-bind the level counts.
+    let text = r#"
+[parameters]
+  theta TVCL(2.0, 0.001, 10.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta PLACEBO[STUDY](0.0, -10.0, 10.0)
+
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV + PLACEBO
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[covariates]
+  WT continuous
+  STUDY continuous
+
+[covariate_model]
+  CL ~ WT power(center = median)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let mut pop = population("WT", &[50.0, 70.0, 90.0]);
+    pop.covariate_names.push("STUDY".to_string());
+    for (i, subject) in pop.subjects.iter_mut().enumerate() {
+        subject
+            .covariates
+            .insert("STUDY".to_string(), (i + 1) as f64);
+    }
+
+    let mut parsed = parse_full_model(text).expect("model should parse");
+    crate::api::bind_theta_levels(&mut parsed, text, &mut pop).expect("levels bind");
+    crate::api::bind_covariate_stats(&mut parsed, text, &pop).expect("statistics bind");
+
+    // The level block is still bound to the three observed studies — two free θ
+    // under the default sum-to-zero contrast, which derives the third.
+    assert_eq!(
+        parsed
+            .model
+            .theta_names
+            .iter()
+            .filter(|n| n.starts_with("PLACEBO["))
+            .count(),
+        2,
+        "{:?}",
+        parsed.model.theta_names
+    );
+    // … and the covariate statistic resolved.
+    assert_eq!(
+        parsed.model.covariate_model.as_ref().unwrap().relations[0].resolved_center,
+        Some(70.0)
+    );
+}

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -27,6 +27,7 @@ fn make_iov_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        covariate_model: None,
         name: "iov_test".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -28,6 +28,7 @@ fn tiny_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        covariate_model: None,
         name: "uncertainty_smoke".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -390,6 +391,7 @@ fn synthetic_fit(template: &ModelParameters) -> FitResult {
     let n_packed = crate::estimation::parameterization::packed_len(template);
     let cov = DMatrix::identity(n_packed, n_packed) * 0.01;
     FitResult {
+        covariate_relations: Vec::new(),
         restored_from_checkpoint: false,
         method: EstimationMethod::FoceI,
         method_chain: vec![EstimationMethod::FoceI],

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 /// for every observation, while the fix yields the per-occasion CL.
 fn minimal_iov_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
     CompiledModel {
+        covariate_model: None,
         frem_config: None,
         residual_error_eta: None,
         analytical_init: Vec::new(),

--- a/src/api/tests/tests_derived_session_clock.rs
+++ b/src/api/tests/tests_derived_session_clock.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 /// Caller supplies `derived_exprs`.
 fn minimal_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
     CompiledModel {
+        covariate_model: None,
         name: "test_session".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Additive,

--- a/src/api/tests/tests_sdtab_tv_cov.rs
+++ b/src/api/tests/tests_sdtab_tv_cov.rs
@@ -47,6 +47,7 @@ fn test_sdtab_ipred_honours_tv_covariates() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         name: "tv_cov_sdtab_regression".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -390,6 +391,7 @@ fn test_simulate_honours_tv_covariates() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         name: "tv_cov_sim_regression".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -554,6 +554,7 @@ pub(crate) fn check_simulation_data(
     population: &Population,
 ) -> Vec<Diagnostic> {
     let mut diags = check_unbound_theta_levels(model);
+    diags.extend(check_covariate_model_bound(model));
     diags.extend(check_covariates(model, population));
     diags.extend(check_kappa_weights(model, population));
     diags.extend(check_theta_gather_indices(model, population));
@@ -581,6 +582,7 @@ pub fn check_model_data_rule(
     iov_rule: &IovOccasionRule,
 ) -> Vec<Diagnostic> {
     let mut diags = check_finite_observations(population);
+    diags.extend(check_covariate_model_bound(model));
     diags.extend(check_covariates(model, population));
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
@@ -1517,6 +1519,29 @@ pub(crate) fn assert_modeled_doses_supported(model: &CompiledModel, population: 
 /// default — so `y[CMT=1] = A * TOTALLY_UNDEFINED_NAME` returned an all-zero
 /// structural prediction with no diagnostic. This closes that gap so `predict()`
 /// fails as loudly as `fit()` does, on the same message.
+/// A `[covariate_model]` relation stated with a symbolic statistic (#1111) is
+/// only buildable once a dataset has been summarised. Reaching a fit with one
+/// still unresolved means the covariate effect is simply *absent* from the
+/// compiled expression — and a missing covariate divides to `0.0` rather than
+/// `inf` in this engine, so nothing further down would have complained. Fail
+/// here instead, exactly as `check_unbound_theta_levels` does for #1064.
+fn check_covariate_model_bound(model: &CompiledModel) -> Vec<Diagnostic> {
+    match crate::api::assert_covariate_model_bound(model) {
+        Ok(()) => Vec::new(),
+        Err(msg) => {
+            vec![Diagnostic::error("E_COVSTAT_UNRESOLVED", msg).with_block("covariate_model")]
+        }
+    }
+}
+
+/// The `predict()`/`simulate()` counterpart of [`check_covariate_model_bound`].
+pub(crate) fn assert_covariate_model_bound(model: &CompiledModel) {
+    panic_if_unsupported(
+        crate::api::assert_covariate_model_bound(model).err(),
+        "a [covariate_model] whose data-derived statistics were never bound",
+    );
+}
+
 pub(crate) fn assert_covariates_present(model: &CompiledModel, population: &Population) {
     panic_if_unsupported(
         first_error(&check_covariates(model, population)).err(),
@@ -3868,6 +3893,42 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
         }
     }
 
+    // 2e. `[covariate_model]` relations that need data-derived statistics
+    //     (#1111), *without* a dataset. With data present this is an
+    //     `E_COVSTAT_UNRESOLVED` error from `check_covariate_model_bound` —
+    //     the binding should have happened and did not. Without one, the model
+    //     is perfectly fine and simply not buildable yet, so it can only be a
+    //     warning. It must still be said: the desugared echo below is
+    //     suppressed in this state, and a silent "no errors" on a model whose
+    //     covariate effects are all still pending reads as "there are none".
+    if data_path.is_none() {
+        if let Some(spec) = parsed.model.covariate_model.as_ref() {
+            let pending: Vec<String> = spec
+                .unresolved()
+                .iter()
+                .map(|r| format!("`{} ~ {}`", r.parameter, r.covariate))
+                .collect();
+            if !pending.is_empty() {
+                diags.push(
+                    Diagnostic::warning(
+                        "W_COVSTAT_UNBOUND",
+                        format!(
+                            "[covariate_model]: {} still need data-derived statistics, so the \
+                             expression they build cannot be shown or fitted yet",
+                            pending.join(", ")
+                        ),
+                    )
+                    .with_block("covariate_model")
+                    .with_suggestion(
+                        "re-run with --data to resolve them, or state the centring constants \
+                         as literals and the θ explicitly (`=> NAME(init, lower, upper)`)"
+                            .to_string(),
+                    ),
+                );
+            }
+        }
+    }
+
     // 3. Data-dependent checks (only when a dataset is supplied). Read through
     //    the same covariate-aware chokepoint the fit uses, so `ferx check` and
     //    `fit()` apply identical covariate validation (declared columns present
@@ -3907,7 +3968,8 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
                 let binding = std::fs::read_to_string(model_path)
                     .map_err(|e| format!("Failed to re-read model file for level binding: {e}"))
                     .and_then(|model_text| {
-                        crate::api::bind_theta_levels(&mut parsed, &model_text, &mut population)
+                        crate::api::bind_theta_levels(&mut parsed, &model_text, &mut population)?;
+                        crate::api::bind_covariate_stats(&mut parsed, &model_text, &population)
                     });
                 if let Err(e) = binding {
                     diags.push(
@@ -3974,7 +4036,23 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
         }
     }
 
-    CheckReport::new(model_name, data, diags)
+    let mut report = CheckReport::new(model_name, data, diags);
+    // #1111: echo the expression the `[covariate_model]` block actually built.
+    // A declarative covariate model is otherwise unauditable — nothing in the
+    // file states the resolved centring constant, the missing-value guard, or
+    // where in the product the factor landed.
+    // Suppressed while any relation is still unresolved: those lines are the
+    // block *without* the pending covariate effects, so printing them under
+    // "as built from [covariate_model]" would state the opposite of the truth.
+    // `W_COVSTAT_UNBOUND` (or `E_COVSTAT_UNRESOLVED`, with data) says so.
+    if let Some(spec) = parsed.model.covariate_model.as_ref() {
+        if spec.unresolved().is_empty() {
+            report
+                .desugared_individual_parameters
+                .clone_from(&spec.desugared_individual_parameters);
+        }
+    }
+    report
 }
 
 /// Validate `model.output_columns` against known quantities, emitting

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -555,6 +555,7 @@ pub(crate) fn check_simulation_data(
 ) -> Vec<Diagnostic> {
     let mut diags = check_unbound_theta_levels(model);
     diags.extend(check_covariate_model_bound(model));
+    diags.extend(check_covariate_levels(model, population));
     diags.extend(check_covariates(model, population));
     diags.extend(check_kappa_weights(model, population));
     diags.extend(check_theta_gather_indices(model, population));
@@ -583,6 +584,7 @@ pub fn check_model_data_rule(
 ) -> Vec<Diagnostic> {
     let mut diags = check_finite_observations(population);
     diags.extend(check_covariate_model_bound(model));
+    diags.extend(check_covariate_levels(model, population));
     diags.extend(check_covariates(model, population));
     diags.extend(check_per_cmt_scaling(model, population));
     diags.extend(check_per_cmt_error_model(model, population));
@@ -1532,6 +1534,64 @@ fn check_covariate_model_bound(model: &CompiledModel) -> Vec<Diagnostic> {
             vec![Diagnostic::error("E_COVSTAT_UNRESOLVED", msg).with_block("covariate_model")]
         }
     }
+}
+
+/// Reject a categorical `[covariate_model]` relation whose data carries a value
+/// outside its declared level set (#1111).
+///
+/// The generated factor is an `if (COV == l1) 1 + θ1 else if (COV == l2) … else 1`
+/// chain: the trailing `1` is the *reference* level's factor, so an unlisted
+/// code — a new site, a typo, a level that only shows up on dose records — is
+/// silently modelled as the reference rather than flagged. That changes the
+/// fitted model with nothing in the output to say so, which is exactly the
+/// class of silent-covariate-drop this block exists to prevent.
+fn check_covariate_levels(model: &CompiledModel, population: &Population) -> Vec<Diagnostic> {
+    let Some(spec) = model.covariate_model.as_ref() else {
+        return Vec::new();
+    };
+    let mut diags = Vec::new();
+    for rel in &spec.relations {
+        if !rel.form.is_categorical() {
+            continue;
+        }
+        // Declared levels = the reference (`ref = …`) plus one θ per contrast.
+        let mut declared: Vec<f64> = rel.thetas.iter().filter_map(|t| t.level).collect();
+        let Some(reference) = rel.resolved_center else {
+            // Still unbound — `check_covariate_model_bound` reports that.
+            continue;
+        };
+        declared.push(reference);
+        let mut unknown: Vec<f64> = Vec::new();
+        for subject in &population.subjects {
+            for v in crate::api::covariate_stats::subject_covariate_values(subject, &rel.covariate)
+            {
+                if !declared.contains(&v) && !unknown.contains(&v) {
+                    unknown.push(v);
+                }
+            }
+        }
+        if unknown.is_empty() {
+            continue;
+        }
+        unknown.sort_by(f64::total_cmp);
+        declared.sort_by(f64::total_cmp);
+        diags.push(
+            Diagnostic::error(
+                "E_COV_LEVEL_UNKNOWN",
+                format!(
+                    "[covariate_model]: `{} ~ {} categorical(...)` declares levels {declared:?} \
+                     (reference {reference}), but `{}` also takes {unknown:?} in the data. An \
+                     undeclared value takes the same factor as the reference level, so the fit \
+                     would silently model it as reference. List every level \
+                     (`{} categorical(levels = [...])`), use `levels = auto` to read them off \
+                     the data, or filter the rows out.",
+                    rel.parameter, rel.covariate, rel.covariate, rel.covariate
+                ),
+            )
+            .with_block("covariate_model"),
+        );
+    }
+    diags
 }
 
 /// The `predict()`/`simulate()` counterpart of [`check_covariate_model_bound`].

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -190,6 +190,7 @@ fn build_warfarin_model() -> CompiledModel {
         },
     );
     CompiledModel {
+        covariate_model: None,
         name: "warfarin".into(),
         pk_model: PkModel::OneCptOral,
         error_model: ErrorModel::Proportional,
@@ -324,6 +325,7 @@ fn generate_two_cpt_iv() {
         },
     );
     let model = CompiledModel {
+        covariate_model: None,
         name: "two_cpt_iv".into(),
         pk_model: PkModel::TwoCptIv,
         error_model: ErrorModel::Proportional,
@@ -455,6 +457,7 @@ fn generate_two_cpt_oral_cov() {
         },
     );
     let model = CompiledModel {
+        covariate_model: None,
         name: "two_cpt_oral_cov".into(),
         pk_model: PkModel::TwoCptOral,
         error_model: ErrorModel::Proportional,
@@ -661,6 +664,7 @@ fn generate_mm_oral() {
         dose_attr_map: Default::default(),
     };
     let model = CompiledModel {
+        covariate_model: None,
         name: "mm_oral".into(),
         pk_model: PkModel::OneCptOral,
         error_model: ErrorModel::Proportional,

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -53,6 +53,8 @@
 //! | `W_OUTPUT_DUPLICATE`      | a name in `[output]` is already in the mandatory sdtab minimum |
 //! | `W_ADDL_MISSING_II`       | ADDL > 0 on a dose row but II is zero or missing; additional doses not expanded |
 //! | `W_MISSING_DV`            | EVID=0 observation row with a missing DV and no MDV=1; skipped rather than scored as DV=0 |
+//! | `E_COVSTAT_UNRESOLVED`    | a `[covariate_model]` relation still needs data-derived statistics (`center = median`, `levels = auto`, or a form whose default bounds come from the data) |
+//! | `W_COVSTAT_UNBOUND`       | the same, reported without a `--data` file — the model is fine, it just cannot be built until a dataset is supplied |
 
 use serde::Serialize;
 
@@ -149,6 +151,16 @@ pub struct CheckReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
     pub diagnostics: Vec<Diagnostic>,
+    /// The `[individual_parameters]` block as the `[covariate_model]` desugar
+    /// rewrote it (#1111), one line per assignment. Empty for a model that
+    /// declares no such block.
+    ///
+    /// `ferx check` prints this so the expression the block actually built is
+    /// visible — a covariate model stated declaratively is otherwise
+    /// unauditable against NONMEM, since nothing in the file spells out the
+    /// centring constant, the missing-value guard or where the factor landed.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub desugared_individual_parameters: Vec<String>,
 }
 
 impl CheckReport {
@@ -165,6 +177,7 @@ impl CheckReport {
             model: model.into(),
             data,
             diagnostics,
+            desugared_individual_parameters: Vec::new(),
         }
     }
 

--- a/src/estimation/fixed_eta_gradient_tests.rs
+++ b/src/estimation/fixed_eta_gradient_tests.rs
@@ -150,6 +150,7 @@ fn obs_nll_subject_grad_iov_matches_fd() {
 
     // Minimal IOV model: CL = TVCL·exp(ETA_CL + KAPPA_CL), V = TVV.
     let model = CompiledModel {
+        covariate_model: None,
         name: "iov_grad_test".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -2083,6 +2083,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            covariate_model: None,
             name: "gn_test".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
@@ -3130,6 +3131,7 @@ mod tests {
             mixture: None,
         };
         let model = CompiledModel {
+            covariate_model: None,
             name: "gn_block_omega_test".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,
@@ -3420,6 +3422,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            covariate_model: None,
             name: "iov_gn_test".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2802,6 +2802,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            covariate_model: None,
             has_conditional_eta_params: false,
             name: "frem_rb_iscale_test".into(),
             pk_model: PkModel::OneCptIv,

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -652,6 +652,7 @@ fn make_iov_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        covariate_model: None,
         name: "iov_test".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -2968,6 +2969,7 @@ fn no_iov_1cpt_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        covariate_model: None,
         name: "no_iov".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -3118,6 +3120,7 @@ fn find_ebe_noniov_invariant_to_large_mu_shift() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         frem_config: None,
         residual_error_eta: None,
         analytical_init: Vec::new(),

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1103,6 +1103,7 @@ fn test_frem_jacobian_overrides_fd_with_exact_values() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         has_conditional_eta_params: false,
         name: "frem_jac_test".into(),
         pk_model: PkModel::OneCptIv,

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -967,6 +967,7 @@ fn make_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        covariate_model: None,
         name: "outer_test".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -1266,6 +1267,7 @@ fn test_outer_ad_gradient_block_omega() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         name: "block_test".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,
@@ -1743,6 +1745,7 @@ fn test_compute_covariance_iov_runs_and_is_pd() {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         frem_config: None,
         residual_error_eta: None,
         analytical_init: Vec::new(),

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -1260,6 +1260,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            covariate_model: None,
             name: "test".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -330,6 +330,7 @@ mod tests {
     /// are filled with sensible defaults.
     fn fit_with_cov(template: &ModelParameters, cov: DMatrix<f64>) -> FitResult {
         FitResult {
+            covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: crate::types::EstimationMethod::FoceI,
             method_chain: vec![],

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1093,6 +1093,7 @@ mod tests {
 
     fn make_test_model() -> CompiledModel {
         CompiledModel {
+            covariate_model: None,
             has_conditional_eta_params: false,
             name: "test".into(),
             pk_model: PkModel::OneCptOral,
@@ -1848,6 +1849,7 @@ mod tests {
 
     fn decl(name: &str, kind: CovariateKind) -> CovariateDecl {
         CovariateDecl {
+            levels: None,
             name: name.to_string(),
             kind,
         }

--- a/src/io/datareader.rs
+++ b/src/io/datareader.rs
@@ -1121,6 +1121,29 @@ fn read_nonmem_csv_impl(
     // `cov_names` is already existing-only, so this is a no-op there.)
     let existing_cov_names: Vec<String> = cov_indices.iter().map(|(n, _)| n.clone()).collect();
 
+    // A covariate column that exists but carries no finite value for some
+    // subjects is stored as `NaN` (see the per-subject reader). Report it once
+    // per covariate: without a `present(COV)` guard those subjects evaluate the
+    // covariate expression to `NaN`, and the fit will fail on them.
+    let mut population_warnings = population_warnings;
+    for name in &existing_cov_names {
+        let missing: Vec<&str> = subjects
+            .iter()
+            .filter(|s| s.covariates.get(name).is_some_and(|v| v.is_nan()))
+            .map(|s| s.id.as_str())
+            .collect();
+        if missing.is_empty() {
+            continue;
+        }
+        population_warnings.push(format!(
+            "covariate {name} has no value for {} of {} subjects ({}{});              it evaluates to NaN for them. Impute the column, exclude the subjects, or guard              the relation with `present({name})`.",
+            missing.len(),
+            subjects.len(),
+            missing.iter().take(5).cloned().collect::<Vec<_>>().join(", "),
+            if missing.len() > 5 { ", ..." } else { "" },
+        ));
+    }
+
     Ok((
         Population {
             subjects,
@@ -1479,15 +1502,27 @@ fn parse_subject(
     // does not yet read per-event snapshots).
     let mut covariates: HashMap<String, f64> = HashMap::new();
     for (name, idx) in cov_indices {
+        let mut found = false;
         for row in rows {
             if let Some(val_str) = row.get(*idx) {
                 if let Ok(val) = val_str.parse::<f64>() {
                     if val.is_finite() {
                         covariates.insert(name.clone(), val);
+                        found = true;
                         break;
                     }
                 }
             }
+        }
+        // The column exists but this subject has no finite value in it. Record
+        // that as `NaN` rather than leaving the key absent: an absent key
+        // resolves to the covariate map's `0.0` default at every evaluation
+        // site, so the gap would be indistinguishable from a genuine zero and
+        // e.g. `(WT/70)^0.75` would silently contribute `0` for that subject
+        // (division underflows here, it does not blow up). `NaN` is what
+        // `present(COV)` reads, and it propagates loudly everywhere else.
+        if !found {
+            covariates.insert(name.clone(), f64::NAN);
         }
     }
 

--- a/src/io/datareader_tests.rs
+++ b/src/io/datareader_tests.rs
@@ -127,6 +127,35 @@ fn declared_covariate_column_missing_is_rejected() {
 }
 
 #[test]
+fn a_wholly_missing_covariate_reads_as_nan_not_zero() {
+    // The column exists (so `check_covariates` passes) but subject 2 has `.`
+    // in every row. Leaving the key absent made it resolve to the covariate
+    // map's `0.0` default at every evaluation site, so `(WT/70)^0.75` silently
+    // contributed `0` for that subject — and `present(WT)`, which is `!is_nan`,
+    // read it as present. `NaN` is what makes both of those correct.
+    let f = write_csv(
+        "ID,TIME,DV,EVID,AMT,WT\n\
+         1,0,.,1,100,70\n\
+         1,1,5.0,0,.,70\n\
+         2,0,.,1,100,.\n\
+         2,1,4.0,0,.,.\n",
+    );
+    let pop = read_nonmem_csv(f.path(), None, None).unwrap();
+    assert_eq!(pop.subjects[0].covariates["WT"], 70.0);
+    assert!(
+        pop.subjects[1].covariates["WT"].is_nan(),
+        "a subject with no finite value must not read as 0.0"
+    );
+    assert!(
+        pop.warnings
+            .iter()
+            .any(|w| w.contains("covariate WT has no value for 1 of 2 subjects")),
+        "the gap must be reported: {:?}",
+        pop.warnings
+    );
+}
+
+#[test]
 fn declared_covariate_non_numeric_value_is_rejected() {
     // A declared covariate must be numerically coded; a text value is a hard
     // error rather than a silent 0.0 that would bias the fit.

--- a/src/io/datareader_tests.rs
+++ b/src/io/datareader_tests.rs
@@ -117,6 +117,7 @@ fn declared_covariate_column_missing_is_rejected() {
     // error (a silently-vanished covariate would evaluate to nothing).
     let f = write_csv("ID,TIME,DV,EVID,AMT\n1,0,.,1,100\n1,1,5.0,0,.\n");
     let decls = vec![CovariateDecl {
+        levels: None,
         name: "WT".to_string(),
         kind: CovariateKind::Continuous,
     }];
@@ -131,6 +132,7 @@ fn declared_covariate_non_numeric_value_is_rejected() {
     // error rather than a silent 0.0 that would bias the fit.
     let f = write_csv("ID,TIME,DV,EVID,AMT,WT\n1,0,.,1,100,heavy\n1,1,5.0,0,.,heavy\n");
     let decls = vec![CovariateDecl {
+        levels: None,
         name: "WT".to_string(),
         kind: CovariateKind::Continuous,
     }];
@@ -311,6 +313,7 @@ fn no_evid_inference_mirrored_in_covariate_table() {
                    1,1,5.0,.,0,70\n";
     let f = write_csv(csv);
     let decls = vec![CovariateDecl {
+        levels: None,
         name: "WT".to_string(),
         kind: CovariateKind::Continuous,
     }];
@@ -708,6 +711,7 @@ fn test_filter_on_undeclared_covariate_via_declared_path() {
                    4,1,3.5,0,.,1,85,2\n";
     let f = write_csv(csv);
     let decls = vec![CovariateDecl {
+        levels: None,
         name: "WT".to_string(),
         kind: CovariateKind::Continuous,
     }];
@@ -1804,6 +1808,7 @@ fn test_missing_dv_and_amt_not_dosed_warnings_coexist() {
 
 fn decl(name: &str, kind: CovariateKind) -> CovariateDecl {
     CovariateDecl {
+        levels: None,
         name: name.to_string(),
         kind,
     }
@@ -2181,6 +2186,7 @@ fn tte_aware_readers_route_through_gaussian_path_with_empty_tte_cmts() {
     // actually pulled into the read union, so the assertion fails if the
     // merge regresses.
     let decls = vec![CovariateDecl {
+        levels: None,
         name: "WT".to_string(),
         kind: CovariateKind::Continuous,
     }];

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1802,6 +1802,7 @@ fn wire_to_fit_result(
 
     Ok(FitResult {
         restored_from_checkpoint: true,
+        covariate_relations: Vec::new(),
         method,
         method_chain,
         method_wall_times_secs: w.method_wall_times_secs,
@@ -2056,6 +2057,7 @@ mod tests {
     fn minimal_fit_result() -> FitResult {
         let n_eta = 2;
         FitResult {
+            covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::FoceI,
             method_chain: vec![EstimationMethod::FoceI],

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2013,6 +2013,49 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
     }
 
     let n_eta = result.omega.nrows();
+    // #1111: the `[covariate_model]` relation table — what covariate model ran,
+    // what each symbolic centring statistic resolved to, and each generated θ
+    // with its estimate and SE. Emitted so a covariate search reads the run's
+    // covariate model back from the fit output instead of re-parsing the model
+    // file. Absent for the models that declare no such block.
+    if !result.covariate_relations.is_empty() {
+        writeln!(f, "\ncovariate_model:").map_err(|e| e.to_string())?;
+        for rel in &result.covariate_relations {
+            writeln!(f, "  - parameter: {}", yaml_quote(&rel.parameter))
+                .map_err(|e| e.to_string())?;
+            writeln!(f, "    covariate: {}", yaml_quote(&rel.covariate))
+                .map_err(|e| e.to_string())?;
+            writeln!(f, "    form: {}", yaml_quote(&rel.form)).map_err(|e| e.to_string())?;
+            if let Some(center) = rel.center {
+                // Both forms: the value the expression was built with, and the
+                // statistic it was written as — a run launched symbolically is
+                // reproducible only if the output says which median it landed on.
+                match rel.center_source.as_deref() {
+                    Some(src) if src != format!("{center}") => {
+                        writeln!(f, "    center: {center}  # resolved from {src}")
+                    }
+                    _ => writeln!(f, "    center: {center}"),
+                }
+                .map_err(|e| e.to_string())?;
+            }
+            writeln!(f, "    thetas:").map_err(|e| e.to_string())?;
+            for theta in &rel.thetas {
+                writeln!(f, "      - name: {}", yaml_quote(&theta.name))
+                    .map_err(|e| e.to_string())?;
+                writeln!(f, "        estimate: {:.6}", theta.estimate)
+                    .map_err(|e| e.to_string())?;
+                match theta.se {
+                    Some(se) => writeln!(f, "        se: {se:.6}"),
+                    None => writeln!(f, "        se: null"),
+                }
+                .map_err(|e| e.to_string())?;
+                if theta.fixed {
+                    writeln!(f, "        fixed: true").map_err(|e| e.to_string())?;
+                }
+            }
+        }
+    }
+
     writeln!(f, "\nomega:").map_err(|e| e.to_string())?;
     for i in 0..n_eta {
         let var = result.omega[(i, i)];
@@ -2567,6 +2610,7 @@ mod tests {
         let sigma_types = error_model.sigma_types();
         let n = sigma.len();
         FitResult {
+            covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::Foce,
             method_chain: vec![EstimationMethod::Foce],
@@ -3267,6 +3311,7 @@ mod tests {
     fn minimal_sdtab_result(subjects: Vec<SubjectResult>) -> FitResult {
         let sigma_types = ErrorModel::Proportional.sigma_types();
         FitResult {
+            covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::Foce,
             method_chain: vec![EstimationMethod::Foce],

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2038,7 +2038,17 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                 }
                 .map_err(|e| e.to_string())?;
             }
-            writeln!(f, "    thetas:").map_err(|e| e.to_string())?;
+            if let Some(expr) = &rel.expression {
+                writeln!(f, "    expression: {}", yaml_quote(expr)).map_err(|e| e.to_string())?;
+            }
+            // `none` and `expr` generate no θ. A bare `thetas:` key parses as
+            // `null`, not as an empty list, which disagrees with the `Vec`
+            // field on `FitResult` — emit the explicit empty sequence.
+            if rel.thetas.is_empty() {
+                writeln!(f, "    thetas: []").map_err(|e| e.to_string())?;
+            } else {
+                writeln!(f, "    thetas:").map_err(|e| e.to_string())?;
+            }
             for theta in &rel.thetas {
                 writeln!(f, "      - name: {}", yaml_quote(&theta.name))
                     .map_err(|e| e.to_string())?;
@@ -2051,6 +2061,9 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                 .map_err(|e| e.to_string())?;
                 if theta.fixed {
                     writeln!(f, "        fixed: true").map_err(|e| e.to_string())?;
+                }
+                if let Some(level) = theta.level {
+                    writeln!(f, "        level: {level}").map_err(|e| e.to_string())?;
                 }
             }
         }
@@ -4216,6 +4229,60 @@ mod tests {
             yaml_quote(&r.environment.username)
         )));
         assert!(yaml.contains(&format!("  ferx_version: {}", r.ferx_version)));
+    }
+
+    /// The `[covariate_model]` echo has to be readable as YAML *and* agree
+    /// with the `Vec` fields on `FitResult` (#1111 review).
+    ///
+    /// A relation with no θ — `none`, `expr` — emitted a bare `thetas:`, which
+    /// YAML reads as `null` rather than as an empty sequence, so a consumer
+    /// deserializing into `Vec<CovariateThetaEstimate>` failed on exactly the
+    /// relations the block generates nothing for. The categorical level and
+    /// the `expr` body are the other two pieces a caller cannot otherwise
+    /// recover without re-parsing the model file.
+    #[test]
+    fn write_yaml_covariate_model_keeps_levels_expression_and_empty_theta_list() {
+        let mut r = comprehensive_result();
+        r.covariate_relations = vec![
+            CovariateRelationEstimate {
+                parameter: "CL".to_string(),
+                covariate: "SEX".to_string(),
+                form: "categorical".to_string(),
+                center_source: Some("mode".to_string()),
+                center: Some(0.0),
+                expression: None,
+                thetas: vec![CovariateThetaEstimate {
+                    name: "THETA_CL_SEX_1".to_string(),
+                    estimate: 0.25,
+                    se: Some(0.05),
+                    fixed: false,
+                    level: Some(1.0),
+                }],
+            },
+            CovariateRelationEstimate {
+                parameter: "V".to_string(),
+                covariate: "WT".to_string(),
+                form: "expr".to_string(),
+                center_source: None,
+                center: None,
+                expression: Some("1 + 0.1 * WT".to_string()),
+                thetas: Vec::new(),
+            },
+        ];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        assert!(yaml.contains("\ncovariate_model:"), "{yaml}");
+        // The categorical θ names its level…
+        assert!(yaml.contains("        level: 1"), "{yaml}");
+        // …the `expr` relation carries the expression that actually ran…
+        assert!(yaml.contains("    expression: \"1 + 0.1 * WT\""), "{yaml}");
+        // …and its empty θ list is an empty *sequence*, not `null`.
+        assert!(yaml.contains("    thetas: []"), "{yaml}");
+        // (A relation that does generate θ still opens a block sequence.)
+        assert!(yaml.contains("    thetas:\n      - name:"), "{yaml}");
     }
 
     #[test]

--- a/src/parser/covariate_model.rs
+++ b/src/parser/covariate_model.rs
@@ -294,6 +294,9 @@ fn parse_relation_line(
         Some(stat) => summary.map(|s| s.value_of(stat)),
         None => None,
     };
+    if let Some(c) = resolved_center {
+        check_center_domain(&form, c, param, covariate)?;
+    }
 
     let mut rel = CovariateRelation {
         parameter: param.to_string(),
@@ -312,6 +315,44 @@ fn parse_relation_line(
     };
     rel.thetas = build_thetas(&rel, decl, summary, explicit.as_deref())?;
     Ok(rel)
+}
+
+/// Reject a centring constant the relation's own algebra cannot use.
+///
+/// `power` and `linear_relative` divide by the centre, and division by a zero
+/// (or missing) value **underflows to `0.0`** in this engine rather than
+/// blowing up — a `center = 0` would silently turn the whole covariate factor
+/// into `0` or `1`. A negative centre in `power` sends a positive covariate
+/// through `(negative)^θ`, which is `NaN` for a non-integer θ. Both are caught
+/// here, at parse time, rather than at the first evaluation.
+fn check_center_domain(
+    form: &CovariateForm,
+    center: f64,
+    param: &str,
+    covariate: &str,
+) -> Result<(), String> {
+    let bad = |why: &str| {
+        Err(format!(
+            "[covariate_model]: `{param} ~ {covariate} {}` resolves its centre to {center}, {why}",
+            form.label()
+        ))
+    };
+    if !center.is_finite() {
+        return bad("which is not a finite number. State it as a literal (`center = 70`).");
+    }
+    match form {
+        CovariateForm::Power if center <= 0.0 => bad(
+            "but `power` evaluates `(COV / centre)^θ` — a zero centre divides to `0` (this \
+             engine underflows rather than raising) and a negative one makes the base negative, \
+             which is `NaN` for a non-integer θ. Use a positive centre.",
+        ),
+        CovariateForm::LinearRelative if center == 0.0 => bad(
+            "but `linear_relative` evaluates `1 + θ·(COV / centre − 1)` — dividing by zero \
+             underflows to `0` here, so the relation would silently contribute `1 − θ` for \
+             every subject. Use a non-zero centre, or `linear`, which subtracts instead.",
+        ),
+        _ => Ok(()),
+    }
 }
 
 /// `power(center = median)` → the form and its keyword arguments.
@@ -638,12 +679,18 @@ fn linear_family_thetas(
 ) -> Result<Vec<CovariateTheta>, String> {
     let below = center - summary.min;
     let above = center - summary.max;
-    if below == 0.0 || above == 0.0 {
+    // The default bounds only order themselves when the centre sits *strictly
+    // inside* the observed range: `below > 0 > above` puts `1/above` below
+    // `1/below`. A constant covariate makes one of them infinite; a centre
+    // outside the range makes both the same sign, which emits `lower > upper`
+    // (e.g. centre 100 over a 50..90 range → `(0.1, 0.02)`).
+    if !(below > 0.0 && above < 0.0) {
         return Err(format!(
-            "[covariate_model]: `{} ~ {} {}` needs a covariate that varies around its centre \
-             ({center}), but `{}` spans [{}, {}] in the data — the PsN default bounds \
-             1/(centre − min) and 1/(centre − max) are infinite there. State the θ explicitly \
-             with `=> NAME(init, lower, upper)`, or drop the relation.",
+            "[covariate_model]: `{} ~ {} {}` needs its centre ({center}) to lie strictly inside \
+             the observed range of `{}`, which spans [{}, {}] in the data — the PsN default \
+             bounds 1/(centre − min) and 1/(centre − max) are only ordered (and only keep the \
+             covariate factor positive) there. State the θ explicitly with \
+             `=> NAME(init, lower, upper)`, or drop the relation.",
             rel.parameter,
             rel.covariate,
             rel.form.label(),
@@ -681,15 +728,30 @@ fn linear_family_thetas(
                 level: None,
             },
         ],
-        _ => vec![CovariateTheta {
-            name: base,
-            init: scale * 0.001 / below,
-            lower: scale * 1.0 / above,
-            upper: scale / below,
-            fixed: false,
-            level: None,
-        }],
+        _ => {
+            // Scaling by a negative centre (`linear_relative` on a covariate
+            // that straddles zero) reverses the interval, so re-order rather
+            // than emit `lower > upper`.
+            let (lower, upper) = ordered(scale * 1.0 / above, scale / below);
+            vec![CovariateTheta {
+                name: base,
+                init: scale * 0.001 / below,
+                lower,
+                upper,
+                fixed: false,
+                level: None,
+            }]
+        }
     })
+}
+
+/// `(min, max)` of two bounds — a negative `linear_relative` centre flips them.
+fn ordered(a: f64, b: f64) -> (f64, f64) {
+    if a <= b {
+        (a, b)
+    } else {
+        (b, a)
+    }
 }
 
 /// How many θ a relation generates, or an error when the answer is unknowable

--- a/src/parser/covariate_model.rs
+++ b/src/parser/covariate_model.rs
@@ -42,6 +42,21 @@
 //! state in a separate table), so it is also the closer translation for someone
 //! coming from `scm`.
 //!
+//! # One θ per relation
+//!
+//! A relation owns the θ it declares, and two relations cannot share one — so
+//! the common hand-written idiom of a *single* allometric exponent estimated
+//! jointly on `CL` and `V` has no spelling here (`examples/two_cpt_oral_cov.ferx`
+//! is exactly that model). This follows PsN, whose `scm` likewise gives every
+//! (parameter, covariate) relation its own θ, and it is what keeps a relation a
+//! self-contained line: sharing would couple two lines, and a search could no
+//! longer drop one without reasoning about the other.
+//!
+//! The workaround is the classical block, which this one does not replace: a θ
+//! declared in `[parameters]` can appear in as many `[individual_parameters]`
+//! expressions as the modeller likes. A model can also mix the two — declare
+//! the shared exponent classically and the rest here.
+//!
 //! # Where the sugar is removed
 //!
 //! Here, on the block *text*, before any block is read — alongside
@@ -70,8 +85,12 @@
 //! A missing covariate is `NaN` in the covariate table, and division here
 //! underflows to `0.0` rather than `inf`, so an unguarded `(WT/70)^θ` on a
 //! missing row would yield a silent `0` instead of a loud `NaN`. Every
-//! generated factor is therefore wrapped in `if (COV == COV) <factor> else 1.0`
-//! — the evaluator compares with IEEE `==`, so `NaN` takes the neutral branch.
+//! generated factor is therefore wrapped in
+//! `if (present(COV)) <factor> else 1.0`, using the `present(...)` predicate
+//! the DSL grew for exactly this. The equivalent spelling `COV == COV` works
+//! too — `NaN` compares false against itself — but this text is what a user
+//! reads back out of `ferx check` and diffs against a NONMEM control stream,
+//! so it says what it means.
 
 use std::collections::{HashMap, HashSet};
 
@@ -189,8 +208,12 @@ fn parse_relations(
         for theta in &rel.thetas {
             if !seen_theta.insert(theta.name.clone()) {
                 return Err(format!(
-                    "[covariate_model]: two relations both generate the θ `{}` — name one of \
-                     them explicitly with `=> NAME(init, lower, upper)`",
+                    "[covariate_model]: two relations both generate the θ `{}`. Each relation \
+                     owns its own θ — the block cannot share one across relations (a shared \
+                     allometric exponent on CL and V, say). Give them distinct names with \
+                     `=> NAME(init, lower, upper)`, or write the shared-θ factor classically \
+                     in [individual_parameters], where one θ can appear in as many \
+                     expressions as you like.",
                     theta.name
                 ));
             }
@@ -804,10 +827,10 @@ fn relation_factor(rel: &CovariateRelation) -> Option<String> {
             expr
         }
     };
-    // `NaN == NaN` is false, so a missing covariate takes the neutral branch —
-    // without this the relation would silently contribute `0` (division by a
-    // missing value underflows to zero here, it does not blow up).
-    Some(format!("(if ({cov} == {cov}) {inner} else 1.0)"))
+    // A missing covariate takes the neutral branch — without this the relation
+    // would silently contribute `0` (division by a missing value underflows to
+    // zero here, it does not blow up).
+    Some(format!("(if (present({cov})) {inner} else 1.0)"))
 }
 
 /// Multiply `factors` into `param`'s right-hand side, immediately before the

--- a/src/parser/covariate_model.rs
+++ b/src/parser/covariate_model.rs
@@ -1,0 +1,1077 @@
+//! The `[covariate_model]` block: declarative covariate relationships (#1111).
+//!
+//! A covariate effect has always been writable directly:
+//!
+//! ```text
+//! [individual_parameters]
+//!   CL = TVCL * (WT/70)^THETA_CL_WT * exp(ETA_CL)
+//! ```
+//!
+//! and still is. This block is *sugar* over exactly that text:
+//!
+//! ```text
+//! [covariate_model]
+//!   CL ~ WT   power(center = median)
+//!   CL ~ SEX  categorical(ref = mode)
+//! ```
+//!
+//! The point is not brevity, it is that the relations are **structured data**.
+//! A covariate search (PsN `scm`, `ferx_cov_screen()`, an agent) rewrites this
+//! one block and nothing else; the lines are independent, so adding or dropping
+//! a relation is a pure line insert/delete rather than a regex over an
+//! arbitrary expression.
+//!
+//! # Why `PARAM ~ COV form(...)` and not `PARAM ~ form(COV, ...)`
+//!
+//! The R-formula spelling — `CL ~ power(WT, center = median)`, echoing
+//! `y ~ s(WT, k = 5)` — reads more naturally to anyone arriving from R, which
+//! is most of this DSL's users. It was considered and rejected for two reasons.
+//!
+//! Once the right-hand side is a term *expression*, `CL ~ power(WT) +
+//! linear(CRCL)` is what an R-literate reader will write next, because that is
+//! what `~` plus function terms means everywhere else they have seen it. That
+//! breaks one-relation-per-line — the property the whole block exists for — and
+//! `+` reads as additive when these effects are multiplicative, so the guess
+//! about the arithmetic is wrong too. A syntax that invites a construct and
+//! then rejects it is worse than one that never invites it.
+//!
+//! And `(parameter, covariate)` is the primary key of a covariate search. This
+//! spelling puts both at fixed positions at the start of the line, with the
+//! form — the thing a search actually varies — as the one token that moves.
+//! PsN's own config keys the same way (`[test_relations] CL=WT,SEX`, with the
+//! state in a separate table), so it is also the closer translation for someone
+//! coming from `scm`.
+//!
+//! # Where the sugar is removed
+//!
+//! Here, on the block *text*, before any block is read — alongside
+//! [`super::model_parser::apply_ode_template`]'s and `apply_algebraic_structural`'s
+//! source rewrites. Everything downstream (expression compilation, `Dual2`
+//! sensitivities, the SAEM mu-reference detector, `covtab`, SE reporting) then
+//! sees an ordinary classical model, and the generated θ are ordinary θ that
+//! get estimated, bounded and reported like any other. There is no second
+//! evaluation path to keep in sync.
+//!
+//! # Where the factor is inserted
+//!
+//! Not at the end of the right-hand side. A multiplicative factor commutes with
+//! `exp(ETA)` numerically but **not** for the mu-reference detector SAEM uses —
+//! see #619, where a typical value that is not log-linear in one θ silently
+//! drops the covariate effect. So the RHS is split into top-level product
+//! factors, partitioned into η/κ-bearing and not, and the covariate factors go
+//! immediately before the first η/κ-bearing factor (or at the end if there is
+//! none), which keeps the original factor order and puts the new factor in the
+//! non-η group. When the RHS is not a top-level product at all — a sum, a logit
+//! transform, a mixture branch — that is a hard error naming the explicit
+//! handle, not a guess.
+//!
+//! # Missing covariate values
+//!
+//! A missing covariate is `NaN` in the covariate table, and division here
+//! underflows to `0.0` rather than `inf`, so an unguarded `(WT/70)^θ` on a
+//! missing row would yield a silent `0` instead of a loud `NaN`. Every
+//! generated factor is therefore wrapped in `if (COV == COV) <factor> else 1.0`
+//! — the evaluator compares with IEEE `==`, so `NaN` takes the neutral branch.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::{
+    CovariateDecl, CovariateForm, CovariateKind, CovariateLevels, CovariateModelSpec,
+    CovariateRelation, CovariateStat, CovariateSummary, CovariateTheta,
+};
+
+/// Data-derived covariate statistics threaded into a second parse, keyed by
+/// covariate name. Empty on the first parse, filled by
+/// [`crate::api::bind_covariate_stats`].
+pub type CovariateStatBindings = HashMap<String, CovariateSummary>;
+
+/// Everything the desugar needs to know about the rest of the model.
+pub(crate) struct CovariateModelContext<'a> {
+    /// `[covariates]` declarations. The block is **authoritative** here: unlike
+    /// the lenient classical path, which warns about an undeclared covariate
+    /// and reads it anyway, a relation on an undeclared covariate is an error —
+    /// the form (`categorical` vs continuous) and the levels are read off this
+    /// declaration, so guessing would generate a different θ vector per dataset.
+    pub decls: &'a [CovariateDecl],
+    /// η and κ names, so a factor can be classified as random-effect-bearing.
+    pub eta_kappa_names: &'a HashSet<String>,
+    /// θ already declared in `[parameters]`. An auto-generated name that
+    /// collides with one of these defers to it (the modeller has stated the
+    /// init and bounds they want); an explicit `=> NAME(...)` that collides is
+    /// an error, since it would declare the same θ twice.
+    pub declared_thetas: &'a HashSet<String>,
+    /// Resolved statistics, empty until the model is bound to a population.
+    pub stats: &'a CovariateStatBindings,
+}
+
+/// Rewrite `[parameters]` and `[individual_parameters]` for the relations in
+/// `block_lines`, returning the structured echo.
+///
+/// Relations that still need data-derived statistics are parsed, validated and
+/// recorded, but **not** desugared — they carry no θ and change no expression.
+/// Every entry point rejects a model that still carries one, so a symbolic
+/// `center = median` can never silently fit as if the covariate were absent.
+pub(crate) fn apply_covariate_model(
+    block_lines: &[String],
+    parameters: &mut Vec<String>,
+    individual_parameters: &mut [String],
+    ctx: &CovariateModelContext<'_>,
+) -> Result<CovariateModelSpec, String> {
+    let indiv_names = top_level_assignments(individual_parameters);
+    let relations = parse_relations(block_lines, ctx, &indiv_names)?;
+
+    let mut generated_thetas = Vec::new();
+    for rel in &relations {
+        for theta in &rel.thetas {
+            // An auto-generated name the modeller already declared defers to
+            // their declaration — re-emitting it would be a duplicate θ.
+            if ctx.declared_thetas.contains(&theta.name) {
+                continue;
+            }
+            generated_thetas.push(theta_declaration(theta));
+        }
+    }
+    parameters.extend(generated_thetas.iter().cloned());
+
+    // Group the factors by parameter so one rewrite pass handles every relation
+    // on a given parameter, in declaration order.
+    let mut factors: Vec<(String, Vec<String>)> = Vec::new();
+    for rel in &relations {
+        let Some(factor) = relation_factor(rel) else {
+            continue;
+        };
+        match factors.iter_mut().find(|(p, _)| *p == rel.parameter) {
+            Some((_, fs)) => fs.push(factor),
+            None => factors.push((rel.parameter.clone(), vec![factor])),
+        }
+    }
+    for (param, fs) in &factors {
+        insert_factors(individual_parameters, param, fs, ctx.eta_kappa_names)?;
+    }
+
+    Ok(CovariateModelSpec {
+        desugared_individual_parameters: individual_parameters
+            .iter()
+            .map(|l| l.trim_end().to_string())
+            .collect(),
+        generated_thetas,
+        relations,
+    })
+}
+
+// ── Relation parsing ───────────────────────────────────────────────────────
+
+/// Parse every line of the block into a [`CovariateRelation`], resolving the
+/// centering statistic and default θ bounds where the data allows.
+fn parse_relations(
+    lines: &[String],
+    ctx: &CovariateModelContext<'_>,
+    indiv_names: &[String],
+) -> Result<Vec<CovariateRelation>, String> {
+    let mut out: Vec<CovariateRelation> = Vec::new();
+    let mut seen_theta: HashSet<String> = HashSet::new();
+    for line in lines {
+        let line = strip_comment(line);
+        if line.is_empty() {
+            continue;
+        }
+        let rel = parse_relation_line(line, ctx, indiv_names)?;
+        if out
+            .iter()
+            .any(|r| r.parameter == rel.parameter && r.covariate == rel.covariate)
+        {
+            return Err(format!(
+                "[covariate_model]: relation `{} ~ {}` is declared more than once — one line \
+                 per (parameter, covariate) pair",
+                rel.parameter, rel.covariate
+            ));
+        }
+        for theta in &rel.thetas {
+            if !seen_theta.insert(theta.name.clone()) {
+                return Err(format!(
+                    "[covariate_model]: two relations both generate the θ `{}` — name one of \
+                     them explicitly with `=> NAME(init, lower, upper)`",
+                    theta.name
+                ));
+            }
+        }
+        out.push(rel);
+    }
+    Ok(out)
+}
+
+/// `PARAM ~ COV form(kwargs) [=> THETA(init, lower, upper)[, ...]]`
+fn parse_relation_line(
+    line: &str,
+    ctx: &CovariateModelContext<'_>,
+    indiv_names: &[String],
+) -> Result<CovariateRelation, String> {
+    let (body, theta_clause) = match line.split_once("=>") {
+        Some((b, t)) => (b.trim(), Some(t.trim())),
+        None => (line, None),
+    };
+    let Some((param, rest)) = body.split_once('~') else {
+        return Err(format!(
+            "[covariate_model]: expected `PARAM ~ COV form(...)`, got `{line}`"
+        ));
+    };
+    let param = param.trim();
+    if param.is_empty() {
+        return Err(format!(
+            "[covariate_model]: missing parameter name in `{line}`"
+        ));
+    }
+    if !indiv_names.iter().any(|n| n == param) {
+        return Err(format!(
+            "[covariate_model]: `{param}` is not a top-level [individual_parameters] name \
+             (declared: {})",
+            join_names(indiv_names)
+        ));
+    }
+    let rest = rest.trim();
+    let (covariate, form_src) = match rest.find(char::is_whitespace) {
+        Some(i) => (rest[..i].trim(), rest[i..].trim()),
+        None => (rest, ""),
+    };
+    if form_src.is_empty() {
+        return Err(format!(
+            "[covariate_model]: `{param} ~ {covariate}` states no form — expected one of \
+             none, linear, linear_relative, exponential, power, hockey, categorical, expr"
+        ));
+    }
+    let decl = ctx
+        .decls
+        .iter()
+        .find(|d| d.name == covariate)
+        .ok_or_else(|| {
+            format!(
+                "[covariate_model]: covariate `{covariate}` is not declared in [covariates] \
+                 (declared: {}). The block is authoritative: a relation's form and levels are \
+                 read off the declaration, so it must be stated.",
+                join_names(&ctx.decls.iter().map(|d| d.name.clone()).collect::<Vec<_>>())
+            )
+        })?;
+
+    let (form, kwargs) = parse_form(form_src)?;
+    check_kind(&form, decl)?;
+
+    let center = center_argument(&form, &kwargs, param, covariate)?;
+    let fix = match kwargs.get("fix") {
+        Some(v) => Some(v.literal().ok_or_else(|| {
+            format!(
+                "[covariate_model]: `fix` takes a number, got `{}`",
+                v.label()
+            )
+        })?),
+        None => None,
+    };
+    let summary = ctx.stats.get(covariate);
+    let resolved_center = match center {
+        Some(CovariateStat::Literal(v)) => Some(v),
+        Some(stat) => summary.map(|s| s.value_of(stat)),
+        None => None,
+    };
+
+    let mut rel = CovariateRelation {
+        parameter: param.to_string(),
+        covariate: covariate.to_string(),
+        form,
+        center,
+        resolved_center,
+        fix,
+        thetas: Vec::new(),
+        source_line: line.to_string(),
+    };
+
+    let explicit = match theta_clause {
+        Some(clause) => Some(parse_theta_clause(clause, ctx)?),
+        None => None,
+    };
+    rel.thetas = build_thetas(&rel, decl, summary, explicit.as_deref())?;
+    Ok(rel)
+}
+
+/// `power(center = median)` → the form and its keyword arguments.
+fn parse_form(src: &str) -> Result<(CovariateForm, HashMap<String, CovariateStat>), String> {
+    let src = src.trim();
+    let (head, body) = match src.find('(') {
+        Some(i) => {
+            let body = src[i..]
+                .strip_prefix('(')
+                .and_then(|r| r.strip_suffix(')'))
+                .ok_or_else(|| {
+                    format!("[covariate_model]: unbalanced parentheses in form `{src}`")
+                })?;
+            (src[..i].trim(), body.trim())
+        }
+        None => (src, ""),
+    };
+    let form = match head.to_lowercase().as_str() {
+        "none" => CovariateForm::None,
+        "linear" => CovariateForm::Linear,
+        "linear_relative" => CovariateForm::LinearRelative,
+        "exponential" => CovariateForm::Exponential,
+        "power" => CovariateForm::Power,
+        "hockey" => CovariateForm::Hockey,
+        "categorical" => CovariateForm::Categorical,
+        "expr" => {
+            let text = body
+                .trim()
+                .strip_prefix('"')
+                .and_then(|r| r.strip_suffix('"'))
+                .ok_or_else(|| {
+                    "[covariate_model]: `expr` takes a quoted expression, e.g. \
+                     `expr(\"(WT/70)^0.75\")`"
+                        .to_string()
+                })?;
+            if text.trim().is_empty() {
+                return Err("[covariate_model]: `expr(\"\")` states no expression".to_string());
+            }
+            return Ok((CovariateForm::Expr(text.to_string()), HashMap::new()));
+        }
+        other => {
+            return Err(format!(
+                "[covariate_model]: unknown form `{other}`{} — expected one of none, linear, \
+                 linear_relative, exponential, power, hockey, categorical, expr",
+                did_you_mean(other)
+            ))
+        }
+    };
+    Ok((form, parse_kwargs(body, head)?))
+}
+
+/// `center = median, fix = 0.75` → a name→value map. Values are a number or one
+/// of the data-derived statistics.
+fn parse_kwargs(body: &str, form: &str) -> Result<HashMap<String, CovariateStat>, String> {
+    let mut out = HashMap::new();
+    for part in body.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = part.split_once('=') else {
+            return Err(format!(
+                "[covariate_model]: `{form}(...)` takes `key = value` arguments, got `{part}`"
+            ));
+        };
+        let key = key.trim().to_lowercase();
+        if !matches!(key.as_str(), "center" | "breakpoint" | "ref" | "fix") {
+            return Err(format!(
+                "[covariate_model]: unknown argument `{key}` to `{form}(...)` — expected \
+                 center, breakpoint, ref or fix"
+            ));
+        }
+        let value = value.trim();
+        let stat = match value.to_lowercase().as_str() {
+            "median" => CovariateStat::Median,
+            "mean" => CovariateStat::Mean,
+            "min" | "minimum" => CovariateStat::Min,
+            "max" | "maximum" => CovariateStat::Max,
+            "mode" => CovariateStat::Mode,
+            _ => CovariateStat::Literal(value.parse::<f64>().map_err(|_| {
+                format!(
+                    "[covariate_model]: `{key} = {value}` is neither a number nor one of \
+                     median, mean, min, max, mode"
+                )
+            })?),
+        };
+        if out.insert(key.clone(), stat).is_some() {
+            return Err(format!(
+                "[covariate_model]: `{key}` is given more than once in `{form}(...)`"
+            ));
+        }
+    }
+    Ok(out)
+}
+
+/// The centering constant a form takes, under the keyword that form spells it
+/// with: `center` for the continuous forms, `breakpoint` for `hockey`, `ref`
+/// for `categorical`.
+fn center_argument(
+    form: &CovariateForm,
+    kwargs: &HashMap<String, CovariateStat>,
+    param: &str,
+    covariate: &str,
+) -> Result<Option<CovariateStat>, String> {
+    let (keyword, default) = match form {
+        CovariateForm::None | CovariateForm::Expr(_) => {
+            for key in ["center", "breakpoint", "ref"] {
+                if kwargs.contains_key(key) {
+                    return Err(format!(
+                        "[covariate_model]: `{}` takes no `{key}`",
+                        form.label()
+                    ));
+                }
+            }
+            return Ok(None);
+        }
+        CovariateForm::Hockey => ("breakpoint", CovariateStat::Median),
+        CovariateForm::Categorical => ("ref", CovariateStat::Mode),
+        _ => ("center", CovariateStat::Median),
+    };
+    for key in ["center", "breakpoint", "ref"] {
+        if key != keyword && kwargs.contains_key(key) {
+            return Err(format!(
+                "[covariate_model]: `{}` centres on `{keyword}`, not `{key}` \
+                 (in `{param} ~ {covariate}`)",
+                form.label()
+            ));
+        }
+    }
+    Ok(Some(kwargs.get(keyword).copied().unwrap_or(default)))
+}
+
+/// A `categorical` form must sit on a categorical covariate and every other
+/// form on a continuous one. Silently allowing the mismatch would generate a
+/// factor keyed on a level that does not exist, or a power of a 0/1 code.
+fn check_kind(form: &CovariateForm, decl: &CovariateDecl) -> Result<(), String> {
+    if matches!(form, CovariateForm::None | CovariateForm::Expr(_)) {
+        return Ok(());
+    }
+    match (form.is_categorical(), decl.kind) {
+        (true, CovariateKind::Continuous) => Err(format!(
+            "[covariate_model]: `categorical(...)` on `{}`, which [covariates] declares \
+             continuous",
+            decl.name
+        )),
+        (false, CovariateKind::Categorical) => Err(format!(
+            "[covariate_model]: `{}` is a continuous form, but [covariates] declares `{}` \
+             categorical — use `categorical(ref = ...)`",
+            form.label(),
+            decl.name
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// `=> NAME(init, lower, upper)[, NAME(...)]` — an explicit θ declaration,
+/// overriding the form's defaults. One entry per θ the form generates.
+fn parse_theta_clause(
+    clause: &str,
+    ctx: &CovariateModelContext<'_>,
+) -> Result<Vec<CovariateTheta>, String> {
+    let mut out = Vec::new();
+    for part in split_top_level(clause, ',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (name, args) = part
+            .split_once('(')
+            .and_then(|(n, a)| a.strip_suffix(')').map(|a| (n.trim(), a)))
+            .ok_or_else(|| {
+                format!("[covariate_model]: expected `=> NAME(init, lower, upper)`, got `{part}`")
+            })?;
+        let nums: Vec<f64> = args
+            .split(',')
+            .map(|t| {
+                t.trim().parse::<f64>().map_err(|_| {
+                    format!(
+                        "[covariate_model]: `{}` is not a number in `{part}`",
+                        t.trim()
+                    )
+                })
+            })
+            .collect::<Result<_, _>>()?;
+        let [init, lower, upper] = nums[..] else {
+            return Err(format!(
+                "[covariate_model]: `{name}(...)` needs exactly (init, lower, upper), got \
+                 {} values",
+                nums.len()
+            ));
+        };
+        if ctx.declared_thetas.contains(name) {
+            return Err(format!(
+                "[covariate_model]: θ `{name}` is already declared in [parameters] — drop the \
+                 `=> {name}(...)` clause to use that declaration, or rename one of them"
+            ));
+        }
+        out.push(CovariateTheta {
+            name: name.to_string(),
+            init,
+            lower,
+            upper,
+            fixed: false,
+            level: None,
+        });
+    }
+    if out.is_empty() {
+        return Err("[covariate_model]: empty `=>` clause".to_string());
+    }
+    Ok(out)
+}
+
+// ── θ construction (PsN defaults) ──────────────────────────────────────────
+
+/// Build the θ a relation declares.
+///
+/// Returns an empty vector — leaving the relation *unresolved* — when the form
+/// needs data-derived statistics that are not bound yet. `none` and `expr(...)`
+/// declare no θ and are never unresolved.
+fn build_thetas(
+    rel: &CovariateRelation,
+    decl: &CovariateDecl,
+    summary: Option<&CovariateSummary>,
+    explicit: Option<&[CovariateTheta]>,
+) -> Result<Vec<CovariateTheta>, String> {
+    // `levels = auto` is the opt-in to data-derived levels: with no population
+    // bound yet the θ count is simply not known, which is an unresolved
+    // relation, not an error.
+    if rel.form.is_categorical()
+        && matches!(decl.levels, Some(CovariateLevels::Auto))
+        && summary.is_none()
+    {
+        return Ok(Vec::new());
+    }
+    let expected = expected_theta_count(rel, decl, summary)?;
+    if expected == 0 {
+        if let Some(explicit) = explicit {
+            return Err(format!(
+                "[covariate_model]: `{}` declares no θ, so the `=> {}(...)` clause has nothing \
+                 to name",
+                rel.form.label(),
+                explicit[0].name
+            ));
+        }
+        return Ok(Vec::new());
+    }
+    if let Some(explicit) = explicit {
+        if explicit.len() != expected {
+            return Err(format!(
+                "[covariate_model]: `{} ~ {} {}` generates {expected} θ but the `=>` clause \
+                 names {}",
+                rel.parameter,
+                rel.covariate,
+                rel.form.label(),
+                explicit.len()
+            ));
+        }
+        let mut out = explicit.to_vec();
+        apply_fix(&mut out, rel);
+        if rel.form.is_categorical() {
+            for (theta, level) in out
+                .iter_mut()
+                .zip(non_reference_levels(rel, decl, summary)?)
+            {
+                theta.level = Some(level);
+            }
+        }
+        return Ok(out);
+    }
+
+    // Every default below needs the centering constant; and the two linear
+    // families need the covariate's spread, which only the data has.
+    let Some(center) = rel.resolved_center else {
+        return Ok(Vec::new());
+    };
+    let mut out = match rel.form {
+        CovariateForm::Categorical => {
+            let base = format!("THETA_{}_{}", rel.parameter, rel.covariate);
+            non_reference_levels(rel, decl, summary)?
+                .into_iter()
+                .map(|level| CovariateTheta {
+                    // PsN's categorical θ is null at 0 and bounded symmetrically
+                    // about it, so the parameterization has no preferred sign.
+                    name: format!("{base}_{}", level_suffix(level)),
+                    init: -0.001,
+                    lower: -1.0,
+                    upper: 5.0,
+                    fixed: false,
+                    level: Some(level),
+                })
+                .collect()
+        }
+        CovariateForm::Exponential | CovariateForm::Power => vec![CovariateTheta {
+            name: format!("THETA_{}_{}", rel.parameter, rel.covariate),
+            init: 0.001,
+            lower: -100.0,
+            upper: 1e6,
+            fixed: false,
+            level: None,
+        }],
+        CovariateForm::Linear | CovariateForm::LinearRelative | CovariateForm::Hockey => {
+            let Some(summary) = summary else {
+                return Ok(Vec::new());
+            };
+            linear_family_thetas(rel, summary, center)?
+        }
+        CovariateForm::None | CovariateForm::Expr(_) => Vec::new(),
+    };
+    apply_fix(&mut out, rel);
+    Ok(out)
+}
+
+/// PsN's default init/bounds for the linear family.
+///
+/// The bounds are not cosmetic: `θ ∈ [1/(med−max), 1/(med−min)]` is exactly
+/// what keeps `1 + θ·(COV − med)` positive over the observed covariate range,
+/// which is why they are adopted verbatim rather than re-invented. A constant
+/// covariate makes both bounds infinite, so it is rejected here instead of
+/// producing a θ the optimiser cannot move.
+fn linear_family_thetas(
+    rel: &CovariateRelation,
+    summary: &CovariateSummary,
+    center: f64,
+) -> Result<Vec<CovariateTheta>, String> {
+    let below = center - summary.min;
+    let above = center - summary.max;
+    if below == 0.0 || above == 0.0 {
+        return Err(format!(
+            "[covariate_model]: `{} ~ {} {}` needs a covariate that varies around its centre \
+             ({center}), but `{}` spans [{}, {}] in the data — the PsN default bounds \
+             1/(centre − min) and 1/(centre − max) are infinite there. State the θ explicitly \
+             with `=> NAME(init, lower, upper)`, or drop the relation.",
+            rel.parameter,
+            rel.covariate,
+            rel.form.label(),
+            rel.covariate,
+            summary.min,
+            summary.max
+        ));
+    }
+    // `linear_relative` is `linear` reparameterized as θ_rel = centre · θ_abs,
+    // so its init and bounds are the linear ones scaled by the centre — the two
+    // forms then start the optimiser at the same place and admit the same
+    // covariate factors, and differ only in the scale θ reports on.
+    let scale = if matches!(rel.form, CovariateForm::LinearRelative) {
+        center
+    } else {
+        1.0
+    };
+    let base = format!("THETA_{}_{}", rel.parameter, rel.covariate);
+    Ok(match rel.form {
+        CovariateForm::Hockey => vec![
+            CovariateTheta {
+                name: format!("{base}_LO"),
+                init: 0.001 / below,
+                lower: -1e6,
+                upper: 1.0 / below,
+                fixed: false,
+                level: None,
+            },
+            CovariateTheta {
+                name: format!("{base}_HI"),
+                init: 0.001 / above,
+                lower: 1.0 / above,
+                upper: 1e6,
+                fixed: false,
+                level: None,
+            },
+        ],
+        _ => vec![CovariateTheta {
+            name: base,
+            init: scale * 0.001 / below,
+            lower: scale * 1.0 / above,
+            upper: scale / below,
+            fixed: false,
+            level: None,
+        }],
+    })
+}
+
+/// How many θ a relation generates, or an error when the answer is unknowable
+/// from the file alone (a `categorical` with neither declared nor bound levels).
+fn expected_theta_count(
+    rel: &CovariateRelation,
+    decl: &CovariateDecl,
+    summary: Option<&CovariateSummary>,
+) -> Result<usize, String> {
+    Ok(match rel.form {
+        CovariateForm::None | CovariateForm::Expr(_) => 0,
+        CovariateForm::Hockey => 2,
+        CovariateForm::Categorical => match levels_of(decl, summary) {
+            Some(levels) => levels.len().saturating_sub(1),
+            None => {
+                return Err(format!(
+                    "[covariate_model]: `categorical(...)` on `{}` needs its levels, but \
+                     [covariates] declares none. Write `{} categorical(levels = [0, 1])` for a \
+                     θ vector fixed by the file, or `levels = auto` to read them off the data.",
+                    decl.name, decl.name
+                ))
+            }
+        },
+        _ => 1,
+    })
+}
+
+/// The covariate's levels: as declared, or as discovered for `levels = auto`.
+/// `None` when `auto` is asked for and no data is bound yet.
+fn levels_of(decl: &CovariateDecl, summary: Option<&CovariateSummary>) -> Option<Vec<f64>> {
+    match decl.levels.as_ref()? {
+        CovariateLevels::Declared(v) => Some(v.clone()),
+        CovariateLevels::Auto => summary.map(|s| s.levels.clone()),
+    }
+}
+
+/// Every level but the reference one, in declaration order — one θ each.
+fn non_reference_levels(
+    rel: &CovariateRelation,
+    decl: &CovariateDecl,
+    summary: Option<&CovariateSummary>,
+) -> Result<Vec<f64>, String> {
+    let levels = levels_of(decl, summary).unwrap_or_default();
+    let Some(reference) = rel.resolved_center else {
+        return Ok(Vec::new());
+    };
+    if !levels.contains(&reference) {
+        return Err(format!(
+            "[covariate_model]: reference level {reference} of `{} ~ {}` is not one of the \
+             declared levels {levels:?}",
+            rel.parameter, rel.covariate
+        ));
+    }
+    Ok(levels.into_iter().filter(|l| *l != reference).collect())
+}
+
+/// `fix = v` pins every θ of the relation at `v`, declared `FIX`.
+fn apply_fix(thetas: &mut [CovariateTheta], rel: &CovariateRelation) {
+    let Some(v) = rel.fix else { return };
+    for theta in thetas {
+        theta.init = v;
+        theta.fixed = true;
+    }
+}
+
+/// `THETA_CL_SEX_1` / `THETA_CL_SEX_M1` / `THETA_CL_SEX_1_5` — a level rendered
+/// as a name fragment, with `-` and `.` spelled out so the result is a valid
+/// identifier.
+fn level_suffix(level: f64) -> String {
+    let text = if level.fract() == 0.0 && level.abs() < 1e15 {
+        format!("{}", level as i64)
+    } else {
+        format!("{level}")
+    };
+    text.replace('-', "M").replace('.', "_")
+}
+
+/// The `[parameters]` line for a generated θ.
+fn theta_declaration(theta: &CovariateTheta) -> String {
+    format!(
+        "  theta {}({}, {}, {}){}",
+        theta.name,
+        fmt(theta.init),
+        fmt(theta.lower),
+        fmt(theta.upper),
+        if theta.fixed { " FIX" } else { "" }
+    )
+}
+
+// ── Factor generation ──────────────────────────────────────────────────────
+
+/// The multiplicative factor a relation contributes, already guarded against a
+/// missing covariate value. `None` for `none` and for a relation still waiting
+/// on data.
+fn relation_factor(rel: &CovariateRelation) -> Option<String> {
+    let cov = &rel.covariate;
+    let inner = match &rel.form {
+        CovariateForm::None => return None,
+        CovariateForm::Expr(text) => format!("({text})"),
+        _ if rel.needs_data() => return None,
+        CovariateForm::Linear => {
+            let c = fmt(rel.resolved_center?);
+            format!("(1 + {} * ({cov} - {c}))", rel.thetas[0].name)
+        }
+        CovariateForm::LinearRelative => {
+            let c = fmt(rel.resolved_center?);
+            format!("(1 + {} * ({cov} / {c} - 1))", rel.thetas[0].name)
+        }
+        CovariateForm::Exponential => {
+            let c = fmt(rel.resolved_center?);
+            format!("exp({} * ({cov} - {c}))", rel.thetas[0].name)
+        }
+        CovariateForm::Power => {
+            let c = fmt(rel.resolved_center?);
+            format!("({cov} / {c})^{}", rel.thetas[0].name)
+        }
+        CovariateForm::Hockey => {
+            let b = fmt(rel.resolved_center?);
+            format!(
+                "(if ({cov} <= {b}) 1 + {} * ({cov} - {b}) else 1 + {} * ({cov} - {b}))",
+                rel.thetas[0].name, rel.thetas[1].name
+            )
+        }
+        CovariateForm::Categorical => {
+            let mut expr = String::from("(");
+            for theta in &rel.thetas {
+                expr.push_str(&format!(
+                    "if ({cov} == {}) 1 + {} else ",
+                    fmt(theta.level?),
+                    theta.name
+                ));
+            }
+            // The reference level, and anything not listed, contributes 1.
+            expr.push_str("1)");
+            expr
+        }
+    };
+    // `NaN == NaN` is false, so a missing covariate takes the neutral branch —
+    // without this the relation would silently contribute `0` (division by a
+    // missing value underflows to zero here, it does not blow up).
+    Some(format!("(if ({cov} == {cov}) {inner} else 1.0)"))
+}
+
+/// Multiply `factors` into `param`'s right-hand side, immediately before the
+/// first η/κ-bearing top-level factor.
+fn insert_factors(
+    lines: &mut [String],
+    param: &str,
+    factors: &[String],
+    eta_kappa: &HashSet<String>,
+) -> Result<(), String> {
+    let idx = assignment_line(lines, param).ok_or_else(|| {
+        format!("[covariate_model]: `{param}` is not assigned in [individual_parameters]")
+    })?;
+    let line = lines[idx].clone();
+    let (lhs, rhs) = line
+        .split_once('=')
+        .expect("assignment_line matched an `=`");
+    let rhs = rhs.trim();
+
+    let parts = split_top_level(rhs, '*');
+    let non_product = parts.len() == 1 && !is_simple_factor(rhs);
+    if non_product || parts.iter().any(|p| p.trim().is_empty()) {
+        return Err(non_product_error(param, rhs));
+    }
+    let first_random = parts
+        .iter()
+        .position(|p| mentions_any(p, eta_kappa))
+        .unwrap_or(parts.len());
+    if first_random == 0 && parts.len() == 1 {
+        // The whole RHS is one random-effect-bearing term (`exp(TVCL + ETA_CL)`);
+        // there is no non-η group to multiply into.
+        return Err(non_product_error(param, rhs));
+    }
+
+    let mut rebuilt: Vec<String> = parts.iter().map(|p| p.trim().to_string()).collect();
+    for (offset, factor) in factors.iter().enumerate() {
+        rebuilt.insert(first_random + offset, factor.clone());
+    }
+    lines[idx] = format!("{}= {}", lhs, rebuilt.join(" * "));
+    Ok(())
+}
+
+fn non_product_error(param: &str, rhs: &str) -> String {
+    format!(
+        "[covariate_model]: cannot place a covariate factor in `{param} = {rhs}` — the \
+         right-hand side is not a top-level product, so multiplying into it would change what \
+         the expression means (and, for a sum or a transform, would move the effect out of the \
+         non-η group the SAEM mu-reference detector reads, #619).\n\
+         Wire the factor by hand instead:\n\
+         \x20 [individual_parameters]\n\
+         \x20   {param} = ... * COV_{param} * ...   # COV_{param} = the factor, placed where you \
+         want it"
+    )
+}
+
+/// Whether a single-factor RHS is a plain multiplicative term (`TVCL`,
+/// `exp(ETA_CL)`, `(WT/70)^0.75`) rather than a sum or a conditional that only
+/// *looks* like one factor because it has no top-level `*`.
+fn is_simple_factor(rhs: &str) -> bool {
+    let rhs = rhs.trim();
+    if rhs.is_empty() {
+        return false;
+    }
+    // A leading `if` is a conditional / mixture branch, never a factor.
+    if rhs.starts_with("if ") || rhs.starts_with("if(") {
+        return false;
+    }
+    // A top-level `+` or `-` makes it a sum. Signs inside exponents (`1e-3`)
+    // and a leading unary sign are not top-level operators.
+    !has_top_level_additive(rhs)
+}
+
+// ── Text helpers ───────────────────────────────────────────────────────────
+
+/// The `[individual_parameters]` names assigned at top level (brace depth 0),
+/// in order. A name assigned inside an `if { ... }` block is deliberately not
+/// listed: the block has no single right-hand side to multiply into.
+fn top_level_assignments(lines: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    for line in lines {
+        let text = strip_comment(line);
+        if depth == 0 {
+            if let Some(name) = assignment_target(text) {
+                if !out.contains(&name) {
+                    out.push(name);
+                }
+            }
+        }
+        depth += text.matches('{').count() as i32;
+        depth -= text.matches('}').count() as i32;
+        depth = depth.max(0);
+    }
+    out
+}
+
+/// The index of the top-level line assigning `param`.
+fn assignment_line(lines: &[String], param: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut found = None;
+    for (i, line) in lines.iter().enumerate() {
+        let text = strip_comment(line);
+        if depth == 0 && assignment_target(text).as_deref() == Some(param) {
+            found = Some(i);
+        }
+        depth += text.matches('{').count() as i32;
+        depth -= text.matches('}').count() as i32;
+        depth = depth.max(0);
+    }
+    found
+}
+
+/// `CL = ...` → `Some("CL")`. Not an assignment if the `=` is part of a
+/// comparison, or the left side is not a bare identifier.
+fn assignment_target(line: &str) -> Option<String> {
+    let (lhs, rhs) = line.split_once('=')?;
+    if rhs.starts_with('=') || lhs.ends_with(['=', '<', '>', '!']) {
+        return None;
+    }
+    let lhs = lhs.trim();
+    if lhs.is_empty() || !is_identifier(lhs) {
+        return None;
+    }
+    Some(lhs.to_string())
+}
+
+fn is_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Split on `sep` at parenthesis/bracket depth 0.
+fn split_top_level(text: &str, sep: char) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut current = String::new();
+    for c in text.chars() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            _ => {}
+        }
+        if c == sep && depth == 0 {
+            out.push(std::mem::take(&mut current));
+        } else {
+            current.push(c);
+        }
+    }
+    out.push(current);
+    out
+}
+
+/// Whether the text carries a `+` or `-` at depth 0 that is a binary operator —
+/// i.e. not a leading unary sign and not the sign of an exponent (`1e-3`).
+fn has_top_level_additive(text: &str) -> bool {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut depth = 0i32;
+    for (i, c) in bytes.iter().enumerate() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            '+' | '-' if depth == 0 => {
+                let prev = bytes[..i].iter().rposition(|c| !c.is_whitespace());
+                let Some(prev) = prev else { continue }; // leading unary sign
+                let p = bytes[prev];
+                // `1e-3` / `1E+3`: the sign belongs to the exponent.
+                if (p == 'e' || p == 'E') && prev > 0 && bytes[prev - 1].is_ascii_digit() {
+                    continue;
+                }
+                // An operator can only follow a value, never another operator.
+                if matches!(p, '+' | '-' | '*' | '/' | '^' | '(' | ',') {
+                    continue;
+                }
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Whether any identifier in `text` is in `names`.
+fn mentions_any(text: &str, names: &HashSet<String>) -> bool {
+    let mut current = String::new();
+    for c in text.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            current.push(c);
+        } else if !current.is_empty() {
+            if names.contains(&current) {
+                return true;
+            }
+            current.clear();
+        }
+    }
+    !current.is_empty() && names.contains(&current)
+}
+
+/// Drop a trailing `# comment`, returning the text before it.
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(i) => line[..i].trim(),
+        None => line.trim(),
+    }
+}
+
+/// Render a number for emission into model text: integral values without the
+/// `.0` so a generated line reads like a hand-written one, and everything else
+/// with enough digits to round-trip.
+fn fmt(v: f64) -> String {
+    if v.fract() == 0.0 && v.abs() < 1e15 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+fn join_names(names: &[String]) -> String {
+    if names.is_empty() {
+        "none".to_string()
+    } else {
+        names.join(", ")
+    }
+}
+
+/// A one-edit-away suggestion for a misspelled form name.
+fn did_you_mean(word: &str) -> String {
+    const FORMS: &[&str] = &[
+        "none",
+        "linear",
+        "linear_relative",
+        "exponential",
+        "power",
+        "hockey",
+        "categorical",
+        "expr",
+    ];
+    let lower = word.to_lowercase();
+    match FORMS
+        .iter()
+        .filter(|f| levenshtein(&lower, f) <= 2)
+        .min_by_key(|f| levenshtein(&lower, f))
+    {
+        Some(best) => format!(" (did you mean `{best}`?)"),
+        None => String::new(),
+    }
+}
+
+/// Levenshtein distance, for the did-you-mean above only.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut current = vec![0usize; b_chars.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        current[0] = i + 1;
+        for (j, cb) in b_chars.iter().enumerate() {
+            let cost = usize::from(ca != *cb);
+            current[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(current[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut current);
+    }
+    prev[b_chars.len()]
+}
+
+#[cfg(test)]
+#[path = "covariate_model_tests.rs"]
+mod tests;

--- a/src/parser/covariate_model.rs
+++ b/src/parser/covariate_model.rs
@@ -164,8 +164,11 @@ pub(crate) fn apply_covariate_model(
             None => factors.push((rel.parameter.clone(), vec![factor])),
         }
     }
+    // Classify factors against the η/κ names *plus* every intermediate that
+    // reads one, so a factor is not mistaken for η-free (see below).
+    let random_bearing = random_bearing_names(individual_parameters, ctx.eta_kappa_names);
     for (param, fs) in &factors {
-        insert_factors(individual_parameters, param, fs, ctx.eta_kappa_names)?;
+        insert_factors(individual_parameters, param, fs, &random_bearing)?;
     }
 
     Ok(CovariateModelSpec {
@@ -459,7 +462,10 @@ fn center_argument(
 ) -> Result<Option<CovariateStat>, String> {
     let (keyword, default) = match form {
         CovariateForm::None | CovariateForm::Expr(_) => {
-            for key in ["center", "breakpoint", "ref"] {
+            // `fix` joins the centring keys here: both forms declare no θ, so
+            // `none(fix = 0.5)` would parse, set `rel.fix`, and then have
+            // `apply_fix` run over an empty θ list — no effect, no diagnostic.
+            for key in ["center", "breakpoint", "ref", "fix"] {
                 if kwargs.contains_key(key) {
                     return Err(format!(
                         "[covariate_model]: `{}` takes no `{key}`",
@@ -588,6 +594,27 @@ fn build_thetas(
         return Ok(Vec::new());
     }
     let expected = expected_theta_count(rel, decl, summary)?;
+    if expected == 0 && rel.form.is_categorical() {
+        // Levels are known (declared, or discovered for `levels = auto`) and
+        // there is exactly one, so there is no contrast to estimate. Without
+        // this the relation would carry no θ, `needs_data()` would read that as
+        // *unresolved*, and the user would be told to supply `--data` — which
+        // can never help.
+        let levels = levels_of(decl, summary).unwrap_or_default();
+        return Err(format!(
+            "[covariate_model]: `{} ~ {} categorical(...)` has nothing to estimate — `{}` has \
+             {} level{} ({}), and a categorical relation spends one θ per *non-reference* level. \
+             Declare the levels the data actually carries (`{} categorical(levels = [...])` in \
+             [covariates]), or drop the relation.",
+            rel.parameter,
+            rel.covariate,
+            decl.name,
+            levels.len(),
+            if levels.len() == 1 { "" } else { "s" },
+            join_levels(&levels),
+            decl.name,
+        ));
+    }
     if expected == 0 {
         if let Some(explicit) = explicit {
             return Err(format!(
@@ -895,6 +922,49 @@ fn relation_factor(rel: &CovariateRelation) -> Option<String> {
     Some(format!("(if (present({cov})) {inner} else 1.0)"))
 }
 
+/// `eta_kappa`, plus every top-level `[individual_parameters]` variable whose
+/// definition transitively reads one.
+///
+/// [`insert_factors`] classifies a factor by the *names* it mentions, so an η
+/// reached through an intermediate —
+///
+/// ```text
+/// CLI = exp(ETA_CL)
+/// CL  = TVCL * CLI
+/// ```
+///
+/// — would otherwise look η-free, and the covariate factor would be appended
+/// *after* `CLI`: the placement #619 is about, silently rather than as the
+/// `COV_<PARAM>` hard error. Adding `CLI` to the set puts the factor back in the
+/// non-η group.
+///
+/// Iterated to a fixed point rather than taken in source order, since an
+/// `if { ... }` block can reassign a name after its first definition.
+fn random_bearing_names(lines: &[String], eta_kappa: &HashSet<String>) -> HashSet<String> {
+    let mut set = eta_kappa.clone();
+    loop {
+        let mut grew = false;
+        for line in lines {
+            let text = strip_comment(line);
+            let Some(name) = assignment_target(text) else {
+                continue;
+            };
+            if set.contains(&name) {
+                continue;
+            }
+            let rhs = text.split_once('=').map(|(_, r)| r).unwrap_or("");
+            if mentions_any(rhs, &set) {
+                set.insert(name);
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+    set
+}
+
 /// Multiply `factors` into `param`'s right-hand side, immediately before the
 /// first η/κ-bearing top-level factor.
 fn insert_factors(
@@ -913,8 +983,13 @@ fn insert_factors(
     let rhs = rhs.trim();
 
     let parts = split_top_level(rhs, '*');
-    let non_product = parts.len() == 1 && !is_simple_factor(rhs);
-    if non_product || parts.iter().any(|p| p.trim().is_empty()) {
+    // *Every* factor has to be a plain multiplicative term, not just the whole
+    // RHS when it happens to carry no top-level `*`. Checking only the latter
+    // let `CL = TVCL * exp(ETA_CL) + BASE_CL` through — `split_top_level` returns
+    // two parts there, so the sum guard was skipped and the covariate factor was
+    // multiplied into the first addend alone. `is_simple_factor` rejects an empty
+    // part too, which covers a trailing/doubled `*`.
+    if parts.iter().any(|p| !is_simple_factor(p)) {
         return Err(non_product_error(param, rhs));
     }
     let first_random = parts
@@ -1107,6 +1182,19 @@ fn fmt(v: f64) -> String {
         format!("{}", v as i64)
     } else {
         format!("{v}")
+    }
+}
+
+/// Covariate levels as they would be written in a `levels = [...]` clause.
+fn join_levels(levels: &[f64]) -> String {
+    if levels.is_empty() {
+        "none".to_string()
+    } else {
+        levels
+            .iter()
+            .map(|v| fmt(*v))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 

--- a/src/parser/covariate_model_tests.rs
+++ b/src/parser/covariate_model_tests.rs
@@ -276,6 +276,53 @@ fn a_non_product_right_hand_side_is_a_hard_error() {
 }
 
 #[test]
+fn a_sum_that_also_carries_a_product_is_a_hard_error() {
+    // `split_top_level(rhs, '*')` returns two parts here, so a guard that only
+    // looked at the whole RHS when it had *no* top-level `*` skipped this shape
+    // entirely — and the factor was multiplied into the first addend alone,
+    // leaving `TVV` uncovered. Every part has to be a plain factor.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
+        .replace("CL = TVCL * exp(ETA_CL)", "CL = TVCL * exp(ETA_CL) + TVV");
+    let e = parse_err(&text);
+    assert!(e.contains("not a top-level product"), "{e}");
+    assert!(e.contains("COV_CL"), "{e}");
+}
+
+#[test]
+fn a_conditional_factor_in_a_product_is_a_hard_error() {
+    // `if (...) a else b * TVCL` parses as one product whose first part is a
+    // conditional: appending the covariate factor would attach it to the `else`
+    // branch, not to the parameter.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)").replace(
+        "CL = TVCL * exp(ETA_CL)",
+        "CL = if (TVV > 1) 1.2 else 1.0 * TVCL * exp(ETA_CL)",
+    );
+    let e = parse_err(&text);
+    assert!(e.contains("not a top-level product"), "{e}");
+}
+
+#[test]
+fn an_eta_reached_through_an_intermediate_still_takes_the_factor_first() {
+    // `first_random` classifies a factor by the η/κ *names* it mentions, so
+    // `CLI` would look η-free and the factor would land after it — the #619
+    // placement, silently. The transitive closure over block-local assignments
+    // is what keeps it in the non-η group.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)").replace(
+        "CL = TVCL * exp(ETA_CL)",
+        "CLI = exp(ETA_CL)\n  CL = TVCL * CLI",
+    );
+    let s = parse_full_model(&text)
+        .expect("model should parse")
+        .model
+        .covariate_model
+        .expect("recorded");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * CLI"
+    );
+}
+
+#[test]
 fn a_log_transformed_right_hand_side_is_a_hard_error() {
     let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
         .replace("CL = TVCL * exp(ETA_CL)", "CL = exp(TVCL + ETA_CL)");
@@ -438,6 +485,30 @@ fn auto_levels_leave_the_relation_unresolved() {
     );
     assert_eq!(s.unresolved().len(), 1);
     assert!(s.generated_thetas.is_empty());
+}
+
+#[test]
+fn a_single_level_categorical_says_it_has_no_contrast() {
+    // One level spends zero θ, which `needs_data()` would otherwise read as
+    // *unresolved* — sending the user to `--data`, which can never help.
+    let e = err(
+        "  SEX categorical(levels = [1])",
+        "  CL ~ SEX categorical(ref = 1)",
+    );
+    assert!(e.contains("has nothing to estimate"), "{e}");
+    assert!(e.contains("`SEX` has 1 level (1)"), "{e}");
+    assert!(
+        !e.contains("needs data-derived statistics"),
+        "must not be reported as unresolved: {e}"
+    );
+}
+
+#[test]
+fn fix_on_a_form_that_declares_no_theta_is_an_error() {
+    // `none` spends no θ, so `apply_fix` would run over an empty list: the
+    // argument would be accepted and then do nothing.
+    let e = err("  WT continuous", "  CL ~ WT none(fix = 0.5)");
+    assert!(e.contains("takes no `fix`"), "{e}");
 }
 
 #[test]

--- a/src/parser/covariate_model_tests.rs
+++ b/src/parser/covariate_model_tests.rs
@@ -73,7 +73,7 @@ fn power_generates_the_classical_allometric_factor() {
     let s = spec("  WT continuous", "  CL ~ WT power(center = 70)");
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
     );
     assert_eq!(
         s.generated_thetas,
@@ -86,7 +86,7 @@ fn exponential_generates_an_exp_of_the_centred_covariate() {
     let s = spec("  WT continuous", "  CL ~ WT exponential(center = 70)");
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) exp(THETA_CL_WT * (WT - 70)) else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) exp(THETA_CL_WT * (WT - 70)) else 1.0) * exp(ETA_CL)"
     );
 }
 
@@ -109,7 +109,7 @@ fn hockey_generates_two_slopes_around_the_breakpoint() {
     );
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (if (WT <= 70) 1 + T_LO * (WT - 70) else 1 + T_HI * (WT - 70)) \
+        "CL = TVCL * (if (present(WT)) (if (WT <= 70) 1 + T_LO * (WT - 70) else 1 + T_HI * (WT - 70)) \
          else 1.0) * exp(ETA_CL)"
     );
 }
@@ -122,7 +122,7 @@ fn categorical_contrasts_every_non_reference_level() {
     );
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (SEX == SEX) (if (SEX == 1) 1 + THETA_CL_SEX_1 else \
+        "CL = TVCL * (if (present(SEX)) (if (SEX == 1) 1 + THETA_CL_SEX_1 else \
          if (SEX == 2) 1 + THETA_CL_SEX_2 else 1) else 1.0) * exp(ETA_CL)"
     );
     // PsN's categorical θ is null at zero, so the bounds straddle it.
@@ -150,7 +150,7 @@ fn expr_is_emitted_verbatim() {
     let s = spec("  WT continuous", "  CL ~ WT expr(\"(WT/70)^0.75\")");
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) ((WT/70)^0.75) else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) ((WT/70)^0.75) else 1.0) * exp(ETA_CL)"
     );
     assert!(s.generated_thetas.is_empty());
 }
@@ -163,7 +163,7 @@ fn linear_relative_is_dimensionless_in_theta() {
     );
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (1 + T * (WT / 70 - 1)) else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) (1 + T * (WT / 70 - 1)) else 1.0) * exp(ETA_CL)"
     );
 }
 
@@ -226,7 +226,7 @@ fn the_factor_lands_before_the_first_eta_bearing_factor() {
     // mu-reference detector reads (#619).
     let s = spec("  WT continuous", "  CL ~ WT power(center = 70)");
     let line = cl_line(&s);
-    let factor = line.find("(if (WT == WT)").expect("factor is present");
+    let factor = line.find("(if (present(WT))").expect("factor is present");
     let eta = line.find("exp(ETA_CL)").expect("η factor is present");
     assert!(
         factor < eta,
@@ -246,7 +246,7 @@ fn a_parameter_with_no_eta_takes_the_factor_at_the_end() {
         .to_string();
     assert_eq!(
         v,
-        "V  = TVV * (if (WT == WT) (WT / 70)^THETA_V_WT else 1.0)"
+        "V  = TVV * (if (present(WT)) (WT / 70)^THETA_V_WT else 1.0)"
     );
 }
 
@@ -258,8 +258,8 @@ fn several_relations_on_one_parameter_all_land_in_the_non_eta_group() {
     );
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * \
-         (if (CRCL == CRCL) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * \
+         (if (present(CRCL)) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)"
     );
 }
 
@@ -485,7 +485,7 @@ fn a_commented_assignment_desugars_on_its_expression_alone() {
         .expect("recorded");
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
     );
 }
 
@@ -524,6 +524,6 @@ fn a_kappa_bearing_factor_counts_as_a_random_effect_factor() {
         .expect("recorded");
     assert_eq!(
         cl_line(&s),
-        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL) * exp(KAPPA_CL)"
+        "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL) * exp(KAPPA_CL)"
     );
 }

--- a/src/parser/covariate_model_tests.rs
+++ b/src/parser/covariate_model_tests.rs
@@ -1,0 +1,529 @@
+//! Tier-1 tests for the `[covariate_model]` block (#1111).
+//!
+//! Every test here asserts on the **generated text**: the block is sugar, so
+//! what it is worth is exactly the expression it desugars to. A test that only
+//! checked the parsed relation would pass while the emitted model said
+//! something else.
+
+use super::*;
+use crate::parser::model_parser::parse_full_model;
+use crate::types::CovariateModelSpec;
+
+/// A one-compartment model with the given `[covariates]` / `[covariate_model]`
+/// blocks spliced in, and `CL` carrying an η so the insertion-point partition
+/// has something to place the factor against.
+fn model_with(covariates: &str, covariate_model: &str) -> String {
+    format!(
+        "[parameters]\n\
+        \x20 theta TVCL(4.0, 0.1, 100.0)\n\
+        \x20 theta TVV(40.0, 1.0, 500.0)\n\
+        \x20 omega ETA_CL ~ 0.09\n\
+        \x20 sigma PROP_ERR ~ 0.02 (sd)\n\
+        \n\
+        [individual_parameters]\n\
+        \x20 CL = TVCL * exp(ETA_CL)\n\
+        \x20 V  = TVV\n\
+        \n\
+        [structural_model]\n\
+        \x20 pk one_cpt_iv(cl=CL, v=V)\n\
+        \n\
+        [covariates]\n{covariates}\n\
+        \n\
+        [covariate_model]\n{covariate_model}\n\
+        \n\
+        [error_model]\n\
+        \x20 DV ~ proportional(PROP_ERR)\n"
+    )
+}
+
+fn spec(covariates: &str, covariate_model: &str) -> CovariateModelSpec {
+    parse_full_model(&model_with(covariates, covariate_model))
+        .expect("model should parse")
+        .model
+        .covariate_model
+        .expect("[covariate_model] should be recorded on the model")
+}
+
+fn err(covariates: &str, covariate_model: &str) -> String {
+    parse_err(&model_with(covariates, covariate_model))
+}
+
+/// `parse_full_model`'s error, with the `Ok` side dropped — `ParsedModel` holds
+/// closures and so is not `Debug`, which `expect_err` would require.
+fn parse_err(text: &str) -> String {
+    parse_full_model(text)
+        .map(|_| ())
+        .expect_err("model should be rejected")
+}
+
+/// The desugared `CL = ...` line.
+fn cl_line(spec: &CovariateModelSpec) -> String {
+    spec.desugared_individual_parameters
+        .iter()
+        .find(|l| l.trim_start().starts_with("CL "))
+        .expect("CL is assigned")
+        .trim()
+        .to_string()
+}
+
+// ── One test per form: the generated factor ────────────────────────────────
+
+#[test]
+fn power_generates_the_classical_allometric_factor() {
+    let s = spec("  WT continuous", "  CL ~ WT power(center = 70)");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+    );
+    assert_eq!(
+        s.generated_thetas,
+        vec!["  theta THETA_CL_WT(0.001, -100, 1000000)"]
+    );
+}
+
+#[test]
+fn exponential_generates_an_exp_of_the_centred_covariate() {
+    let s = spec("  WT continuous", "  CL ~ WT exponential(center = 70)");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) exp(THETA_CL_WT * (WT - 70)) else 1.0) * exp(ETA_CL)"
+    );
+}
+
+#[test]
+fn linear_needs_data_and_stays_unresolved_without_it() {
+    // PsN's linear bounds are `1/(median − max) .. 1/(median − min)`, which only
+    // a dataset can supply — so the relation parses, records itself, and is
+    // deliberately left undesugared until the statistics are bound.
+    let s = spec("  WT continuous", "  CL ~ WT linear(center = 70)");
+    assert_eq!(cl_line(&s), "CL = TVCL * exp(ETA_CL)");
+    assert!(s.generated_thetas.is_empty());
+    assert_eq!(s.unresolved().len(), 1);
+}
+
+#[test]
+fn hockey_generates_two_slopes_around_the_breakpoint() {
+    let s = spec(
+        "  WT continuous",
+        "  CL ~ WT hockey(breakpoint = 70) => T_LO(0.01, -1, 1), T_HI(0.02, -1, 1)",
+    );
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (if (WT <= 70) 1 + T_LO * (WT - 70) else 1 + T_HI * (WT - 70)) \
+         else 1.0) * exp(ETA_CL)"
+    );
+}
+
+#[test]
+fn categorical_contrasts_every_non_reference_level() {
+    let s = spec(
+        "  SEX categorical(levels = [0, 1, 2])",
+        "  CL ~ SEX categorical(ref = 0)",
+    );
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (SEX == SEX) (if (SEX == 1) 1 + THETA_CL_SEX_1 else \
+         if (SEX == 2) 1 + THETA_CL_SEX_2 else 1) else 1.0) * exp(ETA_CL)"
+    );
+    // PsN's categorical θ is null at zero, so the bounds straddle it.
+    assert_eq!(
+        s.generated_thetas,
+        vec![
+            "  theta THETA_CL_SEX_1(-0.001, -1, 5)",
+            "  theta THETA_CL_SEX_2(-0.001, -1, 5)",
+        ]
+    );
+}
+
+#[test]
+fn none_declares_no_theta_and_leaves_the_expression_alone() {
+    // A search writes `none` to record "tested, rejected"; the generated model
+    // must round-trip through the parser unchanged.
+    let s = spec("  WT continuous", "  CL ~ WT none");
+    assert_eq!(cl_line(&s), "CL = TVCL * exp(ETA_CL)");
+    assert!(s.generated_thetas.is_empty());
+    assert!(s.unresolved().is_empty());
+}
+
+#[test]
+fn expr_is_emitted_verbatim() {
+    let s = spec("  WT continuous", "  CL ~ WT expr(\"(WT/70)^0.75\")");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) ((WT/70)^0.75) else 1.0) * exp(ETA_CL)"
+    );
+    assert!(s.generated_thetas.is_empty());
+}
+
+#[test]
+fn linear_relative_is_dimensionless_in_theta() {
+    let s = spec(
+        "  WT continuous",
+        "  CL ~ WT linear_relative(center = 70) => T(0.1, -1, 1)",
+    );
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (1 + T * (WT / 70 - 1)) else 1.0) * exp(ETA_CL)"
+    );
+}
+
+#[test]
+fn fix_pins_the_theta_and_declares_it_fix() {
+    let s = spec(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70, fix = 0.75)",
+    );
+    assert_eq!(
+        s.generated_thetas,
+        vec!["  theta THETA_CL_WT(0.75, -100, 1000000) FIX"]
+    );
+}
+
+// ── The missing-value guard ────────────────────────────────────────────────
+
+#[test]
+fn a_missing_covariate_contributes_exactly_one() {
+    // The guard is `COV == COV`, which is false for NaN. Without it the factor
+    // would be `(NaN/70)^θ`, and a division by a missing value underflows to
+    // `0.0` here rather than blowing up — a silent zero, not a loud failure.
+    let parsed = parse_full_model(&model_with(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70)",
+    ))
+    .expect("model should parse");
+    let theta_idx = parsed
+        .model
+        .theta_names
+        .iter()
+        .position(|n| n == "THETA_CL_WT")
+        .expect("the generated θ is a real θ");
+    let mut theta = vec![4.0; parsed.model.theta_names.len()];
+    theta[theta_idx] = 0.75;
+    let eta = vec![0.0; parsed.model.eta_names.len()];
+
+    let mut covariates = std::collections::HashMap::new();
+    covariates.insert("WT".to_string(), f64::NAN);
+    let missing = (parsed.model.pk_param_fn)(&theta, &eta, &covariates, 0.0);
+
+    covariates.insert("WT".to_string(), 70.0);
+    let at_centre = (parsed.model.pk_param_fn)(&theta, &eta, &covariates, 0.0);
+
+    // At the centring weight the factor is 1, so a missing weight must give the
+    // same CL — and, crucially, not 0.
+    assert_eq!(missing.values[0], at_centre.values[0]);
+    assert!(
+        missing.values[0] > 0.0,
+        "missing covariate must not zero the parameter"
+    );
+}
+
+// ── The insertion point ────────────────────────────────────────────────────
+
+#[test]
+fn the_factor_lands_before_the_first_eta_bearing_factor() {
+    // Not at the end of the RHS: a factor after `exp(ETA)` is numerically
+    // identical but takes the typical value out of the shape the SAEM
+    // mu-reference detector reads (#619).
+    let s = spec("  WT continuous", "  CL ~ WT power(center = 70)");
+    let line = cl_line(&s);
+    let factor = line.find("(if (WT == WT)").expect("factor is present");
+    let eta = line.find("exp(ETA_CL)").expect("η factor is present");
+    assert!(
+        factor < eta,
+        "covariate factor must precede exp(ETA_CL): {line}"
+    );
+}
+
+#[test]
+fn a_parameter_with_no_eta_takes_the_factor_at_the_end() {
+    let s = spec("  WT continuous", "  V ~ WT power(center = 70)");
+    let v = s
+        .desugared_individual_parameters
+        .iter()
+        .find(|l| l.trim_start().starts_with("V "))
+        .expect("V is assigned")
+        .trim()
+        .to_string();
+    assert_eq!(
+        v,
+        "V  = TVV * (if (WT == WT) (WT / 70)^THETA_V_WT else 1.0)"
+    );
+}
+
+#[test]
+fn several_relations_on_one_parameter_all_land_in_the_non_eta_group() {
+    let s = spec(
+        "  WT continuous\n  CRCL continuous",
+        "  CL ~ WT power(center = 70)\n  CL ~ CRCL power(center = 100)",
+    );
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * \
+         (if (CRCL == CRCL) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)"
+    );
+}
+
+#[test]
+fn a_non_product_right_hand_side_is_a_hard_error() {
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
+        .replace("CL = TVCL * exp(ETA_CL)", "CL = TVCL + exp(ETA_CL)");
+    let e = parse_err(&text);
+    assert!(e.contains("not a top-level product"), "{e}");
+    assert!(
+        e.contains("COV_CL"),
+        "the error must name the explicit handle: {e}"
+    );
+}
+
+#[test]
+fn a_log_transformed_right_hand_side_is_a_hard_error() {
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
+        .replace("CL = TVCL * exp(ETA_CL)", "CL = exp(TVCL + ETA_CL)");
+    let e = parse_err(&text);
+    assert!(e.contains("not a top-level product"), "{e}");
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────
+
+#[test]
+fn an_undeclared_covariate_is_an_error() {
+    // Unlike the lenient classical path, which warns and reads the covariate
+    // anyway: the declaration is what states the kind and the levels the
+    // generated θ vector depends on.
+    let e = err("  WT continuous", "  CL ~ AGE power(center = 40)");
+    assert!(e.contains("not declared in [covariates]"), "{e}");
+}
+
+#[test]
+fn a_relation_on_an_unknown_parameter_is_an_error() {
+    let e = err("  WT continuous", "  KA ~ WT power(center = 70)");
+    assert!(
+        e.contains("not a top-level [individual_parameters] name"),
+        "{e}"
+    );
+}
+
+#[test]
+fn a_duplicate_parameter_covariate_pair_is_an_error() {
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70)\n  CL ~ WT linear(center = 70)",
+    );
+    assert!(e.contains("declared more than once"), "{e}");
+}
+
+#[test]
+fn an_explicit_theta_name_that_collides_with_parameters_is_an_error() {
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70) => TVCL(0.5, -1, 1)",
+    );
+    assert!(e.contains("already declared in [parameters]"), "{e}");
+}
+
+#[test]
+fn an_auto_theta_name_defers_to_an_existing_declaration() {
+    // The modeller who declared the θ stated the init and bounds they want;
+    // re-emitting it would declare the same θ twice.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)").replace(
+        "  theta TVV(40.0, 1.0, 500.0)",
+        "  theta TVV(40.0, 1.0, 500.0)\n  theta THETA_CL_WT(0.75, 0.1, 1.5)",
+    );
+    let parsed = parse_full_model(&text).expect("model should parse");
+    assert_eq!(
+        parsed
+            .model
+            .theta_names
+            .iter()
+            .filter(|n| *n == "THETA_CL_WT")
+            .count(),
+        1
+    );
+    let s = parsed.model.covariate_model.expect("recorded");
+    assert!(s.generated_thetas.is_empty());
+}
+
+#[test]
+fn a_categorical_form_on_a_continuous_covariate_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT categorical(ref = 0)");
+    assert!(e.contains("declares continuous"), "{e}");
+}
+
+#[test]
+fn a_continuous_form_on_a_categorical_covariate_is_an_error() {
+    let e = err(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX power(center = 1)",
+    );
+    assert!(e.contains("categorical"), "{e}");
+}
+
+#[test]
+fn a_categorical_relation_without_levels_is_an_error() {
+    let e = err("  SEX categorical", "  CL ~ SEX categorical(ref = 0)");
+    assert!(e.contains("needs its levels"), "{e}");
+    assert!(
+        e.contains("levels = auto"),
+        "the error must offer the data-derived opt-in: {e}"
+    );
+}
+
+#[test]
+fn a_reference_level_outside_the_declared_levels_is_an_error() {
+    let e = err(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX categorical(ref = 2)",
+    );
+    assert!(e.contains("is not one of the declared levels"), "{e}");
+}
+
+#[test]
+fn an_unknown_form_offers_a_suggestion() {
+    let e = err("  WT continuous", "  CL ~ WT powr(center = 70)");
+    assert!(e.contains("did you mean `power`"), "{e}");
+}
+
+#[test]
+fn an_unknown_keyword_argument_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(centre = 70)");
+    assert!(e.contains("unknown argument"), "{e}");
+}
+
+#[test]
+fn the_wrong_centring_keyword_for_the_form_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(breakpoint = 70)");
+    assert!(e.contains("centres on `center`"), "{e}");
+}
+
+#[test]
+fn a_theta_clause_of_the_wrong_arity_is_an_error() {
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT hockey(breakpoint = 70) => T_LO(0.01, -1, 1)",
+    );
+    assert!(e.contains("generates 2 θ"), "{e}");
+}
+
+#[test]
+fn a_misspelled_block_name_is_still_rejected() {
+    // The registry is closed-world; `[covariate_model]` joining it must not
+    // open a door for its neighbours.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
+        .replace("[covariate_model]", "[covariate_models]");
+    let e = parse_err(&text);
+    assert!(e.contains("covariate_models"), "{e}");
+}
+
+// ── The `[covariates]` levels clause ───────────────────────────────────────
+
+#[test]
+fn declared_levels_are_read_off_the_covariates_block() {
+    let parsed = parse_full_model(&model_with(
+        "  SEX categorical(levels = [0, 1])",
+        "  CL ~ SEX categorical(ref = 0)",
+    ))
+    .expect("model should parse");
+    let decls = parsed.covariate_decls.expect("declared");
+    assert_eq!(
+        decls[0].levels,
+        Some(crate::types::CovariateLevels::Declared(vec![0.0, 1.0]))
+    );
+}
+
+#[test]
+fn auto_levels_leave_the_relation_unresolved() {
+    let s = spec(
+        "  SEX categorical(levels = auto)",
+        "  CL ~ SEX categorical(ref = 0)",
+    );
+    assert_eq!(s.unresolved().len(), 1);
+    assert!(s.generated_thetas.is_empty());
+}
+
+#[test]
+fn levels_on_a_continuous_covariate_is_an_error() {
+    let e = err(
+        "  WT continuous(levels = [0, 1])",
+        "  CL ~ WT power(center = 70)",
+    );
+    assert!(
+        e.contains("only meaningful for a categorical covariate"),
+        "{e}"
+    );
+}
+
+// ── Text helpers ───────────────────────────────────────────────────────────
+
+#[test]
+fn top_level_split_ignores_operators_inside_parentheses() {
+    let parts = split_top_level("A * f(B * C) * D", '*');
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[1].trim(), "f(B * C)");
+}
+
+#[test]
+fn an_exponent_sign_is_not_a_top_level_sum() {
+    assert!(!has_top_level_additive("1.5e-3 * TVCL"));
+    assert!(has_top_level_additive("TVCL + 1"));
+    assert!(!has_top_level_additive("-TVCL"));
+}
+
+#[test]
+fn a_commented_assignment_desugars_on_its_expression_alone() {
+    // The block extractor strips comments before any block is read, so the RHS
+    // split here never carries one. Pinned because that split is
+    // parenthesis-aware, not comment-aware: were comments ever preserved, a `#`
+    // would silently become part of the last factor.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)").replace(
+        "CL = TVCL * exp(ETA_CL)",
+        "CL = TVCL * exp(ETA_CL)   # allometric on purpose",
+    );
+    let s = parse_full_model(&text)
+        .expect("model should parse")
+        .model
+        .covariate_model
+        .expect("recorded");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL)"
+    );
+}
+
+#[test]
+fn a_parameter_assigned_only_inside_a_conditional_is_not_addressable() {
+    // There is no single right-hand side to multiply into, so the relation must
+    // be rejected rather than silently landing on one branch.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)").replace(
+        "CL = TVCL * exp(ETA_CL)",
+        "if (WT > 70) {\n    CL = TVCL * exp(ETA_CL)\n  } else {\n    CL = TVCL\n  }",
+    );
+    let e = parse_err(&text);
+    assert!(
+        e.contains("not a top-level [individual_parameters] name"),
+        "{e}"
+    );
+}
+
+#[test]
+fn a_kappa_bearing_factor_counts_as_a_random_effect_factor() {
+    // IOV κ is a random effect too: the covariate factor belongs before it, for
+    // the same mu-referencing reason as η.
+    let text = model_with("  WT continuous", "  CL ~ WT power(center = 70)")
+        .replace(
+            "  omega ETA_CL ~ 0.09",
+            "  omega ETA_CL ~ 0.09\n  kappa KAPPA_CL ~ 0.05",
+        )
+        .replace(
+            "CL = TVCL * exp(ETA_CL)",
+            "CL = TVCL * exp(ETA_CL) * exp(KAPPA_CL)",
+        );
+    let s = parse_full_model(&text)
+        .expect("model should parse")
+        .model
+        .covariate_model
+        .expect("recorded");
+    assert_eq!(
+        cl_line(&s),
+        "CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL) * exp(KAPPA_CL)"
+    );
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,1 +1,2 @@
+pub mod covariate_model;
 pub mod model_parser;

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1,3 +1,4 @@
+use crate::parser::covariate_model::CovariateStatBindings;
 use crate::sim::adaptive::{
     validate_increasing_finite, AdaptiveAction, AdaptiveDosingSpec, AdaptiveRoute, AdaptiveRule,
     Comparison, DoseStep,
@@ -1302,7 +1303,7 @@ fn register_referenced_covariates(
 
 /// Parse a full model string including all optional blocks.
 pub fn parse_full_model(content: &str) -> Result<ParsedModel, String> {
-    parse_full_model_bound(content, &LevelBindings::new())
+    parse_full_model_with(content, &ParseBindings::default())
 }
 
 /// [`parse_full_model`] with the observed levels of every `theta NAME ~
@@ -1317,6 +1318,35 @@ pub fn parse_full_model_bound(
     content: &str,
     level_bindings: &LevelBindings,
 ) -> Result<ParsedModel, String> {
+    parse_full_model_with(
+        content,
+        &ParseBindings {
+            levels: level_bindings.clone(),
+            covariate_stats: CovariateStatBindings::new(),
+        },
+    )
+}
+
+/// Everything a re-parse must be told that only the *data* knows.
+///
+/// Two independent things are bound this way — level-block level counts (#1064)
+/// and `[covariate_model]` statistics (#1111) — and a model may declare both,
+/// so they travel together: binding one must not drop the other's bindings on
+/// the floor when it re-parses.
+#[derive(Debug, Clone, Default)]
+pub struct ParseBindings {
+    /// Observed levels of each `theta NAME[COL, ...]` block.
+    pub levels: LevelBindings,
+    /// Covariate summary statistics, for symbolic `center = median` and friends.
+    pub covariate_stats: CovariateStatBindings,
+}
+
+/// [`parse_full_model`] with every data-derived binding supplied.
+pub fn parse_full_model_with(
+    content: &str,
+    bindings: &ParseBindings,
+) -> Result<ParsedModel, String> {
+    let level_bindings = &bindings.levels;
     let mut extracted = extract_blocks(content)?;
     // `ode_template NAME(...)` desugaring (#322 Phase 0b): if [structural_model]
     // uses `ode_template`, rewrite it (and the [odes]/[scaling] blocks) into the
@@ -1342,6 +1372,12 @@ pub fn parse_full_model_bound(
     // to this fallback. Non-absorption / out-of-scope forms yield `None`. (The equivalent is
     // a normal ODE model with no `pk one_cpt_transit`/`pk one_cpt_ig`/…, so compiling it does
     // not re-enter this branch.)
+    // `[covariate_model]` desugaring (#1111): rewrite the declared relations into
+    // ordinary `[individual_parameters]` expressions and `theta` declarations, so
+    // everything below — including the absorption twin reconstructed on the next
+    // line, which re-emits these very blocks — sees a plain classical model. A
+    // twin built from un-desugared text would silently carry no covariate effect.
+    let covariate_model = apply_covariate_model_block(&mut extracted, bindings)?;
     let absorption_ode_equivalent_src: Option<String> =
         absorption_ode_equivalent_source(&extracted);
     // Keep the historical `blocks` binding for unnamed blocks so the rest of
@@ -2723,6 +2759,7 @@ pub fn parse_full_model_bound(
 
     let model = CompiledModel {
         name,
+        covariate_model,
         pk_model,
         error_model,
         error_spec,
@@ -4041,6 +4078,7 @@ pub fn parse_full_model_bound(
         column_map: data_column_map,
         covariate_decls,
         block_lines: extracted.block_lines.clone(),
+        bindings: bindings.clone(),
     })
 }
 
@@ -4740,11 +4778,91 @@ fn parse_covariate_kind(token: &str) -> Option<CovariateKind> {
     }
 }
 
+/// A `[covariates]` type token, with the optional `(levels = ...)` suffix a
+/// categorical covariate may carry (#1111).
+///
+/// `Ok(None)` means the token names no known type — the callers already have a
+/// form-specific "unknown covariate type" message and keep raising it. `Err` is
+/// a *recognised* type whose `levels` clause is malformed, which must not be
+/// reported as an unknown type.
+fn parse_covariate_type_token(
+    token: &str,
+) -> Result<Option<(CovariateKind, Option<CovariateLevels>)>, String> {
+    let token = token.trim();
+    let Some(open) = token.find('(') else {
+        return Ok(parse_covariate_kind(token).map(|k| (k, None)));
+    };
+    let (head, rest) = token.split_at(open);
+    let Some(kind) = parse_covariate_kind(head) else {
+        return Ok(None);
+    };
+    let body = rest
+        .strip_prefix('(')
+        .and_then(|r| r.strip_suffix(')'))
+        .ok_or_else(|| format!("[covariates]: unbalanced parentheses in '{token}'"))?;
+    let levels = parse_covariate_levels_clause(body, head.trim())?;
+    if kind == CovariateKind::Continuous {
+        return Err(format!(
+            "[covariates]: `levels` is only meaningful for a categorical covariate, \
+             but '{}' is declared continuous",
+            head.trim()
+        ));
+    }
+    Ok(Some((kind, Some(levels))))
+}
+
+/// The inside of `categorical(...)`: `levels = [0, 1]` or `levels = auto`.
+fn parse_covariate_levels_clause(body: &str, type_token: &str) -> Result<CovariateLevels, String> {
+    let body = body.trim();
+    let value = body
+        .strip_prefix("levels")
+        .map(str::trim_start)
+        .and_then(|r| r.strip_prefix('='))
+        .ok_or_else(|| {
+            format!(
+                "[covariates]: `{type_token}(...)` takes only `levels = [..]` or \
+                 `levels = auto`, got `{body}`"
+            )
+        })?
+        .trim();
+    if value.eq_ignore_ascii_case("auto") {
+        return Ok(CovariateLevels::Auto);
+    }
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|r| r.strip_suffix(']'))
+        .ok_or_else(|| {
+            format!("[covariates]: expected `levels = [0, 1]` or `levels = auto`, got `{value}`")
+        })?;
+    let mut levels = Vec::new();
+    for tok in inner.split(',') {
+        let tok = tok.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        let v: f64 = tok.parse().map_err(|_| {
+            format!(
+                "[covariates]: level '{tok}' is not a number (levels must be \
+                 numerically coded, as covariate values are)"
+            )
+        })?;
+        if levels.contains(&v) {
+            return Err(format!("[covariates]: level {v} is listed more than once"));
+        }
+        levels.push(v);
+    }
+    if levels.is_empty() {
+        return Err("[covariates]: `levels = []` declares no levels".to_string());
+    }
+    Ok(CovariateLevels::Declared(levels))
+}
+
 fn push_covariate_decl(
     decls: &mut Vec<CovariateDecl>,
     seen: &mut std::collections::HashSet<String>,
     name: &str,
     kind: CovariateKind,
+    levels: Option<CovariateLevels>,
 ) -> Result<(), String> {
     let name = name.trim();
     if name.is_empty() {
@@ -4760,8 +4878,78 @@ fn push_covariate_decl(
     decls.push(CovariateDecl {
         name: name.to_string(),
         kind,
+        levels,
     });
     Ok(())
+}
+
+/// Desugar the optional `[covariate_model]` block (#1111), rewriting
+/// `[parameters]` and `[individual_parameters]` in place.
+///
+/// Returns `None` when the block is absent — the overwhelming majority of
+/// models, which pay nothing for the feature.
+///
+/// `[parameters]` is parsed **twice** when the block is present: once here, to
+/// learn the η/κ names the insertion-point partition needs and the θ names an
+/// auto-generated name may defer to, and once for real below, after this
+/// rewrite has appended the generated `theta` lines. Parsing is pure and costs
+/// microseconds; the alternative — re-deriving η/κ names by scanning the block
+/// text — would duplicate knowledge that already has exactly one owner.
+fn apply_covariate_model_block(
+    extracted: &mut ExtractedBlocks,
+    bindings: &ParseBindings,
+) -> Result<Option<crate::types::CovariateModelSpec>, String> {
+    let Some(block_lines) = extracted.unnamed.get("covariate_model").cloned() else {
+        return Ok(None);
+    };
+    let param_lines = extracted
+        .unnamed
+        .get("parameters")
+        .ok_or("Missing [parameters] block")?
+        .clone();
+    let (thetas, _, _, _, _, eta_names, kappa_info, _, _, _) =
+        parse_parameters(&param_lines, &bindings.levels)?;
+    let mut eta_kappa_names: std::collections::HashSet<String> = eta_names.into_iter().collect();
+    eta_kappa_names.extend(kappa_info.names_ordered.iter().cloned());
+    let declared_thetas: std::collections::HashSet<String> =
+        thetas.into_iter().map(|t| t.name).collect();
+
+    let decls = match extracted.unnamed.get("covariates") {
+        Some(lines) => parse_covariates_block(lines)?,
+        None => Vec::new(),
+    };
+
+    // Both blocks are rewritten, so take ownership of each and put it back —
+    // the alternative is two simultaneous mutable borrows of the same map.
+    let mut parameters = extracted
+        .unnamed
+        .remove("parameters")
+        .unwrap_or_else(Vec::new);
+    let mut individual_parameters = extracted
+        .unnamed
+        .remove("individual_parameters")
+        .ok_or("[covariate_model] needs an [individual_parameters] block to desugar into")?;
+
+    let ctx = crate::parser::covariate_model::CovariateModelContext {
+        decls: &decls,
+        eta_kappa_names: &eta_kappa_names,
+        declared_thetas: &declared_thetas,
+        stats: &bindings.covariate_stats,
+    };
+    let spec = crate::parser::covariate_model::apply_covariate_model(
+        &block_lines,
+        &mut parameters,
+        &mut individual_parameters,
+        &ctx,
+    )?;
+
+    extracted
+        .unnamed
+        .insert("parameters".to_string(), parameters);
+    extracted
+        .unnamed
+        .insert("individual_parameters".to_string(), individual_parameters);
+    Ok(Some(spec))
 }
 
 /// Parse the optional `[covariates]` block into ordered declarations.
@@ -4784,7 +4972,7 @@ fn parse_covariates_block(lines: &[String]) -> Result<Vec<CovariateDecl>, String
         if let Some(colon) = line.find(':') {
             // `TYPE: NAME, NAME, ...`
             let (ty_str, rest) = line.split_at(colon);
-            let kind = parse_covariate_kind(ty_str).ok_or_else(|| {
+            let (kind, levels) = parse_covariate_type_token(ty_str)?.ok_or_else(|| {
                 format!(
                     "[covariates]: unknown covariate type '{}' (expected continuous/cont or \
                      categorical/cat)",
@@ -4796,7 +4984,7 @@ fn parse_covariates_block(lines: &[String]) -> Result<Vec<CovariateDecl>, String
             for name in names.split(',') {
                 let name = name.trim();
                 if !name.is_empty() {
-                    push_covariate_decl(&mut decls, &mut seen, name, kind)?;
+                    push_covariate_decl(&mut decls, &mut seen, name, kind, levels.clone())?;
                     any = true;
                 }
             }
@@ -4808,22 +4996,26 @@ fn parse_covariates_block(lines: &[String]) -> Result<Vec<CovariateDecl>, String
             }
         } else {
             // `NAME TYPE`
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() != 2 {
+            // `WT continuous`, or `SEX categorical(levels = [0, 1])` — the
+            // levels clause may carry spaces, so everything after the name is
+            // the type token.
+            let mut parts = line.splitn(2, char::is_whitespace);
+            let (Some(name), Some(ty_str)) = (parts.next(), parts.next()) else {
                 return Err(format!(
                     "[covariates]: expected `NAME TYPE` (e.g. `WT continuous`) or \
                      `TYPE: NAME, ...`, got '{}'",
                     line
                 ));
-            }
-            let kind = parse_covariate_kind(parts[1]).ok_or_else(|| {
+            };
+            let (kind, levels) = parse_covariate_type_token(ty_str)?.ok_or_else(|| {
                 format!(
                     "[covariates]: unknown covariate type '{}' for '{}' (expected continuous/cont \
                      or categorical/cat)",
-                    parts[1], parts[0]
+                    ty_str.trim(),
+                    name
                 )
             })?;
-            push_covariate_decl(&mut decls, &mut seen, parts[0], kind)?;
+            push_covariate_decl(&mut decls, &mut seen, name, kind, levels)?;
         }
     }
 
@@ -11622,6 +11814,7 @@ enum BlockForm {
 const BLOCK_REGISTRY: &[(&str, BlockForm, Option<&str>)] = &[
     ("adaptive_dosing", BlockForm::Unnamed, None),
     ("binary_model", BlockForm::Either, Some("survival")),
+    ("covariate_model", BlockForm::Unnamed, None),
     ("covariate_nn", BlockForm::Named, None),
     ("covariates", BlockForm::Unnamed, None),
     ("data", BlockForm::Unnamed, None),

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -162,6 +162,7 @@ fn extract_eta_indices(expr: &Expression) -> Vec<usize> {
                 walk_eta_in_condition(r, out);
             }
             Condition::Not(c) => walk_eta_in_condition(c, out),
+            Condition::Present(e) => walk(e, out),
         }
     }
     walk(expr, &mut out);
@@ -206,6 +207,7 @@ fn expr_references_any(expr: &Expression, names: &[String]) -> Option<String> {
                 walk_cond(l, names).or_else(|| walk_cond(r, names))
             }
             Condition::Not(c) => walk_cond(c, names),
+            Condition::Present(e) => walk(e, names),
         }
     }
     walk(expr, names)
@@ -804,6 +806,7 @@ fn expr_uses_mixnum(expr: &Expression) -> bool {
             Condition::Compare(a, _, b) => expr_uses_mixnum(a) || expr_uses_mixnum(b),
             Condition::And(a, b) | Condition::Or(a, b) => cond_uses(a) || cond_uses(b),
             Condition::Not(a) => cond_uses(a),
+            Condition::Present(a) => expr_uses_mixnum(a),
         }
     }
     match expr {
@@ -4338,6 +4341,7 @@ fn cond_refs_dv(cond: &Condition) -> bool {
         Condition::Compare(l, _, r) => expr_refs_dv(l) || expr_refs_dv(r),
         Condition::And(l, r) | Condition::Or(l, r) => cond_refs_dv(l) || cond_refs_dv(r),
         Condition::Not(c) => cond_refs_dv(c),
+        Condition::Present(e) => expr_refs_dv(e),
     }
 }
 
@@ -4376,6 +4380,7 @@ fn cond_refs_compartments(cond: &Condition, ode_state_names: &[String]) -> bool 
             cond_refs_compartments(l, ode_state_names) || cond_refs_compartments(r, ode_state_names)
         }
         Condition::Not(c) => cond_refs_compartments(c, ode_state_names),
+        Condition::Present(e) => expr_refs_compartments(e, ode_state_names),
     }
 }
 
@@ -4921,10 +4926,7 @@ fn apply_covariate_model_block(
 
     // Both blocks are rewritten, so take ownership of each and put it back —
     // the alternative is two simultaneous mutable borrows of the same map.
-    let mut parameters = extracted
-        .unnamed
-        .remove("parameters")
-        .unwrap_or_else(Vec::new);
+    let mut parameters = extracted.unnamed.remove("parameters").unwrap_or_default();
     let mut individual_parameters = extracted
         .unnamed
         .remove("individual_parameters")
@@ -16140,6 +16142,21 @@ pub(crate) enum Condition {
     And(Box<Condition>, Box<Condition>),
     Or(Box<Condition>, Box<Condition>),
     Not(Box<Condition>),
+    /// `present(COV)` — true when the value is not missing (#1111).
+    ///
+    /// A missing covariate is `NaN`, and NaN compares false against everything
+    /// including itself, so the test is spelled `!v.is_nan()`. It exists
+    /// because the alternative spelling — `COV == COV` — is correct but
+    /// unreadable, and it is what every `[covariate_model]` factor is guarded
+    /// with, so it appears in generated model text a user has to audit against
+    /// a NONMEM control stream.
+    ///
+    /// Deliberately a *condition*, not an expression-level function: it asks a
+    /// yes/no question about data, and as a function returning 0.0/1.0 it would
+    /// invite arithmetic (`CL = TVCL * present(WT)`) whose meaning is a
+    /// silently-zeroed parameter — exactly the failure the guard exists to
+    /// prevent.
+    Present(Expression),
 }
 
 /// A statement in a model block. Supports plain assignments, derivative
@@ -16301,6 +16318,7 @@ fn visit_condition_nodes_mut(cond: &mut Condition, f: &mut dyn FnMut(&mut Expres
             visit_condition_nodes_mut(r, f);
         }
         Condition::Not(c) => visit_condition_nodes_mut(c, f),
+        Condition::Present(e) => visit_expr_nodes_mut(e, f),
     }
 }
 
@@ -16316,6 +16334,7 @@ fn visit_condition_nodes(cond: &Condition, f: &mut dyn FnMut(&Expression)) {
             visit_condition_nodes(r, f);
         }
         Condition::Not(c) => visit_condition_nodes(c, f),
+        Condition::Present(e) => visit_expr_nodes(e, f),
     }
 }
 
@@ -16510,6 +16529,7 @@ fn rewrite_weighted_kappas(
                 walk_cond(r, weights, hit);
             }
             Condition::Not(c) => walk_cond(c, weights, hit),
+            Condition::Present(e) => walk_expr(e, weights, hit),
         }
     }
     let mut hit: HashSet<usize> = HashSet::new();
@@ -17471,6 +17491,7 @@ fn rewrite_readout_synth_cond(cond: &mut Condition, synth: &[ReadoutSynthParam])
             rewrite_readout_synth_cond(r, synth);
         }
         Condition::Not(c) => rewrite_readout_synth_cond(c, synth),
+        Condition::Present(e) => rewrite_readout_synth(e, synth),
     }
 }
 
@@ -17850,6 +17871,11 @@ fn eval_cond<E: EvalEnv>(
             eval_cond(l, theta, eta, env, nn_outputs) || eval_cond(r, theta, eta, env, nn_outputs)
         }
         Condition::Not(c) => !eval_cond(c, theta, eta, env, nn_outputs),
+        // A missing covariate is `NaN`; everything else is present. Spelled
+        // `!is_nan` rather than `is_finite` so it means exactly what the
+        // `COV == COV` idiom it replaces meant — an infinity is a value, not a
+        // gap in the data.
+        Condition::Present(e) => !eval_expr(e, theta, eta, env, nn_outputs).is_nan(),
     }
 }
 
@@ -17943,6 +17969,10 @@ enum Op {
     LogicAnd,
     LogicOr,
     LogicNot,
+    /// `present(x)` (#1111): pops a value, pushes 1.0 unless it is `NaN`.
+    /// Unary in stack terms, and an indicator — its derivative is identically
+    /// zero, which is why the `Dual` evaluator pushes a constant.
+    IsPresent,
     JumpIfFalse(u32), // pops top; jumps to bytecode index if value == 0.0
     Jump(u32),
     Mod,   // rem_euclid (binary)
@@ -18123,6 +18153,7 @@ fn scan_stack_depth(ops: &[Op]) -> (i32, i32) {
             | Op::InvLogit
             | Op::Logit
             | Op::LogicNot
+            | Op::IsPresent
             | Op::Floor
             | Op::Ceil
             | Op::Round => 0,
@@ -18277,6 +18308,10 @@ fn compile_condition_into(bc: &mut Bytecode, cond: &Condition) {
         Condition::Not(c) => {
             compile_condition_into(bc, c);
             bc.ops.push(Op::LogicNot);
+        }
+        Condition::Present(e) => {
+            compile_expr_into(bc, e);
+            bc.ops.push(Op::IsPresent);
         }
     }
 }
@@ -18490,6 +18525,10 @@ fn eval_bytecode(
             Op::LogicNot => {
                 let v = pop!();
                 push!(if v == 0.0 { 1.0 } else { 0.0 });
+            }
+            Op::IsPresent => {
+                let v = pop!();
+                push!(if v.is_nan() { 0.0 } else { 1.0 });
             }
             Op::JumpIfFalse(target) => {
                 let v = pop!();
@@ -18736,6 +18775,10 @@ fn eval_bytecode_g<T: crate::sens::num::PkNum>(
             Op::LogicNot => {
                 let v = pop!();
                 push!(k(if v.val() == 0.0 { 1.0 } else { 0.0 }));
+            }
+            Op::IsPresent => {
+                let v = pop!();
+                push!(k(if v.val().is_nan() { 0.0 } else { 1.0 }));
             }
             Op::JumpIfFalse(target) => {
                 let v = pop!();
@@ -19044,6 +19087,7 @@ fn cond_reads_slots(c: &Condition, slots: &[usize]) -> bool {
             cond_reads_slots(a, slots) || cond_reads_slots(b, slots)
         }
         Condition::Not(a) => cond_reads_slots(a, slots),
+        Condition::Present(e) => expr_reads_slots(e, slots),
     }
 }
 
@@ -19227,6 +19271,7 @@ fn cond_is_dynamic(c: &Condition, dyn_vars: &[bool]) -> bool {
         Condition::And(a, b) | Condition::Or(a, b) => {
             cond_is_dynamic(a, dyn_vars) || cond_is_dynamic(b, dyn_vars)
         }
+        Condition::Present(e) => expr_is_dynamic(e, dyn_vars),
         Condition::Not(c) => cond_is_dynamic(c, dyn_vars),
     }
 }
@@ -20268,6 +20313,7 @@ fn resolve_condition_indices(
             resolve_condition_indices(r, var_idx, cov_idx);
         }
         Condition::Not(c) => resolve_condition_indices(c, var_idx, cov_idx),
+        Condition::Present(e) => resolve_expr_indices(e, var_idx, cov_idx),
     }
 }
 
@@ -21747,6 +21793,26 @@ fn parse_cond_atom(
             return Err("Missing closing `)` in condition".to_string());
         }
         return Ok((inner, p + 1));
+    }
+
+    // `present(EXPR)` (#1111) — a data-presence predicate, not a comparison.
+    // Matched before `parse_add_sub` so the name is only special in condition
+    // position followed by `(`; a covariate that happens to be called
+    // `present` still reads normally everywhere else, including in a
+    // comparison (`present > 0`).
+    if let (Some(Token::Ident(name)), Some(Token::LParen)) = (tokens.get(pos), tokens.get(pos + 1))
+    {
+        if name.eq_ignore_ascii_case("present") {
+            let (inner, p) = parse_add_sub(tokens, pos + 2, ctx)?;
+            if tokens.get(p) != Some(&Token::RParen) {
+                return Err(
+                    "Missing closing `)` in `present(...)` — it takes exactly one value, \
+                     e.g. `present(WT)`"
+                        .to_string(),
+                );
+            }
+            return Ok((Condition::Present(inner), p + 1));
+        }
     }
 
     // comparison: expr <cmpop> expr

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -20342,3 +20342,140 @@ fn test_apply_fit_option_vi_grad_clip() {
     assert!(apply_fit_option(&mut opts, "vi_grad_clip", "nope").is_err());
     assert_eq!(opts.vi_grad_clip, 0.0);
 }
+
+// ── `present(COV)` — the data-presence predicate (#1111) ────────────────────
+//
+// A missing covariate is `NaN`, and `x/NaN` underflows to `0.0` in this engine
+// rather than blowing up, so a model that reads a covariate which may be
+// missing needs a guard or it silently zeroes a parameter. `COV == COV` says
+// that (NaN compares false against itself) but reads like a typo; `present(COV)`
+// is the same test, spelled. It is the guard `[covariate_model]` generates, so
+// it appears in text users audit against NONMEM.
+
+/// A one-compartment model whose `CL` is guarded by `cond`.
+fn present_model(cond: &str) -> String {
+    format!(
+        r#"
+[parameters]
+  theta TVCL(2.0, 0.1, 100.0)
+  theta TVV(10.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * (if ({cond}) (WT / 70) else 1.0)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[covariates]
+  WT continuous
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#
+    )
+}
+
+/// `CL` at the given `WT`, through the production parameter closure — so this
+/// exercises the compiled bytecode path the fit uses, not just the AST walker.
+fn cl_at(cond: &str, wt: f64) -> f64 {
+    let parsed = parse_full_model(&present_model(cond)).expect("model should parse");
+    let mut covariates = HashMap::new();
+    covariates.insert("WT".to_string(), wt);
+    (parsed.model.pk_param_fn)(&[2.0, 10.0], &[0.0], &covariates, 0.0).values[0]
+}
+
+#[test]
+fn present_is_true_for_a_value_and_false_for_a_missing_one() {
+    // WT = 140 → factor 2; WT missing → the neutral branch, NOT 0.
+    assert_eq!(cl_at("present(WT)", 140.0), 4.0);
+    assert_eq!(cl_at("present(WT)", f64::NAN), 2.0);
+}
+
+#[test]
+fn present_means_exactly_what_the_self_comparison_idiom_meant() {
+    // `present(COV)` replaced `COV == COV` in generated model text, so the two
+    // must agree everywhere — including on infinity, which is a value, not a
+    // gap in the data. (`is_finite` would have differed here.)
+    for wt in [140.0, 0.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert_eq!(
+            cl_at("present(WT)", wt),
+            cl_at("WT == WT", wt),
+            "present(WT) and WT == WT disagree at WT = {wt}"
+        );
+    }
+}
+
+/// As [`cl_at`], but with a *constant* then-branch — so a branch taken while
+/// `WT` is missing yields a number rather than propagating the `NaN` the test
+/// is not about.
+fn cl_at_const(cond: &str, wt: f64) -> f64 {
+    let src = present_model(cond).replace("(WT / 70)", "3.0");
+    let parsed = parse_full_model(&src).expect("model should parse");
+    let mut covariates = HashMap::new();
+    covariates.insert("WT".to_string(), wt);
+    (parsed.model.pk_param_fn)(&[2.0, 10.0], &[0.0], &covariates, 0.0).values[0]
+}
+
+#[test]
+fn present_negates_and_combines_like_any_other_condition() {
+    // `!present(...)` selects the other branch …
+    assert_eq!(cl_at_const("!present(WT)", 140.0), 2.0);
+    assert_eq!(cl_at_const("!present(WT)", f64::NAN), 6.0);
+    // … and it composes with `&&`, so a guard can carry a real test alongside
+    // the presence check — and short-circuits, so the comparison against a
+    // missing value never decides the branch on its own.
+    assert_eq!(cl_at_const("present(WT) && WT > 100", 140.0), 6.0);
+    assert_eq!(cl_at_const("present(WT) && WT > 100", 50.0), 2.0);
+    assert_eq!(cl_at_const("present(WT) && WT > 100", f64::NAN), 2.0);
+}
+
+#[test]
+fn present_accepts_an_expression_not_only_a_bare_name() {
+    // The argument is an ordinary expression, so a derived quantity can be
+    // tested for missingness too — `WT * 2` is NaN exactly when `WT` is.
+    assert_eq!(cl_at("present(WT * 2)", 140.0), 4.0);
+    assert_eq!(cl_at("present(WT * 2)", f64::NAN), 2.0);
+}
+
+#[test]
+fn present_is_only_special_in_condition_position() {
+    // A covariate that happens to be named `present` is not shadowed: the
+    // predicate is recognised only as `present(` at the head of a condition.
+    let src = r#"
+[parameters]
+  theta TVCL(2.0, 0.1, 100.0)
+  theta TVV(10.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.02
+
+[individual_parameters]
+  CL = TVCL * (if (present > 0) 2.0 else 1.0)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let parsed = parse_full_model(src).expect("a covariate called `present` still parses");
+    let mut covariates = HashMap::new();
+    covariates.insert("present".to_string(), 1.0);
+    let cl = (parsed.model.pk_param_fn)(&[2.0, 10.0], &[0.0], &covariates, 0.0).values[0];
+    assert_eq!(cl, 4.0);
+}
+
+#[test]
+fn an_unclosed_present_is_a_parse_error() {
+    let src = present_model("present(WT").replace("else 1.0)", "else 1.0)");
+    let e = parse_full_model(&src)
+        .map(|_| ())
+        .expect_err("unbalanced `present(` must not parse");
+    assert!(
+        e.to_lowercase().contains("present") || e.contains(')'),
+        "{e}"
+    );
+}

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -3016,6 +3016,7 @@ mod tests {
             PkModel, ScalingSpec, SigmaVector,
         };
         CompiledModel {
+            covariate_model: None,
             name: "cl_from_cr".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Additive,

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2498,6 +2498,7 @@ mod tests {
 
     fn make_model() -> CompiledModel {
         CompiledModel {
+            covariate_model: None,
             name: "test".into(),
             pk_model: PkModel::OneCptIv,
             error_model: ErrorModel::Proportional,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1605,6 +1605,12 @@ pub struct CovariateRelationEstimate {
     pub center_source: Option<String>,
     /// …and the value it resolved to.
     pub center: Option<f64>,
+    /// The body of an `expr("...")` relation — the expression that actually
+    /// multiplied into the parameter. `None` for every other form, whose
+    /// factor is determined by `form` + `center` + `thetas`. Without it `form:
+    /// "expr"` says a hand-written factor ran but not which one, which is not
+    /// enough for a caller to reproduce or report the model.
+    pub expression: Option<String>,
     pub thetas: Vec<CovariateThetaEstimate>,
 }
 
@@ -1616,6 +1622,11 @@ pub struct CovariateThetaEstimate {
     /// `None` when no covariance step ran, or when the θ is `FIX`ed.
     pub se: Option<f64>,
     pub fixed: bool,
+    /// For a `categorical` relation, the level this θ contrasts against the
+    /// reference — carried over from [`CovariateTheta::level`]. `None` for
+    /// every other form. Without it a caller with explicitly named θ cannot
+    /// say which estimate belongs to which level without re-parsing the model.
+    pub level: Option<f64>,
 }
 
 /// A single row of the [`CovariateTable`], echoing one input dataset record.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1304,11 +1304,318 @@ impl CovariateKind {
 /// modeller declares as a covariate, tagged continuous or categorical. This is
 /// a declaration of *availability* — it does not imply the covariate is used in
 /// the structural model.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CovariateDecl {
     /// Column name, case-sensitive, matching the CSV header.
     pub name: String,
     pub kind: CovariateKind,
+    /// Declared levels of a categorical covariate — `SEX categorical(levels =
+    /// [0, 1])`. `None` for a continuous covariate, and for a categorical one
+    /// declared without levels (legal on its own; only a `[covariate_model]`
+    /// `categorical(...)` relation needs them).
+    #[serde(default)]
+    pub levels: Option<CovariateLevels>,
+}
+
+/// Where the levels of a categorical covariate come from.
+///
+/// Expanding `categorical(ref = …)` into one θ per non-reference level needs
+/// the level set *at parse time*, so silently reading it off the dataset would
+/// make the generated θ vector — its length, its names, its order — a property
+/// of the data rather than of the model file. [`CovariateLevels::Auto`] is the
+/// opt-in to exactly that, and like a symbolic centering statistic it leaves
+/// the relation unresolved until [`crate::api::bind_covariate_stats`] has seen
+/// the population.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CovariateLevels {
+    /// `levels = [0, 1]` — stated in the file, in the order written.
+    Declared(Vec<f64>),
+    /// `levels = auto` — discovered from the data, ascending.
+    Auto,
+}
+
+impl CovariateLevels {
+    /// The declared levels, or `None` for `auto` (not yet resolved).
+    pub fn declared(&self) -> Option<&[f64]> {
+        match self {
+            CovariateLevels::Declared(v) => Some(v),
+            CovariateLevels::Auto => None,
+        }
+    }
+}
+
+impl CovariateDecl {
+    /// A declaration with no levels — the shape every `[covariates]` line had
+    /// before `levels = [...]` existed.
+    pub fn new(name: impl Into<String>, kind: CovariateKind) -> Self {
+        CovariateDecl {
+            name: name.into(),
+            kind,
+            levels: None,
+        }
+    }
+}
+
+// ── `[covariate_model]` — declarative covariate relationships (#1111) ───────
+
+/// The functional form of one `[covariate_model]` relation.
+///
+/// The five non-`Expr` continuous/categorical forms are the five PsN `scm`
+/// states, so a model translated from an `scm` run has a form here for every
+/// state it can be in:
+///
+/// | PsN state | ferx form |
+/// |---|---|
+/// | 1 `none` | [`CovariateForm::None`] |
+/// | 2 `linear` (continuous) | [`CovariateForm::Linear`] |
+/// | 2 `linear` (categorical) | [`CovariateForm::Categorical`] |
+/// | 3 `hockey-stick` | [`CovariateForm::Hockey`] |
+/// | 4 `exponential` | [`CovariateForm::Exponential`] |
+/// | 5 `power` | [`CovariateForm::Power`] |
+/// | arbitrary `[code]` | [`CovariateForm::Expr`] |
+///
+/// [`CovariateForm::LinearRelative`] has no PsN state number: it is an exact
+/// reparameterization of `Linear` (`θ_rel = c·θ_abs`) that makes θ
+/// dimensionless, so the two give the same OFV on the same data and differ only
+/// in the scale θ and its SE are reported on.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CovariateForm {
+    /// Factor `1`. Declares no θ and changes no expression — the point is that
+    /// a search can write "tested, rejected" into the file and have the
+    /// generated model round-trip through the parser unchanged.
+    None,
+    /// `1 + θ·(COV − c)`. θ carries the reciprocal of the covariate's units.
+    Linear,
+    /// `1 + θ·(COV/c − 1)`. Dimensionless θ; ferx extension.
+    LinearRelative,
+    /// `exp(θ·(COV − c))`.
+    Exponential,
+    /// `(COV/c)^θ`.
+    Power,
+    /// `COV <= b ? 1 + θ_lo·(COV − b) : 1 + θ_hi·(COV − b)` — two θ, so the
+    /// relation→θ map is one-to-many from the start rather than retrofitted.
+    Hockey,
+    /// `1 + θ_k` at each non-reference level, `1` at the reference level.
+    Categorical,
+    /// Verbatim ferx expression, the equivalent of PsN's `[code]` escape hatch.
+    /// The string is the expression source with the surrounding quotes removed.
+    Expr(String),
+}
+
+impl CovariateForm {
+    /// The spelling used in the `[covariate_model]` block and in output.
+    pub fn label(&self) -> &'static str {
+        match self {
+            CovariateForm::None => "none",
+            CovariateForm::Linear => "linear",
+            CovariateForm::LinearRelative => "linear_relative",
+            CovariateForm::Exponential => "exponential",
+            CovariateForm::Power => "power",
+            CovariateForm::Hockey => "hockey",
+            CovariateForm::Categorical => "categorical",
+            CovariateForm::Expr(_) => "expr",
+        }
+    }
+
+    /// Whether the form reads a categorical covariate. Cross-checked against
+    /// the `[covariates]` declaration, so `categorical` on a column declared
+    /// `continuous` (or a continuous form on a categorical column) is rejected
+    /// rather than silently producing a factor keyed on a level that does not
+    /// exist.
+    pub fn is_categorical(&self) -> bool {
+        matches!(self, CovariateForm::Categorical)
+    }
+}
+
+/// The centering / breakpoint / reference constant of a relation, either a
+/// literal or a statistic to be read off the dataset.
+///
+/// Requiring a literal would make every generated covariate model
+/// dataset-specific, which defeats the automation this block exists for; so
+/// PsN's data-derived statistics are spelled out symbolically here and resolved
+/// by [`crate::api::bind_covariate_stats`]. Recommendation for users: literals
+/// for a final model (reproducible from the file alone), symbolic for an
+/// automated search.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CovariateStat {
+    Literal(f64),
+    Median,
+    Mean,
+    Min,
+    Max,
+    /// The most common level — PsN's reference category for `categorical`.
+    Mode,
+}
+
+impl CovariateStat {
+    /// The spelling used in the block, for the echo of the *source* form
+    /// alongside the resolved value.
+    pub fn label(&self) -> String {
+        match self {
+            CovariateStat::Literal(v) => format!("{v}"),
+            CovariateStat::Median => "median".into(),
+            CovariateStat::Mean => "mean".into(),
+            CovariateStat::Min => "min".into(),
+            CovariateStat::Max => "max".into(),
+            CovariateStat::Mode => "mode".into(),
+        }
+    }
+
+    /// The literal value, when the statistic is one.
+    pub fn literal(&self) -> Option<f64> {
+        match self {
+            CovariateStat::Literal(v) => Some(*v),
+            _ => None,
+        }
+    }
+}
+
+/// One θ generated by a relation, with the init and bounds it is declared with.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateTheta {
+    /// `THETA_<PARAM>_<COV>`, with `_LO`/`_HI` for `hockey` and `_<LEVEL>` for
+    /// `categorical` — or the name given explicitly after `=>`.
+    pub name: String,
+    pub init: f64,
+    pub lower: f64,
+    pub upper: f64,
+    /// `true` when the relation carried `fix = v`; the θ is declared `FIX` at
+    /// `init` and not estimated.
+    pub fixed: bool,
+    /// For `categorical`, the level this θ contrasts against the reference.
+    pub level: Option<f64>,
+}
+
+/// One line of the `[covariate_model]` block, as structured data.
+///
+/// This is the machine-readable surface an SCM harness or an agent consumes: it
+/// states what covariate model was run without anyone having to parse the
+/// `.ferx` file. Relations are line-oriented and independent, so adding or
+/// dropping one is a pure line insert/delete.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateRelation {
+    /// The `[individual_parameters]` name the factor multiplies into, e.g. `CL`.
+    pub parameter: String,
+    /// The `[covariates]` column, e.g. `WT`.
+    pub covariate: String,
+    pub form: CovariateForm,
+    /// `center = …` / `breakpoint = …` / `ref = …`, as written. `None` for
+    /// `none` and `expr(...)`, which take no constant.
+    pub center: Option<CovariateStat>,
+    /// The value `center` resolved to. Equal to the literal when one was
+    /// written; filled from the data by [`crate::api::bind_covariate_stats`]
+    /// when the statistic was symbolic; `None` while still unresolved.
+    pub resolved_center: Option<f64>,
+    /// `fix = v`, when given.
+    pub fix: Option<f64>,
+    /// The θ this relation declares: one for the single-slope forms, two for
+    /// `hockey`, one per non-reference level for `categorical`, none for `none`
+    /// and `expr(...)`. Empty while the relation is unresolved.
+    pub thetas: Vec<CovariateTheta>,
+    /// The block line verbatim, for the echo and for error messages.
+    pub source_line: String,
+}
+
+impl CovariateRelation {
+    /// Whether this relation still needs data-derived statistics before it can
+    /// be desugared — a symbolic `center`/`ref`, or a form whose PsN default
+    /// bounds are functions of the covariate's median/min/max.
+    ///
+    /// An unresolved relation is **not** desugared into the expression, and
+    /// every entry point rejects a model that still carries one, so it can
+    /// never silently fit without the covariate effect it declares.
+    pub fn needs_data(&self) -> bool {
+        // `none` declares nothing and `expr(...)` is verbatim: neither has a
+        // constant to resolve or a default bound to derive, so neither can be
+        // held up by the absence of a dataset.
+        if matches!(self.form, CovariateForm::None | CovariateForm::Expr(_)) {
+            return false;
+        }
+        (self.center.is_some() && self.resolved_center.is_none()) || self.thetas.is_empty()
+    }
+}
+
+/// The parsed, desugared `[covariate_model]` block.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateModelSpec {
+    pub relations: Vec<CovariateRelation>,
+    /// The `[individual_parameters]` lines as they were rewritten — what
+    /// `ferx check` and `ferx_model_show()` print, so the expression actually
+    /// built is auditable against NONMEM.
+    pub desugared_individual_parameters: Vec<String>,
+    /// The `theta NAME(init, lower, upper)` lines appended to `[parameters]`.
+    pub generated_thetas: Vec<String>,
+}
+
+impl CovariateModelSpec {
+    /// The relations that could not be desugared for want of data-derived
+    /// statistics. Non-empty means the model must be run through
+    /// [`crate::api::bind_covariate_stats`] before it can fit.
+    pub fn unresolved(&self) -> Vec<&CovariateRelation> {
+        self.relations.iter().filter(|r| r.needs_data()).collect()
+    }
+}
+
+/// Summary statistics of one covariate over a dataset — what a symbolic
+/// `center = median` / `ref = mode` / `levels = auto` resolves against (#1111).
+///
+/// Computed over **one value per subject** for a subject-static covariate, and
+/// over every distinct value a subject takes for a time-varying one, matching
+/// PsN's per-individual weighting: a subject with 40 samples must not drag the
+/// median toward their own weight.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateSummary {
+    pub median: f64,
+    pub mean: f64,
+    pub min: f64,
+    pub max: f64,
+    /// The most common value — the reference level of a `categorical` relation.
+    /// Ties break toward the smaller value, so the choice is reproducible.
+    pub mode: f64,
+    /// Distinct observed values, ascending — what `levels = auto` resolves to.
+    pub levels: Vec<f64>,
+}
+
+impl CovariateSummary {
+    /// The statistic `stat` names, or the literal it carries.
+    pub fn value_of(&self, stat: CovariateStat) -> f64 {
+        match stat {
+            CovariateStat::Literal(v) => v,
+            CovariateStat::Median => self.median,
+            CovariateStat::Mean => self.mean,
+            CovariateStat::Min => self.min,
+            CovariateStat::Max => self.max,
+            CovariateStat::Mode => self.mode,
+        }
+    }
+}
+
+/// One relation echoed on [`FitResult`], with the estimate and SE of each θ it
+/// generated — the table a covariate search reads back after a fit.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateRelationEstimate {
+    pub parameter: String,
+    pub covariate: String,
+    /// [`CovariateForm::label`] of the relation's form.
+    pub form: String,
+    /// `center`/`breakpoint`/`ref` as written (`"median"`, `"70"`).
+    pub center_source: Option<String>,
+    /// …and the value it resolved to.
+    pub center: Option<f64>,
+    pub thetas: Vec<CovariateThetaEstimate>,
+}
+
+/// One θ of a [`CovariateRelationEstimate`].
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CovariateThetaEstimate {
+    pub name: String,
+    pub estimate: f64,
+    /// `None` when no covariance step ran, or when the θ is `FIX`ed.
+    pub se: Option<f64>,
+    pub fixed: bool,
 }
 
 /// A single row of the [`CovariateTable`], echoing one input dataset record.
@@ -3176,6 +3483,17 @@ pub struct CompiledModel {
     /// columns before a fit so that a missing/misspelt covariate fails loudly
     /// instead of silently evaluating to zero.
     pub referenced_covariates: Vec<String>,
+    /// The parsed, desugared `[covariate_model]` block (#1111). `None` when the
+    /// block is absent — every model written before this block existed, and
+    /// every model that states its covariate effects classically inside
+    /// `[individual_parameters]`.
+    ///
+    /// The block is *sugar*: it is rewritten into ordinary
+    /// `[individual_parameters]` expressions and `theta` declarations before
+    /// anything else reads the model, so nothing downstream of the parser
+    /// special-cases it. This field is the structured echo of what was written
+    /// — the surface a covariate search reads instead of the `.ferx` text.
+    pub covariate_model: Option<CovariateModelSpec>,
     /// Mirror of [`FitOptions::gradient_method`] so the inner loop can
     /// dispatch at runtime without threading the options struct through
     /// every call site. Set by [`fit_from_files`](crate::fit_from_files)
@@ -5459,6 +5777,16 @@ pub struct FitResult {
     /// (which has no raw rows) or when no `[covariates]` block is declared.
     /// Missing values are `f64::NAN`. See [`CovariateTable`].
     pub covariate_table: Option<CovariateTable>,
+    /// Echo of the `[covariate_model]` relations with the estimate and SE of
+    /// each θ they generated (#1111). Empty when the model declares no
+    /// `[covariate_model]` block.
+    ///
+    /// This is what an SCM harness or an agent reads back after a fit — the
+    /// covariate model that ran, its resolved centering constants, and the
+    /// effect sizes — so it never has to regex the model file or join θ names
+    /// back to relations itself.
+    #[serde(default)]
+    pub covariate_relations: Vec<CovariateRelationEstimate>,
     /// Record-level exclusion statistics; `Some` when `[data_selection]` rules
     /// were active during the fit (or the caller supplied `ignore`/`accept`
     /// expressions).  `None` means no filtering was requested.
@@ -7484,6 +7812,13 @@ pub struct ParsedModel {
     /// `ferx check` to attach a block-level location to diagnostics. Empty when
     /// a model is constructed programmatically rather than parsed from text.
     pub block_lines: std::collections::HashMap<String, usize>,
+    /// The data-derived bindings this parse was given (#1064 level counts,
+    /// #1111 covariate statistics).
+    ///
+    /// Carried on the result so that a *second* binder — the two run in
+    /// sequence on a model that declares both — re-parses with the first one's
+    /// bindings still in hand instead of silently dropping them.
+    pub bindings: crate::parser::model_parser::ParseBindings,
 }
 
 /// Factories that build minimal `CompiledModel` instances for unit tests.

--- a/src/types_test_helpers.rs
+++ b/src/types_test_helpers.rs
@@ -13,6 +13,7 @@ pub(crate) fn ode_model(gradient_method: GradientMethod) -> CompiledModel {
 
 fn make_compiled_model(with_ode: bool, gradient_method: GradientMethod) -> CompiledModel {
     CompiledModel {
+        covariate_model: None,
         name: "test".into(),
         pk_model: PkModel::OneCptOral,
         error_model: ErrorModel::Additive,
@@ -135,6 +136,7 @@ pub(crate) fn tv_cov_iv_model_and_subject() -> (CompiledModel, Subject) {
         mixture: None,
     };
     let model = CompiledModel {
+        covariate_model: None,
         name: "tv_cov_iv".into(),
         pk_model: PkModel::OneCptIv,
         error_model: ErrorModel::Proportional,

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -413,10 +413,12 @@ fn covariate_table_built_from_declarations() {
     use ferx_core::{read_nonmem_csv_with_covariates, CovariateDecl, CovariateKind};
     let decls = vec![
         CovariateDecl {
+            levels: None,
             name: "WT".into(),
             kind: CovariateKind::Continuous,
         },
         CovariateDecl {
+            levels: None,
             name: "CRCL".into(),
             kind: CovariateKind::Continuous,
         },

--- a/tests/covariate_model_equivalence.rs
+++ b/tests/covariate_model_equivalence.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 use ferx_core::parser::model_parser::parse_full_model;
 use ferx_core::types::FitOptions;
-use ferx_core::{fit, predict, read_nonmem_csv};
+use ferx_core::{fit, fit_from_files, predict, read_nonmem_csv};
 
 const DATA: &str = "data/two_cpt_oral_cov.csv";
 
@@ -183,6 +183,45 @@ fn the_relation_table_is_echoed_on_the_fit_result() {
             assert_eq!(theta.estimate, result.theta[idx]);
         }
     }
+}
+
+/// `fit_from_files` must bind the data-derived statistics itself.
+///
+/// `assert_covariate_model_bound`'s error text names this entry point as one
+/// that binds them, so a `center = median` model launched through it has to
+/// run rather than fail `E_COVSTAT_UNRESOLVED` (#1111 review).
+#[test]
+fn fit_from_files_binds_symbolic_covariate_statistics() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("symbolic.ferx");
+    // Symbolic centres throughout: nothing here is resolvable from the file.
+    let text = declarative()
+        .replace("power(center = 70)", "power(center = median)")
+        .replace("power(center = 100)", "power(center = median)");
+    std::fs::write(&path, &text).expect("write model file");
+
+    let opts = FitOptions {
+        outer_maxiter: 2,
+        ..FitOptions::default()
+    };
+    let result = fit_from_files(
+        path.to_str().expect("utf-8 path"),
+        Some(DATA),
+        None,
+        Some(opts),
+    )
+    .expect("fit_from_files must bind `center = median` rather than reject it");
+
+    // Non-degeneracy: the centres actually came from the data, so they are
+    // neither absent nor the literals the file no longer states.
+    let wt = result
+        .covariate_relations
+        .iter()
+        .find(|r| r.covariate == "WT")
+        .expect("the WT relation is echoed");
+    let center = wt.center.expect("a bound relation reports its centre");
+    assert!(center.is_finite() && center > 0.0, "center = {center}");
+    assert_eq!(wt.center_source.as_deref(), Some("median"));
 }
 
 /// The same pair, fit to convergence: identical estimates and identical

--- a/tests/covariate_model_equivalence.rs
+++ b/tests/covariate_model_equivalence.rs
@@ -1,0 +1,240 @@
+//! `[covariate_model]` ≡ the classical expression it desugars to (#1111).
+//!
+//! The block is sugar: it emits nothing the hand-written path could not already
+//! emit. That is also what makes it validatable without a new NONMEM run — the
+//! classical covariate models are already NONMEM-anchored, so the anchor for
+//! this feature is that the two forms are the *same model*, to the last bit.
+//!
+//! Both directions are checked on real data (`data/two_cpt_oral_cov.csv`, which
+//! carries `WT` and `CRCL`):
+//!
+//! - `predict()` agrees **bit-for-bit** at a fixed parameter vector, and
+//! - a short `fit()` reports a bit-identical OFV from the same start.
+//!
+//! Bit-for-bit rather than to-tolerance is deliberate: the desugar emits the
+//! same expression tree in the same multiplication order, so any difference at
+//! all would mean the generated text is not the model the author wrote.
+
+use std::path::Path;
+
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::types::FitOptions;
+use ferx_core::{fit, predict, read_nonmem_csv};
+
+const DATA: &str = "data/two_cpt_oral_cov.csv";
+
+/// Everything the two models share. The θ that the block will generate are
+/// declared here in both arms — with the same name, init and bounds — so the
+/// two parameter vectors are elementwise identical and "the same start" is not
+/// an approximation.
+const HEAD: &str = r"
+[parameters]
+  theta TVCL(4.0, 0.1, 100.0)
+  theta TVV1(40.0, 1.0, 500.0)
+  theta TVQ(8.0, 0.1, 100.0)
+  theta TVV2(80.0, 1.0, 500.0)
+  theta TVKA(1.0, 0.01, 10.0)
+
+  omega ETA_CL ~ 0.15
+  omega ETA_V1 ~ 0.15
+
+  sigma PROP_ERR ~ 0.04 (sd)
+";
+
+const TAIL: &str = r"
+[structural_model]
+  pk two_cpt_oral(cl=CL, v1=V1, q=Q, v2=V2, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method   = focei
+  maxiter  = 2
+  gradient = fd
+";
+
+/// The covariate model written by hand, the way it always has been.
+fn classical() -> String {
+    format!(
+        "{HEAD}
+[individual_parameters]
+  CL = TVCL * (WT / 70)^THETA_CL_WT * (CRCL / 100)^THETA_CL_CRCL * exp(ETA_CL)
+  V1 = TVV1 * (WT / 70)^THETA_V1_WT * exp(ETA_V1)
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[covariates]
+  WT   continuous
+  CRCL continuous
+{THETA_DECLS}{TAIL}"
+    )
+}
+
+/// …and the same model stated declaratively.
+fn declarative() -> String {
+    format!(
+        "{HEAD}
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V1 = TVV1 * exp(ETA_V1)
+  Q  = TVQ
+  V2 = TVV2
+  KA = TVKA
+
+[covariates]
+  WT   continuous
+  CRCL continuous
+
+[covariate_model]
+  CL ~ WT   power(center = 70)  => THETA_CL_WT(0.6, 0.01, 5.0)
+  CL ~ CRCL power(center = 100) => THETA_CL_CRCL(0.3, 0.01, 5.0)
+  V1 ~ WT   power(center = 70)  => THETA_V1_WT(0.9, 0.01, 5.0)
+{TAIL}"
+    )
+}
+
+/// The generated θ, declared explicitly in the classical arm. Appended after
+/// the shared block so both arms order θ identically — the desugar appends its
+/// generated declarations to the end of `[parameters]`.
+const THETA_DECLS: &str = r"
+[parameters]
+  theta THETA_CL_WT(0.6, 0.01, 5.0)
+  theta THETA_CL_CRCL(0.3, 0.01, 5.0)
+  theta THETA_V1_WT(0.9, 0.01, 5.0)
+";
+
+#[test]
+fn the_block_is_the_classical_model_it_desugars_to() {
+    let hand = parse_full_model(&classical()).expect("classical model must parse");
+    let block = parse_full_model(&declarative()).expect("block-declared model must parse");
+
+    // The two θ vectors must line up name for name, or "the same parameter
+    // vector" below would be comparing different models.
+    assert_eq!(hand.model.theta_names, block.model.theta_names);
+    assert_eq!(
+        hand.model.default_params.theta,
+        block.model.default_params.theta
+    );
+
+    let pop = read_nonmem_csv(Path::new(DATA), None, None).expect("covariate dataset must load");
+
+    // 1. Predictions at a fixed parameter vector, bit for bit.
+    let hand_pred = predict(&hand.model, &pop, &hand.model.default_params);
+    let block_pred = predict(&block.model, &pop, &block.model.default_params);
+    assert_eq!(hand_pred.len(), block_pred.len());
+    for (h, b) in hand_pred.iter().zip(&block_pred) {
+        assert_eq!(h.id, b.id);
+        assert_eq!(h.time, b.time);
+        assert_eq!(h.pred, b.pred, "PRED differs for subject {}", h.id);
+    }
+
+    // 2. …and the objective function after a couple of outer iterations from
+    //    that same start. `maxiter = 2` keeps this a Tier-2 test: it exercises
+    //    the fit path without running a convergence loop.
+    // Tier-2: a couple of outer iterations, never a convergence loop.
+    let opts = FitOptions {
+        outer_maxiter: 2,
+        ..FitOptions::default()
+    };
+    let hand_fit = fit(&hand.model, &pop, &hand.model.default_params, &opts)
+        .expect("short classical fit must not error");
+    let block_fit = fit(&block.model, &pop, &block.model.default_params, &opts)
+        .expect("short block-declared fit must not error");
+    assert_eq!(
+        hand_fit.ofv, block_fit.ofv,
+        "the block must be the same objective function as the expression it generates"
+    );
+    assert_eq!(hand_fit.theta, block_fit.theta);
+}
+
+#[test]
+fn the_relation_table_is_echoed_on_the_fit_result() {
+    // The point of the block: a search reads the covariate model back off the
+    // result instead of regexing the `.ferx` file.
+    let block = parse_full_model(&declarative()).expect("block-declared model must parse");
+    let pop = read_nonmem_csv(Path::new(DATA), None, None).expect("covariate dataset must load");
+    let opts = FitOptions {
+        outer_maxiter: 2,
+        ..FitOptions::default()
+    };
+    let result = fit(&block.model, &pop, &block.model.default_params, &opts)
+        .expect("short block-declared fit must not error");
+
+    let relations = &result.covariate_relations;
+    assert_eq!(relations.len(), 3);
+    assert_eq!(relations[0].parameter, "CL");
+    assert_eq!(relations[0].covariate, "WT");
+    assert_eq!(relations[0].form, "power");
+    assert_eq!(relations[0].center, Some(70.0));
+    assert_eq!(relations[0].thetas.len(), 1);
+    assert_eq!(relations[0].thetas[0].name, "THETA_CL_WT");
+
+    // Each echoed estimate is the θ the fit actually reports, joined by name —
+    // that join is the work a caller would otherwise have to redo.
+    for rel in relations {
+        for theta in &rel.thetas {
+            let idx = result
+                .theta_names
+                .iter()
+                .position(|n| *n == theta.name)
+                .expect("every echoed θ is a real θ of the fit");
+            assert_eq!(theta.estimate, result.theta[idx]);
+        }
+    }
+}
+
+/// The same pair, fit to convergence: identical estimates and identical
+/// standard errors.
+///
+/// The short fit above pins the objective; this pins the whole run, including
+/// the covariance step — the level at which a difference in the *gradient* of
+/// the generated expression, rather than in its value, would show up.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn the_two_forms_converge_to_the_same_estimates_and_ses() {
+    let hand = parse_full_model(&classical()).expect("classical model must parse");
+    let block = parse_full_model(&declarative()).expect("block-declared model must parse");
+    let pop = read_nonmem_csv(Path::new(DATA), None, None).expect("covariate dataset must load");
+
+    let opts = FitOptions {
+        run_covariance_step: true,
+        ..FitOptions::default()
+    };
+    let hand_fit = fit(&hand.model, &pop, &hand.model.default_params, &opts)
+        .expect("classical fit must not error");
+    let block_fit = fit(&block.model, &pop, &block.model.default_params, &opts)
+        .expect("block-declared fit must not error");
+
+    // Non-degeneracy first: two fits that both stalled at their start would
+    // agree trivially and prove nothing about the generated expression.
+    assert!(hand_fit.converged, "classical arm must actually converge");
+    assert!(block_fit.converged, "block arm must actually converge");
+    for name in ["THETA_CL_WT", "THETA_CL_CRCL", "THETA_V1_WT"] {
+        let i = block_fit
+            .theta_names
+            .iter()
+            .position(|n| n == name)
+            .expect("generated θ is estimated");
+        let init = block.model.default_params.theta[i];
+        assert!(
+            (block_fit.theta[i] - init).abs() > 1e-6,
+            "{name} never moved from its initial estimate — the covariate effect \
+             is not being estimated, and the comparison below would be vacuous"
+        );
+    }
+
+    assert_eq!(hand_fit.ofv, block_fit.ofv);
+    assert_eq!(hand_fit.theta, block_fit.theta);
+    assert_eq!(hand_fit.omega, block_fit.omega);
+    assert_eq!(hand_fit.sigma, block_fit.sigma);
+    assert_eq!(hand_fit.se_theta, block_fit.se_theta);
+    assert!(
+        hand_fit.se_theta.is_some(),
+        "the covariance step must have run — SEs are half of what this compares"
+    );
+}


### PR DESCRIPTION
## Why

Closes #1111.

A covariate effect has always been written by hand into `[individual_parameters]`:

```
CL = TVCL * (WT/70)^THETA_CL_WT * exp(ETA_CL)
```

along with the theta declaration, the centering constant, sensible bounds and a missing-data
guard. That is fine for a human writing one model. It is the wrong shape for a machine writing a
hundred: a covariate search (PsN `scm`, `ferx_cov_screen()`, an agent) has to do regex surgery on
an arbitrary expression to add or drop a relation, and has no machine-readable statement of what
covariate model was actually run.

This closes the loop on the screening layer that already exists in ferx-r (`ferx_cov_screen()`,
`ferx_eta_cov()`), which today dead-ends at "here is what is worth testing" with no path to
actually test it.

## What changed

An optional `[covariate_model]` block that declares relations as **structured data**:

```
[covariates]
  WT   continuous
  SEX  categorical(levels = [0, 1])

[covariate_model]
  CL ~ WT   power(center = median)
  CL ~ SEX  categorical(ref = mode)
```

The block is **sugar**. Each relation is rewritten into exactly the classical expression, in
`apply_covariate_model_block` at the top of `parse_full_model_with` — alongside the existing
`apply_ode_template` / `apply_algebraic_structural` source rewrites, and **before**
`absorption_ode_equivalent_source`, which re-emits these blocks to build the ODE twin (a twin
built from un-desugared text would silently carry no covariate effect). Everything downstream —
expression compilation, `Dual2` sensitivities, the SAEM mu-reference detector, `covtab`, SE
reporting — sees an ordinary classical model, and the generated thetas are ordinary thetas. There
is no second evaluation path.

All five PsN `scm` states are expressible (`none`, `linear`, `hockey`, `exponential`, `power`),
plus `categorical`, a dimensionless `linear_relative`, and an `expr("…")` escape hatch for scm's
`[code]`. PsN's default inits and bounds are adopted verbatim — `θ ∈ [1/(c−max), 1/(c−min)]` is
exactly what keeps `1 + θ·(COV−c)` positive over the observed range, so a covariate that does not
vary around its centre is rejected rather than handed infinite bounds.

Three decisions worth a reviewer's attention:

**Insertion point.** The factor goes into the non-η half of the product, immediately before the
first η/κ-bearing factor — not appended to the end of the RHS. Appending is numerically identical
but takes the typical value out of the shape the SAEM mu-reference detector reads, which silently
drops the covariate effect (#619). A right-hand side that is not a top-level product (a sum, a
logit transform, a mixture branch) is a hard error naming the explicit `COV_<PARAM>` handle,
not a guess.

**Missing values.** Every generated factor is wrapped in `if (present(COV)) <factor> else 1.0`.
This is not belt-and-braces: division by a missing covariate **underflows to `0.0`** in this
engine rather than producing an infinity, so an unguarded `(WT/70)^θ` on a missing row would
silently zero the parameter instead of failing loudly. Its own test.

`present(x)` is **new DSL surface in this PR** — a condition, true unless the value is `NaN`,
usable anywhere a condition is (`!present(WT)`, `present(WT) && WT > 100`). It replaces the
`COV == COV` spelling the guard first used: correct, but it reads like a typo, and this is text
a user diffs against a NONMEM control stream. Deliberately a condition rather than a function
returning 0.0/1.0 — as arithmetic, `TVCL * present(WT)` would produce exactly the silently zeroed
parameter the guard prevents. It is `!v.is_nan()`, not `is_finite()`, so it means what the idiom
it replaces meant (an infinity is a value, not a gap in the data); a test runs both spellings
over {value, 0, −1, NaN, ±inf} and asserts they agree. Carried through both bytecode evaluators
as `Op::IsPresent`; in the `PkNum` one it pushes a constant, since an indicator's derivative is
identically zero — and the Tier-3 SE comparison is the oracle for that arm.

**One θ per relation.** A relation owns its θ and two relations cannot share one, so a single
allometric exponent estimated jointly on `CL` and `V` — what `examples/two_cpt_oral_cov.ferx`
does — has no spelling here. This follows PsN (`scm` gives every (parameter, covariate) relation
its own θ) and is what keeps a relation a self-contained line: sharing would couple two lines,
and a search could no longer drop one without reasoning about the other. The error message names
the workaround (write that factor classically — the two styles mix), and both the module doc and
the docs page carry it with an example.

**Data-derived statistics.** `center`/`breakpoint`/`ref` accept `median`/`mean`/`min`/`max`/`mode`
and `[covariates]` accepts `levels = auto`, resolved by `bind_covariate_stats()`. A relation that
reaches a fit still unresolved is `E_COVSTAT_UNRESOLVED` — never a quiet fit with the covariate
effect absent. Without `--data` it is `W_COVSTAT_UNBOUND`, and the desugared echo in `ferx check`
is *suppressed* rather than printed without the pending effects (printing it would state the
opposite of the truth).

Structured echo: `FitResult.covariate_relations`, a `covariate_model:` section in the fit YAML
(carrying both the source form and the resolved value — `center: 70.85  # resolved from median`),
and `ferx check` printing the desugared `[individual_parameters]`.

## Alternatives considered

**Symbolic statistics: bound re-parse vs. a late-bound slot.** The issue proposed an
`Arc<OnceLock<CovariateStats>>` on `CompiledModel`, captured by the compiled closures and filled
at each entry point. This PR instead mirrors θ-level binding (#1064): `bind_covariate_stats()`
computes the statistics and re-parses, so the desugared expression carries a literal. Reasons:
no new AST node in the tree-walking *and* bytecode evaluators plus the sens path; and the
`OnceLock` is sticky — a model reused against a second dataset (a bootstrap resample, a VPC on
new data) would silently keep the first dataset's centres. Re-parsing costs milliseconds. The
cost of this choice is that a caller driving `fit(&model, &pop)` directly must call the binder;
that is a loud `E_COVSTAT_UNRESOLVED`, not a silent wrong answer, and literal-centred models
(the recommendation for final models) need no binding at all.

Both binders now travel through one `ParseBindings` struct, because each re-parses and a model
may declare both — binding one must not drop the other's. Pinned by a test.

**Syntax: `PARAM ~ COV form(...)` vs `PARAM ~ form(COV, ...)`.** The R-formula spelling
(`CL ~ power(WT, center = median)`, echoing `y ~ s(WT, k = 5)`) reads more naturally to R users,
who are most of this DSL's audience. Rejected, and the rationale is recorded in the module doc:
once the RHS is a term expression, `CL ~ power(WT) + linear(CRCL)` is what an R-literate reader
writes next — which breaks one-relation-per-line (the property the block exists for), and `+`
reads as additive when these effects are multiplicative. Also, `(parameter, covariate)` is the
primary key of a covariate search; this spelling puts both at fixed positions at line start with
the form — the thing a search varies — as the one token that moves. PsN's own config keys the
same way (`[test_relations] CL=WT,SEX`, state in a separate table).

**Search configuration.** PsN's `[test_relations]`, `valid_states`, `included_relations`,
`p_forward` are deliberately **out of scope**: they are search configuration, not model. They
belong in an SCM harness that reads the relation table and rewrites these lines.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not yet open | after |

The ferx-r side (`ferx_add_covariate()` / `ferx_drop_covariate()`, issue #1111 slice 5) is a
follow-up PR and cannot land first: it needs a `src/rust/Cargo.lock` bump to a ferx-core commit
that has these `pub` items, via `ferx-r/tools/update-ferx-core-lock.sh`. Nothing in ferx-r breaks
without it — this PR only adds API surface and one optional block.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [x] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [ ] None

Additive only — no existing signature or field changed, so nothing downstream breaks. Baseline
regenerated (+166 lines). What was added and who needs it:

| Item | Needed by |
|---|---|
| `types::{CovariateForm, CovariateStat, CovariateLevels, CovariateTheta, CovariateRelation, CovariateModelSpec, CovariateSummary}` | ferx-r's `ferx_add_covariate()` / `ferx_drop_covariate()`, which construct and inspect relations; an SCM harness in ferx-tools reading the relation table |
| `types::{CovariateRelationEstimate, CovariateThetaEstimate}` + `FitResult::covariate_relations` | the post-fit read-back — the whole point of the block; ferx-r surfaces it as a data frame |
| `CompiledModel::covariate_model` | `ferx_model_show()` printing the desugared block without re-parsing |
| `CovariateDecl::levels` + `CovariateDecl::new` | `levels = [...]`; the constructor keeps the pre-existing two-field construction working for external callers |
| `api::{bind_covariate_stats, assert_covariate_model_bound}` | ferx-r calls `parse_full_model_file` + `read_population_for` + `fit` directly, so it must be able to bind statistics itself and to check boundness |
| `parser::model_parser::{ParseBindings, parse_full_model_with}` | the binder's own re-parse; `parse_full_model_bound` is kept as a wrapper so existing callers are untouched |
| `parser::covariate_model::CovariateStatBindings` | type of a `ParseBindings` field. The desugar itself (`apply_covariate_model`, `CovariateModelContext`) stays `pub(crate)` |
| `CheckReport::desugared_individual_parameters` | `ferx check --json`; ferx-r's `ferx_model_validate()` |

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx behaviour — the classical covariate model this block desugars to
- [x] Reference values:

`tests/covariate_model_equivalence.rs` runs the same covariate model both ways on
`data/two_cpt_oral_cov.csv` and asserts **bit-identical** results — `assert_eq!` on f64, not a
tolerance, because the desugar emits the same expression tree in the same multiplication order,
so any difference at all would mean the generated text is not the model the author wrote:

- `predict()` PRED, pointwise, at a fixed parameter vector
- OFV after a short fit from the same start
- (slow-tests) converged θ, Ω, σ **and `se_theta`** — the SE comparison is the level at which a
  difference in the *gradient* of the generated expression, rather than in its value, would show

The convergence test carries non-degeneracy guards — both arms must report `converged`, all three
covariate θ must have moved from their inits, and the covariance step must have run — so a green
result cannot mean both sides stalled identically at the start.

**No new NONMEM run, deliberately.** The block emits nothing the classical path could not already
emit, and the classical covariate models are already NONMEM-anchored, so the anchor for this
feature is that the two forms are the same model. Discussed with @roninsightrx before
implementation.

`examples/two_cpt_oral_covmodel.ferx` on `data/two_cpt_oral_cov.csv`, release build:

```
# classical sibling, examples/two_cpt_oral_cov.ferx (WT exponent shared across CL and V1)
OFV: -1168.4846   converged: true
TVCL 4.948619  TVV1 38.217475  TVQ 10.096271  TVV2 98.422611  TVKA 0.983651
THETA_WT 0.636325  THETA_CRCL 0.562252

# block-declared, examples/two_cpt_oral_covmodel.ferx (a separate exponent per relation)
OFV: -1199.0246   converged: true
TVCL 4.904208  TVV1 48.541162  TVQ 9.620947  TVV2 94.364402  TVKA 1.257439
THETA_CL_WT 0.893249  THETA_CL_CRCL 0.508259  THETA_V1_WT 0.473657
```

Not the same model — the classical example shares one `THETA_WT` between CL and V1, the block
gives each relation its own theta — so these are not expected to match. The
model-for-model comparison is the equivalence test above.

**One thing a reviewer should know.** While running the example for this PR, the block-declared
model came back `converged: false` with every parameter still at its initial estimate. It is
**not** the block: the hand-written model it desugars to, with no `[covariate_model]` anywhere,
stalls identically at the same OFV (-1026.3504) with the same all-at-init vector. Switching the
outer optimizer to BOBYQA converges both to -1199.02. So this is a pre-existing init stall of the
#751 family, exposed by this parameterization and start (three separate covariate exponents
rather than the classical example's two shared ones), not introduced here. The example therefore
carries `optimizer = bobyqa` with a comment saying so. Worth its own issue; happy to open one.

## Performance
- [x] No significant impact expected

The desugar runs once per parse, only when the block is present. A model that declares it parses
`[parameters]` twice (once to learn the η/κ names the insertion-point partition needs, once for
real after the generated `theta` lines are appended) — microseconds, and zero for every model
that does not use the block. Symbolic statistics add one re-parse per fit, the same cost #1064
already pays.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

`cargo test --lib`: 3756 passed, 0 failed.

- **Tier 1** `src/parser/model_parser_tests.rs` (6, new): `present(...)` on its own — true for a
  value and false for a missing one through the compiled bytecode path; agreement with the
  `COV == COV` idiom across `NaN` and both infinities; negation and `&&` composition; an
  expression argument; a covariate column actually *named* `present` still parsing.
- **Tier 1** `src/parser/covariate_model_tests.rs` (37): one test per form asserting the
  *generated text*; the missing-value guard (a NaN covariate must give the same parameter as the
  centring value, and must not be 0); the insertion-point partition, including a κ-bearing factor
  and the hard errors on a sum and on a log-transformed RHS; every validation error; `none`
  round-tripping unchanged.
- **Tier 1** `src/api/tests/covariate_stats_tests.rs` (13): each statistic against a synthetic
  population; per-subject weighting (a subject with 40 records must not drag the median);
  time-varying covariates contributing each distinct value; PsN's `linear` and `hockey` bound
  tables for a known median/min/max; the constant-covariate rejection; the unresolved hard error
  through both `assert_covariate_model_bound` and `check_model_data`; and that binding statistics
  after binding θ-levels preserves the level binding.
- **Tier 2** `tests/covariate_model_equivalence.rs`: the equivalence above, `outer_maxiter = 2`.
- **Tier 3** same file, `slow-tests`-gated: to convergence with a covariance step.

## Example (user-facing features only)
- [x] Example added to `examples/` or inline below

`examples/two_cpt_oral_covmodel.ferx` — `examples/two_cpt_oral_cov.ferx` restated with the block,
and the fixture behind the equivalence test.

`ferx check examples/two_cpt_oral_covmodel.ferx` prints what it built:

```
[individual_parameters] as built from [covariate_model]:
  CL = TVCL * (if (WT == WT) (WT / 70)^THETA_CL_WT else 1.0) * (if (CRCL == CRCL) (CRCL / 100)^THETA_CL_CRCL else 1.0) * exp(ETA_CL)
  V1 = TVV1 * (if (WT == WT) (WT / 70)^THETA_V1_WT else 1.0) * exp(ETA_V1)
  Q  = TVQ  * exp(ETA_Q)
  V2 = TVV2 * exp(ETA_V2)
  KA = TVKA * exp(ETA_KA)
```

and a symbolic-centred run writes the resolved constants back out:

```yaml
covariate_model:
  - parameter: "CL"
    covariate: "WT"
    form: "power"
    center: 70.85  # resolved from median
    thetas:
      - name: "THETA_CL_WT"
        estimate: 0.783371
        se: null
```

## Docs
- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` `[Unreleased]` entry added

New `docs/model-file/covariate-model.qmd` (grammar, form table, the PsN state ↔ ferx form mapping
users coming from scm will look for first, the PsN defaults table, the literal-vs-symbolic
recommendation, the desugaring rule and the `COV_<PARAM>` handle, the SAEM caveat for
`categorical`, and the validation list), cross-linked from `covariates.qmd` and
`individual-parameters.qmd`.

## Checklist
- [x] `cargo clippy` clean (no new warnings from this change)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — none touched; the desugar
      produces ordinary DSL text, and the `Dual2` path compiles it exactly as it compiles a
      hand-written covariate factor. The SE equivalence in the slow test is what pins this.
- [ ] `Cargo.toml` version bumped if breaking (not breaking)

## Docs & examples

### ferx-site
- [x] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened — **not yet; needs a follow-up PR in ferx-site**
- [x] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book — **not yet, same follow-up**
- [x] New data file added to `data/` → none added (reuses `data/two_cpt_oral_cov.csv`)

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened — **not yet, same follow-up**

### Example execution
- [x] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .` — **not run.** The
      local `../ferx-r` checkout does not currently build against `main` either, so a failure there
      would say nothing about this branch; and nothing in ferx-r reads the new surface until its
      own PR.
- [x] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly — no site page exists yet
- [ ] All affected ferx-book chapters render cleanly — no chapter exists yet

## Reviewer hints

Start with the module doc in `src/parser/covariate_model.rs` — it states the three decisions
above (insertion point, missing guard, syntax shape) and why each alternative was rejected.

Worth real scrutiny:

- `insert_factors` / `has_top_level_additive` — the text-level product split. It decides where the
  factor lands, and a wrong classification is a silently different model under SAEM. Look at what
  it accepts as a "simple factor" and whether any real RHS shape is mis-classified rather than
  rejected.
- `build_thetas` / `linear_family_thetas` — the PsN default tables and the constant-covariate
  guard.
- `apply_covariate_model_block` in `model_parser.rs` — the double `parse_parameters`, and its
  placement relative to `absorption_ode_equivalent_source`.

Skimmable: the `types.rs` additions are plain data; the 36 one-line `covariate_model: None` /
`levels: None` / `covariate_relations: Vec::new()` additions across existing test fixtures are
mechanical (new struct fields).

## Open questions

None outstanding. The two raised during review are resolved in the branch: the guard now reads
`if (present(WT)) … else 1.0`, and the one-θ-per-relation restriction is documented rather than
lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ccp783ygYzXWTrXjTLDDgq
