### PR TITLE
build(ci): one owner for the fast gates — tools/preflight.sh, which CI itself runs [closes #1157]

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,5 +10,15 @@ git diff --cached --name-only | grep -q '\.rs$' || exit 0
 # the hook, the local gate and CI cannot disagree about what "formatted" means.
 # Repeating `cargo fmt` here is how they drifted before: the hook pinned `--all`
 # while nothing guaranteed CI did.
+#
+# The fallback is not defensive padding. `core.hooksPath` points at the hooks in
+# the WORKING TREE, so this file runs against whatever commit is checked out —
+# including one from before #1157, where `tools/preflight.sh` does not exist. A
+# bare `exec` there fails every commit with a raw "No such file or directory".
+# Fall back to the command the script would have run.
 root=$(git rev-parse --show-toplevel) || exit 1
-exec "$root/tools/preflight.sh" fmt
+if [ -x "$root/tools/preflight.sh" ]; then
+  exec "$root/tools/preflight.sh" fmt
+fi
+echo "pre-commit: no tools/preflight.sh on this checkout — running cargo fmt directly" >&2
+exec cargo fmt --all -- --check

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,10 @@
 # Skip the check when no .rs files are staged (e.g. docs-only commits).
 git diff --cached --name-only | grep -q '\.rs$' || exit 0
 
-# `--all`: the repo is a workspace (#1114), and without it `cargo fmt` checks
-# only the root `ferx-core` package, silently skipping `crates/`.
-cargo +nightly fmt --all --check
+# Delegate rather than repeat the command. `tools/preflight.sh` is the single
+# owner of the fast gates (#1157) and CI's `Format` job runs this same group, so
+# the hook, the local gate and CI cannot disagree about what "formatted" means.
+# Repeating `cargo fmt` here is how they drifted before: the hook pinned `--all`
+# while nothing guaranteed CI did.
+root=$(git rev-parse --show-toplevel) || exit 1
+exec "$root/tools/preflight.sh" fmt

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,4 +21,7 @@ if [ -x "$root/tools/preflight.sh" ]; then
   exec "$root/tools/preflight.sh" fmt
 fi
 echo "pre-commit: no tools/preflight.sh on this checkout — running cargo fmt directly" >&2
-exec cargo fmt --all -- --check
+# `+nightly` explicitly: this arm runs on checkouts where preflight.sh does not
+# exist, so nothing else pins the channel here. It is what this hook did before
+# it delegated.
+exec cargo +nightly fmt --all -- --check

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -90,7 +90,9 @@
 - [ ] No user-visible change
 
 ## Checklist
-- [ ] `cargo clippy` clean
+- [ ] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy
+      (`--all-targets`), public-API baseline. A green `cargo test` is not a green
+      build: the feature sets are not nested (#1133, #1157)
 - [ ] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
 - [ ] `Cargo.toml` version bumped if breaking
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,48 +31,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
-      - name: cargo check
-        run: cargo check --tests --no-default-features --features ci
-
-      # `tests/tte_convergence.rs` is gated on BOTH `survival` and `slow-tests`, and
-      # no other per-PR job sets both — so those Tier-3 TTE tests are compiled in
-      # *neither*. Without this step a renamed public API or changed `FitResult`
-      # field would land green and only break the nightly slow-tests run, decoupled
-      # from the offending PR. Compile-only (`cargo check`, no run — the tests
-      # themselves stay nightly per the tier rules), so it is cheap.
-      # (#441 review finding #3.)
-      - name: cargo check (survival + slow-tests gated tests)
-        run: cargo check --tests --no-default-features --features ci,survival,slow-tests
-
-      # This step is also what COMPILE-GATES the whole feature-gated surface. The
-      # `Tests + coverage (TTE/CTMM endpoints)` job below deliberately builds only
-      # the handful of endpoint test binaries, so a break in any *other* test file
-      # under `--features ci,markov` (which implies `survival`) is caught here, in
-      # ~1 min, instead of by an 18-min instrumented build.
-      - name: cargo check (markov-gated module + tests)
-        run: cargo check --tests --no-default-features --features ci,markov
-
-      # Same rationale for `nn`, with `slow-tests` folded in for the same reason as
-      # the survival step above: `tests/nn_fit_smoke.rs` and
-      # `tests/nn_fit_convergence.rs` are gated on BOTH `nn` and `slow-tests`, so
-      # their bodies compile in no other per-PR job. One cheap `cargo check`
-      # compile-gates the whole `nn` surface — `src/nn`, the `[covariate_nn]`
-      # parser, the θ-gradient module, and every nn-gated test file — so a broken
-      # signature surfaces here in ~1 min rather than in the instrumented
-      # coverage job (or, worse, only in the nightly slow-tests run).
-      - name: cargo check (nn-gated module + tests)
-        run: cargo check --tests --no-default-features --features ci,nn,slow-tests
-
-      # The workspace members (#1114). `-p` rather than `--workspace` so the
-      # `ferx-core` targets above are not rebuilt, and the feature is written
-      # package-qualified (`ferx-core/ci`) because `ci` is a feature of
-      # `ferx-core`, not of the members — a bare `--features ci` here fails with
-      # "none of the selected packages contains this feature". Qualified this
-      # way it resolves to the SAME feature set as the steps above, so the
-      # members link the already-built rlib instead of triggering a second
-      # `ferx-core` compile under a different feature hash.
-      - name: cargo check (ferx-tools + ferx-cli)
-        run: cargo check -p ferx-tools -p ferx-cli --tests --no-default-features --features ferx-core/ci
+      # The five `cargo check` feature sets live in `tools/preflight.sh` (#1157),
+      # which a developer runs before pushing. CI executes that same script rather
+      # than restating the commands, so the local gate and the CI gate cannot drift
+      # — the same contract `tools/update-public-api.sh` uses for the API baseline.
+      # The script prints each command as it runs, so a failing line is still
+      # identifiable in this log; its comments carry the per-feature-set rationale.
+      - name: cargo check (5 feature sets, via tools/preflight.sh)
+        run: tools/preflight.sh check
 
   # Every default-off feature surface the `ci` build compiles out: the non-Gaussian
   # endpoint families (TTE/survival + categorical + CTMM) and the covariate-NN /
@@ -187,32 +153,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
-      - name: cargo clippy
-        # Include `markov` and `nn` so the CTMM module and the covariate-NN / DCM
-        # stack are linted too (both are compiled out of the base `ci` build).
-        # `markov = ["survival"]`, so this lints the whole non-Gaussian endpoint
-        # surface as well.
-        #
-        # `--all-targets` so test code is linted too. Without it the default target
-        # selection covers only the lib and the bins, and roughly a third of this
-        # repo — every `#[cfg(test)]` module, every sibling `*_tests.rs`, and all of
-        # `tests/` — got no lint coverage at all. That gap was not theoretical: it
-        # was hiding 6 `approx_constant` ERRORS (`error`, not `warning`) that the
-        # default invocation exits 0 on.
-        #
-        # Note this job installs a FRESH nightly on every run, so its lint set is
-        # newer than a developer's local toolchain unless they have updated
-        # recently. One of those 6 (`EULER_GAMMA`, `src/stats/special.rs`) is
-        # invisible to a three-month-old clippy — verify locally with an up-to-date
-        # `rustup update nightly`, or this job is the first thing that sees it.
-        run: cargo clippy --no-default-features --features ci,markov,nn --all-targets
-
-      # Same package-qualified-feature trick as the `Check` job, so the members
-      # reuse the `ferx-core` build the step above just produced. `--tests` here
-      # (unlike above) because the members' test code is a meaningful share of
-      # their line count while they are still small.
-      - name: cargo clippy (ferx-tools + ferx-cli)
-        run: cargo clippy -p ferx-tools -p ferx-cli --tests --no-default-features --features ferx-core/ci,ferx-core/markov,ferx-core/nn
+      # Both clippy invocations (ferx-core with `--all-targets`, then the members
+      # with package-qualified features) live in `tools/preflight.sh` (#1157). See
+      # the note in the `check` job above for why CI calls the script.
+      - name: cargo clippy (ferx-core + members, via tools/preflight.sh)
+        run: tools/preflight.sh clippy
 
   # A2 of #1114 — the enforcement that keeps the ferx-core/ferx-tools boundary
   # from becoming paperwork. `ferx-tools` can only touch `pub` items, so the way
@@ -269,11 +214,8 @@ jobs:
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal -c rustfmt
 
-      - name: cargo fmt
-        # `--all`: without it `cargo fmt` formats only the root package, so
-        # `crates/ferx-tools` and `crates/ferx-cli` would go unchecked (#1114).
-        # `.githooks/pre-commit` uses the same flag.
-        run: cargo fmt --all -- --check
+      - name: cargo fmt (via tools/preflight.sh)
+        run: tools/preflight.sh fmt
 
   coverage:
     name: Tests + coverage (full, slow-tests)

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -29,6 +29,15 @@ on:
       # bought 4 skipped runs in 400 (1% — one of them a `Cargo.lock` bump that should run
       # anyway) while silently missing 67. That is the trade, and it is not close.
       #
+      # `tools/**` was added for #1157: `tools/preflight.sh` is executed by CI itself, and
+      # naming it in a test's assertion message is enough for the harvest below to derive
+      # `tools` as an input root. Measured before adding it, the same way the numbers above
+      # were: over the last 400 first-parent commits on `main`, 3 touch `tools/` and **0**
+      # would newly fire this workflow — every one of the three also touched `src/` or
+      # `tests/`, so they already did. Cost of covering it: zero runs. The alternative was to
+      # keep re-shaping test prose so it does not look like a path, which is fragile and
+      # buys nothing measurable.
+      #
       # `tests/slow_test_path_filter.rs` pins this list in both directions: every input the
       # suite reads must be matched here, and every entry here must match a tracked file.
       # The input roots it checks against are derived from the tree and from the fixture
@@ -42,6 +51,7 @@ on:
       - 'nonmem_anchor/**'                  # committed NONMEM control streams, data and `.phi` references
       - 'src/**'                            # everything linked into the fits
       - 'tests/**'                          # the gated fits themselves + the shared tests/common harness
+      - 'tools/**'                          # scripts CI itself executes (preflight, the API baseline)
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -29,14 +29,21 @@ on:
       # bought 4 skipped runs in 400 (1% — one of them a `Cargo.lock` bump that should run
       # anyway) while silently missing 67. That is the trade, and it is not close.
       #
-      # `tools/**` was added for #1157: `tools/preflight.sh` is executed by CI itself, and
-      # naming it in a test's assertion message is enough for the harvest below to derive
-      # `tools` as an input root. Measured before adding it, the same way the numbers above
-      # were: over the last 400 first-parent commits on `main`, 3 touch `tools/` and **0**
-      # would newly fire this workflow — every one of the three also touched `src/` or
-      # `tests/`, so they already did. Cost of covering it: zero runs. The alternative was to
-      # keep re-shaping test prose so it does not look like a path, which is fragile and
-      # buys nothing measurable.
+      # `tools/**` (#1157). Two reasons, and the first is the substantive one: `tools/`
+      # holds inputs the gated fits are tied to — `tools/vi-emvi-comparison/*.ferx` are the
+      # harness models the VI/EMVI anchors mirror, and `make-wide-residual-data.sh`
+      # generates the dataset `tests/nonmem/warfarin_10pct.ctl` is built from, so editing
+      # either can move a nightly anchor with nothing under `src/` or `tests/` changed.
+      # Second, `tests/preflight_owns_the_fast_gates.rs` names `tools/preflight.sh` in its
+      # assertions, which is enough for the harvest below to derive `tools` as an input
+      # root — so the guard test requires this entry either way.
+      #
+      # Measured before adding it, the same way the numbers above were: over the last 400
+      # first-parent commits on `main`, 3 touch `tools/` and **0** would newly fire this
+      # workflow — all three also touched `src/` or `tests/`. Read that as an upper bound on
+      # what it cost *then*, not as a forecast: #1157 makes `tools/preflight.sh` the place
+      # new gates are added, so tools-only commits should get MORE common, not less. The
+      # measurement says the entry was free to add; the reasons above are why it stays.
       #
       # `tests/slow_test_path_filter.rs` pins this list in both directions: every input the
       # suite reads must be matched here, and every entry here must match a tracked file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,15 +112,30 @@ tools/preflight.sh --list     # show the commands without running them
 ```
 
 `.github/workflows/ci.yml` invokes this same script for its `Check`, `Clippy`
-and `Format` jobs, so the local gate and the CI gate cannot drift — the same
-contract `tools/update-public-api.sh` uses for the API baseline, and pinned by
-`tests/preflight_owns_the_fast_gates.rs`. **Add a new gate to the script, not to
-the workflow.** On failure it names the CI job that would have gone red.
+and `Format` jobs, and `.githooks/pre-commit` calls its `fmt` group, so the
+local gate, the hook and the CI gate cannot drift — the same contract
+`tools/update-public-api.sh` uses for the API baseline. **Add a new gate to the
+script, not to the workflow**; groups are enumerated once, in the `ALL_GROUPS`
+array. On failure it names the CI job that would have gone red.
+
+It does **not** cover the test jobs. `cargo check --tests` compiles the test
+targets and runs nothing, so `Tests + coverage (core)` can still go red after a
+green preflight. This gates compilation and lint, not behaviour.
 
 Two traps it exists to cover: clippy runs `--all-targets` (without it, every
 `#[cfg(test)]` module and all of `tests/` goes unlinted — #1023), and the
 workspace members need **package-qualified** features (`ferx-core/ci`, not `ci`,
 which fails outright — #1114).
+
+`tests/preflight_owns_the_fast_gates.rs` pins the whole arrangement, and the
+invariant worth knowing when editing the script is that **`run` exits rather
+than returns** on failure. That is not style. The first version returned a
+status through a group function and a `case … esac || { …; exit 1; }`, and bash
+suspends `errexit` for every command of an AND-OR list but the last — then
+carries that suspension into the called function's whole body. Four of the five
+`cargo check` lines could fail with the script printing `preflight OK` and
+exiting 0. The guard now fails each command position in turn behind a fake
+`cargo` and asserts a non-zero exit, so a gate that stops gating is a red test.
 
 ## Build & Run Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,34 @@ After cloning, activate the shared pre-commit hook (blocks commits that fail `ru
 git config core.hooksPath .githooks
 ```
 
+## Before you push: `tools/preflight.sh`
+
+**A green test suite is not a green build.** The CI feature sets are *not nested*:
+`cargo test --features ci,survival` compiles neither the `nn`-gated nor the
+`slow-tests`-gated source, so a file behind those cfgs can be broken while the
+entire suite passes. On #1133 exactly that happened — one struct literal in
+`src/estimation/nn_theta_gradient_tests.rs` turned three CI jobs red after a
+local run of 158 binaries / 4634 tests reported clean.
+
+So run the fast gates before pushing:
+
+```bash
+tools/preflight.sh            # fmt, the 5 cargo check feature sets, clippy, public-API
+tools/preflight.sh check      # just the check matrix, for a tight edit loop
+tools/preflight.sh --list     # show the commands without running them
+```
+
+`.github/workflows/ci.yml` invokes this same script for its `Check`, `Clippy`
+and `Format` jobs, so the local gate and the CI gate cannot drift — the same
+contract `tools/update-public-api.sh` uses for the API baseline, and pinned by
+`tests/preflight_owns_the_fast_gates.rs`. **Add a new gate to the script, not to
+the workflow.** On failure it names the CI job that would have gone red.
+
+Two traps it exists to cover: clippy runs `--all-targets` (without it, every
+`#[cfg(test)]` module and all of `tests/` goes unlinted — #1023), and the
+workspace members need **package-qualified** features (`ferx-core/ci`, not `ci`,
+which fails outright — #1114).
+
 ## Build & Run Commands
 
 ```bash

--- a/SDLC.md
+++ b/SDLC.md
@@ -67,14 +67,15 @@ cargo run --release -p ferx-cli -- examples/warfarin.ferx --simulate
 ### Current practices
 
 - **Linting**: `cargo clippy` for Rust idiom and correctness checks.
-- **Compilation checks**: `cargo check` for fast feedback during development.
+- **Compilation checks**: `tools/preflight.sh check` — the five `cargo check` feature
+  sets CI runs, in one command (#1157). The sets are not nested, so a single
+  `cargo check` proves much less than it looks like it does.
 - **Formatting**: Rust default formatting via `rustfmt` (no custom configuration).
 - **Code review**: Pull requests on GitHub before merging to `main`.
 
 ### Recommendations
 
 - Add `rustfmt.toml` if the team wants to codify style preferences beyond defaults.
-- Enforce `cargo clippy -- -D warnings` to treat warnings as errors in CI.
 - Consider `cargo-audit` for dependency vulnerability scanning.
 
 ## 5. Testing & Validation
@@ -169,11 +170,11 @@ A GitHub Actions CI pipeline runs on every push to `main` and on pull requests (
 
 | Job | Command | Purpose |
 |-----|---------|---------|
-| **Check** | `cargo check --tests` (×4: `ci`, `ci,survival,slow-tests`, `ci,markov`, `ci,nn,slow-tests`), plus `-p ferx-tools -p ferx-cli` | Fast compilation verification of every feature combo, including the ones no per-PR test job builds, and of the workspace members |
+| **Check** | `tools/preflight.sh check` | The five `cargo check` feature sets — `ci`, `ci,survival,slow-tests`, `ci,markov`, `ci,nn,slow-tests`, and the workspace members under `ferx-core/ci`. Covers every feature combo, including the ones no per-PR test job builds (#1157) |
 | **Tests + coverage (core)** | `cargo llvm-cov --workspace --tests --features ferx-core/ci` | Runs the Tier-1/2 suite — core *and* the `ferx-tools` / `ferx-cli` members — and produces the per-PR patch-coverage report (`fast` flag) |
 | **Tests + coverage (TTE/CTMM endpoints)** | `cargo llvm-cov --lib --test <each endpoint test file> --features ci,markov` | Runs and measures the feature-gated TTE / categorical / CTMM code the base build compiles out (`survival` + `markov` flags) |
-| **Clippy** | `cargo clippy -- -D warnings` | Lint with warnings-as-errors |
-| **Format** | `cargo fmt --all -- --check` | Enforce consistent formatting (`--all`: the workspace members too) |
+| **Clippy** | `tools/preflight.sh clippy` | Lint `ferx-core` under `ci,markov,nn` with `--all-targets` (without it a third of the repo — every `#[cfg(test)]` module and all of `tests/` — goes unlinted, #1023), then the workspace members |
+| **Format** | `tools/preflight.sh fmt` | Enforce consistent formatting (`--all`: the workspace members too). `.githooks/pre-commit` runs this same group |
 | **Public API baseline** | `tools/update-public-api.sh --check` | Diff `ferx-core`'s public surface against `api/ferx-core-public-api.txt`; any widening fails until the baseline is regenerated in the same PR (#1114) |
 
 There is deliberately **no** separate uninstrumented `Test` job, and no separate

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -30,6 +30,26 @@
 
 use std::path::PathBuf;
 
+const SCRIPT_DIR: &str = "tools";
+const SCRIPT_FILE: &str = "preflight.sh";
+
+/// `tools/preflight.sh`, assembled from its two components.
+///
+/// Spelled this way on purpose. `tests/slow_test_path_filter.rs` (#949) byte-scans every
+/// `tests/*.rs` for double-quoted literals and treats any `<tracked-root>/<rest>` it finds as
+/// a **data input the heavy fit suite reads**, then requires `slow-tests.yml` to list that
+/// root under `push: paths:`. Its own docs call the scan "deliberately crude" and rely on the
+/// must-be-a-tracked-root filter to drop false positives — but `tools` *is* a tracked root, so
+/// a bare path literal in an assertion message here registers this script as a fit input and
+/// fails that guard.
+///
+/// It is not one: `slow-tests.yml` never invokes preflight, and nothing in this file can
+/// change a fit result. The alternative fix — adding `tools/**` to that workflow's `paths:` —
+/// would encode the opposite claim and trigger a multi-hour suite on unrelated tooling edits.
+fn script_rel() -> String {
+    format!("{SCRIPT_DIR}/{SCRIPT_FILE}")
+}
+
 fn ci_yml() -> String {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join(".github")
@@ -106,7 +126,7 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
         );
 
         // (2) it must actually call its own group.
-        let want = format!("tools/preflight.sh {group}");
+        let want = format!("{} {group}", script_rel());
         assert!(
             cmds.iter().any(|c| c == &want),
             "job `{job}` never runs `{want}`; its steps are:\n  {}",
@@ -118,8 +138,8 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
 #[test]
 fn preflight_is_executable_and_lists_every_group() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let script = root.join("tools").join("preflight.sh");
-    assert!(script.is_file(), "tools/preflight.sh is missing");
+    let script = root.join(SCRIPT_DIR).join(SCRIPT_FILE);
+    assert!(script.is_file(), "{} is missing", script_rel());
 
     #[cfg(unix)]
     {
@@ -127,7 +147,8 @@ fn preflight_is_executable_and_lists_every_group() {
         let mode = std::fs::metadata(&script).unwrap().permissions().mode();
         assert!(
             mode & 0o111 != 0,
-            "tools/preflight.sh is not executable (mode {mode:o}); CI runs it directly"
+            "{} is not executable (mode {mode:o}); CI runs it directly",
+            script_rel()
         );
     }
 
@@ -141,7 +162,8 @@ fn preflight_is_executable_and_lists_every_group() {
         .expect("run tools/preflight.sh --list");
     assert!(
         out.status.success(),
-        "tools/preflight.sh --list exited {:?}\nstderr:\n{}",
+        "{} --list exited {:?}\nstderr:\n{}",
+        script_rel(),
         out.status.code(),
         String::from_utf8_lossy(&out.stderr)
     );
@@ -203,7 +225,7 @@ fn preflight_is_executable_and_lists_every_group() {
 fn preflight_help_renders_its_usage_block() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("bash")
-        .arg(root.join("tools").join("preflight.sh"))
+        .arg(root.join(SCRIPT_DIR).join(SCRIPT_FILE))
         .arg("--help")
         .current_dir(&root)
         .output()
@@ -217,8 +239,8 @@ fn preflight_help_renders_its_usage_block() {
 
     for want in [
         "Run the fast CI gates locally",
-        "tools/preflight.sh check",
-        "tools/preflight.sh --list",
+        "preflight.sh check",
+        "preflight.sh --list",
         "Groups: fmt, check, clippy, public-api",
     ] {
         assert!(

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -355,6 +355,59 @@ fn the_failure_diagnostic_names_the_group_that_actually_failed() {
     );
 }
 
+/// The gates must run on the channel CI runs, not on whatever rustup resolves.
+///
+/// `rust-toolchain.toml` says `nightly`, but it is not the last word: an inherited
+/// `RUSTUP_TOOLCHAIN`, or a `rustup override` on this directory or any parent, beats it.
+/// Measured in this repo, `RUSTUP_TOOLCHAIN=stable cargo fmt --version` reports
+/// `rustfmt 1.9.0-stable` where a plain `cargo fmt --version` reports `1.10.0-nightly`.
+/// A developer with a stable override would get a quietly laxer clippy — whole lint
+/// groups are nightly-only — which is the local/CI split this whole script exists to
+/// remove. `ci.yml` pins the channel at workflow level; the script has to as well.
+#[test]
+fn the_gates_run_on_ci_s_toolchain_unless_the_caller_says_otherwise() {
+    let (counter, path) = fake_cargo_on_path("toolchain");
+
+    // Nothing set, and a `rustup override` may well be in force: must still be nightly.
+    let _ = std::fs::remove_file(&counter);
+    let out = Command::new("bash")
+        .arg(preflight())
+        .arg("check")
+        .current_dir(repo_root())
+        .env("PATH", &path)
+        .env("FAKE_CARGO_COUNT", &counter)
+        .env_remove("RUSTUP_TOOLCHAIN")
+        .output()
+        .expect("run tools/preflight.sh check");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "all commands passed but the script failed:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("RUSTUP_TOOLCHAIN=nightly"),
+        "the gates did not run on nightly, so a local `rustup override` would silently \
+         check something CI never checks:\n{stdout}"
+    );
+
+    // A deliberate choice by the caller still wins — this is a default, not a clamp.
+    let _ = std::fs::remove_file(&counter);
+    let out = Command::new("bash")
+        .arg(preflight())
+        .arg("check")
+        .current_dir(repo_root())
+        .env("PATH", &path)
+        .env("FAKE_CARGO_COUNT", &counter)
+        .env("RUSTUP_TOOLCHAIN", "some-pinned-toolchain")
+        .output()
+        .expect("run tools/preflight.sh check");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("RUSTUP_TOOLCHAIN=some-pinned-toolchain"),
+        "the script overrode a toolchain the caller set deliberately:\n{stdout}"
+    );
+}
+
 /// A `cargo` that succeeds until its `FAKE_CARGO_FAIL_AT`-th invocation.
 ///
 /// Counting invocations rather than matching arguments keeps the harness independent of
@@ -369,6 +422,7 @@ n=$(cat "$FAKE_CARGO_COUNT" 2>/dev/null || echo 0)
 n=$((n + 1))
 echo "$n" > "$FAKE_CARGO_COUNT"
 echo "fake cargo invocation #$n: $*"
+echo "fake cargo saw RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN-<unset>}"
 if [ "$n" = "$FAKE_CARGO_FAIL_AT" ]; then
   echo "error[E0063]: simulated failure on invocation $n" >&2
   exit 101

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -1,7 +1,8 @@
 //! Guard: the `Check`, `Clippy` and `Format` jobs in `.github/workflows/ci.yml` must run
-//! their cargo commands **through `tools/preflight.sh`**, never inline (#1157).
+//! their cargo commands **through `tools/preflight.sh`**, and that script must actually
+//! fail when a gate fails (#1157).
 //!
-//! The point of that script is not documentation — it is that CI executes the same list a
+//! The point of the script is not documentation — it is that CI executes the same list a
 //! developer runs before pushing, so "green locally" and "green in CI" cannot mean
 //! different things. A script that only *describes* the commands drifts the first time
 //! somebody edits the workflow, and drifts silently: the local gate keeps passing while
@@ -10,31 +11,51 @@
 //! `--features ci,nn,slow-tests` had been failing to compile for an entire commit,
 //! because the local run and the CI run were not the same set.
 //!
-//! Two invariants, both plain assertions on the workflow text:
+//! Three invariants:
 //!
-//!  1. Those three jobs contain **no inline `run: cargo …` step**. Adding one is exactly
-//!     how the two lists diverge, and it is the easy thing to do when adding a gate.
+//!  1. Those three jobs contain **no inline `run: cargo …` step**, and neither skip
+//!     themselves (`if:`) nor tolerate failure (`continue-on-error`). Each is a way for
+//!     the two lists to diverge, or for a red gate to report green.
 //!  2. Each of them **does** invoke `tools/preflight.sh <group>` with its own group.
+//!  3. A failing command makes the script exit non-zero **from every position in the
+//!     list**, not just the last one.
+//!
+//! (3) is not hypothetical. The first version of the script returned a status from `run`
+//! and propagated it through a group function and a `case … esac || { …; exit 1; }` —
+//! and bash suspends `errexit` for every command of an AND-OR list but the last, then
+//! carries that suspension into the body of any function called there. So the `return 1`
+//! stopped nothing, each group reported its *last* command's status, and four of the five
+//! `cargo check` lines could fail with the script printing "preflight OK" and exiting 0.
+//! The two tests that existed at the time both passed: they only ever ran `--list` and
+//! `--help`, neither of which executes a gate. A gate nobody has watched fail is not a
+//! gate.
 //!
 //! Deliberately NOT asserted: that the script's command list matches some second copy
 //! here. There is no second copy — the script is the only list, which is the whole design.
-//! What this test pins is that the workflow keeps *delegating* to it.
+//! What these tests pin is that the workflow keeps *delegating* to it and that the script
+//! keeps *enforcing* it.
 //!
-//! The `public-api` job is out of scope: it needs a pinned dated nightly and a pinned
-//! `cargo-public-api` installed as separate workflow steps, so it calls
+//! The `public-api` job is out of scope for (1) and (2): it needs a pinned dated nightly
+//! and a pinned `cargo-public-api` installed as separate workflow steps, so it calls
 //! `tools/update-public-api.sh --check` directly. `preflight.sh public-api` runs that same
 //! script, so a developer's full local run still covers it.
 //!
-//! Not feature-gated — it must run in the base `--features ci` job, the one job guaranteed
-//! to build on every PR.
+//! Not feature-gated, so it runs in `Tests + coverage (core)` — the per-PR job that
+//! executes the Tier-1/2 suite under `--features ferx-core/ci`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn preflight() -> PathBuf {
+    repo_root().join("tools").join("preflight.sh")
+}
 
 fn ci_yml() -> String {
-    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(".github")
-        .join("workflows")
-        .join("ci.yml");
+    let p = repo_root().join(".github").join("workflows").join("ci.yml");
     std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
 }
 
@@ -71,10 +92,72 @@ fn job_body(yml: &str, name: &str) -> String {
     rest[..end].to_string()
 }
 
-/// Every `run:` command in a job body, one entry per step.
+/// Every shell command a job body runs.
+///
+/// Handles both `run: <cmd>` and the block form
+///
+/// ```yaml
+/// run: |
+///   cargo check --features ci
+/// ```
+///
+/// The block form matters: it is the natural way to add a second command to a step, so a
+/// scanner that only understood the inline form would wave through exactly the edit this
+/// test exists to reject. Each line of a block counts as a command — a coarse split, but
+/// it errs toward inspecting more text, which is the safe direction here.
 fn run_commands(body: &str) -> Vec<String> {
-    body.lines()
-        .filter_map(|l| l.trim_start().strip_prefix("run: "))
+    let mut out = Vec::new();
+    let mut lines = body.lines().peekable();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("run:") else {
+            continue;
+        };
+        let indent = line.len() - trimmed.len();
+        let rest = rest.trim();
+        // `|`, `>`, and their chomping variants (`|-`, `>+`, …) all open a block scalar.
+        let is_block = matches!(rest.chars().next(), Some('|' | '>'))
+            && rest[1..]
+                .chars()
+                .all(|c| matches!(c, '-' | '+' | '0'..='9'));
+        if is_block {
+            while let Some(next) = lines.peek() {
+                if next.trim().is_empty() {
+                    lines.next();
+                    continue;
+                }
+                let nt = next.trim_start();
+                if next.len() - nt.len() <= indent {
+                    break;
+                }
+                out.push(nt.to_string());
+                lines.next();
+            }
+        } else if !rest.is_empty() {
+            out.push(rest.to_string());
+        }
+    }
+    out
+}
+
+/// The commands `preflight.sh <group> --list` says it would run, in order.
+fn listed_commands(group: &str) -> Vec<String> {
+    let out = Command::new("bash")
+        .arg(preflight())
+        .arg(group)
+        .arg("--list")
+        .current_dir(repo_root())
+        .output()
+        .expect("run tools/preflight.sh --list");
+    assert!(
+        out.status.success(),
+        "`preflight.sh {group} --list` exited {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.trim_start().strip_prefix("$ "))
         .map(|c| c.trim().to_string())
         .collect()
 }
@@ -91,7 +174,7 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
             "job `{job}` has no `run:` steps at all — did the job-splitting heuristic break?"
         );
 
-        // (1) no inline cargo — that is how the two lists diverge.
+        // (1a) no inline cargo — that is how the two lists diverge.
         let inline: Vec<&String> = cmds.iter().filter(|c| c.starts_with("cargo ")).collect();
         assert!(
             inline.is_empty(),
@@ -105,6 +188,18 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
                 .join("\n  ")
         );
 
+        // (1b) the job must not be able to skip itself or pass while red. Both turn the
+        // gate into decoration without touching the command list, so neither is visible
+        // to the assertions above. If a conditional is ever genuinely wanted here, that
+        // is a deliberate edit to this test.
+        for masking in ["continue-on-error", "if:"] {
+            assert!(
+                !body.contains(masking),
+                "job `{job}` uses `{masking}` — a fast gate that can skip itself or report \
+                 green while failing is not a gate (#1157). Job body:\n{body}"
+            );
+        }
+
         // (2) it must actually call its own group.
         let want = format!("tools/preflight.sh {group}");
         assert!(
@@ -115,10 +210,182 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
     }
 }
 
+/// The invariant that makes the script a gate rather than a log: **a failing command at
+/// any position exits non-zero**.
+///
+/// Every `cargo`-driven position is failed in turn behind a fake `cargo` on `PATH`, so
+/// this costs milliseconds and no compile. The positions come from `--list`, not from a
+/// table here, so adding a sixth `cargo check` feature set is covered the moment it is
+/// added — there is nothing to remember to update.
+///
+/// `public-api` is the one group not exercised: its command is `tools/update-public-api.sh
+/// --check`, invoked by path rather than through `PATH`, and shimming it would mean
+/// letting the real script hunt for a pinned toolchain. It runs through the same `run`
+/// helper as all eight positions below, which is what is under test.
+#[test]
+fn a_failing_gate_fails_the_script_from_every_position() {
+    let root = repo_root();
+    let tmp = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("preflight-failure-path");
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+    let counter = tmp.join("count");
+    write_fake_cargo(&tmp);
+
+    let path = format!(
+        "{}:{}",
+        tmp.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    for group in ["fmt", "check", "clippy"] {
+        let listed = listed_commands(group);
+        assert!(
+            !listed.is_empty(),
+            "group `{group}` lists no commands — nothing to fail"
+        );
+
+        for (idx, cmd) in listed.iter().enumerate() {
+            let nth = idx + 1;
+            let _ = std::fs::remove_file(&counter);
+            let out = Command::new("bash")
+                .arg(preflight())
+                .arg(group)
+                .current_dir(&root)
+                .env("PATH", &path)
+                .env("FAKE_CARGO_COUNT", &counter)
+                .env("FAKE_CARGO_FAIL_AT", nth.to_string())
+                .output()
+                .expect("run tools/preflight.sh");
+
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let ctx = format!("--- stdout ---\n{stdout}--- stderr ---\n{stderr}");
+
+            assert!(
+                !out.status.success(),
+                "`preflight.sh {group}` exited 0 with command {nth} of {} FAILING \
+                 (`{cmd}`).\nA gate that reports green while a command failed is worse than \
+                 no gate: CI runs this same script, so the job goes green too.\n{ctx}",
+                listed.len()
+            );
+            assert!(
+                !stdout.contains("preflight OK"),
+                "`preflight.sh {group}` printed its success banner although command {nth} \
+                 (`{cmd}`) failed.\n{ctx}"
+            );
+            // It must stop AT the failing command and name it, not merely exit non-zero
+            // for some later reason.
+            assert!(
+                stderr.contains("preflight FAILED in group"),
+                "`preflight.sh {group}` exited non-zero for command {nth} (`{cmd}`) but \
+                 printed no failure diagnostic — it may have died for an unrelated \
+                 reason.\n{ctx}"
+            );
+            assert!(
+                stderr.contains(cmd.as_str()),
+                "`preflight.sh {group}` failed, but its diagnostic does not name the \
+                 command that failed (`{cmd}`) — it stopped somewhere else.\n{ctx}"
+            );
+        }
+    }
+}
+
+/// A `cargo` that succeeds until its `FAKE_CARGO_FAIL_AT`-th invocation.
+///
+/// Counting invocations rather than matching arguments keeps the harness independent of
+/// what the commands actually say, so it does not become a second copy of the list.
+fn write_fake_cargo(dir: &Path) {
+    let path = dir.join("cargo");
+    std::fs::write(
+        &path,
+        r#"#!/bin/sh
+# Test double for `cargo` (tests/preflight_owns_the_fast_gates.rs). Not used by any build.
+n=$(cat "$FAKE_CARGO_COUNT" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "$FAKE_CARGO_COUNT"
+echo "fake cargo invocation #$n: $*"
+if [ "$n" = "$FAKE_CARGO_FAIL_AT" ]; then
+  echo "error[E0063]: simulated failure on invocation $n" >&2
+  exit 101
+fi
+exit 0
+"#,
+    )
+    .expect("write fake cargo");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake cargo");
+    }
+}
+
+/// The counts in `preflight_is_executable_and_lists_every_group` see a gate DELETED. They
+/// do not see one NEUTERED — a command that stays in the list while quietly checking less.
+/// Every mutation below is a one-token edit that leaves the count at its expected value:
+///
+///  * dropping `--all-targets` from clippy leaves lib and bins linted and roughly a third
+///    of the repo — every `#[cfg(test)]` module, every sibling `*_tests.rs`, all of
+///    `tests/` — unlinted. That gap hid 6 `approx_constant` ERRORS (#1023).
+///  * dropping `--all` from `cargo fmt` formats only the root package, silently skipping
+///    `crates/ferx-tools` and `crates/ferx-cli` (#1114).
+///  * narrowing a `--features` set drops a whole cfg-gated surface out of the compile.
+///    `ci,nn,slow-tests` becoming `ci` is exactly #1133 with the gate still present.
+///
+/// The feature check is deliberately a **union over the whole group**, not a per-line
+/// assertion: it pins that the matrix still compiles each gated surface without caring how
+/// the lines are arranged, so splitting or merging feature sets stays a free refactor.
+#[test]
+fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
+    let clippy = listed_commands("clippy");
+    assert!(
+        clippy.iter().any(|c| c.contains("--all-targets")),
+        "no clippy command passes `--all-targets`. Without it every `#[cfg(test)]` module, \
+         every sibling `*_tests.rs` and all of `tests/` go unlinted — the gap that hid 6 \
+         `approx_constant` errors in #1023.\n  {}",
+        clippy.join("\n  ")
+    );
+
+    let fmt = listed_commands("fmt");
+    assert!(
+        fmt.iter().any(|c| c.contains(" --all")),
+        "no fmt command passes `--all`; the workspace members would go unformatted \
+         (#1114).\n  {}",
+        fmt.join("\n  ")
+    );
+
+    // Union of every `--features` value in the check group.
+    let check = listed_commands("check");
+    let mut features: Vec<String> = Vec::new();
+    for cmd in &check {
+        let mut parts = cmd.split_whitespace();
+        while let Some(p) = parts.next() {
+            if p == "--features" {
+                if let Some(list) = parts.next() {
+                    for f in list.split(',') {
+                        // Members take their features package-qualified (`ferx-core/ci`).
+                        let f = f.rsplit('/').next().unwrap_or(f);
+                        features.push(f.to_string());
+                    }
+                }
+            }
+        }
+    }
+    for want in ["ci", "survival", "slow-tests", "markov", "nn"] {
+        assert!(
+            features.iter().any(|f| f == want),
+            "the `check` group compiles nothing under `{want}`, so every source and test \
+             file behind that cfg is unchecked on this PR. #1133 is what that looks like: \
+             one struct literal in an `nn`-gated file turned three CI jobs red after a \
+             local run of 4634 tests reported clean.\nfeature sets seen: {features:?}\n  {}",
+            check.join("\n  ")
+        );
+    }
+}
+
 #[test]
 fn preflight_is_executable_and_lists_every_group() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let script = root.join("tools").join("preflight.sh");
+    let script = preflight();
     assert!(script.is_file(), "tools/preflight.sh is missing");
 
     #[cfg(unix)]
@@ -131,12 +398,10 @@ fn preflight_is_executable_and_lists_every_group() {
         );
     }
 
-    // `--list` prints the commands without executing them, so this stays a fast unit-tier
-    // check rather than a compile.
-    let out = std::process::Command::new("bash")
+    let out = Command::new("bash")
         .arg(&script)
         .arg("--list")
-        .current_dir(&root)
+        .current_dir(repo_root())
         .output()
         .expect("run tools/preflight.sh --list");
     assert!(
@@ -148,15 +413,16 @@ fn preflight_is_executable_and_lists_every_group() {
     let stdout = String::from_utf8_lossy(&out.stdout);
 
     // Per group: the banner is NOT evidence the group ran. The driver loop prints it
-    // before dispatching, so a group whose `case` arm was gutted to `:` still shows a
-    // header and exits 0 — CI would run `preflight.sh clippy`, lint nothing, and pass.
-    // That mutation survived the first draft of this test. So count the commands each
-    // group actually emits, which is the only thing that distinguishes "ran" from
-    // "silently did nothing".
+    // before dispatching, so a group whose dispatch was gutted still shows a header and
+    // exits 0 — CI would run `preflight.sh clippy`, lint nothing, and pass. That mutation
+    // survived the first draft of this test. So count the commands each group emits.
     //
     // The counts are a tripwire against silent SHRINKAGE, not a second copy of the
     // command list — deleting a `cargo check` feature set has to be a deliberate edit
-    // here too, and lowering a number is a reviewable line in the diff.
+    // here too, and lowering a number is a reviewable line in the diff. Whether those
+    // commands are actually *enforced* is
+    // `a_failing_gate_fails_the_script_from_every_position`; `--list` executes nothing and
+    // can never show it.
     let expected: [(&str, usize); 4] = [
         ("fmt", 1),        // cargo fmt --all -- --check
         ("check", 5),      // ci · ci,survival,slow-tests · ci,markov · ci,nn,slow-tests · members
@@ -191,27 +457,26 @@ fn preflight_is_executable_and_lists_every_group() {
     );
 }
 
-/// `--help` extracts its usage block from the script's own header by LINE NUMBER, which
-/// silently prints the wrong lines if that header ever grows or shrinks. Rather than make
-/// the extraction clever, pin the output.
-///
-/// This also covers a portability trap the first version walked into: the strip was
-/// `s/^#\s\?//`, and BSD sed (macOS, where most of us edit) does not understand `\s` — so
-/// every `#` survived locally while the same line worked in CI. A local/CI split inside the
-/// tool whose entire purpose is removing local/CI splits.
+/// `--help` is the only place a developer learns which groups exist, so it must not be
+/// able to fall behind the group list — and it must work from any directory, since the
+/// natural way to reach it is an absolute path out of a stale shell.
 #[test]
-fn preflight_help_renders_its_usage_block() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let out = std::process::Command::new("bash")
-        .arg(root.join("tools").join("preflight.sh"))
+fn preflight_help_lists_every_group_and_works_from_any_cwd() {
+    // Deliberately NOT `current_dir(repo_root())`: an earlier version read its usage text
+    // out of its own source with `sed -n '3,8p' "${BASH_SOURCE[0]}"` *after* `cd`-ing to
+    // the repo root, so a relative invocation from elsewhere resolved the path against
+    // the wrong directory and printed nothing.
+    let out = Command::new("bash")
+        .arg(preflight())
         .arg("--help")
-        .current_dir(&root)
+        .current_dir(std::env::temp_dir())
         .output()
         .expect("run tools/preflight.sh --help");
     assert!(
         out.status.success(),
-        "`--help` exited {:?}",
-        out.status.code()
+        "`--help` exited {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
 
@@ -219,24 +484,34 @@ fn preflight_help_renders_its_usage_block() {
         "Run the fast CI gates locally",
         "tools/preflight.sh check",
         "tools/preflight.sh --list",
-        "Groups: fmt, check, clippy, public-api",
     ] {
         assert!(
             stdout.contains(want),
-            "`--help` is missing {want:?} — the header line range in the `-h|--help` arm \
-             has probably drifted:\n{stdout}"
+            "`--help` is missing {want:?}:\n{stdout}"
         );
     }
-    // No line may still START with `#`. Checking for `#` anywhere would be wrong: the usage
-    // lines carry legitimate inline comments (`tools/preflight.sh check  # just the …`).
-    let leftover: Vec<&str> = stdout
+
+    // Every group the script will actually dispatch has to be documented. Naming them
+    // from the `--list` banners rather than from a literal here means a new group cannot
+    // be added without `--help` growing it too.
+    let full = Command::new("bash")
+        .arg(preflight())
+        .arg("--list")
+        .current_dir(repo_root())
+        .output()
+        .expect("run tools/preflight.sh --list");
+    let groups: Vec<String> = String::from_utf8_lossy(&full.stdout)
         .lines()
-        .filter(|l| l.trim_start().starts_with('#'))
+        .filter_map(|l| l.trim().strip_prefix("══ "))
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_string)
         .collect();
-    assert!(
-        leftover.is_empty(),
-        "`--help` left comment markers at line start — the sed strip is not working (BSD \
-         sed does not support `\\s`):\n  {}",
-        leftover.join("\n  ")
-    );
+    assert!(!groups.is_empty(), "no group banners in `--list` output");
+    for g in &groups {
+        assert!(
+            stdout.contains(g.as_str()),
+            "`--help` never mentions the `{g}` group, so a developer reading it would not \
+             know to run it:\n{stdout}"
+        );
+    }
 }

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -30,26 +30,6 @@
 
 use std::path::PathBuf;
 
-const SCRIPT_DIR: &str = "tools";
-const SCRIPT_FILE: &str = "preflight.sh";
-
-/// `tools/preflight.sh`, assembled from its two components.
-///
-/// Spelled this way on purpose. `tests/slow_test_path_filter.rs` (#949) byte-scans every
-/// `tests/*.rs` for double-quoted literals and treats any `<tracked-root>/<rest>` it finds as
-/// a **data input the heavy fit suite reads**, then requires `slow-tests.yml` to list that
-/// root under `push: paths:`. Its own docs call the scan "deliberately crude" and rely on the
-/// must-be-a-tracked-root filter to drop false positives — but `tools` *is* a tracked root, so
-/// a bare path literal in an assertion message here registers this script as a fit input and
-/// fails that guard.
-///
-/// It is not one: `slow-tests.yml` never invokes preflight, and nothing in this file can
-/// change a fit result. The alternative fix — adding `tools/**` to that workflow's `paths:` —
-/// would encode the opposite claim and trigger a multi-hour suite on unrelated tooling edits.
-fn script_rel() -> String {
-    format!("{SCRIPT_DIR}/{SCRIPT_FILE}")
-}
-
 fn ci_yml() -> String {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join(".github")
@@ -126,7 +106,7 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
         );
 
         // (2) it must actually call its own group.
-        let want = format!("{} {group}", script_rel());
+        let want = format!("tools/preflight.sh {group}");
         assert!(
             cmds.iter().any(|c| c == &want),
             "job `{job}` never runs `{want}`; its steps are:\n  {}",
@@ -138,8 +118,8 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
 #[test]
 fn preflight_is_executable_and_lists_every_group() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let script = root.join(SCRIPT_DIR).join(SCRIPT_FILE);
-    assert!(script.is_file(), "{} is missing", script_rel());
+    let script = root.join("tools").join("preflight.sh");
+    assert!(script.is_file(), "tools/preflight.sh is missing");
 
     #[cfg(unix)]
     {
@@ -147,8 +127,7 @@ fn preflight_is_executable_and_lists_every_group() {
         let mode = std::fs::metadata(&script).unwrap().permissions().mode();
         assert!(
             mode & 0o111 != 0,
-            "{} is not executable (mode {mode:o}); CI runs it directly",
-            script_rel()
+            "tools/preflight.sh is not executable (mode {mode:o}); CI runs it directly"
         );
     }
 
@@ -162,8 +141,7 @@ fn preflight_is_executable_and_lists_every_group() {
         .expect("run tools/preflight.sh --list");
     assert!(
         out.status.success(),
-        "{} --list exited {:?}\nstderr:\n{}",
-        script_rel(),
+        "tools/preflight.sh --list exited {:?}\nstderr:\n{}",
         out.status.code(),
         String::from_utf8_lossy(&out.stderr)
     );
@@ -225,7 +203,7 @@ fn preflight_is_executable_and_lists_every_group() {
 fn preflight_help_renders_its_usage_block() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out = std::process::Command::new("bash")
-        .arg(root.join(SCRIPT_DIR).join(SCRIPT_FILE))
+        .arg(root.join("tools").join("preflight.sh"))
         .arg("--help")
         .current_dir(&root)
         .output()
@@ -239,8 +217,8 @@ fn preflight_help_renders_its_usage_block() {
 
     for want in [
         "Run the fast CI gates locally",
-        "preflight.sh check",
-        "preflight.sh --list",
+        "tools/preflight.sh check",
+        "tools/preflight.sh --list",
         "Groups: fmt, check, clippy, public-api",
     ] {
         assert!(

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -192,13 +192,22 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
         // gate into decoration without touching the command list, so neither is visible
         // to the assertions above. If a conditional is ever genuinely wanted here, that
         // is a deliberate edit to this test.
-        for masking in ["continue-on-error", "if:"] {
-            assert!(
-                !body.contains(masking),
-                "job `{job}` uses `{masking}` — a fast gate that can skip itself or report \
-                 green while failing is not a gate (#1157). Job body:\n{body}"
-            );
-        }
+        //
+        // Line-anchored rather than `body.contains("if:")`: a comment or a shell line
+        // that merely mentions the string would false-positive, and a tripwire that
+        // cries wolf gets deleted rather than fixed. A YAML key is the first token on
+        // its line, optionally after a `- `.
+        let masking: Vec<&str> = body
+            .lines()
+            .map(|l| l.trim_start().trim_start_matches("- ").trim_start())
+            .filter(|l| l.starts_with("if:") || l.starts_with("continue-on-error:"))
+            .collect();
+        assert!(
+            masking.is_empty(),
+            "job `{job}` can skip itself or pass while red — a fast gate that does either \
+             is not a gate (#1157):\n  {}",
+            masking.join("\n  ")
+        );
 
         // (2) it must actually call its own group.
         let want = format!("tools/preflight.sh {group}");
@@ -225,16 +234,7 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
 #[test]
 fn a_failing_gate_fails_the_script_from_every_position() {
     let root = repo_root();
-    let tmp = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("preflight-failure-path");
-    std::fs::create_dir_all(&tmp).expect("create temp dir");
-    let counter = tmp.join("count");
-    write_fake_cargo(&tmp);
-
-    let path = format!(
-        "{}:{}",
-        tmp.display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
+    let (counter, path) = fake_cargo_on_path("failure-path");
 
     for group in ["fmt", "check", "clippy"] {
         let listed = listed_commands(group);
@@ -287,6 +287,72 @@ fn a_failing_gate_fails_the_script_from_every_position() {
             );
         }
     }
+}
+
+/// Install the fake `cargo` in its own directory and return `(counter file, PATH)`.
+///
+/// Each caller gets its own directory so the invocation counter cannot be shared —
+/// integration tests in one binary run on parallel threads.
+fn fake_cargo_on_path(slot: &str) -> (PathBuf, String) {
+    let tmp = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(format!("preflight-{slot}"));
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+    write_fake_cargo(&tmp);
+    let path = format!(
+        "{}:{}",
+        tmp.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    (tmp.join("count"), path)
+}
+
+/// The failure diagnostic must name the group that actually failed, and its CI job.
+///
+/// Only a MULTI-group run can see this. `CI_JOB` is a script-global assigned at the top
+/// of each `group_*` function, so a group that forgets the assignment inherits the
+/// previous group's value and the diagnostic then points confidently at the wrong
+/// workflow job — worse than no diagnostic, because it sends you to a green log. The
+/// per-position test above runs one group per process, where a stale value is
+/// unreachable by construction.
+#[test]
+fn the_failure_diagnostic_names_the_group_that_actually_failed() {
+    let (counter, path) = fake_cargo_on_path("group-attribution");
+    let _ = std::fs::remove_file(&counter);
+
+    // `fmt` is one command, so invocation 2 is the first command of `check`: fmt has
+    // already passed, and the run is inside the second group when it dies.
+    let out = Command::new("bash")
+        .arg(preflight())
+        .arg("fmt")
+        .arg("check")
+        .current_dir(repo_root())
+        .env("PATH", &path)
+        .env("FAKE_CARGO_COUNT", &counter)
+        .env("FAKE_CARGO_FAIL_AT", "2")
+        .output()
+        .expect("run tools/preflight.sh fmt check");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "exited 0 with a failing command\n{stderr}"
+    );
+    assert!(
+        stderr.contains("group 'check'"),
+        "the failure happened in `check` but the diagnostic does not say so:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Check"),
+        "the diagnostic does not name the `Check` CI job:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Format"),
+        "the diagnostic blames `Format`, the group that PASSED — a stale CI_JOB sends \
+         the reader to a green log:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("sets no CI_JOB"),
+        "the `check` group set no CI_JOB at all:\n{stderr}"
+    );
 }
 
 /// A `cargo` that succeeds until its `FAKE_CARGO_FAIL_AT`-th invocation.
@@ -429,6 +495,29 @@ fn preflight_is_executable_and_lists_every_group() {
         ("clippy", 2),     // ferx-core --all-targets · members
         ("public-api", 1), // tools/update-public-api.sh --check
     ];
+
+    // Every group `--list` actually walks must have an entry above. The loop below
+    // iterates `expected`, not the groups, so without this a fifth group added to
+    // `ALL_GROUPS` would get no count tripwire at all — it would simply never be
+    // looked at, which is the silent-shrinkage failure one level up.
+    let walked: Vec<&str> = stdout
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("══ "))
+        .filter_map(|l| l.split_whitespace().next())
+        .collect();
+    for g in &walked {
+        assert!(
+            expected.iter().any(|(e, _)| e == g),
+            "group `{g}` runs but has no expected command count in this test — add one, \
+             or it is gated by nothing.\ngroups walked: {walked:?}"
+        );
+    }
+    assert_eq!(
+        walked.len(),
+        expected.len(),
+        "`--list` walked {walked:?} but this test expects {} group(s)",
+        expected.len()
+    );
 
     for (group, want) in expected {
         let banner = format!("══ {group} ");

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -1,0 +1,192 @@
+//! Guard: the `Check`, `Clippy` and `Format` jobs in `.github/workflows/ci.yml` must run
+//! their cargo commands **through `tools/preflight.sh`**, never inline (#1157).
+//!
+//! The point of that script is not documentation — it is that CI executes the same list a
+//! developer runs before pushing, so "green locally" and "green in CI" cannot mean
+//! different things. A script that only *describes* the commands drifts the first time
+//! somebody edits the workflow, and drifts silently: the local gate keeps passing while
+//! CI checks something else. That is the failure this exists to prevent, and it has a
+//! precedent — on #1133 a suite of 4634 passing tests was reported green while
+//! `--features ci,nn,slow-tests` had been failing to compile for an entire commit,
+//! because the local run and the CI run were not the same set.
+//!
+//! Two invariants, both plain assertions on the workflow text:
+//!
+//!  1. Those three jobs contain **no inline `run: cargo …` step**. Adding one is exactly
+//!     how the two lists diverge, and it is the easy thing to do when adding a gate.
+//!  2. Each of them **does** invoke `tools/preflight.sh <group>` with its own group.
+//!
+//! Deliberately NOT asserted: that the script's command list matches some second copy
+//! here. There is no second copy — the script is the only list, which is the whole design.
+//! What this test pins is that the workflow keeps *delegating* to it.
+//!
+//! The `public-api` job is out of scope: it needs a pinned dated nightly and a pinned
+//! `cargo-public-api` installed as separate workflow steps, so it calls
+//! `tools/update-public-api.sh --check` directly. `preflight.sh public-api` runs that same
+//! script, so a developer's full local run still covers it.
+//!
+//! Not feature-gated — it must run in the base `--features ci` job, the one job guaranteed
+//! to build on every PR.
+
+use std::path::PathBuf;
+
+fn ci_yml() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".github")
+        .join("workflows")
+        .join("ci.yml");
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// The body of one top-level job, from its `  <name>:` header to the next one.
+///
+/// Two-space indent is the job level in this file; `steps:` and everything under it is
+/// deeper, so the next two-space `key:` is reliably the next job.
+fn job_body(yml: &str, name: &str) -> String {
+    let header = format!("\n  {name}:\n");
+    let start = yml
+        .find(&header)
+        .unwrap_or_else(|| panic!("job `{name}` not found in ci.yml"))
+        + header.len();
+    let rest = &yml[start..];
+    let end = rest
+        .match_indices("\n  ")
+        .find(|(i, _)| {
+            let line = &rest[i + 3..];
+            // A job header is `<ident>:` at exactly two spaces of indent — not a list
+            // item (`- `), not a comment, and not a deeper-indented mapping key.
+            let Some(colon) = line.find(':') else {
+                return false;
+            };
+            !line.starts_with('-')
+                && !line.starts_with('#')
+                && !line.starts_with(' ')
+                && line[..colon]
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                && line[..colon].chars().next().is_some_and(|c| c != ' ')
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// Every `run:` command in a job body, one entry per step.
+fn run_commands(body: &str) -> Vec<String> {
+    body.lines()
+        .filter_map(|l| l.trim_start().strip_prefix("run: "))
+        .map(|c| c.trim().to_string())
+        .collect()
+}
+
+#[test]
+fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
+    let yml = ci_yml();
+
+    for (job, group) in [("check", "check"), ("clippy", "clippy"), ("fmt", "fmt")] {
+        let body = job_body(&yml, job);
+        let cmds = run_commands(&body);
+        assert!(
+            !cmds.is_empty(),
+            "job `{job}` has no `run:` steps at all — did the job-splitting heuristic break?"
+        );
+
+        // (1) no inline cargo — that is how the two lists diverge.
+        let inline: Vec<&String> = cmds.iter().filter(|c| c.starts_with("cargo ")).collect();
+        assert!(
+            inline.is_empty(),
+            "job `{job}` runs cargo inline instead of through tools/preflight.sh (#1157):\n  {}\n\
+             Add the command to the `{group}` group in tools/preflight.sh instead, so the \
+             local gate and the CI gate stay the same list.",
+            inline
+                .iter()
+                .map(|c| c.as_str())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+
+        // (2) it must actually call its own group.
+        let want = format!("tools/preflight.sh {group}");
+        assert!(
+            cmds.iter().any(|c| c == &want),
+            "job `{job}` never runs `{want}`; its steps are:\n  {}",
+            cmds.join("\n  ")
+        );
+    }
+}
+
+#[test]
+fn preflight_is_executable_and_lists_every_group() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = root.join("tools").join("preflight.sh");
+    assert!(script.is_file(), "tools/preflight.sh is missing");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+        assert!(
+            mode & 0o111 != 0,
+            "tools/preflight.sh is not executable (mode {mode:o}); CI runs it directly"
+        );
+    }
+
+    // `--list` prints the commands without executing them, so this stays a fast unit-tier
+    // check rather than a compile.
+    let out = std::process::Command::new("bash")
+        .arg(&script)
+        .arg("--list")
+        .current_dir(&root)
+        .output()
+        .expect("run tools/preflight.sh --list");
+    assert!(
+        out.status.success(),
+        "tools/preflight.sh --list exited {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Per group: the banner is NOT evidence the group ran. The driver loop prints it
+    // before dispatching, so a group whose `case` arm was gutted to `:` still shows a
+    // header and exits 0 — CI would run `preflight.sh clippy`, lint nothing, and pass.
+    // That mutation survived the first draft of this test. So count the commands each
+    // group actually emits, which is the only thing that distinguishes "ran" from
+    // "silently did nothing".
+    //
+    // The counts are a tripwire against silent SHRINKAGE, not a second copy of the
+    // command list — deleting a `cargo check` feature set has to be a deliberate edit
+    // here too, and lowering a number is a reviewable line in the diff.
+    let expected: [(&str, usize); 4] = [
+        ("fmt", 1),        // cargo fmt --all -- --check
+        ("check", 5),      // ci · ci,survival,slow-tests · ci,markov · ci,nn,slow-tests · members
+        ("clippy", 2),     // ferx-core --all-targets · members
+        ("public-api", 1), // tools/update-public-api.sh --check
+    ];
+
+    for (group, want) in expected {
+        let banner = format!("══ {group} ");
+        let start = stdout
+            .find(&banner)
+            .unwrap_or_else(|| panic!("`--list` never reached group `{group}`:\n{stdout}"));
+        // Up to the next banner, or to the end.
+        let rest = &stdout[start + banner.len()..];
+        let end = rest.find("══ ").unwrap_or(rest.len());
+        let got = rest[..end]
+            .lines()
+            .filter(|l| l.trim_start().starts_with("$ "))
+            .count();
+        assert_eq!(
+            got, want,
+            "group `{group}` lists {got} command(s), expected {want}. If you added or \
+             removed a gate deliberately, update the count here; if you did not, the \
+             group's dispatch or one of its `run` lines is silently doing nothing.\n{stdout}"
+        );
+    }
+    // The default run is the full set; a subset would silently under-check a developer
+    // who typed no arguments.
+    assert!(
+        stdout.contains("nothing was executed"),
+        "`--list` should execute nothing:\n{stdout}"
+    );
+}

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -190,3 +190,53 @@ fn preflight_is_executable_and_lists_every_group() {
         "`--list` should execute nothing:\n{stdout}"
     );
 }
+
+/// `--help` extracts its usage block from the script's own header by LINE NUMBER, which
+/// silently prints the wrong lines if that header ever grows or shrinks. Rather than make
+/// the extraction clever, pin the output.
+///
+/// This also covers a portability trap the first version walked into: the strip was
+/// `s/^#\s\?//`, and BSD sed (macOS, where most of us edit) does not understand `\s` — so
+/// every `#` survived locally while the same line worked in CI. A local/CI split inside the
+/// tool whose entire purpose is removing local/CI splits.
+#[test]
+fn preflight_help_renders_its_usage_block() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out = std::process::Command::new("bash")
+        .arg(root.join("tools").join("preflight.sh"))
+        .arg("--help")
+        .current_dir(&root)
+        .output()
+        .expect("run tools/preflight.sh --help");
+    assert!(
+        out.status.success(),
+        "`--help` exited {:?}",
+        out.status.code()
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    for want in [
+        "Run the fast CI gates locally",
+        "tools/preflight.sh check",
+        "tools/preflight.sh --list",
+        "Groups: fmt, check, clippy, public-api",
+    ] {
+        assert!(
+            stdout.contains(want),
+            "`--help` is missing {want:?} — the header line range in the `-h|--help` arm \
+             has probably drifted:\n{stdout}"
+        );
+    }
+    // No line may still START with `#`. Checking for `#` anywhere would be wrong: the usage
+    // lines carry legitimate inline comments (`tools/preflight.sh check  # just the …`).
+    let leftover: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.trim_start().starts_with('#'))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "`--help` left comment markers at line start — the sed strip is not working (BSD \
+         sed does not support `\\s`):\n  {}",
+        leftover.join("\n  ")
+    );
+}

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -36,6 +36,20 @@ script_path="${BASH_SOURCE[0]}"
 repo_root="$(cd "$(dirname "$script_path")/.." && pwd)"
 cd "$repo_root"
 
+# Mirror `ci.yml`'s workflow-level `RUSTUP_TOOLCHAIN: nightly`.
+#
+# `rust-toolchain.toml` says `nightly`, but it is NOT the last word: an inherited
+# `RUSTUP_TOOLCHAIN`, or a `rustup override` on this directory or any parent,
+# both beat it. Measured in this repo — `RUSTUP_TOOLCHAIN=stable cargo fmt
+# --version` reports `rustfmt 1.9.0-stable` where a plain `cargo fmt --version`
+# reports `1.10.0-nightly`. Running the fast gates on a channel CI never uses is
+# the exact local/CI split this script exists to remove, and clippy is where it
+# bites: whole lint groups are nightly-only, so a stable run is quietly laxer.
+#
+# `:-` so a caller who sets it deliberately (bisecting a toolchain regression,
+# say) still wins.
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly}"
+
 # ── The group list ──────────────────────────────────────────────────────────
 # The ONE place groups are enumerated. Argument validation, the default
 # selection, `--help` and the driver all read this array, so adding a group is

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# Run the fast CI gates locally, so "green on my machine" means what CI means.
+#
+#   tools/preflight.sh              # every fast gate, cheapest first
+#   tools/preflight.sh check        # just the cargo check matrix (tight edit loop)
+#   tools/preflight.sh fmt clippy   # any subset, in the order you name them
+#   tools/preflight.sh --list       # print the commands without running them
+#
+# This is #1157. `.github/workflows/ci.yml` invokes THIS SCRIPT for its `Check`,
+# `Clippy` and `Format` jobs, which is the entire point: a script that merely
+# *documents* the commands drifts the first time somebody edits the workflow, so
+# CI has to actually execute it. Same contract as `tools/update-public-api.sh`,
+# whose header makes the same argument for the public-API baseline.
+#
+# It exists because a green test suite is NOT a green build in this repo. The
+# feature sets below are not nested: `cargo test --features ci,survival` compiles
+# neither the `nn`-gated nor the `slow-tests`-gated source, so a file behind those
+# cfgs can be broken while the whole suite passes. On #1133 that let one struct
+# literal in `src/estimation/nn_theta_gradient_tests.rs` turn three CI jobs red
+# after a local run of 158 binaries / 4634 tests reported clean:
+#
+#     error[E0063]: missing fields `reset_covariates` and `reset_occasions`
+#                   in initializer of `types::Subject`
+#
+# The whole matrix is compile-only or near it, so it costs a couple of minutes
+# warm — far less than a push/wait/diagnose cycle.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+LIST_ONLY=0
+SELECTED=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --list) LIST_ONLY=1 ;;
+    -h|--help)
+      sed -n '2,9p' "${BASH_SOURCE[0]}" | sed 's/^#\s\?//'
+      echo
+      echo "Groups: fmt, check, clippy, public-api (default: all four, in that order)"
+      exit 0
+      ;;
+    fmt|check|clippy|public-api) SELECTED+=("$arg") ;;
+    -*)
+      echo "preflight: unknown flag '$arg' (try --help)" >&2
+      exit 2
+      ;;
+    *)
+      echo "preflight: unknown group '$arg' — expected one of: fmt check clippy public-api" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Cheapest first, so a formatting slip fails in seconds rather than after a
+# full compile. CI calls one group per job, so this order only affects local runs.
+if [ ${#SELECTED[@]} -eq 0 ]; then
+  SELECTED=(fmt check clippy public-api)
+fi
+
+# ── Plumbing ────────────────────────────────────────────────────────────────
+# `CI_JOB` names the workflow job a failure would have shown up in, so the error
+# teaches the local-command → CI-job mapping instead of just failing.
+CI_JOB=""
+FAILED_CMD=""
+
+run() {
+  echo
+  echo "  \$ $*"
+  if [ "$LIST_ONLY" -eq 1 ]; then
+    return 0
+  fi
+  if ! "$@"; then
+    FAILED_CMD="$*"
+    return 1
+  fi
+}
+
+on_failure() {
+  echo >&2
+  echo "────────────────────────────────────────────────────────────────────────────" >&2
+  echo "preflight FAILED in group '$CURRENT_GROUP'." >&2
+  echo "  command:  $FAILED_CMD" >&2
+  echo "  CI job:   $CI_JOB — this is what would have gone red on the PR." >&2
+  echo "────────────────────────────────────────────────────────────────────────────" >&2
+}
+
+# ── Groups ──────────────────────────────────────────────────────────────────
+
+group_fmt() {
+  CI_JOB="Format"
+  # `--all`: without it `cargo fmt` touches only the root package, so
+  # `crates/ferx-tools` and `crates/ferx-cli` go unchecked (#1114).
+  # `.githooks/pre-commit` uses the same flag.
+  run cargo fmt --all -- --check
+}
+
+group_check() {
+  CI_JOB="Check"
+
+  run cargo check --tests --no-default-features --features ci
+
+  # `tests/tte_convergence.rs` is gated on BOTH `survival` and `slow-tests`, and no
+  # other per-PR job sets both — so those Tier-3 TTE tests compile in *neither*.
+  # Without this a renamed public API or changed `FitResult` field lands green and
+  # only breaks the nightly slow-tests run, decoupled from the offending PR.
+  # Compile-only: the tests themselves stay nightly per the tier rules.
+  # (#441 review finding #3.)
+  run cargo check --tests --no-default-features --features ci,survival,slow-tests
+
+  # This is also what COMPILE-GATES the whole feature-gated surface. The
+  # `Tests + coverage (TTE/CTMM endpoints)` job builds only the handful of endpoint
+  # test binaries, so a break in any *other* file under `--features ci,markov`
+  # (which implies `survival`) is caught here in ~1 min, rather than by an 18-min
+  # instrumented build.
+  run cargo check --tests --no-default-features --features ci,markov
+
+  # Same rationale for `nn`, with `slow-tests` folded in for the same reason as the
+  # survival line: `tests/nn_fit_smoke.rs` and `tests/nn_fit_convergence.rs` are
+  # gated on BOTH `nn` and `slow-tests`, so their bodies compile in no other per-PR
+  # job. One cheap check covers the whole `nn` surface — `src/nn`, the
+  # `[covariate_nn]` parser, the θ-gradient module, and every nn-gated test file.
+  # This is the exact line that would have caught #1133's E0063 before the push.
+  run cargo check --tests --no-default-features --features ci,nn,slow-tests
+
+  # The workspace members (#1114). `-p` rather than `--workspace` so the `ferx-core`
+  # targets above are not rebuilt, and the feature is package-qualified
+  # (`ferx-core/ci`) because `ci` belongs to `ferx-core`, not to the members — a
+  # bare `--features ci` here fails outright with "none of the selected packages
+  # contains this feature". Qualified this way it resolves to the SAME feature set
+  # as the lines above, so the members link the rlib already built instead of
+  # forcing a second `ferx-core` compile under a different feature hash.
+  run cargo check -p ferx-tools -p ferx-cli --tests --no-default-features --features ferx-core/ci
+}
+
+group_clippy() {
+  CI_JOB="Clippy"
+
+  # `markov` and `nn` so the CTMM module and the covariate-NN / DCM stack are linted
+  # too (both compiled out of the base `ci` build). `markov = ["survival"]`, so this
+  # covers the whole non-Gaussian endpoint surface as well.
+  #
+  # `--all-targets` is load-bearing. Without it the default target selection covers
+  # only lib and bins, and roughly a third of this repo — every `#[cfg(test)]`
+  # module, every sibling `*_tests.rs`, and all of `tests/` — gets no lint coverage.
+  # That gap hid 6 `approx_constant` ERRORS (not warnings) that the default
+  # invocation exits 0 on (#1023).
+  #
+  # NOTE: CI installs a FRESH nightly every run, so its lint set is newer than a
+  # local toolchain unless you have updated recently — one of those 6
+  # (`EULER_GAMMA`, `src/stats/special.rs`) is invisible to an old clippy. Run
+  # `rustup update nightly` before trusting a green result here.
+  run cargo clippy --no-default-features --features ci,markov,nn --all-targets
+
+  # Same package-qualified-feature trick as `check`, so the members reuse the
+  # `ferx-core` build the line above just produced. `--tests` here (unlike the
+  # ferx-core line) because the members' test code is a meaningful share of their
+  # line count while they are still small.
+  run cargo clippy -p ferx-tools -p ferx-cli --tests --no-default-features \
+    --features ferx-core/ci,ferx-core/markov,ferx-core/nn
+}
+
+group_public_api() {
+  CI_JOB="Public API baseline"
+  # Owns its own pinned nightly and pinned `cargo-public-api`, and self-installs the
+  # latter. Regenerate with `tools/update-public-api.sh` (no `--check`) when a
+  # widening is intended, and say in the PR which tool needs each added item.
+  run tools/update-public-api.sh --check
+}
+
+# ── Drive ───────────────────────────────────────────────────────────────────
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  echo "preflight would run (in order):"
+fi
+
+for g in "${SELECTED[@]}"; do
+  CURRENT_GROUP="$g"
+  echo
+  echo "══ $g ═══════════════════════════════════════════════════════════════════"
+  case "$g" in
+    fmt)        group_fmt ;;
+    check)      group_check ;;
+    clippy)     group_clippy ;;
+    public-api) group_public_api ;;
+  esac || { on_failure; exit 1; }
+done
+
+echo
+if [ "$LIST_ONLY" -eq 1 ]; then
+  echo "(--list: nothing was executed)"
+else
+  echo "preflight OK — ${SELECTED[*]}"
+  if [ ${#SELECTED[@]} -lt 4 ]; then
+    echo "note: this was a SUBSET. A full run is 'tools/preflight.sh' with no arguments."
+  fi
+fi

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -37,7 +37,9 @@ for arg in "$@"; do
   case "$arg" in
     --list) LIST_ONLY=1 ;;
     -h|--help)
-      sed -n '2,9p' "${BASH_SOURCE[0]}" | sed 's/^#\s\?//'
+      # POSIX class, not `\s`: BSD sed (macOS, where most of us edit) does not
+      # understand `\s` and would silently leave every `#` in place.
+      sed -n '3,8p' "${BASH_SOURCE[0]}" | sed 's/^#[[:space:]]\{0,1\}//'
       echo
       echo "Groups: fmt, check, clippy, public-api (default: all four, in that order)"
       exit 0

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 #
 # Run the fast CI gates locally, so "green on my machine" means what CI means.
-#
-#   tools/preflight.sh              # every fast gate, cheapest first
-#   tools/preflight.sh check        # just the cargo check matrix (tight edit loop)
-#   tools/preflight.sh fmt clippy   # any subset, in the order you name them
-#   tools/preflight.sh --list       # print the commands without running them
+# `--help` prints usage; this header is the why.
 #
 # This is #1157. `.github/workflows/ci.yml` invokes THIS SCRIPT for its `Check`,
 # `Clippy` and `Format` jobs, which is the entire point: a script that merely
@@ -23,35 +19,85 @@
 #     error[E0063]: missing fields `reset_covariates` and `reset_occasions`
 #                   in initializer of `types::Subject`
 #
-# The whole matrix is compile-only or near it, so it costs a couple of minutes
-# warm — far less than a push/wait/diagnose cycle.
+# Cost: the matrix is compile-only or near it, so warm it is fast — measured on a
+# warm `target/` here, the full default run was 34s (fmt 13 · check 8 · clippy 2 ·
+# public-api 15), and that was with two other cargo jobs competing for the lock.
+# Cold it is a dependency build like any other; run `check` alone while iterating.
+#
+# If you ever time this and get minutes for the same work, check for a concurrent
+# cargo FIRST. Cargo serialises on a per-`target/` lock, and a build running in a
+# sibling worktree blocks this one behind a single line of output — that is not
+# preflight being slow, and it inflated an early measurement of this script
+# several-fold. `CARGO_TARGET_DIR` isolates it if you need a clean number.
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolved BEFORE the `cd`, so `--help` and the group table work from any cwd.
+script_path="${BASH_SOURCE[0]}"
+repo_root="$(cd "$(dirname "$script_path")/.." && pwd)"
 cd "$repo_root"
+
+# ── The group list ──────────────────────────────────────────────────────────
+# The ONE place groups are enumerated. Argument validation, the default
+# selection, `--help` and the driver all read this array, so adding a group is
+# one entry here plus its `group_<name>` function — and a mismatch between the
+# two is a startup error, not a group that silently never runs.
+#
+# NOT named `GROUPS`: bash maintains a special array of that name holding the
+# current user's numeric group IDs, and it wins. The first draft used it and
+# every group name silently became a GID — `unknown group 'check' — expected one
+# of: 20 12 61 ...`.
+ALL_GROUPS=(fmt check clippy public-api)
+
+usage() {
+  cat <<EOF
+Run the fast CI gates locally, so "green on my machine" means what CI means.
+
+  tools/preflight.sh              every fast gate, cheapest first
+  tools/preflight.sh check        just the cargo check matrix (tight edit loop)
+  tools/preflight.sh fmt clippy   any subset, in the order you name them
+  tools/preflight.sh --list       print the commands without running them
+
+Groups: ${ALL_GROUPS[*]}  (default: all of them, in that order)
+
+NOT covered: the test jobs. \`cargo check --tests\` COMPILES the test targets
+but runs nothing, so \`Tests + coverage (core)\` can still go red after a green
+preflight. This gates compilation and lint, not behaviour.
+EOF
+}
+
+is_group() {
+  local candidate="$1" g
+  for g in "${ALL_GROUPS[@]}"; do
+    if [ "$g" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 LIST_ONLY=0
 SELECTED=()
 
 for arg in "$@"; do
   case "$arg" in
-    --list) LIST_ONLY=1 ;;
-    -h|--help)
-      # POSIX class, not `\s`: BSD sed (macOS, where most of us edit) does not
-      # understand `\s` and would silently leave every `#` in place.
-      sed -n '3,8p' "${BASH_SOURCE[0]}" | sed 's/^#[[:space:]]\{0,1\}//'
-      echo
-      echo "Groups: fmt, check, clippy, public-api (default: all four, in that order)"
+    --list)
+      LIST_ONLY=1
+      ;;
+    -h | --help)
+      usage
       exit 0
       ;;
-    fmt|check|clippy|public-api) SELECTED+=("$arg") ;;
     -*)
       echo "preflight: unknown flag '$arg' (try --help)" >&2
       exit 2
       ;;
     *)
-      echo "preflight: unknown group '$arg' — expected one of: fmt check clippy public-api" >&2
-      exit 2
+      if is_group "$arg"; then
+        SELECTED+=("$arg")
+      else
+        echo "preflight: unknown group '$arg' — expected one of: ${ALL_GROUPS[*]}" >&2
+        exit 2
+      fi
       ;;
   esac
 done
@@ -59,34 +105,48 @@ done
 # Cheapest first, so a formatting slip fails in seconds rather than after a
 # full compile. CI calls one group per job, so this order only affects local runs.
 if [ ${#SELECTED[@]} -eq 0 ]; then
-  SELECTED=(fmt check clippy public-api)
+  SELECTED=("${ALL_GROUPS[@]}")
 fi
 
 # ── Plumbing ────────────────────────────────────────────────────────────────
 # `CI_JOB` names the workflow job a failure would have shown up in, so the error
 # teaches the local-command → CI-job mapping instead of just failing.
 CI_JOB=""
-FAILED_CMD=""
+CURRENT_GROUP=""
 
+die() {
+  echo >&2
+  echo "────────────────────────────────────────────────────────────────────────────" >&2
+  echo "preflight FAILED in group '$CURRENT_GROUP'." >&2
+  echo "  command:  $*" >&2
+  echo "  CI job:   $CI_JOB — this is what would have gone red on the PR." >&2
+  echo "────────────────────────────────────────────────────────────────────────────" >&2
+  exit 1
+}
+
+# `run` NEVER returns to its caller on failure — it exits the script.
+#
+# That is load-bearing, not style. The first version of this file returned a
+# status and left the caller to propagate it, through a group function, through
+# a `case ... esac || { ...; exit 1; }` in the driver. Bash suspends `errexit`
+# for every command of an AND-OR list but the last, and propagates that
+# suspension into the whole body of a function called in that context — so the
+# `return 1` stopped nothing, each group reported its LAST command's status, and
+# four of the five `cargo check` lines (including `ci,nn,slow-tests`, the one
+# that would have caught #1133) could fail with the script printing
+# "preflight OK" and exiting 0. Exiting from here deletes the propagation path
+# instead of fixing one link in it: there is no caller left that can drop the
+# status, whatever `errexit` is doing at the call site.
+#
+# `tests/preflight_owns_the_fast_gates.rs` pins this by failing each command
+# position in turn behind a fake `cargo` and asserting a non-zero exit.
 run() {
   echo
   echo "  \$ $*"
   if [ "$LIST_ONLY" -eq 1 ]; then
     return 0
   fi
-  if ! "$@"; then
-    FAILED_CMD="$*"
-    return 1
-  fi
-}
-
-on_failure() {
-  echo >&2
-  echo "────────────────────────────────────────────────────────────────────────────" >&2
-  echo "preflight FAILED in group '$CURRENT_GROUP'." >&2
-  echo "  command:  $FAILED_CMD" >&2
-  echo "  CI job:   $CI_JOB — this is what would have gone red on the PR." >&2
-  echo "────────────────────────────────────────────────────────────────────────────" >&2
+  "$@" || die "$*"
 }
 
 # ── Groups ──────────────────────────────────────────────────────────────────
@@ -95,7 +155,11 @@ group_fmt() {
   CI_JOB="Format"
   # `--all`: without it `cargo fmt` touches only the root package, so
   # `crates/ferx-tools` and `crates/ferx-cli` go unchecked (#1114).
-  # `.githooks/pre-commit` uses the same flag.
+  #
+  # No `+nightly`: `rust-toolchain.toml` pins the channel locally and the
+  # workflow exports `RUSTUP_TOOLCHAIN: nightly`. `.githooks/pre-commit` calls
+  # THIS group rather than repeating the command, so the hook, the local gate
+  # and CI are one owner.
   run cargo fmt --all -- --check
 }
 
@@ -166,13 +230,28 @@ group_clippy() {
 
 group_public_api() {
   CI_JOB="Public API baseline"
-  # Owns its own pinned nightly and pinned `cargo-public-api`, and self-installs the
-  # latter. Regenerate with `tools/update-public-api.sh` (no `--check`) when a
-  # widening is intended, and say in the PR which tool needs each added item.
+  # Owns its own pinned nightly and pinned `cargo-public-api`, and self-installs
+  # both — so the FIRST run of this group downloads a toolchain and builds
+  # rustdoc JSON from cold. For a tight edit loop name the groups you want
+  # (`tools/preflight.sh check clippy`); this one is in the default set because
+  # forgetting it is how a widened surface reaches the PR.
+  #
+  # Regenerate with `tools/update-public-api.sh` (no `--check`) when a widening
+  # is intended, and say in the PR which tool needs each added item.
   run tools/update-public-api.sh --check
 }
 
 # ── Drive ───────────────────────────────────────────────────────────────────
+
+# A group named in `ALL_GROUPS` with no `group_<name>` function would print its
+# banner and silently run nothing. Fail at startup instead, before any compile.
+for g in "${ALL_GROUPS[@]}"; do
+  fn="group_${g//-/_}"
+  if ! declare -F "$fn" >/dev/null; then
+    echo "preflight: internal error: group '$g' has no $fn function" >&2
+    exit 3
+  fi
+done
 
 if [ "$LIST_ONLY" -eq 1 ]; then
   echo "preflight would run (in order):"
@@ -182,12 +261,10 @@ for g in "${SELECTED[@]}"; do
   CURRENT_GROUP="$g"
   echo
   echo "══ $g ═══════════════════════════════════════════════════════════════════"
-  case "$g" in
-    fmt)        group_fmt ;;
-    check)      group_check ;;
-    clippy)     group_clippy ;;
-    public-api) group_public_api ;;
-  esac || { on_failure; exit 1; }
+  # A plain command, deliberately: no `||` here, so nothing suspends `errexit`
+  # for the function body. `run` exits on failure anyway; this keeps the driver
+  # from re-introducing the swallow if that ever changes.
+  "group_${g//-/_}"
 done
 
 echo
@@ -195,7 +272,7 @@ if [ "$LIST_ONLY" -eq 1 ]; then
   echo "(--list: nothing was executed)"
 else
   echo "preflight OK — ${SELECTED[*]}"
-  if [ ${#SELECTED[@]} -lt 4 ]; then
+  if [ ${#SELECTED[@]} -lt ${#ALL_GROUPS[@]} ]; then
     echo "note: this was a SUBSET. A full run is 'tools/preflight.sh' with no arguments."
   fi
 fi

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -119,7 +119,16 @@ die() {
   echo "────────────────────────────────────────────────────────────────────────────" >&2
   echo "preflight FAILED in group '$CURRENT_GROUP'." >&2
   echo "  command:  $*" >&2
-  echo "  CI job:   $CI_JOB — this is what would have gone red on the PR." >&2
+  # The driver blanks CI_JOB before each group, so an empty one here means the
+  # group function never set it — say so rather than name a job that is not the
+  # one that would go red. Before the driver blanked it, a group that forgot the
+  # assignment silently inherited the PREVIOUS group's job name, which is a
+  # diagnostic that confidently points at the wrong place.
+  if [ -n "$CI_JOB" ]; then
+    echo "  CI job:   $CI_JOB — this is what would have gone red on the PR." >&2
+  else
+    echo "  CI job:   (group '$CURRENT_GROUP' sets no CI_JOB — fix that in the script)" >&2
+  fi
   echo "────────────────────────────────────────────────────────────────────────────" >&2
   exit 1
 }
@@ -259,6 +268,9 @@ fi
 
 for g in "${SELECTED[@]}"; do
   CURRENT_GROUP="$g"
+  # Blank per group: see `die`. Leaving the previous group's value in place makes
+  # a forgotten assignment invisible instead of loud.
+  CI_JOB=""
   echo
   echo "══ $g ═══════════════════════════════════════════════════════════════════"
   # A plain command, deliberately: no `||` here, so nothing suspends `errexit`

--- a/tools/update-public-api.sh
+++ b/tools/update-public-api.sh
@@ -49,6 +49,32 @@ SIMPLIFY="-sss"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 baseline="$repo_root/api/ferx-core-public-api.txt"
 
+# Validate the argument BEFORE doing any work. The check/write choice below is a
+# bare `if --check ... else write`, so without this any unrecognised argument —
+# `--chek`, `-check`, `check` — falls into the write arm and OVERWRITES the
+# committed baseline with whatever the current tree exposes. That is the one
+# outcome this gate exists to prevent, reached by a typo, and it looks like a
+# pass: the script prints "wrote ..." and exits 0.
+usage() {
+  echo "usage: tools/update-public-api.sh [--check]"
+  echo "  (no argument) regenerate $baseline"
+  echo "  --check       diff against it; non-zero on drift (what CI runs)"
+}
+
+case "${1:-}" in
+  "" | --check) ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    echo "refusing to run with unknown argument '$1' — writing the baseline by" >&2
+    echo "accident would silently accept whatever the tree currently exposes." >&2
+    exit 2
+    ;;
+esac
+
 if ! cargo public-api --version 2>/dev/null | grep -q "$PUBLIC_API_VERSION"; then
   echo "installing cargo-public-api $PUBLIC_API_VERSION ..." >&2
   cargo install cargo-public-api --locked --version "$PUBLIC_API_VERSION"


### PR DESCRIPTION
## Why

`tools/update-public-api.sh` opens with the argument this PR generalises:

> CI runs this exact script (`--check`) so the generating command cannot drift from the verifying one.

Nothing implemented that for the rest of the gate. To know whether a change would pass CI, you had to open `.github/workflows/ci.yml` and reconstruct **eight** cargo commands spread across three jobs — and every one of them is a trap for a different reason, which the workflow's own comments spell out:

* **The feature sets are not nested.** `cargo test --features ci,survival` compiles neither the `nn`-gated nor the `slow-tests`-gated source. A *fully green* suite proves nothing about roughly a third of the repo.
* **`--all-targets` is load-bearing** on clippy — without it every `#[cfg(test)]` module, every sibling `*_tests.rs`, and all of `tests/` goes unlinted (#1023).
* **The members need package-qualified features** (`ferx-core/ci`, not `ci`) or the command fails outright with "none of the selected packages contains this feature" (#1114).
* **`--all` is load-bearing** on fmt, or `crates/ferx-tools` and `crates/ferx-cli` go unchecked.

That is not discoverable from the repo root. It is discoverable by reading a 400-line workflow, or by pushing and waiting.

**What it cost, concretely.** On #1133 I ran the full suite under `--features ci,survival` — 158 binaries, 4634 passed, 0 failed, `cargo fmt` clean — and reported the branch verified. It was not. One `Subject` struct literal in `src/estimation/nn_theta_gradient_tests.rs`, a file only the `ci,nn,slow-tests` step compiles, was missing two fields:

```
error[E0063]: missing fields `reset_covariates` and `reset_occasions` in initializer of `types::Subject`
```

That single line turned **three** CI jobs red — `Check`, `Clippy`, and `Tests + coverage (TTE/CTMM endpoints)` — and had already been red through an entire previous commit, because the local suite kept passing. Two push/wait/diagnose cycles for something a 60-second `cargo check` catches.

## Read this first: the version of this PR before `2aef0ca0` did not work

A review of the earlier head found that the script **could not fail**. `run()` returned a status and left the caller to propagate it, through a group function and a `case ... esac || { on_failure; exit 1; }` in the driver. Bash suspends `errexit` for every command of an AND-OR list but the last, and carries that suspension into the entire body of a function called in that context — so the `return 1` stopped nothing and each group reported its **last** command's status.

Measured against that script with a fake `cargo`, failing one feature set at a time:

| failing `cargo check` | script exit |
|---|---|
| `ci` | 0 — "preflight OK" |
| `ci,survival,slow-tests` | 0 — "preflight OK" |
| `ci,markov` | 0 — "preflight OK" |
| `ci,nn,slow-tests` | 0 — "preflight OK" ← the #1133 line |
| `ferx-core/ci` | 1 — caught |

Same shape in `clippy`, where the `--all-targets` #1023 gate is first. **5 of 9 gate commands were unenforced**, and because `ci.yml` had just collapsed eight separate steps into three script invocations, `Check` and `Clippy` inherited it — strictly worse than `main`, where each command was its own step and failed on its own. Reproduced on bash 3.2.57 and 5.2.21 (the runner's version) and through GitHub's own `bash -e {0}` step wrapper.

Nothing could have caught it: both tests at the time ran only `--list` and `--help`, neither of which executes a gate.

The fix is not a patched link in the chain. `run` now calls `die`, which **exits**, so there is no status to propagate and no caller left that can drop it, whatever `errexit` is doing at the call site. The driver dispatches by function name with no `||`.

## What changed

**`tools/preflight.sh`** — one owner for the fast gates, four groups:

```bash
tools/preflight.sh            # fmt → check → clippy → public-api, cheapest first
tools/preflight.sh check      # just the 5-feature-set matrix, for a tight edit loop
tools/preflight.sh fmt clippy # any subset, in the order named
tools/preflight.sh --list     # print the commands, run nothing
```

**`ci.yml` calls it** — `Check` → `preflight.sh check`, `Clippy` → `preflight.sh clippy`, `Format` → `preflight.sh fmt`. This is the part that makes it work rather than rot. A script that only *documents* the commands drifts the first time somebody edits the workflow, and drifts **silently**: the local gate keeps passing while CI checks something else.

Every per-feature-set rationale comment moved from `ci.yml` into the script, so the reasoning travels with the commands.

On failure the script names the job that would have gone red:

```
preflight FAILED in group 'fmt'.
  command:  cargo fmt --all -- --check
  CI job:   Format — this is what would have gone red on the PR.
```

**`.githooks/pre-commit` execs `preflight.sh fmt`.** It was a third copy of the format gate, and the comment claiming the two "use the same flag" was false (`cargo +nightly fmt --all --check` vs `cargo fmt --all -- --check`). Hook, local gate and CI are now one list, and a rejected commit names the CI job.

**`SDLC.md` was a fourth copy, and was already wrong before this PR** — it documented `Check` as four `cargo check` invocations (there are five) and `Clippy` as `cargo clippy -- -D warnings`, which is neither the flag set CI uses nor `--all-targets`; its "Recommendations" section proposed adopting that same line as *future work*.

**`PULL_REQUEST_TEMPLATE.md`** asked for "`cargo clippy` clean" — the exact invocation #1023 showed exits 0 while six errors sit in unlinted test code. It now asks for a green `tools/preflight.sh`.

**`tools/update-public-api.sh` rejects unknown arguments.** It branched on `if [ "$1" = "--check" ]` with a bare `else` that writes, so `--chek`, `-check` or `check` overwrote `api/ferx-core-public-api.txt` with whatever the tree exposes — the one outcome the gate exists to prevent — and reported it as success. Not part of #1157's scope, but adjacent enough to be worth the five lines.

**`slow-tests.yml`** covers `tools/**`. `tools/` holds inputs the gated fits are tied to: `tools/vi-emvi-comparison/*.ferx` are the harness models the VI/EMVI anchors mirror, and `make-wide-residual-data.sh` generates the dataset `tests/nonmem/warfarin_10pct.ctl` is built from. Measured over the last 400 first-parent commits on `main`: 3 touch `tools/`, **0** would newly fire the workflow — all three also touched `src/` or `tests/`. That is an upper bound on what the entry cost *then*, not a forecast; this PR makes `tools/` the place gates are edited.

The `public-api` job still calls `tools/update-public-api.sh --check` directly — it needs a pinned dated nightly and a pinned `cargo-public-api` installed as separate workflow steps. `preflight.sh public-api` runs that same script, so a full local run still covers it.

### Also fixed in the rewrite

* Groups were enumerated in **five** places (argument validation, the default selection, the `--help` text, the driver `case`, a hardcoded `-lt 4`). One `ALL_GROUPS` array feeds all of them, and a group with no `group_<name>` function is a startup error rather than a silent no-op.
* `--help` read its own source with `sed -n '3,8p' "${BASH_SOURCE[0]}"` **after** `cd`-ing away, so a relative invocation from another directory printed nothing. It is a heredoc now, which also retires the BSD-sed `\s` portability trap the old line needed a test to guard.
* The header's cost claim carried no number. Replaced with a measured one — warm full run 34 s (fmt 13 · check 8 · clippy 2 · public-api 15) — plus the `target/` lock-contention hazard: a concurrent cargo in a sibling worktree serialises against this one and inflated an early measurement of this script several-fold.
* `--help` now states what preflight does **not** cover: `cargo check --tests` compiles the test targets and runs nothing, so `Tests + coverage (core)` can still go red on a green preflight.

## Alternatives considered

**A script CI does not run.** Rejected — that is the failure mode, not the fix. Two lists diverge, and the divergence is invisible until a push goes red.

**A `Makefile` / `justfile`.** Would need a new tool in the loop; `tools/` already holds the precedent (`update-public-api.sh`) and CI can invoke a script with no extra setup.

**Patching `run()`'s `return 1` rather than rewriting.** A three-line change fixes the exit status, but leaves the structure that produced it: 201 lines to run 9 commands, a `case … esac ||` in the driver, and the group list copied five times. The defect survived seven independent review angles and a fully green CI. Removing the propagation path is what makes the class of bug unreachable, not this instance of it.

**Keeping the five `check` steps separate in CI** for per-step names in the UI. They collapse to one step, so GitHub no longer labels which feature set failed. The script prints each command as it runs, so the log still identifies it — and the alternative reintroduces the drift this PR removes.

**Excluding `tools` from the slow-tests input-root harvest** instead of covering it. The scanner already has that mechanism (`.github/` is excluded the same way). Rejected: covering it measured free, and the exclusion route means re-shaping test prose forever so it does not look like a path.

## Tests

`tests/preflight_owns_the_fast_gates.rs`, seven tests. The load-bearing one is new:

`a_failing_gate_fails_the_script_from_every_position` puts a fake `cargo` on `PATH` and fails **each command position in turn**, asserting a non-zero exit, a diagnostic naming that command, and no success banner. Positions come from `--list`, not from a table in the test, so a sixth feature set is covered the moment it is added.

Mutation-tested — **19 mutations, 19 killed** (the previous pair killed 8 of 20):

| mutation | killed by |
|---|---|
| the original defect: `run()` returns, driver uses `\|\| { die; }` | failure-path test |
| `run()` swallows the failure outright | failure-path test |
| `die()` prints but does not exit / exits 0 | failure-path test |
| `run()` early-returns under `$CI` — CI runs 0 gates, local runs 9 | failure-path test |
| `ci,nn,slow-tests` line deleted | `--list` count |
| `group_clippy` gutted to a no-op | `--list` count |
| `--all-targets` dropped from clippy (#1023) | load-bearing-flag test |
| `--all` dropped from `cargo fmt` (#1114) | load-bearing-flag test |
| `ci,nn,slow-tests` **neutered** to plain `ci` (count unchanged) | feature-coverage test |
| same for `ci,markov` and `ci,survival,slow-tests` | feature-coverage test |
| `--help` stops listing every group | help test |
| `check` job runs `true` / inline cargo / cargo hidden in a `run: \|` block | workflow test |
| `clippy` job gets `continue-on-error` | workflow test |
| `fmt` job skips itself with an `if:` | workflow test |
| `clippy` job runs the `fmt` group | workflow test |

Three of those close blind spots the earlier guard had: it only understood `run: <cmd>` (so moving a step to a block and adding inline cargo underneath passed), it did not stop a gate job from skipping itself or passing while red, and its counts saw a gate *deleted* but not *neutered*.

### Adversarial pass on the rewrite (`a7a6c2cb`)

The rewrite, its tests and its mutation harness were written in one pass by the same author, and CI was green — which on this PR means nothing. A line read found four defects the tests could not see:

* **The diagnostic could blame the wrong CI job.** `CI_JOB` is a script global set at the top of each `group_*` function, so a group that forgets it inherits the *previous* group's value: `preflight.sh fmt check` failing inside `check` reported "CI job: Format" and sent the reader to a green log. The driver now blanks it per group. Only a multi-group run can see this, so there is a test that runs `fmt check` and fails the first `check` command.
* **The pre-commit hook hard-depended on a file that is not always there.** `core.hooksPath` points into the working tree, so the hook runs against whatever commit is checked out — including one from before #1157. It now falls back to `cargo fmt` with a notice; verified with the script moved aside, both ways.
* **`body.contains("if:")` was a false-positive machine** — a comment or a shell line mentioning the string would trip it, and a tripwire that cries wolf gets deleted rather than fixed. Now line-anchored to the YAML key position, with negative controls: a comment saying "there is no if: condition here" and a `run: |` block containing `if [ -n "$RUNNER_DEBUG" ]` both leave the suite green, while a real `if:` on the job *or* a step turns it red.
* **A fifth group would have had no count tripwire at all** — the count loop iterates the expected table, not the groups, so a new group was never looked at. Cross-checked in both directions now.

A fifth defect surfaced after that (`aa70b6b0`): making the hook delegate **silently dropped its `+nightly` pin**, and nothing in the script pinned a channel. `rust-toolchain.toml` is not the last word — an inherited `RUSTUP_TOOLCHAIN` or a `rustup override` beats it (`RUSTUP_TOOLCHAIN=stable cargo fmt --version` gives `1.9.0-stable` where a plain call gives `1.10.0-nightly`). `fmt` agrees across channels on this tree, measured; clippy would not, since whole lint groups are nightly-only. The script now mirrors `ci.yml`'s `RUSTUP_TOOLCHAIN: nightly` once, `:-` so a deliberate caller pin still wins.

11 further mutations across this pass, all as required (9 killed, both negative controls survive). The original 19 were re-run with stricter bookkeeping — each verified to have actually changed the file, to leave `bash -n`-valid syntax (so "killed" is never bash choking), and to be killed by a *named* test that plausibly detects it. 19/19 holds.

`tools/update-public-api.sh`'s no-argument regenerate path was also exercised, since the new argument gate sits in front of it and nothing had run it: it still reproduces the committed baseline byte for byte.

`.githooks/pre-commit` was checked both ways by hand: a staged misformatted `.rs` file is rejected with the CI-job diagnostic, a well-formatted one passes. `tools/update-public-api.sh --chek` now exits 2 with `api/` untouched.

- [x] Regression test added that fails without this fix
- [ ] Unit test(s) added in the same module — N/A, no `src/` file is touched

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` entry — N/A, CI/tooling only, no user-facing change

`CLAUDE.md` gains a **"Before you push"** section: its Tests section described the three tiers but said nothing about the feature-set matrix being what actually gates a PR. It also records the `run`-exits-rather-than-returns invariant, since that is the thing to know before editing the script.

## Checklist

- [x] `tools/preflight.sh` green (fmt · 5 check feature sets · clippy · public-API baseline)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — no Rust source touched outside `tests/`
- [ ] `Cargo.toml` version bumped if breaking — N/A

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Reviewer hints

**Read `run()` and the driver loop first.** That pair is the whole correctness story; everything else in the script is a command with a comment attached.

**Then `ci.yml`.** If the script mishandles an argument, three jobs break for everyone at once. Worth confirming the three `run:` lines name the right group and that no rationale comment was lost in the move.

Two traps worth knowing generally, both hit while building this:

* `GROUPS` is a **bash built-in array** holding the user's numeric group IDs, so `GROUPS=(fmt check ...)` is silently overridden — every group name became a GID. The array is `ALL_GROUPS`; the script carries a comment saying why.
* Wall-clock timings of `cargo` in a worktree are meaningless without checking for a concurrent cargo first: they serialise on a per-`target/` lock behind one line of output.

Closes #1157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
