### PR TITLE
test(parser): cover the [covariate_model] diagnostics the patch gate flagged [#1111]

### DIFF
--- a/src/api/tests/covariate_stats_tests.rs
+++ b/src/api/tests/covariate_stats_tests.rs
@@ -494,3 +494,93 @@ fn binding_preserves_a_level_block_binding_made_first() {
         Some(70.0)
     );
 }
+
+// ── `ferx check` (`validate_model_file`) ───────────────────────────────────
+
+/// The model text written to a `.ferx` temp file, for the entry points that
+/// take a path rather than a string.
+fn temp_model(src: &str) -> tempfile::NamedTempFile {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .suffix(".ferx")
+        .tempfile()
+        .expect("create temp model");
+    f.write_all(src.as_bytes()).expect("write temp model");
+    f.flush().expect("flush temp model");
+    f
+}
+
+#[test]
+fn check_without_data_warns_that_the_statistics_are_still_unbound() {
+    // `center = median` cannot be resolved from the file alone, so the relation
+    // is parsed and recorded but not desugared. Without a dataset that is not an
+    // error — the model is fine, just not buildable yet — but it has to be said:
+    // the desugared echo is suppressed in this state, and a silent "no errors"
+    // on a model whose covariate effects are all still pending reads as "there
+    // are none".
+    let text = model("  WT continuous", "  CL ~ WT power(center = median)");
+    let f = temp_model(&text);
+    let report = crate::api::validate_model_file(f.path().to_str().expect("utf-8 temp path"), None);
+
+    let hit = report
+        .diagnostics
+        .iter()
+        .find(|d| d.code == "W_COVSTAT_UNBOUND")
+        .unwrap_or_else(|| {
+            panic!(
+                "unbound statistics must be reported: {:?}",
+                report.diagnostics
+            )
+        });
+    assert_eq!(hit.severity, crate::Severity::Warning);
+    assert!(hit.message.contains("`CL ~ WT`"), "{}", hit.message);
+    assert!(
+        hit.suggestion
+            .as_deref()
+            .is_some_and(|s| s.contains("--data")),
+        "the suggestion must point at re-running with data: {:?}",
+        hit.suggestion
+    );
+    // A warning does not invalidate the report …
+    assert!(report.valid, "an unbound statistic is not a rejection");
+    // … but the echo stays empty: those lines are the block *without* the
+    // pending covariate effect, so printing them would state the opposite of
+    // the truth.
+    assert!(
+        report.desugared_individual_parameters.is_empty(),
+        "{:?}",
+        report.desugared_individual_parameters
+    );
+}
+
+#[test]
+fn check_with_data_binds_the_statistics_and_echoes_the_desugared_block() {
+    // The same path with a dataset: `bind_covariate_stats` runs, nothing is left
+    // unresolved, and the report carries the expression that was actually built
+    // — the text to diff against a NONMEM control stream.
+    let report = crate::api::validate_model_file(
+        "examples/two_cpt_oral_covmodel.ferx",
+        Some("data/two_cpt_oral_cov.csv"),
+    );
+    assert!(report.valid, "{:?}", report.diagnostics);
+    assert!(
+        !report
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "W_COVSTAT_UNBOUND" || d.code == "E_COVSTAT_UNRESOLVED"),
+        "statistics must be bound once data is supplied: {:?}",
+        report.diagnostics
+    );
+    let cl = report
+        .desugared_individual_parameters
+        .iter()
+        .find(|l| l.trim_start().starts_with("CL "))
+        .unwrap_or_else(|| {
+            panic!(
+                "the desugared block must be echoed: {:?}",
+                report.desugared_individual_parameters
+            )
+        });
+    assert!(cl.contains("present(WT)"), "{cl}");
+    assert!(cl.contains("^THETA_CL_WT"), "{cl}");
+}

--- a/src/parser/covariate_model_tests.rs
+++ b/src/parser/covariate_model_tests.rs
@@ -598,3 +598,126 @@ fn a_kappa_bearing_factor_counts_as_a_random_effect_factor() {
         "CL = TVCL * (if (present(WT)) (WT / 70)^THETA_CL_WT else 1.0) * exp(ETA_CL) * exp(KAPPA_CL)"
     );
 }
+
+// ── Malformed lines: one assert per diagnostic ─────────────────────────────
+//
+// These are the messages a user actually meets when a hand-written or
+// search-generated block is wrong, so each is pinned on the phrase that makes
+// it actionable rather than on the whole string.
+
+#[test]
+fn a_line_without_a_tilde_names_the_expected_shape() {
+    let e = err("  WT continuous", "  CL WT power(center = 70)");
+    assert!(e.contains("expected `PARAM ~ COV form(...)`"), "{e}");
+}
+
+#[test]
+fn a_line_with_no_parameter_before_the_tilde_is_an_error() {
+    let e = err("  WT continuous", "  ~ WT power(center = 70)");
+    assert!(e.contains("missing parameter name"), "{e}");
+}
+
+#[test]
+fn a_relation_that_states_no_form_lists_the_forms() {
+    let e = err("  WT continuous", "  CL ~ WT");
+    assert!(e.contains("states no form"), "{e}");
+    assert!(e.contains("linear_relative"), "{e}");
+}
+
+#[test]
+fn two_relations_generating_the_same_theta_name_is_an_error() {
+    // Each relation owns its θ; sharing one would couple two lines and defeat
+    // the point of a line-oriented block.
+    let e = err(
+        "  WT continuous\n  CRCL continuous",
+        "  CL ~ WT power(center = 70) => SHARED(0.75, -10, 10)\n\
+         \x20 CL ~ CRCL power(center = 100) => SHARED(0.75, -10, 10)",
+    );
+    assert!(e.contains("both generate the θ `SHARED`"), "{e}");
+}
+
+#[test]
+fn an_unbalanced_form_parenthesis_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(center = 70");
+    assert!(e.contains("unbalanced parentheses"), "{e}");
+}
+
+#[test]
+fn an_unquoted_or_empty_expr_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT expr((WT/70)^0.75)");
+    assert!(e.contains("takes a quoted expression"), "{e}");
+
+    let e = err("  WT continuous", "  CL ~ WT expr(\"  \")");
+    assert!(e.contains("states no expression"), "{e}");
+}
+
+#[test]
+fn a_keyword_argument_without_a_value_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(median)");
+    assert!(e.contains("takes `key = value` arguments"), "{e}");
+}
+
+#[test]
+fn a_centring_value_that_is_neither_a_number_nor_a_statistic_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(center = middling)");
+    assert!(e.contains("neither a number nor one of"), "{e}");
+}
+
+#[test]
+fn a_repeated_keyword_argument_is_an_error() {
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70, center = 80)",
+    );
+    assert!(e.contains("is given more than once"), "{e}");
+}
+
+#[test]
+fn a_symbolic_fix_value_is_an_error() {
+    // `fix` pins θ at a number; a data-derived statistic is not one.
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70, fix = median)",
+    );
+    assert!(e.contains("`fix` takes a number"), "{e}");
+}
+
+#[test]
+fn min_and_max_accept_their_long_spellings() {
+    // `minimum`/`maximum` are the spellings PsN users reach for; both resolve
+    // to the same statistic as the short form.
+    let s = spec("  WT continuous", "  CL ~ WT linear(center = minimum)");
+    assert_eq!(s.relations[0].center, Some(CovariateStat::Min));
+    let s = spec("  WT continuous", "  CL ~ WT linear(center = maximum)");
+    assert_eq!(s.relations[0].center, Some(CovariateStat::Max));
+}
+
+#[test]
+fn a_non_finite_literal_centre_is_an_error() {
+    let e = err("  WT continuous", "  CL ~ WT power(center = inf)");
+    assert!(e.contains("not a finite number"), "{e}");
+}
+
+#[test]
+fn a_malformed_theta_clause_is_an_error() {
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70) => THETA_WT",
+    );
+    assert!(e.contains("expected `=> NAME(init, lower, upper)`"), "{e}");
+
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70) => T(0.75, low, 10)",
+    );
+    assert!(e.contains("`low` is not a number"), "{e}");
+
+    let e = err(
+        "  WT continuous",
+        "  CL ~ WT power(center = 70) => T(0.75, -10)",
+    );
+    assert!(e.contains("needs exactly (init, lower, upper)"), "{e}");
+
+    let e = err("  WT continuous", "  CL ~ WT power(center = 70) => ");
+    assert!(e.contains("empty `=>` clause"), "{e}");
+}

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -2418,6 +2418,88 @@ fn call_time_ode_tolerances_reach_the_absorption_twin() {
     assert_eq!(rso.max_steps, 4242);
 }
 
+// ── #1111: the `[covariate_model]` data types ──────────────────────────────
+
+/// Every `label()` spelling is what the fit YAML and the block text both use,
+/// so a renamed arm silently changes a written file and the text a user has to
+/// type back. Pinned as data, one assert per variant.
+#[test]
+fn covariate_form_labels_are_the_block_spellings() {
+    let cases = [
+        (CovariateForm::None, "none"),
+        (CovariateForm::Linear, "linear"),
+        (CovariateForm::LinearRelative, "linear_relative"),
+        (CovariateForm::Exponential, "exponential"),
+        (CovariateForm::Power, "power"),
+        (CovariateForm::Hockey, "hockey"),
+        (CovariateForm::Categorical, "categorical"),
+        (CovariateForm::Expr("(WT/70)^0.75".into()), "expr"),
+    ];
+    for (form, label) in &cases {
+        assert_eq!(&form.label(), label);
+    }
+    // Only `categorical` reads a categorical column; the check against the
+    // `[covariates]` declaration is keyed on this.
+    assert!(CovariateForm::Categorical.is_categorical());
+    assert!(!CovariateForm::Power.is_categorical());
+    assert!(!CovariateForm::Expr("1".into()).is_categorical());
+}
+
+#[test]
+fn covariate_stat_labels_and_literals_round_trip() {
+    let cases = [
+        (CovariateStat::Median, "median"),
+        (CovariateStat::Mean, "mean"),
+        (CovariateStat::Min, "min"),
+        (CovariateStat::Max, "max"),
+        (CovariateStat::Mode, "mode"),
+    ];
+    for (stat, label) in &cases {
+        assert_eq!(&stat.label(), label);
+        // A symbolic statistic is not a literal — that is what defers the
+        // relation until a population has been summarised.
+        assert_eq!(stat.literal(), None);
+    }
+    assert_eq!(CovariateStat::Literal(70.0).label(), "70");
+    assert_eq!(CovariateStat::Literal(70.0).literal(), Some(70.0));
+}
+
+#[test]
+fn a_covariate_summary_resolves_every_statistic_it_names() {
+    let summary = CovariateSummary {
+        median: 70.0,
+        mean: 72.5,
+        min: 50.0,
+        max: 95.0,
+        mode: 70.0,
+        levels: vec![50.0, 70.0, 95.0],
+    };
+    assert_eq!(summary.value_of(CovariateStat::Median), 70.0);
+    assert_eq!(summary.value_of(CovariateStat::Mean), 72.5);
+    assert_eq!(summary.value_of(CovariateStat::Min), 50.0);
+    assert_eq!(summary.value_of(CovariateStat::Max), 95.0);
+    assert_eq!(summary.value_of(CovariateStat::Mode), 70.0);
+    // A literal ignores the summary entirely, so a bound model and a
+    // file-literal one build the same expression.
+    assert_eq!(summary.value_of(CovariateStat::Literal(1.5)), 1.5);
+}
+
+#[test]
+fn declared_levels_are_readable_and_auto_is_not() {
+    assert_eq!(
+        CovariateLevels::Declared(vec![0.0, 1.0]).declared(),
+        Some(&[0.0, 1.0][..])
+    );
+    // `auto` has no levels until a population has been seen — that `None` is
+    // what leaves the relation unresolved rather than generating zero θ.
+    assert_eq!(CovariateLevels::Auto.declared(), None);
+    // The pre-`levels` shape of every `[covariates]` line.
+    let decl = CovariateDecl::new("WT", CovariateKind::Continuous);
+    assert_eq!(decl.name, "WT");
+    assert_eq!(decl.kind, CovariateKind::Continuous);
+    assert_eq!(decl.levels, None);
+}
+
 // ── #1064: scale guardrails for models with hundreds of θ ──────────────────
 mod theta_block_scale_guards {
     use crate::io::output::compact_theta_blocks;


### PR DESCRIPTION
## Why

PR #1156 was merged with `codecov/patch` red: **87.54%** against the enforced **90%** floor
(`codecov.yml`, `status.patch.default`). All GitHub Actions jobs were green, so the merge went
through past the coverage status.

The gap was not untested *behaviour* — the block's semantics are pinned by the tests that shipped
with it — but untested **diagnostics and accessors**: error branches nobody exercised, and the
`label()` / `value_of()` style methods on the new `types.rs` enums. Per CLAUDE.md's ignore policy
("scope `ignore`s by role, not by coverage %"), those are not exclusion candidates: they are
ordinary library code that a user meets, so this covers them instead.

## What changed

Tests only. No production code is touched.

- **`src/api/tests/covariate_stats_tests.rs`** — the two `validate_model_file` (`ferx check`)
  paths for `[covariate_model]`:
  - without `--data`, a symbolic `center = median` raises `W_COVSTAT_UNBOUND` at *warning*
    severity, keeps `report.valid`, points the suggestion at `--data`, **and** suppresses the
    desugared echo (those lines are the block *without* the pending covariate effect, so printing
    them under "as built from `[covariate_model]`" would state the opposite of the truth);
  - with `--data`, `bind_covariate_stats` runs, neither `W_COVSTAT_UNBOUND` nor
    `E_COVSTAT_UNRESOLVED` fires, and the report carries the built expression.
- **`src/types_tests.rs`** — `CovariateForm::label` / `is_categorical`, `CovariateStat::label` /
  `literal`, `CovariateSummary::value_of`, `CovariateLevels::declared`, `CovariateDecl::new`. The
  labels are the spellings written into the fit YAML *and* the spellings a user types back into
  the block, so they are pinned as data, one assert per variant.
- **`src/parser/covariate_model_tests.rs`** — one test per malformed-line diagnostic: a missing
  `~`, an empty parameter name, a relation stating no form, two relations generating the same θ,
  unbalanced form parentheses, an unquoted or empty `expr`, a keyword argument with no value, an
  unrecognised centring value, a repeated keyword, a symbolic `fix`, a non-finite literal centre,
  and the four malformed `=> NAME(init, lower, upper)` shapes. Also pins `minimum` / `maximum` as
  accepted spellings of `min` / `max`, which had no test at all.

## Alternatives considered

Adding a `codecov.yml` `ignore` entry, or `#[cfg(not(coverage))]` around the error branches. Both
rejected on CLAUDE.md's stated rule — exclusions are scoped by what code *is* (dev tooling,
generated code, test scaffolding), never because it reads red. These branches are user-facing
diagnostics.

Also considered leaving it: the weekly `project/floor_weekly` status on `main` is the enforced
90% floor, and merging a sub-90% patch pushes against it.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change, so no `Cargo.lock` bump is needed in ferx-r.

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (tests only — no production code changed, so no estimate, OFV or residual can move)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes: 3805 passed, 0 failed)
- [ ] Regression test added that fails without this fix
- [x] No new tests needed — this PR *is* the tests

Measured with the same command CI uploads under the `fast` flag:

```
cargo llvm-cov --workspace --tests --no-fail-fast \
  --no-default-features --features ferx-core/ci --lcov --output-path lcov.info
```

then grading only the lines added since `b28eed45` (the PR's merge base):

| | patch coverage | missing |
|---|---|---|
| before | 87.57% | 171 / 1376 |
| after | **94.77%** | 72 / 1376 |

The "before" number reproduces Codecov's reported 87.54% to within 0.03pp, so the local
measurement is grading the same set of lines. Per file, after:

| file | before | after |
|---|---|---|
| `src/api/validation.rs` | 64.63% | 98.78% |
| `src/types.rs` | 67.24% | 100% |
| `src/parser/covariate_model.rs` | 89.97% | 96.53% |

CI merges the `survival` / `markov` / `nn` flags on top of `fast`, which can only raise this
further.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] No user-visible change

## Checklist
- [x] `cargo clippy` clean (`--no-default-features --features ci,markov,nn --all-targets`)
- [x] Functions on the `Dual2` sensitivity path stay differentiable — not touched
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site
- [x] No new DSL syntax, example or data file — nothing to mirror

### ferx-book
- [x] No estimator, DSL feature or fit option changed

### Example execution
- [x] No example execution step needed (tests only, no user-visible change)

## Reviewer hints

The two `validate_model_file` tests are the only ones that go through a real entry point; the rest
are one-line assertions on error text. Worth a skim on the *phrases* being pinned — each assert
targets the fragment that makes the message actionable rather than the whole string, so rewording
a diagnostic stays cheap.

`check_without_data_warns_that_the_statistics_are_still_unbound` is the one with actual content
beyond coverage: it pins that the desugared echo is *suppressed* while a relation is unresolved,
which is a correctness property, not decoration.

## Open questions

`src/api/validation.rs:1561` (the `resolved_center == None` early-continue in
`check_covariate_levels`) is still uncovered — it is only reachable with a categorical relation
whose centre is unbound, which `check_covariate_model_bound` reports first on every entry point.
Left alone rather than reached through a contrived construction; happy to add one if preferred.
