### PR TITLE
docs: keep rationale and validation in their own subsection

### DIFF
--- a/docs/development/contributing.qmd
+++ b/docs/development/contributing.qmd
@@ -96,6 +96,51 @@ existing surface does not suffice. Do not reach for `#[doc(hidden)]` — it hide
 the item from the baseline, so a test rejects it outright. See
 [SDLC §8.7](sdlc.qmd#the-public-api-gate).
 
+## Writing a docs page {#writing-a-docs-page}
+
+These pages are read by people and retrieved a section at a time by anything
+else — the site's own anchor links, and agents that pull one chunk rather than a
+whole page. [R1](docs-lint.qmd#r1-section-size) enforces the size of such a
+chunk; this section is the convention that makes staying under it easy, and
+makes the result worth retrieving.
+
+### Keep rationale and validation in their own subsection
+
+Most oversized sections are a usage explanation and its justification welded
+together, so a heading that reads like a how-to serves background instead —
+implementation reasoning, NONMEM comparisons, benchmark tables. Give the
+justification its own subheading. Nothing moves off the page; it just becomes
+separately addressable, so a reader who wants the answer can skip it and one who
+wants the reasoning can link straight to it.
+
+**Use the standard names.** `### Rationale` for why a design or a default is
+what it is, `### Validation` (or `### Validation against NONMEM`) for the parity
+evidence required by [Gold-standard
+validation](sdlc.qmd#gold-standard-validation). Skipping and finding both work
+by matching the heading, so *Background*, *Notes*, *Design* and *History* defeat
+the point.
+
+**Leave the verdict behind.** Rationale is sometimes the answer — a reader
+deciding whether to override a default needs the outcome even if they skip the
+derivation. Keep the conclusion and any scope caveats in the usage section, and
+link down for the reasoning:
+
+> Analytic for the combinations listed below; everything else falls back to FD.
+> See `[Rationale](#rationale-gradient-route)`.
+
+**A rationale subsection is not exempt from R1.** Split it when it grows, the
+same as anything else — otherwise the wall of prose has only been relocated
+under a heading nobody trims.
+
+### Two things the linter cannot see
+
+- **`toc-depth` is 3** (`docs/_quarto.yml`). A subsection added under an `###`
+  lands at `####` and drops out of the on-page TOC, which loses half the benefit
+  of splitting. Promote the parent to `##`, or raise `toc-depth` for that page.
+- **Whether the split is by concern.** Six subheadings that each mean something
+  ("Covariance / standard errors", "ODE solver") make a page navigable; six that
+  say "Part 1 … Part 6" satisfy R1 and help nobody.
+
 **Good first contributions:** add a NONMEM-comparison test for a model we don't
 cover yet, improve a docs page, or fix a reproducible bug with a regression
 test. Small, well-tested PRs are the easiest to merge. Large or experimental

--- a/docs/development/docs-lint.qmd
+++ b/docs/development/docs-lint.qmd
@@ -40,6 +40,12 @@ word has to go. The limit applies to every independently-addressable chunk — a
 terminal section, the prose above a page's first heading, and the prose a parent
 section keeps above its own first subheading.
 
+Where to cut is usually obvious once you look for it: an oversized section is
+typically a usage explanation welded to its justification, and lifting the
+justification out under `### Rationale` or `### Validation` fixes both the size
+and the addressability. See [Writing a docs
+page](contributing.qmd#writing-a-docs-page).
+
 Sections that predate the linter are listed in `docs/.lint-baseline`, which is
 **shrink-only**: a new violation fails, a baselined section that grew fails, and
 a section that no longer violates fails as a stale entry, so fixing one forces

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -311,6 +311,9 @@ brand assets and styling as the main ferx site in `../ferx-nlme.github.io`.
   levels, duplicate anchors and dead internal links. It runs on every PR as the
   `Docs lint` job; the rules and how to fix each one are on the
   [Docs linter](docs-lint.qmd) page.
+- **Keep rationale and validation in their own subsection**, so a usage section
+  is not also a wall of background — see [Writing a docs
+  page](contributing.qmd#writing-a-docs-page).
 
 Render locally with `quarto render docs` before marking documentation-heavy PRs
 ready for review.


### PR DESCRIPTION
## Why

`docs-lint` R1 (#1163) enforces that an addressable chunk stays under 5,000
characters, but it says nothing about *where to cut*. In practice the answer is
almost always the same, and #1162 found it on every one of the five sections it
split: an oversized section is a usage explanation welded to its justification —
implementation reasoning, NONMEM comparisons, benchmark tables — under a single
heading that reads like a how-to.

That hurts both readers. A reader (or an agent retrieving one section) who wants
to know *whether to override `gradient_method`* gets 8k tokens of scope history
about which PR made which combination analytic; and there is no way to link to
"the FD fallback list" — only to the whole thing.

The convention is already half-present: 16 pages carry a `## Validation` or
`## Validation against NONMEM` heading. This writes it down and extends it to
rationale prose.

## What changed

Docs-only. Three files, no code.

- **`docs/development/contributing.qmd`** — new `## Writing a docs page`
  section: lift the justification into `### Rationale` / `### Validation`, with
  the three constraints that make it actually work —
  - **fixed heading names**, because skipping and finding both match on the
    heading text (*Background*, *Notes*, *Design*, *History* defeat it);
  - **the verdict stays behind** in the usage section, because rationale is
    sometimes the answer — a reader deciding whether to override a default needs
    the outcome even if they skip the derivation;
  - **rationale subsections are not exempt from R1**, or the wall of prose has
    only been relocated under a heading nobody trims.

  Plus the two things the linter cannot see: `toc-depth: 3` means a subsection
  added under an `###` lands at `####` and drops out of the on-page TOC; and R1
  is satisfied equally by six meaningful subheadings and by "Part 1 … Part 6".

- **`docs/development/docs-lint.qmd`** — R1's "the fix is always subdivision"
  paragraph now says where the cut usually is, and links to the above.
- **`docs/development/sdlc.qmd`** — one bullet in §8.5 next to the docs-lint
  gate.

## Alternatives considered

**Make it a linter rule.** R1 already catches the symptom mechanically. The
remaining judgement — is this paragraph rationale or usage, is the split by
concern — is not checkable from `.qmd` source, and a rule that fires on "section
contains a NONMEM table" would be noise. Convention documented next to the rule
that enforces its consequence is the right level.

**Put it on the docs-lint page instead.** That page is scoped to what CI
enforces; mixing an unenforced convention into the rule list blurs what turns a
job red.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None

## Numerical validation

- [x] Not applicable (docs / refactor / CI only)

## Performance

- [x] No significant impact expected

## Tests

- [x] No new tests needed (why: docs-only; `cargo test -p docs-lint` covers the
      structure of the pages touched, and passes)

## Example (user-facing features only)

- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs

- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml` — N/A, no new page
- [x] `CHANGELOG.md` `[Unreleased]` entry — N/A: contributor-facing docs
      convention, no user-facing behaviour change
- [ ] No user-visible change

## Checklist

- [x] `cargo run -p docs-lint` → `docs-lint: clean` (9 pre-existing baselined R1
      sections unchanged); both edited pages render clean under
      `quarto render`
- [x] `tools/preflight.sh` — N/A, no Rust source touched
- [x] Functions on the `Dual2` sensitivity path — untouched
- [x] `Cargo.toml` version bump — not needed

## Docs & examples

### ferx-site
- [x] No new `.ferx` DSL syntax or `[fit_options]` key
- [x] No new example or data file

### ferx-book
- [x] No new estimator, DSL feature, or fit option

### Example execution
- [x] No example execution step needed (docs-only / no user-visible change)

## Reviewer hints

The substance is the three constraints in `contributing.qmd` — particularly
*leave the verdict behind*, which is the one that keeps the split from making
answers worse. The rest is placement and cross-links.

Worth a second opinion on the heading vocabulary: `Rationale` and `Validation`
are the two names picked, and `Validation` matches what 16 pages already use.
If a third name is wanted (`Scope`? `Comparison with NONMEM`?), now is the time,
because the value comes from the list being short and closed.

## Open questions

None blocking. The existing `docs/.lint-baseline` entries are untouched — most
of them are exactly this pattern, so they are natural follow-up scope for
applying the convention rather than just recording their size.
