### PR TITLE
fix(tools): reject high-cardinality labels and constant EBEs in GAM screening [#1114]

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -54,6 +54,7 @@ on:
       - 'Cargo.lock'                        # a nlopt/nalgebra/rand bump moves fit numbers and RNG streams
       - 'Cargo.toml'                        # the `ci-test` profile + the `slow-tests` / `survival` features
       - 'crates/**'                         # the workspace members — the job runs `--workspace`
+      - '!crates/docs-lint/**'              # ...except the one the command --excludes; see the run: step
       - 'data/**'                           # fixture CSVs the fits read by literal path
       - 'examples/**'                       # `.ferx` models the anchors load (e.g. the adaptive vanco suite)
       - 'nonmem_anchor/**'                  # committed NONMEM control streams, data and `.phi` references

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -53,6 +53,7 @@ on:
       - '.github/workflows/slow-tests.yml'  # the feature set / cargo command this job runs
       - 'Cargo.lock'                        # a nlopt/nalgebra/rand bump moves fit numbers and RNG streams
       - 'Cargo.toml'                        # the `ci-test` profile + the `slow-tests` / `survival` features
+      - 'crates/**'                         # the workspace members — the job runs `--workspace`
       - 'data/**'                           # fixture CSVs the fits read by literal path
       - 'examples/**'                       # `.ferx` models the anchors load (e.g. the adaptive vanco suite)
       - 'nonmem_anchor/**'                  # committed NONMEM control streams, data and `.phi` references
@@ -105,7 +106,14 @@ jobs:
         # `slow-tests` is declared by both `ferx-core` and `ferx-tools` — an
         # unqualified name would resolve to the root package's and leave the
         # member's gate closed.
+        #
+        # `--exclude docs-lint`: that crate is a structural linter over `docs/**` with its
+        # own seconds-long CI job, and it depends on nothing. Running it here would put
+        # `docs/**` among this job's inputs, so a docs typo would trigger the two-hour fit
+        # suite — and it would couple the linter to the `ferx-core` compile path, which is
+        # exactly what keeping it dependency-free was for (#969). The guard reads this
+        # `--exclude` list, so adding or dropping one moves the path filter with it.
         run: |
-          cargo test --workspace --no-default-features \
+          cargo test --workspace --exclude docs-lint --no-default-features \
             --features ferx-core/ci,ferx-core/survival,ferx-core/slow-tests,ferx-tools/slow-tests \
             --profile ci-test --no-fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,10 @@ section of the SDLC for the versioning policy).
 
   A covariate that cannot be screened is now reported in `GamResult::warnings` rather than
   dropped in silence — being skipped and being screened-but-unimportant are indistinguishable
-  in a ranking. Skips cover: a constant covariate, a single-level or fully saturated
-  categorical, a singular design, a column whose length does not match the subject count, and
-  fewer than three usable subjects. Shrinkage above 30% warns, and so does an ETA whose
+  in a ranking. Skips cover: a constant covariate, a single-level categorical, a categorical
+  spending more than half the subjects as parameters, a singular design, a column whose
+  length does not match the subject count, and fewer than three usable subjects. An ETA whose
+  EBEs are constant is refused outright. Shrinkage above 30% warns, and so does an ETA whose
   shrinkage the fit did not report at all. `gam_screen_raw()` panics on a length mismatch
   instead of truncating to the shortest input.
 - **`PoolPlan` and `FitOptions::quiet()`: the two knobs a tool needs to run many fits (#1115).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,11 +84,11 @@ section of the SDLC for the versioning policy).
   A covariate that cannot be screened is now reported in `GamResult::warnings` rather than
   dropped in silence — being skipped and being screened-but-unimportant are indistinguishable
   in a ranking. Skips cover: a constant covariate, a single-level categorical, a categorical
-  spending more than half the subjects as parameters, a singular design, a column whose
-  length does not match the subject count, and fewer than three usable subjects. An ETA whose
-  EBEs are constant is refused outright. Shrinkage above 30% warns, and so does an ETA whose
-  shrinkage the fit did not report at all. `gam_screen_raw()` panics on a length mismatch
-  instead of truncating to the shortest input.
+  or spline form spending more than half the subjects as parameters, a singular design, a
+  column whose length does not match the subject count, and fewer than three usable subjects.
+  An ETA whose EBEs are constant, or not all finite, is refused outright. Shrinkage above
+  30% warns, and so does an ETA whose shrinkage the fit did not report at all.
+  `gam_screen_raw()` panics on a length mismatch instead of truncating to the shortest input.
 - **`PoolPlan` and `FitOptions::quiet()`: the two knobs a tool needs to run many fits (#1115).**
   `PoolPlan::from_budget(total_threads, n_units)` splits a thread budget between the replicate
   level and `fit()`'s own per-subject level (outer level first, so a 200-replicate bootstrap on

--- a/crates/ferx-tools/src/gam.rs
+++ b/crates/ferx-tools/src/gam.rs
@@ -498,7 +498,18 @@ pub(crate) fn screen_eta_raw(
         .iter()
         .map(|&v| (v - mean_eta).powi(2))
         .sum::<f64>();
-    if !sst_eta.is_finite() || sst_eta <= 0.0 {
+    // Two different failures, reported as two different things. Only NaN is filtered out of
+    // `valid_eta`, so an EBE of ±∞ reaches here and makes the sum non-finite — telling that
+    // user the column is "constant" would hide a fit blow-up behind a benign message.
+    if !sst_eta.is_finite() {
+        warnings.push(
+            "the EBEs are not all finite, so the screening regressions cannot be fitted; \
+             nothing screened."
+                .into(),
+        );
+        return (f64::NAN, vec![], warnings);
+    }
+    if sst_eta <= 0.0 {
         warnings.push(
             "the EBEs are constant across subjects, so no covariate can explain them; \
              nothing screened."
@@ -564,9 +575,15 @@ pub(crate) fn screen_eta_raw(
         // across the population and still be constant over the subset that has
         // a value for *this* covariate, which puts the same NaN into ΔAIC.
         if !aic_null_local.is_finite() {
+            // `−∞` is the constant-EBE case (RSS = 0); anything else non-finite is a blown-up
+            // residual, which is a different problem and gets a different sentence.
+            let cause = if aic_null_local == f64::NEG_INFINITY {
+                "the EBEs are constant over its"
+            } else {
+                "the null model's residuals are not finite over its"
+            };
             warnings.push(format!(
-                "{cov_name}: the EBEs are constant over its {n} subjects, so ΔAIC is undefined; \
-                 skipped."
+                "{cov_name}: {cause} {n} subjects, so ΔAIC is undefined; skipped."
             ));
             continue;
         }
@@ -681,8 +698,14 @@ pub(crate) fn screen_eta_raw(
 
                 // Spline forms.
                 for &df in &opts.spline_df {
-                    // Need at least df+2 subjects to fit df+1 params + intercept.
-                    if df < 1 || n <= df + 1 {
+                    // The same residual-degrees-of-freedom rule the categorical branch
+                    // applies, for the same reason: `n > p` alone admits a fit with one
+                    // residual df, where `n·ln(RSS/n)` dives and `2p` does not keep up.
+                    // `spline_df` is a public `GamOptions` field, and even the default
+                    // `[2, 3]` reaches this on a small population — `n = 5`, `df = 3` spends
+                    // 4 parameters and leaves 1 — so a continuous covariate could reproduce
+                    // the same ranking pathology a high-cardinality label does.
+                    if df < 1 || n < 2 * (df + 1) {
                         continue;
                     }
                     let basis = ns_basis(&z, df);
@@ -1451,6 +1474,79 @@ mod tests {
         assert!(
             scores.is_empty(),
             "11 levels over 20 subjects must be refused"
+        );
+    }
+
+    #[test]
+    fn a_spline_is_refused_the_residual_df_a_categorical_is_refused() {
+        // The guard has to be two-sided. `spline_df` is a public option and even the
+        // default `[2, 3]` reaches this on a small population: 5 subjects with df = 3
+        // spends 4 parameters and leaves 1 residual df, which is the same arithmetic that
+        // let a 99-level label score +474.
+        let n = 5;
+        let x: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 1.7 + 0.4).sin()).collect();
+        let opts = GamOptions {
+            spline_df: vec![3],
+            include_linear: false,
+            ..Default::default()
+        };
+        let cov_refs = [("X", x.as_slice(), CovariateKind::Continuous)];
+        let (_, scores, _) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(
+            scores.is_empty(),
+            "df = 3 over 5 subjects leaves 1 residual df and must be refused, got {:?}",
+            scores.iter().map(|s| s.delta_aic).collect::<Vec<_>>()
+        );
+
+        // Eight subjects spend the same 4 parameters and leave 4 — admitted.
+        let n = 8;
+        let x: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 1.7 + 0.4).sin()).collect();
+        let cov_refs = [("X", x.as_slice(), CovariateKind::Continuous)];
+        let (_, scores, _) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert_eq!(scores.len(), 1, "df = 3 over 8 subjects must be admitted");
+    }
+
+    #[test]
+    fn a_caller_supplied_spline_df_near_n_cannot_win_on_arithmetic() {
+        // `GamOptions::spline_df` is public, so the pathological df is reachable without a
+        // small dataset: 20 subjects and df = 15 leaves 4 residual df.
+        let n = 20;
+        let x: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 0.9 + 0.2).sin()).collect();
+        let opts = GamOptions {
+            spline_df: vec![15],
+            include_linear: false,
+            ..Default::default()
+        };
+        let cov_refs = [("X", x.as_slice(), CovariateKind::Continuous)];
+        let (_, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(
+            scores.is_empty(),
+            "a df spending three quarters of the subjects must be refused; warnings: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_finite_ebe_is_not_reported_as_constant() {
+        // Only NaN is filtered out of the EBE column, so ±∞ reaches the variance check and
+        // makes it non-finite. Saying "constant" there hides a fit blow-up behind a
+        // benign-sounding message.
+        let mut eta: Vec<f64> = (0..20).map(|i| (i as f64 * 0.3).sin()).collect();
+        eta[7] = f64::INFINITY;
+        let cov: Vec<f64> = (0..20).map(|i| i as f64).collect();
+        let opts = GamOptions::default();
+        let cov_refs = [("X", cov.as_slice(), CovariateKind::Continuous)];
+        let (_, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(scores.is_empty());
+        assert!(
+            warns.iter().any(|w| w.contains("not all finite")),
+            "a non-finite EBE must be named as such: {warns:?}"
+        );
+        assert!(
+            !warns.iter().any(|w| w.contains("constant")),
+            "a varying column must not be called constant: {warns:?}"
         );
     }
 

--- a/crates/ferx-tools/src/gam.rs
+++ b/crates/ferx-tools/src/gam.rs
@@ -488,6 +488,25 @@ pub(crate) fn screen_eta_raw(
         return (f64::NAN, vec![], warnings);
     }
 
+    // A constant EBE column — a fixed random effect, or one the data never
+    // identified — makes RSS zero for *every* model including the null, so both
+    // AICs are −∞ and every ΔAIC is `−∞ − (−∞)` = NaN. A NaN compares equal to
+    // nothing, so `partial_cmp` falls back to `Equal` and the score lands in the
+    // ranking looking like a number. Refuse the ETA outright instead.
+    let mean_eta = valid_eta.mean();
+    let sst_eta = valid_eta
+        .iter()
+        .map(|&v| (v - mean_eta).powi(2))
+        .sum::<f64>();
+    if !sst_eta.is_finite() || sst_eta <= 0.0 {
+        warnings.push(
+            "the EBEs are constant across subjects, so no covariate can explain them; \
+             nothing screened."
+                .into(),
+        );
+        return (f64::NAN, vec![], warnings);
+    }
+
     // Global null model (intercept only) AIC.
     let n_all = valid_eta.len();
     let x_null_all = DMatrix::from_element(n_all, 1, 1.0);
@@ -541,6 +560,16 @@ pub(crate) fn screen_eta_raw(
                 continue;
             }
         };
+        // The whole-column check above does not cover this: the EBEs can vary
+        // across the population and still be constant over the subset that has
+        // a value for *this* covariate, which puts the same NaN into ΔAIC.
+        if !aic_null_local.is_finite() {
+            warnings.push(format!(
+                "{cov_name}: the EBEs are constant over its {n} subjects, so ΔAIC is undefined; \
+                 skipped."
+            ));
+            continue;
+        }
 
         // Fit candidate forms and pick the one with the lowest AIC.
         let mut best_aic = f64::INFINITY;
@@ -549,16 +578,37 @@ pub(crate) fn screen_eta_raw(
 
         match kind {
             CovariateKind::Categorical => {
-                let dummies = categorical_design(&x_vals);
-                let n_dummies = dummies.ncols();
+                // Count the levels BEFORE building anything: a label with one
+                // level per subject would otherwise allocate an n × (n−1)
+                // design — O(n²) — only to be rejected on the next line.
+                let levels = categorical_levels(&x_vals);
+                let n_dummies = levels.len().saturating_sub(1);
+                let n_params = n_dummies + 1; // intercept + dummies
 
                 // A single-level categorical carries no information, and a
-                // near-saturated one carries too much: with `n_levels`
-                // approaching `n`, `n·ln(RSS/n)` dives and the `2p` penalty
-                // does not keep up, so a high-cardinality label (STUDY, SITE)
-                // would win the ranking on arithmetic alone. Both are skipped
-                // rather than scored — the continuous branch already refuses a
-                // constant covariate, and this is the same degenerate case.
+                // high-cardinality one carries too much. For a label with `k`
+                // levels over `n` subjects and no real signal,
+                // `E[RSS/RSS₀] ≈ (n−k)/(n−1)`, so
+                //
+                //     ΔAIC ≈ n·ln((n−1)/(n−k)) − 2(k−1)
+                //
+                // which is negative for small `k` but crosses zero near
+                // `k ≈ 0.8n` and reaches +474 at `k = n−1, n = 100`: the fit's
+                // freedom to interpolate outruns the `2p` penalty, and a SITE
+                // or STUDY identifier ranks above every real covariate. Refusing
+                // only `k = n` (residual df ≥ 1) leaves that whole band open.
+                //
+                // So the design must leave at least as many residual degrees of
+                // freedom as it spends parameters — `n ≥ 2p`, i.e. `k ≲ n/2`,
+                // where the expression above is still comfortably negative
+                // (≈ −30 at `k = n/2, n = 100`). Nothing of value is lost: a
+                // label in the discarded band scores negative when AIC works at
+                // all, so it would rank last either way.
+                //
+                // The threshold is a guard, not a scoring change. Switching to
+                // AICc would handle this more smoothly but would move every
+                // ΔAIC by ~0.1, breaking the R / xpose4 parity this module is
+                // validated against.
                 if n_dummies == 0 {
                     warnings.push(format!(
                         "{cov_name}: only one distinct level over the {n} screened subjects; \
@@ -566,16 +616,19 @@ pub(crate) fn screen_eta_raw(
                     ));
                     continue;
                 }
-                if n_dummies + 1 >= n {
+                if n < 2 * n_params {
                     warnings.push(format!(
-                        "{cov_name}: {} levels over {n} subjects leaves no residual degrees of \
-                         freedom; skipped.",
-                        n_dummies + 1
+                        "{cov_name}: {} levels over {n} subjects spends {n_params} parameters and \
+                         leaves only {} residual degrees of freedom, too few for AIC to \
+                         discriminate signal from interpolation; skipped.",
+                        levels.len(),
+                        n.saturating_sub(n_params)
                     ));
                     continue;
                 }
 
                 // Design: [intercept | dummies]
+                let dummies = categorical_design(&x_vals, &levels);
                 let mut x_cat = DMatrix::zeros(n, n_dummies + 1);
                 for row in 0..n {
                     x_cat[(row, 0)] = 1.0;
@@ -811,23 +864,35 @@ pub(crate) fn ols_aic(x: &DMatrix<f64>, y: &DVector<f64>) -> Option<(f64, f64)> 
     Some((aic, r2))
 }
 
+/// The distinct levels of a categorical covariate, ascending.
+///
+/// Separate from [`categorical_design`] so a caller can judge the cardinality
+/// before paying for an `n × (levels − 1)` matrix it may be about to reject.
+///
+/// `pub(crate)` for unit tests.
+pub(crate) fn categorical_levels(x: &[f64]) -> Vec<f64> {
+    let mut levels: Vec<f64> = x.to_vec();
+    levels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    levels.dedup_by(|a, b| (*a - *b).abs() < 1e-10);
+    levels
+}
+
 /// One-hot encoding of a categorical covariate, shape `n × (levels − 1)`.
 ///
 /// The lowest observed level is the reference (dropped). Returns an empty
 /// matrix when there is only one unique level.
 ///
+/// Takes the levels from [`categorical_levels`] rather than recomputing them,
+/// so a caller can reject a design on its cardinality before paying to build
+/// it — for a label with one level per subject that matrix is `n × (n − 1)`.
+///
 /// `pub(crate)` for unit tests.
-pub(crate) fn categorical_design(x: &[f64]) -> DMatrix<f64> {
-    let mut levels: Vec<f64> = x.to_vec();
-    levels.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    levels.dedup_by(|a, b| (*a - *b).abs() < 1e-10);
-
-    let n_levels = levels.len();
-    if n_levels <= 1 {
+pub(crate) fn categorical_design(x: &[f64], levels: &[f64]) -> DMatrix<f64> {
+    if levels.len() <= 1 {
         return DMatrix::zeros(x.len(), 0);
     }
 
-    let n_dummies = n_levels - 1;
+    let n_dummies = levels.len() - 1;
     let mut mat = DMatrix::zeros(x.len(), n_dummies);
     for (row, &val) in x.iter().enumerate() {
         for (col, &level) in levels[1..].iter().enumerate() {
@@ -1295,6 +1360,172 @@ mod tests {
                 .any(|w| w.contains("SITE") && w.contains("residual degrees of freedom")),
             "the skip must name the reason: {warns:?}"
         );
+    }
+
+    #[test]
+    fn near_saturated_categorical_is_skipped_not_ranked_first() {
+        // The `n > p` guard alone was not enough. A label with n−1 levels over
+        // 100 unrelated ETA values has one residual degree of freedom, passes
+        // that guard, and scores ΔAIC ≈ +474 with R² ≈ 0.999 — ranking a SITE
+        // identifier far above a covariate carrying real signal.
+        let n = 100;
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 0.37 + 0.11).sin()).collect();
+        let site: Vec<f64> = (0..n)
+            .map(|i| if i == 0 { 1.0 } else { i as f64 })
+            .collect();
+        assert_eq!(
+            categorical_levels(&site).len(),
+            n - 1,
+            "fixture must be near-saturated, not saturated"
+        );
+        let wt: Vec<f64> = (0..n).map(|i| 60.0 + 0.5 * i as f64).collect();
+
+        let opts = GamOptions::default();
+        let cov_refs = [
+            ("SITE", site.as_slice(), CovariateKind::Categorical),
+            ("WT", wt.as_slice(), CovariateKind::Continuous),
+        ];
+        let (_, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(
+            !scores.iter().any(|s| s.covariate == "SITE"),
+            "a near-saturated label must not be scored: {:?}",
+            scores
+                .iter()
+                .map(|s| (&s.covariate, s.delta_aic))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            warns
+                .iter()
+                .any(|w| w.contains("SITE") && w.contains("residual degrees of freedom")),
+            "the skip must name the reason: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn a_categorical_with_room_to_spare_is_still_scored() {
+        // The cardinality guard must not swallow ordinary factors: 3 levels
+        // over 30 subjects spends 3 parameters and leaves 27.
+        let n = 30;
+        let grp: Vec<f64> = (0..n).map(|i| (i % 3) as f64).collect();
+        let eta: Vec<f64> = grp
+            .iter()
+            .enumerate()
+            .map(|(i, &g)| g * 0.4 + (i as f64 * 0.7).sin() * 0.02)
+            .collect();
+        let opts = GamOptions::default();
+        let cov_refs = [("GRP", grp.as_slice(), CovariateKind::Categorical)];
+        let (_, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert_eq!(scores.len(), 1, "warnings: {warns:?}");
+        assert_eq!(scores[0].best_form, CovariateForm::Categorical);
+        assert!(scores[0].delta_aic > 5.0, "got {}", scores[0].delta_aic);
+    }
+
+    #[test]
+    fn the_cardinality_guard_sits_exactly_at_two_parameters_per_subject() {
+        // n = 20: 10 levels spends 10 parameters and is admitted; 11 levels
+        // spends 11 and is not. Pins the boundary so a later "tidy-up" of the
+        // inequality is a red test rather than a silent widening.
+        let n = 20;
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 0.31 + 0.2).sin()).collect();
+        let ten: Vec<f64> = (0..n).map(|i| (i % 10) as f64).collect();
+        let eleven: Vec<f64> = (0..n).map(|i| (i % 11) as f64).collect();
+        let opts = GamOptions::default();
+
+        let (_, scores, _) = screen_eta_raw(
+            &eta,
+            &[("TEN", ten.as_slice(), CovariateKind::Categorical)],
+            &opts,
+        );
+        assert_eq!(
+            scores.len(),
+            1,
+            "10 levels over 20 subjects must be admitted"
+        );
+
+        let (_, scores, _) = screen_eta_raw(
+            &eta,
+            &[("ELEVEN", eleven.as_slice(), CovariateKind::Categorical)],
+            &opts,
+        );
+        assert!(
+            scores.is_empty(),
+            "11 levels over 20 subjects must be refused"
+        );
+    }
+
+    #[test]
+    fn constant_etas_produce_no_scores_and_a_warning() {
+        // Every model including the null fits perfectly, so both AICs are −∞
+        // and ΔAIC is `−∞ − (−∞)` = NaN — which sorted as "equal" and sat in
+        // the ranking looking like a score.
+        let eta = vec![0.0_f64; 20];
+        let cov: Vec<f64> = (0..20).map(|i| i as f64).collect();
+        let opts = GamOptions::default();
+        let cov_refs = [("X", cov.as_slice(), CovariateKind::Continuous)];
+        let (aic_null, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(aic_null.is_nan());
+        assert!(scores.is_empty(), "no covariate can explain a constant EBE");
+        assert!(
+            warns.iter().any(|w| w.contains("constant")),
+            "the refusal must be reported: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn constant_etas_over_one_covariates_subset_skip_only_that_covariate() {
+        // The EBEs vary across the population but are constant over the
+        // subjects that have a value for this covariate — same NaN, and not
+        // caught by the whole-column check.
+        let n = 24;
+        let eta: Vec<f64> = (0..n)
+            .map(|i| if i < 12 { 0.0 } else { i as f64 * 0.1 })
+            .collect();
+        let patchy: Vec<f64> = (0..n)
+            .map(|i| if i < 12 { i as f64 } else { f64::NAN })
+            .collect();
+        let full: Vec<f64> = (0..n).map(|i| 70.0 + i as f64).collect();
+        let opts = GamOptions::default();
+        let cov_refs = [
+            ("PATCHY", patchy.as_slice(), CovariateKind::Continuous),
+            ("FULL", full.as_slice(), CovariateKind::Continuous),
+        ];
+        let (_, scores, warns) = screen_eta_raw(&eta, &cov_refs, &opts);
+        assert!(
+            !scores.iter().any(|s| s.covariate == "PATCHY"),
+            "a covariate whose subset has constant EBEs must be skipped"
+        );
+        assert!(
+            scores.iter().any(|s| s.covariate == "FULL"),
+            "the other covariate must still be screened"
+        );
+        assert!(
+            warns
+                .iter()
+                .any(|w| w.contains("PATCHY") && w.contains("undefined")),
+            "{warns:?}"
+        );
+    }
+
+    #[test]
+    fn no_score_is_ever_nan() {
+        // The contract the ranking depends on: `sort_by` falls back to `Equal`
+        // for a NaN, so a NaN ΔAIC is not merely wrong, it is unordered.
+        let n = 40;
+        let eta: Vec<f64> = (0..n).map(|i| (i as f64 * 0.3).sin()).collect();
+        let flat = vec![1.0_f64; n];
+        let ramp: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let label: Vec<f64> = (0..n).map(|i| (i % 4) as f64).collect();
+        let opts = GamOptions::default();
+        let cov_refs = [
+            ("FLAT", flat.as_slice(), CovariateKind::Continuous),
+            ("RAMP", ramp.as_slice(), CovariateKind::Continuous),
+            ("LABEL", label.as_slice(), CovariateKind::Categorical),
+        ];
+        let (_, scores, _) = screen_eta_raw(&eta, &cov_refs, &opts);
+        for s in &scores {
+            assert!(!s.delta_aic.is_nan(), "{} produced a NaN ΔAIC", s.covariate);
+        }
     }
 
     #[test]

--- a/docs/tools/gam-screening.qmd
+++ b/docs/tools/gam-screening.qmd
@@ -126,11 +126,43 @@ identical in a ranking, so every skip says which happened:
 | fewer than 3 subjects with both an EBE and a value | nothing to regress |
 | constant over the screened subjects | carries no information |
 | categorical with one distinct level | the same degenerate case |
-| categorical with as many levels as subjects | saturated: RSS → 0 would win the ranking on arithmetic alone, not on signal |
+| categorical spending more than `n/2` parameters | see [High-cardinality labels](#high-cardinality-labels) |
 | singular design | no candidate form could be fitted |
 | column length ≠ subject count | the caller's data is misaligned |
 
+An ETA is refused outright — no scores at all — when its EBEs are constant
+across subjects, which happens for a fixed random effect or one the data never
+identified. Every model then fits perfectly, every AIC is `−∞`, and every ΔAIC
+would be `−∞ − (−∞)`.
+
 Always read the warnings before trusting an empty or short ranking.
+
+### High-cardinality labels
+
+A categorical covariate must leave at least as many residual degrees of freedom
+as it spends parameters — `n ≥ 2p`, so roughly half the subjects. Anything
+above that is skipped, with a warning.
+
+This is not fussiness. For a label with `k` levels over `n` subjects and no real
+relation to the ETA, `E[RSS/RSS₀] ≈ (n−k)/(n−1)`, so
+
+$$\Delta\text{AIC} \approx n \ln\!\frac{n-1}{n-k} - 2(k-1)$$
+
+which is comfortably negative for small `k`, crosses zero near `k ≈ 0.8n`, and
+reaches **+474** at `k = n − 1, n = 100`. A SITE or STUDY identifier declared
+`categorical` would rank far above every covariate carrying real signal — the
+model's freedom to interpolate outruns the `2p` penalty long before the design
+is saturated. Requiring only one residual degree of freedom (`k < n`) leaves
+that entire band open.
+
+Nothing useful is lost below the threshold: in the discarded band, a label with
+genuine signal is better represented by the covariate that explains it than by
+the identifier, and a label without signal scores negative wherever plain AIC
+still works, so it would rank last either way.
+
+The rule is a guard, not a change to the score. AICc would handle the same
+problem more smoothly, but it would shift every ΔAIC by ~0.1 and break the R /
+xpose4 parity this module is validated against.
 
 ## Validation
 

--- a/docs/tools/gam-screening.qmd
+++ b/docs/tools/gam-screening.qmd
@@ -126,22 +126,26 @@ identical in a ranking, so every skip says which happened:
 | fewer than 3 subjects with both an EBE and a value | nothing to regress |
 | constant over the screened subjects | carries no information |
 | categorical with one distinct level | the same degenerate case |
-| categorical spending more than `n/2` parameters | see [High-cardinality labels](#high-cardinality-labels) |
+| a form spending more than `n/2` parameters | see [Designs that spend too much](#designs-that-spend-too-much) |
 | singular design | no candidate form could be fitted |
 | column length ≠ subject count | the caller's data is misaligned |
 
 An ETA is refused outright — no scores at all — when its EBEs are constant
 across subjects, which happens for a fixed random effect or one the data never
 identified. Every model then fits perfectly, every AIC is `−∞`, and every ΔAIC
-would be `−∞ − (−∞)`.
+would be `−∞ − (−∞)`. It is refused separately, and said differently, when the
+EBEs are not all finite: that is a fit that blew up, not a covariate problem.
 
 Always read the warnings before trusting an empty or short ranking.
 
-### High-cardinality labels
+### Designs that spend too much
 
-A categorical covariate must leave at least as many residual degrees of freedom
-as it spends parameters — `n ≥ 2p`, so roughly half the subjects. Anything
-above that is skipped, with a warning.
+**Every** candidate form must leave at least as many residual degrees of freedom
+as it spends parameters — `n ≥ 2p`, so roughly half the subjects. Anything above
+that is skipped, with a warning. The rule is one rule: it refuses a
+high-cardinality categorical, and it refuses a spline whose `df` is large
+relative to the subjects that have a value for that covariate. A `df` of 3 needs
+8 subjects, not 5.
 
 This is not fussiness. For a label with `k` levels over `n` subjects and no real
 relation to the ETA, `E[RSS/RSS₀] ≈ (n−k)/(n−1)`, so
@@ -154,6 +158,11 @@ reaches **+474** at `k = n − 1, n = 100`. A SITE or STUDY identifier declared
 model's freedom to interpolate outruns the `2p` penalty long before the design
 is saturated. Requiring only one residual degree of freedom (`k < n`) leaves
 that entire band open.
+
+A spline gets the same treatment because it has the same arithmetic. `spline_df`
+is a caller-settable option, and a `df` close to the number of usable subjects
+buys the identical interpolation win — the mechanism does not care whether the
+columns came from one-hot levels or from a basis.
 
 Nothing useful is lost below the threshold: in the discarded band, a label with
 genuine signal is better represented by the covariate that explains it than by

--- a/tests/slow_test_path_filter.rs
+++ b/tests/slow_test_path_filter.rs
@@ -328,6 +328,25 @@ fn string_literals(src: &str) -> Vec<String> {
     out
 }
 
+/// A YAML line with its `#` comment removed, respecting quotes.
+///
+/// A `#` inside a quoted scalar (`'!crates/docs-lint/**' # note`) does not start a comment
+/// until the quote closes, and the `paths:` list is full of quoted globs.
+fn strip_yaml_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut quote: Option<u8> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        match quote {
+            Some(q) if b == q => quote = None,
+            Some(_) => {}
+            None if b == b'\'' || b == b'"' => quote = Some(b),
+            None if b == b'#' => return &line[..i],
+            None => {}
+        }
+    }
+    line
+}
+
 /// The package name a member manifest declares, for matching against `--exclude`.
 fn member_package_name(root: &Path, member: &str) -> Option<String> {
     let manifest = std::fs::read_to_string(root.join(member).join("Cargo.toml")).ok()?;
@@ -342,9 +361,21 @@ fn member_package_name(root: &Path, member: &str) -> Option<String> {
 ///
 /// Read out of the workflow rather than listed here, so an exclusion added or dropped
 /// moves this guard's expectations with it in the same commit.
+///
+/// Comments are stripped first, and that is load-bearing rather than tidy: an exclusion
+/// removes a member from `built_members`, which removes its sources from the required set
+/// *and* removes its per-member assertion — so a stray `--exclude ferx-tools` in a YAML
+/// comment (a commented-out variant of the run line, or prose that forgets its backticks)
+/// would silently stop guarding that member while every test still passed. The guard's own
+/// failure mode is the one it exists to prevent.
 fn excluded_packages(workflow: &str) -> BTreeSet<String> {
+    let stripped: String = workflow
+        .lines()
+        .map(|line| strip_yaml_comment(line))
+        .collect::<Vec<_>>()
+        .join("\n");
     let mut out = BTreeSet::new();
-    let mut tokens = workflow.split_whitespace().peekable();
+    let mut tokens = stripped.split_whitespace().peekable();
     while let Some(tok) = tokens.next() {
         match tok.strip_prefix("--exclude=") {
             Some(name) => {
@@ -384,20 +415,30 @@ fn built_members(root: &Path) -> BTreeSet<String> {
 /// stale. Entries are directory paths relative to the root (`crates/ferx-tools`).
 fn workspace_members(root: &Path) -> BTreeSet<String> {
     let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("root Cargo.toml");
+    parse_workspace_members(&manifest)
+}
+
+/// [`workspace_members`] on the manifest text, so the parser is testable without a
+/// fixture repository on disk.
+fn parse_workspace_members(manifest: &str) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     let mut in_members = false;
     for line in manifest.lines() {
         let trimmed = line.trim();
         if in_members {
-            if trimmed.starts_with(']') {
-                break;
-            }
             for literal in string_literals(trimmed) {
                 // Skip a glob member (`crates/*`): the concrete directories under it are
                 // what the caller needs, and those come from the tracked-file walk.
                 if !literal.contains('*') && !literal.is_empty() {
                     out.insert(literal.trim_end_matches('/').to_string());
                 }
+            }
+            // `contains`, not `starts_with`: a reformat that trails the bracket on the last
+            // entry (`"crates/docs-lint"]`) would otherwise never close the list, and every
+            // later quoted string in the manifest — dependency versions, feature names, the
+            // description — would be harvested as a member directory.
+            if trimmed.contains(']') {
+                break;
             }
         } else if trimmed.starts_with("members") && trimmed.contains('[') {
             in_members = true;
@@ -449,9 +490,24 @@ fn required_inputs(root: &Path, tracked: &[String]) -> Vec<String> {
         files.insert(format!("{member}/Cargo.toml"));
     }
 
+    // Subtract the members the command `--exclude`s. This is not belt-and-braces: the
+    // harvested runtime roots are top-level (`crates`), so without it the whole of
+    // `crates/` — the excluded member included — lands back in the required set, and the
+    // exclusion in the cargo command would be quietly undone by the derivation meant to
+    // respect it.
+    let all_members = workspace_members(root);
+    let built = built_members(root);
+    let excluded_prefixes: Vec<String> = all_members
+        .difference(&built)
+        .map(|m| format!("{m}/"))
+        .collect();
+
     tracked
         .iter()
-        .filter(|p| files.contains(p.as_str()) || dir_prefixes.iter().any(|pre| p.starts_with(pre)))
+        .filter(|p| {
+            !excluded_prefixes.iter().any(|pre| p.starts_with(pre))
+                && (files.contains(p.as_str()) || dir_prefixes.iter().any(|pre| p.starts_with(pre)))
+        })
         .cloned()
         .collect()
 }
@@ -534,6 +590,144 @@ fn slow_test_filter_covers_every_input_the_heavy_fits_read() {
             .collect::<Vec<_>>()
             .join("\n")
     );
+}
+
+/// The other direction of the coverage invariant.
+///
+/// `slow_test_filter_covers_every_input_the_heavy_fits_read` asserts `required ⊆ filter`,
+/// which says nothing about a filter that is too *wide*. `crates/**` matches every member,
+/// including the one the cargo command `--exclude`s — so a push touching only that crate
+/// would fire the two-hour fit suite it was excluded to stay out of. Nothing else notices:
+/// the coverage test is one-directional and `slow_test_filter_has_no_dead_globs` is
+/// satisfied by the other members matching the same glob.
+#[test]
+fn the_filter_does_not_select_an_excluded_member() {
+    let root = repo_root();
+    let workflow =
+        std::fs::read_to_string(root.join(WORKFLOW)).expect("slow-tests.yml is readable");
+    let patterns = push_path_patterns(&workflow);
+    let tracked = tracked_files(&root);
+
+    let excluded: BTreeSet<String> = workspace_members(&root)
+        .difference(&built_members(&root))
+        .cloned()
+        .collect();
+    assert!(
+        !excluded.is_empty(),
+        "the slow job `--exclude`s nothing, so this guard has nothing to check — delete it \
+         along with the `--exclude`, or fix the parser that stopped seeing one"
+    );
+
+    for member in &excluded {
+        let prefix = format!("{member}/");
+        let selected: Vec<&str> = tracked
+            .iter()
+            .filter(|p| p.starts_with(&prefix) && filter_selects(&patterns, p))
+            .map(String::as_str)
+            .collect();
+        assert!(
+            selected.is_empty(),
+            "`{member}` is `--exclude`d from the slow job's cargo command, but {} of its \
+             files are still matched by the push filter (e.g. `{}`), so a push touching only \
+             that crate fires the two-hour suite anyway. Add `- '!{member}/**'` after the \
+             `crates/**` entry in {WORKFLOW}.",
+            selected.len(),
+            selected[0]
+        );
+    }
+}
+
+#[test]
+fn excluded_packages_reads_the_command_and_not_the_prose_around_it() {
+    // An exclusion drops a member from `built_members`, which drops its sources from the
+    // required set AND drops its per-member assertion — so a `--exclude` picked up out of a
+    // comment silently stops guarding that member while every test here still passes. The
+    // guard's own worst failure mode is the one it exists to prevent, so pin it.
+    let yaml = r#"
+on:
+  push:
+    paths:
+      - 'crates/**'          # we once considered --exclude ferx-tools here
+      - '!crates/docs-lint/**'
+jobs:
+  slow:
+    steps:
+      # a commented-out variant: --exclude ferx-cli
+      - run: cargo test --workspace --exclude docs-lint --profile ci-test
+"#;
+    let excluded = excluded_packages(yaml);
+    assert!(
+        excluded.contains("docs-lint"),
+        "the real `--exclude` in the run: line must be seen: {excluded:?}"
+    );
+    assert!(
+        !excluded.contains("ferx-tools") && !excluded.contains("ferx-cli"),
+        "an `--exclude` inside a comment must not disarm the guard: {excluded:?}"
+    );
+
+    // The `=` spelling is the same flag.
+    assert!(excluded_packages("- run: cargo test --workspace --exclude=foo").contains("foo"));
+
+    // A `#` inside a quoted scalar does not open a comment, so what follows it is still
+    // command text.
+    let quoted = "      - 'a#b'\n      - run: cargo test --exclude bar\n";
+    assert!(
+        excluded_packages(quoted).contains("bar"),
+        "a `#` inside quotes must not swallow the rest of the file"
+    );
+}
+
+#[test]
+fn workspace_members_closes_on_a_trailing_bracket() {
+    // The list is one line today. If it is ever reformatted, a closing bracket that trails
+    // the last entry must still close it — otherwise every later quoted string in the
+    // manifest (dependency versions, feature names, the description) is harvested as a
+    // member directory, and the failure surfaces as a nonsense member rather than as a
+    // broken parser.
+    let one_line = r#"
+[workspace]
+members = ["crates/ferx-tools", "crates/ferx-cli"]
+resolver = "2"
+
+[package]
+description = "not/a/member"
+"#;
+    let trailing = r#"
+[workspace]
+members = [
+    "crates/ferx-tools",
+    "crates/ferx-cli"]
+resolver = "2"
+
+[package]
+description = "not/a/member"
+"#;
+    let own_line = r#"
+[workspace]
+members = [
+    "crates/ferx-tools",
+    "crates/ferx-cli",
+]
+resolver = "2"
+
+[package]
+description = "not/a/member"
+"#;
+    let expected: BTreeSet<String> = ["crates/ferx-tools", "crates/ferx-cli"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    for (label, manifest) in [
+        ("single line", one_line),
+        ("trailing bracket", trailing),
+        ("bracket on its own line", own_line),
+    ] {
+        assert_eq!(
+            parse_workspace_members(manifest),
+            expected,
+            "{label} form parsed wrong"
+        );
+    }
 }
 
 #[test]

--- a/tests/slow_test_path_filter.rs
+++ b/tests/slow_test_path_filter.rs
@@ -267,10 +267,14 @@ fn runtime_input_roots(root: &Path, tracked: &[String]) -> BTreeSet<String> {
 /// directory and the rest are taken as-is.
 fn referenced_paths(root: &Path, tracked: &[String]) -> Vec<(String, String)> {
     let mut out = Vec::new();
-    for path in tracked
-        .iter()
-        .filter(|p| p.starts_with("tests/") && p.ends_with(".rs"))
-    {
+    let member_test_dirs: Vec<String> = built_members(root)
+        .into_iter()
+        .map(|m| format!("{m}/tests/"))
+        .collect();
+    for path in tracked.iter().filter(|p| {
+        p.ends_with(".rs")
+            && (p.starts_with("tests/") || member_test_dirs.iter().any(|d| p.starts_with(d)))
+    }) {
         let src = std::fs::read_to_string(root.join(path)).expect("test source is UTF-8");
         let dir = path.rsplit_once('/').map_or("", |(head, _)| head);
         for literal in string_literals(&src) {
@@ -324,26 +328,130 @@ fn string_literals(src: &str) -> Vec<String> {
     out
 }
 
+/// The package name a member manifest declares, for matching against `--exclude`.
+fn member_package_name(root: &Path, member: &str) -> Option<String> {
+    let manifest = std::fs::read_to_string(root.join(member).join("Cargo.toml")).ok()?;
+    manifest
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("name") && l.contains('='))
+        .and_then(|l| string_literals(l).into_iter().next())
+}
+
+/// Packages the slow job's cargo command excludes from `--workspace`.
+///
+/// Read out of the workflow rather than listed here, so an exclusion added or dropped
+/// moves this guard's expectations with it in the same commit.
+fn excluded_packages(workflow: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut tokens = workflow.split_whitespace().peekable();
+    while let Some(tok) = tokens.next() {
+        match tok.strip_prefix("--exclude=") {
+            Some(name) => {
+                out.insert(name.to_string());
+            }
+            None if tok == "--exclude" => {
+                if let Some(name) = tokens.next() {
+                    out.insert(name.to_string());
+                }
+            }
+            None => {}
+        }
+    }
+    out
+}
+
+/// The member directories `cargo test --workspace [--exclude ...]` actually compiles.
+///
+/// This is the set whose sources, tests and manifests are inputs of the slow job — and,
+/// equally, the set whose test sources are worth harvesting fixture paths from. An
+/// excluded member's fixtures are not this job's inputs, and pulling them in would widen
+/// the push filter to directories a docs- or tooling-only crate happens to read.
+fn built_members(root: &Path) -> BTreeSet<String> {
+    let workflow = std::fs::read_to_string(root.join(WORKFLOW)).unwrap_or_default();
+    let excluded = excluded_packages(&workflow);
+    workspace_members(root)
+        .into_iter()
+        .filter(|m| member_package_name(root, m).is_none_or(|name| !excluded.contains(&name)))
+        .collect()
+}
+
+/// The workspace members, read out of the root manifest's `[workspace] members` list.
+///
+/// Derived rather than listed for the same reason the input roots are: a member added to
+/// the workspace is compiled by the slow job's `--workspace` command from that moment on,
+/// and a guard that mirrored a hand-written list would agree with a filter that had gone
+/// stale. Entries are directory paths relative to the root (`crates/ferx-tools`).
+fn workspace_members(root: &Path) -> BTreeSet<String> {
+    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("root Cargo.toml");
+    let mut out = BTreeSet::new();
+    let mut in_members = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim();
+        if in_members {
+            if trimmed.starts_with(']') {
+                break;
+            }
+            for literal in string_literals(trimmed) {
+                // Skip a glob member (`crates/*`): the concrete directories under it are
+                // what the caller needs, and those come from the tracked-file walk.
+                if !literal.contains('*') && !literal.is_empty() {
+                    out.insert(literal.trim_end_matches('/').to_string());
+                }
+            }
+        } else if trimmed.starts_with("members") && trimmed.contains('[') {
+            in_members = true;
+            // A single-line `members = ["a", "b"]` both opens and closes here.
+            if trimmed.contains(']') {
+                for literal in string_literals(trimmed) {
+                    if !literal.contains('*') && !literal.is_empty() {
+                        out.insert(literal.trim_end_matches('/').to_string());
+                    }
+                }
+                break;
+            }
+        }
+    }
+    out
+}
+
 /// Every tracked file the slow job compiles, reads, or is configured by.
 ///
-/// Compile inputs are mechanical (`cargo test` builds `src/` and `tests/`, configured by
-/// the manifest and the lock); runtime inputs are derived; the workflow is included because
-/// changing its feature set or cargo invocation changes what runs.
+/// Compile inputs are mechanical (`cargo test --workspace` builds the root package's `src/`
+/// and `tests/` *and* every member's, configured by each manifest and the shared lock);
+/// runtime inputs are derived; the workflow is included because changing its feature set or
+/// cargo invocation changes what runs.
 fn required_inputs(root: &Path, tracked: &[String]) -> Vec<String> {
-    let mut dir_roots: BTreeSet<String> = ["src".to_string(), "tests".to_string()]
+    // Directory prefixes, not top-level roots: a member's sources live two levels down
+    // (`crates/ferx-tools/src/`), and matching on the head alone would pull in the whole of
+    // `crates/` for a root the job does not build (a future docs-only crate, say).
+    let mut dir_prefixes: BTreeSet<String> = ["src/".to_string(), "tests/".to_string()]
         .into_iter()
         .collect();
-    dir_roots.extend(runtime_input_roots(root, tracked));
+    dir_prefixes.extend(
+        runtime_input_roots(root, tracked)
+            .into_iter()
+            .map(|r| format!("{r}/")),
+    );
 
-    let files: BTreeSet<&str> = ["Cargo.toml", "Cargo.lock", WORKFLOW].into_iter().collect();
+    let mut files: BTreeSet<String> = ["Cargo.toml", "Cargo.lock", WORKFLOW]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+    // `--workspace` makes each built member's sources, tests and manifest compile inputs of
+    // this job exactly as the root package's are. An `--exclude`d member is not built, so
+    // it is not an input — and must not drag the directories its own tests read into the
+    // push filter.
+    for member in built_members(root) {
+        dir_prefixes.insert(format!("{member}/src/"));
+        dir_prefixes.insert(format!("{member}/tests/"));
+        files.insert(format!("{member}/Cargo.toml"));
+    }
 
     tracked
         .iter()
-        .filter(|p| {
-            files.contains(p.as_str())
-                || p.split_once('/')
-                    .is_some_and(|(head, _)| dir_roots.contains(head))
-        })
+        .filter(|p| files.contains(p.as_str()) || dir_prefixes.iter().any(|pre| p.starts_with(pre)))
         .cloned()
         .collect()
 }
@@ -375,6 +483,34 @@ fn slow_test_filter_covers_every_input_the_heavy_fits_read() {
             required.iter().any(|p| p.starts_with(expected_root)),
             "no required input under `{expected_root}` — the derivation stopped seeing a root \
              the heavy fits demonstrably read"
+        );
+    }
+
+    // The job runs `--workspace`, so every member's sources, tests and manifest are compile
+    // inputs. Assert the derivation found them: without this the members could drop out of
+    // `required` and the coverage assertion below would pass vacuously for `crates/`.
+    let members = built_members(&root);
+    assert!(
+        !members.is_empty(),
+        "parsed no built `[workspace] members` out of the root Cargo.toml — fix this parser \
+         rather than deleting the check: an empty parse silently stops guarding every member"
+    );
+    assert!(
+        !workspace_members(&root).is_empty(),
+        "parsed no `[workspace] members` at all — the manifest parser broke"
+    );
+    for member in &members {
+        assert!(
+            required
+                .iter()
+                .any(|p| p.starts_with(&format!("{member}/src/"))),
+            "no required input under `{member}/src/` — `cargo test --workspace` compiles it, \
+             so a push touching only that member must re-run the slow suite"
+        );
+        assert!(
+            required.contains(&format!("{member}/Cargo.toml")),
+            "`{member}/Cargo.toml` is not a required input, but it selects that member's \
+             features and dependencies for the slow job"
         );
     }
 


### PR DESCRIPTION
## Why

Follow-up to #1169, which merged before this round of review findings could land on its branch. Three defects, all reproduced against the merged code before being fixed.

**1. A near-saturated categorical wins the ranking outright.** #1169's guard refused only an *exactly* saturated design (`n <= p`, residual df < 1), which leaves the whole band below it open. With 100 unrelated ETA values and a label carrying 99 levels:

```
covariate   delta_aic     R²        form
SITE          474.499   0.998775   Categorical
WT             -0.656   0.013354   Linear
```

A pure-noise SITE identifier ranks first, far above the covariate carrying real signal. For a label with `k` levels over `n` subjects and no relation to the ETA, `E[RSS/RSS₀] ≈ (n−k)/(n−1)`, so

```
ΔAIC ≈ n·ln((n−1)/(n−k)) − 2(k−1)
```

which is comfortably negative for small `k`, crosses zero near `k ≈ 0.8n`, and reaches +474 at `k = n−1, n = 100`. The fit's freedom to interpolate outruns the `2p` penalty long before the design saturates.

**2. A constant ETA scores `NaN`.** Twenty EBEs of `0.0` make RSS zero for every model *including the null*, so both AICs are `−∞` and `aic_null_local - best_aic` is `−∞ − (−∞)` = `NaN`. `sort_by` falls back to `Equal` for a NaN, so the score was not merely wrong but unordered, and it sat in the ranking with no warning:

```
aic_null = -inf
X      dAIC=NaN aic=-inf R2=0
warnings: []
```

Reachable for a fixed random effect, or one the data never identified.

**3. `--workspace` widened what the slow job compiles, but not what triggers it.** #1169 made `slow-tests.yml` run `cargo test --workspace` so the member's Tier-3 test would execute, but left the `push: paths:` filter and its guard hard-coded to root `src/` and `tests/`. A push to `main` touching only `crates/ferx-tools/**` silently skipped the two-hour suite, and `tests/slow_test_path_filter.rs` passed while 32 member files went uncovered.

## What changed

**Cardinality guard (`gam.rs`).** A categorical must leave at least as many residual degrees of freedom as it spends parameters — `n >= 2p`, so roughly `k <= n/2`, where the expression above is still comfortably negative (≈ −30 at `k = n/2, n = 100`). Nothing useful is lost below the threshold: a label in the discarded band scores negative wherever plain AIC still works, so it would rank last either way.

The level count also moved ahead of the allocation. `categorical_design` took the raw column and built an `n × (levels−1)` matrix, so a one-level-per-subject label allocated O(n²) *before* anything rejected it. `categorical_levels` is now split out, and the design takes the levels the caller already computed.

**Constant-EBE guard (`gam.rs`).** The ETA is refused before any model is fitted, with a warning. A second guard covers what the whole-column check cannot see: EBEs that vary across the population but are constant over the subset carrying one particular covariate.

**Slow-job triggers (`slow-tests.yml`, `tests/slow_test_path_filter.rs`).** The filter gained `crates/**`. The guard now derives the members from the root manifest's `[workspace] members` and requires each one's `src/`, `tests/` and `Cargo.toml`, and its fixture-literal harvest reads member test sources so a path opened from `crates/*/tests/` contributes its root like a root-package one.

The command also gained `--exclude docs-lint`. That crate is a structural linter over `docs/**` with its own seconds-long CI job and no dependencies; running it inside the slow suite would make `docs/**` an input of that job — a docs typo triggering the two-hour fit run — and would couple the linter to the `ferx-core` compile path, which is what keeping it dependency-free was for (#969). The guard parses the `--exclude` list out of the workflow rather than hard-coding it, so an exclusion added or dropped moves the expected filter with it in the same commit.

## Alternatives considered

**AICc instead of a threshold.** `AIC + 2p(p+1)/(n−p−1)` handles finding 1 smoothly and is the textbook answer for small `n/p`. Rejected: it shifts every ΔAIC by ~0.1 (for `p=2, n=60` the correction is 0.21 against the null's 0.07), which breaks the R / xpose4 parity this module is validated against to 1e-4. The threshold is a guard on admissibility, not a change to the reported score.

**Adding `docs/**` to the slow-test filter** instead of excluding `docs-lint` from the command. Strictly correct once `--workspace` runs that crate, but it makes every docs edit trigger a 120-minute fit suite.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None

`gam_screen_raw` and `gam_screen` keep their signatures. Some covariates that were previously *scored* are now *skipped with a warning* — that is the fix.

## Numerical validation

- [x] Compared against: R (`splines::ns()` + `lm.fit()` under the same `n·log(RSS/n) + 2p`), unchanged from #1169

`xpose4_anchor_delta_aic_matches_reference` passes untouched at 1e-4 — all six ΔAIC values are identical, which is the point of fixing this with a guard rather than a penalty change:

```
       ETA_CL                    ETA_V
WT     1.882144    (unchanged)   -1.655242   (unchanged)
CRCL  -0.525482    (unchanged)   -1.491354   (unchanged)
SEX   -1.383530    (unchanged)   22.295612   (unchanged)
```

The anchor's `SEX` is a 2-level factor over 60 subjects — 2 parameters, 58 residual df — so it sits nowhere near the new threshold.

## Performance

- [x] No significant impact expected

Strictly less work: the O(n²) dummy matrix for a rejected label is no longer built, and rejected covariates skip their fits.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 45 gam tests, up from 39)
- [x] Regression test added that fails without this fix

| test | pins |
|---|---|
| `near_saturated_categorical_is_skipped_not_ranked_first` | the `n−1` levels over `n` case from the report, asserting the fixture really is near-saturated and not saturated |
| `the_cardinality_guard_sits_exactly_at_two_parameters_per_subject` | the boundary — 10 levels over 20 subjects admitted, 11 refused |
| `a_categorical_with_room_to_spare_is_still_scored` | the guard does not swallow an ordinary 3-level factor |
| `constant_etas_produce_no_scores_and_a_warning` | finding 2 |
| `constant_etas_over_one_covariates_subset_skip_only_that_covariate` | the subset route to the same NaN |
| `no_score_is_ever_nan` | the ranking contract itself, across all three covariate shapes |

For finding 3, `slow_test_filter_covers_every_input_the_heavy_fits_read` was negative-controlled in both directions — a guard that cannot fail is the failure mode that file exists to prevent:

```
drop 'crates/**' from paths:     FAILED — "crates/ — 32 file(s), e.g. crates/docs-lint/Cargo.toml"
drop '--exclude docs-lint':      FAILED — "docs/ — 99 file(s), e.g. docs/.gitignore"
both restored:                   ok. 8 passed
```

## Example (user-facing features only)

- [x] Not applicable (internal API — no new `.ferx` DSL syntax or fit options)

## Docs

- [x] `docs/` updated for user-visible changes — `docs/tools/gam-screening.qmd` gains a **High-cardinality labels** section with the ΔAIC expression and why AICc was not used; the skip table and the constant-EBE refusal are documented
- [x] New pages linked in `docs/_quarto.yml` (the page itself landed in #1169)
- [x] `CHANGELOG.md` `[Unreleased]` entry updated

## Checklist

- [x] `tools/preflight.sh` green
- [x] Functions on the `Dual2` sensitivity path stay differentiable — untouched (`ferx-tools` only)
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site
- [x] No new `.ferx` DSL syntax, `[fit_options]` key, example file or data file

### ferx-book
- [x] No new estimator, DSL feature or fit option

### Example execution
- [x] No example execution step needed (no user-visible `.ferx` change)

## Reviewer hints

The judgement call is the `n >= 2p` threshold, at `gam.rs`'s categorical branch. It is deliberately conservative — it discards a band (`n/2 < k < 0.8n`) where plain AIC still behaves — and the comment carries the arithmetic for why the looser `k < n` rule is not enough. If you would rather have a different constant, that is the one line to argue about; the boundary test pins whatever it ends up being.

Second-guess candidate: `built_members` in the path-filter guard now parses `--exclude` out of the workflow with a whitespace tokeniser. That is crude, but the two negative controls above show it is load-bearing in both directions rather than decorative.

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F42w6iw2bi2qtn9vW1QFXy
