### PR TITLE
fix(test): keep the pool stack probe off the caller's frame — main is red [#1192]

### DIFF
--- a/src/api/tests/pool_plan_tests.rs
+++ b/src/api/tests/pool_plan_tests.rs
@@ -90,6 +90,33 @@ fn the_outer_pool_declares_the_ferx_worker_stack() {
     }
 }
 
+const PROBE: usize = 4 * 1024 * 1024;
+
+/// Touch a frame larger than the platform-default thread stack, and return a
+/// value derived from both of its ends so it cannot be optimised away.
+///
+/// `#[inline(never)]` is load-bearing, not decoration. Rayon's `install` goes
+/// through `Registry::in_worker`, which is `#[inline]` and branches on whether
+/// the calling thread is already a pool worker — the "already a worker" arm
+/// calls `op()` **directly, on the caller's stack**. At the release-level
+/// optimisation the CI profiles use (`ci-fast` inherits `release`), that arm
+/// inlines into this test's own frame, and LLVM hoists the resulting 4 MiB
+/// `alloca` to the frame's entry block, where it is reserved unconditionally
+/// even though the branch is never taken at runtime. The test harness gives each
+/// test thread the std default stack, so the *caller* overflowed before `install`
+/// ever reached a worker — a green debug build and an aborted optimised one, with
+/// nothing wrong with the pool. Behind a call that cannot be inlined, the frame
+/// is only ever built by whoever actually runs the probe: the pool worker.
+#[inline(never)]
+fn touch_a_frame_larger_than_the_default_stack() -> usize {
+    let mut frame = [0u8; PROBE];
+    // Write both ends so the pages are actually committed.
+    frame[0] = 1;
+    frame[PROBE - 1] = 2;
+    std::hint::black_box(&frame);
+    frame[0] as usize + frame[PROBE - 1] as usize
+}
+
 #[test]
 fn the_outer_pool_really_has_more_than_the_default_stack() {
     // The declared size above is only a promise; this is the observation. A
@@ -97,7 +124,8 @@ fn the_outer_pool_really_has_more_than_the_default_stack() {
     // (2 MiB on the platforms ferx runs on), so touching a 4 MiB frame inside
     // `install` overflows unless the plan applied `FIT_RAYON_STACK_SIZE`.
     // `install` runs `op` on a pool worker, so this is the worker's stack, not
-    // the caller's.
+    // the caller's — provided the probe stays behind the `#[inline(never)]`
+    // boundary above, which is what keeps that sentence true under optimisation.
     //
     // A regression here fails loudly but bluntly: a stack overflow aborts the
     // process rather than unwinding, so the whole test binary dies and its other
@@ -105,17 +133,8 @@ fn the_outer_pool_really_has_more_than_the_default_stack() {
     // in the test above is the graceful half of the pair, and it is what names
     // the cause; this one is the observation that the declaration is real, and
     // there is no way to observe it without risking the overflow.
-    const PROBE: usize = 4 * 1024 * 1024;
     let sum = PoolPlan::new(2, 1)
-        .install(|| {
-            let mut frame = [0u8; PROBE];
-            // Write both ends so the pages are actually committed and the array
-            // cannot be optimised away.
-            frame[0] = 1;
-            frame[PROBE - 1] = 2;
-            std::hint::black_box(&frame);
-            frame[0] as usize + frame[PROBE - 1] as usize
-        })
+        .install(touch_a_frame_larger_than_the_default_stack)
         .expect("outer pool");
     assert_eq!(sum, 3);
 }


### PR DESCRIPTION
## Why

`main` is red. Both coverage jobs — `Tests + coverage (core)` and
`Tests + coverage (TTE/CTMM endpoints)` — abort with:

```
thread 'api::pool::pool_plan_tests::the_outer_pool_really_has_more_than_the_default_stack' has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `-p ferx-core --lib`
Caused by:
  process didn't exit successfully: `.../ferx_core-...` (signal: 6, SIGABRT: process abort signal)
```

It started at `ea73e4fe` (merge of #1192) and has been red on every `main` run
since. Because a stack overflow aborts rather than unwinds, the whole `ferx-core`
lib binary dies and its ~3,800 other tests report as "not run" — so this is not
one red test, it is the entire lib suite going dark. Every PR branched off or
merged with `main` inherits it; #1173 went red purely by being updated.

**Nothing is wrong with the pool.** The bug is in the probe.

Rayon's `ThreadPool::install` goes through `Registry::in_worker`, which is
`#[inline]` and branches on whether the calling thread is already a pool worker.
The "already a worker" arm calls `op()` **directly, on the caller's stack**. At
the release-level optimisation the CI profiles use (`ci-fast` inherits
`release`), that arm inlines into the test's own frame, and LLVM hoists the
probe's 4 MiB `alloca` to the frame's entry block — where it is reserved
unconditionally, even though the branch is never taken at runtime. libtest gives
each test thread the std default stack (2 MiB), so the **caller** overflowed
before `install` ever reached a worker.

That is also why it was missed: a debug build does not inline `in_worker`, so
`cargo test --lib` is green locally and only the optimised CI build aborts.

## What changed

Move the probe body into an `#[inline(never)]` free function and pass it to
`install` as a fn item. Behind a call that cannot be inlined, the 4 MiB frame is
only ever built by whoever actually runs the probe: the pool worker.

The assertion is unchanged and still fails loudly if a plan ever hands out a
platform-default-stack pool — which is the whole point of the test. The
`#[inline(never)]` is documented as load-bearing at the call site so it is not
"tidied away" later.

## Alternatives considered

- **Delete the runtime probe, keep only `the_outer_pool_declares_the_ferx_worker_stack`.**
  Rejected — the declared-size assertion is a promise about a constant; the probe
  is the observation that the promise is applied. That pair is exactly what #1115
  added it for.
- **Give the test thread a bigger stack** (spawn the probe from a
  `std::thread::Builder` with an explicit large stack). This masks the symptom
  rather than fixing it: the hoisted `alloca` is still in the caller's frame, so
  the test would stop measuring the worker's stack at all.
- **Shrink the probe below 2 MiB.** Then it no longer exceeds the platform
  default and cannot distinguish a 32 MiB pool from a stock one.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (test-only fix / CI red)

## Performance
- [x] No significant impact expected

## Tests

Reproduced and verified under the exact profile CI uses:

```
cargo test --profile ci-fast --no-default-features --features ci --lib -- pool_plan_tests
```

| | result |
|---|---|
| before | `fatal runtime error: stack overflow, aborting` — SIGABRT, binary dies |
| after  | `test result: ok. 10 passed; 0 failed` |

`cargo test --lib` (debug) passes both before and after — debug does not inline
`in_worker`, which is why this needs the `ci-fast` profile to reproduce.

- [x] Regression test added that fails without this fix — the existing test *is*
      the regression test; it now fails only for the reason it was written to
      catch, instead of for an inlining artefact.
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)

## Docs
- [x] No user-visible change (test-only; no `CHANGELOG.md` entry per CLAUDE.md)

## Checklist
- [x] `tools/preflight.sh` green — `fmt` and `clippy` groups run clean on this branch
- [x] Not on the `Dual2` sensitivity path
- [x] No version bump needed

## Reviewer hints

The whole diff is one file, `src/api/tests/pool_plan_tests.rs`. The thing worth
checking is the comment on `touch_a_frame_larger_than_the_default_stack`: the
`#[inline(never)]` is the fix, not decoration, and removing it silently restores
the abort under `ci-fast` while leaving `cargo test --lib` green.

Worth merging ahead of the open PRs — #1173 and anything else based on current
`main` cannot go green until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VMb63MwV4MCwxWdH2kbd4
