### PR TITLE
chore(package): fix the exclude globs, cut 0.3.1, add registry metadata [#1170]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,13 @@ section of the SDLC for the versioning policy).
   top of them, so a tool and the CLI cannot diverge in how a model is loaded.
 
 ### Fixed
+- **The packaged crate no longer ships two files the CC BY-NC exclusion was meant to cover (#1170).**
+  `exclude`'s `data/mbma_naproxen.*` glob required a literal `.` after the stem, so
+  `data/mbma_naproxen_source.py` slipped through, and `examples/` was never listed, so
+  `examples/mbma_naproxen.ferx` shipped as an example whose data is excluded and so cannot run.
+  Neither file was itself CC BY-NC (both are repo-authored MIT, and the restricted csv was
+  correctly excluded throughout), but the licence note in `data/mbma_naproxen.LICENSE` described
+  a mechanism the globs did not implement. Both are now excluded.
 - **An infusion into a built-in absorption compartment is no longer delivered twice on the
   dense/states engines (#1187).** With a `RATE>0` or `RATE=-2` dose into a `first_order()`,
   `transit()`, `igd()` or `weibull()` kernel (#719 gap 2), the mass was released *both* through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ section of the SDLC for the versioning policy).
   fit with the `--gam` flag. See [GAM covariate screening](https://ferx-nlme.github.io/ferx-core/tools/gam-screening.html).
 
 ### Changed
+- **The three published crates now carry `keywords` and `categories` (#1170).** Registry metadata
+  only -- no code change. It is what covers discoverability on crates.io, which is why claiming
+  the `ferx-nlme` name was judged unnecessary in #1170.
 - **`FitOptions::threads` now also caps a multi-start fit (#1115).** A pinned positive `threads`
   was honored only when `n_starts <= 1`; with several starts the fan-out ran on the full-width
   shared pool regardless, so a tool that pinned one thread per fit from a `PoolPlan` and asked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-02
+
 ### Added
 - **`ferx gam` — GAM covariate pre-screening from the command line (#1114).** Screens every
   declared covariate against every ETA with independent GAM regressions and prints a table
@@ -5398,7 +5400,8 @@ and `git log v0.1.0..v0.1.5` for details.
 Initial tagged release. See the
 [GitHub release](https://github.com/FeRx-NLME/ferx-core/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/FeRx-NLME/ferx-core/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/FeRx-NLME/ferx-core/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/FeRx-NLME/ferx-core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/FeRx-NLME/ferx-core/compare/v0.1.0...v0.1.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferx-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ferx-core",
  "ferx-tools",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "ferx-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "argmin",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "ferx-tools"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "csv",
  "ferx-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,17 @@ readme = "README.md"
 # `cargo test --features slow-tests` on the packaged crate into a panic on a
 # missing file rather than a test that simply is not there.
 #
+# The glob deliberately has no `.` after `mbma_naproxen`: `data/mbma_naproxen.*`
+# matched the csv/LICENSE/README but not `data/mbma_naproxen_source.py` (#1170).
+# `examples/mbma_naproxen.ferx` is listed separately for the same reason the
+# slow test is: without the excluded csv it is an example that cannot run.
+#
 # `api/` is the CI-enforced public-API baseline (#1114) — a 388 KB rustdoc-derived
 # snapshot that is repo infrastructure, not crate content, so it is kept out of
 # the published tarball too.
 exclude = [
-  "data/mbma_naproxen.*",
+  "data/mbma_naproxen*",
+  "examples/mbma_naproxen.ferx",
   "tests/mbma_naproxen_case_study.rs",
   "api/*",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ description = "Nonlinear Mixed Effects modeling engine with FOCE/FOCEI estimatio
 license = "MIT"
 authors = ["Ron Keizer", "Teun Post", "Hidde van de Beek"]
 repository = "https://github.com/FeRx-NLME/ferx-core"
+keywords = ["nlme", "pharmacometrics", "pharmacokinetics", "foce", "ode"]
+categories = ["science", "mathematics", "simulation"]
 readme = "README.md"
 # `data/mbma_naproxen.csv` is CC BY-NC 4.0, not MIT (see the root LICENSE and
 # data/mbma_naproxen.LICENSE). It is a slow-test fixture, so excluding it keeps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 
 [package]
 name = "ferx-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Nonlinear Mixed Effects modeling engine with FOCE/FOCEI estimation"
 license = "MIT"

--- a/crates/ferx-cli/Cargo.toml
+++ b/crates/ferx-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferx-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Command-line interface for the ferx NLME modeling engine"
 license = "MIT"
@@ -23,8 +23,8 @@ path = "src/main.rs"
 # instead of linking the rlib it just built, and `--no-default-features` is
 # silently defeated for `ferx-core` everywhere (harmless only while
 # `default = []`; `survival` is slated to become default-on).
-ferx-core = { path = "../..", version = "0.3.0", default-features = false }
-ferx-tools = { path = "../ferx-tools", version = "0.3.0" }
+ferx-core = { path = "../..", version = "0.3.1", default-features = false }
+ferx-tools = { path = "../ferx-tools", version = "0.3.1" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/ferx-cli/Cargo.toml
+++ b/crates/ferx-cli/Cargo.toml
@@ -6,6 +6,8 @@ description = "Command-line interface for the ferx NLME modeling engine"
 license = "MIT"
 authors = ["Ron Keizer", "Teun Post", "Hidde van de Beek"]
 repository = "https://github.com/FeRx-NLME/ferx-core"
+keywords = ["nlme", "pharmacometrics", "pharmacokinetics", "population-pk", "cli"]
+categories = ["command-line-utilities", "science", "simulation"]
 
 # The installed binary keeps the name `ferx` — the package rename is invisible
 # to users. It lives here rather than in the `ferx-core` package because it will

--- a/crates/ferx-tools/Cargo.toml
+++ b/crates/ferx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferx-tools"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Model-development tooling on top of ferx-core: bootstrap, covariate search, cross-validation"
 license = "MIT"
@@ -15,7 +15,7 @@ repository = "https://github.com/FeRx-NLME/ferx-core"
 # instead of linking the rlib it just built, and `--no-default-features` is
 # silently defeated for `ferx-core` everywhere (harmless only while
 # `default = []`; `survival` is slated to become default-on).
-ferx-core = { path = "../..", version = "0.3.0", default-features = false }
+ferx-core = { path = "../..", version = "0.3.1", default-features = false }
 csv = "1.3"
 nalgebra = "0.35"
 rand = "0.10"

--- a/crates/ferx-tools/Cargo.toml
+++ b/crates/ferx-tools/Cargo.toml
@@ -6,6 +6,8 @@ description = "Model-development tooling on top of ferx-core: bootstrap, covaria
 license = "MIT"
 authors = ["Ron Keizer", "Teun Post", "Hidde van de Beek"]
 repository = "https://github.com/FeRx-NLME/ferx-core"
+keywords = ["nlme", "pharmacometrics", "bootstrap", "covariate-search", "cross-validation"]
+categories = ["science", "mathematics", "simulation"]
 
 [dependencies]
 # `default-features = false` is load-bearing, not tidiness: without it a

--- a/data/mbma_naproxen.LICENSE
+++ b/data/mbma_naproxen.LICENSE
@@ -21,7 +21,7 @@ What this means in practice:
   * **Commercial use of this file is not granted.** The MIT grant in the root
     `LICENSE` does not extend to it.
   * The file is a test fixture only. It is never linked into the `ferx` binary
-    or any published artifact, and `Cargo.toml` excludes `data/mbma_naproxen.*`
+    or any published artifact, and `Cargo.toml` excludes `data/mbma_naproxen*`
     from the packaged crate, so the crate published to crates.io is uniformly
     MIT.
 


### PR DESCRIPTION
## Why

Publish prep for #1170. Three things had to be true before the first `cargo publish`, and none of them were:

1. **The `exclude` globs did not match the files they name.** `data/mbma_naproxen.LICENSE` states that "`Cargo.toml` excludes `data/mbma_naproxen.*` from the packaged crate, so the crate published to crates.io is uniformly MIT." `cargo package --list` disagreed: `data/mbma_naproxen_source.py` shipped (the glob needs a literal `.` after the stem, and this has `_source`) and `examples/mbma_naproxen.ferx` shipped (`exclude` never mentioned `examples/` at all).

   **This was never a licence breach.** The restricted CC BY-NC csv itself *was* correctly excluded, verified absent from the file list throughout. Both leaked files are repo-authored MIT — a conversion script and a model file. But the sentence in the licence note was true by luck rather than by the mechanism it named, and `examples/mbma_naproxen.ferx` shipped as an example that cannot run, because its data is excluded.

2. **The version number collided with an existing tag.** The manifests said `0.3.0`, but git tag `v0.3.0` points at `6c0f317f` (2026-08-07) — 507 commits back, at a point where `crates/` did not exist and neither did `ferx-tools` or `ferx-cli`. Publishing today's main as `0.3.0` would have put the registry copy on a completely different tree from the one the tag names.

3. **No `keywords` or `categories` on any of the three manifests.** #1170 decision 3 declined to claim the `ferx-nlme` name specifically because keywords and categories close the discoverability gap for free — so they have to actually be there.

## What changed

**`exclude` globs** — dropping the `.` covers all four `data/mbma_naproxen*` files; `examples/mbma_naproxen.ferx` is listed alongside the slow test for the same reason the slow test is listed (without the excluded csv it cannot run). The claim in `data/mbma_naproxen.LICENSE` is updated to quote the glob that now exists.

**Release 0.3.1** — all three published crates and their internal `version =` deps bumped, and the accumulated `[Unreleased]` section cut as `## [0.3.1] - 2026-09-02` with the compare links updated. 0.3.1 rather than 0.3.0 keeps tag and registry in agreement; 0.3.0 simply never appears on crates.io.

**Registry metadata** — `keywords` (5 per crate, all within the 20-character limit) and `categories` on all three manifests. Category slugs validated against the live crates.io list at `/api/v1/category_slugs`.

## Alternatives considered

For the version: force-moving tag `v0.3.0` to the publish commit would also make tag and registry agree, but it rewrites what an already-cut internal release means. Publishing as `0.3.0` and documenting the drift was the other option; a fresh patch number is cheaper than a permanent footnote, since a publish can never be undone.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r declares both git deps in `src/rust/Cargo.toml` with no version requirement (`{ git = ..., branch = "main" }`), so the 0.3.1 bump does not change its resolution. No lock bump needed.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Not applicable (docs / refactor / CI only)

Packaging metadata only; no code path is touched.

## Performance
- [x] No significant impact expected

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [ ] Regression test added that fails without this fix
- [x] No new tests needed (why: the assertion is about tarball contents, not runtime behaviour, and it is checked directly — see below)

Verified with `cargo package`, which is the tool that would catch a regression here:

| crate | files in tarball | naproxen or `api/` entries |
|---|---|---|
| ferx-core | 1289 | 0 |
| ferx-tools | 22 | 0 |
| ferx-cli | 8 | 0 |

`cargo package -p ferx-core` (the full verify build, not just `--list`) exits 0, so nothing excluded is load-bearing. Tarball is 5.47 MB, under the 10 MiB registry cap.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `CHANGELOG.md` entry added — under `[0.3.1]`, not `[Unreleased]`, since this PR cuts that release
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml`

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — no `src/` file is touched
- [x] `Cargo.toml` version bumped

## Docs & examples

### ferx-site / ferx-book
- [x] No DSL, estimator, fit-option, example, or data-file change — nothing to mirror

### Example execution
- [x] No example execution step needed (packaging metadata only; no user-visible behaviour change)

Note that `examples/mbma_naproxen.ferx` stays in the repo and stays runnable from a git checkout — it is only kept out of the published tarball, where its data is absent.

## Reviewer hints

The load-bearing line is the missing `.` in `data/mbma_naproxen*`. Worth confirming the intent: it now also matches anything future named `mbma_naproxen<anything>` under `data/`, which is what we want for this fixture but is broader than the old pattern.

The version choice is the other thing to sanity-check — 0.3.1 as a patch bump does understate a month of work that added two crates and `ferx gam`, but it is a deliberate call to keep the first crates.io version aligned with a tag we can actually cut at this commit.

## Open questions

None blocking. Ownership after the first publish (#1170 decision 6) is settled: the org now has a `maintainers` team (privacy `closed`, so crates.io can see it; members TeunP, roninsightrx, hiddevandebeek), so the post-publish step is `cargo owner --add github:FeRx-NLME:maintainers` on each of the three crates. A team owner can publish but cannot edit the owner list, so at least one individual owner should stay on each crate alongside the team.

