### PR TITLE
feat(api): report bootstrap progress as each replicate finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ section of the SDLC for the versioning policy).
 ## [0.3.1] - 2026-09-02
 
 ### Added
+- **A progress bar for `ferx bootstrap`.** A 200-sample bootstrap is minutes to hours of
+  fitting behind one command, with nothing on the terminal to say whether it was working
+  or wedged. The run now reports each fit as it completes: the base model gets a spinner,
+  the replicates a bar with an ETA, `--dofv` its own bar for its second pass, and a
+  `--resume` run counts only what is left to fit. The bar is drawn only when stderr is a
+  terminal; `--no-progress` suppresses it. `ferx_tools::bootstrap::run_bootstrap_with_progress`
+  is the same run with a `BootstrapEvent` sink, which is what ferx-r renders onto a `cli`
+  bar; `run_bootstrap` is unchanged.
 - **`ferx gam` — GAM covariate pre-screening from the command line (#1114).** Screens every
   declared covariate against every ETA with independent GAM regressions and prints a table
   ranked by delta-AIC (`AIC_null − AIC_best`), the Rust equivalent of Xpose4's `xpose.gam()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +285,7 @@ version = "0.3.1"
 dependencies = [
  "ferx-core",
  "ferx-tools",
+ "indicatif",
  "serde_json",
  "tempfile",
 ]
@@ -395,6 +414,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -583,6 +615,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -944,6 +982,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "wasip2"

--- a/crates/ferx-cli/Cargo.toml
+++ b/crates/ferx-cli/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/main.rs"
 # `default = []`; `survival` is slated to become default-on).
 ferx-core = { path = "../..", version = "0.3.1", default-features = false }
 ferx-tools = { path = "../ferx-tools", version = "0.3.1" }
+indicatif = "0.18.4"
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/ferx-cli/src/bootstrap_cmd.rs
+++ b/crates/ferx-cli/src/bootstrap_cmd.rs
@@ -8,8 +8,10 @@
 use std::path::PathBuf;
 
 use ferx_tools::bootstrap::{
-    resummarize, run_bootstrap, BootstrapOptions, BootstrapResult, SampleSize,
+    resummarize, run_bootstrap_with_progress, BootstrapOptions, BootstrapResult, SampleSize,
 };
+
+use crate::bootstrap_progress::BootstrapProgress;
 
 pub const BOOTSTRAP_USAGE: &str = "\
 Usage: ferx bootstrap <model.ferx> [--data <data.csv>] [options]
@@ -31,6 +33,9 @@ estimates. Resampling is always over whole subjects.
                        column must take exactly one value per subject.
   --directory DIR      where the CSV artefacts go (default {model}-bootstrap)
   --ci LEVEL           two-sided confidence level in percent (default 95)
+  --no-progress        do not draw the progress bar. It is already suppressed
+                       when stderr is not a terminal, so this is for an
+                       interactive run whose output you want quiet.
 
   --no-update-inits    start replicates from the model file's initial estimates
                        instead of the base fit's final ones
@@ -217,7 +222,9 @@ fn run_bootstrap_command(args: &[String], model_path: &str) -> Result<i32, Strin
     }
 
     let started = std::time::Instant::now();
-    let result = run_bootstrap(&prepared, &options)?;
+    let progress = BootstrapProgress::new(!flag(args, "--no-progress"));
+    let sink = |event| progress.on_event(event);
+    let result = run_bootstrap_with_progress(&prepared, &options, Some(&sink))?;
     eprintln!(
         "Fitted {} replicates in {:.1}s{}",
         result.replicates.len() - result.n_reused,

--- a/crates/ferx-cli/src/bootstrap_progress.rs
+++ b/crates/ferx-cli/src/bootstrap_progress.rs
@@ -1,0 +1,240 @@
+//! The progress bar for `ferx bootstrap`.
+//!
+//! A 200-sample bootstrap is minutes to hours of fitting behind one line of
+//! output, and until it finished there was nothing on the terminal to say
+//! whether it was making progress or wedged. This renders
+//! [`ferx_tools::bootstrap::BootstrapEvent`]s onto an `indicatif` bar.
+//!
+//! Everything here is presentation: the events themselves carry no terminal
+//! concern, so the R package renders the same stream onto a `cli` bar, and the
+//! numbers a run produces do not depend on whether anyone was watching.
+
+use std::sync::Mutex;
+
+use ferx_tools::bootstrap::BootstrapEvent;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+
+/// `{pos}/{len}` with a bar and an ETA. `{eta}` is indicatif's own estimate
+/// from the completion rate so far, which is the right shape for this run: the
+/// replicates are the same model on the same number of subjects, so their fit
+/// times differ by convergence path rather than by size.
+const BAR_TEMPLATE: &str = "  [{elapsed_precise}] [{bar:30}] {pos}/{len} {msg} (ETA {eta})";
+
+/// The bars for one bootstrap run.
+///
+/// The whole state is behind one `Mutex` because the sink is called from
+/// whichever Rayon worker finished a fit; the lock is taken once per completed
+/// *fit*, so it contends with nothing.
+pub struct BootstrapProgress {
+    enabled: bool,
+    state: Mutex<State>,
+}
+
+#[derive(Default)]
+struct State {
+    /// The base fit's spinner, live only while that fit runs.
+    base: Option<ProgressBar>,
+    /// The replicate bar, and then the Δofv bar. Only one is ever on screen:
+    /// the Δofv pass starts after the last replicate is in.
+    bar: Option<ProgressBar>,
+    /// Replicates still to fit, as `Started` reported them - kept so the bar
+    /// can be created when the base fit clears the screen rather than before.
+    replicates: usize,
+}
+
+impl BootstrapProgress {
+    /// `enabled = false` makes every method a no-op - `--no-progress`, and any
+    /// caller that would rather print its own thing.
+    ///
+    /// A non-terminal stderr needs no flag: `indicatif` resolves
+    /// [`ProgressDrawTarget::stderr`] to a hidden target when stderr is
+    /// redirected, so a bar in a log file or a pipe is already impossible.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    /// Render one event. Never panics: it is called from inside `par_iter`,
+    /// where a panic would take the whole run down with it.
+    pub fn on_event(&self, event: BootstrapEvent) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = match self.state.lock() {
+            Ok(s) => s,
+            // Poisoned means a previous render panicked. Losing the bar is the
+            // correct response to that; losing the run is not.
+            Err(_) => return,
+        };
+        match event {
+            BootstrapEvent::Started {
+                replicates,
+                reused,
+                base_fit,
+            } => {
+                if reused > 0 {
+                    eprintln!("  reusing {reused} replicates already on disk");
+                }
+                state.replicates = replicates;
+                if base_fit {
+                    state.base = Some(spinner("fitting the base model"));
+                } else {
+                    state.bar = Some(bar(replicates, "replicates"));
+                }
+            }
+            BootstrapEvent::BaseFitDone => {
+                if let Some(spinner) = state.base.take() {
+                    spinner.finish_and_clear();
+                }
+                let replicates = state.replicates;
+                state.bar = Some(bar(replicates, "replicates"));
+            }
+            BootstrapEvent::ReplicateDone { completed, .. } => {
+                if let Some(bar) = &state.bar {
+                    bar.set_position(completed as u64);
+                }
+            }
+            BootstrapEvent::DeltaOfvDone { completed, total } => {
+                // The first Δofv event is where the replicate bar is done: the
+                // pass only starts once every replicate is in.
+                if completed == 1 || state.bar.is_none() {
+                    if let Some(previous) = state.bar.take() {
+                        previous.finish_and_clear();
+                    }
+                    state.bar = Some(bar(total, "delta-OFV evaluations"));
+                }
+                if let Some(bar) = &state.bar {
+                    bar.set_position(completed as u64);
+                }
+            }
+            BootstrapEvent::Finished => {
+                if let Some(spinner) = state.base.take() {
+                    spinner.finish_and_clear();
+                }
+                if let Some(bar) = state.bar.take() {
+                    bar.finish_and_clear();
+                }
+            }
+        }
+    }
+}
+
+fn bar(len: usize, unit: &str) -> ProgressBar {
+    let bar = ProgressBar::new(len as u64).with_message(unit.to_string());
+    bar.set_draw_target(ProgressDrawTarget::stderr());
+    // An unparseable template is a bug in the constant above, not a reason to
+    // fail a bootstrap: fall back to indicatif's default style.
+    if let Ok(style) = ProgressStyle::with_template(BAR_TEMPLATE) {
+        bar.set_style(style.progress_chars("=> "));
+    }
+    bar
+}
+
+fn spinner(message: &str) -> ProgressBar {
+    let spinner = ProgressBar::new_spinner().with_message(message.to_string());
+    spinner.set_draw_target(ProgressDrawTarget::stderr());
+    spinner.enable_steady_tick(std::time::Duration::from_millis(120));
+    spinner
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Under `cargo test` stderr is not a terminal, so the bars resolve to a
+    /// hidden draw target and nothing is written - but `position()` is still
+    /// the state the bar would draw, which is what these assert.
+    fn positions(progress: &BootstrapProgress) -> Option<u64> {
+        progress
+            .state
+            .lock()
+            .expect("not poisoned")
+            .bar
+            .as_ref()
+            .map(|b| b.position())
+    }
+
+    #[test]
+    fn the_replicate_bar_appears_after_the_base_fit_and_tracks_completions() {
+        let progress = BootstrapProgress::new(true);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 3,
+            reused: 0,
+            base_fit: true,
+        });
+        // While the base model is fitting there is a spinner and no bar: a bar
+        // sitting at 0/3 through a fit that can take minutes reads as stuck.
+        assert!(positions(&progress).is_none());
+
+        progress.on_event(BootstrapEvent::BaseFitDone);
+        assert_eq!(positions(&progress), Some(0));
+
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 2,
+            total: 3,
+        });
+        assert_eq!(positions(&progress), Some(2));
+
+        progress.on_event(BootstrapEvent::Finished);
+        assert!(positions(&progress).is_none());
+    }
+
+    #[test]
+    fn a_run_without_a_base_fit_starts_the_bar_immediately() {
+        let progress = BootstrapProgress::new(true);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 5,
+            reused: 2,
+            base_fit: false,
+        });
+        assert_eq!(positions(&progress), Some(0));
+        // The length is what is left to fit, not the sample count: the two
+        // reused replicates are already on disk.
+        let state = progress.state.lock().expect("not poisoned");
+        assert_eq!(state.bar.as_ref().and_then(|b| b.length()), Some(5));
+    }
+
+    #[test]
+    fn the_delta_ofv_pass_replaces_the_replicate_bar() {
+        let progress = BootstrapProgress::new(true);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 2,
+            reused: 0,
+            base_fit: false,
+        });
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 2,
+            total: 2,
+        });
+        progress.on_event(BootstrapEvent::DeltaOfvDone {
+            completed: 1,
+            total: 2,
+        });
+        // A fresh bar at 1, not the replicate bar carried on past its end.
+        assert_eq!(positions(&progress), Some(1));
+
+        progress.on_event(BootstrapEvent::DeltaOfvDone {
+            completed: 2,
+            total: 2,
+        });
+        assert_eq!(positions(&progress), Some(2));
+    }
+
+    #[test]
+    fn a_disabled_progress_draws_nothing() {
+        let progress = BootstrapProgress::new(false);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 4,
+            reused: 0,
+            base_fit: true,
+        });
+        progress.on_event(BootstrapEvent::BaseFitDone);
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 1,
+            total: 4,
+        });
+        assert!(positions(&progress).is_none());
+    }
+}

--- a/crates/ferx-cli/src/bootstrap_progress.rs
+++ b/crates/ferx-cli/src/bootstrap_progress.rs
@@ -30,6 +30,18 @@ pub struct BootstrapProgress {
     state: Mutex<State>,
 }
 
+/// Which pass the bar on screen is counting.
+///
+/// The two bars are told apart by this rather than by their counts, because a
+/// count cannot do it: `completed` is handed out by a `fetch_add` inside
+/// `par_iter`, so the event carrying 1 is not necessarily the first one
+/// delivered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Pass {
+    Replicates,
+    DeltaOfv,
+}
+
 #[derive(Default)]
 struct State {
     /// The base fit's spinner, live only while that fit runs.
@@ -37,9 +49,48 @@ struct State {
     /// The replicate bar, and then the Δofv bar. Only one is ever on screen:
     /// the Δofv pass starts after the last replicate is in.
     bar: Option<ProgressBar>,
+    /// Which pass `bar` is counting, or `None` when there is no bar.
+    pass: Option<Pass>,
     /// Replicates still to fit, as `Started` reported them - kept so the bar
     /// can be created when the base fit clears the screen rather than before.
     replicates: usize,
+}
+
+impl State {
+    /// Put a fresh bar for `pass` on screen, clearing whatever was there.
+    fn open(&mut self, pass: Pass, len: usize, unit: &str) {
+        if let Some(previous) = self.bar.take() {
+            previous.finish_and_clear();
+        }
+        self.bar = Some(bar(len, unit));
+        self.pass = Some(pass);
+    }
+
+    /// Step the bar for `pass`, if that is the one on screen.
+    ///
+    /// Never backwards. `completed` is produced by a `fetch_add` inside
+    /// `par_iter` and reported from whichever worker finished the fit, so 5 can
+    /// reach us before 4 - and a bar that steps back also skews indicatif's
+    /// `{eta}`, which it derives from the rate so far.
+    fn advance(&self, pass: Pass, completed: usize) {
+        if self.pass != Some(pass) {
+            return;
+        }
+        if let Some(bar) = &self.bar {
+            bar.set_position(bar.position().max(completed as u64));
+        }
+    }
+
+    /// Take the bar and the spinner off screen.
+    fn clear(&mut self) {
+        if let Some(spinner) = self.base.take() {
+            spinner.finish_and_clear();
+        }
+        if let Some(bar) = self.bar.take() {
+            bar.finish_and_clear();
+        }
+        self.pass = None;
+    }
 }
 
 impl BootstrapProgress {
@@ -81,7 +132,7 @@ impl BootstrapProgress {
                 if base_fit {
                     state.base = Some(spinner("fitting the base model"));
                 } else {
-                    state.bar = Some(bar(replicates, "replicates"));
+                    state.open(Pass::Replicates, replicates, "replicates");
                 }
             }
             BootstrapEvent::BaseFitDone => {
@@ -89,34 +140,26 @@ impl BootstrapProgress {
                     spinner.finish_and_clear();
                 }
                 let replicates = state.replicates;
-                state.bar = Some(bar(replicates, "replicates"));
+                state.open(Pass::Replicates, replicates, "replicates");
             }
             BootstrapEvent::ReplicateDone { completed, .. } => {
-                if let Some(bar) = &state.bar {
-                    bar.set_position(completed as u64);
-                }
+                state.advance(Pass::Replicates, completed);
             }
             BootstrapEvent::DeltaOfvDone { completed, total } => {
-                // The first Δofv event is where the replicate bar is done: the
-                // pass only starts once every replicate is in.
-                if completed == 1 || state.bar.is_none() {
-                    if let Some(previous) = state.bar.take() {
-                        previous.finish_and_clear();
-                    }
-                    state.bar = Some(bar(total, "delta-OFV evaluations"));
+                // Any Δofv event is where the replicate bar is done: the pass
+                // only starts once every replicate is in. Which one arrives
+                // first is not known - the evaluations are handed their count by
+                // a `fetch_add` inside `par_iter` and report from whichever
+                // worker finished - so the swap keys on the pass rather than on
+                // `completed == 1`, which would leave the first evaluations
+                // drawn onto the replicate bar and then restart the Δofv bar
+                // under them.
+                if state.pass != Some(Pass::DeltaOfv) {
+                    state.open(Pass::DeltaOfv, total, "delta-OFV evaluations");
                 }
-                if let Some(bar) = &state.bar {
-                    bar.set_position(completed as u64);
-                }
+                state.advance(Pass::DeltaOfv, completed);
             }
-            BootstrapEvent::Finished => {
-                if let Some(spinner) = state.base.take() {
-                    spinner.finish_and_clear();
-                }
-                if let Some(bar) = state.bar.take() {
-                    bar.finish_and_clear();
-                }
-            }
+            BootstrapEvent::Finished => state.clear(),
         }
     }
 }
@@ -220,6 +263,59 @@ mod tests {
             total: 2,
         });
         assert_eq!(positions(&progress), Some(2));
+    }
+
+    #[test]
+    fn the_delta_ofv_bar_appears_whichever_evaluation_reports_first() {
+        // The evaluations take their `completed` from a `fetch_add` inside
+        // `par_iter` and report from whichever worker finished, so the event
+        // carrying 1 need not arrive first. Keying the swap on `completed == 1`
+        // drew these onto the replicate bar and then restarted under them.
+        // A resumed run, so the two passes have different lengths: 4 replicates
+        // left to fit, but the Δofv sweep covers all 6 including the reused.
+        let progress = BootstrapProgress::new(true);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 4,
+            reused: 2,
+            base_fit: false,
+        });
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 4,
+            total: 4,
+        });
+
+        progress.on_event(BootstrapEvent::DeltaOfvDone {
+            completed: 3,
+            total: 6,
+        });
+        let state = progress.state.lock().expect("not poisoned");
+        assert_eq!(state.pass, Some(Pass::DeltaOfv));
+        // The Δofv bar, at 3 of 6 - not the replicate bar carried on past its
+        // end, which would have shown 3 of 4 under the wrong label and then
+        // been thrown away when `completed == 1` turned up.
+        let bar = state.bar.as_ref().expect("a bar");
+        assert_eq!(bar.position(), 3);
+        assert_eq!(bar.length(), Some(6));
+    }
+
+    #[test]
+    fn a_late_completion_does_not_step_the_bar_backwards() {
+        let progress = BootstrapProgress::new(true);
+        progress.on_event(BootstrapEvent::Started {
+            replicates: 8,
+            reused: 0,
+            base_fit: false,
+        });
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 5,
+            total: 8,
+        });
+        // Worker A finished fourth but reported after worker B finished fifth.
+        progress.on_event(BootstrapEvent::ReplicateDone {
+            completed: 4,
+            total: 8,
+        });
+        assert_eq!(positions(&progress), Some(5));
     }
 
     #[test]

--- a/crates/ferx-cli/src/main.rs
+++ b/crates/ferx-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod bootstrap_cmd;
+mod bootstrap_progress;
 mod gam_cmd;
 
 use ferx_core::NcaInit;

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -71,8 +71,10 @@ pub enum BootstrapEvent {
     /// it counts separately instead of silently extending the first bar past
     /// what it promised.
     DeltaOfvDone { completed: usize, total: usize },
-    /// Every fit is done. The summary and the CSV artefacts still follow, and
-    /// on a large run those are not instant.
+    /// The run is over. Emitted after the last fit on a run that succeeds, and
+    /// on the way out of one that fails, so a sink that has seen `Started` is
+    /// always told where to stop. On success the summary and the CSV artefacts
+    /// still follow, and on a large run those are not instant.
     Finished,
 }
 
@@ -83,6 +85,44 @@ pub enum BootstrapEvent {
 /// carry its own synchronisation (an `AtomicUsize`, a `Mutex`), and the event's
 /// `completed` field is there so that most sinks need neither.
 pub type ProgressFn<'a> = &'a (dyn Fn(BootstrapEvent) + Send + Sync);
+
+/// Emits [`BootstrapEvent::Finished`] however the run leaves.
+///
+/// A dozen `?`s sit between [`BootstrapEvent::Started`] and the end of the
+/// fits: the journal, the base fit, the Δofv reference. A renderer told that a
+/// run started and never told it ended leaves its bar on screen, on top of the
+/// error the caller is about to print. [`FinishGuard::finish`] is the success
+/// path, reporting the end of the fits where it actually is (before the summary
+/// and the artefacts); the `Drop` is every other path. Exactly one of the two
+/// emits.
+struct FinishGuard<'a> {
+    progress: Option<ProgressFn<'a>>,
+    pending: bool,
+}
+
+impl<'a> FinishGuard<'a> {
+    fn new(progress: Option<ProgressFn<'a>>) -> Self {
+        Self {
+            progress,
+            pending: true,
+        }
+    }
+
+    fn finish(&mut self) {
+        if !std::mem::replace(&mut self.pending, false) {
+            return;
+        }
+        if let Some(sink) = self.progress {
+            sink(BootstrapEvent::Finished);
+        }
+    }
+}
+
+impl Drop for FinishGuard<'_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
 
 /// Everything the bootstrap needs beyond the model and data themselves.
 ///
@@ -778,6 +818,9 @@ pub fn run_bootstrap_with_progress(
         reused: n_reused,
         base_fit: options.run_base_model && reused_original.is_none(),
     });
+    // The run has announced itself, so from here it owes a `Finished` whichever
+    // way it leaves.
+    let mut finish = FinishGuard::new(progress);
 
     // ── the incremental journal ─────────────────────────────────────────────
     // Opened before the first fit so that a kill at any point from here on
@@ -952,7 +995,7 @@ pub fn run_bootstrap_with_progress(
             progress,
         )?;
     }
-    emit(BootstrapEvent::Finished);
+    finish.finish();
 
     let n_estimated_parameters = count_estimated(template);
     let summary = summary::summarize(&names, original.as_ref(), &replicates, options);

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -21,6 +21,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use ferx_core::{
@@ -38,6 +39,50 @@ pub mod summary;
 pub use manifest::RunManifest;
 pub use resample::{Replicate, SampleSize, Strata};
 pub use summary::{BootstrapSummary, ParameterSummary};
+
+/// What a running bootstrap reports about its own progress.
+///
+/// The bootstrap is minutes to hours of fitting behind a single call, so a
+/// caller that wants to show progress needs the completion count *as it
+/// happens*, not once the run is over. The events are plain data and carry no
+/// terminal concern of any kind: `ferx bootstrap`'s `indicatif` bar and the R
+/// package's `cli` bar are two renderings of this one stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapEvent {
+    /// Emitted once, before the first fit, describing the work this run will
+    /// actually do. `replicates` is what is still to be fitted, so a `--resume`
+    /// run reports what is left rather than what the whole run was, and
+    /// `reused` is what it read off disk instead.
+    Started {
+        replicates: usize,
+        reused: usize,
+        base_fit: bool,
+    },
+    /// The fit on the original dataset finished. Not emitted when there is no
+    /// base fit to run (`run_base_model = false`, or a resume that reuses it).
+    BaseFitDone,
+    /// One replicate finished, converged or not. `completed` counts in
+    /// completion order, which on a thread pool is not index order, and counts
+    /// only the replicates this run fitted — it reaches `total` at the end of a
+    /// resumed run too.
+    ReplicateDone { completed: usize, total: usize },
+    /// One Δofv evaluation finished (`dofv = true` only). The Δofv pass is a
+    /// second sweep over every replicate that roughly doubles the run time, so
+    /// it counts separately instead of silently extending the first bar past
+    /// what it promised.
+    DeltaOfvDone { completed: usize, total: usize },
+    /// Every fit is done. The summary and the CSV artefacts still follow, and
+    /// on a large run those are not instant.
+    Finished,
+}
+
+/// A sink for [`BootstrapEvent`]s.
+///
+/// `Send + Sync` because the replicates are fitted on a Rayon pool and each one
+/// reports from whichever thread finished it: a sink that keeps state has to
+/// carry its own synchronisation (an `AtomicUsize`, a `Mutex`), and the event's
+/// `completed` field is there so that most sinks need neither.
+pub type ProgressFn<'a> = &'a (dyn Fn(BootstrapEvent) + Send + Sync);
 
 /// Everything the bootstrap needs beyond the model and data themselves.
 ///
@@ -643,6 +688,30 @@ pub fn run_bootstrap(
     prepared: &PreparedRun,
     options: &BootstrapOptions,
 ) -> Result<BootstrapResult, String> {
+    run_bootstrap_with_progress(prepared, options, None)
+}
+
+/// Run the bootstrap, reporting each fit as it completes.
+///
+/// Identical to [`run_bootstrap`] in every respect but the callback: the draws,
+/// the fits and the artefacts do not depend on whether anyone is watching, so a
+/// run with a progress sink and one without produce the same numbers from the
+/// same seed.
+///
+/// The sink is called from the Rayon worker that finished the fit, once per
+/// replicate — never in a hot loop, since a replicate is a whole fit — so it
+/// may do real work (redraw a bar, call back into R). It must not panic: a
+/// panic crosses the `par_iter` boundary and takes the run with it.
+pub fn run_bootstrap_with_progress(
+    prepared: &PreparedRun,
+    options: &BootstrapOptions,
+    progress: Option<ProgressFn<'_>>,
+) -> Result<BootstrapResult, String> {
+    let emit = |event: BootstrapEvent| {
+        if let Some(sink) = progress {
+            sink(event);
+        }
+    };
     reject_id_dependent_model(&prepared.parsed.model)?;
     reject_mixture_model(&prepared.init_params)?;
     options.validate()?;
@@ -698,6 +767,17 @@ pub fn run_bootstrap(
     };
     let n_reused = reused.len();
     let already_done: std::collections::HashSet<usize> = reused.iter().map(|r| r.index).collect();
+
+    // Announced here rather than at the top of the function because this is the
+    // first point at which the run knows its own size: `--resume` decides how
+    // many of the `samples` draws are actually going to be fitted, and a
+    // progress bar promising 200 when 190 are already on disk is a wrong bar.
+    let n_todo = draws.len() - already_done.len();
+    emit(BootstrapEvent::Started {
+        replicates: n_todo,
+        reused: n_reused,
+        base_fit: options.run_base_model && reused_original.is_none(),
+    });
 
     // ── the incremental journal ─────────────────────────────────────────────
     // Opened before the first fit so that a kill at any point from here on
@@ -760,6 +840,7 @@ pub fn run_bootstrap(
             if let Some(j) = &journal {
                 j.append(&base, None);
             }
+            emit(BootstrapEvent::BaseFitDone);
             Some(base)
         }
         None => None,
@@ -774,6 +855,7 @@ pub fn run_bootstrap(
     };
 
     // ── the replicates ──────────────────────────────────────────────────────
+    let n_completed = AtomicUsize::new(0);
     let run_one = |replicate: &Replicate| -> ReplicateResult {
         let population = resample::build_population(&prepared.population, replicate);
         let started = Instant::now();
@@ -818,6 +900,14 @@ pub fn run_bootstrap(
         if let Some(j) = &journal {
             j.append(&result, Some(replicate));
         }
+        // Counted here rather than by the sink so that every sink agrees on the
+        // number: `par_iter` hands results back in index order, but they are
+        // *produced* in completion order, and a bar that steps on the order the
+        // results are collected in would sit still and then jump.
+        emit(BootstrapEvent::ReplicateDone {
+            completed: n_completed.fetch_add(1, Ordering::Relaxed) + 1,
+            total: n_todo,
+        });
         result
     };
 
@@ -853,8 +943,16 @@ pub fn run_bootstrap(
             "--dofv needs the original fit's OFV as its reference; it cannot be combined with \
              --no-run-base-model",
         )?;
-        compute_delta_ofv(prepared, template, base.ofv, &base_options, &mut replicates)?;
+        compute_delta_ofv(
+            prepared,
+            template,
+            base.ofv,
+            &base_options,
+            &mut replicates,
+            progress,
+        )?;
     }
+    emit(BootstrapEvent::Finished);
 
     let n_estimated_parameters = count_estimated(template);
     let summary = summary::summarize(&names, original.as_ref(), &replicates, options);
@@ -1013,22 +1111,36 @@ fn compute_delta_ofv(
     ofv_original: f64,
     base_options: &FitOptions,
     replicates: &mut [ReplicateResult],
+    progress: Option<ProgressFn<'_>>,
 ) -> Result<(), String> {
     let mut eval = base_options.clone();
     eval.outer_maxiter = 0;
     eval.run_covariance_step = false;
 
+    let total = replicates.len();
+    let done = AtomicUsize::new(0);
     let deltas: Vec<(usize, Option<f64>)> = replicates
         .par_iter()
         .map(|r| {
-            if r.error.is_some() || r.estimates.is_empty() {
-                return (r.index, None);
+            let out = if r.error.is_some() || r.estimates.is_empty() {
+                (r.index, None)
+            } else {
+                let params = params_from_estimates(template, &r.estimates);
+                let ofv = fit(&prepared.parsed.model, &prepared.population, &params, &eval)
+                    .map(|f| f.ofv)
+                    .ok();
+                (r.index, ofv.map(|o| o - ofv_original))
+            };
+            // A skipped replicate is counted too: the bar tracks the sweep, and
+            // the sweep is over every replicate whether or not it has estimates
+            // worth evaluating.
+            if let Some(sink) = progress {
+                sink(BootstrapEvent::DeltaOfvDone {
+                    completed: done.fetch_add(1, Ordering::Relaxed) + 1,
+                    total,
+                });
             }
-            let params = params_from_estimates(template, &r.estimates);
-            let ofv = fit(&prepared.parsed.model, &prepared.population, &params, &eval)
-                .map(|f| f.ofv)
-                .ok();
-            (r.index, ofv.map(|o| o - ofv_original))
+            out
         })
         .collect();
 

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -860,6 +860,59 @@ fn a_run_reports_its_fits_in_order() {
     );
 }
 
+/// A run that fails after it has announced itself still reports `Finished`.
+///
+/// A sink told that a run started and never told it ended leaves its bar on the
+/// terminal, over the error the caller is about to print. `--dofv` without a
+/// base fit is the cheapest way in: it passes `validate()` and fails at the
+/// reference OFV, after `Started` and after every replicate is in.
+#[test]
+fn a_failed_run_still_reports_that_it_finished() {
+    let repo = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let prepared = ferx_core::prepare_run(
+        repo.join("examples/warfarin.ferx").to_str().unwrap(),
+        Some(repo.join("data/warfarin.csv").to_str().unwrap()),
+    )
+    .expect("warfarin loads");
+    let options = BootstrapOptions {
+        samples: 1,
+        seed: 5,
+        threads: Some(1),
+        dofv: true,
+        run_base_model: false,
+        update_inits: false,
+        ..BootstrapOptions::default()
+    };
+
+    let events = std::sync::Mutex::new(Vec::new());
+    let sink = |event| events.lock().expect("not poisoned").push(event);
+    let err = run_bootstrap_with_progress(&prepared, &options, Some(&sink))
+        .expect_err("--dofv needs a base fit");
+    assert!(err.contains("--dofv"), "{err}");
+
+    let events = events.into_inner().expect("not poisoned");
+    assert_eq!(
+        events.first(),
+        Some(&BootstrapEvent::Started {
+            replicates: 1,
+            reused: 0,
+            base_fit: false,
+        }),
+        "{events:?}"
+    );
+    assert_eq!(events.last(), Some(&BootstrapEvent::Finished), "{events:?}");
+    // Exactly one, whichever way the run leaves: the guard emits on the way
+    // out, and the success path disarms it by emitting first.
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| **e == BootstrapEvent::Finished)
+            .count(),
+        1,
+        "{events:?}"
+    );
+}
+
 /// A run with no sink is the same run. Nothing about the draws or the fits may
 /// depend on whether a bar was being drawn, so the two results have to agree
 /// down to the estimate.

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -807,3 +807,95 @@ fn resume_needs_a_directory_and_retry_failed_needs_resume() {
     let err = dangling.validate_for_run().unwrap_err();
     assert!(err.contains("--resume"), "{err}");
 }
+
+// ── progress events ─────────────────────────────────────────────────────────
+
+/// One real run with a sink attached, on the smallest useful model.
+///
+/// The event contract is a sequence, not a set - a bar that is told its length
+/// after it has already been stepped draws wrong - so this asserts the order as
+/// well as the counts. Warfarin (10 subjects) at `--samples 1` with `--dofv` is
+/// three fits, one of which is an evaluation: enough to see every variant.
+#[test]
+fn a_run_reports_its_fits_in_order() {
+    let repo = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let prepared = ferx_core::prepare_run(
+        repo.join("examples/warfarin.ferx").to_str().unwrap(),
+        Some(repo.join("data/warfarin.csv").to_str().unwrap()),
+    )
+    .expect("warfarin loads");
+    let options = BootstrapOptions {
+        samples: 1,
+        seed: 5,
+        threads: Some(1),
+        dofv: true,
+        ..BootstrapOptions::default()
+    };
+
+    let events = std::sync::Mutex::new(Vec::new());
+    let sink = |event| events.lock().expect("not poisoned").push(event);
+    run_bootstrap_with_progress(&prepared, &options, Some(&sink)).expect("the run succeeds");
+
+    let events = events.into_inner().expect("not poisoned");
+    assert_eq!(
+        events,
+        vec![
+            BootstrapEvent::Started {
+                replicates: 1,
+                reused: 0,
+                base_fit: true,
+            },
+            BootstrapEvent::BaseFitDone,
+            BootstrapEvent::ReplicateDone {
+                completed: 1,
+                total: 1,
+            },
+            BootstrapEvent::DeltaOfvDone {
+                completed: 1,
+                total: 1,
+            },
+            BootstrapEvent::Finished,
+        ],
+        "{events:?}"
+    );
+}
+
+/// A run with no sink is the same run. Nothing about the draws or the fits may
+/// depend on whether a bar was being drawn, so the two results have to agree
+/// down to the estimate.
+#[test]
+fn watching_a_run_does_not_change_it() {
+    let repo = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let prepared = ferx_core::prepare_run(
+        repo.join("examples/warfarin.ferx").to_str().unwrap(),
+        Some(repo.join("data/warfarin.csv").to_str().unwrap()),
+    )
+    .expect("warfarin loads");
+    let options = BootstrapOptions {
+        samples: 1,
+        seed: 7,
+        threads: Some(1),
+        run_base_model: false,
+        update_inits: false,
+        ..BootstrapOptions::default()
+    };
+
+    let quiet = run_bootstrap(&prepared, &options).expect("the run succeeds");
+    let watched = {
+        let seen = std::sync::atomic::AtomicUsize::new(0);
+        let sink = |_| {
+            seen.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        };
+        let result = run_bootstrap_with_progress(&prepared, &options, Some(&sink))
+            .expect("the run succeeds");
+        // Started, one ReplicateDone, Finished - and no BaseFitDone, because
+        // `run_base_model = false` means there was no base fit to report.
+        assert_eq!(seen.load(std::sync::atomic::Ordering::Relaxed), 3);
+        result
+    };
+
+    assert_eq!(
+        quiet.replicates[0].estimates,
+        watched.replicates[0].estimates
+    );
+}

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -46,7 +46,8 @@ ferx bootstrap model.ferx --data data.csv --samples 200 --seed 12345 --threads 8
 Resamples subjects with replacement, refits the model to each replicate dataset,
 and reports bias, standard errors and confidence intervals from the spread of the
 estimates — the non-parametric case bootstrap, at `PsN::bootstrap` feature parity.
-Writes PsN-named CSV artefacts to `{model}-bootstrap/`.
+Writes PsN-named CSV artefacts to `{model}-bootstrap/`. Progress is drawn as a bar on
+stderr while the replicates fit, when stderr is a terminal; `--no-progress` turns it off.
 
 Unlike a fit, this is a *tool*: it lives in the `ferx-tools` crate and calls the
 estimation engine many times without changing it. See

--- a/docs/tools/bootstrap.qmd
+++ b/docs/tools/bootstrap.qmd
@@ -193,6 +193,40 @@ ferx bootstrap --summarize --directory run12-bootstrap --no-skip-minimization-te
 `--summarize` re-reads `raw_results.csv` — which carries each replicate's diagnostics
 alongside its estimates — and rewrites the statistics. It refits nothing.
 
+## Watching a run
+
+A 200-sample bootstrap is minutes to hours of fitting behind a single command, so the
+run reports each fit as it completes. On the command line that is a progress bar on
+stderr:
+
+```
+  [00:01:23] [===============>              ] 97/200 replicates (ETA 00:01:28)
+```
+
+The base model gets a spinner of its own before the bar appears — it is one fit, and a
+bar sitting at `0/200` through it reads as a run that is stuck. `--dofv` adds a second
+pass over every replicate, so it gets its own bar rather than extending the first one
+past what it promised. A `--resume` run counts what is *left*: 10 replicates missing
+from a 200-sample directory is a bar of 10.
+
+The bar is drawn only when stderr is a terminal, so a run in a log file, a pipe or a
+scheduler is unaffected. `--no-progress` suppresses it for an interactive run you want
+quiet.
+
+```bash
+ferx bootstrap run12.ferx --data data.csv --samples 200 --no-progress
+```
+
+In R the same events drive a [cli](https://cli.r-lib.org) progress bar:
+
+```r
+bs <- ferx_bootstrap(model, data, samples = 200, threads = 8, progress = TRUE)
+```
+
+The progress stream is presentation only. The draws, the fits and the artefacts are
+identical whether or not anything is watching, so a run in a terminal and the same run
+in a cron job produce the same numbers from the same seed.
+
 ## Recovering an interrupted run
 
 A 200-sample bootstrap is hours of fitting, and the two ways it goes wrong need different


### PR DESCRIPTION
## Why

A 200-sample bootstrap is minutes to hours of fitting behind one command, and until it
returned there was nothing on the terminal to say whether it was making progress or
wedged. PsN prints per-sample lines; ferx printed the run header and then went silent
until the table.

The same gap exists in R: `ferx_bootstrap()` blocks with no output at all. Rather than
teach `ferx-tools` about terminals, this gives it an event stream and lets each front end
render it — indicatif here, `cli` in ferx-r.

## What changed

`ferx_tools::bootstrap::run_bootstrap_with_progress(prepared, options, Option<ProgressFn>)`
emits a `BootstrapEvent` per completed fit:

- `Started { replicates, reused, base_fit }` — once the run knows its own size, which
  `--resume` changes: 10 replicates missing from a 200-sample directory is a bar of 10.
- `BaseFitDone`, `ReplicateDone { completed, total }`,
  `DeltaOfvDone { completed, total }`, `Finished`.

`run_bootstrap` is the same call with `None`, so nothing that does not want progress pays
for it, and no existing caller changes.

The completion count lives in an `AtomicUsize` on the producer side rather than in the
sink. `par_iter` hands results back in index order but produces them in completion order,
so a sink counting its own calls would draw a bar that sits still and then jumps; keeping
it in the event also means most sinks need no state at all.

`ferx-cli` gains `bootstrap_progress.rs`: an indicatif bar with the base fit on its own
spinner (a bar at 0/200 through a single fit reads as stuck) and a separate bar for the
`--dofv` pass, which is a second sweep over every replicate and roughly doubles the run
time. New dependency: `indicatif` (CLI only — `ferx-tools` stays free of any terminal
concern).

```
  [00:00:02] [====================>         ] 4/6 replicates (ETA 3s)
Fitted 6 replicates in 4.5s
```

`--no-progress` suppresses it. A redirected stderr needs no flag: indicatif resolves
`ProgressDrawTarget::stderr()` to a hidden target off a terminal, so logs, pipes and
schedulers are unaffected.

## Alternatives considered

**Print from inside the fit loop.** Simplest, and wrong for the second consumer: R cannot
render a `cli` bar from Rust stderr, and the CLI would own a format the R package would
then have to parse back.

**Poll the journal from outside.** `--directory` already appends `raw_results.csv` per
replicate, so a caller could count rows. It forces `--directory` on a run that may not
want artefacts, and gives nothing for the base fit or the Δofv pass.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#321 | open | after (its `Cargo.lock` bump needs this merged) |

## Breaking changes

- [x] None

`ferx-tools` is not covered by the `ferx-core` public-API baseline, and `ferx-core` itself
is untouched, so `api/ferx-core-public-api.txt` is unchanged.

## Numerical validation

- [x] Not applicable (presentation only)

`watching_a_run_does_not_change_it` pins exactly that: the same seed run with and without a
sink returns the same estimates. The draws, the fits and the artefacts do not depend on
whether anyone is watching.

## Performance

- [x] No significant impact expected

One atomic increment and one sink call per completed fit — a fit being seconds to minutes.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes)

`ferx-tools` (`bootstrap/mod_tests.rs`), both real runs on warfarin at `--samples 1`:

- `a_run_reports_its_fits_in_order` — asserts the whole sequence, not a set: a bar told
  its length after it has been stepped draws wrong. Runs with `--dofv` so every variant is
  covered.
- `watching_a_run_does_not_change_it` — no base fit, so it also pins that `BaseFitDone` is
  not emitted when there is nothing to report.

`ferx-cli` (`bootstrap_progress.rs`), 4 render tests: no bar during the base fit, the
length is what is left to fit, the Δofv pass replaces the replicate bar rather than
carrying it past its end, and a disabled progress draws nothing.

## Example

- [x] Not applicable (no `.ferx` surface changes)

```bash
ferx bootstrap warfarin.ferx --data warfarin.csv --samples 200 --threads 8
ferx bootstrap warfarin.ferx --data warfarin.csv --samples 200 --no-progress
```

## Docs

- [x] `docs/` updated for user-visible changes — new "Watching a run" section in
      `docs/tools/bootstrap.qmd`, plus the `--no-progress` note in `docs/cli.qmd`
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No new pages, so `docs/_quarto.yml` is unchanged; `cargo run -p docs-lint -- --check` green

## Checklist

- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy
      (`--all-targets`), rustdoc, docs, public-API baseline
- [x] Nothing on the `Dual2` sensitivity path is touched
- [x] No version bump (additive)

## Docs & examples

- [x] No new DSL syntax, `[fit_options]` key, example model or data file
- [x] Verified by running the CLI under a pty (`script -q /dev/null cargo run -p ferx-cli -- bootstrap examples/warfarin.ferx --data data/warfarin.csv --samples 6`) — the frames above are that run
- [x] ferx-r rebuilt against this branch (`FERX_NO_AUTODIFF=1 R CMD INSTALL .`) and its full testthat suite passes

## Reviewer hints

Two places worth the attention:

- **Where the count comes from** (`mod.rs`, `run_one`). The argument for the producer-side
  atomic is in the comment there; if you disagree with it, the sink signature is what
  changes.
- **`Started` is emitted after the resume bookkeeping**, not at the top of the function.
  That is the first point at which the run knows how many replicates it will actually fit.

The CLI module is mechanical and can be skimmed, apart from the `DeltaOfvDone` arm, which
is where the replicate bar is retired.

## Open questions

The sink is `Fn(BootstrapEvent) + Send + Sync` rather than a trait. A trait would allow a
stateful renderer without interior mutability, at the cost of a public trait in
`ferx-tools`. If a second tool (SCM?) wants the same treatment, that is the moment to
revisit.