### PR TITLE
chore(package): keep repo infrastructure out of the published crate [#1170]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ section of the SDLC for the versioning policy).
   fit with the `--gam` flag. See [GAM covariate screening](https://ferx-nlme.github.io/ferx-core/tools/gam-screening.html).
 
 ### Changed
+- **The published tarball no longer ships repo infrastructure (#1170).** `tests/`,
+  `nonmem_anchor/`, `docs/`, `plans/`, `tools/`, the workflow and hook directories and the
+  repo-process markdown are excluded from the crate: 1289 files / 5.47 MB compressed becomes
+  366 files / 3.22 MB. None of it is needed to build or document the crate. Running the test
+  suite needs a git checkout, as it needed the NONMEM anchors anyway. No source or API change.
 - **The three published crates now carry `keywords` and `categories` (#1170).** Registry metadata
   only -- no code change. It is what covers discoverability on crates.io, which is why claiming
   the `ferx-nlme` name was judged unnecessary in #1170.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,8 @@ readme = "README.md"
 # the crate published to crates.io free of any CC BY-NC file. The glob also takes
 # its README and licence companions, which are MIT / Creative Commons' own text
 # respectively — they are dropped because they are meaningless without the data,
-# not because of their licence. The slow test goes with them for the same reason:
-# it hardcodes the fixture path, so shipping it without the data would turn
-# `cargo test --features slow-tests` on the packaged crate into a panic on a
-# missing file rather than a test that simply is not there.
+# not because of their licence. The slow test that reads the fixture is covered
+# by the blanket `tests/*` exclusion below.
 #
 # The glob deliberately has no `.` after `mbma_naproxen`: `data/mbma_naproxen.*`
 # matched the csv/LICENSE/README but not `data/mbma_naproxen_source.py` (#1170).
@@ -55,8 +53,25 @@ readme = "README.md"
 exclude = [
   "data/mbma_naproxen*",
   "examples/mbma_naproxen.ferx",
-  "tests/mbma_naproxen_case_study.rs",
   "api/*",
+  # Repo infrastructure, not crate content. None of it is needed to build or
+  # document the crate, and together it is roughly 7.5 MB of a 19.6 MB tarball.
+  # `nonmem_anchor/` goes with `tests/`: it is the NONMEM reference output the
+  # anchor tests read, and nothing outside `tests/` opens it (the mentions in
+  # `src/` are prose in doc comments). Consumers who want to run the test suite
+  # clone the repo; the published crate exists to be built against.
+  "tests/*",
+  "nonmem_anchor/*",
+  "docs/*",
+  "plans/*",
+  "tools/*",
+  ".github/*",
+  ".githooks/*",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "SDLC.md",
+  "VI_VALIDATION.md",
+  "codecov.yml",
 ]
 
 [features]


### PR DESCRIPTION
## Why

Two reasons, one of them a live blocker.

**The tarball ships things that are not crate content.** `tests/`, `nonmem_anchor/`, `docs/`, `plans/`, `tools/`, the workflow and hook directories and the repo-process markdown were all in the published crate. None of it is needed to build or document `ferx-core`. #1170 decision 5 asked whether to trim this and the answer was "leave it" — that answer was given when the only cost was a few MB.

**crates.io will not accept the 5.47 MB upload.** Seven `cargo publish` attempts across ~45 minutes, every one failing with a Fastly `503 backend write error`, from two different POPs (`cache-ams-*` and `cache-sjc*`). Measured from the same machine in the same window:

| target | result | body sent |
|---|---|---|
| httpbin.org (not Fastly) | 200 | 2 MB |
| upload.pypi.org (Fastly, different customer) | 405 | 2 MB |
| api.github.com | 401 | 2 MB |
| crates.io publish endpoint | 503 | 5.47 MB rejected |

So it is not the network and not Fastly in general. crates.io reports no incident. A smaller tarball is the one lever available on our side.

**The trim may not be sufficient.** 3.22 MB is smaller, not small. Early size probes suggested a cutoff somewhere under 2 MB, but those probes turned out to be unreliable — a full 1 MB body now uploads completely and still returns 503, so that endpoint rejects malformed unauthenticated payloads regardless of size and tells us nothing about the authenticated path. Only a real publish will settle it. **The trim stands on its own merits either way**, which is why it is worth merging even if the publish still fails afterwards.

## What changed

`exclude` grows to cover repo infrastructure:

```
tests/*  nonmem_anchor/*  docs/*  plans/*  tools/*  .github/*  .githooks/*
AGENTS.md  CLAUDE.md  SDLC.md  VI_VALIDATION.md  codecov.yml
```

| | before | after |
|---|---|---|
| files | 1289 | 366 |
| compressed | 5.47 MB | 3.22 MB |

`nonmem_anchor/` is grouped with `tests/` deliberately: it is the NONMEM reference output the anchor tests read, and nothing outside `tests/` opens it — the `src/` mentions are prose inside doc comments. Anyone running the suite clones the repo, which they already had to do to get the anchors.

`examples/` and `data/` stay. `src/parser/model_parser_tests.rs` pulls `examples/warfarin_bobyqa.ferx` in through `include_str!`, so excluding examples would break the packaged crate's own test build.

The now-stale comment about the naproxen slow test is replaced — that test is covered by the blanket `tests/*` line.

## Alternatives considered

Excluding the in-tree `#[cfg(test)]` modules under `src/` would save another 3.7 MB, which is the only remaining big lump (`src/` is 12 MB of the 19.6 MB uncompressed). Rejected: it means editing `mod` declarations to keep the crate compiling, which is a real source change made for packaging reasons, and it breaks `cargo test` for anyone working from the published crate.

Waiting for crates.io to recover is the other option and costs nothing, but it is not actionable and the trim is worth doing regardless.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r consumes ferx-core through a git dependency, so the tarball contents never reach it.

## Breaking changes
- [x] None

No source file is touched. The public API baseline is unchanged.

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: the claim is about tarball contents, checked directly with `cargo package`)

`cargo package -p ferx-core` — the full verify build, not just `--list` — exits 0 at 366 files, so nothing excluded is load-bearing for a build of the published crate.

## Example (user-facing features only)
- [x] Not applicable

## Docs
- [x] `CHANGELOG.md` entry added, under `[0.3.1]`
- [x] No user-visible behaviour change

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — no `src/` file is touched
- [x] `Cargo.toml` version bumped — stays 0.3.1, see below

## Docs & examples
- [x] No DSL, estimator, fit-option, example or data-file change

### Example execution
- [x] Not needed (packaging metadata only)

## Reviewer hints

Version stays **0.3.1** and the `v0.3.1` tag moves to this PR's merge commit. 0.3.1 has never been published — every publish attempt failed — and the tag is a few hours old, so moving it costs nothing and keeps the first crates.io version aligned with a tag that names the tree it was actually built from. This is deliberately not the same call as leaving `v0.3.0` alone: that one names a real, month-old internal release.

The judgement call worth a second opinion is dropping `docs/`. It is Quarto source for the published site, not rustdoc, so nothing on docs.rs depends on it — but it is the one excluded directory a reader might expect to find in a source tarball.

## Open questions

None.
