### PR TITLE
feat(api): honour a cancellation flag in the bootstrap [closes #1161]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Added
+
+- **A cancellable bootstrap (#1161).** `BootstrapOptions::cancel` takes a `CancelFlag`; setting
+  it from another thread stops a long `ferx_tools::bootstrap` run at the next replicate boundary
+  and returns the new `BootstrapError::Cancelled`, so a caller reports an abort as an abort
+  rather than as "every remaining replicate failed". Replicates the cancel unwound are dropped
+  rather than journaled as failures, so `--resume` refits them; everything already finished stays
+  on disk and resumes into exactly the run that was cancelled.
+
 ## [0.3.1] - 2026-09-02
 
 ### Added

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -25,8 +25,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use ferx_core::{
-    fit, CompiledModel, FitOptions, FitResult, ModelParameters, OmegaMatrix, Population,
-    PreparedRun, SigmaVector, WarningCode,
+    fit, CancelFlag, CompiledModel, FitOptions, FitResult, ModelParameters, OmegaMatrix,
+    Population, PreparedRun, SigmaVector, WarningCode,
 };
 use rayon::prelude::*;
 
@@ -124,6 +124,65 @@ impl Drop for FinishGuard<'_> {
     }
 }
 
+/// Why a bootstrap run ended early.
+///
+/// A cancelled run is not a failed one, and the distinction is not cosmetic
+/// (#1161). Cancellation reaches the replicates as the same [`CancelFlag`] an
+/// ordinary fit polls, so every in-flight fit unwinds with an `Err` of its own;
+/// without a cancelled outcome of its own the run would report an abort as
+/// "every remaining replicate failed", which is both wrong and the one thing a
+/// caller most needs to be able to tell apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootstrapError {
+    /// The [`BootstrapOptions::cancel`] flag was set while the run was in
+    /// flight, so the run stopped at the next replicate boundary.
+    ///
+    /// Whatever had already been fitted is on disk in the run directory - the
+    /// journal flushes each replicate as it lands - so `resume` picks the run
+    /// up where the cancel stopped it, refitting only what never completed.
+    Cancelled,
+    /// Anything else, carrying the message a caller should show.
+    Failed(String),
+}
+
+impl BootstrapError {
+    /// Whether the run stopped because its cancel flag was set.
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, BootstrapError::Cancelled)
+    }
+}
+
+impl std::fmt::Display for BootstrapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootstrapError::Cancelled => f.write_str("the bootstrap was cancelled"),
+            BootstrapError::Failed(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for BootstrapError {}
+
+impl From<String> for BootstrapError {
+    fn from(message: String) -> Self {
+        BootstrapError::Failed(message)
+    }
+}
+
+impl From<&str> for BootstrapError {
+    fn from(message: &str) -> Self {
+        BootstrapError::Failed(message.to_string())
+    }
+}
+
+/// So a caller whose own error type is a `String` - the CLI, the R glue - keeps
+/// working through `?` and loses only the distinction it was not using.
+impl From<BootstrapError> for String {
+    fn from(error: BootstrapError) -> String {
+        error.to_string()
+    }
+}
+
 /// Everything the bootstrap needs beyond the model and data themselves.
 ///
 /// Defaults mirror PsN's, including the two skip filters that are on by default
@@ -179,6 +238,19 @@ pub struct BootstrapOptions {
     /// alternative. Turn it on when the failure was a transient resource
     /// problem — an out-of-memory kill, a full disk — rather than the model.
     pub retry_failed: bool,
+    /// Cooperative cancellation for the whole run (#1161).
+    ///
+    /// Set from another thread, this stops the run at the next replicate
+    /// boundary and returns [`BootstrapError::Cancelled`]. It is also cloned
+    /// into every replicate's [`FitOptions`], so a fit already in flight
+    /// unwinds instead of running to completion first.
+    ///
+    /// The flag lives here rather than only on the model's own `FitOptions`
+    /// because reaching through `prepared.parsed.fit_options` to set it depends
+    /// on the replicate options happening to clone the field — an
+    /// implementation detail of this module. A flag set there is still
+    /// honoured; this one simply takes precedence.
+    pub cancel: Option<CancelFlag>,
 }
 
 impl BootstrapOptions {
@@ -260,6 +332,7 @@ impl Default for BootstrapOptions {
             confidence_level: 95.0,
             resume: false,
             retry_failed: false,
+            cancel: None,
         }
     }
 }
@@ -621,7 +694,16 @@ pub fn strata_from_csv(
 ///   *same* `{model}.tmp`, so they would restore each other's state;
 /// * **no SIR** — a per-replicate uncertainty step inside an uncertainty
 ///   analysis is pure cost.
-fn replicate_options(base: &FitOptions, keep_covariance: bool) -> FitOptions {
+///
+/// `cancel` is the run's one effective flag (see [`effective_cancel`]) and is
+/// installed unconditionally, so a `BootstrapOptions::cancel` overrides
+/// whatever the model file's own `FitOptions` carried and a run without one is
+/// left exactly as it was.
+fn replicate_options(
+    base: &FitOptions,
+    keep_covariance: bool,
+    cancel: &Option<CancelFlag>,
+) -> FitOptions {
     let mut o = base.clone();
     o.verbose = false;
     o.threads = Some(1);
@@ -629,7 +711,23 @@ fn replicate_options(base: &FitOptions, keep_covariance: bool) -> FitOptions {
     o.checkpoint = false;
     o.checkpoint_path = None;
     o.sir = false;
+    o.cancel = cancel.clone();
     o
+}
+
+/// The flag this run polls: [`BootstrapOptions::cancel`] when the caller set
+/// one, otherwise whatever the model's own [`FitOptions`] carried.
+///
+/// The `FitOptions` path is not a fallback for tidiness' sake — it is what
+/// callers had before this field existed, since the replicate options are a
+/// clone of the base ones, and dropping it would silently stop honouring a flag
+/// that used to work.
+fn effective_cancel(options: &BootstrapOptions, base: &FitOptions) -> Option<CancelFlag> {
+    options.cancel.clone().or_else(|| base.cancel.clone())
+}
+
+fn is_cancelled(flag: &Option<CancelFlag>) -> bool {
+    flag.as_ref().is_some_and(|f| f.is_cancelled())
 }
 
 fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
@@ -727,7 +825,7 @@ fn reject_id_dependent(referenced: &[String]) -> Result<(), String> {
 pub fn run_bootstrap(
     prepared: &PreparedRun,
     options: &BootstrapOptions,
-) -> Result<BootstrapResult, String> {
+) -> Result<BootstrapResult, BootstrapError> {
     run_bootstrap_with_progress(prepared, options, None)
 }
 
@@ -742,11 +840,19 @@ pub fn run_bootstrap(
 /// replicate — never in a hot loop, since a replicate is a whole fit — so it
 /// may do real work (redraw a bar, call back into R). It must not panic: a
 /// panic crosses the `par_iter` boundary and takes the run with it.
+/// # Cancellation
+///
+/// Setting [`BootstrapOptions::cancel`] from another thread ends the run at the
+/// next replicate boundary with [`BootstrapError::Cancelled`], leaving the
+/// replicates that had already finished in the run directory for `resume`. A
+/// replicate that was mid-fit when the flag was set is dropped rather than
+/// recorded: its `Err` cannot be told apart from a genuine failure, and a
+/// failure is what `resume` declines to refit.
 pub fn run_bootstrap_with_progress(
     prepared: &PreparedRun,
     options: &BootstrapOptions,
     progress: Option<ProgressFn<'_>>,
-) -> Result<BootstrapResult, String> {
+) -> Result<BootstrapResult, BootstrapError> {
     let emit = |event: BootstrapEvent| {
         if let Some(sink) = progress {
             sink(event);
@@ -756,6 +862,14 @@ pub fn run_bootstrap_with_progress(
     reject_mixture_model(&prepared.init_params)?;
     options.validate()?;
     options.validate_for_run()?;
+
+    let cancel = effective_cancel(options, &prepared.parsed.fit_options);
+    // Checked before the journal is opened, not after: opening it rewrites the
+    // four per-replicate files, and a run that was cancelled before it started
+    // must not be what truncates the previous run's artefacts.
+    if is_cancelled(&cancel) {
+        return Err(BootstrapError::Cancelled);
+    }
 
     let template = &prepared.init_params;
     let names = parameter_names(template);
@@ -777,7 +891,7 @@ pub fn run_bootstrap_with_progress(
     };
     let allocation = strata.allocation(&options.sample_size)?;
     if allocation.iter().all(|(_, n)| *n == 0) {
-        return Err("the resampling allocation draws 0 subjects".to_string());
+        return Err("the resampling allocation draws 0 subjects".into());
     }
 
     // ── the draws ───────────────────────────────────────────────────────────
@@ -843,7 +957,11 @@ pub fn run_bootstrap_with_progress(
     };
 
     // ── the base fit ────────────────────────────────────────────────────────
-    let base_options = replicate_options(&prepared.parsed.fit_options, options.keep_covariance);
+    let base_options = replicate_options(
+        &prepared.parsed.fit_options,
+        options.keep_covariance,
+        &cancel,
+    );
     let original = match reused_original {
         // A resumed run must **not** refit the base model. `--update-inits`
         // starts every replicate from its estimates, and a second fit can land
@@ -897,9 +1015,23 @@ pub fn run_bootstrap_with_progress(
         _ => template.clone(),
     };
 
+    // A cancel during the base fit leaves nothing to resample from — the base
+    // fit is where `--update-inits` starts every replicate — so the run ends
+    // here rather than fitting 200 replicates from the model file's inits.
+    if is_cancelled(&cancel) {
+        return Err(BootstrapError::Cancelled);
+    }
+
     // ── the replicates ──────────────────────────────────────────────────────
     let n_completed = AtomicUsize::new(0);
-    let run_one = |replicate: &Replicate| -> ReplicateResult {
+    let run_one = |replicate: &Replicate| -> Option<ReplicateResult> {
+        // Where a cancelled run stops *scheduling*. Without this the loop still
+        // walks every remaining draw: each one enters `fit`, immediately
+        // observes the same flag, and returns an error — pointless work, and a
+        // long confusing pause before the abort surfaces.
+        if is_cancelled(&cancel) {
+            return None;
+        }
         let population = resample::build_population(&prepared.population, replicate);
         let started = Instant::now();
         let outcome = fit(
@@ -926,6 +1058,12 @@ pub fn run_bootstrap_with_progress(
                     delta_ofv: None,
                 }
             }
+            // A fit that failed while the flag was set cannot be told apart
+            // from one the flag itself unwound, so it is dropped rather than
+            // journaled. Recording it would leave `--resume` a failed row,
+            // which it carries forward instead of refitting by default — the
+            // cancelled replicate would then never be fitted at all.
+            Err(_) if is_cancelled(&cancel) => return None,
             Err(e) => ReplicateResult {
                 index: replicate.index,
                 estimates: Vec::new(),
@@ -951,7 +1089,7 @@ pub fn run_bootstrap_with_progress(
             completed: n_completed.fetch_add(1, Ordering::Relaxed) + 1,
             total: n_todo,
         });
-        result
+        Some(result)
     };
 
     let todo: Vec<Replicate> = draws
@@ -965,9 +1103,9 @@ pub fn run_bootstrap_with_progress(
             .num_threads(n)
             .build()
             .map_err(|e| format!("failed to build the bootstrap thread pool: {e}"))?
-            .install(|| todo.par_iter().map(run_one).collect::<Vec<_>>()),
-        Some(_) => todo.iter().map(run_one).collect(),
-        None => todo.par_iter().map(run_one).collect(),
+            .install(|| todo.par_iter().filter_map(run_one).collect::<Vec<_>>()),
+        Some(_) => todo.iter().filter_map(run_one).collect(),
+        None => todo.par_iter().filter_map(run_one).collect(),
     };
 
     // The journal's handles must be closed before `write_all` truncates the
@@ -975,6 +1113,13 @@ pub fn run_bootstrap_with_progress(
     // loop surfaces.
     if let Some(j) = journal {
         j.into_result()?;
+    }
+
+    // After the journal is closed, so a cancelled run's directory is complete
+    // and resumable, and before the summary, which over a truncated set of
+    // replicates would be an interval nobody asked for.
+    if is_cancelled(&cancel) {
+        return Err(BootstrapError::Cancelled);
     }
 
     replicates.extend(reused);
@@ -993,7 +1138,14 @@ pub fn run_bootstrap_with_progress(
             &base_options,
             &mut replicates,
             progress,
+            &cancel,
         )?;
+        // The Δofv sweep is a second pass over every replicate, so it is its own
+        // cancellation point: the estimates are already journaled, and finishing
+        // the run would write a `delta_ofv` column that is mostly empty.
+        if is_cancelled(&cancel) {
+            return Err(BootstrapError::Cancelled);
+        }
     }
     finish.finish();
 
@@ -1155,6 +1307,7 @@ fn compute_delta_ofv(
     base_options: &FitOptions,
     replicates: &mut [ReplicateResult],
     progress: Option<ProgressFn<'_>>,
+    cancel: &Option<CancelFlag>,
 ) -> Result<(), String> {
     let mut eval = base_options.clone();
     eval.outer_maxiter = 0;
@@ -1165,7 +1318,7 @@ fn compute_delta_ofv(
     let deltas: Vec<(usize, Option<f64>)> = replicates
         .par_iter()
         .map(|r| {
-            let out = if r.error.is_some() || r.estimates.is_empty() {
+            let out = if is_cancelled(cancel) || r.error.is_some() || r.estimates.is_empty() {
                 (r.index, None)
             } else {
                 let params = params_from_estimates(template, &r.estimates);

--- a/crates/ferx-tools/src/bootstrap/mod.rs
+++ b/crates/ferx-tools/src/bootstrap/mod.rs
@@ -24,6 +24,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
+use ferx_core::cancel::is_cancelled;
 use ferx_core::{
     fit, CancelFlag, CompiledModel, FitOptions, FitResult, ModelParameters, OmegaMatrix,
     Population, PreparedRun, SigmaVector, WarningCode,
@@ -132,7 +133,11 @@ impl Drop for FinishGuard<'_> {
 /// without a cancelled outcome of its own the run would report an abort as
 /// "every remaining replicate failed", which is both wrong and the one thing a
 /// caller most needs to be able to tell apart.
+///
+/// `#[non_exhaustive]`: an out-of-workspace caller matches on `Cancelled` and a
+/// catch-all, so a variant added later is not a source break for it.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BootstrapError {
     /// The [`BootstrapOptions::cancel`] flag was set while the run was in
     /// flight, so the run stopped at the next replicate boundary.
@@ -248,8 +253,13 @@ pub struct BootstrapOptions {
     /// The flag lives here rather than only on the model's own `FitOptions`
     /// because reaching through `prepared.parsed.fit_options` to set it depends
     /// on the replicate options happening to clone the field — an
-    /// implementation detail of this module. A flag set there is still
-    /// honoured; this one simply takes precedence.
+    /// implementation detail of this module.
+    ///
+    /// A flag set there is still honoured **when this one is `None`**. When
+    /// both are set only this one is polled: the run's replicate options
+    /// install one flag, so the two cannot be OR-ed, and a caller that passed a
+    /// flag to the tool should not be cancelled by whatever the model file
+    /// happened to carry. Set one or the other, not both.
     pub cancel: Option<CancelFlag>,
 }
 
@@ -726,8 +736,34 @@ fn effective_cancel(options: &BootstrapOptions, base: &FitOptions) -> Option<Can
     options.cancel.clone().or_else(|| base.cancel.clone())
 }
 
-fn is_cancelled(flag: &Option<CancelFlag>) -> bool {
-    flag.as_ref().is_some_and(|f| f.is_cancelled())
+/// Classify a `String` error raised by something that runs a fit, given the
+/// run's flag.
+///
+/// `fit` reports a cancelled fit as an ordinary `Err("cancelled by user")`, and
+/// every `?` in this module funnels a `String` into
+/// [`BootstrapError::Failed`] — so a bare `?` around a fit turns the one
+/// outcome #1161 exists to make distinguishable back into a failure. The base
+/// fit is where that bites: it is the longest single fit in the run, the one a
+/// user is most likely to be sitting through when they cancel, and it happens
+/// *before* the flag is next polled.
+///
+/// A genuine failure racing a cancel is attributed to the cancel. The two are
+/// indistinguishable at this point — the same reason `run_one` drops such a
+/// replicate rather than journaling it — and of the two readings the cancelled
+/// one is what the caller asked for.
+///
+/// **The rule this encodes: any `?` on something that runs a fit goes through
+/// here.** It is deliberately not applied to the whole function body, because
+/// the checks *above* the first cancellation point — `validate`,
+/// `validate_for_run`, the allocation — must keep reporting themselves. A run
+/// with `--samples 0` and a pre-set flag is a misconfigured run, not a
+/// cancelled one, and saying "cancelled" would hide the typo.
+fn cancel_aware(error: String, cancel: &Option<CancelFlag>) -> BootstrapError {
+    if is_cancelled(cancel) {
+        BootstrapError::Cancelled
+    } else {
+        BootstrapError::Failed(error)
+    }
 }
 
 fn diagnostics_from(result: &FitResult) -> (bool, bool, bool) {
@@ -983,7 +1019,10 @@ pub fn run_bootstrap_with_progress(
                     o.run_covariance_step = prepared.parsed.fit_options.run_covariance_step;
                     o
                 },
-            )?;
+            )
+            // Not a bare `?`: `fit` signals a cancelled fit with an ordinary
+            // `Err`, and the flag is not polled again until after this call.
+            .map_err(|e| cancel_aware(e, &cancel))?;
             let (near_boundary, cov_ok, cov_warn) = diagnostics_from(&result);
             let base = ReplicateResult {
                 index: 0,
@@ -1019,6 +1058,14 @@ pub fn run_bootstrap_with_progress(
     // fit is where `--update-inits` starts every replicate — so the run ends
     // here rather than fitting 200 replicates from the model file's inits.
     if is_cancelled(&cancel) {
+        // Closed on this path too. `into_result` is the only place a journal
+        // write failure surfaces, and the row it would have swallowed is the
+        // base fit's — the one a resume reuses instead of refitting. Reporting
+        // a full disk beats returning `Cancelled` over a directory that
+        // `--resume` will then read short a row.
+        if let Some(j) = journal {
+            j.into_result()?;
+        }
         return Err(BootstrapError::Cancelled);
     }
 

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use ferx_core::Subject;
+use ferx_core::{CancelFlag, Subject};
 use nalgebra::DMatrix;
 
 /// A two-theta, two-eta, one-sigma template with a correlated Omega block.
@@ -390,7 +390,7 @@ fn replicate_fits_are_quiet_single_threaded_and_checkpoint_free() {
         ..FitOptions::default()
     };
 
-    let o = replicate_options(&base, false);
+    let o = replicate_options(&base, false, &None);
     assert!(!o.verbose);
     assert_eq!(o.threads, Some(1));
     assert!(!o.checkpoint);
@@ -399,7 +399,86 @@ fn replicate_fits_are_quiet_single_threaded_and_checkpoint_free() {
     assert!(!o.run_covariance_step);
 
     // `--keep-covariance` is the one that turns the step back on.
-    assert!(replicate_options(&base, true).run_covariance_step);
+    assert!(replicate_options(&base, true, &None).run_covariance_step);
+    // Nothing to cancel with, so nothing is installed: a replicate of an
+    // uncancellable run polls no flag.
+    assert!(o.cancel.is_none());
+}
+
+#[test]
+fn the_run_wide_cancel_flag_reaches_every_replicate_fit() {
+    // The propagation #1161 depends on: a replicate is an ordinary `fit`, and
+    // the only way the flag it polls gets there is this clone.
+    let flag = CancelFlag::new();
+    let o = replicate_options(&FitOptions::default(), false, &Some(flag.clone()));
+    let installed = o.cancel.expect("the replicate options carry the flag");
+    assert!(!installed.is_cancelled());
+    flag.cancel();
+    assert!(
+        installed.is_cancelled(),
+        "the replicate got a copy of the flag rather than a share of it"
+    );
+}
+
+#[test]
+fn a_flag_on_the_model_s_own_fit_options_is_still_honoured() {
+    // The pre-#1161 route: callers set `prepared.parsed.fit_options.cancel` and
+    // relied on the replicate options cloning it. That has to keep working, or
+    // this change silently stops honouring a flag that used to abort a run.
+    let flag = CancelFlag::new();
+    let base = FitOptions {
+        cancel: Some(flag.clone()),
+        ..FitOptions::default()
+    };
+    let options = BootstrapOptions::default();
+    let effective = effective_cancel(&options, &base).expect("inherited from the fit options");
+    flag.cancel();
+    assert!(effective.is_cancelled());
+
+    // And the run-wide flag wins when both are set, so a caller that passes one
+    // to the tool is not quietly overridden by whatever the model file carried.
+    let run_wide = CancelFlag::new();
+    let effective = effective_cancel(
+        &BootstrapOptions {
+            cancel: Some(run_wide.clone()),
+            ..BootstrapOptions::default()
+        },
+        &base,
+    )
+    .expect("the run-wide flag");
+    assert!(
+        !effective.is_cancelled(),
+        "the already-cancelled fit-options flag took precedence over the run's own"
+    );
+    run_wide.cancel();
+    assert!(effective.is_cancelled());
+}
+
+#[test]
+fn a_cancellation_is_not_a_failure() {
+    // What a caller reports with. `Cancelled` has to survive the trip through a
+    // `String` error type readably, since that is what the CLI and the R glue
+    // still use.
+    let cancelled = BootstrapError::Cancelled;
+    assert!(cancelled.is_cancelled());
+    assert!(!BootstrapError::Failed("boom".to_string()).is_cancelled());
+
+    assert_eq!(
+        BootstrapError::Failed("boom".to_string()).to_string(),
+        "boom",
+        "a failure must not be dressed up on its way through Display"
+    );
+    assert!(String::from(cancelled).contains("cancel"));
+
+    // `?` on the String-returning helpers inside the run depends on both.
+    assert_eq!(
+        BootstrapError::from("boom"),
+        BootstrapError::Failed("boom".to_string())
+    );
+    assert_eq!(
+        BootstrapError::from("boom".to_string()),
+        BootstrapError::Failed("boom".to_string())
+    );
 }
 
 // ── --summarize ─────────────────────────────────────────────────────────────
@@ -888,7 +967,7 @@ fn a_failed_run_still_reports_that_it_finished() {
     let sink = |event| events.lock().expect("not poisoned").push(event);
     let err = run_bootstrap_with_progress(&prepared, &options, Some(&sink))
         .expect_err("--dofv needs a base fit");
-    assert!(err.contains("--dofv"), "{err}");
+    assert!(err.to_string().contains("--dofv"), "{err}");
 
     let events = events.into_inner().expect("not poisoned");
     assert_eq!(

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -481,6 +481,39 @@ fn a_cancellation_is_not_a_failure() {
     );
 }
 
+#[test]
+fn an_error_raised_under_a_set_flag_is_a_cancellation() {
+    // `fit` reports a cancelled fit as an ordinary `Err("cancelled by user")`,
+    // so the classifier is what keeps a bare `?` around a fit from turning the
+    // whole point of #1161 back into "the base fit failed".
+    let flag = CancelFlag::new();
+    let cancel = Some(flag.clone());
+
+    assert_eq!(
+        cancel_aware("cancelled by user".to_string(), &cancel),
+        BootstrapError::Failed("cancelled by user".to_string()),
+        "an error before the flag is set is a failure, whatever it says"
+    );
+
+    flag.cancel();
+    assert_eq!(
+        cancel_aware("cancelled by user".to_string(), &cancel),
+        BootstrapError::Cancelled
+    );
+    // A genuine failure racing the cancel is attributed to the cancel — the
+    // same call `run_one` makes when it drops rather than journals one.
+    assert_eq!(
+        cancel_aware("the model file is nonsense".to_string(), &cancel),
+        BootstrapError::Cancelled
+    );
+
+    // No flag at all: every error is what it says it is.
+    assert_eq!(
+        cancel_aware("boom".to_string(), &None),
+        BootstrapError::Failed("boom".to_string())
+    );
+}
+
 // ── --summarize ─────────────────────────────────────────────────────────────
 
 fn stored_run(dir: &std::path::Path) {

--- a/crates/ferx-tools/tests/bootstrap_end_to_end.rs
+++ b/crates/ferx-tools/tests/bootstrap_end_to_end.rs
@@ -12,10 +12,10 @@
 
 use std::path::Path;
 
-use ferx_core::{fit, prepare_run, FitOptions, PreparedRun};
+use ferx_core::{fit, prepare_run, CancelFlag, FitOptions, PreparedRun};
 use ferx_tools::bootstrap::{
-    flatten_estimates, params_from_estimates, resample, run_bootstrap, BootstrapOptions, Replicate,
-    SampleSize,
+    flatten_estimates, params_from_estimates, resample, run_bootstrap, run_bootstrap_with_progress,
+    BootstrapError, BootstrapEvent, BootstrapOptions, Replicate, SampleSize,
 };
 
 const MODEL: &str = "../../examples/warfarin.ferx";
@@ -441,7 +441,7 @@ fn resuming_a_directory_from_a_different_seed_is_refused() {
         },
     )
     .expect_err("a different seed must refuse the resume");
-    assert!(err.contains("--seed"), "{err}");
+    assert!(err.to_string().contains("--seed"), "{err}");
 }
 
 /// The mismatch that passes every other check: interrupt a default run and
@@ -466,7 +466,7 @@ fn resuming_with_a_different_replicate_starting_point_is_refused() {
         },
     )
     .expect_err("changing where the replicates start must refuse the resume");
-    assert!(err.contains("--update-inits"), "{err}");
+    assert!(err.to_string().contains("--update-inits"), "{err}");
 
     // `--no-run-base-model` moves the starting point too, and changes whether a
     // `sample = 0` row belongs in the file at all.
@@ -480,7 +480,244 @@ fn resuming_with_a_different_replicate_starting_point_is_refused() {
         },
     )
     .expect_err("dropping the base model must refuse the resume");
-    assert!(err.contains("--run-base-model"), "{err}");
+    assert!(err.to_string().contains("--run-base-model"), "{err}");
+}
+
+// ── cancellation (#1161) ────────────────────────────────────────────────────
+
+/// A run cancelled before it starts must not touch the directory it was aimed
+/// at.
+///
+/// Opening the journal rewrites the four per-replicate files, so the check that
+/// makes this pass is the one *before* the journal is opened. Get the order
+/// wrong and cancelling a mistyped command destroys the artefacts of the run
+/// that is already there — the run the user would otherwise have resumed.
+#[test]
+fn a_run_cancelled_before_it_starts_leaves_the_directory_untouched() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    run_bootstrap(&p, &resume_options(dir.path())).expect("a completed run to protect");
+    let before = raw_results_without_timings(dir.path());
+
+    let flag = CancelFlag::new();
+    flag.cancel();
+    let err = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            cancel: Some(flag),
+            ..resume_options(dir.path())
+        },
+    )
+    .expect_err("a pre-cancelled run must not report success");
+    assert_eq!(err, BootstrapError::Cancelled);
+
+    assert_eq!(
+        raw_results_without_timings(dir.path()),
+        before,
+        "the cancelled run truncated the artefacts of the run already in the directory"
+    );
+}
+
+/// The whole point of #1161: a cancelled run stops fitting, says it was
+/// cancelled rather than that everything failed, and leaves a directory that
+/// resumes into exactly the run that was interrupted.
+#[test]
+fn a_cancelled_run_stops_scheduling_and_resumes_into_the_uninterrupted_run() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let whole_dir = tempfile::tempdir().expect("temp dir");
+    run_bootstrap(&p, &resume_options(whole_dir.path())).expect("the uninterrupted run");
+
+    // Cancel from the progress sink, the moment the first replicate lands. On
+    // one thread that is a hard boundary: replicate 1 is journaled, replicates
+    // 2 and 3 are never fitted.
+    let part_dir = tempfile::tempdir().expect("temp dir");
+    let flag = CancelFlag::new();
+    let sink = |event: BootstrapEvent| {
+        if matches!(event, BootstrapEvent::ReplicateDone { .. }) {
+            flag.cancel();
+        }
+    };
+    let err = run_bootstrap_with_progress(
+        &p,
+        &BootstrapOptions {
+            cancel: Some(flag.clone()),
+            ..resume_options(part_dir.path())
+        },
+        Some(&sink),
+    )
+    .expect_err("a cancelled run must not report success");
+    assert_eq!(
+        err,
+        BootstrapError::Cancelled,
+        "a cancelled run reported as a failure: {err}"
+    );
+
+    // Header, the base fit, and exactly one replicate. The two draws that were
+    // never fitted are absent rather than recorded as failures — recorded, a
+    // resume would carry them forward instead of fitting them.
+    let rows = raw_results_without_timings(part_dir.path());
+    assert_eq!(
+        rows.len(),
+        3,
+        "expected header + base + 1 replicate, got {} rows",
+        rows.len()
+    );
+
+    let resumed = run_bootstrap(
+        &p,
+        &BootstrapOptions {
+            resume: true,
+            ..resume_options(part_dir.path())
+        },
+    )
+    .expect("the cancelled run resumes");
+    assert_eq!(
+        resumed.n_reused, 1,
+        "the resume should reuse the single replicate the cancelled run finished"
+    );
+    assert!(
+        resumed.replicates.iter().all(|r| r.error.is_none()),
+        "a cancelled replicate was carried forward as a failed one"
+    );
+    assert_eq!(
+        raw_results_without_timings(part_dir.path()),
+        raw_results_without_timings(whole_dir.path()),
+        "a cancelled-and-resumed run is not the uninterrupted run"
+    );
+}
+
+/// The same on a thread pool, where a cancel lands while other replicates are
+/// mid-fit.
+///
+/// Those fits unwind with an `Err` of their own, which is indistinguishable
+/// from a genuine failure — so the property asserted here is that none of them
+/// reaches the journal. A recorded failure is one `--resume` carries forward
+/// rather than refits, which would quietly cost the run a replicate.
+#[test]
+fn replicates_unwound_by_a_cancel_are_never_recorded_as_failures() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let flag = CancelFlag::new();
+    let sink = |event: BootstrapEvent| {
+        if matches!(event, BootstrapEvent::ReplicateDone { .. }) {
+            flag.cancel();
+        }
+    };
+    let err = run_bootstrap_with_progress(
+        &p,
+        &BootstrapOptions {
+            samples: 6,
+            threads: Some(4),
+            cancel: Some(flag.clone()),
+            ..resume_options(dir.path())
+        },
+        Some(&sink),
+    )
+    .expect_err("a cancelled run must not report success");
+    assert_eq!(err, BootstrapError::Cancelled);
+
+    let rows = raw_results_without_timings(dir.path());
+    let error_at = rows[0]
+        .iter()
+        .position(|h| h == "error")
+        .expect("an error column");
+    for row in rows.iter().skip(1) {
+        assert_eq!(
+            row[error_at], "",
+            "a replicate the cancel unwound was journaled as a failure: {row:?}"
+        );
+    }
+
+    // Deliberately no assertion on *how many* replicates got through. On a pool
+    // that is a timing property, not a contract: every fit already past the
+    // entry check when the flag is set runs to completion, and the flag itself
+    // is a relaxed atomic, so a loaded machine can let the whole run finish
+    // before the first completion is observed. Asserting a bound here failed
+    // roughly one run in three under load. Where stopping *is* a contract is on
+    // one thread, and
+    // `a_cancelled_run_stops_scheduling_and_resumes_into_the_uninterrupted_run`
+    // pins it there, exactly.
+}
+
+/// A cancel that lands before the first replicate stops the run without fitting
+/// one — the check between the base fit and the replicate loop.
+///
+/// Unlike the mid-loop case this is exact on any number of threads: the flag is
+/// read on the thread that is about to build the pool, so there is no in-flight
+/// fit to finish and nothing racing the read.
+#[test]
+fn a_cancel_between_the_base_fit_and_the_replicates_fits_no_replicate() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let flag = CancelFlag::new();
+    let sink = |event: BootstrapEvent| {
+        if matches!(event, BootstrapEvent::BaseFitDone) {
+            flag.cancel();
+        }
+    };
+    let err = run_bootstrap_with_progress(
+        &p,
+        &BootstrapOptions {
+            samples: 6,
+            threads: Some(4),
+            cancel: Some(flag.clone()),
+            ..resume_options(dir.path())
+        },
+        Some(&sink),
+    )
+    .expect_err("a cancelled run must not report success");
+    assert_eq!(err, BootstrapError::Cancelled);
+
+    // Header and the base fit, and nothing else: the run never reached a
+    // replicate. The base fit is still journaled, so a resume reuses it rather
+    // than refitting it — which is what keeps the resumed run identical.
+    assert_eq!(
+        raw_results_without_timings(dir.path()).len(),
+        2,
+        "a replicate was fitted after the run was cancelled"
+    );
+}
+
+/// The Δofv sweep is a second pass over every replicate that roughly doubles
+/// the run time, so it is its own cancellation point rather than a stretch of
+/// the run that ignores the flag.
+#[test]
+fn a_cancel_during_the_delta_ofv_sweep_ends_the_run() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let flag = CancelFlag::new();
+    let sink = |event: BootstrapEvent| {
+        if matches!(event, BootstrapEvent::DeltaOfvDone { .. }) {
+            flag.cancel();
+        }
+    };
+    let err = run_bootstrap_with_progress(
+        &p,
+        &BootstrapOptions {
+            samples: 2,
+            dofv: true,
+            cancel: Some(flag.clone()),
+            ..resume_options(dir.path())
+        },
+        Some(&sink),
+    )
+    .expect_err("a cancel during the Δofv sweep must not report success");
+    assert_eq!(err, BootstrapError::Cancelled);
+
+    // The fits themselves finished, so the replicates are on disk and resumable
+    // - it is the Δofv column that the cancelled run does not get to write.
+    assert!(!dir.path().join("delta_ofv.csv").exists());
+    assert_eq!(raw_results_without_timings(dir.path()).len(), 4);
 }
 
 /// A fresh run writes its manifest before the first fit, so a process killed at
@@ -630,7 +867,7 @@ fn quick() -> PreparedRun {
 fn err_of(options: BootstrapOptions) -> String {
     match run_bootstrap(&quick(), &options) {
         Ok(_) => panic!("expected an error"),
-        Err(e) => e,
+        Err(e) => e.to_string(),
     }
 }
 

--- a/crates/ferx-tools/tests/bootstrap_end_to_end.rs
+++ b/crates/ferx-tools/tests/bootstrap_end_to_end.rs
@@ -590,6 +590,58 @@ fn a_cancelled_run_stops_scheduling_and_resumes_into_the_uninterrupted_run() {
     );
 }
 
+/// A cancel that lands *during* the base fit is a cancellation, not a failure.
+///
+/// The gap the first round of this change left open. `fit` reports a cancelled
+/// fit with an ordinary `Err("cancelled by user")`, so a bare `?` on the base
+/// fit made the run return `Failed("cancelled by user")` — `is_cancelled()`
+/// false — and the check between the base fit and the replicates was never
+/// reached. That is the worst place to lose the distinction: the base fit is
+/// the longest single fit in the run, and with `--update-inits` it is the one
+/// a user waits through.
+///
+/// `BootstrapEvent::Started` is emitted before the base fit begins, and `fit`
+/// polls the flag at the top of its method chain, so this is exact rather than
+/// a race.
+#[test]
+fn a_cancel_during_the_base_fit_is_a_cancellation_not_a_failure() {
+    let mut p = prepared();
+    p.parsed.fit_options.outer_maxiter = 2;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let flag = CancelFlag::new();
+    let sink = |event: BootstrapEvent| {
+        if matches!(event, BootstrapEvent::Started { .. }) {
+            flag.cancel();
+        }
+    };
+    let err = run_bootstrap_with_progress(
+        &p,
+        &BootstrapOptions {
+            cancel: Some(flag.clone()),
+            ..resume_options(dir.path())
+        },
+        Some(&sink),
+    )
+    .expect_err("a run cancelled during its base fit must not report success");
+    assert_eq!(
+        err,
+        BootstrapError::Cancelled,
+        "a cancel during the base fit was reported as a failure: {err}"
+    );
+    assert!(
+        err.is_cancelled(),
+        "the caller cannot tell the abort apart from a failed base fit"
+    );
+
+    // Header only: the base fit never produced a row, and no replicate ran.
+    assert_eq!(
+        raw_results_without_timings(dir.path()).len(),
+        1,
+        "something was fitted after the run was cancelled"
+    );
+}
+
 /// The same on a thread pool, where a cancel lands while other replicates are
 /// mid-fit.
 ///

--- a/docs/tools/bootstrap.qmd
+++ b/docs/tools/bootstrap.qmd
@@ -439,3 +439,49 @@ for p in &result.summary.parameters {
 the data path against the model's `[data]` block, applies `[data_selection]`, reads the
 population and binds any `theta NAME[...]` level blocks — everything `ferx model.ferx`
 does up to the fit itself.
+
+## Cancelling a run
+
+A 200-sample bootstrap is minutes to hours of fitting behind one call, so a library caller
+gets a cooperative abort: `BootstrapOptions::cancel` takes a `CancelFlag`, and setting it
+from another thread ends the run at the next replicate boundary.
+
+```rust
+use ferx_core::CancelFlag;
+use ferx_tools::bootstrap::{run_bootstrap, BootstrapError, BootstrapOptions};
+
+let flag = CancelFlag::new();
+let options = BootstrapOptions { cancel: Some(flag.clone()), ..Default::default() };
+
+// … from another thread, on a Ctrl-C or a user's "stop" button:
+flag.cancel();
+
+match run_bootstrap(&prepared, &options) {
+    Ok(result) => report(result),
+    Err(BootstrapError::Cancelled) => eprintln!("stopped; --resume picks it up"),
+    Err(e) => eprintln!("Error: {e}"),
+}
+```
+
+Three things follow from where the flag is checked.
+
+**A cancelled run is not a failed one.** The flag also reaches every replicate's own fit,
+so a replicate that was mid-fit unwinds with an error of its own rather than running to
+completion. Those are dropped, never written to `raw_results.csv` — a recorded failure is
+one that [a resume carries forward](#recovering-an-interrupted-run) instead of refitting,
+which would silently cost the run a replicate. What the flag stops is *scheduling*: the
+draws that had not started are not fitted at all.
+
+**Everything already finished is on disk.** The journal flushes each replicate as it
+lands, so a cancelled run leaves the same directory an interrupted one does, and `--resume`
+continues it into exactly the run that was cancelled. The statistics files are the
+exception: a cancelled run does not write an interval over a truncated set of replicates.
+
+**A cancel before the run starts is a no-op on the directory.** The flag is read before
+the journal is opened, and opening it rewrites the per-replicate files — so cancelling a
+mistyped command cannot destroy the artefacts of the run that is already there.
+
+`ferx bootstrap` does not install a signal handler yet, so the CLI has nothing to set the
+flag from; on the R side, `ferx_bootstrap()` currently runs the bootstrap on the R main
+thread and so cannot poll for an interrupt either. Both are tracked separately — this is
+the engine half.


### PR DESCRIPTION
## Why

`ferx_tools::bootstrap::run_bootstrap` had no cooperative cancellation, so a 200-replicate
run could not be aborted once started — it ran to completion or the process died (#1161).

More than nothing already worked, which is what made the gap subtle. `replicate_options`
clones the caller's `FitOptions` and clears `verbose` / `threads` / `run_covariance_step` /
`checkpoint*` / `sir` — but not `cancel`. A caller that set
`prepared.parsed.fit_options.cancel` already reached every replicate's `fit`, and every
in-flight fit unwound on its own. So the problem was not "cancellation is impossible", it
was "cancellation is not clean":

1. **No short-circuit between replicates.** The rayon loop kept scheduling every remaining
   draw; each entered `fit`, observed the flag and returned `Err`. Cheap per draw, but a
   cancelled 200-sample run still walked all 200.
2. **No distinct cancelled outcome.** Those unwound replicates were indistinguishable from
   genuinely failed fits, so a cancelled run reported as "200 replicates failed".
3. **The base fit and the Δofv pass decided nothing** about what a cancel during them
   should return.

## What changed

`BootstrapOptions::cancel: Option<CancelFlag>` carries the flag, so a caller does not reach
through `prepared.parsed.fit_options` to a field whose propagation is an implementation
detail of this module. A flag set there is still honoured — `effective_cancel` falls back to
it, since that is the route callers had before — and the run-wide one takes precedence.

It is polled at four points, and each one is a decision rather than a sprinkle:

| where | why there |
|---|---|
| before `Journal::create` | opening the journal **rewrites** the four per-replicate files. Check after it and cancelling a mistyped command destroys the artefacts of the run already in the directory — the one the user would otherwise have resumed. |
| between the base fit and the replicates | `--update-inits` starts every replicate from the base fit's estimates, so a cancel during it leaves nothing to resample from. |
| top of `run_one` | where scheduling actually stops. |
| around the Δofv sweep | a second pass over every replicate that roughly doubles the run time, so it is its own cancellation point rather than a stretch that ignores the flag. |

The run ends with a new `BootstrapError::Cancelled`, so a caller can report an abort as an
abort. `run_bootstrap` / `run_bootstrap_with_progress` now return
`Result<_, BootstrapError>`; `From<BootstrapError> for String` keeps the CLI's `?` working
unchanged. `resummarize` is untouched — it fits nothing.

**A replicate the cancel unwound is dropped, not journaled.** Its `Err` cannot be told
apart from a genuine failure, and `--resume` carries a recorded failure *forward* rather
than refitting it (PsN's default, and the right one) — so journaling a cancelled replicate
would silently cost the resumed run a replicate.

## Alternatives considered

- **A sentinel string / a `cancelled: bool` on `BootstrapResult`.** Rejected: the result
  would then carry a summary computed over a truncated set of replicates, which is an
  interval nobody asked for and one a caller can forget to check. The issue offered either
  shape; the typed error is the one that cannot be ignored.
- **Recording cancelled replicates with a distinct status instead of dropping them.** That
  needs a new column in `raw_results.csv`, a new state in the resume reader, and a rule for
  what `--retry-failed` does with it — all to represent "nothing happened".
- **A signal handler in `ferx bootstrap`.** Out of scope here and not what the issue asks
  for; the CLI has nothing to set the flag from yet, so its behaviour is unchanged.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#315 | open (consumer half) | after |

ferx-r builds `BootstrapOptions { … }` as an exhaustive literal and types
`run_bootstrap_reporting` as `Result<_, String>`, so its **local** builds need the two-line
follow-up (`cancel: None`, `.map_err(|e| e.to_string())`). Its CI is unaffected until
`src/rust/Cargo.lock` is bumped, which is the same PR's job. FeRx-NLME/ferx-r#315 is the
real consumer work: `ferx_bootstrap()` currently calls `run_bootstrap` on the R main thread
and so cannot poll for Ctrl-C at all. This PR is the engine half.

## Breaking changes
- [x] Public Rust API — `ferx-tools` only, which has no committed baseline (the
      `api/ferx-core-public-api.txt` gate covers `ferx-core`, and it is unchanged; the
      `Public API baseline` job is green). Two source-breaking changes for out-of-workspace
      callers: the new `BootstrapOptions::cancel` field and the `BootstrapError` return
      type. Both land in ferx-r via the PR above.
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed

## Numerical validation
- [x] Not applicable — no numerics changed. The bootstrap's own oracles are untouched and
      still green: the identity-resample bit-for-bit anchor, the duplication complement, the
      PsN percentile thresholds, the stratum-composition check, and thread-count
      determinism. The one *behavioural* equivalence this PR does add is stronger than a
      tolerance: a cancelled-then-resumed run's `raw_results.csv` is compared byte-for-byte
      (timings stripped) against the uninterrupted run's.

## Performance
- [x] No significant impact expected — one relaxed atomic load per replicate, against a fit
      measured in seconds.

## Tests

Tier 1 (`crates/ferx-tools/src/bootstrap/mod_tests.rs`):

- the run-wide flag reaches every replicate's `FitOptions`, and reaches it as a *share*
  rather than a copy (cancel the original, the installed one observes it);
- a flag on the model's own `FitOptions` is still honoured, and the run-wide one wins when
  both are set;
- `BootstrapError`: `is_cancelled`, `Display` (a failure is not dressed up on the way
  through), and both `From` conversions the internal `?`s depend on.

Tier 2 (`crates/ferx-tools/tests/bootstrap_end_to_end.rs`), on warfarin at
`outer_maxiter = 2`:

- **cancelled before it starts** → `Cancelled`, and the completed run already in the
  directory is byte-identical afterwards (this is the check-before-`Journal::create` order);
- **cancelled mid-run on one thread** → `Cancelled`, exactly header + base + one replicate
  on disk, then `--resume` reuses that one and lands on a `raw_results.csv` identical to the
  uninterrupted run's;
- **cancelled between the base fit and the replicates on a 4-thread pool** → no replicate
  fitted at all;
- **cancelled mid-run on a pool** → nothing the cancel unwound is journaled as a failure;
- **cancelled during the Δofv sweep** → `Cancelled`, no `delta_ofv.csv`, replicates intact.

One note for the reviewer, since the test says it and it is easy to read as a gap: the
pool test deliberately asserts *no bound on how many replicates got through*. On a pool
that is a timing property, not a contract — every fit already past the entry check runs to
completion, and the flag is a relaxed atomic. An earlier draft did assert a bound and failed
about one run in three under CPU load (verified by hammering the binary under a full-core
hog: 4/12 failures before, 0/12 after). Where stopping *is* a contract — one thread, and the
base-fit boundary — it is pinned exactly.

## Docs
- [x] `docs/tools/bootstrap.qmd` — a new "Cancelling a run" section: the API, and the three
      consequences of where the flag is checked (a cancelled run is not a failed one;
      everything finished is on disk and resumes; a cancel before the run starts is a no-op
      on the directory). It also states plainly that the CLI installs no signal handler yet
      and that `ferx_bootstrap()` runs on the R main thread, so neither can set the flag —
      both tracked separately.
- [x] `CHANGELOG.md` `[Unreleased]` → `Added`.

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy
      `--all-targets`, rustdoc, docs lint, public-API baseline
- [x] `cargo test -p ferx-tools` (185 tests) and `cargo test -p ferx-cli` (119) green
- [x] Nothing on the `Dual2` sensitivity path is touched

## Reviewer hints

The two subtle spots are both in `run_bootstrap_with_progress`: the *order* of the first
check against `Journal::create`, and the `Err(_) if is_cancelled(&cancel) => return None`
arm in `run_one` — dropping rather than recording is what keeps `--resume` correct. The
rest is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L512jnkzvDYJ4wnKummK6r
