### PR TITLE
fix(api): demote converged on an internal runaway-guard hit [closes #1118]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,23 @@ section of the SDLC for the versioning policy).
 - **A fit whose estimate ran to an internal safety rail no longer reports `converged: true`
   (#1118).** ferx caps a few packed coordinates internally (an implicit THETA cap, the OMEGA /
   SIGMA runaway rails); unlike a THETA bound you declared, one of those cannot be a valid
-  constrained optimum. When a free estimate ends pinned to an *upper* internal guard the fit is
-  now reported as not converged and the `parameter_at_runaway_guard` warning is raised to
-  `Critical`, so a script or agent keying off the boolean stops accepting a point that is by
-  construction not an interior optimum. A *lower*-guard hit (a variance collapsing toward zero)
-  is unchanged: it stays a `Warning` and leaves `converged` alone, because that is usually an
-  unsupported component to remove rather than a numerical runaway.
+  constrained optimum. When a free estimate ends pinned to a rail the fit is now reported as not
+  converged and the `parameter_at_runaway_guard` warning is raised to `Critical`, so a script or
+  agent keying off the boolean stops accepting a point that is by construction not an interior
+  optimum. A *collapse* hit — a variance falling to its floor at zero — is unchanged: it stays a
+  `Warning` and leaves `converged` alone, because that is usually an unsupported component to
+  remove rather than a numerical runaway. Each listed hit now says which of the two it is
+  (`verdict: runaway` / `collapse` in the warning's `details`), because the side does not decide
+  it: an OMEGA off-diagonal is bounded symmetrically at ±10, so a correlation driven to the
+  *lower* rail is a runaway too. A SIGMA at its ceiling additionally suggests rescaling DV or
+  using a proportional / log-transformed error model, since that rail is the one an otherwise
+  sound model can reach on unscaled data.
+- **`ferx bootstrap` reflects the same rule.** A replicate that ends at a runaway rail is now a
+  non-converged replicate, so with the default `skip_minimization_terminated` it is excluded
+  from the confidence intervals and counts against the reported
+  `minimization_successful` fraction. Re-running a bootstrap of an unchanged model can therefore
+  report slightly different CIs than before; `--summarize` over a stored `raw_results.csv`
+  re-applies the criteria without refitting.
 
 ## [0.3.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Fixed
+- **A fit whose estimate ran to an internal safety rail no longer reports `converged: true`
+  (#1118).** ferx caps a few packed coordinates internally (an implicit THETA cap, the OMEGA /
+  SIGMA runaway rails); unlike a THETA bound you declared, one of those cannot be a valid
+  constrained optimum. When a free estimate ends pinned to an *upper* internal guard the fit is
+  now reported as not converged and the `parameter_at_runaway_guard` warning is raised to
+  `Critical`, so a script or agent keying off the boolean stops accepting a point that is by
+  construction not an interior optimum. A *lower*-guard hit (a variance collapsing toward zero)
+  is unchanged: it stays a `Warning` and leaves `converged` alone, because that is usually an
+  unsupported component to remove rather than a numerical runaway.
+
 ## [0.3.1] - 2026-09-02
 
 ### Added

--- a/docs/estimation/parameterization.qmd
+++ b/docs/estimation/parameterization.qmd
@@ -91,8 +91,31 @@ optimizer scaling can introduce), the fit emits the structured
 `parameter_at_runaway_guard` warning. FIX'd coordinates are excluded because
 their equal bounds are intentional. The check is made in packed space, so it
 compares directly with the literal guard even though fit output reports Omega
-on the variance/covariance scale and Sigma on its stored SD scale. A lower hit
-means the component collapsed toward zero; an upper hit means it ran away.
+on the variance/covariance scale and Sigma on its stored SD scale.
+
+Each hit carries a **verdict**, and it is the verdict — not the side — that says
+what happened and what follows from it:
+
+- **`collapse`** — the coordinate fell to a floor at zero. Only the log-packed
+  coordinates have one: a Theta lower cap, an Omega / Omega-IOV Cholesky
+  *diagonal* at $-6$, a Sigma at $-8$. The warning stays a `Warning` and
+  `converged` is left alone, because an unsupported component collapsing is
+  usually a modelling decision to make rather than a numerical failure.
+- **`runaway`** — the coordinate is held at an implementation rail. Every upper
+  hit is one, and so is *either* rail of an Omega / Omega-IOV **off-diagonal**,
+  which is the raw $L_{ij}$ bounded symmetrically at $\pm 10$: a correlation
+  coordinate driven to $-10$ ran away exactly as its $+10$ twin did, and nothing
+  about it collapsed toward zero. A runaway hit **demotes `converged` to `false`
+  and raises the warning to `Critical`** (#1118): a point held at an
+  implementation rail is by construction not an interior optimum, so a script or
+  agent keying off the boolean must not accept it.
+
+One rail is reachable by a model that is otherwise sound: the Sigma ceiling,
+$e^5 \approx 148$ on the stored SD scale. An additive error model on unscaled
+data (DV in ng/mL, µg/L, cell counts) can have a residual SD genuinely above it.
+The remediation there is the data scale rather than the model — rescale DV, or
+use a proportional or log-transformed error model — and the warning message says
+so when the hit is a Sigma.
 
 ## Where the packed space surfaces
 

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -59,7 +59,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
-| `parameter_at_runaway_guard` | Warning | One or more free coordinates are pinned to a hidden optimizer guard: an implicit THETA cap or an OMEGA / SIGMA safety rail. | A lower hit means the component collapsed toward zero — consider removing or simplifying it. An upper hit is a runaway estimate — revisit the model, data, initial estimates, or method. |
+| `parameter_at_runaway_guard` | Critical / Warning | A free coordinate is pinned to a hidden optimizer guard: an implicit THETA cap or an OMEGA / SIGMA safety rail. | Lower hit (`Warning`): it collapsed toward zero — remove or simplify it. Upper hit (`Critical`): a runaway, reported `converged: false` — reject it; revisit model, data, or inits. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -59,7 +59,7 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
-| `parameter_at_runaway_guard` | Critical / Warning | A free coordinate is pinned to a hidden optimizer guard: an implicit THETA cap or an OMEGA / SIGMA safety rail. | Lower hit (`Warning`): it collapsed toward zero — remove or simplify it. Upper hit (`Critical`): a runaway, reported `converged: false` — reject it; revisit model, data, or inits. |
+| `parameter_at_runaway_guard` | Critical / Warning | A free coordinate is pinned to a hidden optimizer guard (implicit THETA cap, OMEGA / SIGMA rail), with a `verdict` the side does not decide. | `collapse` (`Warning`): remove or simplify it. `runaway` (`Critical`): `converged: false` — reject; revisit model, data, inits; for SIGMA, rescale DV. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
@@ -90,7 +90,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `eps_shrinkage` | `eps_shrinkage` (fraction), `eps_shrinkage_pct` |
 | `eta_shrinkage` | `threshold_pct`, `high_shrinkage_etas` (array of `{eta, shrinkage_pct}`) |
 | `boundary_estimate` | `parameters` (array of `{parameter, estimate, bound, side}`) |
-| `parameter_at_runaway_guard` | `guard_space` (`"packed"`), `parameters` (array of `{parameter, estimate, packed_estimate, packed_guard, side}`) |
+| `parameter_at_runaway_guard` | `guard_space` (`"packed"`), `parameters` (array of `{parameter, estimate, packed_estimate, packed_guard, side, verdict}`) |
 | `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
 | `high_correlation` | `threshold`, `pairs` (array of `{parameter_a, parameter_b, correlation}`) |
 | `flip_flop` | `phase` (`"ebe"`), `model`, `subjects` (array of affected subject IDs) |

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -2150,7 +2150,15 @@ fn fit_inner(
     // Parameter estimates pinned to hidden packed-space implementation guards.
     // This is distinct from a user-declared theta bound: the affected result
     // reached an implementation safety limit (#1099).
-    if let Some((msg, entry)) = runaway_guard_warning(&result.params) {
+    //
+    // An upper-guard hit also demotes `converged` (#1118). Unlike a declared
+    // THETA bound — where a boundary hit can be a valid constrained optimum — an
+    // internal ceiling cannot be, so the flag would otherwise hand a programmatic
+    // consumer a point that is by construction not an interior optimum.
+    // `result.params` holds the *final* stage's estimates, so a chained
+    // `methods = vi, focei` is gated on its last stage, like `run_covariance_step`.
+    let mut converged = result.converged;
+    if let Some((msg, entry)) = runaway_guard_warning(&mut converged, &result.params) {
         warnings.push(msg);
         native_warnings.push(entry);
     }
@@ -2298,7 +2306,7 @@ fn fit_inner(
         method_chain: chain.clone(),
         method_wall_times_secs,
         covariance_wall_time_secs,
-        converged: result.converged,
+        converged,
         ofv,
         aic,
         bic,

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1214,8 +1214,18 @@ fn warning_entry(
     message: String,
     details: Option<serde_json::Value>,
 ) -> WarningEntry {
+    warning_entry_with_severity(WarningSeverity::Warning, category, message, details)
+}
+
+/// [`warning_entry`] for the emitters whose severity depends on what they found.
+fn warning_entry_with_severity(
+    severity: WarningSeverity,
+    category: WarningCode,
+    message: String,
+    details: Option<serde_json::Value>,
+) -> WarningEntry {
     WarningEntry {
-        severity: WarningSeverity::Warning,
+        severity,
         category,
         message,
         source_method: None,
@@ -1333,7 +1343,19 @@ pub(crate) fn boundary_estimate_warning(
 
 /// Build the warning for parameter estimates pinned to an internal
 /// runaway guard, or `None` when every free coordinate is interior.
-pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String, WarningEntry)> {
+///
+/// An *upper*-guard hit also demotes `converged` and reports at `Critical`
+/// (#1118): the coordinate stopped at an implementation ceiling, so the point is
+/// by construction not an interior optimum and a consumer keying off the boolean
+/// must not keep it. A *lower*-guard hit stays a plain `Warning` and leaves
+/// `converged` alone — a variance collapsing to the floor is usually a genuinely
+/// unsupported component for the user to remove rather than a numerical runaway,
+/// so demoting there would be noise. This mirrors `vi::run::bad_basin_warning`,
+/// which owns the same consequence for the final ELBO check.
+pub(crate) fn runaway_guard_warning(
+    converged: &mut bool,
+    params: &ModelParameters,
+) -> Option<(String, WarningEntry)> {
     let hits = runaway_guard_estimates(params);
     if hits.is_empty() {
         return None;
@@ -1350,6 +1372,11 @@ pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String,
         .join(", ");
     let has_lower = hits.iter().any(|hit| hit.side == "lower");
     let has_upper = hits.iter().any(|hit| hit.side == "upper");
+    // An estimate held at an implementation ceiling is not a solution of the
+    // problem the user posed, whatever the outer optimizer's stop rule reported.
+    if has_upper {
+        *converged = false;
+    }
     let guidance = match (has_lower, has_upper) {
         (true, false) => {
             "The affected parameter(s) collapsed toward zero at an implementation floor \
@@ -1359,12 +1386,14 @@ pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String,
         (false, true) => {
             "The affected parameter(s) ran to an implementation ceiling rather than \
              reaching an interior optimum; do not treat the value(s) as reliable estimates. \
-             Revisit the model, data, initial estimates, or estimation method."
+             Reported converged: false. Revisit the model, data, initial estimates, or \
+             estimation method."
         }
         (true, true) => {
             "Lower-guard hits indicate parameters collapsing toward zero; consider removing \
              or simplifying those unsupported components. Upper-guard hits indicate runaway \
-             estimates; revisit the model, data, initial estimates, or estimation method."
+             estimates and are reported converged: false; revisit the model, data, initial \
+             estimates, or estimation method."
         }
         (false, false) => unreachable!("every guard hit has a lower or upper side"),
     };
@@ -1386,7 +1415,12 @@ pub(crate) fn runaway_guard_warning(params: &ModelParameters) -> Option<(String,
         "guard_space": "packed",
         "parameters": params_json,
     });
-    let entry = warning_entry(
+    let entry = warning_entry_with_severity(
+        if has_upper {
+            WarningSeverity::Critical
+        } else {
+            WarningSeverity::Warning
+        },
         WarningCode::ParameterAtRunawayGuard,
         msg.clone(),
         Some(details),

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::diagnostics::{first_error, CheckReport, Diagnostic};
 use crate::estimation::outer_optimizer::optimize_population;
 use crate::estimation::parameterization::{
-    chol_lt_idx, lower_tri_iter, omega_packed_len, theta_packs_log,
+    chol_lt_idx, lower_tri_iter, omega_packed_len, theta_packs_log, PackedCoordKind,
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
@@ -1129,6 +1129,32 @@ struct RunawayGuardHit {
     packed_estimate: f64,
     packed_guard: f64,
     side: &'static str,
+    kind: PackedCoordKind,
+}
+
+impl RunawayGuardHit {
+    /// Whether the estimate *ran away* to a rail rather than *collapsed* to a
+    /// floor at zero.
+    ///
+    /// The side alone does not answer this. Ω / Ω_IOV off-diagonals are the raw
+    /// `L[i,j]` bounded symmetrically at ±10, so a correlation coordinate driven
+    /// to −10 is the same runaway as its +10 twin and nothing about it collapsed
+    /// toward zero. Only the log-packed coordinates (Theta, Ω diagonal, Σ) have a
+    /// lower rail that means collapse.
+    fn is_runaway(&self) -> bool {
+        self.side == "upper" || self.kind == PackedCoordKind::OmegaOffDiagonal
+    }
+
+    /// The word carried into both the message and `details.verdict`; the message
+    /// token `classify_warning` keys on to recover the severity from a flat
+    /// (e.g. multi-start-spliced) string.
+    fn verdict(&self) -> &'static str {
+        if self.is_runaway() {
+            "runaway"
+        } else {
+            "collapse"
+        }
+    }
 }
 
 /// Tiny packed-space tolerance for an optimizer guard hit. The optimizer may
@@ -1170,7 +1196,8 @@ pub(crate) fn packed_guard_side(
 /// internal OMEGA/SIGMA, OMEGA_IOV, or mixture guard.
 fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
     use crate::estimation::parameterization::{
-        compute_bounds, coordinate_names, coordinate_values, pack_params, packed_fixed_mask,
+        compute_bounds, coordinate_kinds, coordinate_names, coordinate_values, pack_params,
+        packed_fixed_mask,
     };
 
     let packed = pack_params(params);
@@ -1178,12 +1205,14 @@ fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
     let fixed = packed_fixed_mask(params);
     let names = coordinate_names(params);
     let estimates = coordinate_values(params);
+    let kinds = coordinate_kinds(params);
     let end = packed
         .len()
         .min(bounds.lower.len())
         .min(bounds.upper.len())
         .min(names.len())
-        .min(estimates.len());
+        .min(estimates.len())
+        .min(kinds.len());
 
     (0..end)
         .filter(|&i| !fixed.get(i).copied().unwrap_or(false))
@@ -1199,6 +1228,7 @@ fn runaway_guard_estimates(params: &ModelParameters) -> Vec<RunawayGuardHit> {
                         packed_estimate: packed[i],
                         packed_guard,
                         side,
+                        kind: kinds[i],
                     })
                 },
             )
@@ -1344,14 +1374,18 @@ pub(crate) fn boundary_estimate_warning(
 /// Build the warning for parameter estimates pinned to an internal
 /// runaway guard, or `None` when every free coordinate is interior.
 ///
-/// An *upper*-guard hit also demotes `converged` and reports at `Critical`
-/// (#1118): the coordinate stopped at an implementation ceiling, so the point is
-/// by construction not an interior optimum and a consumer keying off the boolean
-/// must not keep it. A *lower*-guard hit stays a plain `Warning` and leaves
-/// `converged` alone — a variance collapsing to the floor is usually a genuinely
+/// A *runaway* hit also demotes `converged` and reports at `Critical` (#1118):
+/// the coordinate stopped at an implementation rail, so the point is by
+/// construction not an interior optimum and a consumer keying off the boolean
+/// must not keep it. A *collapse* hit stays a plain `Warning` and leaves
+/// `converged` alone — a variance falling to the floor is usually a genuinely
 /// unsupported component for the user to remove rather than a numerical runaway,
 /// so demoting there would be noise. This mirrors `vi::run::bad_basin_warning`,
 /// which owns the same consequence for the final ELBO check.
+///
+/// Which of the two a hit is comes from [`RunawayGuardHit::is_runaway`], not
+/// from the side: an Ω off-diagonal is rail-bounded symmetrically, so its lower
+/// rail is a runaway too.
 pub(crate) fn runaway_guard_warning(
     converged: &mut bool,
     params: &ModelParameters,
@@ -1364,39 +1398,58 @@ pub(crate) fn runaway_guard_warning(
         .iter()
         .map(|hit| {
             format!(
-                "{} (estimate {:.4}; packed coordinate {:.4} at {} guard)",
-                hit.name, hit.estimate, hit.packed_estimate, hit.side
+                "{} (estimate {:.4}; packed coordinate {:.4} at {} guard, {})",
+                hit.name,
+                hit.estimate,
+                hit.packed_estimate,
+                hit.side,
+                hit.verdict()
             )
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let has_lower = hits.iter().any(|hit| hit.side == "lower");
-    let has_upper = hits.iter().any(|hit| hit.side == "upper");
-    // An estimate held at an implementation ceiling is not a solution of the
+    let has_runaway = hits.iter().any(|hit| hit.is_runaway());
+    let has_collapse = hits.iter().any(|hit| !hit.is_runaway());
+    // An estimate held at an implementation rail is not a solution of the
     // problem the user posed, whatever the outer optimizer's stop rule reported.
-    if has_upper {
+    if has_runaway {
         *converged = false;
     }
-    let guidance = match (has_lower, has_upper) {
+    let mut guidance = String::from(match (has_collapse, has_runaway) {
         (true, false) => {
             "The affected parameter(s) collapsed toward zero at an implementation floor \
              rather than reaching an interior optimum; consider removing or simplifying \
              the unsupported parameter, random effect, or error component."
         }
         (false, true) => {
-            "The affected parameter(s) ran to an implementation ceiling rather than \
+            "The affected parameter(s) ran to an implementation rail rather than \
              reaching an interior optimum; do not treat the value(s) as reliable estimates. \
              Reported converged: false. Revisit the model, data, initial estimates, or \
              estimation method."
         }
         (true, true) => {
-            "Lower-guard hits indicate parameters collapsing toward zero; consider removing \
-             or simplifying those unsupported components. Upper-guard hits indicate runaway \
-             estimates and are reported converged: false; revisit the model, data, initial \
-             estimates, or estimation method."
+            "Collapse hits indicate parameters falling toward zero; consider removing \
+             or simplifying those unsupported components. Runaway hits indicate estimates \
+             held at an implementation rail and are reported converged: false; revisit the \
+             model, data, initial estimates, or estimation method."
         }
-        (false, false) => unreachable!("every guard hit has a lower or upper side"),
-    };
+        (false, false) => unreachable!("every guard hit is a runaway or a collapse"),
+    });
+    // The Σ ceiling (exp(5) ≈ 148 on the stored SD scale) is the one rail an
+    // otherwise sound model can legitimately reach — an additive error on
+    // unscaled DV (ng/mL, cell counts) can have a residual SD above it — and the
+    // remediation is then the data scale, not the model. Name it, because the
+    // generic advice above does not.
+    if hits
+        .iter()
+        .any(|hit| hit.is_runaway() && hit.kind == PackedCoordKind::Sigma)
+    {
+        guidance.push_str(
+            " A SIGMA at the ceiling can also mean the residual error is genuinely that \
+             large on the scale of the data: rescale DV, or use a proportional or \
+             log-transformed error model.",
+        );
+    }
     let msg =
         format!("Internal optimizer parameter guard reached by estimate(s): {list}. {guidance}");
     let params_json: Vec<serde_json::Value> = hits
@@ -1408,6 +1461,7 @@ pub(crate) fn runaway_guard_warning(
                 "packed_estimate": hit.packed_estimate,
                 "packed_guard": hit.packed_guard,
                 "side": hit.side,
+                "verdict": hit.verdict(),
             })
         })
         .collect();
@@ -1416,7 +1470,7 @@ pub(crate) fn runaway_guard_warning(
         "parameters": params_json,
     });
     let entry = warning_entry_with_severity(
-        if has_upper {
+        if has_runaway {
             WarningSeverity::Critical
         } else {
             WarningSeverity::Warning

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1183,15 +1183,19 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
     let mut converged = true;
     let (msg, entry) =
         super::runaway_guard_warning(&mut converged, &params).expect("sigma guard hit");
-    assert!(msg.contains("implementation ceiling"));
-    // #1118: an implementation ceiling cannot be an interior optimum.
-    assert!(!converged, "an upper-guard hit is not a converged fit");
+    assert!(msg.contains("implementation rail"));
+    // #1118: an implementation rail cannot be an interior optimum.
+    assert!(!converged, "a runaway hit is not a converged fit");
     assert!(msg.contains("Reported converged: false"));
+    // The Σ ceiling is reachable by a sound model on unscaled data, so the
+    // message names the remediation the generic advice does not (#1205 review).
+    assert!(msg.contains("rescale DV"));
     assert_eq!(entry.severity, crate::types::WarningSeverity::Critical);
     assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
     let details = entry.details.as_ref().expect("details");
     assert_eq!(details["guard_space"], "packed");
     assert_eq!(details["parameters"][0]["side"], "upper");
+    assert_eq!(details["parameters"][0]["verdict"], "runaway");
     assert_eq!(details["parameters"][0]["packed_estimate"], 5.0);
     assert_eq!(details["parameters"][0]["packed_guard"], 5.0);
 
@@ -1214,14 +1218,15 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
     assert!(msg.contains("collapsed toward zero"));
     assert!(msg.contains("removing or simplifying"));
     // #1118: a collapsed component is a modelling decision, not a runaway — the
-    // fit still converged and the entry stays a plain warning.
-    assert!(converged, "a lower-guard hit must not demote convergence");
+    // fit still converged and the entry stays a plain warning. The Σ-ceiling
+    // remediation is for the ceiling only and must not ride along.
+    assert!(converged, "a collapse hit must not demote convergence");
     assert!(!msg.contains("converged: false"));
+    assert!(!msg.contains("rescale DV"));
     assert_eq!(entry.severity, crate::types::WarningSeverity::Warning);
-    assert_eq!(
-        entry.details.as_ref().unwrap()["parameters"][0]["side"],
-        "lower"
-    );
+    let hit = &entry.details.as_ref().unwrap()["parameters"][0];
+    assert_eq!(hit["side"], "lower");
+    assert_eq!(hit["verdict"], "collapse");
 }
 
 #[test]
@@ -1258,9 +1263,9 @@ fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
     let mut converged = true;
     let (msg, entry) =
         super::runaway_guard_warning(&mut converged, &params).expect("mixed guard hits");
-    assert!(msg.contains("Lower-guard hits"));
-    assert!(msg.contains("Upper-guard hits"));
-    // A mixed set still contains an upper hit, so the fit is demoted.
+    assert!(msg.contains("Collapse hits"));
+    assert!(msg.contains("Runaway hits"));
+    // A mixed set still contains a runaway hit, so the fit is demoted.
     assert!(!converged);
     assert_eq!(entry.severity, crate::types::WarningSeverity::Critical);
 
@@ -1269,6 +1274,59 @@ fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
     let mut converged = true;
     assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
     assert!(converged);
+}
+
+/// #1205 review: an Ω off-diagonal is the raw `L[i,j]` bounded symmetrically at
+/// ±10, so the *lower* rail there is a correlation runaway, not a collapse
+/// toward zero. Keying the verdict on the side alone reported that runaway as
+/// `converged: true` with advice to remove the component.
+#[test]
+fn omega_off_diagonal_lower_rail_is_a_runaway_not_a_collapse() {
+    use crate::types::{OmegaMatrix, WarningSeverity};
+    use nalgebra::DMatrix;
+
+    let mut params = tiny_model().default_params;
+    params.sigma.values.fill(1.0);
+    params.sigma_fixed = vec![false; params.sigma.values.len()];
+
+    // A 2×2 block Ω whose off-diagonal ran to the negative rail.
+    let mut chol = DMatrix::<f64>::identity(2, 2);
+    chol[(1, 0)] = -10.0;
+    params.omega = OmegaMatrix::from_chol_factor(
+        chol,
+        vec!["ETA_CL".into(), "ETA_V".into()],
+        false,
+        DMatrix::from_element(2, 2, true),
+    );
+    params.omega_fixed = vec![false; 2];
+
+    let mut converged = true;
+    let (msg, entry) = super::runaway_guard_warning(&mut converged, &params)
+        .expect("omega off-diagonal at its lower rail");
+    assert_eq!(
+        entry.details.as_ref().unwrap()["parameters"][0]["side"],
+        "lower",
+        "the hit is factually on the lower rail"
+    );
+    assert_eq!(
+        entry.details.as_ref().unwrap()["parameters"][0]["verdict"],
+        "runaway",
+        "but a symmetric rail means it ran away, not collapsed"
+    );
+    assert!(
+        !converged,
+        "a runaway must demote convergence on either rail"
+    );
+    assert_eq!(entry.severity, WarningSeverity::Critical);
+    assert!(msg.contains("implementation rail"));
+    assert!(!msg.contains("collapsed toward zero"));
+
+    // The classifier must reach the same severity from the flat message alone,
+    // which is all a spliced multi-start warning carries.
+    assert_eq!(
+        crate::types::classify_warning(&msg).severity,
+        WarningSeverity::Critical
+    );
 }
 
 #[test]
@@ -1286,7 +1344,9 @@ fn hidden_theta_caps_use_internal_guard_warning_not_user_boundary_warning() {
     let mut converged = true;
     let (upper_msg, upper_entry) =
         super::runaway_guard_warning(&mut converged, &params).expect("hidden theta upper cap");
-    assert!(upper_msg.contains("implementation ceiling"));
+    assert!(upper_msg.contains("implementation rail"));
+    // The Σ remediation is Σ-specific; a THETA cap must not pick it up.
+    assert!(!upper_msg.contains("rescale DV"));
     assert!(!converged);
     assert_eq!(upper_entry.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1180,8 +1180,14 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
     params.sigma_fixed = vec![false; params.sigma.values.len()];
 
     params.sigma.values[0] = 5.0_f64.exp();
-    let (msg, entry) = super::runaway_guard_warning(&params).expect("sigma guard hit");
+    let mut converged = true;
+    let (msg, entry) =
+        super::runaway_guard_warning(&mut converged, &params).expect("sigma guard hit");
     assert!(msg.contains("implementation ceiling"));
+    // #1118: an implementation ceiling cannot be an interior optimum.
+    assert!(!converged, "an upper-guard hit is not a converged fit");
+    assert!(msg.contains("Reported converged: false"));
+    assert_eq!(entry.severity, crate::types::WarningSeverity::Critical);
     assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
     let details = entry.details.as_ref().expect("details");
     assert_eq!(details["guard_space"], "packed");
@@ -1191,18 +1197,27 @@ fn runaway_guard_warning_reports_sigma_and_skips_fixed_or_nearby_values() {
 
     // FIX creates lower == upper at this value, but is intentional and excluded.
     params.sigma_fixed[0] = true;
-    assert!(super::runaway_guard_warning(&params).is_none());
+    let mut converged = true;
+    assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
+    assert!(converged, "no hit must leave the flag alone");
 
     // A free value arbitrarily near the safety rail is still an interior result.
     params.sigma_fixed[0] = false;
     params.sigma.values[0] = (5.0_f64 - 1e-12).exp();
-    assert!(super::runaway_guard_warning(&params).is_none());
+    assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
+    assert!(converged);
 
     // The lower rail has opposite meaning and remediation: collapse to zero.
     params.sigma.values[0] = (-8.0_f64).exp();
-    let (msg, entry) = super::runaway_guard_warning(&params).expect("sigma lower guard hit");
+    let (msg, entry) =
+        super::runaway_guard_warning(&mut converged, &params).expect("sigma lower guard hit");
     assert!(msg.contains("collapsed toward zero"));
     assert!(msg.contains("removing or simplifying"));
+    // #1118: a collapsed component is a modelling decision, not a runaway — the
+    // fit still converged and the entry stays a plain warning.
+    assert!(converged, "a lower-guard hit must not demote convergence");
+    assert!(!msg.contains("converged: false"));
+    assert_eq!(entry.severity, crate::types::WarningSeverity::Warning);
     assert_eq!(
         entry.details.as_ref().unwrap()["parameters"][0]["side"],
         "lower"
@@ -1226,7 +1241,10 @@ fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
         params.omega.free_mask.clone(),
     );
 
-    let (_msg, entry) = super::runaway_guard_warning(&params).expect("omega guard hit");
+    let mut converged = true;
+    let (_msg, entry) =
+        super::runaway_guard_warning(&mut converged, &params).expect("omega guard hit");
+    assert!(!converged);
     assert_eq!(entry.category, WarningCode::ParameterAtRunawayGuard);
     let hit = &entry.details.as_ref().unwrap()["parameters"][0];
     assert_eq!(hit["parameter"], params.omega.eta_names[0].as_str());
@@ -1237,13 +1255,20 @@ fn runaway_guard_warning_reports_omega_cholesky_guard_and_skips_fixed() {
 
     // A simultaneous lower collapse and upper runaway gets advice for both.
     params.sigma.values[0] = (-8.0_f64).exp();
-    let (msg, _entry) = super::runaway_guard_warning(&params).expect("mixed guard hits");
+    let mut converged = true;
+    let (msg, entry) =
+        super::runaway_guard_warning(&mut converged, &params).expect("mixed guard hits");
     assert!(msg.contains("Lower-guard hits"));
     assert!(msg.contains("Upper-guard hits"));
+    // A mixed set still contains an upper hit, so the fit is demoted.
+    assert!(!converged);
+    assert_eq!(entry.severity, crate::types::WarningSeverity::Critical);
 
     params.sigma.values[0] = 1.0;
     params.omega_fixed[0] = true;
-    assert!(super::runaway_guard_warning(&params).is_none());
+    let mut converged = true;
+    assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
+    assert!(converged);
 }
 
 #[test]
@@ -1258,9 +1283,11 @@ fn hidden_theta_caps_use_internal_guard_warning_not_user_boundary_warning() {
 
     params.theta[0] = 1e9;
     assert!(super::boundary_estimate_warning(&params).is_none());
+    let mut converged = true;
     let (upper_msg, upper_entry) =
-        super::runaway_guard_warning(&params).expect("hidden theta upper cap");
+        super::runaway_guard_warning(&mut converged, &params).expect("hidden theta upper cap");
     assert!(upper_msg.contains("implementation ceiling"));
+    assert!(!converged);
     assert_eq!(upper_entry.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(
         upper_entry.details.as_ref().unwrap()["parameters"][0]["parameter"],
@@ -1269,9 +1296,11 @@ fn hidden_theta_caps_use_internal_guard_warning_not_user_boundary_warning() {
 
     params.theta[0] = 1e-10;
     assert!(super::boundary_estimate_warning(&params).is_none());
+    let mut converged = true;
     let (lower_msg, lower_entry) =
-        super::runaway_guard_warning(&params).expect("hidden theta lower cap");
+        super::runaway_guard_warning(&mut converged, &params).expect("hidden theta lower cap");
     assert!(lower_msg.contains("collapsed toward zero"));
+    assert!(converged);
     assert_eq!(
         lower_entry.details.as_ref().unwrap()["parameters"][0]["side"],
         "lower"
@@ -1282,14 +1311,15 @@ fn hidden_theta_caps_use_internal_guard_warning_not_user_boundary_warning() {
     params.theta_upper[0] = 100.0;
     params.theta[0] = 0.1;
     assert!(super::boundary_estimate_warning(&params).is_some());
-    assert!(super::runaway_guard_warning(&params).is_none());
+    assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
 
     // FIX'd hidden-cap coordinates remain intentional and excluded.
     params.theta_lower[0] = 0.0;
     params.theta_upper[0] = f64::INFINITY;
     params.theta[0] = 1e9;
     params.theta_fixed[0] = true;
-    assert!(super::runaway_guard_warning(&params).is_none());
+    assert!(super::runaway_guard_warning(&mut converged, &params).is_none());
+    assert!(converged, "a FIX'd cap must not demote convergence");
 }
 
 #[test]

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -325,6 +325,62 @@ pub fn omega_structural_zero_mask(template: &ModelParameters) -> Vec<bool> {
     mask
 }
 
+/// What kind of quantity a packed coordinate holds, in [`pack_params`] order.
+///
+/// The distinction the runaway-guard check needs is whether a coordinate's two
+/// rails mean *different* things. A variance-like coordinate — a log-packed
+/// Theta, an Ω / Ω_IOV Cholesky **diagonal**, a Σ — is packed on a log scale, so
+/// its lower rail is a collapse toward zero and its upper rail a runaway. An
+/// Ω / Ω_IOV **off-diagonal** is the raw `L[i,j]` bounded symmetrically at ±10,
+/// so *either* rail is a runaway and neither is a collapse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PackedCoordKind {
+    Theta,
+    OmegaDiagonal,
+    OmegaOffDiagonal,
+    Sigma,
+}
+
+fn push_omega_kinds(kinds: &mut Vec<PackedCoordKind>, om: &OmegaMatrix) {
+    // Column-major lower triangle — mirrors `pack_params`. `lower_tri_iter`
+    // yields only `(i,i)` when diagonal, so a diagonal Ω pushes no off-diagonal.
+    for (i, j) in lower_tri_iter(om.dim(), om.diagonal) {
+        kinds.push(if i == j {
+            PackedCoordKind::OmegaDiagonal
+        } else {
+            PackedCoordKind::OmegaOffDiagonal
+        });
+    }
+}
+
+/// Per-coordinate [`PackedCoordKind`], in the same order as [`pack_params`]:
+/// `[theta…, Ω (lower-tri col-major)…, sigma…, Ω_IOV…, mixture overrides…]`.
+/// Mixture overrides (#977) are diagonal scalars carrying their base
+/// counterpart's rails, so they take the base kind.
+pub(crate) fn coordinate_kinds(template: &ModelParameters) -> Vec<PackedCoordKind> {
+    let mut kinds = Vec::with_capacity(packed_len(template));
+    kinds.resize(template.theta.len(), PackedCoordKind::Theta);
+    push_omega_kinds(&mut kinds, &template.omega);
+    kinds.resize(
+        kinds.len() + template.sigma.values.len(),
+        PackedCoordKind::Sigma,
+    );
+    if let Some(ref iov) = template.omega_iov {
+        push_omega_kinds(&mut kinds, iov);
+    }
+    if let Some(ref mix) = template.mixture {
+        kinds.resize(
+            kinds.len() + mix.omega_override_addr.len(),
+            PackedCoordKind::OmegaDiagonal,
+        );
+        kinds.resize(
+            kinds.len() + mix.sigma_override_addr.len(),
+            PackedCoordKind::Sigma,
+        );
+    }
+    kinds
+}
+
 /// Compute the number of packed parameters
 pub fn packed_len(template: &ModelParameters) -> usize {
     let n_theta = template.theta.len();
@@ -1765,5 +1821,48 @@ mod tests {
         assert_relative_eq!(bounds.lower[iov_start + 1], -10.0, epsilon = 1e-12); // L21 off-diag
         assert_relative_eq!(bounds.lower[iov_start + 2], -6.0, epsilon = 1e-12);
         // L22 diag
+    }
+
+    /// `coordinate_kinds` must line up slot-for-slot with `compute_bounds`, since
+    /// the runaway-guard check reads a hit's meaning off the kind and the rail off
+    /// the bounds. An off-diagonal is the one kind whose rails are symmetric.
+    #[test]
+    fn test_coordinate_kinds_match_the_bounds_table() {
+        let template = make_block_kappa_iov_template();
+        let kinds = coordinate_kinds(&template);
+        assert_eq!(kinds.len(), packed_len(&template));
+        // theta(1) + diagonal BSV Ω(1) + sigma(1) + block Ω_IOV(L11, L21, L22)
+        assert_eq!(
+            kinds,
+            vec![
+                PackedCoordKind::Theta,
+                PackedCoordKind::OmegaDiagonal,
+                PackedCoordKind::Sigma,
+                PackedCoordKind::OmegaDiagonal,
+                PackedCoordKind::OmegaOffDiagonal,
+                PackedCoordKind::OmegaDiagonal,
+            ]
+        );
+
+        let bounds = compute_bounds(&template);
+        for (i, kind) in kinds.iter().enumerate() {
+            let (lo, hi) = (bounds.lower[i], bounds.upper[i]);
+            match kind {
+                // Symmetric rails: neither side means "collapsed toward zero".
+                PackedCoordKind::OmegaOffDiagonal => {
+                    assert_relative_eq!(lo, -hi, epsilon = 1e-12);
+                }
+                // Log-packed: the lower rail is a floor at (near) zero.
+                PackedCoordKind::OmegaDiagonal => {
+                    assert_relative_eq!(lo, -6.0, epsilon = 1e-12);
+                    assert_relative_eq!(hi, 6.0, epsilon = 1e-12);
+                }
+                PackedCoordKind::Sigma => {
+                    assert_relative_eq!(lo, -8.0, epsilon = 1e-12);
+                    assert_relative_eq!(hi, 5.0, epsilon = 1e-12);
+                }
+                PackedCoordKind::Theta => {}
+            }
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5372,10 +5372,23 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
     } else if lower.contains("internal optimizer parameter guard") {
-        (
-            WarningSeverity::Warning,
-            WarningCode::ParameterAtRunawayGuard,
-        )
+        // #1118: an upper-guard hit is an estimate held at an implementation
+        // ceiling — not an interior optimum — and demotes `converged`, so it is
+        // Critical. A lower-guard hit (a component collapsing to the floor) is
+        // usually a modelling decision to make, and stays a plain Warning. Each
+        // hit is listed as "... at <side> guard", so the side survives into the
+        // flat message a re-classified (e.g. multi-start-spliced) warning carries.
+        if lower.contains("at upper guard") {
+            (
+                WarningSeverity::Critical,
+                WarningCode::ParameterAtRunawayGuard,
+            )
+        } else {
+            (
+                WarningSeverity::Warning,
+                WarningCode::ParameterAtRunawayGuard,
+            )
+        }
     } else if lower.contains("optimizer bound") {
         // Distinctive phrase; the eps-shrinkage message's "sigma at a bound" is
         // matched earlier and never reaches here.

--- a/src/types.rs
+++ b/src/types.rs
@@ -5372,13 +5372,15 @@ pub fn classify_warning(raw: &str) -> WarningEntry {
         // Word-boundary match so "beta shrinkage" (or similar) does not collide.
         (WarningSeverity::Warning, WarningCode::EtaShrinkage)
     } else if lower.contains("internal optimizer parameter guard") {
-        // #1118: an upper-guard hit is an estimate held at an implementation
-        // ceiling — not an interior optimum — and demotes `converged`, so it is
-        // Critical. A lower-guard hit (a component collapsing to the floor) is
-        // usually a modelling decision to make, and stays a plain Warning. Each
-        // hit is listed as "... at <side> guard", so the side survives into the
-        // flat message a re-classified (e.g. multi-start-spliced) warning carries.
-        if lower.contains("at upper guard") {
+        // #1118: a runaway hit is an estimate held at an implementation rail —
+        // not an interior optimum — and demotes `converged`, so it is Critical.
+        // A collapse hit (a component falling to the floor at zero) is usually a
+        // modelling decision to make, and stays a plain Warning. Each hit is
+        // listed as "... at <side> guard, <verdict>", so the verdict — not the
+        // bare side, which an Ω off-diagonal's symmetric rails make ambiguous —
+        // survives into the flat message a re-classified (e.g.
+        // multi-start-spliced) warning carries.
+        if lower.contains("guard, runaway") {
             (
                 WarningSeverity::Critical,
                 WarningCode::ParameterAtRunawayGuard,

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -684,22 +684,30 @@ fn classify_warning_recognizes_internal_runaway_guard() {
     assert_eq!(warning.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(warning.severity, WarningSeverity::Warning);
 
-    // #1118: the side is carried in each listed hit, and an upper hit — the one
-    // that demotes `converged` — classifies Critical even when the entry reaches
-    // this path as a flat string (a spliced multi-start warning, say) instead of
-    // the native typed entry.
+    // #1118: each listed hit carries its verdict, and a runaway — the one that
+    // demotes `converged` — classifies Critical even when the entry reaches this
+    // path as a flat string (a spliced multi-start warning, say) instead of the
+    // native typed entry.
     let upper = classify_warning(
         "Internal optimizer parameter guard reached by estimate(s): PROP_ERR \
-         (estimate 148.4132; packed coordinate 5.0000 at upper guard).",
+         (estimate 148.4132; packed coordinate 5.0000 at upper guard, runaway).",
     );
     assert_eq!(upper.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(upper.severity, WarningSeverity::Critical);
 
     let lower = classify_warning(
         "Internal optimizer parameter guard reached by estimate(s): PROP_ERR \
-         (estimate 0.0003; packed coordinate -8.0000 at lower guard).",
+         (estimate 0.0003; packed coordinate -8.0000 at lower guard, collapse).",
     );
     assert_eq!(lower.severity, WarningSeverity::Warning);
+
+    // #1205 review: the verdict, not the side, is what carries the severity —
+    // an Ω off-diagonal at its *lower* rail is a runaway and must reach Critical.
+    let off_diag = classify_warning(
+        "Internal optimizer parameter guard reached by estimate(s): ETA_CL~ETA_V \
+         (estimate -10.0000; packed coordinate -10.0000 at lower guard, runaway).",
+    );
+    assert_eq!(off_diag.severity, WarningSeverity::Critical);
 }
 
 /// #778: the `WarningCode` serde token is a public API an agent / the R

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -683,6 +683,23 @@ fn classify_warning_recognizes_internal_runaway_guard() {
         classify_warning("Internal optimizer parameter guard reached by estimate(s): PROP_ERR");
     assert_eq!(warning.category, WarningCode::ParameterAtRunawayGuard);
     assert_eq!(warning.severity, WarningSeverity::Warning);
+
+    // #1118: the side is carried in each listed hit, and an upper hit — the one
+    // that demotes `converged` — classifies Critical even when the entry reaches
+    // this path as a flat string (a spliced multi-start warning, say) instead of
+    // the native typed entry.
+    let upper = classify_warning(
+        "Internal optimizer parameter guard reached by estimate(s): PROP_ERR \
+         (estimate 148.4132; packed coordinate 5.0000 at upper guard).",
+    );
+    assert_eq!(upper.category, WarningCode::ParameterAtRunawayGuard);
+    assert_eq!(upper.severity, WarningSeverity::Critical);
+
+    let lower = classify_warning(
+        "Internal optimizer parameter guard reached by estimate(s): PROP_ERR \
+         (estimate 0.0003; packed coordinate -8.0000 at lower guard).",
+    );
+    assert_eq!(lower.severity, WarningSeverity::Warning);
 }
 
 /// #778: the `WarningCode` serde token is a public API an agent / the R

--- a/tests/runaway_guard_demotes_convergence.rs
+++ b/tests/runaway_guard_demotes_convergence.rs
@@ -1,0 +1,58 @@
+//! #1118: a fit whose estimate is pinned to an *internal* packed-space guard is
+//! not an interior optimum, so `converged` must not come back `true`.
+//!
+//! The unit tests in `src/api/postfit.rs`'s sibling own the side/severity rules;
+//! this one pins the wiring — that `fit()` actually applies them to the
+//! `FitResult` every consumer keys off, for every estimator.
+
+use ferx_core::parser::model_parser::parse_model_file;
+use ferx_core::types::{WarningCode, WarningSeverity};
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::path::Path;
+
+/// An evaluation-only IMP stage reports the likelihood at the parameters it is
+/// handed without moving them, which is what lets this exercise the fit-end
+/// check on a guard-pinned point without a convergence loop (Tier 2).
+#[test]
+fn fit_demotes_converged_when_sigma_sits_on_the_internal_ceiling() {
+    let model =
+        parse_model_file(Path::new("examples/warfarin.ferx")).expect("warfarin example must parse");
+    let population = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None)
+        .expect("warfarin data must load");
+
+    let mut opts = FitOptions::default();
+    opts.verbose = false;
+    opts.run_covariance_step = false;
+    opts.method = EstimationMethod::Imp;
+    opts.imp_eval_only = true;
+
+    // Baseline: the same evaluation at the model's own inits is interior, so a
+    // demotion below is attributable to the guard and not to the eval-only path.
+    let interior = fit(&model, &population, &model.default_params, &opts)
+        .expect("eval-only IMP must succeed at the inits");
+    assert!(
+        interior.converged,
+        "control: an interior evaluation must not be demoted"
+    );
+
+    // exp(5) is the literal packed upper guard on a log-packed sigma.
+    let mut params = model.default_params.clone();
+    params.sigma.values[0] = 5.0_f64.exp();
+    let pinned =
+        fit(&model, &population, &params, &opts).expect("eval-only IMP must succeed at the guard");
+
+    assert!(
+        !pinned.converged,
+        "an estimate held at an implementation ceiling is not a converged fit"
+    );
+    let entry = pinned
+        .warnings_structured
+        .iter()
+        .find(|w| w.category == WarningCode::ParameterAtRunawayGuard)
+        .expect("the guard hit must be reported");
+    assert_eq!(entry.severity, WarningSeverity::Critical);
+    assert_eq!(
+        entry.details.as_ref().unwrap()["parameters"][0]["side"],
+        "upper"
+    );
+}


### PR DESCRIPTION
## Why

#1099 added a fit-end check for estimates pinned to ferx's **internal** packed-space guards
(`runaway_guard_estimates` / `runaway_guard_warning`), wired into every fit. It emits a typed
`WarningCode::ParameterAtRunawayGuard` — but it does not touch `converged`. A fit whose Ω or σ ran
to an implementation ceiling still returned `converged: true`, so a programmatic consumer keying
off the boolean retained an estimate that is by construction not an interior optimum.

Unlike a user-declared THETA bound — where a boundary hit can be a valid constrained optimum — an
internal guard hit cannot be. `runaway_guard_estimates` already excludes declared THETA ranges
(`theta_guard_is_internal`), so the remaining hits are exactly the cases where the flag is wrong.

Closes #1118. (Extracted from the closed #1104, which had a VI-only version of this.)

## What changed

- `runaway_guard_warning(converged: &mut bool, params)` — the signature now mirrors
  `vi::run::bad_basin_warning` (#1098), which owns the same consequence for the ELBO check, so the
  side/severity rules and the demotion live in one place and are unit-testable without a fit.
- **Upper-guard hit → `converged = false`, severity `Warning` → `Critical`.** The estimate stopped
  at an implementation ceiling; it is not a solution of the problem the user posed. The message
  says `Reported converged: false`, matching the VI bad-basin wording.
- **Lower-guard hit → unchanged** (`Warning`, `converged` untouched). One of the points the issue
  asked to settle: a variance collapsing to the floor is usually a genuinely unsupported component
  for the user to remove, not a numerical runaway, and demoting there would be noise rather than
  signal. A *mixed* set contains an upper hit, so it demotes.
- **Chained methods**: the call site in `fit()` runs on `result.params`, the final stage's
  estimates, so `methods = vi, focei` is gated on its last stage — same rule as
  `run_covariance_step`. The other point the issue asked to settle.
- `classify_warning` learns the same split. Each hit is listed as `... at <side> guard`, so the
  side survives into the flat message; a warning that reaches the string path (a spliced
  multi-start message) is classified `Critical` iff the native typed entry would have been.
- `warning_entry` gained a `warning_entry_with_severity` variant for emitters whose severity
  depends on what they found; every existing caller is unchanged.

Knock-on, intended: multi-start ranks candidates by `(converged, ofv)`, so a guard-pinned start no
longer outranks a valid one on OFV alone.

## Alternatives considered

- **Demote on any hit, upper or lower.** Rejected per the issue's first open point — an Ω at the
  floor is a modelling decision to make (remove the random effect), not a numerical failure, and
  flipping `converged` on it would fire on a large class of ordinary over-parameterized fits.
- **Keep `Warning` and demote anyway.** Rejected: `Critical` is documented as "the result is
  untrustworthy as-is", and `vi_bad_basin` — the exact analogue, a demotion-carrying quality gate —
  is already `Critical`. Splitting them would make severity useless for branching.
- **Return a third tuple element / a struct instead of `&mut bool`.** The `&mut converged` form is
  what the codebase already uses for this exact job in `bad_basin_warning`; matching it keeps one
  idiom rather than two.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API change (`runaway_guard_warning` is `pub(crate)`; the baseline is unchanged). ferx-r
reads `converged` and `warnings_structured` as it already does.

## Breaking changes
- [x] None

Behavioural note for consumers: a fit that previously reported `converged: true` with a
`parameter_at_runaway_guard` warning now reports `converged: false`. That is the fix.

## Numerical validation
- [x] Not applicable (no numerical path touched — no estimator, kernel, sensitivity, or likelihood
      code is modified; this only changes the fit-end reporting of a point that was already
      computed and already warned about)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes — 3863 passed, 0 failed)
- [x] Regression test added that fails without this fix

Tier 1 (`src/api/tests/simulate_with_uncertainty_tests.rs`, `src/types_tests.rs`) — the existing
guard tests now also pin the flag and the severity on every side, for σ, Ω-Cholesky, and hidden
θ caps: upper demotes and is `Critical`, lower does not and stays `Warning`, mixed demotes, and no
hit / a `FIX`'d coordinate leaves the flag alone. `classify_warning` is pinned on both sides.

Tier 2 (`tests/runaway_guard_demotes_convergence.rs`) — pins the *wiring*, that `fit()` applies the
rule to the `FitResult` a consumer reads. An evaluation-only IMP stage reports at the parameters it
is handed without moving them, which reaches the fit-end check on a guard-pinned point with no
convergence loop (0.09s). It runs a control at the model's own inits first, so the demotion is
attributable to the guard and not to the eval-only path.

## Example (user-facing features only)
- [x] Not applicable (no new API surface — the warning and its `details` payload are #1099's, and
      unchanged)

## Docs
- [x] `docs/` updated for user-visible changes — `docs/warnings.qmd` severity table row now reads
      `Critical / Warning` and says an upper hit is reported `converged: false`
- [x] `CHANGELOG.md` `[Unreleased]` entry added

`docs/warnings.qmd`'s "Warning codes" section is R1-baselined, so the rewritten row was kept
shorter than the one it replaces (349 vs 355 chars) rather than growing a baselined section.

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy `--all-targets`,
      rustdoc, docs lint, public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — none touched
- [x] `Cargo.toml` version bump not needed

## Docs & examples
- [x] No example execution step needed (fix with no user-visible DSL / option / example change)

## Reviewer hints

The two decisions worth your attention are the ones #1118 flagged for review: **lower-guard hits do
not demote** (`src/api/postfit.rs`, the `if has_upper` block and the doc comment above
`runaway_guard_warning`), and **the chain gates on the last stage** (`src/api/fit.rs`, the call
site — it is already positioned after the whole chain, so this is a comment, not a code change).

`src/types.rs`'s `classify_warning` arm is the one easy-to-miss piece: it keys on the literal
`"at upper guard"` substring that each hit's list entry produces. If the hit-line format in
`runaway_guard_warning` ever changes, that arm silently reverts to `Warning` — the test in
`src/types_tests.rs` pins both sides against exactly that.

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ5ksNYgr4jLn6MMUqX1XG
