### PR TITLE
fix(estimation): judge VI trace settling with median/MAD [closes #1119]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ section of the SDLC for the versioning policy).
   still there, and the run reported `converged` at the earliest iteration arithmetically
   allowed. The criterion now uses the median and the MAD (scaled by 1.4826) in the same
   `SETTLE_Z · spread + rel_tol · (1 + |location|)` form, so a tail can no longer buy a
-  premature stop. Estimates are unchanged on healthy fits — `warfarin`, `two_cpt_oral_cov`
-  and `warfarin_iov` agree to four or five significant figures — but the criterion is
-  slightly more conservative, so such a run stops somewhat later (on those three, 5125 →
-  8375, 6625 → 7250 and 3500 → 3625 iterations). A noiseless trace still settles on the
-  relative floor alone (#1119).
+  premature stop. Estimates on healthy fits are unchanged: `propofol_schnider` and
+  `vancomycin_uvm`, which stop on the parameter-stability criterion, are identical down to
+  the last reported digit, and `warfarin`, `two_cpt_oral_cov` and `warfarin_iov`, which
+  stop on the trace, agree to four or five significant figures. The trace criterion is
+  slightly more conservative, so those three run longer for the same answer (5125 → 8375,
+  6625 → 7250 and 3500 → 3625 iterations). A noiseless trace still settles on the relative
+  floor alone (#1119).
 
 ## [0.3.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Changed
+- **VI early stopping is now judged with robust statistics.** The settling test compared
+  the *mean* of the last window of the objective trace against the mean of the one before
+  it, and sized its tolerance from the trace's own sample variance. Both estimators have a
+  breakdown point of zero, so on a heavy-tailed trace — what an unhealthy VI run emits — a
+  handful of outliers inflated the spread until the tolerance swallowed the drift that was
+  still there, and the run reported `converged` at the earliest iteration arithmetically
+  allowed. The criterion now uses the median and the MAD (scaled by 1.4826) in the same
+  `SETTLE_Z · spread + rel_tol · (1 + |location|)` form, so a tail can no longer buy a
+  premature stop. Estimates are unchanged on healthy fits — `warfarin`, `two_cpt_oral_cov`
+  and `warfarin_iov` agree to four or five significant figures — but the criterion is
+  slightly more conservative, so such a run stops somewhat later (on those three, 5125 →
+  8375, 6625 → 7250 and 3500 → 3625 iterations). A noiseless trace still settles on the
+  relative floor alone (#1119).
+
 ## [0.3.1] - 2026-09-02
 
 ### Added

--- a/docs/estimation/vi.qmd
+++ b/docs/estimation/vi.qmd
@@ -209,9 +209,22 @@ optimum, where it is the only remaining noise — and makes the KL gradient vani
 
 The objective is a Monte-Carlo estimate, so a per-iteration improvement test would stop on
 noise rather than on convergence. VI instead treats `vi_iters` as a **ceiling** and stops
-once the remaining drift is indistinguishable from that noise, judged on a moving average of
+once the remaining drift is indistinguishable from that noise, judged on a moving summary of
 the trace together with the stability of the parameters themselves. `n_iterations` reports
 what actually ran and `converged` whether it had in fact settled.
+
+That summary is deliberately **robust**: the two windows are compared by their medians, and
+the tolerance is sized from the median absolute deviation rather than the sample variance.
+A mean/variance version is fooled by exactly the traces that most need catching — an
+unhealthy run is heavy-tailed, and a few outliers inflate the spread until the tolerance
+swallows whatever systematic drift is left, so the run certifies itself at the earliest
+iteration arithmetically allowed (#1119). Median and MAD are unmoved by that tail.
+
+On a healthy fit the change is conservative rather than neutral: the MAD of a mildly
+leptokurtic trace is a little below its standard deviation, so the tolerance tightens and
+the run stops slightly later at the same answer. Measured with default options —
+`warfarin` 5125 → 8375 iterations, `two_cpt_oral_cov` 6625 → 7250, `warfarin_iov`
+3500 → 3625 — with every `θ`, `Ω` and `σ` agreeing to four or five significant figures.
 
 Settling is not the same as landing somewhere good — a stuck optimizer also stops moving.
 Read [`elbo_tightness_ratio`](#is-the-bound-tight-elbo_tightness_ratio) alongside

--- a/docs/estimation/vi.qmd
+++ b/docs/estimation/vi.qmd
@@ -220,11 +220,14 @@ unhealthy run is heavy-tailed, and a few outliers inflate the spread until the t
 swallows whatever systematic drift is left, so the run certifies itself at the earliest
 iteration arithmetically allowed (#1119). Median and MAD are unmoved by that tail.
 
-On a healthy fit the change is conservative rather than neutral: the MAD of a mildly
-leptokurtic trace is a little below its standard deviation, so the tolerance tightens and
-the run stops slightly later at the same answer. Measured with default options —
-`warfarin` 5125 → 8375 iterations, `two_cpt_oral_cov` 6625 → 7250, `warfarin_iov`
-3500 → 3625 — with every `θ`, `Ω` and `σ` agreeing to four or five significant figures.
+Whether a healthy fit notices depends on which of the two criteria stopped it. A run that
+stopped on **parameter stability** is untouched — `propofol_schnider` and
+`vancomycin_uvm` still stop at 2500 and 2000 iterations and reproduce every estimate and
+`−2·ELBO` digit for digit. A run that stopped on the **trace** is slightly more
+conservative, because the MAD of a mildly leptokurtic trace sits a little below its
+standard deviation: the tolerance tightens and the run stops later at the same answer
+(`warfarin` 5125 → 8375 iterations, `two_cpt_oral_cov` 6625 → 7250, `warfarin_iov`
+3500 → 3625, with every `θ`, `Ω` and `σ` agreeing to four or five significant figures).
 
 Settling is not the same as landing somewhere good — a stuck optimizer also stops moving.
 Read [`elbo_tightness_ratio`](#is-the-bound-tight-elbo_tightness_ratio) alongside

--- a/src/estimation/vi/run.rs
+++ b/src/estimation/vi/run.rs
@@ -181,31 +181,82 @@ fn param_criterion_applies(template: &ModelParameters) -> bool {
     fixed.iter().zip(structural.iter()).any(|(&f, &z)| !f && !z)
 }
 
+/// Scale factor turning the median absolute deviation into a consistent estimator of
+/// the standard deviation under normality (`1 / Φ⁻¹(0.75)`).
+const MAD_TO_SIGMA: f64 = 1.4826;
+
+/// Median of a window, averaging the two central values on an even count.
+///
+/// Takes an owned buffer because it sorts in place; callers hand it a copy of the
+/// window rather than the trace itself.
+fn median_of(buf: &mut [f64]) -> f64 {
+    buf.sort_by(f64::total_cmp);
+    let n = buf.len();
+    if n % 2 == 1 {
+        buf[n / 2]
+    } else {
+        0.5 * (buf[n / 2 - 1] + buf[n / 2])
+    }
+}
+
+/// Robust location and spread of a window: the median, and the median absolute
+/// deviation scaled to a standard-deviation equivalent.
+///
+/// Returns `None` if the window holds a non-finite value, which is never "settled".
+fn median_and_mad(window: &[f64]) -> Option<(f64, f64)> {
+    if window.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+    let mut buf: Vec<f64> = window.to_vec();
+    let med = median_of(&mut buf);
+    // Reuse the buffer: absolute deviations, then their median.
+    for (slot, v) in buf.iter_mut().zip(window.iter()) {
+        *slot = (v - med).abs();
+    }
+    Some((med, MAD_TO_SIGMA * median_of(&mut buf)))
+}
+
 /// Whether the tail of the objective trace has stopped moving.
 ///
-/// Compares the mean of the last `window` values against the mean of the `window`
-/// before it. Averaging both sides is the point: single-iteration deltas are
+/// Compares the **median** of the last `window` values against the median of the
+/// `window` before it. Summarising both sides is the point: single-iteration deltas are
 /// dominated by Monte-Carlo noise and would report convergence at random.
 ///
 /// # Why the threshold is noise-aware, not purely relative
 ///
-/// The ELBO is a Monte-Carlo estimate, so the difference between two window means is
+/// The ELBO is a Monte-Carlo estimate, so the difference between two window summaries is
 /// itself a random variable. Judging it against a *relative* tolerance
-/// (`rel_tol·(1 + |mean|)`) asks the wrong question: it scales with the objective's
+/// (`rel_tol·(1 + |location|)`) asks the wrong question: it scales with the objective's
 /// magnitude, which has nothing to do with how noisy the trace is. On a real fit that
 /// threshold is unreachable — a plateaued warfarin run still shows window-to-window
 /// differences orders of magnitude above `1e-4·(1 + 286)`, so the run is reported
 /// unsettled forever and early stopping never fires.
 ///
 /// The right comparison is against the **standard error of the difference**,
-/// `√(s²_recent/w + s²_prior/w)`, estimated from the trace's own within-window
-/// variance. That is scale-free, adapts automatically to `vi_mc_samples`, and asks the
-/// question that matters: *is the remaining drift distinguishable from noise?* If it is
-/// not, more iterations at this noise level cannot resolve it — the fix would be more
-/// Monte-Carlo draws, not more epochs.
+/// `√(s²_recent/w + s²_prior/w)`, estimated from the trace's own within-window spread.
+/// That is scale-free, adapts automatically to `vi_mc_samples`, and asks the question
+/// that matters: *is the remaining drift distinguishable from noise?* If it is not, more
+/// iterations at this noise level cannot resolve it — the fix would be more Monte-Carlo
+/// draws, not more epochs.
+///
+/// # Why median/MAD rather than mean/variance (#1119)
+///
+/// The noise-aware form above is the right question, but the mean and the sample
+/// variance are the wrong estimators to ask it with. They have a breakdown point of
+/// zero: on a heavy-tailed trace — precisely what an *unhealthy* VI run emits — a
+/// handful of outliers inflate `s²`, `se` grows with them, and the tolerance swallows
+/// whatever systematic drift is left. The criterion then fires at the earliest iteration
+/// it is arithmetically allowed to, and the run reports `converged` on a trace that is
+/// still moving. Measured on #1097: every unhealthy run stopped at iteration 1500 of a
+/// 25 000 ceiling.
+///
+/// The median (breakdown 50 %) and the MAD scaled by `MAD_TO_SIGMA` answer the same
+/// question with estimators a tail cannot move. On a clean Gaussian trace they agree
+/// with mean/σ up to their efficiency, so healthy runs are unaffected; on a
+/// contaminated one they keep reporting "not settled" while the drift is real.
 ///
 /// `rel_tol` is retained as an additive **floor** so the criterion is never stricter
-/// than the original one: a noiseless trace (`s² = 0`) still settles on the relative
+/// than the original one: a noiseless trace (`MAD = 0`) still settles on the relative
 /// test alone, which is what the synthetic-trace unit tests exercise.
 pub fn trace_has_settled(trace: &[f64], window: usize, rel_tol: f64) -> bool {
     if window == 0 || trace.len() < 2 * window {
@@ -215,22 +266,17 @@ pub fn trace_has_settled(trace: &[f64], window: usize, rel_tol: f64) -> bool {
     let recent = &trace[n - window..];
     let prior = &trace[n - 2 * window..n - window];
 
-    let mean = |s: &[f64]| s.iter().sum::<f64>() / s.len() as f64;
-    let m_recent = mean(recent);
-    let m_prior = mean(prior);
-    if !m_recent.is_finite() || !m_prior.is_finite() {
+    let Some((m_recent, s_recent)) = median_and_mad(recent) else {
         return false;
-    }
-
-    // Unbiased within-window variance; a 1-wide window carries no variance information,
-    // in which case this degenerates to the plain relative test below.
-    let var = |s: &[f64], m: f64| -> f64 {
-        if s.len() < 2 {
-            return 0.0;
-        }
-        s.iter().map(|v| (v - m) * (v - m)).sum::<f64>() / (s.len() - 1) as f64
     };
-    let se = ((var(recent, m_recent) + var(prior, m_prior)) / window as f64).sqrt();
+    let Some((m_prior, s_prior)) = median_and_mad(prior) else {
+        return false;
+    };
+
+    // Standard error of the difference of the two locations. A 1-wide window carries no
+    // spread information (`MAD = 0`), in which case this degenerates to the plain
+    // relative test below.
+    let se = ((s_recent * s_recent + s_prior * s_prior) / window as f64).sqrt();
     if !se.is_finite() {
         return false;
     }

--- a/src/estimation/vi/run_tests.rs
+++ b/src/estimation/vi/run_tests.rs
@@ -181,6 +181,58 @@ fn systematic_drift_is_detected_below_the_settling_test_noise_floor() {
     assert!(!trace_still_drifting(&poisoned, 40));
 }
 
+/// #1119: a heavy tail must not be able to buy the run a "settled" verdict.
+///
+/// `trace_has_settled` scales its tolerance by the trace's own within-window spread.
+/// With mean/variance that is a lever an unhealthy run can pull: a handful of large
+/// values inflate `s²`, `se` grows with them, and the tolerance swallows the systematic
+/// drift that is still there. Median/MAD asks the same question with estimators the
+/// outliers cannot move.
+#[test]
+fn a_heavy_tail_cannot_mask_systematic_drift() {
+    // Steady descent of 0.02/iteration, contaminated by four large spikes per window.
+    // The spikes are balanced across the two windows, so they barely move either
+    // *location* — only the spread.
+    let contaminated: Vec<f64> = (0..200)
+        .map(|i| 500.0 - 0.02 * i as f64 + if i % 13 == 0 { 150.0 } else { 0.0 })
+        .collect();
+
+    // The fixture only proves something if the mean/variance criterion it replaces
+    // would have been fooled by it. Recompute that criterion here rather than keeping a
+    // second copy of it in `run.rs`.
+    let n = contaminated.len();
+    let recent = &contaminated[n - 50..];
+    let prior = &contaminated[n - 100..n - 50];
+    let mean = |s: &[f64]| s.iter().sum::<f64>() / s.len() as f64;
+    let var =
+        |s: &[f64], m: f64| s.iter().map(|v| (v - m) * (v - m)).sum::<f64>() / (s.len() - 1) as f64;
+    let (m_recent, m_prior) = (mean(recent), mean(prior));
+    let se_meanvar = ((var(recent, m_recent) + var(prior, m_prior)) / 50.0).sqrt();
+    assert!(
+        (m_prior - m_recent).abs() <= 2.0 * se_meanvar + CONVERGENCE_REL_TOL * (1.0 + 500.0),
+        "fixture must actually fool the mean/variance criterion, else it proves nothing"
+    );
+
+    // The robust criterion is not fooled: the drift is 1.0 per window against a MAD-
+    // based standard error of a few hundredths.
+    assert!(
+        !trace_has_settled(&contaminated, 50, CONVERGENCE_REL_TOL),
+        "systematic drift under a heavy tail must not count as settled"
+    );
+
+    // The converse must hold too, or the swap would just make early stopping never
+    // fire: the same contamination on a genuinely flat trace still settles.
+    let flat_contaminated: Vec<f64> = (0..200)
+        .map(|i| {
+            500.0 + if i % 2 == 0 { 0.5 } else { -0.5 } + if i % 13 == 0 { 150.0 } else { 0.0 }
+        })
+        .collect();
+    assert!(
+        trace_has_settled(&flat_contaminated, 50, CONVERGENCE_REL_TOL),
+        "a plateaued trace must still settle, spikes or not"
+    );
+}
+
 /// #1098: an implausibly loose ELBO is evidence that a flat trace is a bad basin,
 /// not successful convergence. It must also suppress the generic iteration-budget
 /// advice, which does not address this failure mode.


### PR DESCRIPTION
## Why

`trace_has_settled` (`src/estimation/vi/run.rs`) decides when a VI run stops. It compares
the tail of the objective trace against the window before it and sizes its tolerance from
the trace's own within-window spread — `SETTLE_Z * se + rel_tol * (1 + |location|)`.

That is the right *question* (is the remaining drift distinguishable from Monte-Carlo
noise?), asked with the wrong *estimators*. The mean and the sample variance both have a
breakdown point of zero. On a heavy-tailed trace — precisely what an unhealthy VI run
emits — a handful of outliers inflate `s²`, `se` grows with them, and the tolerance
swallows whatever systematic drift is left. The criterion then fires at the earliest
iteration it is arithmetically allowed to, and the fit reports `converged: true`.

Observed on #1097: every unhealthy run stopped at iteration 1500 of a 25 000 ceiling. The
optimizer was frozen there, but the settling rule was also being handed a tail wide enough
to hide real movement.

Closes #1119.

## What changed

Median instead of mean, MAD scaled by 1.4826 instead of the square root of the sample
variance, in the **same** `SETTLE_Z * spread + rel_tol * (1 + |location|)` form. Nothing
else about the criterion moves — `SETTLE_Z`, `rel_tol`, the window logic, the
`trace_still_drifting` sign test and every caller are untouched.

Two small consequences:

- A noiseless trace has `MAD = 0` exactly as it had `s² = 0`, so it still settles on the
  relative floor alone, and the existing synthetic-trace tests pass unchanged.
- A window holding a non-finite value is now rejected explicitly (`median_and_mad`
  returns `None`) rather than implicitly, via a `NaN` mean failing `is_finite`. Sorting
  with `f64::total_cmp` would otherwise park a `NaN` at the end of the buffer and leave
  the median finite.

This is a backstop, not a fix for any estimate. The freeze that motivated it is fixed at
its source by #1112 (VI gradient clipping); per the issue, this PR deliberately carries no
numerical change so a trace-criterion change and a numerical change never land together.

## Alternatives considered

Trimming or winsorising the window before taking the mean would also work, but it needs a
trim fraction — one more constant to justify — and buys nothing over the median, whose
breakdown point is already 50 %. Keeping mean/variance and raising `SETTLE_Z` was rejected
outright: it makes the criterion uniformly stricter, including on the well-behaved traces
where the existing estimator is correct, and does not change the fact that the tail sets
the tolerance.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API change (`trace_has_settled` keeps its signature; the two new helpers are
private). `tools/preflight.sh` reports the public-API baseline unchanged.

## Breaking changes

- [x] None

## Numerical validation

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit (`5f7ef926`, this branch's merge base), same
      binary rebuilt with only `run.rs` reverted

Five models fitted with `method = vi` and otherwise default options, before and after.
`propofol_schnider` and `vancomycin_uvm` are the two the issue names; they live in
`ferx-testdata`, not in this repo, and were run from there with only `method` (and, for
vancomycin, the `[data] path`) rewritten.

**Unchanged — bit-identical, every reported digit:**

```
model                before                        after
-------------------  ----------------------------  ----------------------------
propofol_schnider    iters 2500  -2ELBO -3050.291398   identical
                     TVV1 5.807479  TVV2 25.885203  TVV3 307.353209
                     TVCL 1.911163  TVQ2 1.343309   TVQ3   0.863628

vancomycin_uvm       iters 2000  -2ELBO  1001.294556   identical
                     TVCL 5.192219  TVV1 70.081063  TVQ 5.109883
                     TVV2 66.244229  THETA_CRCL 0.879571
```

A full `diff` of each run's console output differs only in wall-clock lines (propofol
12.8 s → 13.5 s, vancomycin 106.7 s → 113.2 s — noise; the fits are the same length).
Their iteration counts also still match the figures quoted for them in
`docs/estimation/vi.qmd` under #1112 (2500 and 2000).

**Moved slightly — same answer, more iterations:**

```
model                before                          after
-------------------  ------------------------------  ------------------------------
warfarin             iters 5125  -2ELBO -284.545373   iters 8375  -2ELBO -284.632408
                     TVCL  0.132694                   TVCL  0.132692
                     TVV   7.737952                   TVV   7.737933
                     TVKA  0.811025                   TVKA  0.811001
                     PROP  0.011645                   PROP  0.011610

two_cpt_oral_cov     iters 6625  -2ELBO -1192.509821  iters 7250  -2ELBO -1192.465571
                     TVCL  4.936182                   TVCL  4.936441
                     TVV1 48.593217                   TVV1 48.593183
                     TVQ   9.561677                   TVQ   9.562072
                     TVV2 94.229472                   TVV2 94.229860
                     TVKA  1.258716                   TVKA  1.258704
                     WT    0.646628                   WT    0.646652
                     CRCL  0.559377                   CRCL  0.559569
                     PROP  0.021721                   PROP  0.021740

warfarin_iov         iters 3500  -2ELBO  310.923800   iters 3625  -2ELBO  310.925075
                     TVCL  0.171336                   TVCL  0.171342
                     TVV   8.634731                   TVV   8.634713
                     TVKA  1.198242                   TVKA  1.198436
                     PROP  0.189155                   PROP  0.189189
```

Every estimate agrees to four or five significant figures. Warfarin's post-change values
also still match the NONMEM FOCEI reference in `docs/estimation/vi.qmd`
(TVCL 0.132695, TVV 7.73770, TVKA 0.810795).

**Why the split, and it is the useful part of this table.** VI has two independently
sufficient stopping criteria — `trace_has_settled` and `estimates_have_settled` — and only
the first one changed. A fit that stops on parameter stability cannot notice this PR at
all, which is why the two `ferx-testdata` models are bit-identical. A fit that stops on the
trace becomes slightly more conservative: for a mildly leptokurtic trace the MAD sits a
little below the standard deviation, so the tolerance tightens and the run stops later at
the same answer (+63 % iterations on warfarin, +9 % on `two_cpt_oral_cov`, +4 % on
`warfarin_iov`). Both the CHANGELOG entry and the docs state this rather than claiming a
uniform no-op.

## Performance

- [x] Slower — justified because: the settling test itself is `O(w log w)` per check
      instead of `O(w)` (two sorts of a window copy), which is invisible next to an
      iteration of VI. The real cost is the conservatism above, and only for fits that
      stop on the trace criterion: such a fit runs more iterations for the same answer
      (warfarin 1.0 s → 1.6 s). Fits that stop on parameter stability are unaffected —
      propofol_schnider and vancomycin_uvm run the same 2500 and 2000 iterations as
      before. That is the intended
      trade — the criterion is a *stopping guarantee*, and buying it back by loosening the
      tolerance would reintroduce the failure this fixes.

## Tests

- [x] Unit test added in the same module (`cargo test --lib` passes: 3989 passed, 0 failed)
- [x] Regression test added that fails without this fix

`a_heavy_tail_cannot_mask_systematic_drift` (`src/estimation/vi/run_tests.rs`) builds a
trace with a steady 0.02/iteration descent contaminated by four large spikes per window,
and asserts three things:

1. the **mean/variance** criterion, recomputed inline, *would* have called it settled — so
   the fixture actually exercises the defect rather than proving nothing;
2. `trace_has_settled` rejects it;
3. the same contamination on a genuinely flat trace still settles — otherwise the swap
   would just disable early stopping.

The existing noiseless- and noisy-trace tests
(`trace_settles_on_a_flat_noisy_tail_but_not_on_a_drifting_one`,
`settling_is_judged_against_noise_not_objective_magnitude`,
`systematic_drift_is_detected_below_the_settling_test_noise_floor`) pass unchanged, which
is the point of keeping the criterion's shape.

## Example

- [x] Not applicable (internal fix, no new API surface or DSL syntax)

## Docs

- [x] `docs/` updated — `docs/estimation/vi.qmd`, "Why there is no convergence tolerance",
      now says the window summary is robust, why mean/variance is fooled, and what the
      conservatism costs in iterations
- [x] `CHANGELOG.md` `[Unreleased]` entry added under `Changed`
- [x] `cargo run -p docs-lint -- --check` clean (no new baseline entries)

## Checklist

- [x] `tools/preflight.sh` green — `preflight OK — fmt check clippy rustdoc docs public-api`
- [x] Not on the `Dual2` sensitivity path
- [x] No version bump needed (not breaking)

## Docs & examples

- [x] No new DSL syntax, `[fit_options]` key, example `.ferx`, or data file — nothing to
      mirror to ferx-site, ferx-book, or `ferx-r/inst/examples/data/`
- [x] Example execution: the three `.ferx` models above were run through
      `target/release/ferx` on both sides of the change (see Numerical validation). No
      committed example changed, so no ferx-site or ferx-book page needs re-rendering, and
      no ferx-r rebuild is implicated (no public API moved).

## Reviewer hints

Focus on `median_and_mad` and the even-length median convention (average of the two
central values) — that is what keeps the alternating-noise fixtures in the existing tests
centred, and a `floor(n/2)` convention would shift them by half the noise amplitude. The
`f64::total_cmp` sort plus the explicit non-finite rejection are a pair: drop the latter
and a `NaN` tail silently becomes a finite median.

Everything else is skimmable — the criterion's algebra, its constants and all callers are
byte-identical.

## Open questions

The conservatism is real and is the one judgement call here. It only reaches fits that
stop on the trace criterion rather than on parameter stability — both `ferx-testdata`
models are in the latter group and are untouched — but +63 % iterations on warfarin for an
identical answer, cheap as it is at 1.6 s, scales with the fit. If that is not
wanted, the lever is `SETTLE_Z`, and re-tuning it against the MAD's efficiency (~64 % of
the mean's on Gaussian data) would be a separate, measured change — not something to fold
into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQqmdvHxVNv9M4rNqcmfeF
