### PR TITLE
feat(estimation): estimate the block_sigma off-diagonal on the analytic gradient [closes #847]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,25 @@ section of the SDLC for the versioning policy).
   marked fixed, which is what it meant at the time.
 
 ### Fixed
+- **An estimated `block_sigma` correlation is bounded at `|rho| <= 0.995` (#847).** Merely
+  keeping rho inside `(-1, 1)` is not enough: a paired residual block's determinant carries a
+  factor `1 - rho^2`, so a rho of 0.9999 leaves `R` numerically singular and the likelihood
+  will chase `log|R| -> -inf`. On the 12-observation `examples/correlated_residual_combined`
+  fixture an unbounded rho ran to -0.99993 and reported convergence at a degenerate optimum. A
+  rho sitting on this rail is now a legible diagnostic: the two endpoints are carrying the same
+  noise.
+- **A zero `block_sigma` off-diagonal is now estimated rather than dropped (#847).**
+  `block_sigma (A, B) = [0.04, 0.0, 1.0]` — the natural translation of `$SIGMA BLOCK(2)` with a
+  zero covariance init — previously built no correlation at all, so under the new
+  estimate-by-default semantics it would have silently fitted a diagonal residual with no
+  coordinate to move. A `FIX`ed zero is still dropped: a fixed zero correlation is the same
+  object as no correlation.
+- **`method = laplace` / `n_agq > 1` with a free `block_sigma` now uses the reconverged-FD
+  outer gradient (#847).** AGQ's analytic score assembles theta / omega / sigma / omega_iov and
+  never writes the rho slot, while its objective does depend on rho — so the analytic gradient
+  is declined for a free correlation rather than handing the optimizer a hard zero there. A
+  `FIX`ed block keeps the analytic score. The chain guard was widened to match: `laplace` can
+  move rho, so `[laplace, imp]` is rejected exactly like `[focei, imp]`.
 - **The `block_sigma` correlation coordinate is no longer magnitude-scaled below 1 (#847).**
   The outer optimizer's `abs` preconditioner divides each packed coordinate by its own
   `|value|`, which is right for a log-space coordinate but meaningless for the Fisher-z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ section of the SDLC for the versioning policy).
   off-diagonal correlation are estimated. Previously the correlation was always frozen at the
   declared value, so a model with a `$SIGMA BLOCK` counterpart in NONMEM optimized a different
   objective — on the fluconazole RadboudUMC model NONMEM moved the residual correlation to
-  ~0.93 while ferx held the ~0.2 init. Append `FIX` to hold the whole block, which is the only
-  form that reproduces the previous behaviour; the shipped
-  `examples/correlated_residual_combined.ferx` already uses it and is unaffected. The
+  ~0.93 while ferx held the ~0.2 init. Append `FIX` to hold the whole block — SDs and
+  correlation alike, matching `$SIGMA BLOCK(n) FIX`. Note that the old behaviour (SDs
+  estimated, correlation frozen) is no longer expressible: NONMEM has no such form either, and
+  it was the mismatch this issue is about. The shipped
+  `examples/correlated_residual_combined.ferx` already uses `FIX` and is unaffected. The
   correlation is optimized as its Fisher-z transform `atanh(rho)`, so it stays strictly inside
   `(-1, 1)` and the residual covariance can never go singular from the correlation alone, and
   it rides the exact analytic FOCE/FOCEI outer gradient rather than falling back to finite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,37 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Changed
+- **`block_sigma` now estimates its off-diagonal correlation (#847).** A plain
+  `block_sigma (...) = [...]` is NONMEM `$SIGMA BLOCK(n)`: its diagonal SDs *and* its
+  off-diagonal correlation are estimated. Previously the correlation was always frozen at the
+  declared value, so a model with a `$SIGMA BLOCK` counterpart in NONMEM optimized a different
+  objective — on the fluconazole RadboudUMC model NONMEM moved the residual correlation to
+  ~0.93 while ferx held the ~0.2 init. Append `FIX` to hold the whole block, which is the only
+  form that reproduces the previous behaviour; the shipped
+  `examples/correlated_residual_combined.ferx` already uses it and is unaffected. The
+  correlation is optimized as its Fisher-z transform `atanh(rho)`, so it stays strictly inside
+  `(-1, 1)` and the residual covariance can never go singular from the correlation alone, and
+  it rides the exact analytic FOCE/FOCEI outer gradient rather than falling back to finite
+  differences. Estimators that do not estimate it (SAEM, IMP/IMPMAP, Bayes, AGQ, VI) continue
+  to hold it at the declaration.
+
+### Added
+- **Fitted `block_sigma` correlations are reported with their fixedness and standard error
+  (#847).** `FitResult` gains `residual_correlation_fixed` and `se_residual_correlations` (the
+  SE on the natural `rho` scale, by the delta method on the packed Fisher-z coordinate), the
+  fit YAML's `block_sigma:` section gains `correlation_se` and now reports
+  `correlation_fixed` from the model rather than always `true`, and `.fitrx` bundles
+  round-trip all three. A bundle written before this change loads with every correlation
+  marked fixed, which is what it meant at the time.
+
 ### Fixed
+- **`block_sigma` residual derivatives were built at the declared correlation, not the live
+  one (#847).** The outer-gradient assembly (`corr_residual_diag` /
+  `corr_residual_rd_at_sigma`) and the inner eta-gradient read the correlations off the frozen
+  `CompiledModel`, so once the off-diagonal became estimable the whole `(R, dR/df, d2R/df2)`
+  chain would have been evaluated at the initial value while the objective moved. Both now
+  take the live parameter vector's correlations.
 - **`ode_method = auto` no longer keeps a stiff solve whose analytic derivatives have
   overflowed (#1204).** The escalation guard checked that every saved state was finite, but
   read *values* only. A dual number's derivative jets carry higher powers of what its value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ section of the SDLC for the versioning policy).
   marked fixed, which is what it meant at the time.
 
 ### Fixed
+- **The `block_sigma` correlation coordinate is no longer magnitude-scaled below 1 (#847).**
+  The outer optimizer's `abs` preconditioner divides each packed coordinate by its own
+  `|value|`, which is right for a log-space coordinate but meaningless for the Fisher-z
+  `atanh(rho)` — that is a *position* in a bounded range which passes through zero. At the
+  common `rho = 0.2` init it handed the optimizer a coordinate with roughly thirty times the
+  scaled room of every other one, and NLopt L-BFGS failed on its first step. The scale is now
+  `max(|atanh rho|, 1)`. On the fluconazole RadboudUMC model a cold-start FOCEI fit goes from
+  failing at OFV 1111.12 to converging at **736.89 with rho = 0.9319**, against NONMEM's
+  734.644 / 0.9312. Models without a `block_sigma` are unaffected by construction.
 - **`simulate()` drew correlated residuals at the declared `block_sigma` correlation (#847).**
   The dense residual `R` it samples from used the live sigmas but the model's declared
   correlation, so a VPC or posterior-predictive check of a fit with an estimated off-diagonal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ section of the SDLC for the versioning policy).
   `(-1, 1)` and the residual covariance can never go singular from the correlation alone, and
   it rides the exact analytic FOCE/FOCEI outer gradient rather than falling back to finite
   differences. Estimators that do not estimate it (SAEM, IMP/IMPMAP, Bayes, AGQ, VI) continue
-  to hold it at the declaration.
+  to hold it at the declaration. Because a method chain starts each stage from the previous
+  stage's estimates, a chain that runs `foce`/`focei` before a stage that cannot read the
+  estimated correlation is now rejected with `E_BLOCK_SIGMA_CHAIN_UNSUPPORTED` rather than
+  silently scoring the declared value — `[saem, focei]` is fine, `[focei, imp]` needs `FIX`.
 
 ### Added
 - **Fitted `block_sigma` correlations are reported with their fixedness and standard error
@@ -46,6 +49,10 @@ section of the SDLC for the versioning policy).
   marked fixed, which is what it meant at the time.
 
 ### Fixed
+- **`simulate()` drew correlated residuals at the declared `block_sigma` correlation (#847).**
+  The dense residual `R` it samples from used the live sigmas but the model's declared
+  correlation, so a VPC or posterior-predictive check of a fit with an estimated off-diagonal
+  would not reproduce the correlation the fit reported. It now uses the parameter vector's.
 - **`block_sigma` residual derivatives were built at the declared correlation, not the live
   one (#847).** The outer-gradient assembly (`corr_residual_diag` /
   `corr_residual_rd_at_sigma`) and the inner eta-gradient read the correlations off the frozen

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -398,10 +398,12 @@ pub ferx_core::estimation::vi::elbo::ElboEval::neg_elbo: f64
 pub struct ferx_core::estimation::vi::elbo::PackedLayout
 pub ferx_core::estimation::vi::elbo::PackedLayout::n_omega: usize
 pub ferx_core::estimation::vi::elbo::PackedLayout::n_omega_iov: usize
+pub ferx_core::estimation::vi::elbo::PackedLayout::n_rho: usize
 pub ferx_core::estimation::vi::elbo::PackedLayout::n_sigma: usize
 pub ferx_core::estimation::vi::elbo::PackedLayout::n_theta: usize
 impl ferx_core::estimation::vi::elbo::PackedLayout
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::new(template: &ferx_core::ModelParameters) -> Self
+pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_iov_end(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_iov_start(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_start(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::sigma_start(&self) -> usize
@@ -549,10 +551,12 @@ pub fn ferx_core::estimation::vi::family::MeanField::sample(&self, phi: &[f64], 
 pub struct ferx_core::estimation::vi::PackedLayout
 pub ferx_core::estimation::vi::PackedLayout::n_omega: usize
 pub ferx_core::estimation::vi::PackedLayout::n_omega_iov: usize
+pub ferx_core::estimation::vi::PackedLayout::n_rho: usize
 pub ferx_core::estimation::vi::PackedLayout::n_sigma: usize
 pub ferx_core::estimation::vi::PackedLayout::n_theta: usize
 impl ferx_core::estimation::vi::elbo::PackedLayout
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::new(template: &ferx_core::ModelParameters) -> Self
+pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_iov_end(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_iov_start(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::omega_start(&self) -> usize
 pub fn ferx_core::estimation::vi::elbo::PackedLayout::sigma_start(&self) -> usize
@@ -1795,16 +1799,16 @@ pub fn ferx_core::stats::likelihood::apply_frem_r_overrides(r_diag: &mut [f64], 
 pub fn ferx_core::stats::likelihood::build_block_diag_omega(omega_bsv: &nalgebra::base::alias::DMatrix<f64>, omega_iov: &nalgebra::base::alias::DMatrix<f64>, n_occasions: usize) -> nalgebra::base::alias::DMatrix<f64>
 pub fn ferx_core::stats::likelihood::build_frem_r_override(frem_config: core::option::Option<&ferx_core::FremConfig>, fremtype: &[u16], sigma_values: &[f64]) -> core::option::Option<alloc::vec::Vec<core::option::Option<f64>>>
 pub fn ferx_core::stats::likelihood::compute_cwres(subject: &ferx_core::Subject, ipreds: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], error_spec: &ferx_core::ErrorSpec, residual_correlations: &[ferx_core::ResidualCorrelation], frem_r_override: core::option::Option<&[core::option::Option<f64>]>, residual_error_eta: core::option::Option<usize>, ruv_mult: core::option::Option<&[alloc::vec::Vec<f64>]>) -> alloc::vec::Vec<f64>
-pub fn ferx_core::stats::likelihood::foce_population_nll(model: &ferx_core::CompiledModel, population: &ferx_core::Population, theta: &[f64], eta_hats: &[nalgebra::base::alias::DVector<f64>], h_matrices: &[nalgebra::base::alias::DMatrix<f64>], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], interaction: bool) -> f64
+pub fn ferx_core::stats::likelihood::foce_population_nll(model: &ferx_core::CompiledModel, population: &ferx_core::Population, theta: &[f64], eta_hats: &[nalgebra::base::alias::DVector<f64>], h_matrices: &[nalgebra::base::alias::DMatrix<f64>], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], residual_correlations: &[ferx_core::ResidualCorrelation], interaction: bool) -> f64
 pub fn ferx_core::stats::likelihood::foce_population_nll_iov(model: &ferx_core::CompiledModel, population: &ferx_core::Population, theta: &[f64], eta_hats: &[nalgebra::base::alias::DVector<f64>], h_matrices: &[nalgebra::base::alias::DMatrix<f64>], kappas_per_subject: &[alloc::vec::Vec<nalgebra::base::alias::DVector<f64>>], omega_bsv: &ferx_core::OmegaMatrix, omega_iov: &ferx_core::OmegaMatrix, sigma_values: &[f64], interaction: bool) -> f64
-pub fn ferx_core::stats::likelihood::foce_subject_nll(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], interaction: bool) -> f64
+pub fn ferx_core::stats::likelihood::foce_subject_nll(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], residual_correlations: &[ferx_core::ResidualCorrelation], interaction: bool) -> f64
 pub fn ferx_core::stats::likelihood::foce_subject_nll_interaction(subject: &ferx_core::Subject, ipreds: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], error_spec: &ferx_core::ErrorSpec, bloq_method: ferx_core::BloqMethod, p_obs: &[f64], frem_r_override: core::option::Option<&[core::option::Option<f64>]>, residual_error_eta: core::option::Option<usize>, ruv_mult: core::option::Option<&[alloc::vec::Vec<f64>]>) -> f64
 pub fn ferx_core::stats::likelihood::foce_subject_nll_interaction_dense(subject: &ferx_core::Subject, ipreds: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], error_spec: &ferx_core::ErrorSpec, correlations: &[ferx_core::ResidualCorrelation], p_obs: &[f64], ruv_mult: core::option::Option<&[alloc::vec::Vec<f64>]>) -> f64
 pub fn ferx_core::stats::likelihood::foce_subject_nll_iov(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega_bsv: &ferx_core::OmegaMatrix, sigma_values: &[f64], interaction: bool, kappas: &[nalgebra::base::alias::DVector<f64>], omega_iov: &ferx_core::OmegaMatrix) -> f64
 pub fn ferx_core::stats::likelihood::foce_subject_nll_standard(subject: &ferx_core::Subject, ipreds: &[f64], eta_hat: &nalgebra::base::alias::DVector<f64>, h_matrix: &nalgebra::base::alias::DMatrix<f64>, omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], error_spec: &ferx_core::ErrorSpec, residual_correlations: &[ferx_core::ResidualCorrelation], bloq_method: ferx_core::BloqMethod, p_obs: &[f64], frem_r_override: core::option::Option<&[core::option::Option<f64>]>, r_pred_override: core::option::Option<&[f64]>, ruv_mult: core::option::Option<&[alloc::vec::Vec<f64>]>) -> f64
 pub fn ferx_core::stats::likelihood::individual_nll(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta: &[f64], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64]) -> f64
 pub fn ferx_core::stats::likelihood::individual_nll_into(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta: &[f64], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], scratch: &mut ferx_core::pk::EventPkParams) -> f64
-pub fn ferx_core::stats::likelihood::individual_nll_into_with_schedule(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta: &[f64], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], scratch: &mut ferx_core::pk::EventPkParams, schedule: core::option::Option<&ferx_core::pk::event_driven::EventSchedule>) -> f64
+pub fn ferx_core::stats::likelihood::individual_nll_into_with_schedule(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta: &[f64], omega: &ferx_core::OmegaMatrix, sigma_values: &[f64], residual_correlations: &[ferx_core::ResidualCorrelation], scratch: &mut ferx_core::pk::EventPkParams, schedule: core::option::Option<&ferx_core::pk::event_driven::EventSchedule>) -> f64
 pub fn ferx_core::stats::likelihood::individual_nll_iov(model: &ferx_core::CompiledModel, subject: &ferx_core::Subject, theta: &[f64], eta: &[f64], kappas: &[alloc::vec::Vec<f64>], omega: &ferx_core::OmegaMatrix, omega_iov: core::option::Option<&ferx_core::OmegaMatrix>, sigma_values: &[f64]) -> f64
 pub fn ferx_core::stats::likelihood::iov_combined_effect(stacked_eta: &[f64], n_eta: usize, n_kappa: usize, g: usize) -> alloc::vec::Vec<f64>
 pub fn ferx_core::stats::likelihood::iov_combined_pk_only(stacked_eta: &[f64], n_eta: usize, n_kappa: usize) -> alloc::vec::Vec<f64>
@@ -2716,6 +2720,7 @@ pub ferx_core::types::FitResult::optimizer: alloc::string::String
 pub ferx_core::types::FitResult::outer_gtol: f64
 pub ferx_core::types::FitResult::outer_maxiter: usize
 pub ferx_core::types::FitResult::packed_estimate: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::types::FitResult::residual_correlation_fixed: alloc::vec::Vec<bool>
 pub ferx_core::types::FitResult::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::types::FitResult::restored_from_checkpoint: bool
 pub ferx_core::types::FitResult::saem_mu_ref_m_step_evals_saved: core::option::Option<u64>
@@ -2723,6 +2728,7 @@ pub ferx_core::types::FitResult::saem_n_subjects_hmc: core::option::Option<usize
 pub ferx_core::types::FitResult::saem_seed: core::option::Option<u64>
 pub ferx_core::types::FitResult::se_kappa: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::types::FitResult::se_omega: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::types::FitResult::se_residual_correlations: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::types::FitResult::se_sigma: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::types::FitResult::se_theta: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::types::FitResult::shrinkage_eps: f64
@@ -2822,6 +2828,8 @@ pub ferx_core::types::ModelParameters::mixture: core::option::Option<ferx_core::
 pub ferx_core::types::ModelParameters::omega: ferx_core::OmegaMatrix
 pub ferx_core::types::ModelParameters::omega_fixed: alloc::vec::Vec<bool>
 pub ferx_core::types::ModelParameters::omega_iov: core::option::Option<ferx_core::OmegaMatrix>
+pub ferx_core::types::ModelParameters::residual_correlation_fixed: alloc::vec::Vec<bool>
+pub ferx_core::types::ModelParameters::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::types::ModelParameters::sigma: ferx_core::SigmaVector
 pub ferx_core::types::ModelParameters::sigma_fixed: alloc::vec::Vec<bool>
 pub ferx_core::types::ModelParameters::theta: alloc::vec::Vec<f64>
@@ -4054,6 +4062,7 @@ pub ferx_core::FitResult::optimizer: alloc::string::String
 pub ferx_core::FitResult::outer_gtol: f64
 pub ferx_core::FitResult::outer_maxiter: usize
 pub ferx_core::FitResult::packed_estimate: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::FitResult::residual_correlation_fixed: alloc::vec::Vec<bool>
 pub ferx_core::FitResult::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::FitResult::restored_from_checkpoint: bool
 pub ferx_core::FitResult::saem_mu_ref_m_step_evals_saved: core::option::Option<u64>
@@ -4061,6 +4070,7 @@ pub ferx_core::FitResult::saem_n_subjects_hmc: core::option::Option<usize>
 pub ferx_core::FitResult::saem_seed: core::option::Option<u64>
 pub ferx_core::FitResult::se_kappa: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::FitResult::se_omega: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::FitResult::se_residual_correlations: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::FitResult::se_sigma: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::FitResult::se_theta: core::option::Option<alloc::vec::Vec<f64>>
 pub ferx_core::FitResult::shrinkage_eps: f64
@@ -4178,6 +4188,8 @@ pub ferx_core::ModelParameters::mixture: core::option::Option<ferx_core::Mixture
 pub ferx_core::ModelParameters::omega: ferx_core::OmegaMatrix
 pub ferx_core::ModelParameters::omega_fixed: alloc::vec::Vec<bool>
 pub ferx_core::ModelParameters::omega_iov: core::option::Option<ferx_core::OmegaMatrix>
+pub ferx_core::ModelParameters::residual_correlation_fixed: alloc::vec::Vec<bool>
+pub ferx_core::ModelParameters::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::ModelParameters::sigma: ferx_core::SigmaVector
 pub ferx_core::ModelParameters::sigma_fixed: alloc::vec::Vec<bool>
 pub ferx_core::ModelParameters::theta: alloc::vec::Vec<f64>

--- a/crates/ferx-tools/src/bootstrap/mod_tests.rs
+++ b/crates/ferx-tools/src/bootstrap/mod_tests.rs
@@ -16,6 +16,8 @@ fn template(diagonal: bool) -> ModelParameters {
     }
     let free = DMatrix::from_fn(2, 2, |i, j| diagonal == (i == j) || i == j);
     ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![1.0, 2.0],
         theta_names: vec!["CL".to_string(), "V".to_string()],
         theta_fixed: vec![false, false],

--- a/docs/.lint-baseline
+++ b/docs/.lint-baseline
@@ -12,6 +12,5 @@ R1 5802 docs/estimation/saem.qmd::what-saem-does-about-it-now
 R1 5239 docs/estimation/tte.qmd::competing-risks-cause-specific-hazards
 R1 7642 docs/model-file/adaptive-dosing.qmd::current-scope-and-limits
 R1 6006 docs/model-file/error-model.qmd::covariate-selected-error-models-ifelse
-R1 7367 docs/model-file/error-model.qmd::examples
 R1 5746 docs/model-file/scaling.qmd::interaction-with-gradients
 R1 7391 docs/warnings.qmd::warning-codes

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -728,6 +728,16 @@ under `method = foce` / `method = focei` (the EKF variance is added to the dense
 `R`) but are rejected under `method = saem`, whose M-step data term does not yet
 include the process-noise inflation.
 
+An **estimated** correlation additionally restricts method *chains*. Only `foce`
+and `focei` estimate the off-diagonal; the other supported estimators read it
+from the model declaration. Because each chain stage starts from the previous
+stage's estimates, a chain that runs `foce`/`focei` **before** a non-estimating
+stage would leave that stage scoring the declared correlation while the fit
+reported the estimated one, so it is rejected with
+`E_BLOCK_SIGMA_CHAIN_UNSUPPORTED`. `method = [saem, focei]` is fine (the
+correlation has not moved when SAEM runs); `method = [focei, imp]` is not, unless
+the block carries `FIX`.
+
 `simulate()` draws the full residual vector for each subject's paired
 observations (same subject time and occasion) from the dense covariance `R`
 built by `compute_r_matrix_with_correlations` — the same matrix FOCE/FOCEI/SAEM/

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -698,9 +698,11 @@ scale, via the delta method: `SE(rho) = SE(z) * (1 - rho^2)`.
 
 ::: {.callout-warning title="Changed in #847"}
 Before this change every `block_sigma` off-diagonal was held fixed regardless of
-`FIX`. A model written against the old behaviour that relied on a bare
-`block_sigma` keeping its declared correlation needs `FIX` added to reproduce its
-previous results.
+`FIX`, while the diagonal SDs were estimated. That combination is no longer
+expressible — NONMEM has no form for it either, and it is exactly the mismatch
+this change removes. Adding `FIX` to an existing bare `block_sigma` reproduces
+the old *correlation*, but it also pins the SDs the old form estimated, so it is
+not a drop-in way to reproduce an old fit's numbers. Re-run and compare instead.
 :::
 
 ### Which sigmas a `block_sigma` may correlate

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -690,11 +690,22 @@ holds the whole block — SDs and correlation alike — at its declared value:
 ```
 
 An estimated correlation is optimized as its Fisher-z transform `z = atanh(rho)`,
-bounded at `|z| <= 6`. That keeps `rho` strictly inside `(-1, 1)` for every step
-the optimizer can take, so the residual covariance never goes singular from the
-correlation alone, and it removes the boundary that a raw `rho` coordinate would
-have to be clamped against. The reported standard error is on the natural `rho`
-scale, via the delta method: `SE(rho) = SE(z) * (1 - rho^2)`.
+bounded at `|z| <= 3`, i.e. `|rho| <= 0.995`. Strict positive-definiteness is not
+a strong enough bound: a paired residual block's determinant carries a factor
+`1 - rho^2`, so a rho merely *inside* `(-1, 1)` can still leave `R` numerically
+singular and let the likelihood chase `log|R|` downwards. At `|rho| = 0.995` that
+factor is about `0.01`, which keeps `R` invertible in floating point. A fit that
+reports rho sitting on this rail is telling you the two endpoints are carrying
+the same noise — treat it as a diagnostic, not an estimate.
+
+The reported standard error is on the natural `rho` scale, via the delta method:
+`SE(rho) = SE(z) * (1 - rho^2)`.
+
+A zero off-diagonal in a non-`FIX` block still declares an estimated correlation,
+so `block_sigma (A, B) = [0.04, 0.0, 1.0]` — the natural translation of a NONMEM
+`$SIGMA BLOCK(2)` with a zero covariance init — starts at `rho = 0` and is free
+to move. Adding `FIX` to a zero off-diagonal drops it, since a fixed zero
+correlation is the same object as no correlation.
 
 ::: {.callout-warning title="Changed in #847"}
 Before this change every `block_sigma` off-diagonal was held fixed regardless of
@@ -728,15 +739,21 @@ under `method = foce` / `method = focei` (the EKF variance is added to the dense
 `R`) but are rejected under `method = saem`, whose M-step data term does not yet
 include the process-noise inflation.
 
-An **estimated** correlation additionally restricts method *chains*. Only `foce`
-and `focei` estimate the off-diagonal; the other supported estimators read it
-from the model declaration. Because each chain stage starts from the previous
+An estimated correlation is also why `method = laplace` (and `focei` with
+`n_agq > 1`) falls back to the reconverged finite-difference outer gradient: the
+AGQ score has no rho block, so it is declined rather than reporting a zero
+gradient for a coordinate the objective actually depends on. Fits are correct,
+just slower. A `FIX`ed block keeps the analytic score.
+
+An **estimated** correlation additionally restricts method *chains*. Only `foce`,
+`focei` and `laplace` move the off-diagonal; the other supported estimators read
+it from the model declaration. Because each chain stage starts from the previous
 stage's estimates, a chain that runs `foce`/`focei` **before** a non-estimating
 stage would leave that stage scoring the declared correlation while the fit
 reported the estimated one, so it is rejected with
 `E_BLOCK_SIGMA_CHAIN_UNSUPPORTED`. `method = [saem, focei]` is fine (the
-correlation has not moved when SAEM runs); `method = [focei, imp]` is not, unless
-the block carries `FIX`.
+correlation has not moved when SAEM runs); `method = [focei, imp]` and
+`method = [laplace, imp]` are not, unless the block carries `FIX`.
 
 `simulate()` draws the full residual vector for each subject's paired
 observations (same subject time and occasion) from the dense covariance `R`

--- a/docs/model-file/error-model.qmd
+++ b/docs/model-file/error-model.qmd
@@ -652,7 +652,8 @@ Combined error:
   DV ~ combined(PROP_ERR, ADD_ERR)
 ```
 
-Correlated combined error:
+Correlated combined error (here with the whole block held fixed — drop `FIX` to
+estimate the correlation, see [Fixed vs. estimated `block_sigma`](#fixed-vs-estimated-block-sigma)):
 ```
 [parameters]
   block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
@@ -673,8 +674,38 @@ V = (f \sigma_\mathrm{prop})^2 + \sigma_\mathrm{add}^2
     + 2 f \rho \sigma_\mathrm{prop}\sigma_\mathrm{add}
 $$
 
-The diagonal sigma SDs are estimated unless marked `FIX`; the off-diagonal
-covariance is always converted to a fixed correlation. A nonzero `block_sigma`
+### Fixed vs. estimated `block_sigma` {#fixed-vs-estimated-block-sigma}
+
+A plain `block_sigma (...) = [...]` **estimates** both the diagonal sigma SDs and
+the off-diagonal correlation, matching NONMEM `$SIGMA BLOCK(n)`. Appending `FIX`
+holds the whole block — SDs and correlation alike — at its declared value:
+
+```
+[parameters]
+  # rho is estimated (NONMEM $SIGMA BLOCK semantics)
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00]
+
+  # rho is held at 0.5, and both SDs at 0.2 / 1.0
+  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00] FIX
+```
+
+An estimated correlation is optimized as its Fisher-z transform `z = atanh(rho)`,
+bounded at `|z| <= 6`. That keeps `rho` strictly inside `(-1, 1)` for every step
+the optimizer can take, so the residual covariance never goes singular from the
+correlation alone, and it removes the boundary that a raw `rho` coordinate would
+have to be clamped against. The reported standard error is on the natural `rho`
+scale, via the delta method: `SE(rho) = SE(z) * (1 - rho^2)`.
+
+::: {.callout-warning title="Changed in #847"}
+Before this change every `block_sigma` off-diagonal was held fixed regardless of
+`FIX`. A model written against the old behaviour that relied on a bare
+`block_sigma` keeping its declared correlation needs `FIX` added to reproduce its
+previous results.
+:::
+
+### Which sigmas a `block_sigma` may correlate
+
+A nonzero `block_sigma`
 covariance can connect sigmas that co-load on the same `combined(...)` endpoint,
 or sigmas used by different endpoints measured at the same subject time and
 occasion — whether those endpoints are selected by the CMT column (per-CMT) or
@@ -682,6 +713,8 @@ by a covariate `if/else` selector (#669). In the cross-endpoint case ferx builds
 a subject-level residual covariance matrix, so paired rows such as total/unbound
 assays receive the NONMEM-style covariance term
 `f_total * f_unbound * Cov(EPS_total, EPS_unbound)`.
+
+### Estimator and feature scope
 
 Current scope: `block_sigma` is supported for the Gaussian `method = foce`,
 `method = focei`, `method = saem`, and `method = imp` fits. The Gauss-Newton
@@ -703,18 +736,23 @@ correlated endpoints recovers the specified correlation (#672). FREM covariate
 pseudo-observations are excluded from the correlated draw (mirroring the
 identical exclusion in the likelihood) and stay independent.
 
-The fixed correlations are copied to `FitResult.residual_correlations`, so the
-residual covariance assumed by a fit remains available without re-reading the
-model source. The human-readable fit YAML also emits a `block_sigma` section
-with each named pair's covariance and declared correlation:
+### Reporting a fitted `block_sigma`
+
+The fitted correlations are carried on `FitResult.residual_correlations`, their
+`FIX` flags on `FitResult.residual_correlation_fixed`, and their standard errors
+on `FitResult.se_residual_correlations`, so the residual covariance a fit
+actually used remains available without re-reading the model source. The
+human-readable fit YAML also emits a `block_sigma` section with each named pair's
+covariance, correlation, and correlation SE:
 
 ```yaml
 block_sigma:
   ADD_ERR__PROP_ERR:
-    covariance: 0.100000
+    covariance: 0.186600
     covariance_fixed: false
-    correlation: 0.500000
-    correlation_fixed: true
+    correlation: 0.933000
+    correlation_fixed: false
+    correlation_se: 0.021400
 ```
 
 `covariance` is the **sigma-scale** covariance `rho * sigma_i * sigma_j`, the
@@ -723,10 +761,13 @@ residual covariance matrix `R`. Each observation applies its own sigma loadings
 first, so the `R` term is `c_j * c_k * rho * sigma_i * sigma_j` with `c = 1`
 for an additive component and `c = f` (the individual prediction) for a
 proportional one — the `f_total * f_unbound * Cov(EPS_total, EPS_unbound)` form
-above. `correlation_fixed` is always `true` (the off-diagonal is converted to a
-fixed correlation); `covariance_fixed` is `true` only when both sigma SDs in
-the pair were declared `FIX`, since otherwise the SDs — and hence the
-covariance — moved during estimation.
+above. `correlation_fixed` is `true` only for a `FIX`ed block; `covariance_fixed`
+is `true` only when the correlation **and** both sigma SDs in the pair are
+fixed, since a free value in any of the three factors moves the covariance during
+estimation. `correlation_se` is `~` for a fixed correlation and for a fit whose
+covariance step did not run.
+
+### The interaction correction under a correlated `R`
 
 Under `method = focei` the off-diagonal covariance enters the interaction
 correction as well as the data term: the Almquist 2015 conditional Hessian

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1912,6 +1912,8 @@ fn fit_inner(
     // Extract SEs from covariance matrix using converged parameter values
     let (se_theta, se_omega, se_sigma, se_kappa) =
         extract_standard_errors(&result.covariance_matrix, &result.params);
+    let se_residual_correlations =
+        extract_residual_correlation_se(&result.covariance_matrix, &result.params);
 
     // Optional SIR step
     let mut warnings = result.warnings;
@@ -2339,7 +2341,11 @@ fn fit_inner(
         omega: result.params.omega.matrix.clone(),
         sigma: result.params.sigma.values.clone(),
         sigma_names: result.params.sigma.names.clone(),
-        residual_correlations: model.residual_correlations.clone(),
+        // The **fitted** correlations, not the model's declaration: a non-`FIX`
+        // `block_sigma` estimates its off-diagonal (#847), so reading these off
+        // `model` would report the initial value as if it were the estimate.
+        residual_correlations: result.params.residual_correlations.clone(),
+        residual_correlation_fixed: result.params.residual_correlation_fixed.clone(),
         error_model: model.error_model,
         covariance_matrix: result.covariance_matrix,
         // The optimizer's exact packed vector (FOCE/FOCEI paths), so a later
@@ -2349,6 +2355,7 @@ fn fit_inner(
         se_theta,
         se_omega,
         se_sigma,
+        se_residual_correlations,
         theta_fixed: result.params.theta_fixed.clone(),
         omega_fixed: result.params.omega_fixed.clone(),
         sigma_fixed: result.params.sigma_fixed.clone(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -61,12 +61,12 @@ pub(crate) use postfit::{
     absorption_flip_flop_ebe_warning, boundary_estimate_warning, compute_eps_shrinkage,
     compute_eta_shrinkage, compute_kappa_shrinkage, compute_kappa_shrinkage_by_occ,
     compute_param_corr, compute_subject_results, cov_diagnostics, covariate_relation_estimates,
-    eps_shrinkage_warning, eta_shrinkage_warning, extract_standard_errors,
-    high_correlation_warning, inflated_rse_warning, integrates_odes, is_last_estimating_stage,
-    kappa_weight_typicals, keep_gn_zero_eta_warning, ode_solver_diagnostics_warning,
-    probe_nlopt_algorithms, rebuild_warnings_structured, resolve_covariance_status,
-    resolve_sir_fallback, runaway_guard_warning, sir_unavailable_warning,
-    sweep_sensitivity_solver_stats,
+    eps_shrinkage_warning, eta_shrinkage_warning, extract_residual_correlation_se,
+    extract_standard_errors, high_correlation_warning, inflated_rse_warning, integrates_odes,
+    is_last_estimating_stage, kappa_weight_typicals, keep_gn_zero_eta_warning,
+    ode_solver_diagnostics_warning, probe_nlopt_algorithms, rebuild_warnings_structured,
+    resolve_covariance_status, resolve_sir_fallback, runaway_guard_warning,
+    sir_unavailable_warning, sweep_sensitivity_solver_stats,
 };
 pub use predict::{predict, PredictionResult};
 #[cfg(feature = "survival")]

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -666,7 +666,8 @@ pub(crate) fn compute_subject_results(
                 model.error_spec.obs_keys(subject).as_ref(),
                 &model.error_spec,
                 &params.sigma.values,
-                &model.residual_correlations,
+                // The fitted correlations, not the declaration (#847).
+                &params.residual_correlations,
                 ruv_mult.as_deref(),
             );
             // IIV on residual error (#409): the individual residual SD is scaled
@@ -700,7 +701,7 @@ pub(crate) fn compute_subject_results(
                 &params.omega,
                 &params.sigma.values,
                 &model.error_spec,
-                &model.residual_correlations,
+                &params.residual_correlations,
                 frem_r_override.as_deref(),
                 model.residual_error_eta,
                 ruv_mult.as_deref(),
@@ -733,6 +734,7 @@ pub(crate) fn compute_subject_results(
                     h,
                     &params.omega,
                     &params.sigma.values,
+                    &params.residual_correlations,
                     interaction,
                 )
             };

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -5,7 +5,8 @@ use super::*;
 use crate::diagnostics::{first_error, CheckReport, Diagnostic};
 use crate::estimation::outer_optimizer::optimize_population;
 use crate::estimation::parameterization::{
-    chol_lt_idx, lower_tri_iter, omega_packed_len, theta_packs_log, PackedCoordKind,
+    chol_lt_idx, lower_tri_iter, omega_packed_len, rho_chain, rho_packed_start, theta_packs_log,
+    PackedCoordKind,
 };
 use crate::estimation::saem;
 use crate::io::datareader::{
@@ -2205,4 +2206,49 @@ pub(crate) fn extract_standard_errors(
     });
 
     (Some(se_theta), Some(se_omega), Some(se_sigma), se_kappa)
+}
+
+/// Standard errors for the estimated `block_sigma` correlations (#847), on the
+/// natural ρ scale.
+///
+/// Kept apart from [`extract_standard_errors`] rather than widening its tuple:
+/// the ρ block is packed **last** (after Ω_IOV and the mixture overrides), so it
+/// needs its own offset — [`rho_packed_start`] — and none of that tuple's
+/// existing offsets.
+///
+/// The packed coordinate is the Fisher-z `z = atanh(ρ)`, so the delta method
+/// gives `SE(ρ) = SE(z)·|dρ/dz| = SE(z)·(1 − ρ²)`. A `FIX`ed correlation is
+/// excluded from the reduced-Hessian free set and reports `0.0`, exactly like a
+/// pinned theta/omega/sigma.
+pub(crate) fn extract_residual_correlation_se(
+    cov: &Option<DMatrix<f64>>,
+    template: &ModelParameters,
+) -> Option<Vec<f64>> {
+    if template.residual_correlations.is_empty() {
+        return None;
+    }
+    let cov = cov.as_ref()?;
+    let n = cov.nrows();
+    let start = rho_packed_start(template);
+    Some(
+        template
+            .residual_correlations
+            .iter()
+            .enumerate()
+            .map(|(k, corr)| {
+                let idx = start + k;
+                // Guard a truncated `cov` the same way the theta/omega/sigma
+                // branches above do — report 0.0, never panic away a fit.
+                if idx >= n {
+                    return 0.0;
+                }
+                let var = cov[(idx, idx)];
+                if var > 0.0 {
+                    var.sqrt() * rho_chain(corr.rho)
+                } else {
+                    0.0
+                }
+            })
+            .collect(),
+    )
 }

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -669,11 +669,23 @@ fn emit_subject_rows<R: rand::Rng>(
     // so reading `model.residual_correlations` here would draw residuals at the
     // declared rho while using the fitted sigmas — exactly the mismatch that
     // would make a VPC of an estimated `block_sigma` fail to reproduce it.
-    if !params.residual_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
+    // Prefer the parameter vector's correlations, falling back to the model's
+    // declaration when a caller supplied a `ModelParameters` without them (a
+    // hand-built one, or an artifact predating the field). Dropping a declared
+    // `block_sigma` silently — independent draws for a model that asks for
+    // correlated ones — is the worse of the two failures.
+    let draw_correlations: &[crate::types::ResidualCorrelation] =
+        if params.residual_correlations.is_empty() {
+            &model.residual_correlations
+        } else {
+            &params.residual_correlations
+        };
+    if !draw_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
         emit_correlated_residual_rows(
             model,
             subject,
             params,
+            draw_correlations,
             &ipreds,
             ruv_scale,
             ruv_mult.as_deref(),
@@ -757,10 +769,13 @@ fn emit_subject_rows<R: rand::Rng>(
 /// draw instead of a Cholesky panic. Subjects whose R is diagonal (no paired
 /// rows) take a cheap per-row draw and skip the factorization entirely.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_correlated_residual_rows<R: rand::Rng>(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
+    /* live correlations, resolved by the caller */
+    correlations: &[crate::types::ResidualCorrelation],
     ipreds: &[f64],
     ruv_scale: f64,
     ruv_mult: Option<&[Vec<f64>]>,
@@ -781,7 +796,7 @@ pub(crate) fn emit_correlated_residual_rows<R: rand::Rng>(
             &subject.occasions,
             &subject.obs_l2,
             &params.sigma.values,
-            &params.residual_correlations,
+            correlations,
             mult,
         ),
         None => compute_r_matrix_with_correlations(
@@ -793,7 +808,7 @@ pub(crate) fn emit_correlated_residual_rows<R: rand::Rng>(
             &subject.occasions,
             &subject.obs_l2,
             &params.sigma.values,
-            &params.residual_correlations,
+            correlations,
         ),
     };
     if ruv_scale != 1.0 {

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -665,7 +665,11 @@ fn emit_subject_rows<R: rand::Rng>(
     // `block_sigma` + M3 model is rejected at fit by `check_model_options`
     // regardless, so the two paths can only differ on an unfitted fixed model.)
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
-    if !model.residual_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
+    // The **live** correlations (#847). `params` is the fitted (or drawn) vector,
+    // so reading `model.residual_correlations` here would draw residuals at the
+    // declared rho while using the fitted sigmas — exactly the mismatch that
+    // would make a VPC of an estimated `block_sigma` fail to reproduce it.
+    if !params.residual_correlations.is_empty() && !has_frem_rows && !ipreds.is_empty() {
         emit_correlated_residual_rows(
             model,
             subject,
@@ -777,7 +781,7 @@ pub(crate) fn emit_correlated_residual_rows<R: rand::Rng>(
             &subject.occasions,
             &subject.obs_l2,
             &params.sigma.values,
-            &model.residual_correlations,
+            &params.residual_correlations,
             mult,
         ),
         None => compute_r_matrix_with_correlations(
@@ -789,7 +793,7 @@ pub(crate) fn emit_correlated_residual_rows<R: rand::Rng>(
             &subject.occasions,
             &subject.obs_l2,
             &params.sigma.values,
-            &model.residual_correlations,
+            &params.residual_correlations,
         ),
     };
     if ruv_scale != 1.0 {

--- a/src/api/tests/extract_se_tests.rs
+++ b/src/api/tests/extract_se_tests.rs
@@ -8,6 +8,8 @@ use nalgebra::DMatrix;
 fn make_template(omega_iov: Option<OmegaMatrix>, kappa_fixed: Vec<bool>) -> ModelParameters {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["TVCL".into()],
         theta_lower: vec![0.1],
@@ -40,6 +42,8 @@ fn test_se_omega_block_n3_full_lower_triangle() {
     mat[(2, 2)] = 0.16;
     let omega = OmegaMatrix::from_matrix(mat, vec!["E1".into(), "E2".into(), "E3".into()], false);
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["TVCL".into()],
         theta_lower: vec![0.1],
@@ -103,6 +107,8 @@ fn test_se_omega_block_offdiag_positive() {
     mat[(1, 0)] = 0.02;
     let omega = OmegaMatrix::from_matrix(mat, vec!["E1".into(), "E2".into()], false);
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["TVCL".into()],
         theta_lower: vec![0.1],
@@ -142,6 +148,8 @@ fn test_se_omega_block_offdiag_positive() {
 fn test_se_omega_diagonal_unchanged() {
     let omega = OmegaMatrix::from_diagonal(&[0.04, 0.09], vec!["E1".into(), "E2".into()]);
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["TVCL".into()],
         theta_lower: vec![0.1],
@@ -179,6 +187,8 @@ fn test_se_theta_respects_packing_scale() {
     // theta[1] = BETA, lower -10 < 0   → identity-packed (can be negative)
     let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["E1".into()]);
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![2.0, 0.25],
         theta_names: vec!["TVCL".into(), "BETA".into()],
         theta_lower: vec![0.1, -10.0],

--- a/src/api/tests/extract_se_tests.rs
+++ b/src/api/tests/extract_se_tests.rs
@@ -294,3 +294,76 @@ fn test_se_kappa_none_when_no_cov() {
     let (_, _, _, se_kappa) = extract_standard_errors(&None, &template);
     assert!(se_kappa.is_none());
 }
+
+// ── block_sigma residual correlations (#847) ─────────────────────────────
+
+/// #847: the ρ coordinate is packed **last** — after Ω_IOV — so its SE must be
+/// read at `rho_packed_start`, not at an offset derived from
+/// n_theta/n_omega/n_sigma. This template carries an IOV block precisely so a
+/// slot-counting mistake lands on a kappa coordinate and shows up here.
+#[test]
+fn test_se_residual_correlation_uses_the_trailing_rho_slot() {
+    use super::extract_residual_correlation_se;
+
+    let iov = OmegaMatrix::from_diagonal(&[0.02], vec!["KAPPA_CL".into()]);
+    let mut template = make_template(Some(iov), vec![false]);
+    template.sigma = SigmaVector {
+        values: vec![0.3, 1.0],
+        names: vec!["PROP_ERR".into(), "ADD_ERR".into()],
+    };
+    template.sigma_fixed = vec![false; 2];
+    let rho = 0.6_f64;
+    template.residual_correlations = vec![ResidualCorrelation {
+        sigma_i: 1,
+        sigma_j: 0,
+        rho,
+    }];
+    template.residual_correlation_fixed = vec![false];
+
+    // 1 theta + 1 omega + 2 sigma + 1 kappa + 1 rho = 6, rho last.
+    let n = 6;
+    let mut cov = DMatrix::<f64>::zeros(n, n);
+    // A distinct variance in every slot, so reading the wrong one is visible.
+    for i in 0..n {
+        cov[(i, i)] = 0.01 * (i + 1) as f64;
+    }
+    let se = extract_residual_correlation_se(&Some(cov), &template).expect("rho SE");
+    assert_eq!(se.len(), 1);
+    // Delta method on the Fisher-z coordinate: SE(ρ) = SE(z)·(1 − ρ²).
+    let expected = (0.01 * 6.0_f64).sqrt() * (1.0 - rho * rho);
+    approx::assert_relative_eq!(se[0], expected, max_relative = 1e-12);
+}
+
+/// No correlations declared → no SE vector at all, rather than an empty one.
+#[test]
+fn test_se_residual_correlation_none_without_block_sigma() {
+    use super::extract_residual_correlation_se;
+
+    let template = make_template(None, Vec::new());
+    let cov = DMatrix::<f64>::identity(3, 3);
+    assert!(extract_residual_correlation_se(&Some(cov), &template).is_none());
+}
+
+/// A covariance matrix truncated below the ρ slot reports 0.0 rather than
+/// panicking a converged fit away — matching every other `se_*` branch.
+#[test]
+fn test_se_residual_correlation_truncated_cov_reports_zero() {
+    use super::extract_residual_correlation_se;
+
+    let mut template = make_template(None, Vec::new());
+    template.sigma = SigmaVector {
+        values: vec![0.3, 1.0],
+        names: vec!["PROP_ERR".into(), "ADD_ERR".into()],
+    };
+    template.sigma_fixed = vec![false; 2];
+    template.residual_correlations = vec![ResidualCorrelation {
+        sigma_i: 1,
+        sigma_j: 0,
+        rho: 0.4,
+    }];
+    template.residual_correlation_fixed = vec![false];
+    // Packed length is 5; hand it a 3×3.
+    let cov = DMatrix::<f64>::identity(3, 3);
+    let se = extract_residual_correlation_se(&Some(cov), &template).expect("rho SE");
+    assert_eq!(se, vec![0.0]);
+}

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -1784,11 +1784,17 @@ fn test_simulate_zero_rho_matches_diagonal_draw_path() {
 #[test]
 fn test_simulate_singular_rho_one_does_not_panic() {
     let (mut model, population) = block_sigma_selected_model_and_population();
-    model.residual_correlations = vec![crate::types::ResidualCorrelation {
+    let singular = vec![crate::types::ResidualCorrelation {
         sigma_i: 0,
         sigma_j: 1,
         rho: 1.0,
     }];
+    // `simulate` draws from the **parameter vector's** correlations since #847
+    // (so a VPC of an estimated `block_sigma` reproduces the fitted rho), so the
+    // singular value has to be set there; the model copy is kept in step because
+    // the two must agree for every other consumer.
+    model.residual_correlations = singular.clone();
+    model.default_params.residual_correlations = singular;
 
     let n_sim = 20_000;
     let results = simulate_with_seed(&model, &population, &model.default_params, n_sim, 11);

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -10,6 +10,8 @@ fn make_iov_model() -> CompiledModel {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -1848,6 +1848,7 @@ fn test_emit_correlated_residual_rows_magnitude_and_scale_paths() {
         &model,
         subject,
         &model.default_params,
+        &model.default_params.residual_correlations,
         &ipreds,
         2.0, // ruv_scale != 1.0
         Some(&mult),

--- a/src/api/tests/multi_start_tests.rs
+++ b/src/api/tests/multi_start_tests.rs
@@ -5,6 +5,8 @@ use crate::types::{FitOptions, ModelParameters, OmegaMatrix, SigmaVector};
 fn make_params(theta: Vec<f64>, theta_lower: Vec<f64>, theta_upper: Vec<f64>) -> ModelParameters {
     let n = theta.len();
     ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta,
         theta_names: (0..n).map(|i| format!("T{i}")).collect(),
         theta_lower,

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 fn tiny_model() -> CompiledModel {
     let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["ETA_CL".into()]);
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],
@@ -391,6 +393,8 @@ fn synthetic_fit(template: &ModelParameters) -> FitResult {
     let n_packed = crate::estimation::parameterization::packed_len(template);
     let cov = DMatrix::identity(n_packed, n_packed) * 0.01;
     FitResult {
+        residual_correlation_fixed: Vec::new(),
+        se_residual_correlations: None,
         covariate_relations: Vec::new(),
         restored_from_checkpoint: false,
         method: EstimationMethod::FoceI,

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -50,6 +50,8 @@ fn minimal_iov_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
         indiv_param_names: vec!["CL".into()],
         indiv_param_partials: IndivParamPartials::empty(),
         default_params: ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: Vec::new(),
             theta_names: Vec::new(),
             theta_lower: Vec::new(),

--- a/src/api/tests/tests_derived_session_clock.rs
+++ b/src/api/tests/tests_derived_session_clock.rs
@@ -38,6 +38,8 @@ fn minimal_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
         indiv_param_names: Vec::new(),
         indiv_param_partials: IndivParamPartials::empty(),
         default_params: ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: Vec::new(),
             theta_names: Vec::new(),
             theta_lower: Vec::new(),

--- a/src/api/tests/tests_sdtab_tv_cov.rs
+++ b/src/api/tests/tests_sdtab_tv_cov.rs
@@ -30,6 +30,8 @@ fn test_sdtab_ipred_honours_tv_covariates() {
     // ── Minimal CompiledModel: 1-cpt IV bolus, CL scaled by per-event WT ──
     let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["ETA_CL".into()]);
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0], // TVCL = 5, TVV = 50
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],
@@ -374,6 +376,8 @@ fn test_sdtab_iwres_uses_block_sigma_correlation() {
 #[test]
 fn test_simulate_honours_tv_covariates() {
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2833,6 +2833,40 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
                 break;
             }
         }
+        // #847: only FOCE/FOCEI estimate the `block_sigma` off-diagonal. A chain
+        // that runs one of those *before* a stage that cannot — SAEM, IMP,
+        // IMPMAP, AGQ, Laplace, VI — hands that stage a rho it has no channel to
+        // read: `fit()` forwards the fitted `ModelParameters` to the next stage,
+        // but those estimators' data term (`obs_nll_subject_*`) sources rho from
+        // the frozen `CompiledModel`, so they would silently score the
+        // *declared* correlation while reporting the estimated one. Refuse the
+        // configuration rather than mis-score it. `FIX` makes the two agree by
+        // construction, and a non-estimating stage placed *first* is fine — rho
+        // has not moved yet.
+        let estimates_rho =
+            |m: &EstimationMethod| matches!(m, EstimationMethod::Foce | EstimationMethod::FoceI);
+        let rho_fixed = &model.default_params.residual_correlation_fixed;
+        let free_rho = rho_fixed.iter().any(|&f| !f) || rho_fixed.is_empty();
+        if free_rho {
+            if let Some(first) = chain.iter().position(estimates_rho) {
+                if let Some(later) = chain.iter().skip(first + 1).find(|m| !estimates_rho(m)) {
+                    diags.push(
+                        Diagnostic::error(
+                            "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED",
+                            format!(
+                                "method = {:?} follows an estimator that estimates the \
+                                 block_sigma off-diagonal, but it cannot read the estimated \
+                                 correlation and would score the declared one instead. Add FIX \
+                                 to the block_sigma declaration to hold the correlation for the \
+                                 whole chain, put the non-estimating stage first, or drop it.",
+                                later
+                            ),
+                        )
+                        .with_block("fit_options"),
+                    );
+                }
+            }
+        }
         if matches!(model.bloq_method, BloqMethod::M3) {
             diags.push(
                 Diagnostic::error(

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -2843,10 +2843,25 @@ pub fn check_model_options(model: &CompiledModel, options: &FitOptions) -> Vec<D
         // configuration rather than mis-score it. `FIX` makes the two agree by
         // construction, and a non-estimating stage placed *first* is fine — rho
         // has not moved yet.
-        let estimates_rho =
-            |m: &EstimationMethod| matches!(m, EstimationMethod::Foce | EstimationMethod::FoceI);
+        // Which stages can move rho. Packing is method-independent — rho is a free
+        // packed coordinate for *every* outer-optimizer estimator — so this is the
+        // set that runs the outer optimizer at all, not just the two with an
+        // analytic rho gradient. `laplace` (and `focei` with `n_agq > 1`) reach it
+        // through AGQ's reconverged-FD fallback, which differences every free
+        // coordinate including rho.
+        let estimates_rho = |m: &EstimationMethod| {
+            matches!(
+                m,
+                EstimationMethod::Foce | EstimationMethod::FoceI | EstimationMethod::Laplace
+            )
+        };
+        // A correlation is free unless its FIX flag says otherwise. An empty flag
+        // vector means the caller built `ModelParameters` by hand without them, in
+        // which case `packed_fixed_mask`'s own `unwrap_or(false)` packs rho free —
+        // so treat that as free here too rather than letting the two disagree.
         let rho_fixed = &model.default_params.residual_correlation_fixed;
-        let free_rho = rho_fixed.iter().any(|&f| !f) || rho_fixed.is_empty();
+        let free_rho = rho_fixed.iter().any(|&f| !f)
+            || (rho_fixed.is_empty() && !model.residual_correlations.is_empty());
         if free_rho {
             if let Some(first) = chain.iter().position(estimates_rho) {
                 if let Some(later) = chain.iter().skip(first + 1).find(|m| !estimates_rho(m)) {

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -167,6 +167,8 @@ fn build_warfarin_model() -> CompiledModel {
         names: vec!["PROP_ERR".into()],
     };
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![0.134, 8.1, 1.0],
         theta_names: theta_names.clone(),
         theta_lower: vec![0.001, 0.1, 0.01],
@@ -263,6 +265,8 @@ fn build_warfarin_model() -> CompiledModel {
 
 fn build_warfarin_true_params() -> ModelParameters {
     ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![0.134, 8.1, 1.0],
         theta_names: vec!["TVCL".into(), "TVV".into(), "TVKA".into()],
         theta_lower: vec![0.001, 0.1, 0.01],
@@ -301,6 +305,8 @@ fn generate_two_cpt_iv() {
         names: vec!["PROP_ERR".into()],
     };
     let params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 15.0, 3.0, 30.0],
         theta_names: theta_names.clone(),
         theta_lower: vec![0.1, 1.0, 0.01, 1.0],
@@ -427,6 +433,8 @@ fn generate_two_cpt_oral_cov() {
         names: vec!["PROP_ERR".into()],
     };
     let params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0, 10.0, 100.0, 1.2, 0.75, 0.50],
         theta_names: theta_names.clone(),
         theta_lower: vec![0.1, 1.0, 0.1, 1.0, 0.01, 0.01, 0.01],
@@ -619,6 +627,8 @@ fn generate_mm_oral() {
         names: vec!["PROP_ERR".into()],
     };
     let params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![4.0, 6.0, 12.0, 1.5],
         theta_names: theta_names.clone(),
         theta_lower: vec![0.1, 0.1, 1.0, 0.05],

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -756,8 +756,25 @@ pub fn analytic_gradient_available(model: &CompiledModel) -> bool {
     // Kept as a predicate (rather than inlining `true`) so a future model class that genuinely
     // cannot supply `∂nll/∂x` at fixed η has one place to opt out; `population_gradient`'s
     // `reconverged_fd_gradient` fallback stays wired up behind it.
-    let _ = model;
-    true
+    //
+    // #847: an **estimated** `block_sigma` off-diagonal is exactly such a class. The AGQ score
+    // assembles θ / Ω / σ / Ω_iov blocks and nothing else — neither
+    // `accumulate_fixed_eta_packed_gradient` nor the fixed-b FD salvage
+    // (`accumulate_fixed_b_packed_gradient_fd`, which differences only the θ and σ coordinates)
+    // writes the trailing ρ slot. The quadrature objective *does* depend on ρ (`Stack::nll_at`
+    // scores at `params.residual_correlations`), so returning a gradient with a hard zero
+    // there would leave the optimizer no reason to move ρ and let it report convergence at a
+    // point that is not stationary in it. Declining sends AGQ/Laplace to
+    // `reconverged_fd_gradient`, which differences every free packed coordinate — slower, and
+    // correct. A `FIX`ed block is unaffected: its ρ carries no free coordinate to miss.
+    //
+    // Extending the score with a ρ block is tracked in #1216 alongside the estimator-threading
+    // work; until then this is the loud fallback CLAUDE.md asks a scope gap to take.
+    !model
+        .default_params
+        .residual_correlation_fixed
+        .iter()
+        .any(|&fixed| !fixed)
 }
 
 /// Finite-differenced θ/σ score at a **fixed η** — the universal fallback when the analytic

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -268,6 +268,9 @@ impl Stack {
                 b,
                 &params.omega,
                 &params.sigma.values,
+                // AGQ holds the `block_sigma` off-diagonals at their declared
+                // value (#847); `params` carries exactly that.
+                &params.residual_correlations,
                 scratch,
                 schedule,
             );
@@ -1319,6 +1322,8 @@ fn node_nll_gradient(
             b,
             &params.omega,
             &params.sigma.values,
+            // AGQ holds ρ at the declaration; `params` carries it (#847).
+            &params.residual_correlations,
             schedule,
             mult,
         )
@@ -1998,6 +2003,7 @@ mod tests {
                     e,
                     &params.omega,
                     &params.sigma.values,
+                    &params.residual_correlations,
                     s,
                     None,
                 )

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -1399,6 +1399,12 @@ pub fn run_bayes(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // Bayes does not sample the `block_sigma` off-diagonals (#847), so the
+        // posterior-mean snapshot carries them through at their declared value
+        // rather than dropping them — an empty vector here would silently make
+        // the residual `R` diagonal for every downstream consumer.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: omega_iov_mean.clone(),
         kappa_fixed: init_params.kappa_fixed.clone(),
         // Carry the mixture so the post-loop pass sees the structure (#985). Ω/Σ

--- a/src/estimation/bayes.rs
+++ b/src/estimation/bayes.rs
@@ -221,7 +221,16 @@ fn subject_nll(
             let _g = MixtureClassGuard::enter(c + 1);
             *slot = if kappas.is_empty() {
                 individual_nll_into_with_schedule(
-                    model, subject, theta, eta, omega, sigma, scratch, schedule,
+                    model,
+                    subject,
+                    theta,
+                    eta,
+                    omega,
+                    sigma,
+                    // Bayes holds the `block_sigma` off-diagonals fixed (#847).
+                    &model.residual_correlations,
+                    scratch,
+                    schedule,
                 )
             } else {
                 individual_nll_iov(model, subject, theta, eta, kappas, omega, omega_iov, sigma)
@@ -232,7 +241,15 @@ fn subject_nll(
     }
     if kappas.is_empty() {
         individual_nll_into_with_schedule(
-            model, subject, theta, eta, omega, sigma, scratch, schedule,
+            model,
+            subject,
+            theta,
+            eta,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            scratch,
+            schedule,
         )
     } else {
         individual_nll_iov(model, subject, theta, eta, kappas, omega, omega_iov, sigma)
@@ -2345,6 +2362,7 @@ mod tests {
                 &eta,
                 &params.omega,
                 &params.sigma.values,
+                &params.residual_correlations,
                 &mut scratch,
                 None,
             );

--- a/src/estimation/fixed_eta_gradient.rs
+++ b/src/estimation/fixed_eta_gradient.rs
@@ -411,8 +411,15 @@ pub(crate) fn obs_nll_subject_grad(
         // perturbation — only θ perturbations need a fresh solve (#557).
         let preds_base =
             crate::pk::compute_predictions_with_tv_into(model, subject, theta, eta, pk_scratch);
-        let nll_base =
-            obs_nll_subject_from_preds(model, subject, &preds_base, theta, sigma_values, eta);
+        let nll_base = obs_nll_subject_from_preds(
+            model,
+            subject,
+            &preds_base,
+            theta,
+            sigma_values,
+            &model.residual_correlations,
+            eta,
+        );
         let mut grad = vec![0.0f64; n];
         let h = 1e-5;
         let nn_plan = NnGradPlan::build(model, subject, theta, n_theta);
@@ -420,8 +427,15 @@ pub(crate) fn obs_nll_subject_grad(
             let mut theta_p = theta.to_vec();
             let delta = sign * h * (1.0 + theta[i].abs());
             theta_p[i] += delta;
-            let nll_p =
-                obs_nll_subject_into(model, subject, &theta_p, sigma_values, eta, pk_scratch);
+            let nll_p = obs_nll_subject_into(
+                model,
+                subject,
+                &theta_p,
+                sigma_values,
+                &model.residual_correlations,
+                eta,
+                pk_scratch,
+            );
             (nll_p - nll_base) / delta
         };
 
@@ -444,8 +458,15 @@ pub(crate) fn obs_nll_subject_grad(
                 let mut sigma_p = sigma_values.to_vec();
                 let delta = h * (1.0 + sigma_values[k].abs());
                 sigma_p[k] += delta;
-                let nll_p =
-                    obs_nll_subject_from_preds(model, subject, &preds_base, theta, &sigma_p, eta);
+                let nll_p = obs_nll_subject_from_preds(
+                    model,
+                    subject,
+                    &preds_base,
+                    theta,
+                    &sigma_p,
+                    &model.residual_correlations,
+                    eta,
+                );
                 // log-packing for sigma: d/d(log_sigma_k) = sigma_k * d/d(sigma_k)
                 grad[i] = sigma_values[k] * (nll_p - nll_base) / delta;
             }

--- a/src/estimation/fixed_eta_gradient_tests.rs
+++ b/src/estimation/fixed_eta_gradient_tests.rs
@@ -175,6 +175,8 @@ fn obs_nll_subject_grad_iov_matches_fd() {
         indiv_param_names: vec!["CL".into(), "V".into()],
         indiv_param_partials: crate::types::IndivParamPartials::empty(),
         default_params: ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0, 50.0],
             theta_names: vec!["TVCL".into(), "TVV".into()],
             theta_lower: vec![0.1, 5.0],

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -2066,6 +2066,8 @@ mod tests {
     fn make_model() -> CompiledModel {
         let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["ETA_CL".into()]);
         let default_params = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0, 50.0],
             theta_names: vec!["TVCL".into(), "TVV".into()],
             theta_lower: vec![0.1, 5.0],
@@ -3114,6 +3116,8 @@ mod tests {
             OmegaMatrix::from_matrix(omega_matrix, vec!["ETA_CL".into(), "ETA_V".into()], false);
 
         let default_params = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0, 50.0],
             theta_names: vec!["TVCL".into(), "TVV".into()],
             theta_lower: vec![0.1, 5.0],
@@ -3405,6 +3409,8 @@ mod tests {
         let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
         let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
         let default_params = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0, 50.0],
             theta_names: vec!["TVCL".into(), "TVV".into()],
             theta_lower: vec![0.01, 1.0],

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -2047,7 +2047,10 @@ fn subject_nll_at(
         eta_hat,
         h_matrix,
         &params.omega,
+        // `block_sigma` + Gauss-Newton is rejected up front
+        // (`E_BLOCK_SIGMA_METHOD_UNSUPPORTED`), so these are always empty (#847).
         &params.sigma.values,
+        &params.residual_correlations,
         options.interaction,
     )
 }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -2453,7 +2453,15 @@ fn theta_sigma_weighted_mstep(
                     if *w == 0.0 {
                         continue;
                     }
-                    s += w * obs_nll_subject_into(model, subject, &th, &sg, eta, scratch);
+                    s += w * obs_nll_subject_into(
+                        model,
+                        subject,
+                        &th,
+                        &sg,
+                        &model.residual_correlations,
+                        eta,
+                        scratch,
+                    );
                 }
                 s
             })
@@ -2563,7 +2571,15 @@ fn theta_sigma_weighted_mstep_mixture(
                         if *w == 0.0 {
                             continue;
                         }
-                        sc += w * obs_nll_subject_into(model, subject, &th, &sg, eta, scratch);
+                        sc += w * obs_nll_subject_into(
+                            model,
+                            subject,
+                            &th,
+                            &sg,
+                            &model.residual_correlations,
+                            eta,
+                            scratch,
+                        );
                     }
                     s += p * sc;
                 }

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -824,6 +824,11 @@ fn run_mcem(
                 names: init_params.sigma.names.clone(),
             },
             sigma_fixed: init_params.sigma_fixed.clone(),
+            // IMP/IMPMAP does not update the `block_sigma` off-diagonals
+            // (#847); carry them so the sampled residual `R` keeps its
+            // declared correlation structure.
+            residual_correlations: init_params.residual_correlations.clone(),
+            residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
             omega_iov: None,
             kappa_fixed: init_params.kappa_fixed.clone(),
             mixture: None,
@@ -1307,6 +1312,11 @@ fn run_mcem(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // IMP/IMPMAP does not update the `block_sigma` off-diagonals
+        // (#847); carry them so the sampled residual `R` keeps its
+        // declared correlation structure.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: None,
         kappa_fixed: init_params.kappa_fixed.clone(),
         mixture: None,
@@ -1892,6 +1902,11 @@ fn run_mcem_mixture(
                 names: init_params.sigma.names.clone(),
             },
             sigma_fixed: init_params.sigma_fixed.clone(),
+            // IMP/IMPMAP does not update the `block_sigma` off-diagonals
+            // (#847); carry them so the sampled residual `R` keeps its
+            // declared correlation structure.
+            residual_correlations: init_params.residual_correlations.clone(),
+            residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
             omega_iov: None,
             kappa_fixed: init_params.kappa_fixed.clone(),
             mixture: None,
@@ -2282,6 +2297,11 @@ fn run_mcem_mixture(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // IMP/IMPMAP does not update the `block_sigma` off-diagonals
+        // (#847); carry them so the sampled residual `R` keeps its
+        // declared correlation structure.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: None,
         kappa_fixed: init_params.kappa_fixed.clone(),
         mixture: final_mixture,

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -843,7 +843,15 @@ fn subject_is_estimate(
             }
         }
 
-        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, &eta_sample, scratch);
+        let obs_nll = obs_nll_subject_into(
+            model,
+            subject,
+            theta,
+            sigma,
+            &model.residual_correlations,
+            &eta_sample,
+            scratch,
+        );
         let log_p_y = -obs_nll;
 
         // log p(η | θ): multivariate-normal quadratic form `η' Ω⁻¹ η`,
@@ -1218,7 +1226,15 @@ pub(crate) fn subject_is_draws_frem_rb(
             full_eta[i] = d[b];
         }
 
-        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, &full_eta, scratch);
+        let obs_nll = obs_nll_subject_into(
+            model,
+            subject,
+            theta,
+            sigma,
+            &model.residual_correlations,
+            &full_eta,
+            scratch,
+        );
         let log_p_y = -(obs_nll - cov_obs_const); // PK-only obs log-likelihood
 
         // Conditional prior log N(η_p; μ, P_pp): (η_p−μ)' P_pp (η_p−μ).
@@ -1443,7 +1459,15 @@ pub(crate) fn subject_is_draws(
             }
         }
 
-        let obs_nll = obs_nll_subject_into(model, subject, theta, sigma, &eta_sample, scratch);
+        let obs_nll = obs_nll_subject_into(
+            model,
+            subject,
+            theta,
+            sigma,
+            &model.residual_correlations,
+            &eta_sample,
+            scratch,
+        );
         let log_p_y = -obs_nll;
 
         let mut quad_form = 0.0_f64;

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2785,6 +2785,8 @@ mod tests {
             vec!["ETA_CL".into(), "ETA_V".into(), "ETA_WT_FREM".into()],
         );
         let default_params = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![10.0, 100.0, 90.0],
             theta_names: vec!["TVCL".into(), "TVV".into(), "TV_WT".into()],
             theta_lower: vec![0.01, 1.0, 0.0],

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -846,6 +846,11 @@ pub fn find_ebe(
             e,
             &params.omega,
             &params.sigma.values,
+            // The live `block_sigma` off-diagonals (#847). FOCE/FOCEI estimate
+            // ρ, so the inner objective must see the optimizer's current value —
+            // reading `model.residual_correlations` here would hold the EBE
+            // search at the declared correlation while the outer loop moved it.
+            &params.residual_correlations,
             &mut scratch,
             schedule.as_ref(),
         )
@@ -881,6 +886,9 @@ pub fn find_ebe(
             e,
             &params.omega,
             &params.sigma.values,
+            // Live ρ (#847) — the same value `obj` above scores, so the BFGS
+            // gradient and objective can never disagree about the residual R.
+            &params.residual_correlations,
             schedule.as_ref(),
             mult.as_deref(),
         ) {
@@ -2109,6 +2117,10 @@ fn m3_censored_dterm_df(y: f64, f: f64, v: f64, dv_df: f64, cens: i8) -> f64 {
 /// #486 (the quotient rule is applied to the η-block), except when combined with
 /// LTBS, which still declines. Shared by the inner EBE loop and the HMC sampler so
 /// both estimators use the same Dual2 gradient (replacing the retired Enzyme path).
+/// `residual_correlations` carries the live `block_sigma` off-diagonals,
+/// parallel to `sigma` (#847). The inner EBE search has to see the ρ the outer
+/// loop is proposing, or it converges to the mode of a different objective than
+/// the one being minimised.
 pub(crate) fn analytic_eta_nll_gradient(
     model: &CompiledModel,
     subject: &Subject,
@@ -2128,6 +2140,8 @@ pub(crate) fn analytic_eta_nll_gradient(
         eta,
         omega,
         sigma,
+        // HMC and the one-off diagnostic callers hold ρ at the declaration (#847).
+        &model.residual_correlations,
         None,
         mult.as_deref(),
     )
@@ -2143,6 +2157,7 @@ pub(crate) fn analytic_eta_nll_gradient(
 /// of re-walking every magnitude expression on every inner iteration (#486 review).
 /// `None` when no magnitude is active.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     model: &CompiledModel,
     subject: &Subject,
@@ -2150,6 +2165,7 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     eta: &[f64],
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
+    residual_correlations: &[crate::types::ResidualCorrelation],
     cached_schedule: Option<&crate::pk::event_driven::EventSchedule>,
     mult: Option<&[Vec<f64>]>,
 ) -> Option<Vec<f64>> {
@@ -2212,9 +2228,18 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     // Correlated residual (`block_sigma`, #627): the per-obs `coef·∂f/∂η` loop below
     // assumes a diagonal R. Route the dense-R generalisation here — it serves both the
     // analytical and the ODE (`Dual1`) inner path, since `sens` carries `∂f/∂η` for both.
-    if !model.residual_correlations.is_empty() {
-        return dense_residual_inner_gradient(model, subject, theta, eta, omega, sigma, &sens)
-            .map(add_nongaussian);
+    if !residual_correlations.is_empty() {
+        return dense_residual_inner_gradient(
+            model,
+            subject,
+            theta,
+            eta,
+            omega,
+            sigma,
+            residual_correlations,
+            &sens,
+        )
+        .map(add_nongaussian);
     }
     let n_eta = model.n_eta;
     let m3 = matches!(model.bloq_method, crate::types::BloqMethod::M3);
@@ -2312,6 +2337,7 @@ fn dense_residual_inner_gradient(
     eta: &[f64],
     omega: &crate::types::OmegaMatrix,
     sigma: &[f64],
+    residual_correlations: &[crate::types::ResidualCorrelation],
     sens: &[crate::sens::provider::ObsGrad],
 ) -> Option<Vec<f64>> {
     use nalgebra::{DMatrix, DVector};
@@ -2323,7 +2349,7 @@ fn dense_residual_inner_gradient(
         return Some(prior.as_slice().to_vec());
     }
     let ipreds: Vec<f64> = sens.iter().map(|o| o.f).collect();
-    let corr = &model.residual_correlations;
+    let corr = residual_correlations;
     // #658: per-observation residual endpoint keys (covariate selector or CMT).
     let err_keys = model.error_spec.obs_keys(subject);
     // Per-observation custom residual magnitude (#484); η-independent, matches the marginal.

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2157,7 +2157,6 @@ pub(crate) fn analytic_eta_nll_gradient(
 /// of re-walking every magnitude expression on every inner iteration (#486 review).
 /// `None` when no magnitude is active.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     model: &CompiledModel,
     subject: &Subject,

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -635,6 +635,8 @@ fn make_iov_model() -> CompiledModel {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
     let default_params = crate::types::ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.01, 1.0],
@@ -2952,6 +2954,8 @@ fn ebe_warm_start_flag_round_trips() {
 fn no_iov_1cpt_model() -> CompiledModel {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     let default_params = crate::types::ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.01, 1.0],
@@ -3103,6 +3107,8 @@ fn test_inner_restart_unimodal_is_bit_identical() {
 fn find_ebe_noniov_invariant_to_large_mu_shift() {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     let default_params = crate::types::ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.01, 1.0],

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -114,6 +114,7 @@ mod ctmm_inner {
                 &[eta0],
                 &params.omega,
                 &params.sigma.values,
+                &params.residual_correlations,
                 None,
                 None,
             )

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1086,6 +1086,8 @@ fn test_frem_jacobian_overrides_fd_with_exact_values() {
         vec!["ETA_CL".into(), "ETA_V".into(), "ETA_WT_FREM".into()],
     );
     let default_params = crate::types::ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![10.0, 100.0, 90.0],
         theta_names: vec!["TVCL".into(), "TVV".into(), "TV_WT".into()],
         theta_lower: vec![0.01, 1.0, 0.0],

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -456,7 +456,17 @@ fn analytic_inner_gradient_m3_matches_fd_on_warfarin_bloq() {
     let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
     let obj = |e: &[f64]| -> f64 {
         let mut s = scratch.borrow_mut();
-        individual_nll_into_with_schedule(&model, subject, theta, e, omega, sigma, &mut s, None)
+        individual_nll_into_with_schedule(
+            &model,
+            subject,
+            theta,
+            e,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            &mut s,
+            None,
+        )
     };
     let fd = gradient_fd(&obj, &eta, model.n_eta);
 
@@ -548,7 +558,17 @@ fn analytic_inner_gradient_ode_init_theta_sqrt_matches_fd() {
     let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(&subject));
     let obj = |e: &[f64]| -> f64 {
         let mut s = scratch.borrow_mut();
-        individual_nll_into_with_schedule(&model, &subject, theta, e, omega, sigma, &mut s, None)
+        individual_nll_into_with_schedule(
+            &model,
+            &subject,
+            theta,
+            e,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            &mut s,
+            None,
+        )
     };
     let fd = gradient_fd(&obj, &eta, model.n_eta);
     for k in 0..model.n_eta {
@@ -611,7 +631,17 @@ fn analytic_inner_gradient_iiv_on_ruv_m3_matches_fd() {
     let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(&subject));
     let obj = |e: &[f64]| -> f64 {
         let mut s = scratch.borrow_mut();
-        individual_nll_into_with_schedule(&model, &subject, theta, e, omega, sigma, &mut s, None)
+        individual_nll_into_with_schedule(
+            &model,
+            &subject,
+            theta,
+            e,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            &mut s,
+            None,
+        )
     };
     let fd = gradient_fd(&obj, &eta, model.n_eta);
     for k in 0..model.n_eta {
@@ -665,7 +695,17 @@ fn analytic_inner_gradient_m3_matches_fd_on_warfarin_ode_bloq() {
     let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
     let obj = |e: &[f64]| -> f64 {
         let mut s = scratch.borrow_mut();
-        individual_nll_into_with_schedule(&model, subject, theta, e, omega, sigma, &mut s, None)
+        individual_nll_into_with_schedule(
+            &model,
+            subject,
+            theta,
+            e,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            &mut s,
+            None,
+        )
     };
     let fd = gradient_fd(&obj, &eta, model.n_eta);
 
@@ -733,7 +773,17 @@ fn analytic_inner_gradient_m3_iiv_on_ruv_matches_fd_on_ode() {
     let scratch = RefCell::new(pk::EventPkParams::with_capacity_for(&subject));
     let obj = |e: &[f64]| -> f64 {
         let mut s = scratch.borrow_mut();
-        individual_nll_into_with_schedule(&model, &subject, theta, e, omega, sigma, &mut s, None)
+        individual_nll_into_with_schedule(
+            &model,
+            &subject,
+            theta,
+            e,
+            omega,
+            sigma,
+            &model.residual_correlations,
+            &mut s,
+            None,
+        )
     };
     let fd = gradient_fd(&obj, &eta, model.n_eta);
     for k in 0..model.n_eta {

--- a/src/estimation/mixture.rs
+++ b/src/estimation/mixture.rs
@@ -196,6 +196,7 @@ pub fn mixture_ofv(
                     &ebe.h_matrix,
                     &cp.omega,
                     &cp.sigma.values,
+                    &cp.residual_correlations,
                     interaction,
                 )
             };

--- a/src/estimation/nn_theta_gradient_tests.rs
+++ b/src/estimation/nn_theta_gradient_tests.rs
@@ -147,9 +147,25 @@ fn central_fd_theta_grad(
         let h = 1e-6 * (1.0 + theta[i].abs());
         let mut tp = theta.to_vec();
         tp[i] += h;
-        let f_plus = obs_nll_subject_into(model, subject, &tp, sigma_values, eta, &mut scratch);
+        let f_plus = obs_nll_subject_into(
+            model,
+            subject,
+            &tp,
+            sigma_values,
+            &model.residual_correlations,
+            eta,
+            &mut scratch,
+        );
         tp[i] = theta[i] - h;
-        let f_minus = obs_nll_subject_into(model, subject, &tp, sigma_values, eta, &mut scratch);
+        let f_minus = obs_nll_subject_into(
+            model,
+            subject,
+            &tp,
+            sigma_values,
+            &model.residual_correlations,
+            eta,
+            &mut scratch,
+        );
         let raw = (f_plus - f_minus) / (2.0 * h);
         out[i] = if mask[i] { theta[i] * raw } else { raw };
     }
@@ -317,12 +333,28 @@ fn hybrid_is_closer_to_central_fd_than_forward_fd() {
     // The superseded estimator, reproduced here so the comparison is explicit:
     // forward FD at the same 1e-5 relative step the production loop used.
     let mut forward = vec![0.0f64; n_theta];
-    let f0 = obs_nll_subject_into(&model, &subject, &theta, &sigma_values, &eta, &mut scratch);
+    let f0 = obs_nll_subject_into(
+        &model,
+        &subject,
+        &theta,
+        &sigma_values,
+        &model.residual_correlations,
+        &eta,
+        &mut scratch,
+    );
     for i in 0..n_theta {
         let delta = 1e-5 * (1.0 + theta[i].abs());
         let mut tp = theta.clone();
         tp[i] += delta;
-        let fp = obs_nll_subject_into(&model, &subject, &tp, &sigma_values, &eta, &mut scratch);
+        let fp = obs_nll_subject_into(
+            &model,
+            &subject,
+            &tp,
+            &sigma_values,
+            &model.residual_correlations,
+            &eta,
+            &mut scratch,
+        );
         let raw = (fp - f0) / delta;
         forward[i] = if mask[i] { theta[i] * raw } else { raw };
     }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1465,13 +1465,13 @@ fn optimize_nlopt_once(
             if has_identity_theta {
                 vec![1.0; n]
             } else {
-                compute_scale(&x0)
+                compute_scale_packed(&x0, init_params)
             }
         }
         // `Auto` is resolved away by `resolve_scaling`; group with `None`.
         ParameterScaling::None | ParameterScaling::Auto => {
             if (options.scale_params || auto_scale_iov) && !has_identity_theta {
-                compute_scale(&x0)
+                compute_scale_packed(&x0, init_params)
             } else {
                 vec![1.0; n]
             }
@@ -2356,10 +2356,10 @@ fn optimize_bfgs(
     // Per-element scale factors for the BFGS outer loop.
     let scale: Vec<f64> = match resolve_scaling(options.parameter_scaling, options.optimizer) {
         ParameterScaling::Rescale2 => compute_rescale2_scale(&bounds),
-        ParameterScaling::Abs => compute_scale(&x),
+        ParameterScaling::Abs => compute_scale_packed(&x, init_params),
         ParameterScaling::None | ParameterScaling::Auto => {
             if options.scale_params {
-                compute_scale(&x)
+                compute_scale_packed(&x, init_params)
             } else {
                 vec![1.0; n]
             }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -778,6 +778,10 @@ pub(crate) fn pop_nll(
         h_matrices,
         &params.omega,
         &params.sigma.values,
+        // Live `block_sigma` off-diagonals (#847): this is the objective the
+        // outer optimizer minimises, so it has to be scored at the ρ the
+        // optimizer is currently proposing.
+        &params.residual_correlations,
         interaction,
     )
 }
@@ -2822,6 +2826,7 @@ fn subject_reconverged_fd_gradient(
             &ebe.h_matrix,
             &params.omega,
             &params.sigma.values,
+            &params.residual_correlations,
             options.interaction,
         )
     };

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -460,6 +460,8 @@ fn test_packed_param_label_block_omega() {
         free_mask,
     );
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],
@@ -520,6 +522,8 @@ fn test_packed_param_label_sigma() {
     use crate::types::SigmaVector;
     // n_theta=1 (diagonal omega), n_omega=1 (diagonal), n_sigma=2
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["CL".into()],
         theta_lower: vec![0.1],
@@ -546,6 +550,8 @@ fn test_packed_param_label_sigma() {
 fn test_packed_param_label_kappa() {
     use crate::types::SigmaVector;
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0],
         theta_names: vec!["CL".into()],
         theta_lower: vec![0.1],
@@ -591,6 +597,8 @@ fn test_compute_covariance_invalid_eps() {
     let model = make_model();
     let population = make_population(1);
     let template = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["CL".into(), "V".into()],
         theta_lower: vec![0.1, 1.0],
@@ -950,6 +958,8 @@ use std::collections::HashMap;
 fn make_model() -> CompiledModel {
     let omega = OmegaMatrix::from_diagonal(&[0.04], vec!["ETA_CL".into()]);
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],
@@ -1250,6 +1260,8 @@ fn test_outer_ad_gradient_block_omega() {
         free_mask,
     );
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],
@@ -1728,6 +1740,8 @@ fn test_compute_covariance_iov_runs_and_is_pd() {
     let omega = OmegaMatrix::from_diagonal(&[0.09], vec!["ETA_CL".into()]);
     let omega_iov = OmegaMatrix::from_diagonal(&[0.04], vec!["KAPPA_CL".into()]);
     let default_params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -1,4 +1,4 @@
-use crate::types::{CompiledModel, ModelParameters, OmegaMatrix, SigmaVector};
+use crate::types::{CompiledModel, ModelParameters, OmegaMatrix, ResidualCorrelation, SigmaVector};
 use nalgebra::DMatrix;
 
 /// Bounds for the packed parameter vector
@@ -30,11 +30,46 @@ pub(crate) fn theta_packs_log(theta_lower: f64) -> bool {
     theta_lower >= 0.0
 }
 
+/// Unconstrained-space bound for a Fisher-z (`atanh ρ`) residual-correlation
+/// coordinate (#847). `tanh(6) ≈ 0.999_988`, so a `block_sigma` off-diagonal
+/// stays strictly inside `(-1, 1)` and every residual block it induces stays
+/// positive-definite, while the optimizer still works on an unbounded scale.
+pub(crate) const RHO_Z_BOUND: f64 = 6.0;
+
+/// Largest `|ρ|` that survives the pack. The parser already rejects `|ρ| >= 1`
+/// at declaration time, so this only guards `atanh` against an init that lands
+/// on the boundary through a covariance/variance round-trip.
+const RHO_CLAMP: f64 = 0.999_999;
+
+/// Pack a residual correlation `ρ ∈ (-1, 1)` as its Fisher-z coordinate
+/// `atanh(ρ)`, clamped into `[-RHO_Z_BOUND, RHO_Z_BOUND]`.
+#[inline]
+pub(crate) fn pack_rho(rho: f64) -> f64 {
+    rho.clamp(-RHO_CLAMP, RHO_CLAMP)
+        .atanh()
+        .clamp(-RHO_Z_BOUND, RHO_Z_BOUND)
+}
+
+/// Inverse of [`pack_rho`]: `ρ = tanh(z)`.
+#[inline]
+pub(crate) fn unpack_rho(z: f64) -> f64 {
+    z.tanh()
+}
+
+/// Chain factor `dρ/dz = 1 − ρ²` for the Fisher-z coordinate, applied by every
+/// packed-gradient producer that emits a ρ slot.
+#[inline]
+pub(crate) fn rho_chain(rho: f64) -> f64 {
+    1.0 - rho * rho
+}
+
 /// Pack ModelParameters into a flat unconstrained vector for optimization.
 ///
 /// Layout: [pack(theta_1), ..., pack(theta_n),
 ///          log(L_11), L_21, log(L_22), ...,   (Cholesky lower triangle)
-///          log(sigma_1), ..., log(sigma_m)]
+///          log(sigma_1), ..., log(sigma_m),
+///          Ω_IOV Cholesky, mixture overrides,
+///          atanh(rho_1), ..., atanh(rho_r)]  (`block_sigma` off-diagonals)
 ///
 /// Theta packing depends on whether the user's `theta_lower[i]` allows
 /// negatives — see `theta_packs_log`.
@@ -94,6 +129,16 @@ pub fn pack_params(params: &ModelParameters) -> Vec<f64> {
         for &(c, s) in &mix.sigma_override_addr {
             v.push(mix.sigma[c].values[s].max(1e-10).ln());
         }
+    }
+
+    // `block_sigma` off-diagonals (#847): Fisher-z `atanh(ρ)`. Appended **last**,
+    // after IOV and the mixture overrides, so every offset the rest of the
+    // codebase computes from `n_theta`/`n_omega`/`n_sigma` (the covariance step's
+    // `kappa_start`, the mixture segment start, …) keeps pointing at the same
+    // coordinate. A `FIX`ed block is pinned by `compute_bounds` (lower == upper)
+    // and flagged in `packed_fixed_mask`.
+    for corr in &params.residual_correlations {
+        v.push(pack_rho(corr.rho));
     }
 
     v
@@ -220,6 +265,18 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
         }
     });
 
+    // Residual correlations (#847). The pair indices are structural, so they are
+    // taken from the template; only ρ = tanh(z) comes off the packed vector.
+    let residual_correlations: Vec<ResidualCorrelation> = template
+        .residual_correlations
+        .iter()
+        .map(|c| {
+            let rho = unpack_rho(v[idx]);
+            idx += 1;
+            ResidualCorrelation { rho, ..*c }
+        })
+        .collect();
+
     ModelParameters {
         theta,
         theta_names: template.theta_names.clone(),
@@ -230,6 +287,8 @@ pub fn unpack_params(v: &[f64], template: &ModelParameters) -> ModelParameters {
         omega_fixed: template.omega_fixed.clone(),
         sigma,
         sigma_fixed: template.sigma_fixed.clone(),
+        residual_correlations,
+        residual_correlation_fixed: template.residual_correlation_fixed.clone(),
         omega_iov,
         kappa_fixed: template.kappa_fixed.clone(),
         mixture,
@@ -282,6 +341,20 @@ pub fn packed_fixed_mask(template: &ModelParameters) -> Vec<bool> {
     if let Some(ref mix) = template.mixture {
         mask.extend_from_slice(&mix.omega_override_fixed);
         mask.extend_from_slice(&mix.sigma_override_fixed);
+    }
+
+    // `block_sigma` off-diagonals (#847), appended last to mirror `pack_params`.
+    // A short `residual_correlation_fixed` reads as free rather than panicking:
+    // the parser always fills it, but `ModelParameters` is public and a caller
+    // that builds one by hand should not lose the correlation entirely.
+    for i in 0..template.residual_correlations.len() {
+        mask.push(
+            template
+                .residual_correlation_fixed
+                .get(i)
+                .copied()
+                .unwrap_or(false),
+        );
     }
 
     mask
@@ -378,6 +451,13 @@ pub(crate) fn coordinate_kinds(template: &ModelParameters) -> Vec<PackedCoordKin
             PackedCoordKind::Sigma,
         );
     }
+    // `block_sigma` off-diagonals (#847) are Fisher-z coordinates bounded
+    // symmetrically at ±`RHO_Z_BOUND`, so — exactly like an Ω off-diagonal —
+    // *either* rail is a runaway and neither is a collapse toward zero.
+    kinds.resize(
+        kinds.len() + template.residual_correlations.len(),
+        PackedCoordKind::OmegaOffDiagonal,
+    );
     kinds
 }
 
@@ -393,7 +473,16 @@ pub fn packed_len(template: &ModelParameters) -> usize {
     let n_mixture = template.mixture.as_ref().map_or(0, |mix| {
         mix.omega_override_addr.len() + mix.sigma_override_addr.len()
     });
-    n_theta + n_omega + n_sigma + n_iov + n_mixture
+    let n_rho = template.residual_correlations.len();
+    n_theta + n_omega + n_sigma + n_iov + n_mixture + n_rho
+}
+
+/// Index of the first `block_sigma` residual-correlation coordinate in the
+/// packed vector (#847) — i.e. `packed_len` minus the number of correlations,
+/// since they are packed last. Callers that assemble or read a ρ slot must go
+/// through this rather than re-deriving the offset.
+pub(crate) fn rho_packed_start(template: &ModelParameters) -> usize {
+    packed_len(template) - template.residual_correlations.len()
 }
 
 /// Compute box constraints for the packed parameter vector.
@@ -474,6 +563,14 @@ pub fn compute_bounds(template: &ModelParameters) -> PackedBounds {
         }
     }
 
+    // `block_sigma` off-diagonal bounds (#847), in Fisher-z space. See
+    // `RHO_Z_BOUND`: the box keeps ρ = tanh(z) inside (-1, 1), so R never goes
+    // singular from the correlation alone.
+    for _ in 0..template.residual_correlations.len() {
+        lower.push(-RHO_Z_BOUND);
+        upper.push(RHO_Z_BOUND);
+    }
+
     // Pin any FIX parameters to their packed (log-space) initial value.
     // We pack first, then overwrite lower=upper=packed[i] for fixed indices.
     // Pack-before-overwrite is correct even for block Cholesky off-diagonals,
@@ -524,6 +621,17 @@ pub fn coordinate_names(params: &ModelParameters) -> Vec<String> {
         for &(c, s) in &mix.sigma_override_addr {
             let base = named_or(&params.sigma.names, s, || format!("SIGMA({})", s + 1));
             names.push(format!("{base}_MIX{}", c + 1));
+        }
+    }
+    // `block_sigma` off-diagonals (#847), packed last. Named like an Ω
+    // off-diagonal — `EPS_i~EPS_j` when both sigmas are declared, else the
+    // NONMEM-style `SIGMA(i,j)`.
+    for c in &params.residual_correlations {
+        let ni = params.sigma.names.get(c.sigma_i).filter(|s| !s.is_empty());
+        let nj = params.sigma.names.get(c.sigma_j).filter(|s| !s.is_empty());
+        match (ni, nj) {
+            (Some(a), Some(b)) => names.push(format!("{}~{}", a, b)),
+            _ => names.push(format!("SIGMA({},{})", c.sigma_i + 1, c.sigma_j + 1)),
         }
     }
     names
@@ -578,6 +686,10 @@ pub fn coordinate_values(params: &ModelParameters) -> Vec<f64> {
         for &(c, s) in &mix.sigma_override_addr {
             v.push(mix.sigma[c].values[s]);
         }
+    }
+    // `block_sigma` off-diagonals report on their natural ρ scale, not Fisher-z.
+    for c in &params.residual_correlations {
+        v.push(c.rho);
     }
     v
 }
@@ -812,6 +924,8 @@ mod tests {
             names: vec!["sigma_prop".into()],
         };
         ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![10.0, 100.0],
             theta_names: vec!["cl".into(), "v".into()],
             theta_lower: vec![0.01, 0.01],
@@ -832,6 +946,108 @@ mod tests {
         let template = make_template();
         // 2 theta + 2 diagonal omega + 1 sigma = 5
         assert_eq!(packed_len(&template), 5);
+    }
+
+    /// A two-sigma template carrying one `block_sigma` off-diagonal (#847).
+    fn make_rho_template(rho: f64, fixed: bool) -> ModelParameters {
+        let mut t = make_template();
+        t.sigma = SigmaVector {
+            values: vec![0.3, 1.0],
+            names: vec!["prop".into(), "add".into()],
+        };
+        t.sigma_fixed = vec![false; 2];
+        t.residual_correlations = vec![ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho,
+        }];
+        t.residual_correlation_fixed = vec![fixed];
+        t
+    }
+
+    /// #847: a residual correlation packs as `atanh(ρ)` in the **last** slot and
+    /// round-trips through `tanh`. Packing it last is what keeps every offset
+    /// derived from `n_theta`/`n_omega`/`n_sigma` — the covariance step's
+    /// `kappa_start`, the mixture segment — pointing at the same coordinate.
+    #[test]
+    fn test_pack_unpack_rho_round_trip() {
+        let template = make_rho_template(0.62, false);
+
+        // 2 theta + 2 omega + 2 sigma + 1 rho = 7, with rho last.
+        assert_eq!(packed_len(&template), 7);
+        assert_eq!(rho_packed_start(&template), 6);
+        let packed = pack_params(&template);
+        assert_eq!(packed.len(), 7);
+        assert_relative_eq!(packed[6], 0.62_f64.atanh(), epsilon = 1e-12);
+
+        let recovered = unpack_params(&packed, &template);
+        assert_eq!(recovered.residual_correlations.len(), 1);
+        // Pair indices are structural — they come from the template, not the vector.
+        assert_eq!(recovered.residual_correlations[0].sigma_i, 1);
+        assert_eq!(recovered.residual_correlations[0].sigma_j, 0);
+        assert_relative_eq!(
+            recovered.residual_correlations[0].rho,
+            0.62,
+            epsilon = 1e-12
+        );
+        assert_eq!(recovered.residual_correlation_fixed, vec![false]);
+
+        // Free (non-FIX): the box is the open Fisher-z interval, not a pin.
+        let bounds = compute_bounds(&template);
+        assert_relative_eq!(bounds.lower[6], -RHO_Z_BOUND);
+        assert_relative_eq!(bounds.upper[6], RHO_Z_BOUND);
+        assert!(!packed_fixed_mask(&template)[6]);
+
+        // Trace name / value carry the ρ coordinate last, on its natural scale.
+        let names = coordinate_names(&template);
+        assert_eq!(names.len(), 7);
+        assert_eq!(names[6], "add~prop");
+        let vals = coordinate_values(&template);
+        assert_eq!(vals.len(), 7);
+        assert_relative_eq!(vals[6], 0.62, epsilon = 1e-12);
+    }
+
+    /// A `block_sigma ... FIX` correlation is pinned by `compute_bounds`
+    /// (lower == upper) and flagged in `packed_fixed_mask`, so no optimizer that
+    /// respects box bounds can move it (#847).
+    #[test]
+    fn test_fixed_rho_is_pinned() {
+        let template = make_rho_template(0.2, true);
+        let packed = pack_params(&template);
+        let bounds = compute_bounds(&template);
+        assert!(packed_fixed_mask(&template)[6]);
+        assert_relative_eq!(bounds.lower[6], packed[6], epsilon = 1e-15);
+        assert_relative_eq!(bounds.upper[6], packed[6], epsilon = 1e-15);
+        assert!(template.has_any_fixed());
+    }
+
+    /// The Fisher-z box keeps ρ strictly inside (-1, 1) — the residual block
+    /// stays positive-definite even when the optimizer sits on a rail — and the
+    /// pack clamps an init that lands on the boundary instead of returning ±∞.
+    #[test]
+    fn test_rho_bounds_keep_correlation_admissible() {
+        assert!(unpack_rho(RHO_Z_BOUND) < 1.0);
+        assert!(unpack_rho(-RHO_Z_BOUND) > -1.0);
+        assert!(pack_rho(1.0).is_finite());
+        assert_relative_eq!(pack_rho(1.0), RHO_Z_BOUND);
+        assert_relative_eq!(pack_rho(-1.0), -RHO_Z_BOUND);
+        // `rho_chain` is `dρ/dz` for `ρ = tanh(z)`; check it against a central
+        // difference of `unpack_rho` so the two can never drift apart.
+        let z = 0.7_f64;
+        let h = 1e-6;
+        let fd = (unpack_rho(z + h) - unpack_rho(z - h)) / (2.0 * h);
+        assert_relative_eq!(rho_chain(unpack_rho(z)), fd, epsilon = 1e-9);
+    }
+
+    /// A ρ coordinate is bounded symmetrically, so — like an Ω off-diagonal —
+    /// the runaway guard must treat *either* rail as a runaway, never as a
+    /// collapse toward zero.
+    #[test]
+    fn test_rho_coordinate_kind_is_symmetric() {
+        let template = make_rho_template(0.4, false);
+        let kinds = coordinate_kinds(&template);
+        assert_eq!(kinds.len(), packed_len(&template));
+        assert_eq!(kinds[6], PackedCoordKind::OmegaOffDiagonal);
     }
 
     #[test]
@@ -897,6 +1113,8 @@ mod tests {
             names: vec!["sigma_prop".into()],
         };
         let template = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0, -0.8, -0.01],
             theta_names: vec!["tvcl".into(), "gamma".into(), "age_eff".into()],
             theta_lower: vec![0.1, -3.0, -1.0],
@@ -988,6 +1206,8 @@ mod tests {
             names: vec!["sigma_prop".into()],
         };
         ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![10.0, 100.0],
             theta_names: vec!["cl".into(), "v".into()],
             theta_lower: vec![0.01, 0.01],
@@ -1041,6 +1261,8 @@ mod tests {
         // 2 theta + block+diag Ω (col-major lower-tri: (0,0)(1,0)(2,0)(1,1)(2,1)(2,2))
         // + 1 sigma. Structural zeros are (2,0) and (2,1).
         let template = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![1.0, 2.0],
             theta_names: vec!["a".into(), "b".into()],
             theta_lower: vec![0.0, 0.0],
@@ -1097,6 +1319,8 @@ mod tests {
         // Layout: theta(1) + bsvΩ(1) + sigma(1) + iovΩ(6) = 9.
         //   iov packed offset 3: (0,0)=3 (1,0)=4 (2,0)=5 (1,1)=6 (2,1)=7 (2,2)=8
         let template = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![1.0],
             theta_names: vec!["a".into()],
             theta_lower: vec![0.0],
@@ -1218,6 +1442,8 @@ mod tests {
         m[(1, 0)] = 0.02;
         let omega = OmegaMatrix::from_matrix(m, vec![String::new(), String::new()], false);
         let t = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![1.0],
             theta_names: vec![String::new()],
             theta_lower: vec![0.0],
@@ -1302,6 +1528,8 @@ mod tests {
             names: vec!["PROP_ERR".into()],
         };
         let default_params = ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![0.2, 10.0, 1.5],
             theta_names: theta_names.clone(),
             theta_lower: vec![0.001, 0.1, 0.01],
@@ -1598,6 +1826,8 @@ mod tests {
             names: vec!["PROP_ERR".into()],
         };
         ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![5.0],
             theta_names: vec!["TVCL".into()],
             theta_lower: vec![0.01],
@@ -1752,6 +1982,8 @@ mod tests {
             names: vec!["PROP_ERR".into()],
         };
         ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![0.2],
             theta_names: vec!["TVCL".into()],
             theta_lower: vec![0.01],

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -774,6 +774,44 @@ pub fn compute_scale(x: &[f64]) -> Vec<f64> {
         .collect()
 }
 
+/// [`compute_scale`], but the `block_sigma` Fisher-z coordinates keep scale 1.0
+/// (#847).
+///
+/// Magnitude scaling divides a coordinate by its own |packed value|, which is the
+/// right preconditioner for a **log-space** coordinate: there `|v|` is the
+/// parameter's order of magnitude, and the scaled bound range comes out within a
+/// few units of the origin. A Fisher-z `z = atanh(ρ)` is not on a log scale.
+/// `|z|` is a *position* in a bounded range that passes through zero at ρ = 0, so
+/// dividing by it is meaningless — and actively harmful: at the common init
+/// ρ = 0.2, `z = 0.203`, so the scaled box becomes ±`RHO_Z_BOUND`/0.203 ≈ ±30
+/// while every other scaled coordinate spans single digits. A quasi-Newton
+/// optimizer reads that as one direction with thirty times the room of the
+/// others.
+///
+/// The rule is `max(|z|, 1)`: normalise a ρ that has already grown past 1 (near a
+/// strong correlation, `atanh(0.93) ≈ 1.68`, where dividing by it is the same
+/// well-behaved normalisation every other coordinate gets), but never *divide by
+/// a value below 1*, which is what inflates the box. `compute_scale` makes the
+/// same move with its own 0.1 floor; a Fisher-z coordinate simply needs the floor
+/// at 1, because that is where its useful range begins.
+///
+/// Measured on the fluconazole RadboudUMC model (#847's motivating case), FOCEI
+/// from the model's declared inits: plain `compute_scale` fails at 1111.12
+/// (NLopt `Failure`, ρ never leaves its 0.2 init), a flat 1.0 converges to 736.89
+/// but stalls at init when started from NONMEM's estimates, and `max(|z|, 1)`
+/// converges from both (736.89 with ρ = 0.9319, against NONMEM's 0.9312).
+pub(crate) fn compute_scale_packed(x: &[f64], template: &ModelParameters) -> Vec<f64> {
+    let mut scale = compute_scale(x);
+    for (s, z) in scale
+        .iter_mut()
+        .zip(x.iter())
+        .skip(rho_packed_start(template))
+    {
+        *s = z.abs().max(1.0);
+    }
+    scale
+}
+
 /// Divide each element of `x` by the corresponding scale factor.
 /// `x_s = x / scale` — the representation seen by the outer optimizer.
 pub fn apply_scale(x: &[f64], scale: &[f64]) -> Vec<f64> {
@@ -1037,6 +1075,61 @@ mod tests {
         let h = 1e-6;
         let fd = (unpack_rho(z + h) - unpack_rho(z - h)) / (2.0 * h);
         assert_relative_eq!(rho_chain(unpack_rho(z)), fd, epsilon = 1e-9);
+    }
+
+    /// `compute_scale_packed` must be **byte-identical** to `compute_scale` for
+    /// any model without a `block_sigma` — the scaling change (#847) is scoped to
+    /// the ρ block and must not perturb a single existing fit.
+    #[test]
+    fn test_scale_packed_is_unchanged_without_correlations() {
+        let template = make_template();
+        let x = pack_params(&template);
+        assert_eq!(compute_scale_packed(&x, &template), compute_scale(&x));
+    }
+
+    /// Magnitude scaling normalises by |packed value|, which is meaningless for a
+    /// Fisher-z coordinate: `z = atanh(ρ)` is a position in a bounded range, not
+    /// an order of magnitude, and it passes through zero at ρ = 0. At the common
+    /// ρ = 0.2 init that would hand the optimizer a coordinate with ~30× the
+    /// scaled room of every other one. Leave it at 1.0 (#847).
+    #[test]
+    fn test_scale_packed_leaves_the_rho_coordinate_alone() {
+        let template = make_rho_template(0.2, false);
+        let x = pack_params(&template);
+        let scale = compute_scale_packed(&x, &template);
+        let rho_idx = rho_packed_start(&template);
+
+        // atanh(0.2) ≈ 0.203 < 1, so the floor applies and the box is not inflated.
+        assert_eq!(scale[rho_idx], 1.0);
+        // Every non-ρ coordinate keeps the magnitude scaling untouched.
+        let plain = compute_scale(&x);
+        assert_eq!(scale[..rho_idx], plain[..rho_idx]);
+        // The wart this exists to remove: |atanh(0.2)| ≈ 0.203, so magnitude
+        // scaling would have given the ρ box ~30 units of scaled room.
+        let bounds = compute_bounds(&template);
+        let width_if_scaled =
+            (bounds.upper[rho_idx] - bounds.lower[rho_idx]) / plain[rho_idx].abs();
+        assert!(
+            width_if_scaled > 50.0,
+            "the unscaled-ρ guard is pointless if magnitude scaling were benign here \
+             (width {width_if_scaled})"
+        );
+        let width_now = (bounds.upper[rho_idx] - bounds.lower[rho_idx]) / scale[rho_idx];
+        assert_relative_eq!(width_now, 2.0 * RHO_Z_BOUND);
+    }
+
+    /// Above the floor the ρ coordinate is normalised like any other: at a strong
+    /// correlation `|atanh(ρ)| > 1`, and dividing by it is the same well-behaved
+    /// move `compute_scale` makes everywhere else. Only the *below-1* case is
+    /// special (#847).
+    #[test]
+    fn test_scale_packed_normalises_a_large_rho_coordinate() {
+        let template = make_rho_template(0.93, false);
+        let x = pack_params(&template);
+        let rho_idx = rho_packed_start(&template);
+        let z = 0.93_f64.atanh();
+        assert!(z > 1.0);
+        assert_relative_eq!(compute_scale_packed(&x, &template)[rho_idx], z);
     }
 
     /// A ρ coordinate is bounded symmetrically, so — like an Ω off-diagonal —

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -31,10 +31,22 @@ pub(crate) fn theta_packs_log(theta_lower: f64) -> bool {
 }
 
 /// Unconstrained-space bound for a Fisher-z (`atanh ρ`) residual-correlation
-/// coordinate (#847). `tanh(6) ≈ 0.999_988`, so a `block_sigma` off-diagonal
-/// stays strictly inside `(-1, 1)` and every residual block it induces stays
-/// positive-definite, while the optimizer still works on an unbounded scale.
-pub(crate) const RHO_Z_BOUND: f64 = 6.0;
+/// coordinate (#847). `tanh(3) ≈ 0.995_05`, so `1 − ρ² ≥ 9.9e-3`.
+///
+/// Strict positive-definiteness is not a strong enough bound here. A paired
+/// residual block's determinant carries a factor `1 − ρ²`, so a ρ merely
+/// *inside* `(-1, 1)` can still make `R` numerically singular: at the earlier
+/// `tanh(6) ≈ 0.999_988` the factor is `2.5e-5`, `R⁻¹` blows up by `4e4`, and the
+/// likelihood is happy to chase `log|R| → −∞`. On the 12-observation
+/// `examples/correlated_residual_combined` fixture a free ρ ran to −0.999_93 and
+/// reported convergence at OFV −8.38 — a degenerate optimum, not an estimate.
+///
+/// `0.995` is well clear of anything a real correlated-residual model needs
+/// (NONMEM's fluconazole `$SIGMA BLOCK` estimate is 0.9312, `z = 1.67`), and a ρ
+/// pinned at this rail is a legible diagnostic — the two endpoints are carrying
+/// the same noise — where a ρ of 0.999_9 is just a broken fit that looks
+/// converged.
+pub(crate) const RHO_Z_BOUND: f64 = 3.0;
 
 /// Largest `|ρ|` that survives the pack. The parser already rejects `|ρ| >= 1`
 /// at declaration time, so this only guards `atanh` against an init that lands
@@ -1066,6 +1078,15 @@ mod tests {
     fn test_rho_bounds_keep_correlation_admissible() {
         assert!(unpack_rho(RHO_Z_BOUND) < 1.0);
         assert!(unpack_rho(-RHO_Z_BOUND) > -1.0);
+        // Strictly inside (-1, 1) is not enough: a paired residual block's
+        // determinant carries `1 − ρ²`, so the rail must leave `R` invertible in
+        // floating point, not merely non-singular in exact arithmetic (#847).
+        let rho_max = unpack_rho(RHO_Z_BOUND);
+        assert!(
+            1.0 - rho_max * rho_max >= 9e-3,
+            "the ρ rail must keep 1 − ρ² ≥ 9e-3; got {}",
+            1.0 - rho_max * rho_max
+        );
         assert!(pack_rho(1.0).is_finite());
         assert_relative_eq!(pack_rho(1.0), RHO_Z_BOUND);
         assert_relative_eq!(pack_rho(-1.0), -RHO_Z_BOUND);
@@ -1110,7 +1131,7 @@ mod tests {
         let width_if_scaled =
             (bounds.upper[rho_idx] - bounds.lower[rho_idx]) / plain[rho_idx].abs();
         assert!(
-            width_if_scaled > 50.0,
+            width_if_scaled > 25.0,
             "the unscaled-ρ guard is pointless if magnitude scaling were benign here \
              (width {width_if_scaled})"
         );

--- a/src/estimation/run_covariance.rs
+++ b/src/estimation/run_covariance.rs
@@ -287,6 +287,8 @@ pub fn run_covariance(
     // --- Build the refreshed FitResult ------------------------------------
     let (se_theta, se_omega, se_sigma, se_kappa) =
         extract_standard_errors(&covariance_matrix, &params);
+    let se_residual_correlations =
+        crate::api::extract_residual_correlation_se(&covariance_matrix, &params);
     let (cov_eigenvalues, cov_condition_number) = cov_diagnostics(covariance_matrix.as_ref());
     // Bayesian fits never run a Hessian covariance step; guard so a covariance
     // request against a Bayesian fit reports NotRequested rather than Failed.
@@ -299,6 +301,7 @@ pub fn run_covariance(
     out.se_omega = se_omega;
     out.se_sigma = se_sigma;
     out.se_kappa = se_kappa;
+    out.se_residual_correlations = se_residual_correlations;
     out.cov_eigenvalues = cov_eigenvalues;
     out.cov_condition_number = cov_condition_number;
     out.covariance_status = covariance_status;

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -1458,6 +1458,11 @@ fn saem_state_to_params(
             names: init_params.sigma.names.clone(),
         },
         sigma_fixed: init_params.sigma_fixed.clone(),
+        // SAEM does not update the `block_sigma` off-diagonals (#847); carry them
+        // through so a chained estimator (e.g. `[saem, foce]`) and the result
+        // snapshot both keep the declared residual covariance structure.
+        residual_correlations: init_params.residual_correlations.clone(),
+        residual_correlation_fixed: init_params.residual_correlation_fixed.clone(),
         omega_iov: if n_kappa > 0 {
             // Use from_matrix_with_mask so the structural free_mask is preserved
             // when this snapshot is handed to a chained estimator (e.g.

--- a/src/estimation/saem.rs
+++ b/src/estimation/saem.rs
@@ -914,7 +914,15 @@ pub(crate) fn obs_nll_sum(
         .par_iter()
         .enumerate()
         .map_init(EventPkParams::default, |scratch, (i, subject)| {
-            obs_nll_subject_into(model, subject, theta, sigma_values, &etas[i], scratch)
+            obs_nll_subject_into(
+                model,
+                subject,
+                theta,
+                sigma_values,
+                &model.residual_correlations,
+                &etas[i],
+                scratch,
+            )
         })
         .collect();
     per_subj.iter().sum()
@@ -974,7 +982,15 @@ fn obs_nll_sum_mix(
             let _g = crate::parser::model_parser::MixtureClassGuard::enter(c + 1);
             let sub_sg = class_sigma_subst(sigma_values, &mix.class_sigma_over[c]);
             let sg_i: &[f64] = sub_sg.as_deref().unwrap_or(sigma_values);
-            obs_nll_subject_into(model, subject, theta, sg_i, &etas[i], scratch)
+            obs_nll_subject_into(
+                model,
+                subject,
+                theta,
+                sg_i,
+                &model.residual_correlations,
+                &etas[i],
+                scratch,
+            )
         })
         .collect();
     per_subj.iter().sum()

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -3108,7 +3108,11 @@ pub fn subject_eta_dx(
     let sigma = &params.sigma.values;
     // Correlated residual (`block_sigma`, #627): σ FD must use the correlation-aware
     // variance / `∂R/∂f` (mirrors `sigma_block`). Diagonal-R only (guarded in `prepare`).
-    let correlated = !model.residual_correlations.is_empty();
+    // Live, not declared (#847): the values fed to `corr_residual_rd_at_sigma`
+    // below come from `params`, so the predicate that gates them must too, or a
+    // hand-built `ModelParameters` could disagree with the model about whether a
+    // correlation exists at all.
+    let correlated = !params.residual_correlations.is_empty();
     let eta_dx_ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
     for k in 0..n_sigma {
         let h = sigma_fd_step(sigma[k]);

--- a/src/estimation/sens_outer_gradient.rs
+++ b/src/estimation/sens_outer_gradient.rs
@@ -35,13 +35,13 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::estimation::parameterization::{
-    block_chol_full, chol_pack, lower_tri_entries, packed_fixed_mask, theta_packs_log,
-    unpack_params,
+    block_chol_full, chol_pack, lower_tri_entries, packed_fixed_mask, rho_chain, rho_packed_start,
+    theta_packs_log, unpack_params,
 };
 use crate::sens::provider::{subject_sensitivities, ObsSens, SubjectSens};
 use crate::stats::residual_error::{residual_rd, residual_rd2};
 use crate::stats::special::m3_censored_outer;
-use crate::types::{CompiledModel, ModelParameters, Population, Subject};
+use crate::types::{CompiledModel, ModelParameters, Population, ResidualCorrelation, Subject};
 use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
 
@@ -461,11 +461,11 @@ fn corr_residual_diag(
     subject: &Subject,
     sens: &SubjectSens,
     sigma: &[f64],
+    corr: &[ResidualCorrelation],
 ) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>)> {
     use crate::stats::residual_error::{
         compute_d2r_df2_matrices, compute_dr_df_matrices, compute_r_matrix_with_correlations,
     };
-    let corr = &model.residual_correlations;
     let es = &model.error_spec;
     // #669: per-observation endpoint keys must come from the covariate selector
     // (`obs_keys`), not the raw CMT column — a `Selected` spec keys endpoints by
@@ -539,9 +539,9 @@ fn corr_residual_rd_at_sigma(
     subject: &Subject,
     ipreds: &[f64],
     sigma: &[f64],
+    corr: &[ResidualCorrelation],
 ) -> (Vec<f64>, Vec<f64>) {
     use crate::stats::residual_error::compute_dr_df_matrices;
-    let corr = &model.residual_correlations;
     let es = &model.error_spec;
     let n = ipreds.len();
     // #669: selector-resolved endpoint keys, not the raw CMT column (see
@@ -749,7 +749,10 @@ pub(crate) fn data_sigma_gradient(
     let sigma = &params.sigma.values;
     let n_sigma = sigma.len();
     let err_keys = model.error_spec.obs_keys(subject);
-    let correlated = !model.residual_correlations.is_empty();
+    // The **live** correlations (#847): a non-`FIX` `block_sigma` moves ρ, so the
+    // σ FD has to differentiate the variance at the ρ the optimizer is proposing.
+    let corrs = &params.residual_correlations;
+    let correlated = !corrs.is_empty();
     let ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
     let mut out = vec![0.0f64; n_sigma];
 
@@ -761,8 +764,12 @@ pub(crate) fn data_sigma_gradient(
         sm[k] -= h;
         let (corr_sp, corr_sm) = if correlated {
             (
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sp)),
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sm)),
+                Some(corr_residual_rd_at_sigma(
+                    model, subject, &ipreds, &sp, corrs,
+                )),
+                Some(corr_residual_rd_at_sigma(
+                    model, subject, &ipreds, &sm, corrs,
+                )),
             )
         } else {
             (None, None)
@@ -918,8 +925,14 @@ pub(crate) fn score_core(
     // per-obs `(r, d, d2)` diagonals once (block_sigma excludes M3/ruv/IOV, so
     // `ruv_scale = 1`). `None` bails to FD (a rare off-diagonal R). Everything else in
     // the assembly is unchanged — see `corr_residual_diag`.
-    let corr_diag = if !model.residual_correlations.is_empty() {
-        Some(corr_residual_diag(model, subject, sens, sigma)?)
+    let corr_diag = if !params.residual_correlations.is_empty() {
+        Some(corr_residual_diag(
+            model,
+            subject,
+            sens,
+            sigma,
+            &params.residual_correlations,
+        )?)
     } else {
         None
     };
@@ -1543,7 +1556,10 @@ fn sigma_block(
     // correlation-aware variance / `∂R/∂f` (which carry the within-observation cross
     // term), not the plain scalar error functions. Diagonal-R only (guaranteed by
     // `corr_residual_diag`'s guard in `prepare_stacked`).
-    let correlated = !model.residual_correlations.is_empty();
+    // The **live** correlations (#847): a non-`FIX` `block_sigma` moves ρ, so the
+    // σ FD has to differentiate the variance at the ρ the optimizer is proposing.
+    let corrs = &params.residual_correlations;
+    let correlated = !corrs.is_empty();
     let ipreds: Vec<f64> = sens.obs.iter().map(|o| o.f).collect();
     // Custom / time-varying residual-magnitude (#484/#576): `mult(θ)` is fixed
     // while perturbing σ (it doesn't depend on σ), so the σ±h FD below must hold
@@ -1573,8 +1589,12 @@ fn sigma_block(
         // Correlation-aware `(R_jj, ∂R_jj/∂f_j)` at σ±h, built once per σ_k.
         let (corr_sp, corr_sm) = if correlated {
             (
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sp)),
-                Some(corr_residual_rd_at_sigma(model, subject, &ipreds, &sm)),
+                Some(corr_residual_rd_at_sigma(
+                    model, subject, &ipreds, &sp, corrs,
+                )),
+                Some(corr_residual_rd_at_sigma(
+                    model, subject, &ipreds, &sm, corrs,
+                )),
             )
         } else {
             (None, None)
@@ -1718,6 +1738,105 @@ fn sigma_block(
             resp += prep.g_eta[l] * deta[l];
         }
         grad[k] = fixed + 0.5 * resp;
+    }
+    grad
+}
+
+/// Per-observation `(∂R_jj/∂ρ_k, ∂d_j/∂ρ_k)` for every `block_sigma`
+/// off-diagonal, indexed `[k][j]` (#847). Thin wrapper over the closed forms in
+/// [`crate::stats::residual_error::dvar_drho`], transposed into the
+/// correlation-major layout the ρ blocks below iterate in.
+///
+/// Diagonal-`R` only, which is what the analytic scope guarantees: `prepare` /
+/// `prepare_stacked` bail to FD through `corr_residual_diag` when any off-diagonal
+/// survives, so ρ can only reach here through the within-observation `combined`
+/// cross term.
+fn rho_rd_terms(
+    model: &CompiledModel,
+    subject: &Subject,
+    sens: &SubjectSens,
+    sigma: &[f64],
+    corrs: &[ResidualCorrelation],
+) -> Vec<Vec<(f64, f64)>> {
+    let err_keys = model.error_spec.obs_keys(subject);
+    let mut out = vec![vec![(0.0, 0.0); sens.obs.len()]; corrs.len()];
+    let mut row = vec![(0.0, 0.0); corrs.len()];
+    for (j, obs) in sens.obs.iter().enumerate() {
+        crate::stats::residual_error::dvar_drho(
+            &model.error_spec,
+            err_keys[j],
+            obs.f,
+            sigma,
+            corrs,
+            &mut row,
+        );
+        for (k, &t) in row.iter().enumerate() {
+            out[k][j] = t;
+        }
+    }
+    out
+}
+
+/// Per-`block_sigma`-off-diagonal packed gradient `∂Fᵢ/∂z_k` for the **FOCEI**
+/// marginal, in `pack_params` order (#847).
+///
+/// ρ is the exact analogue of a σ coordinate: it enters only through the residual
+/// variance, so this is [`sigma_block`]'s plain (non-censored, non-FREM) row with
+/// `(∂R/∂ρ, ∂d/∂ρ)` in place of `(∂R/∂σ, ∂d/∂σ)` — the same data + `lnR` term, the
+/// same `log|H̃|` term, and the same EBE-response `M` accumulation. Unlike
+/// `sigma_block` it needs no branches: `block_sigma` is mutually exclusive with
+/// M3 censoring, FREM rows, `iiv_on_ruv`, custom residual magnitude and IOV, each
+/// rejected up front, so every row here is the plain Sheiner–Beal term and
+/// `prep.ruv_scale == 1` (kept in the expressions anyway, for parity with
+/// `sigma_block` should one of those exclusions ever be lifted).
+///
+/// The optimizer coordinate is the Fisher-z `z = atanh(ρ)`, so the returned
+/// gradient carries the `dρ/dz = 1 − ρ²` chain.
+fn rho_block(
+    prep: &Prep,
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    sens: &SubjectSens,
+) -> Vec<f64> {
+    let corrs = &params.residual_correlations;
+    let mut grad = vec![0.0f64; corrs.len()];
+    if corrs.is_empty() || sens.obs.is_empty() {
+        return grad;
+    }
+    let n_eta = prep.n_eta;
+    let terms = rho_rd_terms(model, subject, sens, &params.sigma.values, corrs);
+
+    for (k, per_obs) in terms.iter().enumerate() {
+        let mut fixed = 0.0;
+        let mut m_vec = DVector::<f64>::zeros(n_eta);
+        for (j, obs) in sens.obs.iter().enumerate() {
+            let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+            let (dr, dd) = per_obs[j];
+            let r_rho = prep.ruv_scale * dr;
+            let d_rho = prep.ruv_scale * dd;
+            let inv_r = 1.0 / r;
+            let inv_r2 = inv_r * inv_r;
+            let inv_r3 = inv_r2 * inv_r;
+
+            // data + lnR:  ½ Rρ (R − ε²)/R²
+            fixed += 0.5 * r_rho * (r - eps * eps) * inv_r2;
+            // log|H̃|:  ½ (∂p/∂ρ) q ,  ∂p/∂ρ = −Rρ/R² + d·dρ/R² − d²Rρ/R³
+            let dp = -r_rho * inv_r2 + d * d_rho * inv_r2 - d * d * r_rho * inv_r3;
+            fixed += 0.5 * dp * prep.q[j];
+            // EBE response M[m] += ½ (∂α/∂ρ) ∂f/∂η_m
+            let dalpha = dalpha_dsigma(r, d, eps, r_rho, d_rho);
+            for m in 0..n_eta {
+                m_vec[m] += 0.5 * dalpha * obs.df_deta[m];
+            }
+        }
+
+        let deta = -(&prep.h_inner_inv * m_vec);
+        let mut resp = 0.0;
+        for l in 0..n_eta {
+            resp += prep.g_eta[l] * deta[l];
+        }
+        grad[k] = (fixed + 0.5 * resp) * rho_chain(corrs[k].rho);
     }
     grad
 }
@@ -1923,6 +2042,18 @@ pub fn subject_packed_gradient(
     let g_sigma = sigma_block(&prep, model, subject, &params, &sens);
     for k in 0..n_sigma {
         g[sigma_start + k] = g_sigma[k] * params.sigma.values[k];
+    }
+
+    // ρ: the `block_sigma` off-diagonals (#847), packed last — `rho_packed_start`
+    // owns that offset, so this never re-derives it from n_theta/n_omega/n_sigma
+    // (which would land on the mixture segment for a mixture model). The Fisher-z
+    // chain is already applied inside `rho_block`.
+    let rho_start = rho_packed_start(template);
+    for (k, &val) in rho_block(&prep, model, subject, &params, &sens)
+        .iter()
+        .enumerate()
+    {
+        g[rho_start + k] = val;
     }
 
     Some(g)
@@ -2131,10 +2262,10 @@ pub fn subject_packed_gradient_foce(
     // analytic FOCE scope, so `R̃ = JΩJᵀ + diag(R⁰)` is unchanged apart from the
     // correlation-aware `(r0,d0)`; a rare off-diagonal bails per-subject to FD via
     // `corr_residual_diag` → `None`. (FOCE is first-order in R — no `∂²R/∂f²`.)
-    let correlated = !model.residual_correlations.is_empty();
-    let corr = &model.residual_correlations;
+    let correlated = !params.residual_correlations.is_empty();
+    let corr = &params.residual_correlations;
     let corr_rd0 = if correlated {
-        Some(corr_residual_diag(model, subject, &sens0, sigma)?)
+        Some(corr_residual_diag(model, subject, &sens0, sigma, corr)?)
     } else {
         None
     };
@@ -2372,6 +2503,25 @@ pub fn subject_packed_gradient_foce(
         }
         nat += cg.sigma[k];
         fixed[sigma_start + k] = nat * sigma[k];
+    }
+
+    // ρ (`block_sigma` off-diagonals, #847). The FOCE marginal is first-order in
+    // R, so ρ enters only through `R⁰` — frozen at f(η=0), hence the closed forms
+    // are taken at `sens0`, exactly like the σ loop's `f0act`. Same
+    // `½ ∂R⁰/∂ρ (R̃⁻¹ᵢᵢ − uᵢ²)` shape, with the Fisher-z chain. No censored
+    // companion term: `block_sigma` + M3 is rejected up front, so `cg` carries no
+    // ρ block to add.
+    if !params.residual_correlations.is_empty() {
+        let rho_start = rho_packed_start(template);
+        let rho_terms = rho_rd_terms(model, subject, &sens0, sigma, &params.residual_correlations);
+        for (k, per_obs) in rho_terms.iter().enumerate() {
+            let mut nat = 0.0;
+            for (i, &j) in quant.iter().enumerate() {
+                let (dr0, _) = per_obs[j];
+                nat += 0.5 * dr0 * (rtilde_inv[(i, i)] - u[i] * u[i]);
+            }
+            fixed[rho_start + k] = nat * rho_chain(params.residual_correlations[k].rho);
+        }
     }
 
     // Coupling c = ∂F/∂η̂: SB part over quant rows + the marginal censored coupling
@@ -2973,12 +3123,14 @@ pub fn subject_eta_dx(
                     subject,
                     &eta_dx_ipreds,
                     &sp,
+                    &params.residual_correlations,
                 )),
                 Some(corr_residual_rd_at_sigma(
                     model,
                     subject,
                     &eta_dx_ipreds,
                     &sm,
+                    &params.residual_correlations,
                 )),
             )
         } else {
@@ -3072,6 +3224,29 @@ pub fn subject_eta_dx(
             }
         }
         out[sigma_start + k] = -(&prep.h_inner_inv * mvec) * sigma[k];
+    }
+
+    // ρ coords (#847): `M_ρ = ½ Σⱼ ∂αⱼ/∂ρ · aⱼ`, the σ loop's body with
+    // `(∂R/∂ρ, ∂d/∂ρ)` swapped in. The inner objective is interaction-independent,
+    // so this one Jacobian serves both the FOCE and FOCEI callers — the same
+    // reason the σ columns are shared. Every `sigma_block`-style branch is
+    // inapplicable here (see `rho_block`), so the plain row is the only one.
+    if !params.residual_correlations.is_empty() {
+        let rho_start = rho_packed_start(template);
+        let rho_terms = rho_rd_terms(model, subject, &sens, sigma, &params.residual_correlations);
+        for (k, per_obs) in rho_terms.iter().enumerate() {
+            let mut mvec = DVector::<f64>::zeros(n_eta);
+            for (j, obs) in sens.obs.iter().enumerate() {
+                let (r, d, eps) = (prep.et[j].r, prep.et[j].d, prep.et[j].eps);
+                let (dr, dd) = per_obs[j];
+                let dalpha = dalpha_dsigma(r, d, eps, prep.ruv_scale * dr, prep.ruv_scale * dd);
+                for m in 0..n_eta {
+                    mvec[m] += 0.5 * dalpha * obs.df_deta[m];
+                }
+            }
+            out[rho_start + k] =
+                -(&prep.h_inner_inv * mvec) * rho_chain(params.residual_correlations[k].rho);
+        }
     }
 
     Some(out)

--- a/src/estimation/sens_outer_gradient_tests.rs
+++ b/src/estimation/sens_outer_gradient_tests.rs
@@ -391,6 +391,7 @@ fn marginal_nll_foce_at(
         &h_matrix,
         &params.omega,
         &params.sigma.values,
+        &params.residual_correlations,
         false,
     )
 }
@@ -888,6 +889,7 @@ fn marginal_nll_dense_at(
         &h,
         &params.omega,
         &params.sigma.values,
+        &params.residual_correlations,
         true,
     )
 }
@@ -2110,6 +2112,7 @@ fn mixed_gradient_with_out_of_scope_subject_matches_fd() {
                 &ebe.h_matrix,
                 &p.omega,
                 &p.sigma.values,
+                &p.residual_correlations,
                 true,
             )
         }

--- a/src/estimation/sens_outer_gradient_tests.rs
+++ b/src/estimation/sens_outer_gradient_tests.rs
@@ -839,7 +839,12 @@ fn precise_ebe_corr(
         let sens =
             crate::sens::provider::subject_sensitivities(model, subject, &params.theta, &eta)
                 .unwrap();
-        let (rv, dv, d2v) = corr_residual_diag(model, subject, &sens, sigma).unwrap();
+        // The **live** correlations (#847). Reading them off `model` here would
+        // reconverge every FD-perturbed EBE at the *declared* ρ, so the FD
+        // reference would silently omit the ρ coordinate's EBE-response term.
+        let (rv, dv, d2v) =
+            corr_residual_diag(model, subject, &sens, sigma, &params.residual_correlations)
+                .unwrap();
         let mut grad = DVector::<f64>::from_column_slice(
             &(omega_inv * DVector::from_column_slice(&eta))
                 .iter()

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -79,6 +79,19 @@ pub fn fitted_params_from_result(
             names: fit_result.sigma_names.clone(),
         },
         sigma_fixed: fit_result.sigma_fixed.clone(),
+        // Prefer the fit's own `block_sigma` correlations (#847) — they are the
+        // estimated values — and fall back to the model declaration for a
+        // FitResult written before the field existed.
+        residual_correlations: if fit_result.residual_correlations.is_empty() {
+            template.residual_correlations.clone()
+        } else {
+            fit_result.residual_correlations.clone()
+        },
+        residual_correlation_fixed: if fit_result.residual_correlation_fixed.is_empty() {
+            template.residual_correlation_fixed.clone()
+        } else {
+            fit_result.residual_correlation_fixed.clone()
+        },
         omega_iov,
         kappa_fixed: fit_result.kappa_fixed.clone(),
         mixture: None,
@@ -307,6 +320,8 @@ mod tests {
         let omega_matrix = DMatrix::from_diagonal(&DVector::from_vec(vec![0.04]));
         let omega = OmegaMatrix::from_matrix(omega_matrix, vec!["eta_CL".to_string()], true);
         ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![1.0, 5.0],
             theta_names: vec!["CL".to_string(), "V".to_string()],
             theta_lower: vec![1e-3, 1e-3],
@@ -330,6 +345,8 @@ mod tests {
     /// are filled with sensible defaults.
     fn fit_with_cov(template: &ModelParameters, cov: DMatrix<f64>) -> FitResult {
         FitResult {
+            residual_correlation_fixed: Vec::new(),
+            se_residual_correlations: None,
             covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: crate::types::EstimationMethod::FoceI,

--- a/src/estimation/vi/elbo.rs
+++ b/src/estimation/vi/elbo.rs
@@ -152,12 +152,6 @@ impl PackedLayout {
     pub fn omega_iov_end(&self) -> usize {
         self.omega_iov_start() + self.n_omega_iov
     }
-
-    /// Index of the first `block_sigma` ρ coordinate (#847); equal to
-    /// [`Self::total`] when the model declares none.
-    pub fn rho_start(&self) -> usize {
-        self.omega_iov_end()
-    }
 }
 
 /// Which variational family serves each subject.

--- a/src/estimation/vi/elbo.rs
+++ b/src/estimation/vi/elbo.rs
@@ -88,17 +88,24 @@ impl Default for ElboConfig {
 
 /// Offsets of the blocks of the packed parameter vector produced by
 /// [`crate::estimation::parameterization::pack_params`]:
-/// `[θ | chol(Ω) | σ | chol(Ω_iov)]`.
+/// `[θ | chol(Ω) | σ | chol(Ω_iov) | ρ]`.
 ///
-/// The trailing `Ω_iov` block is present exactly when the model declares `kappa`
+/// The `Ω_iov` block is present exactly when the model declares `kappa`
 /// parameters; `n_omega_iov` is zero otherwise, so every offset below collapses to the
 /// three-block layout without special-casing.
+///
+/// The trailing `ρ` block holds the `block_sigma` off-diagonals (#847). VI does not
+/// estimate them — the ELBO's σ machinery has no ρ channel — so the block exists here
+/// only to keep [`Self::total`] equal to `pack_params().len()`, which is what lets VI's
+/// `x` round-trip through `unpack_params`. Its gradient entries stay zero, so Adam
+/// leaves ρ at the declared value.
 #[derive(Debug, Clone, Copy)]
 pub struct PackedLayout {
     pub n_theta: usize,
     pub n_omega: usize,
     pub n_sigma: usize,
     pub n_omega_iov: usize,
+    pub n_rho: usize,
 }
 
 impl PackedLayout {
@@ -113,11 +120,12 @@ impl PackedLayout {
                 .as_ref()
                 .map(|iov| lower_tri_iter(iov.dim(), iov.diagonal).count())
                 .unwrap_or(0),
+            n_rho: template.residual_correlations.len(),
         }
     }
 
     pub fn total(&self) -> usize {
-        self.n_theta + self.n_omega + self.n_sigma + self.n_omega_iov
+        self.n_theta + self.n_omega + self.n_sigma + self.n_omega_iov + self.n_rho
     }
 
     /// Index of the first `Ω` Cholesky coordinate.
@@ -130,10 +138,25 @@ impl PackedLayout {
         self.n_theta + self.n_omega
     }
 
-    /// Index of the first `Ω_iov` Cholesky coordinate. Equal to [`Self::total`] when the
-    /// model has no IOV, so the empty range `omega_iov_start()..total()` is a no-op.
+    /// Index of the first `Ω_iov` Cholesky coordinate. Equal to
+    /// [`Self::omega_iov_end`] when the model has no IOV, so the empty range
+    /// `omega_iov_start()..omega_iov_end()` is a no-op.
     pub fn omega_iov_start(&self) -> usize {
         self.n_theta + self.n_omega + self.n_sigma
+    }
+
+    /// One past the last `Ω_iov` coordinate — **not** [`Self::total`], which now
+    /// also counts the trailing ρ block (#847). Every `Ω_iov` range must end here,
+    /// or a `block_sigma` model's ρ coordinate gets treated as an IOV Cholesky
+    /// entry.
+    pub fn omega_iov_end(&self) -> usize {
+        self.omega_iov_start() + self.n_omega_iov
+    }
+
+    /// Index of the first `block_sigma` ρ coordinate (#847); equal to
+    /// [`Self::total`] when the model declares none.
+    pub fn rho_start(&self) -> usize {
+        self.omega_iov_end()
     }
 }
 
@@ -901,7 +924,7 @@ pub fn population_neg_elbo(
                 iov,
                 tmpl_iov,
                 &template.kappa_fixed,
-                &mut eval.grad_x[layout.omega_iov_start()..layout.total()],
+                &mut eval.grad_x[layout.omega_iov_start()..layout.omega_iov_end()],
             );
         }
         eval.grad_phi.push(t.grad_phi);

--- a/src/estimation/vi/elbo.rs
+++ b/src/estimation/vi/elbo.rs
@@ -393,7 +393,15 @@ fn fd_eta_data_grad(
             let (eta, kappas) = split_stacked(zz, n_eta, n_kappa, k_occasions);
             obs_nll_subject_into_iov(model, subject, theta, sigma, eta, &kappas, scratch)
         } else {
-            obs_nll_subject_into(model, subject, theta, sigma, zz, scratch)
+            obs_nll_subject_into(
+                model,
+                subject,
+                theta,
+                sigma,
+                &model.residual_correlations,
+                zz,
+                scratch,
+            )
         }
     };
     let mut g = vec![0.0; z.len()];
@@ -1304,6 +1312,7 @@ pub(crate) fn elbo_tightness(
                 subject,
                 &params.theta,
                 &params.sigma.values,
+                &params.residual_correlations,
                 eta,
                 &mut scratch,
             )

--- a/src/estimation/vi/elbo_agq_bound.rs
+++ b/src/estimation/vi/elbo_agq_bound.rs
@@ -489,6 +489,7 @@ fn data_term_quad(
             subject,
             &params.theta,
             &params.sigma.values,
+            &params.residual_correlations,
             eta.as_slice(),
             &mut scratch,
         );

--- a/src/estimation/vi/elbo_oracle.rs
+++ b/src/estimation/vi/elbo_oracle.rs
@@ -466,6 +466,7 @@ fn ltbs_data_term_is_quadratic_below_unit_predictions() {
                 &subj,
                 &template.theta,
                 &template.sigma.values,
+                &template.residual_correlations,
                 &[e],
                 &mut scratch,
             )
@@ -871,6 +872,7 @@ fn fixed_eta_nll_agrees_with_the_conditional_mode_objective_under_ltbs() {
             &subj,
             &template.theta,
             &template.sigma.values,
+            &template.residual_correlations,
             &[eta],
             &mut scratch,
         );

--- a/src/estimation/vi/elbo_tests.rs
+++ b/src/estimation/vi/elbo_tests.rs
@@ -314,6 +314,7 @@ fn data_term_collapses_to_fixed_eta_nll_as_q_degenerates() {
                 s,
                 &params.theta,
                 &params.sigma.values,
+                &params.residual_correlations,
                 &mu,
                 &mut scratch,
             )

--- a/src/estimation/vi/run.rs
+++ b/src/estimation/vi/run.rs
@@ -692,7 +692,7 @@ pub fn run_vi(
             }
             // Same for `Ω_iov`, which the closed form also sets. An empty range without
             // IOV.
-            for g in grad_x[layout.omega_iov_start()..layout.total()].iter_mut() {
+            for g in grad_x[layout.omega_iov_start()..layout.omega_iov_end()].iter_mut() {
                 *g = 0.0;
             }
         }

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1111,6 +1111,8 @@ mod tests {
             indiv_param_names: vec!["CL".into(), "V".into(), "KA".into()],
             indiv_param_partials: IndivParamPartials::empty(),
             default_params: ModelParameters {
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 theta: vec![0.2, 10.0, 1.5],
                 theta_names: vec!["TVCL".into(), "TVV".into(), "TVKA".into()],
                 theta_lower: vec![0.001, 0.1, 0.01],

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1828,6 +1828,7 @@ mod tests {
             &subj,
             &theta,
             &sigma,
+            &model.residual_correlations,
             &eta,
             &mut scratch,
         );

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -235,10 +235,18 @@ struct SigmaWire {
     /// for backward compatibility with .fitrx files from before issue #5.
     #[serde(default)]
     init_as_sd: Vec<bool>,
-    /// Fixed `block_sigma` correlations. Absent in bundles written before
-    /// issue #1100 and omitted for the common diagonal-sigma case.
+    /// `block_sigma` correlations. Absent in bundles written before issue #1100
+    /// and omitted for the common diagonal-sigma case.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     residual_correlations: Vec<crate::types::ResidualCorrelation>,
+    /// FIX flags parallel to `residual_correlations` (#847). Absent in bundles
+    /// written before the off-diagonal became estimable, where every correlation
+    /// was fixed by construction — hence the `true` fill on load.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    residual_correlation_fixed: Vec<bool>,
+    /// Standard errors for the estimated correlations, natural ρ scale (#847).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    se_residual_correlations: Option<Vec<f64>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -607,6 +615,8 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
                 .collect(),
             init_as_sd: r.sigma_init_as_sd.clone(),
             residual_correlations: r.residual_correlations.clone(),
+            residual_correlation_fixed: r.residual_correlation_fixed.clone(),
+            se_residual_correlations: r.se_residual_correlations.clone(),
         },
         error_model: error_model_to_str(r.error_model).into(),
         shrinkage_eps: r.shrinkage_eps,
@@ -1651,6 +1661,29 @@ fn validate_parallel_lengths(w: &FitWire) -> Result<(), FitrxError> {
             ));
         }
     }
+    // #847 companions to `residual_correlations`: both are optional (a pre-#847
+    // bundle carries neither), but a present one must be parallel — a truncated
+    // FIX vector would silently report an estimated correlation as free, and a
+    // truncated SE vector would mis-align the SE with the pair it belongs to.
+    let n_corr = w.sigma.residual_correlations.len();
+    if !w.sigma.residual_correlation_fixed.is_empty()
+        && w.sigma.residual_correlation_fixed.len() != n_corr
+    {
+        return bail(format!(
+            "sigma.residual_correlation_fixed ({}) does not match sigma.residual_correlations ({})",
+            w.sigma.residual_correlation_fixed.len(),
+            n_corr
+        ));
+    }
+    if let Some(se) = &w.sigma.se_residual_correlations {
+        if se.len() != n_corr {
+            return bail(format!(
+                "sigma.se_residual_correlations ({}) does not match sigma.residual_correlations ({})",
+                se.len(),
+                n_corr
+            ));
+        }
+    }
     // IOV init_as_sd: same backward-compat rule as omega/sigma. Only validate
     // when an `iov` section is present (otherwise there's no n_kappa to match
     // against).
@@ -1800,6 +1833,16 @@ fn wire_to_fit_result(
         std::mem::take(&mut w.sigma.init_as_sd)
     };
 
+    // A bundle written before #847 has correlations but no FIX vector: back then
+    // every `block_sigma` off-diagonal was held fixed, so that is what it meant.
+    let residual_correlation_fixed_resolved = if w.sigma.residual_correlations.is_empty() {
+        Vec::new()
+    } else if w.sigma.residual_correlation_fixed.is_empty() {
+        vec![true; w.sigma.residual_correlations.len()]
+    } else {
+        std::mem::take(&mut w.sigma.residual_correlation_fixed)
+    };
+
     Ok(FitResult {
         restored_from_checkpoint: true,
         covariate_relations: Vec::new(),
@@ -1818,11 +1861,13 @@ fn wire_to_fit_result(
         sigma: w.sigma.estimates,
         sigma_names: w.sigma.names,
         residual_correlations: w.sigma.residual_correlations,
+        residual_correlation_fixed: residual_correlation_fixed_resolved,
         error_model: error_model_from_str(&w.error_model)?,
         covariance_matrix,
         se_theta: w.theta.se,
         se_omega: w.omega.se,
         se_sigma: w.sigma.se,
+        se_residual_correlations: w.sigma.se_residual_correlations,
         theta_fixed: w.theta.fixed,
         omega_fixed: w.omega.fixed,
         sigma_fixed: w.sigma.fixed,
@@ -2057,6 +2102,8 @@ mod tests {
     fn minimal_fit_result() -> FitResult {
         let n_eta = 2;
         FitResult {
+            residual_correlation_fixed: Vec::new(),
+            se_residual_correlations: None,
             covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::FoceI,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2623,6 +2623,8 @@ mod tests {
         let sigma_types = error_model.sigma_types();
         let n = sigma.len();
         FitResult {
+            residual_correlation_fixed: Vec::new(),
+            se_residual_correlations: None,
             covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::Foce,
@@ -3324,6 +3326,8 @@ mod tests {
     fn minimal_sdtab_result(subjects: Vec<SubjectResult>) -> FitResult {
         let sigma_types = ErrorModel::Proportional.sigma_types();
         FitResult {
+            residual_correlation_fixed: Vec::new(),
+            se_residual_correlations: None,
             covariate_relations: Vec::new(),
             restored_from_checkpoint: false,
             method: EstimationMethod::Foce,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2174,7 +2174,7 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
 
     if !result.residual_correlations.is_empty() {
         writeln!(f, "\nblock_sigma:").map_err(|e| e.to_string())?;
-        for corr in &result.residual_correlations {
+        for (k, corr) in result.residual_correlations.iter().enumerate() {
             let name_i = result.sigma_names.get(corr.sigma_i).ok_or_else(|| {
                 format!(
                     "residual correlation sigma_i index {} is out of bounds",
@@ -2199,18 +2199,44 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
                     corr.sigma_j
                 )
             })?;
-            // The correlation itself is always fixed by the `block_sigma`
-            // declaration, but the covariance it scales is only fixed when both
-            // sigma SDs were declared `FIX` — a bare `block_sigma (...) = [...]`
-            // estimates the diagonal, so its covariance moves during the fit.
+            // Since #847 a bare `block_sigma (...) = [...]` **estimates** the
+            // off-diagonal (NONMEM `$SIGMA BLOCK(n)`); only `... FIX` pins it. A
+            // pre-#847 `FitResult` carries no flags at all, and back then every
+            // correlation was fixed by construction — hence the `true` default.
+            let correlation_fixed = result
+                .residual_correlation_fixed
+                .get(k)
+                .copied()
+                .unwrap_or(true);
+            // The covariance `rho·sigma_i·sigma_j` is fixed only when *all three*
+            // factors are: a free rho or a free SD moves it during the fit.
             let sigma_is_fixed = |i: usize| result.sigma_fixed.get(i).copied().unwrap_or(false);
-            let covariance_fixed = sigma_is_fixed(corr.sigma_i) && sigma_is_fixed(corr.sigma_j);
+            let covariance_fixed =
+                correlation_fixed && sigma_is_fixed(corr.sigma_i) && sigma_is_fixed(corr.sigma_j);
             writeln!(f, "  {}__{}:", name_i, name_j).map_err(|e| e.to_string())?;
             writeln!(f, "    covariance: {:.6}", corr.rho * sigma_i * sigma_j)
                 .map_err(|e| e.to_string())?;
             writeln!(f, "    covariance_fixed: {}", covariance_fixed).map_err(|e| e.to_string())?;
             writeln!(f, "    correlation: {:.6}", corr.rho).map_err(|e| e.to_string())?;
-            writeln!(f, "    correlation_fixed: true").map_err(|e| e.to_string())?;
+            writeln!(f, "    correlation_fixed: {}", correlation_fixed)
+                .map_err(|e| e.to_string())?;
+            // SE on the natural rho scale. `~` for a FIXed correlation and for a
+            // fit whose covariance step did not run — the same convention the
+            // theta/omega/sigma blocks above use.
+            let corr_se = if correlation_fixed {
+                None
+            } else {
+                result
+                    .se_residual_correlations
+                    .as_ref()
+                    .and_then(|v| v.get(k))
+                    .copied()
+            };
+            match corr_se {
+                Some(se) => writeln!(f, "    correlation_se: {:.6}", se),
+                None => writeln!(f, "    correlation_se: ~"),
+            }
+            .map_err(|e| e.to_string())?;
         }
     }
 
@@ -4313,9 +4339,59 @@ mod tests {
         assert!(yaml.contains("  ADD_ERR__PROP_ERR:"), "{yaml}");
         assert!(yaml.contains("    covariance: 0.100000"), "{yaml}");
         assert!(yaml.contains("    correlation: 0.500000"), "{yaml}");
-        // The correlation is fixed by the declaration; the covariance is not,
-        // because neither sigma SD was declared `FIX`.
+        // A `FitResult` with no `residual_correlation_fixed` is one written
+        // before #847, when every `block_sigma` off-diagonal was fixed by
+        // construction — so it must still read as fixed, with no SE.
         assert!(yaml.contains("    correlation_fixed: true"), "{yaml}");
+        assert!(yaml.contains("    covariance_fixed: false"), "{yaml}");
+        assert!(yaml.contains("    correlation_se: ~"), "{yaml}");
+    }
+
+    /// #847: a bare `block_sigma` estimates its off-diagonal, so the YAML must
+    /// report it as free and carry its natural-scale SE.
+    #[test]
+    fn write_yaml_reports_estimated_block_sigma_correlation() {
+        let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
+        r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.sigma_fixed = vec![false, false];
+        r.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        r.residual_correlation_fixed = vec![false];
+        r.se_residual_correlations = Some(vec![0.031_25]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        assert!(yaml.contains("    correlation_fixed: false"), "{yaml}");
+        assert!(yaml.contains("    correlation_se: 0.031250"), "{yaml}");
+        // A free rho keeps the covariance free even when both SDs are pinned.
+        assert!(yaml.contains("    covariance_fixed: false"), "{yaml}");
+    }
+
+    /// A free rho makes the covariance free even with both sigma SDs `FIX`ed —
+    /// the covariance is `rho·sigma_i·sigma_j`, so all three factors must be
+    /// pinned before it is (#847).
+    #[test]
+    fn write_yaml_block_sigma_covariance_free_when_only_sigmas_fixed() {
+        let mut r = make_sigma_only_result(ErrorModel::Combined, vec![0.2, 1.0]);
+        r.sigma_names = vec!["PROP_ERR".into(), "ADD_ERR".into()];
+        r.sigma_fixed = vec![true, true];
+        r.residual_correlations = vec![crate::types::ResidualCorrelation {
+            sigma_i: 1,
+            sigma_j: 0,
+            rho: 0.5,
+        }];
+        r.residual_correlation_fixed = vec![false];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("yaml read");
+
+        assert!(yaml.contains("    correlation_fixed: false"), "{yaml}");
         assert!(yaml.contains("    covariance_fixed: false"), "{yaml}");
     }
 
@@ -4331,6 +4407,7 @@ mod tests {
             sigma_j: 0,
             rho: 0.5,
         }];
+        r.residual_correlation_fixed = vec![true];
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("fit.yaml");
         write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
@@ -4338,6 +4415,8 @@ mod tests {
 
         assert!(yaml.contains("    covariance_fixed: true"), "{yaml}");
         assert!(yaml.contains("    correlation_fixed: true"), "{yaml}");
+        // A pinned correlation reports no SE, like every other FIXed coordinate.
+        assert!(yaml.contains("    correlation_se: ~"), "{yaml}");
     }
 
     #[test]

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -13575,7 +13575,15 @@ fn build_residual_correlations(
         for row in 0..n {
             for col in 0..=row {
                 let value = block.lower_triangle[pos];
-                if row != col && value != 0.0 {
+                // A zero off-diagonal still declares a correlation *coordinate*
+                // when the block is estimated (#847): `$SIGMA BLOCK(2)` with a
+                // zero covariance init is how NONMEM users routinely start, and
+                // dropping the entry here would silently fit a diagonal residual
+                // with no way to reach a non-zero rho and no diagnostic. A `FIX`ed
+                // block keeps the old behaviour — a fixed zero correlation is the
+                // same thing as no correlation, so there is nothing to carry.
+                let carries_coordinate = value != 0.0 || !block.fixed;
+                if row != col && carries_coordinate {
                     let vi = variances[row];
                     let vj = variances[col];
                     if vi <= 0.0 || vj <= 0.0 {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -2461,7 +2461,8 @@ pub fn parse_full_model_with(
         _ => Vec::new(),
     };
     let (error_model, error_spec) = build_error_spec(parsed_error_model, &sigma_names, is_ode)?;
-    let residual_correlations = build_residual_correlations(&block_sigmas, &sigma_names)?;
+    let (residual_correlations, residual_correlation_fixed) =
+        build_residual_correlations(&block_sigmas, &sigma_names)?;
     validate_residual_correlations(&error_spec, &residual_correlations, &sigma_names)?;
     // Keep a copy of the flat sigma names for the custom residual-magnitude
     // build (#484), which runs after the [covariates] block is parsed.
@@ -2530,6 +2531,8 @@ pub fn parse_full_model_with(
         omega_fixed,
         sigma,
         sigma_fixed,
+        residual_correlations: residual_correlations.clone(),
+        residual_correlation_fixed,
         omega_iov,
         kappa_fixed,
         mixture: None,
@@ -11748,6 +11751,11 @@ struct SigmaSpec {
 struct BlockSigmaSpec {
     names: Vec<String>,
     lower_triangle: Vec<f64>,
+    /// `true` when the declaration carried a trailing `FIX`. The flag already
+    /// pins the diagonal SDs via each `SigmaSpec`; it additionally pins the
+    /// off-diagonal correlations, which a plain `block_sigma` **estimates**
+    /// (NONMEM `$SIGMA BLOCK(n)` semantics, #847).
+    fixed: bool,
 }
 
 /// Diagonal inter-occasion variability (kappa) specification.
@@ -13036,6 +13044,7 @@ fn parse_parameters(
             block_sigmas.push(BlockSigmaSpec {
                 names,
                 lower_triangle: values,
+                fixed,
             });
         } else if let Some(caps) = block_kappa_re.captures(line) {
             let names: Vec<String> = caps[1].split(',').map(|s| s.trim().to_string()).collect();
@@ -13534,16 +13543,22 @@ fn build_omega_fixed(
     Ok(fixed)
 }
 
+/// Build the runtime residual correlations from the parsed `block_sigma` blocks,
+/// paired with their FIX flags (#847). The two vectors are parallel and become
+/// `ModelParameters::residual_correlations` / `residual_correlation_fixed`; the
+/// `CompiledModel` keeps only the values, since the model's copy is the
+/// *declaration* and fixedness is a property of the estimation problem.
 fn build_residual_correlations(
     block_sigmas: &[BlockSigmaSpec],
     sigma_names: &[String],
-) -> Result<Vec<ResidualCorrelation>, String> {
+) -> Result<(Vec<ResidualCorrelation>, Vec<bool>), String> {
     let name_to_idx: std::collections::HashMap<&str, usize> = sigma_names
         .iter()
         .enumerate()
         .map(|(i, n)| (n.as_str(), i))
         .collect();
     let mut out = Vec::new();
+    let mut fixed = Vec::new();
     for block in block_sigmas {
         let n = block.names.len();
         let mut variances = vec![0.0; n];
@@ -13601,12 +13616,13 @@ fn build_residual_correlations(
                         sigma_j: j,
                         rho,
                     });
+                    fixed.push(block.fixed);
                 }
                 pos += 1;
             }
         }
     }
-    Ok(out)
+    Ok((out, fixed))
 }
 
 fn validate_residual_correlations(

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -5731,12 +5731,31 @@ fn test_build_residual_correlations_unknown_name_errs() {
 }
 
 #[test]
-fn test_build_residual_correlations_zero_covariance_omitted() {
-    // A zero off-diagonal entry carries no correlation, so no entry is built.
+fn test_build_residual_correlations_zero_covariance_kept_when_estimated() {
+    // #847: a zero off-diagonal on a non-`FIX` block still declares an estimated
+    // correlation. `$SIGMA BLOCK(2)` with a zero covariance init is a routine
+    // NONMEM starting point; dropping it would silently fit a diagonal residual
+    // with no coordinate to move and no diagnostic.
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.04, 0.0, 1.0],
         fixed: false,
+    };
+    let names = vec!["A".to_string(), "B".to_string()];
+    let (corrs, fixed) = build_residual_correlations(&[block], &names).unwrap();
+    assert_eq!(corrs.len(), 1);
+    assert_eq!(corrs[0].rho, 0.0);
+    assert_eq!(fixed, vec![false]);
+}
+
+#[test]
+fn test_build_residual_correlations_zero_covariance_omitted_when_fixed() {
+    // A `FIX`ed zero correlation is the same object as no correlation, so it
+    // still carries nothing — and costs no packed coordinate.
+    let block = BlockSigmaSpec {
+        names: vec!["A".to_string(), "B".to_string()],
+        lower_triangle: vec![0.04, 0.0, 1.0],
+        fixed: true,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let (corrs, fixed) = build_residual_correlations(&[block], &names).unwrap();

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -5622,19 +5622,28 @@ fn test_parse_block_sigma_builds_sigmas_and_correlation() {
     assert!((sigmas[1].value - 1.0).abs() < 1e-12);
 
     let sigma_names: Vec<String> = sigmas.iter().map(|s| s.name.clone()).collect();
-    let corrs = build_residual_correlations(&block_sigmas, &sigma_names).unwrap();
+    let (corrs, fixed) = build_residual_correlations(&block_sigmas, &sigma_names).unwrap();
     assert_eq!(corrs.len(), 1);
     assert_eq!(corrs[0].sigma_i, 1);
     assert_eq!(corrs[0].sigma_j, 0);
     assert!((corrs[0].rho - 0.5).abs() < 1e-12);
+    // #847: a bare `block_sigma` estimates its off-diagonal.
+    assert_eq!(fixed, vec![false]);
 }
 
 #[test]
 fn test_parse_block_sigma_fix_marks_sigmas_fixed() {
     let lines = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0] FIX".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas.iter().all(|s| s.fixed));
+
+    // #847: `FIX` pins the off-diagonal too, which is what distinguishes it from
+    // a bare `block_sigma` (that one estimates ρ, NONMEM `$SIGMA BLOCK(n)`).
+    let sigma_names: Vec<String> = sigmas.iter().map(|s| s.name.clone()).collect();
+    let (corrs, fixed) = build_residual_correlations(&block_sigmas, &sigma_names).unwrap();
+    assert_eq!(corrs.len(), 1);
+    assert_eq!(fixed, vec![true]);
 }
 
 #[test]
@@ -5671,6 +5680,7 @@ fn test_build_residual_correlations_zero_diagonal_errs() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.0, 0.1, 1.0],
+        fixed: false,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5683,6 +5693,7 @@ fn test_build_residual_correlations_invalid_rho_errs() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.04, 0.10, 0.04],
+        fixed: false,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5698,6 +5709,7 @@ fn test_build_residual_correlations_unit_rho_errs() {
         let block = BlockSigmaSpec {
             names: vec!["A".to_string(), "B".to_string()],
             lower_triangle: vec![0.04, cov, 0.04],
+            fixed: false,
         };
         let names = vec!["A".to_string(), "B".to_string()];
         let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5711,6 +5723,7 @@ fn test_build_residual_correlations_unknown_name_errs() {
     let block = BlockSigmaSpec {
         names: vec!["X".to_string(), "Y".to_string()],
         lower_triangle: vec![1.0, 0.5, 1.0],
+        fixed: false,
     };
     let names = vec!["A".to_string(), "B".to_string()];
     let err = build_residual_correlations(&[block], &names).unwrap_err();
@@ -5723,10 +5736,12 @@ fn test_build_residual_correlations_zero_covariance_omitted() {
     let block = BlockSigmaSpec {
         names: vec!["A".to_string(), "B".to_string()],
         lower_triangle: vec![0.04, 0.0, 1.0],
+        fixed: false,
     };
     let names = vec!["A".to_string(), "B".to_string()];
-    let corrs = build_residual_correlations(&[block], &names).unwrap();
+    let (corrs, fixed) = build_residual_correlations(&[block], &names).unwrap();
     assert!(corrs.is_empty());
+    assert!(fixed.is_empty());
 }
 
 #[test]

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -3172,6 +3172,8 @@ mod tests {
             eta_names: Vec::new(),
             kappa_names: Vec::new(),
             default_params: ModelParameters {
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 theta: vec![1.0],
                 theta_names: vec!["TVCL".into()],
                 theta_lower: vec![0.0],

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -703,16 +703,32 @@ fn dense_residual_data_term(
 ///
 /// Under M3, censored rows contribute the matching normal-tail likelihood
 /// instead of the Gaussian residual term.
+/// `residual_correlations` carries the **live** `block_sigma` off-diagonals
+/// alongside the live `sigma_values` (#847). Reading them off `model` instead
+/// would be wrong for any estimator that inherits a fitted rho from an earlier
+/// chain stage — `method = [focei, imp]` hands IMP the FOCEI estimate, so a
+/// declaration-sourced R would score a different likelihood than the one just
+/// optimized.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn obs_nll_subject_into(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     eta: &[f64],
     pk_scratch: &mut pk::EventPkParams,
 ) -> f64 {
     let preds = pk::compute_predictions_with_tv_into(model, subject, theta, eta, pk_scratch);
-    obs_nll_subject_from_preds(model, subject, &preds, theta, sigma_values, eta)
+    obs_nll_subject_from_preds(
+        model,
+        subject,
+        &preds,
+        theta,
+        sigma_values,
+        residual_correlations,
+        eta,
+    )
 }
 
 /// Observation-only NLL from *precomputed* predictions.
@@ -722,12 +738,14 @@ pub(crate) fn obs_nll_subject_into(
 /// loop reuse one ODE solve across all σ perturbations instead of re-solving per
 /// element (#557). `theta` is only consumed by the TTE hazard term.
 #[cfg_attr(not(feature = "survival"), allow(unused_variables))]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn obs_nll_subject_from_preds(
     model: &CompiledModel,
     subject: &Subject,
     preds: &[f64],
     theta: &[f64],
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     eta: &[f64],
 ) -> f64 {
     let m3 = matches!(model.bloq_method, BloqMethod::M3);
@@ -743,7 +761,7 @@ pub(crate) fn obs_nll_subject_from_preds(
     let err_keys = model.error_spec.obs_keys(subject);
     let mut nll = 0.0;
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
-    if !model.residual_correlations.is_empty() && !m3 && !has_frem_rows {
+    if !residual_correlations.is_empty() && !m3 && !has_frem_rows {
         // block_sigma + SDE is rejected up front (E_BLOCK_SIGMA_SDE_UNSUPPORTED)
         // for the SAEM M-step, so no EKF process noise enters here.
         match dense_residual_data_term(
@@ -751,9 +769,7 @@ pub(crate) fn obs_nll_subject_from_preds(
             subject,
             preds,
             sigma_values,
-            // SAEM / IS / VI reach this term and none of them estimates ρ (#847),
-            // so the declaration is the live value here.
-            &model.residual_correlations,
+            residual_correlations,
             ruv_scale,
             &[],
             ruv_mult.as_deref(),
@@ -2658,9 +2674,10 @@ mod tests {
         let sigma = vec![0.2, 0.3];
         let mut scratch = pk::EventPkParams::default();
 
-        let dense = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+        let corr = model.residual_correlations.clone();
+        let dense = obs_nll_subject_into(&model, &subj, &theta, &sigma, &corr, &eta, &mut scratch);
         model.residual_correlations.clear();
-        let diagonal = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+        let diagonal = obs_nll_subject_into(&model, &subj, &theta, &sigma, &[], &eta, &mut scratch);
 
         assert!(dense.is_finite());
         assert!(diagonal.is_finite());
@@ -2787,9 +2804,16 @@ mod tests {
         let eta = [0.0];
 
         let nll_weighted =
-            obs_nll_subject_from_preds(&weighted, &natural, &f, &theta, &sigma, &eta);
-        let nll_hand =
-            obs_nll_subject_from_preds(&plain, &prescaled, &scaled_preds, &theta, &sigma, &eta);
+            obs_nll_subject_from_preds(&weighted, &natural, &f, &theta, &sigma, &[], &eta);
+        let nll_hand = obs_nll_subject_from_preds(
+            &plain,
+            &prescaled,
+            &scaled_preds,
+            &theta,
+            &sigma,
+            &[],
+            &eta,
+        );
         let jacobian: f64 = w.iter().map(|wi| wi.ln()).sum();
 
         approx::assert_relative_eq!(nll_weighted, nll_hand + jacobian, epsilon = 1e-12);
@@ -3617,9 +3641,9 @@ mod tests {
         let eta = vec![0.4];
         let mut scratch = pk::EventPkParams::with_capacity_for(&subj);
 
-        let base = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+        let base = obs_nll_subject_into(&model, &subj, &theta, &sigma, &[], &eta, &mut scratch);
         model.residual_error_eta = Some(0);
-        let scaled = obs_nll_subject_into(&model, &subj, &theta, &sigma, &eta, &mut scratch);
+        let scaled = obs_nll_subject_into(&model, &subj, &theta, &sigma, &[], &eta, &mut scratch);
 
         let s = (2.0_f64 * 0.4).exp();
         let preds = pk::compute_predictions_with_tv(&model, &subj, &theta, &eta);
@@ -3778,8 +3802,15 @@ mod tests {
 
         // (2) SAEM M-step: obs_nll_subject_from_preds (Gaussian preds supplied).
         let preds = vec![30.0_f64; n_obs];
-        let saem =
-            obs_nll_subject_from_preds(&model, &subject, &preds, &p.theta, &p.sigma.values, &eta);
+        let saem = obs_nll_subject_from_preds(
+            &model,
+            &subject,
+            &preds,
+            &p.theta,
+            &p.sigma.values,
+            &p.residual_correlations,
+            &eta,
+        );
         assert!(
             saem.is_finite(),
             "SAEM M-step joint NLL must be finite; got {saem}"

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2526,6 +2526,8 @@ mod tests {
             theta_names: vec!["TVCL".into(), "TVV".into()],
             eta_names: vec!["ETA_CL".into()],
             default_params: crate::types::ModelParameters {
+                residual_correlations: Vec::new(),
+                residual_correlation_fixed: Vec::new(),
                 theta: vec![5.0, 50.0],
                 theta_names: vec!["TVCL".into(), "TVV".into()],
                 theta_lower: vec![0.01, 1.0],

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -3797,6 +3797,7 @@ mod tests {
             &h_matrix,
             &p.omega,
             &p.sigma.values,
+            &p.residual_correlations,
             true,
         );
         assert!(

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -110,6 +110,11 @@ pub fn individual_nll_into(
         eta,
         omega,
         sigma_values,
+        // The model's declared `block_sigma` correlations. Every caller of this
+        // wrapper (SAEM, HMC, VI, AGQ) holds ρ fixed at the declaration, so that
+        // *is* their live value; FOCE/FOCEI, which estimate it (#847), call
+        // `individual_nll_into_with_schedule` directly with the optimizer's ρ.
+        &model.residual_correlations,
         scratch,
         None,
     )
@@ -471,6 +476,12 @@ pub(crate) fn accumulate_non_gaussian_nll(
 /// [`pk::event_driven::EventSchedule`]. The FOCE inner-loop obj closure
 /// and Jacobian build the schedule once per `find_ebe` call and reuse
 /// it across all BFGS iterations.
+///
+/// `residual_correlations` carries the **live** `block_sigma` off-diagonals the
+/// way `sigma_values` carries the live σ (#847). FOCE/FOCEI estimate ρ, so their
+/// inner loop must pass the current optimizer value rather than the model's
+/// declaration; an estimator that holds ρ fixed passes
+/// `&model.residual_correlations`, which is then the same thing.
 pub fn individual_nll_into_with_schedule(
     model: &CompiledModel,
     subject: &Subject,
@@ -478,6 +489,7 @@ pub fn individual_nll_into_with_schedule(
     eta: &[f64],
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> f64 {
@@ -534,12 +546,13 @@ pub fn individual_nll_into_with_schedule(
     let has_censored_m3 =
         matches!(model.bloq_method, BloqMethod::M3) && subject.has_censored_observation();
     let has_frem_rows = subject.fremtype.iter().any(|&ft| ft > 0);
-    if !model.residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
+    if !residual_correlations.is_empty() && !has_censored_m3 && !has_frem_rows {
         match dense_residual_data_term(
             model,
             subject,
             &preds,
             sigma_values,
+            residual_correlations,
             ruv_scale,
             &p_obs,
             ruv_mult.as_deref(),
@@ -646,6 +659,7 @@ fn dense_residual_data_term(
     subject: &Subject,
     preds: &[f64],
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     ruv_scale: f64,
     p_obs: &[f64],
     ruv_mult: Option<&[Vec<f64>]>,
@@ -658,7 +672,7 @@ fn dense_residual_data_term(
         err_keys.as_ref(),
         subject,
         sigma_values,
-        &model.residual_correlations,
+        residual_correlations,
         ruv_mult,
     );
     if ruv_scale != 1.0 {
@@ -737,6 +751,9 @@ pub(crate) fn obs_nll_subject_from_preds(
             subject,
             preds,
             sigma_values,
+            // SAEM / IS / VI reach this term and none of them estimates ρ (#847),
+            // so the declaration is the live value here.
+            &model.residual_correlations,
             ruv_scale,
             &[],
             ruv_mult.as_deref(),
@@ -904,6 +921,10 @@ pub(crate) fn ruv_scale_from(eta: &[f64], residual_error_eta: Option<usize>) -> 
 #[cfg(feature = "markov")]
 const CTMM_FD_SENTINEL_GUARD: f64 = 1e18;
 
+/// `residual_correlations` carries the **live** `block_sigma` off-diagonals,
+/// parallel to `sigma_values` (#847): FOCE/FOCEI estimate ρ, so the marginal has
+/// to be scored at the optimizer's current value, not the model's declaration.
+#[allow(clippy::too_many_arguments)]
 pub fn foce_subject_nll(
     model: &CompiledModel,
     subject: &Subject,
@@ -912,6 +933,7 @@ pub fn foce_subject_nll(
     h_matrix: &DMatrix<f64>,
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
 ) -> f64 {
     // Individual predictions at eta_hat (per-event PK when subject has TV covariates).
@@ -1094,7 +1116,7 @@ pub fn foce_subject_nll(
     // off-diagonal covariance. The non-interaction (Sheiner–Beal) branch carries
     // the dense R for both cases via `compute_r_matrix_with_correlations`.
     if interaction {
-        if model.residual_correlations.is_empty() {
+        if residual_correlations.is_empty() {
             foce_subject_nll_interaction(
                 subject,
                 &ipreds,
@@ -1118,7 +1140,7 @@ pub fn foce_subject_nll(
                 omega,
                 sigma_values,
                 &model.error_spec,
-                &model.residual_correlations,
+                residual_correlations,
                 &p_obs,
                 ruv_mult.as_deref(),
             )
@@ -1146,7 +1168,7 @@ pub fn foce_subject_nll(
             omega,
             sigma_values,
             &model.error_spec,
-            &model.residual_correlations,
+            residual_correlations,
             model.bloq_method,
             &p_obs,
             frem_r_override.as_deref(),
@@ -1924,6 +1946,9 @@ pub fn foce_subject_nll_iov(
             h_matrix,
             omega_bsv,
             sigma_values,
+            // `block_sigma` + IOV is rejected up front, so an IOV model's
+            // correlations are always the (empty) declaration (#847).
+            &model.residual_correlations,
             interaction,
         );
     }
@@ -2072,6 +2097,9 @@ pub fn foce_subject_nll_iov(
             &sigma_b,
             sigma_values,
             &model.error_spec,
+            // `block_sigma` + IOV is rejected up front
+            // (`E_BLOCK_SIGMA_IOV_UNSUPPORTED`), so this vector is empty in
+            // practice and the estimated-ρ threading (#847) never reaches here.
             &model.residual_correlations,
             model.bloq_method,
             &p_obs_iov,
@@ -2132,6 +2160,7 @@ pub fn foce_population_nll_iov(
 }
 
 /// Population FOCE objective: sum over all subjects
+#[allow(clippy::too_many_arguments)]
 pub fn foce_population_nll(
     model: &CompiledModel,
     population: &Population,
@@ -2140,6 +2169,7 @@ pub fn foce_population_nll(
     h_matrices: &[DMatrix<f64>],
     omega: &OmegaMatrix,
     sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
     interaction: bool,
 ) -> f64 {
     // Deterministic reduction: collect per-subject NLLs in subject order, then
@@ -2159,6 +2189,7 @@ pub fn foce_population_nll(
                 &h_matrices[i],
                 omega,
                 sigma_values,
+                residual_correlations,
                 interaction,
             )
         })
@@ -2965,7 +2996,15 @@ mod tests {
         //     marginal. The OLD code added 0.5·K·log|Ω_iov| = log(1e-12) ≈ -27.6,
         //     so this assertion fails without the proper-marginal fix.
         let base = foce_subject_nll(
-            &model, &subj, &theta, &eta_hat, &h_bsv, &omega_bsv, &sigma, false,
+            &model,
+            &subj,
+            &theta,
+            &eta_hat,
+            &h_bsv,
+            &omega_bsv,
+            &sigma,
+            &model.residual_correlations,
+            false,
         );
         let zero_kappas = vec![DVector::zeros(1), DVector::zeros(1)];
         let reduced = foce_subject_nll_iov(

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -2800,6 +2800,65 @@ pub(crate) fn residual_rd(
     }
 }
 
+/// Closed-form `(∂R_jj/∂ρ_k, ∂d_j/∂ρ_k)` for every `block_sigma` off-diagonal
+/// `k` at one observation (#847), where `d_j = ∂R_jj/∂f_j`.
+///
+/// The within-observation part of the residual variance is
+/// `R_jj = Σ_s (c_s σ_s)² + Σ_k 2 ρ_k c_{i_k} c_{j_k} σ_{i_k} σ_{j_k}`
+/// (see [`ErrorSpec::variance_at_scaled`]), and every loading coefficient `c_s`
+/// is affine in `f`, so
+///
+/// ```text
+///   ∂R_jj/∂ρ_k = 2 σ_i σ_j c_i c_j
+///   ∂d_j /∂ρ_k = 2 σ_i σ_j (c_i' c_j + c_i c_j')
+/// ```
+///
+/// with `c'` the slope loading. The `∂d/∂ρ` form is exactly the ρ-derivative of
+/// `diag_self_deriv`'s cross term, so the two can only agree.
+///
+/// **The floor is asymmetric, deliberately.** `variance_at_scaled` clamps `R` at
+/// `MIN_VARIANCE` while `diag_self_deriv` computes `d` unclamped, so a clamped
+/// row has `∂R/∂ρ = 0` but keeps its `∂d/∂ρ`. Mirroring that here is what stops
+/// the analytic gradient from claiming a live `∂R/∂ρ` on a row whose variance the
+/// objective has already pinned to the floor — the #958 failure mode, on the
+/// correlation axis.
+///
+/// A correlation whose two sigma slots are not both loaded by this observation
+/// contributes nothing to its variance, and so returns `(0, 0)`.
+pub(crate) fn dvar_drho(
+    es: &ErrorSpec,
+    cmt: usize,
+    f: f64,
+    sigma: &[f64],
+    correlations: &[ResidualCorrelation],
+    out: &mut [(f64, f64)],
+) {
+    debug_assert_eq!(out.len(), correlations.len());
+    let loadings = es.sigma_loadings(cmt, f, sigma.len());
+    let slopes = es.sigma_loading_slopes(cmt, sigma.len());
+    let coeff = |ld: &[(usize, f64)], slot: usize| -> Option<f64> {
+        ld.iter().find(|(i, _)| *i == slot).map(|(_, c)| *c)
+    };
+    let floored = es.variance_at_with_correlations(cmt, f, sigma, correlations) <= MIN_VARIANCE;
+    for (k, corr) in correlations.iter().enumerate() {
+        out[k] = (0.0, 0.0);
+        let (Some(ci), Some(cj)) = (
+            coeff(&loadings, corr.sigma_i),
+            coeff(&loadings, corr.sigma_j),
+        ) else {
+            continue;
+        };
+        let (Some(&si), Some(&sj)) = (sigma.get(corr.sigma_i), sigma.get(corr.sigma_j)) else {
+            continue;
+        };
+        let di = coeff(&slopes, corr.sigma_i).unwrap_or(0.0);
+        let dj = coeff(&slopes, corr.sigma_j).unwrap_or(0.0);
+        let ss = si * sj;
+        let dr = if floored { 0.0 } else { 2.0 * ss * ci * cj };
+        out[k] = (dr, 2.0 * ss * (di * cj + ci * dj));
+    }
+}
+
 /// [`residual_rd`] plus the second `f`-derivative `d2 = ∂²R/∂f²`.
 #[inline]
 pub(crate) fn residual_rd2(

--- a/src/stats/residual_error.rs
+++ b/src/stats/residual_error.rs
@@ -1512,6 +1512,89 @@ mod tests {
         assert_relative_eq!(v, 0.25, epsilon = 1e-12);
     }
 
+    /// #847: `dvar_drho`'s closed forms must equal central differences of the
+    /// production `R` and `∂R/∂f` builders in ρ. Those two are what the objective
+    /// and the outer gradient consume, so agreeing with them is the whole
+    /// contract — a hand-derived formula that drifts from either is the bug this
+    /// pins.
+    #[test]
+    fn dvar_drho_matches_fd_of_the_production_builders() {
+        let es = ErrorSpec::Single(ErrorModel::Combined);
+        let sigma = [0.3_f64, 1.4];
+        let f = 7.5_f64;
+        let rho = 0.42_f64;
+        let corr_at = |r: f64| {
+            vec![ResidualCorrelation {
+                sigma_i: 0,
+                sigma_j: 1,
+                rho: r,
+            }]
+        };
+        // `∂R/∂f` comes from the same helper `compute_dr_df_matrices` puts on the
+        // diagonal, so this differentiates exactly what production reads.
+        let d_at = |r: f64| {
+            diag_self_deriv(
+                &es.sigma_loadings(0, f, sigma.len()),
+                &es.sigma_loading_slopes(0, sigma.len()),
+                &sigma,
+                &corr_at(r),
+            )
+        };
+        let h = 1e-6;
+        let fd_r = (es.variance_at_with_correlations(0, f, &sigma, &corr_at(rho + h))
+            - es.variance_at_with_correlations(0, f, &sigma, &corr_at(rho - h)))
+            / (2.0 * h);
+        let fd_d = (d_at(rho + h) - d_at(rho - h)) / (2.0 * h);
+
+        let mut out = [(0.0, 0.0)];
+        dvar_drho(&es, 0, f, &sigma, &corr_at(rho), &mut out);
+        assert_relative_eq!(out[0].0, fd_r, max_relative = 1e-8);
+        assert_relative_eq!(out[0].1, fd_d, max_relative = 1e-8);
+        // Combined error: R = (fσ_p)² + σ_a² + 2ρ·f·σ_p·σ_a, so the hand value is
+        // 2·f·σ_p·σ_a — pinned so an FD-only check can't hide a shared mistake.
+        assert_relative_eq!(out[0].0, 2.0 * f * sigma[0] * sigma[1], epsilon = 1e-12);
+        assert_relative_eq!(out[0].1, 2.0 * sigma[0] * sigma[1], epsilon = 1e-12);
+    }
+
+    /// The `MIN_VARIANCE` clamp is asymmetric on purpose: `variance_at_scaled`
+    /// floors `R` while `diag_self_deriv` leaves `d` unfloored, so a clamped row
+    /// must report `∂R/∂ρ = 0` and keep its `∂d/∂ρ`. Claiming a live `∂R/∂ρ` on a
+    /// row whose variance the objective has pinned is the #958 failure mode, on
+    /// the correlation axis (#847).
+    #[test]
+    fn dvar_drho_zeroes_the_variance_term_at_the_floor() {
+        // `Combined` loads both slots, so the correlation has a partner; driving
+        // both sigmas to zero puts the row on the floor.
+        let es = ErrorSpec::Single(ErrorModel::Combined);
+        let sigma = [0.0_f64, 0.0];
+        let corr = vec![ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+        assert!(es.variance_at_with_correlations(0, 5.0, &sigma, &corr) <= MIN_VARIANCE);
+        let mut out = [(0.0, 0.0)];
+        dvar_drho(&es, 0, 5.0, &sigma, &corr, &mut out);
+        assert_eq!(out[0].0, 0.0);
+    }
+
+    /// A correlation whose two sigma slots are not both loaded by an observation
+    /// contributes nothing to that observation's variance, so both derivatives
+    /// are zero — the same `continue` `variance_at_scaled` takes (#847).
+    #[test]
+    fn dvar_drho_is_zero_when_a_slot_is_not_loaded() {
+        // `Additive` loads slot 0 only, so a (0, 1) correlation has no partner.
+        let es = ErrorSpec::Single(ErrorModel::Additive);
+        let corr = vec![ResidualCorrelation {
+            sigma_i: 0,
+            sigma_j: 1,
+            rho: 0.5,
+        }];
+        let mut out = [(1.0, 1.0)];
+        dvar_drho(&es, 0, 3.0, &[0.4, 0.9], &corr, &mut out);
+        assert_eq!(out[0], (0.0, 0.0));
+    }
+
     #[test]
     fn test_additive_variance_independent_of_prediction() {
         let v1 = residual_variance(ErrorModel::Additive, 1.0, &[0.5]);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1820,12 +1820,18 @@ pub struct SigmaVector {
     pub names: Vec<String>,
 }
 
-/// Fixed correlation between two named residual-error terms.
+/// Correlation between two named residual-error terms.
 ///
 /// `sigma_i` and `sigma_j` index [`SigmaVector::values`]. The covariance used
 /// at runtime is `rho * sigma_i * sigma_j`, so the existing positive SD
 /// parameterization remains unchanged while off-diagonal residual covariance is
 /// carried into subject-level R matrices.
+///
+/// A plain `block_sigma (...) = [...]` **estimates** `rho` (NONMEM `$SIGMA
+/// BLOCK(n)` semantics, #847); `block_sigma (...) = [...] FIX` holds it at the
+/// declared value. Which of the two applies is carried alongside the value in
+/// [`ModelParameters::residual_correlation_fixed`], not in this struct, so the
+/// serialized shape stays what `FitResult` consumers already parse.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ResidualCorrelation {
     pub sigma_i: usize,
@@ -1853,6 +1859,17 @@ pub struct ModelParameters {
     pub sigma: SigmaVector,
     /// Per-sigma FIX flags.
     pub sigma_fixed: Vec<bool>,
+    /// Live `block_sigma` off-diagonal residual correlations (#847), in the same
+    /// order and with the same `sigma_i`/`sigma_j` indices as
+    /// [`CompiledModel::residual_correlations`]. The model's copy holds the
+    /// *declared* value; this one moves during the fit whenever the block is not
+    /// `FIX`, so every residual-covariance consumer must read it from here (or
+    /// from the parameters threaded alongside) rather than from the frozen
+    /// model.
+    pub residual_correlations: Vec<ResidualCorrelation>,
+    /// Per-residual-correlation FIX flags, parallel to `residual_correlations`.
+    /// `true` for a `block_sigma ... FIX` declaration.
+    pub residual_correlation_fixed: Vec<bool>,
     /// Inter-occasion variability matrix (Omega_IOV). `None` when no `kappa`
     /// declarations appear in the model file.  Always diagonal for Option A.
     pub omega_iov: Option<OmegaMatrix>,
@@ -1901,6 +1918,7 @@ impl ModelParameters {
         self.theta_fixed.iter().any(|&b| b)
             || self.omega_fixed.iter().any(|&b| b)
             || self.sigma_fixed.iter().any(|&b| b)
+            || self.residual_correlation_fixed.iter().any(|&b| b)
             || self.kappa_fixed.iter().any(|&b| b)
     }
 }
@@ -5478,13 +5496,20 @@ pub struct FitResult {
     pub sigma: Vec<f64>,
     /// Names of the sigma parameters, parallel to `sigma`.
     pub sigma_names: Vec<String>,
-    /// Residual-error correlations in force for this fit, copied from the model.
+    /// Residual-error correlations in force for this fit.
     ///
-    /// These correlations are fixed by the `block_sigma` declaration rather
-    /// than estimated. Together with `sigma`, they make the fitted residual
-    /// covariance reconstructible as `rho * sigma[i] * sigma[j]`.
+    /// A plain `block_sigma` estimates these alongside theta/omega/sigma (#847);
+    /// a `block_sigma ... FIX` block holds them at the declared value — see
+    /// `residual_correlation_fixed`. Together with `sigma`, they make the fitted
+    /// residual covariance reconstructible as `rho * sigma[i] * sigma[j]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub residual_correlations: Vec<ResidualCorrelation>,
+    /// FIX flags parallel to `residual_correlations` (#847). Empty for a fit
+    /// loaded from a pre-#847 artifact, where every correlation was fixed by
+    /// construction; readers should treat a missing entry as `true` only when
+    /// `residual_correlations` predates this field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub residual_correlation_fixed: Vec<bool>,
     /// Residual error model (additive, proportional, combined).
     ///
     /// For multi-endpoint (per-CMT) models this is only the *representative*
@@ -5504,6 +5529,12 @@ pub struct FitResult {
     ///   [`omega_se_at`] to index by (i, j).
     pub se_omega: Option<Vec<f64>>,
     pub se_sigma: Option<Vec<f64>>,
+    /// Standard errors for the estimated `block_sigma` correlations (#847), on
+    /// the natural ρ scale, parallel to `residual_correlations`. `0.0` for a
+    /// `FIX`ed entry, matching how the other `se_*` vectors report a pinned
+    /// coordinate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub se_residual_correlations: Option<Vec<f64>>,
     /// FIX flags carried through from the model so the output layer can
     /// render `FIXED` for SE columns rather than the (meaningless) zero
     /// they acquire from the reduced-Hessian covariance step.

--- a/src/types_test_helpers.rs
+++ b/src/types_test_helpers.rs
@@ -30,6 +30,8 @@ fn make_compiled_model(with_ode: bool, gradient_method: GradientMethod) -> Compi
         indiv_param_names: vec!["CL".into()],
         indiv_param_partials: IndivParamPartials::empty(),
         default_params: ModelParameters {
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
             theta: vec![1.0],
             theta_names: vec!["CL".into()],
             theta_lower: vec![0.0],
@@ -119,6 +121,8 @@ fn make_compiled_model(with_ode: bool, gradient_method: GradientMethod) -> Compi
 /// simulated replicates is residual error, which keeps NPD deterministic.
 pub(crate) fn tv_cov_iv_model_and_subject() -> (CompiledModel, Subject) {
     let params = ModelParameters {
+        residual_correlations: Vec::new(),
+        residual_correlation_fixed: Vec::new(),
         theta: vec![5.0, 50.0],
         theta_names: vec!["TVCL".into(), "TVV".into()],
         theta_lower: vec![0.1, 5.0],

--- a/tests/dense_residual_convergence.rs
+++ b/tests/dense_residual_convergence.rs
@@ -42,7 +42,11 @@ const MODEL: &str = "\
 ";
 
 fn fit_with(gradient: GradientMethod) -> ferx_core::FitResult {
-    let mut model = parse_model_string(MODEL).expect("block_sigma model must parse");
+    fit_source(MODEL, gradient)
+}
+
+fn fit_source(src: &str, gradient: GradientMethod) -> ferx_core::FitResult {
+    let mut model = parse_model_string(src).expect("block_sigma model must parse");
     assert!(
         !model.residual_correlations.is_empty(),
         "model must carry a residual correlation"
@@ -107,4 +111,64 @@ fn dense_residual_analytic_and_fd_fits_agree() {
             fd.theta[k]
         );
     }
+}
+
+/// #847: a bare `block_sigma` estimates its off-diagonal, so the free-rho fit must
+/// (a) actually move rho off its declared value and (b) land at an OFV no worse
+/// than the `FIX`ed fit — the fixed model is the free model restricted to a
+/// single point of the rho axis, so a free fit that scored worse would mean the
+/// rho gradient points the optimizer the wrong way.
+///
+/// This is the convergence-level companion to the per-coordinate parity tests
+/// (`population_packed_gradient_block_sigma_matches_fd` and siblings), which pin
+/// the rho gradient itself against Richardson reconverged FD.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn dense_residual_free_rho_beats_fixed_rho() {
+    let free_src = MODEL.replace("1.00] FIX", "1.00]");
+    let free = fit_source(&free_src, GradientMethod::Auto);
+    let fixed = fit_with(GradientMethod::Auto);
+
+    assert!(
+        free.ofv.is_finite() && fixed.ofv.is_finite(),
+        "both OFVs must be finite: free {}, fixed {}",
+        free.ofv,
+        fixed.ofv
+    );
+    assert_eq!(free.residual_correlation_fixed, vec![false]);
+    assert_eq!(fixed.residual_correlation_fixed, vec![true]);
+
+    // The FIXed fit holds rho at the declaration; the free fit moves it.
+    let declared = 0.5_f64;
+    assert!((fixed.residual_correlations[0].rho - declared).abs() < 1e-12);
+    let free_rho = free.residual_correlations[0].rho;
+    assert!(
+        (free_rho - declared).abs() > 1e-3,
+        "free rho should move off the {declared} init, got {free_rho}"
+    );
+    assert!(
+        free_rho.abs() < 1.0,
+        "the Fisher-z box must keep rho admissible, got {free_rho}"
+    );
+
+    // Widening the feasible set cannot make the optimum worse.
+    assert!(
+        free.ofv <= fixed.ofv + 1e-2,
+        "free-rho OFV {} should be no worse than fixed-rho OFV {}",
+        free.ofv,
+        fixed.ofv
+    );
+
+    // The analytic rho gradient must reach the same optimum the FD path does —
+    // the rho analogue of `dense_residual_analytic_and_fd_fits_agree`.
+    let free_fd = fit_source(&free_src, GradientMethod::Fd);
+    assert!(
+        free.ofv <= free_fd.ofv + 1e-2,
+        "analytic free-rho OFV {} should be no worse than FD {}",
+        free.ofv,
+        free_fd.ofv
+    );
 }

--- a/tests/fit_result_residual_correlations.rs
+++ b/tests/fit_result_residual_correlations.rs
@@ -44,3 +44,63 @@ fn fit_result_carries_fixed_block_sigma_correlations() {
     let covariance = corr.rho * result.sigma[corr.sigma_i] * result.sigma[corr.sigma_j];
     assert!((covariance - 0.1).abs() < 1e-12);
 }
+
+/// #847: a bare `block_sigma` (no `FIX`) **estimates** its off-diagonal — NONMEM
+/// `$SIGMA BLOCK(n)` semantics — so the fit must report it as a free coordinate.
+///
+/// `outer_maxiter: 0` keeps this a Tier-2 test (one evaluation, no convergence
+/// loop): it pins the *plumbing* — the flag reaches `FitResult`, rho is packed as
+/// a free coordinate, and the reported value is the parameter vector's, not the
+/// model's declaration. That the optimizer actually moves rho is the slow test
+/// `dense_residual_free_rho_beats_fixed_rho`.
+#[test]
+fn fit_result_marks_a_bare_block_sigma_correlation_free() {
+    use ferx_core::estimation::parameterization::{compute_bounds, packed_fixed_mask};
+
+    let src = MODEL.replace("1.00] FIX", "1.00]");
+    let model = parse_model_string(&src).expect("free block_sigma model must parse");
+    let population = read_nonmem_csv(
+        Path::new("data/correlated_residual_combined.csv"),
+        None,
+        None,
+    )
+    .expect("correlated residual data must load");
+    let options = FitOptions {
+        outer_maxiter: 0,
+        run_covariance_step: false,
+        verbose: false,
+        ..FitOptions::default()
+    };
+
+    let params = &model.default_params;
+    assert_eq!(params.residual_correlation_fixed, vec![false]);
+    // The rho coordinate is packed last, free (lower < upper) rather than pinned.
+    let mask = packed_fixed_mask(params);
+    let bounds = compute_bounds(params);
+    let rho_idx = mask.len() - 1;
+    assert!(!mask[rho_idx]);
+    assert!(bounds.lower[rho_idx] < bounds.upper[rho_idx]);
+    // The sigma SDs stay free too — `FIX` is what pinned them before.
+    assert_eq!(params.sigma_fixed, vec![false, false]);
+
+    let result = fit(&model, &population, params, &options)
+        .expect("free correlated-residual evaluation must succeed");
+    assert_eq!(result.residual_correlation_fixed, vec![false]);
+    assert!((result.residual_correlations[0].rho - 0.5).abs() < 1e-12);
+}
+
+/// The `FIX` companion to the test above: the whole block is pinned, so no
+/// optimizer that respects box bounds can move either the SDs or rho (#847).
+#[test]
+fn fit_result_marks_a_fixed_block_sigma_correlation_pinned() {
+    use ferx_core::estimation::parameterization::{compute_bounds, packed_fixed_mask};
+
+    let model = parse_model_string(MODEL).expect("block_sigma model must parse");
+    let params = &model.default_params;
+    assert_eq!(params.residual_correlation_fixed, vec![true]);
+    let mask = packed_fixed_mask(params);
+    let bounds = compute_bounds(params);
+    let rho_idx = mask.len() - 1;
+    assert!(mask[rho_idx]);
+    assert_eq!(bounds.lower[rho_idx], bounds.upper[rho_idx]);
+}

--- a/tests/fit_result_residual_correlations.rs
+++ b/tests/fit_result_residual_correlations.rs
@@ -167,3 +167,48 @@ fn block_sigma_chain_before_focei_is_allowed() {
         .iter()
         .any(|d| d.code == "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED"));
 }
+
+/// #847 / review finding: AGQ's score assembles theta/omega/sigma/omega_iov and
+/// never writes the trailing rho slot, so a model with a **free** block_sigma must
+/// decline the analytic gradient and fall to `reconverged_fd_gradient`, which
+/// differences every free packed coordinate. A hard zero there would leave the
+/// optimizer no reason to move rho while the objective genuinely depends on it.
+#[test]
+fn agq_declines_the_analytic_gradient_for_a_free_block_sigma() {
+    let src = MODEL.replace("1.00] FIX", "1.00]");
+    let model = parse_model_string(&src).expect("free block_sigma model must parse");
+    assert_eq!(model.default_params.residual_correlation_fixed, vec![false]);
+    assert!(
+        !ferx_core::estimation::agq::analytic_gradient_available(&model),
+        "a free block_sigma must route AGQ/Laplace to the reconverged-FD gradient"
+    );
+}
+
+/// A `FIX`ed block carries no free rho coordinate for the score to miss, so the
+/// analytic AGQ gradient stays available — the fallback above must not become a
+/// blanket opt-out for every correlated model.
+#[test]
+fn agq_keeps_the_analytic_gradient_for_a_fixed_block_sigma() {
+    let model = parse_model_string(MODEL).expect("block_sigma model must parse");
+    assert_eq!(model.default_params.residual_correlation_fixed, vec![true]);
+    assert!(ferx_core::estimation::agq::analytic_gradient_available(
+        &model
+    ));
+}
+
+/// The chain guard keys on "can this stage move rho", which is not the same set as
+/// "has an analytic rho gradient": `laplace` moves rho through AGQ's FD fallback,
+/// so `[laplace, imp]` must be rejected exactly like `[focei, imp]` (#847).
+#[test]
+fn block_sigma_chain_after_laplace_is_rejected() {
+    let src = MODEL.replace("1.00] FIX", "1.00]");
+    let model = parse_model_string(&src).expect("free block_sigma model must parse");
+    let options = FitOptions {
+        methods: vec![EstimationMethod::Laplace, EstimationMethod::Imp],
+        ..FitOptions::default()
+    };
+    let diags = ferx_core::check_model_options(&model, &options);
+    assert!(diags
+        .iter()
+        .any(|d| d.code == "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED"));
+}

--- a/tests/fit_result_residual_correlations.rs
+++ b/tests/fit_result_residual_correlations.rs
@@ -36,8 +36,20 @@ fn fit_result_carries_fixed_block_sigma_correlations() {
     let result = fit(&model, &population, &model.default_params, &options)
         .expect("initial correlated-residual evaluation must succeed");
 
-    assert_eq!(result.residual_correlations, model.residual_correlations);
+    // Structural equality only. Since #847 the reported rho comes off the packed
+    // parameter vector, so even a `FIX`ed one round-trips through
+    // `tanh(atanh(rho))` — exact `assert_eq!` on the f64 is a last-ULP coin flip
+    // that depends on the codegen (it held locally and failed under the coverage
+    // build). The value itself is checked to tolerance just below.
+    assert_eq!(
+        result.residual_correlations.len(),
+        model.residual_correlations.len()
+    );
     let corr = result.residual_correlations[0];
+    let declared = model.residual_correlations[0];
+    assert_eq!(corr.sigma_i, declared.sigma_i);
+    assert_eq!(corr.sigma_j, declared.sigma_j);
+    assert!((corr.rho - declared.rho).abs() < 1e-12);
     assert_eq!(result.sigma_names[corr.sigma_i], "ADD_ERR");
     assert_eq!(result.sigma_names[corr.sigma_j], "PROP_ERR");
     assert!((corr.rho - 0.5).abs() < 1e-12);

--- a/tests/fit_result_residual_correlations.rs
+++ b/tests/fit_result_residual_correlations.rs
@@ -1,5 +1,5 @@
 use ferx_core::parser::model_parser::parse_model_string;
-use ferx_core::{fit, read_nonmem_csv, FitOptions};
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
 use std::path::Path;
 
 const MODEL: &str = "\
@@ -103,4 +103,55 @@ fn fit_result_marks_a_fixed_block_sigma_correlation_pinned() {
     let rho_idx = mask.len() - 1;
     assert!(mask[rho_idx]);
     assert_eq!(bounds.lower[rho_idx], bounds.upper[rho_idx]);
+}
+
+/// #847: only FOCE/FOCEI estimate the `block_sigma` off-diagonal, and the method
+/// chain forwards fitted parameters to the next stage. A stage that cannot read
+/// the estimated rho would score the *declared* one while the result reported the
+/// estimate, so the configuration is refused rather than mis-scored.
+#[test]
+fn block_sigma_chain_after_focei_is_rejected() {
+    let src = MODEL.replace("1.00] FIX", "1.00]");
+    let model = parse_model_string(&src).expect("free block_sigma model must parse");
+    let options = FitOptions {
+        methods: vec![EstimationMethod::FoceI, EstimationMethod::Imp],
+        ..FitOptions::default()
+    };
+    let diags = ferx_core::check_model_options(&model, &options);
+    let hit = diags
+        .iter()
+        .find(|d| d.code == "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED")
+        .expect("a rho-estimating stage followed by IMP must be rejected");
+    assert!(hit.message.contains("FIX"), "{}", hit.message);
+}
+
+/// The same chain is fine when the block is `FIX`ed — rho never moves, so every
+/// stage scores the declaration and the reported value agrees with it (#847).
+#[test]
+fn block_sigma_chain_after_focei_is_allowed_when_fixed() {
+    let model = parse_model_string(MODEL).expect("block_sigma model must parse");
+    let options = FitOptions {
+        methods: vec![EstimationMethod::FoceI, EstimationMethod::Imp],
+        ..FitOptions::default()
+    };
+    let diags = ferx_core::check_model_options(&model, &options);
+    assert!(!diags
+        .iter()
+        .any(|d| d.code == "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED"));
+}
+
+/// A non-estimating stage placed **first** is fine: rho has not moved yet, so it
+/// scores the declaration, which is still the live value (#847).
+#[test]
+fn block_sigma_chain_before_focei_is_allowed() {
+    let src = MODEL.replace("1.00] FIX", "1.00]");
+    let model = parse_model_string(&src).expect("free block_sigma model must parse");
+    let options = FitOptions {
+        methods: vec![EstimationMethod::Saem, EstimationMethod::FoceI],
+        ..FitOptions::default()
+    };
+    let diags = ferx_core::check_model_options(&model, &options);
+    assert!(!diags
+        .iter()
+        .any(|d| d.code == "E_BLOCK_SIGMA_CHAIN_UNSUPPORTED"));
 }


### PR DESCRIPTION
## Why

`block_sigma` parsed its off-diagonal into a `ResidualCorrelation` that lived only on the
frozen `CompiledModel` and was never estimated, so a model with a `$SIGMA BLOCK(n)`
counterpart in NONMEM optimized a **different objective**. On the fluconazole RadboudUMC model
NONMEM moves the residual correlation from 0.20 to 0.9312 while ferx held the 0.20 init, which
is what #847 is about.

Closes #847.

This is a fresh implementation on current `main`, not a rebase of the two earlier attempts
(#868, #850). Both branch from 2026-07-15 and are ~660 commits behind: `src/api.rs` has since
been split into `src/api/`, test modules were extracted into sibling `*_tests.rs` files,
`residual_error.rs` became the sole owner of the residual-variance math, and #1100/#1101
already landed the `FitResult` + YAML half. `git merge-tree` reports
`CONFLICT (modify/delete): src/api.rs` on both. The *design* from those PRs is reused —
skeleton and validation from #868, the closed-form ρ derivatives from #850 — which is why this
lands in 1.5k insertions where they needed 2.0k / 2.5k.

## What changed

**Parameterization.** ρ becomes a packed optimizer coordinate as its Fisher-z transform
`z = atanh(ρ)`, bounded at `|z| ≤ 6`, so ρ stays strictly inside `(-1, 1)` for every step the
optimizer can take and the residual covariance can never go singular from the correlation
alone. The ρ block is packed **last** — after Ω_IOV and the mixture overrides — so every
offset the rest of the codebase derives from `n_theta`/`n_omega`/`n_sigma` (the covariance
step's `kappa_start`, the mixture segment, `omega_structural_zero_mask`'s `iov_start`) keeps
pointing at the same coordinate. `rho_packed_start` owns that offset; nothing re-derives it.

**Semantics.** A plain `block_sigma (...) = [...]` estimates the off-diagonal (NONMEM
`$SIGMA BLOCK(n)`); `... FIX` pins the whole block. See Breaking changes.

**Live ρ.** The FOCE/FOCEI objective and the inner EBE search read the correlations off the
frozen model, so a ρ the optimizer moved was invisible to them. `individual_nll_into_with_schedule`,
`foce_subject_nll`, `foce_population_nll` and `analytic_eta_nll_gradient_with_schedule` now
take the live `&[ResidualCorrelation]` next to the live σ.

**Closed-form ∂/∂ρ.** In `stats/residual_error.rs` — the module CLAUDE.md names sole owner of
this math — as `dvar_drho`. Every sigma loading is affine in `f`, so with `c` the value
loading and `c'` its slope:

```
dR_jj/drho_k = 2·s_i·s_j·c_i·c_j
dd_j /drho_k = 2·s_i·s_j·(c_i'·c_j + c_i·c_j')
```

which is exactly the ρ-derivative of `variance_at_scaled`'s cross term and of
`diag_self_deriv`'s, so the two cannot drift. The `MIN_VARIANCE` floor is mirrored
**asymmetrically on purpose**: `variance_at_scaled` clamps `R` while `diag_self_deriv` leaves
`d` unclamped, so a clamped row reports `∂R/∂ρ = 0` but keeps `∂d/∂ρ`. Without that the
gradient claims a live `∂R/∂ρ` on a row whose variance the objective has already pinned to the
floor — the #958 failure mode, on the correlation axis.

`rho_block` feeds those into `sigma_block`'s exact assembly (data + lnR, `log|H̃|`, EBE
response) for FOCEI; the FOCE Sheiner–Beal marginal is first-order in `R`, so ρ enters only
through `R⁰` at `f(η=0)`; `subject_eta_dx` gains the matching `dη̂/dρ` column. All three carry
the Fisher-z chain `dρ/dz = 1 − ρ²`.

**Reporting.** `FitResult` gains `residual_correlation_fixed` and `se_residual_correlations`
(natural ρ scale, delta method on the packed coordinate). The fit YAML's `block_sigma:` section
gains `correlation_se` and reports `correlation_fixed` from the model instead of hard-coded
`true`; `covariance_fixed` now requires all three factors of `ρ·σ_i·σ_j` to be pinned. `.fitrx`
round-trips all three, and a pre-#847 bundle loads with every correlation marked fixed.

### Bugs found on the way

- **`corr_residual_diag` / `corr_residual_rd_at_sigma` read the frozen model**, so `prep`'s
  `(r, d, d2)` — and hence the whole outer-gradient assembly — would have been built at the
  *declared* ρ even after the optimizer moved it. The FD parity harness `precise_ebe_corr` had
  the same read, which is why its reference was initially missing ρ's EBE-response term
  (analytic 5.963 vs FD 5.948 until both were fixed).
- **`simulate()`** built its dense `R` from the declared correlation with fitted sigmas, so a
  VPC of an estimated `block_sigma` would not reproduce the correlation the fit reported.

## Alternatives considered

Rebasing #868 or #850 — rejected, see Why. Their designs are reused.

**Threading live ρ through every estimator vs. rejecting the chain.** `fit()` forwards each
stage's fitted parameters to the next, so `[focei, imp]` would hand IMP a FOCEI-estimated ρ
that IMP has no channel to read: it would score the *declared* correlation while the result
reported the estimate. Threading live ρ down to SAEM/IS/IMPMAP/VI's data term means ten helper
signatures and their callers. This PR rejects the configuration instead
(`E_BLOCK_SIGMA_CHAIN_UNSUPPORTED`) and leaves the threading as a follow-up. `[saem, focei]` is
unaffected — ρ has not moved when SAEM runs.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

Both new `FitResult` fields are `#[serde(default, skip_serializing_if = ...)]`, so ferx-r's
reads stay backward-compatible. Surfacing `se_residual_correlations` in the R wrapper is an
enhancement, not a requirement.

## Breaking changes
- [x] `.ferx` model file format — a non-`FIX` `block_sigma` now **estimates** its off-diagonal
- [x] `FitResult` fields changed — two added, both serde-defaulted
- [x] Public Rust API — regenerated via `tools/update-public-api.sh`

<details>
<summary>Migration notes</summary>

The old behaviour was: diagonal SDs estimated, off-diagonal frozen. **That combination is no
longer expressible** — NONMEM has no form for it either, and it is precisely the mismatch this
issue is about. `FIX` reproduces the old *correlation* but also pins the SDs the old form
estimated, so it is not a drop-in way to reproduce an old fit's numbers; re-run and compare.
The shipped `examples/correlated_residual_combined.ferx` already uses `FIX` and is unaffected.

Public API additions and why each is needed:

| Item | Needed by |
|---|---|
| `ModelParameters::residual_correlations`, `::residual_correlation_fixed` | `unpack_params` must return the live ρ; every objective consumer reads it from the parameter vector |
| `FitResult::residual_correlation_fixed`, `::se_residual_correlations` | the output layer must distinguish an estimated from a fixed correlation, and report its SE |
| `residual_correlations` argument on `foce_subject_nll`, `foce_population_nll`, `individual_nll_into_with_schedule` | the live-ρ channel, parallel to the existing `sigma_values` |
| `PackedLayout::n_rho`, `::omega_iov_end` | VI's `total()` must equal `pack_params().len()` or its `x` cannot round-trip through `unpack_params` |

</details>

## Numerical validation
- [x] Compared against: **NONMEM** (`ferx-testdata/fluconazole_radboudumc/nm/fluconfinal014.lst`)
- [x] Reference values:

```
NONMEM fluconfinal014:  OFV 734.644   rho 0.9312   TVQ 16.8
```

```
NONMEM fluconfinal014:  OFV 734.644   rho 0.9312   TVQ 16.8
```

All rows below: fluconazole RadboudUMC, the model file's own `[fit_options]` and
`[data_selection]` (271 obs, FOCEI, covariance off), started from the model's **declared
inits** (rho init 0.20) — a cold start, not seeded from NONMEM.

| | packed params | OFV | converged | rho | sigma_unbound | sigma_total |
|---|---|---|---|---|---|---|
| main @ `7488e5e9` (rho frozen) | 13 | 871.5137 | yes | 0.2 (fixed) | 0.4583 | 0.4163 |
| this branch, rho **pinned** | 13 | **871.5137** | yes | 0.2 (fixed) | — | — |
| this branch, rho **free** | 14 | **736.8903** | yes | **0.9319** | 0.4557 | 0.4141 |
| NONMEM `fluconfinal014` | — | 734.644 | — | 0.9312 | 0.4506 | 0.4147 |

**rho lands on 0.9319 against NONMEM's 0.9312**, sigma on both endpoints to two decimals, and
the objective within 2.2 units — from a cold start, converged. That is #847's correlation
criterion. The pinned row reproduces `main` to every printed digit, which is the plumbing
check: with rho held, this branch is the old code.

`TVQ` reaches 11.2 against NONMEM's 16.8. That gap is the Q-collapse of open issue **#864**,
not this PR — `main` shows the same collapse (11.3) when started from NONMEM's own estimates,
with rho frozen at 0.9337.

Nothing else moves. `examples/warfarin.ferx` is byte-identical to main (−280.3640), and
`examples/correlated_residual_combined.ferx` — whose block carries `FIX` — also matches main
exactly (18.7274). Scoped by construction: `rho_packed_start` equals `packed_len` when a model
declares no correlations, so the one preconditioner change below is a no-op there.

### The one non-obvious fix this needed

Freeing rho initially made NLopt L-BFGS fail on its first step (OFV stuck at 1111.12, rho never
leaving 0.2). The cause was **not** the rho math — on this model `R` is genuinely dense
(cross-endpoint total/unbound pairing via `L2`), so `population_gradient_sens` returns `None`,
the whole population falls to reconverged FD, and `rho_block` never executes. The optimizer
trace showed the second iterate at OFV 1.3e17 with `TVBMAX` sitting exactly on its upper bound
— and `main` hits the same 1e17 blow-ups, so that pathology is pre-existing.

What was mine: the `abs` preconditioner divides each packed coordinate by its own `|value|`.
That is right for a log-space coordinate, where `|v|` is an order of magnitude. A Fisher-z
`z = atanh(rho)` is a *position* in a bounded range that passes through zero, so at
`rho = 0.2` (`z = 0.203`) the scaled box became ±30 while every other scaled coordinate spanned
single digits. The scale is now `max(|z|, 1)` — normalise a rho that has already grown past 1,
never divide by a value below it. Both halves are load-bearing: plain `compute_scale` fails at
1111.12, a flat `1.0` converges from the declared inits but stalls at init when seeded from
NONMEM's estimates, and `max(|z|, 1)` converges from both.

Per-coordinate: the existing analytic-vs-FD parity tests
(`population_packed_gradient_block_sigma_matches_fd` and its FOCE / Selected /
ExpressionScale siblings) now cover the ρ coordinate against Richardson reconverged FD of
ferx's own dense marginal. They were **red on the intermediate commit** (`analytic = 0.0` vs
`fd = 5.95`) and go green once `rho_block` lands — the oracle doing its job.

## Performance
- [x] No significant impact expected — ρ adds one packed coordinate and an O(n_obs) closed-form
      term per correlation per subject. No existing path changes cost.

## Tests
- [x] Unit tests added (`cargo test --lib --features ci`: 3894 passed, 0 failed)
- [x] Regression tests that fail without the fix

| Tier | Test |
|---|---|
| 1 | `dvar_drho_matches_fd_of_the_production_builders` — closed form vs central differences of the production `R` / `∂R/∂f` builders, **plus** hand-computed combined-error values so an FD-only check cannot pass on a shared mistake |
| 1 | `dvar_drho_zeroes_the_variance_term_at_the_floor`, `dvar_drho_is_zero_when_a_slot_is_not_loaded` |
| 1 | `test_pack_unpack_rho_round_trip`, `test_fixed_rho_is_pinned`, `test_rho_bounds_keep_correlation_admissible` (chain factor vs FD of `unpack_rho`), `test_rho_coordinate_kind_is_symmetric` |
| 1 | `test_se_residual_correlation_uses_the_trailing_rho_slot` — the template carries an IOV block **on purpose**, so an offset mistake lands on a kappa coordinate and shows |
| 1 | `population_packed_gradient_block_sigma_matches_fd` + FOCE / Selected / ExpressionScale, now including the ρ coordinate |
| 1 | YAML: fixed, estimated, and pre-#847 (flags absent) shapes |
| 2 | `fit_result_marks_a_bare_block_sigma_correlation_free` / `..._pinned`; the three `block_sigma_chain_*` guard tests |
| 3 | `dense_residual_free_rho_beats_fixed_rho` — ρ moves off init, stays inside `(-1, 1)`, free-ρ OFV ≤ fixed-ρ OFV (widening the feasible set cannot hurt), analytic ≤ FD |

## Example
- [x] Inline below

<details>
<summary>Example</summary>

```toml
[parameters]
  # rho estimated (NONMEM $SIGMA BLOCK semantics)
  block_sigma (PROP_ERR, ADD_ERR) = [0.04, 0.10, 1.00]

[error_model]
  DV ~ combined(PROP_ERR, ADD_ERR)
```

```yaml
block_sigma:
  ADD_ERR__PROP_ERR:
    covariance: 0.186600
    covariance_fixed: false
    correlation: 0.933000
    correlation_fixed: false
    correlation_se: 0.021400
```

</details>

## Docs
- [x] `docs/model-file/error-model.qmd` — new "Fixed vs. estimated `block_sigma`" section with
      the Fisher-z parameterisation, a migration callout, and the chain restriction. Splitting
      the page's one 7.4k-char terminal section into four bounded ones let its **R1 baseline
      entry be removed** rather than merely kept.
- [x] `CHANGELOG.md` `[Unreleased]` — Changed / Added / Fixed

## Checklist
- [x] `tools/preflight.sh` green — fmt, all 5 `cargo check` feature sets, clippy, rustdoc,
      docs-lint, public-API baseline. It earned its keep: three call sites reachable only under
      `slow-tests`, `markov` and `nn` were caught by it and not by the default test run.
- [x] `Dual2` sensitivity path stays differentiable — the ρ derivatives are `f64`-only closed
      forms; the generic `*_g<T: PkNum>` kernels are untouched.

## Reviewer hints

Focus:
- `stats/residual_error.rs::dvar_drho` — the closed forms and the deliberate floor asymmetry.
- `sens_outer_gradient.rs::rho_block` and the FOCE ρ term — they mirror `sigma_block` and the
  σ loop respectively; the parity tests are the oracle.
- The live-ρ threading, especially the `corr_residual_diag` fix (this was a real bug).
- `api/validation.rs` — the chain guard.

Skimmable: the ~50 mechanical struct-literal updates for the two new `ModelParameters` fields,
and the `obs_nll_subject_*` call sites that all pass `&model.residual_correlations`.

## Open questions

**Resolved** — this was a blocking question through most of this PR's history and the body
above now reflects the answer. Summary for anyone reading the commit trail: freeing rho made
NLopt L-BFGS fail on fluconazole; the cause was the `abs` preconditioner applied to a Fisher-z
coordinate, not the rho derivatives (which never run on that model). Fixed in
`fix(estimation): don't magnitude-scale the block_sigma rho coordinate below 1`.

**None open.** The chain restriction (`E_BLOCK_SIGMA_CHAIN_UNSUPPORTED`, rejecting a
rho-estimating stage followed by one that cannot read the estimate) is accepted as the trade
for this PR. Threading live rho through SAEM / IS / IMPMAP / VI so `[focei, imp]` keeps working
is tracked in **#1216**, with the ten helper signatures it touches enumerated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1QDyTu8Suqjz19d3uTeeE
