### PR TITLE
fix(ode): visit a one-break timeline's sole break so a single-instant grid reads the post-dose state [closes #1218]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,11 @@ section of the SDLC for the versioning policy).
   pass the subject's first dose or observation — returned `NaN` for `cum_hazard` and `hazard`
   with no warning, while the same `t = 0` on a longer grid was fine. It now returns the state
   at that instant, post-dose, exactly what the longer grid reads. The same one-break timeline
-  left `[derived]` output columns `NaN` for a subject whose only observation coincides with its
-  dose; fixed by the same change.
+  reached two other readers of the dense state: `[derived]` output columns on the event-driven
+  path (time-varying covariates, resets, or a model-time read) were `NaN` for a subject whose
+  only observation coincides with its dose, and a joint PK-TTE subject outside the shared
+  single-solve (same routing) whose only event or censor sits on its first dose scored the
+  `1e20` sentinel instead of its finite likelihood. Both fixed by the same change.
 - **An `SS=1` dose no longer carries the steady-state run-in into a joint PK-TTE model's
   cumulative hazard (#1210).** The appended `d/dt(__chz_<cmt>)` accumulator was cycled through
   the equilibration along with the PK compartments, but it is a pure integrator with no steady

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ section of the SDLC for the versioning policy).
   marked fixed, which is what it meant at the time.
 
 ### Fixed
+- **`predict_survival` returned `NaN` for a time grid with no point past the first event
+  (#1218).** Asking for the curve at `[0.0]` alone — or any grid whose largest time does not
+  pass the subject's first dose or observation — returned `NaN` for `cum_hazard` and `hazard`
+  with no warning, while the same `t = 0` on a longer grid was fine. It now returns the state
+  at that instant, post-dose, exactly what the longer grid reads. The same one-break timeline
+  left `[derived]` output columns `NaN` for a subject whose only observation coincides with its
+  dose; fixed by the same change.
 - **An `SS=1` dose no longer carries the steady-state run-in into a joint PK-TTE model's
   cumulative hazard (#1210).** The appended `d/dt(__chz_<cmt>)` accumulator was cycled through
   the equilibration along with the PK compartments, but it is a pure integrator with no steady

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -6532,9 +6532,21 @@ pub fn ode_dense_solve_states(
     // the `saveat` re-read post-dose) so the two paths agree and #570's
     // one-solve == two-solve equivalence holds at a dose-on-`t_last`. When no dose
     // lands there this re-reads the identical carried `u`, so it stays byte-identical
-    // everywhere else. Guarded to a timeline the loop actually ran (`len >= 2`); a
-    // single-instant `saveat` keeps its prior behaviour.
-    if break_times.len() >= 2 {
+    // everywhere else.
+    //
+    // Unconditional, including the one-break timeline (#1218). When every `saveat`
+    // sits at or before the first event the horizon `t_last` coincides with the
+    // integration start, `break_times` is a single instant, the loop above never runs,
+    // and this visit is the *only* one: it applies whatever lands there (an SS
+    // equilibration, a bolus) and writes the `saveat` rows post-dose, exactly as the
+    // loop's `t_start` write does when a later point is also requested. Until #1218 this
+    // block was guarded to `len >= 2` and a single-instant grid kept "its prior
+    // behaviour" — the `f64::NAN` prefill, which `predict_survival(&[0.0])` and the
+    // `[derived]` state path returned as a silent non-answer. The pre-first-event
+    // prefill above is deliberately *not* widened to cover the instant: it holds the
+    // seeded, pre-dose state, and a drug-driven hazard read off it is wrong in a way
+    // that looks finite.
+    {
         let t_last_break = break_times[break_times.len() - 1];
         let _ = apply_segment_boundary(
             ode,

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -6444,11 +6444,37 @@ pub fn ode_dense_solve_states(
         }
     }
 
-    for w in break_times.windows(2) {
-        let (t_start, t_end) = (w[0], w[1]);
-        if (t_end - t_start).abs() < 1e-15 {
-            continue;
+    // Walk every break as a **left boundary** — bound `0..len`, the walk
+    // `ode_predictions` and `ode_predictions_with_states` use (#731) — so a dose
+    // landing on the final break is applied and its `saveat` read post-dose, and a
+    // one-break timeline is visited exactly once (#1218: every `saveat` at or before
+    // the first event puts the horizon `t_last` on the integration start, so the
+    // timeline is a single instant). The integration half runs only while a next
+    // break exists; on the last break the boundary visit is all there is.
+    //
+    // History, because both defects lived in this loop's shape: it was a
+    // `windows(2)` walk that saw the final break only as a segment *end*, patched by
+    // a post-loop re-visit for #731 that was guarded to `len >= 2` — "a single-instant
+    // `saveat` keeps its prior behaviour", and the prior behaviour was the `f64::NAN`
+    // prefill, which `predict_survival(&[0.0])` and the event-driven `[derived]` state
+    // path returned as a silent non-answer. The `0..len` walk has no special case to
+    // guard. The pre-first-event prefill above is deliberately *not* widened to cover
+    // the instant: it holds the seeded, pre-dose state, and a drug-driven hazard read
+    // off it is wrong in a way that looks finite.
+    //
+    // The last break's visit is skipped when no `saveat` sits on it: `u`, `ext_params`
+    // and `active_infusions` are dead after this loop, so the SS equilibration it
+    // would run for a grid entirely before the first event (`[-1.0]` with a dose at
+    // `0`, where the `0.0`-seeded horizon fold still puts the dose on the timeline)
+    // has no reader. Unobservable on every other timeline: `t_last` is a `saveat`
+    // whenever any point is non-negative.
+    for k in 0..break_times.len() {
+        let t_start = break_times[k];
+        let next = break_times.get(k + 1).copied();
+        if next.is_none() && !saveat_map.contains_key(&t_start.to_bits()) {
+            break;
         }
+        let t_end = next.unwrap_or(t_start);
 
         let forcings = apply_segment_boundary(
             ode,
@@ -6474,6 +6500,10 @@ pub fn ode_dense_solve_states(
                 result[i] = u.clone();
             }
         }
+
+        let Some(t_end) = next else {
+            break;
+        };
 
         let mut seg_saveat: Vec<f64> = saveat
             .iter()
@@ -6521,52 +6551,6 @@ pub fn ode_dense_solve_states(
 
         if let Some(last) = sol.last() {
             u.copy_from_slice(&last.u);
-        }
-    }
-
-    // #731: the `windows(2)` loop visits the final break `t_last` only as a segment
-    // *end*, so a dose landing exactly on it is never applied and a `saveat` there
-    // reads the pre-dose state — the same terminal-break bug fixed on the
-    // constant-parameter engine (`ode_predictions_and_chz`). Visit `t_last` once more
-    // as a left boundary (dose applied via the shared `apply_segment_boundary`, then
-    // the `saveat` re-read post-dose) so the two paths agree and #570's
-    // one-solve == two-solve equivalence holds at a dose-on-`t_last`. When no dose
-    // lands there this re-reads the identical carried `u`, so it stays byte-identical
-    // everywhere else.
-    //
-    // Unconditional, including the one-break timeline (#1218). When every `saveat`
-    // sits at or before the first event the horizon `t_last` coincides with the
-    // integration start, `break_times` is a single instant, the loop above never runs,
-    // and this visit is the *only* one: it applies whatever lands there (an SS
-    // equilibration, a bolus) and writes the `saveat` rows post-dose, exactly as the
-    // loop's `t_start` write does when a later point is also requested. Until #1218 this
-    // block was guarded to `len >= 2` and a single-instant grid kept "its prior
-    // behaviour" — the `f64::NAN` prefill, which `predict_survival(&[0.0])` and the
-    // `[derived]` state path returned as a silent non-answer. The pre-first-event
-    // prefill above is deliberately *not* widened to cover the instant: it holds the
-    // seeded, pre-dose state, and a drug-driven hazard read off it is wrong in a way
-    // that looks finite.
-    {
-        let t_last_break = break_times[break_times.len() - 1];
-        let _ = apply_segment_boundary(
-            ode,
-            subject,
-            &dose_lagtimes,
-            &dose_f_bio,
-            &zo_windows,
-            pk_params_flat,
-            n,
-            &opts,
-            t_last_break,
-            t_last_break,
-            &mut u,
-            &mut active_infusions,
-            &mut ext_params,
-        );
-        if let Some(idxs) = saveat_map.get(&t_last_break.to_bits()) {
-            for &i in idxs {
-                result[i] = u.clone();
-            }
         }
     }
 
@@ -6621,6 +6605,12 @@ pub enum ThresholdOutcome {
 /// `prepare_input_rates`, `wrap_rhs_with_forcings`); only the segment *loop* is
 /// restated, and it is pinned against drift by the `until_chz_threshold` parity
 /// test (the crossing time it returns must satisfy `CHZ_dense(t) ≈ threshold`).
+///
+/// One deliberate difference from the dense walk: the final break is visited only as
+/// a segment *end*, never as a left boundary (#731 / #1218). A dose landing exactly on
+/// `horizon` cannot move the accumulator before `horizon`, and a one-break timeline —
+/// `horizon` at the integration start — is a censored draw, not a solve; so there is
+/// no post-dose state to read here and nothing for the parity test to miss.
 #[cfg(feature = "survival")]
 pub(crate) fn ode_solve_until_chz_threshold(
     ode: &OdeSpec,

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -9298,43 +9298,41 @@ fn a_nonlinear_joint_model_judges_convergence_on_the_pk_rows() {
 #[cfg(feature = "survival")]
 const SS_CHZ_BETA: f64 = 0.01;
 
-/// 1-cpt IV bolus + a **drug-driven** accumulator: `d/dt(__chz) = H0 · exp(BETA · central)`.
-/// Same declaration as [`one_cpt_const_chz_spec`]; the hazard reads the state, so a row read
-/// from the wrong state is visible in `h` as well as in the compartments.
+/// [`one_cpt_const_chz_spec`] with a **drug-driven** accumulator:
+/// `d/dt(__chz) = H0 · exp(BETA · central)`. Derived from the const spec — the same
+/// declaration, tolerances and slot, as `mm_const_chz_spec` does — so the two stay twins;
+/// the hazard reads the state, so a row read from the wrong state is visible in `h` as well
+/// as in the compartments.
 #[cfg(feature = "survival")]
 fn one_cpt_drug_chz_spec() -> OdeSpec {
-    OdeSpec {
-        chz_state_slots: vec![1],
-        rhs: Box::new(|y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
-            let cl = p[crate::types::PK_IDX_CL];
-            let v = p[crate::types::PK_IDX_V];
-            let ke = if v > 0.0 { cl / v } else { 0.0 };
-            dy[0] = -ke * y[0];
-            dy[1] = SS_CHZ_H0 * (SS_CHZ_BETA * y[0]).exp();
-        }),
-        n_states: 2,
-        state_names: vec!["central".into(), "__chz_3".into()],
-        readout: OdeReadout::ObsCmt(0),
-        diffusion_var: Vec::new(),
-        solver_opts: OdeSolverOptions {
-            abstol: 1e-11,
-            reltol: 1e-9,
-            ..OdeSolverOptions::default()
-        },
-        input_rate: Vec::new(),
-        rhs_program: None,
-        readout_program: None,
-        indiv_param_program: None,
-        dose_attr_map: Default::default(),
-        init_fn: None,
-    }
+    let mut ode = one_cpt_const_chz_spec();
+    ode.rhs = Box::new(|y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
+        let cl = p[crate::types::PK_IDX_CL];
+        let v = p[crate::types::PK_IDX_V];
+        let ke = if v > 0.0 { cl / v } else { 0.0 };
+        dy[0] = -ke * y[0];
+        dy[1] = SS_CHZ_H0 * (SS_CHZ_BETA * y[0]).exp();
+    });
+    ode
+}
+
+/// The #1218 fixture: the drug-driven accumulator on an `SS=1` bolus at `t = 0`, whose
+/// post-dose state (trough + pulse) is what every single-instant arm must read.
+#[cfg(feature = "survival")]
+fn ss_instant_fixture() -> (OdeSpec, PkParams, Subject) {
+    let ode = one_cpt_drug_chz_spec();
+    let pk = pk_one(1.0, 10.0);
+    let subject = make_subject(
+        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, SS_CHZ_II)],
+        vec![],
+    );
+    (ode, pk, subject)
 }
 
 /// Every state of `got` is finite and bit-identical to `want`.
 ///
 /// Finiteness first and on its own: `NaN == NaN` is `false`, so the equality would fail on a
 /// `NaN` row too, but it would say "bits differ" about a row that was never computed.
-#[cfg(feature = "survival")]
 fn assert_states_bit_identical(got: &[f64], want: &[f64], arm: &str) {
     assert_eq!(
         got.len(),
@@ -9364,12 +9362,7 @@ fn assert_states_bit_identical(got: &[f64], want: &[f64], arm: &str) {
 #[cfg(feature = "survival")]
 #[test]
 fn a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state() {
-    let ode = one_cpt_drug_chz_spec();
-    let pk = pk_one(1.0, 10.0);
-    let subject = make_subject(
-        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, SS_CHZ_II)],
-        vec![],
-    );
+    let (ode, pk, subject) = ss_instant_fixture();
     let single = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0]);
     let multi = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 1.0]);
     assert_eq!(single.len(), 1, "one row per saveat");
@@ -9377,8 +9370,9 @@ fn a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state() {
     assert_states_bit_identical(&single[0], &multi[0], "[0.0] vs [0.0, 1.0]");
 
     // The straddle, asserted: the row is the post-SS-dose state, not the seeded one. An SS
-    // bolus lands on its own trough, so central exceeds the bare 100 mg pulse, and the
-    // hazard read off it is not the drug-free `H0` the seeded state would give.
+    // bolus lands on its own trough, so central exceeds the bare 100 mg pulse — and since
+    // the accumulator's rate is `H0 · exp(BETA · central)`, that is also what makes `h(0)`
+    // differ from the drug-free `H0` the seeded state would give (the `<=` variant's number).
     let got = &single[0];
     assert!(
         got[0] > 100.0,
@@ -9386,13 +9380,6 @@ fn a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state() {
         got[0]
     );
     assert_eq!(got[1], 0.0, "H(0) must be exactly 0.0 at the first record");
-    let mut du = vec![0.0; ode.n_states];
-    (ode.rhs)(got, &pk.values, 0.0, &mut du);
-    assert!(
-        du[1] > 2.0 * SS_CHZ_H0,
-        "h(0) = {} reads as the drug-free hazard {SS_CHZ_H0}; the row is not post-dose",
-        du[1]
-    );
 }
 
 /// Duplicate nodes at the instant are all written, and a node *before* the first event keeps
@@ -9405,12 +9392,7 @@ fn a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state() {
 #[cfg(feature = "survival")]
 #[test]
 fn a_single_instant_grid_writes_every_duplicate_and_leaves_pre_event_nodes_seeded() {
-    let ode = one_cpt_drug_chz_spec();
-    let pk = pk_one(1.0, 10.0);
-    let subject = make_subject(
-        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, SS_CHZ_II)],
-        vec![],
-    );
+    let (ode, pk, subject) = ss_instant_fixture();
     let want = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 1.0]);
 
     let dup = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 0.0]);
@@ -9435,59 +9417,32 @@ fn a_single_instant_grid_writes_every_duplicate_and_leaves_pre_event_nodes_seede
 /// `[derived]` output column reads. Both a plain bolus and an SS dose, since they take
 /// different arms of `apply_segment_boundary` at the sole break.
 ///
-/// The readout is the compartment amount, so the state must also equal `ipred` exactly — the
-/// invariant the two-pass engine promises.
+/// The readout is the compartment amount, so the state row must also equal `ipred` exactly —
+/// the invariant the two-pass engine promises.
 #[test]
 fn with_states_on_a_single_instant_timeline_returns_the_post_dose_state() {
     let ode = one_cpt_ode_spec();
     let pk = pk_one(1.0, 10.0);
-    let at = |n: usize| vec![pk; n];
+    let run = |ss: bool, ii: f64, obs: Vec<f64>| {
+        let n_obs = obs.len();
+        let subject = make_subject(vec![DoseEvent::new(0.0, 100.0, 1, 0.0, ss, ii)], obs);
+        ode_predictions_event_driven_with_states(
+            &ode,
+            &subject,
+            &[],
+            &[],
+            &vec![pk; 1],
+            &vec![pk; n_obs],
+            &[],
+            &[],
+        )
+    };
     for (arm, ss, ii) in [("bolus", false, 0.0), ("ss", true, 12.0)] {
-        let one = make_subject(vec![DoseEvent::new(0.0, 100.0, 1, 0.0, ss, ii)], vec![0.0]);
-        let two = make_subject(
-            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, ss, ii)],
-            vec![0.0, 1.0],
-        );
-        let (ipred1, states1) = ode_predictions_event_driven_with_states(
-            &ode,
-            &one,
-            &[],
-            &[],
-            &at(1),
-            &at(1),
-            &[],
-            &[],
-        );
-        let (ipred2, states2) = ode_predictions_event_driven_with_states(
-            &ode,
-            &two,
-            &[],
-            &[],
-            &at(1),
-            &at(2),
-            &[],
-            &[],
-        );
+        let (ipred1, states1) = run(ss, ii, vec![0.0]);
+        let (ipred2, states2) = run(ss, ii, vec![0.0, 1.0]);
         assert_eq!(states1.len(), 1, "{arm}: one state row per observation");
-        assert!(
-            states1[0][0].is_finite(),
-            "{arm}: the single-instant state row is {:?}",
-            states1[0]
-        );
-        assert_eq!(
-            states1[0][0].to_bits(),
-            states2[0][0].to_bits(),
-            "{arm}: single-observation state {} differs from the two-observation row {}",
-            states1[0][0],
-            states2[0][0]
-        );
-        assert_eq!(
-            states1[0][0].to_bits(),
-            ipred1[0].to_bits(),
-            "{arm}: state {} and ipred {} disagree on an amount readout",
-            states1[0][0],
-            ipred1[0]
-        );
+        assert_states_bit_identical(&states1[0], &states2[0], arm);
+        assert_states_bit_identical(&states1[0], &[ipred1[0]], arm);
         assert_eq!(
             ipred1[0].to_bits(),
             ipred2[0].to_bits(),

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -9274,3 +9274,229 @@ fn a_nonlinear_joint_model_judges_convergence_on_the_pk_rows() {
         crate::dosing::SS_EQUILIBRATION_CYCLES
     );
 }
+
+// ── #1218 — a single-instant `saveat` reads the post-dose state, never the `NaN` prefill ──
+//
+// `ode_dense_solve_states` takes its horizon as the largest `saveat`, so a grid with no point
+// past the first event builds a one-break timeline. The `windows(2)` loop never runs on it,
+// and until #1218 the post-loop `#731` left-boundary visit was skipped for exactly that
+// timeline — "a single-instant `saveat` keeps its prior behaviour", and the prior behaviour was
+// the `f64::NAN` prefill. `predict_survival(&[0.0])` returned `NaN, NaN` while `[0.0, 1.0]`
+// returned a finite `t = 0` row; `ode_predictions_event_driven_with_states` returned a finite
+// `ipred` over an all-`NaN` state row for a subject whose only observation sits on its dose.
+//
+// The wrong fix is as quiet as the bug: filling the node from the *seeded* initial state
+// (widening the pre-first-event prefill from `<` to `<=`) gives `H(0) = 0` and a pre-dose
+// `h(0)`. On a drug-driven hazard that is the hazard at zero drug — `0.02` where the
+// multi-point grid reads `0.219` on #1210's fixture. A constant hazard cannot tell the two
+// apart, so the arms below use a drug-driven accumulator and compare the single-instant row
+// against the multi-point row on **every** state, bit for bit.
+
+/// Exposure slope of the drug-driven accumulator below. Small enough that `h` stays O(1) at
+/// an SS peak of ~143 amount units, large enough that "post-dose" and "seeded" differ by far
+/// more than a rounding error.
+#[cfg(feature = "survival")]
+const SS_CHZ_BETA: f64 = 0.01;
+
+/// 1-cpt IV bolus + a **drug-driven** accumulator: `d/dt(__chz) = H0 · exp(BETA · central)`.
+/// Same declaration as [`one_cpt_const_chz_spec`]; the hazard reads the state, so a row read
+/// from the wrong state is visible in `h` as well as in the compartments.
+#[cfg(feature = "survival")]
+fn one_cpt_drug_chz_spec() -> OdeSpec {
+    OdeSpec {
+        chz_state_slots: vec![1],
+        rhs: Box::new(|y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
+            let cl = p[crate::types::PK_IDX_CL];
+            let v = p[crate::types::PK_IDX_V];
+            let ke = if v > 0.0 { cl / v } else { 0.0 };
+            dy[0] = -ke * y[0];
+            dy[1] = SS_CHZ_H0 * (SS_CHZ_BETA * y[0]).exp();
+        }),
+        n_states: 2,
+        state_names: vec!["central".into(), "__chz_3".into()],
+        readout: OdeReadout::ObsCmt(0),
+        diffusion_var: Vec::new(),
+        solver_opts: OdeSolverOptions {
+            abstol: 1e-11,
+            reltol: 1e-9,
+            ..OdeSolverOptions::default()
+        },
+        input_rate: Vec::new(),
+        rhs_program: None,
+        readout_program: None,
+        indiv_param_program: None,
+        dose_attr_map: Default::default(),
+        init_fn: None,
+    }
+}
+
+/// Every state of `got` is finite and bit-identical to `want`.
+///
+/// Finiteness first and on its own: `NaN == NaN` is `false`, so the equality would fail on a
+/// `NaN` row too, but it would say "bits differ" about a row that was never computed.
+#[cfg(feature = "survival")]
+fn assert_states_bit_identical(got: &[f64], want: &[f64], arm: &str) {
+    assert_eq!(
+        got.len(),
+        want.len(),
+        "{arm}: state vectors differ in length"
+    );
+    for (k, (g, w)) in got.iter().zip(want).enumerate() {
+        assert!(
+            g.is_finite() && w.is_finite(),
+            "{arm}: state {k} is not finite on both sides: got {g}, want {w}"
+        );
+        assert_eq!(
+            g.to_bits(),
+            w.to_bits(),
+            "{arm}: state {k} differs: got {g}, want {w}"
+        );
+    }
+}
+
+/// `[0.0]` on an SS dose at `t = 0` must equal the `t = 0` row of `[0.0, 1.0]` — every state,
+/// bit for bit — and that row must be the *post-dose* state.
+///
+/// Killed by: the `len >= 2` guard restored (the row is the `NaN` prefill); the `<=` prefill
+/// variant (central reads the seeded `0.0` instead of trough + pulse — `H` still reads `0.0`
+/// under that variant, which is why the comparison is on every state and not on `H`); a
+/// second visit of the sole break (another pulse moves central by 100).
+#[cfg(feature = "survival")]
+#[test]
+fn a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state() {
+    let ode = one_cpt_drug_chz_spec();
+    let pk = pk_one(1.0, 10.0);
+    let subject = make_subject(
+        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, SS_CHZ_II)],
+        vec![],
+    );
+    let single = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0]);
+    let multi = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 1.0]);
+    assert_eq!(single.len(), 1, "one row per saveat");
+    assert_eq!(multi.len(), 2, "one row per saveat");
+    assert_states_bit_identical(&single[0], &multi[0], "[0.0] vs [0.0, 1.0]");
+
+    // The straddle, asserted: the row is the post-SS-dose state, not the seeded one. An SS
+    // bolus lands on its own trough, so central exceeds the bare 100 mg pulse, and the
+    // hazard read off it is not the drug-free `H0` the seeded state would give.
+    let got = &single[0];
+    assert!(
+        got[0] > 100.0,
+        "central at t = 0 is {} — the seeded pre-dose state, not trough + pulse",
+        got[0]
+    );
+    assert_eq!(got[1], 0.0, "H(0) must be exactly 0.0 at the first record");
+    let mut du = vec![0.0; ode.n_states];
+    (ode.rhs)(got, &pk.values, 0.0, &mut du);
+    assert!(
+        du[1] > 2.0 * SS_CHZ_H0,
+        "h(0) = {} reads as the drug-free hazard {SS_CHZ_H0}; the row is not post-dose",
+        du[1]
+    );
+}
+
+/// Duplicate nodes at the instant are all written, and a node *before* the first event keeps
+/// the seeded initial state (nothing has acted on the system yet) while the node on the event
+/// reads post-dose.
+///
+/// The `-1.0` row is the pre-first-event prefill's territory and must not move: widening that
+/// prefill to cover the instant is the wrong fix, and this is the arm that would see the two
+/// rows collapse onto the same (seeded) state.
+#[cfg(feature = "survival")]
+#[test]
+fn a_single_instant_grid_writes_every_duplicate_and_leaves_pre_event_nodes_seeded() {
+    let ode = one_cpt_drug_chz_spec();
+    let pk = pk_one(1.0, 10.0);
+    let subject = make_subject(
+        vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, SS_CHZ_II)],
+        vec![],
+    );
+    let want = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 1.0]);
+
+    let dup = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[0.0, 0.0]);
+    assert_eq!(dup.len(), 2, "one row per saveat, duplicates included");
+    assert_states_bit_identical(&dup[0], &want[0], "[0.0, 0.0] row 0");
+    assert_states_bit_identical(&dup[1], &want[0], "[0.0, 0.0] row 1");
+
+    let pre = ode_dense_solve_states(&ode, &pk.values, &[], &[], &subject, &[-1.0, 0.0]);
+    assert_eq!(pre.len(), 2);
+    let seeded = ode.initial_state(&pk.values);
+    assert_states_bit_identical(&pre[0], &seeded, "[-1.0, 0.0] row 0 (pre-event)");
+    assert_states_bit_identical(&pre[1], &want[0], "[-1.0, 0.0] row 1");
+    assert!(
+        pre[0][0] < pre[1][0],
+        "the pre-event row and the on-event row collapsed onto one state: {pre:?}"
+    );
+}
+
+/// `ode_predictions_event_driven_with_states` hands `subject.obs_times` to the dense solve, so
+/// a subject whose only observation sits on its dose returned `ipred = [100.0]` over
+/// `states = [[NaN]]` — a finite prediction with a `NaN` state behind it, which is what a
+/// `[derived]` output column reads. Both a plain bolus and an SS dose, since they take
+/// different arms of `apply_segment_boundary` at the sole break.
+///
+/// The readout is the compartment amount, so the state must also equal `ipred` exactly — the
+/// invariant the two-pass engine promises.
+#[test]
+fn with_states_on_a_single_instant_timeline_returns_the_post_dose_state() {
+    let ode = one_cpt_ode_spec();
+    let pk = pk_one(1.0, 10.0);
+    let at = |n: usize| vec![pk; n];
+    for (arm, ss, ii) in [("bolus", false, 0.0), ("ss", true, 12.0)] {
+        let one = make_subject(vec![DoseEvent::new(0.0, 100.0, 1, 0.0, ss, ii)], vec![0.0]);
+        let two = make_subject(
+            vec![DoseEvent::new(0.0, 100.0, 1, 0.0, ss, ii)],
+            vec![0.0, 1.0],
+        );
+        let (ipred1, states1) = ode_predictions_event_driven_with_states(
+            &ode,
+            &one,
+            &[],
+            &[],
+            &at(1),
+            &at(1),
+            &[],
+            &[],
+        );
+        let (ipred2, states2) = ode_predictions_event_driven_with_states(
+            &ode,
+            &two,
+            &[],
+            &[],
+            &at(1),
+            &at(2),
+            &[],
+            &[],
+        );
+        assert_eq!(states1.len(), 1, "{arm}: one state row per observation");
+        assert!(
+            states1[0][0].is_finite(),
+            "{arm}: the single-instant state row is {:?}",
+            states1[0]
+        );
+        assert_eq!(
+            states1[0][0].to_bits(),
+            states2[0][0].to_bits(),
+            "{arm}: single-observation state {} differs from the two-observation row {}",
+            states1[0][0],
+            states2[0][0]
+        );
+        assert_eq!(
+            states1[0][0].to_bits(),
+            ipred1[0].to_bits(),
+            "{arm}: state {} and ipred {} disagree on an amount readout",
+            states1[0][0],
+            ipred1[0]
+        );
+        assert_eq!(
+            ipred1[0].to_bits(),
+            ipred2[0].to_bits(),
+            "{arm}: ipred moved"
+        );
+        assert!(
+            ipred1[0] >= 100.0,
+            "{arm}: the post-dose amount is {}",
+            ipred1[0]
+        );
+    }
+}

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -4522,4 +4522,121 @@ mod tests {
             );
         }
     }
+
+    /// #1218 on the fit path. `tte_ode_nll` is the two-solve arm `tte_endpoint_nll` takes when
+    /// `try_joint_pktte_shared_solve` declines — time-varying covariates, EVID-3/4 resets, a
+    /// model-time read, SDE, FREM. A subject whose only TTE record sits on its first dose
+    /// builds `times = [0.0]`, a one-break timeline in `ode_dense_solve_states`, and until
+    /// #1218 read `NaN` there, which `tte_nll_from_curves` maps to the `1e20` sentinel: the
+    /// subject was repelled, not scored. It now scores `H(0) − ln h(0)` with `h(0)` the
+    /// post-dose hazard — the number the multi-point grid already gave.
+    ///
+    /// An exact event rather than a censor, on purpose: a censor at `t = 0` scores
+    /// `H(0) = 0` under the fix *and* under the wrong fix (filling the row from the seeded
+    /// pre-dose state), while `−ln h(0)` sees the difference — `h(0) = H0·exp(BETA·C)` at the
+    /// SS trough + pulse against the drug-free `H0`. Measured: `1e20` before, and under the
+    /// seeded-state variant `−ln 0.02 = 3.91` where the post-dose row gives `−ln 25.6`.
+    #[cfg(feature = "survival")]
+    #[test]
+    fn tte_ode_nll_scores_an_event_on_the_first_dose_instead_of_the_sentinel() {
+        use crate::parser::model_parser::parse_model_string;
+        use crate::types::{DoseEvent, EventType, ObsRecord};
+
+        // #1210's drug arm, IV: CL=1, V=10, H0=0.02, BETA=0.5, hazard on central/V.
+        let src = r"
+[parameters]
+  theta TVCL(1.0, 0.01, 100.0)
+  theta TVV(10.0, 0.1, 500.0)
+  theta TVH0(0.02, 1e-5, 10.0)
+  theta TVBETA(0.5, -10.0, 10.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.1 (sd)
+[individual_parameters]
+  CL   = TVCL * exp(ETA_CL)
+  V    = TVV
+  H0   = TVH0
+  BETA = TVBETA
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[event_model]
+  cmt    = 2
+  hazard = H0 * exp(BETA * (central / V))
+[error_model]
+  DV ~ proportional(PROP_ERR)
+[fit_options]
+  method = focei
+  ode_reltol = 1e-9
+  ode_abstol = 1e-11
+";
+        let model = parse_model_string(src).expect("joint PK-TTE model must parse");
+
+        // An `SS=1` bolus at t = 0 (so drug is present on the incoming side of the record)
+        // and nothing else: no PK rows, one exact event on the dose instant.
+        let mut subject = make_simple_subject();
+        subject.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 12.0)];
+        subject.obs_times = Vec::new();
+        subject.observations = Vec::new();
+        subject.obs_cmts = Vec::new();
+        subject.cens = Vec::new();
+        subject.occasions = Vec::new();
+        subject.obs_records = vec![ObsRecord::Event {
+            time: 0.0,
+            event_type: EventType::Exact,
+            entry_time: 0.0,
+            cmt: 2,
+        }];
+
+        let theta = &model.default_params.theta;
+        let eta = [0.0_f64];
+        let chz_state = match model.endpoints.get(&2) {
+            Some(EndpointLikelihood::Tte {
+                hazard: HazardSpec::OdeAccumulated { chz_state },
+                ..
+            }) => *chz_state,
+            _ => panic!("expected an OdeAccumulated TTE endpoint on CMT 2"),
+        };
+
+        let nll = tte_ode_nll(
+            &model,
+            &subject,
+            chz_state,
+            &subject.obs_records,
+            theta,
+            &eta,
+        );
+        assert!(
+            nll.is_finite() && nll < 1e20,
+            "an event on the first dose is scored with the sentinel, not a likelihood: {nll}"
+        );
+
+        // The reference: the same H/h read off a grid that also asks for a later point.
+        let (cum, haz) = crate::survival::ode_cumhaz_hazard(
+            &model,
+            &subject,
+            chz_state,
+            theta,
+            &eta,
+            &[0.0, 1.0],
+        );
+        assert!(
+            cum[0].is_finite() && haz[0].is_finite(),
+            "the multi-point reference row is not finite: {}, {}",
+            cum[0],
+            haz[0]
+        );
+        // The straddle: the post-dose hazard must be far from the drug-free `H0 = 0.02`, or
+        // this test could not tell the post-dose row from a seeded one.
+        assert!(
+            haz[0] > 5.0 * 0.02,
+            "h(0) = {} is not distinguishable from the drug-free hazard",
+            haz[0]
+        );
+        let want = cum[0] - haz[0].ln();
+        assert!(
+            (nll - want).abs() < 1e-12,
+            "tte_ode_nll = {nll} but H(0) - ln h(0) from the multi-point grid = {want}"
+        );
+    }
 }

--- a/tests/ss_chz_nonmem_anchor.rs
+++ b/tests/ss_chz_nonmem_anchor.rs
@@ -398,16 +398,10 @@ fn a_joint_steady_state_fit_does_not_bank_the_run_in_into_the_objective() {
 
     // The property, on the fit path's own model and data. Measured exactly 0.0.
     //
-    // The `0.0` is asked for as part of a multi-point grid on purpose: `predict_survival` on a
-    // grid whose **maximum is 0** returns `NaN`, so `&[0.0]` alone would trip the `is_finite`
-    // guard below and say nothing about #1210. `ode_dense_solve_states` takes its integration
-    // horizon as `saveat.iter().fold(0.0, f64::max)`, so such a grid builds no segment and the
-    // rows keep their `f64::NAN` prefill. Not a single-point problem — measured:
-    // `[0.0] -> NaN`, `[0.0, 0.0] -> NaN`, but `[1.0] -> 0.02` and `[12.0] -> 0.24` are fine,
-    // and `[0.0, 1.0] -> [0.0, 0.02]`. Tracked as #1218; do not shorten this grid.
-    let mut probe = vec![0.0];
-    probe.extend_from_slice(&GRID);
-    let sv = predict_survival(&m, &pop, &m.default_params, &probe);
+    // Asked for on its own. Until #1218 a grid whose maximum is 0 returned `NaN` and this had
+    // to pad the grid with `GRID` to get a finite row; the single-instant path is pinned by
+    // `predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid` below.
+    let sv = predict_survival(&m, &pop, &m.default_params, &[0.0]);
     let at_zero: Vec<_> = sv.iter().filter(|r| r.time == 0.0).collect();
     assert!(!at_zero.is_empty(), "no survival row at t = 0");
     for r in at_zero {
@@ -624,4 +618,85 @@ fn a_reset_zeroes_the_accumulated_hazard_and_matches_nonmem() {
         worst_pred < 2e-8,
         "worst relative PRED disagreement vs the r4 train = {worst_pred}"
     );
+}
+
+/// #1218: a grid with no point past the first event returned `NaN, NaN` — `[0.0]`, `[0.0, 0.0]`
+/// and the `0` row of `[-1.0, 0.0]` — while the same `t = 0` asked for alongside a later point
+/// was finite. Measured before the fix on both arms.
+///
+/// The single-instant row must be the multi-point row bit for bit. The drug arm is the one that
+/// can tell the post-dose state from the seeded one — `h(0) = 0.2193` at the SS trough against
+/// the drug-free `H0 = 0.02` — so its `h(0)` is asserted away from `H0` explicitly: the guard
+/// against fixing this by widening the pre-first-event prefill (which would return a finite,
+/// wrong `h(0)` and pass every other assertion here). The `-1.0` row *is* that prefill's
+/// territory and is asserted unchanged: seeded state, drug-free hazard.
+#[test]
+fn predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid() {
+    fn at(rows: &[ferx_core::SurvivalPredictionResult], t: f64) -> Vec<(f64, f64)> {
+        rows.iter()
+            .filter(|r| r.time == t)
+            .map(|r| (r.cum_hazard, r.hazard))
+            .collect()
+    }
+    for arm in ["const", "drug"] {
+        let (m, pop) = load(arm);
+        let want = at(
+            &predict_survival(&m, &pop, &m.default_params, &[0.0, 1.0]),
+            0.0,
+        );
+        assert_eq!(want.len(), 1, "{arm}: one subject, one row at t = 0");
+        let (want_h, want_haz) = want[0];
+        assert!(
+            want_h.is_finite() && want_haz.is_finite(),
+            "{arm}: the multi-point reference row is not finite: {want_h}, {want_haz}"
+        );
+        assert_eq!(want_h, 0.0, "{arm}: H(0) is not exactly zero");
+
+        for grid in [&[0.0][..], &[0.0, 0.0], &[-1.0, 0.0]] {
+            let got = at(&predict_survival(&m, &pop, &m.default_params, grid), 0.0);
+            let n_zero = grid.iter().filter(|&&t| t == 0.0).count();
+            assert_eq!(
+                got.len(),
+                n_zero,
+                "{arm} {grid:?}: one row per requested t = 0"
+            );
+            for (h, haz) in got {
+                assert!(
+                    h.is_finite() && haz.is_finite(),
+                    "{arm} {grid:?}: non-finite (H, h) at t = 0: {h}, {haz}"
+                );
+                assert_eq!(
+                    h.to_bits(),
+                    want_h.to_bits(),
+                    "{arm} {grid:?}: H(0) {h} != {want_h}"
+                );
+                assert_eq!(
+                    haz.to_bits(),
+                    want_haz.to_bits(),
+                    "{arm} {grid:?}: h(0) {haz} != {want_haz}"
+                );
+            }
+        }
+
+        // Before the first event: the seeded state, so no drug and the bare `H0`.
+        let pre = at(
+            &predict_survival(&m, &pop, &m.default_params, &[-1.0, 0.0]),
+            -1.0,
+        );
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0].0, 0.0, "{arm}: H(-1) is not zero");
+        assert!(
+            (pre[0].1 - H0).abs() < 1e-15,
+            "{arm}: h(-1) = {} is not the drug-free hazard {H0}",
+            pre[0].1
+        );
+
+        if arm == "drug" {
+            assert!(
+                want_haz > 5.0 * H0,
+                "drug arm: h(0) = {want_haz} is not distinguishable from the drug-free {H0}; \
+                 this test could not tell a post-dose row from a seeded one"
+            );
+        }
+    }
 }

--- a/tests/ss_chz_nonmem_anchor.rs
+++ b/tests/ss_chz_nonmem_anchor.rs
@@ -76,6 +76,14 @@ fn load_with(arm: &str, data: &str) -> (CompiledModel, Population) {
     (m, pop)
 }
 
+/// `(H, h)` of every survival row at time `t`, matched at the file's `1e-9` tolerance.
+fn survival_rows_at(rows: &[ferx_core::SurvivalPredictionResult], t: f64) -> Vec<(f64, f64)> {
+    rows.iter()
+        .filter(|r| (r.time - t).abs() < 1e-9)
+        .map(|r| (r.cum_hazard, r.hazard))
+        .collect()
+}
+
 /// `nonmem_anchor/ss_chz_ss2.csv`: an `SS=1` dose at `t = 0` **and** a second at `t = 48`.
 const DATA_MID_RECORD: &str = "nonmem_anchor/ss_chz_ss2.csv";
 
@@ -402,18 +410,13 @@ fn a_joint_steady_state_fit_does_not_bank_the_run_in_into_the_objective() {
     // to pad the grid with `GRID` to get a finite row; the single-instant path is pinned by
     // `predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid` below.
     let sv = predict_survival(&m, &pop, &m.default_params, &[0.0]);
-    let at_zero: Vec<_> = sv.iter().filter(|r| r.time == 0.0).collect();
+    let at_zero = survival_rows_at(&sv, 0.0);
     assert!(!at_zero.is_empty(), "no survival row at t = 0");
-    for r in at_zero {
+    for (h, _) in at_zero {
+        assert!(h.is_finite(), "non-finite H at t = 0: {h}");
         assert!(
-            r.cum_hazard.is_finite(),
-            "non-finite H at t = 0: {}",
-            r.cum_hazard
-        );
-        assert!(
-            r.cum_hazard.abs() < 1e-12,
-            "the SS run-in is still banked into H(0): {} (pre-#1210 this read 12.0 = H0*50*II)",
-            r.cum_hazard
+            h.abs() < 1e-12,
+            "the SS run-in is still banked into H(0): {h} (pre-#1210 this read 12.0 = H0*50*II)"
         );
     }
 
@@ -632,15 +635,9 @@ fn a_reset_zeroes_the_accumulated_hazard_and_matches_nonmem() {
 /// territory and is asserted unchanged: seeded state, drug-free hazard.
 #[test]
 fn predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid() {
-    fn at(rows: &[ferx_core::SurvivalPredictionResult], t: f64) -> Vec<(f64, f64)> {
-        rows.iter()
-            .filter(|r| r.time == t)
-            .map(|r| (r.cum_hazard, r.hazard))
-            .collect()
-    }
-    for arm in ["const", "drug"] {
+    for (arm, drug_driven) in [("const", false), ("drug", true)] {
         let (m, pop) = load(arm);
-        let want = at(
+        let want = survival_rows_at(
             &predict_survival(&m, &pop, &m.default_params, &[0.0, 1.0]),
             0.0,
         );
@@ -651,38 +648,51 @@ fn predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid() {
             "{arm}: the multi-point reference row is not finite: {want_h}, {want_haz}"
         );
         assert_eq!(want_h, 0.0, "{arm}: H(0) is not exactly zero");
+        // The straddle, before any comparison: on the drug arm the reference row must be
+        // distinguishable from the seeded state, or the bit comparisons below could not tell
+        // a post-dose row from a seeded one.
+        if drug_driven {
+            assert!(
+                want_haz > 5.0 * H0,
+                "{arm}: h(0) = {want_haz} is not distinguishable from the drug-free {H0}"
+            );
+        }
 
-        for grid in [&[0.0][..], &[0.0, 0.0], &[-1.0, 0.0]] {
-            let got = at(&predict_survival(&m, &pop, &m.default_params, grid), 0.0);
-            let n_zero = grid.iter().filter(|&&t| t == 0.0).count();
+        let single = predict_survival(&m, &pop, &m.default_params, &[0.0]);
+        let dup = predict_survival(&m, &pop, &m.default_params, &[0.0, 0.0]);
+        let pre_grid = predict_survival(&m, &pop, &m.default_params, &[-1.0, 0.0]);
+        for (label, rows, n_zero) in [
+            ("[0.0]", &single, 1),
+            ("[0.0, 0.0]", &dup, 2),
+            ("[-1.0, 0.0]", &pre_grid, 1),
+        ] {
+            let got = survival_rows_at(rows, 0.0);
             assert_eq!(
                 got.len(),
                 n_zero,
-                "{arm} {grid:?}: one row per requested t = 0"
+                "{arm} {label}: one row per requested t = 0"
             );
             for (h, haz) in got {
                 assert!(
                     h.is_finite() && haz.is_finite(),
-                    "{arm} {grid:?}: non-finite (H, h) at t = 0: {h}, {haz}"
+                    "{arm} {label}: non-finite (H, h) at t = 0: {h}, {haz}"
                 );
                 assert_eq!(
                     h.to_bits(),
                     want_h.to_bits(),
-                    "{arm} {grid:?}: H(0) {h} != {want_h}"
+                    "{arm} {label}: H(0) {h} != {want_h}"
                 );
                 assert_eq!(
                     haz.to_bits(),
                     want_haz.to_bits(),
-                    "{arm} {grid:?}: h(0) {haz} != {want_haz}"
+                    "{arm} {label}: h(0) {haz} != {want_haz}"
                 );
             }
         }
 
-        // Before the first event: the seeded state, so no drug and the bare `H0`.
-        let pre = at(
-            &predict_survival(&m, &pop, &m.default_params, &[-1.0, 0.0]),
-            -1.0,
-        );
+        // Before the first event: the seeded state, so no drug and the bare `H0` — the
+        // pre-first-event prefill's row, asserted unchanged.
+        let pre = survival_rows_at(&pre_grid, -1.0);
         assert_eq!(pre.len(), 1);
         assert_eq!(pre[0].0, 0.0, "{arm}: H(-1) is not zero");
         assert!(
@@ -690,13 +700,5 @@ fn predict_survival_on_a_single_instant_grid_matches_the_multi_point_grid() {
             "{arm}: h(-1) = {} is not the drug-free hazard {H0}",
             pre[0].1
         );
-
-        if arm == "drug" {
-            assert!(
-                want_haz > 5.0 * H0,
-                "drug arm: h(0) = {want_haz} is not distinguishable from the drug-free {H0}; \
-                 this test could not tell a post-dose row from a seeded one"
-            );
-        }
     }
 }


### PR DESCRIPTION
## Why

`predict_survival` returned `cum_hazard = NaN`, `hazard = NaN` for any time grid with no point
past the subject's first event — `[0.0]`, `[0.0, 0.0]`, the `0` row of `[-1.0, 0.0]` — while the
same `t = 0` asked for alongside a later point was finite. No warning, no `Err`; a caller folding
the rows through `f64::max` never sees it. Asking for `H` at `t = 0` alone is how you check a
subject's cumulative hazard starts at zero, and #1210's anchor had to pad its grid to do it.

Measured on `nonmem_anchor/ss_chz_{const,drug}_fit.ferx` + `ss_chz_ss.csv` (SS dose at `t = 0`):

| grid | const `(H, h)` at 0 | drug `(H, h)` at 0 |
|---|---|---|
| `[0.0]` | `NaN, NaN` | `NaN, NaN` |
| `[0.0, 1.0]` | `0.0, 0.02` | `0.0, 0.21925018531273352` |
| `[-1.0]` | `0.0, 0.02` (pre-event, correct) | `0.0, 0.02` (pre-event, correct) |

The same one-break timeline also reached `ode_predictions_event_driven_with_states`, which hands
`subject.obs_times` to the dense solve: a subject whose only observation coincides with its dose
returned `ipred = [100.0]` over `states = [[NaN]]` — a finite prediction with a `NaN` state behind
it, which is what a `[derived]` column reads. `predict()` itself was never affected (its engine
walks `0..len`, #731).

Closes #1218.

## What changed

`ode_dense_solve_states` takes its horizon as the largest `saveat`, so such a grid builds a
one-break timeline; the `windows(2)` loop never ran on it, and the post-loop `#731`
left-boundary visit was guarded to `len >= 2` ("a single-instant `saveat` keeps its prior
behaviour" — the prior behaviour was the `NaN` prefill).

The loop is now the `0..len` left-boundary walk `ode_predictions` and
`ode_predictions_with_states` already use: boundary at `t_k`, write the `saveat` rows at `t_k`,
integrate to `t_{k+1}` only while a next break exists. Byte-identical to the old code where the
old code ran — for `k < len−1` it is the old `windows(2)` body, for `k = len−1` it is the old
post-loop block — and the one-break timeline gets its single visit with no special case to
guard. The last break's visit is skipped when no `saveat` sits on it (`u` is dead after the
loop), so an all-pre-event grid no longer runs a discarded SS equilibration.

The same one-break timeline reached two other readers of the dense state, both fixed by the same
change: `[derived]` columns on the event-driven arm, and the two-solve TTE likelihood
(`tte_ode_nll`, taken when the shared solve declines — TV covariates, resets, model time, SDE,
FREM) for a subject whose only event or censor sits on its first dose, which scored the `1e20`
sentinel instead of a likelihood.

**The issue's own suggested fix is not taken, and the tests are built to reject it.** Widening
the pre-first-event prefill from `<` to `<=` fills the node from the *seeded* initial state:
`H(0) = 0` looks right, but `h(0)` is the hazard at zero drug — `0.02` on the drug arm where the
multi-point grid reads `0.219`. Finite, silent, 11× wrong. A constant hazard cannot see it, so
every new arm uses a drug-driven accumulator and compares the single-instant row against the
multi-point row on **every** state, `to_bits()`-equal.

## Alternatives considered

- `<` → `<=` on the prefill: see above; measured wrong on the drug arm.
- Returning the initial state from `ode_cumhaz_hazard` when the solve is empty: same wrong
  number one level up, and it would not fix the `with_states` site.
- A `NaN` guard in `predict_survival`: turns a wrong answer into an error rather than the right
  answer, and the right answer is one boundary visit away.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

ferx-r's `predict_survival` wrapper picks the fix up at its next lock bump; no R-side change.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: the same predictor on a longer grid — bit-identity is the oracle. The
  multi-point `t = 0` row is not itself a NONMEM row (#1210's r2 reader keeps only `T > 600`
  records); it is transitively pinned by the `t ≥ 1` rows of the same single integration, which
  are. Plus the closed-form pre-event state for the `-1.0` row.

```
# before: predict_survival(&[0.0]) on the drug arm
(t = 0, H = NaN, h = NaN)

# after (bit-identical to the [0.0, 1.0] row)
(t = 0, H = 0.0, h = 0.21925018531273352)
```

Fit path: subjects that qualify for the #570 shared solve are unchanged (probed two ways, OFV
identical to the last digit: const `0.14355663345737385` / `0.22355663353423236`, drug
`0.14355663421974166` / `13.630392883948005`). Subjects on the two-solve arm with their only
TTE record on the first dose move from the `1e20` sentinel to `H(0) − ln h(0)`; measured on the
new Tier-1: `1e20` → `−3.2430407991464754`, equal to the multi-point grid's row to `< 1e-12`.

## Performance
- [x] No significant impact expected — one `apply_segment_boundary(t, t)` on a timeline that
  previously did nothing.

## Tests
- [x] Unit tests added in `src/ode/predictions_tests.rs` and `src/stats/likelihood.rs` (`cargo test --lib` passes)
- [x] Regression tests that fail without this fix — and under the wrong fix, **both observed**:

| mutation | Tier-1 (3 arms) | Tier-1 `tte_ode_nll…` | Tier-2 `predict_survival_on_a_single_instant_grid…` | #1210's `…does_not_bank_the_run_in…` |
|---|---|---|---|---|
| M1: never visit the last break as a left boundary | 3 red (`NaN`) | red, `1e20` | red (both arms) | red |
| M2: M1 + the issue's `<=` prefill | 3 red (`state 0: got 0, want 143.10127609149242`) | red, `3.912 ≠ −3.243` | red, drug arm only: `h(0) 0.02 != 0.21925018531273352` | **green** |

(Observed twice: on the first commit's guard removal, and again on the restructured walk.)

The last column is why the new Tier-2 arm exists: the #1210 test only checks `H(0) = 0`, which
the wrong fix satisfies. Its padded-grid workaround ("do not shorten this grid — #1218") is
retired; it now asks for `[0.0]` directly.

New arms: `a_single_instant_grid_on_an_ss_dose_reads_the_post_dose_state` (bit-identity on
every state + the straddle asserted: central > 100, which with the drug-driven rate is also what moves `h(0)` off the drug-free `H0`),
`a_single_instant_grid_writes_every_duplicate_and_leaves_pre_event_nodes_seeded` (`[0.0, 0.0]`,
and `[-1.0, 0.0]` where the `-1` row must stay the seeded state — the arm that would notice the
prefill being widened), `with_states_on_a_single_instant_timeline_returns_the_post_dose_state`
(ungated; bolus and SS; `states == ipred` on an amount readout),
`tte_ode_nll_scores_an_event_on_the_first_dose_instead_of_the_sentinel` (the fit-path arm, an
exact event so `−ln h(0)` sees the seeded-vs-post-dose difference a censor would not), and the
Tier-2 arm on both #1210 fixtures.

## Example (user-facing features only)
- [x] Not applicable (fix with no new API surface)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No docs page: no option or syntax changed

## Checklist
- [x] `tools/preflight.sh` green
- [x] No `Dual2` path touched (`ode_dense_solve_states` is `f64`-only; the dual walk has its own
  single-instant handling, `sens/ode_provider.rs` "Degenerate single-instant timeline")
- [x] No version bump (not breaking)

## Docs & examples
- [x] No example execution step needed (fix, no user-visible syntax change)

## Reviewer hints

`src/ode/predictions.rs`: the loop restructure is the thing to read — check that the `0..len`
body is the old `windows(2)` body plus the old post-loop block and nothing else (the full
`ci,survival` suite, with its bit-exact anchors, is the measurement that it is). Then the tests:
whether each new assertion can fail (the mutation table above), and the `[-1.0, 0.0]` arm,
which pins that the pre-event prefill was **not** the thing to change. The review comment on
this PR lists the ten findings and what each changed.

## Open questions

None. Filed from the review: #1223 (the one-solve share NaN-fills a pre-start hazard time
while the two-solve path seeds it — pre-existing, the presence of a PK row decides the
likelihood). Earlier follow-up: #1220 (lagged mid-record SS × hazard anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
