### PR TITLE
test(per-route-lag): FIX the zero-variance omega so the Tier-3 fit is identifiable [closes #1227]

### DIFF
--- a/tests/per_route_lag.rs
+++ b/tests/per_route_lag.rs
@@ -19,7 +19,7 @@
 mod common;
 
 use ferx_core::parser::model_parser::parse_full_model;
-use ferx_core::{check_model_data, predict, DoseEvent, Population};
+use ferx_core::{check_model_data, predict, DoseEvent, Population, WarningCode};
 
 // ── Per-route-lag models under test ──────────────────────────────────────────
 
@@ -591,12 +591,22 @@ fn per_route_lag_fit_runs_end_to_end() {
 /// The models in this file declare `omega ETA_CL ~ 0.0 FIX`, and the `FIX` is what makes
 /// this test's `converged` assertion meaningful (#1227). Fitting **one** subject leaves ω²
 /// with no between-subject information to estimate from, so a *free* zero-variance omega is
-/// unidentifiable by construction: nothing bounds it above and it walks to `compute_bounds`'
-/// `+6` Cholesky-diagonal ceiling (ω² ≈ 162 755). Since #1205 that rail is a `runaway`
-/// verdict and demotes `converged`, so the assertion below failed on every nightly run —
-/// on a fit whose TVLAG was nonetheless recovered to eight decimals. Declaring the omega
-/// FIX'd matches what the model already says (zero IIV) and removes the coordinate from the
-/// packed vector, rather than teaching the assertion to accept a runaway.
+/// unidentifiable by construction and walks to `compute_bounds`' `+6` Cholesky-diagonal
+/// ceiling (ω² ≈ 162 755). Since #1205 that rail carries a `runaway` verdict and demotes
+/// `converged`, so the assertion below failed on every nightly run — on a fit whose TVLAG
+/// was nonetheless recovered to eight decimals.
+///
+/// Worth knowing before reading that as "it starts at ln(0)": it does not. The parser floors
+/// a declared `~ 0.0` to a Cholesky diagonal of `1e-4` — measured, and *identical* with and
+/// without `FIX` — so the free coordinate's packed start is `ln(1e-4) = -9.21`, which is
+/// below its own `-6` lower rail (`parameterization.rs`, `compute_bounds`). It begins clamped
+/// outside its admissible interval and ends at the opposite one. `FIX` changes nothing but
+/// `omega_fixed`, which is why it is inert for the predict-only twins here (verified
+/// bit-identical, 0 ulp over the sampled curve) and decisive for the two fits: the coordinate
+/// leaves the packed vector instead of being optimized from a start it cannot reach.
+///
+/// So the fix declares what the model already says — zero IIV — rather than teaching the
+/// assertion to accept a runaway.
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
@@ -629,6 +639,15 @@ fn per_route_lag_fit_recovers_lag() {
         warnings: vec![],
         subjects: vec![common::subject("1", vec![dose], obs_times, obs, vec![1; n])],
     };
+    // Only KA and LAG start off truth; TVCL and TVV start at their data-generating values,
+    // deliberately. Perturbing them was tried (CL 5.0 -> 3.0, V 50.0 -> 70.0) and the fit does
+    // not come back: it returns `converged: true` with no guard hit and TVV at 43.55, 12.9%
+    // off. One subject of noise-free data identifies the absorption pair strongly and the
+    // disposition pair only weakly — the fit's own output says so, reporting
+    // `TVV ~ TVKA = -1.00`. So the two assertions on TVCL / TVV below are *drift* guards, not
+    // identifiability claims: they say a sound fit must not drag them away from a start that
+    // is already correct. That is exactly the regression they exist for — the runaway-omega
+    // fit moved them 48% and 13% off from these same starting values.
     let mut init = model.default_params.clone();
     init.theta[2] = 0.7; // KA off truth (1.0)
     init.theta[3] = 3.0; // LAG off truth (2.0)
@@ -639,12 +658,29 @@ fn per_route_lag_fit_recovers_lag() {
         "recovered per-route lag {} should be near 2.0",
         fitted.theta[3]
     );
-    // Pin the disposition too, not just the lag (#1227). While ω ran to the +6 rail it
-    // absorbed the structural signal and these came back TVCL −48%, TVKA −29%, TVV −13%
-    // on the same noise-free data — a fit this test called a success because it only ever
-    // looked at theta[3]. With the omega FIX'd the worst of the three is TVKA at 1.5%
-    // (TVCL 0.09%, TVV 0.59%), so 5% sits ~3x above what the sound fit produces and ~1/9
-    // of the smallest error the degenerate one produced. Both numbers are measured.
+    // Assert the *cause*, not only its downstream boolean. `converged` alone cannot tell
+    // "omega is identifiable" apart from "the #1205 demotion rule stopped firing" — a change
+    // to `RunawayGuardHit::is_runaway` would flip the boolean back to true with ETA_CL still
+    // pinned at +6, and every other assertion here would still pass.
+    assert!(
+        !fitted
+            .warnings_structured
+            .iter()
+            .any(|w| w.category == WarningCode::ParameterAtRunawayGuard),
+        "no estimate should sit at an internal guard; got: {:?}",
+        fitted
+            .warnings_structured
+            .iter()
+            .filter(|w| w.category == WarningCode::ParameterAtRunawayGuard)
+            .map(|w| w.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    // Pin the disposition too, not just the lag (#1227). What is measured, twice, on the same
+    // noise-free data: with omega free the fit ends at the +6 rail and TVCL / TVV / TVKA come
+    // back −48% / −13% / −29% off truth; with omega FIX'd it converges and the worst of the
+    // three is TVKA at 1.5% (TVCL 0.09%, TVV 0.59%). The 5% band is set from those two
+    // measurements — ~3x above what the sound fit produces, ~1/9 of the smallest error the
+    // degenerate one produced — not from a view about what a good tolerance looks like.
     for (i, truth, name) in [(0usize, 5.0, "TVCL"), (1, 50.0, "TVV"), (2, 1.0, "TVKA")] {
         let rel = (fitted.theta[i] - truth).abs() / truth;
         assert!(
@@ -652,6 +688,51 @@ fn per_route_lag_fit_recovers_lag() {
             "{name} = {} is {:.1}% off truth {truth}; the noise-free optimum recovers it",
             fitted.theta[i],
             rel * 100.0
+        );
+    }
+}
+
+/// Tier-2 (runs on every PR): the fixtures above keep `omega ETA_CL ~ 0.0 FIX`.
+///
+/// Without this, the `FIX` that #1227 turns on is defended only by
+/// [`per_route_lag_fit_recovers_lag`], which is `slow-tests`-gated and therefore skipped in
+/// PR CI — so dropping a `FIX` would merge green and reappear in the next nightly, which is
+/// the loop #1227 was filed to end. `per_route_lag_fit_runs_end_to_end` does not close the
+/// gap either: it runs two outer iterations and asserts only that the OFV is finite, and an
+/// omega parked at the `+6` rail gives a perfectly finite OFV.
+///
+/// Four of these carry `[fit_options] method = focei` and are one `fit()` call away from the
+/// same trap; the compartment-lag twins are predict-only today, but a twin whose declaration
+/// drifts from its pair undercuts the "compared at identical parameters" claim the equality
+/// tests rest on. Parsing is all this needs, so it costs nothing.
+#[test]
+fn per_route_lag_fixtures_fix_their_zero_variance_omega() {
+    for (name, src) in [
+        ("ROUTE_LAG_SINGLE", ROUTE_LAG_SINGLE),
+        ("COMP_LAG_SINGLE", COMP_LAG_SINGLE),
+        ("ROUTE_LAG_ZERO", ROUTE_LAG_ZERO),
+        ("COMP_LAG_ZERO", COMP_LAG_ZERO),
+        ("ROUTE_LAG_PARALLEL", ROUTE_LAG_PARALLEL),
+        ("ROUTE_LAG_MIXED", ROUTE_LAG_MIXED),
+        ("TRANSIT_ROUTE_LAG", TRANSIT_ROUTE_LAG),
+        ("TRANSIT_COMP_LAG", TRANSIT_COMP_LAG),
+        ("IGD_ROUTE_LAG", IGD_ROUTE_LAG),
+        ("IGD_COMP_LAG", IGD_COMP_LAG),
+    ] {
+        let params = parse_full_model(src)
+            .unwrap_or_else(|e| panic!("{name} parses: {e}"))
+            .model
+            .default_params;
+        assert!(
+            !params.omega_fixed.is_empty(),
+            "{name} declares no omega, so this guard would be vacuous"
+        );
+        assert!(
+            params.omega_fixed.iter().all(|&f| f),
+            "{name} has a FREE omega ({:?}); these models fit ONE subject, so a free \
+             zero-variance omega runs to the +6 Cholesky rail and #1205 demotes converged \
+             (#1227). Declare it `~ 0.0 FIX`.",
+            params.omega_fixed
         );
     }
 }

--- a/tests/per_route_lag.rs
+++ b/tests/per_route_lag.rs
@@ -662,18 +662,36 @@ fn per_route_lag_fit_recovers_lag() {
     // "omega is identifiable" apart from "the #1205 demotion rule stopped firing" — a change
     // to `RunawayGuardHit::is_runaway` would flip the boolean back to true with ETA_CL still
     // pinned at +6, and every other assertion here would still pass.
+    //
+    // Key on the per-hit `verdict`, NOT on the category: `ParameterAtRunawayGuard` carries
+    // both verdicts, and one *collapse* here is expected and correct. The data are noise-free,
+    // so the residual SD has nothing to estimate and PROP_ERR walks to its `-8` floor — which
+    // #1205 deliberately leaves as a `Warning` that does not demote `converged`. Whether it
+    // gets all the way there is platform-dependent (macOS stops around 0.0153, Linux CI
+    // reaches 3e-4), so asserting no guard hit at all is both wrong and flaky. `runaway` is
+    // the verdict that means an estimate is held at a rail, and it is the one #1227 is about.
+    let runaways: Vec<&str> = fitted
+        .warnings_structured
+        .iter()
+        .filter(|w| w.category == WarningCode::ParameterAtRunawayGuard)
+        .filter(|w| {
+            w.details
+                .as_ref()
+                .and_then(|d| d.get("parameters"))
+                .and_then(|p| p.as_array())
+                .map(|hits| {
+                    hits.iter()
+                        .any(|h| h.get("verdict").and_then(|v| v.as_str()) == Some("runaway"))
+                })
+                // No structured payload to read: fall back to the message token
+                // `classify_warning` keys on, rather than silently passing.
+                .unwrap_or_else(|| w.message.contains("guard, runaway"))
+        })
+        .map(|w| w.message.as_str())
+        .collect();
     assert!(
-        !fitted
-            .warnings_structured
-            .iter()
-            .any(|w| w.category == WarningCode::ParameterAtRunawayGuard),
-        "no estimate should sit at an internal guard; got: {:?}",
-        fitted
-            .warnings_structured
-            .iter()
-            .filter(|w| w.category == WarningCode::ParameterAtRunawayGuard)
-            .map(|w| w.message.as_str())
-            .collect::<Vec<_>>()
+        runaways.is_empty(),
+        "no estimate should be held at an internal rail; got: {runaways:?}"
     );
     // Pin the disposition too, not just the lag (#1227). What is measured, twice, on the same
     // noise-free data: with omega free the fit ends at the +6 rail and TVCL / TVV / TVKA come

--- a/tests/per_route_lag.rs
+++ b/tests/per_route_lag.rs
@@ -31,7 +31,7 @@ const ROUTE_LAG_SINGLE: &str = r#"
   theta TVV(50.0,  5.0, 500.0)
   theta TVKA(1.0, 0.01,  24.0)
   theta TVLAG(2.0, 0.0,  12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -59,7 +59,7 @@ const COMP_LAG_SINGLE: &str = r#"
   theta TVV(50.0,  5.0, 500.0)
   theta TVKA(1.0, 0.01,  24.0)
   theta TVLAG(2.0, 0.0,  12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL      = TVCL * exp(ETA_CL)
@@ -84,7 +84,7 @@ const ROUTE_LAG_ZERO: &str = r#"
   theta TVV(50.0,  5.0, 500.0)
   theta TVDUR(3.0, 0.05, 24.0)
   theta TVLAG(2.0, 0.0,  12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -110,7 +110,7 @@ const COMP_LAG_ZERO: &str = r#"
   theta TVV(50.0,  5.0, 500.0)
   theta TVDUR(3.0, 0.05, 24.0)
   theta TVLAG(2.0, 0.0,  12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL      = TVCL * exp(ETA_CL)
@@ -138,7 +138,7 @@ const ROUTE_LAG_PARALLEL: &str = r#"
   theta TVKA2(0.7, 0.05,  24.0)
   theta TVL1(0.5,  0.0,   12.0)
   theta TVL2(3.0,  0.0,   12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -171,7 +171,7 @@ const ROUTE_LAG_MIXED: &str = r#"
   theta TVKA(1.0,  0.05,  24.0)
   theta TVDUR(3.0, 0.05,  24.0)
   theta TVLAG(2.0, 0.0,   12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL   = TVCL * exp(ETA_CL)
@@ -415,7 +415,7 @@ fn zero_route_lag_is_bit_identical_to_no_lag() {
   theta TVCL(5.0,  0.1, 100.0)
   theta TVV(50.0,  5.0, 500.0)
   theta TVKA(1.0, 0.01,  24.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -436,7 +436,7 @@ fn zero_route_lag_is_bit_identical_to_no_lag() {
   theta TVV(50.0,  5.0, 500.0)
   theta TVKA(1.0, 0.01,  24.0)
   theta TVLAG(0.0, 0.0,  12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -587,6 +587,16 @@ fn per_route_lag_fit_runs_end_to_end() {
 /// Tier-3 (slow): a full FOCEI fit (exact analytic gradients since #859) recovers the
 /// per-route lag from a perturbed start on noise-free data — the optimum sits at the
 /// data-generating lag.
+///
+/// The models in this file declare `omega ETA_CL ~ 0.0 FIX`, and the `FIX` is what makes
+/// this test's `converged` assertion meaningful (#1227). Fitting **one** subject leaves ω²
+/// with no between-subject information to estimate from, so a *free* zero-variance omega is
+/// unidentifiable by construction: nothing bounds it above and it walks to `compute_bounds`'
+/// `+6` Cholesky-diagonal ceiling (ω² ≈ 162 755). Since #1205 that rail is a `runaway`
+/// verdict and demotes `converged`, so the assertion below failed on every nightly run —
+/// on a fit whose TVLAG was nonetheless recovered to eight decimals. Declaring the omega
+/// FIX'd matches what the model already says (zero IIV) and removes the coordinate from the
+/// packed vector, rather than teaching the assertion to accept a runaway.
 #[test]
 #[cfg_attr(
     not(feature = "slow-tests"),
@@ -629,6 +639,21 @@ fn per_route_lag_fit_recovers_lag() {
         "recovered per-route lag {} should be near 2.0",
         fitted.theta[3]
     );
+    // Pin the disposition too, not just the lag (#1227). While ω ran to the +6 rail it
+    // absorbed the structural signal and these came back TVCL −48%, TVKA −29%, TVV −13%
+    // on the same noise-free data — a fit this test called a success because it only ever
+    // looked at theta[3]. With the omega FIX'd the worst of the three is TVKA at 1.5%
+    // (TVCL 0.09%, TVV 0.59%), so 5% sits ~3x above what the sound fit produces and ~1/9
+    // of the smallest error the degenerate one produced. Both numbers are measured.
+    for (i, truth, name) in [(0usize, 5.0, "TVCL"), (1, 50.0, "TVV"), (2, 1.0, "TVKA")] {
+        let rel = (fitted.theta[i] - truth).abs() / truth;
+        assert!(
+            rel < 0.05,
+            "{name} = {} is {:.1}% off truth {truth}; the noise-free optimum recovers it",
+            fitted.theta[i],
+            rel * 100.0
+        );
+    }
 }
 
 #[test]
@@ -698,7 +723,7 @@ const TRANSIT_ROUTE_LAG: &str = r#"
   theta TVN(3.0, 0.1, 20.0)
   theta TVMTT(1.0, 0.05, 24.0)
   theta TVLAG(2.0, 0.0, 12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -723,7 +748,7 @@ const TRANSIT_COMP_LAG: &str = r#"
   theta TVN(3.0, 0.1, 20.0)
   theta TVMTT(1.0, 0.05, 24.0)
   theta TVLAG(2.0, 0.0, 12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL      = TVCL * exp(ETA_CL)
@@ -748,7 +773,7 @@ const IGD_ROUTE_LAG: &str = r#"
   theta TVMAT(2.0, 0.05, 24.0)
   theta TVCV2(0.5, 0.01, 10.0)
   theta TVLAG(2.0, 0.0, 12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL  = TVCL * exp(ETA_CL)
@@ -773,7 +798,7 @@ const IGD_COMP_LAG: &str = r#"
   theta TVMAT(2.0, 0.05, 24.0)
   theta TVCV2(0.5, 0.01, 10.0)
   theta TVLAG(2.0, 0.0, 12.0)
-  omega ETA_CL ~ 0.0
+  omega ETA_CL ~ 0.0 FIX
   sigma PROP_ERR ~ 0.01 (sd)
 [individual_parameters]
   CL      = TVCL * exp(ETA_CL)


### PR DESCRIPTION
## Why

`tests/per_route_lag.rs::per_route_lag_fit_recovers_lag` has failed on **every** `Slow tests`
run since #1205 landed — the nightly suite has been red on this one test for two days, with
everything else green (5477 passed, 1 failed, one binary).

```
thread 'per_route_lag_fit_recovers_lag' panicked at tests/per_route_lag.rs:626:5:
per-route-lag fit should converge
```

Bisected on run history:

| run | head | verdict |
|---|---|---|
| [33657468069](https://github.com/FeRx-NLME/ferx-core/actions/runs/33657468069) | `5f7ef926` (#1200) | last success |
| [33672091642](https://github.com/FeRx-NLME/ferx-core/actions/runs/33672091642) | `6bb6ebd5` (#1205, `fix/1118-demote-converged-runaway-guard`) | first failure |

**The fixture is what is wrong, not #1205.** `ROUTE_LAG_SINGLE` declared
`omega ETA_CL ~ 0.0` **free**, and the test fits **one** subject. A single subject carries no
between-subject information, so ω² is unidentifiable by construction: nothing bounds it above
and it walks to `compute_bounds`' `+6` Cholesky-diagonal ceiling
(`src/estimation/parameterization.rs:555`, `exp(6) ≈ 403`, so ω² ≈ 162 755). Printing the
post-fit warnings:

```
Internal optimizer parameter guard reached by estimate(s):
  ETA_CL (estimate 162754.7914; packed coordinate 6.0000 at upper guard, runaway)
severity = Critical, verdict = runaway
```

#1205 (#1118) made that rail demote `converged`. The optimizer's stop rule did not change —
only the boolean did. Before #1205 this test was green on a fit whose ω had run to an
implementation rail; it passed for the wrong reason, and the new gate is reporting that
honestly.

## What changed

`omega ETA_CL ~ 0.0 FIX` in the file's model fixtures. That matches what the model already
says — zero IIV — and `packed_fixed_mask` then drops the coordinate from the packed vector, so
there is no guard hit and no demotion.

**The runaway ω was not cosmetic — it was absorbing the structural signal.** Same noise-free
data, same perturbed start, measured before and after:

| | free ω | ω `FIX`'d | truth |
|---|---|---|---|
| `converged` | false | **true** | |
| OFV | −323.2803 | **−610.0915** | |
| TVCL | 2.5889 (−48%) | **4.99536** (−0.09%) | 5.0 |
| TVV | 43.4805 (−13%) | **49.70493** (−0.59%) | 50.0 |
| TVKA | 0.7092 (−29%) | **0.98482** (−1.5%) | 1.0 |
| TVLAG | 2.0000000137 | 1.999999992 | 2.0 |
| ω² | 162 754.79 (at rail) | 1e-8 | 0 |
| σ | 0.15554 | 0.015277 | |
| runaway warning | `Critical` | none | |

The test only ever asserted `theta[3]`, so it called that first column a success — TVCL was 48%
off and nothing looked. It now also pins TVCL / TVV / TVKA at a 5% relative tolerance.

The fit's own diagnostics corroborated the diagnosis independently: `TVV ~ TVKA = -1.00`,
`TVV ~ TVLAG = -1.00`, `TVKA ~ TVLAG = 1.00`, RSE up to 11 650%, 3 of 6 Hessian eigenvalues
clipped.

## Alternatives considered

Relaxing the `converged` assertion (accept the runaway, keep asserting TVLAG). Rejected: it
keeps a degenerate fixture and re-hides exactly what #1205 was built to surface. The numbers
above are the argument — under that alternative the test would still be certifying a fit with
TVCL 48% off.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

Test-only. No `src/` change, no public API change, no `.ferx` format change.

## Numerical validation
- [x] Reference values:

```
# before (free omega) — the state the nightly was asserting against
converged = false
ofv       = -323.2803206134488
theta     = [2.5889440954763097, 43.48050992397635, 0.7092055671949157, 2.0000000137391107]
omega     = [162754.79141900392]      # packed coordinate 6.0000 == the +6 rail
sigma     = [0.15554372229775465]
WARNING (Critical/ParameterAtRunawayGuard): ETA_CL ... at upper guard, runaway

# after (omega FIX'd)
converged = true
ofv       = -610.0915442332105
theta     = [4.995361202997973, 49.70493043301984, 0.9848154826201589, 1.999999992082745]
omega     = [1.0000000000000017e-8]
sigma     = [0.015276884273925536]
runaway guard warning present = false
```

Truth is `theta = [5.0, 50.0, 1.0, 2.0]` (the data-generating parameters — the data are
`predict()` at truth, noise-free), so the second block recovers all four.

No NONMEM anchor: this changes no numerical path. It corrects a test fixture's identifiability
so the existing analytic-gradient FOCEI path is exercised on a well-posed problem.

## Performance
- [x] No significant impact expected

## Tests
- [x] Regression test added that fails without this fix

Mutation-verified, not assumed. Dropping the `FIX` from `ROUTE_LAG_SINGLE`'s line **alone**
(leaving the other eleven) reproduces the original failure exactly:

```
thread 'per_route_lag_fit_recovers_lag' panicked at tests/per_route_lag.rs:636:5:
per-route-lag fit should converge
test result: FAILED. 15 passed; 1 failed
```

Restored:

```
test result: ok. 16 passed; 0 failed
```

The new TVCL/TVV/TVKA assertions are bounded by measurement, not preference: 5% is ~3x above
the worst error the sound fit produces (TVKA, 1.5%) and ~1/9 of the smallest error the
degenerate fit produced (TVV, 13%), so the band separates the two states with room on both
sides.

One trap worth recording, since it nearly produced a false "the fix does not work": restoring
the mutated file with `mv file.bak file` gave it the backup's **older** mtime, so cargo
considered the target up to date and re-ran the *mutated* binary. `touch` before re-running.

## Example
- [x] Not applicable (internal / test fix with no new API surface)

## Docs
- [x] No user-visible change

Test-only, so no `CHANGELOG.md` entry per `CLAUDE.md`.

## Checklist
- [x] `tools/preflight.sh` green — `preflight OK — fmt check clippy rustdoc docs public-api`
- [x] Not touching the `Dual2` sensitivity path
- [x] No version bump needed

## Reviewer hints

The load-bearing line is **one**: `ROUTE_LAG_SINGLE`'s omega (line 34). The mutation above
proves it and nothing else in the diff.

The other eleven `FIX`es are deliberate uniformity, and are the part worth pushing back on if
you disagree. `FIX` is a no-op for a model that is only predicted, so none of them changes any
current test; four of them (`ROUTE_LAG_ZERO`, `ROUTE_LAG_PARALLEL`, `ROUTE_LAG_MIXED`, and
`ROUTE_LAG_SINGLE` itself) already carry `[fit_options] method = focei` and would walk into the
identical trap the moment someone adds a fit test; and leaving one twin `FIX`'d while its pair
stays free would undercut the "compared at identical parameters" claim the route-lag /
compartment-lag equalities rest on. Happy to narrow it to line 34 if you would rather keep the
diff minimal.

## Open questions

None blocking. One observation for whoever owns #1118 follow-up: a *free* omega declared at
exactly `~ 0.0` is a shape that can only ever end at a rail or at the floor — the packed start
is `log(0)`. Worth considering whether `fit()` should say so up front rather than let it run,
but that is a separate change and not this PR.

Closes #1227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
